### PR TITLE
test(cc-switch): cover CC Switch export flows

### DIFF
--- a/e2e/accountOnboardingCommonFlows.spec.ts
+++ b/e2e/accountOnboardingCommonFlows.spec.ts
@@ -10,8 +10,10 @@ import {
 import {
   ACCOUNT_MANAGEMENT_TEST_IDS,
   getAccountManagementListItemTestId,
+  getCopyKeyDialogRuntimeKeyItemTestId,
 } from "~/features/AccountManagement/testIds"
 import { TOKEN_PROVISIONING_TEST_IDS } from "~/features/TokenProvisioning/testIds"
+import { buildAccountTokenRuntimeKeyId } from "~/services/accounts/accountRuntimeKeys"
 import { STORAGE_KEYS } from "~/services/core/storageKeys"
 import type { ApiToken, SiteAccount } from "~/types"
 import { expect, test } from "~~/e2e/fixtures/extensionTest"
@@ -584,12 +586,19 @@ test("exports an account key from the copy-key dialog to CC Switch", async ({
     getAccountManagementListItemTestId("e2e-copy-dialog-cc-switch-account"),
   )
   await expect(accountRow).toBeVisible()
+  await accountRow.hover()
   await accountRow
     .getByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.rowCopyKeyButton)
     .click()
 
   await expect(page.getByRole("heading", { name: "Key List" })).toBeVisible()
-  await page.getByRole("heading", { name: "Copy Dialog CC Key" }).click()
+  await page
+    .getByTestId(
+      getCopyKeyDialogRuntimeKeyItemTestId(
+        buildAccountTokenRuntimeKeyId("e2e-copy-dialog-cc-switch-account", 1),
+      ),
+    )
+    .click()
   await page
     .getByTestId(
       ACCOUNT_MANAGEMENT_TEST_IDS.copyKeyDialogExportToCCSwitchButton,

--- a/e2e/accountOnboardingCommonFlows.spec.ts
+++ b/e2e/accountOnboardingCommonFlows.spec.ts
@@ -7,10 +7,13 @@ import {
   AIHUBMIX_WEB_ORIGIN,
   SITE_TYPES,
 } from "~/constants/siteType"
-import { ACCOUNT_MANAGEMENT_TEST_IDS } from "~/features/AccountManagement/testIds"
+import {
+  ACCOUNT_MANAGEMENT_TEST_IDS,
+  getAccountManagementListItemTestId,
+} from "~/features/AccountManagement/testIds"
 import { TOKEN_PROVISIONING_TEST_IDS } from "~/features/TokenProvisioning/testIds"
 import { STORAGE_KEYS } from "~/services/core/storageKeys"
-import type { SiteAccount } from "~/types"
+import type { ApiToken, SiteAccount } from "~/types"
 import { expect, test } from "~~/e2e/fixtures/extensionTest"
 import { runAccountAutoDetectScenario } from "~~/e2e/scenarios/accountAutoDetect"
 import { saveExistingAccountTokenToApiProfileScenario } from "~~/e2e/scenarios/accountKeyToApiProfile"
@@ -18,6 +21,7 @@ import {
   openApiCredentialProfilesPopupScenario,
   verifyApiCredentialProfileModelsProbeScenario,
 } from "~~/e2e/scenarios/apiCredentialProfileVerification"
+import { verifyCcSwitchModelExportDeepLink } from "~~/e2e/scenarios/ccSwitchExport"
 import {
   createStoredAccount,
   forceExtensionLanguage,
@@ -39,6 +43,29 @@ const AIHUBMIX_SITE_URL = AIHUBMIX_WEB_ORIGIN
 const MANAGED_SITE_BASE_URL = "https://managed-site.example.com"
 const MANAGED_SITE_ADMIN_TOKEN = "managed-site-admin-token"
 const MANAGED_SITE_USER_ID = "1"
+
+function createCopyDialogToken(overrides: Partial<ApiToken> = {}): ApiToken {
+  const nowSeconds = Math.floor(Date.now() / 1000)
+
+  return {
+    id: 1,
+    user_id: 1,
+    key: "sk-copy-dialog-token",
+    status: 1,
+    name: "Copy Dialog Key",
+    created_time: nowSeconds,
+    accessed_time: nowSeconds,
+    expired_time: -1,
+    remain_quota: -1,
+    unlimited_quota: true,
+    model_limits_enabled: false,
+    model_limits: "",
+    allow_ips: "",
+    used_quota: 0,
+    group: "default",
+    ...overrides,
+  }
+}
 
 async function readStoredAccounts(
   serviceWorker: Awaited<ReturnType<typeof getServiceWorker>>,
@@ -509,6 +536,76 @@ test("enables default-key provisioning, adds an account, saves the created key a
     page: popupPage,
     profileName: savedProfile.name,
     expectedModelCount: 2,
+  })
+})
+
+test("exports an account key from the copy-key dialog to CC Switch", async ({
+  context,
+  extensionId,
+  page,
+}) => {
+  const serviceWorker = await getServiceWorker(context)
+  await seedStoredAccounts(serviceWorker, [
+    createStoredAccount({
+      id: "e2e-copy-dialog-cc-switch-account",
+      site_name: "Copy Dialog CC Source",
+      site_url: "https://copy-dialog-cc.example.com",
+      account_info: {
+        id: "45",
+        username: "copy-dialog-user",
+        access_token: "copy-dialog-access-token",
+      },
+    }),
+  ])
+  await stubNewApiSiteRoutes(context, {
+    baseUrl: "https://copy-dialog-cc.example.com",
+    models: ["gpt-copy-dialog-cc"],
+    initialTokens: [
+      createCopyDialogToken({
+        id: 1,
+        name: "Copy Dialog CC Key",
+        key: "sk-copy-dialog-cc",
+      }),
+      createCopyDialogToken({
+        id: 2,
+        name: "Copy Dialog Secondary Key",
+        key: "sk-copy-dialog-secondary",
+      }),
+    ],
+  })
+
+  await page.goto(
+    `chrome-extension://${extensionId}/${OPTIONS_PAGE_PATH}#${MENU_ITEM_IDS.ACCOUNT}`,
+  )
+  await waitForExtensionRoot(page)
+  await expectPermissionOnboardingHidden(page)
+
+  const accountRow = page.getByTestId(
+    getAccountManagementListItemTestId("e2e-copy-dialog-cc-switch-account"),
+  )
+  await expect(accountRow).toBeVisible()
+  await accountRow
+    .getByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.rowCopyKeyButton)
+    .click()
+
+  await expect(page.getByRole("heading", { name: "Key List" })).toBeVisible()
+  await page.getByRole("heading", { name: "Copy Dialog CC Key" }).click()
+  await page
+    .getByTestId(
+      ACCOUNT_MANAGEMENT_TEST_IDS.copyKeyDialogExportToCCSwitchButton,
+    )
+    .click()
+
+  await verifyCcSwitchModelExportDeepLink({
+    page,
+    modelName: "gpt-copy-dialog-cc",
+    expected: {
+      app: "claude",
+      name: "Copy Dialog CC Source",
+      homepage: "https://copy-dialog-cc.example.com",
+      endpoint: "https://copy-dialog-cc.example.com",
+      apiKey: "sk-copy-dialog-cc",
+    },
   })
 })
 

--- a/e2e/apiCredentialProfilesOptionsActions.spec.ts
+++ b/e2e/apiCredentialProfilesOptionsActions.spec.ts
@@ -5,6 +5,7 @@ import { MENU_ITEM_IDS } from "~/constants/optionsMenuIds"
 import { API_CREDENTIAL_PROFILES_TEST_IDS } from "~/features/ApiCredentialProfiles/testIds"
 import { STORAGE_KEYS } from "~/services/core/storageKeys"
 import { expect, test } from "~~/e2e/fixtures/extensionTest"
+import { verifyApiCredentialProfileCcSwitchModelPickerScenario } from "~~/e2e/scenarios/apiCredentialProfileVerification"
 import {
   createStoredApiCredentialProfile,
   forceExtensionLanguage,
@@ -253,4 +254,42 @@ test("opens model management for an options-page API credential profile", async 
   expect(targetUrl.hash).toBe(`#${MENU_ITEM_IDS.MODELS}`)
   expect(targetUrl.searchParams.get("profileId")).toBe("profile-models")
   await expect(targetPage.getByText("gpt-options-model")).toBeVisible()
+})
+
+test("opens the CC Switch model picker for an API credential profile", async ({
+  context,
+  extensionId,
+  page,
+}) => {
+  const serviceWorker = await getServiceWorker(context)
+  await seedApiCredentialProfiles(serviceWorker, [
+    createStoredApiCredentialProfile({
+      id: "profile-cc-switch",
+      name: "CC Switch Profile",
+      baseUrl: "https://cc-switch-profile.example.com",
+      apiKey: "sk-cc-switch-profile",
+    }),
+  ])
+
+  await context.route(
+    "https://cc-switch-profile.example.com/v1/models",
+    (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          data: [{ id: "gpt-cc-switch-profile" }],
+        }),
+      }),
+  )
+
+  await openProfilesPage(page, extensionId)
+
+  await verifyApiCredentialProfileCcSwitchModelPickerScenario({
+    page,
+    profileName: "CC Switch Profile",
+    modelName: "gpt-cc-switch-profile",
+    expectedBaseUrl: "https://cc-switch-profile.example.com",
+    expectedApiKey: "sk-cc-switch-profile",
+  })
 })

--- a/e2e/keyManagementCommonFlow.spec.ts
+++ b/e2e/keyManagementCommonFlow.spec.ts
@@ -1,11 +1,16 @@
 import { OPTIONS_PAGE_PATH } from "~/constants/extensionPages"
+import { SITE_TYPES } from "~/constants/siteType"
 import {
   getKeyManagementTokenRowTestId,
   KEY_MANAGEMENT_TEST_IDS,
 } from "~/features/KeyManagement/testIds"
-import type { ApiToken } from "~/types"
+import { AuthTypeEnum, type ApiToken } from "~/types"
 import { expect, test } from "~~/e2e/fixtures/extensionTest"
-import { verifyAccountKeyLifecycleUsage } from "~~/e2e/scenarios/accountUsage"
+import {
+  verifyAccountKeyLifecycleUsage,
+  verifyAccountTokenCcSwitchModelPickerUsage,
+} from "~~/e2e/scenarios/accountUsage"
+import { verifyCcSwitchModelExportDeepLink } from "~~/e2e/scenarios/ccSwitchExport"
 import { saveTokenToApiCredentialProfilesFromKeyManagementPage } from "~~/e2e/utils/accountLifecycle"
 import {
   createStoredAccount,
@@ -45,6 +50,69 @@ function createStubApiToken(overrides: Partial<ApiToken> = {}): ApiToken {
   }
 }
 
+async function stubSharedChatServiceCredentialRoutes(
+  context: Parameters<typeof stubNewApiSiteRoutes>[0],
+) {
+  await context.route("https://new.sharedchat.cc/**", async (route) => {
+    const request = route.request()
+    const url = new URL(request.url())
+
+    if (
+      request.method() === "GET" &&
+      url.pathname === "/frontend-api/vibe-code/quota"
+    ) {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          code: 1,
+          msg: "ok",
+          data: {
+            codex: {
+              isAuth: true,
+              apiKey: "sk-sharedchat-service-e2e",
+              subscriptions: {
+                remainingAmount: 12.5,
+              },
+              currentUsage: {
+                totalRequests: 3,
+                totalTokens: 456,
+                totalCost: 0.42,
+              },
+              recentRecords: [],
+            },
+          },
+        }),
+      })
+      return
+    }
+
+    if (request.method() === "GET" && url.pathname === "/codex/v1/models") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          object: "list",
+          data: [
+            {
+              id: "gpt-sharedchat-service",
+              object: "model",
+              owned_by: "e2e",
+            },
+          ],
+        }),
+      })
+      return
+    }
+
+    await route.fulfill({
+      status: 404,
+      contentType: "application/json",
+      body: JSON.stringify({ error: "Unhandled SharedChat E2E route" }),
+    })
+  })
+}
+
 test.beforeEach(async ({ context, page }) => {
   installExtensionPageGuards(page)
   await forceExtensionLanguage(page, "en")
@@ -74,6 +142,99 @@ test("creates a token from key management and reloads it into the visible list",
     account: accountFixture,
     openFromAccountRow: false,
     buildTokenName: () => "E2E Created Key",
+  })
+})
+
+test("opens the CC Switch model picker for an account API key", async ({
+  context,
+  extensionId,
+  page,
+}) => {
+  const serviceWorker = await getServiceWorker(context)
+
+  const accountFixture = await seedMockAccountFixture({
+    serviceWorker,
+    account: createStoredAccount({
+      id: "e2e-cc-switch-account",
+      site_name: "CC Switch Source",
+      site_url: "https://cc-switch-source.example.com",
+    }),
+  })
+  await stubNewApiSiteRoutes(context, {
+    baseUrl: "https://cc-switch-source.example.com",
+    models: ["gpt-cc-switch-smoke"],
+  })
+
+  await verifyAccountTokenCcSwitchModelPickerUsage({
+    extensionId,
+    page,
+    serviceWorker,
+    account: accountFixture,
+    openFromAccountRow: false,
+    buildTokenName: () => "E2E CC Switch Key",
+    modelName: "gpt-cc-switch-smoke",
+    expectedCcSwitchDeepLink: {
+      app: "claude",
+      name: "CC Switch Source",
+      homepage: "https://cc-switch-source.example.com",
+      endpoint: "https://cc-switch-source.example.com",
+      apiKey: "sk-created-1",
+    },
+  })
+})
+
+test("exports a SharedChat service credential to CC Switch", async ({
+  context,
+  extensionId,
+  page,
+}) => {
+  const serviceWorker = await getServiceWorker(context)
+  await seedStoredAccounts(serviceWorker, [
+    createStoredAccount({
+      id: "e2e-sharedchat-service-account",
+      site_name: "SharedChat Service",
+      site_type: SITE_TYPES.SHAREDCHAT,
+      site_url: "https://new.sharedchat.cc",
+      authType: AuthTypeEnum.Cookie,
+      account_info: {
+        id: "sharedchat-user",
+        access_token: "sharedchat-session",
+        username: "sharedchat-user",
+      },
+    }),
+  ])
+  await stubSharedChatServiceCredentialRoutes(context)
+
+  await page.goto(
+    `chrome-extension://${extensionId}/${OPTIONS_PAGE_PATH}#keys?accountId=e2e-sharedchat-service-account`,
+  )
+  await waitForExtensionRoot(page)
+  await expectPermissionOnboardingHidden(page)
+
+  const serviceCredentialCard = page.getByTestId(
+    KEY_MANAGEMENT_TEST_IDS.serviceCredentialCard,
+  )
+  await expect(serviceCredentialCard).toBeVisible()
+  await expect(
+    serviceCredentialCard.getByRole("heading", { name: "Codex" }),
+  ).toBeVisible()
+
+  await serviceCredentialCard
+    .getByTestId(
+      KEY_MANAGEMENT_TEST_IDS.serviceCredentialExportToCCSwitchButton,
+    )
+    .click()
+
+  await verifyCcSwitchModelExportDeepLink({
+    page,
+    modelName: "gpt-sharedchat-service",
+    expected: {
+      app: "claude",
+      name: "SharedChat Service - Codex",
+      homepage: "https://new.sharedchat.cc/codex",
+      endpoint: "https://new.sharedchat.cc/codex",
+      apiKey: "sk-sharedchat-service-e2e",
+    },
   })
 })
 

--- a/e2e/scenarios/accountUsage.ts
+++ b/e2e/scenarios/accountUsage.ts
@@ -1,5 +1,6 @@
 import type { Page } from "@playwright/test"
 
+import { KEY_MANAGEMENT_TEST_IDS } from "~/features/KeyManagement/testIds"
 import type { ApiCredentialProfile } from "~/types/apiCredentialProfiles"
 import type { AccountFixture } from "~~/e2e/scenarios/accountFixtures"
 import { runAccountKeyLifecycleScenario } from "~~/e2e/scenarios/accountKeyLifecycle"
@@ -9,10 +10,25 @@ import {
   type ProviderDestinationValidationOptions,
 } from "~~/e2e/scenarios/accountProviderDestinations"
 import {
+  verifyOpenApiCredentialProfileModelsProbeDialog,
+  type ApiCredentialProfileModelsProbeDialogExpectation,
+} from "~~/e2e/scenarios/apiCredentialProfileVerification"
+import {
+  verifyCcSwitchModelExportDeepLink,
+  verifyCcSwitchModelPickerCancelable,
+  type CcSwitchDeepLinkExpectation,
+} from "~~/e2e/scenarios/ccSwitchExport"
+import {
   verifyAccountModelCatalog,
   type ModelListCatalogExpectations,
 } from "~~/e2e/scenarios/modelListCatalog"
-import type { SavedApiCredentialProfileExpectation } from "~~/e2e/utils/accountLifecycle"
+import {
+  deleteTokenFromKeyManagementPage,
+  expectTokenCreatedInKeyManagementPage,
+  openKeyManagementForAccount,
+  submitTokenCreationFromKeyManagementPage,
+  type SavedApiCredentialProfileExpectation,
+} from "~~/e2e/utils/accountLifecycle"
 import type { getServiceWorker } from "~~/e2e/utils/extensionState"
 
 type ServiceWorker = Awaited<ReturnType<typeof getServiceWorker>>
@@ -22,6 +38,108 @@ type AccountUsageScenarioContext = {
   extensionId: string
   serviceWorker: ServiceWorker
   account: AccountFixture
+}
+
+type ModelsProbeExpectation = Omit<
+  ApiCredentialProfileModelsProbeDialogExpectation,
+  "page"
+>
+
+type CreatedTokenUiContext = {
+  page: Page
+  row: Awaited<ReturnType<typeof expectTokenCreatedInKeyManagementPage>>["row"]
+}
+
+type AccountTokenUiScenarioContext = AccountUsageScenarioContext & {
+  buildTokenName: () => string
+  openFromAccountRow?: boolean
+  cleanupAccountFixture?: boolean
+  cleanup?: () => Promise<void>
+}
+
+async function runAccountTokenUiScenario(
+  context: AccountTokenUiScenarioContext & {
+    useCreatedToken: (params: CreatedTokenUiContext) => Promise<void>
+  },
+) {
+  const account = context.account
+  const tokenName = context.buildTokenName()
+  let keyManagementPage = context.page
+  let submittedTokenName: string | null = null
+  let primaryError: unknown
+
+  try {
+    keyManagementPage = await openKeyManagementForAccount({
+      page: context.page,
+      extensionId: context.extensionId,
+      accountId: account.accountId,
+      siteType: account.siteType,
+      baseUrl: account.baseUrl,
+      openFromAccountRow: context.openFromAccountRow ?? true,
+    })
+    await submitTokenCreationFromKeyManagementPage({
+      page: keyManagementPage,
+      tokenName,
+    })
+    submittedTokenName = tokenName
+
+    const tokenResult = await expectTokenCreatedInKeyManagementPage({
+      page: keyManagementPage,
+      tokenName,
+    })
+    keyManagementPage = tokenResult.page
+    await context.useCreatedToken({
+      page: keyManagementPage,
+      row: tokenResult.row,
+    })
+  } catch (error) {
+    primaryError = error
+  }
+
+  const cleanupErrors: unknown[] = []
+  const runCleanup = async (cleanup: () => Promise<void>) => {
+    try {
+      await cleanup()
+    } catch (error) {
+      cleanupErrors.push(error)
+    }
+  }
+
+  if (submittedTokenName) {
+    await runCleanup(async () => {
+      await deleteTokenFromKeyManagementPage({
+        page: keyManagementPage,
+        token: submittedTokenName,
+      })
+    })
+  }
+  if (context.cleanupAccountFixture !== false) {
+    await runCleanup(async () => {
+      await account.cleanup()
+    })
+  }
+  if (context.cleanup) {
+    await runCleanup(context.cleanup)
+  }
+
+  let cleanupError: unknown
+  if (cleanupErrors.length === 1) {
+    cleanupError = cleanupErrors[0]
+  } else if (cleanupErrors.length > 1) {
+    cleanupError = new AggregateError(
+      cleanupErrors,
+      "Account token UI scenario cleanup failed",
+    )
+  }
+
+  if (primaryError && cleanupError) {
+    throw new AggregateError(
+      [primaryError, cleanupError],
+      "Account token UI scenario failed",
+    )
+  }
+  if (primaryError) throw primaryError
+  if (cleanupError) throw cleanupError
 }
 
 export async function verifyAccountKeyLifecycleUsage(
@@ -95,5 +213,52 @@ export async function verifyAccountModelCatalogUsage(
     extensionId: context.extensionId,
     accountId: context.account.accountId,
     expectations: context.expectations,
+  })
+}
+
+export async function verifyAccountTokenModelsProbeUsage(
+  context: AccountTokenUiScenarioContext & {
+    modelsProbe?: ModelsProbeExpectation
+  },
+) {
+  await runAccountTokenUiScenario({
+    ...context,
+    useCreatedToken: async ({ page, row }) => {
+      await row
+        .getByTestId(KEY_MANAGEMENT_TEST_IDS.verifyTokenApiButton)
+        .click()
+      await verifyOpenApiCredentialProfileModelsProbeDialog({
+        page,
+        expectedStatus: "handled",
+        closeDialog: true,
+        ...context.modelsProbe,
+      })
+    },
+  })
+}
+
+export async function verifyAccountTokenCcSwitchModelPickerUsage(
+  context: AccountTokenUiScenarioContext & {
+    modelName?: string
+    expectedCcSwitchDeepLink?: CcSwitchDeepLinkExpectation
+  },
+) {
+  await runAccountTokenUiScenario({
+    ...context,
+    useCreatedToken: async ({ page, row }) => {
+      await row
+        .getByTestId(KEY_MANAGEMENT_TEST_IDS.exportToCCSwitchButton)
+        .click()
+      if (context.modelName) {
+        await verifyCcSwitchModelExportDeepLink({
+          page,
+          modelName: context.modelName,
+          expected: context.expectedCcSwitchDeepLink ?? { app: "claude" },
+        })
+        return
+      }
+
+      await verifyCcSwitchModelPickerCancelable({ page })
+    },
   })
 }

--- a/e2e/scenarios/apiCredentialProfileVerification.ts
+++ b/e2e/scenarios/apiCredentialProfileVerification.ts
@@ -102,9 +102,11 @@ export async function verifyApiCredentialProfileModelsProbeScenario(params: {
     })
     await expect(profileHeading).toBeVisible()
 
-    const profileCard = profileHeading.locator(
-      `xpath=ancestor::*[.//*[@data-testid="${API_CREDENTIAL_PROFILES_TEST_IDS.verifyButton}"]][1]`,
-    )
+    const profileCard = await getApiCredentialProfileCard({
+      page: params.page,
+      profileName: params.profileName,
+      actionTestId: API_CREDENTIAL_PROFILES_TEST_IDS.verifyButton,
+    })
     verifyButton = profileCard.getByTestId(
       API_CREDENTIAL_PROFILES_TEST_IDS.verifyButton,
     )
@@ -118,6 +120,7 @@ export async function verifyApiCredentialProfileModelsProbeScenario(params: {
 async function getApiCredentialProfileCard(params: {
   page: Page
   profileName: string
+  actionTestId?: string
 }) {
   const profileHeading = params.page.getByRole("heading", {
     name: params.profileName,
@@ -125,7 +128,7 @@ async function getApiCredentialProfileCard(params: {
   await expect(profileHeading).toBeVisible()
 
   return profileHeading.locator(
-    `xpath=ancestor::*[.//*[@data-testid="${API_CREDENTIAL_PROFILES_TEST_IDS.exportMenuButton}"]][1]`,
+    `xpath=ancestor::*[.//*[@data-testid="${params.actionTestId ?? API_CREDENTIAL_PROFILES_TEST_IDS.exportMenuButton}"]][1]`,
   )
 }
 

--- a/e2e/scenarios/apiCredentialProfileVerification.ts
+++ b/e2e/scenarios/apiCredentialProfileVerification.ts
@@ -8,10 +8,22 @@ import {
 } from "~/features/ApiCredentialProfiles/testIds"
 import { expect } from "~~/e2e/fixtures/extensionTest"
 import {
+  verifyCcSwitchModelExportDeepLink,
+  verifyCcSwitchModelPickerCancelable,
+} from "~~/e2e/scenarios/ccSwitchExport"
+import {
   forceExtensionLanguage,
   installExtensionPageGuards,
 } from "~~/e2e/utils/commonUserFlows"
 import { waitForExtensionRoot } from "~~/e2e/utils/lazyLoading"
+
+export type ApiCredentialProfileModelsProbeDialogExpectation = {
+  page: Page
+  expectedStatus?: "pass" | "fail" | "handled"
+  expectedModelCount?: number
+  expectedSummaryText?: string
+  closeDialog?: boolean
+}
 
 export async function openApiCredentialProfilesPopupScenario(params: {
   page: Page
@@ -32,10 +44,50 @@ export async function openApiCredentialProfilesPopupScenario(params: {
   return params.page
 }
 
+export async function verifyOpenApiCredentialProfileModelsProbeDialog(
+  params: ApiCredentialProfileModelsProbeDialogExpectation,
+) {
+  const modelsProbe = params.page.getByTestId(
+    getApiCredentialProfileVerifyProbeTestId("models"),
+  )
+  await expect(
+    params.page.getByTestId(API_CREDENTIAL_PROFILES_TEST_IDS.verifyModelId),
+  ).toBeVisible()
+
+  await modelsProbe
+    .getByTestId(API_CREDENTIAL_PROFILES_TEST_IDS.verifyProbeRunButton)
+    .click()
+
+  if (params.expectedStatus === "handled") {
+    await expect(modelsProbe).toContainText(/Pass|Fail/)
+  } else {
+    await expect(modelsProbe).toContainText(
+      params.expectedStatus === "fail" ? "Fail" : "Pass",
+    )
+  }
+  if (typeof params.expectedModelCount === "number") {
+    await expect(modelsProbe).toContainText(
+      `Fetched ${params.expectedModelCount} models.`,
+    )
+  }
+  if (params.expectedSummaryText) {
+    await expect(modelsProbe).toContainText(params.expectedSummaryText)
+  }
+
+  if (params.closeDialog) {
+    await params.page
+      .getByTestId(API_CREDENTIAL_PROFILES_TEST_IDS.verifyDialogCloseButton)
+      .click()
+    await expect(
+      params.page.getByRole("heading", { name: "API Verification" }),
+    ).toHaveCount(0)
+  }
+}
+
 export async function verifyApiCredentialProfileModelsProbeScenario(params: {
   page: Page
   profileName?: string
-  expectedStatus?: "pass" | "fail"
+  expectedStatus?: "pass" | "fail" | "handled"
   expectedModelCount?: number
   expectedSummaryText?: string
   closeDialog?: boolean
@@ -60,35 +112,56 @@ export async function verifyApiCredentialProfileModelsProbeScenario(params: {
 
   await verifyButton.click()
 
-  const modelsProbe = params.page.getByTestId(
-    getApiCredentialProfileVerifyProbeTestId("models"),
-  )
-  await expect(
-    params.page.getByTestId(API_CREDENTIAL_PROFILES_TEST_IDS.verifyModelId),
-  ).toBeVisible()
+  await verifyOpenApiCredentialProfileModelsProbeDialog(params)
+}
 
-  await modelsProbe
-    .getByTestId(API_CREDENTIAL_PROFILES_TEST_IDS.verifyProbeRunButton)
+async function getApiCredentialProfileCard(params: {
+  page: Page
+  profileName: string
+}) {
+  const profileHeading = params.page.getByRole("heading", {
+    name: params.profileName,
+  })
+  await expect(profileHeading).toBeVisible()
+
+  return profileHeading.locator(
+    `xpath=ancestor::*[.//*[@data-testid="${API_CREDENTIAL_PROFILES_TEST_IDS.exportMenuButton}"]][1]`,
+  )
+}
+
+export async function verifyApiCredentialProfileCcSwitchModelPickerScenario(params: {
+  page: Page
+  profileName: string
+  modelName?: string
+  expectedApiKey?: string
+  expectedBaseUrl?: string
+}) {
+  const profileCard = await getApiCredentialProfileCard({
+    page: params.page,
+    profileName: params.profileName,
+  })
+
+  await profileCard
+    .getByTestId(API_CREDENTIAL_PROFILES_TEST_IDS.exportMenuButton)
+    .click()
+  await params.page
+    .getByTestId(API_CREDENTIAL_PROFILES_TEST_IDS.exportToCCSwitchMenuItem)
     .click()
 
-  await expect(modelsProbe).toContainText(
-    params.expectedStatus === "fail" ? "Fail" : "Pass",
-  )
-  if (typeof params.expectedModelCount === "number") {
-    await expect(modelsProbe).toContainText(
-      `Fetched ${params.expectedModelCount} models.`,
-    )
-  }
-  if (params.expectedSummaryText) {
-    await expect(modelsProbe).toContainText(params.expectedSummaryText)
+  if (params.modelName) {
+    await verifyCcSwitchModelExportDeepLink({
+      page: params.page,
+      modelName: params.modelName,
+      expected: {
+        app: "claude",
+        name: params.profileName,
+        homepage: params.expectedBaseUrl,
+        endpoint: params.expectedBaseUrl,
+        apiKey: params.expectedApiKey,
+      },
+    })
+    return
   }
 
-  if (params.closeDialog) {
-    await params.page
-      .getByTestId(API_CREDENTIAL_PROFILES_TEST_IDS.verifyDialogCloseButton)
-      .click()
-    await expect(
-      params.page.getByRole("heading", { name: "API Verification" }),
-    ).toHaveCount(0)
-  }
+  await verifyCcSwitchModelPickerCancelable({ page: params.page })
 }

--- a/e2e/scenarios/ccSwitchExport.ts
+++ b/e2e/scenarios/ccSwitchExport.ts
@@ -1,0 +1,160 @@
+import type { Page } from "@playwright/test"
+
+import { CC_SWITCH_EXPORT_TEST_IDS } from "~/components/CCSwitchExportDialog.testIds"
+import { expect } from "~~/e2e/fixtures/extensionTest"
+
+const OPENED_CC_SWITCH_URLS_KEY = "__aah_e2e_opened_cc_switch_urls__"
+
+export type CcSwitchDeepLinkExpectation = {
+  app?: string
+  name?: string
+  homepage?: string
+  endpoint?: string
+  apiKey?: string
+  model?: string
+}
+
+async function installCcSwitchWindowOpenRecorder(page: Page) {
+  await page.evaluate((storageKey) => {
+    window.sessionStorage.setItem(storageKey, JSON.stringify([]))
+
+    const readUrls = () => {
+      try {
+        const raw = window.sessionStorage.getItem(storageKey)
+        return raw ? (JSON.parse(raw) as string[]) : []
+      } catch {
+        return []
+      }
+    }
+
+    window.open = ((url?: string | URL) => {
+      window.sessionStorage.setItem(
+        storageKey,
+        JSON.stringify([...readUrls(), url?.toString() ?? ""]),
+      )
+      return null
+    }) as typeof window.open
+  }, OPENED_CC_SWITCH_URLS_KEY)
+}
+
+async function readOpenedCcSwitchUrls(page: Page) {
+  return await page.evaluate((storageKey) => {
+    try {
+      const raw = window.sessionStorage.getItem(storageKey)
+      return raw ? (JSON.parse(raw) as string[]) : []
+    } catch {
+      return []
+    }
+  }, OPENED_CC_SWITCH_URLS_KEY)
+}
+
+function expectCcSwitchDeepLink(
+  url: string,
+  expected: CcSwitchDeepLinkExpectation,
+) {
+  const parsed = new URL(url)
+  expect(parsed.protocol).toBe("ccswitch:")
+  expect(parsed.host).toBe("v1")
+  expect(parsed.pathname).toBe("/import")
+  expect(parsed.searchParams.get("resource")).toBe("provider")
+
+  for (const [key, value] of Object.entries(expected)) {
+    if (value !== undefined) {
+      expect(parsed.searchParams.get(key)).toBe(value)
+    }
+  }
+}
+
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&")
+}
+
+async function selectCcSwitchModel(params: {
+  page: Page
+  modelPicker: ReturnType<Page["getByTestId"]>
+  modelName: string
+}) {
+  await params.modelPicker.click()
+
+  const searchInput = params.page.getByTestId(
+    CC_SWITCH_EXPORT_TEST_IDS.modelSearchInput,
+  )
+  await expect(searchInput).toBeVisible({ timeout: 10_000 })
+  await searchInput.fill(params.modelName)
+  await expect(
+    params.page
+      .getByRole("option", {
+        name: new RegExp(escapeRegExp(params.modelName), "u"),
+      })
+      .first(),
+  ).toBeVisible({ timeout: 10_000 })
+  await searchInput.press("Enter")
+
+  const selected = await expect(params.modelPicker)
+    .toContainText(params.modelName, { timeout: 3_000 })
+    .then(() => true)
+    .catch(() => false)
+
+  if (selected) {
+    return
+  }
+
+  await params.modelPicker.click()
+  await searchInput.fill(params.modelName)
+  await params.page
+    .getByRole("option", {
+      name: new RegExp(escapeRegExp(params.modelName), "u"),
+    })
+    .first()
+    .click()
+}
+
+export async function verifyCcSwitchModelPickerCancelable(params: {
+  page: Page
+}) {
+  const dialog = params.page.getByTestId(CC_SWITCH_EXPORT_TEST_IDS.dialog)
+  await expect(dialog).toBeVisible({ timeout: 30_000 })
+
+  const modelPicker = dialog.getByTestId(CC_SWITCH_EXPORT_TEST_IDS.modelPicker)
+  await expect(modelPicker).toBeVisible({ timeout: 30_000 })
+  await expect(modelPicker).toBeEnabled({ timeout: 30_000 })
+
+  await dialog.getByTestId(CC_SWITCH_EXPORT_TEST_IDS.cancelButton).click()
+  await expect(dialog).toHaveCount(0, { timeout: 30_000 })
+}
+
+export async function verifyCcSwitchModelExportDeepLink(params: {
+  page: Page
+  modelName: string
+  expected: CcSwitchDeepLinkExpectation
+}) {
+  await installCcSwitchWindowOpenRecorder(params.page)
+
+  const dialog = params.page.getByTestId(CC_SWITCH_EXPORT_TEST_IDS.dialog)
+  await expect(dialog).toBeVisible({ timeout: 30_000 })
+
+  const modelPicker = dialog.getByTestId(CC_SWITCH_EXPORT_TEST_IDS.modelPicker)
+  await expect(modelPicker).toBeVisible({ timeout: 30_000 })
+  await expect(modelPicker).toBeEnabled({ timeout: 30_000 })
+  await selectCcSwitchModel({
+    page: params.page,
+    modelPicker,
+    modelName: params.modelName,
+  })
+  await expect(modelPicker).toContainText(params.modelName)
+
+  await dialog.getByTestId(CC_SWITCH_EXPORT_TEST_IDS.exportButton).click()
+  await expect(dialog).toHaveCount(0, { timeout: 30_000 })
+
+  await expect
+    .poll(async () => await readOpenedCcSwitchUrls(params.page), {
+      timeout: 30_000,
+    })
+    .toHaveLength(1)
+
+  const [url] = await readOpenedCcSwitchUrls(params.page)
+  expectCcSwitchDeepLink(url, {
+    model: params.modelName,
+    ...params.expected,
+  })
+}

--- a/e2e/utils/realSite/accountUsage.ts
+++ b/e2e/utils/realSite/accountUsage.ts
@@ -48,7 +48,7 @@ type RealSiteAccountUsageCheck =
   AccountUsagePlanCheck<RealSiteAccountUsagePlanContext>
 
 type ApiProfilePopupModelsProbeExpectation = {
-  expectedStatus?: "pass" | "fail"
+  expectedStatus?: "pass" | "fail" | "handled"
   expectedSummaryText?: string
 }
 
@@ -152,6 +152,23 @@ export async function maybeVerifyRealSiteModelToKeyUsage(
   })
 }
 
+async function withApiCredentialProfilesPopupPage(
+  context: Pick<RealSiteAccountUsageContext, "page" | "extensionId">,
+  verify: (popupPage: Page) => Promise<void>,
+) {
+  const popupPage = await context.page.context().newPage()
+
+  try {
+    await openApiCredentialProfilesPopupScenario({
+      page: popupPage,
+      extensionId: context.extensionId,
+    })
+    await verify(popupPage)
+  } finally {
+    await popupPage.close()
+  }
+}
+
 async function verifyRealSiteApiProfilePopupModelsUsage(
   context: RealSiteAccountUsageContext & {
     profileLabel?: string
@@ -166,21 +183,14 @@ async function verifyRealSiteApiProfilePopupModelsUsage(
     profileLabel: context.profileLabel,
     expectedProfile: context.expectedProfile,
     afterProfileSaved: async (profile) => {
-      const popupPage = await openApiCredentialProfilesPopupScenario({
-        page: await context.page.context().newPage(),
-        extensionId: context.extensionId,
-      })
-
-      try {
+      await withApiCredentialProfilesPopupPage(context, async (popupPage) => {
         await verifyApiCredentialProfileModelsProbeScenario({
           page: popupPage,
           profileName: profile.name,
           ...context.popupModelsProbe,
         })
         verifiedProfile = profile
-      } finally {
-        await popupPage.close()
-      }
+      })
     },
   })
 

--- a/src/components/CCSwitchExportDialog.testIds.ts
+++ b/src/components/CCSwitchExportDialog.testIds.ts
@@ -1,0 +1,7 @@
+export const CC_SWITCH_EXPORT_TEST_IDS = {
+  dialog: "cc-switch-export-dialog",
+  modelPicker: "cc-switch-export-model-picker",
+  modelSearchInput: "cc-switch-export-model-search-input",
+  exportButton: "cc-switch-export-submit-button",
+  cancelButton: "cc-switch-export-cancel-button",
+} as const

--- a/src/components/CCSwitchExportDialog.tsx
+++ b/src/components/CCSwitchExportDialog.tsx
@@ -45,6 +45,8 @@ import {
   stripTrailingOpenAIV1,
 } from "~/utils/core/url"
 
+import { CC_SWITCH_EXPORT_TEST_IDS } from "./CCSwitchExportDialog.testIds"
+
 interface CCSwitchExportDialogProps {
   isOpen: boolean
   onClose: () => void
@@ -152,6 +154,7 @@ export function CCSwitchExportDialog(props: CCSwitchExportDialogProps) {
       : ""
     if (!upstreamBaseUrl) {
       setUpstreamModelOptions([])
+      setIsLoadingModels(false)
       return
     }
 
@@ -247,6 +250,7 @@ export function CCSwitchExportDialog(props: CCSwitchExportDialogProps) {
     <Modal
       isOpen={isOpen}
       onClose={onClose}
+      panelTestId={CC_SWITCH_EXPORT_TEST_IDS.dialog}
       header={
         <div className="flex items-center gap-2">
           <CCSwitchIcon size="lg" />
@@ -262,10 +266,19 @@ export function CCSwitchExportDialog(props: CCSwitchExportDialogProps) {
       }
       footer={
         <div className="flex flex-wrap justify-end gap-2">
-          <Button variant="ghost" type="button" onClick={onClose}>
+          <Button
+            variant="ghost"
+            type="button"
+            data-testid={CC_SWITCH_EXPORT_TEST_IDS.cancelButton}
+            onClick={onClose}
+          >
             {t("common:actions.cancel")}
           </Button>
-          <Button type="submit" form={formId}>
+          <Button
+            type="submit"
+            form={formId}
+            data-testid={CC_SWITCH_EXPORT_TEST_IDS.exportButton}
+          >
             {t("ui:dialog.ccswitch.actions.export")}
           </Button>
         </div>
@@ -376,6 +389,8 @@ export function CCSwitchExportDialog(props: CCSwitchExportDialogProps) {
             ]}
             allowCustomValue
             disabled={isLoadingModels}
+            data-testid={CC_SWITCH_EXPORT_TEST_IDS.modelPicker}
+            searchInputTestId={CC_SWITCH_EXPORT_TEST_IDS.modelSearchInput}
           />
           <p className="dark:text-dark-text-secondary mt-1 text-xs text-gray-500">
             {t("ui:dialog.ccswitch.descriptions.model")}

--- a/src/components/ui/SearchableSelect.tsx
+++ b/src/components/ui/SearchableSelect.tsx
@@ -108,6 +108,11 @@ export interface SearchableSelectProps
    * Optional stable test id resolver for option rows.
    */
   getOptionTestId?: (option: SearchableSelectOption) => string | undefined
+
+  /**
+   * Optional stable test id for the popover search input.
+   */
+  searchInputTestId?: string
 }
 
 /**
@@ -134,6 +139,7 @@ export const SearchableSelect = React.forwardRef<
     portalContainer,
     listClassName,
     getOptionTestId,
+    searchInputTestId,
     className,
     disabled,
     ...buttonProps
@@ -217,6 +223,7 @@ export const SearchableSelect = React.forwardRef<
             placeholder={resolvedSearchPlaceholder}
             value={searchTerm}
             onValueChange={setSearchTerm}
+            data-testid={searchInputTestId}
           />
           <CommandList
             className={cn(

--- a/src/features/AccountManagement/components/CopyKeyDialog/RuntimeKeyDetails.tsx
+++ b/src/features/AccountManagement/components/CopyKeyDialog/RuntimeKeyDetails.tsx
@@ -15,6 +15,7 @@ import { ManagedSiteIcon } from "~/components/icons/ManagedSiteIcon"
 import { KiloCodeExportDialog } from "~/components/KiloCodeExportDialog"
 import { IconButton } from "~/components/ui"
 import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
+import { ACCOUNT_MANAGEMENT_TEST_IDS } from "~/features/AccountManagement/testIds"
 import { KiloCodeProfileExportDialog } from "~/features/ApiCredentialProfiles/components/KiloCodeProfileExportDialog"
 import {
   createCliProxyExportPayload,
@@ -431,6 +432,9 @@ export function RuntimeKeyDetails({
                 aria-label={t("dialog.copyKey.exportToCCSwitch")}
                 variant="ghost"
                 size="sm"
+                data-testid={
+                  ACCOUNT_MANAGEMENT_TEST_IDS.copyKeyDialogExportToCCSwitchButton
+                }
                 onClick={handleExportToCCSwitch}
               >
                 <CCSwitchIcon />

--- a/src/features/AccountManagement/components/CopyKeyDialog/RuntimeKeyItem.tsx
+++ b/src/features/AccountManagement/components/CopyKeyDialog/RuntimeKeyItem.tsx
@@ -6,6 +6,7 @@ import {
 import { useTranslation } from "react-i18next"
 
 import { Badge, Card, CardContent, IconButton } from "~/components/ui"
+import { getCopyKeyDialogRuntimeKeyItemTestId } from "~/features/AccountManagement/testIds"
 import {
   ACCOUNT_RUNTIME_KEY_STATUSES,
   isAccountTokenRuntimeKey,
@@ -57,6 +58,7 @@ export function RuntimeKeyItem({
         padding="sm"
         className="dark:hover:bg-dark-bg-tertiary cursor-pointer transition-colors hover:bg-gray-50"
         onClick={onToggle}
+        data-testid={getCopyKeyDialogRuntimeKeyItemTestId(runtimeKey.id)}
       >
         <div className="flex items-center justify-between">
           <div className="min-w-0 flex-1 space-y-1.5">

--- a/src/features/AccountManagement/testIds.ts
+++ b/src/features/AccountManagement/testIds.ts
@@ -32,6 +32,8 @@ export const ACCOUNT_MANAGEMENT_TEST_IDS = {
   rowOpenButton: "account-management-row-open-button",
   rowCopyUrlButton: "account-management-row-copy-url-button",
   rowCopyKeyButton: "account-management-row-copy-key-button",
+  copyKeyDialogExportToCCSwitchButton:
+    "account-management-copy-key-dialog-export-to-cc-switch-button",
   rowEditButton: "account-management-row-edit-button",
   rowMoreActionsButton: "account-management-row-more-actions-button",
   rowKeyManagementMenuItem: "account-management-row-key-management-menu-item",

--- a/src/features/AccountManagement/testIds.ts
+++ b/src/features/AccountManagement/testIds.ts
@@ -32,6 +32,8 @@ export const ACCOUNT_MANAGEMENT_TEST_IDS = {
   rowOpenButton: "account-management-row-open-button",
   rowCopyUrlButton: "account-management-row-copy-url-button",
   rowCopyKeyButton: "account-management-row-copy-key-button",
+  copyKeyDialogRuntimeKeyItem:
+    "account-management-copy-key-dialog-runtime-key-item",
   copyKeyDialogExportToCCSwitchButton:
     "account-management-copy-key-dialog-export-to-cc-switch-button",
   rowEditButton: "account-management-row-edit-button",
@@ -90,4 +92,11 @@ export const ACCOUNT_MANAGEMENT_TEST_IDS = {
  */
 export function getAccountManagementListItemTestId(accountId: string) {
   return `account-management-account-list-item-${accountId}`
+}
+
+/**
+ * Returns a stable test id for a runtime key row inside the copy-key dialog.
+ */
+export function getCopyKeyDialogRuntimeKeyItemTestId(runtimeKeyId: string) {
+  return `${ACCOUNT_MANAGEMENT_TEST_IDS.copyKeyDialogRuntimeKeyItem}-${runtimeKeyId}`
 }

--- a/src/features/ApiCredentialProfiles/components/ApiCredentialProfileListItem.tsx
+++ b/src/features/ApiCredentialProfiles/components/ApiCredentialProfileListItem.tsx
@@ -605,6 +605,9 @@ export function ApiCredentialProfileListItem({
                     aria-label={t("common:actions.export")}
                     size="sm"
                     variant="ghost"
+                    data-testid={
+                      API_CREDENTIAL_PROFILES_TEST_IDS.exportMenuButton
+                    }
                     analyticsAction={
                       PRODUCT_ANALYTICS_ACTION_IDS.OpenApiCredentialExportMenu
                     }
@@ -622,6 +625,9 @@ export function ApiCredentialProfileListItem({
                     {t("keyManagement:actions.useInCherry")}
                   </DropdownMenuItem>
                   <DropdownMenuItem
+                    data-testid={
+                      API_CREDENTIAL_PROFILES_TEST_IDS.exportToCCSwitchMenuItem
+                    }
                     onSelect={() => onExport(profile, "ccSwitch")}
                   >
                     <span aria-hidden="true">

--- a/src/features/ApiCredentialProfiles/testIds.ts
+++ b/src/features/ApiCredentialProfiles/testIds.ts
@@ -7,6 +7,9 @@ export const API_CREDENTIAL_PROFILES_TEST_IDS = {
   deleteConfirmButton: "api-credential-profile-delete-confirm-button",
   deleteTriggerButton: "api-credential-profile-delete-trigger-button",
   editButton: "api-credential-profile-edit-button",
+  exportMenuButton: "api-credential-profile-export-menu-button",
+  exportToCCSwitchMenuItem:
+    "api-credential-profile-export-to-cc-switch-menu-item",
   openModelManagementButton:
     "api-credential-profile-open-model-management-button",
   popupView: "api-credential-profiles-popup-view",

--- a/src/features/KeyManagement/components/ServiceCredentialCard.tsx
+++ b/src/features/KeyManagement/components/ServiceCredentialCard.tsx
@@ -436,6 +436,9 @@ export function ServiceCredentialCard({
                   aria-label={t("actions.exportToCCSwitch")}
                   size="sm"
                   variant="ghost"
+                  data-testid={
+                    KEY_MANAGEMENT_TEST_IDS.serviceCredentialExportToCCSwitchButton
+                  }
                   onClick={() => setCCSwitchProfile(transientProfile)}
                 >
                   <CCSwitchIcon />

--- a/src/features/KeyManagement/components/TokenListItem/TokenHeader.tsx
+++ b/src/features/KeyManagement/components/TokenListItem/TokenHeader.tsx
@@ -647,6 +647,7 @@ function TokenActionButtons({
           aria-label={t("actions.exportToCCSwitch")}
           size="sm"
           variant="ghost"
+          data-testid={KEY_MANAGEMENT_TEST_IDS.exportToCCSwitchButton}
           onClick={onOpenCCSwitchDialog}
         >
           <CCSwitchIcon />

--- a/src/features/KeyManagement/testIds.ts
+++ b/src/features/KeyManagement/testIds.ts
@@ -2,6 +2,9 @@ export const KEY_MANAGEMENT_TEST_IDS = {
   addTokenButton: "key-management-add-token-button",
   emptyStateAddTokenButton: "key-management-empty-state-add-token-button",
   saveToApiProfilesButton: "key-management-save-to-api-profiles-button",
+  exportToCCSwitchButton: "key-management-export-to-cc-switch-button",
+  serviceCredentialExportToCCSwitchButton:
+    "key-management-service-credential-export-to-cc-switch-button",
   verifyTokenApiButton: "key-management-verify-token-api-button",
   verifyTokenCliSupportButton: "key-management-verify-token-cli-support-button",
   batchSaveToApiProfilesButton:

--- a/tests/components/CCSwitchExportDialog.test.tsx
+++ b/tests/components/CCSwitchExportDialog.test.tsx
@@ -2,6 +2,7 @@ import userEvent from "@testing-library/user-event"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { CCSwitchExportDialog } from "~/components/CCSwitchExportDialog"
+import { CC_SWITCH_EXPORT_TEST_IDS } from "~/components/CCSwitchExportDialog.testIds"
 import {
   createExportAccount,
   createExportToken,
@@ -73,6 +74,40 @@ describe("CCSwitchExportDialog", () => {
     startProductAnalyticsActionMock.mockReturnValue({
       complete: completeProductAnalyticsActionMock,
     })
+  })
+
+  it("exposes stable test ids for E2E flows", async () => {
+    const user = userEvent.setup()
+    mockFetchOpenAICompatibleModelIds.mockResolvedValueOnce([])
+
+    render(
+      <CCSwitchExportDialog
+        isOpen={true}
+        onClose={() => {}}
+        account={
+          { id: "acc", name: "Example", baseUrl: "https://x.test/v1" } as any
+        }
+        token={{ id: "tok", key: "sk-test" } as any}
+      />,
+    )
+
+    expect(
+      await screen.findByTestId(CC_SWITCH_EXPORT_TEST_IDS.dialog),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByTestId(CC_SWITCH_EXPORT_TEST_IDS.modelPicker),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByTestId(CC_SWITCH_EXPORT_TEST_IDS.exportButton),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByTestId(CC_SWITCH_EXPORT_TEST_IDS.cancelButton),
+    ).toBeInTheDocument()
+
+    await user.click(screen.getByTestId(CC_SWITCH_EXPORT_TEST_IDS.modelPicker))
+    expect(
+      await screen.findByTestId(CC_SWITCH_EXPORT_TEST_IDS.modelSearchInput),
+    ).toBeInTheDocument()
   })
 
   it("places the app selector before provider details", async () => {
@@ -358,6 +393,7 @@ describe("CCSwitchExportDialog", () => {
     const modelCombo = await screen.findByLabelText(
       "ui:dialog.ccswitch.fields.model",
     )
+    expect(modelCombo).toBeEnabled()
     expect(modelCombo).toHaveTextContent("ui:dialog.ccswitch.modelOptions.none")
     expect(screen.queryByText("gpt-4")).toBeNull()
     warnSpy.mockRestore()

--- a/tests/utils/accountScenarios.test.ts
+++ b/tests/utils/accountScenarios.test.ts
@@ -12,6 +12,11 @@ import {
   runAccountKeyToApiProfileScenario,
   saveExistingAccountTokenToApiProfileScenario,
 } from "~~/e2e/scenarios/accountKeyToApiProfile"
+import { verifyAccountTokenModelsProbeUsage } from "~~/e2e/scenarios/accountUsage"
+import {
+  verifyApiCredentialProfileModelsProbeScenario,
+  verifyOpenApiCredentialProfileModelsProbeDialog,
+} from "~~/e2e/scenarios/apiCredentialProfileVerification"
 import {
   deleteApiCredentialProfileFromStorage,
   deleteTokenFromKeyManagementPage,
@@ -30,6 +35,8 @@ const mocks = vi.hoisted(() => ({
   openKeyManagementForAccount: vi.fn(),
   saveTokenToApiCredentialProfilesFromKeyManagementPage: vi.fn(),
   submitTokenCreationFromKeyManagementPage: vi.fn(),
+  verifyApiCredentialProfileModelsProbeScenario: vi.fn(),
+  verifyOpenApiCredentialProfileModelsProbeDialog: vi.fn(),
 }))
 
 vi.mock("~~/e2e/utils/accountLifecycle", () => ({
@@ -44,6 +51,13 @@ vi.mock("~~/e2e/utils/accountLifecycle", () => ({
     mocks.saveTokenToApiCredentialProfilesFromKeyManagementPage,
   submitTokenCreationFromKeyManagementPage:
     mocks.submitTokenCreationFromKeyManagementPage,
+}))
+
+vi.mock("~~/e2e/scenarios/apiCredentialProfileVerification", () => ({
+  verifyApiCredentialProfileModelsProbeScenario:
+    mocks.verifyApiCredentialProfileModelsProbeScenario,
+  verifyOpenApiCredentialProfileModelsProbeDialog:
+    mocks.verifyOpenApiCredentialProfileModelsProbeDialog,
 }))
 
 describe("account E2E scenarios", () => {
@@ -361,6 +375,108 @@ describe("account E2E scenarios", () => {
     ).rejects.toMatchObject({
       errors: [primaryError, cleanupError],
     })
+  })
+
+  it("runs account token cleanup finalizers when token deletion fails", async () => {
+    const extensionPage = {} as any
+    const keyPage = {} as any
+    const deletionError = new Error("delete failed")
+    const fixtureCleanup = vi.fn().mockResolvedValue(undefined)
+    const environmentCleanup = vi.fn().mockResolvedValue(undefined)
+    const verifyButton = {
+      click: vi.fn().mockResolvedValue(undefined),
+    }
+    const tokenRow = {
+      getByTestId: vi.fn().mockReturnValue(verifyButton),
+    }
+    const fixture = createAccountFixture({
+      accountId: "seeded-account",
+      siteType: SITE_TYPES.NEW_API,
+      baseUrl: "https://seeded.example.com",
+      cleanup: fixtureCleanup,
+    })
+
+    vi.mocked(openKeyManagementForAccount).mockResolvedValue(keyPage)
+    vi.mocked(submitTokenCreationFromKeyManagementPage).mockResolvedValue(
+      undefined,
+    )
+    vi.mocked(expectTokenCreatedInKeyManagementPage).mockResolvedValue({
+      page: keyPage,
+      row: tokenRow as any,
+    })
+    vi.mocked(
+      verifyOpenApiCredentialProfileModelsProbeDialog,
+    ).mockResolvedValue(undefined)
+    vi.mocked(deleteTokenFromKeyManagementPage).mockRejectedValue(deletionError)
+
+    await expect(
+      verifyAccountTokenModelsProbeUsage({
+        page: extensionPage,
+        extensionId: "extension-id",
+        serviceWorker: {} as any,
+        account: fixture,
+        buildTokenName: () => "E2E Models Probe Key",
+        cleanup: environmentCleanup,
+      }),
+    ).rejects.toThrow(deletionError)
+
+    expect(deleteTokenFromKeyManagementPage).toHaveBeenCalledWith({
+      page: keyPage,
+      token: "E2E Models Probe Key",
+    })
+    expect(fixtureCleanup).toHaveBeenCalledOnce()
+    expect(environmentCleanup).toHaveBeenCalledOnce()
+  })
+
+  it("runs account token models probe in the already-open verification dialog", async () => {
+    const extensionPage = {} as any
+    const keyPage = {} as any
+    const verifyButton = {
+      click: vi.fn().mockResolvedValue(undefined),
+    }
+    const tokenRow = {
+      getByTestId: vi.fn().mockReturnValue(verifyButton),
+    }
+    const fixture = createAccountFixture({
+      accountId: "seeded-account",
+      siteType: SITE_TYPES.NEW_API,
+      baseUrl: "https://seeded.example.com",
+      cleanup: createNoopAccountFixtureCleanup(),
+    })
+
+    vi.mocked(openKeyManagementForAccount).mockResolvedValue(keyPage)
+    vi.mocked(submitTokenCreationFromKeyManagementPage).mockResolvedValue(
+      undefined,
+    )
+    vi.mocked(expectTokenCreatedInKeyManagementPage).mockResolvedValue({
+      page: keyPage,
+      row: tokenRow as any,
+    })
+    vi.mocked(
+      verifyOpenApiCredentialProfileModelsProbeDialog,
+    ).mockResolvedValue(undefined)
+
+    await verifyAccountTokenModelsProbeUsage({
+      page: extensionPage,
+      extensionId: "extension-id",
+      serviceWorker: {} as any,
+      account: fixture,
+      buildTokenName: () => "E2E Models Probe Key",
+      modelsProbe: {
+        expectedStatus: "handled",
+        closeDialog: true,
+      },
+    })
+
+    expect(verifyButton.click).toHaveBeenCalledOnce()
+    expect(
+      verifyOpenApiCredentialProfileModelsProbeDialog,
+    ).toHaveBeenCalledWith({
+      page: keyPage,
+      expectedStatus: "handled",
+      closeDialog: true,
+    })
+    expect(verifyApiCredentialProfileModelsProbeScenario).not.toHaveBeenCalled()
   })
 
   it("creates a key, saves it to API profiles, and cleans up both artifacts", async () => {

--- a/tests/utils/realSiteAccountUsage.test.ts
+++ b/tests/utils/realSiteAccountUsage.test.ts
@@ -347,6 +347,46 @@ describe("real-site account usage adapters", () => {
     expect(popupPage.close).toHaveBeenCalledOnce()
   })
 
+  it("closes the popup page when popup model opening fails after page creation", async () => {
+    const error = new Error("popup open failed")
+    const popupPage = {
+      close: vi.fn().mockResolvedValue(undefined),
+    }
+    const pageWithContext = {
+      context: () => ({
+        newPage: vi.fn().mockResolvedValue(popupPage),
+      }),
+    } as any
+    vi.mocked(openApiCredentialProfilesPopupScenario).mockRejectedValue(error)
+    vi.mocked(verifyAccountKeyToApiProfileUsage).mockImplementation(
+      async (params) => {
+        await params.afterProfileSaved?.({
+          id: "profile-id",
+          name: "Saved profile",
+        } as any)
+        return { id: "profile-id", name: "Saved profile" } as any
+      },
+    )
+
+    await expect(
+      realSiteAccountUsageChecks.keyToApiProfileAndPopupModels().run({
+        testInfo: { annotations: [] } as any,
+        page: pageWithContext,
+        extensionId: "extension-id",
+        serviceWorker,
+        account,
+        label: "New API",
+      }),
+    ).rejects.toThrow(error)
+
+    expect(openApiCredentialProfilesPopupScenario).toHaveBeenCalledWith({
+      page: popupPage,
+      extensionId: "extension-id",
+    })
+    expect(verifyApiCredentialProfileModelsProbeScenario).not.toHaveBeenCalled()
+    expect(popupPage.close).toHaveBeenCalledOnce()
+  })
+
   it("fails when key-to-profile usage does not run popup verification", async () => {
     vi.mocked(verifyAccountKeyToApiProfileUsage).mockResolvedValue({
       id: "profile-id",


### PR DESCRIPTION
## Summary
- add E2E coverage for CC Switch export from API credential profiles, account keys, copy-key dialog keys, and SharedChat service credentials
- add stable test ids needed by those browser flows
- cover shared CC Switch export helpers and dialog test-id exposure with focused Vitest coverage

## Validation
- pnpm run validate:staged
- pnpm run validate:push
- pnpm vitest related --run src/components/CCSwitchExportDialog.tsx src/components/ui/SearchableSelect.tsx e2e/scenarios/accountUsage.ts e2e/scenarios/apiCredentialProfileVerification.ts e2e/scenarios/ccSwitchExport.ts e2e/utils/realSite/accountUsage.ts tests/components/CCSwitchExportDialog.test.tsx tests/utils/accountScenarios.test.ts tests/utils/realSiteAccountUsage.test.ts
- pnpm exec playwright test e2e/apiCredentialProfilesOptionsActions.spec.ts e2e/keyManagementCommonFlow.spec.ts e2e/accountOnboardingCommonFlows.spec.ts --project=chromium --workers=1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded “Export to CC Switch” to support account keys, service credentials, and API credential profiles, including model picking and deep-link verification.
  * Added end-to-end coverage for the CC Switch model picker/export flow and cancellation behavior.

* **Bug Fixes**
  * Improved export dialog loading behavior when no upstream model source is available.
  * Strengthened cleanup and error handling for failed token/profile probe flows.

* **Tests**
  * Added and standardized UI test identifiers and updated E2E scenarios around CC Switch export and models probing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->