### PR TITLE
test(e2e): expand user-flow coverage

### DIFF
--- a/e2e/accountActionShortcuts.spec.ts
+++ b/e2e/accountActionShortcuts.spec.ts
@@ -360,7 +360,7 @@ test("opens an LDOH site lookup search from the account row action", async ({
     STORAGE_KEYS.SITE_LIST_CACHE,
     ldohCache,
   )
-  await context.route(/^https:\/\/ldoh\.105117\.xyz\/.*/, async (route) => {
+  await context.route(`${LDOH_ORIGIN}/**`, async (route) => {
     await route.fulfill({
       status: 200,
       contentType: "text/html",

--- a/e2e/accountActionShortcuts.spec.ts
+++ b/e2e/accountActionShortcuts.spec.ts
@@ -7,6 +7,9 @@ import {
   ACCOUNT_MANAGEMENT_TEST_IDS,
   getAccountManagementListItemTestId,
 } from "~/features/AccountManagement/testIds"
+import { STORAGE_KEYS } from "~/services/core/storageKeys"
+import { LDOH_ORIGIN } from "~/services/integrations/ldohSiteLookup/constants"
+import type { LdohSiteListCache } from "~/services/integrations/ldohSiteLookup/types"
 import type { ApiToken } from "~/types"
 import { expect, test } from "~~/e2e/fixtures/extensionTest"
 import { verifyAccountProviderDestinationUsage } from "~~/e2e/scenarios/accountUsage"
@@ -22,6 +25,7 @@ import {
 import {
   expectPermissionOnboardingHidden,
   getServiceWorker,
+  setPlasmoStorageValue,
 } from "~~/e2e/utils/extensionState"
 import { waitForExtensionRoot } from "~~/e2e/utils/lazyLoading"
 
@@ -100,6 +104,59 @@ async function openAccountActionsMenu(page: Page, accountName: string) {
   await row
     .getByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.rowMoreActionsButton)
     .click()
+}
+
+async function expectBrowserTabOpenedAtOrigin(
+  serviceWorker: Awaited<ReturnType<typeof getServiceWorker>>,
+  origin: string,
+) {
+  await expect
+    .poll(async () => {
+      return await serviceWorker.evaluate(async (targetOrigin) => {
+        const chromeApi = (globalThis as any).chrome
+        const tabs = await chromeApi.tabs.query({})
+        return tabs.some((tab: { url?: string }) =>
+          tab.url?.startsWith(`${targetOrigin}/`),
+        )
+      }, origin)
+    })
+    .toBe(true)
+}
+
+async function installTabsCreateRecorder(page: Page) {
+  await page.evaluate(() => {
+    const browserApi = (globalThis as any).browser ?? (globalThis as any).chrome
+    const originalCreate = browserApi.tabs.create.bind(browserApi.tabs)
+    ;(globalThis as any).__aahTabsCreateCalls = []
+    browserApi.tabs.create = async (
+      createProperties: browser.tabs._CreateCreateProperties,
+    ) => {
+      ;(globalThis as any).__aahTabsCreateCalls.push(createProperties)
+      return await originalCreate(createProperties)
+    }
+  })
+}
+
+async function expectTabsCreateCalledWithUrl(page: Page, url: string) {
+  await expect
+    .poll(async () => {
+      return await page.evaluate((targetUrl) => {
+        const calls = (globalThis as any).__aahTabsCreateCalls
+        return Array.isArray(calls)
+          ? calls.some(
+              (call: browser.tabs._CreateCreateProperties) =>
+                call.url === targetUrl,
+            )
+          : false
+      }, url)
+    })
+    .toBe(true)
+}
+
+function buildLdohSearchUrl(hostname: string) {
+  const url = new URL(LDOH_ORIGIN)
+  url.searchParams.set("q", hostname)
+  return url.toString()
 }
 
 test.beforeEach(async ({ context, page }) => {
@@ -262,6 +319,72 @@ test("opens per-account key and model management from the row menu", async ({
   await expect(
     modelsPage.getByRole("heading", { name: "gpt-shortcut" }),
   ).toBeVisible()
+})
+
+test("opens an LDOH site lookup search from the account row action", async ({
+  context,
+  extensionId,
+  page,
+}) => {
+  const serviceWorker = await getServiceWorker(context)
+  const now = Date.now()
+  const accountHostname = "ldoh-account.example.invalid"
+  const expectedLdohSearchUrl = buildLdohSearchUrl(accountHostname)
+  const ldohCache: LdohSiteListCache = {
+    version: 1,
+    fetchedAt: now,
+    expiresAt: now + 60 * 60 * 1000,
+    items: [
+      {
+        id: "ldoh-e2e-site",
+        name: "LDOH E2E Site",
+        apiBaseUrl: `https://${accountHostname}/api`,
+      },
+    ],
+  }
+
+  await seedStoredAccounts(serviceWorker, [
+    createStoredAccount({
+      id: "ldoh-shortcut-account",
+      site_name: "LDOH Shortcut Account",
+      site_url: `https://${accountHostname}`,
+      account_info: {
+        id: "301",
+        username: "ldoh-shortcut-user",
+        access_token: "ldoh-shortcut-token",
+      },
+    }),
+  ])
+  await setPlasmoStorageValue(
+    serviceWorker,
+    STORAGE_KEYS.SITE_LIST_CACHE,
+    ldohCache,
+  )
+  await context.route(/^https:\/\/ldoh\.105117\.xyz\/.*/, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "text/html",
+      body: "<!doctype html><title>LDOH lookup</title>",
+    })
+  })
+
+  await page.goto(
+    `chrome-extension://${extensionId}/${OPTIONS_PAGE_PATH}#${MENU_ITEM_IDS.ACCOUNT}`,
+  )
+  await waitForExtensionRoot(page)
+  await expectPermissionOnboardingHidden(page)
+  await installTabsCreateRecorder(page)
+
+  const row = getAccountRow(page, "LDOH Shortcut Account")
+  await row.hover()
+  const ldohLookupButton = row.getByTestId(
+    ACCOUNT_MANAGEMENT_TEST_IDS.rowLdohLookupButton,
+  )
+  await expect(ldohLookupButton).toBeVisible()
+  await ldohLookupButton.click()
+
+  await expectTabsCreateCalledWithUrl(page, expectedLdohSearchUrl)
+  await expectBrowserTabOpenedAtOrigin(serviceWorker, LDOH_ORIGIN)
 })
 
 test("opens provider usage and redeem destinations from the account row menu", async ({

--- a/e2e/accountBookmarkImportBrowserFlow.spec.ts
+++ b/e2e/accountBookmarkImportBrowserFlow.spec.ts
@@ -1,0 +1,540 @@
+import http from "node:http"
+import type { AddressInfo } from "node:net"
+import type { BrowserContext, Worker } from "@playwright/test"
+
+import { OPTIONS_PAGE_PATH } from "~/constants/extensionPages"
+import { MENU_ITEM_IDS } from "~/constants/optionsMenuIds"
+import {
+  ACCOUNT_MANAGEMENT_TEST_IDS,
+  getAccountManagementListItemTestId,
+} from "~/features/AccountManagement/testIds"
+import { STORAGE_KEYS } from "~/services/core/storageKeys"
+import type { SiteAccount } from "~/types"
+import { expect, test } from "~~/e2e/fixtures/extensionTest"
+import {
+  forceExtensionLanguage,
+  installExtensionPageGuards,
+  stubLlmMetadataIndex,
+} from "~~/e2e/utils/commonUserFlows"
+import {
+  E2E_BUILD_VARIANT_ENV,
+  E2E_BUILD_VARIANTS,
+} from "~~/e2e/utils/e2eBuildVariants"
+import {
+  expectPermissionOnboardingHidden,
+  getPlasmoStorageRawValue,
+  getServiceWorker,
+} from "~~/e2e/utils/extensionState"
+import { waitForExtensionRoot } from "~~/e2e/utils/lazyLoading"
+
+const BOOKMARK_IMPORT_TITLE = "Bookmark Import Candidate"
+const BOOKMARK_IMPORT_SITE_NAME = "Bookmark Import New API"
+const BOOKMARK_IMPORT_USERNAME = "bookmark-import-user"
+const BOOKMARK_IMPORT_TOKEN = "bookmark-import-token"
+const ADD_DIALOG_BOOKMARK_IMPORT_ORIGIN =
+  "https://add-dialog-import.example.invalid"
+
+type BrowserBookmarkNode = {
+  id: string
+}
+
+type BookmarkImportServer = {
+  close: () => Promise<void>
+  origin: string
+}
+
+async function closeHttpServer(server: http.Server) {
+  server.closeAllConnections()
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error)
+        return
+      }
+      resolve()
+    })
+  })
+}
+
+async function createBrowserBookmark(serviceWorker: Worker, url: string) {
+  return await serviceWorker.evaluate(
+    async ({ title, url }) => {
+      const chromeApi = (globalThis as any).chrome
+
+      return await new Promise<BrowserBookmarkNode>((resolve, reject) => {
+        chromeApi.bookmarks.create(
+          { title, url },
+          (node: BrowserBookmarkNode) => {
+            const error = chromeApi.runtime?.lastError
+            if (error) {
+              reject(new Error(error.message))
+              return
+            }
+
+            resolve({ id: node.id })
+          },
+        )
+      })
+    },
+    { title: BOOKMARK_IMPORT_TITLE, url },
+  )
+}
+
+async function removeBrowserBookmark(
+  serviceWorker: Worker,
+  bookmarkId: string,
+) {
+  await serviceWorker.evaluate(async (id) => {
+    const chromeApi = (globalThis as any).chrome
+
+    await new Promise<void>((resolve) => {
+      chromeApi.bookmarks.removeTree(id, () => {
+        resolve()
+      })
+    })
+  }, bookmarkId)
+}
+
+async function readStoredAccounts(
+  serviceWorker: Worker,
+): Promise<SiteAccount[]> {
+  const raw = await getPlasmoStorageRawValue<unknown>(
+    serviceWorker,
+    STORAGE_KEYS.ACCOUNTS,
+  )
+
+  if (typeof raw !== "string") return []
+
+  try {
+    const parsed = JSON.parse(raw) as { accounts?: SiteAccount[] }
+    return Array.isArray(parsed.accounts) ? parsed.accounts : []
+  } catch {
+    return []
+  }
+}
+
+async function startBookmarkImportServer(): Promise<BookmarkImportServer> {
+  const server = http.createServer((request, response) => {
+    const origin = `http://${request.headers.host ?? "127.0.0.1"}`
+    const url = new URL(request.url ?? "/", origin)
+    const method = request.method ?? "GET"
+
+    const sendJson = (status: number, body: unknown) => {
+      response.writeHead(status, { "content-type": "application/json" })
+      response.end(JSON.stringify(body))
+    }
+
+    if (method === "GET" && url.pathname === "/") {
+      response.writeHead(200, { "content-type": "text/html" })
+      response.end(
+        `<!doctype html><html><head><title>${BOOKMARK_IMPORT_SITE_NAME}</title></head><body>${BOOKMARK_IMPORT_SITE_NAME}</body></html>`,
+      )
+      return
+    }
+
+    if (method === "GET" && url.pathname === "/dashboard") {
+      response.writeHead(200, { "content-type": "text/html" })
+      response.end(
+        `<!doctype html><html><head><title>${BOOKMARK_IMPORT_SITE_NAME}</title></head><body>${BOOKMARK_IMPORT_SITE_NAME}</body></html>`,
+      )
+      return
+    }
+
+    if (method === "GET" && url.pathname === "/favicon.ico") {
+      response.writeHead(204)
+      response.end()
+      return
+    }
+
+    if (method === "GET" && url.pathname === "/api/status") {
+      sendJson(200, {
+        success: true,
+        message: "ok",
+        data: {
+          system_name: BOOKMARK_IMPORT_SITE_NAME,
+          price: 7,
+          checkin_enabled: false,
+        },
+      })
+      return
+    }
+
+    if (method === "GET" && url.pathname === "/api/user/self") {
+      sendJson(200, {
+        success: true,
+        message: "ok",
+        data: {
+          id: 787,
+          username: BOOKMARK_IMPORT_USERNAME,
+          access_token: BOOKMARK_IMPORT_TOKEN,
+          quota: 1000,
+        },
+      })
+      return
+    }
+
+    if (method === "GET" && url.pathname === "/api/log/self") {
+      sendJson(200, {
+        success: true,
+        message: "ok",
+        data: {
+          page: Number(url.searchParams.get("p") ?? "1"),
+          page_size: Number(url.searchParams.get("page_size") ?? "100"),
+          total: 0,
+          items: [],
+        },
+      })
+      return
+    }
+
+    if (method === "GET" && url.pathname === "/api/log/self/stat") {
+      sendJson(200, {
+        success: true,
+        message: "ok",
+        data: {
+          quota: 0,
+          rpm: 0,
+          tpm: 0,
+        },
+      })
+      return
+    }
+
+    if (method === "GET" && url.pathname === "/api/token/") {
+      sendJson(200, {
+        success: true,
+        message: "ok",
+        data: [],
+      })
+      return
+    }
+
+    sendJson(404, {
+      success: false,
+      message: `Unhandled bookmark import E2E route: ${method} ${url.pathname}`,
+    })
+  })
+
+  const origin = await new Promise<string>((resolve, reject) => {
+    server.once("error", reject)
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address() as AddressInfo
+      resolve(`http://127.0.0.1:${address.port}`)
+    })
+  })
+
+  return {
+    origin,
+    close: async () => {
+      await closeHttpServer(server)
+    },
+  }
+}
+
+async function startFailedBookmarkImportServer(): Promise<BookmarkImportServer> {
+  const server = http.createServer((request, response) => {
+    const origin = `http://${request.headers.host ?? "127.0.0.1"}`
+    const url = new URL(request.url ?? "/", origin)
+
+    if (url.pathname === "/" || url.pathname === "/dashboard") {
+      response.writeHead(200, { "content-type": "text/html" })
+      response.end(
+        "<!doctype html><html><head><title>Unsupported Import Target</title></head><body>Unsupported Import Target</body></html>",
+      )
+      return
+    }
+
+    response.writeHead(200, { "content-type": "application/json" })
+    response.end(JSON.stringify({ success: false, message: "not found" }))
+  })
+
+  const origin = await new Promise<string>((resolve, reject) => {
+    server.once("error", reject)
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address() as AddressInfo
+      resolve(`http://127.0.0.1:${address.port}`)
+    })
+  })
+
+  return {
+    origin,
+    close: async () => {
+      await closeHttpServer(server)
+    },
+  }
+}
+
+async function seedBookmarkImportSiteSession(
+  context: BrowserContext,
+  origin: string,
+) {
+  const sitePage = await context.newPage()
+
+  try {
+    await sitePage.goto(`${origin}/dashboard`)
+    await sitePage.evaluate(
+      ({ token, username }) => {
+        localStorage.setItem(
+          "user",
+          JSON.stringify({
+            id: 787,
+            username,
+            access_token: token,
+          }),
+        )
+      },
+      {
+        token: BOOKMARK_IMPORT_TOKEN,
+        username: BOOKMARK_IMPORT_USERNAME,
+      },
+    )
+  } finally {
+    await sitePage.close()
+  }
+}
+
+test.beforeEach(async ({ context, page }) => {
+  installExtensionPageGuards(page)
+  await forceExtensionLanguage(page, "en")
+  await stubLlmMetadataIndex(context)
+})
+
+test("opens bookmark import from the add account dialog", async ({
+  context,
+  extensionId,
+  page,
+}) => {
+  skipUnlessBookmarksRequiredVariant()
+
+  const serviceWorker = await getServiceWorker(context)
+  const bookmark = await createBrowserBookmark(
+    serviceWorker,
+    `${ADD_DIALOG_BOOKMARK_IMPORT_ORIGIN}/dashboard`,
+  )
+
+  try {
+    await page.goto(
+      `chrome-extension://${extensionId}/${OPTIONS_PAGE_PATH}#${MENU_ITEM_IDS.ACCOUNT}`,
+    )
+    await waitForExtensionRoot(page)
+    await expectPermissionOnboardingHidden(page)
+
+    await page.getByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.addAccountButton).click()
+
+    const accountDialog = page.getByTestId(
+      ACCOUNT_MANAGEMENT_TEST_IDS.accountDialog,
+    )
+    await expect(accountDialog).toBeVisible()
+    await accountDialog
+      .getByTestId(
+        ACCOUNT_MANAGEMENT_TEST_IDS.bookmarkImportFromAddDialogButton,
+      )
+      .click()
+    await expect(accountDialog).toHaveCount(0)
+
+    const importDialog = page.getByTestId(
+      ACCOUNT_MANAGEMENT_TEST_IDS.bookmarkImportDialog,
+    )
+    await expect(importDialog).toBeVisible()
+    await importDialog
+      .getByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.bookmarkImportAllowScanButton)
+      .click()
+
+    await expect(
+      importDialog.getByTestId(
+        ACCOUNT_MANAGEMENT_TEST_IDS.bookmarkImportScopeTree,
+      ),
+    ).toBeVisible()
+    await importDialog.getByRole("button", { name: "Select all" }).click()
+    await importDialog
+      .getByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.bookmarkImportScanSelectedButton)
+      .click()
+
+    await expect(
+      importDialog.getByTestId(
+        ACCOUNT_MANAGEMENT_TEST_IDS.bookmarkImportCandidateRow,
+      ),
+    ).toContainText(ADD_DIALOG_BOOKMARK_IMPORT_ORIGIN)
+  } finally {
+    await removeBrowserBookmark(serviceWorker, bookmark.id)
+  }
+})
+
+test("imports an account from a native browser bookmark", async ({
+  context,
+  extensionId,
+  page,
+}) => {
+  skipUnlessBookmarksRequiredVariant()
+
+  const serviceWorker = await getServiceWorker(context)
+  const localSite = await startBookmarkImportServer()
+  const bookmark = await createBrowserBookmark(
+    serviceWorker,
+    `${localSite.origin}/dashboard`,
+  )
+  await seedBookmarkImportSiteSession(context, localSite.origin)
+
+  try {
+    await page.goto(
+      `chrome-extension://${extensionId}/${OPTIONS_PAGE_PATH}#${MENU_ITEM_IDS.ACCOUNT}`,
+    )
+    await waitForExtensionRoot(page)
+    await expectPermissionOnboardingHidden(page)
+
+    await page
+      .getByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.bookmarkImportButton)
+      .click()
+
+    const dialog = page.getByTestId(
+      ACCOUNT_MANAGEMENT_TEST_IDS.bookmarkImportDialog,
+    )
+    await expect(dialog).toBeVisible()
+    await dialog
+      .getByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.bookmarkImportAllowScanButton)
+      .click()
+
+    await expect(
+      dialog.getByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.bookmarkImportScopeTree),
+    ).toBeVisible()
+    await dialog.getByRole("button", { name: "Select all" }).click()
+    await dialog
+      .getByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.bookmarkImportScanSelectedButton)
+      .click()
+
+    await expect(
+      dialog.getByTestId(
+        ACCOUNT_MANAGEMENT_TEST_IDS.bookmarkImportCandidateRow,
+      ),
+    ).toContainText(localSite.origin)
+
+    await dialog
+      .getByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.bookmarkImportImportButton)
+      .click()
+
+    await expect(
+      dialog.getByText("Imported 1, failed 0, skipped 0."),
+    ).toBeVisible()
+
+    await expect
+      .poll(async () => {
+        const account = (await readStoredAccounts(serviceWorker)).find(
+          (candidate) =>
+            candidate.site_url === localSite.origin &&
+            candidate.account_info.username === BOOKMARK_IMPORT_USERNAME,
+        )
+
+        return account
+          ? {
+              accessToken: account.account_info.access_token,
+              siteUrl: account.site_url,
+              username: account.account_info.username,
+            }
+          : null
+      })
+      .toEqual({
+        accessToken: BOOKMARK_IMPORT_TOKEN,
+        siteUrl: localSite.origin,
+        username: BOOKMARK_IMPORT_USERNAME,
+      })
+
+    const importedAccount = (await readStoredAccounts(serviceWorker)).find(
+      (candidate) => candidate.site_url === localSite.origin,
+    )
+    expect(importedAccount?.id).toBeTruthy()
+
+    await dialog.getByRole("button", { name: "Close" }).click()
+    await expect(dialog).toBeHidden()
+
+    await expect(
+      page.getByTestId(getAccountManagementListItemTestId(importedAccount!.id)),
+    ).toContainText(BOOKMARK_IMPORT_USERNAME)
+  } finally {
+    await removeBrowserBookmark(serviceWorker, bookmark.id)
+    await localSite.close()
+  }
+})
+
+test("opens add account recovery for a failed bookmark import", async ({
+  context,
+  extensionId,
+  page,
+}) => {
+  skipUnlessBookmarksRequiredVariant()
+
+  const serviceWorker = await getServiceWorker(context)
+  const localSite = await startFailedBookmarkImportServer()
+  const bookmark = await createBrowserBookmark(
+    serviceWorker,
+    `${localSite.origin}/dashboard`,
+  )
+
+  try {
+    await page.goto(
+      `chrome-extension://${extensionId}/${OPTIONS_PAGE_PATH}#${MENU_ITEM_IDS.ACCOUNT}`,
+    )
+    await waitForExtensionRoot(page)
+    await expectPermissionOnboardingHidden(page)
+
+    await page
+      .getByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.bookmarkImportButton)
+      .click()
+
+    const importDialog = page.getByTestId(
+      ACCOUNT_MANAGEMENT_TEST_IDS.bookmarkImportDialog,
+    )
+    await expect(importDialog).toBeVisible()
+    await importDialog
+      .getByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.bookmarkImportAllowScanButton)
+      .click()
+
+    await expect(
+      importDialog.getByTestId(
+        ACCOUNT_MANAGEMENT_TEST_IDS.bookmarkImportScopeTree,
+      ),
+    ).toBeVisible()
+    await importDialog.getByRole("button", { name: "Select all" }).click()
+    await importDialog
+      .getByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.bookmarkImportScanSelectedButton)
+      .click()
+
+    await expect(
+      importDialog.getByTestId(
+        ACCOUNT_MANAGEMENT_TEST_IDS.bookmarkImportCandidateRow,
+      ),
+    ).toContainText(localSite.origin)
+    await importDialog
+      .getByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.bookmarkImportImportButton)
+      .click()
+
+    await expect(
+      importDialog.getByText("Imported 0, failed 1, skipped 0."),
+    ).toBeVisible()
+    await importDialog
+      .getByTestId(
+        ACCOUNT_MANAGEMENT_TEST_IDS.bookmarkImportOpenFailedAddAccountButton,
+      )
+      .click()
+
+    const accountDialog = page.getByTestId(
+      ACCOUNT_MANAGEMENT_TEST_IDS.accountDialog,
+    )
+    await expect(accountDialog).toBeVisible()
+    await expect(
+      accountDialog.getByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.siteUrlInput),
+    ).toHaveValue(localSite.origin)
+  } finally {
+    await removeBrowserBookmark(serviceWorker, bookmark.id)
+    await localSite.close()
+  }
+})
+
+function skipUnlessBookmarksRequiredVariant() {
+  test.skip(
+    process.env[E2E_BUILD_VARIANT_ENV] !== E2E_BUILD_VARIANTS.BookmarksRequired,
+    [
+      "Native browser bookmark import requires the E2E-only bookmarks-required manifest variant.",
+      `Run with ${E2E_BUILD_VARIANT_ENV}=${E2E_BUILD_VARIANTS.BookmarksRequired}.`,
+    ].join(" "),
+  )
+}

--- a/e2e/accountBookmarkImportBrowserFlow.spec.ts
+++ b/e2e/accountBookmarkImportBrowserFlow.spec.ts
@@ -19,6 +19,7 @@ import {
 import {
   E2E_BUILD_VARIANT_ENV,
   E2E_BUILD_VARIANTS,
+  readE2eBuildVariant,
 } from "~~/e2e/utils/e2eBuildVariants"
 import {
   expectPermissionOnboardingHidden,
@@ -345,7 +346,9 @@ test("opens bookmark import from the add account dialog", async ({
         ACCOUNT_MANAGEMENT_TEST_IDS.bookmarkImportScopeTree,
       ),
     ).toBeVisible()
-    await importDialog.getByRole("button", { name: "Select all" }).click()
+    await importDialog
+      .getByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.bookmarkImportSelectAllButton)
+      .click()
     await importDialog
       .getByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.bookmarkImportScanSelectedButton)
       .click()
@@ -397,7 +400,9 @@ test("imports an account from a native browser bookmark", async ({
     await expect(
       dialog.getByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.bookmarkImportScopeTree),
     ).toBeVisible()
-    await dialog.getByRole("button", { name: "Select all" }).click()
+    await dialog
+      .getByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.bookmarkImportSelectAllButton)
+      .click()
     await dialog
       .getByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.bookmarkImportScanSelectedButton)
       .click()
@@ -493,7 +498,9 @@ test("opens add account recovery for a failed bookmark import", async ({
         ACCOUNT_MANAGEMENT_TEST_IDS.bookmarkImportScopeTree,
       ),
     ).toBeVisible()
-    await importDialog.getByRole("button", { name: "Select all" }).click()
+    await importDialog
+      .getByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.bookmarkImportSelectAllButton)
+      .click()
     await importDialog
       .getByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.bookmarkImportScanSelectedButton)
       .click()
@@ -531,7 +538,7 @@ test("opens add account recovery for a failed bookmark import", async ({
 
 function skipUnlessBookmarksRequiredVariant() {
   test.skip(
-    process.env[E2E_BUILD_VARIANT_ENV] !== E2E_BUILD_VARIANTS.BookmarksRequired,
+    readE2eBuildVariant() !== E2E_BUILD_VARIANTS.BookmarksRequired,
     [
       "Native browser bookmark import requires the E2E-only bookmarks-required manifest variant.",
       `Run with ${E2E_BUILD_VARIANT_ENV}=${E2E_BUILD_VARIANTS.BookmarksRequired}.`,

--- a/e2e/apiCredentialProfilesOptionsActions.spec.ts
+++ b/e2e/apiCredentialProfilesOptionsActions.spec.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs/promises"
 import type { Page } from "@playwright/test"
 
 import { OPTIONS_PAGE_PATH } from "~/constants/extensionPages"
@@ -11,6 +12,7 @@ import {
   forceExtensionLanguage,
   installExtensionPageGuards,
   seedApiCredentialProfiles,
+  seedUserPreferences,
   stubLlmMetadataIndex,
   waitForExtensionPage,
 } from "~~/e2e/utils/commonUserFlows"
@@ -292,4 +294,348 @@ test("opens the CC Switch model picker for an API credential profile", async ({
     expectedBaseUrl: "https://cc-switch-profile.example.com",
     expectedApiKey: "sk-cc-switch-profile",
   })
+})
+
+test("downloads Kilo Code settings for an API credential profile", async ({
+  context,
+  extensionId,
+  page,
+}) => {
+  const serviceWorker = await getServiceWorker(context)
+  await seedApiCredentialProfiles(serviceWorker, [
+    createStoredApiCredentialProfile({
+      id: "profile-kilo-export",
+      name: "Kilo Export Profile",
+      baseUrl: "https://kilo-export.example.com",
+      apiKey: "sk-kilo-export-profile",
+    }),
+  ])
+
+  await context.route("https://kilo-export.example.com/v1/models", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        data: [{ id: "gpt-kilo-export" }],
+      }),
+    }),
+  )
+
+  await openProfilesPage(page, extensionId)
+
+  await page
+    .getByTestId(API_CREDENTIAL_PROFILES_TEST_IDS.exportMenuButton)
+    .click()
+  await page
+    .getByTestId(API_CREDENTIAL_PROFILES_TEST_IDS.exportToKiloCodeMenuItem)
+    .click()
+
+  await expect(page.getByText("Export Kilo Code JSON")).toBeVisible()
+  await expect(page.getByText("gpt-kilo-export")).toBeVisible()
+
+  const downloadPromise = page.waitForEvent("download")
+  await page.getByRole("button", { name: "Download settings" }).click()
+  const download = await downloadPromise
+
+  expect(download.suggestedFilename()).toBe("kilo-code-settings.json")
+  const downloadPath = await download.path()
+  if (!downloadPath) {
+    throw new Error(
+      "Kilo Code settings export did not produce a readable download",
+    )
+  }
+
+  const settings = JSON.parse(await fs.readFile(downloadPath, "utf8")) as {
+    providerProfiles?: {
+      currentApiConfigName?: string
+      apiConfigs?: Record<
+        string,
+        {
+          id?: string
+          apiProvider?: string
+          openAiBaseUrl?: string
+          openAiApiKey?: string
+          openAiModelId?: string
+        }
+      >
+    }
+  }
+
+  const profileName = "Kilo Export Profile - API Key"
+  expect(settings.providerProfiles?.currentApiConfigName).toBe(profileName)
+  expect(settings.providerProfiles?.apiConfigs?.[profileName]).toMatchObject({
+    apiProvider: "openai",
+    openAiBaseUrl: "https://kilo-export.example.com/v1",
+    openAiApiKey: "sk-kilo-export-profile",
+    openAiModelId: "gpt-kilo-export",
+  })
+  expect(settings.providerProfiles?.apiConfigs?.[profileName]?.id).toEqual(
+    expect.any(String),
+  )
+})
+
+test("imports an API credential profile into CLI Proxy", async ({
+  context,
+  extensionId,
+  page,
+}) => {
+  const serviceWorker = await getServiceWorker(context)
+  await seedUserPreferences(serviceWorker, {
+    cliProxy: {
+      baseUrl: "https://cli-proxy.example.com/v0/management",
+      managementKey: "mgmt-cli-proxy",
+    },
+  })
+  await seedApiCredentialProfiles(serviceWorker, [
+    createStoredApiCredentialProfile({
+      id: "profile-cli-proxy",
+      name: "CLI Proxy Profile",
+      baseUrl: "https://cli-source.example.com",
+      apiKey: "sk-cli-proxy-profile",
+    }),
+  ])
+
+  await context.route("https://cli-source.example.com/v1/models", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        data: [{ id: "gpt-cli-proxy" }],
+      }),
+    }),
+  )
+  await context.route(
+    "https://cli-proxy.example.com/v0/management/openai-compatibility",
+    async (route) => {
+      if (route.request().method() === "GET") {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ "openai-compatibility": [] }),
+        })
+        return
+      }
+
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ ok: true }),
+      })
+    },
+  )
+
+  await openProfilesPage(page, extensionId)
+
+  await page
+    .getByTestId(API_CREDENTIAL_PROFILES_TEST_IDS.exportMenuButton)
+    .click()
+  await page
+    .getByTestId(API_CREDENTIAL_PROFILES_TEST_IDS.exportToCliProxyMenuItem)
+    .click()
+
+  const dialog = page.getByRole("dialog")
+  await expect(dialog.getByText("Import to CLIProxyAPI")).toBeVisible()
+  await expect(page.getByLabel("Provider name")).toHaveValue(
+    "CLI Proxy Profile",
+  )
+  await expect(page.getByLabel("Provider base URL")).toHaveValue(
+    "https://cli-source.example.com/v1",
+  )
+
+  const importRequestPromise = page.waitForRequest((request) => {
+    return (
+      request.method() === "PUT" &&
+      request.url() ===
+        "https://cli-proxy.example.com/v0/management/openai-compatibility"
+    )
+  })
+  await dialog.getByRole("button", { name: "Import", exact: true }).click()
+  const importRequest = await importRequestPromise
+
+  expect(importRequest.headers()["authorization"]).toBe("Bearer mgmt-cli-proxy")
+  expect(JSON.parse(importRequest.postData() ?? "[]")).toEqual([
+    {
+      name: "CLI Proxy Profile",
+      "base-url": "https://cli-source.example.com/v1",
+      "api-key-entries": [
+        {
+          "api-key": "sk-cli-proxy-profile",
+          "proxy-url": "",
+        },
+      ],
+      headers: {},
+    },
+  ])
+  await expect(
+    page.getByText(
+      "Successfully imported provider CLI Proxy Profile to CLIProxyAPI",
+    ),
+  ).toBeVisible()
+})
+
+test("imports an API credential profile into Claude Code Router", async ({
+  context,
+  extensionId,
+  page,
+}) => {
+  const serviceWorker = await getServiceWorker(context)
+  const routerConfigRequests: Array<{
+    method: string
+    authorization?: string
+    body: unknown
+  }> = []
+  const restartRequests: Array<{ authorization?: string }> = []
+  let sourceModelsRequested = false
+
+  await seedUserPreferences(serviceWorker, {
+    claudeCodeRouter: {
+      baseUrl: "https://router.example.invalid",
+      apiKey: "mgmt-claude-router",
+    },
+  })
+  await seedApiCredentialProfiles(serviceWorker, [
+    createStoredApiCredentialProfile({
+      id: "profile-claude-code-router",
+      name: "Claude Router Profile",
+      baseUrl: "https://claude-source.example.invalid",
+      apiKey: "sk-claude-router-profile",
+    }),
+  ])
+
+  await context.route(
+    "https://claude-source.example.invalid/v1/models",
+    async (route) => {
+      sourceModelsRequested = true
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          data: [{ id: "gpt-claude-router-profile" }],
+        }),
+      })
+    },
+  )
+  await context.route(
+    "https://router.example.invalid/api/config",
+    async (route) => {
+      const request = route.request()
+
+      if (request.method() === "GET") {
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            LOG: true,
+            Providers: [
+              {
+                name: "Existing Provider",
+                api_base_url:
+                  "https://existing.example.invalid/v1/chat/completions",
+                api_key: "sk-existing",
+                models: ["existing-model"],
+              },
+            ],
+          }),
+        })
+        return
+      }
+
+      routerConfigRequests.push({
+        method: request.method(),
+        authorization: request.headers()["authorization"],
+        body: JSON.parse(request.postData() ?? "{}"),
+      })
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ ok: true }),
+      })
+    },
+  )
+  await context.route(
+    "https://router.example.invalid/api/restart",
+    async (route) => {
+      restartRequests.push({
+        authorization: route.request().headers()["authorization"],
+      })
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ ok: true }),
+      })
+    },
+  )
+
+  await openProfilesPage(page, extensionId)
+
+  await page
+    .getByTestId(API_CREDENTIAL_PROFILES_TEST_IDS.exportMenuButton)
+    .click()
+  await page
+    .getByTestId(
+      API_CREDENTIAL_PROFILES_TEST_IDS.exportToClaudeCodeRouterMenuItem,
+    )
+    .click()
+
+  const dialog = page.getByRole("dialog")
+  await expect(dialog.getByText("Import to Claude Code Router")).toBeVisible()
+  await expect(page.getByLabel("Provider name")).toHaveValue(
+    "Claude Router Profile",
+  )
+  await expect(page.getByLabel("Provider API endpoint")).toHaveValue(
+    "https://claude-source.example.invalid/v1/chat/completions",
+  )
+
+  const modelsInput = dialog.getByPlaceholder("Type to add models")
+  await expect(modelsInput).toBeVisible()
+  await expect.poll(() => sourceModelsRequested).toBe(true)
+  await modelsInput.fill("gpt-claude-router-profile")
+  await page.keyboard.press("Enter")
+  await expect(
+    dialog.getByRole("button", {
+      name: "Copy gpt-claude-router-profile",
+    }),
+  ).toBeVisible()
+
+  await dialog.getByRole("button", { name: "Import", exact: true }).click()
+
+  await expect
+    .poll(() => routerConfigRequests)
+    .toEqual([
+      {
+        method: "POST",
+        authorization: "Bearer mgmt-claude-router",
+        body: {
+          LOG: true,
+          Providers: [
+            {
+              name: "Existing Provider",
+              api_base_url:
+                "https://existing.example.invalid/v1/chat/completions",
+              api_key: "sk-existing",
+              models: ["existing-model"],
+            },
+            {
+              name: "Claude Router Profile",
+              api_base_url:
+                "https://claude-source.example.invalid/v1/chat/completions",
+              api_key: "sk-claude-router-profile",
+              models: ["gpt-claude-router-profile"],
+            },
+          ],
+        },
+      },
+    ])
+  await expect
+    .poll(() => restartRequests)
+    .toEqual([
+      {
+        authorization: "Bearer mgmt-claude-router",
+      },
+    ])
+  await expect(
+    page.getByText(
+      "Successfully imported provider Claude Router Profile to Claude Code Router",
+    ),
+  ).toBeVisible()
 })

--- a/e2e/apiCredentialProfilesOptionsActions.spec.ts
+++ b/e2e/apiCredentialProfilesOptionsActions.spec.ts
@@ -1,5 +1,5 @@
 import fs from "node:fs/promises"
-import type { Page } from "@playwright/test"
+import type { BrowserContext, Page } from "@playwright/test"
 
 import { OPTIONS_PAGE_PATH } from "~/constants/extensionPages"
 import { MENU_ITEM_IDS } from "~/constants/optionsMenuIds"
@@ -69,6 +69,27 @@ async function openProfilesPage(page: Page, extensionId: string) {
   )
   await waitForExtensionRoot(page)
   await expectPermissionOnboardingHidden(page)
+}
+
+async function installOpenAiCompatibleModelsRoute(
+  context: BrowserContext,
+  params: {
+    baseUrl: string
+    modelId: string
+    onRequest?: () => void
+  },
+) {
+  const normalizedBaseUrl = params.baseUrl.replace(/\/+$/, "")
+  await context.route(`${normalizedBaseUrl}/v1/models`, async (route) => {
+    params.onRequest?.()
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        data: [{ id: params.modelId }],
+      }),
+    })
+  })
 }
 
 test.beforeEach(async ({ context, page }) => {
@@ -311,15 +332,10 @@ test("downloads Kilo Code settings for an API credential profile", async ({
     }),
   ])
 
-  await context.route("https://kilo-export.example.com/v1/models", (route) =>
-    route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: JSON.stringify({
-        data: [{ id: "gpt-kilo-export" }],
-      }),
-    }),
-  )
+  await installOpenAiCompatibleModelsRoute(context, {
+    baseUrl: "https://kilo-export.example.com",
+    modelId: "gpt-kilo-export",
+  })
 
   await openProfilesPage(page, extensionId)
 
@@ -395,15 +411,10 @@ test("imports an API credential profile into CLI Proxy", async ({
     }),
   ])
 
-  await context.route("https://cli-source.example.com/v1/models", (route) =>
-    route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: JSON.stringify({
-        data: [{ id: "gpt-cli-proxy" }],
-      }),
-    }),
-  )
+  await installOpenAiCompatibleModelsRoute(context, {
+    baseUrl: "https://cli-source.example.com",
+    modelId: "gpt-cli-proxy",
+  })
   await context.route(
     "https://cli-proxy.example.com/v0/management/openai-compatibility",
     async (route) => {
@@ -502,19 +513,13 @@ test("imports an API credential profile into Claude Code Router", async ({
     }),
   ])
 
-  await context.route(
-    "https://claude-source.example.invalid/v1/models",
-    async (route) => {
+  await installOpenAiCompatibleModelsRoute(context, {
+    baseUrl: "https://claude-source.example.invalid",
+    modelId: "gpt-claude-router-profile",
+    onRequest: () => {
       sourceModelsRequested = true
-      await route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify({
-          data: [{ id: "gpt-claude-router-profile" }],
-        }),
-      })
     },
-  )
+  })
   await context.route(
     "https://router.example.invalid/api/config",
     async (route) => {

--- a/e2e/autoCheckinNativePageFallback.spec.ts
+++ b/e2e/autoCheckinNativePageFallback.spec.ts
@@ -1,0 +1,302 @@
+import { createServer, type ServerResponse } from "node:http"
+import type { AddressInfo } from "node:net"
+import type { Worker } from "@playwright/test"
+
+import { OPTIONS_PAGE_PATH } from "~/constants/extensionPages"
+import { MENU_ITEM_IDS } from "~/constants/optionsMenuIds"
+import { SITE_TYPES } from "~/constants/siteType"
+import { DEFAULT_PREFERENCES } from "~/services/preferences/userPreferences"
+import {
+  AUTO_CHECKIN_SCHEDULE_MODE,
+  type AutoCheckinStatus,
+} from "~/types/autoCheckin"
+import { expect, test } from "~~/e2e/fixtures/extensionTest"
+import {
+  createStoredAccount,
+  forceExtensionLanguage,
+  installExtensionPageGuards,
+  seedStoredAccounts,
+  seedUserPreferences,
+  stubLlmMetadataIndex,
+} from "~~/e2e/utils/commonUserFlows"
+import {
+  expectPermissionOnboardingHidden,
+  getPlasmoStorageRawValue,
+  getServiceWorker,
+} from "~~/e2e/utils/extensionState"
+import { waitForExtensionRoot } from "~~/e2e/utils/lazyLoading"
+
+const AUTO_CHECKIN_STATUS_STORAGE_KEY = "autoCheckin_status"
+const NATIVE_ACCOUNT_ID = "native-page-fallback-account"
+const NATIVE_ACCOUNT_NAME = "Native Page Fallback Account"
+const NATIVE_ACCOUNT_USER_ID = "native-user"
+
+type NativeCheckinFixture = {
+  siteUrl: string
+  counts: {
+    directCheckinPostCount: number
+    nativePageClickCount: number
+    nativePageRequestCount: number
+    statusCheckCount: number
+  }
+  close: () => Promise<void>
+}
+
+function autoCheckinOptionsUrl(extensionId: string) {
+  return `chrome-extension://${extensionId}/${OPTIONS_PAGE_PATH}#${MENU_ITEM_IDS.AUTO_CHECKIN}`
+}
+
+async function readAutoCheckinStatus(
+  serviceWorker: Worker,
+): Promise<AutoCheckinStatus | null> {
+  const raw = await getPlasmoStorageRawValue<unknown>(
+    serviceWorker,
+    AUTO_CHECKIN_STATUS_STORAGE_KEY,
+  )
+
+  if (typeof raw !== "string") return null
+
+  return JSON.parse(raw) as AutoCheckinStatus
+}
+
+function fulfillJson(
+  response: ServerResponse,
+  status: number,
+  payload: unknown,
+) {
+  response.writeHead(status, { "content-type": "application/json" })
+  response.end(JSON.stringify(payload))
+}
+
+function fulfillHtml(response: ServerResponse, body: string) {
+  response.writeHead(200, { "content-type": "text/html" })
+  response.end(body)
+}
+
+async function createNativeCheckinFixture(): Promise<NativeCheckinFixture> {
+  const counts = {
+    directCheckinPostCount: 0,
+    nativePageClickCount: 0,
+    nativePageRequestCount: 0,
+    statusCheckCount: 0,
+  }
+
+  const server = createServer(async (request, response) => {
+    const url = new URL(request.url ?? "/", "http://127.0.0.1")
+
+    if (url.pathname === "/api/status") {
+      fulfillJson(response, 200, {
+        success: true,
+        message: "",
+        data: {},
+      })
+      return
+    }
+
+    if (url.pathname === "/api/user/checkin") {
+      if (request.method === "POST") {
+        counts.directCheckinPostCount += 1
+        fulfillJson(response, 200, {
+          success: false,
+          message: "dynamic check-in requires page action",
+          data: null,
+        })
+        return
+      }
+
+      counts.statusCheckCount += 1
+      fulfillJson(response, 200, {
+        success: true,
+        message: "",
+        data: {
+          stats: {
+            checked_in_today: counts.directCheckinPostCount > 0,
+          },
+        },
+      })
+      return
+    }
+
+    if (url.pathname === "/native-clicked") {
+      counts.nativePageClickCount += 1
+      response.writeHead(204)
+      response.end()
+      return
+    }
+
+    if (url.pathname === "/profile" || url.pathname === "/console/personal") {
+      counts.nativePageRequestCount += 1
+      fulfillHtml(
+        response,
+        `<!doctype html>
+<html>
+  <head><title>Native check-in fixture</title></head>
+  <body>
+    <button type="button" id="check-in">Check in</button>
+    <script>
+      window.localStorage.setItem(
+        "user",
+        JSON.stringify({
+          id: "${NATIVE_ACCOUNT_USER_ID}",
+          username: "native-page-user"
+        })
+      )
+
+      document.getElementById("check-in").addEventListener("click", () => {
+        const request = new XMLHttpRequest()
+        request.open("POST", "/native-clicked", false)
+        request.send()
+      })
+    </script>
+  </body>
+</html>`,
+      )
+      return
+    }
+
+    fulfillJson(response, 404, {
+      success: false,
+      message: `Unhandled native check-in fixture route: ${request.method} ${url.pathname}`,
+    })
+  })
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject)
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject)
+      resolve()
+    })
+  })
+
+  const address = server.address() as AddressInfo
+  return {
+    siteUrl: `http://127.0.0.1:${address.port}`,
+    counts,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error)
+            return
+          }
+          resolve()
+        })
+        server.closeAllConnections?.()
+        server.closeIdleConnections?.()
+      }),
+  }
+}
+
+test("New API native page fallback clicks the site page and confirms checked-in status", async ({
+  context,
+  extensionId,
+  page,
+}) => {
+  const serviceWorker = await getServiceWorker(context)
+  const nativeFixture = await createNativeCheckinFixture()
+
+  try {
+    await stubLlmMetadataIndex(context)
+
+    await seedUserPreferences(serviceWorker, {
+      autoCheckin: {
+        ...DEFAULT_PREFERENCES.autoCheckin!,
+        globalEnabled: true,
+        pretriggerDailyOnUiOpen: false,
+        notifyUiOnCompletion: true,
+        windowStart: "00:00",
+        windowEnd: "23:59",
+        scheduleMode: AUTO_CHECKIN_SCHEDULE_MODE.DETERMINISTIC,
+        deterministicTime: "23:58",
+        retryStrategy: {
+          enabled: false,
+          intervalMinutes: 30,
+          maxAttemptsPerDay: 1,
+        },
+      },
+      tempWindowFallback: {
+        ...DEFAULT_PREFERENCES.tempWindowFallback!,
+        enabled: true,
+        tempContextMode: "tab",
+      },
+    })
+    await seedStoredAccounts(serviceWorker, [
+      createStoredAccount({
+        id: NATIVE_ACCOUNT_ID,
+        site_name: NATIVE_ACCOUNT_NAME,
+        site_url: nativeFixture.siteUrl,
+        site_type: SITE_TYPES.NEW_API,
+        account_info: {
+          id: NATIVE_ACCOUNT_USER_ID,
+          username: "native-page-user",
+          access_token: "native-page-token",
+        },
+        checkIn: {
+          enableDetection: true,
+          autoCheckInEnabled: true,
+          siteStatus: {
+            isCheckedInToday: false,
+          },
+        },
+      }),
+    ])
+
+    await forceExtensionLanguage(page, "en")
+    installExtensionPageGuards(page)
+    await page.goto(autoCheckinOptionsUrl(extensionId))
+    await waitForExtensionRoot(page)
+    await expectPermissionOnboardingHidden(page)
+
+    await page.getByRole("button", { name: "Run now" }).click()
+
+    try {
+      await expect
+        .poll(() => nativeFixture.counts.nativePageClickCount, {
+          message: "native page fallback should click the site check-in button",
+          timeout: 30_000,
+        })
+        .toBeGreaterThan(0)
+      expect(nativeFixture.counts.nativePageRequestCount).toBeGreaterThan(0)
+    } catch (error) {
+      const status = await readAutoCheckinStatus(serviceWorker)
+      throw new Error(
+        `Native page fallback did not click the fixture button. Request counters: ${JSON.stringify(
+          nativeFixture.counts,
+        )}. Persisted status: ${JSON.stringify(status)}`,
+        { cause: error },
+      )
+    }
+
+    try {
+      await expect
+        .poll(() => readAutoCheckinStatus(serviceWorker))
+        .toMatchObject({
+          summary: {
+            totalEligible: 1,
+            executed: 1,
+            successCount: 1,
+            failedCount: 0,
+            skippedCount: 0,
+            needsRetry: false,
+          },
+          perAccount: {
+            [NATIVE_ACCOUNT_ID]: {
+              accountId: NATIVE_ACCOUNT_ID,
+              accountName: NATIVE_ACCOUNT_NAME,
+              status: "already_checked",
+            },
+          },
+        })
+    } catch (error) {
+      const status = await readAutoCheckinStatus(serviceWorker)
+      throw new Error(
+        `Native page fallback did not persist a successful result. Request counters: ${JSON.stringify(
+          nativeFixture.counts,
+        )}. Persisted status: ${JSON.stringify(status)}`,
+        { cause: error },
+      )
+    }
+  } finally {
+    await nativeFixture.close()
+  }
+})

--- a/e2e/autoCheckinNativePageFallback.spec.ts
+++ b/e2e/autoCheckinNativePageFallback.spec.ts
@@ -5,6 +5,7 @@ import type { Worker } from "@playwright/test"
 import { OPTIONS_PAGE_PATH } from "~/constants/extensionPages"
 import { MENU_ITEM_IDS } from "~/constants/optionsMenuIds"
 import { SITE_TYPES } from "~/constants/siteType"
+import { BASIC_SETTINGS_TEST_IDS } from "~/features/BasicSettings/testIds"
 import { DEFAULT_PREFERENCES } from "~/services/preferences/userPreferences"
 import {
   AUTO_CHECKIN_SCHEDULE_MODE,
@@ -247,7 +248,9 @@ test("New API native page fallback clicks the site page and confirms checked-in 
     await waitForExtensionRoot(page)
     await expectPermissionOnboardingHidden(page)
 
-    await page.getByRole("button", { name: "Run now" }).click()
+    await page
+      .getByTestId(BASIC_SETTINGS_TEST_IDS.autoCheckinRunNowButton)
+      .click()
 
     try {
       await expect

--- a/e2e/balanceHistoryUserFlows.spec.ts
+++ b/e2e/balanceHistoryUserFlows.spec.ts
@@ -23,22 +23,12 @@ import {
   expectPermissionOnboardingHidden,
   getPlasmoStorageJsonValue,
   getServiceWorker,
+  getStoredUserPreferences,
 } from "~~/e2e/utils/extensionState"
 import { waitForExtensionRoot } from "~~/e2e/utils/lazyLoading"
 
 const BALANCE_HISTORY_URL = (extensionId: string) =>
   `chrome-extension://${extensionId}/${OPTIONS_PAGE_PATH}#${MENU_ITEM_IDS.BALANCE_HISTORY}`
-
-async function readStoredPreferences(
-  serviceWorker: Awaited<ReturnType<typeof getServiceWorker>>,
-) {
-  return (
-    (await getPlasmoStorageJsonValue<Record<string, unknown>>(
-      serviceWorker,
-      STORAGE_KEYS.USER_PREFERENCES,
-    )) ?? {}
-  )
-}
 
 async function readDailyBalanceHistoryStore(
   serviceWorker: Awaited<ReturnType<typeof getServiceWorker>>,
@@ -183,7 +173,7 @@ test("filters balance history by tag/account and persists the selected currency"
   await page.getByRole("button", { name: "CNY (¥)" }).click()
 
   await expect
-    .poll(async () => readStoredPreferences(serviceWorker))
+    .poll(async () => getStoredUserPreferences(serviceWorker))
     .toMatchObject({ currencyType: "CNY" })
   await expect(page.getByRole("button", { name: "CNY (¥)" })).toHaveAttribute(
     "aria-pressed",

--- a/e2e/balanceHistoryUserFlows.spec.ts
+++ b/e2e/balanceHistoryUserFlows.spec.ts
@@ -21,7 +21,7 @@ import {
 } from "~~/e2e/utils/commonUserFlows"
 import {
   expectPermissionOnboardingHidden,
-  getPlasmoStorageRawValue,
+  getPlasmoStorageJsonValue,
   getServiceWorker,
 } from "~~/e2e/utils/extensionState"
 import { waitForExtensionRoot } from "~~/e2e/utils/lazyLoading"
@@ -32,33 +32,21 @@ const BALANCE_HISTORY_URL = (extensionId: string) =>
 async function readStoredPreferences(
   serviceWorker: Awaited<ReturnType<typeof getServiceWorker>>,
 ) {
-  const raw = await getPlasmoStorageRawValue<unknown>(
-    serviceWorker,
-    STORAGE_KEYS.USER_PREFERENCES,
+  return (
+    (await getPlasmoStorageJsonValue<Record<string, unknown>>(
+      serviceWorker,
+      STORAGE_KEYS.USER_PREFERENCES,
+    )) ?? {}
   )
-
-  if (typeof raw !== "string") return {}
-
-  return JSON.parse(raw) as Record<string, unknown>
 }
 
 async function readDailyBalanceHistoryStore(
   serviceWorker: Awaited<ReturnType<typeof getServiceWorker>>,
 ) {
-  const raw = await getPlasmoStorageRawValue<unknown>(
+  return await getPlasmoStorageJsonValue<DailyBalanceHistoryStore>(
     serviceWorker,
     STORAGE_KEYS.DAILY_BALANCE_HISTORY_STORE,
   )
-
-  if (typeof raw === "string") {
-    return JSON.parse(raw) as DailyBalanceHistoryStore
-  }
-
-  if (raw && typeof raw === "object") {
-    return raw as DailyBalanceHistoryStore
-  }
-
-  return null
 }
 
 function createBalanceSnapshots(): DailyBalanceHistoryStore["snapshotsByAccountId"] {
@@ -267,7 +255,8 @@ test("refreshes balance snapshots through the background runtime", async ({
       }),
     ])
   await expect(
-    page.getByTestId(BALANCE_HISTORY_TEST_IDS.accountSummary),
+    page
+      .getByTestId(BALANCE_HISTORY_TEST_IDS.accountSummary)
+      .getByText("Balance Refresh Hub", { exact: true }),
   ).toBeVisible()
-  await expect(page.getByText("Balance Refresh Hub").first()).toBeVisible()
 })

--- a/e2e/balanceHistoryUserFlows.spec.ts
+++ b/e2e/balanceHistoryUserFlows.spec.ts
@@ -17,6 +17,7 @@ import {
   seedTagStore,
   seedUserPreferences,
   stubLlmMetadataIndex,
+  stubNewApiSiteRoutes,
 } from "~~/e2e/utils/commonUserFlows"
 import {
   expectPermissionOnboardingHidden,
@@ -39,6 +40,25 @@ async function readStoredPreferences(
   if (typeof raw !== "string") return {}
 
   return JSON.parse(raw) as Record<string, unknown>
+}
+
+async function readDailyBalanceHistoryStore(
+  serviceWorker: Awaited<ReturnType<typeof getServiceWorker>>,
+) {
+  const raw = await getPlasmoStorageRawValue<unknown>(
+    serviceWorker,
+    STORAGE_KEYS.DAILY_BALANCE_HISTORY_STORE,
+  )
+
+  if (typeof raw === "string") {
+    return JSON.parse(raw) as DailyBalanceHistoryStore
+  }
+
+  if (raw && typeof raw === "object") {
+    return raw as DailyBalanceHistoryStore
+  }
+
+  return null
 }
 
 function createBalanceSnapshots(): DailyBalanceHistoryStore["snapshotsByAccountId"] {
@@ -181,4 +201,73 @@ test("filters balance history by tag/account and persists the selected currency"
     "aria-pressed",
     "true",
   )
+})
+
+test("refreshes balance snapshots through the background runtime", async ({
+  context,
+  extensionId,
+  page,
+}) => {
+  const serviceWorker = await getServiceWorker(context)
+  const accountId = "balance-refresh-account"
+  const siteUrl = "https://balance-refresh.example.com"
+
+  await seedStoredAccounts(serviceWorker, [
+    createStoredAccount({
+      id: accountId,
+      site_name: "Balance Refresh Hub",
+      site_url: siteUrl,
+      account_info: {
+        id: "31",
+        username: "balance-refresh-user",
+        access_token: "balance-refresh-token",
+      },
+    }),
+  ])
+  await seedDailyBalanceHistoryStore(serviceWorker, { [accountId]: {} })
+  await seedUserPreferences(serviceWorker, {
+    currencyType: "USD",
+    showTodayCashflow: true,
+    balanceHistory: {
+      enabled: true,
+      endOfDayCapture: { enabled: false },
+      retentionDays: 365,
+    },
+  })
+  await stubNewApiSiteRoutes(context, {
+    baseUrl: siteUrl,
+    userId: "31",
+    username: "balance-refresh-user",
+    accessToken: "balance-refresh-token",
+    initialQuota: 12_345_678,
+    todayQuotaConsumption: 234_567,
+  })
+
+  await page.goto(BALANCE_HISTORY_URL(extensionId))
+  await waitForExtensionRoot(page)
+  await expectPermissionOnboardingHidden(page)
+  await expect(
+    page.getByRole("heading", { name: "Balance History" }),
+  ).toBeVisible()
+
+  await page.getByRole("button", { name: "Refresh now" }).click()
+
+  await expect
+    .poll(async () => {
+      const store = await readDailyBalanceHistoryStore(serviceWorker)
+      return Object.values(store?.snapshotsByAccountId[accountId] ?? {})
+    })
+    .toEqual([
+      expect.objectContaining({
+        quota: 12_345_678,
+        today_income: 0,
+        today_quota_consumption: 234_567,
+        source: "refresh",
+        capturedAt: expect.any(Number),
+      }),
+    ])
+  await expect(
+    page.getByTestId(BALANCE_HISTORY_TEST_IDS.accountSummary),
+  ).toBeVisible()
+  await expect(page.getByText("Balance Refresh Hub").first()).toBeVisible()
 })

--- a/e2e/basicSettingsCommonFlows.spec.ts
+++ b/e2e/basicSettingsCommonFlows.spec.ts
@@ -11,19 +11,9 @@ import {
 import {
   getPlasmoStorageJsonValue,
   getServiceWorker,
+  getStoredUserPreferences,
 } from "~~/e2e/utils/extensionState"
 import { waitForExtensionRoot } from "~~/e2e/utils/lazyLoading"
-
-async function readStoredPreferences(
-  serviceWorker: Awaited<ReturnType<typeof getServiceWorker>>,
-): Promise<Record<string, unknown>> {
-  return (
-    (await getPlasmoStorageJsonValue<Record<string, unknown>>(
-      serviceWorker,
-      STORAGE_KEYS.USER_PREFERENCES,
-    )) ?? {}
-  )
-}
 
 async function expectStoredPreference(
   serviceWorker: Awaited<ReturnType<typeof getServiceWorker>>,
@@ -32,7 +22,7 @@ async function expectStoredPreference(
 ) {
   await expect
     .poll(async () => {
-      const preferences = await readStoredPreferences(serviceWorker)
+      const preferences = await getStoredUserPreferences(serviceWorker)
       return preferences[key]
     })
     .toEqual(value)

--- a/e2e/basicSettingsCommonFlows.spec.ts
+++ b/e2e/basicSettingsCommonFlows.spec.ts
@@ -9,7 +9,7 @@ import {
   stubLlmMetadataIndex,
 } from "~~/e2e/utils/commonUserFlows"
 import {
-  getPlasmoStorageRawValue,
+  getPlasmoStorageJsonValue,
   getServiceWorker,
 } from "~~/e2e/utils/extensionState"
 import { waitForExtensionRoot } from "~~/e2e/utils/lazyLoading"
@@ -17,41 +17,12 @@ import { waitForExtensionRoot } from "~~/e2e/utils/lazyLoading"
 async function readStoredPreferences(
   serviceWorker: Awaited<ReturnType<typeof getServiceWorker>>,
 ): Promise<Record<string, unknown>> {
-  const raw = await getPlasmoStorageRawValue<unknown>(
-    serviceWorker,
-    STORAGE_KEYS.USER_PREFERENCES,
+  return (
+    (await getPlasmoStorageJsonValue<Record<string, unknown>>(
+      serviceWorker,
+      STORAGE_KEYS.USER_PREFERENCES,
+    )) ?? {}
   )
-
-  if (typeof raw !== "string") {
-    return {}
-  }
-
-  try {
-    return JSON.parse(raw) as Record<string, unknown>
-  } catch {
-    return {}
-  }
-}
-
-async function readJsonStorageValue<T>(
-  serviceWorker: Awaited<ReturnType<typeof getServiceWorker>>,
-  storageKey: string,
-): Promise<T | null> {
-  const raw = await getPlasmoStorageRawValue<unknown>(serviceWorker, storageKey)
-
-  if (typeof raw === "string") {
-    try {
-      return JSON.parse(raw) as T
-    } catch {
-      return null
-    }
-  }
-
-  if (raw && typeof raw === "object") {
-    return raw as T
-  }
-
-  return null
 }
 
 async function expectStoredPreference(
@@ -203,7 +174,7 @@ test("persists product analytics opt-out through dedicated storage and reload", 
 
   await expect
     .poll(async () => {
-      const preferences = await readJsonStorageValue<{
+      const preferences = await getPlasmoStorageJsonValue<{
         enabled?: boolean
         updatedAt?: number
       }>(serviceWorker, STORAGE_KEYS.PRODUCT_ANALYTICS_PREFERENCES)

--- a/e2e/basicSettingsCommonFlows.spec.ts
+++ b/e2e/basicSettingsCommonFlows.spec.ts
@@ -33,6 +33,27 @@ async function readStoredPreferences(
   }
 }
 
+async function readJsonStorageValue<T>(
+  serviceWorker: Awaited<ReturnType<typeof getServiceWorker>>,
+  storageKey: string,
+): Promise<T | null> {
+  const raw = await getPlasmoStorageRawValue<unknown>(serviceWorker, storageKey)
+
+  if (typeof raw === "string") {
+    try {
+      return JSON.parse(raw) as T
+    } catch {
+      return null
+    }
+  }
+
+  if (raw && typeof raw === "object") {
+    return raw as T
+  }
+
+  return null
+}
+
 async function expectStoredPreference(
   serviceWorker: Awaited<ReturnType<typeof getServiceWorker>>,
   key: string,
@@ -154,6 +175,60 @@ test("persists an options setting through extension storage and reload", async (
   await expect(page.getByRole("button", { name: "CNY (¥)" })).toHaveAttribute(
     "aria-pressed",
     "true",
+  )
+})
+
+test("persists product analytics opt-out through dedicated storage and reload", async ({
+  context,
+  extensionId,
+  page,
+}) => {
+  const serviceWorker = await getServiceWorker(context)
+
+  await page.goto(
+    `chrome-extension://${extensionId}/${OPTIONS_PAGE_PATH}#${MENU_ITEM_IDS.BASIC}`,
+  )
+  await waitForExtensionRoot(page)
+
+  const productAnalyticsSection = page.locator("#product-analytics")
+  await expect(productAnalyticsSection).toBeVisible()
+
+  const productAnalyticsSwitch = productAnalyticsSection.getByRole("switch", {
+    name: "Toggle",
+  })
+  await expect(productAnalyticsSwitch).toBeEnabled()
+  await expect(productAnalyticsSwitch).toHaveAttribute("aria-checked", "true")
+
+  await productAnalyticsSwitch.click()
+
+  await expect
+    .poll(async () => {
+      const preferences = await readJsonStorageValue<{
+        enabled?: boolean
+        updatedAt?: number
+      }>(serviceWorker, STORAGE_KEYS.PRODUCT_ANALYTICS_PREFERENCES)
+
+      return {
+        enabled: preferences?.enabled,
+        hasUpdatedAt: typeof preferences?.updatedAt === "number",
+      }
+    })
+    .toEqual({
+      enabled: false,
+      hasUpdatedAt: true,
+    })
+  await expect(productAnalyticsSwitch).toHaveAttribute("aria-checked", "false")
+
+  await page.reload()
+  await waitForExtensionRoot(page)
+
+  const reloadedProductAnalyticsSwitch = page
+    .locator("#product-analytics")
+    .getByRole("switch", { name: "Toggle" })
+  await expect(reloadedProductAnalyticsSwitch).toBeEnabled()
+  await expect(reloadedProductAnalyticsSwitch).toHaveAttribute(
+    "aria-checked",
+    "false",
   )
 })
 

--- a/e2e/contentWebAiApiCheck.spec.ts
+++ b/e2e/contentWebAiApiCheck.spec.ts
@@ -24,6 +24,7 @@ import {
 import { waitForExtensionRoot } from "~~/e2e/utils/lazyLoading"
 
 const TEST_PAGE_URL = "https://api-console.example.test/console"
+const TEST_PAGE_ORIGIN = "https://api-console.example.test"
 const API_BASE_URL = "https://api-console.example.test/api"
 const API_KEY = "sk-e2e-content-api-check-key"
 
@@ -71,6 +72,29 @@ async function openApiCheckModalFromCopiedCredentials(page: Page): Promise<{
       }),
     )
   }, selectedCredentialText)
+
+  const contentHost = page.locator("all-api-hub-redemption-toast")
+  await contentHost.getByRole("button", { name: "Open" }).click()
+
+  const modal = contentHost.getByTestId(WEB_AI_API_CHECK_TEST_IDS.modal)
+  await expect(modal).toBeVisible()
+  await expect(modal.locator("input").nth(0)).toHaveValue(API_BASE_URL)
+
+  return { contentHost, modal }
+}
+
+async function openApiCheckModalFromClipboardRead(page: Page): Promise<{
+  contentHost: Locator
+  modal: Locator
+}> {
+  await page.goto(TEST_PAGE_URL)
+  await page.evaluate(
+    (clipboardText) => navigator.clipboard.writeText(clipboardText),
+    `base_url=${API_BASE_URL}\napi_key=${API_KEY}`,
+  )
+  await page.evaluate(() => window.getSelection()?.removeAllRanges())
+
+  await page.getByRole("button", { name: "Copy credentials" }).click()
 
   const contentHost = page.locator("all-api-hub-redemption-toast")
   await contentHost.getByRole("button", { name: "Open" }).click()
@@ -155,6 +179,51 @@ async function sendApiCheckContextMenuTrigger(
     .toMatchObject({ success: true })
 }
 
+async function installClipboardReadPermissionBridge(
+  serviceWorker: Awaited<ReturnType<typeof getServiceWorker>>,
+) {
+  await serviceWorker.evaluate(() => {
+    const chromeApi = (globalThis as any).chrome
+    const browserApi = (globalThis as any).browser
+    const originalChromeContains = chromeApi?.permissions?.contains?.bind(
+      chromeApi.permissions,
+    )
+    const originalBrowserContains = browserApi?.permissions?.contains?.bind(
+      browserApi.permissions,
+    )
+
+    const containsWithClipboardRead = (
+      details: { permissions?: string[] },
+      callback?: (result: boolean) => void,
+    ) => {
+      // Chromium does not resolve this optional-permission prompt reliably in the
+      // headless extension harness; keep the test focused on the content read path.
+      if (details.permissions?.includes("clipboardRead")) {
+        callback?.(true)
+        return Promise.resolve(true)
+      }
+
+      if (originalChromeContains) {
+        return originalChromeContains(details, callback)
+      }
+
+      if (originalBrowserContains) {
+        return originalBrowserContains(details, callback)
+      }
+
+      callback?.(false)
+      return Promise.resolve(false)
+    }
+
+    if (chromeApi?.permissions) {
+      chromeApi.permissions.contains = containsWithClipboardRead
+    }
+    if (browserApi?.permissions) {
+      browserApi.permissions.contains = containsWithClipboardRead
+    }
+  })
+}
+
 test.beforeEach(async ({ context, page }) => {
   installExtensionPageGuards(page)
   await forceExtensionLanguage(page, "en")
@@ -172,6 +241,9 @@ test.beforeEach(async ({ context, page }) => {
             <button id="copy-credentials">
               base_url=${API_BASE_URL}
               api_key=${API_KEY}
+            </button>
+            <button id="copy-from-clipboard" data-copy>
+              Copy credentials
             </button>
           </body>
         </html>`,
@@ -320,6 +392,22 @@ test("opens the API check modal from the background context-menu message path", 
   const modal = contentHost.getByTestId(WEB_AI_API_CHECK_TEST_IDS.modal)
   await expect(modal).toBeVisible()
   await expect(modal.locator("input").nth(0)).toHaveValue(API_BASE_URL)
+})
+
+test("reads copied web API credentials from the clipboard after clicking a copy-like control", async ({
+  context,
+  page,
+}) => {
+  const serviceWorker = await getServiceWorker(context)
+  await seedAutoDetectApiCheckPreferences(serviceWorker)
+  await installClipboardReadPermissionBridge(serviceWorker)
+
+  await context.grantPermissions(["clipboard-read", "clipboard-write"], {
+    origin: TEST_PAGE_ORIGIN,
+  })
+
+  const { modal } = await openApiCheckModalFromClipboardRead(page)
+  await expect(modal.locator("input").nth(1)).toHaveValue(API_KEY)
 })
 
 test("opens API credential profiles from the content save success toast", async ({

--- a/e2e/contentWebAiApiCheck.spec.ts
+++ b/e2e/contentWebAiApiCheck.spec.ts
@@ -78,7 +78,9 @@ async function openApiCheckModalFromCopiedCredentials(page: Page): Promise<{
 
   const modal = contentHost.getByTestId(WEB_AI_API_CHECK_TEST_IDS.modal)
   await expect(modal).toBeVisible()
-  await expect(modal.locator("input").nth(0)).toHaveValue(API_BASE_URL)
+  await expect(modal.getByRole("textbox", { name: "Base URL" })).toHaveValue(
+    API_BASE_URL,
+  )
 
   return { contentHost, modal }
 }
@@ -101,7 +103,9 @@ async function openApiCheckModalFromClipboardRead(page: Page): Promise<{
 
   const modal = contentHost.getByTestId(WEB_AI_API_CHECK_TEST_IDS.modal)
   await expect(modal).toBeVisible()
-  await expect(modal.locator("input").nth(0)).toHaveValue(API_BASE_URL)
+  await expect(modal.getByRole("textbox", { name: "Base URL" })).toHaveValue(
+    API_BASE_URL,
+  )
 
   return { contentHost, modal }
 }
@@ -391,7 +395,9 @@ test("opens the API check modal from the background context-menu message path", 
   const contentHost = page.locator("all-api-hub-redemption-toast")
   const modal = contentHost.getByTestId(WEB_AI_API_CHECK_TEST_IDS.modal)
   await expect(modal).toBeVisible()
-  await expect(modal.locator("input").nth(0)).toHaveValue(API_BASE_URL)
+  await expect(modal.getByRole("textbox", { name: "Base URL" })).toHaveValue(
+    API_BASE_URL,
+  )
 })
 
 test("reads copied web API credentials from the clipboard after clicking a copy-like control", async ({
@@ -407,7 +413,9 @@ test("reads copied web API credentials from the clipboard after clicking a copy-
   })
 
   const { modal } = await openApiCheckModalFromClipboardRead(page)
-  await expect(modal.locator("input").nth(1)).toHaveValue(API_KEY)
+  await expect(modal.getByRole("textbox", { name: "API key" })).toHaveValue(
+    API_KEY,
+  )
 })
 
 test("opens API credential profiles from the content save success toast", async ({

--- a/e2e/e2e-build-variants.json
+++ b/e2e/e2e-build-variants.json
@@ -14,6 +14,11 @@
         "cookies",
         "declarativeNetRequestWithHostAccess"
       ]
+    },
+    "bookmarks-required": {
+      "extensionDirName": "chrome-mv3-test-bookmarks-required",
+      "testOutDirTemplate": "{{browser}}-mv{{manifestVersion}}-test-bookmarks-required",
+      "requiredChromiumPermissions": ["bookmarks"]
     }
   }
 }

--- a/e2e/importExportCommonFlows.spec.ts
+++ b/e2e/importExportCommonFlows.spec.ts
@@ -1543,7 +1543,9 @@ test("runs WebDAV auto-sync from settings and uploads the local snapshot", async
   ).toBeVisible()
 
   await page.locator(`#${WEBDAV_AUTO_SYNC_TARGET_IDS.syncNow}`).click()
-  await expect(page.getByText("同步成功")).toBeVisible()
+  await expect(
+    page.locator("#_rht_toaster").getByText("Sync successful", { exact: true }),
+  ).toBeVisible()
 
   await expect.poll(() => uploadedPayloads.length).toBe(1)
   expect(tempDeleteUrls).toEqual([])
@@ -1571,5 +1573,9 @@ test("runs WebDAV auto-sync from settings and uploads the local snapshot", async
     }),
   })
 
-  await expect(page.getByText("Sync successful")).toBeVisible()
+  await expect(
+    page
+      .locator(`#${WEBDAV_AUTO_SYNC_TARGET_IDS.root}`)
+      .getByText("Sync successful", { exact: true }),
+  ).toBeVisible()
 })

--- a/e2e/importExportCommonFlows.spec.ts
+++ b/e2e/importExportCommonFlows.spec.ts
@@ -40,6 +40,7 @@ import {
 import {
   getPlasmoStorageRawValue,
   getServiceWorker,
+  getStoredUserPreferences,
   setPlasmoStorageValue,
 } from "~~/e2e/utils/extensionState"
 import { waitForExtensionRoot } from "~~/e2e/utils/lazyLoading"
@@ -76,25 +77,6 @@ async function readStoredAccountConfig(
     return JSON.parse(raw) as AccountStorageConfig
   } catch {
     return createDefaultAccountStorageConfig()
-  }
-}
-
-async function readStoredPreferences(
-  serviceWorker: Awaited<ReturnType<typeof getServiceWorker>>,
-): Promise<Record<string, unknown>> {
-  const raw = await getPlasmoStorageRawValue<unknown>(
-    serviceWorker,
-    STORAGE_KEYS.USER_PREFERENCES,
-  )
-
-  if (typeof raw !== "string") {
-    return {}
-  }
-
-  try {
-    return JSON.parse(raw) as Record<string, unknown>
-  } catch {
-    return {}
   }
 }
 
@@ -578,7 +560,7 @@ test("round-trips a full backup through export download and file import", async 
       const [accountConfig, profileConfig, preferences] = await Promise.all([
         readStoredAccountConfig(serviceWorker),
         readStoredApiCredentialProfiles(serviceWorker),
-        readStoredPreferences(serviceWorker),
+        getStoredUserPreferences(serviceWorker),
       ])
       const channelConfigs = await readStoredChannelConfigs(serviceWorker)
 
@@ -969,7 +951,7 @@ test("restores a full backup and keeps common popup workflows available", async 
       now,
     ),
     preferences: {
-      ...(await readStoredPreferences(serviceWorker)),
+      ...(await getStoredUserPreferences(serviceWorker)),
       currencyType: "CNY",
       actionClickBehavior: "sidepanel",
     },
@@ -1002,7 +984,7 @@ test("restores a full backup and keeps common popup workflows available", async 
       const [accountConfig, profileConfig, preferences] = await Promise.all([
         readStoredAccountConfig(serviceWorker),
         readStoredApiCredentialProfiles(serviceWorker),
-        readStoredPreferences(serviceWorker),
+        getStoredUserPreferences(serviceWorker),
       ])
 
       return {
@@ -1094,7 +1076,7 @@ test("restores a full backup and keeps the sidepanel model workflow available", 
       now,
     ),
     preferences: {
-      ...(await readStoredPreferences(serviceWorker)),
+      ...(await getStoredUserPreferences(serviceWorker)),
       currencyType: "CNY",
       actionClickBehavior: "sidepanel",
     },
@@ -1158,7 +1140,7 @@ test("restores a full backup and keeps the sidepanel model workflow available", 
       const [accountConfig, profileConfig, preferences] = await Promise.all([
         readStoredAccountConfig(serviceWorker),
         readStoredApiCredentialProfiles(serviceWorker),
-        readStoredPreferences(serviceWorker),
+        getStoredUserPreferences(serviceWorker),
       ])
 
       return {
@@ -1222,7 +1204,7 @@ test("imports preference backup JSON and applies settings after reload", async (
     type: "preferences",
     timestamp: Date.parse("2026-03-30T12:30:00.000Z"),
     preferences: {
-      ...(await readStoredPreferences(serviceWorker)),
+      ...(await getStoredUserPreferences(serviceWorker)),
       currencyType: "CNY",
       actionClickBehavior: "sidepanel",
       themeMode: "dark",
@@ -1245,7 +1227,7 @@ test("imports preference backup JSON and applies settings after reload", async (
   await page.getByTestId(IMPORT_EXPORT_TEST_IDS.importBackupButton).click()
 
   await expect
-    .poll(() => readStoredPreferences(serviceWorker))
+    .poll(() => getStoredUserPreferences(serviceWorker))
     .toMatchObject({
       currencyType: "CNY",
       actionClickBehavior: "sidepanel",
@@ -1424,7 +1406,7 @@ test("uploads a WebDAV backup and restores it through the WebDAV download flow",
       const [accountConfig, profileConfig, preferences] = await Promise.all([
         readStoredAccountConfig(serviceWorker),
         readStoredApiCredentialProfiles(serviceWorker),
-        readStoredPreferences(serviceWorker),
+        getStoredUserPreferences(serviceWorker),
       ])
 
       return {

--- a/e2e/importExportCommonFlows.spec.ts
+++ b/e2e/importExportCommonFlows.spec.ts
@@ -1,5 +1,5 @@
 import fs from "node:fs/promises"
-import type { Page } from "@playwright/test"
+import type { BrowserContext, Page } from "@playwright/test"
 
 import {
   OPTIONS_PAGE_PATH,
@@ -9,6 +9,7 @@ import {
 import { MENU_ITEM_IDS } from "~/constants/optionsMenuIds"
 import { getPopupViewTestId, POPUP_TEST_IDS } from "~/entrypoints/popup/testIds"
 import { API_CREDENTIAL_PROFILES_TEST_IDS } from "~/features/ApiCredentialProfiles/testIds"
+import { WEBDAV_AUTO_SYNC_TARGET_IDS } from "~/features/ImportExport/searchTargets"
 import { IMPORT_EXPORT_TEST_IDS } from "~/features/ImportExport/testIds"
 import { SITE_BOOKMARKS_TEST_IDS } from "~/features/SiteBookmarks/testIds"
 import {
@@ -22,6 +23,7 @@ import {
   type ApiCredentialProfilesConfig,
 } from "~/types/apiCredentialProfiles"
 import type { ChannelConfigMap } from "~/types/channelConfig"
+import { WEBDAV_SYNC_STRATEGIES } from "~/types/webdav"
 import { expect, test } from "~~/e2e/fixtures/extensionTest"
 import {
   createStoredAccount,
@@ -158,6 +160,121 @@ function buildAccountBackup(accounts: SiteAccount[]) {
       },
       now,
     ),
+  }
+}
+
+async function installWebdavBackupRoute(
+  context: BrowserContext,
+  webdavFileUrl: string,
+) {
+  const uploadedPayloads: unknown[] = []
+  const stagedBackups = new Map<string, string>()
+  const tempDeleteUrls: string[] = []
+  let remoteBackup = ""
+  const webdavBackupFile = new URL(webdavFileUrl)
+  const webdavBackupDirectoryPath = webdavBackupFile.pathname.replace(
+    /\/[^/]*$/,
+    "",
+  )
+  const webdavBackupFileName = webdavBackupFile.pathname.split("/").pop() ?? ""
+
+  await context.route(`${webdavBackupFile.origin}/**`, async (route) => {
+    const method = route.request().method()
+    const url = new URL(route.request().url())
+    const isBackupFile = url.href === webdavFileUrl
+    const requestDirectoryPath = url.pathname.replace(/\/[^/]*$/, "")
+    const requestFileName = url.pathname.split("/").pop() ?? ""
+    const isTempBackupFile =
+      requestDirectoryPath === webdavBackupDirectoryPath &&
+      (requestFileName.startsWith(`${webdavBackupFileName}.tmp.`) ||
+        requestFileName.startsWith(`.${webdavBackupFileName}.tmp.`))
+
+    if (method === "GET" && (isBackupFile || isTempBackupFile)) {
+      const body = isTempBackupFile ? stagedBackups.get(url.href) : remoteBackup
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: body || "{}",
+      })
+      return
+    }
+
+    if (method === "PUT" && (isBackupFile || isTempBackupFile)) {
+      const body = route.request().postData() ?? ""
+      if (isTempBackupFile) {
+        stagedBackups.set(url.href, body)
+      } else {
+        await route.fulfill({
+          status: 500,
+          contentType: "application/json",
+          body: JSON.stringify({ error: "direct final backup PUT rejected" }),
+        })
+        return
+      }
+      await route.fulfill({
+        status: 204,
+        contentType: "application/json",
+        body: "{}",
+      })
+      return
+    }
+
+    if (method === "PROPFIND") {
+      await route.fulfill({
+        status: 207,
+        contentType: "application/xml",
+        body: `<?xml version="1.0" encoding="utf-8"?><d:multistatus xmlns:d="DAV:" />`,
+      })
+      return
+    }
+
+    if (method === "MOVE" && isTempBackupFile) {
+      const destination = route.request().headers()["destination"]
+      const body = stagedBackups.get(url.href)
+      if (destination !== webdavFileUrl || body === undefined) {
+        await route.fulfill({
+          status: 404,
+          contentType: "application/json",
+          body: JSON.stringify({ error: "missing staged backup" }),
+        })
+        return
+      }
+
+      remoteBackup = body
+      stagedBackups.delete(url.href)
+      uploadedPayloads.push(JSON.parse(remoteBackup))
+      await route.fulfill({
+        status: 201,
+        contentType: "application/json",
+        body: "{}",
+      })
+      return
+    }
+
+    if (method === "DELETE" && isTempBackupFile) {
+      tempDeleteUrls.push(url.href)
+      stagedBackups.delete(url.href)
+      await route.fulfill({
+        status: 204,
+        contentType: "text/plain",
+        body: "",
+      })
+      return
+    }
+
+    await route.fulfill({
+      status: method === "MKCOL" ? 201 : 204,
+      contentType: "text/plain",
+      body: "",
+    })
+  })
+
+  return {
+    uploadedPayloads,
+    tempDeleteUrls,
+    setRemoteBackup(body: string) {
+      remoteBackup = body
+    },
   }
 }
 
@@ -1160,116 +1277,10 @@ test("uploads a WebDAV backup and restores it through the WebDAV download flow",
   const serviceWorker = await getServiceWorker(context)
   const now = Date.parse("2026-03-30T18:00:00.000Z")
   const webdavFileUrl = "https://webdav.example.com/all-api-hub-e2e.json"
-  const uploadedPayloads: unknown[] = []
-  const stagedBackups = new Map<string, string>()
-  const tempDeleteUrls: string[] = []
-  let remoteBackup = ""
-  const webdavBackupFile = new URL(webdavFileUrl)
-  const webdavBackupDirectoryPath = webdavBackupFile.pathname.replace(
-    /\/[^/]*$/,
-    "",
+  const { uploadedPayloads, tempDeleteUrls } = await installWebdavBackupRoute(
+    context,
+    webdavFileUrl,
   )
-  const webdavBackupFileName = webdavBackupFile.pathname.split("/").pop() ?? ""
-
-  await context.route("https://webdav.example.com/**", async (route) => {
-    const method = route.request().method()
-    const url = new URL(route.request().url())
-    const isBackupFile = url.href === webdavFileUrl
-    const requestDirectoryPath = url.pathname.replace(/\/[^/]*$/, "")
-    const requestFileName = url.pathname.split("/").pop() ?? ""
-    const isTempBackupFile =
-      requestDirectoryPath === webdavBackupDirectoryPath &&
-      (requestFileName.startsWith(`${webdavBackupFileName}.tmp.`) ||
-        requestFileName.startsWith(`.${webdavBackupFileName}.tmp.`))
-
-    if (method === "GET" && (isBackupFile || isTempBackupFile)) {
-      const body = isTempBackupFile ? stagedBackups.get(url.href) : remoteBackup
-      if (!body) {
-        await route.fulfill({
-          status: 200,
-          contentType: "application/json",
-          body: "{}",
-        })
-        return
-      }
-
-      await route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body,
-      })
-      return
-    }
-
-    if (method === "PUT" && (isBackupFile || isTempBackupFile)) {
-      const body = route.request().postData() ?? ""
-      if (isTempBackupFile) {
-        stagedBackups.set(url.href, body)
-      } else {
-        await route.fulfill({
-          status: 500,
-          contentType: "application/json",
-          body: JSON.stringify({ error: "direct final backup PUT rejected" }),
-        })
-        return
-      }
-      await route.fulfill({
-        status: isTempBackupFile ? 204 : 201,
-        contentType: "application/json",
-        body: "{}",
-      })
-      return
-    }
-
-    if (method === "PROPFIND") {
-      await route.fulfill({
-        status: 207,
-        contentType: "application/xml",
-        body: `<?xml version="1.0" encoding="utf-8"?><d:multistatus xmlns:d="DAV:" />`,
-      })
-      return
-    }
-
-    if (method === "MOVE" && isTempBackupFile) {
-      const destination = route.request().headers()["destination"]
-      const body = stagedBackups.get(url.href)
-      if (destination !== webdavFileUrl || body === undefined) {
-        await route.fulfill({
-          status: 404,
-          contentType: "application/json",
-          body: JSON.stringify({ error: "missing staged backup" }),
-        })
-        return
-      }
-
-      remoteBackup = body
-      stagedBackups.delete(url.href)
-      uploadedPayloads.push(JSON.parse(remoteBackup))
-      await route.fulfill({
-        status: 201,
-        contentType: "application/json",
-        body: "{}",
-      })
-      return
-    }
-
-    if (method === "DELETE" && isTempBackupFile) {
-      tempDeleteUrls.push(url.href)
-      stagedBackups.delete(url.href)
-      await route.fulfill({
-        status: 204,
-        contentType: "text/plain",
-        body: "",
-      })
-      return
-    }
-
-    await route.fulfill({
-      status: method === "MKCOL" ? 201 : 204,
-      contentType: "text/plain",
-      body: "",
-    })
-  })
 
   const webdavAccount = createStoredAccount({
     id: "webdav-account",
@@ -1454,4 +1465,111 @@ test("uploads a WebDAV backup and restores it through the WebDAV download flow",
   await expect(
     restorePage.getByRole("heading", { name: "WebDAV Profile" }),
   ).toBeVisible()
+})
+
+test("runs WebDAV auto-sync from settings and uploads the local snapshot", async ({
+  context,
+  extensionId,
+  page,
+}) => {
+  const serviceWorker = await getServiceWorker(context)
+  const now = Date.parse("2026-03-30T19:00:00.000Z")
+  const webdavFileUrl =
+    "https://webdav-auto-sync.example.invalid/all-api-hub-auto-sync.json"
+  const { uploadedPayloads, tempDeleteUrls } = await installWebdavBackupRoute(
+    context,
+    webdavFileUrl,
+  )
+
+  const syncedAccount = createStoredAccount({
+    id: "webdav-auto-sync-account",
+    site_name: "WebDAV Auto Sync Account",
+    site_url: "https://webdav-auto-sync-account.example.invalid",
+    account_info: {
+      id: "901",
+      username: "auto-sync-user",
+      access_token: "auto-sync-token",
+    },
+  })
+  const syncedProfile = createStoredApiCredentialProfile({
+    id: "webdav-auto-sync-profile",
+    name: "WebDAV Auto Sync Profile",
+    baseUrl: "https://webdav-auto-sync-profile.example.invalid",
+    apiKey: "sk-webdav-auto-sync-profile",
+    createdAt: now,
+    updatedAt: now,
+  })
+
+  await setPlasmoStorageValue(
+    serviceWorker,
+    STORAGE_KEYS.ACCOUNTS,
+    normalizeAccountStorageConfigForWrite(
+      {
+        ...createDefaultAccountStorageConfig(now),
+        accounts: [syncedAccount],
+        pinnedAccountIds: [syncedAccount.id],
+        orderedAccountIds: [syncedAccount.id],
+      } as AccountStorageConfig,
+      now,
+    ),
+  )
+  await seedApiCredentialProfiles(serviceWorker, [syncedProfile])
+  await seedUserPreferences(serviceWorker, {
+    currencyType: "CNY",
+    actionClickBehavior: "sidepanel",
+    webdav: {
+      url: webdavFileUrl,
+      username: "webdav-user",
+      password: "webdav-password",
+      autoSync: false,
+      syncInterval: 3600,
+      syncStrategy: WEBDAV_SYNC_STRATEGIES.UPLOAD_ONLY,
+    },
+  })
+
+  await page.goto(
+    `chrome-extension://${extensionId}/${OPTIONS_PAGE_PATH}?tab=dataBackup&anchor=${WEBDAV_AUTO_SYNC_TARGET_IDS.root}#${MENU_ITEM_IDS.BASIC}`,
+  )
+  await waitForExtensionRoot(page)
+
+  await expect(
+    page.locator(`#${WEBDAV_AUTO_SYNC_TARGET_IDS.root}`),
+  ).toBeVisible()
+  await page.locator(`#${WEBDAV_AUTO_SYNC_TARGET_IDS.enable} button`).click()
+  await page.locator(`#${WEBDAV_AUTO_SYNC_TARGET_IDS.interval}`).fill("120")
+  await page.locator(`#${WEBDAV_AUTO_SYNC_TARGET_IDS.saveSettings}`).click()
+  await expect(
+    page.getByText("WebDAV Auto Sync Update successful"),
+  ).toBeVisible()
+
+  await page.locator(`#${WEBDAV_AUTO_SYNC_TARGET_IDS.syncNow}`).click()
+  await expect(page.getByText("同步成功")).toBeVisible()
+
+  await expect.poll(() => uploadedPayloads.length).toBe(1)
+  expect(tempDeleteUrls).toEqual([])
+  expect(uploadedPayloads[0]).toMatchObject({
+    version: "2.0",
+    accounts: {
+      accounts: [
+        expect.objectContaining({
+          id: "webdav-auto-sync-account",
+          site_name: "WebDAV Auto Sync Account",
+        }),
+      ],
+    },
+    apiCredentialProfiles: {
+      profiles: [
+        expect.objectContaining({
+          id: "webdav-auto-sync-profile",
+          name: "WebDAV Auto Sync Profile",
+        }),
+      ],
+    },
+    preferences: expect.objectContaining({
+      currencyType: "CNY",
+      actionClickBehavior: "sidepanel",
+    }),
+  })
+
+  await expect(page.getByText("Sync successful")).toBeVisible()
 })

--- a/e2e/keyManagementCommonFlow.spec.ts
+++ b/e2e/keyManagementCommonFlow.spec.ts
@@ -4,7 +4,10 @@ import {
   getKeyManagementTokenRowTestId,
   KEY_MANAGEMENT_TEST_IDS,
 } from "~/features/KeyManagement/testIds"
+import { ACCOUNT_KEY_AUTO_PROVISIONING_STORAGE_KEYS } from "~/services/core/storageKeys"
 import { AuthTypeEnum, type ApiToken } from "~/types"
+import type { AccountKeyRepairProgress } from "~/types/accountKeyAutoProvisioning"
+import { ACCOUNT_KEY_REPAIR_JOB_STATES } from "~/types/accountKeyAutoProvisioning"
 import { expect, test } from "~~/e2e/fixtures/extensionTest"
 import {
   verifyAccountKeyLifecycleUsage,
@@ -22,6 +25,7 @@ import {
 } from "~~/e2e/utils/commonUserFlows"
 import {
   expectPermissionOnboardingHidden,
+  getPlasmoStorageRawValue,
   getServiceWorker,
 } from "~~/e2e/utils/extensionState"
 import { waitForExtensionRoot } from "~~/e2e/utils/lazyLoading"
@@ -111,6 +115,18 @@ async function stubSharedChatServiceCredentialRoutes(
       body: JSON.stringify({ error: "Unhandled SharedChat E2E route" }),
     })
   })
+}
+
+async function readJsonStorageValue<T>(
+  serviceWorker: Awaited<ReturnType<typeof getServiceWorker>>,
+  storageKey: string,
+): Promise<T | null> {
+  const raw = await getPlasmoStorageRawValue<unknown>(serviceWorker, storageKey)
+  if (typeof raw !== "string") {
+    return null
+  }
+
+  return JSON.parse(raw) as T
 }
 
 test.beforeEach(async ({ context, page }) => {
@@ -346,6 +362,158 @@ test("filters keys by search query and shows the no-results state", async ({
   await searchInput.fill("")
   await expect(page.getByRole("heading", { name: "Alpha Key" })).toBeVisible()
   await expect(page.getByRole("heading", { name: "Beta Key" })).toBeVisible()
+})
+
+test("repairs missing account keys and deletes invalid group keys", async ({
+  context,
+  extensionId,
+  page,
+}) => {
+  const serviceWorker = await getServiceWorker(context)
+  const accountId = "e2e-key-repair-account"
+  const baseUrl = "https://key-repair.example.com"
+
+  await seedStoredAccounts(serviceWorker, [
+    createStoredAccount({
+      id: accountId,
+      site_name: "Key Repair Source",
+      site_url: baseUrl,
+      account_info: {
+        id: "1",
+        access_token: "repair-token",
+        username: "repair-user",
+      },
+    }),
+  ])
+  await stubNewApiSiteRoutes(context, {
+    baseUrl,
+    accessToken: "repair-token",
+    username: "repair-user",
+    groups: {
+      default: { desc: "Default", ratio: 1 },
+      vip: { desc: "VIP", ratio: 1.5 },
+    },
+    initialTokens: [
+      createStubApiToken({
+        id: 1,
+        name: "Default Key",
+        key: "sk-default-token",
+        group: "default",
+      }),
+      createStubApiToken({
+        id: 2,
+        name: "Legacy Group Key",
+        key: "sk-legacy-token",
+        group: "legacy",
+      }),
+    ],
+  })
+
+  await page.goto(
+    `chrome-extension://${extensionId}/${OPTIONS_PAGE_PATH}#keys?accountId=${accountId}`,
+  )
+  await waitForExtensionRoot(page)
+  await expectPermissionOnboardingHidden(page)
+  await expect(page.getByRole("heading", { name: "Default Key" })).toBeVisible()
+  await expect(
+    page.getByRole("heading", { name: "Legacy Group Key" }),
+  ).toBeVisible()
+
+  await page.getByRole("button", { name: "Key check" }).click()
+  await expect(
+    page.getByRole("heading", { name: "Key coverage check" }),
+  ).toBeVisible()
+  await page.getByRole("button", { name: "Start check and fill gaps" }).click()
+
+  await expect
+    .poll(
+      async () => {
+        const progress = await readJsonStorageValue<AccountKeyRepairProgress>(
+          serviceWorker,
+          ACCOUNT_KEY_AUTO_PROVISIONING_STORAGE_KEYS.REPAIR_PROGRESS,
+        )
+        return progress?.state
+      },
+      { timeout: 30_000 },
+    )
+    .toBe(ACCOUNT_KEY_REPAIR_JOB_STATES.Completed)
+
+  const completedProgress =
+    await readJsonStorageValue<AccountKeyRepairProgress>(
+      serviceWorker,
+      ACCOUNT_KEY_AUTO_PROVISIONING_STORAGE_KEYS.REPAIR_PROGRESS,
+    )
+
+  expect(completedProgress?.summary).toMatchObject({
+    created: 1,
+    availableGroups: 2,
+    coveredGroups: 2,
+    createdKeys: 1,
+    invalidKeys: 1,
+  })
+  expect(completedProgress?.results[0]).toMatchObject({
+    accountId,
+    accountName: "Key Repair Source",
+    availableGroups: ["default", "vip"],
+    coveredGroups: ["default", "vip"],
+    createdGroups: ["vip"],
+    invalidTokens: [
+      expect.objectContaining({
+        tokenId: 2,
+        tokenName: "Legacy Group Key",
+        group: "legacy",
+      }),
+    ],
+  })
+
+  await expect(page.getByText("Covered 2/2 groups")).toBeVisible()
+  await expect(page.getByText("Created: vip")).toBeVisible()
+  await expect(page.getByTestId("repair-missing-keys-result-count")).toHaveText(
+    "1/1",
+  )
+
+  await page.getByRole("button", { name: /Invalid keys/ }).click()
+  await expect(page.getByTestId("repair-missing-keys-result-count")).toHaveText(
+    "1/1",
+  )
+  await expect(
+    page.getByRole("checkbox", { name: "Legacy Group Key", exact: true }),
+  ).toBeVisible()
+  await expect(
+    page.getByText("Group legacy is currently unavailable"),
+  ).toBeVisible()
+
+  await page
+    .getByRole("checkbox", { name: "Legacy Group Key", exact: true })
+    .click()
+  await page.getByRole("button", { name: "Delete selected" }).click()
+  await expect(
+    page.getByText(
+      "These keys will also be deleted from the corresponding sites and cannot be restored through the extension.",
+    ),
+  ).toBeVisible()
+  await page.getByTestId("repair-invalid-keys-confirm-delete").click()
+
+  await expect(page.getByText("Deleted 1 invalid key")).toBeVisible()
+  await expect(page.getByText("No invalid keys")).toBeVisible()
+  await expect(
+    page.getByRole("checkbox", { name: "Legacy Group Key", exact: true }),
+  ).toHaveCount(0)
+  await expect(page.getByTestId("repair-missing-keys-result-count")).toHaveText(
+    "0/0",
+  )
+  await expect
+    .poll(
+      async () => {
+        const progress = await readJsonStorageValue<AccountKeyRepairProgress>(
+          serviceWorker,
+          ACCOUNT_KEY_AUTO_PROVISIONING_STORAGE_KEYS.REPAIR_PROGRESS,
+        )
+        return progress?.summary.invalidKeys
+      },
+      { timeout: 10_000 },
+    )
+    .toBe(0)
 })
 
 test("saves a key to API credential profiles and opens the profiles page", async ({

--- a/e2e/keyManagementCommonFlow.spec.ts
+++ b/e2e/keyManagementCommonFlow.spec.ts
@@ -25,7 +25,7 @@ import {
 } from "~~/e2e/utils/commonUserFlows"
 import {
   expectPermissionOnboardingHidden,
-  getPlasmoStorageRawValue,
+  getPlasmoStorageJsonValue,
   getServiceWorker,
 } from "~~/e2e/utils/extensionState"
 import { waitForExtensionRoot } from "~~/e2e/utils/lazyLoading"
@@ -115,18 +115,6 @@ async function stubSharedChatServiceCredentialRoutes(
       body: JSON.stringify({ error: "Unhandled SharedChat E2E route" }),
     })
   })
-}
-
-async function readJsonStorageValue<T>(
-  serviceWorker: Awaited<ReturnType<typeof getServiceWorker>>,
-  storageKey: string,
-): Promise<T | null> {
-  const raw = await getPlasmoStorageRawValue<unknown>(serviceWorker, storageKey)
-  if (typeof raw !== "string") {
-    return null
-  }
-
-  return JSON.parse(raw) as T
 }
 
 test.beforeEach(async ({ context, page }) => {
@@ -428,10 +416,11 @@ test("repairs missing account keys and deletes invalid group keys", async ({
   await expect
     .poll(
       async () => {
-        const progress = await readJsonStorageValue<AccountKeyRepairProgress>(
-          serviceWorker,
-          ACCOUNT_KEY_AUTO_PROVISIONING_STORAGE_KEYS.REPAIR_PROGRESS,
-        )
+        const progress =
+          await getPlasmoStorageJsonValue<AccountKeyRepairProgress>(
+            serviceWorker,
+            ACCOUNT_KEY_AUTO_PROVISIONING_STORAGE_KEYS.REPAIR_PROGRESS,
+          )
         return progress?.state
       },
       { timeout: 30_000 },
@@ -439,7 +428,7 @@ test("repairs missing account keys and deletes invalid group keys", async ({
     .toBe(ACCOUNT_KEY_REPAIR_JOB_STATES.Completed)
 
   const completedProgress =
-    await readJsonStorageValue<AccountKeyRepairProgress>(
+    await getPlasmoStorageJsonValue<AccountKeyRepairProgress>(
       serviceWorker,
       ACCOUNT_KEY_AUTO_PROVISIONING_STORAGE_KEYS.REPAIR_PROGRESS,
     )
@@ -505,10 +494,11 @@ test("repairs missing account keys and deletes invalid group keys", async ({
   await expect
     .poll(
       async () => {
-        const progress = await readJsonStorageValue<AccountKeyRepairProgress>(
-          serviceWorker,
-          ACCOUNT_KEY_AUTO_PROVISIONING_STORAGE_KEYS.REPAIR_PROGRESS,
-        )
+        const progress =
+          await getPlasmoStorageJsonValue<AccountKeyRepairProgress>(
+            serviceWorker,
+            ACCOUNT_KEY_AUTO_PROVISIONING_STORAGE_KEYS.REPAIR_PROGRESS,
+          )
         return progress?.summary.invalidKeys
       },
       { timeout: 10_000 },

--- a/e2e/keyManagementCommonFlow.spec.ts
+++ b/e2e/keyManagementCommonFlow.spec.ts
@@ -25,6 +25,7 @@ import {
 } from "~~/e2e/utils/commonUserFlows"
 import {
   expectPermissionOnboardingHidden,
+  expectPlasmoStorageJsonValueToBecome,
   getPlasmoStorageJsonValue,
   getServiceWorker,
 } from "~~/e2e/utils/extensionState"
@@ -413,19 +414,15 @@ test("repairs missing account keys and deletes invalid group keys", async ({
   ).toBeVisible()
   await page.getByRole("button", { name: "Start check and fill gaps" }).click()
 
-  await expect
-    .poll(
-      async () => {
-        const progress =
-          await getPlasmoStorageJsonValue<AccountKeyRepairProgress>(
-            serviceWorker,
-            ACCOUNT_KEY_AUTO_PROVISIONING_STORAGE_KEYS.REPAIR_PROGRESS,
-          )
-        return progress?.state
-      },
-      { timeout: 30_000 },
-    )
-    .toBe(ACCOUNT_KEY_REPAIR_JOB_STATES.Completed)
+  await expectPlasmoStorageJsonValueToBecome<
+    AccountKeyRepairProgress,
+    string | undefined
+  >(
+    serviceWorker,
+    ACCOUNT_KEY_AUTO_PROVISIONING_STORAGE_KEYS.REPAIR_PROGRESS,
+    (progress) => progress?.state,
+    ACCOUNT_KEY_REPAIR_JOB_STATES.Completed,
+  )
 
   const completedProgress =
     await getPlasmoStorageJsonValue<AccountKeyRepairProgress>(
@@ -491,19 +488,16 @@ test("repairs missing account keys and deletes invalid group keys", async ({
   await expect(page.getByTestId("repair-missing-keys-result-count")).toHaveText(
     "0/0",
   )
-  await expect
-    .poll(
-      async () => {
-        const progress =
-          await getPlasmoStorageJsonValue<AccountKeyRepairProgress>(
-            serviceWorker,
-            ACCOUNT_KEY_AUTO_PROVISIONING_STORAGE_KEYS.REPAIR_PROGRESS,
-          )
-        return progress?.summary.invalidKeys
-      },
-      { timeout: 10_000 },
-    )
-    .toBe(0)
+  await expectPlasmoStorageJsonValueToBecome<
+    AccountKeyRepairProgress,
+    number | undefined
+  >(
+    serviceWorker,
+    ACCOUNT_KEY_AUTO_PROVISIONING_STORAGE_KEYS.REPAIR_PROGRESS,
+    (progress) => progress?.summary.invalidKeys,
+    0,
+    10_000,
+  )
 })
 
 test("saves a key to API credential profiles and opens the profiles page", async ({

--- a/e2e/managedSiteCoreFlows.spec.ts
+++ b/e2e/managedSiteCoreFlows.spec.ts
@@ -994,3 +994,91 @@ test("applies model redirect mapping during selected managed-site model sync thr
     }),
   ])
 })
+
+test("clears selected model redirect mappings from managed-site settings", async ({
+  context,
+  extensionId,
+  page,
+}) => {
+  await seedManagedSitePreferences(context)
+  const { updatePayloads } = await stubManagedSiteAdminRoutes(context, {
+    channels: [
+      createManagedSiteChannel({
+        id: 101,
+        name: "Redirect OpenAI",
+        models: "legacy-openai",
+        model_mapping: JSON.stringify({
+          "gpt-4o-mini": "openai/gpt-4o-mini",
+        }),
+      }),
+      createManagedSiteChannel({
+        id: 202,
+        name: "Empty Anthropic",
+        models: "legacy-anthropic",
+        model_mapping: "{}",
+      }),
+      createManagedSiteChannel({
+        id: 303,
+        name: "Keep Gemini",
+        models: "legacy-gemini",
+        model_mapping: JSON.stringify({
+          "gemini-pro": "google/gemini-pro",
+        }),
+      }),
+    ],
+  })
+
+  await page.goto(
+    basicSettingsUrl(extensionId, {
+      tab: "managedSite",
+      anchor: "managed-site-model-redirect",
+    }),
+  )
+  await waitForExtensionRoot(page)
+  await expectPermissionOnboardingHidden(page)
+
+  await expect(page.locator("#managed-site-model-redirect")).toContainText(
+    "Model Redirect",
+  )
+  await expect(
+    page.locator("#managed-site-model-redirect-bulk-clear"),
+  ).toBeEnabled()
+  await page.locator("#managed-site-model-redirect-bulk-clear").click()
+
+  await expect(page.getByText("Channels", { exact: true })).toBeVisible()
+  await expect(page.getByText("Redirect OpenAI")).toBeVisible()
+  await expect(page.getByText("Keep Gemini")).toBeVisible()
+  await page.getByRole("checkbox", { name: "Keep Gemini (#303)" }).click()
+  await page.getByRole("button", { name: "Continue" }).click()
+
+  await expect(page.getByText("Clear model redirect maps?")).toBeVisible()
+  await page.getByRole("button", { name: "Clear", exact: true }).click()
+
+  await expect(
+    page.getByText("Cleared 1 channel(s); 1 already empty."),
+  ).toBeVisible()
+  await expect
+    .poll(() =>
+      updatePayloads.some(
+        (payload) =>
+          typeof payload === "object" &&
+          payload !== null &&
+          "id" in payload &&
+          payload.id === 101 &&
+          "models" in payload &&
+          payload.models === "legacy-openai" &&
+          "model_mapping" in payload &&
+          payload.model_mapping === "{}",
+      ),
+    )
+    .toBe(true)
+  expect(
+    updatePayloads.some(
+      (payload) =>
+        typeof payload === "object" &&
+        payload !== null &&
+        "id" in payload &&
+        (payload.id === 202 || payload.id === 303),
+    ),
+  ).toBe(false)
+})

--- a/e2e/managedSiteCoreFlows.spec.ts
+++ b/e2e/managedSiteCoreFlows.spec.ts
@@ -5,7 +5,6 @@ import { OPTIONS_PAGE_PATH } from "~/constants/extensionPages"
 import { MENU_ITEM_IDS } from "~/constants/optionsMenuIds"
 import { SITE_TYPES } from "~/constants/siteType"
 import { BASIC_SETTINGS_TEST_IDS } from "~/features/BasicSettings/testIds"
-import { STORAGE_KEYS } from "~/services/core/storageKeys"
 import { CHANNEL_STATUS, type ManagedSiteChannel } from "~/types/managedSite"
 import { expect, test } from "~~/e2e/fixtures/extensionTest"
 import {
@@ -18,6 +17,7 @@ import {
   expectPermissionOnboardingHidden,
   getPlasmoStorageRawValue,
   getServiceWorker,
+  getStoredUserPreferences,
   setPlasmoStorageValue,
 } from "~~/e2e/utils/extensionState"
 import { waitForExtensionRoot } from "~~/e2e/utils/lazyLoading"
@@ -159,20 +159,7 @@ async function readStoredPreferences(
   context: BrowserContext,
 ): Promise<Record<string, unknown>> {
   const serviceWorker = await getServiceWorker(context)
-  const raw = await getPlasmoStorageRawValue<unknown>(
-    serviceWorker,
-    STORAGE_KEYS.USER_PREFERENCES,
-  )
-
-  if (typeof raw !== "string") {
-    return {}
-  }
-
-  try {
-    return JSON.parse(raw) as Record<string, unknown>
-  } catch {
-    return {}
-  }
+  return await getStoredUserPreferences(serviceWorker)
 }
 
 async function readStoredManagedSiteModelSync(

--- a/e2e/managedSiteCoreFlows.spec.ts
+++ b/e2e/managedSiteCoreFlows.spec.ts
@@ -4,6 +4,7 @@ import { ChannelType } from "~/constants"
 import { OPTIONS_PAGE_PATH } from "~/constants/extensionPages"
 import { MENU_ITEM_IDS } from "~/constants/optionsMenuIds"
 import { SITE_TYPES } from "~/constants/siteType"
+import { BASIC_SETTINGS_TEST_IDS } from "~/features/BasicSettings/testIds"
 import { STORAGE_KEYS } from "~/services/core/storageKeys"
 import { CHANNEL_STATUS, type ManagedSiteChannel } from "~/types/managedSite"
 import { expect, test } from "~~/e2e/fixtures/extensionTest"
@@ -1043,16 +1044,32 @@ test("clears selected model redirect mappings from managed-site settings", async
   await expect(
     page.locator("#managed-site-model-redirect-bulk-clear"),
   ).toBeEnabled()
-  await page.locator("#managed-site-model-redirect-bulk-clear").click()
+  await page
+    .getByTestId(
+      BASIC_SETTINGS_TEST_IDS.managedSiteModelRedirectBulkClearButton,
+    )
+    .click()
 
   await expect(page.getByText("Channels", { exact: true })).toBeVisible()
   await expect(page.getByText("Redirect OpenAI")).toBeVisible()
   await expect(page.getByText("Keep Gemini")).toBeVisible()
-  await page.getByRole("checkbox", { name: "Keep Gemini (#303)" }).click()
-  await page.getByRole("button", { name: "Continue" }).click()
+  await page
+    .getByTestId(
+      `${BASIC_SETTINGS_TEST_IDS.managedSiteModelRedirectBulkClearChannelCheckboxPrefix}-303`,
+    )
+    .click()
+  await page
+    .getByTestId(
+      BASIC_SETTINGS_TEST_IDS.managedSiteModelRedirectBulkClearContinueButton,
+    )
+    .click()
 
   await expect(page.getByText("Clear model redirect maps?")).toBeVisible()
-  await page.getByRole("button", { name: "Clear", exact: true }).click()
+  await page
+    .getByTestId(
+      BASIC_SETTINGS_TEST_IDS.managedSiteModelRedirectBulkClearConfirmButton,
+    )
+    .click()
 
   await expect(
     page.getByText("Cleared 1 channel(s); 1 already empty."),

--- a/e2e/optionsOverviewDefaultRoute.spec.ts
+++ b/e2e/optionsOverviewDefaultRoute.spec.ts
@@ -82,6 +82,6 @@ test("overview action center opens disabled auto check-in settings", async ({
   await expect(
     page
       .locator(`#${SETTINGS_ANCHORS.AUTO_CHECKIN}`)
-      .getByRole("heading", { name: "Auto Check-in" }),
+      .getByRole("heading", { name: "Auto Check-in", exact: true }),
   ).toBeVisible()
 })

--- a/e2e/optionsOverviewDefaultRoute.spec.ts
+++ b/e2e/optionsOverviewDefaultRoute.spec.ts
@@ -80,6 +80,8 @@ test("overview action center opens disabled auto check-in settings", async ({
     page.locator(`#${SETTINGS_ANCHORS.AUTO_CHECKIN}`),
   ).toBeInViewport()
   await expect(
-    page.getByRole("heading", { name: "Auto Check-in" }).first(),
+    page
+      .locator(`#${SETTINGS_ANCHORS.AUTO_CHECKIN}`)
+      .getByRole("heading", { name: "Auto Check-in" }),
   ).toBeVisible()
 })

--- a/e2e/optionsOverviewDefaultRoute.spec.ts
+++ b/e2e/optionsOverviewDefaultRoute.spec.ts
@@ -1,7 +1,23 @@
 import { OPTIONS_PAGE_PATH } from "~/constants/extensionPages"
 import { MENU_ITEM_IDS } from "~/constants/optionsMenuIds"
+import { SETTINGS_ANCHORS } from "~/constants/settingsAnchors"
+import { BASIC_SETTINGS_TEST_IDS } from "~/features/BasicSettings/testIds"
 import { OPTIONS_OVERVIEW_TEST_IDS } from "~/features/OptionsOverview/testIds"
 import { expect, test } from "~~/e2e/fixtures/extensionTest"
+import {
+  forceExtensionLanguage,
+  installExtensionPageGuards,
+  seedUserPreferences,
+  stubLlmMetadataIndex,
+} from "~~/e2e/utils/commonUserFlows"
+import { getServiceWorker } from "~~/e2e/utils/extensionState"
+import { waitForExtensionRoot } from "~~/e2e/utils/lazyLoading"
+
+test.beforeEach(async ({ context, page }) => {
+  installExtensionPageGuards(page)
+  await forceExtensionLanguage(page, "en")
+  await stubLlmMetadataIndex(context)
+})
 
 test("options default route opens overview and preserves explicit basic links", async ({
   extensionId,
@@ -15,4 +31,55 @@ test("options default route opens overview and preserves explicit basic links", 
     `chrome-extension://${extensionId}/${OPTIONS_PAGE_PATH}#${MENU_ITEM_IDS.BASIC}`,
   )
   await expect(page).toHaveURL(new RegExp(`#${MENU_ITEM_IDS.BASIC}$`))
+})
+
+test("overview action center opens disabled auto check-in settings", async ({
+  context,
+  extensionId,
+  page,
+}) => {
+  const serviceWorker = await getServiceWorker(context)
+  await seedUserPreferences(serviceWorker, {
+    autoCheckin: {
+      globalEnabled: false,
+    },
+  })
+
+  await page.goto(
+    `chrome-extension://${extensionId}/${OPTIONS_PAGE_PATH}#${MENU_ITEM_IDS.OVERVIEW}`,
+  )
+  await waitForExtensionRoot(page)
+
+  await expect(page.getByTestId(OPTIONS_OVERVIEW_TEST_IDS.page)).toBeVisible()
+  const actionCenter = page.getByTestId(OPTIONS_OVERVIEW_TEST_IDS.actionCenter)
+  await expect(actionCenter).toBeVisible()
+
+  await actionCenter
+    .getByRole("button", { name: "Auto check-in", exact: true })
+    .click()
+
+  await expect
+    .poll(() => {
+      const url = new URL(page.url())
+      return {
+        hash: url.hash,
+        tab: url.searchParams.get("tab"),
+        anchor: url.searchParams.get("anchor"),
+        highlight: url.searchParams.get("highlight"),
+      }
+    })
+    .toEqual({
+      hash: `#${MENU_ITEM_IDS.BASIC}`,
+      tab: "checkinRedeem",
+      anchor: SETTINGS_ANCHORS.AUTO_CHECKIN,
+      highlight: SETTINGS_ANCHORS.AUTO_CHECKIN,
+    })
+
+  await expect(page.getByTestId(BASIC_SETTINGS_TEST_IDS.page)).toBeVisible()
+  await expect(
+    page.locator(`#${SETTINGS_ANCHORS.AUTO_CHECKIN}`),
+  ).toBeInViewport()
+  await expect(
+    page.getByRole("heading", { name: "Auto Check-in" }).first(),
+  ).toBeVisible()
 })

--- a/e2e/optionsSearchNavigation.spec.ts
+++ b/e2e/optionsSearchNavigation.spec.ts
@@ -1,6 +1,7 @@
 import { OPTIONS_PAGE_PATH } from "~/constants/extensionPages"
 import { MENU_ITEM_IDS } from "~/constants/optionsMenuIds"
 import { BASIC_SETTINGS_TEST_IDS } from "~/features/BasicSettings/testIds"
+import { WEBDAV_TARGET_IDS } from "~/features/ImportExport/searchTargets"
 import { STORAGE_KEYS } from "~/services/core/storageKeys"
 import { expect, test } from "~~/e2e/fixtures/extensionTest"
 import {
@@ -42,6 +43,27 @@ async function readRecentSearchItemIds(
   } catch {
     return []
   }
+}
+
+async function readProductAnalyticsPreferences(
+  serviceWorker: Awaited<ReturnType<typeof getServiceWorker>>,
+): Promise<{ enabled?: boolean; updatedAt?: number } | null> {
+  const raw = await getPlasmoStorageRawValue<unknown>(
+    serviceWorker,
+    STORAGE_KEYS.PRODUCT_ANALYTICS_PREFERENCES,
+  )
+
+  if (typeof raw === "string") {
+    try {
+      return JSON.parse(raw) as { enabled?: boolean; updatedAt?: number }
+    } catch {
+      return null
+    }
+  }
+
+  return raw && typeof raw === "object"
+    ? (raw as { enabled?: boolean; updatedAt?: number })
+    : null
 }
 
 test("opens a common options page from settings search", async ({
@@ -147,6 +169,120 @@ test("opens a searched settings control and preserves its tab and anchor in the 
     page.getByRole("button", { name: "Data Refresh" }),
   ).toHaveAttribute("aria-pressed", "true")
   await expect(page.getByText("Refresh Interval").first()).toBeVisible()
+})
+
+test("opens product analytics from settings search and persists opt-out", async ({
+  context,
+  extensionId,
+  page,
+}) => {
+  const serviceWorker = await getServiceWorker(context)
+
+  await page.goto(
+    `chrome-extension://${extensionId}/${OPTIONS_PAGE_PATH}#${MENU_ITEM_IDS.BASIC}`,
+  )
+  await waitForExtensionRoot(page)
+  await expectPermissionOnboardingHidden(page)
+
+  await page.getByRole("button", { name: "Open settings search" }).click()
+
+  const dialog = page.getByRole("dialog", { name: "Search settings" })
+  await expect(dialog).toBeVisible()
+  await dialog
+    .getByPlaceholder("Search settings...")
+    .fill("anonymous product analytics")
+  await dialog
+    .getByRole("option", { name: /Enable anonymous product analytics/ })
+    .first()
+    .click()
+
+  await expect(dialog).toHaveCount(0)
+  await expect(page).toHaveURL(/options\.html\?.*#basic$/)
+  await expect
+    .poll(() => {
+      const url = new URL(page.url())
+      return {
+        hash: url.hash,
+        tab: url.searchParams.get("tab"),
+        anchor: url.searchParams.get("anchor"),
+      }
+    })
+    .toEqual({
+      hash: "#basic",
+      tab: "general",
+      anchor: "product-analytics-enabled",
+    })
+
+  await expect(page.locator("#product-analytics-enabled")).toBeInViewport()
+  const productAnalyticsSwitch = page
+    .locator("#product-analytics")
+    .getByRole("switch", { name: "Toggle" })
+  await expect(productAnalyticsSwitch).toHaveAttribute("aria-checked", "true")
+
+  await productAnalyticsSwitch.click()
+
+  await expect
+    .poll(async () => {
+      const preferences = await readProductAnalyticsPreferences(serviceWorker)
+
+      return {
+        enabled: preferences?.enabled,
+        hasUpdatedAt: typeof preferences?.updatedAt === "number",
+      }
+    })
+    .toEqual({
+      enabled: false,
+      hasUpdatedAt: true,
+    })
+  await expect(productAnalyticsSwitch).toHaveAttribute("aria-checked", "false")
+
+  await page.reload()
+  await waitForExtensionRoot(page)
+
+  await expect(
+    page.locator("#product-analytics").getByRole("switch", { name: "Toggle" }),
+  ).toHaveAttribute("aria-checked", "false")
+})
+
+test("opens an import export WebDAV control from settings search", async ({
+  extensionId,
+  page,
+}) => {
+  await page.goto(
+    `chrome-extension://${extensionId}/${OPTIONS_PAGE_PATH}#${MENU_ITEM_IDS.BASIC}`,
+  )
+  await waitForExtensionRoot(page)
+  await expectPermissionOnboardingHidden(page)
+
+  await page.getByRole("button", { name: "Open settings search" }).click()
+
+  const dialog = page.getByRole("dialog", { name: "Search settings" })
+  await expect(dialog).toBeVisible()
+  await dialog.getByPlaceholder("Search settings...").fill("webdav url")
+  await dialog
+    .getByRole("option", { name: /Webdav URL/ })
+    .filter({ hasText: "Import/Export" })
+    .click()
+
+  await expect(dialog).toHaveCount(0)
+  await expect(page).toHaveURL(/options\.html\?.*#importExport$/)
+
+  await expect
+    .poll(() => {
+      const url = new URL(page.url())
+      return {
+        hash: url.hash,
+        anchor: url.searchParams.get("anchor"),
+        highlight: url.searchParams.get("highlight"),
+      }
+    })
+    .toEqual({
+      hash: "#importExport",
+      anchor: WEBDAV_TARGET_IDS.url,
+      highlight: null,
+    })
+
+  await expect(page.locator(`#${WEBDAV_TARGET_IDS.url}`)).toBeInViewport()
 })
 
 test("persists selected settings search results as recent items across page reloads", async ({

--- a/e2e/optionsSearchNavigation.spec.ts
+++ b/e2e/optionsSearchNavigation.spec.ts
@@ -1,5 +1,6 @@
 import { OPTIONS_PAGE_PATH } from "~/constants/extensionPages"
 import { MENU_ITEM_IDS } from "~/constants/optionsMenuIds"
+import { SETTINGS_ANCHORS } from "~/constants/settingsAnchors"
 import { BASIC_SETTINGS_TEST_IDS } from "~/features/BasicSettings/testIds"
 import { WEBDAV_TARGET_IDS } from "~/features/ImportExport/searchTargets"
 import { STORAGE_KEYS } from "~/services/core/storageKeys"
@@ -12,6 +13,7 @@ import {
 } from "~~/e2e/utils/commonUserFlows"
 import {
   expectPermissionOnboardingHidden,
+  getPlasmoStorageJsonValue,
   getPlasmoStorageRawValue,
   getServiceWorker,
 } from "~~/e2e/utils/extensionState"
@@ -48,22 +50,10 @@ async function readRecentSearchItemIds(
 async function readProductAnalyticsPreferences(
   serviceWorker: Awaited<ReturnType<typeof getServiceWorker>>,
 ): Promise<{ enabled?: boolean; updatedAt?: number } | null> {
-  const raw = await getPlasmoStorageRawValue<unknown>(
-    serviceWorker,
-    STORAGE_KEYS.PRODUCT_ANALYTICS_PREFERENCES,
-  )
-
-  if (typeof raw === "string") {
-    try {
-      return JSON.parse(raw) as { enabled?: boolean; updatedAt?: number }
-    } catch {
-      return null
-    }
-  }
-
-  return raw && typeof raw === "object"
-    ? (raw as { enabled?: boolean; updatedAt?: number })
-    : null
+  return await getPlasmoStorageJsonValue<{
+    enabled?: boolean
+    updatedAt?: number
+  }>(serviceWorker, STORAGE_KEYS.PRODUCT_ANALYTICS_PREFERENCES)
 }
 
 test("opens a common options page from settings search", async ({
@@ -210,12 +200,14 @@ test("opens product analytics from settings search and persists opt-out", async 
     .toEqual({
       hash: "#basic",
       tab: "general",
-      anchor: "product-analytics-enabled",
+      anchor: SETTINGS_ANCHORS.PRODUCT_ANALYTICS_ENABLED,
     })
 
-  await expect(page.locator("#product-analytics-enabled")).toBeInViewport()
+  await expect(
+    page.locator(`#${SETTINGS_ANCHORS.PRODUCT_ANALYTICS_ENABLED}`),
+  ).toBeInViewport()
   const productAnalyticsSwitch = page
-    .locator("#product-analytics")
+    .locator(`#${SETTINGS_ANCHORS.PRODUCT_ANALYTICS}`)
     .getByRole("switch", { name: "Toggle" })
   await expect(productAnalyticsSwitch).toHaveAttribute("aria-checked", "true")
 
@@ -240,7 +232,9 @@ test("opens product analytics from settings search and persists opt-out", async 
   await waitForExtensionRoot(page)
 
   await expect(
-    page.locator("#product-analytics").getByRole("switch", { name: "Toggle" }),
+    page
+      .locator(`#${SETTINGS_ANCHORS.PRODUCT_ANALYTICS}`)
+      .getByRole("switch", { name: "Toggle" }),
   ).toHaveAttribute("aria-checked", "false")
 })
 

--- a/e2e/popupSavedItems.spec.ts
+++ b/e2e/popupSavedItems.spec.ts
@@ -9,6 +9,7 @@ import {
   getAccountManagementListItemTestId,
 } from "~/features/AccountManagement/testIds"
 import { API_CREDENTIAL_PROFILES_TEST_IDS } from "~/features/ApiCredentialProfiles/testIds"
+import { SHARE_SNAPSHOT_TEST_IDS } from "~/features/ShareSnapshots/testIds"
 import {
   getSiteBookmarkListItemTestId,
   SITE_BOOKMARKS_TEST_IDS,
@@ -509,7 +510,9 @@ test("downloads an overview share snapshot from the popup and copies the fallbac
     page.getByText("Caption wasn't copied automatically."),
   ).toBeVisible()
 
-  const captionTextArea = page.locator("textarea").first()
+  const captionTextArea = page.getByTestId(
+    SHARE_SNAPSHOT_TEST_IDS.captionTextarea,
+  )
   await expect(captionTextArea).toHaveValue(/All API Hub.*Overview/s)
   await expect(captionTextArea).toHaveValue(/Total balance: \$1\.00/)
   await expect(captionTextArea).toHaveValue(/Accounts: 2/)
@@ -612,6 +615,10 @@ test("opens pending external check-ins from the popup and marks them checked in"
     .getByRole("button", { name: "Open all external check-ins" })
     .click()
 
+  await expect(
+    page.getByText("Opened external check-in for 1 account (unchecked only)."),
+  ).toBeVisible()
+
   await expectBrowserTabOpened(
     serviceWorker,
     "https://benefits.example.com/pending/redeem",
@@ -628,10 +635,6 @@ test("opens pending external check-ins from the popup and marks them checked in"
     serviceWorker,
     "https://benefits.example.com/done/checkin",
   )
-
-  await expect(
-    page.getByText("Opened external check-in for 1 account (unchecked only)."),
-  ).toBeVisible()
 
   await expect
     .poll(async () => {
@@ -699,6 +702,10 @@ test("ctrl-clicking popup external check-ins opens already checked accounts too"
     .getByRole("button", { name: "Open all external check-ins" })
     .click({ modifiers: ["Control"] })
 
+  await expect(
+    page.getByText("Opened external check-ins for 2 accounts (all)."),
+  ).toBeVisible()
+
   for (const targetUrl of [
     "https://benefits.example.com/ctrl-pending/redeem",
     "https://benefits.example.com/ctrl-pending/checkin",
@@ -707,10 +714,6 @@ test("ctrl-clicking popup external check-ins opens already checked accounts too"
   ]) {
     await expectBrowserTabOpened(serviceWorker, targetUrl)
   }
-
-  await expect(
-    page.getByText("Opened external check-ins for 2 accounts (all)."),
-  ).toBeVisible()
 
   await expect
     .poll(async () => {
@@ -787,6 +790,10 @@ test("shift-clicking popup external check-ins groups opened pages into one brows
     .getByRole("button", { name: "Open all external check-ins" })
     .click({ modifiers: ["Shift"] })
 
+  await expect(
+    page.getByText("Opened external check-in for 1 account (unchecked only)."),
+  ).toBeVisible()
+
   await expectBrowserTabsOpenedInSameWindow(serviceWorker, [
     "https://benefits.example.com/shift-pending/redeem",
     "https://benefits.example.com/shift-pending/checkin",
@@ -799,10 +806,6 @@ test("shift-clicking popup external check-ins groups opened pages into one brows
     serviceWorker,
     "https://benefits.example.com/shift-done/checkin",
   )
-
-  await expect(
-    page.getByText("Opened external check-in for 1 account (unchecked only)."),
-  ).toBeVisible()
 
   await expect
     .poll(async () => {

--- a/e2e/popupSavedItems.spec.ts
+++ b/e2e/popupSavedItems.spec.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs/promises"
 import type { Page } from "@playwright/test"
 
 import { OPTIONS_PAGE_PATH, POPUP_PAGE_PATH } from "~/constants/extensionPages"
@@ -34,6 +35,9 @@ import {
 } from "~~/e2e/utils/extensionState"
 import { waitForExtensionRoot } from "~~/e2e/utils/lazyLoading"
 
+const SHARE_SNAPSHOT_CAPTION_WRITES_KEY =
+  "__aah_e2e_share_snapshot_caption_writes__"
+
 async function readStoredBookmarks(
   serviceWorker: Awaited<ReturnType<typeof getServiceWorker>>,
 ): Promise<SiteBookmark[]> {
@@ -68,6 +72,50 @@ async function readStoredAccounts(
   } catch {
     return []
   }
+}
+
+async function installShareSnapshotDownloadFallback(page: Page) {
+  await page.addInitScript((storageKey) => {
+    window.sessionStorage.setItem(storageKey, JSON.stringify([]))
+
+    let writeTextCalls = 0
+    const readWrites = (): string[] => {
+      try {
+        const raw = window.sessionStorage.getItem(storageKey)
+        return raw ? (JSON.parse(raw) as string[]) : []
+      } catch {
+        return []
+      }
+    }
+
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: async (text: string) => {
+          writeTextCalls += 1
+          if (writeTextCalls === 1) {
+            throw new Error("caption clipboard unavailable during export")
+          }
+
+          window.sessionStorage.setItem(
+            storageKey,
+            JSON.stringify([...readWrites(), text]),
+          )
+        },
+      },
+    })
+  }, SHARE_SNAPSHOT_CAPTION_WRITES_KEY)
+}
+
+async function readShareSnapshotCaptionWrites(page: Page): Promise<string[]> {
+  return await page.evaluate((storageKey) => {
+    try {
+      const raw = window.sessionStorage.getItem(storageKey)
+      return raw ? (JSON.parse(raw) as string[]) : []
+    } catch {
+      return []
+    }
+  }, SHARE_SNAPSHOT_CAPTION_WRITES_KEY)
 }
 
 async function expectBrowserTabOpened(
@@ -371,6 +419,108 @@ test("updates popup account totals after disabling an account from management", 
       getAccountManagementListItemTestId("popup-disable-account"),
     ),
   ).toContainText("Disabled")
+})
+
+test("downloads an overview share snapshot from the popup and copies the fallback caption", async ({
+  context,
+  extensionId,
+  page,
+}) => {
+  const serviceWorker = await getServiceWorker(context)
+  await seedUserPreferences(serviceWorker, {
+    currencyType: "USD",
+    showTodayCashflow: true,
+  })
+  await seedStoredAccounts(serviceWorker, [
+    createStoredAccount({
+      id: "popup-share-included",
+      site_name: "Popup Share Included",
+      site_url: "https://share-included.example.com",
+      last_sync_time: 1_765_000_000_000,
+      account_info: {
+        id: "731",
+        username: "share-included-user",
+        access_token: "share-included-token",
+        quota: 500000,
+        today_income: 200000,
+        today_quota_consumption: 100000,
+      },
+    }),
+    createStoredAccount({
+      id: "popup-share-excluded",
+      site_name: "Popup Share Excluded",
+      site_url: "https://share-excluded.example.com",
+      excludeFromTotalBalance: true,
+      excludeFromTodayIncome: true,
+      last_sync_time: 1_765_000_100_000,
+      account_info: {
+        id: "732",
+        username: "share-excluded-user",
+        access_token: "share-excluded-token",
+        quota: 700000,
+        today_income: 300000,
+        today_quota_consumption: 200000,
+      },
+    }),
+    createStoredAccount({
+      id: "popup-share-disabled",
+      site_name: "Popup Share Disabled",
+      site_url: "https://share-disabled.example.com",
+      disabled: true,
+      last_sync_time: 1_765_000_200_000,
+      account_info: {
+        id: "733",
+        username: "share-disabled-user",
+        access_token: "share-disabled-token",
+        quota: 900000,
+        today_income: 400000,
+        today_quota_consumption: 300000,
+      },
+    }),
+  ])
+
+  await installShareSnapshotDownloadFallback(page)
+  await page.goto(`chrome-extension://${extensionId}/${POPUP_PAGE_PATH}`)
+  await waitForExtensionRoot(page)
+
+  await expect(page.getByTestId(getPopupViewTestId("accounts"))).toBeVisible()
+  await expect(
+    page.getByRole("button", { name: "Popup Share Included" }),
+  ).toBeVisible()
+
+  const downloadPromise = page.waitForEvent("download")
+  await page.getByRole("button", { name: "Share overview snapshot" }).click()
+  const download = await downloadPromise
+
+  expect(download.suggestedFilename()).toMatch(
+    /^all-api-hub-snapshot-overview-\d{4}-\d{2}-\d{2}\.png$/,
+  )
+  const downloadPath = await download.path()
+  if (!downloadPath) {
+    throw new Error("Share snapshot download did not produce a readable file")
+  }
+  const pngBytes = await fs.readFile(downloadPath)
+  expect([...pngBytes.subarray(0, 8)]).toEqual([
+    0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+  ])
+
+  await expect(page.getByText("Snapshot downloaded")).toBeVisible()
+  await expect(
+    page.getByText("Caption wasn't copied automatically."),
+  ).toBeVisible()
+
+  const captionTextArea = page.locator("textarea").first()
+  await expect(captionTextArea).toHaveValue(/All API Hub.*Overview/s)
+  await expect(captionTextArea).toHaveValue(/Total balance: \$1\.00/)
+  await expect(captionTextArea).toHaveValue(/Accounts: 2/)
+  await expect(captionTextArea).not.toHaveValue(/Popup Share Included/)
+  await expect(captionTextArea).not.toHaveValue(/share-included\.example/)
+
+  await page.getByRole("button", { name: "Copy caption" }).click()
+  await expect(page.getByText("Caption copied")).toBeVisible()
+  await expect
+    .poll(() => readShareSnapshotCaptionWrites(page))
+    .toEqual([await captionTextArea.inputValue()])
 })
 
 test("opens a saved account site from the popup accounts tab", async ({

--- a/e2e/productAnnouncementsUserFlows.spec.ts
+++ b/e2e/productAnnouncementsUserFlows.spec.ts
@@ -1,7 +1,12 @@
 import { OPTIONS_PAGE_PATH, POPUP_PAGE_PATH } from "~/constants/extensionPages"
 import { MENU_ITEM_IDS } from "~/constants/optionsMenuIds"
-import { PRODUCT_ANNOUNCEMENT_TEST_IDS } from "~/features/ProductAnnouncements/testIds"
+import {
+  getProductAnnouncementDismissButtonTestId,
+  getProductAnnouncementRestoreButtonTestId,
+  PRODUCT_ANNOUNCEMENT_TEST_IDS,
+} from "~/features/ProductAnnouncements/testIds"
 import { STORAGE_KEYS } from "~/services/core/storageKeys"
+import { PRODUCT_ANNOUNCEMENT_REMOTE_URL } from "~/services/productAnnouncements/constants"
 import type {
   ProductAnnouncementState,
   RawProductAnnouncementFeed,
@@ -24,8 +29,6 @@ const RISK_ANNOUNCEMENT_ID = "e2e-critical-product-risk"
 const INFO_ANNOUNCEMENT_ID = "e2e-info-product-update"
 const RISK_ANNOUNCEMENT_TITLE = "Critical extension compatibility notice"
 const INFO_ANNOUNCEMENT_TITLE = "New dashboard overview available"
-const PRODUCT_ANNOUNCEMENT_REMOTE_URL =
-  "https://raw.githubusercontent.com/qixing-jk/all-api-hub/main/public/product-announcements.json"
 
 const PRODUCT_ANNOUNCEMENT_FEED: RawProductAnnouncementFeed = {
   schemaVersion: 1,
@@ -168,7 +171,9 @@ test("persists product announcement seen, dismiss, and restore state across opti
 
   await page
     .getByTestId(PRODUCT_ANNOUNCEMENT_TEST_IDS.activeList)
-    .getByRole("button", { name: `Dismiss ${RISK_ANNOUNCEMENT_TITLE}` })
+    .getByTestId(
+      getProductAnnouncementDismissButtonTestId(RISK_ANNOUNCEMENT_ID),
+    )
     .click()
 
   await expect
@@ -198,14 +203,16 @@ test("persists product announcement seen, dismiss, and restore state across opti
   ).toHaveCount(0)
   await popupPage.close()
 
-  await page.getByRole("button", { name: "Dismissed" }).click()
+  await page.getByTestId(PRODUCT_ANNOUNCEMENT_TEST_IDS.dismissedTab).click()
   await expect(
     page.getByTestId(PRODUCT_ANNOUNCEMENT_TEST_IDS.dismissedList),
   ).toContainText(RISK_ANNOUNCEMENT_TITLE)
 
   await page
     .getByTestId(PRODUCT_ANNOUNCEMENT_TEST_IDS.dismissedList)
-    .getByRole("button", { name: `Restore ${RISK_ANNOUNCEMENT_TITLE}` })
+    .getByTestId(
+      getProductAnnouncementRestoreButtonTestId(RISK_ANNOUNCEMENT_ID),
+    )
     .click()
 
   await expect

--- a/e2e/productAnnouncementsUserFlows.spec.ts
+++ b/e2e/productAnnouncementsUserFlows.spec.ts
@@ -1,0 +1,232 @@
+import { OPTIONS_PAGE_PATH, POPUP_PAGE_PATH } from "~/constants/extensionPages"
+import { MENU_ITEM_IDS } from "~/constants/optionsMenuIds"
+import { PRODUCT_ANNOUNCEMENT_TEST_IDS } from "~/features/ProductAnnouncements/testIds"
+import { STORAGE_KEYS } from "~/services/core/storageKeys"
+import type {
+  ProductAnnouncementState,
+  RawProductAnnouncementFeed,
+} from "~/services/productAnnouncements/types"
+import { expect, test } from "~~/e2e/fixtures/extensionTest"
+import {
+  forceExtensionLanguage,
+  installExtensionPageGuards,
+  stubLlmMetadataIndex,
+} from "~~/e2e/utils/commonUserFlows"
+import {
+  expectPermissionOnboardingHidden,
+  getPlasmoStorageRawValue,
+  getServiceWorker,
+  setPlasmoStorageValue,
+} from "~~/e2e/utils/extensionState"
+import { waitForExtensionRoot } from "~~/e2e/utils/lazyLoading"
+
+const RISK_ANNOUNCEMENT_ID = "e2e-critical-product-risk"
+const INFO_ANNOUNCEMENT_ID = "e2e-info-product-update"
+const RISK_ANNOUNCEMENT_TITLE = "Critical extension compatibility notice"
+const INFO_ANNOUNCEMENT_TITLE = "New dashboard overview available"
+const PRODUCT_ANNOUNCEMENT_REMOTE_URL =
+  "https://raw.githubusercontent.com/qixing-jk/all-api-hub/main/public/product-announcements.json"
+
+const PRODUCT_ANNOUNCEMENT_FEED: RawProductAnnouncementFeed = {
+  schemaVersion: 1,
+  defaultLocale: "en",
+  announcements: [
+    {
+      id: RISK_ANNOUNCEMENT_ID,
+      revision: 2,
+      severity: "critical",
+      priority: 100,
+      affectedVersions: "*",
+      startsAt: "2026-01-01T00:00:00.000Z",
+      expiresAt: "2099-01-01T00:00:00.000Z",
+      content: {
+        en: {
+          title: RISK_ANNOUNCEMENT_TITLE,
+          message:
+            "Open this notice from the header before updating managed sites.",
+          cta: {
+            label: "Read compatibility notes",
+            url: "https://example.invalid/product-announcements/risk",
+          },
+        },
+      },
+    },
+    {
+      id: INFO_ANNOUNCEMENT_ID,
+      revision: 1,
+      severity: "info",
+      priority: 10,
+      affectedVersions: "*",
+      startsAt: "2026-01-01T00:00:00.000Z",
+      expiresAt: "2099-01-01T00:00:00.000Z",
+      content: {
+        en: {
+          title: INFO_ANNOUNCEMENT_TITLE,
+          message: "The options overview now summarizes setup and automation.",
+        },
+      },
+    },
+  ],
+}
+
+function createProductAnnouncementState(): ProductAnnouncementState {
+  return {
+    schemaVersion: 1,
+    cachedFeed: PRODUCT_ANNOUNCEMENT_FEED,
+    lastFetchedAt: Date.now(),
+    dismissed: {},
+    seenAt: {},
+    lastShownAt: {},
+  }
+}
+
+async function seedProductAnnouncementState(
+  serviceWorker: Awaited<ReturnType<typeof getServiceWorker>>,
+) {
+  await setPlasmoStorageValue(
+    serviceWorker,
+    STORAGE_KEYS.PRODUCT_ANNOUNCEMENTS_STATE,
+    createProductAnnouncementState(),
+  )
+}
+
+async function readProductAnnouncementState(
+  serviceWorker: Awaited<ReturnType<typeof getServiceWorker>>,
+): Promise<ProductAnnouncementState | null> {
+  const raw = await getPlasmoStorageRawValue<unknown>(
+    serviceWorker,
+    STORAGE_KEYS.PRODUCT_ANNOUNCEMENTS_STATE,
+  )
+
+  if (typeof raw === "string") {
+    return JSON.parse(raw) as ProductAnnouncementState
+  }
+
+  return raw && typeof raw === "object"
+    ? (raw as ProductAnnouncementState)
+    : null
+}
+
+test.beforeEach(async ({ context, page }) => {
+  installExtensionPageGuards(page)
+  await forceExtensionLanguage(page, "en")
+  await stubLlmMetadataIndex(context)
+  await context.route(PRODUCT_ANNOUNCEMENT_REMOTE_URL, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(PRODUCT_ANNOUNCEMENT_FEED),
+    }),
+  )
+})
+
+test("persists product announcement seen, dismiss, and restore state across options and popup headers", async ({
+  context,
+  extensionId,
+  page,
+}) => {
+  const serviceWorker = await getServiceWorker(context)
+  await seedProductAnnouncementState(serviceWorker)
+
+  await page.goto(
+    `chrome-extension://${extensionId}/${OPTIONS_PAGE_PATH}#${MENU_ITEM_IDS.OVERVIEW}`,
+  )
+  await waitForExtensionRoot(page)
+  await expectPermissionOnboardingHidden(page)
+
+  await expect(page.getByText(RISK_ANNOUNCEMENT_TITLE)).toBeVisible()
+  await expect(
+    page.getByText(
+      "Open this notice from the header before updating managed sites.",
+    ),
+  ).toBeVisible()
+  await expect(
+    page.getByTestId(PRODUCT_ANNOUNCEMENT_TEST_IDS.badge),
+  ).toHaveText("1")
+
+  await page.getByTestId(PRODUCT_ANNOUNCEMENT_TEST_IDS.button).click()
+
+  await expect(
+    page.getByTestId(PRODUCT_ANNOUNCEMENT_TEST_IDS.popover),
+  ).toBeVisible()
+  await expect(
+    page.getByTestId(PRODUCT_ANNOUNCEMENT_TEST_IDS.activeList),
+  ).toContainText(RISK_ANNOUNCEMENT_TITLE)
+  await expect(
+    page.getByTestId(PRODUCT_ANNOUNCEMENT_TEST_IDS.activeList),
+  ).toContainText(INFO_ANNOUNCEMENT_TITLE)
+
+  await expect
+    .poll(async () => {
+      const state = await readProductAnnouncementState(serviceWorker)
+      return {
+        infoSeen: typeof state?.seenAt[INFO_ANNOUNCEMENT_ID] === "number",
+        riskSeen: typeof state?.seenAt[RISK_ANNOUNCEMENT_ID] === "number",
+      }
+    })
+    .toEqual({ infoSeen: true, riskSeen: true })
+
+  await page
+    .getByTestId(PRODUCT_ANNOUNCEMENT_TEST_IDS.activeList)
+    .getByRole("button", { name: `Dismiss ${RISK_ANNOUNCEMENT_TITLE}` })
+    .click()
+
+  await expect
+    .poll(async () => {
+      const state = await readProductAnnouncementState(serviceWorker)
+      return state?.dismissed[RISK_ANNOUNCEMENT_ID]
+    })
+    .toBe(2)
+
+  await expect(page.getByText(RISK_ANNOUNCEMENT_TITLE)).toHaveCount(0)
+  await expect(page.getByText(INFO_ANNOUNCEMENT_TITLE)).toBeVisible()
+  await expect(
+    page.getByTestId(PRODUCT_ANNOUNCEMENT_TEST_IDS.badge),
+  ).toHaveCount(0)
+
+  const popupPage = await context.newPage()
+  installExtensionPageGuards(popupPage)
+  await forceExtensionLanguage(popupPage, "en")
+  await popupPage.goto(`chrome-extension://${extensionId}/${POPUP_PAGE_PATH}`)
+  await waitForExtensionRoot(popupPage)
+
+  await expect(
+    popupPage.getByTestId(PRODUCT_ANNOUNCEMENT_TEST_IDS.reservedSlot),
+  ).toBeVisible()
+  await expect(
+    popupPage.getByTestId(PRODUCT_ANNOUNCEMENT_TEST_IDS.button),
+  ).toHaveCount(0)
+  await popupPage.close()
+
+  await page.getByRole("button", { name: "Dismissed" }).click()
+  await expect(
+    page.getByTestId(PRODUCT_ANNOUNCEMENT_TEST_IDS.dismissedList),
+  ).toContainText(RISK_ANNOUNCEMENT_TITLE)
+
+  await page
+    .getByTestId(PRODUCT_ANNOUNCEMENT_TEST_IDS.dismissedList)
+    .getByRole("button", { name: `Restore ${RISK_ANNOUNCEMENT_TITLE}` })
+    .click()
+
+  await expect
+    .poll(async () => {
+      const state = await readProductAnnouncementState(serviceWorker)
+      return state?.dismissed[RISK_ANNOUNCEMENT_ID] ?? null
+    })
+    .toBeNull()
+
+  const restoredPopupPage = await context.newPage()
+  installExtensionPageGuards(restoredPopupPage)
+  await forceExtensionLanguage(restoredPopupPage, "en")
+  await restoredPopupPage.goto(
+    `chrome-extension://${extensionId}/${POPUP_PAGE_PATH}`,
+  )
+  await waitForExtensionRoot(restoredPopupPage)
+
+  await expect(
+    restoredPopupPage.getByTestId(PRODUCT_ANNOUNCEMENT_TEST_IDS.button),
+  ).toBeVisible()
+  await expect(
+    restoredPopupPage.getByTestId(PRODUCT_ANNOUNCEMENT_TEST_IDS.badge),
+  ).toHaveText("1")
+})

--- a/e2e/productAnnouncementsUserFlows.spec.ts
+++ b/e2e/productAnnouncementsUserFlows.spec.ts
@@ -6,7 +6,7 @@ import {
   PRODUCT_ANNOUNCEMENT_TEST_IDS,
 } from "~/features/ProductAnnouncements/testIds"
 import { STORAGE_KEYS } from "~/services/core/storageKeys"
-import { PRODUCT_ANNOUNCEMENT_REMOTE_URL } from "~/services/productAnnouncements/constants"
+import { PRODUCT_ANNOUNCEMENT_REMOTE_URL } from "~/services/productAnnouncements/remoteFeed"
 import type {
   ProductAnnouncementState,
   RawProductAnnouncementFeed,

--- a/e2e/redemptionAssistUserFlows.spec.ts
+++ b/e2e/redemptionAssistUserFlows.spec.ts
@@ -442,7 +442,10 @@ test("opens Redemption Assist settings from the content prompt", async ({
 
   const contentHost = page.locator("all-api-hub-redemption-toast")
   await expect(
-    contentHost.getByRole("heading", { name: "Redemption Assist" }),
+    contentHost.getByRole("heading", {
+      name: "Redemption Assist",
+      exact: true,
+    }),
   ).toBeVisible()
 
   const settingsPagePromise = waitForExtensionPage(context, {

--- a/e2e/redemptionAssistUserFlows.spec.ts
+++ b/e2e/redemptionAssistUserFlows.spec.ts
@@ -206,7 +206,10 @@ test("detects a redemption code on a real page, redeems it for the matched accou
 
   const contentHost = page.locator("all-api-hub-redemption-toast")
   await expect(
-    contentHost.getByRole("heading", { name: "Redemption Assist" }),
+    contentHost.getByRole("heading", {
+      name: "Redemption Assist",
+      exact: true,
+    }),
   ).toBeVisible()
   await expect(
     contentHost.getByText("a1b2****c5d6", { exact: true }),

--- a/e2e/redemptionAssistUserFlows.spec.ts
+++ b/e2e/redemptionAssistUserFlows.spec.ts
@@ -1,4 +1,5 @@
-import { POPUP_PAGE_PATH } from "~/constants/extensionPages"
+import { OPTIONS_PAGE_PATH, POPUP_PAGE_PATH } from "~/constants/extensionPages"
+import { MENU_ITEM_IDS } from "~/constants/optionsMenuIds"
 import { RuntimeActionIds } from "~/constants/runtimeActions"
 import { getPopupViewTestId } from "~/entrypoints/popup/testIds"
 import { STORAGE_KEYS } from "~/services/core/storageKeys"
@@ -11,6 +12,7 @@ import {
   seedStoredAccounts,
   seedUserPreferences,
   stubNewApiSiteRoutes,
+  waitForExtensionPage,
 } from "~~/e2e/utils/commonUserFlows"
 import {
   getPlasmoStorageRawValue,
@@ -351,4 +353,122 @@ test("forwards selected redemption text from the background context-menu path to
       )?.account_info.quota
     })
     .toBe(2_250_000)
+})
+
+test("opens Redemption Assist settings from the content prompt", async ({
+  context,
+  extensionId,
+  page,
+}) => {
+  await context.route(REDEEM_PAGE_URL, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "text/html",
+      body: `<!doctype html>
+        <html lang="en">
+          <head>
+            <title>Redeem Settings Fixture</title>
+          </head>
+          <body>
+            <main>
+              <h1>Redeem Settings Center</h1>
+              <button id="copy-code">Copy ${REDEMPTION_CODE}</button>
+            </main>
+          </body>
+        </html>`,
+    })
+  })
+
+  const serviceWorker = await getServiceWorker(context)
+  await seedUserPreferences(serviceWorker, {
+    language: "en",
+    redemptionAssist: {
+      enabled: true,
+      contextMenu: {
+        enabled: true,
+      },
+      relaxedCodeValidation: false,
+      urlWhitelist: {
+        enabled: true,
+        patterns: ["^https://redeem\\.example\\.test/console/redeem"],
+        includeAccountSiteUrls: false,
+        includeCheckInAndRedeemUrls: false,
+      },
+    },
+  })
+  await seedStoredAccounts(serviceWorker, [
+    createStoredAccount({
+      id: "redeem-settings-account",
+      site_name: "Redeem Settings Hub",
+      site_url: REDEEM_SITE_URL,
+      account_info: {
+        id: "903",
+        username: "redeem-settings-user",
+        access_token: "redeem-settings-access-token",
+        quota: 1_000_000,
+      },
+      checkIn: {
+        enableDetection: false,
+        customCheckIn: {
+          url: REDEEM_PAGE_URL,
+          redeemUrl: REDEEM_PAGE_URL,
+        },
+      },
+    }),
+  ])
+
+  await page.goto(REDEEM_PAGE_URL)
+
+  await page.locator("#copy-code").evaluate((target, code) => {
+    const selection = window.getSelection()
+    const range = document.createRange()
+    range.selectNodeContents(target)
+    selection?.removeAllRanges()
+    selection?.addRange(range)
+
+    const clipboardData = new DataTransfer()
+    clipboardData.setData("text", code)
+    target.dispatchEvent(
+      new ClipboardEvent("copy", {
+        bubbles: true,
+        cancelable: true,
+        clipboardData,
+      }),
+    )
+  }, REDEMPTION_CODE)
+
+  const contentHost = page.locator("all-api-hub-redemption-toast")
+  await expect(
+    contentHost.getByRole("heading", { name: "Redemption Assist" }),
+  ).toBeVisible()
+
+  const settingsPagePromise = waitForExtensionPage(context, {
+    extensionId,
+    path: OPTIONS_PAGE_PATH,
+    hash: `#${MENU_ITEM_IDS.BASIC}`,
+    searchParams: {
+      tab: "checkinRedeem",
+      anchor: "redemption-assist",
+    },
+  })
+
+  await contentHost
+    .getByRole("link", { name: "Open Redemption Assist settings" })
+    .click()
+
+  const settingsPage = await settingsPagePromise
+  installExtensionPageGuards(settingsPage)
+  await waitForExtensionRoot(settingsPage)
+
+  const targetUrl = new URL(settingsPage.url())
+  expect(targetUrl.hash).toBe(`#${MENU_ITEM_IDS.BASIC}`)
+  expect(targetUrl.searchParams.get("tab")).toBe("checkinRedeem")
+  expect(targetUrl.searchParams.get("anchor")).toBe("redemption-assist")
+
+  await expect(
+    settingsPage.getByRole("heading", {
+      name: "Redemption Assist",
+      exact: true,
+    }),
+  ).toBeInViewport()
 })

--- a/e2e/releaseUpdateUserFlows.spec.ts
+++ b/e2e/releaseUpdateUserFlows.spec.ts
@@ -1,4 +1,4 @@
-import type { Worker } from "@playwright/test"
+import type { BrowserContext, Page, Worker } from "@playwright/test"
 
 import { RELEASE_UPDATE_STATUS_PANEL_TEST_IDS } from "~/components/ReleaseUpdateStatusPanel.testIds"
 import { OPTIONS_PAGE_PATH } from "~/constants/extensionPages"
@@ -42,6 +42,42 @@ async function readReleaseUpdateStatus(
   return null
 }
 
+async function openAboutPageAndCheckForReleaseUpdate(params: {
+  context: BrowserContext
+  extensionId: string
+  page: Page
+  responseStatus: number
+  responseBody: unknown
+}): Promise<() => number> {
+  let githubReleaseRequests = 0
+
+  await params.context.route(GITHUB_LATEST_RELEASE_API_URL, (route) => {
+    githubReleaseRequests += 1
+    return route.fulfill({
+      status: params.responseStatus,
+      contentType: "application/json",
+      body: JSON.stringify(params.responseBody),
+    })
+  })
+
+  await params.page.goto(
+    `chrome-extension://${params.extensionId}/${OPTIONS_PAGE_PATH}#${MENU_ITEM_IDS.ABOUT}`,
+  )
+  await waitForExtensionRoot(params.page)
+  await expectPermissionOnboardingHidden(params.page)
+
+  const panel = params.page.getByTestId(
+    RELEASE_UPDATE_STATUS_PANEL_TEST_IDS.panel,
+  )
+  await expect(panel).toBeVisible()
+
+  await panel
+    .getByTestId(RELEASE_UPDATE_STATUS_PANEL_TEST_IDS.checkNowButton)
+    .click()
+
+  return () => githubReleaseRequests
+}
+
 test.beforeEach(async ({ context, page }) => {
   installExtensionPageGuards(page)
   await forceExtensionLanguage(page, "en")
@@ -54,32 +90,19 @@ test("checks for a GitHub release update from the About page", async ({
   page,
 }) => {
   const serviceWorker = await getServiceWorker(context)
-  let githubReleaseRequests = 0
-
-  await context.route(GITHUB_LATEST_RELEASE_API_URL, (route) => {
-    githubReleaseRequests += 1
-    return route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: JSON.stringify({
+  const readGithubReleaseRequests = await openAboutPageAndCheckForReleaseUpdate(
+    {
+      context,
+      extensionId,
+      page,
+      responseStatus: 200,
+      responseBody: {
         tag_name: "v9.9.9",
         html_url: LATEST_RELEASE_URL,
-      }),
-    })
-  })
-
-  await page.goto(
-    `chrome-extension://${extensionId}/${OPTIONS_PAGE_PATH}#${MENU_ITEM_IDS.ABOUT}`,
+      },
+    },
   )
-  await waitForExtensionRoot(page)
-  await expectPermissionOnboardingHidden(page)
-
   const panel = page.getByTestId(RELEASE_UPDATE_STATUS_PANEL_TEST_IDS.panel)
-  await expect(panel).toBeVisible()
-
-  await panel
-    .getByTestId(RELEASE_UPDATE_STATUS_PANEL_TEST_IDS.checkNowButton)
-    .click()
 
   await expect(
     panel.getByText("A newer version is available to upgrade"),
@@ -90,7 +113,7 @@ test("checks for a GitHub release update from the About page", async ({
   ).toHaveAttribute("href", LATEST_RELEASE_URL)
 
   await expect
-    .poll(() => githubReleaseRequests, {
+    .poll(readGithubReleaseRequests, {
       message: "manual check should call the GitHub latest-release API",
     })
     .toBeGreaterThanOrEqual(1)
@@ -118,29 +141,16 @@ test("shows a failed GitHub release check from the About page", async ({
   page,
 }) => {
   const serviceWorker = await getServiceWorker(context)
-  let githubReleaseRequests = 0
-
-  await context.route(GITHUB_LATEST_RELEASE_API_URL, (route) => {
-    githubReleaseRequests += 1
-    return route.fulfill({
-      status: 503,
-      contentType: "application/json",
-      body: JSON.stringify({ message: "Service unavailable" }),
-    })
-  })
-
-  await page.goto(
-    `chrome-extension://${extensionId}/${OPTIONS_PAGE_PATH}#${MENU_ITEM_IDS.ABOUT}`,
+  const readGithubReleaseRequests = await openAboutPageAndCheckForReleaseUpdate(
+    {
+      context,
+      extensionId,
+      page,
+      responseStatus: 503,
+      responseBody: { message: "Service unavailable" },
+    },
   )
-  await waitForExtensionRoot(page)
-  await expectPermissionOnboardingHidden(page)
-
   const panel = page.getByTestId(RELEASE_UPDATE_STATUS_PANEL_TEST_IDS.panel)
-  await expect(panel).toBeVisible()
-
-  await panel
-    .getByTestId(RELEASE_UPDATE_STATUS_PANEL_TEST_IDS.checkNowButton)
-    .click()
 
   await expect(
     panel.getByText(
@@ -150,7 +160,7 @@ test("shows a failed GitHub release check from the About page", async ({
   await expect(panel.getByText("Latest stable: unavailable")).toBeVisible()
 
   await expect
-    .poll(() => githubReleaseRequests, {
+    .poll(readGithubReleaseRequests, {
       message: "manual check should call the GitHub latest-release API",
     })
     .toBeGreaterThanOrEqual(1)

--- a/e2e/releaseUpdateUserFlows.spec.ts
+++ b/e2e/releaseUpdateUserFlows.spec.ts
@@ -1,0 +1,172 @@
+import type { Worker } from "@playwright/test"
+
+import { RELEASE_UPDATE_STATUS_PANEL_TEST_IDS } from "~/components/ReleaseUpdateStatusPanel.testIds"
+import { OPTIONS_PAGE_PATH } from "~/constants/extensionPages"
+import { MENU_ITEM_IDS } from "~/constants/optionsMenuIds"
+import { STORAGE_KEYS } from "~/services/core/storageKeys"
+import type { ReleaseUpdateStatus } from "~/services/updates/releaseUpdateStatus"
+import { expect, test } from "~~/e2e/fixtures/extensionTest"
+import {
+  forceExtensionLanguage,
+  installExtensionPageGuards,
+  stubLlmMetadataIndex,
+} from "~~/e2e/utils/commonUserFlows"
+import {
+  expectPermissionOnboardingHidden,
+  getPlasmoStorageRawValue,
+  getServiceWorker,
+} from "~~/e2e/utils/extensionState"
+import { waitForExtensionRoot } from "~~/e2e/utils/lazyLoading"
+
+const GITHUB_LATEST_RELEASE_API_URL =
+  "https://api.github.com/repos/qixing-jk/all-api-hub/releases/latest"
+const LATEST_RELEASE_URL =
+  "https://github.com/qixing-jk/all-api-hub/releases/tag/v9.9.9"
+
+async function readReleaseUpdateStatus(
+  serviceWorker: Worker,
+): Promise<ReleaseUpdateStatus | null> {
+  const raw = await getPlasmoStorageRawValue<unknown>(
+    serviceWorker,
+    STORAGE_KEYS.RELEASE_UPDATE_STATUS,
+  )
+
+  if (typeof raw === "string") {
+    return JSON.parse(raw) as ReleaseUpdateStatus
+  }
+
+  if (raw && typeof raw === "object") {
+    return raw as ReleaseUpdateStatus
+  }
+
+  return null
+}
+
+test.beforeEach(async ({ context, page }) => {
+  installExtensionPageGuards(page)
+  await forceExtensionLanguage(page, "en")
+  await stubLlmMetadataIndex(context)
+})
+
+test("checks for a GitHub release update from the About page", async ({
+  context,
+  extensionId,
+  page,
+}) => {
+  const serviceWorker = await getServiceWorker(context)
+  let githubReleaseRequests = 0
+
+  await context.route(GITHUB_LATEST_RELEASE_API_URL, (route) => {
+    githubReleaseRequests += 1
+    return route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        tag_name: "v9.9.9",
+        html_url: LATEST_RELEASE_URL,
+      }),
+    })
+  })
+
+  await page.goto(
+    `chrome-extension://${extensionId}/${OPTIONS_PAGE_PATH}#${MENU_ITEM_IDS.ABOUT}`,
+  )
+  await waitForExtensionRoot(page)
+  await expectPermissionOnboardingHidden(page)
+
+  const panel = page.getByTestId(RELEASE_UPDATE_STATUS_PANEL_TEST_IDS.panel)
+  await expect(panel).toBeVisible()
+
+  await panel
+    .getByTestId(RELEASE_UPDATE_STATUS_PANEL_TEST_IDS.checkNowButton)
+    .click()
+
+  await expect(
+    panel.getByText("A newer version is available to upgrade"),
+  ).toBeVisible()
+  await expect(panel.getByText("Latest stable: v9.9.9")).toBeVisible()
+  await expect(
+    panel.getByTestId(RELEASE_UPDATE_STATUS_PANEL_TEST_IDS.primaryAction),
+  ).toHaveAttribute("href", LATEST_RELEASE_URL)
+
+  await expect
+    .poll(() => githubReleaseRequests, {
+      message: "manual check should call the GitHub latest-release API",
+    })
+    .toBeGreaterThanOrEqual(1)
+
+  await expect
+    .poll(() => readReleaseUpdateStatus(serviceWorker), {
+      message:
+        "manual check should persist the latest release metadata through the background service",
+    })
+    .toEqual(
+      expect.objectContaining({
+        eligible: true,
+        reason: "chromium-development",
+        latestVersion: "9.9.9",
+        updateAvailable: true,
+        releaseUrl: LATEST_RELEASE_URL,
+        lastError: null,
+      }),
+    )
+})
+
+test("shows a failed GitHub release check from the About page", async ({
+  context,
+  extensionId,
+  page,
+}) => {
+  const serviceWorker = await getServiceWorker(context)
+  let githubReleaseRequests = 0
+
+  await context.route(GITHUB_LATEST_RELEASE_API_URL, (route) => {
+    githubReleaseRequests += 1
+    return route.fulfill({
+      status: 503,
+      contentType: "application/json",
+      body: JSON.stringify({ message: "Service unavailable" }),
+    })
+  })
+
+  await page.goto(
+    `chrome-extension://${extensionId}/${OPTIONS_PAGE_PATH}#${MENU_ITEM_IDS.ABOUT}`,
+  )
+  await waitForExtensionRoot(page)
+  await expectPermissionOnboardingHidden(page)
+
+  const panel = page.getByTestId(RELEASE_UPDATE_STATUS_PANEL_TEST_IDS.panel)
+  await expect(panel).toBeVisible()
+
+  await panel
+    .getByTestId(RELEASE_UPDATE_STATUS_PANEL_TEST_IDS.checkNowButton)
+    .click()
+
+  await expect(
+    panel.getByText(
+      "Check failed, so the latest stable release could not be retrieved",
+    ),
+  ).toBeVisible()
+  await expect(panel.getByText("Latest stable: unavailable")).toBeVisible()
+
+  await expect
+    .poll(() => githubReleaseRequests, {
+      message: "manual check should call the GitHub latest-release API",
+    })
+    .toBeGreaterThanOrEqual(1)
+
+  await expect
+    .poll(() => readReleaseUpdateStatus(serviceWorker), {
+      message:
+        "manual check failure should persist the release-check error through the background service",
+    })
+    .toEqual(
+      expect.objectContaining({
+        eligible: true,
+        reason: "chromium-development",
+        latestVersion: null,
+        updateAvailable: false,
+        lastError: "GitHub release request failed with HTTP 503",
+      }),
+    )
+})

--- a/e2e/shieldBypassContentPrompt.spec.ts
+++ b/e2e/shieldBypassContentPrompt.spec.ts
@@ -1,0 +1,149 @@
+import type { Worker } from "@playwright/test"
+
+import { OPTIONS_PAGE_PATH } from "~/constants/extensionPages"
+import { MENU_ITEM_IDS } from "~/constants/optionsMenuIds"
+import { RuntimeActionIds } from "~/constants/runtimeActions"
+import { expect, test } from "~~/e2e/fixtures/extensionTest"
+import {
+  forceExtensionLanguage,
+  installExtensionPageGuards,
+  seedUserPreferences,
+  stubLlmMetadataIndex,
+  waitForExtensionPage,
+} from "~~/e2e/utils/commonUserFlows"
+import { getServiceWorker } from "~~/e2e/utils/extensionState"
+import { waitForExtensionRoot } from "~~/e2e/utils/lazyLoading"
+
+const SHIELD_FIXTURE_URL = "https://shield-bypass.example.test/challenge"
+const SHIELD_FIXTURE_ORIGIN = "https://shield-bypass.example.test"
+
+async function sendShieldBypassUiMessage(
+  serviceWorker: Worker,
+  pageUrl: string,
+) {
+  await expect
+    .poll(async () => {
+      return await serviceWorker.evaluate(
+        async ({ action, origin, pageUrl, requestId }) => {
+          const chromeApi = (globalThis as any).chrome
+          const tabs = await chromeApi.tabs.query({})
+          const targetTab = tabs.find(
+            (tab: { id?: number; url?: string }) => tab.url === pageUrl,
+          )
+
+          if (targetTab?.id == null) {
+            return { success: false, error: "Target tab not found" }
+          }
+
+          return await new Promise<{ success: boolean; error?: string }>(
+            (resolve) => {
+              chromeApi.tabs.sendMessage(
+                targetTab.id,
+                {
+                  action,
+                  origin,
+                  requestId,
+                },
+                (response?: { success?: boolean; error?: string }) => {
+                  const error = chromeApi.runtime?.lastError
+                  const errorMessage =
+                    typeof error?.message === "string" ? error.message : ""
+
+                  if (errorMessage) {
+                    resolve({ success: false, error: errorMessage })
+                    return
+                  }
+
+                  resolve(
+                    response?.success === false
+                      ? { success: false, error: response.error }
+                      : { success: true },
+                  )
+                },
+              )
+            },
+          )
+        },
+        {
+          action: RuntimeActionIds.ContentShowShieldBypassUi,
+          origin: SHIELD_FIXTURE_ORIGIN,
+          pageUrl,
+          requestId: "e2e-shield-bypass-prompt",
+        },
+      )
+    })
+    .toMatchObject({ success: true })
+}
+
+test.beforeEach(async ({ context, page }) => {
+  installExtensionPageGuards(page)
+  await forceExtensionLanguage(page, "en")
+  await stubLlmMetadataIndex(context)
+
+  await context.route(SHIELD_FIXTURE_URL, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "text/html",
+      body: `<!doctype html>
+        <html lang="en">
+          <head>
+            <title>Shield Fixture</title>
+          </head>
+          <body>
+            <main>
+              <h1>Shield challenge fixture</h1>
+            </main>
+          </body>
+        </html>`,
+    })
+  })
+})
+
+test("shows the shield-bypass content prompt and opens its settings anchor", async ({
+  context,
+  extensionId,
+  page,
+}) => {
+  const serviceWorker = await getServiceWorker(context)
+  await seedUserPreferences(serviceWorker, { language: "en" })
+
+  await page.goto(SHIELD_FIXTURE_URL)
+  await sendShieldBypassUiMessage(serviceWorker, SHIELD_FIXTURE_URL)
+
+  const contentHost = page.locator("all-api-hub-redemption-toast")
+  await expect(
+    contentHost.getByRole("heading", {
+      name: "All API Hub shielded bypass helper (temporary window)",
+    }),
+  ).toBeVisible()
+  await expect(page).toHaveTitle(/All API Hub · Shield Bypass · Shield Fixture/)
+
+  const settingsPagePromise = waitForExtensionPage(context, {
+    extensionId,
+    path: OPTIONS_PAGE_PATH,
+    hash: `#${MENU_ITEM_IDS.BASIC}`,
+    searchParams: {
+      tab: "refresh",
+      anchor: "shield-settings",
+    },
+  })
+
+  await contentHost
+    .getByRole("button", { name: "Open shield bypass settings" })
+    .click()
+
+  const settingsPage = await settingsPagePromise
+  installExtensionPageGuards(settingsPage)
+  await waitForExtensionRoot(settingsPage)
+
+  const targetUrl = new URL(settingsPage.url())
+  expect(targetUrl.hash).toBe(`#${MENU_ITEM_IDS.BASIC}`)
+  expect(targetUrl.searchParams.get("tab")).toBe("refresh")
+  expect(targetUrl.searchParams.get("anchor")).toBe("shield-settings")
+
+  await expect(
+    settingsPage.getByRole("heading", {
+      name: "Temp-window protection bypass",
+    }),
+  ).toBeInViewport()
+})

--- a/e2e/sidepanelUserFlows.spec.ts
+++ b/e2e/sidepanelUserFlows.spec.ts
@@ -3,7 +3,10 @@ import {
   SIDEPANEL_PAGE_PATH,
 } from "~/constants/extensionPages"
 import { MENU_ITEM_IDS } from "~/constants/optionsMenuIds"
+import { SITE_TYPES } from "~/constants/siteType"
 import { getPopupViewTestId, POPUP_TEST_IDS } from "~/entrypoints/popup/testIds"
+import { SPONSOR_ADD_ACCOUNT_PREFILL_SOURCE } from "~/features/AccountManagement/sponsors/types"
+import { ACCOUNT_MANAGEMENT_TEST_IDS } from "~/features/AccountManagement/testIds"
 import { API_CREDENTIAL_PROFILES_TEST_IDS } from "~/features/ApiCredentialProfiles/testIds"
 import { SITE_BOOKMARKS_TEST_IDS } from "~/features/SiteBookmarks/testIds"
 import {
@@ -11,6 +14,7 @@ import {
   normalizeAccountStorageConfigForWrite,
 } from "~/services/accounts/accountDefaults"
 import { STORAGE_KEYS } from "~/services/core/storageKeys"
+import { AuthTypeEnum } from "~/types"
 import { expect, test } from "~~/e2e/fixtures/extensionTest"
 import {
   createStoredAccount,
@@ -24,6 +28,7 @@ import {
 } from "~~/e2e/utils/commonUserFlows"
 import {
   expectPermissionOnboardingHidden,
+  getPlasmoStorageRawValue,
   getServiceWorker,
   setPlasmoStorageValue,
 } from "~~/e2e/utils/extensionState"
@@ -284,4 +289,55 @@ test("sidepanel opens the model list for a saved API credential profile", async 
       .getByText("Profile: Sidepanel Model Profile", { exact: false })
       .first(),
   ).toBeVisible()
+})
+
+test("sidepanel consumes pending sponsor add-account prefill", async ({
+  context,
+  extensionId,
+  page,
+}) => {
+  const serviceWorker = await getServiceWorker(context)
+  await setPlasmoStorageValue(
+    serviceWorker,
+    STORAGE_KEYS.SPONSOR_ADD_ACCOUNT_PENDING_PREFILL,
+    {
+      createdAt: Date.now(),
+      prefill: {
+        source: SPONSOR_ADD_ACCOUNT_PREFILL_SOURCE,
+        sponsorId: "e2e-supported-provider",
+        siteType: SITE_TYPES.NEW_API,
+        siteUrl: "https://sponsor-prefill.example.invalid",
+        authType: AuthTypeEnum.AccessToken,
+      },
+    },
+  )
+
+  await page.goto(SIDEPANEL_URL(extensionId))
+  await waitForExtensionRoot(page)
+  await expectPermissionOnboardingHidden(page)
+
+  const accountDialog = page.getByTestId(
+    ACCOUNT_MANAGEMENT_TEST_IDS.accountDialog,
+  )
+  await expect(accountDialog).toBeVisible()
+  await expect(
+    accountDialog.getByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.siteUrlInput),
+  ).toHaveValue("https://sponsor-prefill.example.invalid")
+  await expect(
+    accountDialog.getByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.authTypeTrigger),
+  ).toHaveAttribute("data-auth-type", AuthTypeEnum.AccessToken)
+  await accountDialog
+    .getByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.manualAddButton)
+    .click()
+  await expect(
+    accountDialog.getByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.siteTypeTrigger),
+  ).toHaveAttribute("data-site-type", SITE_TYPES.NEW_API)
+  await expect
+    .poll(() =>
+      getPlasmoStorageRawValue(
+        serviceWorker,
+        STORAGE_KEYS.SPONSOR_ADD_ACCOUNT_PENDING_PREFILL,
+      ),
+    )
+    .toBeUndefined()
 })

--- a/e2e/taskNotificationsUserFlows.spec.ts
+++ b/e2e/taskNotificationsUserFlows.spec.ts
@@ -269,7 +269,9 @@ test("sends a browser task notification from notification settings", async ({
         isClickable: true,
       },
     })
-  await expect(page.getByText("Test notification sent")).toBeVisible()
+  await expect(
+    page.getByText("Test notification sent", { exact: true }),
+  ).toBeVisible()
 })
 
 test("keeps browser task notification disabled when notification permission is denied", async ({

--- a/e2e/taskNotificationsUserFlows.spec.ts
+++ b/e2e/taskNotificationsUserFlows.spec.ts
@@ -247,7 +247,7 @@ test("sends a browser task notification from notification settings", async ({
   await expect(
     page
       .locator(`#${SETTINGS_ANCHORS.TASK_NOTIFICATIONS_PERMISSION}`)
-      .getByText("Granted"),
+      .getByText("Granted", { exact: true }),
   ).toBeVisible()
 
   const testButton = page.getByTestId(

--- a/e2e/taskNotificationsUserFlows.spec.ts
+++ b/e2e/taskNotificationsUserFlows.spec.ts
@@ -1,0 +1,313 @@
+import type { Page, Worker } from "@playwright/test"
+
+import { OPTIONS_PAGE_PATH } from "~/constants/extensionPages"
+import { MENU_ITEM_IDS } from "~/constants/optionsMenuIds"
+import { SETTINGS_ANCHORS } from "~/constants/settingsAnchors"
+import { BASIC_SETTINGS_TEST_IDS } from "~/features/BasicSettings/testIds"
+import { expect, test } from "~~/e2e/fixtures/extensionTest"
+import {
+  forceExtensionLanguage,
+  installExtensionPageGuards,
+  stubLlmMetadataIndex,
+} from "~~/e2e/utils/commonUserFlows"
+import {
+  expectPermissionOnboardingHidden,
+  getServiceWorker,
+  hasOptionalPermission,
+} from "~~/e2e/utils/extensionState"
+import { waitForExtensionRoot } from "~~/e2e/utils/lazyLoading"
+
+const NOTIFICATIONS_PERMISSION = "notifications"
+const RECORDED_NOTIFICATIONS_KEY = "__aahE2eTaskNotifications"
+const NOTIFICATIONS_PERMISSION_STATE_KEY =
+  "__aahE2eNotificationsPermissionState"
+
+type RecordedNotification = {
+  id: string
+  options: {
+    type?: string
+    title?: string
+    message?: string
+    isClickable?: boolean
+  }
+}
+
+type NotificationsPermissionState = {
+  granted: boolean
+  grantOnRequest: boolean
+}
+
+type NotificationsApiStub = {
+  __aahE2ePatched?: boolean
+  create?: (
+    id: string,
+    options: browser.notifications.CreateNotificationOptions,
+  ) => Promise<string>
+  clear?: (notificationId?: string) => Promise<boolean>
+  onClicked?: {
+    addListener: (callback?: (notificationId: string) => void) => void
+    removeListener: (callback?: (notificationId: string) => void) => void
+  }
+}
+
+async function installNotificationRecorder(serviceWorker: Worker) {
+  await serviceWorker.evaluate((storageKey) => {
+    const host = globalThis as typeof globalThis & Record<string, unknown>
+    const root = (host.browser ?? host.chrome) as
+      | (Record<string, unknown> & {
+          notifications?: NotificationsApiStub
+        })
+      | undefined
+
+    host[storageKey] = []
+
+    if (!root) {
+      return
+    }
+
+    root.notifications ??= {}
+    const api = root.notifications
+
+    if (!api || (api as any).__aahE2ePatched) {
+      return
+    }
+
+    const originalCreate = api.create?.bind(api)
+    api.create = async (
+      id: string,
+      options: browser.notifications.CreateNotificationOptions,
+    ) => {
+      ;(host[storageKey] as RecordedNotification[] | undefined)?.push({
+        id,
+        options: {
+          type: options.type,
+          title: options.title,
+          message: options.message,
+          isClickable: options.isClickable,
+        },
+      })
+
+      if (!originalCreate) {
+        return id
+      }
+
+      try {
+        const createdId = await originalCreate(id, options)
+        return createdId || id
+      } catch {
+        return id
+      }
+    }
+    api.clear ??= async () => true
+    api.onClicked ??= {
+      addListener: () => undefined,
+      removeListener: () => undefined,
+    }
+    ;(api as any).__aahE2ePatched = true
+  }, RECORDED_NOTIFICATIONS_KEY)
+}
+
+async function readRecordedNotifications(
+  serviceWorker: Worker,
+): Promise<RecordedNotification[]> {
+  return await serviceWorker.evaluate((storageKey) => {
+    const host = globalThis as typeof globalThis & Record<string, unknown>
+    return (host[storageKey] as RecordedNotification[] | undefined) ?? []
+  }, RECORDED_NOTIFICATIONS_KEY)
+}
+
+async function installNotificationsPermissionStub(
+  page: Page,
+  options: { grantOnRequest?: boolean } = {},
+) {
+  await page.addInitScript(
+    ({ grantOnRequest, permission, stateKey }) => {
+      const host = globalThis as typeof globalThis & {
+        browser?: typeof browser
+        chrome?: typeof chrome
+      } & Record<string, unknown>
+      const permissionState = {
+        granted: false,
+        grantOnRequest,
+      }
+      host[stateKey] = permissionState
+
+      const patchPermissions = (api?: typeof chrome.permissions) => {
+        if (!api || (api as any).__aahE2eNotificationsPermissionPatched) {
+          return
+        }
+
+        const originalContains = api.contains.bind(api)
+        const originalRequest = api.request.bind(api)
+        const getPermissionState = () =>
+          (host[stateKey] as NotificationsPermissionState | undefined) ??
+          permissionState
+
+        api.contains = ((permissions: chrome.permissions.Permissions) => {
+          if (permissions.permissions?.includes(permission)) {
+            return Promise.resolve(getPermissionState().granted)
+          }
+          return originalContains(permissions)
+        }) as typeof api.contains
+
+        api.request = ((permissions: chrome.permissions.Permissions) => {
+          if (permissions.permissions?.includes(permission)) {
+            const state = getPermissionState()
+            state.granted = state.grantOnRequest
+            return Promise.resolve(state.grantOnRequest)
+          }
+          return originalRequest(permissions)
+        }) as typeof api.request
+        ;(api as any).__aahE2eNotificationsPermissionPatched = true
+      }
+
+      patchPermissions(host.chrome?.permissions)
+      patchPermissions(host.browser?.permissions as typeof chrome.permissions)
+    },
+    {
+      grantOnRequest: options.grantOnRequest ?? true,
+      permission: NOTIFICATIONS_PERMISSION,
+      stateKey: NOTIFICATIONS_PERMISSION_STATE_KEY,
+    },
+  )
+}
+
+async function grantNotificationsPermissionInServiceWorker(
+  serviceWorker: Worker,
+) {
+  await serviceWorker.evaluate((permission) => {
+    const host = globalThis as typeof globalThis & {
+      browser?: typeof browser
+      chrome?: typeof chrome
+    }
+
+    const patchPermissions = (api?: typeof chrome.permissions) => {
+      if (!api || (api as any).__aahE2eNotificationsPermissionPatched) {
+        return
+      }
+
+      const originalContains = api.contains.bind(api)
+
+      api.contains = ((permissions: chrome.permissions.Permissions) => {
+        if (permissions.permissions?.includes(permission)) {
+          return Promise.resolve(true)
+        }
+        return originalContains(permissions)
+      }) as typeof api.contains
+      ;(api as any).__aahE2eNotificationsPermissionPatched = true
+    }
+
+    patchPermissions(host.chrome?.permissions)
+    patchPermissions(host.browser?.permissions as typeof chrome.permissions)
+  }, NOTIFICATIONS_PERMISSION)
+}
+
+test.beforeEach(async ({ context, page }) => {
+  installExtensionPageGuards(page)
+  await forceExtensionLanguage(page, "en")
+  await installNotificationsPermissionStub(page)
+  await stubLlmMetadataIndex(context)
+})
+
+test("sends a browser task notification from notification settings", async ({
+  context,
+  extensionId,
+  page,
+}) => {
+  const serviceWorker = await getServiceWorker(context)
+  await grantNotificationsPermissionInServiceWorker(serviceWorker)
+  await installNotificationRecorder(serviceWorker)
+
+  await page.goto(
+    `chrome-extension://${extensionId}/${OPTIONS_PAGE_PATH}?tab=notifications&anchor=${SETTINGS_ANCHORS.TASK_NOTIFICATIONS_CHANNEL_BROWSER}#${MENU_ITEM_IDS.BASIC}`,
+  )
+  await waitForExtensionRoot(page)
+  await expectPermissionOnboardingHidden(page)
+  await expect(page.getByTestId(BASIC_SETTINGS_TEST_IDS.page)).toBeVisible()
+
+  const browserChannel = page.locator(
+    `#${SETTINGS_ANCHORS.TASK_NOTIFICATIONS_CHANNEL_BROWSER}`,
+  )
+  await expect(browserChannel).toBeVisible()
+
+  if (!(await hasOptionalPermission(page, NOTIFICATIONS_PERMISSION))) {
+    await page
+      .getByTestId(
+        BASIC_SETTINGS_TEST_IDS.taskNotificationsPermissionGrantButton,
+      )
+      .click()
+  }
+
+  await expect
+    .poll(() => hasOptionalPermission(page, NOTIFICATIONS_PERMISSION), {
+      message: "Notifications permission should be granted before testing",
+    })
+    .toBe(true)
+
+  await expect(
+    page
+      .locator(`#${SETTINGS_ANCHORS.TASK_NOTIFICATIONS_PERMISSION}`)
+      .getByText("Granted"),
+  ).toBeVisible()
+
+  const testButton = page.getByTestId(
+    BASIC_SETTINGS_TEST_IDS.taskNotificationsBrowserTestButton,
+  )
+  await expect(testButton).toBeEnabled()
+  await testButton.click()
+
+  await expect
+    .poll(() => readRecordedNotifications(serviceWorker), {
+      message: "Browser task notification should be created",
+    })
+    .toContainEqual({
+      id: "all-api-hub:task:autoCheckin",
+      options: {
+        type: "basic",
+        title: "All API Hub test notification",
+        message: "This is an All API Hub task notification test.",
+        isClickable: true,
+      },
+    })
+  await expect(page.getByText("Test notification sent")).toBeVisible()
+})
+
+test("keeps browser task notification disabled when notification permission is denied", async ({
+  extensionId,
+  page,
+}) => {
+  await installNotificationsPermissionStub(page, { grantOnRequest: false })
+
+  await page.goto(
+    `chrome-extension://${extensionId}/${OPTIONS_PAGE_PATH}?tab=notifications&anchor=${SETTINGS_ANCHORS.TASK_NOTIFICATIONS_PERMISSION}#${MENU_ITEM_IDS.BASIC}`,
+  )
+  await waitForExtensionRoot(page)
+  await expectPermissionOnboardingHidden(page)
+  await expect(page.getByTestId(BASIC_SETTINGS_TEST_IDS.page)).toBeVisible()
+
+  const permissionSection = page.locator(
+    `#${SETTINGS_ANCHORS.TASK_NOTIFICATIONS_PERMISSION}`,
+  )
+  await expect(permissionSection).toBeVisible()
+  await expect(permissionSection.getByText("Not granted")).toBeVisible()
+
+  const browserTestButton = page.getByTestId(
+    BASIC_SETTINGS_TEST_IDS.taskNotificationsBrowserTestButton,
+  )
+  await expect(browserTestButton).toBeDisabled()
+
+  await page
+    .getByTestId(BASIC_SETTINGS_TEST_IDS.taskNotificationsPermissionGrantButton)
+    .click()
+
+  await expect(
+    page.getByText("Notification permission was not granted"),
+  ).toBeVisible()
+  await expect(permissionSection.getByText("Not granted")).toBeVisible()
+  await expect(browserTestButton).toBeDisabled()
+  await expect
+    .poll(() => hasOptionalPermission(page, NOTIFICATIONS_PERMISSION), {
+      message: "Notifications permission should remain denied",
+    })
+    .toBe(false)
+})

--- a/e2e/usageHistorySyncUserFlows.spec.ts
+++ b/e2e/usageHistorySyncUserFlows.spec.ts
@@ -1,7 +1,8 @@
-import type { BrowserContext, Worker } from "@playwright/test"
+import type { BrowserContext } from "@playwright/test"
 
 import { OPTIONS_PAGE_PATH } from "~/constants/extensionPages"
 import { MENU_ITEM_IDS } from "~/constants/optionsMenuIds"
+import { BASIC_SETTINGS_TEST_IDS } from "~/features/BasicSettings/testIds"
 import { STORAGE_KEYS } from "~/services/core/storageKeys"
 import { USAGE_HISTORY_STORAGE_KEYS } from "~/services/history/usageHistory/constants"
 import { getDayKeyFromUnixSeconds } from "~/services/history/usageHistory/core"
@@ -23,24 +24,13 @@ import {
 } from "~~/e2e/utils/commonUserFlows"
 import {
   expectPermissionOnboardingHidden,
-  getPlasmoStorageRawValue,
+  getPlasmoStorageJsonValue,
   getServiceWorker,
 } from "~~/e2e/utils/extensionState"
 import { waitForExtensionRoot } from "~~/e2e/utils/lazyLoading"
 
 const USAGE_HISTORY_SYNC_URL = (extensionId: string) =>
   `chrome-extension://${extensionId}/${OPTIONS_PAGE_PATH}?tab=accountUsage&anchor=usage-history-sync#${MENU_ITEM_IDS.BASIC}`
-
-async function readJsonStorageValue<T>(
-  serviceWorker: Worker,
-  storageKey: string,
-): Promise<T | null> {
-  const raw = await getPlasmoStorageRawValue<unknown>(serviceWorker, storageKey)
-  if (typeof raw !== "string") {
-    return null
-  }
-  return JSON.parse(raw) as T
-}
 
 async function stubUsageHistoryLogRoute(
   context: BrowserContext,
@@ -55,7 +45,7 @@ async function stubUsageHistoryLogRoute(
     quota: number
     promptTokens: number
     completionTokens: number
-    onLogRequest?: () => void
+    onLogRequest?: (type: string | null) => void
   },
 ) {
   const origin = new URL(params.baseUrl).origin
@@ -65,8 +55,7 @@ async function stubUsageHistoryLogRoute(
     const url = new URL(request.url())
 
     if (request.method() === "GET" && url.pathname === "/api/log/self") {
-      params.onLogRequest?.()
-      expect(url.searchParams.get("type")).toBe(String(LogType.Consume))
+      params.onLogRequest?.(url.searchParams.get("type"))
       await route.fulfill({
         status: 200,
         contentType: "application/json",
@@ -133,8 +122,8 @@ test("updates usage-history sync settings and syncs only the selected account", 
   const unselectedBaseUrl = "https://usage-sync-b.example.com"
   const logCreatedAt = Math.floor(Date.now() / 1000) - 60
   const usageDayKey = getDayKeyFromUnixSeconds(logCreatedAt)
-  let selectedLogRequests = 0
-  let unselectedLogRequests = 0
+  const selectedLogRequestTypes: Array<string | null> = []
+  const unselectedLogRequestTypes: Array<string | null> = []
 
   await seedStoredAccounts(serviceWorker, [
     createStoredAccount({
@@ -185,8 +174,8 @@ test("updates usage-history sync settings and syncs only the selected account", 
     quota: 654,
     promptTokens: 123,
     completionTokens: 456,
-    onLogRequest: () => {
-      selectedLogRequests += 1
+    onLogRequest: (type) => {
+      selectedLogRequestTypes.push(type)
     },
   })
   await stubUsageHistoryLogRoute(context, {
@@ -200,8 +189,8 @@ test("updates usage-history sync settings and syncs only the selected account", 
     quota: 999,
     promptTokens: 900,
     completionTokens: 90,
-    onLogRequest: () => {
-      unselectedLogRequests += 1
+    onLogRequest: (type) => {
+      unselectedLogRequestTypes.push(type)
     },
   })
 
@@ -213,16 +202,19 @@ test("updates usage-history sync settings and syncs only the selected account", 
   await page.locator("#usage-history-sync").getByRole("switch").click()
   await page.locator("#usage-history-sync-retention-days input").fill("14")
   await page.locator("#usage-history-sync-schedule-mode").click()
-  await page.getByRole("option", { name: "After account refresh" }).click()
+  await page
+    .getByTestId(
+      BASIC_SETTINGS_TEST_IDS.usageHistorySyncScheduleModeAfterRefreshOption,
+    )
+    .click()
   await page.locator("#usage-history-sync-interval-hours input").fill("2")
   await page.locator("#usage-history-sync-apply-settings").click()
 
   await expect
     .poll(async () => {
-      const preferences = await readJsonStorageValue<Record<string, unknown>>(
-        serviceWorker,
-        STORAGE_KEYS.USER_PREFERENCES,
-      )
+      const preferences = await getPlasmoStorageJsonValue<
+        Record<string, unknown>
+      >(serviceWorker, STORAGE_KEYS.USER_PREFERENCES)
       return preferences?.usageHistory
     })
     .toMatchObject({
@@ -233,13 +225,17 @@ test("updates usage-history sync settings and syncs only the selected account", 
     })
 
   await page
-    .getByRole("checkbox", { name: "Select account: Usage Sync Hub A" })
+    .getByTestId(
+      `${BASIC_SETTINGS_TEST_IDS.usageHistorySyncAccountCheckboxPrefix}-${selectedAccountId}`,
+    )
     .click()
-  await page.getByRole("button", { name: "Sync selected" }).click()
+  await page
+    .getByTestId(BASIC_SETTINGS_TEST_IDS.usageHistorySyncSelectedButton)
+    .click()
 
   await expect
     .poll(async () => {
-      const store = await readJsonStorageValue<UsageHistoryStore>(
+      const store = await getPlasmoStorageJsonValue<UsageHistoryStore>(
         serviceWorker,
         USAGE_HISTORY_STORAGE_KEYS.STORE,
       )
@@ -271,7 +267,7 @@ test("updates usage-history sync settings and syncs only the selected account", 
       }),
     )
 
-  const store = await readJsonStorageValue<UsageHistoryStore>(
+  const store = await getPlasmoStorageJsonValue<UsageHistoryStore>(
     serviceWorker,
     USAGE_HISTORY_STORAGE_KEYS.STORE,
   )
@@ -281,6 +277,6 @@ test("updates usage-history sync settings and syncs only the selected account", 
       daily: {},
     }),
   )
-  expect(selectedLogRequests).toBeGreaterThanOrEqual(1)
-  expect(unselectedLogRequests).toBe(0)
+  expect(selectedLogRequestTypes).toContain(String(LogType.Consume))
+  expect(unselectedLogRequestTypes).toHaveLength(0)
 })

--- a/e2e/usageHistorySyncUserFlows.spec.ts
+++ b/e2e/usageHistorySyncUserFlows.spec.ts
@@ -1,0 +1,286 @@
+import type { BrowserContext, Worker } from "@playwright/test"
+
+import { OPTIONS_PAGE_PATH } from "~/constants/extensionPages"
+import { MENU_ITEM_IDS } from "~/constants/optionsMenuIds"
+import { STORAGE_KEYS } from "~/services/core/storageKeys"
+import { USAGE_HISTORY_STORAGE_KEYS } from "~/services/history/usageHistory/constants"
+import { getDayKeyFromUnixSeconds } from "~/services/history/usageHistory/core"
+import { LogType } from "~/services/history/usageHistory/usageLogModel"
+import {
+  USAGE_HISTORY_SCHEDULE_MODE,
+  type UsageHistoryStore,
+} from "~/types/usageHistory"
+import { expect, test } from "~~/e2e/fixtures/extensionTest"
+import {
+  createStoredAccount,
+  createUsageHistoryAccountStore,
+  forceExtensionLanguage,
+  installExtensionPageGuards,
+  seedStoredAccounts,
+  seedUsageHistoryStore,
+  seedUserPreferences,
+  stubLlmMetadataIndex,
+} from "~~/e2e/utils/commonUserFlows"
+import {
+  expectPermissionOnboardingHidden,
+  getPlasmoStorageRawValue,
+  getServiceWorker,
+} from "~~/e2e/utils/extensionState"
+import { waitForExtensionRoot } from "~~/e2e/utils/lazyLoading"
+
+const USAGE_HISTORY_SYNC_URL = (extensionId: string) =>
+  `chrome-extension://${extensionId}/${OPTIONS_PAGE_PATH}?tab=accountUsage&anchor=usage-history-sync#${MENU_ITEM_IDS.BASIC}`
+
+async function readJsonStorageValue<T>(
+  serviceWorker: Worker,
+  storageKey: string,
+): Promise<T | null> {
+  const raw = await getPlasmoStorageRawValue<unknown>(serviceWorker, storageKey)
+  if (typeof raw !== "string") {
+    return null
+  }
+  return JSON.parse(raw) as T
+}
+
+async function stubUsageHistoryLogRoute(
+  context: BrowserContext,
+  params: {
+    baseUrl: string
+    userId: number
+    username: string
+    tokenName: string
+    modelName: string
+    tokenId: number
+    createdAt: number
+    quota: number
+    promptTokens: number
+    completionTokens: number
+    onLogRequest?: () => void
+  },
+) {
+  const origin = new URL(params.baseUrl).origin
+
+  await context.route(`${origin}/**`, async (route) => {
+    const request = route.request()
+    const url = new URL(request.url())
+
+    if (request.method() === "GET" && url.pathname === "/api/log/self") {
+      params.onLogRequest?.()
+      expect(url.searchParams.get("type")).toBe(String(LogType.Consume))
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: true,
+          message: "ok",
+          data: {
+            total: 1,
+            items: [
+              {
+                id: 101,
+                user_id: params.userId,
+                created_at: params.createdAt,
+                type: LogType.Consume,
+                content: "completion",
+                username: params.username,
+                token_name: params.tokenName,
+                model_name: params.modelName,
+                quota: params.quota,
+                prompt_tokens: params.promptTokens,
+                completion_tokens: params.completionTokens,
+                use_time: 1.25,
+                is_stream: false,
+                channel_id: 7,
+                channel_name: "OpenAI",
+                token_id: params.tokenId,
+                group: "default",
+                ip: "127.0.0.1",
+                other: "{}",
+              },
+            ],
+          },
+        }),
+      })
+      return
+    }
+
+    await route.fulfill({
+      status: 404,
+      contentType: "application/json",
+      body: JSON.stringify({
+        success: false,
+        message: `Unhandled usage-history E2E route: ${request.method()} ${url.pathname}`,
+      }),
+    })
+  })
+}
+
+test.beforeEach(async ({ context, page }) => {
+  installExtensionPageGuards(page)
+  await forceExtensionLanguage(page, "en")
+  await stubLlmMetadataIndex(context)
+})
+
+test("updates usage-history sync settings and syncs only the selected account", async ({
+  context,
+  extensionId,
+  page,
+}) => {
+  const serviceWorker = await getServiceWorker(context)
+  const selectedAccountId = "usage-sync-account-a"
+  const unselectedAccountId = "usage-sync-account-b"
+  const selectedBaseUrl = "https://usage-sync-a.example.com"
+  const unselectedBaseUrl = "https://usage-sync-b.example.com"
+  const logCreatedAt = Math.floor(Date.now() / 1000) - 60
+  const usageDayKey = getDayKeyFromUnixSeconds(logCreatedAt)
+  let selectedLogRequests = 0
+  let unselectedLogRequests = 0
+
+  await seedStoredAccounts(serviceWorker, [
+    createStoredAccount({
+      id: selectedAccountId,
+      site_name: "Usage Sync Hub A",
+      site_url: selectedBaseUrl,
+      account_info: {
+        id: "51",
+        username: "usage-sync-user-a",
+        access_token: "usage-sync-token-a",
+      },
+    }),
+    createStoredAccount({
+      id: unselectedAccountId,
+      site_name: "Usage Sync Hub B",
+      site_url: unselectedBaseUrl,
+      account_info: {
+        id: "52",
+        username: "usage-sync-user-b",
+        access_token: "usage-sync-token-b",
+      },
+    }),
+  ])
+  await seedUsageHistoryStore(serviceWorker, {
+    [selectedAccountId]: createUsageHistoryAccountStore({
+      status: { state: "never" },
+    }),
+    [unselectedAccountId]: createUsageHistoryAccountStore({
+      status: { state: "never" },
+    }),
+  })
+  await seedUserPreferences(serviceWorker, {
+    usageHistory: {
+      enabled: false,
+      retentionDays: 7,
+      scheduleMode: USAGE_HISTORY_SCHEDULE_MODE.MANUAL,
+      syncIntervalMinutes: 6 * 60,
+    },
+  })
+  await stubUsageHistoryLogRoute(context, {
+    baseUrl: selectedBaseUrl,
+    userId: 51,
+    username: "usage-sync-user-a",
+    tokenName: "Selected key",
+    modelName: "gpt-4o-mini",
+    tokenId: 501,
+    createdAt: logCreatedAt,
+    quota: 654,
+    promptTokens: 123,
+    completionTokens: 456,
+    onLogRequest: () => {
+      selectedLogRequests += 1
+    },
+  })
+  await stubUsageHistoryLogRoute(context, {
+    baseUrl: unselectedBaseUrl,
+    userId: 52,
+    username: "usage-sync-user-b",
+    tokenName: "Unselected key",
+    modelName: "gpt-4o-mini",
+    tokenId: 502,
+    createdAt: logCreatedAt,
+    quota: 999,
+    promptTokens: 900,
+    completionTokens: 90,
+    onLogRequest: () => {
+      unselectedLogRequests += 1
+    },
+  })
+
+  await page.goto(USAGE_HISTORY_SYNC_URL(extensionId))
+  await waitForExtensionRoot(page)
+  await expectPermissionOnboardingHidden(page)
+  await expect(page.locator("#usage-history-sync")).toBeVisible()
+
+  await page.locator("#usage-history-sync").getByRole("switch").click()
+  await page.locator("#usage-history-sync-retention-days input").fill("14")
+  await page.locator("#usage-history-sync-schedule-mode").click()
+  await page.getByRole("option", { name: "After account refresh" }).click()
+  await page.locator("#usage-history-sync-interval-hours input").fill("2")
+  await page.locator("#usage-history-sync-apply-settings").click()
+
+  await expect
+    .poll(async () => {
+      const preferences = await readJsonStorageValue<Record<string, unknown>>(
+        serviceWorker,
+        STORAGE_KEYS.USER_PREFERENCES,
+      )
+      return preferences?.usageHistory
+    })
+    .toMatchObject({
+      enabled: true,
+      retentionDays: 14,
+      scheduleMode: USAGE_HISTORY_SCHEDULE_MODE.AFTER_REFRESH,
+      syncIntervalMinutes: 120,
+    })
+
+  await page
+    .getByRole("checkbox", { name: "Select account: Usage Sync Hub A" })
+    .click()
+  await page.getByRole("button", { name: "Sync selected" }).click()
+
+  await expect
+    .poll(async () => {
+      const store = await readJsonStorageValue<UsageHistoryStore>(
+        serviceWorker,
+        USAGE_HISTORY_STORAGE_KEYS.STORE,
+      )
+      return store?.accounts[selectedAccountId]
+    })
+    .toEqual(
+      expect.objectContaining({
+        status: expect.objectContaining({
+          state: "success",
+          lastSuccessAt: expect.any(Number),
+        }),
+        daily: expect.objectContaining({
+          [usageDayKey]: expect.objectContaining({
+            requests: 1,
+            promptTokens: 123,
+            completionTokens: 456,
+            totalTokens: 579,
+            quotaConsumed: 654,
+          }),
+        }),
+        dailyByToken: expect.objectContaining({
+          "501": expect.objectContaining({
+            [usageDayKey]: expect.objectContaining({
+              requests: 1,
+              quotaConsumed: 654,
+            }),
+          }),
+        }),
+      }),
+    )
+
+  const store = await readJsonStorageValue<UsageHistoryStore>(
+    serviceWorker,
+    USAGE_HISTORY_STORAGE_KEYS.STORE,
+  )
+  expect(store?.accounts[unselectedAccountId]).toEqual(
+    expect.objectContaining({
+      status: { state: "never" },
+      daily: {},
+    }),
+  )
+  expect(selectedLogRequests).toBeGreaterThanOrEqual(1)
+  expect(unselectedLogRequests).toBe(0)
+})

--- a/e2e/utils/e2eBuildVariants.shared.d.ts
+++ b/e2e/utils/e2eBuildVariants.shared.d.ts
@@ -1,22 +1,23 @@
 export declare const E2E_BUILD_VARIANTS: {
   readonly Default: "default"
   readonly DnrRequired: "dnr-required"
+  readonly BookmarksRequired: "bookmarks-required"
 }
 
 export declare const E2E_BUILD_VARIANT_ENV: string
 
 export declare function readE2eBuildVariant(
   env?: Record<string, string | undefined>,
-): "default" | "dnr-required"
+): "default" | "dnr-required" | "bookmarks-required"
 
 export declare function getE2eExtensionDirName(
-  variant?: "default" | "dnr-required",
+  variant?: "default" | "dnr-required" | "bookmarks-required",
 ): string
 
 export declare function getE2eTestOutDirTemplate(
-  variant?: "default" | "dnr-required",
+  variant?: "default" | "dnr-required" | "bookmarks-required",
 ): string
 
 export declare function getE2eRequiredChromiumPermissions(
-  variant?: "default" | "dnr-required",
+  variant?: "default" | "dnr-required" | "bookmarks-required",
 ): string[]

--- a/e2e/utils/e2eBuildVariants.shared.js
+++ b/e2e/utils/e2eBuildVariants.shared.js
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url"
 export const E2E_BUILD_VARIANTS = {
   Default: "default",
   DnrRequired: "dnr-required",
+  BookmarksRequired: "bookmarks-required",
 }
 
 const E2E_BUILD_VARIANT_VALUES = Object.values(E2E_BUILD_VARIANTS)

--- a/e2e/utils/e2eBuildVariants.ts
+++ b/e2e/utils/e2eBuildVariants.ts
@@ -12,6 +12,7 @@ export const E2E_BUILD_VARIANTS = SHARED_E2E_BUILD_VARIANTS
 const _E2E_BUILD_VARIANT_VALUES = [
   E2E_BUILD_VARIANTS.Default,
   E2E_BUILD_VARIANTS.DnrRequired,
+  E2E_BUILD_VARIANTS.BookmarksRequired,
 ] as const
 
 type E2eBuildVariant = (typeof _E2E_BUILD_VARIANT_VALUES)[number]

--- a/e2e/utils/extensionState.ts
+++ b/e2e/utils/extensionState.ts
@@ -2,6 +2,7 @@ import type { BrowserContext, Page, Worker } from "@playwright/test"
 import { expect } from "@playwright/test"
 
 import { OPTIONS_OVERVIEW_TEST_IDS } from "~/features/OptionsOverview/testIds"
+import { STORAGE_KEYS } from "~/services/core/storageKeys"
 import { getExtensionServiceWorker } from "~~/e2e/utils/extension"
 
 /**
@@ -124,6 +125,20 @@ export async function getPlasmoStorageJsonValue<T>(
   }
 
   return null
+}
+
+/**
+ * Read JSON-normalized user preferences from extension local storage.
+ */
+export async function getStoredUserPreferences(
+  serviceWorker: Worker,
+): Promise<Record<string, unknown>> {
+  return (
+    (await getPlasmoStorageJsonValue<Record<string, unknown>>(
+      serviceWorker,
+      STORAGE_KEYS.USER_PREFERENCES,
+    )) ?? {}
+  )
 }
 
 async function getManifestPermissionsField(

--- a/e2e/utils/extensionState.ts
+++ b/e2e/utils/extensionState.ts
@@ -102,6 +102,30 @@ export async function getPlasmoStorageRawValue<T>(
   }, key)
 }
 
+/**
+ * Read and JSON-normalize a Plasmo-backed storage value.
+ */
+export async function getPlasmoStorageJsonValue<T>(
+  serviceWorker: Worker,
+  key: string,
+): Promise<T | null> {
+  const raw = await getPlasmoStorageRawValue<unknown>(serviceWorker, key)
+
+  if (typeof raw === "string") {
+    try {
+      return JSON.parse(raw) as T
+    } catch {
+      return null
+    }
+  }
+
+  if (raw && typeof raw === "object") {
+    return raw as T
+  }
+
+  return null
+}
+
 async function getManifestPermissionsField(
   page: Page,
   field: "permissions" | "optional_permissions",

--- a/e2e/utils/extensionState.ts
+++ b/e2e/utils/extensionState.ts
@@ -103,15 +103,7 @@ export async function getPlasmoStorageRawValue<T>(
   }, key)
 }
 
-/**
- * Read and JSON-normalize a Plasmo-backed storage value.
- */
-export async function getPlasmoStorageJsonValue<T>(
-  serviceWorker: Worker,
-  key: string,
-): Promise<T | null> {
-  const raw = await getPlasmoStorageRawValue<unknown>(serviceWorker, key)
-
+export function normalizePlasmoStorageJsonValue<T>(raw: unknown): T | null {
   if (typeof raw === "string") {
     try {
       return JSON.parse(raw) as T
@@ -120,11 +112,22 @@ export async function getPlasmoStorageJsonValue<T>(
     }
   }
 
-  if (raw && typeof raw === "object") {
-    return raw as T
+  if (raw === null || typeof raw === "undefined") {
+    return null
   }
 
-  return null
+  return raw as T
+}
+
+/**
+ * Read and JSON-normalize a Plasmo-backed storage value.
+ */
+export async function getPlasmoStorageJsonValue<T>(
+  serviceWorker: Worker,
+  key: string,
+): Promise<T | null> {
+  const raw = await getPlasmoStorageRawValue<unknown>(serviceWorker, key)
+  return normalizePlasmoStorageJsonValue<T>(raw)
 }
 
 /**

--- a/e2e/utils/extensionState.ts
+++ b/e2e/utils/extensionState.ts
@@ -141,6 +141,22 @@ export async function getStoredUserPreferences(
   )
 }
 
+export async function expectPlasmoStorageJsonValueToBecome<T, V>(
+  serviceWorker: Worker,
+  key: string,
+  selectValue: (value: T | null) => V,
+  expectedValue: V,
+  timeout = 30_000,
+) {
+  await expect
+    .poll(
+      async () =>
+        selectValue(await getPlasmoStorageJsonValue<T>(serviceWorker, key)),
+      { timeout },
+    )
+    .toBe(expectedValue)
+}
+
 async function getManifestPermissionsField(
   page: Page,
   field: "permissions" | "optional_permissions",

--- a/src/components/ClaudeCodeRouterImportDialog.tsx
+++ b/src/components/ClaudeCodeRouterImportDialog.tsx
@@ -94,6 +94,8 @@ export function ClaudeCodeRouterImportDialog(
     () => `claude-code-router-import-form-${token.id}`,
     [token.id],
   )
+  const providerNameInputId = `${formId}-provider-name`
+  const providerApiBaseUrlInputId = `${formId}-provider-api-base-url`
 
   useEffect(() => {
     if (!isOpen) return
@@ -254,8 +256,10 @@ export function ClaudeCodeRouterImportDialog(
         <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
           <FormField
             label={t("ui:dialog.claudeCodeRouter.fields.providerName")}
+            htmlFor={providerNameInputId}
           >
             <Input
+              id={providerNameInputId}
               value={providerName}
               onChange={(e) => setProviderName(e.target.value)}
               placeholder={t(
@@ -266,11 +270,13 @@ export function ClaudeCodeRouterImportDialog(
 
           <FormField
             label={t("ui:dialog.claudeCodeRouter.fields.providerApiBaseUrl")}
+            htmlFor={providerApiBaseUrlInputId}
             description={t(
               "ui:dialog.claudeCodeRouter.descriptions.providerApiBaseUrl",
             )}
           >
             <Input
+              id={providerApiBaseUrlInputId}
               value={providerApiBaseUrl}
               onChange={(e) => setProviderApiBaseUrl(e.target.value)}
               placeholder={t(

--- a/src/components/ReleaseUpdateStatusPanel.testIds.ts
+++ b/src/components/ReleaseUpdateStatusPanel.testIds.ts
@@ -1,0 +1,5 @@
+export const RELEASE_UPDATE_STATUS_PANEL_TEST_IDS = {
+  panel: "release-update-status-panel",
+  checkNowButton: "release-update-check-now-button",
+  primaryAction: "release-update-primary-action",
+} as const

--- a/src/components/ReleaseUpdateStatusPanel.tsx
+++ b/src/components/ReleaseUpdateStatusPanel.tsx
@@ -8,6 +8,7 @@ import type { TFunction } from "i18next"
 import toast from "react-hot-toast"
 import { useTranslation } from "react-i18next"
 
+import { RELEASE_UPDATE_STATUS_PANEL_TEST_IDS } from "~/components/ReleaseUpdateStatusPanel.testIds"
 import { BodySmall, Button, Card, CardItem, CardList } from "~/components/ui"
 import { useReleaseUpdateStatus } from "~/contexts/ReleaseUpdateStatusContext"
 import {
@@ -242,7 +243,10 @@ export function ReleaseUpdateStatusPanel() {
   }
 
   return (
-    <Card padding="none">
+    <Card
+      padding="none"
+      data-testid={RELEASE_UPDATE_STATUS_PANEL_TEST_IDS.panel}
+    >
       <CardList>
         <CardItem
           icon={
@@ -278,6 +282,9 @@ export function ReleaseUpdateStatusPanel() {
                 onClick={() => void handleCheckNow()}
                 loading={isChecking}
                 leftIcon={<ArrowPathIcon className="h-4 w-4" />}
+                data-testid={
+                  RELEASE_UPDATE_STATUS_PANEL_TEST_IDS.checkNowButton
+                }
               >
                 {t("settings:releaseUpdate.checkNow")}
               </Button>
@@ -288,6 +295,9 @@ export function ReleaseUpdateStatusPanel() {
                   size="sm"
                   rightIcon={actionIcon}
                   onClick={reloadRuntime}
+                  data-testid={
+                    RELEASE_UPDATE_STATUS_PANEL_TEST_IDS.primaryAction
+                  }
                 >
                   {actionLabel}
                 </Button>
@@ -297,6 +307,9 @@ export function ReleaseUpdateStatusPanel() {
                   variant={hasUpdate ? "default" : "secondary"}
                   size="sm"
                   rightIcon={actionIcon}
+                  data-testid={
+                    RELEASE_UPDATE_STATUS_PANEL_TEST_IDS.primaryAction
+                  }
                 >
                   <a
                     href={actionHref}

--- a/src/constants/settingsAnchors.ts
+++ b/src/constants/settingsAnchors.ts
@@ -42,5 +42,7 @@ export const SETTINGS_ANCHORS = {
   BALANCE_HISTORY: "balance-history",
   MANAGED_SITE_MODEL_SYNC: "managed-site-model-sync",
   MANAGED_SITE_SELECTOR: "managed-site-selector",
+  PRODUCT_ANALYTICS: "product-analytics",
+  PRODUCT_ANALYTICS_ENABLED: "product-analytics-enabled",
   USAGE_HISTORY_SYNC: "usage-history-sync",
 } as const

--- a/src/features/AccountManagement/components/AccountList/SiteInfo.tsx
+++ b/src/features/AccountManagement/components/AccountList/SiteInfo.tsx
@@ -565,6 +565,7 @@ export default function SiteInfo({
                   variant="ghost"
                   size="xs"
                   aria-label={t("actions.viewOnLdoh")}
+                  data-testid={ACCOUNT_MANAGEMENT_TEST_IDS.rowLdohLookupButton}
                 >
                   <span aria-hidden="true">
                     <LdohIcon />

--- a/src/features/AccountManagement/components/BookmarkAccountImportDialog/BookmarkTreeSelector.tsx
+++ b/src/features/AccountManagement/components/BookmarkAccountImportDialog/BookmarkTreeSelector.tsx
@@ -422,6 +422,9 @@ export function BookmarkTreeSelector({
             size="sm"
             disabled={!hasVisibleNodes}
             onClick={() => onSetNodeSelection(visibleNodeIds, "select")}
+            data-testid={
+              ACCOUNT_MANAGEMENT_TEST_IDS.bookmarkImportSelectAllButton
+            }
           >
             {t("ui:dialog.bookmarkAccountImport.actions.selectAll")}
           </Button>

--- a/src/features/AccountManagement/testIds.ts
+++ b/src/features/AccountManagement/testIds.ts
@@ -63,6 +63,8 @@ export const ACCOUNT_MANAGEMENT_TEST_IDS = {
     "account-management-bookmark-import-scan-selected-button",
   bookmarkImportBackToScopeButton:
     "account-management-bookmark-import-back-to-scope-button",
+  bookmarkImportSelectAllButton:
+    "account-management-bookmark-import-select-all-button",
   bookmarkImportScopeCheckbox:
     "account-management-bookmark-import-scope-checkbox",
   bookmarkImportScopeTree: "account-management-bookmark-import-scope-tree",

--- a/src/features/AccountManagement/testIds.ts
+++ b/src/features/AccountManagement/testIds.ts
@@ -30,6 +30,7 @@ export const ACCOUNT_MANAGEMENT_TEST_IDS = {
     "account-management-cookie-permission-grant-button",
   confirmAddButton: "account-management-confirm-add-button",
   rowOpenButton: "account-management-row-open-button",
+  rowLdohLookupButton: "account-management-row-ldoh-lookup-button",
   rowCopyUrlButton: "account-management-row-copy-url-button",
   rowCopyKeyButton: "account-management-row-copy-key-button",
   copyKeyDialogRuntimeKeyItem:

--- a/src/features/ApiCredentialProfiles/components/ApiCredentialProfileListItem.tsx
+++ b/src/features/ApiCredentialProfiles/components/ApiCredentialProfileListItem.tsx
@@ -636,6 +636,9 @@ export function ApiCredentialProfileListItem({
                     {t("keyManagement:actions.exportToCCSwitch")}
                   </DropdownMenuItem>
                   <DropdownMenuItem
+                    data-testid={
+                      API_CREDENTIAL_PROFILES_TEST_IDS.exportToKiloCodeMenuItem
+                    }
                     onSelect={() => onExport(profile, "kiloCode")}
                   >
                     <span aria-hidden="true">
@@ -645,6 +648,9 @@ export function ApiCredentialProfileListItem({
                   </DropdownMenuItem>
                   <DropdownMenuSeparator />
                   <DropdownMenuItem
+                    data-testid={
+                      API_CREDENTIAL_PROFILES_TEST_IDS.exportToCliProxyMenuItem
+                    }
                     onSelect={() => onExport(profile, "cliProxy")}
                   >
                     <span aria-hidden="true">
@@ -653,6 +659,9 @@ export function ApiCredentialProfileListItem({
                     {t("keyManagement:actions.importToCliProxy")}
                   </DropdownMenuItem>
                   <DropdownMenuItem
+                    data-testid={
+                      API_CREDENTIAL_PROFILES_TEST_IDS.exportToClaudeCodeRouterMenuItem
+                    }
                     onSelect={() => onExport(profile, "claudeCodeRouter")}
                   >
                     <span aria-hidden="true">

--- a/src/features/ApiCredentialProfiles/testIds.ts
+++ b/src/features/ApiCredentialProfiles/testIds.ts
@@ -10,6 +10,12 @@ export const API_CREDENTIAL_PROFILES_TEST_IDS = {
   exportMenuButton: "api-credential-profile-export-menu-button",
   exportToCCSwitchMenuItem:
     "api-credential-profile-export-to-cc-switch-menu-item",
+  exportToKiloCodeMenuItem:
+    "api-credential-profile-export-to-kilo-code-menu-item",
+  exportToCliProxyMenuItem:
+    "api-credential-profile-export-to-cli-proxy-menu-item",
+  exportToClaudeCodeRouterMenuItem:
+    "api-credential-profile-export-to-claude-code-router-menu-item",
   openModelManagementButton:
     "api-credential-profile-open-model-management-button",
   popupView: "api-credential-profiles-popup-view",

--- a/src/features/AutoCheckin/components/ActionBar.tsx
+++ b/src/features/AutoCheckin/components/ActionBar.tsx
@@ -9,6 +9,7 @@ import { useTranslation } from "react-i18next"
 import { WorkflowTransitionIcon } from "~/components/icons/WorkflowTransitionIcon"
 import { Button } from "~/components/ui"
 import { ProductAnalyticsScope } from "~/contexts/ProductAnalyticsScopeContext"
+import { BASIC_SETTINGS_TEST_IDS } from "~/features/BasicSettings/testIds"
 import {
   PRODUCT_ANALYTICS_ENTRYPOINTS,
   PRODUCT_ANALYTICS_FEATURE_IDS,
@@ -90,6 +91,7 @@ export default function ActionBar({
             onClick={onRunNow}
             disabled={isBusy}
             leftIcon={<PlayIcon className="h-4 w-4" />}
+            data-testid={BASIC_SETTINGS_TEST_IDS.autoCheckinRunNowButton}
           >
             {t("execution.runNow")}
           </Button>

--- a/src/features/BasicSettings/components/dialogs/ClearModelRedirectMappingsDialog.tsx
+++ b/src/features/BasicSettings/components/dialogs/ClearModelRedirectMappingsDialog.tsx
@@ -11,6 +11,7 @@ import {
   Input,
   Modal,
 } from "~/components/ui"
+import { BASIC_SETTINGS_TEST_IDS } from "~/features/BasicSettings/testIds"
 import { ModelRedirectService } from "~/services/models/modelRedirect"
 import { isEmptyModelMapping } from "~/services/models/modelRedirect/utils"
 import type { ManagedSiteChannel } from "~/types/managedSite"
@@ -316,6 +317,9 @@ export function ClearModelRedirectMappingsDialog({
                 variant="destructive"
                 onClick={() => setIsConfirmOpen(true)}
                 disabled={!canContinue || isClearing}
+                data-testid={
+                  BASIC_SETTINGS_TEST_IDS.managedSiteModelRedirectBulkClearContinueButton
+                }
               >
                 {t("bulkClear.actions.continue")}
               </Button>
@@ -398,6 +402,7 @@ export function ClearModelRedirectMappingsDialog({
                       <div className="flex items-start gap-3">
                         <Checkbox
                           aria-label={`${channel.name} (#${channel.id})`}
+                          data-testid={`${BASIC_SETTINGS_TEST_IDS.managedSiteModelRedirectBulkClearChannelCheckboxPrefix}-${channel.id}`}
                           checked={checked}
                           onCheckedChange={() =>
                             handleToggleSelected(channel.id)
@@ -497,6 +502,9 @@ export function ClearModelRedirectMappingsDialog({
           isClearing
             ? t("bulkClear.status.clearing")
             : t("bulkClear.actions.confirm")
+        }
+        confirmButtonTestId={
+          BASIC_SETTINGS_TEST_IDS.managedSiteModelRedirectBulkClearConfirmButton
         }
         onConfirm={() => {
           void handleConfirm()

--- a/src/features/BasicSettings/components/tabs/General/General.search.ts
+++ b/src/features/BasicSettings/components/tabs/General/General.search.ts
@@ -285,7 +285,7 @@ export const generalSearchControls: OptionsSearchItemDefinition[] = [
   buildControlDefinition(
     "control:product-analytics-enabled",
     "general",
-    "product-analytics-enabled",
+    SETTINGS_ANCHORS.PRODUCT_ANALYTICS_ENABLED,
     "settings:productAnalytics.enableLabel",
     512,
     {

--- a/src/features/BasicSettings/components/tabs/General/ProductAnalyticsSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/General/ProductAnalyticsSettings.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next"
 
 import { SettingSection } from "~/components/SettingSection"
 import { Card, CardItem, CardList, Switch } from "~/components/ui"
+import { SETTINGS_ANCHORS } from "~/constants/settingsAnchors"
 import { trackProductAnalyticsActionStarted } from "~/services/productAnalytics/actions"
 import {
   PRODUCT_ANALYTICS_ACTION_IDS,
@@ -95,14 +96,14 @@ export default function ProductAnalyticsSettings() {
 
   return (
     <SettingSection
-      id="product-analytics"
+      id={SETTINGS_ANCHORS.PRODUCT_ANALYTICS}
       title={t("productAnalytics.title")}
       description={t("productAnalytics.description")}
     >
       <Card padding="none">
         <CardList>
           <CardItem
-            id="product-analytics-enabled"
+            id={SETTINGS_ANCHORS.PRODUCT_ANALYTICS_ENABLED}
             icon={
               <ChartBarIcon className="h-5 w-5 text-slate-600 dark:text-slate-300" />
             }

--- a/src/features/BasicSettings/components/tabs/ManagedSite/ModelRedirectSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/ManagedSite/ModelRedirectSettings.tsx
@@ -6,6 +6,7 @@ import { SettingSection } from "~/components/SettingSection"
 import { Button, Card, CardContent, CompactMultiSelect } from "~/components/ui"
 import { Switch } from "~/components/ui/Switch"
 import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
+import { BASIC_SETTINGS_TEST_IDS } from "~/features/BasicSettings/testIds"
 import {
   getManagedSiteServiceForType,
   hasValidManagedSiteConfig,
@@ -217,6 +218,9 @@ export default function ModelRedirectSettings() {
               variant="destructive"
               disabled={!canUseManagedSiteAdmin}
               onClick={() => setIsBulkClearOpen(true)}
+              data-testid={
+                BASIC_SETTINGS_TEST_IDS.managedSiteModelRedirectBulkClearButton
+              }
             >
               {t("bulkClear.action")}
             </Button>

--- a/src/features/BasicSettings/components/tabs/Notifications/TaskNotificationSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/Notifications/TaskNotificationSettings.tsx
@@ -20,6 +20,7 @@ import {
 } from "~/components/ui"
 import { SETTINGS_ANCHORS } from "~/constants/settingsAnchors"
 import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
+import { BASIC_SETTINGS_TEST_IDS } from "~/features/BasicSettings/testIds"
 import {
   sendTaskNotificationMessage,
   TaskNotificationMessageTypes,
@@ -116,6 +117,7 @@ interface NotificationChannelActionsProps {
   loading: boolean
   testDisabled: boolean
   testLabel: string
+  testButtonTestId?: string
   onToggle: (enabled: boolean) => void
   onTest: () => void
 }
@@ -129,6 +131,7 @@ function NotificationChannelActions({
   loading,
   testDisabled,
   testLabel,
+  testButtonTestId,
   onToggle,
   onTest,
 }: NotificationChannelActionsProps) {
@@ -141,6 +144,7 @@ function NotificationChannelActions({
         className="h-8 shadow-none"
         loading={loading}
         disabled={testDisabled}
+        data-testid={testButtonTestId}
         onClick={onTest}
       >
         {testLabel}
@@ -704,6 +708,9 @@ export default function TaskNotificationSettings() {
                       variant="outline"
                       className="h-8 shadow-none"
                       loading={isRequestingPermission}
+                      data-testid={
+                        BASIC_SETTINGS_TEST_IDS.taskNotificationsPermissionGrantButton
+                      }
                       onClick={() => void handleRequestPermission()}
                     >
                       {t("taskNotifications.permission.request")}
@@ -738,6 +745,9 @@ export default function TaskNotificationSettings() {
                   }
                   testDisabled={!canSendBrowserTest}
                   testLabel={t("taskNotifications.test.action")}
+                  testButtonTestId={
+                    BASIC_SETTINGS_TEST_IDS.taskNotificationsBrowserTestButton
+                  }
                   onToggle={(enabled) =>
                     void handleBrowserChannelToggle(enabled)
                   }

--- a/src/features/BasicSettings/components/tabs/UsageHistorySync/UsageHistorySyncSettingsSection.tsx
+++ b/src/features/BasicSettings/components/tabs/UsageHistorySync/UsageHistorySyncSettingsSection.tsx
@@ -14,6 +14,7 @@ import {
   SelectValue,
   Switch,
 } from "~/components/ui"
+import { BASIC_SETTINGS_TEST_IDS } from "~/features/BasicSettings/testIds"
 import { USAGE_HISTORY_SCHEDULE_MODE } from "~/types/usageHistory"
 import type { UsageHistoryScheduleMode } from "~/types/usageHistory"
 
@@ -115,7 +116,12 @@ export default function UsageHistorySyncSettingsSection({
                 <SelectItem value={USAGE_HISTORY_SCHEDULE_MODE.MANUAL}>
                   {t("settings.scheduleModes.manual")}
                 </SelectItem>
-                <SelectItem value={USAGE_HISTORY_SCHEDULE_MODE.AFTER_REFRESH}>
+                <SelectItem
+                  value={USAGE_HISTORY_SCHEDULE_MODE.AFTER_REFRESH}
+                  data-testid={
+                    BASIC_SETTINGS_TEST_IDS.usageHistorySyncScheduleModeAfterRefreshOption
+                  }
+                >
                   {t("settings.scheduleModes.afterRefresh")}
                 </SelectItem>
                 <SelectItem

--- a/src/features/BasicSettings/components/tabs/UsageHistorySync/UsageHistorySyncStateTable.tsx
+++ b/src/features/BasicSettings/components/tabs/UsageHistorySync/UsageHistorySyncStateTable.tsx
@@ -21,6 +21,7 @@ import {
   TableRow,
 } from "~/components/ui/table"
 import { Z_INDEX } from "~/constants/designTokens"
+import { BASIC_SETTINGS_TEST_IDS } from "~/features/BasicSettings/testIds"
 import { cn } from "~/lib/utils"
 
 import UsageHistorySyncRowActions from "./UsageHistorySyncRowActions"
@@ -125,6 +126,7 @@ export default function UsageHistorySyncStateTable({
             aria-label={t("syncTab.table.selectRow", {
               name: row.original.accountName,
             })}
+            data-testid={`${BASIC_SETTINGS_TEST_IDS.usageHistorySyncAccountCheckboxPrefix}-${row.original.id}`}
             disabled={isSyncingAll}
           />
         ),
@@ -245,6 +247,7 @@ export default function UsageHistorySyncStateTable({
             size="sm"
             onClick={() => void onSyncAccounts(selectedAccountIds)}
             disabled={!selectedAccountIds.length || isSyncingAll}
+            data-testid={BASIC_SETTINGS_TEST_IDS.usageHistorySyncSelectedButton}
           >
             {t("syncTab.actions.syncSelected")}
           </Button>

--- a/src/features/BasicSettings/testIds.ts
+++ b/src/features/BasicSettings/testIds.ts
@@ -3,4 +3,17 @@ export const BASIC_SETTINGS_TEST_IDS = {
   taskNotificationsBrowserTestButton: "task-notifications-browser-test-button",
   taskNotificationsPermissionGrantButton:
     "task-notifications-permission-grant-button",
+  autoCheckinRunNowButton: "auto-checkin-run-now-button",
+  managedSiteModelRedirectBulkClearButton:
+    "managed-site-model-redirect-bulk-clear-button",
+  managedSiteModelRedirectBulkClearContinueButton:
+    "managed-site-model-redirect-bulk-clear-continue-button",
+  managedSiteModelRedirectBulkClearConfirmButton:
+    "managed-site-model-redirect-bulk-clear-confirm-button",
+  managedSiteModelRedirectBulkClearChannelCheckboxPrefix:
+    "managed-site-model-redirect-bulk-clear-channel-checkbox",
+  usageHistorySyncScheduleModeAfterRefreshOption:
+    "usage-history-sync-schedule-mode-after-refresh-option",
+  usageHistorySyncSelectedButton: "usage-history-sync-selected-button",
+  usageHistorySyncAccountCheckboxPrefix: "usage-history-sync-account-checkbox",
 } as const

--- a/src/features/BasicSettings/testIds.ts
+++ b/src/features/BasicSettings/testIds.ts
@@ -1,3 +1,6 @@
 export const BASIC_SETTINGS_TEST_IDS = {
   page: "basic-settings-page",
+  taskNotificationsBrowserTestButton: "task-notifications-browser-test-button",
+  taskNotificationsPermissionGrantButton:
+    "task-notifications-permission-grant-button",
 } as const

--- a/src/features/ImportExport/components/WebDAVAutoSyncSettings.tsx
+++ b/src/features/ImportExport/components/WebDAVAutoSyncSettings.tsx
@@ -211,7 +211,7 @@ export default function WebDAVAutoSyncSettings() {
           }),
         })
         await loadStatus()
-        toast.success(response.data?.message || t("webdav.syncSuccess"))
+        toast.success(t("webdav.syncSuccess"))
       } else {
         toast.error(response.error || t("webdav.syncFailed"))
         tracker.complete(PRODUCT_ANALYTICS_RESULTS.Failure, {

--- a/src/features/ProductAnnouncements/ProductAnnouncementList.tsx
+++ b/src/features/ProductAnnouncements/ProductAnnouncementList.tsx
@@ -10,6 +10,10 @@ import {
   getProductAnnouncementSeverityLabel,
   PRODUCT_ANNOUNCEMENT_SEVERITY_STYLES,
 } from "./presentation"
+import {
+  getProductAnnouncementDismissButtonTestId,
+  getProductAnnouncementRestoreButtonTestId,
+} from "./testIds"
 
 interface ProductAnnouncementListProps {
   notices: ProductAnnouncement[]
@@ -138,6 +142,9 @@ export function ProductAnnouncementList({
                   className="h-6 shrink-0 px-2 text-xs leading-none"
                   aria-label={restoreAriaLabel}
                   onClick={() => onRestore(notice.id)}
+                  data-testid={getProductAnnouncementRestoreButtonTestId(
+                    notice.id,
+                  )}
                 >
                   {t("actions.restore")}
                 </Button>
@@ -149,6 +156,9 @@ export function ProductAnnouncementList({
                   className="h-6 shrink-0 px-2 text-xs leading-none"
                   aria-label={dismissAriaLabel}
                   onClick={() => onDismiss(notice.id, notice.revision)}
+                  data-testid={getProductAnnouncementDismissButtonTestId(
+                    notice.id,
+                  )}
                 >
                   {t("actions.dismiss")}
                 </Button>

--- a/src/features/ProductAnnouncements/ProductAnnouncementPopover.tsx
+++ b/src/features/ProductAnnouncements/ProductAnnouncementPopover.tsx
@@ -104,6 +104,7 @@ function ProductAnnouncementPanel({
           )}
           aria-pressed={filter === "active"}
           onClick={() => setFilter("active")}
+          data-testid={PRODUCT_ANNOUNCEMENT_TEST_IDS.activeTab}
         >
           <Bell className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
           <span className="truncate">{t("filters.active")}</span>
@@ -119,6 +120,7 @@ function ProductAnnouncementPanel({
           )}
           aria-pressed={filter === "dismissed"}
           onClick={() => setFilter("dismissed")}
+          data-testid={PRODUCT_ANNOUNCEMENT_TEST_IDS.dismissedTab}
         >
           <Archive className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
           <span className="truncate">{t("filters.dismissed")}</span>

--- a/src/features/ProductAnnouncements/testIds.ts
+++ b/src/features/ProductAnnouncements/testIds.ts
@@ -5,6 +5,24 @@ export const PRODUCT_ANNOUNCEMENT_TEST_IDS = {
   popover: "product-announcement-popover",
   sheet: "product-announcement-sheet",
   closeButton: "product-announcement-close-button",
+  activeTab: "product-announcement-active-tab",
+  dismissedTab: "product-announcement-dismissed-tab",
   activeList: "product-announcement-active-list",
   dismissedList: "product-announcement-dismissed-list",
+  dismissButtonPrefix: "product-announcement-dismiss-button",
+  restoreButtonPrefix: "product-announcement-restore-button",
 } as const
+
+/**
+ * Builds the stable dismiss-button test id for a product announcement.
+ */
+export function getProductAnnouncementDismissButtonTestId(id: string) {
+  return `${PRODUCT_ANNOUNCEMENT_TEST_IDS.dismissButtonPrefix}-${id}`
+}
+
+/**
+ * Builds the stable restore-button test id for a product announcement.
+ */
+export function getProductAnnouncementRestoreButtonTestId(id: string) {
+  return `${PRODUCT_ANNOUNCEMENT_TEST_IDS.restoreButtonPrefix}-${id}`
+}

--- a/src/features/ShareSnapshots/components/ShareSnapshotCaptionToast.tsx
+++ b/src/features/ShareSnapshots/components/ShareSnapshotCaptionToast.tsx
@@ -5,6 +5,7 @@
  */
 import { useEffect, useRef, useState } from "react"
 
+import { SHARE_SNAPSHOT_TEST_IDS } from "~/features/ShareSnapshots/testIds"
 import { getErrorMessage } from "~/utils/core/error"
 import { createLogger } from "~/utils/core/logger"
 
@@ -66,6 +67,7 @@ export const ShareSnapshotCaptionToast = ({
       <textarea
         readOnly
         value={caption}
+        data-testid={SHARE_SNAPSHOT_TEST_IDS.captionTextarea}
         className="dark:border-dark-bg-tertiary dark:bg-dark-bg-primary dark:text-dark-text-primary mb-3 h-28 w-full resize-none rounded-md border border-gray-200 bg-gray-50 p-2 text-xs text-gray-900 focus:outline-none"
       />
       {copyError ? (

--- a/src/features/ShareSnapshots/testIds.ts
+++ b/src/features/ShareSnapshots/testIds.ts
@@ -1,0 +1,3 @@
+export const SHARE_SNAPSHOT_TEST_IDS = {
+  captionTextarea: "share-snapshot-caption-textarea",
+} as const

--- a/src/services/productAnnouncements/constants.ts
+++ b/src/services/productAnnouncements/constants.ts
@@ -1,12 +1,9 @@
 import bundledProductAnnouncementFeed from "~~/public/product-announcements.json"
 
+export { PRODUCT_ANNOUNCEMENT_REMOTE_URL } from "./remoteFeed"
+
 export const PRODUCT_ANNOUNCEMENT_SCHEMA_VERSION =
   bundledProductAnnouncementFeed.schemaVersion
-
-// Product-owned data-only feed from public/product-announcements.json on main;
-// consumers schema-validate it and fall back to the bundled feed.
-export const PRODUCT_ANNOUNCEMENT_REMOTE_URL =
-  "https://raw.githubusercontent.com/qixing-jk/all-api-hub/main/public/product-announcements.json"
 
 export const PRODUCT_ANNOUNCEMENT_REFRESH_ALARM = "productAnnouncementsRefresh"
 

--- a/src/services/productAnnouncements/remoteFeed.ts
+++ b/src/services/productAnnouncements/remoteFeed.ts
@@ -1,0 +1,4 @@
+// Product-owned data-only feed from public/product-announcements.json on main;
+// consumers schema-validate it and fall back to the bundled feed.
+export const PRODUCT_ANNOUNCEMENT_REMOTE_URL =
+  "https://raw.githubusercontent.com/qixing-jk/all-api-hub/main/public/product-announcements.json"

--- a/tests/features/ImportExport/components/WebDAVAutoSyncSettings.test.tsx
+++ b/tests/features/ImportExport/components/WebDAVAutoSyncSettings.test.tsx
@@ -279,7 +279,9 @@ describe("WebDAVAutoSyncSettings", () => {
         WebdavAutoSyncMessageTypes.SyncNow,
       )
     })
-    expect(toast.success).toHaveBeenCalledWith("custom sync ok")
+    expect(toast.success).toHaveBeenCalledWith(
+      "importExport:webdav.syncSuccess",
+    )
     expect(mockStartProductAnalyticsAction).toHaveBeenCalledWith({
       featureId: PRODUCT_ANALYTICS_FEATURE_IDS.WebDavSync,
       actionId: PRODUCT_ANALYTICS_ACTION_IDS.SyncWebDavNow,

--- a/tests/features/ImportExport/components/WebDAVSettings.test.tsx
+++ b/tests/features/ImportExport/components/WebDAVSettings.test.tsx
@@ -1137,7 +1137,9 @@ describe("WebDAVSettings", () => {
     )
 
     await waitFor(() => {
-      expect(toast.success).toHaveBeenCalledWith("custom sync ok")
+      expect(toast.success).toHaveBeenCalledWith(
+        "importExport:webdav.syncSuccess",
+      )
     })
 
     fireEvent.click(
@@ -1185,7 +1187,9 @@ describe("WebDAVSettings", () => {
     )
 
     await waitFor(() => {
-      expect(toast.success).toHaveBeenCalledWith("custom sync ok")
+      expect(toast.success).toHaveBeenCalledWith(
+        "importExport:webdav.syncSuccess",
+      )
     })
 
     clickWebdavAction("webdav-test-connection")

--- a/tests/utils/extensionState.test.ts
+++ b/tests/utils/extensionState.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest"
+
+import { normalizePlasmoStorageJsonValue } from "~~/e2e/utils/extensionState"
+
+describe("normalizePlasmoStorageJsonValue", () => {
+  it("parses JSON-stringified storage values", () => {
+    expect(
+      normalizePlasmoStorageJsonValue<{ enabled: boolean }>(
+        JSON.stringify({ enabled: true }),
+      ),
+    ).toEqual({ enabled: true })
+  })
+
+  it("passes through raw object and primitive storage values", () => {
+    expect(
+      normalizePlasmoStorageJsonValue<{ count: number }>({ count: 2 }),
+    ).toEqual({ count: 2 })
+    expect(normalizePlasmoStorageJsonValue<boolean>(true)).toBe(true)
+    expect(normalizePlasmoStorageJsonValue<number>(0)).toBe(0)
+  })
+
+  it("returns null for missing or invalid string values", () => {
+    expect(normalizePlasmoStorageJsonValue<unknown>(undefined)).toBeNull()
+    expect(normalizePlasmoStorageJsonValue<unknown>(null)).toBeNull()
+    expect(normalizePlasmoStorageJsonValue<unknown>("not json")).toBeNull()
+  })
+})

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -122,12 +122,13 @@ function getManifestOptionalPermissions(browser: BrowserTarget) {
   const browserOptionalPermissions = isFirefoxManifestTarget(browser)
     ? FIREFOX_COOKIE_OPTIONAL_PERMISSIONS
     : getChromiumOptionalPermissions()
+  const requiredPermissions = getManifestRequiredPermissions(browser)
 
   return [
     ...browserOptionalPermissions,
     ...COMMON_OPTIONAL_PERMISSIONS,
     ...BOOKMARK_IMPORT_OPTIONAL_PERMISSIONS,
-  ]
+  ].filter((permission) => !requiredPermissions.includes(permission))
 }
 
 function getChromiumOptionalPermissions() {


### PR DESCRIPTION
## Summary
- Add E2E coverage for bookmark import, credential profiles, account management, settings navigation, extension surfaces, and automation sync flows.
- Add narrow test IDs and E2E build-variant wiring required by the new browser-flow coverage.
- Tighten task notification E2E stubs so the branch passes TypeScript validation.

## Validation
- pnpm run validate:push
- git diff --check origin/main...HEAD
- git push pre-push hook: pnpm compile && pnpm knip

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * WebDAV auto-sync “Sync now” success toast now consistently uses the localized message.
  * Optional permission prompts no longer include permissions that are already required.

* **Tests/QA**
  * Expanded end-to-end coverage for LDOH site lookup, native bookmark import, clipboard-based API credential checks, usage-history sync, task notifications, native page fallback auto check-in, release/update + announcements flows, and additional settings navigation scenarios.
  * Added a **bookmarks-required** E2E build variant.

* **UI Testing & Reliability**
  * Improved and stabilized UI automation identifiers across key settings and dialogs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->