### PR TITLE
fix(new-api): stabilize channel update flows

### DIFF
--- a/e2e/managedSiteCoreFlows.spec.ts
+++ b/e2e/managedSiteCoreFlows.spec.ts
@@ -243,6 +243,7 @@ async function stubManagedSiteAdminRoutes(
   let nextChannelId = 303
   const createPayloads: unknown[] = []
   const updatePayloads: unknown[] = []
+  const statusPayloads: unknown[] = []
   const origin = new URL(MANAGED_SITE_BASE_URL).origin
 
   await context.route(`${origin}/**`, async (route: Route) => {
@@ -415,6 +416,41 @@ async function stubManagedSiteAdminRoutes(
       return
     }
 
+    if (
+      method === "POST" &&
+      /^\/api\/channel\/\d+\/status$/.test(url.pathname)
+    ) {
+      const payload = request.postDataJSON()
+      const channelId = Number(url.pathname.split("/").filter(Boolean)[2])
+      statusPayloads.push({ id: channelId, ...payload })
+
+      const channel = channels.find((item) => item.id === channelId)
+      const status =
+        payload && typeof payload === "object" && "status" in payload
+          ? (payload as { status?: unknown }).status
+          : undefined
+
+      if (
+        channel &&
+        (status === CHANNEL_STATUS.Enable ||
+          status === CHANNEL_STATUS.ManuallyDisabled ||
+          status === CHANNEL_STATUS.AutoDisabled)
+      ) {
+        channel.status = status
+      }
+
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: true,
+          message: "status updated",
+          data: true,
+        }),
+      })
+      return
+    }
+
     if (method === "DELETE" && url.pathname.startsWith("/api/channel/")) {
       const channelId = Number(url.pathname.split("/").filter(Boolean).pop())
       const channelIndex = channels.findIndex((item) => item.id === channelId)
@@ -448,6 +484,7 @@ async function stubManagedSiteAdminRoutes(
   return {
     createPayloads,
     updatePayloads,
+    statusPayloads,
   }
 }
 
@@ -786,7 +823,8 @@ test("edits a managed-site channel from row actions", async ({
   page,
 }) => {
   await seedManagedSitePreferences(context)
-  const { updatePayloads } = await stubManagedSiteAdminRoutes(context)
+  const { statusPayloads, updatePayloads } =
+    await stubManagedSiteAdminRoutes(context)
 
   await page.goto(channelsUrl(extensionId, { search: "Production" }))
   await waitForExtensionRoot(page)
@@ -830,9 +868,13 @@ test("edits a managed-site channel from row actions", async ({
     group: "default,vip",
     priority: 3,
     weight: 2,
-    status: 1,
   })
+  expect(editedPayload).not.toHaveProperty("status")
   expect(editedPayload).not.toHaveProperty("groups")
+  expect(statusPayloads).toContainEqual({
+    id: 101,
+    status: CHANNEL_STATUS.Enable,
+  })
 })
 
 test("loads managed-site channels, deep-links into manual model sync, and runs a selected sync", async ({

--- a/e2e/shieldBypassContentPrompt.spec.ts
+++ b/e2e/shieldBypassContentPrompt.spec.ts
@@ -16,14 +16,42 @@ import { waitForExtensionRoot } from "~~/e2e/utils/lazyLoading"
 
 const SHIELD_FIXTURE_URL = "https://shield-bypass.example.test/challenge"
 const SHIELD_FIXTURE_ORIGIN = "https://shield-bypass.example.test"
+const CLOSED_MESSAGE_RESPONSE_ERRORS = [
+  "message port closed before a response",
+  "message channel closed before a response",
+]
+
+type ShieldBypassMessageResult = {
+  success: boolean
+  error?: string
+}
+
+function getShieldBypassMessageStatus(result: ShieldBypassMessageResult) {
+  if (result.success) {
+    return "success"
+  }
+
+  const error = result.error?.toLowerCase() ?? ""
+  if (
+    CLOSED_MESSAGE_RESPONSE_ERRORS.some((closedMessageResponseError) =>
+      error.includes(closedMessageResponseError),
+    )
+  ) {
+    return "message-port-closed"
+  }
+
+  return "retry"
+}
 
 async function sendShieldBypassUiMessage(
   serviceWorker: Worker,
   pageUrl: string,
-) {
+): Promise<ShieldBypassMessageResult> {
+  let lastResult: ShieldBypassMessageResult | undefined
+
   await expect
     .poll(async () => {
-      return await serviceWorker.evaluate(
+      lastResult = await serviceWorker.evaluate(
         async ({ action, origin, pageUrl, requestId }) => {
           const chromeApi = (globalThis as any).chrome
           const tabs = await chromeApi.tabs.query({})
@@ -35,34 +63,32 @@ async function sendShieldBypassUiMessage(
             return { success: false, error: "Target tab not found" }
           }
 
-          return await new Promise<{ success: boolean; error?: string }>(
-            (resolve) => {
-              chromeApi.tabs.sendMessage(
-                targetTab.id,
-                {
-                  action,
-                  origin,
-                  requestId,
-                },
-                (response?: { success?: boolean; error?: string }) => {
-                  const error = chromeApi.runtime?.lastError
-                  const errorMessage =
-                    typeof error?.message === "string" ? error.message : ""
+          return await new Promise<ShieldBypassMessageResult>((resolve) => {
+            chromeApi.tabs.sendMessage(
+              targetTab.id,
+              {
+                action,
+                origin,
+                requestId,
+              },
+              (response?: { success?: boolean; error?: string }) => {
+                const error = chromeApi.runtime?.lastError
+                const errorMessage =
+                  typeof error?.message === "string" ? error.message : ""
 
-                  if (errorMessage) {
-                    resolve({ success: false, error: errorMessage })
-                    return
-                  }
+                if (errorMessage) {
+                  resolve({ success: false, error: errorMessage })
+                  return
+                }
 
-                  resolve(
-                    response?.success === false
-                      ? { success: false, error: response.error }
-                      : { success: true },
-                  )
-                },
-              )
-            },
-          )
+                resolve(
+                  response?.success === false
+                    ? { success: false, error: response.error }
+                    : { success: true },
+                )
+              },
+            )
+          })
         },
         {
           action: RuntimeActionIds.ContentShowShieldBypassUi,
@@ -71,8 +97,12 @@ async function sendShieldBypassUiMessage(
           requestId: "e2e-shield-bypass-prompt",
         },
       )
+
+      return getShieldBypassMessageStatus(lastResult)
     })
-    .toMatchObject({ success: true })
+    .toMatch(/^(success|message-port-closed)$/)
+
+  return lastResult ?? { success: false, error: "No message result" }
 }
 
 test.beforeEach(async ({ context, page }) => {
@@ -108,13 +138,19 @@ test("shows the shield-bypass content prompt and opens its settings anchor", asy
   await seedUserPreferences(serviceWorker, { language: "en" })
 
   await page.goto(SHIELD_FIXTURE_URL)
-  await sendShieldBypassUiMessage(serviceWorker, SHIELD_FIXTURE_URL)
+  const messageResult = await sendShieldBypassUiMessage(
+    serviceWorker,
+    SHIELD_FIXTURE_URL,
+  )
 
   const contentHost = page.locator("all-api-hub-redemption-toast")
   await expect(
     contentHost.getByRole("heading", {
       name: "All API Hub shielded bypass helper (temporary window)",
     }),
+    `Expected shield bypass prompt to render after content message; last result: ${JSON.stringify(
+      messageResult,
+    )}`,
   ).toBeVisible()
   await expect(page).toHaveTitle(/All API Hub · Shield Bypass · Shield Fixture/)
 

--- a/e2e/shieldBypassContentPrompt.spec.ts
+++ b/e2e/shieldBypassContentPrompt.spec.ts
@@ -49,60 +49,73 @@ async function sendShieldBypassUiMessage(
 ): Promise<ShieldBypassMessageResult> {
   let lastResult: ShieldBypassMessageResult | undefined
 
-  await expect
-    .poll(async () => {
-      lastResult = await serviceWorker.evaluate(
-        async ({ action, origin, pageUrl, requestId }) => {
-          const chromeApi = (globalThis as any).chrome
-          const tabs = await chromeApi.tabs.query({})
-          const targetTab = tabs.find(
-            (tab: { id?: number; url?: string }) => tab.url === pageUrl,
-          )
-
-          if (targetTab?.id == null) {
-            return { success: false, error: "Target tab not found" }
-          }
-
-          return await new Promise<ShieldBypassMessageResult>((resolve) => {
-            chromeApi.tabs.sendMessage(
-              targetTab.id,
-              {
-                action,
-                origin,
-                requestId,
-              },
-              (response?: { success?: boolean; error?: string }) => {
-                const error = chromeApi.runtime?.lastError
-                const errorMessage =
-                  typeof error?.message === "string" ? error.message : ""
-
-                if (errorMessage) {
-                  resolve({ success: false, error: errorMessage })
-                  return
-                }
-
-                resolve(
-                  response?.success === false
-                    ? { success: false, error: response.error }
-                    : { success: true },
-                )
-              },
+  try {
+    await expect
+      .poll(async () => {
+        lastResult = await serviceWorker.evaluate(
+          async ({ action, origin, pageUrl, requestId }) => {
+            const chromeApi = (globalThis as any).chrome
+            const tabs = await chromeApi.tabs.query({})
+            const targetTab = tabs.find(
+              (tab: { id?: number; url?: string }) => tab.url === pageUrl,
             )
-          })
-        },
-        {
-          action: RuntimeActionIds.ContentShowShieldBypassUi,
-          origin: SHIELD_FIXTURE_ORIGIN,
-          pageUrl,
-          requestId: "e2e-shield-bypass-prompt",
-        },
-      )
 
-      return getShieldBypassMessageStatus(lastResult)
-    })
-    .toMatch(/^(success|message-port-closed)$/)
+            if (targetTab?.id == null) {
+              return { success: false, error: "Target tab not found" }
+            }
 
-  return lastResult ?? { success: false, error: "No message result" }
+            return await new Promise<ShieldBypassMessageResult>((resolve) => {
+              chromeApi.tabs.sendMessage(
+                targetTab.id,
+                {
+                  action,
+                  origin,
+                  requestId,
+                },
+                (response?: { success?: boolean; error?: string }) => {
+                  const error = chromeApi.runtime?.lastError
+                  const errorMessage =
+                    typeof error?.message === "string" ? error.message : ""
+
+                  if (errorMessage) {
+                    resolve({ success: false, error: errorMessage })
+                    return
+                  }
+
+                  resolve(
+                    response?.success === false
+                      ? { success: false, error: response.error }
+                      : { success: true },
+                  )
+                },
+              )
+            })
+          },
+          {
+            action: RuntimeActionIds.ContentShowShieldBypassUi,
+            origin: SHIELD_FIXTURE_ORIGIN,
+            pageUrl,
+            requestId: "e2e-shield-bypass-prompt",
+          },
+        )
+
+        return getShieldBypassMessageStatus(lastResult)
+      })
+      .toMatch(/^(success|message-port-closed)$/)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    throw new Error(
+      `Timed out waiting for shield bypass content message; last result: ${JSON.stringify(
+        lastResult,
+      )}\n${message}`,
+    )
+  }
+
+  if (!lastResult) {
+    throw new Error("Shield bypass content message did not produce a result")
+  }
+
+  return lastResult
 }
 
 test.beforeEach(async ({ context, page }) => {

--- a/src/services/apiService/newApiFamily/channelManagement.ts
+++ b/src/services/apiService/newApiFamily/channelManagement.ts
@@ -2,7 +2,10 @@ import { REQUEST_CONFIG } from "~/services/apiTransport/constant"
 import { ApiError } from "~/services/apiTransport/errors"
 import { fetchAllItems } from "~/services/apiTransport/pagination"
 import { fetchApi, fetchApiData } from "~/services/apiTransport/request"
-import type { ApiServiceRequest } from "~/services/apiTransport/type"
+import type {
+  ApiResponse,
+  ApiServiceRequest,
+} from "~/services/apiTransport/type"
 import { CHANNEL_STATUS } from "~/types/managedSite"
 import type {
   CreateChannelPayload,
@@ -43,7 +46,7 @@ const serializeUpdateChannelPayload = (payload: UpdateChannelPayload) => {
     }
   }
 
-  const { key, ...payloadWithoutEmptyKey } = payloadWithoutStatus
+  const { key: _key, ...payloadWithoutEmptyKey } = payloadWithoutStatus
   return {
     payload: payloadWithoutEmptyKey,
     status,
@@ -72,6 +75,17 @@ const updateChannelStatus = async (
 
 const isNewApiManualStatus = (status: number) =>
   status === CHANNEL_STATUS.Enable || status === CHANNEL_STATUS.ManuallyDisabled
+
+const buildPartialStatusUpdateFailureResponse = <T>(
+  updateResponse: ApiResponse<T>,
+  statusResponse: ApiResponse<unknown>,
+): ApiResponse<T> => ({
+  ...updateResponse,
+  success: false,
+  message: statusResponse.message
+    ? `Channel fields were updated, but status update failed: ${statusResponse.message}`
+    : "Channel fields were updated, but status update failed.",
+})
 
 /**
  * 搜索指定关键词的渠道。
@@ -158,7 +172,9 @@ export async function updateChannel(
       status,
     )
 
-    return statusResponse.success ? updateResponse : statusResponse
+    return statusResponse.success
+      ? updateResponse
+      : buildPartialStatusUpdateFailureResponse(updateResponse, statusResponse)
   } catch (error) {
     logger.error("更新渠道失败", error)
     throw new Error("更新渠道失败，请检查网络或 New API 配置。")

--- a/src/services/apiService/newApiFamily/channelManagement.ts
+++ b/src/services/apiService/newApiFamily/channelManagement.ts
@@ -3,6 +3,7 @@ import { ApiError } from "~/services/apiTransport/errors"
 import { fetchAllItems } from "~/services/apiTransport/pagination"
 import { fetchApi, fetchApiData } from "~/services/apiTransport/request"
 import type { ApiServiceRequest } from "~/services/apiTransport/type"
+import { CHANNEL_STATUS } from "~/types/managedSite"
 import type {
   CreateChannelPayload,
   ManagedSiteChannel,
@@ -31,15 +32,46 @@ const serializeChannelGroups = <T extends { groups?: string[] }>(
 
 const serializeUpdateChannelPayload = (payload: UpdateChannelPayload) => {
   const serializedPayload = serializeChannelGroups(payload)
+  const { status, ...payloadWithoutStatus } = serializedPayload
 
-  // New API v1.0.0-rc.16 rejects an empty update key; omitting it preserves the existing secret.
-  if (serializedPayload.key?.trim() !== "") {
-    return serializedPayload
+  // QuantumNous/new-api omits blank edit keys; sending an empty key can
+  // overwrite or reject the secret.
+  if (payloadWithoutStatus.key?.trim() !== "") {
+    return {
+      payload: payloadWithoutStatus,
+      status,
+    }
   }
 
-  const { key, ...payloadWithoutEmptyKey } = serializedPayload
-  return payloadWithoutEmptyKey
+  const { key, ...payloadWithoutEmptyKey } = payloadWithoutStatus
+  return {
+    payload: payloadWithoutEmptyKey,
+    status,
+  }
 }
+
+const updateChannelStatus = async (
+  request: ApiServiceRequest,
+  channelId: number,
+  status: number,
+) => {
+  // QuantumNous/new-api router/channel-router.go maps manual status changes to
+  // POST /api/channel/:id/status and rejects `status` in PUT /api/channel/.
+  return await fetchApi<boolean>(
+    request,
+    {
+      endpoint: `${CHANNEL_API_BASE}${channelId}/status`,
+      options: {
+        method: "POST",
+        body: JSON.stringify({ status }),
+      },
+    },
+    false,
+  )
+}
+
+const isNewApiManualStatus = (status: number) =>
+  status === CHANNEL_STATUS.Enable || status === CHANNEL_STATUS.ManuallyDisabled
 
 /**
  * 搜索指定关键词的渠道。
@@ -102,15 +134,31 @@ export async function updateChannel(
   channelData: UpdateChannelPayload,
 ) {
   try {
-    const payload = serializeUpdateChannelPayload(channelData)
+    const { payload, status } = serializeUpdateChannelPayload(channelData)
 
-    return await fetchApi<void>(request, {
+    const updateResponse = await fetchApi<void>(request, {
       endpoint: CHANNEL_API_BASE,
       options: {
         method: "PUT",
         body: JSON.stringify(payload),
       },
     })
+
+    if (
+      !updateResponse.success ||
+      typeof status !== "number" ||
+      !isNewApiManualStatus(status)
+    ) {
+      return updateResponse
+    }
+
+    const statusResponse = await updateChannelStatus(
+      request,
+      channelData.id,
+      status,
+    )
+
+    return statusResponse.success ? updateResponse : statusResponse
   } catch (error) {
     logger.error("更新渠道失败", error)
     throw new Error("更新渠道失败，请检查网络或 New API 配置。")

--- a/src/services/apiService/newApiFamily/channelManagement.ts
+++ b/src/services/apiService/newApiFamily/channelManagement.ts
@@ -29,6 +29,18 @@ const serializeChannelGroups = <T extends { groups?: string[] }>(
   }
 }
 
+const serializeUpdateChannelPayload = (payload: UpdateChannelPayload) => {
+  const serializedPayload = serializeChannelGroups(payload)
+
+  // New API v1.0.0-rc.16 rejects an empty update key; omitting it preserves the existing secret.
+  if (serializedPayload.key?.trim() !== "") {
+    return serializedPayload
+  }
+
+  const { key, ...payloadWithoutEmptyKey } = serializedPayload
+  return payloadWithoutEmptyKey
+}
+
 /**
  * 搜索指定关键词的渠道。
  * @param request ApiServiceRequest（包含 baseUrl + 认证信息）。
@@ -90,7 +102,7 @@ export async function updateChannel(
   channelData: UpdateChannelPayload,
 ) {
   try {
-    const payload = serializeChannelGroups(channelData)
+    const payload = serializeUpdateChannelPayload(channelData)
 
     return await fetchApi<void>(request, {
       endpoint: CHANNEL_API_BASE,

--- a/src/types/newApi.ts
+++ b/src/types/newApi.ts
@@ -124,6 +124,11 @@ export interface UpdateChannelPayload {
   remark?: string | null
   key?: string
   /**
+   * QuantumNous/new-api rejects status in the ordinary channel update endpoint.
+   * Adapters that accept this field must send it through the dedicated status endpoint.
+   */
+  status?: ChannelStatus
+  /**
    * 多密钥模式下专用
    * @see https://github.com/QuantumNous/new-api/blob/7156bf238276d2089435eacc3efb266403f27c8e/controller/channel.go#L769
    */

--- a/tests/services/apiService/newApiFamily/channelManagement.test.ts
+++ b/tests/services/apiService/newApiFamily/channelManagement.test.ts
@@ -161,6 +161,57 @@ describe("newApiFamily channel management APIs", () => {
     expect(body.groups).toBeUndefined()
   })
 
+  it("updateChannel sends status through the New API status endpoint", async () => {
+    mockFetchApi
+      .mockResolvedValueOnce({ success: true })
+      .mockResolvedValueOnce({ success: true, data: true })
+
+    await updateChannel(baseRequest, {
+      id: 1,
+      name: "Updated",
+      status: 1,
+      groups: ["default"],
+    } as any)
+
+    const updateBody = JSON.parse(mockFetchApi.mock.calls[0][1].options.body)
+    expect(updateBody).toMatchObject({
+      id: 1,
+      name: "Updated",
+      group: "default",
+    })
+    expect(updateBody.status).toBeUndefined()
+    expect(mockFetchApi).toHaveBeenNthCalledWith(
+      2,
+      baseRequest,
+      expect.objectContaining({
+        endpoint: "/api/channel/1/status",
+        options: {
+          method: "POST",
+          body: JSON.stringify({ status: 1 }),
+        },
+      }),
+      false,
+    )
+  })
+
+  it("updateChannel omits auto-disabled status without calling the manual status endpoint", async () => {
+    mockFetchApi.mockResolvedValueOnce({ success: true })
+
+    await updateChannel(baseRequest, {
+      id: 1,
+      name: "Updated",
+      status: 3,
+    } as any)
+
+    const updateBody = JSON.parse(mockFetchApi.mock.calls[0][1].options.body)
+    expect(updateBody).toMatchObject({
+      id: 1,
+      name: "Updated",
+    })
+    expect(updateBody.status).toBeUndefined()
+    expect(mockFetchApi).toHaveBeenCalledTimes(1)
+  })
+
   it("listAllChannels should paginate and aggregate type_counts", async () => {
     const baseUrl = "https://example.com"
     const token = "token"

--- a/tests/services/apiService/newApiFamily/channelManagement.test.ts
+++ b/tests/services/apiService/newApiFamily/channelManagement.test.ts
@@ -139,6 +139,28 @@ describe("newApiFamily channel management APIs", () => {
     expect(body.groups).toBeUndefined()
   })
 
+  it("updateChannel omits an empty key so New API preserves the existing secret", async () => {
+    mockFetchApi.mockResolvedValueOnce({ success: true })
+
+    await updateChannel(baseRequest, {
+      id: 1,
+      name: "Updated",
+      key: "",
+      base_url: "https://upstream.example.invalid/v1",
+      groups: ["default"],
+    } as any)
+
+    const body = JSON.parse(mockFetchApi.mock.calls[0][1].options.body)
+    expect(body).toMatchObject({
+      id: 1,
+      name: "Updated",
+      base_url: "https://upstream.example.invalid/v1",
+      group: "default",
+    })
+    expect(body.key).toBeUndefined()
+    expect(body.groups).toBeUndefined()
+  })
+
   it("listAllChannels should paginate and aggregate type_counts", async () => {
     const baseUrl = "https://example.com"
     const token = "token"

--- a/tests/services/apiService/newApiFamily/channelManagement.test.ts
+++ b/tests/services/apiService/newApiFamily/channelManagement.test.ts
@@ -194,6 +194,64 @@ describe("newApiFamily channel management APIs", () => {
     )
   })
 
+  it("updateChannel sends manually disabled status through the New API status endpoint", async () => {
+    mockFetchApi
+      .mockResolvedValueOnce({ success: true })
+      .mockResolvedValueOnce({ success: true, data: true })
+
+    await updateChannel(baseRequest, {
+      id: 1,
+      name: "Updated",
+      status: 2,
+    } as any)
+
+    const updateBody = JSON.parse(mockFetchApi.mock.calls[0][1].options.body)
+    expect(updateBody).toMatchObject({
+      id: 1,
+      name: "Updated",
+    })
+    expect(updateBody.status).toBeUndefined()
+    expect(mockFetchApi).toHaveBeenNthCalledWith(
+      2,
+      baseRequest,
+      expect.objectContaining({
+        endpoint: "/api/channel/1/status",
+        options: {
+          method: "POST",
+          body: JSON.stringify({ status: 2 }),
+        },
+      }),
+      false,
+    )
+  })
+
+  it("updateChannel reports partial success when the status endpoint fails after the update", async () => {
+    mockFetchApi
+      .mockResolvedValueOnce({
+        success: true,
+        message: "updated",
+        data: { id: 1 },
+      })
+      .mockResolvedValueOnce({
+        success: false,
+        message: "status rejected",
+        data: false,
+      })
+
+    await expect(
+      updateChannel(baseRequest, {
+        id: 1,
+        name: "Updated",
+        status: 1,
+      } as any),
+    ).resolves.toEqual({
+      success: false,
+      message:
+        "Channel fields were updated, but status update failed: status rejected",
+      data: { id: 1 },
+    })
+  })
+
   it("updateChannel omits auto-disabled status without calling the manual status endpoint", async () => {
     mockFetchApi.mockResolvedValueOnce({ success: true })
 

--- a/tests/services/apiService/newApiFamily/channelManagement.test.ts
+++ b/tests/services/apiService/newApiFamily/channelManagement.test.ts
@@ -252,6 +252,32 @@ describe("newApiFamily channel management APIs", () => {
     })
   })
 
+  it("updateChannel reports partial success with a fallback when status failure has no message", async () => {
+    mockFetchApi
+      .mockResolvedValueOnce({
+        success: true,
+        message: "updated",
+        data: { id: 1 },
+      })
+      .mockResolvedValueOnce({
+        success: false,
+        message: "",
+        data: false,
+      })
+
+    await expect(
+      updateChannel(baseRequest, {
+        id: 1,
+        name: "Updated",
+        status: 1,
+      } as any),
+    ).resolves.toEqual({
+      success: false,
+      message: "Channel fields were updated, but status update failed.",
+      data: { id: 1 },
+    })
+  })
+
   it("updateChannel omits auto-disabled status without calling the manual status endpoint", async () => {
     mockFetchApi.mockResolvedValueOnce({ success: true })
 


### PR DESCRIPTION
## Summary
- omit blank New API channel keys from edit payloads
- route New API channel status changes through `/api/channel/:id/status`
- tolerate Chrome message-port closure in the shield-bypass E2E after asserting the prompt renders

## Validation
- `pnpm vitest --run tests/services/apiService/newApiFamily/channelManagement.test.ts`
- `pnpm exec tsc --noEmit`
- `pnpm exec playwright test e2e/shieldBypassContentPrompt.spec.ts --project=chromium --workers=1`
- `AAH_E2E_MANAGED_SITE_TARGET=new-api pnpm exec playwright test e2e/realSite/managedSiteChannels.spec.ts --project=chromium --workers=1 --reporter=list`
- `pnpm run validate:staged`
- pre-push hook: `pnpm run validate:push`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved channel updates to avoid sending/overwriting empty secret keys and to route manual channel status changes through a dedicated status update request.
  * Prevents unsupported/auto statuses from being sent during the primary channel update, with clearer failure messaging when status updates fail.
  * Shield-bypass prompt checks now better handle closed message ports and retries, improving validation failure details.
* **Tests**
  * Added unit coverage for conditional update/status request behavior.
  * Updated end-to-end flows to assert status updates are sent via the new status endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->