### PR TITLE
feat(voapi-v2): add account adapter

### DIFF
--- a/docs/superpowers/plans/2026-07-06-voapi-v2-account-adapter.md
+++ b/docs/superpowers/plans/2026-07-06-voapi-v2-account-adapter.md
@@ -1,0 +1,2468 @@
+# VoAPI v2 Account Adapter Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add deployment-neutral VoAPI v2 account-site support for balance refresh, API key management, and check-in without changing the existing old `VoAPI` New API-family adapter.
+
+**Architecture:** Add one narrow shared transport option for raw access-token authorization, then route `voapi-v2` through dedicated account-site definition, detection, content-session, backend service, adapter capabilities, and check-in provider modules. Detection prefers safe backend API signatures over rendered-page/title/temp-window signals so self-hosted deployments are recognized without depending on `demo.voapi.top`. VoAPI v2 is treated as single-dashboard-JWT auth: no refresh-token storage, refresh locks, or automatic renewal are added because logged-in verification found no stable refresh-token field, cookie, or renewal endpoint.
+
+**Tech Stack:** TypeScript, WXT extension services, Vitest/MSW for unit and service tests, existing `apiTransport`, `accountSiteDefinitions`, `apiAdapters`, and `autoCheckin` registries.
+
+---
+
+## Source Spec
+
+- `docs/superpowers/specs/2026-07-06-voapi-v2-account-adapter-design.md`
+
+## File Structure
+
+### Existing files to modify
+
+- `src/services/apiTransport/type.ts`: add `ApiAuthTokenMode` constants/types and `FetchApiOptions.authTokenMode`.
+- `src/services/apiTransport/request.ts`: apply raw-vs-Bearer authorization formatting in `createRequestHeaders(...)` and pass the option from `_fetchApi(...)`.
+- `tests/services/apiTransport/request.test.ts`: cover default Bearer behavior, raw mode, header override, and cookie-auth preservation.
+- `src/services/accountSiteDefinitions/identifiers.ts`: add `SITE_TYPES.VO_API_V2 = "voapi-v2"`.
+- `src/services/accountSiteDefinitions/contracts.ts`: add `ACCOUNT_SITE_ADAPTER_FAMILIES.VoApiV2`.
+- `src/services/accountSiteDefinitions/definitions.ts`: add `voapi-v2` definition and order it before old `SITE_TYPES.VO_API`.
+- `tests/constants/siteType.test.ts`: assert the new site type value is exported and old `VoAPI` remains.
+- `tests/services/accountSiteDefinitions/registry.test.ts`: assert definition ordering, scope, adapter family, routes, and auth policy.
+- `tests/services/accounts/accountSiteProfile.test.ts`: assert product profile defaults.
+- `tests/services/modelList/accountSources/readiness.definitions.test.ts`: assert model-list readiness is intentionally unsupported for first version account pricing.
+- `src/services/accountSiteOnboarding/registry.ts`: register the VoAPI v2 content-session extractor before `compatible-user`.
+- `tests/services/accountSiteOnboarding/registry.test.ts`: assert extractor priority.
+- `src/services/siteDetection/detectSiteType.ts`: add VoAPI v2 protected-endpoint probe and run backend probes before title/temp-window matching.
+- `tests/services/detectSiteType.test.ts`: cover custom-domain VoAPI v2 signature, no title fetch on strong backend signature, old VoAPI compatibility, and fallback.
+- `tests/services/detectSiteType.fallback.test.ts`: assert existing Sub2API fallback coverage still passes after endpoint probes run before title matching.
+- `src/services/apiAdapters/contracts/siteTypeCapabilities.ts`: extend `SiteBackendFamily` with `voapiV2`.
+- `src/services/apiAdapters/registry.ts`: route `SITE_TYPES.VO_API_V2` to dedicated capabilities before New API-family fallback.
+- `tests/services/apiAdapters/registry.test.ts`: assert `voapi-v2` capabilities are dedicated and old `VoAPI` still uses New API-family capabilities.
+- `src/services/checkin/autoCheckin/providers/index.ts`: register the VoAPI v2 provider.
+- `tests/services/autoCheckin/providers/voapiV2.test.ts`: cover provider eligibility, success, already checked, and auth-expired failures.
+
+### New files to create
+
+- `src/services/accountSiteOnboarding/contentSession/voapiV2.ts`: read `localStorage.userStore.auth.token`, decode safe identity fields, and return `siteTypeHint: SITE_TYPES.VO_API_V2`.
+- `tests/services/accountSiteOnboarding/contentSession/voapiV2.test.ts`: cover JWT extraction, identity fallback, missing token, malformed storage, null `localStorage.user.access_token`, and absence of refresh-token persistence.
+- `src/services/apiService/voapiV2/type.ts`: VoAPI v2 endpoint constants and response DTOs.
+- `src/services/apiService/voapiV2/parsing.ts`: envelope parser, auth-expired classifier, amount/quota conversion, key/status normalization helpers.
+- `src/services/apiService/voapiV2/index.ts`: account-info, dashboard statistics, key list/template/CRUD/reveal, and check-in API functions.
+- `tests/services/apiService/voapiV2/parsing.test.ts`: parser and conversion coverage.
+- `tests/services/apiService/voapiV2/index.test.ts`: service request/response mapping coverage.
+- `src/services/apiAdapters/voapiV2/index.ts`: exported `voApiV2Capabilities`.
+- `src/services/apiAdapters/voapiV2/accountBootstrap.ts`: account-site bootstrap functions for site status, user info, default exchange rate, and check-in support.
+- `src/services/apiAdapters/voapiV2/accountCompletion.ts`: complete detected page-session accounts with raw JWT access-token auth.
+- `src/services/apiAdapters/voapiV2/accountData.ts`: expose `fetchData` by delegating to `fetchVoApiV2AccountData`.
+- `src/services/apiAdapters/voapiV2/accountRefresh.ts`: expose `refreshAccount` and `fetchCheckInSupport` by delegating to the VoAPI v2 service.
+- `src/services/apiAdapters/voapiV2/keyManagement.ts`: expose key inventory, create, update, reveal, delete, groups, and model choices.
+- `src/services/apiAdapters/voapiV2/tokenProvisioning.ts`: default-token provisioning policy for create-with-inventory-refetch and reveal-after-create.
+- `tests/services/apiAdapters/voapiV2/accountCompletion.test.ts`: account completion coverage.
+- `tests/services/apiAdapters/voapiV2/accountCompletion.test.ts`: account completion coverage.
+- `tests/services/apiAdapters/registry.test.ts`: capability registration and mapping coverage.
+- `tests/services/apiService/voapiV2/index.test.ts`: account refresh, key management, token provisioning, and expired JWT recovery coverage.
+- `tests/services/apiService/voapiV2/tokenResync.test.ts`: browser-session dashboard JWT re-read coverage.
+- `tests/services/apiAdapters/voapiV2/testUtils.ts`: shared VoAPI v2 adapter test request fixture.
+- `src/services/checkin/autoCheckin/providers/voapiV2.ts`: API-based check-in provider.
+
+## Refresh-Token Contract Decision
+
+Logged-in verification against the demo deployment found no stable refresh-token contract:
+
+- `localStorage.userStore.auth` contains `email`, `phone`, `registerTime`, `role`, and `token` only.
+- The dashboard JWT payload contains `exp`, `iat`, `nbf`, `role`, `sign`, and `userId` only.
+- `localStorage`, `sessionStorage`, and cookies do not contain `refreshToken`, `refresh_token`, or a refresh-like credential.
+- The logged-in `/profile/api-key` page load performs reads such as `/api/user/info` and `/api/user_api_key`, but no refresh or token-renewal request.
+- The frontend bundle sends `userStore.auth.token` as the raw `Authorization` value and clears auth plus routes to `/auth` on `code === 2` instead of retrying a refresh endpoint.
+
+Implementation consequence: VoAPI v2 must not add Sub2API-style refresh-token storage, refresh locks, proactive refresh, or refresh-token renewal. Expired dashboard JWTs are reported as a recoverable re-login/re-detection health state, with one best-effort re-read of the currently logged-in page-session JWT when browser-session state is available.
+
+## Implementation Tasks
+
+### Task 1: Add request-scoped raw token support to `fetchApi`
+
+**Files:**
+- Modify: `src/services/apiTransport/type.ts`
+- Modify: `src/services/apiTransport/request.ts`
+- Test: `tests/services/apiTransport/request.test.ts`
+
+- [ ] **Step 1: Add failing transport tests**
+
+In `tests/services/apiTransport/request.test.ts`, extend the existing import from `~/services/apiTransport/type`:
+
+```ts
+import {
+  API_AUTH_TOKEN_MODES,
+  API_TRANSPORT_FETCH_CONTEXT_KINDS,
+} from "~/services/apiTransport/type"
+```
+
+Add these tests next to `fetchApiData merges custom headers without dropping auth headers`:
+
+```ts
+it("uses Bearer authorization for access tokens by default", async () => {
+  let capturedAuthorization: string | null = null
+
+  server.use(
+    http.get(API_URL, ({ request }) => {
+      capturedAuthorization = request.headers.get("authorization")
+      return HttpResponse.json({
+        success: true,
+        data: { ok: true },
+        message: "ok",
+      })
+    }),
+  )
+
+  await fetchApi(
+    {
+      baseUrl: BASE_URL,
+      auth: {
+        authType: AuthTypeEnum.AccessToken,
+        accessToken: "jwt-default",
+      },
+    },
+    { endpoint: ENDPOINT },
+    true,
+  )
+
+  expect(capturedAuthorization).toBe("Bearer jwt-default")
+})
+
+it("uses raw authorization when authTokenMode is raw", async () => {
+  let capturedAuthorization: string | null = null
+
+  server.use(
+    http.get(API_URL, ({ request }) => {
+      capturedAuthorization = request.headers.get("authorization")
+      return HttpResponse.json({
+        success: true,
+        data: { ok: true },
+        message: "ok",
+      })
+    }),
+  )
+
+  await fetchApi(
+    {
+      baseUrl: BASE_URL,
+      auth: {
+        authType: AuthTypeEnum.AccessToken,
+        accessToken: "jwt-raw",
+      },
+    },
+    {
+      endpoint: "/api/user/info",
+      authTokenMode: API_AUTH_TOKEN_MODES.Raw,
+    },
+    true,
+  )
+
+  expect(capturedAuthorization).toBe("jwt-raw")
+})
+
+it("keeps caller-provided Authorization header override in raw-token mode", async () => {
+  let capturedAuthorization: string | null = null
+
+  server.use(
+    http.get(API_URL, ({ request }) => {
+      capturedAuthorization = request.headers.get("authorization")
+      return HttpResponse.json({
+        success: true,
+        data: { ok: true },
+        message: "ok",
+      })
+    }),
+  )
+
+  await fetchApi(
+    {
+      baseUrl: BASE_URL,
+      auth: {
+        authType: AuthTypeEnum.AccessToken,
+        accessToken: "jwt-from-account",
+      },
+    },
+    {
+      endpoint: "/api/user/info",
+      authTokenMode: API_AUTH_TOKEN_MODES.Raw,
+      options: {
+        headers: {
+          Authorization: "manual-header",
+        },
+      },
+    },
+    true,
+  )
+
+  expect(capturedAuthorization).toBe("manual-header")
+})
+```
+
+- [ ] **Step 2: Run the failing transport tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/apiTransport/request.test.ts
+```
+
+Expected: the raw-token test fails because `FetchApiOptions` has no `authTokenMode` and `createRequestHeaders(...)` always emits `Bearer <token>`.
+
+- [ ] **Step 3: Add the transport type**
+
+In `src/services/apiTransport/type.ts`, add this above `FetchApiOptions`:
+
+```ts
+export const API_AUTH_TOKEN_MODES = {
+  Bearer: "bearer",
+  Raw: "raw",
+} as const
+
+export type ApiAuthTokenMode =
+  (typeof API_AUTH_TOKEN_MODES)[keyof typeof API_AUTH_TOKEN_MODES]
+```
+
+Then extend `FetchApiOptions`:
+
+```ts
+export interface FetchApiOptions {
+  endpoint: string
+  options?: RequestInit
+  responseType?: TempWindowResponseType
+  tempWindowFallback?: TempWindowFallbackAllowlist
+  currentTabTransport?: "prefer" | "disabled"
+  authTokenMode?: ApiAuthTokenMode
+}
+```
+
+- [ ] **Step 4: Apply token mode in request headers**
+
+In `src/services/apiTransport/request.ts`, import the new type:
+
+```ts
+import type {
+  ApiAuthTokenMode,
+  ApiResponse,
+  ApiTransportFetchContext,
+  ApiTransportRequest,
+  AuthConfig,
+  FetchApiOptions,
+} from "~/services/apiTransport/type"
+```
+
+Change `createRequestHeaders(...)` to accept a mode:
+
+```ts
+const createRequestHeaders = async (
+  auth: NormalizedAuthContext,
+  authTokenMode: ApiAuthTokenMode = "bearer",
+): Promise<Record<string, string>> => {
+  const baseHeaders = {
+    "Content-Type": REQUEST_CONFIG.HEADERS.CONTENT_TYPE,
+    Pragma: REQUEST_CONFIG.HEADERS.PRAGMA,
+  }
+
+  const userHeaders = buildCompatUserIdHeaders(auth.userId)
+
+  let headers: Record<string, string> = { ...baseHeaders, ...userHeaders }
+
+  headers = addExtensionHeader(headers)
+
+  if (auth.authType === AuthTypeEnum.Cookie) {
+    headers = await addAuthMethodHeader(headers, AUTH_MODE.COOKIE_AUTH_MODE)
+  } else if (auth.authType === AuthTypeEnum.AccessToken) {
+    headers = await addAuthMethodHeader(headers, AUTH_MODE.TOKEN_AUTH_MODE)
+  }
+
+  if (auth.accessToken) {
+    headers["Authorization"] =
+      authTokenMode === "raw"
+        ? auth.accessToken
+        : `Bearer ${auth.accessToken}`
+  }
+
+  if (auth.authType === AuthTypeEnum.Cookie && auth.cookie) {
+    headers["Cookie"] = auth.cookie
+
+    const hasCookieInterceptorHeader =
+      COOKIE_AUTH_HEADER_NAME in headers &&
+      headers[COOKIE_AUTH_HEADER_NAME] === AUTH_MODE.COOKIE_AUTH_MODE
+    if (hasCookieInterceptorHeader) {
+      headers[COOKIE_SESSION_OVERRIDE_HEADER_NAME] = auth.cookie
+    }
+  }
+
+  return headers
+}
+```
+
+Change `createAuthRequest(...)` to accept and forward the mode:
+
+```ts
+const createAuthRequest = async (
+  auth: NormalizedAuthContext,
+  options: RequestInit = {},
+  authTokenMode: ApiAuthTokenMode = "bearer",
+): Promise<RequestInit> => {
+  const credentials: RequestCredentials =
+    auth.authType === AuthTypeEnum.Cookie ? "include" : "omit"
+
+  const normalizedOptions: RequestInit = {
+    ...options,
+    headers: normalizeHeaderInit(options.headers),
+  }
+
+  return createBaseRequest(
+    await createRequestHeaders(auth, authTokenMode),
+    credentials,
+    normalizedOptions,
+  )
+}
+```
+
+In `_fetchApi(...)`, pass the request option:
+
+```ts
+const fetchOptions = await createAuthRequest(
+  resolvedAuth,
+  {
+    ...options.options,
+    signal: options.options?.signal ?? request.abortSignal,
+  },
+  options.authTokenMode,
+)
+```
+
+- [ ] **Step 5: Run transport tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/apiTransport/request.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit transport change**
+
+Run:
+
+```powershell
+git add src/services/apiTransport/type.ts src/services/apiTransport/request.ts tests/services/apiTransport/request.test.ts
+git commit -m "feat(api-transport): support raw access token auth"
+```
+
+### Task 2: Add `voapi-v2` definition, detection, and content-session extraction
+
+**Files:**
+- Modify: `src/services/accountSiteDefinitions/identifiers.ts`
+- Modify: `src/services/accountSiteDefinitions/contracts.ts`
+- Modify: `src/services/accountSiteDefinitions/definitions.ts`
+- Create: `src/services/accountSiteOnboarding/contentSession/voapiV2.ts`
+- Modify: `src/services/accountSiteOnboarding/registry.ts`
+- Modify: `src/services/siteDetection/detectSiteType.ts`
+- Test: `tests/constants/siteType.test.ts`
+- Test: `tests/services/accountSiteDefinitions/registry.test.ts`
+- Test: `tests/services/accounts/accountSiteProfile.test.ts`
+- Test: `tests/services/modelList/accountSources/readiness.definitions.test.ts`
+- Test: `tests/services/accountSiteOnboarding/contentSession/voapiV2.test.ts`
+- Test: `tests/services/accountSiteOnboarding/registry.test.ts`
+- Test: `tests/services/detectSiteType.test.ts`
+- Test: `tests/services/detectSiteType.fallback.test.ts`
+
+- [ ] **Step 1: Write failing site-definition tests**
+
+Add assertions that prove the new type is distinct from old `VoAPI`:
+
+```ts
+expect(SITE_TYPES.VO_API_V2).toBe("voapi-v2")
+expect(SITE_TYPES.VO_API).toBe("VoAPI")
+expect(SITE_TYPES.VO_API_V2).not.toBe(SITE_TYPES.VO_API)
+```
+
+In registry tests, assert:
+
+```ts
+const voApiV2 = getAccountSiteDefinition(SITE_TYPES.VO_API_V2)
+expect(voApiV2).toMatchObject({
+  siteType: SITE_TYPES.VO_API_V2,
+  adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.VoApiV2,
+})
+expect(voApiV2?.scopes).toEqual([ACCOUNT_SITE_DEFINITION_SCOPES.Account])
+expect(voApiV2?.onboarding?.routes).toMatchObject({
+  usagePath: "/dash?_userMenuKey=dash",
+  checkInPath: "/checkIn?_userMenuKey=checkIn",
+  adminCredentialsPath: "/keys?_userMenuKey=keys",
+})
+
+expect(ACCOUNT_SITE_TYPE_ORDER.indexOf(SITE_TYPES.VO_API_V2)).toBeLessThan(
+  ACCOUNT_SITE_TYPE_ORDER.indexOf(SITE_TYPES.VO_API),
+)
+```
+
+In model-list readiness tests, assert first-version pricing/catalog readiness is unsupported:
+
+```ts
+expect(getAccountSiteDefinition(SITE_TYPES.VO_API_V2)?.readiness).toEqual({
+  modelList: {
+    expectedRoute: ACCOUNT_SITE_MODEL_LIST_EXPECTED_ROUTES.Unsupported,
+  },
+})
+```
+
+- [ ] **Step 2: Write failing content-session extractor tests**
+
+Create `tests/services/accountSiteOnboarding/contentSession/voapiV2.test.ts`:
+
+```ts
+import { SITE_TYPES } from "~/constants/siteType"
+import { voApiV2ContentSessionExtractor } from "~/services/accountSiteOnboarding/contentSession/voapiV2"
+
+const jwtWithUserId =
+  "eyJhbGciOiJub25lIn0.eyJ1c2VySWQiOjQyLCJleHAiOjQxMDI0NDQ4MDB9.signature"
+
+describe("voApiV2ContentSessionExtractor", () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it("extracts the dashboard JWT from userStore.auth.token", async () => {
+    localStorage.setItem(
+      "userStore",
+      JSON.stringify({
+        auth: {
+          token: jwtWithUserId,
+          email: "owner@example.invalid",
+        },
+      }),
+    )
+    localStorage.setItem(
+      "user",
+      JSON.stringify({
+        id: 7,
+        username: "owner",
+        display_name: "Owner",
+        email: "owner@example.invalid",
+        access_token: null,
+      }),
+    )
+
+    await expect(
+      voApiV2ContentSessionExtractor.extract({ url: "https://example.invalid" }),
+    ).resolves.toEqual({
+      userId: 7,
+      user: {
+        id: 7,
+        username: "owner",
+        display_name: "Owner",
+        email: "owner@example.invalid",
+      },
+      accessToken: jwtWithUserId,
+      siteTypeHint: SITE_TYPES.VO_API_V2,
+    })
+  })
+
+  it("falls back to JWT userId when localStorage.user has no id", async () => {
+    localStorage.setItem("userStore", JSON.stringify({ auth: { token: jwtWithUserId } }))
+    localStorage.setItem("user", JSON.stringify({ access_token: null }))
+
+    const result = await voApiV2ContentSessionExtractor.extract({})
+
+    expect(result?.userId).toBe(42)
+    expect(result?.accessToken).toBe(jwtWithUserId)
+  })
+
+  it("does not use localStorage.user.access_token", async () => {
+    localStorage.setItem(
+      "userStore",
+      JSON.stringify({ auth: { token: jwtWithUserId } }),
+    )
+    localStorage.setItem(
+      "user",
+      JSON.stringify({ id: 7, access_token: "wrong-token" }),
+    )
+
+    const result = await voApiV2ContentSessionExtractor.extract({})
+
+    expect(result?.accessToken).toBe(jwtWithUserId)
+    expect(result?.accessToken).not.toBe("wrong-token")
+  })
+
+  it("does not project refresh-token-shaped fields into the session result", async () => {
+    localStorage.setItem(
+      "userStore",
+      JSON.stringify({
+        auth: {
+          token: jwtWithUserId,
+          refreshToken: "unsupported-refresh",
+          refresh_token: "unsupported-refresh-snake",
+        },
+      }),
+    )
+
+    const result = await voApiV2ContentSessionExtractor.extract({})
+
+    expect(result).toEqual(
+      expect.not.objectContaining({
+        refreshToken: expect.anything(),
+        sub2apiAuth: expect.anything(),
+      }),
+    )
+  })
+
+  it("returns null when userStore is absent or malformed", async () => {
+    await expect(voApiV2ContentSessionExtractor.extract({})).resolves.toBeNull()
+
+    localStorage.setItem("userStore", "{")
+    await expect(voApiV2ContentSessionExtractor.extract({})).resolves.toBeNull()
+  })
+})
+```
+
+- [ ] **Step 3: Write failing detection tests**
+
+In `tests/services/detectSiteType.test.ts`, add a protected-endpoint test with a custom origin and no title dependency:
+
+```ts
+it("detects VoAPI v2 from a protected endpoint signature on custom origins", async () => {
+  const titleSpy = vi
+    .spyOn(detectSiteTypeModule, "fetchSiteOriginalTitle")
+    .mockResolvedValue("Custom Portal")
+
+  server.use(
+    http.get("https://example.invalid/api/user/info", () =>
+      HttpResponse.json(
+        { code: 2, data: null, msg: "Unauthorized", rid: "request-id" },
+        { status: 403 },
+      ),
+    ),
+  )
+
+  await expect(getAccountSiteType("https://example.invalid")).resolves.toBe(
+    SITE_TYPES.VO_API_V2,
+  )
+  expect(titleSpy).not.toHaveBeenCalled()
+})
+
+it("keeps old VoAPI title-only detection on the old site type", async () => {
+  vi.spyOn(detectSiteTypeModule, "fetchSiteOriginalTitle").mockResolvedValue(
+    "VoAPI",
+  )
+  server.use(
+    http.get("https://old.example.invalid/api/user/info", () =>
+      HttpResponse.text("not voapi v2", {
+        status: 404,
+        headers: { "Content-Type": "text/plain" },
+      }),
+    ),
+  )
+
+  await expect(getAccountSiteType("https://old.example.invalid")).resolves.toBe(
+    SITE_TYPES.VO_API,
+  )
+})
+```
+
+Add a fallback test for an unavailable VoAPI v2 probe:
+
+```ts
+it("falls back when the VoAPI v2 probe is inconclusive", async () => {
+  vi.spyOn(detectSiteTypeModule, "fetchSiteOriginalTitle").mockResolvedValue(
+    "New API",
+  )
+  server.use(
+    http.get("https://fallback.example.invalid/api/user/info", () =>
+      HttpResponse.json({ ok: false }, { status: 404 }),
+    ),
+  )
+
+  await expect(
+    getAccountSiteType("https://fallback.example.invalid"),
+  ).resolves.toBe(SITE_TYPES.NEW_API)
+})
+```
+
+- [ ] **Step 4: Run the failing definition, session, and detection tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/constants/siteType.test.ts tests/services/accountSiteDefinitions/registry.test.ts tests/services/accounts/accountSiteProfile.test.ts tests/services/modelList/accountSources/readiness.definitions.test.ts tests/services/accountSiteOnboarding/contentSession/voapiV2.test.ts tests/services/accountSiteOnboarding/registry.test.ts tests/services/detectSiteType.test.ts tests/services/detectSiteType.fallback.test.ts
+```
+
+Expected: FAIL because `voapi-v2`, its adapter family, content-session extractor, and detection probe do not exist yet.
+
+- [ ] **Step 5: Add the site type and adapter family**
+
+In `src/services/accountSiteDefinitions/identifiers.ts`, add:
+
+```ts
+VO_API_V2: "voapi-v2",
+```
+
+Place it near `VO_API` so the old/new relationship is visible.
+
+In `src/services/accountSiteDefinitions/contracts.ts`, add:
+
+```ts
+VoApiV2: "voapiV2",
+```
+
+to `ACCOUNT_SITE_ADAPTER_FAMILIES`.
+
+- [ ] **Step 6: Add the account-site definition**
+
+In `src/services/accountSiteDefinitions/definitions.ts`, add `SITE_TYPES.VO_API_V2` before `SITE_TYPES.VO_API` in `ACCOUNT_SITE_TYPE_ORDER`:
+
+```ts
+SITE_TYPES.V_API,
+SITE_TYPES.VO_API_V2,
+SITE_TYPES.VO_API,
+SITE_TYPES.SUPER_API,
+```
+
+Add this definition before the old `VO_API` compatible definition:
+
+```ts
+const voApiV2Readiness = {
+  modelList: {
+    expectedRoute: ACCOUNT_SITE_MODEL_LIST_EXPECTED_ROUTES.Unsupported,
+  },
+} as const
+```
+
+```ts
+{
+  siteType: SITE_TYPES.VO_API_V2,
+  scopes: ACCOUNT_SCOPE,
+  adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.VoApiV2,
+  onboarding: {
+    detection: {
+      titlePatterns: [/^VoAPI公益站$/i],
+    },
+    routes: {
+      usagePath: "/dash?_userMenuKey=dash",
+      checkInPath: "/checkIn?_userMenuKey=checkIn",
+      adminCredentialsPath: "/keys?_userMenuKey=keys",
+    },
+  },
+  productProfile: {
+    auth: {
+      allowedAuthTypes: [ACCOUNT_SITE_AUTH_TYPES.AccessToken],
+      defaultAuthType: ACCOUNT_SITE_AUTH_TYPES.AccessToken,
+      defaultAuthHostnames: [],
+      supportsCookieAuth: false,
+      supportsBuiltInCheckInDetection: true,
+    },
+    identity: {
+      usernameRequired: false,
+      storedUserIdentityFields: ["id", "username"],
+    },
+    modelList: {
+      directPricing: ACCOUNT_SITE_MODEL_LIST_DIRECT_PRICING.Unsupported,
+      tokenScopedCatalogFallback:
+        ACCOUNT_SITE_MODEL_LIST_TOKEN_SCOPED_CATALOG_FALLBACKS.None,
+      dashboardEstimateLoader:
+        ACCOUNT_SITE_MODEL_LIST_DASHBOARD_ESTIMATE_LOADERS.None,
+      statusScope: ACCOUNT_SITE_MODEL_LIST_STATUS_SCOPES.Account,
+      displayCapabilitiesSource:
+        ACCOUNT_SITE_MODEL_LIST_DISPLAY_CAPABILITY_SOURCES.Profile,
+    },
+  },
+  readiness: voApiV2Readiness,
+},
+```
+
+This definition records a precise title fallback, but the detection contract remains backend-signature first.
+
+- [ ] **Step 7: Add the content-session extractor**
+
+Create `src/services/accountSiteOnboarding/contentSession/voapiV2.ts`:
+
+```ts
+import { SITE_TYPES } from "~/constants/siteType"
+
+import type { ContentSessionExtractor } from "../contracts"
+
+const VOAPI_V2_STORAGE_KEYS = {
+  userStore: "userStore",
+  user: "user",
+} as const
+
+const parseJsonObject = (value: string | null): Record<string, unknown> | null => {
+  if (!value) return null
+  try {
+    const parsed = JSON.parse(value) as unknown
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : null
+  } catch {
+    return null
+  }
+}
+
+const trimString = (value: unknown): string | undefined =>
+  typeof value === "string" && value.trim() ? value.trim() : undefined
+
+const readObject = (value: unknown): Record<string, unknown> | null =>
+  value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null
+
+const decodeJwtPayload = (token: string): Record<string, unknown> | null => {
+  const [, payload] = token.split(".")
+  if (!payload) return null
+  try {
+    const padded = payload.padEnd(payload.length + ((4 - (payload.length % 4)) % 4), "=")
+    const normalized = padded.replace(/-/g, "+").replace(/_/g, "/")
+    return readObject(JSON.parse(atob(normalized)) as unknown)
+  } catch {
+    return null
+  }
+}
+
+const readUserId = (
+  user: Record<string, unknown> | null,
+  jwtPayload: Record<string, unknown> | null,
+): string | number | undefined => {
+  const localId = user?.id
+  if (typeof localId === "string" || typeof localId === "number") return localId
+
+  const jwtUserId = jwtPayload?.userId
+  if (typeof jwtUserId === "string" || typeof jwtUserId === "number") {
+    return jwtUserId
+  }
+
+  return undefined
+}
+
+export const voApiV2ContentSessionExtractor: ContentSessionExtractor = {
+  id: "voapi-v2",
+  canExtract: () => {
+    const userStore = parseJsonObject(localStorage.getItem(VOAPI_V2_STORAGE_KEYS.userStore))
+    const auth = readObject(userStore?.auth)
+    return Boolean(trimString(auth?.token))
+  },
+  async extract() {
+    const userStore = parseJsonObject(localStorage.getItem(VOAPI_V2_STORAGE_KEYS.userStore))
+    const auth = readObject(userStore?.auth)
+    const token = trimString(auth?.token)
+    if (!token) return null
+
+    const user = parseJsonObject(localStorage.getItem(VOAPI_V2_STORAGE_KEYS.user))
+    const jwtPayload = decodeJwtPayload(token)
+    const userId = readUserId(user, jwtPayload)
+    if (userId === undefined) return null
+
+    return {
+      userId,
+      user: {
+        id: userId,
+        ...(trimString(user?.username) ? { username: trimString(user?.username) } : {}),
+        ...(trimString(user?.display_name)
+          ? { display_name: trimString(user?.display_name) }
+          : {}),
+        ...(trimString(user?.email) || trimString(auth?.email)
+          ? { email: trimString(user?.email) ?? trimString(auth?.email) }
+          : {}),
+      },
+      accessToken: token,
+      siteTypeHint: SITE_TYPES.VO_API_V2,
+    }
+  },
+}
+```
+
+Use line wrapping that satisfies the repository formatter; keep all token handling log-free.
+
+- [ ] **Step 8: Register the extractor before generic compatible user**
+
+In `src/services/accountSiteOnboarding/registry.ts`, import:
+
+```ts
+import { voApiV2ContentSessionExtractor } from "./contentSession/voapiV2"
+```
+
+Return it before `compatibleUserContentSessionExtractor`:
+
+```ts
+return [
+  sub2ApiContentSessionExtractor,
+  sharedChatContentSessionExtractor,
+  voApiV2ContentSessionExtractor,
+  compatibleUserContentSessionExtractor,
+]
+```
+
+- [ ] **Step 9: Add backend-signature detection**
+
+In `src/services/siteDetection/detectSiteType.ts`, add a contract comment and helper near `detectSub2ApiFromAuthEndpoint(...)`:
+
+```ts
+const VOAPI_V2_USER_INFO_ENDPOINT = "/api/user/info"
+
+const readVoApiV2Message = (body: Record<string, unknown>): string => {
+  const message = body.msg ?? body.message
+  return typeof message === "string" ? message.trim() : ""
+}
+
+/**
+ * VoAPI v2 protected endpoints return a `{ code, data, msg }` envelope.
+ * Source: https://github.com/VoAPI/VoAPI and verified against demo.voapi.top:
+ * unauthenticated `/api/user/info` returns a numeric code with an auth message.
+ */
+async function detectVoApiV2FromProtectedEndpoint(
+  url: string,
+): Promise<AccountSiteType> {
+  try {
+    const response = await fetch(new URL(VOAPI_V2_USER_INFO_ENDPOINT, url), {
+      method: "GET",
+      cache: "no-store",
+      credentials: "omit",
+      headers: {
+        Accept: "application/json",
+      },
+    })
+
+    const contentType = response.headers.get("content-type") || ""
+    if (!/\bjson\b/i.test(contentType)) return SITE_TYPES.UNKNOWN
+
+    const responseBody = (await response.json()) as unknown
+    if (!isJsonObject(responseBody)) return SITE_TYPES.UNKNOWN
+
+    const code = responseBody.code
+    if (typeof code !== "number") return SITE_TYPES.UNKNOWN
+
+    if (code === 0 && isJsonObject(responseBody.data)) {
+      const data = responseBody.data
+      if (
+        "basicBalance" in data ||
+        "bindBalance" in data ||
+        "totalRequest" in data
+      ) {
+        return SITE_TYPES.VO_API_V2
+      }
+    }
+
+    const message = readVoApiV2Message(responseBody)
+    if (
+      responseBody.data === null &&
+      /unauthorized|auth\s*expire|token/i.test(message)
+    ) {
+      return SITE_TYPES.VO_API_V2
+    }
+  } catch (error) {
+    logger.debug("VoAPI v2 protected endpoint probe failed", { url, error })
+  }
+
+  return SITE_TYPES.UNKNOWN
+}
+```
+
+Change `getAccountSiteType(...)` order:
+
+```ts
+const voApiV2SiteType = await detectVoApiV2FromProtectedEndpoint(url)
+if (voApiV2SiteType !== SITE_TYPES.UNKNOWN) {
+  return voApiV2SiteType
+}
+
+const sub2ApiSiteType = await detectSub2ApiFromAuthEndpoint(url)
+if (sub2ApiSiteType !== SITE_TYPES.UNKNOWN) {
+  return sub2ApiSiteType
+}
+
+const title = await fetchSiteOriginalTitle(url)
+```
+
+Keep domain rules first. Keep old New API-family auth-error fallback last.
+
+- [ ] **Step 10: Run definition, session, and detection tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/constants/siteType.test.ts tests/services/accountSiteDefinitions/registry.test.ts tests/services/accounts/accountSiteProfile.test.ts tests/services/modelList/accountSources/readiness.definitions.test.ts tests/services/accountSiteOnboarding/contentSession/voapiV2.test.ts tests/services/accountSiteOnboarding/registry.test.ts tests/services/detectSiteType.test.ts tests/services/detectSiteType.fallback.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 11: Commit detection and onboarding change**
+
+Run:
+
+```powershell
+git add src/services/accountSiteDefinitions/identifiers.ts src/services/accountSiteDefinitions/contracts.ts src/services/accountSiteDefinitions/definitions.ts src/services/accountSiteOnboarding/contentSession/voapiV2.ts src/services/accountSiteOnboarding/registry.ts src/services/siteDetection/detectSiteType.ts tests/constants/siteType.test.ts tests/services/accountSiteDefinitions/registry.test.ts tests/services/accounts/accountSiteProfile.test.ts tests/services/modelList/accountSources/readiness.definitions.test.ts tests/services/accountSiteOnboarding/contentSession/voapiV2.test.ts tests/services/accountSiteOnboarding/registry.test.ts tests/services/detectSiteType.test.ts tests/services/detectSiteType.fallback.test.ts
+git commit -m "feat(voapi-v2): detect account site sessions"
+```
+
+### Task 3: Add VoAPI v2 backend service
+
+**Files:**
+- Create: `src/services/apiService/voapiV2/type.ts`
+- Create: `src/services/apiService/voapiV2/parsing.ts`
+- Create: `src/services/apiService/voapiV2/index.ts`
+- Test: `tests/services/apiService/voapiV2/parsing.test.ts`
+- Test: `tests/services/apiService/voapiV2/index.test.ts`
+
+- [ ] **Step 1: Write failing parser tests**
+
+Create `tests/services/apiService/voapiV2/parsing.test.ts` with coverage for success, top-level token, non-zero code, auth-expired classification, and amount conversion:
+
+```ts
+import { UI_CONSTANTS } from "~/constants/ui"
+import { ApiError } from "~/services/apiTransport/errors"
+import {
+  amountToQuota,
+  isVoApiV2AuthExpiredError,
+  parseVoApiV2Envelope,
+  quotaToAmountString,
+} from "~/services/apiService/voapiV2/parsing"
+
+describe("VoAPI v2 parsing", () => {
+  it("unwraps code zero data envelopes", () => {
+    expect(
+      parseVoApiV2Envelope({ code: 0, data: { id: 1 } }, "/api/user/info"),
+    ).toEqual({ id: 1 })
+  })
+
+  it("unwraps top-level token reveal envelopes", () => {
+    expect(
+      parseVoApiV2Envelope(
+        { code: 0, token: "sk-secret" },
+        "/api/keys/1/token",
+        { allowTopLevelToken: true },
+      ),
+    ).toBe("sk-secret")
+  })
+
+  it("throws ApiError for business errors", () => {
+    expect(() =>
+      parseVoApiV2Envelope({ code: 1, data: null, msg: "Signed in today" }, "/api/check_in"),
+    ).toThrow(ApiError)
+  })
+
+  it("classifies auth-expired business errors", () => {
+    try {
+      parseVoApiV2Envelope({ code: 2, data: null, msg: "Auth expire" }, "/api/user/info")
+    } catch (error) {
+      expect(isVoApiV2AuthExpiredError(error)).toBe(true)
+    }
+  })
+
+  it("converts decimal amounts to internal quota points", () => {
+    expect(amountToQuota("1.25")).toBe(
+      Math.round(1.25 * UI_CONSTANTS.EXCHANGE_RATE.CONVERSION_FACTOR),
+    )
+    expect(amountToQuota("invalid")).toBe(0)
+    expect(quotaToAmountString(UI_CONSTANTS.EXCHANGE_RATE.CONVERSION_FACTOR)).toBe("1")
+  })
+})
+```
+
+- [ ] **Step 2: Write failing service tests**
+
+Create `tests/services/apiService/voapiV2/index.test.ts` using MSW handlers. Add this helper at the top of the file:
+
+```ts
+const createVoApiV2Request = (): ApiServiceAccountRequest => ({
+  baseUrl: "https://example.invalid",
+  accountId: "account-1",
+  auth: {
+    authType: AuthTypeEnum.AccessToken,
+    accessToken: "jwt-dashboard",
+    userId: 7,
+  },
+  checkIn: {
+    enableDetection: true,
+  },
+})
+```
+
+Then add these tests:
+
+```ts
+it("fetches account data with raw authorization and today statistics", async () => {
+  server.use(
+    http.get("https://example.invalid/api/user/info", ({ request }) => {
+      expect(request.headers.get("authorization")).toBe("jwt-dashboard")
+      return HttpResponse.json({
+        code: 0,
+        data: {
+          id: 7,
+          username: "owner",
+          basicBalance: "2",
+          bindBalance: "3",
+          totalRequest: 123,
+          totalToken: 456,
+          currency: "USD",
+        },
+      })
+    }),
+    http.get("https://example.invalid/api/dash/statistics", () =>
+      HttpResponse.json({
+        code: 0,
+        data: {
+          d: {
+            requests: 9,
+            usedBasicBalance: "0.5",
+            usedBindBalance: "0.25",
+            errors: 0,
+            maxRpm: 1,
+          },
+        },
+      }),
+    ),
+  )
+
+  const data = await fetchVoApiV2AccountData({
+    baseUrl: "https://example.invalid",
+    auth: {
+      authType: AuthTypeEnum.AccessToken,
+      accessToken: "jwt-dashboard",
+      userId: 7,
+    },
+  })
+
+  expect(data.quota).toBe(2500000)
+  expect(data.today_quota_consumption).toBe(375000)
+  expect(data.today_requests_count).toBe(9)
+})
+
+it("reveals token secrets from the VoAPI v2 reveal endpoint", async () => {
+  server.use(
+    http.post("https://example.invalid/api/keys/11/token", () =>
+      HttpResponse.json({ code: 0, token: "sk-voapi-secret" }),
+    ),
+  )
+
+  await expect(
+    resolveVoApiV2TokenKey(createVoApiV2Request(), { id: 11, key: "sk-***" }),
+  ).resolves.toBe("sk-voapi-secret")
+})
+```
+
+Add these additional service tests in the same file:
+
+```ts
+it("normalizes VoAPI v2 key inventory", async () => {
+  server.use(
+    http.get("https://example.invalid/api/keys", () =>
+      HttpResponse.json({
+        code: 0,
+        data: [
+          {
+            id: 11,
+            name: "default",
+            tokenMasked: "sk-***",
+            groups: [2],
+            enable: true,
+            expireTime: 1893456000000,
+            amount: "2",
+            used: "0.5",
+          },
+        ],
+      }),
+    ),
+  )
+
+  await expect(fetchVoApiV2Tokens(createVoApiV2Request())).resolves.toEqual([
+    expect.objectContaining({
+      id: 11,
+      name: "default",
+      key: "sk-***",
+      status: 1,
+      remain_quota: 1000000,
+      used_quota: 250000,
+      group: "2",
+      expired_time: 1893456000,
+    }),
+  ])
+})
+
+it("creates keys with VoAPI v2 amount and group payloads", async () => {
+  let payload: unknown
+  server.use(
+    http.get("https://example.invalid/api/keys/template", () =>
+      HttpResponse.json({
+        code: 0,
+        data: {
+          groups: [{ id: 2, name: "default", ratio: 1 }],
+          models: [],
+        },
+      }),
+    ),
+    http.post("https://example.invalid/api/keys", async ({ request }) => {
+      payload = await request.json()
+      return HttpResponse.json({ code: 0, data: null })
+    }),
+  )
+
+  await expect(
+    createVoApiV2Token(createVoApiV2Request(), {
+      name: "default",
+      group: "2",
+      remain_quota: 500000,
+      expired_time: 1893456000,
+      unlimited_quota: false,
+      model_limits_enabled: false,
+      model_limits: "",
+      allow_ips: "",
+    }),
+  ).resolves.toBe(true)
+
+  expect(payload).toEqual({
+    name: "default",
+    groups: [2],
+    amount: "1",
+    genCount: 1,
+    enable: true,
+    expireTime: 1893456000000,
+  })
+})
+
+it("maps VoAPI v2 template groups and models", async () => {
+  server.use(
+    http.get("https://example.invalid/api/keys/template", () =>
+      HttpResponse.json({
+        code: 0,
+        data: {
+          groups: [{ id: 2, name: "Default", ratio: 1, note: "main" }],
+          models: [
+            { idKey: "gpt-4.1", enable: true, hidden: false },
+            { idKey: "hidden-model", enable: true, hidden: true },
+            { idKey: "disabled-model", enable: false, hidden: false },
+          ],
+        },
+      }),
+    ),
+  )
+
+  await expect(fetchVoApiV2AvailableModels(createVoApiV2Request())).resolves.toEqual([
+    "gpt-4.1",
+  ])
+  await expect(fetchVoApiV2UserGroups(createVoApiV2Request())).resolves.toEqual({
+    "2": { desc: "main", ratio: 1 },
+  })
+})
+
+it("classifies repeated VoAPI v2 check-in as already signed", async () => {
+  server.use(
+    http.post("https://example.invalid/api/check_in", () =>
+      HttpResponse.json({ code: 1, data: null, msg: "Signed in today" }),
+    ),
+  )
+
+  await expect(submitVoApiV2CheckIn(createVoApiV2Request())).resolves.toEqual({
+    alreadySigned: true,
+  })
+})
+```
+
+- [ ] **Step 3: Run the failing service tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/apiService/voapiV2/parsing.test.ts tests/services/apiService/voapiV2/index.test.ts
+```
+
+Expected: FAIL because the `voapiV2` service module does not exist.
+
+- [ ] **Step 4: Add endpoint constants and DTOs**
+
+Create `src/services/apiService/voapiV2/type.ts`:
+
+```ts
+export const VOAPI_V2_ENDPOINTS = {
+  UserInfo: "/api/user/info",
+  DashboardStatistics: "/api/dash/statistics",
+  Keys: "/api/keys",
+  KeyTemplate: "/api/keys/template",
+  CheckInTemplate: "/api/check_in/template",
+  CheckInStats: "/api/check_in/stats",
+  CheckInRecords: "/api/check_in",
+  CheckInSubmit: "/api/check_in",
+} as const
+
+export type VoApiV2Envelope<TData = unknown> = {
+  code: number
+  data?: TData
+  msg?: string
+  message?: string
+  token?: string
+  rid?: string
+}
+
+export type VoApiV2UserInfo = {
+  id: number | string
+  username?: string
+  nickname?: string
+  basicBalance?: string
+  bindBalance?: string
+  usedBasicBalance?: string
+  usedBindBalance?: string
+  currency?: string
+  totalRequest?: number
+  totalToken?: number
+}
+
+export type VoApiV2DashboardStatistics = {
+  d?: {
+    requests?: number
+    usedBasicBalance?: string
+    usedBindBalance?: string
+    errors?: number
+    maxRpm?: number
+  }
+}
+
+export type VoApiV2Key = {
+  id: number
+  name?: string
+  tokenMasked?: string
+  groups?: Array<string | number>
+  enable?: boolean
+  expireTime?: number
+  amount?: string
+  used?: string
+  note?: string
+}
+
+export type VoApiV2KeyTemplate = {
+  groups?: Array<{
+    id: string | number
+    name?: string
+    ratio?: number
+    timeRatio?: number
+    chargingType?: string
+    subBalanceType?: string
+    note?: string
+  }>
+  models?: Array<{
+    idKey?: string
+    enable?: boolean
+    hidden?: boolean
+  }>
+  ssb?: boolean
+}
+
+export type VoApiV2CheckInStats = {
+  todaySigned?: boolean
+  nextAmount?: string | number
+  todayRecord?: unknown
+  consecutiveDays?: number
+}
+
+export type VoApiV2CheckInSubmitData = {
+  amount?: string | number
+  bonusAmount?: string | number
+}
+```
+
+- [ ] **Step 5: Add parser and conversion helpers**
+
+Create `src/services/apiService/voapiV2/parsing.ts`:
+
+```ts
+import { UI_CONSTANTS } from "~/constants/ui"
+import {
+  API_ERROR_CODES,
+  ApiError,
+} from "~/services/apiTransport/errors"
+
+import type { VoApiV2Envelope } from "./type"
+
+export class VoApiV2AuthExpiredError extends ApiError {}
+
+export type VoApiV2EnvelopeOptions = {
+  allowNullData?: boolean
+  allowTopLevelToken?: boolean
+}
+
+const getMessage = (body: VoApiV2Envelope<unknown>): string =>
+  (typeof body.msg === "string" && body.msg.trim()) ||
+  (typeof body.message === "string" && body.message.trim()) ||
+  "VoAPI v2 request failed"
+
+const isObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+export function parseVoApiV2Envelope<TData>(
+  value: unknown,
+  endpoint: string,
+  options: VoApiV2EnvelopeOptions = {},
+): TData {
+  if (!isObject(value) || typeof value.code !== "number") {
+    throw new ApiError(
+      "Invalid VoAPI v2 response",
+      undefined,
+      endpoint,
+      API_ERROR_CODES.JSON_PARSE_ERROR,
+    )
+  }
+
+  const body = value as VoApiV2Envelope<TData>
+  if (body.code !== 0) {
+    const message = getMessage(body)
+    const ErrorClass =
+      body.code === 2 && /auth\s*expire|unauthorized|token/i.test(message)
+        ? VoApiV2AuthExpiredError
+        : ApiError
+    throw new ErrorClass(
+      message,
+      undefined,
+      endpoint,
+      API_ERROR_CODES.BUSINESS_ERROR,
+    )
+  }
+
+  if (options.allowTopLevelToken && typeof body.token === "string") {
+    return body.token as TData
+  }
+
+  if (body.data === null && options.allowNullData) {
+    return null as TData
+  }
+
+  if (body.data === undefined || body.data === null) {
+    throw new ApiError(
+      "Missing VoAPI v2 response data",
+      undefined,
+      endpoint,
+      API_ERROR_CODES.JSON_PARSE_ERROR,
+    )
+  }
+
+  return body.data
+}
+
+export const isVoApiV2AuthExpiredError = (
+  error: unknown,
+): error is VoApiV2AuthExpiredError => error instanceof VoApiV2AuthExpiredError
+
+export const amountToQuota = (amount: unknown): number => {
+  const parsed =
+    typeof amount === "number"
+      ? amount
+      : typeof amount === "string"
+        ? Number.parseFloat(amount)
+        : 0
+  if (!Number.isFinite(parsed) || parsed <= 0) return 0
+  return Math.round(parsed * UI_CONSTANTS.EXCHANGE_RATE.CONVERSION_FACTOR)
+}
+
+export const quotaToAmountString = (quota: unknown): string => {
+  const parsed = typeof quota === "number" ? quota : 0
+  if (!Number.isFinite(parsed) || parsed <= 0) return "0"
+  const amount = parsed / UI_CONSTANTS.EXCHANGE_RATE.CONVERSION_FACTOR
+  return Number.isInteger(amount) ? String(amount) : amount.toFixed(6).replace(/0+$/, "").replace(/\.$/, "")
+}
+```
+
+Keep the error messages local and generic; do not include tokens, URLs, key names, or raw response bodies.
+
+- [ ] **Step 6: Add service functions**
+
+Create `src/services/apiService/voapiV2/index.ts` with these exports:
+
+```ts
+import type { CreateTokenRequest } from "~/services/accountTokens/tokenProvisioningModel"
+import { determineHealthStatus } from "~/services/accounts/accountHealth"
+import type {
+  AccountData,
+  ApiServiceAccountRequest,
+  RefreshAccountResult,
+} from "~/services/accounts/accountDataModel"
+import { API_AUTH_TOKEN_MODES } from "~/services/apiTransport/type"
+import type { ApiServiceRequest } from "~/services/apiTransport/type"
+import { fetchApi } from "~/services/apiTransport/request"
+import { SiteHealthStatus, type ApiToken } from "~/types"
+import { t } from "~/utils/i18n/core"
+
+import {
+  amountToQuota,
+  isVoApiV2AuthExpiredError,
+  parseVoApiV2Envelope,
+  type VoApiV2EnvelopeOptions,
+  quotaToAmountString,
+} from "./parsing"
+import {
+  VOAPI_V2_ENDPOINTS,
+  type VoApiV2CheckInStats,
+  type VoApiV2CheckInSubmitData,
+  type VoApiV2DashboardStatistics,
+  type VoApiV2Key,
+  type VoApiV2KeyTemplate,
+  type VoApiV2UserInfo,
+} from "./type"
+
+export async function fetchVoApiV2Data<TData>(
+  request: ApiServiceRequest,
+  endpoint: string,
+  options: RequestInit = {},
+  parseOptions?: VoApiV2EnvelopeOptions,
+): Promise<TData> {
+  const body = await fetchApi<unknown>(
+    request,
+    {
+      endpoint,
+      options,
+      authTokenMode: API_AUTH_TOKEN_MODES.Raw,
+    },
+    true,
+  )
+
+  return parseVoApiV2Envelope<TData>(body, endpoint, parseOptions)
+}
+
+const buildTodayStatisticsEndpoint = () => {
+  const start = new Date()
+  start.setHours(0, 0, 0, 0)
+  const end = new Date()
+  end.setHours(23, 59, 59, 999)
+  return `${VOAPI_V2_ENDPOINTS.DashboardStatistics}?t=h&s=${start.getTime()}&e=${end.getTime()}`
+}
+
+export const fetchVoApiV2UserInfo = (request: ApiServiceRequest) =>
+  fetchVoApiV2Data<VoApiV2UserInfo>(request, VOAPI_V2_ENDPOINTS.UserInfo, {
+    cache: "no-store",
+  })
+
+export const fetchSupportCheckIn = async (
+  _request: ApiServiceRequest,
+): Promise<boolean | undefined> => true
+
+export async function fetchVoApiV2AccountData(
+  request: ApiServiceAccountRequest,
+): Promise<AccountData> {
+  const userInfo = await fetchVoApiV2UserInfo(request)
+  let stats: VoApiV2DashboardStatistics | null = null
+
+  if (request.includeTodayCashflow !== false) {
+    try {
+      stats = await fetchVoApiV2Data<VoApiV2DashboardStatistics>(
+        request,
+        buildTodayStatisticsEndpoint(),
+        { cache: "no-store" },
+      )
+    } catch {
+      stats = null
+    }
+  }
+
+  const quota =
+    amountToQuota(userInfo.basicBalance) + amountToQuota(userInfo.bindBalance)
+  const todayUsage =
+    amountToQuota(stats?.d?.usedBasicBalance) +
+    amountToQuota(stats?.d?.usedBindBalance)
+
+  return {
+    quota,
+    today_quota_consumption: todayUsage,
+    today_requests_count: Number(stats?.d?.requests ?? 0),
+    today_prompt_tokens: 0,
+    today_completion_tokens: 0,
+    today_income: 0,
+    checkIn: {
+      ...(request.checkIn ?? { enableDetection: false }),
+      siteStatus: {
+        ...(request.checkIn?.siteStatus ?? {}),
+      },
+    },
+  }
+}
+
+export async function refreshAccountData(
+  request: ApiServiceAccountRequest,
+): Promise<RefreshAccountResult> {
+  try {
+    const data = await fetchVoApiV2AccountData(request)
+    return {
+      success: true,
+      data,
+      healthStatus: {
+        status: SiteHealthStatus.Healthy,
+        message: t("account:healthStatus.normal"),
+      },
+    }
+  } catch (error) {
+    if (isVoApiV2AuthExpiredError(error)) {
+      return {
+        success: false,
+        healthStatus: {
+          status: SiteHealthStatus.Warning,
+          message: t("account:healthStatus.httpError", {
+            statusCode: 401,
+            message: error.message,
+          }),
+        },
+      }
+    }
+
+    return {
+      success: false,
+      healthStatus: determineHealthStatus(error),
+    }
+  }
+}
+
+export async function fetchVoApiV2Tokens(
+  request: ApiServiceRequest,
+  page = 1,
+  size = 10,
+): Promise<ApiToken[]> {
+  const endpoint = `${VOAPI_V2_ENDPOINTS.Keys}?page=${page}&size=${size}&sl[name]=true&sl[token]=true&sl[note]=true`
+  const data = await fetchVoApiV2Data<VoApiV2Key[] | { list?: VoApiV2Key[] }>(
+    request,
+    endpoint,
+    { cache: "no-store" },
+  )
+  const keys = Array.isArray(data) ? data : (data.list ?? [])
+  return keys.map((token) => ({
+    id: token.id,
+    name: token.name ?? "",
+    key: token.tokenMasked ?? "",
+    status: token.enable === false ? 2 : 1,
+    remain_quota: amountToQuota(token.amount),
+    used_quota: amountToQuota(token.used),
+    expired_time:
+      typeof token.expireTime === "number" && token.expireTime > 0
+        ? Math.floor(token.expireTime / 1000)
+        : -1,
+    created_time: 0,
+    accessed_time: 0,
+    user_id: Number(request.auth.userId ?? 0),
+    DeletedAt: null,
+    models: "",
+    group: token.groups?.[0] !== undefined ? String(token.groups[0]) : "",
+    unlimited_quota: false,
+    model_limits_enabled: false,
+    model_limits: "",
+    allow_ips: "",
+  }))
+}
+
+export const fetchVoApiV2Template = (request: ApiServiceRequest) =>
+  fetchVoApiV2Data<VoApiV2KeyTemplate>(
+    request,
+    VOAPI_V2_ENDPOINTS.KeyTemplate,
+    { cache: "no-store" },
+  )
+
+export async function resolveVoApiV2TokenKey(
+  request: ApiServiceRequest,
+  token: Pick<ApiToken, "id" | "key">,
+): Promise<string> {
+  return await fetchVoApiV2Data<string>(
+    request,
+    `${VOAPI_V2_ENDPOINTS.Keys}/${token.id}/token`,
+    { method: "POST" },
+    { allowTopLevelToken: true },
+  )
+}
+
+const toExpireTimeMillis = (expiredTime: number | undefined): number =>
+  typeof expiredTime === "number" && expiredTime > 0 ? expiredTime * 1000 : -1
+
+export async function createVoApiV2Token(
+  request: ApiServiceRequest,
+  tokenData: CreateTokenRequest,
+): Promise<boolean> {
+  const groups = await resolveVoApiV2GroupIds(request, tokenData.group)
+
+  await fetchVoApiV2Data<null>(
+    request,
+    VOAPI_V2_ENDPOINTS.Keys,
+    {
+      method: "POST",
+      body: JSON.stringify({
+        name: tokenData.name,
+        groups,
+        amount: quotaToAmountString(tokenData.remain_quota),
+        genCount: 1,
+        enable: true,
+        expireTime: toExpireTimeMillis(tokenData.expired_time),
+      }),
+    },
+    { allowNullData: true },
+  )
+  return true
+}
+
+export async function deleteVoApiV2Token(
+  request: ApiServiceRequest,
+  tokenId: number,
+): Promise<boolean> {
+  await fetchVoApiV2Data<null>(
+    request,
+    `${VOAPI_V2_ENDPOINTS.Keys}/${tokenId}`,
+    { method: "DELETE" },
+    { allowNullData: true },
+  )
+  return true
+}
+
+export const fetchVoApiV2CheckInStats = (request: ApiServiceRequest) =>
+  fetchVoApiV2Data<VoApiV2CheckInStats>(
+    request,
+    VOAPI_V2_ENDPOINTS.CheckInStats,
+    { cache: "no-store" },
+  )
+
+export const submitVoApiV2CheckIn = (request: ApiServiceRequest) =>
+  fetchVoApiV2Data<VoApiV2CheckInSubmitData>(
+    request,
+    VOAPI_V2_ENDPOINTS.CheckInSubmit,
+    { method: "POST" },
+  )
+```
+
+Add `fetchVoApiV2TokenById(...)`, `updateVoApiV2Token(...)`, `setVoApiV2TokenEnabled(...)`, `fetchVoApiV2AvailableModels(...)`, and `fetchVoApiV2UserGroups(...)` in the same file. Also add a `resolveVoApiV2GroupIds(...)` helper that resolves the selected form value against `/api/keys/template` and returns numeric backend group ids for create/update payloads. `updateVoApiV2Token(...)` fetches current inventory first, preserves `used` and `note`, then sends the full update payload:
+
+```ts
+body: JSON.stringify({
+  id: tokenId,
+  name: tokenData.name,
+  groups: await resolveVoApiV2GroupIds(request, tokenData.group, existing.groups),
+  enable: existing.enable !== false,
+  expireTime: toExpireTimeMillis(tokenData.expired_time),
+  amount: quotaToAmountString(tokenData.remain_quota),
+  used: existing.used ?? "0",
+  note: existing.note ?? "",
+})
+```
+
+For `setVoApiV2TokenEnabled(...)`, call the same update endpoint with `enable` set to the requested boolean and the rest of the preserved fields from `fetchVoApiV2TokenById(...)`.
+
+For duplicate check-in (`code: 1`, `Signed in today`), `submitVoApiV2CheckIn(...)` reads the raw envelope and returns a local union:
+
+```ts
+export type VoApiV2CheckInSubmitResult =
+  | VoApiV2CheckInSubmitData
+  | { alreadySigned: true }
+```
+
+Ordinary non-zero codes still throw `ApiError`.
+
+- [ ] **Step 7: Run service tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/apiService/voapiV2/parsing.test.ts tests/services/apiService/voapiV2/index.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit service module**
+
+Run:
+
+```powershell
+git add src/services/apiService/voapiV2 tests/services/apiService/voapiV2
+git commit -m "feat(voapi-v2): add backend service"
+```
+
+### Task 4: Wire VoAPI v2 adapter capabilities
+
+**Files:**
+- Modify: `src/services/apiAdapters/contracts/siteTypeCapabilities.ts`
+- Modify: `src/services/apiAdapters/registry.ts`
+- Create: `src/services/apiAdapters/voapiV2/index.ts`
+- Create: `src/services/apiAdapters/voapiV2/accountBootstrap.ts`
+- Create: `src/services/apiAdapters/voapiV2/accountCompletion.ts`
+- Create: `src/services/apiAdapters/voapiV2/accountData.ts`
+- Create: `src/services/apiAdapters/voapiV2/accountRefresh.ts`
+- Create: `src/services/apiAdapters/voapiV2/keyManagement.ts`
+- Create: `src/services/apiAdapters/voapiV2/tokenProvisioning.ts`
+- Test: `tests/services/apiAdapters/registry.test.ts`
+- Test: `tests/services/apiAdapters/voapiV2/accountCompletion.test.ts`
+- Test: `tests/services/apiAdapters/voapiV2/accountRefresh.test.ts`
+- Test: `tests/services/apiAdapters/voapiV2/keyManagement.test.ts`
+- Test: `tests/services/apiAdapters/voapiV2/tokenProvisioning.test.ts`
+- Test helper: `tests/services/apiAdapters/voapiV2/testUtils.ts`
+
+- [ ] **Step 1: Write failing registry and adapter tests**
+
+In `tests/services/apiAdapters/registry.test.ts`, assert:
+
+```ts
+const voApiV2Capabilities = getSiteTypeCapabilities(SITE_TYPES.VO_API_V2)
+expect(voApiV2Capabilities.family).toBe(ACCOUNT_SITE_ADAPTER_FAMILIES.VoApiV2)
+expect(voApiV2Capabilities.account?.data).toBeDefined()
+expect(voApiV2Capabilities.account?.completion).toBeDefined()
+expect(voApiV2Capabilities.account?.keyManagement).toBeDefined()
+
+const oldVoApiCapabilities = getSiteTypeCapabilities(SITE_TYPES.VO_API)
+expect(oldVoApiCapabilities.family).toBe(ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily)
+```
+
+In `tests/services/apiAdapters/voapiV2/testUtils.ts`, create a shared request helper:
+
+```ts
+import { AuthTypeEnum } from "~/types"
+import type { ApiServiceAccountRequest } from "~/services/accounts/accountDataModel"
+
+export const createVoApiV2Request = (): ApiServiceAccountRequest => ({
+  baseUrl: "https://example.invalid",
+  accountId: "account-1",
+  auth: {
+    authType: AuthTypeEnum.AccessToken,
+    accessToken: "jwt-dashboard",
+    userId: 7,
+  },
+  checkIn: {
+    enableDetection: true,
+  },
+})
+```
+
+Create account completion tests:
+
+```ts
+it("stores the dashboard JWT as the access token", async () => {
+  server.use(
+    http.get("https://example.invalid/api/user/info", () =>
+      HttpResponse.json({
+        code: 0,
+        data: {
+          id: 7,
+          username: "owner",
+          nickname: "Owner",
+          basicBalance: "1",
+          bindBalance: "0",
+        },
+      }),
+    ),
+  )
+
+  const completed = await voApiV2AccountCompletion.complete(
+    {
+      url: "https://example.invalid",
+      detected: {
+        userId: 7,
+        user: { username: "owner" },
+        accessToken: "jwt-dashboard",
+        siteTypeHint: SITE_TYPES.VO_API_V2,
+      },
+      context: undefined,
+    },
+    helpers,
+  )
+
+  expect(completed).toMatchObject({
+    accessToken: "jwt-dashboard",
+    userId: "7",
+    username: "owner",
+    authType: AuthTypeEnum.AccessToken,
+  })
+  expect(completed.checkIn.enableDetection).toBe(true)
+})
+
+it("fails completion when the dashboard JWT is missing", async () => {
+  await expect(
+    voApiV2AccountCompletion.complete(
+      {
+        url: "https://example.invalid",
+        detected: { userId: 7, user: {} },
+        context: undefined,
+      },
+      helpers,
+    ),
+  ).rejects.toMatchObject({
+    reason: AUTO_DETECT_FAILURE_REASONS.AccessTokenMissing,
+  })
+})
+```
+
+Create account refresh tests in `tests/services/apiAdapters/voapiV2/accountRefresh.test.ts`:
+
+```ts
+it("reports expired dashboard JWT without trying refresh-token recovery", async () => {
+  server.use(
+    http.get("https://example.invalid/api/user/info", () =>
+      HttpResponse.json({ code: 2, data: null, msg: "Auth expire" }),
+    ),
+  )
+
+  await expect(
+    voApiV2AccountRefresh.refreshAccount(createVoApiV2Request()),
+  ).resolves.toEqual(
+    expect.objectContaining({
+      success: false,
+      authUpdate: undefined,
+      healthStatus: expect.objectContaining({
+        status: SiteHealthStatus.Warning,
+      }),
+    }),
+  )
+})
+
+it("does not expose refresh-token fields in VoAPI v2 refresh results", async () => {
+  server.use(
+    http.get("https://example.invalid/api/user/info", () =>
+      HttpResponse.json({
+        code: 0,
+        data: {
+          id: 7,
+          username: "owner",
+          basicBalance: "1",
+          bindBalance: "0",
+        },
+      }),
+    ),
+    http.get("https://example.invalid/api/dash/statistics", () =>
+      HttpResponse.json({ code: 0, data: { d: { requests: 0 } } }),
+    ),
+  )
+
+  const result = await voApiV2AccountRefresh.refreshAccount(
+    createVoApiV2Request(),
+  )
+
+  expect(result.authUpdate).toBeUndefined()
+})
+```
+
+Create this key-management test in `tests/services/apiAdapters/voapiV2/keyManagement.test.ts`:
+
+```ts
+it("reveals keys through VoAPI v2 and does not call New API key reveal routes", async () => {
+  const newApiReveal = vi.fn()
+
+  server.use(
+    http.post("https://example.invalid/api/keys/11/token", () =>
+      HttpResponse.json({ code: 0, token: "sk-voapi-secret" }),
+    ),
+    http.get("https://example.invalid/api/token/11/key", () => {
+      newApiReveal()
+      return HttpResponse.json({ success: true, data: "wrong", message: "ok" })
+    }),
+  )
+
+  await expect(
+    voApiV2KeyManagement.resolveTokenKey({
+      request: createVoApiV2Request(),
+      token: { id: 11, key: "sk-***" },
+    }),
+  ).resolves.toBe("sk-voapi-secret")
+
+  expect(newApiReveal).not.toHaveBeenCalled()
+})
+```
+
+- [ ] **Step 2: Run failing adapter tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/apiAdapters/registry.test.ts tests/services/apiAdapters/voapiV2/accountCompletion.test.ts tests/services/apiAdapters/voapiV2/accountRefresh.test.ts tests/services/apiAdapters/voapiV2/keyManagement.test.ts tests/services/apiAdapters/voapiV2/tokenProvisioning.test.ts
+```
+
+Expected: FAIL because the adapter modules and registry branch do not exist.
+
+- [ ] **Step 3: Extend capability family type**
+
+In `src/services/apiAdapters/contracts/siteTypeCapabilities.ts`, change:
+
+```ts
+export type SiteBackendFamily = "newApiFamily" | "sub2api"
+```
+
+to:
+
+```ts
+export type SiteBackendFamily = "newApiFamily" | "sub2api" | "voapiV2"
+```
+
+- [ ] **Step 4: Add account bootstrap**
+
+Create `src/services/apiAdapters/voapiV2/accountBootstrap.ts`:
+
+```ts
+import { UI_CONSTANTS } from "~/constants/ui"
+import {
+  ACCOUNT_BOOTSTRAP_ROUTE_KINDS,
+  type AccountBootstrapCapability,
+  type AccountBootstrapRouteKind,
+} from "~/services/apiAdapters/contracts/accountBootstrap"
+import { fetchVoApiV2UserInfo } from "~/services/apiService/voapiV2"
+
+const VOAPI_V2_ROUTES: Record<AccountBootstrapRouteKind, string> = {
+  [ACCOUNT_BOOTSTRAP_ROUTE_KINDS.Login]: "/",
+  [ACCOUNT_BOOTSTRAP_ROUTE_KINDS.Usage]: "/dash?_userMenuKey=dash",
+  [ACCOUNT_BOOTSTRAP_ROUTE_KINDS.CheckIn]: "/checkIn?_userMenuKey=checkIn",
+  [ACCOUNT_BOOTSTRAP_ROUTE_KINDS.AdminCredentials]: "/keys?_userMenuKey=keys",
+  [ACCOUNT_BOOTSTRAP_ROUTE_KINDS.Redeem]: "/dash?_userMenuKey=dash",
+  [ACCOUNT_BOOTSTRAP_ROUTE_KINDS.SiteAnnouncements]: "/dash?_userMenuKey=dash",
+}
+
+export const voApiV2AccountBootstrap: AccountBootstrapCapability = {
+  fetchUserInfo: async (request) => {
+    const user = await fetchVoApiV2UserInfo(request)
+    return {
+      id: user.id,
+      username: user.username ?? user.nickname ?? String(user.id),
+      access_token: request.auth.accessToken ?? "",
+    }
+  },
+  getOrCreateAccessToken: async (request) => {
+    const user = await fetchVoApiV2UserInfo(request)
+    return {
+      username: user.username ?? user.nickname ?? String(user.id),
+      access_token: request.auth.accessToken ?? "",
+    }
+  },
+  fetchSiteStatus: async () => ({
+    system_name: "VoAPI",
+    checkin_enabled: true,
+  }),
+  extractDefaultExchangeRate: () => UI_CONSTANTS.EXCHANGE_RATE.DEFAULT,
+  fetchCheckInSupport: async () => true,
+  resolveRoutePath: async (_target, route) => VOAPI_V2_ROUTES[route],
+}
+```
+
+- [ ] **Step 5: Add completion**
+
+Create `src/services/apiAdapters/voapiV2/accountCompletion.ts`:
+
+```ts
+import { AUTO_DETECT_FAILURE_REASONS } from "~/constants/autoDetect"
+import { UI_CONSTANTS } from "~/constants/ui"
+import { fetchVoApiV2UserInfo } from "~/services/apiService/voapiV2"
+import { AuthTypeEnum } from "~/types"
+
+import type { AccountCompletionCapability } from "../contracts/accountCompletion"
+
+export const voApiV2AccountCompletion: AccountCompletionCapability = {
+  async complete(request, helpers) {
+    const { url, detected, context } = request
+    const accessToken = helpers.trimString(detected.accessToken)
+
+    if (!accessToken) {
+      throw helpers.createCompletionError(
+        AUTO_DETECT_FAILURE_REASONS.AccessTokenMissing,
+        new Error("VoAPI v2 dashboard JWT missing"),
+      )
+    }
+
+    let userInfo
+    try {
+      userInfo = await fetchVoApiV2UserInfo(
+        helpers.createServiceRequest({
+          baseUrl: url,
+          context,
+          auth: {
+            authType: AuthTypeEnum.AccessToken,
+            accessToken,
+            userId: detected.userId,
+          },
+        }),
+      )
+    } catch (error) {
+      throw helpers.createCompletionError(
+        AUTO_DETECT_FAILURE_REASONS.TokenFetchFailed,
+        error,
+      )
+    }
+
+    const userId = helpers.trimString(detected.userId) || String(userInfo.id)
+    const username =
+      helpers.trimString(detected.user?.username) ||
+      helpers.trimString(detected.user?.display_name) ||
+      helpers.trimString(detected.user?.email) ||
+      helpers.trimString(userInfo.username) ||
+      helpers.trimString(userInfo.nickname) ||
+      userId
+
+    return {
+      username,
+      siteName: await helpers.fetchSiteName({ system_name: "VoAPI" }),
+      accessToken,
+      userId,
+      exchangeRate: UI_CONSTANTS.EXCHANGE_RATE.DEFAULT,
+      authType: AuthTypeEnum.AccessToken,
+      checkIn: helpers.createInitialCheckInConfig({
+        enableDetection: true,
+        autoCheckInEnabled: false,
+      }),
+    }
+  },
+}
+```
+
+- [ ] **Step 6: Add data, refresh, key-management, and token-provisioning capabilities**
+
+Create `src/services/apiAdapters/voapiV2/accountData.ts`:
+
+```ts
+import type { AccountDataCapability } from "~/services/apiAdapters/contracts/accountData"
+import { fetchVoApiV2AccountData } from "~/services/apiService/voapiV2"
+
+export const voApiV2AccountData: AccountDataCapability = {
+  fetchData: (request) => fetchVoApiV2AccountData(request),
+}
+```
+
+Create `src/services/apiAdapters/voapiV2/accountRefresh.ts`:
+
+```ts
+import type { AccountRefreshCapability } from "~/services/apiAdapters/contracts/accountRefresh"
+import {
+  fetchSupportCheckIn,
+  refreshAccountData,
+} from "~/services/apiService/voapiV2"
+
+export const voApiV2AccountRefresh: AccountRefreshCapability = {
+  fetchCheckInSupport: (request) => fetchSupportCheckIn(request),
+  refreshAccount: (request) => refreshAccountData(request),
+}
+```
+
+Create `src/services/apiAdapters/voapiV2/keyManagement.ts`:
+
+```ts
+import type { KeyManagementCapability } from "~/services/apiAdapters/contracts/keyManagement"
+import {
+  createVoApiV2Token,
+  deleteVoApiV2Token,
+  fetchVoApiV2AvailableModels,
+  fetchVoApiV2Tokens,
+  fetchVoApiV2UserGroups,
+  resolveVoApiV2TokenKey,
+  updateVoApiV2Token,
+} from "~/services/apiService/voapiV2"
+
+export const voApiV2KeyManagement: KeyManagementCapability = {
+  fetchTokens: (request, options) =>
+    fetchVoApiV2Tokens(request, options?.page, options?.size),
+  createToken: (request, tokenData) => createVoApiV2Token(request, tokenData),
+  updateToken: ({ request, tokenId, tokenData }) =>
+    updateVoApiV2Token(request, tokenId, tokenData),
+  resolveTokenKey: ({ request, token }) => resolveVoApiV2TokenKey(request, token),
+  deleteToken: ({ request, tokenId }) => deleteVoApiV2Token(request, tokenId),
+  fetchAvailableModels: (request) => fetchVoApiV2AvailableModels(request),
+  userGroups: {
+    fetch: (request) => fetchVoApiV2UserGroups(request),
+  },
+}
+```
+
+Create `src/services/apiAdapters/voapiV2/tokenProvisioning.ts` using the existing provisioning constants:
+
+```ts
+import type { TokenProvisioningCapability } from "~/services/apiAdapters/contracts/tokenProvisioning"
+import {
+  CREATED_TOKEN_SECRET_DECISION_KINDS,
+  DEFAULT_TOKEN_CREATION_DECISION_KINDS,
+  TOKEN_CREATION_SECRET_RECOVERY,
+  TOKEN_PROVISIONING_BLOCK_REASONS,
+  TOKEN_PROVISIONING_REPAIR_POLICY_KINDS,
+} from "~/services/apiAdapters/contracts/tokenProvisioning"
+
+export const voApiV2TokenProvisioning: TokenProvisioningCapability = {
+  isInventoryTokenUsable: ({ token }) => Boolean(token.id),
+  resolveDefaultTokenCreation({ defaultTokenData, explicitGroup, userGroups }) {
+    if (defaultTokenData.unlimited_quota) {
+      return {
+        kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.Blocked,
+        reason: TOKEN_PROVISIONING_BLOCK_REASONS.CreatedTokenSecretUnavailable,
+      }
+    }
+
+    if (explicitGroup) {
+      return {
+        kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.Create,
+        tokenData: { ...defaultTokenData, group: explicitGroup },
+        oneTimeSecret: false,
+        recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.InventoryRefetch,
+      }
+    }
+
+    const allowedGroups = Object.keys(userGroups ?? {})
+    if (allowedGroups.length === 0) {
+      return { kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.NeedsUserGroups }
+    }
+    if (allowedGroups.length === 1) {
+      return {
+        kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.Create,
+        tokenData: { ...defaultTokenData, group: allowedGroups[0] },
+        oneTimeSecret: false,
+        recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.InventoryRefetch,
+      }
+    }
+    return {
+      kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.SelectionRequired,
+      allowedGroups,
+      reason: TOKEN_PROVISIONING_BLOCK_REASONS.GroupSelectionRequired,
+    }
+  },
+  classifyCreatedToken() {
+    return { kind: CREATED_TOKEN_SECRET_DECISION_KINDS.NeedsInventoryRefetch }
+  },
+  getRepairPolicy() {
+    return { kind: TOKEN_PROVISIONING_REPAIR_POLICY_KINDS.Eligible }
+  },
+}
+```
+
+- [ ] **Step 7: Add capability index and registry branch**
+
+Create `src/services/apiAdapters/voapiV2/index.ts`:
+
+```ts
+import { ACCOUNT_SITE_ADAPTER_FAMILIES, SITE_TYPES } from "~/constants/siteType"
+import type { SiteTypeCapabilities } from "~/services/apiAdapters/contracts/siteTypeCapabilities"
+
+import { voApiV2AccountBootstrap } from "./accountBootstrap"
+import { voApiV2AccountCompletion } from "./accountCompletion"
+import { voApiV2AccountData } from "./accountData"
+import { voApiV2AccountRefresh } from "./accountRefresh"
+import { voApiV2KeyManagement } from "./keyManagement"
+import { voApiV2TokenProvisioning } from "./tokenProvisioning"
+
+export const voApiV2Capabilities: SiteTypeCapabilities = {
+  siteType: SITE_TYPES.VO_API_V2,
+  family: ACCOUNT_SITE_ADAPTER_FAMILIES.VoApiV2,
+  account: {
+    data: voApiV2AccountData,
+    bootstrap: voApiV2AccountBootstrap,
+    completion: voApiV2AccountCompletion,
+    keyManagement: voApiV2KeyManagement,
+    tokenProvisioning: voApiV2TokenProvisioning,
+    refresh: voApiV2AccountRefresh,
+  },
+}
+```
+
+In `src/services/apiAdapters/registry.ts`, import:
+
+```ts
+import { voApiV2Capabilities } from "./voapiV2"
+```
+
+Add this branch before the New API-family branch:
+
+```ts
+if (siteType === SITE_TYPES.VO_API_V2) return voApiV2Capabilities
+```
+
+- [ ] **Step 8: Run adapter tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/apiAdapters/registry.test.ts tests/services/apiAdapters/voapiV2/accountCompletion.test.ts tests/services/apiAdapters/voapiV2/accountRefresh.test.ts tests/services/apiAdapters/voapiV2/keyManagement.test.ts tests/services/apiAdapters/voapiV2/tokenProvisioning.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit adapter capabilities**
+
+Run:
+
+```powershell
+git add src/services/apiAdapters/contracts/siteTypeCapabilities.ts src/services/apiAdapters/registry.ts src/services/apiAdapters/voapiV2 tests/services/apiAdapters/registry.test.ts tests/services/apiAdapters/voapiV2
+git commit -m "feat(voapi-v2): add account adapter capabilities"
+```
+
+### Task 5: Add VoAPI v2 auto check-in provider
+
+**Files:**
+- Create: `src/services/checkin/autoCheckin/providers/voapiV2.ts`
+- Modify: `src/services/checkin/autoCheckin/providers/index.ts`
+- Test: `tests/services/autoCheckin/providers/voapiV2.test.ts`
+
+- [ ] **Step 1: Write failing check-in provider tests**
+
+Create `tests/services/autoCheckin/providers/voapiV2.test.ts`:
+
+```ts
+import { SITE_TYPES } from "~/constants/siteType"
+import { voApiV2Provider } from "~/services/checkin/autoCheckin/providers/voapiV2"
+import type { SiteAccount } from "~/types"
+import { CHECKIN_RESULT_STATUS } from "~/types/autoCheckin"
+
+const account = {
+  id: "account-1",
+  site_type: SITE_TYPES.VO_API_V2,
+  site_url: "https://example.invalid",
+  account_info: {
+    id: "7",
+    access_token: "jwt-dashboard",
+  },
+  checkIn: {
+    enableDetection: true,
+  },
+} as unknown as SiteAccount
+
+it("checks in through the VoAPI v2 API and confirms stats", async () => {
+  server.use(
+    http.post("https://example.invalid/api/check_in", ({ request }) => {
+      expect(request.headers.get("authorization")).toBe("jwt-dashboard")
+      return HttpResponse.json({ code: 0, data: { amount: "0.1", bonusAmount: "0" } })
+    }),
+    http.get("https://example.invalid/api/check_in/stats", () =>
+      HttpResponse.json({ code: 0, data: { todaySigned: true } }),
+    ),
+  )
+
+  await expect(voApiV2Provider.checkIn(account)).resolves.toMatchObject({
+    status: CHECKIN_RESULT_STATUS.SUCCESS,
+  })
+})
+
+it("treats repeated same-day sign-in as already checked", async () => {
+  server.use(
+    http.post("https://example.invalid/api/check_in", () =>
+      HttpResponse.json({ code: 1, data: null, msg: "Signed in today" }),
+    ),
+    http.get("https://example.invalid/api/check_in/stats", () =>
+      HttpResponse.json({ code: 0, data: { todaySigned: true } }),
+    ),
+  )
+
+  await expect(voApiV2Provider.checkIn(account)).resolves.toMatchObject({
+    status: CHECKIN_RESULT_STATUS.ALREADY_CHECKED,
+  })
+})
+
+it("does not run without the saved dashboard JWT", () => {
+  expect(
+    voApiV2Provider.canCheckIn({
+      ...account,
+      account_info: { ...account.account_info, access_token: "" },
+    } as unknown as SiteAccount),
+  ).toBe(false)
+})
+```
+
+- [ ] **Step 2: Run failing check-in tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/autoCheckin/providers/voapiV2.test.ts
+```
+
+Expected: FAIL because the provider does not exist.
+
+- [ ] **Step 3: Implement the provider**
+
+Create `src/services/checkin/autoCheckin/providers/voapiV2.ts`:
+
+```ts
+import { SITE_TYPES } from "~/constants/siteType"
+import type { ApiServiceRequest } from "~/services/apiTransport/type"
+import {
+  fetchVoApiV2CheckInStats,
+  submitVoApiV2CheckIn,
+} from "~/services/apiService/voapiV2"
+import type { AutoCheckinProvider } from "~/services/checkin/autoCheckin/providers"
+import {
+  AUTO_CHECKIN_PROVIDER_FALLBACK_MESSAGE_KEYS,
+  resolveProviderErrorResult,
+} from "~/services/checkin/autoCheckin/providers/shared"
+import type { AutoCheckinProviderResult } from "~/services/checkin/autoCheckin/providers/types"
+import { AuthTypeEnum, type SiteAccount } from "~/types"
+import { CHECKIN_RESULT_STATUS } from "~/types/autoCheckin"
+
+const createRequest = (account: SiteAccount): ApiServiceRequest => ({
+  baseUrl: account.site_url,
+  accountId: account.id,
+  auth: {
+    authType: AuthTypeEnum.AccessToken,
+    accessToken: account.account_info.access_token,
+    userId: account.account_info.id,
+  },
+})
+
+const isVoApiV2Account = (account: SiteAccount): boolean =>
+  account.site_type === SITE_TYPES.VO_API_V2
+
+export const voApiV2Provider: AutoCheckinProvider = {
+  canCheckIn(account) {
+    return Boolean(
+      isVoApiV2Account(account as SiteAccount) &&
+        (account as SiteAccount).checkIn?.enableDetection &&
+        (account as SiteAccount).account_info?.access_token,
+    )
+  },
+  async checkIn(account): Promise<AutoCheckinProviderResult> {
+    try {
+      const siteAccount = account as SiteAccount
+      if (!this.canCheckIn(siteAccount)) {
+        return {
+          status: CHECKIN_RESULT_STATUS.FAILED,
+          messageKey: AUTO_CHECKIN_PROVIDER_FALLBACK_MESSAGE_KEYS.checkinFailed,
+        }
+      }
+
+      const request = createRequest(siteAccount)
+      const submitResult = await submitVoApiV2CheckIn(request)
+      const stats = await fetchVoApiV2CheckInStats(request)
+
+      if ("alreadySigned" in submitResult) {
+        return {
+          status: CHECKIN_RESULT_STATUS.ALREADY_CHECKED,
+          messageKey:
+            AUTO_CHECKIN_PROVIDER_FALLBACK_MESSAGE_KEYS.alreadyCheckedToday,
+          data: stats,
+        }
+      }
+
+      return {
+        status:
+          stats.todaySigned === true
+            ? CHECKIN_RESULT_STATUS.SUCCESS
+            : CHECKIN_RESULT_STATUS.FAILED,
+        messageKey:
+          stats.todaySigned === true
+            ? AUTO_CHECKIN_PROVIDER_FALLBACK_MESSAGE_KEYS.checkinSuccessful
+            : AUTO_CHECKIN_PROVIDER_FALLBACK_MESSAGE_KEYS.checkinFailed,
+        data: stats,
+      }
+    } catch (error) {
+      return resolveProviderErrorResult({ error })
+    }
+  },
+}
+```
+
+Do not add a native-page click fallback for VoAPI v2 in this first version.
+
+- [ ] **Step 4: Register the provider**
+
+In `src/services/checkin/autoCheckin/providers/index.ts`, import:
+
+```ts
+import { voApiV2Provider } from "~/services/checkin/autoCheckin/providers/voapiV2"
+```
+
+Add to `providers`:
+
+```ts
+[SITE_TYPES.VO_API_V2]: voApiV2Provider,
+```
+
+- [ ] **Step 5: Run check-in tests**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/autoCheckin/providers/voapiV2.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit check-in provider**
+
+Run:
+
+```powershell
+git add src/services/checkin/autoCheckin/providers/voapiV2.ts src/services/checkin/autoCheckin/providers/index.ts tests/services/autoCheckin/providers/voapiV2.test.ts
+git commit -m "feat(voapi-v2): add api check-in provider"
+```
+
+### Task 6: Integration validation, maintainability audit, and handoff
+
+**Files:**
+- Review: all files touched in Tasks 1-5.
+
+- [ ] **Step 1: Run focused test set**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/apiTransport/request.test.ts tests/services/accountSiteOnboarding/contentSession/voapiV2.test.ts tests/services/accountSiteOnboarding/registry.test.ts tests/services/detectSiteType.test.ts tests/services/detectSiteType.fallback.test.ts tests/services/apiService/voapiV2/parsing.test.ts tests/services/apiService/voapiV2/index.test.ts tests/services/apiAdapters/registry.test.ts tests/services/apiAdapters/voapiV2/accountCompletion.test.ts tests/services/apiAdapters/voapiV2/accountRefresh.test.ts tests/services/apiAdapters/voapiV2/keyManagement.test.ts tests/services/apiAdapters/voapiV2/tokenProvisioning.test.ts tests/services/autoCheckin/providers/voapiV2.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run type-check**
+
+Run:
+
+```powershell
+pnpm compile
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Inspect task-scoped diff**
+
+Run:
+
+```powershell
+git diff --stat
+git diff -- src/services/apiTransport src/services/accountSiteDefinitions src/services/accountSiteOnboarding src/services/siteDetection src/services/apiService/voapiV2 src/services/apiAdapters/voapiV2 src/services/apiAdapters/registry.ts src/services/apiAdapters/contracts/siteTypeCapabilities.ts src/services/checkin/autoCheckin/providers tests/services tests/constants
+```
+
+Check these invariants in the diff:
+
+- no token, JWT, cookie, `voak-*`, or account identifier is committed;
+- old `SITE_TYPES.VO_API` still routes through New API-family capabilities;
+- `fetchApi` default behavior remains Bearer;
+- all VoAPI v2 service calls pass `authTokenMode: API_AUTH_TOKEN_MODES.Raw`;
+- VoAPI v2 does not persist `refreshToken`, `refresh_token`, `sub2apiAuth`, or
+  any `authUpdate`-style refresh credential;
+- `voapi-v2` detection does not require `demo.voapi.top`;
+- title/temp-window detection is not the primary VoAPI v2 recognition path;
+- `voak-*` is not stored or used;
+- check-in provider uses API endpoints only.
+
+- [ ] **Step 4: Run staged validation before final commit**
+
+Stage only the task-scoped files:
+
+```powershell
+git add src/services/apiTransport/type.ts src/services/apiTransport/request.ts src/services/accountSiteDefinitions/identifiers.ts src/services/accountSiteDefinitions/contracts.ts src/services/accountSiteDefinitions/definitions.ts src/services/accountSiteOnboarding/contentSession/voapiV2.ts src/services/accountSiteOnboarding/registry.ts src/services/siteDetection/detectSiteType.ts src/services/apiService/voapiV2 src/services/apiAdapters/contracts/siteTypeCapabilities.ts src/services/apiAdapters/registry.ts src/services/apiAdapters/voapiV2 src/services/checkin/autoCheckin/providers/voapiV2.ts src/services/checkin/autoCheckin/providers/index.ts tests/constants/siteType.test.ts tests/services/apiTransport/request.test.ts tests/services/accountSiteDefinitions/registry.test.ts tests/services/accounts/accountSiteProfile.test.ts tests/services/modelList/accountSources/readiness.definitions.test.ts tests/services/accountSiteOnboarding/contentSession/voapiV2.test.ts tests/services/accountSiteOnboarding/registry.test.ts tests/services/detectSiteType.test.ts tests/services/detectSiteType.fallback.test.ts tests/services/apiService/voapiV2 tests/services/apiAdapters/registry.test.ts tests/services/apiAdapters/voapiV2 tests/services/autoCheckin/providers/voapiV2.test.ts
+pnpm run validate:staged
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run push gate before remote handoff**
+
+Run:
+
+```powershell
+pnpm run validate:push
+```
+
+Expected: PASS. This gate is required before pushing or opening a PR because the slice changes shared transport contracts, adapter registry exports, and site-type definitions.
+
+- [ ] **Step 6: Final commit if any changes remain uncommitted**
+
+If Tasks 1-5 were committed individually and `git status --porcelain` is clean, skip this step. If integration fixes remain staged after validation, commit:
+
+```powershell
+git commit -m "feat(voapi-v2): integrate account adapter"
+```
+
+## Telemetry Decision
+
+Decision: reuse existing telemetry.
+
+This plan adds a site adapter and reuses existing account add, refresh, key-management, and check-in flows. It does not add a new settings surface or new visible funnel. If implementation adds a new user-visible expired-session recovery action, add privacy-safe result categories in that task and avoid recording URLs, hosts, paths, key ids, token values, raw backend messages, or account names.
+
+## Settings Search Decision
+
+Decision: no settings search change.
+
+No settings UI, deep link target, or options-page search definition is added.
+
+## E2E Decision
+
+Decision: no retained Playwright E2E by default.
+
+The primary risks are protocol mapping, detection ordering, authorization header formatting, and adapter registry wiring, all covered by Vitest/MSW tests. Add Playwright only if the implementation changes browser tab/runtime message routing or temp-window behavior beyond the content-session extractor unit path.
+
+## Self-Review
+
+- Spec coverage: site identity, raw JWT transport, storage policy, balance mapping, key management, check-in, browser-session extraction, `voak-*` non-use, detection priority, telemetry, settings search, and E2E decisions are each mapped to Tasks 1-6.
+- Compatibility: old `VoAPI` remains a New API-family site type; `Sub2API` remains Bearer JWT and keeps its refresh-token flow.
+- Detection: backend probes run before title/temp-window matching; custom/self-hosted origins are covered by tests.
+- Storage: dashboard JWT is stored in `account_info.access_token`; no secondary `voak-*` storage and no refresh-token-shaped storage are introduced.
+- Validation: focused Vitest, `pnpm compile`, `pnpm run validate:staged`, and `pnpm run validate:push` are specified.

--- a/docs/superpowers/specs/2026-07-06-voapi-v2-account-adapter-design.md
+++ b/docs/superpowers/specs/2026-07-06-voapi-v2-account-adapter-design.md
@@ -1,0 +1,904 @@
+# VoAPI v2 Account Adapter Design
+
+Date: 2026-07-06
+
+## Purpose
+
+Add first-class support for the newer VoAPI account-site surface, first
+observed on `https://demo.voapi.top/`, without treating it as the existing
+`VoAPI` site type.
+
+The current `VoAPI` support in this repository is an older compatibility bucket
+that routes through the New API-family adapter. The observed deployment is not
+New API-compatible: it uses different routes, different response envelopes, and
+a dashboard JWT stored in the browser page rather than a New API-style long
+access token. It should therefore become a new account site type instead of a
+variant of the old `VoAPI` bucket.
+
+The upstream `VoAPI/VoAPI` repository describes the project as a new
+next-generation AI model API aggregation and distribution system and documents
+Docker/self-hosted deployment. The adapter must therefore be deployment-neutral:
+`demo.voapi.top` is evidence for the protocol contract, not the only supported
+origin. Other operators may use different hostnames, ports, branding, or page
+titles while keeping the same backend API shape.
+
+## Current Findings
+
+The observed demo site identifies itself as `VoAPI公益站` and uses these routes:
+
+- dashboard: `/dash?_userMenuKey=dash`
+- key management page: `/keys?_userMenuKey=keys`
+- check-in page: `/checkIn?_userMenuKey=checkIn`
+- site API key page: `/profile/api-key`
+
+The authenticated web API uses a JWT-like value from:
+
+```text
+JSON.parse(localStorage.getItem("userStore")).auth.token
+```
+
+The token persists across page refresh and browser reopen with the same
+profile. It is a three-part JWT with payload fields such as `userId`, `sign`,
+`role`, `exp`, `nbf`, and `iat`. `localStorage.userStore.auth` also contains
+safe identity metadata such as `email`, `phone`, `role`, and `registerTime`.
+`localStorage.user` contains legacy-looking user fields such as `id`,
+`username`, `display_name`, `email`, `role`, `status`, and quota fields, but
+its `access_token` field is `null` and must not be used as the VoAPI v2
+dashboard API token. Implementations must parse the `userStore` localStorage
+JSON object; `userStore.auth.token` is a JSON path, not a literal
+localStorage key name.
+
+Logged-in demo-profile verification did not reveal a refresh-token contract.
+In the logged-in `/profile/api-key` page, `localStorage.userStore.auth`
+contained only `email`, `phone`, `registerTime`, `role`, and `token`.
+The JWT payload contained `exp`, `iat`, `nbf`, `role`, `sign`, and `userId`.
+No `refreshToken`, `refresh_token`, or refresh-like field was present in
+`localStorage`, `sessionStorage`, or cookies. The page-load network trace
+showed reads such as `/api/user/info`, `/api/i18n/pack/...`,
+`/api/notice`, `/api/notify_inbox/unread-count`, and `/api/user_api_key`,
+but no refresh or token-renewal endpoint. The shipped frontend bundle also
+uses `userStore.auth.token` directly as `Authorization` and clears auth plus
+routes to `/auth` when the backend returns `code === 2`; it does not perform a
+refresh retry.
+
+Requests send this value as a raw authorization header:
+
+```http
+Authorization: <jwt>
+```
+
+They do not use:
+
+```http
+Authorization: Bearer <jwt>
+```
+
+The existing `localStorage.user.access_token` value was observed as `null`.
+
+Expired or invalid JWTs return business errors inside a successful HTTP
+response:
+
+```ts
+{
+  code: 2,
+  data: null,
+  msg: "Auth expire"
+}
+```
+
+The adapter must therefore treat non-zero `code` values as failures instead of
+relying on HTTP 401 or 403.
+
+The account-info endpoint is:
+
+```http
+GET /api/user/info
+```
+
+It returns an envelope shaped like:
+
+```ts
+{
+  code: 0,
+  data: {
+    basicBalance,
+    bindBalance,
+    usedBasicBalance,
+    usedBindBalance,
+    level,
+    bud,
+    id,
+    currency,
+    nickname,
+    loginTime,
+    role,
+    inviteAmount,
+    inviteTotal,
+    totalRequest,
+    totalToken,
+    username,
+    ban,
+    customAvatar,
+    hasPassword,
+    passkeyCount,
+    twoFactorEnabled,
+    oauthList
+  }
+}
+```
+
+Balance fields are decimal strings. Dashboard UI renders `basicBalance` and
+`bindBalance` as currency balances. `totalRequest` and `totalToken` are
+lifetime counters.
+
+Dashboard statistics endpoints exist for time-windowed usage:
+
+```http
+GET /api/dash/statistics?t=h&s=<start>&e=<end>
+GET /api/dash/statistics/requests?t=h&s=<start>&e=<end>
+GET /api/dash/statistics/models?t=h&s=<start>&e=<end>
+GET /api/dash/statistics/tokens?t=h&s=<start>&e=<end>
+```
+
+The aggregate statistics payload includes `data.d.requests`,
+`data.d.usedBasicBalance`, `data.d.usedBindBalance`, `data.d.errors`, and
+`data.d.maxRpm` when called with a valid time window. The child endpoints
+return arrays keyed by `created`; the request/model variants include request
+and error counts. These endpoints return business errors when required time
+window parameters are omitted.
+
+Key inventory uses:
+
+```http
+GET /api/keys?page=1&size=10&sl[name]=true&sl[token]=true&sl[note]=true
+GET /api/keys/template
+```
+
+Known list fields include:
+
+```ts
+{
+  id,
+  name,
+  tokenMasked,
+  groups,
+  enable,
+  expireTime,
+  amount,
+  used
+}
+```
+
+Key templates use:
+
+```http
+GET /api/keys/template
+```
+
+The template response is `HTTP 200 { code: 0, data }`. `data.groups` is an
+array with fields such as `id`, `name`, `visibleLevels`, `ratio`, `timeRatio`,
+`chargingType`, `subBalanceType`, and `note`. `data.models` is an array with
+fields such as `idKey`, `firm`, price strings, `flags`, `modalities`,
+`sortOrder`, `enable`, and `hidden`. `data.ssb` is a boolean.
+
+Confirmed key mutation endpoints:
+
+```http
+POST /api/keys
+PUT /api/keys/{id}
+POST /api/keys/{id}/token
+DELETE /api/keys/{id}
+```
+
+Create and update/delete responses use `HTTP 200 { code: 0, data: null }`.
+Create accepts `name`, `groups`, `amount`, `genCount`, `enable`, and
+`expireTime`; it does not return the full secret. Enable and disable are done
+by `PUT /api/keys/{id}` with `enable: true|false`, not by a separate status
+endpoint. Secret reveal uses `POST /api/keys/{id}/token` with no body and
+returns `HTTP 200 { code: 0, token }`, where `token` is the full `sk-` secret.
+
+Check-in reads use:
+
+```http
+GET /api/check_in/template
+GET /api/check_in/stats
+GET /api/check_in?year=2026&month=7
+```
+
+`stats.todaySigned === false` means the account has not checked in today.
+`stats.nextAmount` appears to represent the next reward.
+
+The submit request is:
+
+```http
+POST /api/check_in
+```
+
+It sends no request body and uses raw JWT authorization. A request with
+`Content-Type: application/json` and an omitted/empty body is accepted.
+Successful submit returns `HTTP 200 { code: 0, data: { amount, bonusAmount } }`.
+Repeating the submit after today's sign-in returns
+`HTTP 200 { code: 1, msg: "Signed in today" }`.
+
+The `/profile/api-key` page manages long-lived site API keys with a `voak-*`
+format. These keys can authenticate some site API reads with raw
+`Authorization: voak-*`, including `/api/user/info`, but the same key was
+rejected for `/api/keys` and `/api/check_in/*` with an operation-not-allowed
+message. Therefore `voak-*` is not the primary authentication mechanism for the
+first account adapter version.
+
+## Problem
+
+The implementation has three pressure points:
+
+1. **Site identity**: the new VoAPI surface must not be routed through the
+   existing New API-family `VoAPI` adapter.
+2. **Auth transport**: the generic `fetchApi` helper currently sends saved
+   access tokens as Bearer tokens, which is wrong for this backend.
+3. **Storage shape**: existing account storage has one primary
+   `account_info.access_token` slot and no generic secondary site API key slot.
+   The first version should avoid adding a partial secondary credential that
+   only supports account-info reads.
+
+## Goals
+
+- Add a new site type, recommended string value: `voapi-v2`.
+- Store the dashboard JWT in the existing `account_info.access_token` field.
+- Keep `authType = AuthTypeEnum.AccessToken`.
+- Extend `fetchApi` with a narrow request option that controls whether
+  `Authorization` uses Bearer or raw token formatting.
+- Build a VoAPI v2 account adapter for account balance, API key management,
+  and check-in.
+- Treat dashboard JWT expiry as a recoverable re-login/re-detection health
+  state, with a narrow re-read of the logged-in page-session JWT when browser
+  session state is available.
+- Keep old `VoAPI` behavior unchanged.
+- Keep Sub2API behavior unchanged; it continues to use Bearer JWTs and its
+  existing refresh/resync logic.
+
+## Non-Goals
+
+- Do not merge this backend into the New API-family adapter.
+- Do not expand saved account storage for `voak-*` in the first version.
+- Do not use `voak-*` as a fallback for key management or check-in.
+- Do not migrate AIHubMix or other raw-token sites onto the new transport
+  option in this slice.
+- Do not add VoAPI v2 refresh-token storage, refresh locks, proactive refresh,
+  or a Sub2API-style renewal flow. Logged-in storage, cookies, frontend
+  behavior, and observed network requests did not expose a stable refresh-token
+  contract. A best-effort re-read of the current logged-in dashboard JWT is
+  allowed because it uses the same `userStore.auth.token` extraction contract as
+  account detection.
+- Do not redesign Sub2API refresh-token storage, locks, or browser-session
+  resync.
+- Do not perform real check-in during protocol probing unless the user
+  explicitly approves it for that probe.
+
+## Approaches Considered
+
+### Approach A: Adapter-Local `fetch`
+
+The VoAPI v2 adapter could bypass `fetchApi` and hand-build raw `fetch`
+requests. This avoids changing shared transport, but it loses established
+features such as site request limiting, current-tab transport, temp-window
+fallback, abort-signal wiring, and shared HTTP error handling.
+
+This is not recommended.
+
+### Approach B: Add A New Auth Type
+
+A new auth type such as `RawAccessToken` would make the account auth mode more
+explicit. However, it would require storage, UI, import/export, and product
+policy updates for what is currently only a request-header formatting
+difference. It also risks making existing saved-account surfaces understand a
+site-specific protocol detail.
+
+This is too broad for the first adapter version.
+
+### Approach C: Add A Request-Level Token Formatting Option
+
+Extend `fetchApi` with a small option, for example:
+
+```ts
+authTokenMode?: "bearer" | "raw"
+```
+
+Default behavior remains `"bearer"`. VoAPI v2 calls pass `"raw"`, while
+existing New API-family, Sub2API, and other callers continue to behave as they
+do today.
+
+This is the recommended path. It is the smallest shared abstraction that maps
+to the observed backend contract without widening account storage or auth-type
+semantics.
+
+## Design
+
+### 1. Site Type And Definition
+
+Add a new account site type:
+
+```ts
+SITE_TYPES.VO_API_V2 = "voapi-v2"
+```
+
+Add it to the account-site definition registry with:
+
+- account scope only;
+- insert it before old `SITE_TYPES.VO_API` in `ACCOUNT_SITE_TYPE_ORDER` so the
+  specific v2 matcher runs before the old broad `VoAPI` compatibility matcher;
+- a new adapter family such as `VoApiV2`, or a direct registry branch if the
+  current adapter-family set remains deliberately small;
+- allowed/default auth type: `AccessToken`;
+- cookie auth disabled by default for saved accounts;
+- built-in check-in detection enabled once check-in submit is verified;
+- route overrides:
+  - usage path: `/dash?_userMenuKey=dash`
+  - key management path/admin credentials path: `/keys?_userMenuKey=keys`
+  - check-in path: `/checkIn?_userMenuKey=checkIn`
+
+Do not add `demo.voapi.top` as the only or required recognition rule. The
+definition may record known official/demo hostnames as hints, but any origin
+that exposes the VoAPI v2 backend signature must be eligible for detection.
+
+Adapter registry wiring should mirror existing non-New-API sites such as
+Sub2API and AIHubMix: add `apiAdapters/voapiV2` capabilities and return them
+from `getSiteTypeCapabilities(SITE_TYPES.VO_API_V2)` by either adding a
+dedicated adapter-family enum value or an explicit registry branch. The old
+`VoAPI` definition must remain in the New API-family compatibility bucket.
+
+Detection should be deployment-neutral and should prefer backend request
+signatures over rendered-page or temporary-window signals. In particular, do
+not make `demo.voapi.top`, `VoAPI公益站`, or the demo route titles the primary
+contract for recognizing this backend.
+
+Recommended detection order:
+
+1. Parse URL/domain only as a cheap sanity step. Known hostnames may be used as
+   positive evidence for official or configured deployments, but hostname
+   matching must not be required for self-hosted VoAPI v2 instances.
+2. Run direct API signature probes before fetching rendered/original titles and
+   before any temp-window-only title path. These probes should use ordinary
+   fetch with `credentials: "omit"`, no dashboard JWT, no cookies, no extension
+   auth headers, and no mutation. Candidate probes:
+   - `GET /api/user/info`
+   - optionally `GET /api/keys/template` as a confirming second protected
+     endpoint when the first result is ambiguous
+3. Recognize the VoAPI v2 unauthenticated protected-endpoint signature as a JSON
+   response with a numeric `code`, `data: null`, and an auth failure message such
+   as `Unauthorized` or `Auth expire`; the observed demo currently returns HTTP
+   403 with `{ code: 2, data: null, msg: "Unauthorized", rid }` for these
+   no-auth probes. Treat this as a backend fingerprint, not as an account auth
+   failure during site detection.
+4. Use content-session evidence from
+   `JSON.parse(localStorage.getItem("userStore"))` with a usable `auth.token`
+   as a strong logged-in-page signal during account completion or current-tab
+   onboarding.
+5. Use page title patterns only as a fallback or supporting signal. If used, the
+   pattern must be specific to the observed v2 title, such as an exact
+   `/(^| - )VoAPI公益站$/`-style matcher, rather than a broad `VoAPI` matcher.
+6. Run the old New API-family `VoAPI` compatibility matcher only after the v2
+   API signature/content-session checks have had a chance to match.
+
+The implementation should add an explicit VoAPI v2 API-probe helper to
+`detectSiteType` instead of relying on `fetchSiteOriginalTitle(...)`, because
+the current title helper may open a temporary browser context before falling
+back to direct fetch. Temp-window title detection remains useful for WAF-heavy
+HTML pages, but it should not be the first-class recognition path for this
+backend.
+
+The narrow first version can implement this as a dedicated
+`detectVoApiV2FromProtectedEndpoint(...)` helper, similar in spirit to the
+current Sub2API endpoint probe. If the implementation broadens this pattern for
+future self-hosted backends, add a typed backend-signature/probe field to
+`AccountSiteDetectionMetadata`; otherwise keep the VoAPI v2 probe local to
+`detectSiteType` to avoid over-generalizing before a second backend needs the
+same metadata shape.
+
+Recommended `getAccountSiteType(url)` order after adding VoAPI v2:
+
+1. exact configured domain rules;
+2. safe backend signature probes, including VoAPI v2 and existing Sub2API;
+3. original-title matching, including the precise VoAPI v2 title fallback;
+4. New API-family compatible auth-error fallback.
+
+If domain rules return old `VoAPI` for a known old deployment, keep that result.
+For unknown/self-hosted domains, the VoAPI v2 backend probe must run before the
+old broad `VoAPI` title matcher.
+
+The implementation must avoid broad title matching that would steal old `VoAPI`
+deployments from the existing New API-family bucket. Route strings such as
+`/dash`, `/keys`, `/checkIn`, and `?_userMenuKey=...` are useful positive
+evidence, but the current account-site metadata registry does not project
+route-based detection rules. Do not rely on route matching unless the
+implementation explicitly adds that metadata and tests it.
+
+Required detection tests:
+
+- a self-hosted/custom origin such as `https://example.invalid` with the VoAPI
+  v2 API signature maps to `voapi-v2`; do not use the real demo hostname in
+  this test;
+- a direct no-auth `GET /api/user/info` probe returning the VoAPI v2 protected
+  endpoint envelope maps to `voapi-v2` without calling the title/temp-window
+  path;
+- a direct authenticated `GET /api/user/info` probe with raw authorization and
+  account-data fields is treated as a strong VoAPI v2 confirmation when the
+  caller already has a content-session JWT;
+- an inconclusive or unavailable VoAPI v2 API probe falls back to the existing
+  title and New API-family probes without throwing;
+- `VoAPI公益站` plus a v2 content-session result maps to `voapi-v2`;
+- a custom title plus a v2 content-session result maps to `voapi-v2`;
+- `VoAPI公益站` title alone must not be the only required proof for
+  self-hosted recognition;
+- old `VoAPI` title-only compatibility signals still map to old `VoAPI`;
+- old `voapi-user` compatible auth-error signals still map to old `VoAPI`;
+- the v2 content-session extractor runs before the generic compatible
+  `localStorage.user` extractor so the JWT is not lost.
+
+### 2. Raw Token Support In `fetchApi`
+
+Extend the transport types:
+
+```ts
+export const API_AUTH_TOKEN_MODES = {
+  Bearer: "bearer",
+  Raw: "raw",
+} as const
+
+export type ApiAuthTokenMode =
+  (typeof API_AUTH_TOKEN_MODES)[keyof typeof API_AUTH_TOKEN_MODES]
+
+export interface FetchApiOptions {
+  endpoint: string
+  options?: RequestInit
+  responseType?: TempWindowResponseType
+  tempWindowFallback?: TempWindowFallbackAllowlist
+  currentTabTransport?: "prefer" | "disabled"
+  authTokenMode?: ApiAuthTokenMode
+}
+```
+
+`createRequestHeaders(...)` should default to Bearer:
+
+```ts
+if (auth.accessToken) {
+  headers["Authorization"] =
+    authTokenMode === "raw"
+      ? auth.accessToken
+      : `Bearer ${auth.accessToken}`
+}
+```
+
+The option is request-scoped, not stored-account scoped. This keeps storage
+stable and avoids making every account auth consumer understand a
+backend-specific header format.
+
+Tests should prove:
+
+- existing callers still send `Authorization: Bearer <token>` by default;
+- `authTokenMode: "raw"` sends `Authorization: <token>`;
+- caller-provided headers still follow the existing override rules;
+- cookie-auth behavior remains unchanged.
+
+### 3. VoAPI v2 Service Module
+
+Create a dedicated backend module:
+
+```text
+src/services/apiService/voapiV2/
+```
+
+It should own:
+
+- endpoint constants;
+- raw-token `fetchVoApiV2Data(...)` wrapper;
+- `{ code, data?, msg?, message?, token? }` envelope parsing;
+- account balance normalization;
+- key inventory and key mutation normalization;
+- check-in status and submit normalization;
+- redaction-safe logging helpers if needed.
+
+The local fetch wrapper should use the shared transport:
+
+```ts
+fetchApi<unknown>(
+  request,
+  {
+    endpoint,
+    options,
+    authTokenMode: "raw",
+  },
+  true,
+)
+```
+
+Envelope parsing should treat `code === 0` as success. It must support both
+ordinary data envelopes and VoAPI v2's reveal response where the secret is in
+top-level `token` instead of `data`. Non-zero `code`, missing `data` or `token`
+where required, HTTP failures, and invalid JSON should become `ApiError`
+instances with local fallback messages. `code === 2` and an auth-expired
+message should be classified as a session-expired/auth failure, not as an
+unknown backend error.
+
+### 4. Account Balance Mapping
+
+The first implementation should normalize `/api/user/info` into
+`AccountData`.
+
+Confirmed mapping rules:
+
+- parse `basicBalance`, `bindBalance`, `usedBasicBalance`, and
+  `usedBindBalance` as decimal strings;
+- treat those decimal strings as USD/display-currency amounts for the
+  extension's existing quota model and convert them to internal quota points
+  with `UI_CONSTANTS.EXCHANGE_RATE.CONVERSION_FACTOR` (`500000`, USD to quota);
+- `quota`: convert `basicBalance + bindBalance` to internal quota points as the
+  usable balance shown by the dashboard, unless a later backend contract proves
+  only one balance bucket is usable for runtime requests;
+- `today_quota_consumption`: sum
+  `/api/dash/statistics` aggregate `data.d.usedBasicBalance` and
+  `data.d.usedBindBalance` for a current-day time window when the endpoint is
+  available, then convert the decimal amount to internal quota points;
+- `today_requests_count`: use `/api/dash/statistics` aggregate
+  `data.d.requests` for a current-day time window when available;
+- `today_prompt_tokens`: `0` unless a stable daily prompt-token field is
+  identified;
+- `today_completion_tokens`: `0` unless a stable daily completion-token field
+  is identified;
+- `today_income`: `0`;
+- `checkIn.enableDetection`: preserve saved setting, but site status should be
+  populated from the VoAPI v2 check-in endpoints when enabled.
+
+Do not map lifetime `usedBasicBalance` or `usedBindBalance` into "today"
+fields from `/api/user/info`. Those fields are lifetime balances, not daily
+usage.
+
+Numeric policy:
+
+| Source field | Backend unit | Internal field | Conversion |
+| --- | --- | --- | --- |
+| `basicBalance`, `bindBalance` | decimal amount string in `currency` | `quota` | sum, clamp invalid values to `0`, multiply by `CONVERSION_FACTOR`, round to nearest integer |
+| `usedBasicBalance`, `usedBindBalance` from `/api/user/info` | lifetime decimal amount string | no daily mapping | do not use for today fields |
+| `data.d.usedBasicBalance`, `data.d.usedBindBalance` from `/api/dash/statistics` | time-window decimal amount string | `today_quota_consumption` | sum, clamp invalid values to `0`, multiply by `CONVERSION_FACTOR`, round to nearest integer |
+| key `amount`, key `used` | decimal amount string | `remain_quota`, `used_quota` | multiply by `CONVERSION_FACTOR`, round to nearest integer |
+
+When writing key quota values back to VoAPI v2, divide internal quota points by
+`CONVERSION_FACTOR` and serialize the amount as a decimal string. Keep
+`expired_time < 0` mapped to VoAPI v2's non-expiring sentinel if the UI sends
+one; otherwise send the epoch-millisecond `expireTime` expected by the backend.
+For current-day statistics, use a local current-day start/end window consistent
+with the dashboard's `s`/`e` millisecond timestamp query parameters. If the
+statistics endpoint fails, return zeroed today fields instead of failing the
+whole account refresh. Honor `includeTodayCashflow === false` by skipping the
+statistics call and returning zeroed today fields.
+
+### 5. API Key Management
+
+The adapter should provide key-management and token-provisioning capabilities
+using the confirmed VoAPI v2 key endpoints.
+
+Known inventory mapping:
+
+- `id` -> token id;
+- `name` -> token name;
+- `tokenMasked` -> masked key field;
+- `enable: true` -> `status: 1`; `enable: false` -> `status: 2`;
+- `expireTime` -> `expired_time` after converting epoch milliseconds to epoch
+  seconds for the shared `ApiToken` shape;
+- `amount` -> `remain_quota` after decimal-amount-to-quota conversion;
+- `used` -> `used_quota` after decimal-amount-to-quota conversion;
+- `groups` -> `group` by selecting the first group name/id that can be
+  represented in the existing single-group product model;
+- missing `user_id` -> default to `request.auth.userId` when available,
+  otherwise `0`;
+- missing model/IP fields -> default `model_limits_enabled: false`,
+  `model_limits: ""`, and `allow_ips: ""`;
+- `DeletedAt` -> `null`.
+
+Template mapping:
+
+- `groups`: build user-group choices from `id`, `name`, `ratio`, `timeRatio`,
+  `chargingType`, `subBalanceType`, and `note` where the existing product
+  model has matching fields;
+- `models`: use `idKey` as the model id and preserve enabled/hidden state when
+  mapping available-model options;
+- `ssb`: preserve as a backend flag if a product caller needs it later, but do
+  not invent UI behavior around it in the first implementation.
+
+Mutation contract:
+
+- create: translate `CreateTokenRequest` to `POST /api/keys` with:
+  - `name`: `tokenData.name`;
+  - `groups`: an array containing the selected numeric VoAPI v2 group id
+    resolved from `tokenData.group`;
+  - `amount`: decimal string converted from `tokenData.remain_quota`;
+  - `genCount`: `1`;
+  - `enable`: `true`;
+  - `expireTime`: epoch milliseconds converted from `tokenData.expired_time`;
+  success is `HTTP 200 { code: 0, data: null }`;
+- update: translate `CreateTokenRequest` to `PUT /api/keys/{id}` with `id`,
+  `name`, `groups`, `enable`, `expireTime`, `amount`, preserved `used`, and
+  preserved `note`; success is
+  `HTTP 200 { code: 0, data: null }`;
+- enable/disable: use the same update endpoint with `enable: true|false`;
+- reveal: `POST /api/keys/{id}/token` with no body returns
+  `HTTP 200 { code: 0, token }`;
+- delete: `DELETE /api/keys/{id}` returns `HTTP 200 { code: 0, data: null }`.
+
+Create does not return the full secret. `resolveApiTokenKey` should use the
+VoAPI v2 reveal endpoint. It must not fall through to New API-family
+`/api/token/{id}/key` behavior. All key CRUD operations must use VoAPI v2
+endpoints; do not fall back to New API-family create, update, status, reveal,
+or delete routes. No separate reset or rotate endpoint is part of the confirmed
+first-version contract.
+
+`fetchAvailableModels(request)` should return enabled, non-hidden
+`data.models[].idKey` values from `/api/keys/template`. `userGroups.fetch`
+should map `data.groups` into the existing `Record<string, UserGroupInfo>`
+shape by using the stringified backend group id as the key and exposing `ratio`
+plus `note` as `desc` where possible. Because the existing create form has only
+one `group` field, first-version writes should resolve that selected id/name
+back to the backend group id and submit a single numeric id in `groups`.
+Multi-group create can be added later only if the product form grows an
+explicit multi-group selection.
+
+VoAPI v2 unlimited quota behavior is not confirmed. First-version
+token-provisioning should reject `tokenData.unlimited_quota === true` with a
+local unsupported-field error instead of guessing an `amount` sentinel.
+
+### 6. Check-In
+
+The adapter should support built-in check-in with the VoAPI v2 check-in
+endpoints.
+
+Known read endpoints:
+
+- `/api/check_in/template`
+- `/api/check_in/stats`
+- `/api/check_in?year=<year>&month=<month>`
+
+Expected submit endpoint:
+
+```http
+POST /api/check_in
+```
+
+Known response shapes:
+
+- `GET /api/check_in/template`: `data.consecutiveBonus`,
+  `data.notice`, and `data.now`;
+- `GET /api/check_in/stats`: `data.consecutiveDays`, `currentDayNo`,
+  `monthCount`, `monthTotal`, `nextAmount`, `nextBonus`,
+  `nextConsecutiveNo`, `todayRecord`, `todaySigned`, and `totalCount`;
+- `GET /api/check_in?year=<year>&month=<month>`: array of records with `id`,
+  `created`, `updated`, `uid`, `ymd`, `amount`, `consecutiveNo`, and
+  `bonusAmount`.
+
+Submit contract:
+
+- `POST /api/check_in`;
+- no request body;
+- `Content-Type: application/json` is accepted even with an omitted/empty body,
+  so VoAPI v2 does not require a transport option to suppress the default JSON
+  content type for this route;
+- raw JWT authorization;
+- success response is `HTTP 200 { code: 0, data: { amount, bonusAmount } }`;
+- repeated same-day submit is `HTTP 200 { code: 1, msg: "Signed in today" }`;
+- after success, `GET /api/check_in/stats` reports `todaySigned: true` and a
+  `todayRecord`; `/api/user/info.bindBalance` increases by the signed
+  `amount`.
+
+The first check-in implementation should be API-based. Do not click the page's
+native check-in button unless a later probe proves the API route cannot be used
+reliably.
+
+Parser code should accept the successful amount response and should refetch
+stats after submit, so final status confirmation does not rely solely on the
+submit body. The duplicate-sign-in response should be classified as
+already-checked rather than as an unknown failure.
+
+Check-in submit is currently owned by the auto-checkin provider layer, not by
+account-data adapters alone. Implementation should either add a VoAPI v2
+provider to the existing `resolveAutoCheckinProvider(...)` map or introduce an
+explicit adapter-backed check-in submit seam before wiring scheduled/manual
+submit. Status reads can remain in the VoAPI v2 account-data service.
+
+### 7. Account Completion And Browser Session
+
+Auto-detection should read the dashboard JWT from page storage through the
+existing account-site onboarding/content-session path where possible.
+
+Add a dedicated VoAPI v2 content-session extractor before the generic
+compatible `localStorage.user` extractor. The generic compatible extractor can
+see `localStorage.user`, but it cannot supply the VoAPI v2 JWT. If it runs
+first, account completion may receive identity without the required
+`accessToken`.
+
+Recommended content-session extractor behavior:
+
+- detect `JSON.parse(localStorage.getItem("userStore")).auth.token`;
+- return `siteTypeHint: SITE_TYPES.VO_API_V2` when the token is present, even
+  if the earlier URL/title detection result was `UNKNOWN` or old `VoAPI`;
+- normalize the token as `accessToken`;
+- extract identity from `localStorage.user.id`, `localStorage.user.username`,
+  `localStorage.user.display_name`, and `localStorage.user.email` when present;
+- optionally read `userStore.auth.email`, `phone`, `role`, and `registerTime`
+  as supporting metadata, but do not treat those fields as the account access
+  token;
+- avoid returning `localStorage.user.access_token` when it is `null`;
+- never log the token or raw localStorage payload.
+
+`accountCompletion` should:
+
+- require a non-empty detected access token;
+- require a non-empty stored account id, derived from `localStorage.user.id`
+  when present or from `/api/user/info.id` as a fallback;
+- derive saved username/display name using this priority:
+  `localStorage.user.username`, `localStorage.user.display_name`,
+  `localStorage.user.email`, `/api/user/info.username`,
+  `/api/user/info.nickname`, then the stored id string;
+- classify a missing dashboard JWT as the existing access-token-missing
+  completion failure rather than silently falling back to cookie or
+  `localStorage.user.access_token`;
+- save it into `account_info.access_token`;
+- set `authType: AuthTypeEnum.AccessToken`;
+- disable cookie auth for the saved account;
+- set initial check-in config according to the adapter's verified support.
+
+JWT expiry should be handled as a recoverable account health problem, not as a
+refresh-token flow. Because expired JWTs return `HTTP 200 { code: 2, data:
+null, msg: "Auth expire" }`, the envelope parser should classify that code as
+an auth failure and surface a re-detection or re-login recovery path. The
+adapter must not invent Sub2API-style refresh-token storage, refresh locks, or
+proactive refresh. It may make one best-effort re-read of the current logged-in
+dashboard JWT from browser-session state because logged-in verification found no
+stable VoAPI v2 refresh-token field or renewal endpoint.
+
+`refreshAccountData` should not rely on generic `determineHealthStatus` for
+this auth-expired case. It should return a VoAPI v2-specific warning/error
+health status that tells the product layer the saved dashboard JWT is expired
+and the account must be re-detected from a logged-in VoAPI v2 page.
+
+### 8. Site API Key (`voak-*`) Policy
+
+Do not store or use `voak-*` in the first adapter version.
+
+Reason:
+
+- it can read limited site API endpoints such as `/api/user/info`;
+- it cannot manage `/api/keys`;
+- it cannot use `/api/check_in/*`;
+- using it as a fallback would create a confusing partial-success state where
+  balance refresh works but key management and check-in fail.
+
+If a future product need requires long-lived balance-only refresh, add an
+explicit secondary credential design instead of hiding it in
+`account_info.access_token`.
+
+## Open Protocol Facts
+
+These facts affect edge behavior or numeric fidelity and can be resolved
+during implementation or by a later safe probe:
+
+- deployment variance across self-hosted VoAPI v2 instances, especially custom
+  branding, localized titles, reverse-proxy status codes, and whether protected
+  endpoint auth failures always include `code: 2`;
+- whether a future VoAPI v2 release documents a refresh-token contract; the
+  current verified contract has no refresh-token storage field, cookie, or
+  renewal endpoint, so first-version implementation must not assume one;
+- exact balance-unit and precision rules for converting decimal-string
+  balances into the extension's numeric quota model for non-USD `currency`
+  deployments;
+- whether `basicBalance + bindBalance` is always the runtime-usable balance or
+  whether some deployments restrict one bucket;
+- whether `consecutiveBonus` can be a non-null array/object and how it should
+  map to product copy;
+- whether `/api/dash/statistics/tokens` exposes token counts in accounts with
+  richer daily data;
+- old VoAPI counter-signals if broad title matching ever risks confusing old
+  and new deployments.
+
+## Telemetry Decision
+
+Telemetry decision: reuse existing initially.
+
+This slice adds a new site adapter but does not introduce a new product funnel
+or settings surface by itself. If implementation adds new visible recovery
+actions for expired VoAPI v2 sessions, add privacy-safe result categories at
+that point. Do not record URLs, tokens, host paths, raw backend messages, key
+names, key ids, or user-entered names.
+
+## Settings Search Decision
+
+Settings search decision: none.
+
+No new settings UI, deep link target, or settings search definition is required
+for the first adapter version.
+
+## E2E Decision
+
+E2E decision: no new Playwright E2E by default.
+
+The main implementation risk is adapter protocol mapping and auth-header
+formatting, which should be covered by focused Vitest tests. Add Playwright
+only if implementation changes browser-session extraction, temp-window
+behavior, or extension runtime routing in a way lower-level tests cannot
+exercise.
+
+Live Playwright contract probes are exploratory evidence, not retained E2E
+tests, unless a later deterministic test can run without private credentials.
+Content-session extraction should be covered by focused extractor/unit tests by
+default; add E2E only if the implementation changes runtime message routing,
+tab selection, or temp-window behavior.
+
+## Testing Strategy
+
+Use TDD for executable implementation.
+
+Focused tests should cover:
+
+- `fetchApi` default Bearer behavior remains unchanged;
+- `fetchApi` raw token mode sends the token without a Bearer prefix;
+- VoAPI v2 envelope parser accepts `code === 0`, supports top-level `token`
+  reveal responses, and rejects non-zero codes with `msg` or `message`;
+- VoAPI v2 account-info normalization handles decimal-string balances,
+  internal quota conversion, missing optional fields, and invalid response
+  shapes;
+- VoAPI v2 JWT missing/expired states return useful health status;
+- VoAPI v2 JWT expiry does not attempt automatic refresh and does not persist
+  any refresh-token-shaped data;
+- old `VoAPI` still routes through the existing New API-family behavior;
+- `voapi-v2` routes through the new dedicated adapter;
+- `voapi-v2` backend API signature detection runs before title/temp-window
+  title detection and before old `VoAPI`;
+- `voapi-v2` detection works for a custom/self-hosted origin such as
+  `https://example.invalid`;
+- `voapi-v2` detection runs before old `VoAPI` for `VoAPI公益站`, while old
+  `VoAPI` title-only and `voapi-user` compatibility signals still map to old
+  `VoAPI`;
+- content-session extraction reads `JSON.parse(localStorage.getItem("userStore")).auth.token`
+  without using a null `localStorage.user.access_token`, returns
+  `siteTypeHint: voapi-v2`, and is registered before the generic compatible
+  extractor;
+- key inventory normalization handles masked keys and active/inactive state;
+- `CreateTokenRequest` maps to VoAPI v2 create/update payloads with group,
+  amount, expiration, and unsupported unlimited-quota behavior;
+- key creation does not expect a secret in the create response and secret
+  resolution uses `POST /api/keys/{id}/token`;
+- check-in status parsing handles template, stats, and month-record shapes;
+- check-in submit sends an empty-body `POST /api/check_in`, works with the
+  default JSON content type, classifies `code: 1` / `Signed in today` as
+  already checked, and confirms final state by refetching stats.
+
+Suggested focused validation after implementation:
+
+```powershell
+pnpm vitest run tests/services/apiTransport/request.test.ts
+pnpm vitest run tests/services/accountSiteOnboarding/contentSession
+pnpm vitest run tests/services/apiService/voapiV2
+pnpm vitest run tests/services/apiAdapters/voapiV2
+pnpm vitest run tests/constants/siteType.test.ts
+pnpm compile
+pnpm run validate:staged
+```
+
+Run `pnpm run validate:push` before pushing or creating a PR because this
+adapter will touch shared site-type registries, transport contracts, and
+adapter capability wiring.
+
+## Done Criteria
+
+- New VoAPI v2 deployments can be saved as `voapi-v2` accounts.
+- Existing old `VoAPI` accounts keep their current New API-family behavior.
+- VoAPI v2 authenticated API calls use raw `Authorization: <jwt>`.
+- Other token-authenticated backends keep default Bearer behavior.
+- Account balance refresh works with useful expired-session feedback.
+- Expired VoAPI v2 dashboard JWTs are reported as requiring re-login or
+  re-detection; no refresh-token flow is implemented.
+- VoAPI v2 decimal amount fields are converted consistently into internal
+  quota points.
+- API key inventory, create, update, enable/disable, reveal, and delete match
+  the confirmed backend contract.
+- Check-in status and submit use the confirmed request shapes and verify final
+  status through the stats endpoint.
+- No `voak-*`, JWT, cookie, or API key secret is logged, committed, or stored
+  outside the intended account credential field.

--- a/e2e/utils/commonUserFlows.ts
+++ b/e2e/utils/commonUserFlows.ts
@@ -627,6 +627,17 @@ export async function stubNewApiSiteRoutes(
       return
     }
 
+    if (
+      method === "GET" &&
+      (url.pathname === "/api/user/info" || url.pathname === "/api/v1/auth/me")
+    ) {
+      await route.fulfill({
+        status: 204,
+        body: "",
+      })
+      return
+    }
+
     if (method === "GET" && url.pathname === "/api/user/self") {
       await route.fulfill({
         status: 200,

--- a/src/features/KeyManagement/KeyManagement.tsx
+++ b/src/features/KeyManagement/KeyManagement.tsx
@@ -125,6 +125,7 @@ export default function KeyManagement(props: {
     editingToken,
     serviceCredentials,
     currentAccountLoadError,
+    currentAccountUnsupportedKeyManagement,
     tokenLoadProgress,
     failedAccounts,
     accountSummaryItems,
@@ -415,6 +416,9 @@ export default function KeyManagement(props: {
         selectedAccount={selectedAccount}
         displayData={displayData}
         currentAccountLoadError={currentAccountLoadError}
+        currentAccountUnsupportedKeyManagement={
+          currentAccountUnsupportedKeyManagement
+        }
         serviceCredentials={serviceCredentials}
         onCopyServiceCredential={copyServiceCredential}
         onRotateServiceCredential={rotateServiceCredential}

--- a/src/features/KeyManagement/components/AccountSummaryBar.tsx
+++ b/src/features/KeyManagement/components/AccountSummaryBar.tsx
@@ -6,7 +6,7 @@ interface AccountSummaryItem {
   accountId: string
   name: string
   count: number
-  errorType?: "load-failed"
+  errorType?: "load-failed" | "unsupported"
 }
 
 interface AccountSummaryBarProps {
@@ -59,7 +59,9 @@ export function AccountSummaryBar({
                   </span>
                   {item.errorType && (
                     <span className="ml-2 text-xs text-red-500 dark:text-red-400">
-                      {t("accountSummary.loadFailed")}
+                      {item.errorType === "unsupported"
+                        ? t("accountSummary.unsupported")
+                        : t("accountSummary.loadFailed")}
                     </span>
                   )}
                 </Badge>

--- a/src/features/KeyManagement/components/TokenList.tsx
+++ b/src/features/KeyManagement/components/TokenList.tsx
@@ -40,6 +40,7 @@ import type {
 import { createTab } from "~/utils/browser/browserApi"
 import { createLogger } from "~/utils/core/logger"
 import { openSiteSupportRequestPage } from "~/utils/navigation"
+import { SITE_SUPPORT_ERROR_TYPES } from "~/utils/navigation/feedbackLinks"
 
 import { KEY_MANAGEMENT_ALL_ACCOUNTS_VALUE } from "../constants"
 import { KEY_MANAGEMENT_TEST_IDS } from "../testIds"
@@ -178,12 +179,20 @@ function TokenEmptyState({
   }
 
   const handleRequestSiteSupport = () => {
-    if (!currentAccount) return
+    const baseUrl = currentAccount?.baseUrl?.trim()
+    if (!currentAccount || !baseUrl) return
 
     void openSiteSupportRequestPage({
-      siteUrl: currentAccount.baseUrl,
-      errorType: "key_management_unsupported",
-      errorMessage: `Key management is not implemented for ${currentAccount.siteType}`,
+      siteUrl: baseUrl,
+      errorType: SITE_SUPPORT_ERROR_TYPES.KeyManagementUnsupported,
+      errorMessage: t(
+        "keyManagement:unsupportedSource.supportRequestErrorMessage",
+        {
+          siteType: currentAccount.siteType,
+        },
+      ),
+    }).catch((error) => {
+      logger.error("Failed to open key-management site-support request", error)
     })
   }
 
@@ -267,6 +276,7 @@ function TokenEmptyState({
         action={{
           label: t("keyManagement:unsupportedSource.requestSiteSupport"),
           onClick: handleRequestSiteSupport,
+          disabled: !currentAccount.baseUrl?.trim(),
         }}
       />
     )

--- a/src/features/KeyManagement/components/TokenList.tsx
+++ b/src/features/KeyManagement/components/TokenList.tsx
@@ -39,6 +39,7 @@ import type {
 } from "~/types/managedSiteTokenBatchExport"
 import { createTab } from "~/utils/browser/browserApi"
 import { createLogger } from "~/utils/core/logger"
+import { openSiteSupportRequestPage } from "~/utils/navigation"
 
 import { KEY_MANAGEMENT_ALL_ACCOUNTS_VALUE } from "../constants"
 import { KEY_MANAGEMENT_TEST_IDS } from "../testIds"
@@ -90,6 +91,7 @@ interface TokenListProps {
   selectedAccount: string
   displayData: DisplaySiteData[]
   currentAccountLoadError?: string | null
+  currentAccountUnsupportedKeyManagement?: boolean
   onRetryCurrentAccount?: () => void
   managedSiteTokenStatuses?: Record<
     string,
@@ -135,6 +137,7 @@ function LoadingSkeleton() {
  * @param props.canCreateTokens Whether the current account scope supports token creation.
  * @param props.displayData Account display data used to determine empty states.
  * @param props.currentAccountLoadError Error message shown when the selected account fails to load.
+ * @param props.currentAccountUnsupportedKeyManagement Whether the selected account site type lacks a key-management route.
  * @param props.onRetryCurrentAccount Optional callback to retry loading the selected account.
  * @param props.onAddAccount Optional callback to open the add-account flow.
  * @param props.onRequestAccountSelection Optional callback to focus the account selector.
@@ -146,6 +149,7 @@ function TokenEmptyState({
   canCreateTokens = true,
   displayData,
   currentAccountLoadError,
+  currentAccountUnsupportedKeyManagement = false,
   onRetryCurrentAccount,
   onAddAccount,
   onRequestAccountSelection,
@@ -156,6 +160,7 @@ function TokenEmptyState({
   canCreateTokens?: boolean
   displayData: DisplaySiteData[]
   currentAccountLoadError?: string | null
+  currentAccountUnsupportedKeyManagement?: boolean
   onRetryCurrentAccount?: () => void
   onAddAccount?: () => void
   onRequestAccountSelection?: () => void
@@ -170,6 +175,16 @@ function TokenEmptyState({
     const baseUrl = currentAccount?.baseUrl?.trim()
     if (!baseUrl) return
     void createTab(baseUrl, true)
+  }
+
+  const handleRequestSiteSupport = () => {
+    if (!currentAccount) return
+
+    void openSiteSupportRequestPage({
+      siteUrl: currentAccount.baseUrl,
+      errorType: "key_management_unsupported",
+      errorMessage: `Key management is not implemented for ${currentAccount.siteType}`,
+    })
   }
 
   // 如果没有账户
@@ -243,6 +258,20 @@ function TokenEmptyState({
     )
   }
 
+  if (currentAccountUnsupportedKeyManagement && currentAccount) {
+    return (
+      <EmptyState
+        icon={<KeyIcon className="h-12 w-12" />}
+        title={t("keyManagement:unsupportedSource.title")}
+        description={t("keyManagement:unsupportedSource.description")}
+        action={{
+          label: t("keyManagement:unsupportedSource.requestSiteSupport"),
+          onClick: handleRequestSiteSupport,
+        }}
+      />
+    )
+  }
+
   // 如果没有密钥
   if (tokens.length === 0) {
     return (
@@ -289,6 +318,7 @@ function TokenEmptyState({
  * @param props.selectedAccount Currently selected account identifier.
  * @param props.displayData Account metadata used to render contextual info.
  * @param props.currentAccountLoadError Optional load error for the currently selected account.
+ * @param props.currentAccountUnsupportedKeyManagement Whether the selected account lacks a key-management route.
  * @param props.onRetryCurrentAccount Optional retry handler for the current account load.
  * @param props.managedSiteTokenStatuses Optional managed-site channel status by token identity.
  * @param props.onManagedSiteImportSuccess Optional callback after a managed-site token import succeeds.
@@ -316,6 +346,7 @@ export function TokenList(props: TokenListProps) {
     selectedAccount,
     displayData,
     currentAccountLoadError,
+    currentAccountUnsupportedKeyManagement,
     onRetryCurrentAccount,
     managedSiteTokenStatuses,
     onManagedSiteImportSuccess,
@@ -713,6 +744,9 @@ export function TokenList(props: TokenListProps) {
         canCreateTokens={canCreateTokens}
         displayData={displayData}
         currentAccountLoadError={currentAccountLoadError}
+        currentAccountUnsupportedKeyManagement={
+          currentAccountUnsupportedKeyManagement
+        }
         onRetryCurrentAccount={onRetryCurrentAccount}
         onAddAccount={onAddAccount}
         onRequestAccountSelection={onRequestAccountSelection}

--- a/src/features/KeyManagement/hooks/useKeyManagement.ts
+++ b/src/features/KeyManagement/hooks/useKeyManagement.ts
@@ -140,6 +140,14 @@ const TOKEN_LOAD_ERROR_KINDS = {
 type TokenLoadErrorKind =
   (typeof TOKEN_LOAD_ERROR_KINDS)[keyof typeof TOKEN_LOAD_ERROR_KINDS]
 
+const ACCOUNT_TOKEN_LOAD_ERROR_TYPES = {
+  LoadFailed: "load-failed",
+  Unsupported: "unsupported",
+} as const
+
+type AccountTokenLoadErrorType =
+  (typeof ACCOUNT_TOKEN_LOAD_ERROR_TYPES)[keyof typeof ACCOUNT_TOKEN_LOAD_ERROR_TYPES]
+
 interface TokenInventoryState {
   status: TokenLoadStatus
   tokens: AccountToken[]
@@ -1120,7 +1128,9 @@ export function useKeyManagement(routeParams?: Record<string, string>) {
     const failedAccountIds = enabledDisplayData
       .filter(
         (account) =>
-          tokenInventoriesRef.current[account.id]?.status === "error",
+          tokenInventoriesRef.current[account.id]?.status === "error" &&
+          tokenInventoriesRef.current[account.id]?.errorKind !==
+            TOKEN_LOAD_ERROR_KINDS.UnsupportedKeyManagement,
       )
       .map((account) => account.id)
 
@@ -1348,6 +1358,12 @@ export function useKeyManagement(routeParams?: Record<string, string>) {
       .map((account): FailedAccountTokenLoad | null => {
         const inventory = tokenInventories[account.id]
         if (inventory?.status !== "error") return null
+        if (
+          inventory.errorKind ===
+          TOKEN_LOAD_ERROR_KINDS.UnsupportedKeyManagement
+        ) {
+          return null
+        }
         return {
           accountId: account.id,
           accountName: account.name,
@@ -1412,10 +1428,14 @@ export function useKeyManagement(routeParams?: Record<string, string>) {
       accountId: account.id,
       name: account.name,
       count: countMap.get(account.id) ?? 0,
-      errorType:
-        tokenInventories[account.id]?.status === "error"
-          ? ("load-failed" as const)
-          : undefined,
+      errorType: (() => {
+        const inventory = tokenInventories[account.id]
+        if (inventory?.status !== "error") return undefined
+        return inventory.errorKind ===
+          TOKEN_LOAD_ERROR_KINDS.UnsupportedKeyManagement
+          ? ACCOUNT_TOKEN_LOAD_ERROR_TYPES.Unsupported
+          : ACCOUNT_TOKEN_LOAD_ERROR_TYPES.LoadFailed
+      })() satisfies AccountTokenLoadErrorType | undefined,
     }))
   }, [enabledDisplayData, filteredEntries, isAllAccountsMode, tokenInventories])
 

--- a/src/features/KeyManagement/hooks/useKeyManagement.ts
+++ b/src/features/KeyManagement/hooks/useKeyManagement.ts
@@ -1336,17 +1336,27 @@ export function useKeyManagement(routeParams?: Record<string, string>) {
   const tokenLoadProgress = useMemo((): TokenLoadProgress | null => {
     if (!isAllAccountsMode) return null
 
-    const total = enabledDisplayData.length
+    let total = 0
     let loaded = 0
     let loading = 0
     let error = 0
 
     for (const account of enabledDisplayData) {
-      const status = tokenInventories[account.id]?.status ?? "idle"
+      const inventory = tokenInventories[account.id]
+      if (
+        inventory?.errorKind === TOKEN_LOAD_ERROR_KINDS.UnsupportedKeyManagement
+      ) {
+        continue
+      }
+
+      total += 1
+      const status = inventory?.status ?? "idle"
       if (status === "loaded") loaded += 1
       if (status === "loading") loading += 1
       if (status === "error") error += 1
     }
+
+    if (total === 0) return null
 
     return { total, loaded, loading, error }
   }, [enabledDisplayData, isAllAccountsMode, tokenInventories])

--- a/src/features/KeyManagement/hooks/useKeyManagement.ts
+++ b/src/features/KeyManagement/hooks/useKeyManagement.ts
@@ -132,11 +132,20 @@ const isClipboardPermissionError = (error: unknown) => {
 }
 
 type TokenLoadStatus = "idle" | "loading" | "loaded" | "error"
+
+const TOKEN_LOAD_ERROR_KINDS = {
+  UnsupportedKeyManagement: "unsupported-key-management",
+} as const
+
+type TokenLoadErrorKind =
+  (typeof TOKEN_LOAD_ERROR_KINDS)[keyof typeof TOKEN_LOAD_ERROR_KINDS]
+
 interface TokenInventoryState {
   status: TokenLoadStatus
   tokens: AccountToken[]
   errorMessage?: string
   errorCategory?: ProductAnalyticsErrorCategory
+  errorKind?: TokenLoadErrorKind
 }
 
 interface FailedAccountTokenLoad {
@@ -694,12 +703,29 @@ export function useKeyManagement(routeParams?: Record<string, string>) {
           tokens: prev[accountId]?.tokens ?? [],
           errorMessage: undefined,
           errorCategory: undefined,
+          errorKind: undefined,
         },
       }))
 
       try {
         const { keyManagement, serviceCredential, request } =
           createDisplayAccountApiContext(account)
+
+        if (!keyManagement && !serviceCredential) {
+          const errorCategory = PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unsupported
+          tokenLoadErrorCategoriesRef.current[accountId] = errorCategory
+          setTokenInventories((prev) => ({
+            ...prev,
+            [accountId]: {
+              status: "error",
+              tokens: prev[accountId]?.tokens ?? [],
+              errorMessage: undefined,
+              errorCategory,
+              errorKind: TOKEN_LOAD_ERROR_KINDS.UnsupportedKeyManagement,
+            },
+          }))
+          return "error"
+        }
 
         const serviceCredentialLoad =
           await loadServiceCredentialKeyManagementRuntimeKey({
@@ -742,6 +768,7 @@ export function useKeyManagement(routeParams?: Record<string, string>) {
               tokens: [],
               errorMessage: undefined,
               errorCategory: undefined,
+              errorKind: undefined,
             },
           }))
           delete tokenLoadErrorCategoriesRef.current[accountId]
@@ -776,6 +803,7 @@ export function useKeyManagement(routeParams?: Record<string, string>) {
               tokens: prev[accountId]?.tokens ?? [],
               errorMessage,
               errorCategory,
+              errorKind: undefined,
             },
           }))
           if (toastOnError) {
@@ -797,6 +825,7 @@ export function useKeyManagement(routeParams?: Record<string, string>) {
             tokens: tokensWithAccount,
             errorMessage: undefined,
             errorCategory: undefined,
+            errorKind: undefined,
           },
         }))
         delete tokenLoadErrorCategoriesRef.current[accountId]
@@ -834,6 +863,7 @@ export function useKeyManagement(routeParams?: Record<string, string>) {
             tokens: prev[accountId]?.tokens ?? [],
             errorMessage,
             errorCategory,
+            errorKind: undefined,
           },
         }))
         if (toastOnError) {
@@ -1336,6 +1366,13 @@ export function useKeyManagement(routeParams?: Record<string, string>) {
     }
 
     const tokenInventory = tokenInventories[selectedAccount]
+    if (
+      tokenInventory?.errorKind ===
+      TOKEN_LOAD_ERROR_KINDS.UnsupportedKeyManagement
+    ) {
+      return null
+    }
+
     if (tokenInventory?.status === "error") {
       return tokenInventory.errorMessage ?? loadFailedMessage
     }
@@ -1347,6 +1384,20 @@ export function useKeyManagement(routeParams?: Record<string, string>) {
 
     return null
   }, [loadFailedMessage, selectedAccount, serviceCredentials, tokenInventories])
+
+  const currentAccountUnsupportedKeyManagement = useMemo(() => {
+    if (
+      !selectedAccount ||
+      selectedAccount === KEY_MANAGEMENT_ALL_ACCOUNTS_VALUE
+    ) {
+      return false
+    }
+
+    return (
+      tokenInventories[selectedAccount]?.errorKind ===
+      TOKEN_LOAD_ERROR_KINDS.UnsupportedKeyManagement
+    )
+  }, [selectedAccount, tokenInventories])
 
   const accountSummaryItems = useMemo(() => {
     if (!isAllAccountsMode) return []
@@ -1864,6 +1915,7 @@ export function useKeyManagement(routeParams?: Record<string, string>) {
     tokenInventories,
     serviceCredentials,
     currentAccountLoadError,
+    currentAccountUnsupportedKeyManagement,
     tokenLoadProgress,
     failedAccounts,
     accountSummaryItems,

--- a/src/features/ModelList/ModelList.tsx
+++ b/src/features/ModelList/ModelList.tsx
@@ -124,6 +124,7 @@ export default function ModelList(props: {
     pricingContexts,
     isLoading,
     dataFormatError,
+    unsupportedSource,
     loadErrorMessage,
     accountFallback,
     isFallbackCatalogActive,
@@ -551,6 +552,7 @@ export default function ModelList(props: {
           selectedSource={selectedSource}
           isLoading={isLoading}
           dataFormatError={dataFormatError}
+          unsupportedSource={unsupportedSource}
           loadErrorMessage={loadErrorMessage}
           currentAccount={currentAccount}
           loadPricingData={loadPricingData}

--- a/src/features/ModelList/components/AccountSummaryBar.tsx
+++ b/src/features/ModelList/components/AccountSummaryBar.tsx
@@ -74,6 +74,14 @@ export function AccountSummaryBar({
       }
     }
 
+    if (item.errorType === MODEL_LIST_ACCOUNT_ERROR_TYPES.UNSUPPORTED_SOURCE) {
+      return {
+        label: t("accountSummary.unsupported"),
+        className: "text-blue-600 dark:text-blue-300",
+        title: item.errorMessage,
+      }
+    }
+
     if (item.errorType === MODEL_LIST_ACCOUNT_ERROR_TYPES.PARTIAL_LOAD_FAILED) {
       return {
         label: t("accountSummary.partialLoadFailed"),

--- a/src/features/ModelList/components/StatusIndicator.tsx
+++ b/src/features/ModelList/components/StatusIndicator.tsx
@@ -20,6 +20,7 @@ import {
   type ModelManagementSource,
 } from "~/features/ModelList/modelManagementSources"
 import type { DisplaySiteData } from "~/types"
+import { openSiteSupportRequestPage } from "~/utils/navigation"
 
 interface StatusIndicatorProps {
   selectedSource: ModelManagementSource | null
@@ -29,6 +30,7 @@ interface StatusIndicatorProps {
   currentAccount: DisplaySiteData | undefined
   loadPricingData: () => void
   accountFallback: AccountFallbackControls | null
+  unsupportedSource: boolean
 }
 
 /**
@@ -41,6 +43,7 @@ interface StatusIndicatorProps {
  * @param props.currentAccount Account details for navigation links.
  * @param props.loadPricingData Retry handler.
  * @param props.accountFallback Transient account-key fallback controls for the current account.
+ * @param props.unsupportedSource Whether the selected source has no model-list route.
  * @returns Status UI for loading/error or null when idle.
  */
 export function StatusIndicator({
@@ -51,6 +54,7 @@ export function StatusIndicator({
   currentAccount,
   loadPricingData,
   accountFallback,
+  unsupportedSource,
 }: StatusIndicatorProps) {
   const { t } = useTranslation("modelList")
   const fallbackRuntimeKeySelectId = `model-list-fallback-runtime-key-${useId()}`
@@ -71,6 +75,32 @@ export function StatusIndicator({
           {t("status.loading")}
         </p>
       </div>
+    )
+  }
+
+  if (
+    unsupportedSource &&
+    selectedSource.kind === MODEL_MANAGEMENT_SOURCE_KINDS.ACCOUNT &&
+    currentAccount
+  ) {
+    const handleRequestSiteSupport = () => {
+      void openSiteSupportRequestPage({
+        siteUrl: currentAccount.baseUrl,
+        errorType: "model_list_unsupported",
+        errorMessage: `Model list is not implemented for ${currentAccount.siteType}`,
+      })
+    }
+
+    return (
+      <EmptyState
+        icon={<CpuChipIcon className="h-12 w-12" />}
+        title={t("status.unsupportedSourceTitle")}
+        description={t("status.unsupportedSourceDescription")}
+        action={{
+          label: t("status.requestSiteSupport"),
+          onClick: handleRequestSiteSupport,
+        }}
+      />
     )
   }
 

--- a/src/features/ModelList/components/StatusIndicator.tsx
+++ b/src/features/ModelList/components/StatusIndicator.tsx
@@ -20,7 +20,11 @@ import {
   type ModelManagementSource,
 } from "~/features/ModelList/modelManagementSources"
 import type { DisplaySiteData } from "~/types"
+import { createLogger } from "~/utils/core/logger"
 import { openSiteSupportRequestPage } from "~/utils/navigation"
+import { SITE_SUPPORT_ERROR_TYPES } from "~/utils/navigation/feedbackLinks"
+
+const logger = createLogger("ModelListStatusIndicator")
 
 interface StatusIndicatorProps {
   selectedSource: ModelManagementSource | null
@@ -84,10 +88,17 @@ export function StatusIndicator({
     currentAccount
   ) {
     const handleRequestSiteSupport = () => {
+      const baseUrl = currentAccount.baseUrl?.trim()
+      if (!baseUrl) return
+
       void openSiteSupportRequestPage({
-        siteUrl: currentAccount.baseUrl,
-        errorType: "model_list_unsupported",
-        errorMessage: `Model list is not implemented for ${currentAccount.siteType}`,
+        siteUrl: baseUrl,
+        errorType: SITE_SUPPORT_ERROR_TYPES.ModelListUnsupported,
+        errorMessage: t("status.unsupportedSourceSupportRequestErrorMessage", {
+          siteType: currentAccount.siteType,
+        }),
+      }).catch((error) => {
+        logger.error("Failed to open model-list site-support request", error)
       })
     }
 
@@ -99,6 +110,7 @@ export function StatusIndicator({
         action={{
           label: t("status.requestSiteSupport"),
           onClick: handleRequestSiteSupport,
+          disabled: !currentAccount.baseUrl?.trim(),
         }}
       />
     )

--- a/src/features/ModelList/hooks/useModelData.ts
+++ b/src/features/ModelList/hooks/useModelData.ts
@@ -16,6 +16,7 @@ import {
   type AccountRuntimeKey,
 } from "~/services/accounts/accountRuntimeKeys"
 import {
+  ACCOUNT_SITE_MODEL_LIST_TOKEN_SCOPED_CATALOG_FALLBACKS,
   getAccountSiteModelListProfile,
   shouldUseAccountSiteRuntimeKeyCatalogFallback,
   supportsAccountSiteDirectModelPricing,
@@ -132,6 +133,7 @@ interface UseModelDataReturn {
   pricingContexts: AccountPricingContext[]
   isLoading: boolean
   dataFormatError: boolean
+  unsupportedSource: boolean
   accountQueryStates: AccountQueryState[]
   loadPricingData: () => Promise<void>
   loadErrorMessage: string | null
@@ -148,11 +150,18 @@ function createInvalidFormatError() {
 
 const MODEL_PRICING_UNSUPPORTED_ERROR = "model_pricing_unsupported"
 
-const createUnsupportedModelPricingError = () =>
-  new Error(MODEL_PRICING_UNSUPPORTED_ERROR)
+const createUnsupportedModelPricingError = () => {
+  const error = new Error(MODEL_PRICING_UNSUPPORTED_ERROR)
+  ;(error as { code?: string }).code =
+    MODEL_LIST_DATA_ERROR_CODES.UNSUPPORTED_SOURCE
+  return error
+}
 
 const isUnsupportedModelPricingError = (error: unknown) =>
-  error instanceof Error && error.message === MODEL_PRICING_UNSUPPORTED_ERROR
+  error instanceof Error &&
+  (error.message === MODEL_PRICING_UNSUPPORTED_ERROR ||
+    (error as { code?: string }).code ===
+      MODEL_LIST_DATA_ERROR_CODES.UNSUPPORTED_SOURCE)
 
 const shouldRetryModelPricingQuery = (failureCount: number, error: Error) =>
   !isUnsupportedModelPricingError(error) && failureCount < 1
@@ -1152,6 +1161,14 @@ function useSingleAccountModelData(params: {
   const isFallbackCatalogActive = Boolean(
     scopedFallbackPricingData && !query.data,
   )
+  const unsupportedSource = Boolean(
+    query.isError &&
+      isUnsupportedModelPricingError(query.error) &&
+      currentAccount &&
+      getAccountSiteModelListProfile(currentAccount.siteType)
+        .tokenScopedCatalogFallback !==
+        ACCOUNT_SITE_MODEL_LIST_TOKEN_SCOPED_CATALOG_FALLBACKS.RuntimeKey,
+  )
 
   const pricingContexts: AccountPricingContext[] = useMemo(
     () =>
@@ -1228,6 +1245,7 @@ function useSingleAccountModelData(params: {
     pricingContexts,
     isLoading: query.isFetching || scopedIsLoadingFallbackCatalog,
     dataFormatError,
+    unsupportedSource,
     accountQueryStates: [],
     loadPricingData,
     loadErrorMessage,
@@ -1442,6 +1460,9 @@ function useAllAccountsModelData(
         if (error?.code === MODEL_LIST_DATA_ERROR_CODES.INVALID_FORMAT) {
           errorType = MODEL_LIST_ACCOUNT_ERROR_TYPES.INVALID_FORMAT
           errorMessage = t("accountSummary.failureReasons.invalidFormat")
+        } else if (isUnsupportedModelPricingError(query?.error)) {
+          errorType = MODEL_LIST_ACCOUNT_ERROR_TYPES.UNSUPPORTED_SOURCE
+          errorMessage = t("accountSummary.failureReasons.unsupportedSource")
         } else if (hasPartialFailure) {
           errorType = MODEL_LIST_ACCOUNT_ERROR_TYPES.PARTIAL_LOAD_FAILED
           errorMessage = t("accountSummary.partialLoadFailedReason", {
@@ -1485,6 +1506,7 @@ function useAllAccountsModelData(
     pricingContexts,
     isLoading,
     dataFormatError,
+    unsupportedSource: false,
     accountQueryStates,
     loadPricingData,
     loadErrorMessage,
@@ -1609,6 +1631,7 @@ function useProfileModelData(
     pricingContexts: [],
     isLoading: query.isFetching,
     dataFormatError: false,
+    unsupportedSource: false,
     accountQueryStates: [],
     loadPricingData,
     loadErrorMessage,

--- a/src/features/ModelList/modelDataStates.ts
+++ b/src/features/ModelList/modelDataStates.ts
@@ -10,6 +10,7 @@ export const MODEL_LIST_QUERY_SCOPE_VALUES = {
 // Internal enum-style codes used by the data layer; casing is intentional.
 export const MODEL_LIST_DATA_ERROR_CODES = {
   INVALID_FORMAT: "INVALID_FORMAT",
+  UNSUPPORTED_SOURCE: "UNSUPPORTED_SOURCE",
 } as const
 
 // UI-facing account classifications; do not unify with internal error codes.
@@ -17,6 +18,7 @@ export const MODEL_LIST_ACCOUNT_ERROR_TYPES = {
   INVALID_FORMAT: "invalid-format",
   LOAD_FAILED: "load-failed",
   PARTIAL_LOAD_FAILED: "partial-load-failed",
+  UNSUPPORTED_SOURCE: "unsupported-source",
 } as const
 
 export type ModelListAccountErrorType =

--- a/src/locales/en/keyManagement.json
+++ b/src/locales/en/keyManagement.json
@@ -3,7 +3,8 @@
     "keys_one": "{{count}} key",
     "keys_other": "{{count}} keys",
     "loadFailed": "Load failed",
-    "title": "Accounts overview"
+    "title": "Accounts overview",
+    "unsupported": "unsupported"
   },
   "actions": {
     "collapseAll": "Collapse all",
@@ -405,6 +406,7 @@
   "unsupportedSource": {
     "description": "This account's site type can be saved, but the extension has not adapted its key-list protocol yet. Submit a site-support request to help us add key-management support.",
     "requestSiteSupport": "Request site support",
+    "supportRequestErrorMessage": "Key management is not implemented for {{siteType}}",
     "title": "Key management is not supported for this site type yet"
   }
 }

--- a/src/locales/en/keyManagement.json
+++ b/src/locales/en/keyManagement.json
@@ -401,5 +401,10 @@
   "showingCount_other": "Showing {{count}}",
   "title": "Key Management",
   "totalKeys_one": "Total {{count}} key",
-  "totalKeys_other": "Total {{count}} keys"
+  "totalKeys_other": "Total {{count}} keys",
+  "unsupportedSource": {
+    "description": "This account's site type can be saved, but the extension has not adapted its key-list protocol yet. Submit a site-support request to help us add key-management support.",
+    "requestSiteSupport": "Request site support",
+    "title": "Key management is not supported for this site type yet"
+  }
 }

--- a/src/locales/en/modelList.json
+++ b/src/locales/en/modelList.json
@@ -14,7 +14,8 @@
   "accountSummary": {
     "failureReasons": {
       "invalidFormat": "The model list returned an unsupported format.",
-      "unknown": "Unknown error"
+      "unknown": "Unknown error",
+      "unsupportedSource": "Model List is not supported for this site type yet."
     },
     "incompatible": "format incompatible",
     "loadFailed": "load failed",
@@ -23,7 +24,8 @@
     "models_other": "{{count}} models",
     "partialLoadFailed": "partial",
     "partialLoadFailedReason": "Some keys failed to load. First failure: {{reason}}",
-    "title": "Accounts overview"
+    "title": "Accounts overview",
+    "unsupported": "unsupported"
   },
   "actions": {
     "copyModelName": "Copy model name",
@@ -246,11 +248,14 @@
     "loading": "Loading model data...",
     "profileLoadFailed": "Failed to load models for this API credential: {{errorMessage}}",
     "profileLoadFailedTitle": "Failed to load models for this API credential",
+    "requestSiteSupport": "Request site support",
     "retryLoad": "Retry Load",
     "runtimeKeyScopedCatalogDescription": "This source account does not provide an account-level model list. The extension fetches the models available to this account through its API keys.",
     "runtimeKeyScopedCatalogFallbackDescription": "Select an API key. If only one available key exists, the extension will use it automatically.",
     "runtimeKeyScopedCatalogFallbackTitle": "Fetch models through a key",
-    "runtimeKeyScopedCatalogTitle": "Fetching the model list through an API key"
+    "runtimeKeyScopedCatalogTitle": "Fetching the model list through an API key",
+    "unsupportedSourceDescription": "This account's site type can be managed, but its model-list protocol has not been adapted yet. Submit a site-support request to help us add this model-list path.",
+    "unsupportedSourceTitle": "Model List is not supported for this site type yet"
   },
   "title": "Model List",
   "totalModels_one": "Total {{count}} model",

--- a/src/locales/en/modelList.json
+++ b/src/locales/en/modelList.json
@@ -255,6 +255,7 @@
     "runtimeKeyScopedCatalogFallbackTitle": "Fetch models through a key",
     "runtimeKeyScopedCatalogTitle": "Fetching the model list through an API key",
     "unsupportedSourceDescription": "This account's site type can be managed, but its model-list protocol has not been adapted yet. Submit a site-support request to help us add this model-list path.",
+    "unsupportedSourceSupportRequestErrorMessage": "Model list is not implemented for {{siteType}}",
     "unsupportedSourceTitle": "Model List is not supported for this site type yet"
   },
   "title": "Model List",

--- a/src/locales/es-419/keyManagement.json
+++ b/src/locales/es-419/keyManagement.json
@@ -4,7 +4,8 @@
     "keys_many": "{{count}} claves",
     "keys_other": "{{count}} claves",
     "loadFailed": "Error al cargar",
-    "title": "Resumen de cuentas"
+    "title": "Resumen de cuentas",
+    "unsupported": "no compatible"
   },
   "actions": {
     "collapseAll": "Contraer todo",
@@ -419,6 +420,7 @@
   "unsupportedSource": {
     "description": "El tipo de sitio de esta cuenta se puede guardar, pero la extensión aún no ha adaptado su protocolo de lista de claves. Envía una solicitud de soporte del sitio para ayudarnos a agregar soporte de gestión de claves.",
     "requestSiteSupport": "Solicitar soporte del sitio",
+    "supportRequestErrorMessage": "La gestión de claves no está implementada para {{siteType}}",
     "title": "La gestión de claves aún no es compatible con este tipo de sitio"
   }
 }

--- a/src/locales/es-419/keyManagement.json
+++ b/src/locales/es-419/keyManagement.json
@@ -415,5 +415,10 @@
   "title": "Administración de claves",
   "totalKeys_one": "Total {{count}} clave",
   "totalKeys_many": "Total {{count}} claves",
-  "totalKeys_other": "Total {{count}} claves"
+  "totalKeys_other": "Total {{count}} claves",
+  "unsupportedSource": {
+    "description": "El tipo de sitio de esta cuenta se puede guardar, pero la extensión aún no ha adaptado su protocolo de lista de claves. Envía una solicitud de soporte del sitio para ayudarnos a agregar soporte de gestión de claves.",
+    "requestSiteSupport": "Solicitar soporte del sitio",
+    "title": "La gestión de claves aún no es compatible con este tipo de sitio"
+  }
 }

--- a/src/locales/es-419/modelList.json
+++ b/src/locales/es-419/modelList.json
@@ -15,7 +15,8 @@
   "accountSummary": {
     "failureReasons": {
       "invalidFormat": "La lista de modelos devolvió un formato no compatible.",
-      "unknown": "Error desconocido"
+      "unknown": "Error desconocido",
+      "unsupportedSource": "La lista de modelos aún no es compatible con este tipo de sitio."
     },
     "incompatible": "formato incompatible",
     "loadFailed": "error al cargar",
@@ -25,7 +26,8 @@
     "models_other": "{{count}} modelos",
     "partialLoadFailed": "parcial",
     "partialLoadFailedReason": "No se pudieron cargar algunas claves. Primer error: {{reason}}",
-    "title": "Resumen de cuentas"
+    "title": "Resumen de cuentas",
+    "unsupported": "no compatible"
   },
   "actions": {
     "copyModelName": "Copiar nombre del modelo",
@@ -253,11 +255,14 @@
     "loading": "Cargando datos de modelos...",
     "profileLoadFailed": "No se pudieron cargar modelos para esta credencial de API: {{errorMessage}}",
     "profileLoadFailedTitle": "No se pudieron cargar modelos para esta credencial de API",
+    "requestSiteSupport": "Solicitar soporte del sitio",
     "retryLoad": "Reintentar carga",
     "runtimeKeyScopedCatalogDescription": "Esta cuenta de origen no proporciona una lista de modelos a nivel de cuenta. La extensión obtiene los modelos disponibles para esta cuenta mediante sus claves de API.",
     "runtimeKeyScopedCatalogFallbackDescription": "Selecciona una clave de API. Si solo existe una clave disponible, la extensión la usará automáticamente.",
     "runtimeKeyScopedCatalogFallbackTitle": "Obtener modelos mediante una clave",
-    "runtimeKeyScopedCatalogTitle": "Obteniendo la lista de modelos mediante una clave de API"
+    "runtimeKeyScopedCatalogTitle": "Obteniendo la lista de modelos mediante una clave de API",
+    "unsupportedSourceDescription": "El tipo de sitio de esta cuenta se puede administrar, pero su protocolo de lista de modelos aún no se ha adaptado. Envía una solicitud de soporte del sitio para ayudarnos a agregar esta ruta de lista de modelos.",
+    "unsupportedSourceTitle": "La lista de modelos aún no es compatible con este tipo de sitio"
   },
   "title": "Lista de modelos",
   "totalModels_one": "Total {{count}} modelo",

--- a/src/locales/es-419/modelList.json
+++ b/src/locales/es-419/modelList.json
@@ -262,6 +262,7 @@
     "runtimeKeyScopedCatalogFallbackTitle": "Obtener modelos mediante una clave",
     "runtimeKeyScopedCatalogTitle": "Obteniendo la lista de modelos mediante una clave de API",
     "unsupportedSourceDescription": "El tipo de sitio de esta cuenta se puede administrar, pero su protocolo de lista de modelos aún no se ha adaptado. Envía una solicitud de soporte del sitio para ayudarnos a agregar esta ruta de lista de modelos.",
+    "unsupportedSourceSupportRequestErrorMessage": "La lista de modelos no está implementada para {{siteType}}",
     "unsupportedSourceTitle": "La lista de modelos aún no es compatible con este tipo de sitio"
   },
   "title": "Lista de modelos",

--- a/src/locales/ja/keyManagement.json
+++ b/src/locales/ja/keyManagement.json
@@ -2,7 +2,8 @@
   "accountSummary": {
     "keys_other": "{{count}} キー",
     "loadFailed": "読み込み失敗",
-    "title": "アカウント概要"
+    "title": "アカウント概要",
+    "unsupported": "未対応"
   },
   "actions": {
     "collapseAll": "すべて折りたたむ",
@@ -391,6 +392,7 @@
   "unsupportedSource": {
     "description": "このアカウントのサイト種別は保存できますが、拡張機能はこのサイトのキー一覧プロトコルにはまだ対応していません。サイト対応リクエストを送信すると、キー管理機能の追加に役立ちます。",
     "requestSiteSupport": "サイト対応をリクエスト",
+    "supportRequestErrorMessage": "{{siteType}} のキー管理はまだ実装されていません",
     "title": "このサイト種別のキー管理にはまだ対応していません"
   }
 }

--- a/src/locales/ja/keyManagement.json
+++ b/src/locales/ja/keyManagement.json
@@ -387,5 +387,10 @@
   },
   "showingCount_other": "{{count}} 件を表示中",
   "title": "キー管理",
-  "totalKeys_other": "合計 {{count}} キー"
+  "totalKeys_other": "合計 {{count}} キー",
+  "unsupportedSource": {
+    "description": "このアカウントのサイト種別は保存できますが、拡張機能はこのサイトのキー一覧プロトコルにはまだ対応していません。サイト対応リクエストを送信すると、キー管理機能の追加に役立ちます。",
+    "requestSiteSupport": "サイト対応をリクエスト",
+    "title": "このサイト種別のキー管理にはまだ対応していません"
+  }
 }

--- a/src/locales/ja/modelList.json
+++ b/src/locales/ja/modelList.json
@@ -248,6 +248,7 @@
     "runtimeKeyScopedCatalogFallbackTitle": "キーでモデルを取得",
     "runtimeKeyScopedCatalogTitle": "API キーでモデル一覧を取得しています",
     "unsupportedSourceDescription": "このアカウントのサイト種別は管理できますが、モデル一覧のプロトコルにはまだ対応していません。サイト対応リクエストを送信すると、このモデル一覧経路の追加に役立ちます。",
+    "unsupportedSourceSupportRequestErrorMessage": "{{siteType}} のモデル一覧はまだ実装されていません",
     "unsupportedSourceTitle": "このサイト種別のモデル一覧にはまだ対応していません"
   },
   "title": "モデル一覧",

--- a/src/locales/ja/modelList.json
+++ b/src/locales/ja/modelList.json
@@ -13,7 +13,8 @@
   "accountSummary": {
     "failureReasons": {
       "invalidFormat": "モデル一覧が対応していない形式で返されました。",
-      "unknown": "不明なエラー"
+      "unknown": "不明なエラー",
+      "unsupportedSource": "このサイト種別のモデル一覧にはまだ対応していません。"
     },
     "incompatible": "形式非互換",
     "loadFailed": "読み込み失敗",
@@ -21,7 +22,8 @@
     "models_other": "{{count}} モデル",
     "partialLoadFailed": "一部読み込み",
     "partialLoadFailedReason": "一部のキーの読み込みに失敗しました。最初の理由: {{reason}}",
-    "title": "アカウント概要"
+    "title": "アカウント概要",
+    "unsupported": "未対応"
   },
   "actions": {
     "copyModelName": "モデル名をコピー",
@@ -239,11 +241,14 @@
     "loading": "モデルデータを読み込み中...",
     "profileLoadFailed": "この API 認証情報のモデル読み込みに失敗しました: {{errorMessage}}",
     "profileLoadFailedTitle": "この API 認証情報のモデル読み込みに失敗しました",
+    "requestSiteSupport": "サイト対応をリクエスト",
     "retryLoad": "再読み込み",
     "runtimeKeyScopedCatalogDescription": "このソースアカウントはアカウント単位のモデル一覧を提供していません。拡張機能は、このアカウントの API キーを使って実際に利用できるモデルを取得します。",
     "runtimeKeyScopedCatalogFallbackDescription": "API キーを選択してください。利用可能なキーが 1 つだけの場合は、拡張機能が自動的にそのキーでモデルを読み込みます。",
     "runtimeKeyScopedCatalogFallbackTitle": "キーでモデルを取得",
-    "runtimeKeyScopedCatalogTitle": "API キーでモデル一覧を取得しています"
+    "runtimeKeyScopedCatalogTitle": "API キーでモデル一覧を取得しています",
+    "unsupportedSourceDescription": "このアカウントのサイト種別は管理できますが、モデル一覧のプロトコルにはまだ対応していません。サイト対応リクエストを送信すると、このモデル一覧経路の追加に役立ちます。",
+    "unsupportedSourceTitle": "このサイト種別のモデル一覧にはまだ対応していません"
   },
   "title": "モデル一覧",
   "totalModels_other": "合計 {{count}} モデル",

--- a/src/locales/vi/keyManagement.json
+++ b/src/locales/vi/keyManagement.json
@@ -387,5 +387,10 @@
   },
   "showingCount_other": "Đang hiển thị {{count}}",
   "title": "Quản lý khóa",
-  "totalKeys_other": "Tổng cộng {{count}} key"
+  "totalKeys_other": "Tổng cộng {{count}} key",
+  "unsupportedSource": {
+    "description": "Loại trang của tài khoản này có thể được lưu, nhưng tiện ích chưa thích ứng giao thức danh sách khóa của trang này. Hãy gửi yêu cầu hỗ trợ trang để giúp chúng tôi bổ sung khả năng quản lý khóa.",
+    "requestSiteSupport": "Yêu cầu hỗ trợ trang",
+    "title": "Loại trang này chưa hỗ trợ quản lý khóa"
+  }
 }

--- a/src/locales/vi/keyManagement.json
+++ b/src/locales/vi/keyManagement.json
@@ -2,7 +2,8 @@
   "accountSummary": {
     "keys_other": "{{count}} key",
     "loadFailed": "Tải thất bại",
-    "title": "Tổng quan tài khoản"
+    "title": "Tổng quan tài khoản",
+    "unsupported": "chưa hỗ trợ"
   },
   "actions": {
     "collapseAll": "Thu gọn tất cả",
@@ -391,6 +392,7 @@
   "unsupportedSource": {
     "description": "Loại trang của tài khoản này có thể được lưu, nhưng tiện ích chưa thích ứng giao thức danh sách khóa của trang này. Hãy gửi yêu cầu hỗ trợ trang để giúp chúng tôi bổ sung khả năng quản lý khóa.",
     "requestSiteSupport": "Yêu cầu hỗ trợ trang",
+    "supportRequestErrorMessage": "Quản lý khóa chưa được triển khai cho {{siteType}}",
     "title": "Loại trang này chưa hỗ trợ quản lý khóa"
   }
 }

--- a/src/locales/vi/modelList.json
+++ b/src/locales/vi/modelList.json
@@ -13,7 +13,8 @@
   "accountSummary": {
     "failureReasons": {
       "invalidFormat": "Danh sách mô hình trả về định dạng không được hỗ trợ.",
-      "unknown": "Lỗi không xác định"
+      "unknown": "Lỗi không xác định",
+      "unsupportedSource": "Loại trang này chưa hỗ trợ danh sách mô hình."
     },
     "incompatible": "Định dạng không tương thích",
     "loadFailed": "Tải thất bại",
@@ -21,7 +22,8 @@
     "models_other": "{{count}} mô hình",
     "partialLoadFailed": "Tải một phần",
     "partialLoadFailedReason": "Một số khóa tải thất bại. Lỗi đầu tiên: {{reason}}",
-    "title": "Tổng quan tài khoản"
+    "title": "Tổng quan tài khoản",
+    "unsupported": "chưa hỗ trợ"
   },
   "actions": {
     "copyModelName": "Sao chép tên mô hình",
@@ -239,11 +241,14 @@
     "loading": "Đang tải dữ liệu mô hình...",
     "profileLoadFailed": "Tải mô hình của thông tin xác thực API này thất bại: {{errorMessage}}",
     "profileLoadFailedTitle": "Tải mô hình của thông tin xác thực API này thất bại",
+    "requestSiteSupport": "Yêu cầu hỗ trợ trang",
     "retryLoad": "Thử tải lại",
     "runtimeKeyScopedCatalogDescription": "Tài khoản nguồn này không cung cấp danh sách mô hình ở cấp tài khoản. Tiện ích sẽ dùng API key của tài khoản này để lấy các mô hình thực sự có thể sử dụng.",
     "runtimeKeyScopedCatalogFallbackDescription": "Chọn một API key. Nếu chỉ có một key khả dụng, tiện ích sẽ tự động dùng key đó để tải mô hình.",
     "runtimeKeyScopedCatalogFallbackTitle": "Lấy mô hình qua key",
-    "runtimeKeyScopedCatalogTitle": "Đang lấy danh sách mô hình qua API key"
+    "runtimeKeyScopedCatalogTitle": "Đang lấy danh sách mô hình qua API key",
+    "unsupportedSourceDescription": "Loại trang của tài khoản này đã có thể quản lý tài khoản, nhưng giao thức danh sách mô hình chưa được thích ứng. Hãy gửi yêu cầu hỗ trợ trang để giúp chúng tôi bổ sung đường dẫn danh sách mô hình này.",
+    "unsupportedSourceTitle": "Loại trang này chưa hỗ trợ danh sách mô hình"
   },
   "title": "Danh sách mô hình",
   "totalModels_other": "Tổng cộng {{count}} mô hình",

--- a/src/locales/vi/modelList.json
+++ b/src/locales/vi/modelList.json
@@ -248,6 +248,7 @@
     "runtimeKeyScopedCatalogFallbackTitle": "Lấy mô hình qua key",
     "runtimeKeyScopedCatalogTitle": "Đang lấy danh sách mô hình qua API key",
     "unsupportedSourceDescription": "Loại trang của tài khoản này đã có thể quản lý tài khoản, nhưng giao thức danh sách mô hình chưa được thích ứng. Hãy gửi yêu cầu hỗ trợ trang để giúp chúng tôi bổ sung đường dẫn danh sách mô hình này.",
+    "unsupportedSourceSupportRequestErrorMessage": "Danh sách mô hình chưa được triển khai cho {{siteType}}",
     "unsupportedSourceTitle": "Loại trang này chưa hỗ trợ danh sách mô hình"
   },
   "title": "Danh sách mô hình",

--- a/src/locales/zh-CN/keyManagement.json
+++ b/src/locales/zh-CN/keyManagement.json
@@ -387,5 +387,10 @@
   },
   "showingCount": "显示 {{count}} 个",
   "title": "密钥管理",
-  "totalKeys": "总计 {{count}} 个密钥"
+  "totalKeys": "总计 {{count}} 个密钥",
+  "unsupportedSource": {
+    "description": "当前账号的站点类型已支持保存账号，但插件还没有适配该站点的密钥列表协议。你可以提交站点支持请求，帮助我们补齐密钥管理能力。",
+    "requestSiteSupport": "反馈站点支持",
+    "title": "该站点类型暂未适配密钥管理"
+  }
 }

--- a/src/locales/zh-CN/keyManagement.json
+++ b/src/locales/zh-CN/keyManagement.json
@@ -2,7 +2,8 @@
   "accountSummary": {
     "keys": "{{count}} 个密钥",
     "loadFailed": "加载失败",
-    "title": "账号概览"
+    "title": "账号概览",
+    "unsupported": "不支持"
   },
   "actions": {
     "collapseAll": "全部折叠",
@@ -391,6 +392,7 @@
   "unsupportedSource": {
     "description": "当前账号的站点类型已支持保存账号，但插件还没有适配该站点的密钥列表协议。你可以提交站点支持请求，帮助我们补齐密钥管理能力。",
     "requestSiteSupport": "反馈站点支持",
+    "supportRequestErrorMessage": "{{siteType}} 暂未实现密钥管理",
     "title": "该站点类型暂未适配密钥管理"
   }
 }

--- a/src/locales/zh-CN/modelList.json
+++ b/src/locales/zh-CN/modelList.json
@@ -248,6 +248,7 @@
     "runtimeKeyScopedCatalogFallbackTitle": "通过密钥获取模型",
     "runtimeKeyScopedCatalogTitle": "正在通过 API 密钥获取模型列表",
     "unsupportedSourceDescription": "当前账号的站点类型已支持账号能力，但模型列表还没有适配。你可以提交站点支持请求，帮助我们补齐该站点的模型列表协议。",
+    "unsupportedSourceSupportRequestErrorMessage": "{{siteType}} 暂未实现模型列表",
     "unsupportedSourceTitle": "该站点类型暂未适配模型列表"
   },
   "title": "模型列表",

--- a/src/locales/zh-CN/modelList.json
+++ b/src/locales/zh-CN/modelList.json
@@ -13,7 +13,8 @@
   "accountSummary": {
     "failureReasons": {
       "invalidFormat": "模型列表返回格式不受支持。",
-      "unknown": "未知错误"
+      "unknown": "未知错误",
+      "unsupportedSource": "该站点类型暂未适配模型列表。"
     },
     "incompatible": "格式不兼容",
     "loadFailed": "加载失败",
@@ -21,7 +22,8 @@
     "models": "{{count}} 个模型",
     "partialLoadFailed": "部分加载",
     "partialLoadFailedReason": "部分密钥加载失败。首个原因：{{reason}}",
-    "title": "账号概览"
+    "title": "账号概览",
+    "unsupported": "暂未适配"
   },
   "actions": {
     "copyModelName": "复制模型名称",
@@ -239,11 +241,14 @@
     "loading": "正在加载模型数据...",
     "profileLoadFailed": "加载该 API 凭据的模型失败：{{errorMessage}}",
     "profileLoadFailedTitle": "加载该 API 凭据的模型失败",
+    "requestSiteSupport": "反馈站点支持",
     "retryLoad": "重新尝试加载",
     "runtimeKeyScopedCatalogDescription": "该来源账号不提供账号级模型列表。插件会通过账号下的 API 密钥获取实际可用模型。",
     "runtimeKeyScopedCatalogFallbackDescription": "请选择一个 API 密钥；如果只有一个可用密钥，插件会自动使用它加载模型。",
     "runtimeKeyScopedCatalogFallbackTitle": "通过密钥获取模型",
-    "runtimeKeyScopedCatalogTitle": "正在通过 API 密钥获取模型列表"
+    "runtimeKeyScopedCatalogTitle": "正在通过 API 密钥获取模型列表",
+    "unsupportedSourceDescription": "当前账号的站点类型已支持账号能力，但模型列表还没有适配。你可以提交站点支持请求，帮助我们补齐该站点的模型列表协议。",
+    "unsupportedSourceTitle": "该站点类型暂未适配模型列表"
   },
   "title": "模型列表",
   "totalModels": "总计 {{count}} 个模型",

--- a/src/locales/zh-TW/keyManagement.json
+++ b/src/locales/zh-TW/keyManagement.json
@@ -2,7 +2,8 @@
   "accountSummary": {
     "keys_other": "{{count}} 個金鑰",
     "loadFailed": "載入失敗",
-    "title": "帳號概覽"
+    "title": "帳號概覽",
+    "unsupported": "不支援"
   },
   "actions": {
     "collapseAll": "全部摺疊",
@@ -391,6 +392,7 @@
   "unsupportedSource": {
     "description": "目前帳號的站點類型已支援儲存帳號，但擴充功能尚未適配此站點的金鑰列表協議。你可以提交站點支援請求，協助我們補齊金鑰管理能力。",
     "requestSiteSupport": "回報站點支援",
+    "supportRequestErrorMessage": "{{siteType}} 尚未實作金鑰管理",
     "title": "此站點類型尚未支援金鑰管理"
   }
 }

--- a/src/locales/zh-TW/keyManagement.json
+++ b/src/locales/zh-TW/keyManagement.json
@@ -387,5 +387,10 @@
   },
   "showingCount_other": "顯示 {{count}} 個",
   "title": "金鑰管理",
-  "totalKeys_other": "總計 {{count}} 個金鑰"
+  "totalKeys_other": "總計 {{count}} 個金鑰",
+  "unsupportedSource": {
+    "description": "目前帳號的站點類型已支援儲存帳號，但擴充功能尚未適配此站點的金鑰列表協議。你可以提交站點支援請求，協助我們補齊金鑰管理能力。",
+    "requestSiteSupport": "回報站點支援",
+    "title": "此站點類型尚未支援金鑰管理"
+  }
 }

--- a/src/locales/zh-TW/modelList.json
+++ b/src/locales/zh-TW/modelList.json
@@ -13,7 +13,8 @@
   "accountSummary": {
     "failureReasons": {
       "invalidFormat": "模型列表返回格式不受支援。",
-      "unknown": "未知錯誤"
+      "unknown": "未知錯誤",
+      "unsupportedSource": "此站點類型尚未支援模型列表。"
     },
     "incompatible": "格式不相容",
     "loadFailed": "載入失敗",
@@ -21,7 +22,8 @@
     "models_other": "{{count}} 個模型",
     "partialLoadFailed": "部分載入",
     "partialLoadFailedReason": "部分金鑰載入失敗。第一個原因：{{reason}}",
-    "title": "帳號概覽"
+    "title": "帳號概覽",
+    "unsupported": "尚未支援"
   },
   "actions": {
     "copyModelName": "複製模型名稱",
@@ -239,11 +241,14 @@
     "loading": "正在載入模型資料...",
     "profileLoadFailed": "載入該 API 憑據的模型失敗：{{errorMessage}}",
     "profileLoadFailedTitle": "載入該 API 憑據的模型失敗",
+    "requestSiteSupport": "回報站點支援",
     "retryLoad": "重新嘗試載入",
     "runtimeKeyScopedCatalogDescription": "此來源帳號不提供帳號級模型列表。擴充功能會透過該帳號下的 API 密鑰取得實際可用模型。",
     "runtimeKeyScopedCatalogFallbackDescription": "請選擇一個 API 密鑰；如果只有一個可用密鑰，擴充功能會自動使用它載入模型。",
     "runtimeKeyScopedCatalogFallbackTitle": "透過密鑰取得模型",
-    "runtimeKeyScopedCatalogTitle": "正在透過 API 密鑰取得模型列表"
+    "runtimeKeyScopedCatalogTitle": "正在透過 API 密鑰取得模型列表",
+    "unsupportedSourceDescription": "目前帳號的站點類型已支援帳號功能，但模型列表協議尚未適配。你可以提交站點支援請求，協助我們補齊此站點的模型列表支援。",
+    "unsupportedSourceTitle": "此站點類型尚未支援模型列表"
   },
   "title": "模型列表",
   "totalModels_other": "總計 {{count}} 個模型",

--- a/src/locales/zh-TW/modelList.json
+++ b/src/locales/zh-TW/modelList.json
@@ -248,6 +248,7 @@
     "runtimeKeyScopedCatalogFallbackTitle": "透過密鑰取得模型",
     "runtimeKeyScopedCatalogTitle": "正在透過 API 密鑰取得模型列表",
     "unsupportedSourceDescription": "目前帳號的站點類型已支援帳號功能，但模型列表協議尚未適配。你可以提交站點支援請求，協助我們補齊此站點的模型列表支援。",
+    "unsupportedSourceSupportRequestErrorMessage": "{{siteType}} 尚未實作模型列表",
     "unsupportedSourceTitle": "此站點類型尚未支援模型列表"
   },
   "title": "模型列表",

--- a/src/services/accountSiteDefinitions/contracts.ts
+++ b/src/services/accountSiteDefinitions/contracts.ts
@@ -20,6 +20,7 @@ export interface AccountSiteDetectionMetadata {
 export const ACCOUNT_SITE_ADAPTER_FAMILIES = {
   NewApiFamily: "newApiFamily",
   Sub2Api: "sub2api",
+  VoApiV2: "voapiV2",
   Aihubmix: "aihubmix",
   SharedChat: "sharedchat",
   Unsupported: "unsupported",

--- a/src/services/accountSiteDefinitions/definitions.ts
+++ b/src/services/accountSiteDefinitions/definitions.ts
@@ -66,6 +66,12 @@ const tokenScopedRuntimeModelListReadiness = {
   },
 } as const
 
+const unsupportedModelListReadiness = {
+  modelList: {
+    expectedRoute: ACCOUNT_SITE_MODEL_LIST_EXPECTED_ROUTES.Unsupported,
+  },
+} as const
+
 export const ACCOUNT_SITE_TYPE_ORDER = [
   SITE_TYPES.ONE_API,
   SITE_TYPES.NEW_API,
@@ -74,6 +80,7 @@ export const ACCOUNT_SITE_TYPE_ORDER = [
   SITE_TYPES.ONE_HUB,
   SITE_TYPES.DONE_HUB,
   SITE_TYPES.V_API,
+  SITE_TYPES.VO_API_V2,
   SITE_TYPES.VO_API,
   SITE_TYPES.SUPER_API,
   SITE_TYPES.RIX_API,
@@ -292,6 +299,45 @@ const ACCOUNT_SITE_DEFINITIONS = [
       },
     },
     readiness: tokenScopedRuntimeModelListReadiness,
+  },
+  {
+    siteType: SITE_TYPES.VO_API_V2,
+    scopes: ACCOUNT_SCOPE,
+    adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.VoApiV2,
+    onboarding: {
+      detection: {
+        titlePatterns: [/^(?:.* - )?VoAPI公益站$/i],
+      },
+      routes: {
+        usagePath: "/dash?_userMenuKey=dash",
+        checkInPath: "/checkIn?_userMenuKey=checkIn",
+        adminCredentialsPath: "/keys?_userMenuKey=keys",
+      },
+    },
+    productProfile: {
+      auth: {
+        allowedAuthTypes: [ACCOUNT_SITE_AUTH_TYPES.AccessToken],
+        defaultAuthType: ACCOUNT_SITE_AUTH_TYPES.AccessToken,
+        defaultAuthHostnames: [],
+        supportsCookieAuth: false,
+        supportsBuiltInCheckInDetection: true,
+      },
+      identity: {
+        usernameRequired: false,
+        storedUserIdentityFields: ["id", "username"],
+      },
+      modelList: {
+        directPricing: ACCOUNT_SITE_MODEL_LIST_DIRECT_PRICING.Unsupported,
+        tokenScopedCatalogFallback:
+          ACCOUNT_SITE_MODEL_LIST_TOKEN_SCOPED_CATALOG_FALLBACKS.None,
+        dashboardEstimateLoader:
+          ACCOUNT_SITE_MODEL_LIST_DASHBOARD_ESTIMATE_LOADERS.None,
+        statusScope: ACCOUNT_SITE_MODEL_LIST_STATUS_SCOPES.Account,
+        displayCapabilitiesSource:
+          ACCOUNT_SITE_MODEL_LIST_DISPLAY_CAPABILITY_SOURCES.Response,
+      },
+    },
+    readiness: unsupportedModelListReadiness,
   },
 ] as const satisfies readonly AccountSiteDefinition[]
 

--- a/src/services/accountSiteDefinitions/identifiers.ts
+++ b/src/services/accountSiteDefinitions/identifiers.ts
@@ -6,6 +6,7 @@ export const SITE_TYPES = {
   ONE_HUB: "one-hub",
   DONE_HUB: "done-hub",
   V_API: "v-api",
+  VO_API_V2: "voapi-v2",
   VO_API: "VoAPI",
   SUPER_API: "Super-API",
   RIX_API: "Rix-Api",

--- a/src/services/accountSiteOnboarding/contentSession/voapiV2.ts
+++ b/src/services/accountSiteOnboarding/contentSession/voapiV2.ts
@@ -68,11 +68,7 @@ export const voApiV2ContentSessionExtractor: ContentSessionExtractor = {
       pickIdentityField(user, "id") ?? pickIdentityField(jwtPayload, "userId")
     if (userId === undefined) return null
 
-    const safeUser = {
-      ...(user ?? {}),
-      access_token: undefined,
-    }
-    delete safeUser.access_token
+    const { access_token: _accessToken, ...safeUser } = user ?? {}
 
     return {
       userId,

--- a/src/services/accountSiteOnboarding/contentSession/voapiV2.ts
+++ b/src/services/accountSiteOnboarding/contentSession/voapiV2.ts
@@ -1,0 +1,84 @@
+import { SITE_TYPES } from "~/constants/siteType"
+
+import type { ContentSessionExtractor } from "../contracts"
+
+const VOAPI_V2_USER_STORE_STORAGE_KEY = "userStore"
+const COMPATIBLE_USER_STORAGE_KEY = "user"
+
+const getRecord = (value: unknown): Record<string, unknown> | null =>
+  value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null
+
+const getString = (value: unknown): string =>
+  typeof value === "string" ? value.trim() : ""
+
+const parseStorageObject = (key: string): Record<string, unknown> | null => {
+  const raw = localStorage.getItem(key)
+  if (!raw) return null
+
+  try {
+    return getRecord(JSON.parse(raw))
+  } catch {
+    return null
+  }
+}
+
+const decodeJwtPayload = (token: string): Record<string, unknown> | null => {
+  const payload = token.split(".")[1]
+  if (!payload) return null
+
+  try {
+    const paddedPayload = payload.padEnd(
+      payload.length + ((4 - (payload.length % 4)) % 4),
+      "=",
+    )
+    const json = globalThis.atob(
+      paddedPayload.replace(/-/g, "+").replace(/_/g, "/"),
+    )
+    return getRecord(JSON.parse(json))
+  } catch {
+    return null
+  }
+}
+
+const pickIdentityField = (
+  source: Record<string, unknown> | null,
+  key: string,
+): string | number | undefined => {
+  const value = source?.[key]
+  if (typeof value === "number" && Number.isFinite(value)) return value
+  const text = getString(value)
+  return text || undefined
+}
+
+export const voApiV2ContentSessionExtractor: ContentSessionExtractor = {
+  id: "voapi-v2",
+  canExtract: () =>
+    localStorage.getItem(VOAPI_V2_USER_STORE_STORAGE_KEY) !== null,
+  async extract() {
+    const userStore = parseStorageObject(VOAPI_V2_USER_STORE_STORAGE_KEY)
+    const auth = getRecord(userStore?.auth)
+    const accessToken = getString(auth?.token)
+    if (!accessToken) return null
+
+    const user = parseStorageObject(COMPATIBLE_USER_STORAGE_KEY)
+    const jwtPayload = decodeJwtPayload(accessToken)
+    const userId =
+      pickIdentityField(user, "id") ?? pickIdentityField(jwtPayload, "userId")
+    if (userId === undefined) return null
+
+    const safeUser = {
+      ...(user ?? {}),
+      access_token: undefined,
+    }
+    delete safeUser.access_token
+
+    return {
+      userId,
+      user: safeUser,
+      accessToken,
+      siteTypeHint: SITE_TYPES.VO_API_V2,
+    }
+  },
+}

--- a/src/services/accountSiteOnboarding/registry.ts
+++ b/src/services/accountSiteOnboarding/registry.ts
@@ -7,6 +7,7 @@ import {
 import { compatibleUserContentSessionExtractor } from "./contentSession/compatibleUser"
 import { sharedChatContentSessionExtractor } from "./contentSession/sharedchat"
 import { sub2ApiContentSessionExtractor } from "./contentSession/sub2api"
+import { voApiV2ContentSessionExtractor } from "./contentSession/voapiV2"
 import type { ContentSessionExtractor } from "./contracts"
 
 /**
@@ -37,6 +38,7 @@ export function getContentSessionExtractors(): readonly ContentSessionExtractor[
   return [
     sub2ApiContentSessionExtractor,
     sharedChatContentSessionExtractor,
+    voApiV2ContentSessionExtractor,
     compatibleUserContentSessionExtractor,
   ]
 }

--- a/src/services/apiAdapters/contracts/siteTypeCapabilities.ts
+++ b/src/services/apiAdapters/contracts/siteTypeCapabilities.ts
@@ -21,7 +21,7 @@ import type { TokenProvisioningCapability } from "./tokenProvisioning"
 
 export type SiteType = AccountSiteType | ManagedSiteType
 
-export type SiteBackendFamily = "newApiFamily" | "sub2api"
+export type SiteBackendFamily = "newApiFamily" | "sub2api" | "voapiV2"
 
 export type SiteTypeCapabilities = {
   siteType: SiteType

--- a/src/services/apiAdapters/contracts/siteTypeCapabilities.ts
+++ b/src/services/apiAdapters/contracts/siteTypeCapabilities.ts
@@ -1,4 +1,5 @@
 import type { AccountSiteType, ManagedSiteType } from "~/constants/siteType"
+import type { AccountSiteBackendFamily } from "~/services/accountSiteDefinitions/contracts"
 
 import type { AccountBootstrapCapability } from "./accountBootstrap"
 import type { AccountCompletionCapability } from "./accountCompletion"
@@ -21,7 +22,7 @@ import type { TokenProvisioningCapability } from "./tokenProvisioning"
 
 export type SiteType = AccountSiteType | ManagedSiteType
 
-export type SiteBackendFamily = "newApiFamily" | "sub2api" | "voapiV2"
+export type SiteBackendFamily = AccountSiteBackendFamily
 
 export type SiteTypeCapabilities = {
   siteType: SiteType

--- a/src/services/apiAdapters/registry.ts
+++ b/src/services/apiAdapters/registry.ts
@@ -19,6 +19,7 @@ import { veloeraManagedSiteCapabilities } from "./managedSites/veloera"
 import { createNewApiCapabilities } from "./newApi"
 import { sharedChatCapabilities } from "./sharedchat"
 import { sub2ApiCapabilities } from "./sub2api"
+import { voApiV2Capabilities } from "./voapiV2"
 
 type ManagedSiteCapabilities = NonNullable<SiteTypeCapabilities["managedSites"]>
 
@@ -67,6 +68,7 @@ export function getSiteTypeCapabilities(
     ACCOUNT_SITE_ADAPTER_FAMILIES.Unsupported
 
   if (siteType === SITE_TYPES.SUB2API) return sub2ApiCapabilities
+  if (siteType === SITE_TYPES.VO_API_V2) return voApiV2Capabilities
   if (siteType === SITE_TYPES.AIHUBMIX) return aihubmixCapabilities
   if (siteType === SITE_TYPES.SHAREDCHAT) return sharedChatCapabilities
 

--- a/src/services/apiAdapters/voapiV2/accountBootstrap.ts
+++ b/src/services/apiAdapters/voapiV2/accountBootstrap.ts
@@ -6,6 +6,7 @@ import {
   fetchSupportCheckIn,
   fetchVoApiV2UserInfo,
 } from "~/services/apiService/voapiV2"
+import { VOAPI_V2_SYSTEM_NAME } from "~/services/apiService/voapiV2/type"
 
 export const voApiV2AccountBootstrap: AccountBootstrapCapability = {
   fetchUserInfo: async (request) => {
@@ -25,7 +26,7 @@ export const voApiV2AccountBootstrap: AccountBootstrapCapability = {
     access_token: request.auth.accessToken ?? "",
   }),
   fetchSiteStatus: async () => ({
-    system_name: "VoAPI",
+    system_name: VOAPI_V2_SYSTEM_NAME,
     checkin_enabled: true,
   }),
   fetchCheckInSupport: (request) => fetchSupportCheckIn(request),

--- a/src/services/apiAdapters/voapiV2/accountBootstrap.ts
+++ b/src/services/apiAdapters/voapiV2/accountBootstrap.ts
@@ -1,0 +1,38 @@
+import { SITE_TYPES } from "~/constants/siteType"
+import { UI_CONSTANTS } from "~/constants/ui"
+import { resolveStaticAccountRoutePath } from "~/services/apiAdapters/accountRoutes"
+import type { AccountBootstrapCapability } from "~/services/apiAdapters/contracts/accountBootstrap"
+import {
+  fetchSupportCheckIn,
+  fetchVoApiV2UserInfo,
+} from "~/services/apiService/voapiV2"
+
+export const voApiV2AccountBootstrap: AccountBootstrapCapability = {
+  fetchUserInfo: async (request) => {
+    const userInfo = await fetchVoApiV2UserInfo(request)
+    const id = userInfo.id
+    const username =
+      userInfo.username?.trim() || userInfo.nickname?.trim() || String(id)
+
+    return {
+      id: String(id),
+      username,
+      access_token: request.auth.accessToken ?? null,
+    }
+  },
+  getOrCreateAccessToken: async (request) => ({
+    username: String(request.auth.userId ?? ""),
+    access_token: request.auth.accessToken ?? "",
+  }),
+  fetchSiteStatus: async () => ({
+    system_name: "VoAPI",
+    checkin_enabled: true,
+  }),
+  fetchCheckInSupport: (request) => fetchSupportCheckIn(request),
+  extractDefaultExchangeRate: () => UI_CONSTANTS.EXCHANGE_RATE.DEFAULT,
+  resolveRoutePath: async (target, route) =>
+    resolveStaticAccountRoutePath(
+      { ...target, siteType: SITE_TYPES.VO_API_V2 },
+      route,
+    ),
+}

--- a/src/services/apiAdapters/voapiV2/accountCompletion.ts
+++ b/src/services/apiAdapters/voapiV2/accountCompletion.ts
@@ -2,6 +2,7 @@ import { AUTO_DETECT_FAILURE_REASONS } from "~/constants/autoDetect"
 import { UI_CONSTANTS } from "~/constants/ui"
 import type { AccountCompletionCapability } from "~/services/apiAdapters/contracts/accountCompletion"
 import { fetchVoApiV2UserInfo } from "~/services/apiService/voapiV2"
+import { VOAPI_V2_SYSTEM_NAME } from "~/services/apiService/voapiV2/type"
 import { AuthTypeEnum } from "~/types"
 
 export const voApiV2AccountCompletion: AccountCompletionCapability = {
@@ -48,7 +49,9 @@ export const voApiV2AccountCompletion: AccountCompletionCapability = {
 
     return {
       username,
-      siteName: await helpers.fetchSiteName({ system_name: "VoAPI" }),
+      siteName: await helpers.fetchSiteName({
+        system_name: VOAPI_V2_SYSTEM_NAME,
+      }),
       accessToken,
       userId,
       exchangeRate: UI_CONSTANTS.EXCHANGE_RATE.DEFAULT,

--- a/src/services/apiAdapters/voapiV2/accountCompletion.ts
+++ b/src/services/apiAdapters/voapiV2/accountCompletion.ts
@@ -1,0 +1,62 @@
+import { AUTO_DETECT_FAILURE_REASONS } from "~/constants/autoDetect"
+import { UI_CONSTANTS } from "~/constants/ui"
+import type { AccountCompletionCapability } from "~/services/apiAdapters/contracts/accountCompletion"
+import { fetchVoApiV2UserInfo } from "~/services/apiService/voapiV2"
+import { AuthTypeEnum } from "~/types"
+
+export const voApiV2AccountCompletion: AccountCompletionCapability = {
+  async complete(request, helpers) {
+    const { url, detected, context } = request
+    const accessToken = helpers.trimString(detected.accessToken)
+
+    if (!accessToken) {
+      throw helpers.createCompletionError(
+        AUTO_DETECT_FAILURE_REASONS.AccessTokenMissing,
+        new Error("VoAPI v2 dashboard JWT missing"),
+      )
+    }
+
+    let userInfo
+    try {
+      userInfo = await fetchVoApiV2UserInfo(
+        helpers.createServiceRequest({
+          baseUrl: url,
+          context,
+          auth: {
+            authType: AuthTypeEnum.AccessToken,
+            accessToken,
+            userId: detected.userId,
+          },
+        }),
+      )
+    } catch (error) {
+      throw helpers.createCompletionError(
+        AUTO_DETECT_FAILURE_REASONS.TokenFetchFailed,
+        error,
+      )
+    }
+
+    const detectedUser = detected.user as Record<string, unknown> | undefined
+    const userId = helpers.trimString(detected.userId) || String(userInfo.id)
+    const username =
+      helpers.trimString(detectedUser?.username) ||
+      helpers.trimString(detectedUser?.display_name) ||
+      helpers.trimString(detectedUser?.email) ||
+      helpers.trimString(userInfo.username) ||
+      helpers.trimString(userInfo.nickname) ||
+      userId
+
+    return {
+      username,
+      siteName: await helpers.fetchSiteName({ system_name: "VoAPI" }),
+      accessToken,
+      userId,
+      exchangeRate: UI_CONSTANTS.EXCHANGE_RATE.DEFAULT,
+      authType: AuthTypeEnum.AccessToken,
+      checkIn: helpers.createInitialCheckInConfig({
+        enableDetection: true,
+        autoCheckInEnabled: true,
+      }),
+    }
+  },
+}

--- a/src/services/apiAdapters/voapiV2/accountData.ts
+++ b/src/services/apiAdapters/voapiV2/accountData.ts
@@ -1,0 +1,6 @@
+import type { AccountDataCapability } from "~/services/apiAdapters/contracts/accountData"
+import { fetchVoApiV2AccountData } from "~/services/apiService/voapiV2"
+
+export const voApiV2AccountData: AccountDataCapability = {
+  fetchData: (request) => fetchVoApiV2AccountData(request),
+}

--- a/src/services/apiAdapters/voapiV2/accountRefresh.ts
+++ b/src/services/apiAdapters/voapiV2/accountRefresh.ts
@@ -1,0 +1,10 @@
+import type { AccountRefreshCapability } from "~/services/apiAdapters/contracts/accountRefresh"
+import {
+  fetchSupportCheckIn,
+  refreshAccountData,
+} from "~/services/apiService/voapiV2"
+
+export const voApiV2AccountRefresh: AccountRefreshCapability = {
+  fetchCheckInSupport: (request) => fetchSupportCheckIn(request),
+  refreshAccount: (request) => refreshAccountData(request),
+}

--- a/src/services/apiAdapters/voapiV2/index.ts
+++ b/src/services/apiAdapters/voapiV2/index.ts
@@ -1,0 +1,22 @@
+import { ACCOUNT_SITE_ADAPTER_FAMILIES, SITE_TYPES } from "~/constants/siteType"
+import type { SiteTypeCapabilities } from "~/services/apiAdapters/contracts/siteTypeCapabilities"
+
+import { voApiV2AccountBootstrap } from "./accountBootstrap"
+import { voApiV2AccountCompletion } from "./accountCompletion"
+import { voApiV2AccountData } from "./accountData"
+import { voApiV2AccountRefresh } from "./accountRefresh"
+import { voApiV2KeyManagement } from "./keyManagement"
+import { voApiV2TokenProvisioning } from "./tokenProvisioning"
+
+export const voApiV2Capabilities: SiteTypeCapabilities = {
+  siteType: SITE_TYPES.VO_API_V2,
+  family: ACCOUNT_SITE_ADAPTER_FAMILIES.VoApiV2,
+  account: {
+    data: voApiV2AccountData,
+    bootstrap: voApiV2AccountBootstrap,
+    completion: voApiV2AccountCompletion,
+    keyManagement: voApiV2KeyManagement,
+    tokenProvisioning: voApiV2TokenProvisioning,
+    refresh: voApiV2AccountRefresh,
+  },
+}

--- a/src/services/apiAdapters/voapiV2/keyManagement.ts
+++ b/src/services/apiAdapters/voapiV2/keyManagement.ts
@@ -1,0 +1,25 @@
+import type { KeyManagementCapability } from "~/services/apiAdapters/contracts/keyManagement"
+import {
+  createVoApiV2Token,
+  deleteVoApiV2Token,
+  fetchVoApiV2AvailableModels,
+  fetchVoApiV2Tokens,
+  fetchVoApiV2UserGroups,
+  resolveVoApiV2TokenKey,
+  updateVoApiV2Token,
+} from "~/services/apiService/voapiV2"
+
+export const voApiV2KeyManagement: KeyManagementCapability = {
+  fetchTokens: (request, options) =>
+    fetchVoApiV2Tokens(request, options?.page, options?.size),
+  createToken: (request, tokenData) => createVoApiV2Token(request, tokenData),
+  updateToken: ({ request, tokenId, tokenData }) =>
+    updateVoApiV2Token(request, tokenId, tokenData),
+  resolveTokenKey: ({ request, token }) =>
+    resolveVoApiV2TokenKey(request, token),
+  deleteToken: ({ request, tokenId }) => deleteVoApiV2Token(request, tokenId),
+  fetchAvailableModels: (request) => fetchVoApiV2AvailableModels(request),
+  userGroups: {
+    fetch: (request) => fetchVoApiV2UserGroups(request),
+  },
+}

--- a/src/services/apiAdapters/voapiV2/tokenProvisioning.ts
+++ b/src/services/apiAdapters/voapiV2/tokenProvisioning.ts
@@ -1,0 +1,75 @@
+import {
+  CREATED_TOKEN_SECRET_DECISION_KINDS,
+  DEFAULT_TOKEN_CREATION_DECISION_KINDS,
+  TOKEN_CREATION_SECRET_RECOVERY,
+  TOKEN_PROVISIONING_BLOCK_REASONS,
+  TOKEN_PROVISIONING_REPAIR_POLICY_KINDS,
+  type TokenProvisioningCapability,
+} from "~/services/apiAdapters/contracts/tokenProvisioning"
+
+const normalizeGroupNames = (groups: Record<string, unknown>): string[] => {
+  const seen = new Set<string>()
+  const normalizedGroups: string[] = []
+
+  for (const group of Object.keys(groups)) {
+    const normalizedGroup = group.trim()
+    if (!normalizedGroup || seen.has(normalizedGroup)) continue
+
+    seen.add(normalizedGroup)
+    normalizedGroups.push(normalizedGroup)
+  }
+
+  return normalizedGroups
+}
+
+export const voApiV2TokenProvisioning: TokenProvisioningCapability = {
+  isInventoryTokenUsable: ({ token }) => Boolean(token.id),
+  resolveDefaultTokenCreation({ defaultTokenData, explicitGroup, userGroups }) {
+    if (defaultTokenData.unlimited_quota) {
+      return {
+        kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.Blocked,
+        reason: TOKEN_PROVISIONING_BLOCK_REASONS.CreatedTokenSecretUnavailable,
+      }
+    }
+
+    const normalizedExplicitGroup = explicitGroup?.trim()
+    if (normalizedExplicitGroup) {
+      return {
+        kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.Create,
+        tokenData: { ...defaultTokenData, group: normalizedExplicitGroup },
+        oneTimeSecret: false,
+        recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.InventoryRefetch,
+      }
+    }
+
+    if (!userGroups) {
+      return { kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.NeedsUserGroups }
+    }
+
+    const allowedGroups = normalizeGroupNames(userGroups)
+    if (allowedGroups.length === 0) {
+      return { kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.NeedsUserGroups }
+    }
+
+    if (allowedGroups.length === 1) {
+      return {
+        kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.Create,
+        tokenData: { ...defaultTokenData, group: allowedGroups[0] },
+        oneTimeSecret: false,
+        recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.InventoryRefetch,
+      }
+    }
+
+    return {
+      kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.SelectionRequired,
+      allowedGroups,
+      reason: TOKEN_PROVISIONING_BLOCK_REASONS.GroupSelectionRequired,
+    }
+  },
+  classifyCreatedToken() {
+    return { kind: CREATED_TOKEN_SECRET_DECISION_KINDS.NeedsInventoryRefetch }
+  },
+  getRepairPolicy() {
+    return { kind: TOKEN_PROVISIONING_REPAIR_POLICY_KINDS.Eligible }
+  },
+}

--- a/src/services/apiService/voapiV2/index.ts
+++ b/src/services/apiService/voapiV2/index.ts
@@ -1,0 +1,696 @@
+import type {
+  AccountData,
+  ApiServiceAccountRequest,
+  RefreshAccountResult,
+} from "~/services/accounts/accountDataModel"
+import { determineHealthStatus } from "~/services/accounts/accountHealth"
+import type {
+  CreateTokenRequest,
+  UserGroupInfo,
+} from "~/services/accountTokens/tokenProvisioningModel"
+import { fetchApi } from "~/services/apiTransport/request"
+import {
+  API_AUTH_TOKEN_MODES,
+  type ApiServiceRequest,
+} from "~/services/apiTransport/type"
+import { SiteHealthStatus, type ApiToken, type CheckInConfig } from "~/types"
+import { t } from "~/utils/i18n/core"
+
+import {
+  amountToQuota,
+  isVoApiV2AuthExpiredError,
+  parseVoApiV2Envelope,
+  quotaToAmountString,
+  type VoApiV2EnvelopeOptions,
+} from "./parsing"
+import { resyncVoApiV2AuthToken } from "./tokenResync"
+import {
+  VOAPI_V2_ENDPOINTS,
+  type VoApiV2CheckInStats,
+  type VoApiV2CheckInSubmitData,
+  type VoApiV2DashboardStatistics,
+  type VoApiV2Envelope,
+  type VoApiV2Key,
+  type VoApiV2KeyTemplate,
+  type VoApiV2UserInfo,
+} from "./type"
+
+const DEFAULT_KEYS_PAGE = 1
+const DEFAULT_KEYS_PAGE_SIZE = 10
+
+type VoApiV2AccountDataRequest = ApiServiceRequest &
+  Partial<Pick<ApiServiceAccountRequest, "checkIn" | "includeTodayCashflow">>
+
+type VoApiV2CheckInSubmitResult =
+  | VoApiV2CheckInSubmitData
+  | { alreadySigned: true }
+
+/**
+ * Fetches a VoAPI v2 endpoint with the dashboard JWT sent as raw Authorization.
+ */
+async function fetchVoApiV2Data<TData>(
+  request: ApiServiceRequest,
+  endpoint: string,
+  options: RequestInit = {},
+  parseOptions?: VoApiV2EnvelopeOptions,
+): Promise<TData> {
+  const body = await fetchApi<unknown>(
+    request,
+    {
+      endpoint,
+      options,
+      authTokenMode: API_AUTH_TOKEN_MODES.Raw,
+    },
+    true,
+  )
+
+  return parseVoApiV2Envelope<TData>(body, endpoint, parseOptions)
+}
+
+const buildTodayStatisticsEndpoint = () => {
+  const start = new Date()
+  start.setHours(0, 0, 0, 0)
+
+  const end = new Date()
+  end.setHours(23, 59, 59, 999)
+
+  return `${VOAPI_V2_ENDPOINTS.DashboardStatistics}?t=h&s=${start.getTime()}&e=${end.getTime()}`
+}
+
+const toFiniteInteger = (value: unknown, fallback = 0): number => {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return Math.trunc(value)
+  }
+  if (typeof value === "string" && value.trim()) {
+    const parsed = Number(value)
+    return Number.isFinite(parsed) ? Math.trunc(parsed) : fallback
+  }
+
+  return fallback
+}
+
+const toExpireTimeMillis = (expiredTime: number | undefined): number =>
+  typeof expiredTime === "number" && expiredTime > 0 ? expiredTime * 1000 : -1
+
+const toVoApiV2GroupId = (value: unknown): number | undefined => {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return Math.trunc(value)
+  }
+  if (typeof value !== "string" || !value.trim()) return undefined
+
+  const parsed = Number(value.trim())
+  return Number.isFinite(parsed) ? Math.trunc(parsed) : undefined
+}
+
+const toExpiredTimeSeconds = (expireTime: unknown): number => {
+  const value = toFiniteInteger(expireTime, -1)
+  if (value <= 0) return -1
+
+  return value > 1_000_000_000_000 ? Math.floor(value / 1000) : value
+}
+
+const toVoApiV2GroupMapKey = (value: unknown): string => {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(Math.trunc(value))
+  }
+  if (typeof value === "string") return value.trim()
+  return ""
+}
+
+const buildVoApiV2GroupNameById = (
+  template: VoApiV2KeyTemplate,
+): Map<string, string> => {
+  return new Map(
+    (template.groups ?? []).flatMap((group) => {
+      const id = toVoApiV2GroupMapKey(group.id)
+      const name = typeof group.name === "string" ? group.name.trim() : ""
+      if (!id || !name) return []
+      return [[id, name]]
+    }),
+  )
+}
+
+const resolveVoApiV2TokenGroup = (
+  groups: VoApiV2Key["groups"],
+  groupNameById: ReadonlyMap<string, string>,
+): string => {
+  const groupId = toVoApiV2GroupMapKey(groups?.[0])
+  if (!groupId) return ""
+
+  return groupNameById.get(groupId) ?? groupId
+}
+
+const buildKeysEndpoint = (
+  page = DEFAULT_KEYS_PAGE,
+  size = DEFAULT_KEYS_PAGE_SIZE,
+) =>
+  `${VOAPI_V2_ENDPOINTS.Keys}?page=${page}&size=${size}&sl[name]=true&sl[token]=true&sl[note]=true`
+
+const normalizeVoApiV2Token = (
+  token: VoApiV2Key,
+  defaultUserId: unknown,
+  groupNameById: ReadonlyMap<string, string> = new Map(),
+): ApiToken => ({
+  id: toFiniteInteger(token.id),
+  user_id: toFiniteInteger(defaultUserId),
+  key: typeof token.tokenMasked === "string" ? token.tokenMasked : "",
+  status: token.enable === false ? 2 : 1,
+  name: typeof token.name === "string" ? token.name : "",
+  note: token.note,
+  created_time: 0,
+  accessed_time: 0,
+  expired_time: toExpiredTimeSeconds(token.expireTime),
+  remain_quota: amountToQuota(token.amount),
+  unlimited_quota: token.boundlessAmount === true,
+  model_limits_enabled: false,
+  model_limits: "",
+  allow_ips: "",
+  used_quota: amountToQuota(token.used),
+  group: resolveVoApiV2TokenGroup(token.groups, groupNameById),
+  DeletedAt: null,
+  models: "",
+})
+
+type VoApiV2KeyListPayload =
+  | VoApiV2Key[]
+  | {
+      list?: VoApiV2Key[]
+      records?: VoApiV2Key[]
+    }
+
+const extractKeyList = (payload: VoApiV2KeyListPayload) =>
+  Array.isArray(payload) ? payload : payload.records ?? payload.list ?? []
+
+const fetchVoApiV2RawKeys = async (
+  request: ApiServiceRequest,
+  page = DEFAULT_KEYS_PAGE,
+  size = DEFAULT_KEYS_PAGE_SIZE,
+) =>
+  extractKeyList(
+    await fetchVoApiV2Data<VoApiV2KeyListPayload>(
+      request,
+      buildKeysEndpoint(page, size),
+      { cache: "no-store" },
+    ),
+  )
+
+const fetchVoApiV2GroupNameById = async (
+  request: ApiServiceRequest,
+): Promise<Map<string, string>> => {
+  try {
+    return buildVoApiV2GroupNameById(await fetchVoApiV2Template(request))
+  } catch {
+    return new Map()
+  }
+}
+
+const normalizeVoApiV2GroupSelector = (value: unknown): string =>
+  typeof value === "string" ? value.trim() : ""
+
+const resolveVoApiV2GroupIds = async (
+  request: ApiServiceRequest,
+  selectedGroup: unknown,
+  fallbackGroups: Array<string | number> = [],
+): Promise<number[]> => {
+  const normalizedGroup = normalizeVoApiV2GroupSelector(selectedGroup)
+  if (!normalizedGroup) {
+    return fallbackGroups
+      .map((group) => toVoApiV2GroupId(group))
+      .filter((group): group is number => typeof group === "number")
+  }
+
+  const template = await fetchVoApiV2Template(request)
+  const selectedLower = normalizedGroup.toLowerCase()
+  const matchedGroup = (template.groups ?? []).find((group) => {
+    const id = String(group.id).trim()
+    const name = typeof group.name === "string" ? group.name.trim() : ""
+    return id === normalizedGroup || name.toLowerCase() === selectedLower
+  })
+  const groupId = toVoApiV2GroupId(matchedGroup?.id ?? normalizedGroup)
+
+  if (typeof groupId !== "number") {
+    throw new Error("VoAPI v2 group not found")
+  }
+
+  return [groupId]
+}
+
+const createVoApiV2TokenPayload = (
+  tokenData: CreateTokenRequest,
+  groups: number[],
+  existing?: Pick<
+    VoApiV2Key,
+    "enable" | "groups" | "boundlessAmount" | "used" | "note"
+  >,
+) => ({
+  name: tokenData.name,
+  groups,
+  amount: quotaToAmountString(tokenData.remain_quota),
+  boundlessAmount: tokenData.unlimited_quota === true,
+  enable: existing?.enable ?? true,
+  expireTime: toExpireTimeMillis(tokenData.expired_time),
+  ...(existing
+    ? {
+        used: existing.used ?? "0",
+        note: existing.note ?? "",
+      }
+    : {
+        genCount: 1,
+      }),
+})
+
+/**
+ * Fetches the authenticated VoAPI v2 account profile.
+ */
+export const fetchVoApiV2UserInfo = (request: ApiServiceRequest) =>
+  fetchVoApiV2Data<VoApiV2UserInfo>(request, VOAPI_V2_ENDPOINTS.UserInfo, {
+    cache: "no-store",
+  })
+
+/**
+ * Reports check-in support for VoAPI v2 accounts.
+ */
+export const fetchSupportCheckIn = async (
+  _request: ApiServiceRequest,
+): Promise<boolean | undefined> => true
+
+const fetchVoApiV2CheckedInToday = async (
+  request: ApiServiceRequest,
+): Promise<boolean | undefined> => {
+  try {
+    const stats = await fetchVoApiV2CheckInStats(request)
+    return typeof stats.todaySigned === "boolean"
+      ? stats.todaySigned
+      : undefined
+  } catch {
+    return undefined
+  }
+}
+
+const resolveVoApiV2CheckInSiteStatus = (
+  checkIn: CheckInConfig,
+  isCheckedInToday: boolean | undefined,
+) => {
+  if (typeof isCheckedInToday !== "boolean") {
+    return {
+      ...(checkIn.siteStatus ?? {}),
+      isCheckedInToday: checkIn.siteStatus?.isCheckedInToday,
+      lastDetectedAt: checkIn.siteStatus?.lastDetectedAt,
+    }
+  }
+
+  return {
+    ...(checkIn.siteStatus ?? {}),
+    isCheckedInToday,
+    lastDetectedAt: Date.now(),
+  }
+}
+
+/**
+ * Maps VoAPI v2 balances and current-day statistics into account dashboard data.
+ */
+export async function fetchVoApiV2AccountData(
+  request: VoApiV2AccountDataRequest,
+): Promise<AccountData> {
+  const resolvedCheckIn = request.checkIn ?? { enableDetection: false }
+  const userInfoPromise = fetchVoApiV2UserInfo(request)
+  const statsPromise =
+    request.includeTodayCashflow !== false
+      ? fetchVoApiV2Data<VoApiV2DashboardStatistics>(
+          request,
+          buildTodayStatisticsEndpoint(),
+          { cache: "no-store" },
+        ).catch(() => null)
+      : Promise.resolve<VoApiV2DashboardStatistics | null>(null)
+  const checkedInTodayPromise = resolvedCheckIn.enableDetection
+    ? fetchVoApiV2CheckedInToday(request)
+    : Promise.resolve<boolean | undefined>(undefined)
+
+  const [userInfo, stats, isCheckedInToday] = await Promise.all([
+    userInfoPromise,
+    statsPromise,
+    checkedInTodayPromise,
+  ])
+
+  const quota =
+    amountToQuota(userInfo.basicBalance) + amountToQuota(userInfo.bindBalance)
+  const todayUsage =
+    amountToQuota(stats?.d?.usedBasicBalance) +
+    amountToQuota(stats?.d?.usedBindBalance)
+
+  return {
+    quota,
+    today_quota_consumption: todayUsage,
+    today_requests_count: Number(stats?.d?.requests ?? 0),
+    today_prompt_tokens: 0,
+    today_completion_tokens: 0,
+    today_income: 0,
+    checkIn: {
+      ...resolvedCheckIn,
+      siteStatus: resolveVoApiV2CheckInSiteStatus(
+        resolvedCheckIn,
+        isCheckedInToday,
+      ),
+    },
+  }
+}
+
+/**
+ * Refreshes VoAPI v2 account data with a site-specific expired-session status.
+ */
+export async function refreshAccountData(
+  request: ApiServiceAccountRequest,
+): Promise<RefreshAccountResult> {
+  try {
+    const data = await fetchVoApiV2AccountData(request)
+    return {
+      success: true,
+      data,
+      healthStatus: {
+        status: SiteHealthStatus.Healthy,
+        message: t("account:healthStatus.normal"),
+      },
+    }
+  } catch (error) {
+    if (isVoApiV2AuthExpiredError(error)) {
+      const resynced = await resyncVoApiV2AuthToken(request.baseUrl)
+      if (resynced) {
+        const resyncedRequest: ApiServiceAccountRequest = {
+          ...request,
+          auth: {
+            ...request.auth,
+            accessToken: resynced.accessToken,
+            userId: resynced.userId,
+          },
+        }
+
+        try {
+          const data = await fetchVoApiV2AccountData(resyncedRequest)
+          return {
+            success: true,
+            data,
+            authUpdate: {
+              accessToken: resynced.accessToken,
+              userId: resynced.userId,
+              ...(resynced.username ? { username: resynced.username } : {}),
+            },
+            healthStatus: {
+              status: SiteHealthStatus.Healthy,
+              message: t("account:healthStatus.normal"),
+            },
+          }
+        } catch (retryError) {
+          if (!isVoApiV2AuthExpiredError(retryError)) {
+            return {
+              success: false,
+              healthStatus: determineHealthStatus(retryError),
+            }
+          }
+        }
+      }
+
+      return {
+        success: false,
+        healthStatus: {
+          status: SiteHealthStatus.Warning,
+          message: t("account:healthStatus.httpError", {
+            statusCode: 401,
+            message: error.message,
+          }),
+        },
+      }
+    }
+
+    return {
+      success: false,
+      healthStatus: determineHealthStatus(error),
+    }
+  }
+}
+
+/**
+ * Lists VoAPI v2 API keys and normalizes them into the shared ApiToken shape.
+ */
+export async function fetchVoApiV2Tokens(
+  request: ApiServiceRequest,
+  page = DEFAULT_KEYS_PAGE,
+  size = DEFAULT_KEYS_PAGE_SIZE,
+): Promise<ApiToken[]> {
+  const [keys, groupNameById] = await Promise.all([
+    fetchVoApiV2RawKeys(request, page, size),
+    fetchVoApiV2GroupNameById(request),
+  ])
+
+  return keys.map((token) =>
+    normalizeVoApiV2Token(token, request.auth.userId, groupNameById),
+  )
+}
+
+/**
+ * Fetches VoAPI v2 key creation metadata, including groups and model ids.
+ */
+const fetchVoApiV2Template = (request: ApiServiceRequest) =>
+  fetchVoApiV2Data<VoApiV2KeyTemplate>(
+    request,
+    VOAPI_V2_ENDPOINTS.KeyTemplate,
+    { cache: "no-store" },
+  )
+
+/**
+ * Finds one VoAPI v2 key by id from the key inventory.
+ */
+async function fetchVoApiV2TokenById(
+  request: ApiServiceRequest,
+  tokenId: number,
+): Promise<VoApiV2Key> {
+  const token = (await fetchVoApiV2RawKeys(request, 1, 100)).find(
+    (item) => item.id === tokenId,
+  )
+
+  if (!token) {
+    throw new Error("VoAPI v2 token not found")
+  }
+
+  return token
+}
+
+type VoApiV2RevealTokenResponse = string | { token?: unknown }
+
+const extractVoApiV2RevealedToken = (
+  value: VoApiV2RevealTokenResponse,
+): string => {
+  if (typeof value === "string") return value
+  if (typeof value.token === "string") return value.token
+
+  throw new Error("VoAPI v2 token reveal response is missing token")
+}
+
+/**
+ * Reveals the full secret for a VoAPI v2 key without falling back to common routes.
+ */
+export async function resolveVoApiV2TokenKey(
+  request: ApiServiceRequest,
+  token: Pick<ApiToken, "id" | "key">,
+): Promise<string> {
+  const revealedToken = await fetchVoApiV2Data<VoApiV2RevealTokenResponse>(
+    request,
+    `${VOAPI_V2_ENDPOINTS.Keys}/${token.id}/token`,
+    { method: "POST" },
+    { allowTopLevelToken: true },
+  )
+
+  return extractVoApiV2RevealedToken(revealedToken)
+}
+
+/**
+ * Creates a VoAPI v2 key and relies on inventory refetch for the created secret.
+ */
+export async function createVoApiV2Token(
+  request: ApiServiceRequest,
+  tokenData: CreateTokenRequest,
+): Promise<boolean> {
+  const groups = await resolveVoApiV2GroupIds(request, tokenData.group)
+
+  await fetchVoApiV2Data<null>(
+    request,
+    VOAPI_V2_ENDPOINTS.Keys,
+    {
+      method: "POST",
+      body: JSON.stringify(createVoApiV2TokenPayload(tokenData, groups)),
+    },
+    { allowNullData: true },
+  )
+
+  return true
+}
+
+/**
+ * Updates a VoAPI v2 key through the backend's `/api/keys/{id}` endpoint.
+ */
+export async function updateVoApiV2Token(
+  request: ApiServiceRequest,
+  tokenId: number,
+  tokenData: CreateTokenRequest,
+): Promise<boolean> {
+  const existing = await fetchVoApiV2TokenById(request, tokenId)
+  const groups = await resolveVoApiV2GroupIds(
+    request,
+    tokenData.group,
+    existing.groups,
+  )
+
+  await fetchVoApiV2Data<null>(
+    request,
+    `${VOAPI_V2_ENDPOINTS.Keys}/${tokenId}`,
+    {
+      method: "PUT",
+      body: JSON.stringify({
+        id: tokenId,
+        ...createVoApiV2TokenPayload(tokenData, groups, existing),
+      }),
+    },
+    { allowNullData: true },
+  )
+
+  return true
+}
+
+/**
+ * Enables or disables a VoAPI v2 key through the standard update endpoint.
+ */
+export async function setVoApiV2TokenEnabled(
+  request: ApiServiceRequest,
+  tokenId: number,
+  enable: boolean,
+): Promise<boolean> {
+  const existing = await fetchVoApiV2TokenById(request, tokenId)
+
+  await fetchVoApiV2Data<null>(
+    request,
+    `${VOAPI_V2_ENDPOINTS.Keys}/${tokenId}`,
+    {
+      method: "PUT",
+      body: JSON.stringify({
+        id: tokenId,
+        name: existing.name ?? "",
+        groups: await resolveVoApiV2GroupIds(request, "", existing.groups),
+        enable,
+        expireTime: existing.expireTime ?? -1,
+        boundlessAmount: existing.boundlessAmount === true,
+        amount: existing.amount ?? "0",
+        used: existing.used ?? "0",
+        note: existing.note ?? "",
+      }),
+    },
+    { allowNullData: true },
+  )
+
+  return true
+}
+
+/**
+ * Deletes a VoAPI v2 key.
+ */
+export async function deleteVoApiV2Token(
+  request: ApiServiceRequest,
+  tokenId: number,
+): Promise<boolean> {
+  await fetchVoApiV2Data<null>(
+    request,
+    `${VOAPI_V2_ENDPOINTS.Keys}/${tokenId}`,
+    { method: "DELETE" },
+    { allowNullData: true },
+  )
+
+  return true
+}
+
+/**
+ * Fetches VoAPI v2 check-in stats for final status confirmation.
+ */
+export const fetchVoApiV2CheckInStats = (request: ApiServiceRequest) =>
+  fetchVoApiV2Data<VoApiV2CheckInStats>(
+    request,
+    VOAPI_V2_ENDPOINTS.CheckInStats,
+    { cache: "no-store" },
+  )
+
+/**
+ * Submits the VoAPI v2 API check-in and classifies same-day repeats.
+ */
+export async function submitVoApiV2CheckIn(
+  request: ApiServiceRequest,
+): Promise<VoApiV2CheckInSubmitResult> {
+  const body = await fetchApi<VoApiV2Envelope<VoApiV2CheckInSubmitData>>(
+    request,
+    {
+      endpoint: VOAPI_V2_ENDPOINTS.CheckInSubmit,
+      options: { method: "POST" },
+      authTokenMode: API_AUTH_TOKEN_MODES.Raw,
+    },
+    true,
+  )
+
+  if (
+    body &&
+    typeof body === "object" &&
+    body.code === 1 &&
+    /signed|check/i.test(body.msg ?? body.message ?? "")
+  ) {
+    return { alreadySigned: true }
+  }
+
+  return parseVoApiV2Envelope<VoApiV2CheckInSubmitData>(
+    body,
+    VOAPI_V2_ENDPOINTS.CheckInSubmit,
+  )
+}
+
+/**
+ * Returns enabled, visible VoAPI v2 model ids from the key template.
+ */
+export async function fetchVoApiV2AvailableModels(
+  request: ApiServiceRequest,
+): Promise<string[]> {
+  const template = await fetchVoApiV2Template(request)
+  const models = template.models ?? []
+
+  return Array.from(
+    new Set(
+      models
+        .filter((model) => model.enable !== false && model.hidden !== true)
+        .map((model) => (typeof model.idKey === "string" ? model.idKey : ""))
+        .map((model) => model.trim())
+        .filter(Boolean),
+    ),
+  )
+}
+
+/**
+ * Maps VoAPI v2 group template data into the shared user-group inventory.
+ */
+export async function fetchVoApiV2UserGroups(
+  request: ApiServiceRequest,
+): Promise<Record<string, UserGroupInfo>> {
+  const template = await fetchVoApiV2Template(request)
+
+  return (template.groups ?? []).reduce<Record<string, UserGroupInfo>>(
+    (groups, group) => {
+      const id = String(group.id).trim()
+      if (!id) return groups
+
+      const name = typeof group.name === "string" ? group.name.trim() : ""
+      const note = typeof group.note === "string" ? group.note.trim() : ""
+      groups[id] = {
+        desc: note || name,
+        ratio:
+          typeof group.ratio === "number" && Number.isFinite(group.ratio)
+            ? group.ratio
+            : 1,
+      }
+
+      return groups
+    },
+    {},
+  )
+}

--- a/src/services/apiService/voapiV2/index.ts
+++ b/src/services/apiService/voapiV2/index.ts
@@ -8,6 +8,7 @@ import type {
   CreateTokenRequest,
   UserGroupInfo,
 } from "~/services/accountTokens/tokenProvisioningModel"
+import { API_ERROR_CODES, ApiError } from "~/services/apiTransport/errors"
 import { fetchApi } from "~/services/apiTransport/request"
 import {
   API_AUTH_TOKEN_MODES,
@@ -26,6 +27,7 @@ import {
 import { resyncVoApiV2AuthToken } from "./tokenResync"
 import {
   VOAPI_V2_ENDPOINTS,
+  VOAPI_V2_PROTOCOL_CODES,
   type VoApiV2CheckInStats,
   type VoApiV2CheckInSubmitData,
   type VoApiV2DashboardStatistics,
@@ -37,6 +39,7 @@ import {
 
 const DEFAULT_KEYS_PAGE = 1
 const DEFAULT_KEYS_PAGE_SIZE = 10
+const TOKEN_LOOKUP_PAGE_SIZE = 100
 
 type VoApiV2AccountDataRequest = ApiServiceRequest &
   Partial<Pick<ApiServiceAccountRequest, "checkIn" | "includeTodayCashflow">>
@@ -229,7 +232,12 @@ const resolveVoApiV2GroupIds = async (
   const groupId = toVoApiV2GroupId(matchedGroup?.id ?? normalizedGroup)
 
   if (typeof groupId !== "number") {
-    throw new Error("VoAPI v2 group not found")
+    throw new ApiError(
+      "VoAPI v2 group not found",
+      undefined,
+      VOAPI_V2_ENDPOINTS.KeyTemplate,
+      API_ERROR_CODES.BUSINESS_ERROR,
+    )
   }
 
   return [groupId]
@@ -400,11 +408,22 @@ export async function refreshAccountData(
             },
           }
         } catch (retryError) {
-          if (!isVoApiV2AuthExpiredError(retryError)) {
+          if (isVoApiV2AuthExpiredError(retryError)) {
             return {
               success: false,
-              healthStatus: determineHealthStatus(retryError),
+              healthStatus: {
+                status: SiteHealthStatus.Warning,
+                message: t("account:healthStatus.httpError", {
+                  statusCode: 401,
+                  message: retryError.message,
+                }),
+              },
             }
+          }
+
+          return {
+            success: false,
+            healthStatus: determineHealthStatus(retryError),
           }
         }
       }
@@ -463,15 +482,33 @@ async function fetchVoApiV2TokenById(
   request: ApiServiceRequest,
   tokenId: number,
 ): Promise<VoApiV2Key> {
-  const token = (await fetchVoApiV2RawKeys(request, 1, 100)).find(
-    (item) => item.id === tokenId,
-  )
+  let page = DEFAULT_KEYS_PAGE
 
-  if (!token) {
-    throw new Error("VoAPI v2 token not found")
+  while (true) {
+    const keys = await fetchVoApiV2RawKeys(
+      request,
+      page,
+      TOKEN_LOOKUP_PAGE_SIZE,
+    )
+    const token = keys.find((item) => item.id === tokenId)
+
+    if (token) {
+      return token
+    }
+
+    if (keys.length < TOKEN_LOOKUP_PAGE_SIZE) {
+      break
+    }
+
+    page += 1
   }
 
-  return token
+  throw new ApiError(
+    "VoAPI v2 token not found",
+    undefined,
+    VOAPI_V2_ENDPOINTS.Keys,
+    API_ERROR_CODES.BUSINESS_ERROR,
+  )
 }
 
 type VoApiV2RevealTokenResponse = string | { token?: unknown }
@@ -480,9 +517,16 @@ const extractVoApiV2RevealedToken = (
   value: VoApiV2RevealTokenResponse,
 ): string => {
   if (typeof value === "string") return value
-  if (typeof value.token === "string") return value.token
+  if (value && typeof value === "object" && typeof value.token === "string") {
+    return value.token
+  }
 
-  throw new Error("VoAPI v2 token reveal response is missing token")
+  throw new ApiError(
+    "VoAPI v2 token reveal response is missing token",
+    undefined,
+    VOAPI_V2_ENDPOINTS.Keys,
+    API_ERROR_CODES.JSON_PARSE_ERROR,
+  )
 }
 
 /**
@@ -634,7 +678,7 @@ export async function submitVoApiV2CheckIn(
   if (
     body &&
     typeof body === "object" &&
-    body.code === 1 &&
+    body.code === VOAPI_V2_PROTOCOL_CODES.AlreadySigned &&
     /signed|check/i.test(body.msg ?? body.message ?? "")
   ) {
     return { alreadySigned: true }

--- a/src/services/apiService/voapiV2/index.ts
+++ b/src/services/apiService/voapiV2/index.ts
@@ -40,6 +40,7 @@ import {
 const DEFAULT_KEYS_PAGE = 1
 const DEFAULT_KEYS_PAGE_SIZE = 10
 const TOKEN_LOOKUP_PAGE_SIZE = 100
+const TOKEN_LOOKUP_MAX_PAGES = 100
 
 type VoApiV2AccountDataRequest = ApiServiceRequest &
   Partial<Pick<ApiServiceAccountRequest, "checkIn" | "includeTodayCashflow">>
@@ -484,7 +485,7 @@ async function fetchVoApiV2TokenById(
 ): Promise<VoApiV2Key> {
   let page = DEFAULT_KEYS_PAGE
 
-  while (true) {
+  while (page <= TOKEN_LOOKUP_MAX_PAGES) {
     const keys = await fetchVoApiV2RawKeys(
       request,
       page,

--- a/src/services/apiService/voapiV2/parsing.ts
+++ b/src/services/apiService/voapiV2/parsing.ts
@@ -1,7 +1,7 @@
 import { UI_CONSTANTS } from "~/constants/ui"
 import { API_ERROR_CODES, ApiError } from "~/services/apiTransport/errors"
 
-import type { VoApiV2Envelope } from "./type"
+import { VOAPI_V2_PROTOCOL_CODES, type VoApiV2Envelope } from "./type"
 
 class VoApiV2AuthExpiredError extends ApiError {}
 
@@ -19,7 +19,7 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value)
 
 const isAuthExpiredEnvelope = (body: VoApiV2Envelope<unknown>): boolean =>
-  body.code === 2 &&
+  body.code === VOAPI_V2_PROTOCOL_CODES.AuthExpired &&
   /auth\s*expire|unauthorized|token|jwt|login/i.test(getEnvelopeMessage(body))
 
 /**
@@ -40,7 +40,7 @@ export function parseVoApiV2Envelope<TData>(
   }
 
   const body = value as VoApiV2Envelope<TData>
-  if (body.code !== 0) {
+  if (body.code !== VOAPI_V2_PROTOCOL_CODES.Success) {
     const message = getEnvelopeMessage(body)
     const ErrorClass = isAuthExpiredEnvelope(body)
       ? VoApiV2AuthExpiredError

--- a/src/services/apiService/voapiV2/parsing.ts
+++ b/src/services/apiService/voapiV2/parsing.ts
@@ -1,0 +1,102 @@
+import { UI_CONSTANTS } from "~/constants/ui"
+import { API_ERROR_CODES, ApiError } from "~/services/apiTransport/errors"
+
+import type { VoApiV2Envelope } from "./type"
+
+class VoApiV2AuthExpiredError extends ApiError {}
+
+export type VoApiV2EnvelopeOptions = {
+  allowNullData?: boolean
+  allowTopLevelToken?: boolean
+}
+
+const getEnvelopeMessage = (body: VoApiV2Envelope<unknown>): string =>
+  (typeof body.msg === "string" && body.msg.trim()) ||
+  (typeof body.message === "string" && body.message.trim()) ||
+  "VoAPI v2 request failed"
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+const isAuthExpiredEnvelope = (body: VoApiV2Envelope<unknown>): boolean =>
+  body.code === 2 &&
+  /auth\s*expire|unauthorized|token|jwt|login/i.test(getEnvelopeMessage(body))
+
+/**
+ * Unwraps VoAPI v2 business envelopes and converts backend failures into ApiError.
+ */
+export function parseVoApiV2Envelope<TData>(
+  value: unknown,
+  endpoint: string,
+  options: VoApiV2EnvelopeOptions = {},
+): TData {
+  if (!isRecord(value) || typeof value.code !== "number") {
+    throw new ApiError(
+      "Invalid VoAPI v2 response",
+      undefined,
+      endpoint,
+      API_ERROR_CODES.JSON_PARSE_ERROR,
+    )
+  }
+
+  const body = value as VoApiV2Envelope<TData>
+  if (body.code !== 0) {
+    const message = getEnvelopeMessage(body)
+    const ErrorClass = isAuthExpiredEnvelope(body)
+      ? VoApiV2AuthExpiredError
+      : ApiError
+
+    throw new ErrorClass(
+      message,
+      undefined,
+      endpoint,
+      API_ERROR_CODES.BUSINESS_ERROR,
+    )
+  }
+
+  if (options.allowTopLevelToken && typeof body.token === "string") {
+    return body.token as TData
+  }
+
+  if (body.data === null && options.allowNullData) {
+    return null as TData
+  }
+
+  if (body.data === undefined || body.data === null) {
+    throw new ApiError(
+      "Missing VoAPI v2 response data",
+      undefined,
+      endpoint,
+      API_ERROR_CODES.JSON_PARSE_ERROR,
+    )
+  }
+
+  return body.data
+}
+
+export const isVoApiV2AuthExpiredError = (
+  error: unknown,
+): error is VoApiV2AuthExpiredError => error instanceof VoApiV2AuthExpiredError
+
+const toFiniteNumber = (value: unknown): number => {
+  if (typeof value === "number" && Number.isFinite(value)) return value
+  if (typeof value !== "string") return 0
+
+  const parsed = Number.parseFloat(value.trim())
+  return Number.isFinite(parsed) ? parsed : 0
+}
+
+export const amountToQuota = (amount: unknown): number => {
+  const parsed = toFiniteNumber(amount)
+  if (parsed <= 0) return 0
+
+  return Math.round(parsed * UI_CONSTANTS.EXCHANGE_RATE.CONVERSION_FACTOR)
+}
+
+export const quotaToAmountString = (quota: unknown): string => {
+  const parsed = typeof quota === "number" && Number.isFinite(quota) ? quota : 0
+  if (parsed <= 0) return "0"
+
+  const amount = parsed / UI_CONSTANTS.EXCHANGE_RATE.CONVERSION_FACTOR
+  return Number(amount.toFixed(6)).toString()
+}

--- a/src/services/apiService/voapiV2/tokenResync.ts
+++ b/src/services/apiService/voapiV2/tokenResync.ts
@@ -1,0 +1,75 @@
+import { SITE_TYPES } from "~/constants/siteType"
+import {
+  ACCOUNT_BROWSER_SESSION_SOURCES,
+  resolveAccountBrowserSession,
+  type AccountBrowserSession,
+} from "~/services/accountBrowserSession"
+
+type VoApiV2ResyncedToken = {
+  accessToken: string
+  userId: string
+  username?: string
+  source:
+    | typeof ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB
+    | typeof ACCOUNT_BROWSER_SESSION_SOURCES.TEMP_WINDOW
+}
+
+const VOAPI_V2_RESYNC_SOURCE_BY_BROWSER_SESSION_SOURCE = {
+  [ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB]:
+    ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB,
+  [ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB]:
+    ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB,
+  [ACCOUNT_BROWSER_SESSION_SOURCES.TEMP_WINDOW]:
+    ACCOUNT_BROWSER_SESSION_SOURCES.TEMP_WINDOW,
+} as const satisfies Record<
+  AccountBrowserSession["source"],
+  VoApiV2ResyncedToken["source"]
+>
+
+const normalizeString = (value: unknown): string =>
+  typeof value === "string" ? value.trim() : ""
+
+const isVoApiV2Session = (session: AccountBrowserSession): boolean =>
+  session.siteType === SITE_TYPES.VO_API_V2 ||
+  session.siteTypeHint === SITE_TYPES.VO_API_V2
+
+const hasUsableDashboardJwt = (session: AccountBrowserSession): boolean =>
+  isVoApiV2Session(session) && normalizeString(session.accessToken).length > 0
+
+const resolveUsername = (session: AccountBrowserSession): string | undefined =>
+  normalizeString(session.user?.username) ||
+  normalizeString(session.user?.display_name) ||
+  normalizeString(session.user?.email) ||
+  undefined
+
+/**
+ * Re-sync a VoAPI v2 dashboard JWT from logged-in browser-session state.
+ *
+ * VoAPI v2 has no verified refresh-token contract; this only re-reads the
+ * page-session JWT that the content-session extractor already knows how to
+ * collect from `userStore.auth.token`.
+ */
+export async function resyncVoApiV2AuthToken(
+  baseUrl: string,
+): Promise<VoApiV2ResyncedToken | null> {
+  const session = await resolveAccountBrowserSession({
+    baseUrl,
+    siteType: SITE_TYPES.VO_API_V2,
+    useExistingTabs: true,
+    useTempWindow: true,
+    requestIdPrefix: "voapi-v2-token-resync",
+    isUsableSession: hasUsableDashboardJwt,
+  })
+
+  const accessToken = normalizeString(session?.accessToken)
+  if (!session || !accessToken) return null
+
+  const username = resolveUsername(session)
+
+  return {
+    accessToken,
+    userId: session.userId,
+    ...(username ? { username } : {}),
+    source: VOAPI_V2_RESYNC_SOURCE_BY_BROWSER_SESSION_SOURCE[session.source],
+  }
+}

--- a/src/services/apiService/voapiV2/type.ts
+++ b/src/services/apiService/voapiV2/type.ts
@@ -9,6 +9,14 @@ export const VOAPI_V2_ENDPOINTS = {
   CheckInSubmit: "/api/check_in",
 } as const
 
+export const VOAPI_V2_PROTOCOL_CODES = {
+  Success: 0,
+  AlreadySigned: 1,
+  AuthExpired: 2,
+} as const
+
+export const VOAPI_V2_SYSTEM_NAME = "VoAPI"
+
 export type VoApiV2Envelope<TData = unknown> = {
   code: number
   data?: TData

--- a/src/services/apiService/voapiV2/type.ts
+++ b/src/services/apiService/voapiV2/type.ts
@@ -1,0 +1,85 @@
+export const VOAPI_V2_ENDPOINTS = {
+  UserInfo: "/api/user/info",
+  DashboardStatistics: "/api/dash/statistics",
+  Keys: "/api/keys",
+  KeyTemplate: "/api/keys/template",
+  CheckInTemplate: "/api/check_in/template",
+  CheckInStats: "/api/check_in/stats",
+  CheckInRecords: "/api/check_in",
+  CheckInSubmit: "/api/check_in",
+} as const
+
+export type VoApiV2Envelope<TData = unknown> = {
+  code: number
+  data?: TData
+  msg?: string
+  message?: string
+  token?: string
+  rid?: string
+}
+
+export type VoApiV2UserInfo = {
+  id: number | string
+  username?: string
+  nickname?: string
+  basicBalance?: string | number
+  bindBalance?: string | number
+  usedBasicBalance?: string | number
+  usedBindBalance?: string | number
+  currency?: string
+  totalRequest?: number
+  totalToken?: number
+}
+
+export type VoApiV2DashboardStatistics = {
+  d?: {
+    requests?: number
+    usedBasicBalance?: string | number
+    usedBindBalance?: string | number
+    errors?: number
+    maxRpm?: number
+  }
+}
+
+export type VoApiV2Key = {
+  id: number
+  name?: string
+  tokenMasked?: string
+  groups?: Array<string | number>
+  enable?: boolean
+  expireTime?: number
+  boundlessAmount?: boolean
+  amount?: string | number
+  used?: string | number
+  note?: string
+}
+
+export type VoApiV2KeyTemplate = {
+  groups?: Array<{
+    id: string | number
+    name?: string
+    ratio?: number
+    timeRatio?: number
+    chargingType?: string
+    subBalanceType?: string
+    note?: string
+  }>
+  models?: Array<{
+    idKey?: string
+    enable?: boolean
+    hidden?: boolean
+  }>
+  ssb?: boolean
+}
+
+export type VoApiV2CheckInStats = {
+  todaySigned?: boolean
+  nextAmount?: string | number
+  todayRecord?: unknown
+  consecutiveDays?: number
+}
+
+export type VoApiV2CheckInSubmitData = {
+  amount?: string | number
+  bonusAmount?: string | number
+}

--- a/src/services/apiTransport/request.ts
+++ b/src/services/apiTransport/request.ts
@@ -10,6 +10,7 @@ import { createMinIntervalLimiter } from "~/services/apiTransport/minIntervalLim
 import { extractDataFromApiResponseBody } from "~/services/apiTransport/response"
 import { withSiteApiRequestLimit } from "~/services/apiTransport/siteRequestLimiter"
 import type {
+  ApiAuthTokenMode,
   ApiResponse,
   ApiTransportFetchContext,
   ApiTransportRequest,
@@ -17,6 +18,7 @@ import type {
   FetchApiOptions,
 } from "~/services/apiTransport/type"
 import {
+  API_AUTH_TOKEN_MODES,
   API_TRANSPORT_FETCH_CONTEXT_KINDS,
   summarizeApiTransportFetchContext,
 } from "~/services/apiTransport/type"
@@ -93,14 +95,19 @@ function extractBackendErrorDetails(body: unknown): BackendErrorDetails | null {
     return null
   }
 
-  const topLevelMessage = getNonEmptyString(
-    (body as { message?: unknown }).message,
-  )
+  const topLevelMessage =
+    getNonEmptyString((body as { message?: unknown }).message) ??
+    getNonEmptyString((body as { msg?: unknown }).msg)
   if (topLevelMessage) {
+    const code = (body as { code?: unknown }).code
+    const isBusinessEnvelope =
+      (typeof code === "number" && code !== 0) ||
+      (typeof code === "string" && code.trim() !== "" && code.trim() !== "0")
+
     return {
       message: topLevelMessage,
       isBackendError: Boolean(
-        (body as { success?: unknown }).success === false,
+        (body as { success?: unknown }).success === false || isBusinessEnvelope,
       ),
     }
   }
@@ -196,6 +203,7 @@ async function enforceLogRequestRateLimit(options: {
  */
 const createRequestHeaders = async (
   auth: NormalizedAuthContext,
+  authTokenMode: ApiAuthTokenMode = API_AUTH_TOKEN_MODES.Bearer,
 ): Promise<Record<string, string>> => {
   const baseHeaders = {
     "Content-Type": REQUEST_CONFIG.HEADERS.CONTENT_TYPE,
@@ -216,7 +224,10 @@ const createRequestHeaders = async (
   }
 
   if (auth.accessToken) {
-    headers["Authorization"] = `Bearer ${auth.accessToken}`
+    headers["Authorization"] =
+      authTokenMode === API_AUTH_TOKEN_MODES.Raw
+        ? auth.accessToken
+        : `Bearer ${auth.accessToken}`
   }
 
   if (auth.authType === AuthTypeEnum.Cookie && auth.cookie) {
@@ -398,6 +409,7 @@ async function executeWithCurrentTabContentPreference<T>(
 const createAuthRequest = async (
   auth: NormalizedAuthContext,
   options: RequestInit = {},
+  authTokenMode: ApiAuthTokenMode = API_AUTH_TOKEN_MODES.Bearer,
 ): Promise<RequestInit> => {
   const credentials: RequestCredentials =
     auth.authType === AuthTypeEnum.Cookie ? "include" : "omit"
@@ -408,7 +420,7 @@ const createAuthRequest = async (
   }
 
   return createBaseRequest(
-    await createRequestHeaders(auth),
+    await createRequestHeaders(auth, authTokenMode),
     credentials,
     normalizedOptions,
   )
@@ -543,10 +555,14 @@ const _fetchApi = async <T>(
     cookie: request.auth?.cookie,
   }
 
-  const fetchOptions = await createAuthRequest(resolvedAuth, {
-    ...options.options,
-    signal: options.options?.signal ?? request.abortSignal,
-  })
+  const fetchOptions = await createAuthRequest(
+    resolvedAuth,
+    {
+      ...options.options,
+      signal: options.options?.signal ?? request.abortSignal,
+    },
+    options.authTokenMode,
+  )
 
   await enforceLogRequestRateLimit({ baseUrl, endpoint: options.endpoint })
 

--- a/src/services/apiTransport/request.ts
+++ b/src/services/apiTransport/request.ts
@@ -203,7 +203,7 @@ async function enforceLogRequestRateLimit(options: {
  */
 const createRequestHeaders = async (
   auth: NormalizedAuthContext,
-  authTokenMode: ApiAuthTokenMode = API_AUTH_TOKEN_MODES.Bearer,
+  authTokenMode: ApiAuthTokenMode,
 ): Promise<Record<string, string>> => {
   const baseHeaders = {
     "Content-Type": REQUEST_CONFIG.HEADERS.CONTENT_TYPE,

--- a/src/services/apiTransport/type.ts
+++ b/src/services/apiTransport/type.ts
@@ -56,6 +56,14 @@ export type ApiTransportFetchContext =
 export type ApiServiceFetchContextKind = ApiTransportFetchContextKind
 export type ApiServiceFetchContext = ApiTransportFetchContext
 
+export const API_AUTH_TOKEN_MODES = {
+  Bearer: "bearer",
+  Raw: "raw",
+} as const
+
+export type ApiAuthTokenMode =
+  (typeof API_AUTH_TOKEN_MODES)[keyof typeof API_AUTH_TOKEN_MODES]
+
 /**
  * Builds a log-safe summary of a fetch context without exposing cookie-store values.
  */
@@ -99,6 +107,7 @@ export interface FetchApiOptions {
   responseType?: TempWindowResponseType
   tempWindowFallback?: TempWindowFallbackAllowlist
   currentTabTransport?: "prefer" | "disabled"
+  authTokenMode?: ApiAuthTokenMode
 }
 
 export interface OpenAIAuthParams {

--- a/src/services/checkin/autoCheckin/providers/index.ts
+++ b/src/services/checkin/autoCheckin/providers/index.ts
@@ -1,6 +1,7 @@
 import { SITE_TYPES } from "~/constants/siteType"
 import { newApiProvider } from "~/services/checkin/autoCheckin/providers/newApi"
 import type { AutoCheckinProviderResult } from "~/services/checkin/autoCheckin/providers/types"
+import { voApiV2Provider } from "~/services/checkin/autoCheckin/providers/voapiV2"
 import type { SiteAccount } from "~/types"
 
 import { AnyrouterCheckInParams, anyrouterProvider } from "./anyrouter"
@@ -26,6 +27,7 @@ const providers: Record<string, AutoCheckinProvider> = {
   [SITE_TYPES.VELOERA]: veloeraProvider,
   [SITE_TYPES.WONG_GONGYI]: wongGongyiProvider,
   [SITE_TYPES.NEW_API]: newApiProvider,
+  [SITE_TYPES.VO_API_V2]: voApiV2Provider,
 }
 
 /**

--- a/src/services/checkin/autoCheckin/providers/voapiV2.ts
+++ b/src/services/checkin/autoCheckin/providers/voapiV2.ts
@@ -87,6 +87,7 @@ export const voApiV2Provider: AutoCheckinProvider = {
     return Boolean(
       isVoApiV2Account(account) &&
         account.checkIn?.enableDetection &&
+        account.checkIn?.autoCheckInEnabled !== false &&
         account.account_info?.access_token,
     )
   },

--- a/src/services/checkin/autoCheckin/providers/voapiV2.ts
+++ b/src/services/checkin/autoCheckin/providers/voapiV2.ts
@@ -1,0 +1,131 @@
+import { SITE_TYPES } from "~/constants/siteType"
+import { AccountUpdateUserTimestampMode } from "~/services/accounts/accountDefaults"
+import { accountStorage } from "~/services/accounts/accountStorage"
+import {
+  fetchVoApiV2CheckInStats,
+  submitVoApiV2CheckIn,
+} from "~/services/apiService/voapiV2"
+import { isVoApiV2AuthExpiredError } from "~/services/apiService/voapiV2/parsing"
+import { resyncVoApiV2AuthToken } from "~/services/apiService/voapiV2/tokenResync"
+import type { ApiServiceRequest } from "~/services/apiTransport/type"
+import type { AutoCheckinProvider } from "~/services/checkin/autoCheckin/providers"
+import {
+  AUTO_CHECKIN_PROVIDER_FALLBACK_MESSAGE_KEYS,
+  resolveProviderErrorResult,
+} from "~/services/checkin/autoCheckin/providers/shared"
+import type { AutoCheckinProviderResult } from "~/services/checkin/autoCheckin/providers/types"
+import { AuthTypeEnum, type SiteAccount } from "~/types"
+import { CHECKIN_RESULT_STATUS } from "~/types/autoCheckin"
+
+const createRequest = (account: SiteAccount): ApiServiceRequest => ({
+  baseUrl: account.site_url,
+  accountId: account.id,
+  auth: {
+    authType: AuthTypeEnum.AccessToken,
+    accessToken: account.account_info.access_token,
+    userId: account.account_info.id,
+  },
+})
+
+const isVoApiV2Account = (account: SiteAccount): boolean =>
+  account.site_type === SITE_TYPES.VO_API_V2
+
+const updateAccountAuthFromResync = async (
+  account: SiteAccount,
+  authUpdate: {
+    accessToken: string
+    userId: string
+    username?: string
+  },
+) => {
+  await accountStorage.updateAccount(
+    account.id,
+    {
+      account_info: {
+        ...account.account_info,
+        access_token: authUpdate.accessToken,
+        id: authUpdate.userId,
+        ...(authUpdate.username ? { username: authUpdate.username } : {}),
+      },
+    },
+    {
+      userTimestampMode: AccountUpdateUserTimestampMode.Preserve,
+    },
+  )
+}
+
+const runCheckIn = async (
+  request: ApiServiceRequest,
+): Promise<AutoCheckinProviderResult> => {
+  const submitResult = await submitVoApiV2CheckIn(request)
+  const stats = await fetchVoApiV2CheckInStats(request)
+
+  if ("alreadySigned" in submitResult) {
+    return {
+      status: CHECKIN_RESULT_STATUS.ALREADY_CHECKED,
+      messageKey:
+        AUTO_CHECKIN_PROVIDER_FALLBACK_MESSAGE_KEYS.alreadyCheckedToday,
+      data: stats,
+    }
+  }
+
+  const signed = stats.todaySigned === true
+
+  return {
+    status: signed
+      ? CHECKIN_RESULT_STATUS.SUCCESS
+      : CHECKIN_RESULT_STATUS.FAILED,
+    messageKey: signed
+      ? AUTO_CHECKIN_PROVIDER_FALLBACK_MESSAGE_KEYS.checkinSuccessful
+      : AUTO_CHECKIN_PROVIDER_FALLBACK_MESSAGE_KEYS.checkinFailed,
+    data: stats,
+  }
+}
+
+export const voApiV2Provider: AutoCheckinProvider = {
+  canCheckIn(account) {
+    return Boolean(
+      isVoApiV2Account(account) &&
+        account.checkIn?.enableDetection &&
+        account.account_info?.access_token,
+    )
+  },
+  async checkIn(account): Promise<AutoCheckinProviderResult> {
+    try {
+      if (!this.canCheckIn(account as SiteAccount)) {
+        return {
+          status: CHECKIN_RESULT_STATUS.FAILED,
+          messageKey: AUTO_CHECKIN_PROVIDER_FALLBACK_MESSAGE_KEYS.checkinFailed,
+        }
+      }
+
+      const siteAccount = account as SiteAccount
+      const request = createRequest(siteAccount)
+      try {
+        return await runCheckIn(request)
+      } catch (error) {
+        if (!isVoApiV2AuthExpiredError(error)) {
+          throw error
+        }
+
+        const resynced = await resyncVoApiV2AuthToken(siteAccount.site_url)
+        if (!resynced) {
+          throw error
+        }
+
+        await updateAccountAuthFromResync(siteAccount, resynced)
+
+        return await runCheckIn({
+          ...request,
+          auth: {
+            ...request.auth,
+            accessToken: resynced.accessToken,
+            userId: resynced.userId,
+          },
+        })
+      }
+    } catch (error) {
+      return resolveProviderErrorResult({ error })
+    }
+  },
+}

--- a/src/services/siteDetection/detectSiteType.ts
+++ b/src/services/siteDetection/detectSiteType.ts
@@ -16,6 +16,7 @@ import { safeRandomUUID } from "~/utils/core/identifier"
 import { createLogger } from "~/utils/core/logger"
 
 const logger = createLogger("DetectSiteType")
+const PROTECTED_ENDPOINT_PROBE_TIMEOUT_MS = 5000
 const COMPAT_USER_ID_HEADER_MESSAGE_RULES =
   getAccountSiteCompatUserIdHeaderRules().map(({ headerName, siteType }) => ({
     siteType,
@@ -25,6 +26,29 @@ const COMPAT_USER_ID_HEADER_MESSAGE_RULES =
     ),
   }))
 const VOAPI_V2_USER_INFO_ENDPOINT = "/api/user/info"
+
+/** Create an abort signal for bounded protected-endpoint probes. */
+function createProbeTimeoutSignal(timeoutMs: number): {
+  signal: AbortSignal
+  cleanup: () => void
+} {
+  if (typeof AbortSignal.timeout === "function") {
+    return {
+      signal: AbortSignal.timeout(timeoutMs),
+      cleanup: () => {},
+    }
+  }
+
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => {
+    controller.abort()
+  }, timeoutMs)
+
+  return {
+    signal: controller.signal,
+    cleanup: () => clearTimeout(timeoutId),
+  }
+}
 
 /**
  * Fetch the raw HTML title from the site root.
@@ -195,11 +219,14 @@ async function detectSub2ApiFromAuthEndpoint(
 async function detectVoApiV2FromProtectedEndpoint(
   url: string,
 ): Promise<AccountSiteType> {
+  const timeout = createProbeTimeoutSignal(PROTECTED_ENDPOINT_PROBE_TIMEOUT_MS)
+
   try {
     const response = await fetch(new URL(VOAPI_V2_USER_INFO_ENDPOINT, url), {
       method: "GET",
       cache: "no-store",
       credentials: "omit",
+      signal: timeout.signal,
     })
 
     const contentType = response.headers.get("content-type") || ""
@@ -232,6 +259,8 @@ async function detectVoApiV2FromProtectedEndpoint(
     }
   } catch (error) {
     logger.debug("VoAPI v2 protected endpoint probe failed", { url, error })
+  } finally {
+    timeout.cleanup()
   }
 
   return SITE_TYPES.UNKNOWN

--- a/src/services/siteDetection/detectSiteType.ts
+++ b/src/services/siteDetection/detectSiteType.ts
@@ -16,7 +16,6 @@ import { safeRandomUUID } from "~/utils/core/identifier"
 import { createLogger } from "~/utils/core/logger"
 
 const logger = createLogger("DetectSiteType")
-const PROTECTED_ENDPOINT_PROBE_TIMEOUT_MS = 5000
 const COMPAT_USER_ID_HEADER_MESSAGE_RULES =
   getAccountSiteCompatUserIdHeaderRules().map(({ headerName, siteType }) => ({
     siteType,
@@ -26,29 +25,6 @@ const COMPAT_USER_ID_HEADER_MESSAGE_RULES =
     ),
   }))
 const VOAPI_V2_USER_INFO_ENDPOINT = "/api/user/info"
-
-/** Create an abort signal for bounded protected-endpoint probes. */
-function createProbeTimeoutSignal(timeoutMs: number): {
-  signal: AbortSignal
-  cleanup: () => void
-} {
-  if (typeof AbortSignal.timeout === "function") {
-    return {
-      signal: AbortSignal.timeout(timeoutMs),
-      cleanup: () => {},
-    }
-  }
-
-  const controller = new AbortController()
-  const timeoutId = setTimeout(() => {
-    controller.abort()
-  }, timeoutMs)
-
-  return {
-    signal: controller.signal,
-    cleanup: () => clearTimeout(timeoutId),
-  }
-}
 
 /**
  * Fetch the raw HTML title from the site root.
@@ -219,14 +195,11 @@ async function detectSub2ApiFromAuthEndpoint(
 async function detectVoApiV2FromProtectedEndpoint(
   url: string,
 ): Promise<AccountSiteType> {
-  const timeout = createProbeTimeoutSignal(PROTECTED_ENDPOINT_PROBE_TIMEOUT_MS)
-
   try {
     const response = await fetch(new URL(VOAPI_V2_USER_INFO_ENDPOINT, url), {
       method: "GET",
       cache: "no-store",
       credentials: "omit",
-      signal: timeout.signal,
     })
 
     const contentType = response.headers.get("content-type") || ""
@@ -259,8 +232,6 @@ async function detectVoApiV2FromProtectedEndpoint(
     }
   } catch (error) {
     logger.debug("VoAPI v2 protected endpoint probe failed", { url, error })
-  } finally {
-    timeout.cleanup()
   }
 
   return SITE_TYPES.UNKNOWN

--- a/src/services/siteDetection/detectSiteType.ts
+++ b/src/services/siteDetection/detectSiteType.ts
@@ -24,6 +24,7 @@ const COMPAT_USER_ID_HEADER_MESSAGE_RULES =
       "i",
     ),
   }))
+const VOAPI_V2_USER_INFO_ENDPOINT = "/api/user/info"
 
 /**
  * Fetch the raw HTML title from the site root.
@@ -183,6 +184,60 @@ async function detectSub2ApiFromAuthEndpoint(
 }
 
 /**
+ * VoAPI v2 exposes a protected account-info endpoint that returns a distinctive
+ * JSON business envelope even without credentials. Probe it before page-title
+ * detection so white-label/self-hosted deployments do not depend on branding.
+ *
+ * Source: https://github.com/VoAPI/VoAPI and observed `/api/user/info`
+ * contract: raw JWT auth, `{ code, data, msg }` envelope, auth failures with
+ * numeric non-zero code and null data.
+ */
+async function detectVoApiV2FromProtectedEndpoint(
+  url: string,
+): Promise<AccountSiteType> {
+  try {
+    const response = await fetch(new URL(VOAPI_V2_USER_INFO_ENDPOINT, url), {
+      method: "GET",
+      cache: "no-store",
+      credentials: "omit",
+    })
+
+    const contentType = response.headers.get("content-type") || ""
+    if (!/\bjson\b/i.test(contentType)) {
+      return SITE_TYPES.UNKNOWN
+    }
+
+    const responseBody = (await response.json()) as unknown
+    if (!isJsonObject(responseBody)) {
+      return SITE_TYPES.UNKNOWN
+    }
+
+    const code = responseBody.code
+    const message = [responseBody.msg, responseBody.message]
+      .filter((value): value is string => typeof value === "string")
+      .join(" ")
+    const hasProtectedEndpointEnvelope =
+      typeof code === "number" &&
+      "data" in responseBody &&
+      responseBody.data === null &&
+      /\b(?:unauthorized|auth\s*expire|token|jwt)\b/i.test(message)
+    const hasAccountInfoEnvelope =
+      code === 0 &&
+      isJsonObject(responseBody.data) &&
+      ("basicBalance" in responseBody.data ||
+        "bindBalance" in responseBody.data)
+
+    if (hasProtectedEndpointEnvelope || hasAccountInfoEnvelope) {
+      return SITE_TYPES.VO_API_V2
+    }
+  } catch (error) {
+    logger.debug("VoAPI v2 protected endpoint probe failed", { url, error })
+  }
+
+  return SITE_TYPES.UNKNOWN
+}
+
+/**
  * detectAccountSiteTypeFromDomain parses the URL hostname and compares it
  * case-insensitively against account-site domain rules. It returns the matched
  * AccountSiteType rule name, or SITE_TYPES.UNKNOWN when parsing fails or no
@@ -208,16 +263,21 @@ export const getAccountSiteType = async (
     return domainSiteType
   }
 
-  const title = await fetchSiteOriginalTitle(url)
-  for (const rule of getAccountSiteTitleRules()) {
-    if (rule.regex.test(title)) {
-      return rule.name
-    }
+  const voApiV2SiteType = await detectVoApiV2FromProtectedEndpoint(url)
+  if (voApiV2SiteType !== SITE_TYPES.UNKNOWN) {
+    return voApiV2SiteType
   }
 
   const sub2ApiSiteType = await detectSub2ApiFromAuthEndpoint(url)
   if (sub2ApiSiteType !== SITE_TYPES.UNKNOWN) {
     return sub2ApiSiteType
+  }
+
+  const title = await fetchSiteOriginalTitle(url)
+  for (const rule of getAccountSiteTitleRules()) {
+    if (rule.regex.test(title)) {
+      return rule.name
+    }
   }
 
   return await detectNewApiFamilySiteTypeFromCompatAuthError(url)

--- a/src/utils/navigation/feedbackLinks.ts
+++ b/src/utils/navigation/feedbackLinks.ts
@@ -1,3 +1,4 @@
+import type { AutoDetectErrorType } from "~/services/accounts/utils/autoDetectUtils"
 import { getDocsCommunityUrl } from "~/utils/navigation/docsLinks"
 import { getRepository } from "~/utils/navigation/packageMeta"
 
@@ -6,16 +7,20 @@ const FEATURE_REQUEST_TEMPLATE = "feature_request.yml"
 const LANGUAGE_REQUEST_TEMPLATE = "language_request.yml"
 const SITE_SUPPORT_REQUEST_TEMPLATE = "site_support_request.yml"
 
-export interface SiteSupportRequestContext {
-  siteUrl?: string
-  errorType?: string
-  errorMessage?: string
-}
-
 export const SITE_SUPPORT_ERROR_TYPES = {
   KeyManagementUnsupported: "key_management_unsupported",
   ModelListUnsupported: "model_list_unsupported",
 } as const
+
+export type SiteSupportErrorType =
+  | AutoDetectErrorType
+  | (typeof SITE_SUPPORT_ERROR_TYPES)[keyof typeof SITE_SUPPORT_ERROR_TYPES]
+
+export interface SiteSupportRequestContext {
+  siteUrl?: string
+  errorType?: SiteSupportErrorType
+  errorMessage?: string
+}
 
 interface FeedbackDestinationUrls {
   repository: string

--- a/src/utils/navigation/feedbackLinks.ts
+++ b/src/utils/navigation/feedbackLinks.ts
@@ -12,6 +12,11 @@ export interface SiteSupportRequestContext {
   errorMessage?: string
 }
 
+export const SITE_SUPPORT_ERROR_TYPES = {
+  KeyManagementUnsupported: "key_management_unsupported",
+  ModelListUnsupported: "model_list_unsupported",
+} as const
+
 interface FeedbackDestinationUrls {
   repository: string
   bugReport: string

--- a/tests/constants/siteType.test.ts
+++ b/tests/constants/siteType.test.ts
@@ -14,6 +14,7 @@ describe("siteType constants", () => {
   it("recognizes account site type values only", () => {
     expect(isAccountSiteType(SITE_TYPES.NEW_API)).toBe(true)
     expect(isAccountSiteType(SITE_TYPES.V_API)).toBe(true)
+    expect(isAccountSiteType(SITE_TYPES.VO_API_V2)).toBe(true)
     expect(isAccountSiteType(SITE_TYPES.SUB2API)).toBe(true)
     expect(isAccountSiteType(SITE_TYPES.AIHUBMIX)).toBe(true)
     expect(isAccountSiteType(SITE_TYPES.SHAREDCHAT)).toBe(true)
@@ -55,6 +56,12 @@ describe("siteType constants", () => {
       adminCredentialsPath: "/panel/profile",
       siteAnnouncementsPath: "/",
     })
+  })
+
+  it("keeps VoAPI v2 distinct from old VoAPI", () => {
+    expect(SITE_TYPES.VO_API_V2).toBe("voapi-v2")
+    expect(SITE_TYPES.VO_API).toBe("VoAPI")
+    expect(SITE_TYPES.VO_API_V2).not.toBe(SITE_TYPES.VO_API)
   })
 
   it("returns default routes for AIHubMix account pages", () => {

--- a/tests/entrypoints/options/pages/KeyManagement/TokenList.emptyStates.test.tsx
+++ b/tests/entrypoints/options/pages/KeyManagement/TokenList.emptyStates.test.tsx
@@ -21,6 +21,7 @@ vi.mock("~/utils/navigation", async (importOriginal) => {
 describe("TokenList empty states", () => {
   beforeEach(() => {
     openSiteSupportRequestPageMock.mockReset()
+    openSiteSupportRequestPageMock.mockResolvedValue(undefined)
   })
 
   it("guides the user to add an account when none exist", async () => {
@@ -224,7 +225,8 @@ describe("TokenList empty states", () => {
     expect(openSiteSupportRequestPageMock).toHaveBeenCalledWith({
       siteUrl: "https://unsupported.example.invalid",
       errorType: "key_management_unsupported",
-      errorMessage: "Key management is not implemented for future-site",
+      errorMessage:
+        "keyManagement:unsupportedSource.supportRequestErrorMessage",
     })
   })
 

--- a/tests/entrypoints/options/pages/KeyManagement/TokenList.emptyStates.test.tsx
+++ b/tests/entrypoints/options/pages/KeyManagement/TokenList.emptyStates.test.tsx
@@ -1,11 +1,28 @@
 import userEvent from "@testing-library/user-event"
-import { describe, expect, it, vi } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { TokenList } from "~/features/KeyManagement/components/TokenList"
 import { render, screen } from "~~/tests/test-utils/render"
 import { createAccount } from "~~/tests/utils/keyManagementFactories"
 
+const { openSiteSupportRequestPageMock } = vi.hoisted(() => ({
+  openSiteSupportRequestPageMock: vi.fn(),
+}))
+
+vi.mock("~/utils/navigation", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("~/utils/navigation")>()
+
+  return {
+    ...actual,
+    openSiteSupportRequestPage: openSiteSupportRequestPageMock,
+  }
+})
+
 describe("TokenList empty states", () => {
+  beforeEach(() => {
+    openSiteSupportRequestPageMock.mockReset()
+  })
+
   it("guides the user to add an account when none exist", async () => {
     const user = userEvent.setup()
     const onAddAccount = vi.fn()
@@ -162,6 +179,53 @@ describe("TokenList empty states", () => {
     await user.click(createButton)
 
     expect(handleAddToken).not.toHaveBeenCalled()
+  })
+
+  it("shows a site-support request entry when key management is unsupported", async () => {
+    const user = userEvent.setup()
+    const account = createAccount({
+      id: "unsupported-account",
+      baseUrl: "https://unsupported.example.invalid",
+      siteType: "future-site",
+    })
+
+    render(
+      <TokenList
+        isLoading={false}
+        tokens={[]}
+        filteredTokens={[]}
+        visibleKeys={new Set()}
+        resolvingVisibleKeys={new Set()}
+        getVisibleTokenKey={vi.fn()}
+        toggleKeyVisibility={vi.fn()}
+        copyKey={vi.fn()}
+        handleEditToken={vi.fn()}
+        handleDeleteToken={vi.fn()}
+        handleAddToken={vi.fn()}
+        selectedAccount={account.id}
+        displayData={[account]}
+        currentAccountUnsupportedKeyManagement={true}
+      />,
+    )
+
+    expect(
+      await screen.findByText("keyManagement:unsupportedSource.title"),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText("keyManagement:unsupportedSource.description"),
+    ).toBeInTheDocument()
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "keyManagement:unsupportedSource.requestSiteSupport",
+      }),
+    )
+
+    expect(openSiteSupportRequestPageMock).toHaveBeenCalledWith({
+      siteUrl: "https://unsupported.example.invalid",
+      errorType: "key_management_unsupported",
+      errorMessage: "Key management is not implemented for future-site",
+    })
   })
 
   it("keeps the current single-account token list visible while refreshing", async () => {

--- a/tests/entrypoints/options/pages/KeyManagement/useKeyManagement.test.tsx
+++ b/tests/entrypoints/options/pages/KeyManagement/useKeyManagement.test.tsx
@@ -963,6 +963,43 @@ describe("useKeyManagement enabled account filtering", () => {
     expect(result.current.tokenInventories[account.id]?.status).toBe("error")
   })
 
+  it("marks missing key-management capability as unsupported without parsing error text", async () => {
+    const account = createDisplayAccount({
+      id: "unsupported-key-management-acc",
+      name: "Unsupported Key Management",
+      siteType: SITE_TYPES.UNKNOWN,
+      baseUrl: "https://unsupported-key-management.example.invalid",
+    })
+
+    vi.mocked(useAccountData).mockReturnValue({
+      enabledDisplayData: [account],
+    } as any)
+
+    vi.mocked(getSiteTypeCapabilities).mockReturnValue({
+      siteType: SITE_TYPES.UNKNOWN,
+      account: {},
+    } as any)
+
+    const { result } = renderHook(() => useKeyManagement(), {
+      wrapper: createWrapper(),
+    })
+
+    act(() => {
+      result.current.setSelectedAccount(account.id)
+    })
+
+    await waitFor(() =>
+      expect(result.current.tokenInventories[account.id]?.status).toBe("error"),
+    )
+
+    expect(result.current.currentAccountUnsupportedKeyManagement).toBe(true)
+    expect(result.current.currentAccountLoadError).toBeNull()
+    expect(result.current.serviceCredentials[account.id]).toMatchObject({
+      status: "idle",
+      errorMessage: undefined,
+    })
+  })
+
   it("copies and rotates a singleton service credential without token CRUD", async () => {
     const writeText = vi.fn().mockResolvedValue(undefined)
     Object.assign(navigator, {

--- a/tests/entrypoints/options/pages/KeyManagement/useKeyManagement.test.tsx
+++ b/tests/entrypoints/options/pages/KeyManagement/useKeyManagement.test.tsx
@@ -552,6 +552,83 @@ describe("useKeyManagement enabled account filtering", () => {
     expect(vi.mocked(toast.error)).not.toHaveBeenCalled()
   })
 
+  it("excludes unsupported key-management accounts from retryable all-account failures", async () => {
+    const mockedUseAccountData = vi.mocked(useAccountData)
+
+    const unsupportedAccount = createDisplayAccount({
+      id: "unsupported-key-management-acc",
+      name: "Unsupported Account",
+      siteType: SITE_TYPES.UNKNOWN,
+      baseUrl: "https://unsupported.example.invalid",
+    })
+    const failedAccount = createDisplayAccount({
+      id: "failed-key-management-acc",
+      name: "Failed Account",
+      siteType: SITE_TYPES.NEW_API,
+      baseUrl: "https://failed.example.invalid",
+    })
+
+    mockedUseAccountData.mockReturnValue({
+      enabledDisplayData: [unsupportedAccount, failedAccount],
+    } as any)
+
+    const fetchAccountTokens = vi.fn(async () => {
+      throw new Error("retryable load failure")
+    })
+    vi.mocked(getSiteTypeCapabilities).mockImplementation((siteType) => {
+      if (siteType === SITE_TYPES.UNKNOWN) {
+        return {
+          siteType: SITE_TYPES.UNKNOWN,
+          account: {},
+        } as any
+      }
+
+      return createAdapterWithKeyManagement({
+        fetchTokens: fetchAccountTokens,
+      }) as any
+    })
+
+    const { result } = renderHook(() => useKeyManagement(), {
+      wrapper: createWrapper(),
+    })
+
+    act(() => {
+      result.current.setSelectedAccount("all")
+    })
+
+    await waitFor(() =>
+      expect(result.current.accountSummaryItems).toEqual([
+        {
+          accountId: unsupportedAccount.id,
+          name: unsupportedAccount.name,
+          count: 0,
+          errorType: "unsupported",
+        },
+        {
+          accountId: failedAccount.id,
+          name: failedAccount.name,
+          count: 0,
+          errorType: "load-failed",
+        },
+      ]),
+    )
+    expect(result.current.failedAccounts).toEqual([
+      {
+        accountId: failedAccount.id,
+        accountName: failedAccount.name,
+        errorMessage: "retryable load failure",
+      },
+    ])
+
+    fetchAccountTokens.mockClear()
+
+    await act(async () => {
+      await result.current.retryFailedAccounts()
+    })
+
+    expect(fetchAccountTokens).toHaveBeenCalledTimes(1)
+  })
+
   it("tracks all-account token refresh with sanitized aggregate buckets", async () => {
     const mockedUseAccountData = vi.mocked(useAccountData)
 

--- a/tests/entrypoints/options/pages/KeyManagement/useKeyManagement.test.tsx
+++ b/tests/entrypoints/options/pages/KeyManagement/useKeyManagement.test.tsx
@@ -619,6 +619,12 @@ describe("useKeyManagement enabled account filtering", () => {
         errorMessage: "retryable load failure",
       },
     ])
+    expect(result.current.tokenLoadProgress).toEqual({
+      total: 1,
+      loaded: 0,
+      loading: 0,
+      error: 1,
+    })
 
     fetchAccountTokens.mockClear()
 

--- a/tests/entrypoints/options/pages/ModelList/StatusIndicator.test.tsx
+++ b/tests/entrypoints/options/pages/ModelList/StatusIndicator.test.tsx
@@ -43,6 +43,7 @@ describe("StatusIndicator", () => {
         loadErrorMessage={null}
         currentAccount={sub2apiAccount as any}
         loadPricingData={vi.fn()}
+        unsupportedSource={false}
         accountFallback={{
           isAvailable: true,
           isActive: false,
@@ -95,6 +96,7 @@ describe("StatusIndicator", () => {
         loadErrorMessage={null}
         currentAccount={compatibleAccount as any}
         loadPricingData={vi.fn()}
+        unsupportedSource={false}
         accountFallback={{
           isAvailable: true,
           isActive: false,
@@ -131,6 +133,7 @@ describe("StatusIndicator", () => {
         loadErrorMessage="modelList:status.loadFailed"
         currentAccount={ACCOUNT as any}
         loadPricingData={vi.fn()}
+        unsupportedSource={false}
         accountFallback={{
           isAvailable: true,
           isActive: false,
@@ -172,6 +175,7 @@ describe("StatusIndicator", () => {
         loadErrorMessage="modelList:status.loadFailed"
         currentAccount={ACCOUNT as any}
         loadPricingData={vi.fn()}
+        unsupportedSource={false}
         accountFallback={{
           isAvailable: true,
           isActive: false,
@@ -235,6 +239,7 @@ describe("StatusIndicator", () => {
         loadErrorMessage="modelList:status.profileLoadFailed"
         currentAccount={undefined}
         loadPricingData={vi.fn()}
+        unsupportedSource={false}
         accountFallback={{
           isAvailable: true,
           isActive: false,

--- a/tests/entrypoints/options/pages/ModelList/useModelData.test.tsx
+++ b/tests/entrypoints/options/pages/ModelList/useModelData.test.tsx
@@ -514,6 +514,47 @@ describe("useModelData all-accounts loading", () => {
     expect(mockFetchDisplayAccountTokens).not.toHaveBeenCalled()
   })
 
+  it("marks VoAPI v2 model lists as unsupported even when account keys are listable", async () => {
+    toastSuccessMock.mockReset()
+    toastErrorMock.mockReset()
+    const fetchPricing = vi
+      .fn()
+      .mockRejectedValue(new Error("fetch should not be called"))
+    vi.mocked(getSiteTypeCapabilities).mockReturnValue({
+      siteType: SITE_TYPES.VO_API_V2,
+      account: {
+        keyManagement: {},
+      },
+    } as any)
+
+    const account = createDisplayAccount({
+      id: "unsupported-voapi-v2",
+      baseUrl: "https://voapi-v2.example.invalid",
+      siteType: SITE_TYPES.VO_API_V2,
+      userId: "unsupported-voapi-v2-user",
+    })
+    mockFetchDisplayAccountTokens.mockResolvedValueOnce([])
+
+    const { result } = renderHook(
+      () =>
+        useModelData({
+          selectedSource: createAccountSource(account),
+          accounts: [account],
+        }),
+      { wrapper: createWrapper() },
+    )
+
+    await waitFor(
+      () => {
+        expect(result.current.unsupportedSource).toBe(true)
+      },
+      { timeout: 3000 },
+    )
+    expect(result.current.loadErrorMessage).toBeNull()
+    expect(result.current.accountFallback?.isAvailable).toBe(true)
+    expect(fetchPricing).not.toHaveBeenCalled()
+  })
+
   it("does not invoke all-account pricing when Sub2API has no fallback key", async () => {
     toastSuccessMock.mockReset()
     toastErrorMock.mockReset()

--- a/tests/features/ModelList/ModelList.test.tsx
+++ b/tests/features/ModelList/ModelList.test.tsx
@@ -273,6 +273,7 @@ function createModelListData() {
     pricingContexts: [],
     isLoading: false,
     dataFormatError: null,
+    unsupportedSource: false,
     loadErrorMessage: null,
     accountFallback: null,
     isFallbackCatalogActive: false,

--- a/tests/features/ModelList/components/AccountSummaryBar.test.tsx
+++ b/tests/features/ModelList/components/AccountSummaryBar.test.tsx
@@ -143,4 +143,34 @@ describe("AccountSummaryBar", () => {
       "dark:text-amber-300",
     )
   })
+
+  it("shows unsupported accounts as informational instead of failed", () => {
+    render(
+      <AccountSummaryBar
+        items={[
+          {
+            accountId: "account-unsupported",
+            name: "Unsupported Account",
+            count: 0,
+            errorType: "unsupported-source",
+            errorMessage: "Model list is not implemented yet.",
+          },
+        ]}
+      />,
+    )
+
+    const unsupportedBadge = screen
+      .getByText("Unsupported Account")
+      .closest("[data-slot='badge']")
+
+    expect(unsupportedBadge).toHaveAttribute(
+      "title",
+      "Model list is not implemented yet.",
+    )
+    expect(screen.getByText("accountSummary.unsupported")).toHaveClass(
+      "text-blue-600",
+      "dark:text-blue-300",
+    )
+    expect(screen.queryByText("accountSummary.loadFailed")).toBeNull()
+  })
 })

--- a/tests/features/ModelList/components/StatusIndicator.test.tsx
+++ b/tests/features/ModelList/components/StatusIndicator.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { StatusIndicator } from "~/features/ModelList/components/StatusIndicator"
+import { MODEL_MANAGEMENT_SOURCE_KINDS } from "~/features/ModelList/modelManagementSources"
+
+const { openSiteSupportRequestPageMock } = vi.hoisted(() => ({
+  openSiteSupportRequestPageMock: vi.fn(),
+}))
+
+vi.mock("react-i18next", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-i18next")>()
+
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string) => key,
+    }),
+  }
+})
+
+vi.mock("~/utils/navigation", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("~/utils/navigation")>()
+
+  return {
+    ...actual,
+    openSiteSupportRequestPage: openSiteSupportRequestPageMock,
+  }
+})
+
+const ACCOUNT = {
+  id: "account-1",
+  name: "VoAPI v2 Demo",
+  baseUrl: "https://example.invalid",
+  siteType: "voapi-v2",
+} as any
+
+const ACCOUNT_SOURCE = {
+  kind: MODEL_MANAGEMENT_SOURCE_KINDS.ACCOUNT,
+  value: "account:account-1",
+  account: ACCOUNT,
+  capabilities: {
+    supportsPricing: false,
+    supportsRatioDisplay: false,
+    supportsGroupFiltering: false,
+    supportsAccountSummary: false,
+    supportsTokenCompatibility: true,
+    supportsCredentialVerification: true,
+    supportsBatchCredentialVerification: true,
+    supportsCliVerification: true,
+  },
+} as any
+
+describe("StatusIndicator", () => {
+  beforeEach(() => {
+    openSiteSupportRequestPageMock.mockReset()
+  })
+
+  it("shows an unsupported model-list state with a site-support request action", async () => {
+    const user = userEvent.setup()
+
+    render(
+      <StatusIndicator
+        selectedSource={ACCOUNT_SOURCE}
+        isLoading={false}
+        dataFormatError={false}
+        loadErrorMessage={null}
+        currentAccount={ACCOUNT}
+        loadPricingData={vi.fn()}
+        accountFallback={null}
+        unsupportedSource={true}
+      />,
+    )
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "status.unsupportedSourceTitle",
+    )
+    expect(
+      screen.getByText("status.unsupportedSourceDescription"),
+    ).toBeVisible()
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "status.requestSiteSupport",
+      }),
+    )
+
+    expect(openSiteSupportRequestPageMock).toHaveBeenCalledWith({
+      siteUrl: "https://example.invalid",
+      errorType: "model_list_unsupported",
+      errorMessage: "Model list is not implemented for voapi-v2",
+    })
+  })
+})

--- a/tests/features/ModelList/components/StatusIndicator.test.tsx
+++ b/tests/features/ModelList/components/StatusIndicator.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
+import { SITE_TYPES } from "~/constants/siteType"
 import { StatusIndicator } from "~/features/ModelList/components/StatusIndicator"
 import { MODEL_MANAGEMENT_SOURCE_KINDS } from "~/features/ModelList/modelManagementSources"
 
@@ -33,7 +34,7 @@ const ACCOUNT = {
   id: "account-1",
   name: "VoAPI v2 Demo",
   baseUrl: "https://example.invalid",
-  siteType: "voapi-v2",
+  siteType: SITE_TYPES.VO_API_V2,
 } as any
 
 const ACCOUNT_SOURCE = {
@@ -55,6 +56,7 @@ const ACCOUNT_SOURCE = {
 describe("StatusIndicator", () => {
   beforeEach(() => {
     openSiteSupportRequestPageMock.mockReset()
+    openSiteSupportRequestPageMock.mockResolvedValue(undefined)
   })
 
   it("shows an unsupported model-list state with a site-support request action", async () => {
@@ -89,7 +91,7 @@ describe("StatusIndicator", () => {
     expect(openSiteSupportRequestPageMock).toHaveBeenCalledWith({
       siteUrl: "https://example.invalid",
       errorType: "model_list_unsupported",
-      errorMessage: "Model list is not implemented for voapi-v2",
+      errorMessage: "status.unsupportedSourceSupportRequestErrorMessage",
     })
   })
 })

--- a/tests/services/accountSiteDefinitions/registry.test.ts
+++ b/tests/services/accountSiteDefinitions/registry.test.ts
@@ -63,6 +63,7 @@ type ExpectedAccountSiteType =
   | typeof SITE_TYPES.ONE_HUB
   | typeof SITE_TYPES.DONE_HUB
   | typeof SITE_TYPES.V_API
+  | typeof SITE_TYPES.VO_API_V2
   | typeof SITE_TYPES.VO_API
   | typeof SITE_TYPES.SUPER_API
   | typeof SITE_TYPES.RIX_API
@@ -220,6 +221,7 @@ describe("account site definition registry", () => {
       SITE_TYPES.ONE_HUB,
       SITE_TYPES.DONE_HUB,
       SITE_TYPES.V_API,
+      SITE_TYPES.VO_API_V2,
       SITE_TYPES.VO_API,
       SITE_TYPES.SUPER_API,
       SITE_TYPES.RIX_API,
@@ -278,6 +280,9 @@ describe("account site definition registry", () => {
     expect(getAccountSiteDefinition(SITE_TYPES.SUB2API)?.adapterFamily).toBe(
       ACCOUNT_SITE_ADAPTER_FAMILIES.Sub2Api,
     )
+    expect(getAccountSiteDefinition(SITE_TYPES.VO_API_V2)?.adapterFamily).toBe(
+      ACCOUNT_SITE_ADAPTER_FAMILIES.VoApiV2,
+    )
     expect(getAccountSiteDefinition(SITE_TYPES.AIHUBMIX)?.adapterFamily).toBe(
       ACCOUNT_SITE_ADAPTER_FAMILIES.Aihubmix,
     )
@@ -286,6 +291,24 @@ describe("account site definition registry", () => {
     )
     expect(getAccountSiteDefinition(SITE_TYPES.OCTOPUS)?.adapterFamily).toBe(
       ACCOUNT_SITE_ADAPTER_FAMILIES.Unsupported,
+    )
+  })
+
+  it("defines VoAPI v2 before old VoAPI with account-only policy", () => {
+    const voApiV2 = getAccountSiteDefinition(SITE_TYPES.VO_API_V2)
+
+    expect(voApiV2).toMatchObject({
+      siteType: SITE_TYPES.VO_API_V2,
+      adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.VoApiV2,
+    })
+    expect(voApiV2?.scopes).toEqual([ACCOUNT_SITE_DEFINITION_SCOPES.Account])
+    expect(voApiV2?.onboarding?.routes).toMatchObject({
+      usagePath: "/dash?_userMenuKey=dash",
+      checkInPath: "/checkIn?_userMenuKey=checkIn",
+      adminCredentialsPath: "/keys?_userMenuKey=keys",
+    })
+    expect(ACCOUNT_SITE_TYPE_ORDER.indexOf(SITE_TYPES.VO_API_V2)).toBeLessThan(
+      ACCOUNT_SITE_TYPE_ORDER.indexOf(SITE_TYPES.VO_API),
     )
   })
 
@@ -305,6 +328,15 @@ describe("account site definition registry", () => {
         (definition) => definition.siteType === SITE_TYPES.SHAREDCHAT,
       )?.detection?.hostnames,
     ).toEqual(SHAREDCHAT_HOSTNAMES)
+    expect(
+      onboardingDefinitions.find(
+        (definition) => definition.siteType === SITE_TYPES.VO_API_V2,
+      )?.routes,
+    ).toMatchObject({
+      usagePath: "/dash?_userMenuKey=dash",
+      checkInPath: "/checkIn?_userMenuKey=checkIn",
+      adminCredentialsPath: "/keys?_userMenuKey=keys",
+    })
     expect(
       onboardingDefinitions.find(
         (definition) => definition.siteType === SITE_TYPES.SUB2API,
@@ -511,6 +543,10 @@ describe("account site definition registry", () => {
       getAccountSiteDefinition(SITE_TYPES.AIHUBMIX)?.readiness?.modelList
         ?.expectedRoute,
     ).toBe(MODEL_LIST_ACCOUNT_SOURCE_ROUTES.DirectPricing)
+    expect(
+      getAccountSiteDefinition(SITE_TYPES.VO_API_V2)?.readiness?.modelList
+        ?.expectedRoute,
+    ).toBe(MODEL_LIST_ACCOUNT_SOURCE_ROUTES.Unsupported)
     expect(
       getAccountSiteDefinition(SITE_TYPES.SHAREDCHAT)?.readiness?.modelList
         ?.expectedRoute,

--- a/tests/services/accountSiteOnboarding/contentSession/voapiV2.test.ts
+++ b/tests/services/accountSiteOnboarding/contentSession/voapiV2.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { SITE_TYPES } from "~/constants/siteType"
+import { voApiV2ContentSessionExtractor } from "~/services/accountSiteOnboarding/contentSession/voapiV2"
+
+const jwtWithUserId =
+  "eyJhbGciOiJub25lIn0.eyJ1c2VySWQiOjQyLCJleHAiOjQxMDI0NDQ4MDB9.signature"
+
+function createLocalStorageMock() {
+  const store = new Map<string, string>()
+
+  return {
+    clear: vi.fn(() => {
+      store.clear()
+    }),
+    getItem: vi.fn((key: string) => store.get(key) ?? null),
+    key: vi.fn((index: number) => Array.from(store.keys())[index] ?? null),
+    removeItem: vi.fn((key: string) => {
+      store.delete(key)
+    }),
+    setItem: vi.fn((key: string, value: string) => {
+      store.set(key, String(value))
+    }),
+    get length() {
+      return store.size
+    },
+  }
+}
+
+describe("voApiV2ContentSessionExtractor", () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals()
+    vi.stubGlobal("localStorage", createLocalStorageMock())
+  })
+
+  it("extracts the dashboard JWT from userStore.auth.token", async () => {
+    localStorage.setItem(
+      "userStore",
+      JSON.stringify({
+        auth: {
+          token: jwtWithUserId,
+          email: "owner@example.invalid",
+        },
+      }),
+    )
+    localStorage.setItem(
+      "user",
+      JSON.stringify({
+        id: 7,
+        username: "owner",
+        display_name: "Owner",
+        email: "owner@example.invalid",
+        access_token: null,
+      }),
+    )
+
+    await expect(
+      voApiV2ContentSessionExtractor.extract({
+        url: "https://example.invalid",
+      }),
+    ).resolves.toEqual({
+      userId: 7,
+      user: {
+        id: 7,
+        username: "owner",
+        display_name: "Owner",
+        email: "owner@example.invalid",
+      },
+      accessToken: jwtWithUserId,
+      siteTypeHint: SITE_TYPES.VO_API_V2,
+    })
+  })
+
+  it("falls back to JWT userId when localStorage.user has no id", async () => {
+    localStorage.setItem(
+      "userStore",
+      JSON.stringify({ auth: { token: jwtWithUserId } }),
+    )
+    localStorage.setItem("user", JSON.stringify({ access_token: null }))
+
+    const result = await voApiV2ContentSessionExtractor.extract({})
+
+    expect(result?.userId).toBe(42)
+    expect(result?.accessToken).toBe(jwtWithUserId)
+  })
+
+  it("does not use localStorage.user.access_token", async () => {
+    localStorage.setItem(
+      "userStore",
+      JSON.stringify({ auth: { token: jwtWithUserId } }),
+    )
+    localStorage.setItem(
+      "user",
+      JSON.stringify({ id: 7, access_token: "wrong-token" }),
+    )
+
+    const result = await voApiV2ContentSessionExtractor.extract({})
+
+    expect(result?.accessToken).toBe(jwtWithUserId)
+    expect(result?.accessToken).not.toBe("wrong-token")
+  })
+
+  it("returns null when userStore is absent or malformed", async () => {
+    await expect(voApiV2ContentSessionExtractor.extract({})).resolves.toBeNull()
+
+    localStorage.setItem("userStore", "{")
+    await expect(voApiV2ContentSessionExtractor.extract({})).resolves.toBeNull()
+  })
+})

--- a/tests/services/accountSiteOnboarding/contentSession/voapiV2.test.ts
+++ b/tests/services/accountSiteOnboarding/contentSession/voapiV2.test.ts
@@ -71,6 +71,14 @@ describe("voApiV2ContentSessionExtractor", () => {
     })
   })
 
+  it("detects whether the VoAPI v2 user store is present", () => {
+    expect(voApiV2ContentSessionExtractor.canExtract({})).toBe(false)
+
+    localStorage.setItem("userStore", JSON.stringify({ auth: {} }))
+
+    expect(voApiV2ContentSessionExtractor.canExtract({})).toBe(true)
+  })
+
   it("falls back to JWT userId when localStorage.user has no id", async () => {
     localStorage.setItem(
       "userStore",
@@ -104,6 +112,15 @@ describe("voApiV2ContentSessionExtractor", () => {
     await expect(voApiV2ContentSessionExtractor.extract({})).resolves.toBeNull()
 
     localStorage.setItem("userStore", "{")
+    await expect(voApiV2ContentSessionExtractor.extract({})).resolves.toBeNull()
+  })
+
+  it("returns null when the dashboard JWT payload is malformed and no stored user id exists", async () => {
+    localStorage.setItem(
+      "userStore",
+      JSON.stringify({ auth: { token: "not-a.jwt" } }),
+    )
+
     await expect(voApiV2ContentSessionExtractor.extract({})).resolves.toBeNull()
   })
 })

--- a/tests/services/accountSiteOnboarding/registry.test.ts
+++ b/tests/services/accountSiteOnboarding/registry.test.ts
@@ -157,7 +157,7 @@ describe("account site onboarding registry", () => {
   it("returns content session extractors in onboarding order", () => {
     expect(
       getContentSessionExtractors().map((extractor) => extractor.id),
-    ).toEqual(["sub2api", "sharedchat", "compatible-user"])
+    ).toEqual(["sub2api", "sharedchat", "voapi-v2", "compatible-user"])
   })
 
   it("returns default routes for site types without route metadata", () => {

--- a/tests/services/accountStorage.test.ts
+++ b/tests/services/accountStorage.test.ts
@@ -2170,6 +2170,60 @@ describe("accountStorage core behaviors", () => {
     })
   })
 
+  it("refreshAccount should persist VoAPI v2 dashboard JWT re-sync auth updates", async () => {
+    const account = createAccount({
+      id: "voapi-v2-resync",
+      site_url: "https://voapi.example.invalid",
+      site_type: SITE_TYPES.VO_API_V2,
+      account_info: {
+        id: "7",
+        username: "old-user",
+        access_token: "old-dashboard-jwt",
+        quota: 1_000_000,
+        today_prompt_tokens: 0,
+        today_completion_tokens: 0,
+        today_quota_consumption: 0,
+        today_requests_count: 0,
+        today_income: 0,
+      },
+    })
+    seedStorage([account])
+
+    mockFetchSupportCheckIn.mockResolvedValue(true)
+    mockRefreshAccountData.mockResolvedValueOnce({
+      success: true,
+      data: {
+        quota: 42,
+        today_prompt_tokens: 0,
+        today_completion_tokens: 0,
+        today_quota_consumption: 0,
+        today_requests_count: 0,
+        today_income: 0,
+        checkIn: {
+          enableDetection: true,
+        },
+      },
+      healthStatus: {
+        status: SiteHealthStatus.Healthy,
+        message: "",
+      },
+      authUpdate: {
+        accessToken: "new-dashboard-jwt",
+        userId: "8",
+        username: "new-user",
+      },
+    })
+
+    await accountStorage.refreshAccount("voapi-v2-resync", true)
+
+    const updatedAccount =
+      await accountStorage.getAccountById("voapi-v2-resync")
+    expect(updatedAccount?.account_info.access_token).toBe("new-dashboard-jwt")
+    expect(updatedAccount?.account_info.id).toBe("8")
+    expect(updatedAccount?.account_info.username).toBe("new-user")
+    expect(updatedAccount?.sub2apiAuth).toBeUndefined()
+  })
+
   it("refreshAccount ignores blank auth updates and invalid Sub2API token refresh payloads", async () => {
     const account = createAccount({
       id: "sub2api-blank-auth",

--- a/tests/services/accounts/accountSiteProfile.test.ts
+++ b/tests/services/accounts/accountSiteProfile.test.ts
@@ -96,6 +96,26 @@ describe("accountSiteProfile", () => {
     )
   })
 
+  it("resolves VoAPI v2 saved-account product rules", () => {
+    const profile = getAccountSiteProductProfile(SITE_TYPES.VO_API_V2)
+
+    expect(profile.identity.usernameRequired).toBe(false)
+    expect(profile.identity.storedUserIdentityFields).toEqual([
+      "id",
+      "username",
+    ])
+    expect(profile.auth.allowedAuthTypes).toEqual([AuthTypeEnum.AccessToken])
+    expect(profile.auth.defaultAuthType).toBe(AuthTypeEnum.AccessToken)
+    expect(profile.auth.supportsCookieAuth).toBe(false)
+    expect(profile.auth.supportsBuiltInCheckInDetection).toBe(true)
+    expect(profile.modelList.directPricing).toBe(
+      ACCOUNT_SITE_MODEL_LIST_DIRECT_PRICING.Unsupported,
+    )
+    expect(profile.modelList.tokenScopedCatalogFallback).toBe(
+      ACCOUNT_SITE_MODEL_LIST_TOKEN_SCOPED_CATALOG_FALLBACKS.None,
+    )
+  })
+
   it("resolves site-specific overrides from account-site definitions", async () => {
     const { getAccountSiteProductProfileOverride } = await import(
       "~/services/accountSiteDefinitions"

--- a/tests/services/apiAdapters/accountBootstrap.test.ts
+++ b/tests/services/apiAdapters/accountBootstrap.test.ts
@@ -6,6 +6,7 @@ import { aihubmixAccountBootstrap } from "~/services/apiAdapters/aihubmix/accoun
 import { ACCOUNT_BOOTSTRAP_ROUTE_KINDS } from "~/services/apiAdapters/contracts/accountBootstrap"
 import { createNewApiAccountBootstrap } from "~/services/apiAdapters/newApi/accountBootstrap"
 import { sub2ApiAccountBootstrap } from "~/services/apiAdapters/sub2api/accountBootstrap"
+import { voApiV2AccountBootstrap } from "~/services/apiAdapters/voapiV2/accountBootstrap"
 import { AuthTypeEnum } from "~/types"
 
 const {
@@ -24,6 +25,8 @@ const {
   mockSub2ApiFetchSupportCheckIn,
   mockSub2ApiFetchUserInfo,
   mockSub2ApiGetOrCreateAccessToken,
+  mockVoApiV2FetchSupportCheckIn,
+  mockVoApiV2FetchUserInfo,
 } = vi.hoisted(() => ({
   mockAihubmixExtractDefaultExchangeRate: vi.fn(),
   mockAihubmixFetchSiteStatus: vi.fn(),
@@ -40,6 +43,8 @@ const {
   mockSub2ApiFetchSupportCheckIn: vi.fn(),
   mockSub2ApiFetchUserInfo: vi.fn(),
   mockSub2ApiGetOrCreateAccessToken: vi.fn(),
+  mockVoApiV2FetchSupportCheckIn: vi.fn(),
+  mockVoApiV2FetchUserInfo: vi.fn(),
 }))
 
 vi.mock(
@@ -72,6 +77,11 @@ vi.mock("~/services/apiService/aihubmix", () => ({
   fetchSupportCheckIn: mockAihubmixFetchSupportCheckIn,
   fetchUserInfo: mockAihubmixFetchUserInfo,
   getOrCreateAccessToken: mockAihubmixGetOrCreateAccessToken,
+}))
+
+vi.mock("~/services/apiService/voapiV2", () => ({
+  fetchSupportCheckIn: mockVoApiV2FetchSupportCheckIn,
+  fetchVoApiV2UserInfo: mockVoApiV2FetchUserInfo,
 }))
 
 const request = {
@@ -255,5 +265,58 @@ describe("account bootstrap adapters", () => {
     expect(mockAihubmixExtractDefaultExchangeRate).toHaveBeenCalledWith(
       siteStatus,
     )
+  })
+
+  it("maps VoAPI v2 bootstrap operations through the dashboard JWT account", async () => {
+    const voapiRequest = {
+      ...request,
+      auth: {
+        authType: AuthTypeEnum.AccessToken,
+        accessToken: "dashboard-jwt",
+        userId: "7",
+      },
+    }
+    mockVoApiV2FetchUserInfo.mockResolvedValueOnce({
+      id: 7,
+      username: "",
+      nickname: "VoAPI Owner",
+    })
+    mockVoApiV2FetchSupportCheckIn.mockResolvedValueOnce(true)
+
+    await expect(
+      voApiV2AccountBootstrap.fetchUserInfo(voapiRequest),
+    ).resolves.toEqual({
+      id: "7",
+      username: "VoAPI Owner",
+      access_token: "dashboard-jwt",
+    })
+    await expect(
+      voApiV2AccountBootstrap.getOrCreateAccessToken(voapiRequest),
+    ).resolves.toEqual({
+      username: "7",
+      access_token: "dashboard-jwt",
+    })
+    await expect(
+      voApiV2AccountBootstrap.fetchSiteStatus(voapiRequest),
+    ).resolves.toEqual({
+      system_name: "VoAPI",
+      checkin_enabled: true,
+    })
+    await expect(
+      voApiV2AccountBootstrap.fetchCheckInSupport(voapiRequest),
+    ).resolves.toBe(true)
+    expect(voApiV2AccountBootstrap.extractDefaultExchangeRate(null)).toBe(7.2)
+    await expect(
+      voApiV2AccountBootstrap.resolveRoutePath(
+        {
+          baseUrl: "https://voapi.example.invalid",
+          siteType: SITE_TYPES.VO_API_V2,
+        },
+        ACCOUNT_BOOTSTRAP_ROUTE_KINDS.Login,
+      ),
+    ).resolves.toBe("/login")
+
+    expect(mockVoApiV2FetchUserInfo).toHaveBeenCalledWith(voapiRequest)
+    expect(mockVoApiV2FetchSupportCheckIn).toHaveBeenCalledWith(voapiRequest)
   })
 })

--- a/tests/services/apiAdapters/accountData.test.ts
+++ b/tests/services/apiAdapters/accountData.test.ts
@@ -5,6 +5,7 @@ import type { AccountData } from "~/services/accounts/accountDataModel"
 import { aihubmixAccountData } from "~/services/apiAdapters/aihubmix/accountData"
 import { createNewApiAccountData } from "~/services/apiAdapters/newApi/accountData"
 import { sub2ApiAccountData } from "~/services/apiAdapters/sub2api/accountData"
+import { voApiV2AccountData } from "~/services/apiAdapters/voapiV2/accountData"
 import { AuthTypeEnum } from "~/types"
 
 const {
@@ -12,11 +13,13 @@ const {
   mockDoneHubFetchAccountData,
   mockFetchAccountData,
   mockSub2ApiFetchAccountData,
+  mockVoApiV2FetchAccountData,
 } = vi.hoisted(() => ({
   mockAihubmixFetchAccountData: vi.fn(),
   mockDoneHubFetchAccountData: vi.fn(),
   mockFetchAccountData: vi.fn(),
   mockSub2ApiFetchAccountData: vi.fn(),
+  mockVoApiV2FetchAccountData: vi.fn(),
 }))
 
 vi.mock("~/services/apiService/newApiFamily/default/accountData", () => ({
@@ -37,6 +40,10 @@ vi.mock("~/services/apiService/sub2api", async (importOriginal) => ({
 
 vi.mock("~/services/apiService/aihubmix", () => ({
   fetchAccountData: mockAihubmixFetchAccountData,
+}))
+
+vi.mock("~/services/apiService/voapiV2", () => ({
+  fetchVoApiV2AccountData: mockVoApiV2FetchAccountData,
 }))
 
 const request = {
@@ -137,5 +144,16 @@ describe("apiAdapter accountData", () => {
 
     expect(mockAihubmixFetchAccountData).toHaveBeenCalledOnce()
     expect(mockAihubmixFetchAccountData).toHaveBeenCalledWith(request)
+  })
+
+  it("delegates VoAPI v2 account data without reshaping the service result", async () => {
+    mockVoApiV2FetchAccountData.mockResolvedValueOnce(accountData)
+
+    await expect(voApiV2AccountData.fetchData(request)).resolves.toBe(
+      accountData,
+    )
+
+    expect(mockVoApiV2FetchAccountData).toHaveBeenCalledOnce()
+    expect(mockVoApiV2FetchAccountData).toHaveBeenCalledWith(request)
   })
 })

--- a/tests/services/apiAdapters/keyManagement.test.ts
+++ b/tests/services/apiAdapters/keyManagement.test.ts
@@ -4,6 +4,7 @@ import { SITE_TYPES } from "~/constants/siteType"
 import { aihubmixKeyManagement } from "~/services/apiAdapters/aihubmix/keyManagement"
 import { createNewApiKeyManagement } from "~/services/apiAdapters/newApi/keyManagement"
 import { sub2ApiKeyManagement } from "~/services/apiAdapters/sub2api/keyManagement"
+import { voApiV2KeyManagement } from "~/services/apiAdapters/voapiV2/keyManagement"
 import { AuthTypeEnum, type ApiToken } from "~/types"
 
 const {
@@ -30,6 +31,13 @@ const {
   mockSub2ApiResolveApiTokenKey,
   mockSub2ApiUpdateApiToken,
   mockUpdateApiToken,
+  mockVoApiV2CreateToken,
+  mockVoApiV2DeleteToken,
+  mockVoApiV2FetchAvailableModels,
+  mockVoApiV2FetchTokens,
+  mockVoApiV2FetchUserGroups,
+  mockVoApiV2ResolveTokenKey,
+  mockVoApiV2UpdateToken,
   mockWongResolveApiTokenKey,
 } = vi.hoisted(() => ({
   mockAihubmixCreateApiToken: vi.fn(),
@@ -55,6 +63,13 @@ const {
   mockSub2ApiResolveApiTokenKey: vi.fn(),
   mockSub2ApiUpdateApiToken: vi.fn(),
   mockUpdateApiToken: vi.fn(),
+  mockVoApiV2CreateToken: vi.fn(),
+  mockVoApiV2DeleteToken: vi.fn(),
+  mockVoApiV2FetchAvailableModels: vi.fn(),
+  mockVoApiV2FetchTokens: vi.fn(),
+  mockVoApiV2FetchUserGroups: vi.fn(),
+  mockVoApiV2ResolveTokenKey: vi.fn(),
+  mockVoApiV2UpdateToken: vi.fn(),
   mockWongResolveApiTokenKey: vi.fn(),
 }))
 
@@ -97,6 +112,16 @@ vi.mock("~/services/apiService/newApiFamily/variants/oneHub", () => ({
 
 vi.mock("~/services/apiService/newApiFamily/variants/wong", () => ({
   resolveApiTokenKey: mockWongResolveApiTokenKey,
+}))
+
+vi.mock("~/services/apiService/voapiV2", () => ({
+  createVoApiV2Token: mockVoApiV2CreateToken,
+  deleteVoApiV2Token: mockVoApiV2DeleteToken,
+  fetchVoApiV2AvailableModels: mockVoApiV2FetchAvailableModels,
+  fetchVoApiV2Tokens: mockVoApiV2FetchTokens,
+  fetchVoApiV2UserGroups: mockVoApiV2FetchUserGroups,
+  resolveVoApiV2TokenKey: mockVoApiV2ResolveTokenKey,
+  updateVoApiV2Token: mockVoApiV2UpdateToken,
 }))
 
 const request = {
@@ -287,6 +312,55 @@ describe("apiAdapter keyManagement", () => {
     expect(mockSub2ApiDeleteApiToken).toHaveBeenCalledWith(request, token.id)
     expect(mockSub2ApiFetchUserGroups).toHaveBeenCalledWith(request)
     expect(mockSub2ApiFetchAccountAvailableModels).toHaveBeenCalledWith(request)
+  })
+
+  it("delegates VoAPI v2 key operations to backend key helpers", async () => {
+    const expectedTokens = [token]
+    mockVoApiV2FetchTokens.mockResolvedValueOnce(expectedTokens)
+    mockVoApiV2CreateToken.mockResolvedValueOnce(true)
+    mockVoApiV2UpdateToken.mockResolvedValueOnce(true)
+    mockVoApiV2ResolveTokenKey.mockResolvedValueOnce("sk-voapi-v2")
+    mockVoApiV2DeleteToken.mockResolvedValueOnce(true)
+    mockVoApiV2FetchAvailableModels.mockResolvedValueOnce(availableModels)
+    mockVoApiV2FetchUserGroups.mockResolvedValueOnce(userGroups)
+
+    await expect(
+      voApiV2KeyManagement.fetchTokens(request, { page: 4, size: 40 }),
+    ).resolves.toBe(expectedTokens)
+    await expect(
+      voApiV2KeyManagement.createToken(request, tokenData),
+    ).resolves.toBe(true)
+    await expect(
+      voApiV2KeyManagement.updateToken({
+        request,
+        tokenId: token.id,
+        tokenData,
+      }),
+    ).resolves.toBe(true)
+    await expect(
+      voApiV2KeyManagement.resolveTokenKey({ request, token }),
+    ).resolves.toBe("sk-voapi-v2")
+    await expect(
+      voApiV2KeyManagement.deleteToken({ request, tokenId: token.id }),
+    ).resolves.toBe(true)
+    await expect(
+      voApiV2KeyManagement.fetchAvailableModels(request),
+    ).resolves.toBe(availableModels)
+    await expect(voApiV2KeyManagement.userGroups?.fetch(request)).resolves.toBe(
+      userGroups,
+    )
+
+    expect(mockVoApiV2FetchTokens).toHaveBeenCalledWith(request, 4, 40)
+    expect(mockVoApiV2CreateToken).toHaveBeenCalledWith(request, tokenData)
+    expect(mockVoApiV2UpdateToken).toHaveBeenCalledWith(
+      request,
+      token.id,
+      tokenData,
+    )
+    expect(mockVoApiV2ResolveTokenKey).toHaveBeenCalledWith(request, token)
+    expect(mockVoApiV2DeleteToken).toHaveBeenCalledWith(request, token.id)
+    expect(mockVoApiV2FetchAvailableModels).toHaveBeenCalledWith(request)
+    expect(mockVoApiV2FetchUserGroups).toHaveBeenCalledWith(request)
   })
 
   it("propagates Sub2API key inventory errors from backend helpers", async () => {

--- a/tests/services/apiAdapters/registry.test.ts
+++ b/tests/services/apiAdapters/registry.test.ts
@@ -177,6 +177,28 @@ describe("apiAdapters registry", () => {
     expect(capabilities.site?.notice).toBeUndefined()
   })
 
+  it("returns dedicated VoAPI v2 account capabilities while old VoAPI stays New API-family", () => {
+    const capabilities = getSiteTypeCapabilities(SITE_TYPES.VO_API_V2)
+
+    expect(capabilities).toMatchObject({
+      siteType: SITE_TYPES.VO_API_V2,
+      family: ACCOUNT_SITE_ADAPTER_FAMILIES.VoApiV2,
+    })
+    expectAccountDataCapability(capabilities)
+    expectAccountBootstrapCapability(capabilities)
+    expectAccountCompletionCapability(capabilities)
+    expectKeyManagementCapability(capabilities)
+    expectTokenProvisioningCapability(capabilities)
+    expectAccountRefreshCapability(capabilities)
+    expect(capabilities.account?.modelPricing).toBeUndefined()
+    expect(capabilities.managedSites).toBeUndefined()
+
+    expect(getSiteTypeCapabilities(SITE_TYPES.VO_API)).toMatchObject({
+      siteType: SITE_TYPES.VO_API,
+      family: ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily,
+    })
+  })
+
   it("returns AIHubMix account capabilities without managed-site capabilities", () => {
     const capabilities = getSiteTypeCapabilities(SITE_TYPES.AIHUBMIX)
 

--- a/tests/services/apiAdapters/tokenProvisioning.test.ts
+++ b/tests/services/apiAdapters/tokenProvisioning.test.ts
@@ -15,6 +15,7 @@ import {
   normalizeTokenProvisioningGroupNames,
   sub2ApiTokenProvisioning,
 } from "~/services/apiAdapters/sub2api/tokenProvisioning"
+import { voApiV2TokenProvisioning } from "~/services/apiAdapters/voapiV2/tokenProvisioning"
 import type { ApiToken } from "~/types"
 import { ACCOUNT_KEY_REPAIR_SKIP_REASONS } from "~/types/accountKeyAutoProvisioning"
 
@@ -289,6 +290,95 @@ describe("apiAdapter tokenProvisioning", () => {
     ).toEqual({
       kind: CREATED_TOKEN_SECRET_DECISION_KINDS.Failed,
       reason: TOKEN_PROVISIONING_BLOCK_REASONS.CreateFailed,
+    })
+  })
+
+  it("resolves VoAPI v2 default-token provisioning policy", () => {
+    expect(
+      voApiV2TokenProvisioning.isInventoryTokenUsable({
+        workflow: TOKEN_PROVISIONING_WORKFLOWS.SharedEnsure,
+        token: token({ id: 0 }),
+      }),
+    ).toBe(false)
+    expect(
+      voApiV2TokenProvisioning.resolveDefaultTokenCreation({
+        workflow: TOKEN_PROVISIONING_WORKFLOWS.SharedEnsure,
+        defaultTokenData: { ...defaultTokenData, unlimited_quota: true },
+      }),
+    ).toEqual({
+      kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.Blocked,
+      reason: TOKEN_PROVISIONING_BLOCK_REASONS.CreatedTokenSecretUnavailable,
+    })
+    expect(
+      voApiV2TokenProvisioning.resolveDefaultTokenCreation({
+        workflow: TOKEN_PROVISIONING_WORKFLOWS.SharedEnsure,
+        defaultTokenData,
+        explicitGroup: " vip ",
+      }),
+    ).toEqual({
+      kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.Create,
+      tokenData: { ...defaultTokenData, group: "vip" },
+      oneTimeSecret: false,
+      recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.InventoryRefetch,
+    })
+    expect(
+      voApiV2TokenProvisioning.resolveDefaultTokenCreation({
+        workflow: TOKEN_PROVISIONING_WORKFLOWS.SharedEnsure,
+        defaultTokenData,
+      }),
+    ).toEqual({
+      kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.NeedsUserGroups,
+    })
+    expect(
+      voApiV2TokenProvisioning.resolveDefaultTokenCreation({
+        workflow: TOKEN_PROVISIONING_WORKFLOWS.SharedEnsure,
+        defaultTokenData,
+        userGroups: {
+          " ": { desc: "Blank", ratio: 1 },
+        },
+      }),
+    ).toEqual({
+      kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.NeedsUserGroups,
+    })
+    expect(
+      voApiV2TokenProvisioning.resolveDefaultTokenCreation({
+        workflow: TOKEN_PROVISIONING_WORKFLOWS.SharedEnsure,
+        defaultTokenData,
+        userGroups: {
+          " default ": { desc: "Default", ratio: 1 },
+          default: { desc: "Duplicate", ratio: 1 },
+        },
+      }),
+    ).toEqual({
+      kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.Create,
+      tokenData: { ...defaultTokenData, group: "default" },
+      oneTimeSecret: false,
+      recoverCreatedToken: TOKEN_CREATION_SECRET_RECOVERY.InventoryRefetch,
+    })
+    expect(
+      voApiV2TokenProvisioning.resolveDefaultTokenCreation({
+        workflow: TOKEN_PROVISIONING_WORKFLOWS.SharedEnsure,
+        defaultTokenData,
+        userGroups: {
+          " vip ": { desc: "VIP", ratio: 2 },
+          default: { desc: "Default", ratio: 1 },
+        },
+      }),
+    ).toEqual({
+      kind: DEFAULT_TOKEN_CREATION_DECISION_KINDS.SelectionRequired,
+      allowedGroups: ["vip", "default"],
+      reason: TOKEN_PROVISIONING_BLOCK_REASONS.GroupSelectionRequired,
+    })
+    expect(
+      voApiV2TokenProvisioning.classifyCreatedToken({
+        workflow: TOKEN_PROVISIONING_WORKFLOWS.SharedEnsure,
+        result: token(),
+      }),
+    ).toEqual({
+      kind: CREATED_TOKEN_SECRET_DECISION_KINDS.NeedsInventoryRefetch,
+    })
+    expect(voApiV2TokenProvisioning.getRepairPolicy()).toEqual({
+      kind: TOKEN_PROVISIONING_REPAIR_POLICY_KINDS.Eligible,
     })
   })
 

--- a/tests/services/apiAdapters/voapiV2/accountCompletion.test.ts
+++ b/tests/services/apiAdapters/voapiV2/accountCompletion.test.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+  AUTO_DETECT_FAILURE_REASONS,
+  type AutoDetectFailureReason,
+} from "~/constants/autoDetect"
+import { SITE_TYPES } from "~/constants/siteType"
+import { UI_CONSTANTS } from "~/constants/ui"
+import { AutoDetectCompletionError } from "~/services/accounts/autoDetectCompletion/types"
+import type { AccountCompletionHelpers } from "~/services/apiAdapters/contracts/accountCompletion"
+import { voApiV2AccountCompletion } from "~/services/apiAdapters/voapiV2/accountCompletion"
+import { fetchVoApiV2UserInfo } from "~/services/apiService/voapiV2"
+import { API_SERVICE_FETCH_CONTEXT_KINDS } from "~/services/apiTransport/type"
+import { AuthTypeEnum } from "~/types"
+
+vi.mock("~/services/apiService/voapiV2", () => ({
+  fetchVoApiV2UserInfo: vi.fn(),
+}))
+
+const currentTabFetchContext = {
+  kind: API_SERVICE_FETCH_CONTEXT_KINDS.CURRENT_TAB,
+  tabId: 123,
+  origin: "https://voapi.example.invalid",
+}
+
+const createServiceRequest = vi.fn(
+  ({
+    baseUrl,
+    auth,
+    context,
+  }: Parameters<AccountCompletionHelpers["createServiceRequest"]>[0]) => ({
+    baseUrl,
+    auth,
+    ...(context.fetchContext ? { fetchContext: context.fetchContext } : {}),
+  }),
+)
+
+const fetchSiteName = vi.fn(async (siteStatus) =>
+  typeof siteStatus?.system_name === "string" && siteStatus.system_name.trim()
+    ? siteStatus.system_name.trim()
+    : "Example API",
+)
+
+const createCompletionError = vi.fn(
+  (reason: AutoDetectFailureReason, cause: unknown) =>
+    new AutoDetectCompletionError(reason, cause),
+)
+
+const trimString = vi.fn((value: unknown) =>
+  typeof value === "string" ? value.trim() : "",
+)
+
+const createInitialCheckInConfig = vi.fn(
+  ({ enableDetection, autoCheckInEnabled }) => ({
+    enableDetection,
+    autoCheckInEnabled,
+    siteStatus: {
+      isCheckedInToday: false,
+    },
+    customCheckIn: {
+      url: "",
+      redeemUrl: "",
+      openRedeemWithCheckIn: true,
+      isCheckedInToday: false,
+    },
+  }),
+)
+
+const helpers = {
+  createServiceRequest,
+  fetchSiteName,
+  createCompletionError,
+  trimString,
+  createInitialCheckInConfig,
+  handleCheckInSupportFetchFailure: vi.fn(() => false as const),
+} satisfies AccountCompletionHelpers
+
+describe("voApiV2AccountCompletion", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("saves the dashboard JWT and enables daily auto check-in after auto-detect", async () => {
+    vi.mocked(fetchVoApiV2UserInfo).mockResolvedValueOnce({
+      id: 42,
+      username: "api-owner",
+      nickname: "API Owner",
+    })
+
+    const result = await voApiV2AccountCompletion.complete(
+      {
+        url: "https://voapi.example.invalid",
+        requestedAuthType: AuthTypeEnum.AccessToken,
+        detected: {
+          userId: "42",
+          user: {
+            id: 42,
+            username: "  dashboard-owner  ",
+          },
+          siteType: SITE_TYPES.VO_API_V2,
+          accessToken: "  dashboard-jwt  ",
+        },
+        context: {
+          fetchContext: currentTabFetchContext,
+        },
+      },
+      helpers,
+    )
+
+    expect(fetchVoApiV2UserInfo).toHaveBeenCalledWith({
+      baseUrl: "https://voapi.example.invalid",
+      fetchContext: currentTabFetchContext,
+      auth: {
+        authType: AuthTypeEnum.AccessToken,
+        accessToken: "dashboard-jwt",
+        userId: "42",
+      },
+    })
+    expect(createInitialCheckInConfig).toHaveBeenCalledWith({
+      enableDetection: true,
+      autoCheckInEnabled: true,
+    })
+    expect(result).toEqual({
+      username: "dashboard-owner",
+      siteName: "VoAPI",
+      accessToken: "dashboard-jwt",
+      userId: "42",
+      exchangeRate: UI_CONSTANTS.EXCHANGE_RATE.DEFAULT,
+      authType: AuthTypeEnum.AccessToken,
+      checkIn: {
+        enableDetection: true,
+        autoCheckInEnabled: true,
+        siteStatus: {
+          isCheckedInToday: false,
+        },
+        customCheckIn: {
+          url: "",
+          redeemUrl: "",
+          openRedeemWithCheckIn: true,
+          isCheckedInToday: false,
+        },
+      },
+    })
+  })
+
+  it("classifies missing dashboard JWT as an access-token completion failure", async () => {
+    await expect(
+      voApiV2AccountCompletion.complete(
+        {
+          url: "https://voapi.example.invalid",
+          requestedAuthType: AuthTypeEnum.AccessToken,
+          detected: {
+            userId: "42",
+            siteType: SITE_TYPES.VO_API_V2,
+          },
+          context: {},
+        },
+        helpers,
+      ),
+    ).rejects.toMatchObject({
+      reason: AUTO_DETECT_FAILURE_REASONS.AccessTokenMissing,
+    })
+    expect(fetchVoApiV2UserInfo).not.toHaveBeenCalled()
+  })
+})

--- a/tests/services/apiAdapters/voapiV2/accountCompletion.test.ts
+++ b/tests/services/apiAdapters/voapiV2/accountCompletion.test.ts
@@ -162,4 +162,28 @@ describe("voApiV2AccountCompletion", () => {
     })
     expect(fetchVoApiV2UserInfo).not.toHaveBeenCalled()
   })
+
+  it("classifies user-info fetch failures as token-fetch completion failures", async () => {
+    vi.mocked(fetchVoApiV2UserInfo).mockRejectedValueOnce(
+      new Error("user info unavailable"),
+    )
+
+    await expect(
+      voApiV2AccountCompletion.complete(
+        {
+          url: "https://voapi.example.invalid",
+          requestedAuthType: AuthTypeEnum.AccessToken,
+          detected: {
+            userId: "42",
+            siteType: SITE_TYPES.VO_API_V2,
+            accessToken: "dashboard-jwt",
+          },
+          context: {},
+        },
+        helpers,
+      ),
+    ).rejects.toMatchObject({
+      reason: AUTO_DETECT_FAILURE_REASONS.TokenFetchFailed,
+    })
+  })
 })

--- a/tests/services/apiAdapters/voapiV2/accountRefresh.test.ts
+++ b/tests/services/apiAdapters/voapiV2/accountRefresh.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { voApiV2AccountRefresh } from "~/services/apiAdapters/voapiV2/accountRefresh"
+
+const { mockFetchSupportCheckIn, mockRefreshAccountData } = vi.hoisted(() => ({
+  mockFetchSupportCheckIn: vi.fn(),
+  mockRefreshAccountData: vi.fn(),
+}))
+
+vi.mock("~/services/apiService/voapiV2", () => ({
+  fetchSupportCheckIn: mockFetchSupportCheckIn,
+  refreshAccountData: mockRefreshAccountData,
+}))
+
+const request = {
+  baseUrl: "https://voapi.example.invalid",
+  accountId: "account-1",
+  auth: {
+    authType: "accessToken",
+    accessToken: "dashboard-jwt",
+  },
+} as any
+
+describe("voApiV2AccountRefresh", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("delegates support probing and account refresh to VoAPI v2 service helpers", async () => {
+    const refreshResult = {
+      success: true,
+      data: {
+        quota: 1,
+      },
+    }
+    mockFetchSupportCheckIn.mockResolvedValueOnce(true)
+    mockRefreshAccountData.mockResolvedValueOnce(refreshResult)
+
+    await expect(
+      voApiV2AccountRefresh.fetchCheckInSupport?.(request),
+    ).resolves.toBe(true)
+    await expect(voApiV2AccountRefresh.refreshAccount(request)).resolves.toBe(
+      refreshResult,
+    )
+
+    expect(mockFetchSupportCheckIn).toHaveBeenCalledWith(request)
+    expect(mockRefreshAccountData).toHaveBeenCalledWith(request)
+  })
+})

--- a/tests/services/apiService/voapiV2/index.test.ts
+++ b/tests/services/apiService/voapiV2/index.test.ts
@@ -820,6 +820,48 @@ describe("apiService VoAPI v2", () => {
     expect(requestedPages).toEqual([1, 2])
   })
 
+  it("bounds token lookup when the backend keeps returning full pages", async () => {
+    const requestedPages: number[] = []
+    const fullPageKeys = Array.from({ length: 100 }, (_, index) => ({
+      id: index + 1,
+      name: `repeated-${index + 1}`,
+      groups: [1],
+      enable: true,
+      expireTime: -1,
+      boundlessAmount: false,
+      amount: "0",
+      used: "0",
+    }))
+
+    server.use(
+      http.get("https://example.invalid/api/keys", ({ request }) => {
+        const url = new URL(request.url)
+        requestedPages.push(Number(url.searchParams.get("page")))
+
+        return HttpResponse.json({
+          code: 0,
+          data: fullPageKeys,
+        })
+      }),
+      http.get("https://example.invalid/api/keys/template", () =>
+        HttpResponse.json({
+          code: 0,
+          data: {
+            groups: [{ id: 2, name: "default", ratio: 1 }],
+            models: [],
+          },
+        }),
+      ),
+    )
+
+    await expect(
+      updateVoApiV2Token(createVoApiV2Request(), 150, tokenRequest),
+    ).rejects.toThrow("VoAPI v2 token not found")
+    expect(requestedPages).toHaveLength(100)
+    expect(requestedPages[0]).toBe(1)
+    expect(requestedPages.at(-1)).toBe(100)
+  })
+
   it("deletes VoAPI v2 keys", async () => {
     let deleted = false
     server.use(

--- a/tests/services/apiService/voapiV2/index.test.ts
+++ b/tests/services/apiService/voapiV2/index.test.ts
@@ -1,0 +1,638 @@
+import { http, HttpResponse } from "msw"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import type { ApiServiceAccountRequest } from "~/services/accounts/accountDataModel"
+import type { CreateTokenRequest } from "~/services/accountTokens/tokenProvisioningModel"
+import {
+  createVoApiV2Token,
+  deleteVoApiV2Token,
+  fetchSupportCheckIn,
+  fetchVoApiV2AccountData,
+  fetchVoApiV2AvailableModels,
+  fetchVoApiV2Tokens,
+  fetchVoApiV2UserGroups,
+  refreshAccountData,
+  resolveVoApiV2TokenKey,
+  setVoApiV2TokenEnabled,
+  submitVoApiV2CheckIn,
+  updateVoApiV2Token,
+} from "~/services/apiService/voapiV2"
+import { AuthTypeEnum, SiteHealthStatus } from "~/types"
+import { server } from "~~/tests/msw/server"
+
+const { mockResyncVoApiV2AuthToken } = vi.hoisted(() => ({
+  mockResyncVoApiV2AuthToken: vi.fn(),
+}))
+
+vi.mock("~/services/apiService/voapiV2/tokenResync", () => ({
+  resyncVoApiV2AuthToken: mockResyncVoApiV2AuthToken,
+}))
+
+const createVoApiV2Request = (): ApiServiceAccountRequest => ({
+  baseUrl: "https://example.invalid",
+  accountId: "account-1",
+  auth: {
+    authType: AuthTypeEnum.AccessToken,
+    accessToken: "example-dashboard-token",
+    userId: 7,
+  },
+  checkIn: {
+    enableDetection: true,
+  },
+})
+
+const tokenRequest: CreateTokenRequest = {
+  name: "default",
+  group: "default",
+  remain_quota: 500000,
+  expired_time: 1893456000,
+  unlimited_quota: false,
+  model_limits_enabled: false,
+  model_limits: "",
+  allow_ips: "",
+}
+
+describe("apiService VoAPI v2", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    mockResyncVoApiV2AuthToken.mockReset()
+    mockResyncVoApiV2AuthToken.mockResolvedValue(null)
+    server.resetHandlers()
+  })
+
+  it("fetches account data with raw authorization and today statistics", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(1_700_000_000_000)
+
+    server.use(
+      http.get("https://example.invalid/api/user/info", ({ request }) => {
+        expect(request.headers.get("authorization")).toBe(
+          "example-dashboard-token",
+        )
+        return HttpResponse.json({
+          code: 0,
+          data: {
+            id: 7,
+            username: "owner",
+            basicBalance: "2",
+            bindBalance: "3",
+            totalRequest: 123,
+            totalToken: 456,
+            currency: "USD",
+          },
+        })
+      }),
+      http.get("https://example.invalid/api/dash/statistics", () =>
+        HttpResponse.json({
+          code: 0,
+          data: {
+            d: {
+              requests: 9,
+              usedBasicBalance: "0.5",
+              usedBindBalance: "0.25",
+              errors: 0,
+              maxRpm: 1,
+            },
+          },
+        }),
+      ),
+      http.get("https://example.invalid/api/check_in/stats", () =>
+        HttpResponse.json({
+          code: 0,
+          data: { todaySigned: true, consecutiveDays: 2 },
+        }),
+      ),
+    )
+
+    const data = await fetchVoApiV2AccountData(createVoApiV2Request())
+
+    expect(data.quota).toBe(2500000)
+    expect(data.today_quota_consumption).toBe(375000)
+    expect(data.today_requests_count).toBe(9)
+    expect(data.checkIn.siteStatus).toMatchObject({
+      isCheckedInToday: true,
+      lastDetectedAt: 1_700_000_000_000,
+    })
+  })
+
+  it("skips today statistics when cashflow refresh is disabled but still detects check-in status", async () => {
+    let statsCalled = false
+    server.use(
+      http.get("https://example.invalid/api/user/info", () =>
+        HttpResponse.json({
+          code: 0,
+          data: { id: 7, basicBalance: "2", bindBalance: "0" },
+        }),
+      ),
+      http.get("https://example.invalid/api/dash/statistics", () => {
+        statsCalled = true
+        return HttpResponse.json({ code: 0, data: { d: { requests: 1 } } })
+      }),
+      http.get("https://example.invalid/api/check_in/stats", () =>
+        HttpResponse.json({
+          code: 0,
+          data: { todaySigned: false },
+        }),
+      ),
+    )
+
+    const data = await fetchVoApiV2AccountData({
+      ...createVoApiV2Request(),
+      includeTodayCashflow: false,
+    })
+
+    expect(data.quota).toBe(1000000)
+    expect(data.today_quota_consumption).toBe(0)
+    expect(statsCalled).toBe(false)
+    expect(data.checkIn.siteStatus?.isCheckedInToday).toBe(false)
+  })
+
+  it("preserves existing check-in status when VoAPI v2 status detection fails", async () => {
+    server.use(
+      http.get("https://example.invalid/api/user/info", () =>
+        HttpResponse.json({
+          code: 0,
+          data: { id: 7, basicBalance: "2", bindBalance: "0" },
+        }),
+      ),
+      http.get("https://example.invalid/api/dash/statistics", () =>
+        HttpResponse.json({ code: 0, data: { d: { requests: 1 } } }),
+      ),
+      http.get("https://example.invalid/api/check_in/stats", () =>
+        HttpResponse.json({ code: 2, data: null, msg: "Auth expire" }),
+      ),
+    )
+
+    const data = await fetchVoApiV2AccountData({
+      ...createVoApiV2Request(),
+      checkIn: {
+        enableDetection: true,
+        siteStatus: {
+          isCheckedInToday: true,
+          lastDetectedAt: 123,
+        },
+      },
+    })
+
+    expect(data.checkIn.siteStatus).toEqual({
+      isCheckedInToday: true,
+      lastDetectedAt: 123,
+    })
+  })
+
+  it("refreshes account data and maps expired dashboard JWT failures", async () => {
+    server.use(
+      http.get("https://example.invalid/api/user/info", () =>
+        HttpResponse.json({
+          code: 2,
+          data: null,
+          msg: "Auth expire",
+        }),
+      ),
+      http.get("https://example.invalid/api/dash/statistics", () =>
+        HttpResponse.json({
+          code: 2,
+          data: null,
+          msg: "Auth expire",
+        }),
+      ),
+      http.get("https://example.invalid/api/check_in/stats", () =>
+        HttpResponse.json({
+          code: 2,
+          data: null,
+          msg: "Auth expire",
+        }),
+      ),
+    )
+
+    await expect(refreshAccountData(createVoApiV2Request())).resolves.toEqual({
+      success: false,
+      healthStatus: expect.objectContaining({
+        status: SiteHealthStatus.Warning,
+      }),
+    })
+  })
+
+  it("re-syncs the dashboard JWT from a logged-in browser session after auth expiry", async () => {
+    const authorizations: (string | null)[] = []
+    mockResyncVoApiV2AuthToken.mockResolvedValueOnce({
+      accessToken: "resynced-dashboard-token",
+      userId: "8",
+      username: "resynced-owner",
+      source: "existing_tab",
+    })
+
+    server.use(
+      http.get("https://example.invalid/api/user/info", ({ request }) => {
+        const authorization = request.headers.get("authorization")
+        authorizations.push(authorization)
+
+        if (authorization === "example-dashboard-token") {
+          return HttpResponse.json({
+            code: 2,
+            data: null,
+            msg: "Auth expire",
+          })
+        }
+
+        return HttpResponse.json({
+          code: 0,
+          data: {
+            id: 8,
+            username: "resynced-owner",
+            basicBalance: "2",
+            bindBalance: "0",
+          },
+        })
+      }),
+      http.get("https://example.invalid/api/dash/statistics", () =>
+        HttpResponse.json({
+          code: 0,
+          data: { d: { requests: 1, usedBasicBalance: "0" } },
+        }),
+      ),
+      http.get("https://example.invalid/api/check_in/stats", () =>
+        HttpResponse.json({
+          code: 0,
+          data: { todaySigned: false },
+        }),
+      ),
+    )
+
+    await expect(refreshAccountData(createVoApiV2Request())).resolves.toEqual(
+      expect.objectContaining({
+        success: true,
+        authUpdate: {
+          accessToken: "resynced-dashboard-token",
+          userId: "8",
+          username: "resynced-owner",
+        },
+      }),
+    )
+
+    expect(authorizations).toContain("example-dashboard-token")
+    expect(authorizations).toContain("resynced-dashboard-token")
+    expect(mockResyncVoApiV2AuthToken).toHaveBeenCalledWith(
+      "https://example.invalid",
+    )
+  })
+
+  it("reveals token secrets from the VoAPI v2 reveal endpoint", async () => {
+    server.use(
+      http.post("https://example.invalid/api/keys/11/token", () =>
+        HttpResponse.json({
+          code: 0,
+          data: { token: "example-revealed-api-key" },
+        }),
+      ),
+    )
+
+    await expect(
+      resolveVoApiV2TokenKey(createVoApiV2Request(), {
+        id: 11,
+        key: "masked-example-key",
+      }),
+    ).resolves.toBe("example-revealed-api-key")
+  })
+
+  it("normalizes VoAPI v2 key inventory", async () => {
+    server.use(
+      http.get("https://example.invalid/api/keys", () =>
+        HttpResponse.json({
+          code: 0,
+          data: [
+            {
+              id: 11,
+              name: "default",
+              tokenMasked: "masked-example-key",
+              groups: [2],
+              enable: true,
+              expireTime: 1893456000000,
+              amount: "2",
+              used: "0.5",
+            },
+          ],
+        }),
+      ),
+      http.get("https://example.invalid/api/keys/template", () =>
+        HttpResponse.json({
+          code: 0,
+          data: {
+            groups: [{ id: 2, name: "standard", ratio: 1 }],
+            models: [],
+          },
+        }),
+      ),
+    )
+
+    await expect(fetchVoApiV2Tokens(createVoApiV2Request())).resolves.toEqual([
+      expect.objectContaining({
+        id: 11,
+        name: "default",
+        key: "masked-example-key",
+        status: 1,
+        remain_quota: 1000000,
+        used_quota: 250000,
+        group: "standard",
+        expired_time: 1893456000,
+      }),
+    ])
+  })
+
+  it("normalizes VoAPI v2 paginated key inventory records with group names", async () => {
+    server.use(
+      http.get("https://example.invalid/api/keys", () =>
+        HttpResponse.json({
+          code: 0,
+          data: {
+            page: 1,
+            size: 10,
+            total: 2,
+            pages: 1,
+            records: [
+              {
+                id: 8396,
+                name: "default",
+                tokenMasked: "sk-example****0001",
+                groups: [1],
+                enable: true,
+                expireTime: -1,
+                boundlessAmount: true,
+                amount: "0.00000000",
+                used: "0.00000000",
+              },
+              {
+                id: 8395,
+                name: "quota-limited",
+                tokenMasked: "sk-example****0002",
+                groups: [2],
+                enable: false,
+                expireTime: 4102329600000,
+                amount: "100.00000000",
+                used: "0.50000000",
+              },
+            ],
+          },
+        }),
+      ),
+      http.get("https://example.invalid/api/keys/template", () =>
+        HttpResponse.json({
+          code: 0,
+          data: {
+            groups: [
+              { id: 1, name: "default", ratio: 1 },
+              { id: 2, name: "priority", ratio: 1 },
+            ],
+            models: [],
+          },
+        }),
+      ),
+    )
+
+    await expect(fetchVoApiV2Tokens(createVoApiV2Request())).resolves.toEqual([
+      expect.objectContaining({
+        id: 8396,
+        name: "default",
+        key: "sk-example****0001",
+        status: 1,
+        remain_quota: 0,
+        unlimited_quota: true,
+        used_quota: 0,
+        group: "default",
+        expired_time: -1,
+      }),
+      expect.objectContaining({
+        id: 8395,
+        name: "quota-limited",
+        key: "sk-example****0002",
+        status: 2,
+        remain_quota: 50000000,
+        used_quota: 250000,
+        group: "priority",
+        expired_time: 4102329600,
+      }),
+    ])
+  })
+
+  it("creates keys with VoAPI v2 amount and group payloads", async () => {
+    let payload: unknown
+    server.use(
+      http.get("https://example.invalid/api/keys/template", () =>
+        HttpResponse.json({
+          code: 0,
+          data: {
+            groups: [{ id: 2, name: "default", ratio: 1 }],
+            models: [],
+          },
+        }),
+      ),
+      http.post("https://example.invalid/api/keys", async ({ request }) => {
+        payload = await request.json()
+        return HttpResponse.json({ code: 0, data: null })
+      }),
+    )
+
+    await expect(
+      createVoApiV2Token(createVoApiV2Request(), tokenRequest),
+    ).resolves.toBe(true)
+
+    expect(payload).toEqual({
+      name: "default",
+      groups: [2],
+      amount: "1",
+      boundlessAmount: false,
+      genCount: 1,
+      enable: true,
+      expireTime: 1893456000000,
+    })
+  })
+
+  it("creates unlimited keys with VoAPI v2 boundlessAmount", async () => {
+    let payload: unknown
+    server.use(
+      http.get("https://example.invalid/api/keys/template", () =>
+        HttpResponse.json({
+          code: 0,
+          data: {
+            groups: [{ id: 2, name: "default", ratio: 1 }],
+            models: [],
+          },
+        }),
+      ),
+      http.post("https://example.invalid/api/keys", async ({ request }) => {
+        payload = await request.json()
+        return HttpResponse.json({ code: 0, data: null })
+      }),
+    )
+
+    await expect(
+      createVoApiV2Token(createVoApiV2Request(), {
+        ...tokenRequest,
+        remain_quota: 0,
+        unlimited_quota: true,
+      }),
+    ).resolves.toBe(true)
+
+    expect(payload).toEqual({
+      name: "default",
+      groups: [2],
+      amount: "0",
+      boundlessAmount: true,
+      genCount: 1,
+      enable: true,
+      expireTime: 1893456000000,
+    })
+  })
+
+  it("updates and toggles keys with preserved VoAPI v2 fields", async () => {
+    const payloads: unknown[] = []
+    server.use(
+      http.get("https://example.invalid/api/keys/template", () =>
+        HttpResponse.json({
+          code: 0,
+          data: {
+            groups: [
+              { id: 2, name: "default", ratio: 1 },
+              { id: 3, name: "previous-group", ratio: 1 },
+            ],
+            models: [],
+          },
+        }),
+      ),
+      http.get("https://example.invalid/api/keys", () =>
+        HttpResponse.json({
+          code: 0,
+          data: [
+            {
+              id: 11,
+              name: "previous",
+              groups: [3],
+              enable: true,
+              expireTime: -1,
+              boundlessAmount: true,
+              amount: "2",
+              used: "0.25",
+              note: "keep me",
+            },
+          ],
+        }),
+      ),
+      http.put("https://example.invalid/api/keys/11", async ({ request }) => {
+        payloads.push(await request.json())
+        return HttpResponse.json({ code: 0, data: null })
+      }),
+    )
+
+    await expect(
+      updateVoApiV2Token(createVoApiV2Request(), 11, {
+        ...tokenRequest,
+        remain_quota: 0,
+        unlimited_quota: true,
+      }),
+    ).resolves.toBe(true)
+    await expect(
+      setVoApiV2TokenEnabled(createVoApiV2Request(), 11, false),
+    ).resolves.toBe(true)
+
+    expect(payloads[0]).toEqual({
+      id: 11,
+      name: "default",
+      groups: [2],
+      amount: "0",
+      boundlessAmount: true,
+      enable: true,
+      expireTime: 1893456000000,
+      used: "0.25",
+      note: "keep me",
+    })
+    expect(payloads[1]).toEqual({
+      id: 11,
+      name: "previous",
+      groups: [3],
+      enable: false,
+      expireTime: -1,
+      boundlessAmount: true,
+      amount: "2",
+      used: "0.25",
+      note: "keep me",
+    })
+  })
+
+  it("deletes VoAPI v2 keys", async () => {
+    let deleted = false
+    server.use(
+      http.delete("https://example.invalid/api/keys/11", () => {
+        deleted = true
+        return HttpResponse.json({ code: 0, data: null })
+      }),
+    )
+
+    await expect(deleteVoApiV2Token(createVoApiV2Request(), 11)).resolves.toBe(
+      true,
+    )
+    expect(deleted).toBe(true)
+  })
+
+  it("maps VoAPI v2 template groups and models", async () => {
+    server.use(
+      http.get("https://example.invalid/api/keys/template", () =>
+        HttpResponse.json({
+          code: 0,
+          data: {
+            groups: [{ id: 2, name: "Default", ratio: 1, note: "main" }],
+            models: [
+              { idKey: "gpt-4.1", enable: true, hidden: false },
+              { idKey: "hidden-model", enable: true, hidden: true },
+              { idKey: "disabled-model", enable: false, hidden: false },
+            ],
+          },
+        }),
+      ),
+    )
+
+    await expect(
+      fetchVoApiV2AvailableModels(createVoApiV2Request()),
+    ).resolves.toEqual(["gpt-4.1"])
+    await expect(
+      fetchVoApiV2UserGroups(createVoApiV2Request()),
+    ).resolves.toEqual({
+      "2": { desc: "main", ratio: 1 },
+    })
+  })
+
+  it("supports VoAPI v2 API check-in helpers", async () => {
+    server.use(
+      http.get("https://example.invalid/api/check_in/stats", () =>
+        HttpResponse.json({
+          code: 0,
+          data: { todaySigned: true, consecutiveDays: 2 },
+        }),
+      ),
+      http.post("https://example.invalid/api/check_in", () =>
+        HttpResponse.json({ code: 0, data: { amount: "0.1" } }),
+      ),
+    )
+
+    await expect(fetchSupportCheckIn(createVoApiV2Request())).resolves.toBe(
+      true,
+    )
+    await expect(submitVoApiV2CheckIn(createVoApiV2Request())).resolves.toEqual(
+      {
+        amount: "0.1",
+      },
+    )
+  })
+
+  it("classifies repeated VoAPI v2 check-in as already signed", async () => {
+    server.use(
+      http.post("https://example.invalid/api/check_in", () =>
+        HttpResponse.json({ code: 1, data: null, msg: "Signed in today" }),
+      ),
+    )
+
+    await expect(submitVoApiV2CheckIn(createVoApiV2Request())).resolves.toEqual(
+      {
+        alreadySigned: true,
+      },
+    )
+  })
+})

--- a/tests/services/apiService/voapiV2/index.test.ts
+++ b/tests/services/apiService/voapiV2/index.test.ts
@@ -276,6 +276,99 @@ describe("apiService VoAPI v2", () => {
     )
   })
 
+  it("reports the retry auth-expired message after dashboard JWT re-sync", async () => {
+    mockResyncVoApiV2AuthToken.mockResolvedValueOnce({
+      accessToken: "resynced-dashboard-token",
+      userId: "8",
+      username: "resynced-owner",
+      source: "existing_tab",
+    })
+
+    server.use(
+      http.get("https://example.invalid/api/user/info", ({ request }) => {
+        const authorization = request.headers.get("authorization")
+        return HttpResponse.json({
+          code: 2,
+          data: null,
+          msg:
+            authorization === "example-dashboard-token"
+              ? "Initial auth expire"
+              : "Retry auth expire",
+        })
+      }),
+      http.get("https://example.invalid/api/dash/statistics", () =>
+        HttpResponse.json({
+          code: 2,
+          data: null,
+          msg: "Retry auth expire",
+        }),
+      ),
+      http.get("https://example.invalid/api/check_in/stats", () =>
+        HttpResponse.json({
+          code: 2,
+          data: null,
+          msg: "Retry auth expire",
+        }),
+      ),
+    )
+
+    await expect(refreshAccountData(createVoApiV2Request())).resolves.toEqual({
+      success: false,
+      healthStatus: {
+        status: SiteHealthStatus.Warning,
+        message: "account:healthStatus.httpError",
+      },
+    })
+  })
+
+  it("reports non-auth retry failures after dashboard JWT re-sync", async () => {
+    mockResyncVoApiV2AuthToken.mockResolvedValueOnce({
+      accessToken: "resynced-dashboard-token",
+      userId: "8",
+      username: "resynced-owner",
+      source: "existing_tab",
+    })
+
+    server.use(
+      http.get("https://example.invalid/api/user/info", ({ request }) => {
+        const authorization = request.headers.get("authorization")
+        if (authorization === "example-dashboard-token") {
+          return HttpResponse.json({
+            code: 2,
+            data: null,
+            msg: "Initial auth expire",
+          })
+        }
+
+        return HttpResponse.json(
+          { code: 500, data: null, msg: "Backend unavailable" },
+          { status: 500 },
+        )
+      }),
+      http.get(/https:\/\/example\.invalid\/api\/dash\/statistics/, () =>
+        HttpResponse.json(
+          { code: 500, data: null, msg: "Backend unavailable" },
+          { status: 500 },
+        ),
+      ),
+      http.get("https://example.invalid/api/check_in/stats", () =>
+        HttpResponse.json(
+          { code: 500, data: null, msg: "Backend unavailable" },
+          { status: 500 },
+        ),
+      ),
+    )
+
+    await expect(refreshAccountData(createVoApiV2Request())).resolves.toEqual(
+      expect.objectContaining({
+        success: false,
+        healthStatus: expect.objectContaining({
+          status: SiteHealthStatus.Warning,
+        }),
+      }),
+    )
+  })
+
   it("reveals token secrets from the VoAPI v2 reveal endpoint", async () => {
     server.use(
       http.post("https://example.invalid/api/keys/11/token", () =>
@@ -292,6 +385,36 @@ describe("apiService VoAPI v2", () => {
         key: "masked-example-key",
       }),
     ).resolves.toBe("example-revealed-api-key")
+  })
+
+  it("accepts string token reveal responses and rejects malformed reveal payloads", async () => {
+    server.use(
+      http.post("https://example.invalid/api/keys/11/token", () =>
+        HttpResponse.json({
+          code: 0,
+          data: "example-revealed-api-key",
+        }),
+      ),
+      http.post("https://example.invalid/api/keys/12/token", () =>
+        HttpResponse.json({
+          code: 0,
+          data: { masked: "still-hidden" },
+        }),
+      ),
+    )
+
+    await expect(
+      resolveVoApiV2TokenKey(createVoApiV2Request(), {
+        id: 11,
+        key: "masked-example-key",
+      }),
+    ).resolves.toBe("example-revealed-api-key")
+    await expect(
+      resolveVoApiV2TokenKey(createVoApiV2Request(), {
+        id: 12,
+        key: "masked-example-key",
+      }),
+    ).rejects.toThrow("VoAPI v2 token reveal response is missing token")
   })
 
   it("normalizes VoAPI v2 key inventory", async () => {
@@ -483,6 +606,27 @@ describe("apiService VoAPI v2", () => {
     })
   })
 
+  it("rejects key creation when the requested VoAPI v2 group cannot resolve", async () => {
+    server.use(
+      http.get("https://example.invalid/api/keys/template", () =>
+        HttpResponse.json({
+          code: 0,
+          data: {
+            groups: [{ id: 2, name: "default", ratio: 1 }],
+            models: [],
+          },
+        }),
+      ),
+    )
+
+    await expect(
+      createVoApiV2Token(createVoApiV2Request(), {
+        ...tokenRequest,
+        group: "missing-group",
+      }),
+    ).rejects.toThrow("VoAPI v2 group not found")
+  })
+
   it("updates and toggles keys with preserved VoAPI v2 fields", async () => {
     const payloads: unknown[] = []
     server.use(
@@ -557,6 +701,125 @@ describe("apiService VoAPI v2", () => {
     })
   })
 
+  it("paginates key inventory when updating a token beyond the first lookup page", async () => {
+    const requestedPages: number[] = []
+    let payload: unknown
+    const firstPageKeys = Array.from({ length: 100 }, (_, index) => ({
+      id: index + 1,
+      name: `page-one-${index + 1}`,
+      groups: [1],
+      enable: true,
+      expireTime: -1,
+      boundlessAmount: false,
+      amount: "0",
+      used: "0",
+    }))
+
+    server.use(
+      http.get("https://example.invalid/api/keys", ({ request }) => {
+        const url = new URL(request.url)
+        const page = Number(url.searchParams.get("page"))
+        requestedPages.push(page)
+
+        return HttpResponse.json({
+          code: 0,
+          data:
+            page === 1
+              ? firstPageKeys
+              : [
+                  {
+                    id: 150,
+                    name: "page-two-target",
+                    groups: [3],
+                    enable: true,
+                    expireTime: -1,
+                    boundlessAmount: true,
+                    amount: "2",
+                    used: "0.25",
+                    note: "keep me",
+                  },
+                ],
+        })
+      }),
+      http.get("https://example.invalid/api/keys/template", () =>
+        HttpResponse.json({
+          code: 0,
+          data: {
+            groups: [
+              { id: 2, name: "default", ratio: 1 },
+              { id: 3, name: "previous-group", ratio: 1 },
+            ],
+            models: [],
+          },
+        }),
+      ),
+      http.put("https://example.invalid/api/keys/150", async ({ request }) => {
+        payload = await request.json()
+        return HttpResponse.json({ code: 0, data: null })
+      }),
+    )
+
+    await expect(
+      updateVoApiV2Token(createVoApiV2Request(), 150, {
+        ...tokenRequest,
+        remain_quota: 0,
+        unlimited_quota: true,
+      }),
+    ).resolves.toBe(true)
+
+    expect(requestedPages).toEqual([1, 2])
+    expect(payload).toEqual(
+      expect.objectContaining({
+        id: 150,
+        name: "default",
+        groups: [2],
+        used: "0.25",
+        note: "keep me",
+      }),
+    )
+  })
+
+  it("reports missing tokens after exhausting paginated lookup", async () => {
+    const requestedPages: number[] = []
+    const firstPageKeys = Array.from({ length: 100 }, (_, index) => ({
+      id: index + 1,
+      name: `page-one-${index + 1}`,
+      groups: [1],
+      enable: true,
+      expireTime: -1,
+      boundlessAmount: false,
+      amount: "0",
+      used: "0",
+    }))
+
+    server.use(
+      http.get("https://example.invalid/api/keys", ({ request }) => {
+        const url = new URL(request.url)
+        const page = Number(url.searchParams.get("page"))
+        requestedPages.push(page)
+
+        return HttpResponse.json({
+          code: 0,
+          data: page === 1 ? firstPageKeys : [],
+        })
+      }),
+      http.get("https://example.invalid/api/keys/template", () =>
+        HttpResponse.json({
+          code: 0,
+          data: {
+            groups: [{ id: 2, name: "default", ratio: 1 }],
+            models: [],
+          },
+        }),
+      ),
+    )
+
+    await expect(
+      updateVoApiV2Token(createVoApiV2Request(), 150, tokenRequest),
+    ).rejects.toThrow("VoAPI v2 token not found")
+    expect(requestedPages).toEqual([1, 2])
+  })
+
   it("deletes VoAPI v2 keys", async () => {
     let deleted = false
     server.use(
@@ -597,6 +860,24 @@ describe("apiService VoAPI v2", () => {
     ).resolves.toEqual({
       "2": { desc: "main", ratio: 1 },
     })
+  })
+
+  it("ignores VoAPI v2 user groups with blank ids", async () => {
+    server.use(
+      http.get("https://example.invalid/api/keys/template", () =>
+        HttpResponse.json({
+          code: 0,
+          data: {
+            groups: [{ id: " ", name: "Blank", ratio: 1 }],
+            models: [],
+          },
+        }),
+      ),
+    )
+
+    await expect(
+      fetchVoApiV2UserGroups(createVoApiV2Request()),
+    ).resolves.toEqual({})
   })
 
   it("supports VoAPI v2 API check-in helpers", async () => {

--- a/tests/services/apiService/voapiV2/parsing.test.ts
+++ b/tests/services/apiService/voapiV2/parsing.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest"
+
+import { UI_CONSTANTS } from "~/constants/ui"
+import {
+  amountToQuota,
+  isVoApiV2AuthExpiredError,
+  parseVoApiV2Envelope,
+  quotaToAmountString,
+} from "~/services/apiService/voapiV2/parsing"
+import { ApiError } from "~/services/apiTransport/errors"
+
+describe("VoAPI v2 parsing", () => {
+  it("unwraps code zero data envelopes", () => {
+    expect(
+      parseVoApiV2Envelope({ code: 0, data: { id: 1 } }, "/api/user/info"),
+    ).toEqual({ id: 1 })
+  })
+
+  it("unwraps top-level token reveal envelopes", () => {
+    expect(
+      parseVoApiV2Envelope(
+        { code: 0, token: "example-revealed-api-key" },
+        "/api/keys/1/token",
+        { allowTopLevelToken: true },
+      ),
+    ).toBe("example-revealed-api-key")
+  })
+
+  it("throws ApiError for business errors", () => {
+    expect(() =>
+      parseVoApiV2Envelope(
+        { code: 1, data: null, msg: "Signed in today" },
+        "/api/check_in",
+      ),
+    ).toThrow(ApiError)
+  })
+
+  it("classifies auth-expired business errors", () => {
+    try {
+      parseVoApiV2Envelope(
+        { code: 2, data: null, msg: "Auth expire" },
+        "/api/user/info",
+      )
+    } catch (error) {
+      expect(isVoApiV2AuthExpiredError(error)).toBe(true)
+    }
+  })
+
+  it("converts decimal amounts to internal quota points", () => {
+    expect(amountToQuota("1.25")).toBe(
+      Math.round(1.25 * UI_CONSTANTS.EXCHANGE_RATE.CONVERSION_FACTOR),
+    )
+    expect(amountToQuota("invalid")).toBe(0)
+    expect(
+      quotaToAmountString(UI_CONSTANTS.EXCHANGE_RATE.CONVERSION_FACTOR),
+    ).toBe("1")
+  })
+})

--- a/tests/services/apiService/voapiV2/parsing.test.ts
+++ b/tests/services/apiService/voapiV2/parsing.test.ts
@@ -35,7 +35,28 @@ describe("VoAPI v2 parsing", () => {
     ).toThrow(ApiError)
   })
 
+  it("uses message and default fallback text for business errors", () => {
+    expect(() =>
+      parseVoApiV2Envelope(
+        { code: 1, data: null, message: "Backend says no" },
+        "/api/example",
+      ),
+    ).toThrow("Backend says no")
+    expect(() =>
+      parseVoApiV2Envelope({ code: 1, data: null }, "/api/example"),
+    ).toThrow("VoAPI v2 request failed")
+  })
+
+  it("rejects invalid or empty success envelopes", () => {
+    expect(() => parseVoApiV2Envelope({}, "/api/example")).toThrow(ApiError)
+    expect(() =>
+      parseVoApiV2Envelope({ code: 0, data: null }, "/api/example"),
+    ).toThrow("Missing VoAPI v2 response data")
+  })
+
   it("classifies auth-expired business errors", () => {
+    expect.assertions(1)
+
     try {
       parseVoApiV2Envelope(
         { code: 2, data: null, msg: "Auth expire" },
@@ -47,6 +68,9 @@ describe("VoAPI v2 parsing", () => {
   })
 
   it("converts decimal amounts to internal quota points", () => {
+    expect(amountToQuota(1.25)).toBe(
+      Math.round(1.25 * UI_CONSTANTS.EXCHANGE_RATE.CONVERSION_FACTOR),
+    )
     expect(amountToQuota("1.25")).toBe(
       Math.round(1.25 * UI_CONSTANTS.EXCHANGE_RATE.CONVERSION_FACTOR),
     )

--- a/tests/services/apiService/voapiV2/tokenResync.test.ts
+++ b/tests/services/apiService/voapiV2/tokenResync.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { ACCOUNT_BROWSER_SESSION_SOURCES } from "~/services/accountBrowserSession"
+import { resyncVoApiV2AuthToken } from "~/services/apiService/voapiV2/tokenResync"
+
+const { mockResolveAccountBrowserSession } = vi.hoisted(() => ({
+  mockResolveAccountBrowserSession: vi.fn(),
+}))
+
+vi.mock("~/services/accountBrowserSession", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("~/services/accountBrowserSession")>()
+
+  return {
+    ...actual,
+    resolveAccountBrowserSession: mockResolveAccountBrowserSession,
+  }
+})
+
+describe("VoAPI v2 token re-sync", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("returns a dashboard JWT from the browser-session reader", async () => {
+    mockResolveAccountBrowserSession.mockResolvedValueOnce({
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB,
+      siteType: "voapi-v2",
+      siteTypeHint: "voapi-v2",
+      userId: "42",
+      user: { username: "tab-user" },
+      accessToken: " dashboard-jwt-from-tab ",
+    })
+
+    await expect(
+      resyncVoApiV2AuthToken("https://voapi.example.invalid"),
+    ).resolves.toEqual({
+      accessToken: "dashboard-jwt-from-tab",
+      userId: "42",
+      username: "tab-user",
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB,
+    })
+    expect(mockResolveAccountBrowserSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseUrl: "https://voapi.example.invalid",
+        siteType: "voapi-v2",
+        useExistingTabs: true,
+        useTempWindow: true,
+        requestIdPrefix: "voapi-v2-token-resync",
+        isUsableSession: expect.any(Function),
+      }),
+    )
+  })
+
+  it("maps current-tab source to existing-tab for public result shape", async () => {
+    mockResolveAccountBrowserSession.mockResolvedValueOnce({
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB,
+      siteType: "voapi-v2",
+      userId: "42",
+      user: { display_name: "Current User" },
+      accessToken: "current-tab-token",
+    })
+
+    await expect(
+      resyncVoApiV2AuthToken("https://voapi.example.invalid"),
+    ).resolves.toEqual({
+      accessToken: "current-tab-token",
+      userId: "42",
+      username: "Current User",
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB,
+    })
+  })
+
+  it("returns null when no usable dashboard JWT is available", async () => {
+    mockResolveAccountBrowserSession.mockResolvedValueOnce(null)
+
+    await expect(
+      resyncVoApiV2AuthToken("https://voapi.example.invalid"),
+    ).resolves.toBeNull()
+  })
+
+  it("accepts only VoAPI v2 sessions with non-empty access tokens", async () => {
+    mockResolveAccountBrowserSession.mockImplementationOnce(
+      async ({ isUsableSession }) => {
+        expect(
+          isUsableSession({
+            source: ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB,
+            siteType: "voapi-v2",
+            siteTypeHint: "voapi-v2",
+            userId: "42",
+            user: { username: "blank-user" },
+            accessToken: "   ",
+          }),
+        ).toBe(false)
+        expect(
+          isUsableSession({
+            source: ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB,
+            siteType: "VoAPI",
+            siteTypeHint: "VoAPI",
+            userId: "42",
+            user: { username: "old-voapi-user" },
+            accessToken: "old-token",
+          }),
+        ).toBe(false)
+        expect(
+          isUsableSession({
+            source: ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB,
+            siteType: "voapi-v2",
+            siteTypeHint: "voapi-v2",
+            userId: "42",
+            user: { username: "usable-user" },
+            accessToken: " usable-token ",
+          }),
+        ).toBe(true)
+
+        return {
+          source: ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB,
+          siteType: "voapi-v2",
+          siteTypeHint: "voapi-v2",
+          userId: "42",
+          user: { username: "usable-user" },
+          accessToken: " usable-token ",
+        }
+      },
+    )
+
+    await expect(
+      resyncVoApiV2AuthToken("https://voapi.example.invalid"),
+    ).resolves.toEqual({
+      accessToken: "usable-token",
+      userId: "42",
+      username: "usable-user",
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB,
+    })
+  })
+})

--- a/tests/services/apiTransport/request.test.ts
+++ b/tests/services/apiTransport/request.test.ts
@@ -2,7 +2,10 @@ import { http, HttpResponse } from "msw"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { RuntimeActionIds } from "~/constants/runtimeActions"
-import { API_TRANSPORT_FETCH_CONTEXT_KINDS } from "~/services/apiTransport/type"
+import {
+  API_AUTH_TOKEN_MODES,
+  API_TRANSPORT_FETCH_CONTEXT_KINDS,
+} from "~/services/apiTransport/type"
 import { AuthTypeEnum, TEMP_WINDOW_HEALTH_STATUS_CODES } from "~/types"
 import {
   COOKIE_AUTH_HEADER_NAME,
@@ -271,6 +274,104 @@ describe("apiTransport request helpers", () => {
 
     expect(capturedAccept).toBe("application/json")
     expect(capturedAuthorization).toBe("Bearer token")
+  })
+
+  it("uses Bearer authorization for access tokens by default", async () => {
+    let capturedAuthorization: string | null = null
+
+    server.use(
+      http.get(API_URL, ({ request }) => {
+        capturedAuthorization = request.headers.get("authorization")
+        return HttpResponse.json({
+          success: true,
+          data: { ok: true },
+          message: "ok",
+        })
+      }),
+    )
+
+    await fetchApi(
+      {
+        baseUrl: BASE_URL,
+        auth: {
+          authType: AuthTypeEnum.AccessToken,
+          accessToken: "jwt-default",
+        },
+      },
+      { endpoint: ENDPOINT },
+      true,
+    )
+
+    expect(capturedAuthorization).toBe("Bearer jwt-default")
+  })
+
+  it("uses raw authorization when authTokenMode is raw", async () => {
+    let capturedAuthorization: string | null = null
+
+    server.use(
+      http.get(API_URL, ({ request }) => {
+        capturedAuthorization = request.headers.get("authorization")
+        return HttpResponse.json({
+          success: true,
+          data: { ok: true },
+          message: "ok",
+        })
+      }),
+    )
+
+    await fetchApi(
+      {
+        baseUrl: BASE_URL,
+        auth: {
+          authType: AuthTypeEnum.AccessToken,
+          accessToken: "jwt-raw",
+        },
+      },
+      {
+        endpoint: ENDPOINT,
+        authTokenMode: API_AUTH_TOKEN_MODES.Raw,
+      },
+      true,
+    )
+
+    expect(capturedAuthorization).toBe("jwt-raw")
+  })
+
+  it("keeps caller-provided Authorization header override in raw-token mode", async () => {
+    let capturedAuthorization: string | null = null
+
+    server.use(
+      http.get(API_URL, ({ request }) => {
+        capturedAuthorization = request.headers.get("authorization")
+        return HttpResponse.json({
+          success: true,
+          data: { ok: true },
+          message: "ok",
+        })
+      }),
+    )
+
+    await fetchApi(
+      {
+        baseUrl: BASE_URL,
+        auth: {
+          authType: AuthTypeEnum.AccessToken,
+          accessToken: "jwt-from-account",
+        },
+      },
+      {
+        endpoint: ENDPOINT,
+        authTokenMode: API_AUTH_TOKEN_MODES.Raw,
+        options: {
+          headers: {
+            Authorization: "manual-header",
+          },
+        },
+      },
+      true,
+    )
+
+    expect(capturedAuthorization).toBe("manual-header")
   })
 
   it("fetchApiData applies the site API limiter with a normalized origin key", async () => {
@@ -1544,6 +1645,41 @@ describe("apiTransport request helpers", () => {
       statusCode: 403,
       code: ApiErrorCodes.BUSINESS_ERROR,
       message: "Access denied for test group",
+    })
+
+    expect(mockSendRuntimeMessage).not.toHaveBeenCalled()
+  })
+
+  it("fetchApiData should surface VoAPI v2 403 business error messages", async () => {
+    const modelsEndpoint = "/v1/models"
+    const modelsUrl = "https://example.com/base/v1/models"
+
+    server.use(
+      http.get(modelsUrl, () => {
+        return HttpResponse.json(
+          {
+            code: 2,
+            data: null,
+            msg: "api key expire",
+          },
+          { status: 403 },
+        )
+      }),
+    )
+
+    await expect(
+      fetchApiData(
+        {
+          baseUrl: BASE_URL,
+          auth: { authType: AuthTypeEnum.AccessToken, accessToken: "token" },
+        },
+        { endpoint: modelsEndpoint },
+      ),
+    ).rejects.toMatchObject({
+      endpoint: modelsEndpoint,
+      statusCode: 403,
+      code: ApiErrorCodes.BUSINESS_ERROR,
+      message: "api key expire",
     })
 
     expect(mockSendRuntimeMessage).not.toHaveBeenCalled()

--- a/tests/services/autoCheckin/providers/voapiV2.test.ts
+++ b/tests/services/autoCheckin/providers/voapiV2.test.ts
@@ -95,6 +95,83 @@ describe("voApiV2Provider", () => {
     ).toBe(false)
   })
 
+  it("does not run when automatic check-in is disabled", () => {
+    expect(
+      voApiV2Provider.canCheckIn({
+        ...account,
+        checkIn: {
+          enableDetection: true,
+          autoCheckInEnabled: false,
+        },
+      } as SiteAccount),
+    ).toBe(false)
+  })
+
+  it("returns a failed result for unusable VoAPI v2 accounts", async () => {
+    await expect(
+      voApiV2Provider.checkIn({
+        ...account,
+        account_info: { ...account.account_info, access_token: "" },
+      } as SiteAccount),
+    ).resolves.toMatchObject({
+      status: CHECKIN_RESULT_STATUS.FAILED,
+    })
+  })
+
+  it("reports failure when submit succeeds but final stats are not checked in", async () => {
+    server.use(
+      http.post("https://example.invalid/api/check_in", () =>
+        HttpResponse.json({
+          code: 0,
+          data: { amount: "0.1", bonusAmount: "0" },
+        }),
+      ),
+      http.get("https://example.invalid/api/check_in/stats", () =>
+        HttpResponse.json({ code: 0, data: { todaySigned: false } }),
+      ),
+    )
+
+    await expect(voApiV2Provider.checkIn(account)).resolves.toMatchObject({
+      status: CHECKIN_RESULT_STATUS.FAILED,
+    })
+  })
+
+  it("returns a provider error result when an expired JWT cannot be resynced", async () => {
+    mockResyncVoApiV2AuthToken.mockResolvedValueOnce(null)
+    server.use(
+      http.post("https://example.invalid/api/check_in", () =>
+        HttpResponse.json({
+          code: 2,
+          data: null,
+          msg: "Auth expire",
+        }),
+      ),
+    )
+
+    await expect(voApiV2Provider.checkIn(account)).resolves.toMatchObject({
+      status: CHECKIN_RESULT_STATUS.FAILED,
+    })
+    expect(mockResyncVoApiV2AuthToken).toHaveBeenCalledWith(
+      "https://example.invalid",
+    )
+  })
+
+  it("reports generic backend failures without dashboard JWT re-sync", async () => {
+    server.use(
+      http.post("https://example.invalid/api/check_in", () =>
+        HttpResponse.json(
+          { code: 500, data: null, msg: "Backend unavailable" },
+          { status: 500 },
+        ),
+      ),
+    )
+
+    await expect(voApiV2Provider.checkIn(account)).resolves.toMatchObject({
+      status: CHECKIN_RESULT_STATUS.FAILED,
+    })
+    expect(mockResyncVoApiV2AuthToken).not.toHaveBeenCalled()
+  })
+
   it("re-syncs an expired dashboard JWT before retrying API check-in", async () => {
     const postAuthorizations: (string | null)[] = []
     const statsAuthorizations: (string | null)[] = []

--- a/tests/services/autoCheckin/providers/voapiV2.test.ts
+++ b/tests/services/autoCheckin/providers/voapiV2.test.ts
@@ -1,0 +1,155 @@
+import { http, HttpResponse } from "msw"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { SITE_TYPES } from "~/constants/siteType"
+import {
+  resolveAutoCheckinProvider,
+  type AutoCheckinProvider,
+} from "~/services/checkin/autoCheckin/providers"
+import { voApiV2Provider } from "~/services/checkin/autoCheckin/providers/voapiV2"
+import type { SiteAccount } from "~/types"
+import { CHECKIN_RESULT_STATUS } from "~/types/autoCheckin"
+import { server } from "~~/tests/msw/server"
+
+const { mockResyncVoApiV2AuthToken, mockUpdateAccount } = vi.hoisted(() => ({
+  mockResyncVoApiV2AuthToken: vi.fn(),
+  mockUpdateAccount: vi.fn(),
+}))
+
+vi.mock("~/services/apiService/voapiV2/tokenResync", () => ({
+  resyncVoApiV2AuthToken: mockResyncVoApiV2AuthToken,
+}))
+
+vi.mock("~/services/accounts/accountStorage", () => ({
+  accountStorage: {
+    updateAccount: mockUpdateAccount,
+  },
+}))
+
+const account = {
+  id: "account-1",
+  site_type: SITE_TYPES.VO_API_V2,
+  site_url: "https://example.invalid",
+  account_info: {
+    id: "7",
+    access_token: "jwt-dashboard",
+  },
+  checkIn: {
+    enableDetection: true,
+  },
+} as unknown as SiteAccount
+
+describe("voApiV2Provider", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockResyncVoApiV2AuthToken.mockResolvedValue(null)
+    mockUpdateAccount.mockResolvedValue(true)
+  })
+
+  it("registers the VoAPI v2 auto-check-in provider", () => {
+    expect(resolveAutoCheckinProvider(account)).toBe(
+      voApiV2Provider as AutoCheckinProvider,
+    )
+  })
+
+  it("checks in through the VoAPI v2 API and confirms stats", async () => {
+    server.use(
+      http.post("https://example.invalid/api/check_in", ({ request }) => {
+        expect(request.headers.get("authorization")).toBe("jwt-dashboard")
+        return HttpResponse.json({
+          code: 0,
+          data: { amount: "0.1", bonusAmount: "0" },
+        })
+      }),
+      http.get("https://example.invalid/api/check_in/stats", () =>
+        HttpResponse.json({ code: 0, data: { todaySigned: true } }),
+      ),
+    )
+
+    await expect(voApiV2Provider.checkIn(account)).resolves.toMatchObject({
+      status: CHECKIN_RESULT_STATUS.SUCCESS,
+    })
+  })
+
+  it("treats repeated same-day sign-in as already checked", async () => {
+    server.use(
+      http.post("https://example.invalid/api/check_in", () =>
+        HttpResponse.json({ code: 1, data: null, msg: "Signed in today" }),
+      ),
+      http.get("https://example.invalid/api/check_in/stats", () =>
+        HttpResponse.json({ code: 0, data: { todaySigned: true } }),
+      ),
+    )
+
+    await expect(voApiV2Provider.checkIn(account)).resolves.toMatchObject({
+      status: CHECKIN_RESULT_STATUS.ALREADY_CHECKED,
+    })
+  })
+
+  it("does not run without the saved dashboard JWT", () => {
+    expect(
+      voApiV2Provider.canCheckIn({
+        ...account,
+        account_info: { ...account.account_info, access_token: "" },
+      } as SiteAccount),
+    ).toBe(false)
+  })
+
+  it("re-syncs an expired dashboard JWT before retrying API check-in", async () => {
+    const postAuthorizations: (string | null)[] = []
+    const statsAuthorizations: (string | null)[] = []
+    mockResyncVoApiV2AuthToken.mockResolvedValueOnce({
+      accessToken: "resynced-dashboard-token",
+      userId: "8",
+      username: "resynced-owner",
+      source: "existing_tab",
+    })
+
+    server.use(
+      http.post("https://example.invalid/api/check_in", ({ request }) => {
+        const authorization = request.headers.get("authorization")
+        postAuthorizations.push(authorization)
+        if (authorization === "jwt-dashboard") {
+          return HttpResponse.json({
+            code: 2,
+            data: null,
+            msg: "Auth expire",
+          })
+        }
+
+        return HttpResponse.json({
+          code: 0,
+          data: { amount: "0.1", bonusAmount: "0" },
+        })
+      }),
+      http.get("https://example.invalid/api/check_in/stats", ({ request }) => {
+        statsAuthorizations.push(request.headers.get("authorization"))
+        return HttpResponse.json({ code: 0, data: { todaySigned: true } })
+      }),
+    )
+
+    await expect(voApiV2Provider.checkIn(account)).resolves.toMatchObject({
+      status: CHECKIN_RESULT_STATUS.SUCCESS,
+    })
+
+    expect(postAuthorizations).toEqual([
+      "jwt-dashboard",
+      "resynced-dashboard-token",
+    ])
+    expect(statsAuthorizations).toEqual(["resynced-dashboard-token"])
+    expect(mockResyncVoApiV2AuthToken).toHaveBeenCalledWith(
+      "https://example.invalid",
+    )
+    expect(mockUpdateAccount).toHaveBeenCalledWith(
+      "account-1",
+      expect.objectContaining({
+        account_info: expect.objectContaining({
+          access_token: "resynced-dashboard-token",
+          id: "8",
+          username: "resynced-owner",
+        }),
+      }),
+      expect.any(Object),
+    )
+  })
+})

--- a/tests/services/detectSiteType.test.ts
+++ b/tests/services/detectSiteType.test.ts
@@ -20,16 +20,20 @@ vi.mock("~/utils/browser/tempWindowFetch", async (importOriginal) => {
 })
 
 describe("detectSiteType", () => {
-  beforeEach(() => {
-    server.resetHandlers()
+  const addDefaultUnsupportedProtectedProbeHandlers = () => {
     server.use(
-      http.get("https://example.com/api/user/info", () => {
+      http.get(/\/api\/user\/info$/, () => {
         return HttpResponse.json({ message: "not found" }, { status: 404 })
       }),
-      http.get("https://example.com/api/v1/auth/me", () => {
+      http.get(/\/api\/v1\/auth\/me$/, () => {
         return HttpResponse.json({ message: "not found" }, { status: 404 })
       }),
     )
+  }
+
+  beforeEach(() => {
+    server.resetHandlers()
+    addDefaultUnsupportedProtectedProbeHandlers()
   })
 
   describe("fetchSiteOriginalTitle", () => {
@@ -302,6 +306,7 @@ describe("detectSiteType", () => {
 
         for (const [title] of managedOnlyTitles) {
           server.resetHandlers()
+          addDefaultUnsupportedProtectedProbeHandlers()
           server.use(
             http.get("https://example.com", () => {
               return new HttpResponse(`<html><title>${title}</title></html>`, {
@@ -366,6 +371,47 @@ describe("detectSiteType", () => {
           SITE_TYPES.VO_API_V2,
         )
         expect(titleFetched).toBe(false)
+      })
+
+      it("detects VoAPI v2 from a successful account-info envelope", async () => {
+        let titleFetched = false
+        server.use(
+          http.get("https://example.com", () => {
+            titleFetched = true
+            return new HttpResponse("<html><title>Custom Portal</title></html>")
+          }),
+          http.get("https://example.com/api/user/info", () =>
+            HttpResponse.json({
+              code: 0,
+              data: {
+                id: 7,
+                basicBalance: "1",
+              },
+            }),
+          ),
+        )
+
+        await expect(getAccountSiteType("https://example.com")).resolves.toBe(
+          SITE_TYPES.VO_API_V2,
+        )
+        expect(titleFetched).toBe(false)
+      })
+
+      it("falls back when the VoAPI v2 probe returns non-object JSON", async () => {
+        server.use(
+          http.get("https://example.com", () => {
+            return new HttpResponse("<html><title>New API</title></html>", {
+              headers: { "Content-Type": "text/html" },
+            })
+          }),
+          http.get("https://example.com/api/user/info", () =>
+            HttpResponse.json(["not", "an", "envelope"]),
+          ),
+        )
+
+        await expect(getAccountSiteType("https://example.com")).resolves.toBe(
+          SITE_TYPES.NEW_API,
+        )
       })
 
       it("keeps old VoAPI title-only detection on the old site type", async () => {

--- a/tests/services/detectSiteType.test.ts
+++ b/tests/services/detectSiteType.test.ts
@@ -23,6 +23,9 @@ describe("detectSiteType", () => {
   beforeEach(() => {
     server.resetHandlers()
     server.use(
+      http.get("https://example.com/api/user/info", () => {
+        return HttpResponse.json({ message: "not found" }, { status: 404 })
+      }),
       http.get("https://example.com/api/v1/auth/me", () => {
         return HttpResponse.json({ message: "not found" }, { status: 404 })
       }),
@@ -344,6 +347,64 @@ describe("detectSiteType", () => {
     })
 
     describe("Fallback to API detection", () => {
+      it("detects VoAPI v2 from a protected endpoint signature on custom origins", async () => {
+        let titleFetched = false
+        server.use(
+          http.get("https://example.com", () => {
+            titleFetched = true
+            return new HttpResponse("<html><title>Custom Portal</title></html>")
+          }),
+          http.get("https://example.com/api/user/info", () =>
+            HttpResponse.json(
+              { code: 2, data: null, msg: "Unauthorized", rid: "request-id" },
+              { status: 403 },
+            ),
+          ),
+        )
+
+        await expect(getAccountSiteType("https://example.com")).resolves.toBe(
+          SITE_TYPES.VO_API_V2,
+        )
+        expect(titleFetched).toBe(false)
+      })
+
+      it("keeps old VoAPI title-only detection on the old site type", async () => {
+        server.use(
+          http.get("https://example.com", () => {
+            return new HttpResponse("<html><title>VoAPI</title></html>", {
+              headers: { "Content-Type": "text/html" },
+            })
+          }),
+          http.get("https://example.com/api/user/info", () =>
+            HttpResponse.text("not voapi v2", {
+              status: 404,
+              headers: { "Content-Type": "text/plain" },
+            }),
+          ),
+        )
+
+        await expect(getAccountSiteType("https://example.com")).resolves.toBe(
+          SITE_TYPES.VO_API,
+        )
+      })
+
+      it("falls back when the VoAPI v2 probe is inconclusive", async () => {
+        server.use(
+          http.get("https://example.com", () => {
+            return new HttpResponse("<html><title>New API</title></html>", {
+              headers: { "Content-Type": "text/html" },
+            })
+          }),
+          http.get("https://example.com/api/user/info", () =>
+            HttpResponse.json({ ok: false }, { status: 404 }),
+          ),
+        )
+
+        await expect(getAccountSiteType("https://example.com")).resolves.toBe(
+          SITE_TYPES.NEW_API,
+        )
+      })
+
       it("detects Sub2API from its unauthenticated auth endpoint JSON code", async () => {
         server.use(
           http.get("https://example.com", () => {

--- a/tests/services/modelList/accountSources/readiness.definitions.test.ts
+++ b/tests/services/modelList/accountSources/readiness.definitions.test.ts
@@ -44,6 +44,16 @@ describe("Model List readiness definition expectations", () => {
         ACCOUNT_SITE_MODEL_LIST_DISPLAY_CAPABILITY_SOURCES.Response,
     })
     expect(
+      resolveModelListAccountSourceReadiness({
+        siteType: SITE_TYPES.VO_API_V2,
+      }),
+    ).toMatchObject({
+      route: MODEL_LIST_ACCOUNT_SOURCE_ROUTES.Unsupported,
+      statusScope: ACCOUNT_SITE_MODEL_LIST_STATUS_SCOPES.Account,
+      displayCapabilitiesSource:
+        ACCOUNT_SITE_MODEL_LIST_DISPLAY_CAPABILITY_SOURCES.Response,
+    })
+    expect(
       resolveModelListAccountSourceReadiness({ siteType: SITE_TYPES.AIHUBMIX }),
     ).toMatchObject({
       route: MODEL_LIST_ACCOUNT_SOURCE_ROUTES.DirectPricing,

--- a/tests/utils/packageMeta.test.ts
+++ b/tests/utils/packageMeta.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
 
 import { DOCS_BASE_URL, REPO_URL } from "~/constants/about"
+import { AutoDetectErrorType } from "~/services/accounts/utils/autoDetectUtils"
 import {
   getFeedbackDestinationUrls,
   getSiteSupportRequestUrl,
@@ -177,7 +178,7 @@ describe("packageMeta", () => {
     it("prefills site-support request destinations with site context", () => {
       const destination = getSiteSupportRequestUrl({
         siteUrl: "https://relay.example.com/console?token=redacted",
-        errorType: "notFound",
+        errorType: AutoDetectErrorType.NOT_FOUND,
         errorMessage: "Auto-detect failed",
       })
       const url = new URL(destination)


### PR DESCRIPTION
## Summary
- Add a distinct voapi-v2 account site type with dedicated detection, content-session JWT extraction, raw Authorization support, and old VoAPI compatibility preserved.
- Add VoAPI v2 account refresh, key inventory/mutation/reveal, token provisioning policy, check-in support, envelope parsing, quota normalization, and focused tests.
- Add user-facing unsupported states for model list and key management where a saved account lacks those protocols, with locale coverage.

Closes #8, closes #900, closes #1030, closes #1086, closes #1120.

## Validation
- pnpm run validate:push
- pre-push hook: pnpm run validate:push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for a VoAPI v2 account/site type, including onboarding, account data, token/key management, check-in, and auto check-in.
  * Added dedicated “unsupported” states for both key management and model lists, with an action to request site support.
  * Added VoAPI v2 documentation plans/specifications covering architecture and auth/refresh policy.
* **Bug Fixes**
  * Improved VoAPI v2 detection and auth-expired recovery behavior.
  * Enhanced request/auth handling (Bearer vs raw) and better surfacing of backend “business error” responses.
  * Refined unsupported-source status labeling/tooltips across UI and summaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->