### PR TITLE
fix(checkin): guard unsafe temp-window fallbacks

### DIFF
--- a/src/entrypoints/background/tempWindowPool.ts
+++ b/src/entrypoints/background/tempWindowPool.ts
@@ -126,6 +126,23 @@ interface TempContextTabSnapshot {
   status?: string
 }
 
+/**
+ * Removes any download-block rules installed for a temp-context tab.
+ */
+async function removeInstalledDownloadBlockRules(
+  downloadBlockRuleId: number | null | undefined,
+  firefoxDownloadBlockTabId: number | null | undefined,
+): Promise<void> {
+  await Promise.all([
+    downloadBlockRuleId != null
+      ? removeTempWindowDownloadBlockRule(downloadBlockRuleId)
+      : Promise.resolve(),
+    firefoxDownloadBlockTabId != null
+      ? removeFirefoxTempWindowDownloadBlockRule(firefoxDownloadBlockTabId)
+      : Promise.resolve(),
+  ])
+}
+
 /** Retry delay when the content script is not ready to receive messages. */
 const SHIELD_BYPASS_UI_RETRY_MS = 250
 /** Max retry attempts for showing the shield-bypass UI in the temp tab. */
@@ -2222,6 +2239,12 @@ async function createTempContextInstance(
       applyTempWindowDownloadBlockRule(tabId),
       applyFirefoxTempWindowDownloadBlockRule(tabId),
     ])
+    if (downloadBlockRuleId == null && firefoxDownloadBlockTabId == null) {
+      logger.warn(
+        "No temp-window download block rule could be installed before navigation",
+        { requestId, origin, tabId },
+      )
+    }
     await updateTab(tabId, { url })
 
     logTempWindow("createTempContextInstance", {
@@ -2287,14 +2310,10 @@ async function createTempContextInstance(
         )
       }
     }
-    await Promise.all([
-      downloadBlockRuleId != null
-        ? removeTempWindowDownloadBlockRule(downloadBlockRuleId)
-        : Promise.resolve(),
-      firefoxDownloadBlockTabId != null
-        ? removeFirefoxTempWindowDownloadBlockRule(firefoxDownloadBlockTabId)
-        : Promise.resolve(),
-    ])
+    await removeInstalledDownloadBlockRules(
+      downloadBlockRuleId,
+      firefoxDownloadBlockTabId,
+    )
     throw error
   }
 }
@@ -2671,16 +2690,10 @@ async function destroyContext(
   }
   context.activeRequestIds.clear()
 
-  await Promise.all([
-    context.downloadBlockRuleId != null
-      ? removeTempWindowDownloadBlockRule(context.downloadBlockRuleId)
-      : Promise.resolve(),
-    context.firefoxDownloadBlockTabId != null
-      ? removeFirefoxTempWindowDownloadBlockRule(
-          context.firefoxDownloadBlockTabId,
-        )
-      : Promise.resolve(),
-  ])
+  await removeInstalledDownloadBlockRules(
+    context.downloadBlockRuleId,
+    context.firefoxDownloadBlockTabId,
+  )
   context.downloadBlockRuleId = null
   context.firefoxDownloadBlockTabId = null
 

--- a/src/entrypoints/background/tempWindowPool.ts
+++ b/src/entrypoints/background/tempWindowPool.ts
@@ -71,7 +71,9 @@ import {
 import { mergeCookieHeaders } from "~/utils/browser/cookieString"
 import {
   applyTempWindowCookieRule,
+  applyTempWindowDownloadBlockRule,
   removeTempWindowCookieRule,
+  removeTempWindowDownloadBlockRule,
 } from "~/utils/browser/dnrCookieInjector"
 import { isProtectionBypassFirefoxEnv } from "~/utils/browser/protectionBypass"
 import { normalizeRequestInitForMessage } from "~/utils/browser/requestInitMessage"
@@ -404,6 +406,7 @@ type TempContext = {
   currentUrl?: string
   activeRequestIds: Set<string>
   lastUsed: number
+  downloadBlockRuleId?: number | null
   releaseTimer?: ReturnType<typeof setTimeout>
 }
 
@@ -2183,6 +2186,7 @@ async function createTempContextInstance(
 ) {
   let contextId: number | undefined
   let tabId: number | undefined
+  let downloadBlockRuleId: number | null = null
   let type: "window" | "tab" = "window"
   const useIncognito = Boolean(options.incognito)
   const requestedMode = resolveTempContextOpenMode({
@@ -2207,6 +2211,7 @@ async function createTempContextInstance(
     contextId = opened.id
     tabId = opened.tabId
     type = opened.type
+    downloadBlockRuleId = await applyTempWindowDownloadBlockRule(tabId)
 
     logTempWindow("createTempContextInstance", {
       requestId,
@@ -2214,6 +2219,7 @@ async function createTempContextInstance(
       contextId,
       tabId,
       type,
+      downloadBlockRuleInstalled: downloadBlockRuleId != null,
       preferredMode,
       requestedMode,
       url: sanitizeUrlForLog(url),
@@ -2243,6 +2249,7 @@ async function createTempContextInstance(
       currentUrl: readyTab?.url ?? url,
       activeRequestIds: new Set<string>(),
       lastUsed: Date.now(),
+      ...(downloadBlockRuleId != null ? { downloadBlockRuleId } : {}),
     }
   } catch (error) {
     logTempWindow("createTempContextInstanceError", {
@@ -2264,6 +2271,9 @@ async function createTempContextInstance(
           cleanupError,
         )
       }
+    }
+    if (downloadBlockRuleId != null) {
+      await removeTempWindowDownloadBlockRule(downloadBlockRuleId)
     }
     throw error
   }
@@ -2639,6 +2649,11 @@ async function destroyContext(
     }
   }
   context.activeRequestIds.clear()
+
+  if (context.downloadBlockRuleId != null) {
+    await removeTempWindowDownloadBlockRule(context.downloadBlockRuleId)
+    context.downloadBlockRuleId = null
+  }
 
   if (!options.skipBrowserRemoval) {
     try {

--- a/src/entrypoints/background/tempWindowPool.ts
+++ b/src/entrypoints/background/tempWindowPool.ts
@@ -75,6 +75,10 @@ import {
   removeTempWindowCookieRule,
   removeTempWindowDownloadBlockRule,
 } from "~/utils/browser/dnrCookieInjector"
+import {
+  applyFirefoxTempWindowDownloadBlockRule,
+  removeFirefoxTempWindowDownloadBlockRule,
+} from "~/utils/browser/firefoxTempWindowDownloadBlocker"
 import { isProtectionBypassFirefoxEnv } from "~/utils/browser/protectionBypass"
 import { normalizeRequestInitForMessage } from "~/utils/browser/requestInitMessage"
 import { resolveAuthTypeEnum } from "~/utils/core/authType"
@@ -407,6 +411,7 @@ type TempContext = {
   activeRequestIds: Set<string>
   lastUsed: number
   downloadBlockRuleId?: number | null
+  firefoxDownloadBlockTabId?: number | null
   releaseTimer?: ReturnType<typeof setTimeout>
 }
 
@@ -2187,6 +2192,7 @@ async function createTempContextInstance(
   let contextId: number | undefined
   let tabId: number | undefined
   let downloadBlockRuleId: number | null = null
+  let firefoxDownloadBlockTabId: number | null = null
   let type: "window" | "tab" = "window"
   const useIncognito = Boolean(options.incognito)
   const requestedMode = resolveTempContextOpenMode({
@@ -2212,6 +2218,8 @@ async function createTempContextInstance(
     tabId = opened.tabId
     type = opened.type
     downloadBlockRuleId = await applyTempWindowDownloadBlockRule(tabId)
+    firefoxDownloadBlockTabId =
+      await applyFirefoxTempWindowDownloadBlockRule(tabId)
 
     logTempWindow("createTempContextInstance", {
       requestId,
@@ -2220,6 +2228,7 @@ async function createTempContextInstance(
       tabId,
       type,
       downloadBlockRuleInstalled: downloadBlockRuleId != null,
+      firefoxDownloadBlockRuleInstalled: firefoxDownloadBlockTabId != null,
       preferredMode,
       requestedMode,
       url: sanitizeUrlForLog(url),
@@ -2250,6 +2259,9 @@ async function createTempContextInstance(
       activeRequestIds: new Set<string>(),
       lastUsed: Date.now(),
       ...(downloadBlockRuleId != null ? { downloadBlockRuleId } : {}),
+      ...(firefoxDownloadBlockTabId != null
+        ? { firefoxDownloadBlockTabId }
+        : {}),
     }
   } catch (error) {
     logTempWindow("createTempContextInstanceError", {
@@ -2274,6 +2286,9 @@ async function createTempContextInstance(
     }
     if (downloadBlockRuleId != null) {
       await removeTempWindowDownloadBlockRule(downloadBlockRuleId)
+    }
+    if (firefoxDownloadBlockTabId != null) {
+      await removeFirefoxTempWindowDownloadBlockRule(firefoxDownloadBlockTabId)
     }
     throw error
   }
@@ -2653,6 +2668,12 @@ async function destroyContext(
   if (context.downloadBlockRuleId != null) {
     await removeTempWindowDownloadBlockRule(context.downloadBlockRuleId)
     context.downloadBlockRuleId = null
+  }
+  if (context.firefoxDownloadBlockTabId != null) {
+    await removeFirefoxTempWindowDownloadBlockRule(
+      context.firefoxDownloadBlockTabId,
+    )
+    context.firefoxDownloadBlockTabId = null
   }
 
   if (!options.skipBrowserRemoval) {

--- a/src/entrypoints/background/tempWindowPool.ts
+++ b/src/entrypoints/background/tempWindowPool.ts
@@ -95,6 +95,7 @@ import { t } from "~/utils/i18n/core"
 const logger = createLogger("TempWindowPool")
 
 const TEMP_CONTEXT_IDLE_TIMEOUT = 5000
+const TEMP_CONTEXT_INITIAL_URL = "about:blank"
 const QUIET_WINDOW_IDLE_TIMEOUT = 3000
 const DEFAULT_TEMP_CONTEXT_MODE: TempWindowFallbackPreferences["tempContextMode"] =
   "composite"
@@ -850,7 +851,7 @@ export async function handleOpenTempWindow(
 
     if (shouldUseComposite) {
       const { windowId, tabId } = await openTabInCompositeWindow({
-        url,
+        initialUrl: url,
         origin,
         requestId,
         suppressMinimize: true,
@@ -1990,9 +1991,12 @@ function classifyWindowCreationFailure(params: {
  * Opens a standard tab-backed temp context.
  */
 async function openPlainTabTempContext(
-  url: string,
+  options: { windowId?: number } = {},
 ): Promise<TempContextOpenResult> {
-  const tab = await createTab(url, false)
+  const tab =
+    options.windowId == null
+      ? await createTab(TEMP_CONTEXT_INITIAL_URL, false)
+      : await createTab(TEMP_CONTEXT_INITIAL_URL, false, options)
 
   if (!tab?.id) {
     throw new Error(t("messages:background.cannotCreateWindowOrTab"))
@@ -2009,7 +2013,6 @@ async function openPlainTabTempContext(
  * Opens a popup-backed temp context and cleans up partial windows on failure.
  */
 async function openPopupWindowTempContext(params: {
-  url: string
   origin: string
   requestId: string
   suppressMinimize?: boolean
@@ -2022,7 +2025,7 @@ async function openPopupWindowTempContext(params: {
 
     try {
       popupWindow = await createWindow({
-        url: params.url,
+        url: TEMP_CONTEXT_INITIAL_URL,
         type: "popup",
         width: 420,
         height: 520,
@@ -2120,13 +2123,12 @@ async function openFallbackAwareTempContext(params: {
   incognito?: boolean
 }): Promise<TempContextOpenResult> {
   if (params.requestedMode === "tab") {
-    return await openPlainTabTempContext(params.url)
+    return await openPlainTabTempContext()
   }
 
   try {
     if (params.requestedMode === "composite") {
       const opened = await openTabInCompositeWindow({
-        url: params.url,
         origin: params.origin,
         requestId: params.requestId,
         suppressMinimize: params.suppressMinimize,
@@ -2140,7 +2142,6 @@ async function openFallbackAwareTempContext(params: {
     }
 
     return await openPopupWindowTempContext({
-      url: params.url,
       origin: params.origin,
       requestId: params.requestId,
       suppressMinimize: params.suppressMinimize,
@@ -2164,7 +2165,7 @@ async function openFallbackAwareTempContext(params: {
       throw createUnsupportedTempContextError(error.reason)
     }
 
-    const fallbackContext = await openPlainTabTempContext(params.url)
+    const fallbackContext = await openPlainTabTempContext()
 
     logTempWindow("tempContextWindowCreationRolledBackToTab", {
       requestId: params.requestId,
@@ -2217,9 +2218,11 @@ async function createTempContextInstance(
     contextId = opened.id
     tabId = opened.tabId
     type = opened.type
-    downloadBlockRuleId = await applyTempWindowDownloadBlockRule(tabId)
-    firefoxDownloadBlockTabId =
-      await applyFirefoxTempWindowDownloadBlockRule(tabId)
+    ;[downloadBlockRuleId, firefoxDownloadBlockTabId] = await Promise.all([
+      applyTempWindowDownloadBlockRule(tabId),
+      applyFirefoxTempWindowDownloadBlockRule(tabId),
+    ])
+    await updateTab(tabId, { url })
 
     logTempWindow("createTempContextInstance", {
       requestId,
@@ -2284,12 +2287,14 @@ async function createTempContextInstance(
         )
       }
     }
-    if (downloadBlockRuleId != null) {
-      await removeTempWindowDownloadBlockRule(downloadBlockRuleId)
-    }
-    if (firefoxDownloadBlockTabId != null) {
-      await removeFirefoxTempWindowDownloadBlockRule(firefoxDownloadBlockTabId)
-    }
+    await Promise.all([
+      downloadBlockRuleId != null
+        ? removeTempWindowDownloadBlockRule(downloadBlockRuleId)
+        : Promise.resolve(),
+      firefoxDownloadBlockTabId != null
+        ? removeFirefoxTempWindowDownloadBlockRule(firefoxDownloadBlockTabId)
+        : Promise.resolve(),
+    ])
     throw error
   }
 }
@@ -2339,11 +2344,12 @@ async function getTempContextTabSnapshot(
  * Reuses the shared window when possible and falls back to recreating it when closed.
  */
 async function openTabInCompositeWindow(params: {
-  url: string
+  initialUrl?: string
   origin: string
   requestId: string
   suppressMinimize?: boolean
 }): Promise<{ windowId: number; tabId: number }> {
+  const initialUrl = params.initialUrl ?? TEMP_CONTEXT_INITIAL_URL
   if (!hasWindowsAPI()) {
     throw createRecoverableWindowCreationError(
       WINDOW_CREATION_FAILURE_REASONS.WINDOWS_API_UNAVAILABLE,
@@ -2362,7 +2368,7 @@ async function openTabInCompositeWindow(params: {
         )
       }
       existingCompositeWindowConfirmed = true
-      const tab = await createTab(params.url, false, {
+      const tab = await createTab(initialUrl, false, {
         windowId: previousCompositeWindowId,
       })
       const tabId = tab?.id
@@ -2402,7 +2408,7 @@ async function openTabInCompositeWindow(params: {
 
   if (compositeWindowCreatePromise) {
     const { windowId } = await compositeWindowCreatePromise
-    const tab = await createTab(params.url, false, { windowId })
+    const tab = await createTab(initialUrl, false, { windowId })
     const tabId = tab?.id
     const missingTabReason = classifyWindowCreationFailure({
       missingHandle: !tabId,
@@ -2425,7 +2431,7 @@ async function openTabInCompositeWindow(params: {
 
       try {
         compositeWindow = await createWindow({
-          url: params.url,
+          url: initialUrl,
           type: "normal",
           width: 420,
           height: 520,
@@ -2665,16 +2671,18 @@ async function destroyContext(
   }
   context.activeRequestIds.clear()
 
-  if (context.downloadBlockRuleId != null) {
-    await removeTempWindowDownloadBlockRule(context.downloadBlockRuleId)
-    context.downloadBlockRuleId = null
-  }
-  if (context.firefoxDownloadBlockTabId != null) {
-    await removeFirefoxTempWindowDownloadBlockRule(
-      context.firefoxDownloadBlockTabId,
-    )
-    context.firefoxDownloadBlockTabId = null
-  }
+  await Promise.all([
+    context.downloadBlockRuleId != null
+      ? removeTempWindowDownloadBlockRule(context.downloadBlockRuleId)
+      : Promise.resolve(),
+    context.firefoxDownloadBlockTabId != null
+      ? removeFirefoxTempWindowDownloadBlockRule(
+          context.firefoxDownloadBlockTabId,
+        )
+      : Promise.resolve(),
+  ])
+  context.downloadBlockRuleId = null
+  context.firefoxDownloadBlockTabId = null
 
   if (!options.skipBrowserRemoval) {
     try {

--- a/src/services/checkin/autoCheckin/providers/newApi.ts
+++ b/src/services/checkin/autoCheckin/providers/newApi.ts
@@ -117,11 +117,13 @@ function isEndpointUnsupportedFailure(params: {
   message: string
   error?: unknown
 }): boolean {
-  if (getErrorStatusCode(params.error) === 404) return true
+  const statusCode = getErrorStatusCode(params.error)
+  if (statusCode === 404 || statusCode === 405) return true
 
   const normalized = params.message.toLowerCase()
   return (
     normalized.includes("404") ||
+    normalized.includes("method not allowed") ||
     normalized.includes("not found") ||
     normalized.includes("unsupported") ||
     normalized.includes("not supported") ||

--- a/src/utils/browser/dnrCookieInjector.ts
+++ b/src/utils/browser/dnrCookieInjector.ts
@@ -2,7 +2,10 @@ import {
   COOKIE_AUTH_HEADER_NAME,
   EXTENSION_HEADER_NAME,
 } from "~/utils/browser/cookieHelper"
-import { buildTempWindowBlockedDownloadExtensionPattern } from "~/utils/browser/tempWindowDownloadRules"
+import {
+  buildTempWindowBlockedDownloadExtensionPattern,
+  TEMP_WINDOW_DOWNLOAD_BLOCK_RESOURCE_TYPES,
+} from "~/utils/browser/tempWindowDownloadRules"
 import { createLogger } from "~/utils/core/logger"
 
 /**
@@ -103,14 +106,8 @@ export function buildTempWindowDownloadBlockRule(tabId: number) {
     },
     condition: {
       tabIds: [tabId],
-      regexFilter: `^https?://.*\\.(${buildTempWindowBlockedDownloadExtensionPattern()})(?:[?#].*)?$`,
-      resourceTypes: [
-        "main_frame",
-        "sub_frame",
-        "object",
-        "xmlhttprequest",
-        "other",
-      ],
+      regexFilter: `^https?://[^?#]*\\.(${buildTempWindowBlockedDownloadExtensionPattern()})(?:[?#].*)?$`,
+      resourceTypes: [...TEMP_WINDOW_DOWNLOAD_BLOCK_RESOURCE_TYPES],
     },
   } as const
 }

--- a/src/utils/browser/dnrCookieInjector.ts
+++ b/src/utils/browser/dnrCookieInjector.ts
@@ -2,6 +2,7 @@ import {
   COOKIE_AUTH_HEADER_NAME,
   EXTENSION_HEADER_NAME,
 } from "~/utils/browser/cookieHelper"
+import { buildTempWindowBlockedDownloadExtensionPattern } from "~/utils/browser/tempWindowDownloadRules"
 import { createLogger } from "~/utils/core/logger"
 
 /**
@@ -20,25 +21,6 @@ const logger = createLogger("DnrCookieInjector")
 
 export const TEMP_WINDOW_DNR_RULE_ID_BASE = 1_000_000 as const
 export const TEMP_WINDOW_DOWNLOAD_BLOCK_RULE_ID_BASE = 2_000_000 as const
-
-const TEMP_WINDOW_BLOCKED_DOWNLOAD_EXTENSION_PATTERN = [
-  "[aA][pP][kK]",
-  "[aA][pP][pP][iI][mM][aA][gG][eE]",
-  "[bB][aA][tT]",
-  "[cC][mM][dD]",
-  "[cC][oO][mM]",
-  "[dD][eE][bB]",
-  "[dD][mM][gG]",
-  "[eE][xX][eE]",
-  "[mM][sS][iI]",
-  "[mM][sS][pP]",
-  "[pP][kK][gG]",
-  "[pP][sS]1",
-  "[rR][pP][mM]",
-  "[sS][cC][rR]",
-  "[sS][hH]",
-  "[vV][bB][sS]",
-].join("|")
 
 interface TempWindowCookieRuleParams {
   tabId: number
@@ -121,7 +103,7 @@ export function buildTempWindowDownloadBlockRule(tabId: number) {
     },
     condition: {
       tabIds: [tabId],
-      regexFilter: `^https?://.*\\.(${TEMP_WINDOW_BLOCKED_DOWNLOAD_EXTENSION_PATTERN})(?:[?#].*)?$`,
+      regexFilter: `^https?://.*\\.(${buildTempWindowBlockedDownloadExtensionPattern()})(?:[?#].*)?$`,
       resourceTypes: [
         "main_frame",
         "sub_frame",

--- a/src/utils/browser/dnrCookieInjector.ts
+++ b/src/utils/browser/dnrCookieInjector.ts
@@ -19,6 +19,26 @@ const logger = createLogger("DnrCookieInjector")
  */
 
 export const TEMP_WINDOW_DNR_RULE_ID_BASE = 1_000_000 as const
+export const TEMP_WINDOW_DOWNLOAD_BLOCK_RULE_ID_BASE = 2_000_000 as const
+
+const TEMP_WINDOW_BLOCKED_DOWNLOAD_EXTENSION_PATTERN = [
+  "[aA][pP][kK]",
+  "[aA][pP][pP][iI][mM][aA][gG][eE]",
+  "[bB][aA][tT]",
+  "[cC][mM][dD]",
+  "[cC][oO][mM]",
+  "[dD][eE][bB]",
+  "[dD][mM][gG]",
+  "[eE][xX][eE]",
+  "[mM][sS][iI]",
+  "[mM][sS][pP]",
+  "[pP][kK][gG]",
+  "[pP][sS]1",
+  "[rR][pP][mM]",
+  "[sS][cC][rR]",
+  "[sS][hH]",
+  "[vV][bB][sS]",
+].join("|")
 
 interface TempWindowCookieRuleParams {
   tabId: number
@@ -45,6 +65,14 @@ function hasDnrApi(): boolean {
 function buildRuleId(tabId: number): number {
   const safeTabId = Number.isFinite(tabId) ? Math.max(0, Math.floor(tabId)) : 0
   return TEMP_WINDOW_DNR_RULE_ID_BASE + safeTabId
+}
+
+/**
+ * Builds a stable download block rule ID for a given temp tab.
+ */
+function buildDownloadBlockRuleId(tabId: number): number {
+  const safeTabId = Number.isFinite(tabId) ? Math.max(0, Math.floor(tabId)) : 0
+  return TEMP_WINDOW_DOWNLOAD_BLOCK_RULE_ID_BASE + safeTabId
 }
 
 /**
@@ -78,6 +106,75 @@ export function buildTempWindowCookieRule(params: TempWindowCookieRuleParams) {
       resourceTypes: ["xmlhttprequest", "other"],
     },
   } as const
+}
+
+/**
+ * Build a session-scoped DNR rule that blocks executable/installer downloads
+ * initiated inside a specific temp-context tab.
+ */
+export function buildTempWindowDownloadBlockRule(tabId: number) {
+  return {
+    id: buildDownloadBlockRuleId(tabId),
+    priority: 1,
+    action: {
+      type: "block",
+    },
+    condition: {
+      tabIds: [tabId],
+      regexFilter: `^https?://.*\\.(${TEMP_WINDOW_BLOCKED_DOWNLOAD_EXTENSION_PATTERN})(?:[?#].*)?$`,
+      resourceTypes: [
+        "main_frame",
+        "sub_frame",
+        "object",
+        "xmlhttprequest",
+        "other",
+      ],
+    },
+  } as const
+}
+
+/**
+ * Installs (or replaces) a per-tab temp-context rule that blocks obvious
+ * executable/installer downloads before they leave the browser.
+ */
+export async function applyTempWindowDownloadBlockRule(
+  tabId: number,
+): Promise<number | null> {
+  if (!hasDnrApi()) {
+    return null
+  }
+
+  const ruleId = buildDownloadBlockRuleId(tabId)
+
+  try {
+    await (globalThis as any).chrome.declarativeNetRequest.updateSessionRules({
+      removeRuleIds: [ruleId],
+      addRules: [buildTempWindowDownloadBlockRule(tabId)],
+    })
+    return ruleId
+  } catch (error) {
+    logger.warn("Failed to install temp-window download block rule", error)
+    return null
+  }
+}
+
+/**
+ * Best-effort removal of a previously installed temp-window download block rule.
+ */
+export async function removeTempWindowDownloadBlockRule(
+  ruleId: number,
+): Promise<void> {
+  if (!hasDnrApi()) {
+    return
+  }
+
+  try {
+    await (globalThis as any).chrome.declarativeNetRequest.updateSessionRules({
+      removeRuleIds: [ruleId],
+    })
+  } catch (error) {
+    logger.warn("Failed to remove temp-window download block rule", error)
+  }
 }
 
 /**

--- a/src/utils/browser/firefoxTempWindowDownloadBlocker.ts
+++ b/src/utils/browser/firefoxTempWindowDownloadBlocker.ts
@@ -1,0 +1,131 @@
+import { isProtectionBypassFirefoxEnv } from "~/utils/browser/protectionBypass"
+import { isTempWindowBlockedDownloadUrl } from "~/utils/browser/tempWindowDownloadRules"
+import { createLogger } from "~/utils/core/logger"
+
+const logger = createLogger("FirefoxTempWindowDownloadBlocker")
+
+const TEMP_WINDOW_DOWNLOAD_BLOCK_RESOURCE_TYPES = [
+  "main_frame",
+  "sub_frame",
+  "object",
+  "xmlhttprequest",
+  "other",
+] as const
+
+const activeBlockedTabIds = new Set<number>()
+let isListenerRegistered = false
+
+/**
+ * Returns whether the Firefox webRequest blocking API can be used in this runtime.
+ */
+function hasFirefoxWebRequestBlockingApi(): boolean {
+  try {
+    return Boolean(
+      isProtectionBypassFirefoxEnv() &&
+        (globalThis as any).browser?.webRequest?.onBeforeRequest?.addListener &&
+        (globalThis as any).browser?.webRequest?.onBeforeRequest
+          ?.removeListener,
+    )
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Cancels obvious executable requests only when they originate from tracked temp tabs.
+ */
+function handleBeforeRequest(
+  details: browser.webRequest._OnBeforeRequestDetails,
+) {
+  if (!activeBlockedTabIds.has(details.tabId)) {
+    return {}
+  }
+
+  if (!isTempWindowBlockedDownloadUrl(details.url)) {
+    return {}
+  }
+
+  return { cancel: true }
+}
+
+/**
+ * Registers the shared Firefox request blocker listener on demand.
+ */
+function registerFirefoxDownloadBlockListener(): boolean {
+  if (isListenerRegistered) {
+    return true
+  }
+
+  if (!hasFirefoxWebRequestBlockingApi()) {
+    return false
+  }
+
+  try {
+    ;(globalThis as any).browser.webRequest.onBeforeRequest.addListener(
+      handleBeforeRequest,
+      {
+        urls: ["<all_urls>"],
+        types: [...TEMP_WINDOW_DOWNLOAD_BLOCK_RESOURCE_TYPES],
+      },
+      ["blocking"],
+    )
+    isListenerRegistered = true
+    return true
+  } catch (error) {
+    logger.warn(
+      "Failed to install Firefox temp-window download block listener",
+      error,
+    )
+    isListenerRegistered = false
+    return false
+  }
+}
+
+/**
+ * Enables Firefox webRequest blocking for obvious executable requests in a temp tab.
+ */
+export async function applyFirefoxTempWindowDownloadBlockRule(
+  tabId: number,
+): Promise<number | null> {
+  if (!Number.isFinite(tabId) || tabId < 0) {
+    return null
+  }
+
+  if (!registerFirefoxDownloadBlockListener()) {
+    return null
+  }
+
+  const normalizedTabId = Math.floor(tabId)
+  activeBlockedTabIds.add(normalizedTabId)
+  return normalizedTabId
+}
+
+/**
+ * Disables Firefox webRequest blocking for a temp tab and unregisters the listener when idle.
+ */
+export async function removeFirefoxTempWindowDownloadBlockRule(
+  tabId: number,
+): Promise<void> {
+  if (!Number.isFinite(tabId)) {
+    return
+  }
+
+  activeBlockedTabIds.delete(Math.floor(tabId))
+
+  if (activeBlockedTabIds.size > 0 || !isListenerRegistered) {
+    return
+  }
+
+  try {
+    ;(globalThis as any).browser?.webRequest?.onBeforeRequest?.removeListener(
+      handleBeforeRequest,
+    )
+  } catch (error) {
+    logger.warn(
+      "Failed to remove Firefox temp-window download block listener",
+      error,
+    )
+  } finally {
+    isListenerRegistered = false
+  }
+}

--- a/src/utils/browser/firefoxTempWindowDownloadBlocker.ts
+++ b/src/utils/browser/firefoxTempWindowDownloadBlocker.ts
@@ -1,16 +1,11 @@
 import { isProtectionBypassFirefoxEnv } from "~/utils/browser/protectionBypass"
-import { isTempWindowBlockedDownloadUrl } from "~/utils/browser/tempWindowDownloadRules"
+import {
+  isTempWindowBlockedDownloadUrl,
+  TEMP_WINDOW_DOWNLOAD_BLOCK_RESOURCE_TYPES,
+} from "~/utils/browser/tempWindowDownloadRules"
 import { createLogger } from "~/utils/core/logger"
 
 const logger = createLogger("FirefoxTempWindowDownloadBlocker")
-
-const TEMP_WINDOW_DOWNLOAD_BLOCK_RESOURCE_TYPES = [
-  "main_frame",
-  "sub_frame",
-  "object",
-  "xmlhttprequest",
-  "other",
-] as const
 
 const activeBlockedTabIds = new Set<number>()
 let isListenerRegistered = false

--- a/src/utils/browser/tempWindowDownloadRules.ts
+++ b/src/utils/browser/tempWindowDownloadRules.ts
@@ -1,0 +1,47 @@
+const TEMP_WINDOW_BLOCKED_DOWNLOAD_EXTENSIONS = [
+  "apk",
+  "appimage",
+  "bat",
+  "cmd",
+  "com",
+  "deb",
+  "dmg",
+  "exe",
+  "msi",
+  "msp",
+  "pkg",
+  "ps1",
+  "rpm",
+  "scr",
+  "sh",
+  "vbs",
+] as const
+
+/**
+ * Builds a case-insensitive DNR regex fragment for blocked installer suffixes.
+ */
+export function buildTempWindowBlockedDownloadExtensionPattern(): string {
+  return TEMP_WINDOW_BLOCKED_DOWNLOAD_EXTENSIONS.map((extension) =>
+    Array.from(extension)
+      .map((char) =>
+        /[a-z]/i.test(char)
+          ? `[${char.toLowerCase()}${char.toUpperCase()}]`
+          : char,
+      )
+      .join(""),
+  ).join("|")
+}
+
+/**
+ * Returns whether a URL points to an obvious executable or installer payload.
+ */
+export function isTempWindowBlockedDownloadUrl(url: string): boolean {
+  try {
+    const pathname = new URL(url).pathname.toLowerCase()
+    return TEMP_WINDOW_BLOCKED_DOWNLOAD_EXTENSIONS.some((extension) =>
+      pathname.endsWith(`.${extension}`),
+    )
+  } catch {
+    return false
+  }
+}

--- a/src/utils/browser/tempWindowDownloadRules.ts
+++ b/src/utils/browser/tempWindowDownloadRules.ts
@@ -17,6 +17,14 @@ const TEMP_WINDOW_BLOCKED_DOWNLOAD_EXTENSIONS = [
   "vbs",
 ] as const
 
+export const TEMP_WINDOW_DOWNLOAD_BLOCK_RESOURCE_TYPES = [
+  "main_frame",
+  "sub_frame",
+  "object",
+  "xmlhttprequest",
+  "other",
+] as const
+
 /**
  * Builds a case-insensitive DNR regex fragment for blocked installer suffixes.
  */

--- a/tests/entrypoints/background/tempWindowPoolSuspendCleanup.test.ts
+++ b/tests/entrypoints/background/tempWindowPoolSuspendCleanup.test.ts
@@ -23,6 +23,7 @@ describe("cleanupTempContextsOnSuspend", () => {
       },
       tabs: {
         get: vi.fn().mockResolvedValue({ status: "complete" }),
+        update: vi.fn().mockResolvedValue(undefined),
         sendMessage: vi.fn(
           async (_tabId: number, message: { action: string }) => {
             switch (message.action) {

--- a/tests/entrypoints/background/tempWindowPoolWindowFallback.test.ts
+++ b/tests/entrypoints/background/tempWindowPoolWindowFallback.test.ts
@@ -21,10 +21,12 @@ const {
   trackProductAnalyticsActionCompletedMock,
   recordTempWindowFetchResultMock,
   recordTempWindowTurnstileFetchResultMock,
+  loggerWarnMock,
 } = vi.hoisted(() => ({
   trackProductAnalyticsActionCompletedMock: vi.fn(),
   recordTempWindowFetchResultMock: vi.fn(),
   recordTempWindowTurnstileFetchResultMock: vi.fn(),
+  loggerWarnMock: vi.fn(),
 }))
 
 vi.mock("~/services/productAnalytics/actions", () => ({
@@ -36,6 +38,14 @@ vi.mock("~/services/productAnalytics/shieldBypassSummary", () => ({
   recordShieldBypassTempWindowFetchResult: recordTempWindowFetchResultMock,
   recordShieldBypassTempWindowTurnstileFetchResult:
     recordTempWindowTurnstileFetchResultMock,
+}))
+
+vi.mock("~/utils/core/logger", () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    error: vi.fn(),
+    warn: loggerWarnMock,
+  }),
 }))
 
 const originalBrowser = (globalThis as any).browser
@@ -155,6 +165,7 @@ describe("tempWindowPool window fallback", () => {
     trackProductAnalyticsActionCompletedMock.mockReset()
     recordTempWindowFetchResultMock.mockReset()
     recordTempWindowTurnstileFetchResultMock.mockReset()
+    loggerWarnMock.mockReset()
 
     vi.useFakeTimers()
     vi.resetModules()
@@ -404,6 +415,41 @@ describe("tempWindowPool window fallback", () => {
       602,
     )
     expect(removeTabOrWindowMock).toHaveBeenCalledWith(602)
+  })
+
+  it("warns when no temp-context download blocker can be installed before navigation", async () => {
+    tempContextMode = "tab"
+    createTabMock.mockResolvedValueOnce({ id: 603 })
+
+    const { handleTempWindowFetch } = await import(
+      "~/entrypoints/background/tempWindowPool"
+    )
+
+    const sendResponse = vi.fn()
+    const request = handleTempWindowFetch(
+      {
+        originUrl: "https://example.invalid",
+        fetchUrl: "https://example.invalid/api/test",
+        fetchOptions: { method: "GET" },
+        requestId: "req-download-block-unavailable",
+      },
+      sendResponse,
+    )
+
+    await vi.advanceTimersByTimeAsync(500)
+    await request
+
+    expect(loggerWarnMock).toHaveBeenCalledWith(
+      "No temp-window download block rule could be installed before navigation",
+      {
+        requestId: "req-download-block-unavailable",
+        origin: "https://example.invalid",
+        tabId: 603,
+      },
+    )
+    expect(tabsUpdateMock).toHaveBeenCalledWith(603, {
+      url: "https://example.invalid",
+    })
   })
 
   it("rolls back composite temp-context creation to a plain tab", async () => {

--- a/tests/entrypoints/background/tempWindowPoolWindowFallback.test.ts
+++ b/tests/entrypoints/background/tempWindowPoolWindowFallback.test.ts
@@ -74,6 +74,7 @@ describe("tempWindowPool window fallback", () => {
   let sendMessageMock: ReturnType<typeof vi.fn>
   let tabsGetMock: ReturnType<typeof vi.fn>
   let tabsQueryMock: ReturnType<typeof vi.fn>
+  let tabsUpdateMock: ReturnType<typeof vi.fn>
   let tempContextMode: "window" | "composite" | "tab"
   let defaultTempContextMode: "window" | "composite" | "tab"
 
@@ -148,6 +149,7 @@ describe("tempWindowPool window fallback", () => {
     )
     tabsGetMock = vi.fn().mockResolvedValue({ status: "complete" })
     tabsQueryMock = vi.fn().mockResolvedValue([])
+    tabsUpdateMock = vi.fn().mockResolvedValue(undefined)
     tempContextMode = "window"
     defaultTempContextMode = "window"
     trackProductAnalyticsActionCompletedMock.mockReset()
@@ -163,7 +165,7 @@ describe("tempWindowPool window fallback", () => {
       tabs: {
         get: tabsGetMock,
         query: tabsQueryMock,
-        update: vi.fn().mockResolvedValue(undefined),
+        update: tabsUpdateMock,
         sendMessage: sendMessageMock,
       },
       windows: {
@@ -300,7 +302,10 @@ describe("tempWindowPool window fallback", () => {
       PRODUCT_ANALYTICS_RESULTS.Success,
     )
     expect(createWindowMock).toHaveBeenCalledTimes(1)
-    expect(createTabMock).toHaveBeenCalledWith("https://example.com", false)
+    expect(createTabMock).toHaveBeenCalledWith("about:blank", false)
+    expect(tabsUpdateMock).toHaveBeenCalledWith(101, {
+      url: "https://example.com",
+    })
 
     await vi.advanceTimersByTimeAsync(2500)
     expect(removeTabOrWindowMock).toHaveBeenCalledWith(101)
@@ -308,8 +313,25 @@ describe("tempWindowPool window fallback", () => {
 
   it("installs and removes a temp-context download block rule for the owned tab", async () => {
     tempContextMode = "tab"
-    createTabMock.mockResolvedValueOnce({ id: 601 })
-    applyTempWindowDownloadBlockRuleMock.mockResolvedValueOnce(2_000_601)
+    const setupOrder: string[] = []
+    createTabMock.mockImplementationOnce(async () => {
+      setupOrder.push("open")
+      return { id: 601 }
+    })
+    applyTempWindowDownloadBlockRuleMock.mockImplementationOnce(async () => {
+      setupOrder.push("dnr")
+      return 2_000_601
+    })
+    applyFirefoxTempWindowDownloadBlockRuleMock.mockImplementationOnce(
+      async () => {
+        setupOrder.push("firefox")
+        return null
+      },
+    )
+    tabsUpdateMock.mockImplementationOnce(async () => {
+      setupOrder.push("navigate")
+      return undefined
+    })
 
     const { handleTempWindowFetch } = await import(
       "~/entrypoints/background/tempWindowPool"
@@ -329,7 +351,11 @@ describe("tempWindowPool window fallback", () => {
     await vi.advanceTimersByTimeAsync(500)
     await request
 
+    expect(setupOrder).toEqual(["open", "dnr", "firefox", "navigate"])
     expect(applyTempWindowDownloadBlockRuleMock).toHaveBeenCalledWith(601)
+    expect(tabsUpdateMock).toHaveBeenCalledWith(601, {
+      url: "https://example.invalid",
+    })
     expect(sendMessageMock).toHaveBeenCalledWith(
       601,
       expect.objectContaining({
@@ -416,10 +442,13 @@ describe("tempWindowPool window fallback", () => {
     expect(createWindowMock).toHaveBeenCalledWith(
       expect.objectContaining({
         type: "normal",
-        url: "https://example.com",
+        url: "about:blank",
       }),
     )
-    expect(createTabMock).toHaveBeenCalledWith("https://example.com", false)
+    expect(createTabMock).toHaveBeenCalledWith("about:blank", false)
+    expect(tabsUpdateMock).toHaveBeenCalledWith(202, {
+      url: "https://example.com",
+    })
 
     await vi.advanceTimersByTimeAsync(2500)
     expect(removeTabOrWindowMock).toHaveBeenCalledWith(202)
@@ -458,7 +487,10 @@ describe("tempWindowPool window fallback", () => {
       },
     })
     expect(removeTabOrWindowMock).toHaveBeenNthCalledWith(1, 303)
-    expect(createTabMock).toHaveBeenCalledWith("https://example.com", false)
+    expect(createTabMock).toHaveBeenCalledWith("about:blank", false)
+    expect(tabsUpdateMock).toHaveBeenCalledWith(304, {
+      url: "https://example.com",
+    })
 
     await vi.advanceTimersByTimeAsync(2500)
     expect(removeTabOrWindowMock).toHaveBeenNthCalledWith(2, 304)
@@ -718,7 +750,7 @@ describe("tempWindowPool window fallback", () => {
     expect(createWindowMock).toHaveBeenCalledWith(
       expect.objectContaining({
         type: "normal",
-        url: "https://example.com",
+        url: "about:blank",
       }),
     )
     expect(createTabMock).not.toHaveBeenCalled()
@@ -759,7 +791,10 @@ describe("tempWindowPool window fallback", () => {
     await request
 
     expect(createWindowMock).not.toHaveBeenCalled()
-    expect(createTabMock).toHaveBeenCalledWith("https://example.com", false)
+    expect(createTabMock).toHaveBeenCalledWith("about:blank", false)
+    expect(tabsUpdateMock).toHaveBeenCalledWith(492, {
+      url: "https://example.com",
+    })
     expect(sendResponse).toHaveBeenCalledWith({
       success: true,
       data: {
@@ -1020,10 +1055,13 @@ describe("tempWindowPool window fallback", () => {
     expect(isAllowedIncognitoAccessMock).toHaveBeenCalled()
     expect(createWindowMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        url: "https://example.com/account",
+        url: "about:blank",
         incognito: true,
       }),
     )
+    expect(tabsUpdateMock).toHaveBeenCalledWith(609, {
+      url: "https://example.com/account",
+    })
     expect(createTabMock).not.toHaveBeenCalled()
     expect(sendResponse).toHaveBeenCalledWith({
       success: true,
@@ -1061,10 +1099,13 @@ describe("tempWindowPool window fallback", () => {
 
     expect(createWindowMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        url: "https://aihubmix.com",
+        url: "about:blank",
         focused: false,
       }),
     )
+    expect(tabsUpdateMock).toHaveBeenCalledWith(611, {
+      url: "https://aihubmix.com",
+    })
     expect((globalThis as any).browser.windows.update).not.toHaveBeenCalledWith(
       610,
       {
@@ -1107,11 +1148,14 @@ describe("tempWindowPool window fallback", () => {
 
     expect(createWindowMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        url: "https://aihubmix.com",
+        url: "about:blank",
         focused: false,
         type: "normal",
       }),
     )
+    expect(tabsUpdateMock).toHaveBeenCalledWith(613, {
+      url: "https://aihubmix.com",
+    })
     expect((globalThis as any).browser.windows.update).not.toHaveBeenCalledWith(
       612,
       {
@@ -1590,10 +1634,10 @@ describe("tempWindowPool window fallback", () => {
     await secondRequest
 
     expect(createTabMock).toHaveBeenCalledTimes(2)
-    expect(createTabMock).toHaveBeenLastCalledWith(
-      "https://example.com/suspend-two",
-      false,
-    )
+    expect(createTabMock).toHaveBeenLastCalledWith("about:blank", false)
+    expect(tabsUpdateMock).toHaveBeenCalledWith(616, {
+      url: "https://example.com/suspend-two",
+    })
     expect(secondResponse).toHaveBeenCalledWith({
       success: true,
       data: {
@@ -2040,10 +2084,10 @@ describe("tempWindowPool window fallback", () => {
     await thirdRequest
 
     expect(createTabMock).toHaveBeenCalledTimes(2)
-    expect(createTabMock).toHaveBeenLastCalledWith(
-      "https://example.com/c",
-      false,
-    )
+    expect(createTabMock).toHaveBeenLastCalledWith("about:blank", false)
+    expect(tabsUpdateMock).toHaveBeenCalledWith(607, {
+      url: "https://example.com/c",
+    })
   })
 
   it("defers same-origin cleanup while a reused temp tab is still busy", async () => {
@@ -2306,10 +2350,10 @@ describe("tempWindowPool window fallback", () => {
     await thirdRequest
 
     expect(createTabMock).toHaveBeenCalledTimes(2)
-    expect(createTabMock).toHaveBeenLastCalledWith(
-      "https://example.com/force-close-three",
-      false,
-    )
+    expect(createTabMock).toHaveBeenLastCalledWith("about:blank", false)
+    expect(tabsUpdateMock).toHaveBeenCalledWith(651, {
+      url: "https://example.com/force-close-three",
+    })
     expect(thirdResponse).toHaveBeenCalledWith({
       success: true,
       data: {

--- a/tests/entrypoints/background/tempWindowPoolWindowFallback.test.ts
+++ b/tests/entrypoints/background/tempWindowPoolWindowFallback.test.ts
@@ -62,6 +62,8 @@ describe("tempWindowPool window fallback", () => {
   let getAccountByIdMock: ReturnType<typeof vi.fn>
   let getCookieHeaderForUrlMock: ReturnType<typeof vi.fn>
   let addAuthMethodHeaderMock: ReturnType<typeof vi.fn>
+  let applyFirefoxTempWindowDownloadBlockRuleMock: ReturnType<typeof vi.fn>
+  let removeFirefoxTempWindowDownloadBlockRuleMock: ReturnType<typeof vi.fn>
   let applyTempWindowDownloadBlockRuleMock: ReturnType<typeof vi.fn>
   let removeTempWindowDownloadBlockRuleMock: ReturnType<typeof vi.fn>
   let applyTempWindowCookieRuleMock: ReturnType<typeof vi.fn>
@@ -91,6 +93,12 @@ describe("tempWindowPool window fallback", () => {
         "X-Auth-Mode": mode,
       }),
     )
+    applyFirefoxTempWindowDownloadBlockRuleMock = vi
+      .fn()
+      .mockResolvedValue(null)
+    removeFirefoxTempWindowDownloadBlockRuleMock = vi
+      .fn()
+      .mockResolvedValue(undefined)
     applyTempWindowDownloadBlockRuleMock = vi.fn().mockResolvedValue(null)
     removeTempWindowDownloadBlockRuleMock = vi.fn().mockResolvedValue(undefined)
     applyTempWindowCookieRuleMock = vi.fn().mockResolvedValue(null)
@@ -200,6 +208,12 @@ describe("tempWindowPool window fallback", () => {
       removeTempWindowDownloadBlockRule: removeTempWindowDownloadBlockRuleMock,
       removeTempWindowCookieRule: removeTempWindowCookieRuleMock,
     }))
+    vi.doMock("~/utils/browser/firefoxTempWindowDownloadBlocker", () => ({
+      applyFirefoxTempWindowDownloadBlockRule:
+        applyFirefoxTempWindowDownloadBlockRuleMock,
+      removeFirefoxTempWindowDownloadBlockRule:
+        removeFirefoxTempWindowDownloadBlockRuleMock,
+    }))
     vi.doMock("~/utils/browser/protectionBypass", () => ({
       isProtectionBypassFirefoxEnv: isProtectionBypassFirefoxEnvMock,
     }))
@@ -228,6 +242,7 @@ describe("tempWindowPool window fallback", () => {
     vi.doUnmock("~/services/accounts/accountStorage")
     vi.doUnmock("~/utils/browser/cookieHelper")
     vi.doUnmock("~/utils/browser/dnrCookieInjector")
+    vi.doUnmock("~/utils/browser/firefoxTempWindowDownloadBlocker")
     vi.doUnmock("~/utils/browser/protectionBypass")
     vi.doUnmock("~/utils/browser/browserApi")
     vi.doUnmock("~/services/siteDetection/detectSiteType")
@@ -328,6 +343,41 @@ describe("tempWindowPool window fallback", () => {
       2_000_601,
     )
     expect(removeTabOrWindowMock).toHaveBeenCalledWith(601)
+  })
+
+  it("installs and removes a Firefox temp-context download block rule for the owned tab", async () => {
+    tempContextMode = "tab"
+    createTabMock.mockResolvedValueOnce({ id: 602 })
+    applyFirefoxTempWindowDownloadBlockRuleMock.mockResolvedValueOnce(602)
+
+    const { handleTempWindowFetch } = await import(
+      "~/entrypoints/background/tempWindowPool"
+    )
+
+    const sendResponse = vi.fn()
+    const request = handleTempWindowFetch(
+      {
+        originUrl: "https://example.invalid",
+        fetchUrl: "https://example.invalid/api/test",
+        fetchOptions: { method: "GET" },
+        requestId: "req-firefox-download-block-rule",
+      },
+      sendResponse,
+    )
+
+    await vi.advanceTimersByTimeAsync(500)
+    await request
+
+    expect(applyFirefoxTempWindowDownloadBlockRuleMock).toHaveBeenCalledWith(
+      602,
+    )
+
+    await vi.advanceTimersByTimeAsync(2500)
+
+    expect(removeFirefoxTempWindowDownloadBlockRuleMock).toHaveBeenCalledWith(
+      602,
+    )
+    expect(removeTabOrWindowMock).toHaveBeenCalledWith(602)
   })
 
   it("rolls back composite temp-context creation to a plain tab", async () => {

--- a/tests/entrypoints/background/tempWindowPoolWindowFallback.test.ts
+++ b/tests/entrypoints/background/tempWindowPoolWindowFallback.test.ts
@@ -62,6 +62,8 @@ describe("tempWindowPool window fallback", () => {
   let getAccountByIdMock: ReturnType<typeof vi.fn>
   let getCookieHeaderForUrlMock: ReturnType<typeof vi.fn>
   let addAuthMethodHeaderMock: ReturnType<typeof vi.fn>
+  let applyTempWindowDownloadBlockRuleMock: ReturnType<typeof vi.fn>
+  let removeTempWindowDownloadBlockRuleMock: ReturnType<typeof vi.fn>
   let applyTempWindowCookieRuleMock: ReturnType<typeof vi.fn>
   let removeTempWindowCookieRuleMock: ReturnType<typeof vi.fn>
   let isProtectionBypassFirefoxEnvMock: ReturnType<typeof vi.fn>
@@ -89,6 +91,8 @@ describe("tempWindowPool window fallback", () => {
         "X-Auth-Mode": mode,
       }),
     )
+    applyTempWindowDownloadBlockRuleMock = vi.fn().mockResolvedValue(null)
+    removeTempWindowDownloadBlockRuleMock = vi.fn().mockResolvedValue(undefined)
     applyTempWindowCookieRuleMock = vi.fn().mockResolvedValue(null)
     removeTempWindowCookieRuleMock = vi.fn().mockResolvedValue(undefined)
     isProtectionBypassFirefoxEnvMock = vi.fn(() => false)
@@ -191,7 +195,9 @@ describe("tempWindowPool window fallback", () => {
       }
     })
     vi.doMock("~/utils/browser/dnrCookieInjector", () => ({
+      applyTempWindowDownloadBlockRule: applyTempWindowDownloadBlockRuleMock,
       applyTempWindowCookieRule: applyTempWindowCookieRuleMock,
+      removeTempWindowDownloadBlockRule: removeTempWindowDownloadBlockRuleMock,
       removeTempWindowCookieRule: removeTempWindowCookieRuleMock,
     }))
     vi.doMock("~/utils/browser/protectionBypass", () => ({
@@ -283,6 +289,45 @@ describe("tempWindowPool window fallback", () => {
 
     await vi.advanceTimersByTimeAsync(2500)
     expect(removeTabOrWindowMock).toHaveBeenCalledWith(101)
+  })
+
+  it("installs and removes a temp-context download block rule for the owned tab", async () => {
+    tempContextMode = "tab"
+    createTabMock.mockResolvedValueOnce({ id: 601 })
+    applyTempWindowDownloadBlockRuleMock.mockResolvedValueOnce(2_000_601)
+
+    const { handleTempWindowFetch } = await import(
+      "~/entrypoints/background/tempWindowPool"
+    )
+
+    const sendResponse = vi.fn()
+    const request = handleTempWindowFetch(
+      {
+        originUrl: "https://example.invalid",
+        fetchUrl: "https://example.invalid/api/test",
+        fetchOptions: { method: "GET" },
+        requestId: "req-download-block-rule",
+      },
+      sendResponse,
+    )
+
+    await vi.advanceTimersByTimeAsync(500)
+    await request
+
+    expect(applyTempWindowDownloadBlockRuleMock).toHaveBeenCalledWith(601)
+    expect(sendMessageMock).toHaveBeenCalledWith(
+      601,
+      expect.objectContaining({
+        action: RuntimeActionIds.ContentPerformTempWindowFetch,
+      }),
+    )
+
+    await vi.advanceTimersByTimeAsync(2500)
+
+    expect(removeTempWindowDownloadBlockRuleMock).toHaveBeenCalledWith(
+      2_000_601,
+    )
+    expect(removeTabOrWindowMock).toHaveBeenCalledWith(601)
   })
 
   it("rolls back composite temp-context creation to a plain tab", async () => {

--- a/tests/services/autoCheckin/providers/newApi.test.ts
+++ b/tests/services/autoCheckin/providers/newApi.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { SITE_TYPES } from "~/constants/siteType"
 import { SITE_ROUTE_KINDS } from "~/services/accounts/utils/siteRouteResolver"
+import { ApiError } from "~/services/apiTransport/errors"
 import { newApiProvider } from "~/services/checkin/autoCheckin/providers/newApi"
 import { AuthTypeEnum, SiteHealthStatus } from "~/types"
 import { safeRandomUUID } from "~/utils/core/identifier"
@@ -317,6 +318,26 @@ describe("newApiProvider", () => {
         expect(tempWindowTurnstileFetch).not.toHaveBeenCalled()
       },
     )
+
+    it("does not use native page check-in when the API endpoint rejects POST with 405", async () => {
+      const { fetchApi } = await import("~/services/apiTransport/request")
+      const { tempWindowTriggerCheckinPageAction, tempWindowTurnstileFetch } =
+        await import("~/utils/browser/tempWindowFetch")
+
+      const error = new ApiError("请求失败: 405", 405, "/api/user/checkin")
+
+      vi.mocked(fetchApi).mockRejectedValueOnce(error)
+
+      const result = await newApiProvider.checkIn(mockAccount)
+
+      expect(result).toEqual({
+        status: "failed",
+        rawMessage: "请求失败: 405",
+        messageKey: undefined,
+      })
+      expect(tempWindowTriggerCheckinPageAction).not.toHaveBeenCalled()
+      expect(tempWindowTurnstileFetch).not.toHaveBeenCalled()
+    })
 
     it("refuses native page check-in when temp page identity is missing", async () => {
       const { fetchApi } = await import("~/services/apiTransport/request")

--- a/tests/utils/dnrCookieInjector.test.ts
+++ b/tests/utils/dnrCookieInjector.test.ts
@@ -111,6 +111,20 @@ describe("dnrCookieInjector", () => {
     expect(rule.condition.resourceTypes).toContain("other")
   })
 
+  it("buildTempWindowDownloadBlockRule only matches executable suffixes in the URL path", () => {
+    const rule = buildTempWindowDownloadBlockRule(321)
+    const regex = new RegExp(rule.condition.regexFilter)
+
+    expect(
+      regex.test("https://downloads.example.invalid/releases/tool.exe?via=ui"),
+    ).toBe(true)
+    expect(
+      regex.test(
+        "https://downloads.example.invalid/api/check?callback=tool.exe",
+      ),
+    ).toBe(false)
+  })
+
   it("applyTempWindowDownloadBlockRule should call updateSessionRules with a per-tab block rule", async () => {
     const updateSessionRules = vi.fn().mockResolvedValue(undefined)
 
@@ -139,6 +153,22 @@ describe("dnrCookieInjector", () => {
     await expect(applyTempWindowDownloadBlockRule(6)).resolves.toBeNull()
   })
 
+  it("applyTempWindowDownloadBlockRule logs and returns null when session rule installation fails", async () => {
+    const updateSessionRules = vi
+      .fn()
+      .mockRejectedValue(new Error("download block unavailable"))
+
+    ;(globalThis as any).chrome = {
+      declarativeNetRequest: { updateSessionRules },
+    }
+
+    await expect(applyTempWindowDownloadBlockRule(6)).resolves.toBeNull()
+    expect(loggerWarnMock).toHaveBeenCalledWith(
+      "Failed to install temp-window download block rule",
+      expect.any(Error),
+    )
+  })
+
   it("removeTempWindowDownloadBlockRule should call updateSessionRules with remove only", async () => {
     const updateSessionRules = vi.fn().mockResolvedValue(undefined)
 
@@ -152,6 +182,24 @@ describe("dnrCookieInjector", () => {
     expect(updateSessionRules).toHaveBeenCalledWith({
       removeRuleIds: [2_000_042],
     })
+  })
+
+  it("removeTempWindowDownloadBlockRule logs cleanup failures without throwing", async () => {
+    const updateSessionRules = vi
+      .fn()
+      .mockRejectedValue(new Error("download cleanup failed"))
+
+    ;(globalThis as any).chrome = {
+      declarativeNetRequest: { updateSessionRules },
+    }
+
+    await expect(
+      removeTempWindowDownloadBlockRule(2_000_042),
+    ).resolves.toBeUndefined()
+    expect(loggerWarnMock).toHaveBeenCalledWith(
+      "Failed to remove temp-window download block rule",
+      expect.any(Error),
+    )
   })
 
   it("applyTempWindowCookieRule returns null when no cookie header is available", async () => {

--- a/tests/utils/dnrCookieInjector.test.ts
+++ b/tests/utils/dnrCookieInjector.test.ts
@@ -2,9 +2,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import {
   applyTempWindowCookieRule,
+  applyTempWindowDownloadBlockRule,
   buildTempWindowCookieRule,
+  buildTempWindowDownloadBlockRule,
   removeTempWindowCookieRule,
+  removeTempWindowDownloadBlockRule,
   TEMP_WINDOW_DNR_RULE_ID_BASE,
+  TEMP_WINDOW_DOWNLOAD_BLOCK_RULE_ID_BASE,
 } from "~/utils/browser/dnrCookieInjector"
 
 const { loggerWarnMock } = vi.hoisted(() => ({
@@ -93,6 +97,61 @@ describe("dnrCookieInjector", () => {
     const call = updateSessionRules.mock.calls[0]?.[0]
     expect(call.removeRuleIds).toEqual([TEMP_WINDOW_DNR_RULE_ID_BASE + 5])
     expect(call.addRules?.[0]?.id).toBe(TEMP_WINDOW_DNR_RULE_ID_BASE + 5)
+  })
+
+  it("buildTempWindowDownloadBlockRule creates a per-tab executable download block rule", () => {
+    const rule = buildTempWindowDownloadBlockRule(321)
+
+    expect(rule.id).toBe(TEMP_WINDOW_DOWNLOAD_BLOCK_RULE_ID_BASE + 321)
+    expect(rule.action.type).toBe("block")
+    expect(rule.condition.tabIds).toEqual([321])
+    expect(rule.condition.regexFilter).toContain("[eE][xX][eE]")
+    expect(rule.condition.regexFilter).toContain("[mM][sS][iI]")
+    expect(rule.condition.resourceTypes).toContain("main_frame")
+    expect(rule.condition.resourceTypes).toContain("other")
+  })
+
+  it("applyTempWindowDownloadBlockRule should call updateSessionRules with a per-tab block rule", async () => {
+    const updateSessionRules = vi.fn().mockResolvedValue(undefined)
+
+    ;(globalThis as any).chrome = {
+      declarativeNetRequest: { updateSessionRules },
+    }
+
+    const ruleId = await applyTempWindowDownloadBlockRule(6)
+
+    expect(ruleId).toBe(TEMP_WINDOW_DOWNLOAD_BLOCK_RULE_ID_BASE + 6)
+    expect(updateSessionRules).toHaveBeenCalledTimes(1)
+
+    const call = updateSessionRules.mock.calls[0]?.[0]
+    expect(call.removeRuleIds).toEqual([
+      TEMP_WINDOW_DOWNLOAD_BLOCK_RULE_ID_BASE + 6,
+    ])
+    expect(call.addRules?.[0]?.id).toBe(
+      TEMP_WINDOW_DOWNLOAD_BLOCK_RULE_ID_BASE + 6,
+    )
+    expect(call.addRules?.[0]?.action.type).toBe("block")
+  })
+
+  it("applyTempWindowDownloadBlockRule returns null when the DNR API is unavailable", async () => {
+    ;(globalThis as any).chrome = {}
+
+    await expect(applyTempWindowDownloadBlockRule(6)).resolves.toBeNull()
+  })
+
+  it("removeTempWindowDownloadBlockRule should call updateSessionRules with remove only", async () => {
+    const updateSessionRules = vi.fn().mockResolvedValue(undefined)
+
+    ;(globalThis as any).chrome = {
+      declarativeNetRequest: { updateSessionRules },
+    }
+
+    await removeTempWindowDownloadBlockRule(2_000_042)
+
+    expect(updateSessionRules).toHaveBeenCalledTimes(1)
+    expect(updateSessionRules).toHaveBeenCalledWith({
+      removeRuleIds: [2_000_042],
+    })
   })
 
   it("applyTempWindowCookieRule returns null when no cookie header is available", async () => {

--- a/tests/utils/firefoxTempWindowDownloadBlocker.test.ts
+++ b/tests/utils/firefoxTempWindowDownloadBlocker.test.ts
@@ -118,6 +118,37 @@ describe("firefoxTempWindowDownloadBlocker", () => {
     ).resolves.toBeNull()
   })
 
+  it("returns null when browser API probing throws", async () => {
+    ;(globalThis as any).browser = {
+      get webRequest() {
+        throw new Error("blocked getter")
+      },
+    }
+    const { applyFirefoxTempWindowDownloadBlockRule } = await import(
+      "~/utils/browser/firefoxTempWindowDownloadBlocker"
+    )
+
+    await expect(
+      applyFirefoxTempWindowDownloadBlockRule(77),
+    ).resolves.toBeNull()
+  })
+
+  it("ignores invalid tab ids", async () => {
+    const {
+      applyFirefoxTempWindowDownloadBlockRule,
+      removeFirefoxTempWindowDownloadBlockRule,
+    } = await import("~/utils/browser/firefoxTempWindowDownloadBlocker")
+
+    await expect(
+      applyFirefoxTempWindowDownloadBlockRule(-1),
+    ).resolves.toBeNull()
+    await expect(
+      removeFirefoxTempWindowDownloadBlockRule(Number.NaN),
+    ).resolves.toBeUndefined()
+    expect(addListenerMock).not.toHaveBeenCalled()
+    expect(removeListenerMock).not.toHaveBeenCalled()
+  })
+
   it("cleans up state when listener registration fails", async () => {
     addListenerMock.mockImplementationOnce(() => {
       throw new Error("missing permission")
@@ -134,5 +165,24 @@ describe("firefoxTempWindowDownloadBlocker", () => {
       expect.any(Error),
     )
     expect(registeredListener).toBeUndefined()
+  })
+
+  it("logs listener cleanup failures without throwing", async () => {
+    removeListenerMock.mockImplementationOnce(() => {
+      throw new Error("cleanup failed")
+    })
+    const {
+      applyFirefoxTempWindowDownloadBlockRule,
+      removeFirefoxTempWindowDownloadBlockRule,
+    } = await import("~/utils/browser/firefoxTempWindowDownloadBlocker")
+
+    await applyFirefoxTempWindowDownloadBlockRule(77)
+    await expect(
+      removeFirefoxTempWindowDownloadBlockRule(77),
+    ).resolves.toBeUndefined()
+    expect(loggerWarnMock).toHaveBeenCalledWith(
+      "Failed to remove Firefox temp-window download block listener",
+      expect.any(Error),
+    )
   })
 })

--- a/tests/utils/firefoxTempWindowDownloadBlocker.test.ts
+++ b/tests/utils/firefoxTempWindowDownloadBlocker.test.ts
@@ -1,0 +1,138 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const { loggerWarnMock } = vi.hoisted(() => ({
+  loggerWarnMock: vi.fn(),
+}))
+
+vi.mock("~/utils/core/logger", () => ({
+  createLogger: () => ({
+    warn: loggerWarnMock,
+  }),
+}))
+
+describe("firefoxTempWindowDownloadBlocker", () => {
+  const originalBrowser = (globalThis as any).browser
+  let addListenerMock: ReturnType<typeof vi.fn>
+  let removeListenerMock: ReturnType<typeof vi.fn>
+  let isFirefoxEnvMock: ReturnType<typeof vi.fn>
+  let registeredListener:
+    | ((details: browser.webRequest._OnBeforeRequestDetails) => unknown)
+    | undefined
+
+  beforeEach(() => {
+    vi.resetModules()
+    loggerWarnMock.mockReset()
+    registeredListener = undefined
+    addListenerMock = vi.fn((listener) => {
+      registeredListener = listener
+    })
+    removeListenerMock = vi.fn()
+    isFirefoxEnvMock = vi.fn(() => true)
+    ;(globalThis as any).browser = {
+      webRequest: {
+        onBeforeRequest: {
+          addListener: addListenerMock,
+          removeListener: removeListenerMock,
+        },
+      },
+    }
+    vi.doMock("~/utils/browser/protectionBypass", () => ({
+      isProtectionBypassFirefoxEnv: isFirefoxEnvMock,
+    }))
+  })
+
+  afterEach(() => {
+    ;(globalThis as any).browser = originalBrowser
+    vi.doUnmock("~/utils/browser/protectionBypass")
+    vi.restoreAllMocks()
+  })
+
+  it("cancels executable requests only for active temp tabs", async () => {
+    const { applyFirefoxTempWindowDownloadBlockRule } = await import(
+      "~/utils/browser/firefoxTempWindowDownloadBlocker"
+    )
+
+    await expect(applyFirefoxTempWindowDownloadBlockRule(77)).resolves.toBe(77)
+
+    expect(addListenerMock).toHaveBeenCalledWith(
+      expect.any(Function),
+      {
+        urls: ["<all_urls>"],
+        types: ["main_frame", "sub_frame", "object", "xmlhttprequest", "other"],
+      },
+      ["blocking"],
+    )
+    expect(registeredListener).toBeTypeOf("function")
+
+    expect(
+      registeredListener!({
+        tabId: 77,
+        url: "https://downloads.example.invalid/tool.EXE?source=temp",
+      } as any),
+    ).toEqual({ cancel: true })
+    expect(
+      registeredListener!({
+        tabId: 78,
+        url: "https://downloads.example.invalid/tool.exe",
+      } as any),
+    ).toEqual({})
+    expect(
+      registeredListener!({
+        tabId: 77,
+        url: "https://downloads.example.invalid/manual.pdf",
+      } as any),
+    ).toEqual({})
+  })
+
+  it("unregisters the listener after the last temp tab is removed", async () => {
+    const {
+      applyFirefoxTempWindowDownloadBlockRule,
+      removeFirefoxTempWindowDownloadBlockRule,
+    } = await import("~/utils/browser/firefoxTempWindowDownloadBlocker")
+
+    await applyFirefoxTempWindowDownloadBlockRule(77)
+    await applyFirefoxTempWindowDownloadBlockRule(88)
+
+    expect(addListenerMock).toHaveBeenCalledTimes(1)
+
+    await removeFirefoxTempWindowDownloadBlockRule(77)
+    expect(removeListenerMock).not.toHaveBeenCalled()
+
+    await removeFirefoxTempWindowDownloadBlockRule(88)
+    expect(removeListenerMock).toHaveBeenCalledWith(registeredListener)
+  })
+
+  it("returns null outside Firefox or when webRequest blocking is unavailable", async () => {
+    const { applyFirefoxTempWindowDownloadBlockRule } = await import(
+      "~/utils/browser/firefoxTempWindowDownloadBlocker"
+    )
+
+    isFirefoxEnvMock.mockReturnValueOnce(false)
+    await expect(
+      applyFirefoxTempWindowDownloadBlockRule(77),
+    ).resolves.toBeNull()
+    expect(addListenerMock).not.toHaveBeenCalled()
+    ;(globalThis as any).browser = {}
+    await expect(
+      applyFirefoxTempWindowDownloadBlockRule(77),
+    ).resolves.toBeNull()
+  })
+
+  it("cleans up state when listener registration fails", async () => {
+    addListenerMock.mockImplementationOnce(() => {
+      throw new Error("missing permission")
+    })
+    const { applyFirefoxTempWindowDownloadBlockRule } = await import(
+      "~/utils/browser/firefoxTempWindowDownloadBlocker"
+    )
+
+    await expect(
+      applyFirefoxTempWindowDownloadBlockRule(77),
+    ).resolves.toBeNull()
+    expect(loggerWarnMock).toHaveBeenCalledWith(
+      "Failed to install Firefox temp-window download block listener",
+      expect.any(Error),
+    )
+    expect(registeredListener).toBeUndefined()
+  })
+})

--- a/tests/utils/tempWindowDownloadRules.test.ts
+++ b/tests/utils/tempWindowDownloadRules.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  buildTempWindowBlockedDownloadExtensionPattern,
+  isTempWindowBlockedDownloadUrl,
+  TEMP_WINDOW_DOWNLOAD_BLOCK_RESOURCE_TYPES,
+} from "~/utils/browser/tempWindowDownloadRules"
+
+describe("tempWindowDownloadRules", () => {
+  it("builds a case-insensitive executable extension pattern", () => {
+    const regex = new RegExp(
+      `\\.(${buildTempWindowBlockedDownloadExtensionPattern()})$`,
+    )
+
+    expect(regex.test("installer.EXE")).toBe(true)
+    expect(regex.test("package.msi")).toBe(true)
+    expect(regex.test("manual.pdf")).toBe(false)
+  })
+
+  it("checks executable suffixes from the URL path only", () => {
+    expect(
+      isTempWindowBlockedDownloadUrl(
+        "https://downloads.example.invalid/file.exe?source=temp",
+      ),
+    ).toBe(true)
+    expect(
+      isTempWindowBlockedDownloadUrl(
+        "https://downloads.example.invalid/check?file=tool.exe",
+      ),
+    ).toBe(false)
+    expect(isTempWindowBlockedDownloadUrl("not a valid url")).toBe(false)
+  })
+
+  it("shares the request resource types used by temp-window download blockers", () => {
+    expect(TEMP_WINDOW_DOWNLOAD_BLOCK_RESOURCE_TYPES).toEqual([
+      "main_frame",
+      "sub_frame",
+      "object",
+      "xmlhttprequest",
+      "other",
+    ])
+  })
+})


### PR DESCRIPTION
## Summary
- stop New API auto check-in from entering native page fallback when `/api/user/checkin` rejects POST with `405 Method Not Allowed`
- add per-temp-tab executable request blocking for temp-window contexts on Chromium via DNR session rules
- add matching Firefox protection via `webRequest.onBeforeRequest` cancellation scoped to active temp tabs
- keep the previous decision not to add `downloads` permission or download event cancellation

Closes #1132, closes #1133.

## Validation
- `pnpm run validate:push`
- pre-push hook: `pnpm run validate:push`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Temp contexts now consistently start from a blank initial tab/window before navigating to the target URL.
  * Temp-window downloads are blocked more reliably using browser-specific mechanisms (Chrome per-tab rules + Firefox request cancellation).

* **Bug Fixes**
  * Improved installation/teardown of download-block rules, including best-effort cleanup on failures and during context destruction.
  * Check-in fallback logic now treats HTTP 404/405 (and “method not allowed”) as unsupported to avoid unnecessary fallbacks.

* **Tests**
  * Added/updated coverage for temp download-block rule lifecycle, rule failure paths, and the updated fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->