### PR TITLE
fix(auto-checkin): limit concurrent account checkins

### DIFF
--- a/src/services/checkin/autoCheckin/scheduler.ts
+++ b/src/services/checkin/autoCheckin/scheduler.ts
@@ -237,6 +237,7 @@ class AutoCheckinScheduler {
   private static readonly DAILY_ALARM_NAME = "autoCheckinDaily"
   private static readonly RETRY_ALARM_NAME = "autoCheckinRetry"
   private static readonly DETERMINISTIC_CATCH_UP_DELAY_MS = 60_000
+  private static readonly CHECKIN_EXECUTION_BATCH_SIZE = 3
   private isInitialized = false
 
   /**
@@ -1010,6 +1011,43 @@ class AutoCheckinScheduler {
         successful: false,
       }
     }
+  }
+
+  private async runAccountCheckinsInBatches(params: {
+    accounts: SiteAccount[]
+    accountDisplayNameById: Map<string, string>
+  }): Promise<
+    Array<{
+      result: CheckinAccountResult
+      successful: boolean
+    }>
+  > {
+    const outcomes: Array<{
+      result: CheckinAccountResult
+      successful: boolean
+    }> = []
+
+    for (
+      let index = 0;
+      index < params.accounts.length;
+      index += AutoCheckinScheduler.CHECKIN_EXECUTION_BATCH_SIZE
+    ) {
+      const batch = params.accounts.slice(
+        index,
+        index + AutoCheckinScheduler.CHECKIN_EXECUTION_BATCH_SIZE,
+      )
+      const batchOutcomes = await Promise.all(
+        batch.map((account) =>
+          this.runAccountCheckin(
+            account,
+            params.accountDisplayNameById.get(account.id) ?? account.id,
+          ),
+        ),
+      )
+      outcomes.push(...batchOutcomes)
+    }
+
+    return outcomes
   }
 
   /**
@@ -2035,18 +2073,14 @@ class AutoCheckinScheduler {
         return
       }
 
-      // Execute check-ins concurrently
+      // Execute check-ins in small batches because some providers open pages.
       let successCount = 0
       let failedCount = 0
 
-      const checkinOutcomes = await Promise.all(
-        runnableAccounts.map((account) =>
-          this.runAccountCheckin(
-            account,
-            accountDisplayNameById.get(account.id) ?? account.id,
-          ),
-        ),
-      )
+      const checkinOutcomes = await this.runAccountCheckinsInBatches({
+        accounts: runnableAccounts,
+        accountDisplayNameById,
+      })
 
       for (const outcome of checkinOutcomes) {
         results[outcome.result.accountId] = outcome.result

--- a/src/services/checkin/autoCheckin/scheduler.ts
+++ b/src/services/checkin/autoCheckin/scheduler.ts
@@ -151,6 +151,8 @@ const AUTO_CHECKIN_BACKGROUND_ANALYTICS_CONTEXT = {
   entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Background,
 } as const
 
+type PostCheckinRefreshOutcome = "refreshed" | "unchanged" | "failed"
+
 /**
  * Scheduler service for Auto Check-in
  *
@@ -159,6 +161,9 @@ const AUTO_CHECKIN_BACKGROUND_ANALYTICS_CONTEXT = {
  * - A separate *retry* alarm retries only the accounts that failed in today's normal run.
  */
 class AutoCheckinScheduler {
+  private static readonly CHECKIN_EXECUTION_BATCH_SIZE = 3
+  private static readonly CHECKIN_EXECUTION_BATCH_DELAY_MS = 250
+
   /**
    * Post-checkin account refresh to ensure balances/quotas reflect the effect of a successful check-in.
    *
@@ -180,29 +185,30 @@ class AutoCheckinScheduler {
         return
       }
 
-      const force = params.force ?? true
-      const batchSize = 3
       let refreshedCount = 0
       let failedCount = 0
 
-      for (let i = 0; i < uniqueAccountIds.length; i += batchSize) {
-        const batch = uniqueAccountIds.slice(i, i + batchSize)
-        const results = await Promise.allSettled(
-          batch.map((accountId) =>
-            accountStorage.refreshAccount(accountId, force),
-          ),
-        )
-
-        for (const result of results) {
-          if (result.status === "fulfilled") {
-            if (result.value?.refreshed === true) {
-              refreshedCount += 1
-            } else if (result.value == null) {
-              failedCount += 1
-            }
-          } else {
-            failedCount += 1
+      const force = params.force ?? true
+      const results = await this.processInBatches({
+        items: uniqueAccountIds,
+        batchSize: AutoCheckinScheduler.CHECKIN_EXECUTION_BATCH_SIZE,
+        processItem: async (accountId): Promise<PostCheckinRefreshOutcome> => {
+          try {
+            const result = await accountStorage.refreshAccount(accountId, force)
+            if (result?.refreshed === true) return "refreshed"
+            if (result == null) return "failed"
+            return "unchanged"
+          } catch {
+            return "failed"
           }
+        },
+      })
+
+      for (const result of results) {
+        if (result === "refreshed") {
+          refreshedCount += 1
+        } else if (result === "failed") {
+          failedCount += 1
         }
       }
 
@@ -237,7 +243,6 @@ class AutoCheckinScheduler {
   private static readonly DAILY_ALARM_NAME = "autoCheckinDaily"
   private static readonly RETRY_ALARM_NAME = "autoCheckinRetry"
   private static readonly DETERMINISTIC_CATCH_UP_DELAY_MS = 60_000
-  private static readonly CHECKIN_EXECUTION_BATCH_SIZE = 3
   private isInitialized = false
 
   /**
@@ -1013,6 +1018,36 @@ class AutoCheckinScheduler {
     }
   }
 
+  private async processInBatches<TItem, TResult>(params: {
+    items: TItem[]
+    batchSize: number
+    processItem: (item: TItem) => Promise<TResult>
+    delayBetweenBatchesMs?: number
+  }): Promise<TResult[]> {
+    const outcomes: TResult[] = []
+    const batchSize = Math.max(1, Math.floor(params.batchSize))
+    const delayBetweenBatchesMs = Math.max(0, params.delayBetweenBatchesMs ?? 0)
+
+    for (let index = 0; index < params.items.length; index += batchSize) {
+      const batch = params.items.slice(index, index + batchSize)
+      const batchOutcomes = await Promise.all(batch.map(params.processItem))
+      outcomes.push(...batchOutcomes)
+
+      const hasMoreBatches = index + batchSize < params.items.length
+      if (hasMoreBatches && delayBetweenBatchesMs > 0) {
+        await this.delay(delayBetweenBatchesMs)
+      }
+    }
+
+    return outcomes
+  }
+
+  private async delay(ms: number): Promise<void> {
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, ms)
+    })
+  }
+
   private async runAccountCheckinsInBatches(params: {
     accounts: SiteAccount[]
     accountDisplayNameById: Map<string, string>
@@ -1022,32 +1057,17 @@ class AutoCheckinScheduler {
       successful: boolean
     }>
   > {
-    const outcomes: Array<{
-      result: CheckinAccountResult
-      successful: boolean
-    }> = []
-
-    for (
-      let index = 0;
-      index < params.accounts.length;
-      index += AutoCheckinScheduler.CHECKIN_EXECUTION_BATCH_SIZE
-    ) {
-      const batch = params.accounts.slice(
-        index,
-        index + AutoCheckinScheduler.CHECKIN_EXECUTION_BATCH_SIZE,
-      )
-      const batchOutcomes = await Promise.all(
-        batch.map((account) =>
-          this.runAccountCheckin(
-            account,
-            params.accountDisplayNameById.get(account.id) ?? account.id,
-          ),
+    return this.processInBatches({
+      items: params.accounts,
+      batchSize: AutoCheckinScheduler.CHECKIN_EXECUTION_BATCH_SIZE,
+      delayBetweenBatchesMs:
+        AutoCheckinScheduler.CHECKIN_EXECUTION_BATCH_DELAY_MS,
+      processItem: (account) =>
+        this.runAccountCheckin(
+          account,
+          params.accountDisplayNameById.get(account.id) ?? account.id,
         ),
-      )
-      outcomes.push(...batchOutcomes)
-    }
-
-    return outcomes
+    })
   }
 
   /**

--- a/src/services/checkin/autoCheckin/scheduler.ts
+++ b/src/services/checkin/autoCheckin/scheduler.ts
@@ -189,19 +189,19 @@ class AutoCheckinScheduler {
       let failedCount = 0
 
       const force = params.force ?? true
-      const results = await this.processInBatches({
+      const results = await this.processInBatches<
+        string,
+        PostCheckinRefreshOutcome
+      >({
         items: uniqueAccountIds,
         batchSize: AutoCheckinScheduler.CHECKIN_EXECUTION_BATCH_SIZE,
-        processItem: async (accountId): Promise<PostCheckinRefreshOutcome> => {
-          try {
-            const result = await accountStorage.refreshAccount(accountId, force)
-            if (result?.refreshed === true) return "refreshed"
-            if (result == null) return "failed"
-            return "unchanged"
-          } catch {
-            return "failed"
-          }
+        processItem: async (accountId) => {
+          const result = await accountStorage.refreshAccount(accountId, force)
+          if (result?.refreshed === true) return "refreshed"
+          if (result == null) return "failed"
+          return "unchanged"
         },
+        onItemError: () => "failed",
       })
 
       for (const result of results) {
@@ -1022,6 +1022,7 @@ class AutoCheckinScheduler {
     items: TItem[]
     batchSize: number
     processItem: (item: TItem) => Promise<TResult>
+    onItemError?: (error: unknown, item: TItem) => TResult | Promise<TResult>
     delayBetweenBatchesMs?: number
   }): Promise<TResult[]> {
     const outcomes: TResult[] = []
@@ -1030,7 +1031,18 @@ class AutoCheckinScheduler {
 
     for (let index = 0; index < params.items.length; index += batchSize) {
       const batch = params.items.slice(index, index + batchSize)
-      const batchOutcomes = await Promise.all(batch.map(params.processItem))
+      const batchOutcomes = await Promise.all(
+        batch.map(async (item) => {
+          try {
+            return await params.processItem(item)
+          } catch (error) {
+            if (!params.onItemError) {
+              throw error
+            }
+            return params.onItemError(error, item)
+          }
+        }),
+      )
       outcomes.push(...batchOutcomes)
 
       const hasMoreBatches = index + batchSize < params.items.length
@@ -1062,6 +1074,17 @@ class AutoCheckinScheduler {
       batchSize: AutoCheckinScheduler.CHECKIN_EXECUTION_BATCH_SIZE,
       delayBetweenBatchesMs:
         AutoCheckinScheduler.CHECKIN_EXECUTION_BATCH_DELAY_MS,
+      onItemError: (error, account) => ({
+        result: {
+          accountId: account.id,
+          accountName:
+            params.accountDisplayNameById.get(account.id) ?? account.id,
+          status: CHECKIN_RESULT_STATUS.FAILED,
+          rawMessage: getErrorMessage(error),
+          timestamp: Date.now(),
+        },
+        successful: false,
+      }),
       processItem: (account) =>
         this.runAccountCheckin(
           account,

--- a/tests/services/autoCheckin/scheduler.test.ts
+++ b/tests/services/autoCheckin/scheduler.test.ts
@@ -1160,6 +1160,80 @@ describe("autoCheckinScheduler daily+retry behavior", () => {
     vi.useRealTimers()
   })
 
+  it("continues later check-in batches when one account task rejects unexpectedly", async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2024, 0, 1, 9, 0, 0))
+
+    mockedUserPreferences.getPreferences.mockResolvedValue({
+      autoCheckin: {
+        ...(DEFAULT_PREFERENCES as any).autoCheckin,
+        globalEnabled: true,
+        notifyUiOnCompletion: false,
+        retryStrategy: {
+          enabled: false,
+          intervalMinutes: 30,
+          maxAttemptsPerDay: 3,
+        },
+      },
+    })
+
+    const accounts = Array.from({ length: 4 }, (_, index) => ({
+      id: `account-${index + 1}`,
+      disabled: false,
+      site_name: `Site ${index + 1}`,
+      site_type: SITE_TYPES.VELOERA,
+      account_info: { username: `user-${index + 1}` },
+      checkIn: { enableDetection: true, autoCheckInEnabled: true },
+    }))
+    mockedAccountStorage.getAllAccounts.mockResolvedValue(accounts)
+
+    const provider = {
+      canCheckIn: vi.fn(() => true),
+      checkIn: vi.fn(async () => ({ status: "success" })),
+    }
+    mockedProviders.resolveAutoCheckinProvider.mockReturnValue(provider)
+
+    const runAccountCheckinSpy = vi
+      .spyOn(autoCheckinScheduler as any, "runAccountCheckin")
+      .mockImplementation(async (...args: unknown[]) => {
+        const account = args[0] as any
+        const accountName = args[1] as string
+        if (account.id === "account-2") {
+          throw new Error("unexpected task failure")
+        }
+        return {
+          result: {
+            accountId: account.id,
+            accountName,
+            status: "success",
+            timestamp: Date.now(),
+          },
+          successful: true,
+        }
+      })
+
+    const runPromise = autoCheckinScheduler.runCheckins({
+      runType: AUTO_CHECKIN_RUN_TYPE.DAILY,
+    })
+    await vi.advanceTimersByTimeAsync(250)
+    await runPromise
+
+    expect(runAccountCheckinSpy).toHaveBeenCalledTimes(4)
+    expect(storedStatus.lastRunResult).toBe("partial")
+    expect(storedStatus.summary).toMatchObject({
+      executed: 4,
+      successCount: 3,
+      failedCount: 1,
+    })
+    expect(storedStatus.perAccount["account-2"]).toMatchObject({
+      status: "failed",
+      rawMessage: "Error: unexpected task failure",
+    })
+
+    runAccountCheckinSpy.mockRestore()
+    vi.useRealTimers()
+  })
+
   it("does not create a retry queue when daily failures already reached the max-attempts boundary", async () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date(2024, 0, 1, 9, 0, 0))

--- a/tests/services/autoCheckin/scheduler.test.ts
+++ b/tests/services/autoCheckin/scheduler.test.ts
@@ -1141,9 +1141,11 @@ describe("autoCheckinScheduler daily+retry behavior", () => {
     expect(maxInFlight).toBeLessThanOrEqual(3)
 
     resolvers.splice(0).forEach((resolve) => resolve())
-    await vi.waitFor(() => {
-      expect(provider.checkIn).toHaveBeenCalledTimes(5)
-    })
+    await vi.advanceTimersByTimeAsync(0)
+    expect(provider.checkIn).toHaveBeenCalledTimes(3)
+
+    await vi.advanceTimersByTimeAsync(250)
+    expect(provider.checkIn).toHaveBeenCalledTimes(5)
     expect(maxInFlight).toBeLessThanOrEqual(3)
 
     resolvers.splice(0).forEach((resolve) => resolve())

--- a/tests/services/autoCheckin/scheduler.test.ts
+++ b/tests/services/autoCheckin/scheduler.test.ts
@@ -1085,6 +1085,79 @@ describe("autoCheckinScheduler daily+retry behavior", () => {
     vi.useRealTimers()
   })
 
+  it("limits concurrent account check-ins during daily runs", async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2024, 0, 1, 9, 0, 0))
+
+    mockedUserPreferences.getPreferences.mockResolvedValue({
+      autoCheckin: {
+        ...(DEFAULT_PREFERENCES as any).autoCheckin,
+        globalEnabled: true,
+        notifyUiOnCompletion: false,
+        retryStrategy: {
+          enabled: false,
+          intervalMinutes: 30,
+          maxAttemptsPerDay: 3,
+        },
+      },
+    })
+
+    const accounts = Array.from({ length: 5 }, (_, index) => ({
+      id: `account-${index + 1}`,
+      disabled: false,
+      site_name: `Site ${index + 1}`,
+      site_type: SITE_TYPES.VELOERA,
+      account_info: { username: `user-${index + 1}` },
+      checkIn: { enableDetection: true, autoCheckInEnabled: true },
+    }))
+    mockedAccountStorage.getAllAccounts.mockResolvedValue(accounts)
+
+    const resolvers: Array<() => void> = []
+    let inFlight = 0
+    let maxInFlight = 0
+    const provider = {
+      canCheckIn: vi.fn(() => true),
+      checkIn: vi.fn(
+        () =>
+          new Promise<{ status: "success" }>((resolve) => {
+            inFlight += 1
+            maxInFlight = Math.max(maxInFlight, inFlight)
+            resolvers.push(() => {
+              inFlight -= 1
+              resolve({ status: "success" })
+            })
+          }),
+      ),
+    }
+    mockedProviders.resolveAutoCheckinProvider.mockReturnValue(provider)
+
+    const runPromise = autoCheckinScheduler.runCheckins({
+      runType: AUTO_CHECKIN_RUN_TYPE.DAILY,
+    })
+
+    await vi.waitFor(() => {
+      expect(provider.checkIn).toHaveBeenCalledTimes(3)
+    })
+    expect(maxInFlight).toBeLessThanOrEqual(3)
+
+    resolvers.splice(0).forEach((resolve) => resolve())
+    await vi.waitFor(() => {
+      expect(provider.checkIn).toHaveBeenCalledTimes(5)
+    })
+    expect(maxInFlight).toBeLessThanOrEqual(3)
+
+    resolvers.splice(0).forEach((resolve) => resolve())
+    await runPromise
+
+    expect(storedStatus.summary).toMatchObject({
+      executed: 5,
+      successCount: 5,
+      failedCount: 0,
+    })
+
+    vi.useRealTimers()
+  })
+
   it("does not create a retry queue when daily failures already reached the max-attempts boundary", async () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date(2024, 0, 1, 9, 0, 0))

--- a/tests/services/autoCheckin/scheduler.test.ts
+++ b/tests/services/autoCheckin/scheduler.test.ts
@@ -5263,6 +5263,18 @@ describe("autoCheckinScheduler private helpers", () => {
     expect(mockedAccountStorage.refreshAccount).not.toHaveBeenCalled()
   })
 
+  it("propagates batch item failures when no item fallback is provided", async () => {
+    await expect(
+      (autoCheckinScheduler as any).processInBatches({
+        items: ["account-1"],
+        batchSize: 3,
+        processItem: async () => {
+          throw new Error("batch item failed")
+        },
+      }),
+    ).rejects.toThrow("batch item failed")
+  })
+
   it("parses time strings and rejects invalid hour or minute values", () => {
     expect((autoCheckinScheduler as any).parseTimeToMinutes("09:30")).toBe(570)
     expect((autoCheckinScheduler as any).parseTimeToMinutes("24:00")).toBeNull()


### PR DESCRIPTION
## Summary
- Limit bulk auto-checkin execution to small batches of 3 accounts
- Preserve existing per-account result aggregation, retry queue behavior, and post-checkin refresh flow
- Add a regression test proving daily auto-checkin no longer launches all runnable accounts at once

Closes #1131

## Validation
- pnpm exec vitest run tests/services/autoCheckin/scheduler.test.ts
- pnpm run validate:staged
- pnpm compile
- pnpm run validate:push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of scheduled daily account check-ins by processing eligible accounts in bounded batches (max concurrency reduced to 3) with controlled pacing between batches.
  * After successful check-ins, post-checkin account refreshes are now processed in batches and outcomes are normalized for more reliable run summaries.
* **Tests**
  * Added a unit test ensuring daily runs never exceed the maximum concurrent check-in limit (and still complete successfully for all eligible accounts).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->