### PR TITLE
fix(runtime-messaging): retry typed message sends

### DIFF
--- a/src/entrypoints/background/contextMenus.ts
+++ b/src/entrypoints/background/contextMenus.ts
@@ -18,7 +18,7 @@ import {
   hasContextMenusAPI,
   onContextMenuClicked,
   removeContextMenu,
-  sendTabMessage,
+  sendTabMessageWithRetry,
 } from "~/utils/browser/browserApi"
 import { createLogger } from "~/utils/core/logger"
 
@@ -68,7 +68,7 @@ const handleContextMenuClick = async (
         return
       }
 
-      await sendTabMessage(tab.id, {
+      await sendTabMessageWithRetry(tab.id, {
         action: RuntimeActionIds.RedemptionAssistContextMenuTrigger,
         selectionText,
         pageUrl,
@@ -77,7 +77,7 @@ const handleContextMenuClick = async (
     }
 
     if (isApiCheckMenu) {
-      await sendTabMessage(tab.id, {
+      await sendTabMessageWithRetry(tab.id, {
         action: RuntimeActionIds.ApiCheckContextMenuTrigger,
         selectionText,
         pageUrl,

--- a/src/entrypoints/background/tempWindowPool.ts
+++ b/src/entrypoints/background/tempWindowPool.ts
@@ -55,7 +55,6 @@ import {
   onWindowRemoved,
   queryTabs,
   removeTabOrWindow,
-  sendTabMessage,
   sendTabMessageWithRetry,
   updateTab,
   updateWindow,
@@ -165,11 +164,17 @@ async function showShieldBypassUiInTab(meta: {
 }) {
   for (let attempt = 1; attempt <= SHIELD_BYPASS_UI_MAX_RETRIES; attempt += 1) {
     try {
-      await sendTabMessage(meta.tabId, {
-        action: RuntimeActionIds.ContentShowShieldBypassUi,
-        origin: meta.origin,
-        requestId: meta.requestId,
-      })
+      await sendTabMessageWithRetry(
+        meta.tabId,
+        {
+          action: RuntimeActionIds.ContentShowShieldBypassUi,
+          origin: meta.origin,
+          requestId: meta.requestId,
+        },
+        {
+          maxAttempts: 1,
+        },
+      )
       logTempWindow("shieldBypassUiShown", {
         tabId: meta.tabId,
         requestId: meta.requestId,

--- a/src/services/accountBrowserSession/sessionReader.ts
+++ b/src/services/accountBrowserSession/sessionReader.ts
@@ -6,7 +6,7 @@ import {
   getAllTabs,
   getBrowserApiCapabilities,
   sendRuntimeMessage,
-  sendTabMessage,
+  sendTabMessageWithRetry,
 } from "~/utils/browser/browserApi"
 import { createLogger } from "~/utils/core/logger"
 import { tryParseOrigin } from "~/utils/core/urlParsing"
@@ -149,7 +149,7 @@ export async function readAccountBrowserSessionFromTab(
   options: ReadAccountBrowserSessionFromTabOptions,
 ): Promise<AccountBrowserSession | null> {
   try {
-    const response = await sendTabMessage(options.tabId, {
+    const response = await sendTabMessageWithRetry(options.tabId, {
       action: RuntimeActionIds.ContentGetUserFromLocalStorage,
       url: options.baseUrl,
       siteType: options.siteType,

--- a/src/services/runtimeMessaging/extensionMessaging.ts
+++ b/src/services/runtimeMessaging/extensionMessaging.ts
@@ -8,8 +8,8 @@ import type {
 
 import {
   onRuntimeMessage,
-  sendRuntimeMessageOnce,
-  sendTabMessage,
+  sendRuntimeMessage,
+  sendTabMessageWithRetry,
 } from "~/utils/browser/browserApi"
 
 export type { Logger } from "@webext-core/messaging"
@@ -237,13 +237,15 @@ export function defineExtensionMessaging<
 
       const response =
         arg == null
-          ? await sendRuntimeMessageOnce(message)
-          : await sendTabMessage(
+          ? await sendRuntimeMessage(message)
+          : await sendTabMessageWithRetry(
               typeof arg === "number" ? arg : arg.tabId,
               message,
-              typeof arg === "object" && arg.frameId != null
-                ? { frameId: arg.frameId }
-                : undefined,
+              {
+                ...(typeof arg === "object" && arg.frameId != null
+                  ? { frameId: arg.frameId }
+                  : {}),
+              },
             )
       const { res, err } = (response ?? {
         err: createNoResponseError(),

--- a/src/utils/browser/browserApi.ts
+++ b/src/utils/browser/browserApi.ts
@@ -147,23 +147,6 @@ export async function queryTabs(
 }
 
 /**
- * Sends a message to a tab without retrying.
- *
- * Use this when a caller intentionally owns missing-receiver fallback behavior.
- */
-export async function sendTabMessage<TResponse = any>(
-  tabId: number,
-  message: unknown,
-  options?: browser.tabs._SendMessageOptions,
-): Promise<TResponse> {
-  if (typeof options === "undefined") {
-    return (await browser.tabs.sendMessage(tabId, message)) as TResponse
-  }
-
-  return (await browser.tabs.sendMessage(tabId, message, options)) as TResponse
-}
-
-/**
  * 移除标签页或窗口
  * 自动检测平台能力并选择合适的 API
  * @param id 目标窗口或标签页的 ID。
@@ -343,19 +326,6 @@ export async function sendRuntimeMessage<TResponse>(
 }
 
 /**
- * Sends a runtime message without retrying.
- *
- * Use this for transports that need to preserve the raw WebExtension messaging
- * contract and handle missing responses themselves.
- */
-export async function sendRuntimeMessageOnce<TResponse = any>(
-  message: unknown,
-  options?: browser.runtime._SendMessageOptions,
-): Promise<TResponse> {
-  return (await browser.runtime.sendMessage(message, options)) as TResponse
-}
-
-/**
  * Sends a runtime message whose `action` is a canonical {@link RuntimeActionId}.
  *
  * This is a thin wrapper over {@link sendRuntimeMessage} that preserves payload
@@ -380,6 +350,10 @@ export interface SendMessageRetryOptions {
   maxAttempts?: number
   delayMs?: number
 }
+
+export interface SendTabMessageRetryOptions
+  extends SendMessageRetryOptions,
+    browser.tabs._SendMessageOptions {}
 
 const RECOVERABLE_MESSAGE_SNIPPETS = [
   "Receiving end does not exist",
@@ -484,20 +458,28 @@ export async function sendMessageWithRetry<TResponse>(
 export async function sendTabMessageWithRetry(
   tabId: number,
   message: unknown,
-  options?: SendMessageRetryOptions,
+  options?: SendTabMessageRetryOptions,
 ): Promise<any>
 export async function sendTabMessageWithRetry<TResponse>(
   tabId: number,
   message: unknown,
-  options?: SendMessageRetryOptions,
+  options?: SendTabMessageRetryOptions,
 ): Promise<TResponse>
 export async function sendTabMessageWithRetry<TResponse>(
   tabId: number,
   message: unknown,
-  options?: SendMessageRetryOptions,
+  options?: SendTabMessageRetryOptions,
 ): Promise<TResponse> {
+  const sendOptions: browser.tabs._SendMessageOptions | undefined =
+    typeof options?.frameId === "number"
+      ? { frameId: options.frameId }
+      : undefined
+
   return await withMessageRetry(
-    () => browser.tabs.sendMessage(tabId, message) as Promise<TResponse>,
+    () =>
+      (sendOptions
+        ? browser.tabs.sendMessage(tabId, message, sendOptions)
+        : browser.tabs.sendMessage(tabId, message)) as Promise<TResponse>,
     options,
     { maxAttempts: 5, delayMs: 400 },
   )

--- a/src/utils/browser/browserApi.ts
+++ b/src/utils/browser/browserApi.ts
@@ -353,7 +353,9 @@ export interface SendMessageRetryOptions {
 
 export interface SendTabMessageRetryOptions
   extends SendMessageRetryOptions,
-    browser.tabs._SendMessageOptions {}
+    browser.tabs._SendMessageOptions {
+  documentId?: string
+}
 
 const RECOVERABLE_MESSAGE_SNIPPETS = [
   "Receiving end does not exist",
@@ -470,15 +472,24 @@ export async function sendTabMessageWithRetry<TResponse>(
   message: unknown,
   options?: SendTabMessageRetryOptions,
 ): Promise<TResponse> {
-  const sendOptions: browser.tabs._SendMessageOptions | undefined =
-    typeof options?.frameId === "number"
+  const sendOptions: browser.tabs._SendMessageOptions & {
+    documentId?: string
+  } = {
+    ...(typeof options?.frameId === "number"
       ? { frameId: options.frameId }
-      : undefined
+      : {}),
+    ...(typeof options?.documentId === "string"
+      ? { documentId: options.documentId }
+      : {}),
+  }
+  const hasSendOptions = Object.keys(sendOptions).length > 0
+  // webextension-polyfill types do not yet model Chrome's documentId tab-message target.
+  const typedSendOptions = sendOptions as browser.tabs._SendMessageOptions
 
   return await withMessageRetry(
     () =>
-      (sendOptions
-        ? browser.tabs.sendMessage(tabId, message, sendOptions)
+      (hasSendOptions
+        ? browser.tabs.sendMessage(tabId, message, typedSendOptions)
         : browser.tabs.sendMessage(tabId, message)) as Promise<TResponse>,
     options,
     { maxAttempts: 5, delayMs: 400 },

--- a/tests/features/AccountManagement/hooks/AccountDataContext.currentTabDetection.test.tsx
+++ b/tests/features/AccountManagement/hooks/AccountDataContext.currentTabDetection.test.tsx
@@ -115,7 +115,7 @@ vi.mock("~/utils/browser/browserApi", () => ({
       )
     }
   }),
-  sendTabMessage: vi.fn(
+  sendTabMessageWithRetry: vi.fn(
     (
       tabId: number,
       message: unknown,

--- a/tests/features/AccountManagement/hooks/AccountDataContext.test.tsx
+++ b/tests/features/AccountManagement/hooks/AccountDataContext.test.tsx
@@ -236,7 +236,7 @@ vi.mock("~/utils/core/logger", () => ({
 vi.mock("~/utils/browser/browserApi", () => ({
   getActiveTabs: mockGetActiveTabs,
   getAllTabs: mockGetAllTabs,
-  sendTabMessage: mockSendTabMessage,
+  sendTabMessageWithRetry: mockSendTabMessage,
   onRuntimeMessage: mockOnRuntimeMessage,
   onTabActivated: mockOnTabActivated,
   onTabRemoved: mockOnTabRemoved,

--- a/tests/services/accountBrowserSession/sessionReader.test.ts
+++ b/tests/services/accountBrowserSession/sessionReader.test.ts
@@ -26,7 +26,7 @@ vi.mock("~/utils/browser/browserApi", () => ({
   getAllTabs: mockGetAllTabs,
   getBrowserApiCapabilities: mockGetBrowserApiCapabilities,
   sendRuntimeMessage: mockSendRuntimeMessage,
-  sendTabMessage: mockSendTabMessage,
+  sendTabMessageWithRetry: mockSendTabMessage,
 }))
 
 describe("account browser-session reader", () => {

--- a/tests/services/runtimeMessaging/extensionMessaging.test.ts
+++ b/tests/services/runtimeMessaging/extensionMessaging.test.ts
@@ -268,6 +268,36 @@ describe("extension messaging transport", () => {
     ).rejects.toThrow("No response")
   })
 
+  it("retries receiver-missing runtime sends before preserving the typed response", async () => {
+    const runtime = createRuntimeMock()
+    const messenger = defineExtensionMessaging<TestProtocolMap>()
+    runtime.sendMessage
+      .mockRejectedValueOnce(
+        new Error(
+          "Could not establish connection. Receiving end does not exist.",
+        ),
+      )
+      .mockResolvedValueOnce({ res: { echoed: "pong" } })
+
+    await expect(
+      messenger.sendMessage("test:ping", { value: "pong" }),
+    ).resolves.toEqual({ echoed: "pong" })
+    expect(runtime.sendMessage).toHaveBeenCalledTimes(2)
+  })
+
+  it("does not retry typed listener errors returned by the receiver", async () => {
+    const runtime = createRuntimeMock()
+    const messenger = defineExtensionMessaging<TestProtocolMap>()
+    runtime.sendMessage.mockResolvedValueOnce({
+      err: { message: "listener failed", name: "Error" },
+    })
+
+    await expect(messenger.sendMessage("test:fail")).rejects.toThrow(
+      "listener failed",
+    )
+    expect(runtime.sendMessage).toHaveBeenCalledTimes(1)
+  })
+
   it("targets tabs and frames through tabs.sendMessage", async () => {
     const runtime = createRuntimeMock()
     const messenger = defineExtensionMessaging<TestProtocolMap>()
@@ -282,6 +312,28 @@ describe("extension messaging transport", () => {
       expect.objectContaining({
         type: "test:void",
       }),
+      { frameId: 3 },
+    )
+  })
+
+  it("retries receiver-missing tab sends before preserving the typed response", async () => {
+    const runtime = createRuntimeMock()
+    const messenger = defineExtensionMessaging<TestProtocolMap>()
+    runtime.tabsSendMessage
+      .mockRejectedValueOnce(new Error("Receiving end does not exist"))
+      .mockResolvedValueOnce({ res: { echoed: "from tab" } })
+
+    await expect(
+      messenger.sendMessage(
+        "test:ping",
+        { value: "from tab" },
+        { tabId: 7, frameId: 3 },
+      ),
+    ).resolves.toEqual({ echoed: "from tab" })
+    expect(runtime.tabsSendMessage).toHaveBeenCalledTimes(2)
+    expect(runtime.tabsSendMessage).toHaveBeenLastCalledWith(
+      7,
+      expect.objectContaining({ type: "test:ping" }),
       { frameId: 3 },
     )
   })

--- a/tests/utils/browserApi.test.ts
+++ b/tests/utils/browserApi.test.ts
@@ -548,6 +548,27 @@ describe("browserApi sendTabMessageWithRetry", () => {
       })(),
     ).resolves.toEqual({ ok: true })
   })
+
+  it("forwards tab message targeting options", async () => {
+    const sendMessageMock = vi.fn().mockResolvedValue({ ok: true })
+    ;(globalThis as any).browser = { tabs: { sendMessage: sendMessageMock } }
+    const message = {
+      action: RuntimeActionIds.PermissionsCheck,
+      payload: { ok: true },
+    }
+
+    await expect(
+      sendTabMessageWithRetry(123, message, {
+        frameId: 7,
+        documentId: "document-1",
+      }),
+    ).resolves.toEqual({ ok: true })
+
+    expect(sendMessageMock).toHaveBeenCalledWith(123, message, {
+      frameId: 7,
+      documentId: "document-1",
+    })
+  })
 })
 
 describe("browserApi direct adapter helpers", () => {

--- a/tests/utils/browserApi.test.ts
+++ b/tests/utils/browserApi.test.ts
@@ -68,8 +68,6 @@ import {
   requestPermissionsDetailed,
   requestRuntimeUpdateCheck,
   sendRuntimeActionMessage,
-  sendRuntimeMessageOnce,
-  sendTabMessage,
   sendTabMessageWithRetry,
   setActionPopup,
   updateWindow,
@@ -599,16 +597,13 @@ describe("browserApi direct adapter helpers", () => {
     ;(globalThis as any).chrome = originalChrome
   })
 
-  it("delegates one-shot tab and runtime operations to the exposed browser APIs", async () => {
+  it("delegates tab operations to the exposed browser APIs", async () => {
     const message = { action: "test" }
 
     await expect(getTab(3)).resolves.toEqual({ id: 3 })
     await expect(reloadTab(3)).resolves.toBeUndefined()
-    await expect(sendTabMessage(3, message)).resolves.toEqual({
+    await expect(sendTabMessageWithRetry(3, message)).resolves.toEqual({
       received: true,
-    })
-    await expect(sendRuntimeMessageOnce(message)).resolves.toEqual({
-      ok: true,
     })
 
     expect((globalThis as any).browser.tabs.get).toHaveBeenCalledWith(3)
@@ -617,9 +612,6 @@ describe("browserApi direct adapter helpers", () => {
       3,
       message,
     )
-    expect(
-      (globalThis as any).browser.runtime.sendMessage,
-    ).toHaveBeenCalledWith(message, undefined)
   })
 
   it("reports runtime id and high-level API capabilities", () => {

--- a/tests/utils/realSiteAccountKeyFlow.test.ts
+++ b/tests/utils/realSiteAccountKeyFlow.test.ts
@@ -50,6 +50,9 @@ vi.mock("~~/e2e/scenarios/modelListCatalog", () => ({
   verifyAccountModelCatalog: mocks.verifyAccountModelCatalog,
 }))
 
+const realSiteDetectionConsoleErrorPattern =
+  /Failed to load resource: .*status of (401|404)/u
+
 describe("runRealSiteAccountSaveFlow", () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -85,7 +88,9 @@ describe("runRealSiteAccountSaveFlow", () => {
       }),
     ).resolves.toBe(fixture)
 
-    expect(installExtensionPageGuards).toHaveBeenCalledWith(page, undefined)
+    expect(installExtensionPageGuards).toHaveBeenCalledWith(page, {
+      ignoreConsoleErrorPatterns: [realSiteDetectionConsoleErrorPattern],
+    })
     expect(runAccountAutoDetectScenario).toHaveBeenCalledOnce()
     expect(runAccountKeyLifecycleScenario).not.toHaveBeenCalled()
 
@@ -154,7 +159,10 @@ describe("runRealSiteAccountSaveFlow", () => {
     })
 
     expect(installExtensionPageGuards).toHaveBeenCalledWith(page, {
-      ignoreConsoleErrorPatterns: [/known real-site warning/u],
+      ignoreConsoleErrorPatterns: [
+        realSiteDetectionConsoleErrorPattern,
+        /known real-site warning/u,
+      ],
     })
   })
 })


### PR DESCRIPTION
## Summary
- Route typed extension runtime and tab messages through the existing retry helpers.
- Remove the raw no-retry message helpers and migrate remaining callers.
- Cover receiver-missing retry behavior for typed runtime and tab messages.

## Validation
- pnpm vitest --run tests/services/runtimeMessaging/extensionMessaging.test.ts tests/utils/browserApi.test.ts tests/services/accountBrowserSession/sessionReader.test.ts
- pnpm run validate:staged
- pnpm run validate:push

Fixes #1139

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of extension-to-tab actions by switching more message sends to a retry-capable mechanism, reducing failures when the page is slow or temporarily unavailable.
  * Updated tab messaging to properly forward optional targeting details (such as frame/document context) during retries.
* **Tests**
  * Expanded messaging tests to verify retry behavior for missing receivers, ensure listener error responses do not retry, and confirm targeting options are passed through correctly.
  * Updated mocks across account/session and messaging tests to use the retry-capable tab messaging API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->