### PR TITLE
fix(webdav): encode move destination headers

### DIFF
--- a/.github/workflows/e2e-real-site.yml
+++ b/.github/workflows/e2e-real-site.yml
@@ -147,6 +147,9 @@ jobs:
             write_env "AAH_E2E_WEBDAV_URL" "$WEBDAV_URL"
             write_env "AAH_E2E_WEBDAV_USERNAME" "$WEBDAV_USERNAME"
             write_env "AAH_E2E_WEBDAV_PASSWORD" "$WEBDAV_PASSWORD"
+            write_env "AAH_E2E_${prefix}_URL" "$WEBDAV_URL"
+            write_env "AAH_E2E_${prefix}_USERNAME" "$WEBDAV_USERNAME"
+            write_env "AAH_E2E_${prefix}_PASSWORD" "$WEBDAV_PASSWORD"
             [ -z "$WEBDAV_URL" ] && missing+=("AAH_E2E_${prefix}_URL")
             [ -z "$WEBDAV_USERNAME" ] && missing+=("AAH_E2E_${prefix}_USERNAME")
             [ -z "$WEBDAV_PASSWORD" ] && missing+=("AAH_E2E_${prefix}_PASSWORD")
@@ -223,7 +226,7 @@ jobs:
         env:
           AAH_SKIP_E2E_BUILD: "1"
           REAL_SITE_SPEC: ${{ matrix.spec }}
-        run: pnpm exec playwright test "$REAL_SITE_SPEC" --project=chromium --reporter=list
+        run: pnpm exec playwright test "$REAL_SITE_SPEC" --project=chromium --reporter=list --no-deps
 
       - name: Upload Playwright artifacts (failure)
         if: failure()

--- a/e2e/realSite/README.md
+++ b/e2e/realSite/README.md
@@ -20,9 +20,9 @@ Provider compatibility checks:
 
 - WebDAV providers: verify the live provider's UI-driven save, connection
   test, upload overwrite, and download/import flow. Nutstore is included as a
-  regression target for existing-file `MOVE` compatibility. CTFile is included
-  as a regression target for providers that reject hidden temporary upload
-  names.
+  regression target for existing-file `MOVE` compatibility and non-ASCII
+  `Destination` header paths. CTFile is included as a regression target for
+  providers that reject hidden temporary upload names.
 
 For current coverage details, inspect the specs in this directory and the shared
 helpers under `e2e/scenarios/`.
@@ -199,11 +199,14 @@ AAH_E2E_SUB2API_PASSWORD=replace-with-test-password
 ## Nutstore WebDAV
 
 Use a dedicated low-value Nutstore app password and a test-only JSON file URL.
+Keep the test file under a clearly named non-ASCII child directory, such as
+`all-api-hub-e2e/中文目录测试`, so the live run also covers percent-encoded WebDAV
+`MOVE` `Destination` headers while reusing the existing test root collection.
 The spec deletes this exact file before and after the run. The local WebDAV
 runner selects these variables by default.
 
 ```env
-AAH_E2E_NUTSTORE_WEBDAV_URL=https://dav.jianguoyun.com/dav/all-api-hub-e2e/all-api-hub-nutstore-move.json
+AAH_E2E_NUTSTORE_WEBDAV_URL=https://dav.jianguoyun.com/dav/all-api-hub-e2e/中文目录测试/all-api-hub-nutstore-move.json
 AAH_E2E_NUTSTORE_WEBDAV_USERNAME=test-user@example.com
 AAH_E2E_NUTSTORE_WEBDAV_PASSWORD=replace-with-nutstore-app-password
 ```

--- a/src/services/webdav/webdavService.ts
+++ b/src/services/webdav/webdavService.ts
@@ -178,6 +178,20 @@ function joinWebdavUrl(baseUrl: string, fileName: string) {
 }
 
 /**
+ * Encodes WebDAV URLs before they are placed in request headers.
+ *
+ * Browser header values are ByteStrings, so non-ASCII path segments such as
+ * Jianguoyun/Nutstore Chinese folder names must be percent-encoded first.
+ */
+function encodeWebdavHeaderUrl(url: string) {
+  try {
+    return new URL(url).toString()
+  } catch {
+    return encodeURI(url)
+  }
+}
+
+/**
  * Creates a compact UTC timestamp for temporary backup names.
  */
 function createTimestampForTempFile(now: number = Date.now()) {
@@ -397,7 +411,7 @@ async function moveWebdavContent(params: {
       method: "MOVE",
       headers: {
         Authorization: buildAuthHeader(params.username, params.password),
-        Destination: params.destinationUrl,
+        Destination: encodeWebdavHeaderUrl(params.destinationUrl),
         Overwrite: "T",
       },
     })

--- a/tests/services/webdavService.test.ts
+++ b/tests/services/webdavService.test.ts
@@ -892,6 +892,41 @@ describe("webdavService", () => {
       })
     })
 
+    it("encodes non-ASCII destination URLs before sending them as MOVE headers", async () => {
+      const responses = [
+        { status: 201 },
+        { status: 405 },
+        { status: 204 },
+        {
+          status: 200,
+          text: vi.fn().mockResolvedValue('{"jianguoyun":true}'),
+        },
+        { status: 201 },
+      ]
+      mockedUserPreferences.getPreferences.mockResolvedValue({
+        webdav: {
+          ...basePrefs.webdav,
+          url: "https://dav.jianguoyun.com/dav/all-api-hub-e2e/中文目录测试",
+        },
+      })
+      globalAny.fetch.mockImplementation(
+        async (_url: string, init?: RequestInit) => {
+          expect(() => new Headers(init?.headers)).not.toThrow()
+          return responses.shift()
+        },
+      )
+
+      await expect(uploadBackup('{"jianguoyun":true}')).resolves.toBe(true)
+
+      const moveInit = globalAny.fetch.mock.calls.find(
+        ([, init]: [unknown, RequestInit]) => init?.method === "MOVE",
+      )?.[1] as RequestInit
+      expect(moveInit.headers).toMatchObject({
+        Destination:
+          "https://dav.jianguoyun.com/dav/all-api-hub-e2e/%E4%B8%AD%E6%96%87%E7%9B%AE%E5%BD%95%E6%B5%8B%E8%AF%95/all-api-hub-backup/all-api-hub-1-0.json",
+      })
+    })
+
     it("throws authFailed for 401 from temp readback", async () => {
       mockedUserPreferences.getPreferences.mockResolvedValue(basePrefs)
       globalAny.fetch


### PR DESCRIPTION
## Summary
- Encode WebDAV MOVE `Destination` header URLs so non-ASCII paths are safe for browser `fetch`.
- Add regression coverage for Chinese WebDAV directory paths.
- Fix the real-site WebDAV workflow so category runs execute instead of skipping and provider-prefixed env reaches the spec.
- Document the Nutstore Chinese-directory real-site URL.

## Validation
- `pnpm exec vitest run tests/services/webdavService.test.ts -- -t "encodes non-ASCII destination URLs"`
- `pnpm e2e:real-site:nutstore`
- `pnpm run validate:staged`
- pre-push: `pnpm compile && pnpm knip`
- GitHub Actions Real-Site E2E run `28852435382`: WebDAV / Nutstore and WebDAV / CTFile passed.
- Old-code check run `28851601002`: Nutstore failed after CI-only workflow fixes, confirming the regression coverage is active.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebDAV MOVE requests to properly encode non-ASCII destination paths in the request header.
  * Updated the real-site E2E WebDAV setup to use the correct credential environment variables and run the Playwright suite with reduced setup steps.
* **Documentation**
  * Revised real-site WebDAV guidance to cover non-ASCII MOVE behavior using a non-ASCII test directory and updated default URL.
* **Tests**
  * Added coverage validating that MOVE requests contain percent-encoded destination header values for non-ASCII paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->