### PR TITLE
fix(updates): clarify store rollout pending state

### DIFF
--- a/src/components/ReleaseUpdateStatusPanel.tsx
+++ b/src/components/ReleaseUpdateStatusPanel.tsx
@@ -86,6 +86,8 @@ function getStatusTitle(options: {
       return t("settings:releaseUpdate.states.unavailable")
     case RELEASE_UPDATE_PRESENTATION_STATES.StoreUpdateReady:
       return t("settings:releaseUpdate.states.storeUpdateReady")
+    case RELEASE_UPDATE_PRESENTATION_STATES.StoreUpdatePending:
+      return t("settings:releaseUpdate.states.storeUpdatePending")
     case RELEASE_UPDATE_PRESENTATION_STATES.UpdateAvailable:
       return t("settings:releaseUpdate.states.updateAvailable")
     case RELEASE_UPDATE_PRESENTATION_STATES.CheckFailed:
@@ -117,6 +119,8 @@ function getStatusHelper(options: {
       return t("settings:releaseUpdate.helpers.unavailable")
     case RELEASE_UPDATE_PRESENTATION_STATES.StoreUpdateReady:
       return t("settings:releaseUpdate.helpers.storeUpdateReady")
+    case RELEASE_UPDATE_PRESENTATION_STATES.StoreUpdatePending:
+      return t("settings:releaseUpdate.helpers.storeUpdate")
     case RELEASE_UPDATE_PRESENTATION_STATES.UpdateAvailable:
       switch (reason) {
         case RELEASE_UPDATE_REASONS.StoreBuild:
@@ -232,6 +236,9 @@ export function ReleaseUpdateStatusPanel() {
         return
       case RELEASE_UPDATE_CHECK_OUTCOMES.StoreUpdateReady:
         toast.success(t("settings:releaseUpdate.states.storeUpdateReady"))
+        return
+      case RELEASE_UPDATE_CHECK_OUTCOMES.StoreUpdatePending:
+        toast.success(t("settings:releaseUpdate.states.storeUpdatePending"))
         return
       case RELEASE_UPDATE_CHECK_OUTCOMES.UpdateAvailable:
         toast.success(t("settings:releaseUpdate.states.updateAvailable"))

--- a/src/locales/en/settings.json
+++ b/src/locales/en/settings.json
@@ -467,6 +467,7 @@
     "states": {
       "checkFailed": "Check failed, so the latest stable release could not be retrieved",
       "notChecked": "The latest stable release has not been checked yet. Run a manual check to compare versions",
+      "storeUpdatePending": "GitHub has a newer release, but the store update is not ready yet",
       "storeUpdateReady": "Store update is ready. Reload to apply it",
       "unavailable": "Update status is currently unavailable",
       "updateAvailable": "A newer version is available to upgrade",

--- a/src/locales/es-419/settings.json
+++ b/src/locales/es-419/settings.json
@@ -467,6 +467,7 @@
     "states": {
       "checkFailed": "La comprobación falló, así que no se pudo obtener la última versión estable",
       "notChecked": "La última versión estable aún no se ha comprobado. Ejecuta una comprobación manual para comparar versiones",
+      "storeUpdatePending": "GitHub tiene una versión más nueva, pero la actualización de la tienda aún no está lista",
       "storeUpdateReady": "La actualización de tienda está lista. Recarga para aplicarla",
       "unavailable": "El estado de actualización no está disponible actualmente",
       "updateAvailable": "Hay una versión más nueva disponible para actualizar",

--- a/src/locales/ja/settings.json
+++ b/src/locales/ja/settings.json
@@ -467,6 +467,7 @@
     "states": {
       "checkFailed": "確認に失敗したため、最新安定版の情報を取得できませんでした",
       "notChecked": "最新安定版はまだ確認していません。手動チェックで比較できます",
+      "storeUpdatePending": "GitHub には新しいリリースがありますが、ストア更新はまだ利用できません",
       "storeUpdateReady": "ストア更新を適用できます。再読み込みしてください",
       "unavailable": "更新状態を取得できませんでした",
       "updateAvailable": "アップグレード可能な新しいバージョンがあります",

--- a/src/locales/vi/settings.json
+++ b/src/locales/vi/settings.json
@@ -467,6 +467,7 @@
     "states": {
       "checkFailed": "Kiểm tra thất bại, chưa lấy được thông tin bản chính thức mới nhất",
       "notChecked": "Chưa kiểm tra bản chính thức mới nhất, có thể kiểm tra thủ công",
+      "storeUpdatePending": "GitHub đã có bản phát hành mới hơn, nhưng bản cập nhật trên cửa hàng chưa sẵn sàng",
       "storeUpdateReady": "Bản cập nhật cửa hàng đã sẵn sàng, hãy tải lại để áp dụng",
       "unavailable": "Tạm thời không thể đọc trạng thái cập nhật",
       "updateAvailable": "Phát hiện phiên bản mới có thể nâng cấp",

--- a/src/locales/zh-CN/settings.json
+++ b/src/locales/zh-CN/settings.json
@@ -467,6 +467,7 @@
     "states": {
       "checkFailed": "检查失败，暂未获取最新正式版信息",
       "notChecked": "尚未检查最新正式版，可手动检查",
+      "storeUpdatePending": "GitHub 已发布新版本，商店更新暂未可用",
       "storeUpdateReady": "商店更新已可用，等待重新加载",
       "unavailable": "暂时无法读取更新状态",
       "updateAvailable": "发现可升级的新版本",

--- a/src/locales/zh-TW/settings.json
+++ b/src/locales/zh-TW/settings.json
@@ -467,6 +467,7 @@
     "states": {
       "checkFailed": "檢查失敗，暫未取得最新正式版資訊",
       "notChecked": "尚未檢查最新正式版，可手動檢查",
+      "storeUpdatePending": "GitHub 已發布新版本，商店更新暫未可用",
       "storeUpdateReady": "商店更新已可用，等待重新載入",
       "unavailable": "暫時無法讀取更新狀態",
       "updateAvailable": "發現可升級的新版本",

--- a/src/services/updates/presentation.ts
+++ b/src/services/updates/presentation.ts
@@ -1,10 +1,14 @@
 import type { ReleaseUpdateStatus } from "./releaseUpdateStatus"
-import { BROWSER_STORE_UPDATE_STATUSES } from "./releaseUpdateStatus"
+import {
+  BROWSER_STORE_UPDATE_STATUSES,
+  RELEASE_UPDATE_REASONS,
+} from "./releaseUpdateStatus"
 
 export const RELEASE_UPDATE_PRESENTATION_STATES = {
   Loading: "loading",
   Unavailable: "unavailable",
   StoreUpdateReady: "store-update-ready",
+  StoreUpdatePending: "store-update-pending",
   UpdateAvailable: "update-available",
   CheckFailed: "check-failed",
   UpToDate: "up-to-date",
@@ -27,6 +31,7 @@ type ReleaseUpdateActionKind =
 export const RELEASE_UPDATE_CHECK_OUTCOMES = {
   CheckFailed: "check-failed",
   StoreUpdateReady: "store-update-ready",
+  StoreUpdatePending: "store-update-pending",
   UpdateAvailable: "update-available",
   UpToDate: "up-to-date",
 } as const
@@ -52,7 +57,31 @@ export function getReleaseUpdateLatestVersion(
 export function hasAvailableReleaseUpdate(
   status: ReleaseUpdateStatus | null | undefined,
 ): boolean {
-  return !!(status?.updateAvailable && getReleaseUpdateLatestVersion(status))
+  const latestVersion = getReleaseUpdateLatestVersion(status)
+  if (!status?.updateAvailable || !latestVersion) {
+    return false
+  }
+
+  if (isStoreReleasePending(status)) {
+    return false
+  }
+
+  return true
+}
+
+/**
+ * Store installs may see a newer GitHub release before the browser store has
+ * published or rolled it out. That is informational, not an actionable update.
+ */
+function isStoreReleasePending(
+  status: ReleaseUpdateStatus | null | undefined,
+): boolean {
+  return !!(
+    status?.reason === RELEASE_UPDATE_REASONS.StoreBuild &&
+    status.updateAvailable &&
+    getReleaseUpdateLatestVersion(status) &&
+    status.storeUpdate.status !== BROWSER_STORE_UPDATE_STATUSES.UpdateAvailable
+  )
 }
 
 /**
@@ -97,6 +126,15 @@ export function deriveReleaseUpdatePresentation(options: {
       hasUpdate: true,
       latestVersion,
       state: RELEASE_UPDATE_PRESENTATION_STATES.StoreUpdateReady,
+    }
+  }
+
+  if (isStoreReleasePending(status)) {
+    return {
+      actionKind: RELEASE_UPDATE_ACTION_KINDS.OpenLatest,
+      hasUpdate: false,
+      latestVersion,
+      state: RELEASE_UPDATE_PRESENTATION_STATES.StoreUpdatePending,
     }
   }
 
@@ -158,6 +196,10 @@ export function deriveReleaseUpdateCheckOutcome(
     status.storeUpdate.status === BROWSER_STORE_UPDATE_STATUSES.UpdateAvailable
   ) {
     return RELEASE_UPDATE_CHECK_OUTCOMES.StoreUpdateReady
+  }
+
+  if (isStoreReleasePending(status)) {
+    return RELEASE_UPDATE_CHECK_OUTCOMES.StoreUpdatePending
   }
 
   if (status.lastError) {

--- a/tests/components/ReleaseUpdateStatusPanel.test.tsx
+++ b/tests/components/ReleaseUpdateStatusPanel.test.tsx
@@ -249,6 +249,91 @@ describe("ReleaseUpdateStatusPanel", () => {
     )
   })
 
+  it("shows store rollout pending copy when GitHub is newer but the store has no update yet", () => {
+    mockHook(
+      buildStatus({
+        eligible: true,
+        reason: "store-build",
+        currentVersion: "3.50.0",
+        latestVersion: "3.51.0",
+        updateAvailable: true,
+        releaseUrl:
+          "https://github.com/qixing-jk/all-api-hub/releases/tag/v3.51.0",
+        checkedAt: Date.now(),
+        storeUpdate: {
+          supported: true,
+          status: "no_update",
+          version: "3.50.0",
+        },
+      }),
+    )
+
+    renderSubject()
+
+    expect(
+      screen.getByText("settings:releaseUpdate.states.storeUpdatePending"),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText("settings:releaseUpdate.helpers.storeUpdate"),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByText("settings:releaseUpdate.states.updateAvailable"),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.getByRole("link", {
+        name: "settings:releaseUpdate.openLatest",
+      }),
+    ).toHaveAttribute(
+      "href",
+      "https://github.com/qixing-jk/all-api-hub/releases/tag/v3.51.0",
+    )
+    expect(
+      screen.queryByRole("link", {
+        name: "settings:releaseUpdate.downloadUpdate",
+      }),
+    ).not.toBeInTheDocument()
+  })
+
+  it("shows a store rollout pending toast after checking a store build with no browser update yet", async () => {
+    const user = userEvent.setup()
+
+    mockInteractiveHook({
+      initialStatus: buildStatus({
+        eligible: true,
+        reason: "store-build",
+        storeUpdate: {
+          supported: true,
+          status: "not_checked",
+          version: null,
+        },
+      }),
+      nextStatus: buildStatus({
+        eligible: true,
+        reason: "store-build",
+        currentVersion: "3.50.0",
+        latestVersion: "3.51.0",
+        updateAvailable: true,
+        checkedAt: Date.now(),
+        storeUpdate: {
+          supported: true,
+          status: "no_update",
+          version: "3.50.0",
+        },
+      }),
+    })
+
+    renderSubject()
+    await user.click(
+      screen.getByRole("button", { name: "settings:releaseUpdate.checkNow" }),
+    )
+
+    await waitFor(() => {
+      expect(toastMocks.success).toHaveBeenCalledWith(
+        "settings:releaseUpdate.states.storeUpdatePending",
+      )
+    })
+  })
+
   it("shows an unavailable latest-version line after a failed check", () => {
     mockHook(
       buildStatus({

--- a/tests/components/VersionBadge.test.tsx
+++ b/tests/components/VersionBadge.test.tsx
@@ -124,6 +124,57 @@ describe("VersionBadge", () => {
     )
   })
 
+  it("does not show an update marker for store builds while the store rollout is pending", async () => {
+    const { getExtensionVersion } = await import("~/utils/browser/browserApi")
+    const { getDocsChangelogUrl } = await import("~/utils/navigation/docsLinks")
+    const { useReleaseUpdateStatus } = await import(
+      "~/contexts/ReleaseUpdateStatusContext"
+    )
+
+    vi.mocked(getExtensionVersion).mockReturnValue("3.50.0")
+    vi.mocked(getDocsChangelogUrl).mockReturnValue(
+      "https://example.com/changelog.html#_3-50-0",
+    )
+    vi.mocked(useReleaseUpdateStatus).mockReturnValue({
+      status: {
+        eligible: true,
+        reason: "store-build",
+        currentVersion: "3.50.0",
+        latestVersion: "3.51.0",
+        updateAvailable: true,
+        releaseUrl:
+          "https://github.com/qixing-jk/all-api-hub/releases/tag/v3.51.0",
+        checkedAt: 0,
+        lastError: null,
+        storeUpdate: {
+          supported: true,
+          status: "no_update",
+          version: "3.50.0",
+        },
+      },
+      isLoading: false,
+      isChecking: false,
+      error: null,
+      refresh: vi.fn(),
+      checkNow: vi.fn(),
+    })
+
+    render(<VersionBadge />, { withReleaseUpdateStatusProvider: false })
+
+    const link = await screen.findByRole("link", {
+      name: "changelog for v3.50.0",
+    })
+    expect(link).toHaveAttribute(
+      "href",
+      "https://example.com/changelog.html#_3-50-0",
+    )
+    expect(
+      screen.queryByRole("link", {
+        name: "update available for v3.50.0",
+      }),
+    ).not.toBeInTheDocument()
+  })
+
   it("uses the translated aria label while keeping the visible version compact", async () => {
     const { getExtensionVersion } = await import("~/utils/browser/browserApi")
     const { getDocsChangelogUrl } = await import("~/utils/navigation/docsLinks")


### PR DESCRIPTION
## Summary
- add a store-rollout-pending presentation state for browser-store installs when GitHub has a newer release but the browser store has not published an update yet
- keep the version badge from showing an actionable update marker in that pending store state
- add localized copy across app locales

## Validation
- pnpm vitest run tests/components/ReleaseUpdateStatusPanel.test.tsx tests/components/VersionBadge.test.tsx
- pnpm run i18n:extract:ci
- pnpm vitest run tests/components/ReleaseUpdateStatusPanel.test.tsx tests/components/VersionBadge.test.tsx tests/utils/i18nLocaleValidation.test.ts
- pnpm compile
- pnpm run validate:staged
- pnpm run validate:push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “store update pending” status for release updates, with localized messaging across supported languages.
  * When a newer release exists but the store update isn’t ready yet, the app now shows a dedicated status and points users to the latest release page.

* **Bug Fixes**
  * Improved release-update checks so pending store rollouts are handled separately from regular updates.
  * Updated related UI behavior so users don’t see a direct download option when the store update is still pending.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->