### PR TITLE
fix(key-management): stabilize New API duplicate channel checks

### DIFF
--- a/src/features/KeyManagement/KeyManagement.tsx
+++ b/src/features/KeyManagement/KeyManagement.tsx
@@ -141,6 +141,7 @@ export default function KeyManagement(props: {
     getVisibleTokenKey,
     refreshManagedSiteTokenStatuses,
     refreshManagedSiteTokenStatusForToken,
+    confirmManagedSiteTokenStatusWithChannelKey,
     copyKey,
     copyServiceCredential,
     rotateServiceCredential,
@@ -261,11 +262,14 @@ export default function KeyManagement(props: {
           resolvedChannelKey = key
         },
         onLoaded: async () => {
-          await refreshManagedSiteTokenStatusForToken(token, {
-            resolvedChannelKeysById: {
-              [candidateChannel.id]: resolvedChannelKey,
+          await confirmManagedSiteTokenStatusWithChannelKey(
+            token,
+            managedSiteStatus,
+            {
+              channelId: candidateChannel.id,
+              channelKey: resolvedChannelKey,
             },
-          })
+          )
         },
         openVerification: verification.openNewApiManagedVerification,
       })

--- a/src/features/KeyManagement/components/ManagedSiteTokenBatchExportDialog.tsx
+++ b/src/features/KeyManagement/components/ManagedSiteTokenBatchExportDialog.tsx
@@ -394,7 +394,7 @@ export function ManagedSiteTokenBatchExportDialog({
 
     const verificationTargets = preview
       ? getPreviewVerificationTargets(preview)
-      : [{ item: requestedItem, candidate: requestedCandidate }]
+      : []
     const targets =
       verificationTargets.length > 0
         ? verificationTargets

--- a/src/features/KeyManagement/components/ManagedSiteTokenBatchExportDialog.tsx
+++ b/src/features/KeyManagement/components/ManagedSiteTokenBatchExportDialog.tsx
@@ -1,9 +1,10 @@
 import type { TFunction } from "i18next"
 import { Loader2, RefreshCcw, SendToBack } from "lucide-react"
-import { useEffect, useMemo, useState } from "react"
+import { useEffect, useMemo, useRef, useState } from "react"
 import toast from "react-hot-toast"
 import { useTranslation } from "react-i18next"
 
+import { ManagedSiteChannelAssessmentSignalsRow } from "~/components/ManagedSiteChannelAssessmentSignals"
 import {
   Badge,
   Button,
@@ -12,6 +13,13 @@ import {
   DestructiveConfirmDialog,
   Modal,
 } from "~/components/ui"
+import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
+import { loadNewApiChannelKeyWithVerification } from "~/features/ManagedSiteVerification/loadNewApiChannelKeyWithVerification"
+import { NewApiManagedVerificationDialog } from "~/features/ManagedSiteVerification/NewApiManagedVerificationDialog"
+import {
+  NEW_API_MANAGED_VERIFICATION_CLOSE_MODES,
+  useNewApiManagedVerification,
+} from "~/features/ManagedSiteVerification/useNewApiManagedVerification"
 import {
   executeManagedSiteTokenBatchExport,
   prepareManagedSiteTokenBatchExportPreview,
@@ -31,6 +39,7 @@ import {
 import type {
   ManagedSiteTokenBatchExportExecutionResult,
   ManagedSiteTokenBatchExportItemInput,
+  ManagedSiteTokenBatchExportMatchedChannel,
   ManagedSiteTokenBatchExportPreview,
   ManagedSiteTokenBatchExportPreviewItem,
 } from "~/types/managedSiteTokenBatchExport"
@@ -42,6 +51,17 @@ import {
 } from "~/types/managedSiteTokenBatchExport"
 import { getErrorMessage } from "~/utils/core/error"
 
+import {
+  applyResolvedChannelKeyToPreviewItem,
+  canEditItemModels,
+  countPreviewItems,
+  getPreviewItemVerificationCandidate,
+  getPreviewVerificationTargets,
+  normalizeModels,
+  shouldSelectPreviewItemByDefault,
+  toModelOptions,
+} from "./managedSiteTokenBatchExportPreview"
+
 interface ManagedSiteTokenBatchExportDialogProps {
   isOpen: boolean
   onClose: () => void
@@ -49,49 +69,8 @@ interface ManagedSiteTokenBatchExportDialogProps {
   onCompleted?: (result: ManagedSiteTokenBatchExportExecutionResult) => void
 }
 
-const canEditItemModels = (item: ManagedSiteTokenBatchExportPreviewItem) =>
-  isExecutablePreviewItem(item) ||
-  (Boolean(item.draft) &&
-    item.status === MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.BLOCKED &&
-    item.blockingReasonCode ===
-      MANAGED_SITE_TOKEN_BATCH_EXPORT_BLOCKED_REASON_CODES.MODELS_REQUIRED)
-
 const formatValues = (items: string[] | undefined) =>
   items && items.length > 0 ? items.join(", ") : "-"
-
-const toModelOptions = (models: string[]) =>
-  models.map((model) => ({ label: model, value: model }))
-
-const normalizeModels = (models: string[]) =>
-  Array.from(new Set(models.map((model) => model.trim()).filter(Boolean)))
-
-const countPreviewItems = (items: ManagedSiteTokenBatchExportPreviewItem[]) =>
-  items.reduce(
-    (accumulator, item) => {
-      switch (item.status) {
-        case MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.READY:
-          accumulator.readyCount += 1
-          break
-        case MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.WARNING:
-          accumulator.warningCount += 1
-          break
-        case MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.SKIPPED:
-          accumulator.skippedCount += 1
-          break
-        case MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.BLOCKED:
-          accumulator.blockedCount += 1
-          break
-      }
-
-      return accumulator
-    },
-    {
-      readyCount: 0,
-      warningCount: 0,
-      skippedCount: 0,
-      blockedCount: 0,
-    },
-  )
 
 const getWarningText = (t: TFunction, code: string) => {
   switch (code) {
@@ -218,6 +197,14 @@ export function ManagedSiteTokenBatchExportDialog({
     "common",
     "channelDialog",
   ])
+  const {
+    newApiBaseUrl,
+    newApiUserId,
+    newApiUsername,
+    newApiPassword,
+    newApiTotpSecret,
+  } = useUserPreferencesContext()
+  const verification = useNewApiManagedVerification()
   const [preview, setPreview] =
     useState<ManagedSiteTokenBatchExportPreview | null>(null)
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
@@ -229,6 +216,10 @@ export function ManagedSiteTokenBatchExportDialog({
   const [executionResult, setExecutionResult] =
     useState<ManagedSiteTokenBatchExportExecutionResult | null>(null)
   const [refreshKey, setRefreshKey] = useState(0)
+  const [verifyingItemId, setVerifyingItemId] = useState<string | null>(null)
+  const resolvedChannelKeysByItemIdRef = useRef<
+    Record<string, Record<number, string>>
+  >({})
 
   useEffect(() => {
     if (!isOpen) {
@@ -241,6 +232,8 @@ export function ManagedSiteTokenBatchExportDialog({
       setIsRunning(false)
       setExecutionResult(null)
       setRefreshKey(0)
+      setVerifyingItemId(null)
+      resolvedChannelKeysByItemIdRef.current = {}
       return
     }
 
@@ -256,13 +249,14 @@ export function ManagedSiteTokenBatchExportDialog({
       try {
         const nextPreview = await prepareManagedSiteTokenBatchExportPreview({
           items,
+          resolvedChannelKeysByItemId: resolvedChannelKeysByItemIdRef.current,
         })
         if (cancelled) return
         setPreview(nextPreview)
         setSelectedIds(
           new Set(
             nextPreview.items
-              .filter(isExecutablePreviewItem)
+              .filter(shouldSelectPreviewItemByDefault)
               .map((item) => item.id),
           ),
         )
@@ -314,6 +308,9 @@ export function ManagedSiteTokenBatchExportDialog({
 
   const handleClose = () => {
     if (isRunning) return
+    if (verification.dialogState.isOpen) {
+      verification.closeDialog()
+    }
     onClose()
   }
 
@@ -321,6 +318,175 @@ export function ManagedSiteTokenBatchExportDialog({
     if (isLoadingPreview || isRunning) return
     setExecutionError(null)
     setRefreshKey((value) => value + 1)
+  }
+
+  const mergeResolvedChannelKeyForItem = (
+    itemId: string,
+    channelId: number,
+    key: string,
+  ) => {
+    resolvedChannelKeysByItemIdRef.current = {
+      ...resolvedChannelKeysByItemIdRef.current,
+      [itemId]: {
+        ...(resolvedChannelKeysByItemIdRef.current[itemId] ?? {}),
+        [channelId]: key,
+      },
+    }
+  }
+
+  const applyResolvedChannelKeyForItem = (
+    item: ManagedSiteTokenBatchExportPreviewItem,
+    candidate: ManagedSiteTokenBatchExportMatchedChannel,
+    resolvedKey: string,
+  ) => {
+    setPreview((currentPreview) => {
+      if (!currentPreview) return currentPreview
+
+      const nextItems = currentPreview.items.map((previewItem) =>
+        previewItem.id === item.id
+          ? applyResolvedChannelKeyToPreviewItem({
+              item: previewItem,
+              candidate,
+              resolvedKey,
+              siteType: currentPreview.siteType,
+            })
+          : previewItem,
+      )
+
+      return {
+        ...currentPreview,
+        items: nextItems,
+        ...countPreviewItems(nextItems),
+      }
+    })
+    setSelectedIds((currentSelectedIds) => {
+      const nextSelectedIds = new Set(currentSelectedIds)
+      const updatedItem = applyResolvedChannelKeyToPreviewItem({
+        item,
+        candidate,
+        resolvedKey,
+        siteType: preview?.siteType,
+      })
+
+      if (
+        updatedItem.status ===
+        MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.SKIPPED
+      ) {
+        nextSelectedIds.delete(item.id)
+      }
+
+      return nextSelectedIds
+    })
+  }
+
+  const handleVerifyAndRefresh = async (
+    requestedItem: ManagedSiteTokenBatchExportPreviewItem,
+    requestedCandidate: ManagedSiteTokenBatchExportMatchedChannel,
+  ) => {
+    if (
+      verifyingItemId ||
+      verification.dialogState.isOpen ||
+      isLoadingPreview ||
+      isRunning
+    ) {
+      return
+    }
+
+    const verificationTargets = preview
+      ? getPreviewVerificationTargets(preview)
+      : [{ item: requestedItem, candidate: requestedCandidate }]
+    const targets =
+      verificationTargets.length > 0
+        ? verificationTargets
+        : [{ item: requestedItem, candidate: requestedCandidate }]
+    const failureMessages: string[] = []
+
+    setExecutionError(null)
+
+    const verifyTargetsFromIndex = async (startIndex: number) => {
+      for (let index = startIndex; index < targets.length; index += 1) {
+        const { item, candidate } = targets[index]
+        let resolvedChannelKey = ""
+        let shouldContinueAfterDeferredLoad = false
+        let loadCompleted = false
+
+        setVerifyingItemId(item.id)
+
+        const handleLoaded = async () => {
+          loadCompleted = true
+          if (resolvedChannelKey) {
+            mergeResolvedChannelKeyForItem(
+              item.id,
+              candidate.id,
+              resolvedChannelKey,
+            )
+            applyResolvedChannelKeyForItem(item, candidate, resolvedChannelKey)
+          }
+          setExecutionError(null)
+          if (shouldContinueAfterDeferredLoad) {
+            await verifyTargetsFromIndex(index + 1)
+          }
+        }
+
+        try {
+          const loadedImmediately = await loadNewApiChannelKeyWithVerification({
+            channelId: candidate.id,
+            label: candidate.name,
+            requestKind: "channel",
+            config: {
+              baseUrl: newApiBaseUrl,
+              userId: newApiUserId,
+              username: newApiUsername,
+              password: newApiPassword,
+              totpSecret: newApiTotpSecret,
+            },
+            setKey: (key) => {
+              resolvedChannelKey = key
+            },
+            onLoaded: handleLoaded,
+            openVerification: (request) =>
+              verification.openNewApiManagedVerification({
+                ...request,
+                closeMode:
+                  NEW_API_MANAGED_VERIFICATION_CLOSE_MODES.CLOSE_AFTER_VERIFICATION,
+              }),
+          })
+
+          if (!loadedImmediately) {
+            if (!loadCompleted) {
+              shouldContinueAfterDeferredLoad = true
+              setVerifyingItemId(null)
+              return
+            }
+          }
+        } catch (error) {
+          failureMessages.push(getErrorMessage(error))
+        }
+      }
+
+      setVerifyingItemId(null)
+      if (failureMessages.length > 0) {
+        setExecutionError(
+          t(
+            "keyManagement:batchManagedSiteExport.messages.verificationFailed",
+            {
+              error: failureMessages.join("; "),
+            },
+          ),
+        )
+      }
+    }
+
+    try {
+      await verifyTargetsFromIndex(0)
+    } catch (error) {
+      setVerifyingItemId(null)
+      setExecutionError(
+        t("keyManagement:batchManagedSiteExport.messages.verificationFailed", {
+          error: getErrorMessage(error),
+        }),
+      )
+    }
   }
 
   const handleToggleAll = () => {
@@ -650,9 +816,43 @@ export function ManagedSiteTokenBatchExportDialog({
             <div className="max-h-[60vh] space-y-3 overflow-y-auto rounded-md border p-3 md:max-h-[min(70vh,48rem)]">
               {preview.items.map((item) => {
                 const badge = getStatusBadge(t, item)
+                const verificationCandidate =
+                  getPreviewItemVerificationCandidate(item, preview.siteType)
                 const result = executionResult?.items.find(
                   (resultItem) => resultItem.id === item.id,
                 )
+                const verificationButton = verificationCandidate ? (
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    leftIcon={
+                      verifyingItemId === item.id ? (
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                      ) : (
+                        <RefreshCcw className="h-4 w-4" />
+                      )
+                    }
+                    disabled={
+                      isLoadingPreview ||
+                      isRunning ||
+                      Boolean(executionResult) ||
+                      verification.dialogState.isOpen ||
+                      Boolean(verifyingItemId)
+                    }
+                    onClick={() =>
+                      void handleVerifyAndRefresh(item, verificationCandidate)
+                    }
+                  >
+                    {verifyingItemId === item.id
+                      ? t(
+                          "keyManagement:batchManagedSiteExport.actions.verifying",
+                        )
+                      : t(
+                          "keyManagement:batchManagedSiteExport.actions.verifyAndRefresh",
+                        )}
+                  </Button>
+                ) : null
 
                 return (
                   <div
@@ -679,7 +879,7 @@ export function ManagedSiteTokenBatchExportDialog({
                           </span>
                         </span>
                       </label>
-                      <div className="flex shrink-0 flex-wrap justify-end gap-2">
+                      <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">
                         {result ? (
                           <Badge
                             variant={
@@ -708,6 +908,7 @@ export function ManagedSiteTokenBatchExportDialog({
                             {badge.label}
                           </Badge>
                         )}
+                        {verificationButton}
                       </div>
                     </div>
 
@@ -782,11 +983,19 @@ export function ManagedSiteTokenBatchExportDialog({
                     ) : null}
 
                     {item.warningCodes.length > 0 ? (
-                      <ul className="list-disc space-y-1 pl-5 text-xs text-amber-700 dark:text-amber-300">
-                        {item.warningCodes.map((code) => (
-                          <li key={code}>{getWarningText(t, code)}</li>
-                        ))}
-                      </ul>
+                      <div className="space-y-2 rounded-md border border-amber-200/70 bg-amber-50/55 p-2 text-xs text-amber-900 dark:border-amber-900/40 dark:bg-amber-950/20 dark:text-amber-100">
+                        <ul className="list-disc space-y-1 pl-4 leading-5">
+                          {item.warningCodes.map((code) => (
+                            <li key={code}>{getWarningText(t, code)}</li>
+                          ))}
+                        </ul>
+                        {item.assessment ? (
+                          <ManagedSiteChannelAssessmentSignalsRow
+                            assessment={item.assessment}
+                            managedSiteType={preview.siteType}
+                          />
+                        ) : null}
+                      </div>
                     ) : null}
 
                     {item.blockingReasonCode ? (
@@ -828,6 +1037,21 @@ export function ManagedSiteTokenBatchExportDialog({
         confirmLabel={t("keyManagement:batchManagedSiteExport.actions.start")}
         cancelLabel={t("common:actions.cancel")}
         isWorking={isRunning}
+      />
+      <NewApiManagedVerificationDialog
+        isOpen={verification.dialogState.isOpen}
+        step={verification.dialogState.step}
+        request={verification.dialogState.request}
+        code={verification.dialogState.code}
+        errorMessage={verification.dialogState.errorMessage}
+        isBusy={verification.dialogState.isBusy}
+        busyMessage={verification.dialogState.busyMessage}
+        onCodeChange={verification.setCode}
+        onClose={verification.closeDialog}
+        onSubmit={verification.submitCode}
+        onRetry={verification.retryVerification}
+        onOpenSite={verification.openBaseUrl}
+        onUpdateRequestConfig={verification.patchRequestConfig}
       />
     </>
   )

--- a/src/features/KeyManagement/components/TokenListItem/TokenHeader.tsx
+++ b/src/features/KeyManagement/components/TokenListItem/TokenHeader.tsx
@@ -736,6 +736,10 @@ export function TokenHeader({
 }: TokenHeaderProps) {
   const { t } = useTranslation(["keyManagement", "common"])
   const { managedSiteType } = useUserPreferencesContext()
+  const [
+    isManagedSiteVerificationRetrying,
+    setIsManagedSiteVerificationRetrying,
+  ] = useState(false)
   const isManagedSiteStatusSupported =
     supportsManagedSiteBaseUrlChannelLookup(managedSiteType)
 
@@ -784,7 +788,11 @@ export function TokenHeader({
     : null
 
   const handleManagedSiteVerificationRetryClick = () => {
-    if (!managedSiteStatus || !onManagedSiteVerificationRetry) {
+    if (
+      isManagedSiteVerificationRetrying ||
+      !managedSiteStatus ||
+      !onManagedSiteVerificationRetry
+    ) {
       return
     }
 
@@ -795,18 +803,21 @@ export function TokenHeader({
       entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Options,
     })
 
-    void Promise.resolve(
-      onManagedSiteVerificationRetry(token, managedSiteStatus),
-    )
-      .then(() => {
+    setIsManagedSiteVerificationRetrying(true)
+
+    void (async () => {
+      try {
+        await onManagedSiteVerificationRetry(token, managedSiteStatus)
         tracker.complete(PRODUCT_ANALYTICS_RESULTS.Success)
-      })
-      .catch((error) => {
+      } catch (error) {
         logger.error("Managed-site verification retry callback failed", error)
         tracker.complete(PRODUCT_ANALYTICS_RESULTS.Failure, {
           errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
         })
-      })
+      } finally {
+        setIsManagedSiteVerificationRetrying(false)
+      }
+    })()
   }
 
   const handleOpenManagedSiteSettings = () => {
@@ -939,6 +950,7 @@ export function TokenHeader({
                 data-testid={
                   KEY_MANAGEMENT_TEST_IDS.managedSiteVerificationRetryButton
                 }
+                loading={isManagedSiteVerificationRetrying}
                 onClick={handleManagedSiteVerificationRetryClick}
               >
                 {t("managedSiteStatus.actions.verifyNow")}

--- a/src/features/KeyManagement/components/managedSiteTokenBatchExportPreview.ts
+++ b/src/features/KeyManagement/components/managedSiteTokenBatchExportPreview.ts
@@ -1,0 +1,188 @@
+import { SITE_TYPES, type ManagedSiteType } from "~/constants/siteType"
+import { applyVerifiedManagedSiteChannelKey } from "~/services/managedSites/verifiedChannelKeyAssessment"
+import type {
+  ManagedSiteTokenBatchExportMatchedChannel,
+  ManagedSiteTokenBatchExportPreview,
+  ManagedSiteTokenBatchExportPreviewItem,
+  ManagedSiteTokenBatchExportWarningCode,
+} from "~/types/managedSiteTokenBatchExport"
+import {
+  isExecutableManagedSiteTokenBatchExportPreviewItem as isExecutablePreviewItem,
+  MANAGED_SITE_TOKEN_BATCH_EXPORT_BLOCKED_REASON_CODES,
+  MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES,
+  MANAGED_SITE_TOKEN_BATCH_EXPORT_WARNING_CODES,
+} from "~/types/managedSiteTokenBatchExport"
+
+export const canEditItemModels = (
+  item: ManagedSiteTokenBatchExportPreviewItem,
+) =>
+  isExecutablePreviewItem(item) ||
+  (Boolean(item.draft) &&
+    item.status === MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.BLOCKED &&
+    item.blockingReasonCode ===
+      MANAGED_SITE_TOKEN_BATCH_EXPORT_BLOCKED_REASON_CODES.MODELS_REQUIRED)
+
+export const toModelOptions = (models: string[]) =>
+  models.map((model) => ({ label: model, value: model }))
+
+export const normalizeModels = (models: string[]) =>
+  Array.from(new Set(models.map((model) => model.trim()).filter(Boolean)))
+
+const hasDuplicateRiskWarning = (
+  item: ManagedSiteTokenBatchExportPreviewItem,
+) =>
+  item.warningCodes.some(
+    (code) =>
+      code ===
+        MANAGED_SITE_TOKEN_BATCH_EXPORT_WARNING_CODES.EXACT_VERIFICATION_UNAVAILABLE ||
+      code ===
+        MANAGED_SITE_TOKEN_BATCH_EXPORT_WARNING_CODES.MATCH_REQUIRES_CONFIRMATION,
+  )
+
+const hasExactVerificationUnavailableWarning = (
+  item: ManagedSiteTokenBatchExportPreviewItem,
+) =>
+  item.warningCodes.includes(
+    MANAGED_SITE_TOKEN_BATCH_EXPORT_WARNING_CODES.EXACT_VERIFICATION_UNAVAILABLE,
+  )
+
+export const shouldSelectPreviewItemByDefault = (
+  item: ManagedSiteTokenBatchExportPreviewItem,
+) => isExecutablePreviewItem(item) && !hasDuplicateRiskWarning(item)
+
+export const getPreviewItemVerificationCandidate = (
+  item: ManagedSiteTokenBatchExportPreviewItem,
+  siteType: ManagedSiteType,
+): ManagedSiteTokenBatchExportMatchedChannel | undefined => {
+  if (
+    siteType !== SITE_TYPES.NEW_API ||
+    !hasExactVerificationUnavailableWarning(item)
+  ) {
+    return undefined
+  }
+
+  return (
+    item.verificationCandidate ??
+    item.matchedChannel ??
+    item.assessment?.url.channel ??
+    item.assessment?.models.channel ??
+    item.assessment?.key.channel
+  )
+}
+
+export const getPreviewVerificationTargets = (
+  preview: ManagedSiteTokenBatchExportPreview,
+) =>
+  preview.items.flatMap((item) => {
+    const candidate = getPreviewItemVerificationCandidate(
+      item,
+      preview.siteType,
+    )
+
+    return candidate ? [{ item, candidate }] : []
+  })
+
+export const countPreviewItems = (
+  items: ManagedSiteTokenBatchExportPreviewItem[],
+) =>
+  items.reduce(
+    (accumulator, item) => {
+      switch (item.status) {
+        case MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.READY:
+          accumulator.readyCount += 1
+          break
+        case MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.WARNING:
+          accumulator.warningCount += 1
+          break
+        case MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.SKIPPED:
+          accumulator.skippedCount += 1
+          break
+        case MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.BLOCKED:
+          accumulator.blockedCount += 1
+          break
+      }
+
+      return accumulator
+    },
+    {
+      readyCount: 0,
+      warningCount: 0,
+      skippedCount: 0,
+      blockedCount: 0,
+    },
+  )
+
+const removeWarningCode = (
+  codes: ManagedSiteTokenBatchExportWarningCode[],
+  codeToRemove: ManagedSiteTokenBatchExportWarningCode,
+): ManagedSiteTokenBatchExportWarningCode[] =>
+  codes.filter((code) => code !== codeToRemove)
+
+const addWarningCode = (
+  codes: ManagedSiteTokenBatchExportWarningCode[],
+  codeToAdd: ManagedSiteTokenBatchExportWarningCode,
+): ManagedSiteTokenBatchExportWarningCode[] =>
+  codes.includes(codeToAdd) ? codes : [...codes, codeToAdd]
+
+export const applyResolvedChannelKeyToPreviewItem = (params: {
+  item: ManagedSiteTokenBatchExportPreviewItem
+  candidate: ManagedSiteTokenBatchExportMatchedChannel
+  resolvedKey: string
+  siteType?: ManagedSiteType
+}): ManagedSiteTokenBatchExportPreviewItem => {
+  const { item, candidate } = params
+  const assessment = item.assessment
+  const normalizedResolvedKey = params.resolvedKey.trim()
+  const normalizedDraftKey = item.draft?.key.trim() ?? ""
+
+  if (!assessment || !normalizedResolvedKey || !normalizedDraftKey) {
+    return item
+  }
+
+  const applied = applyVerifiedManagedSiteChannelKey({
+    assessment,
+    candidate,
+    sourceKey: normalizedDraftKey,
+    verifiedChannelKey: normalizedResolvedKey,
+    siteType: params.siteType,
+  })
+  const nextAssessment = applied.assessment
+
+  if (applied.exactMatch) {
+    return {
+      ...item,
+      status: MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.SKIPPED,
+      warningCodes: removeWarningCode(
+        item.warningCodes,
+        MANAGED_SITE_TOKEN_BATCH_EXPORT_WARNING_CODES.EXACT_VERIFICATION_UNAVAILABLE,
+      ),
+      matchedChannel: candidate,
+      verificationCandidate: undefined,
+      assessment: nextAssessment,
+    }
+  }
+
+  let warningCodes = removeWarningCode(
+    item.warningCodes,
+    MANAGED_SITE_TOKEN_BATCH_EXPORT_WARNING_CODES.EXACT_VERIFICATION_UNAVAILABLE,
+  )
+
+  if (applied.hasAnyMatch) {
+    warningCodes = addWarningCode(
+      warningCodes,
+      MANAGED_SITE_TOKEN_BATCH_EXPORT_WARNING_CODES.MATCH_REQUIRES_CONFIRMATION,
+    )
+  }
+
+  return {
+    ...item,
+    status:
+      warningCodes.length > 0
+        ? MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.WARNING
+        : MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.READY,
+    warningCodes,
+    matchedChannel: undefined,
+    verificationCandidate: undefined,
+    assessment: nextAssessment,
+  }
+}

--- a/src/features/KeyManagement/hooks/useKeyManagement.ts
+++ b/src/features/KeyManagement/hooks/useKeyManagement.ts
@@ -17,7 +17,11 @@ import {
 } from "~/services/accounts/utils/apiServiceRequest"
 import { formatOptionalSkPrefixSiteTokenAuthKey } from "~/services/accountTokens/apiTokenKey"
 import type { ApiServiceRequest } from "~/services/apiTransport/type"
-import { getManagedSiteTokenChannelStatus } from "~/services/managedSites/tokenChannelStatus"
+import { createManagedSiteOperationContext } from "~/services/managedSites/operationContext"
+import {
+  getManagedSiteTokenChannelStatus,
+  resolveManagedSiteTokenChannelStatusWithVerifiedKey,
+} from "~/services/managedSites/tokenChannelStatus"
 import { supportsManagedSiteBaseUrlChannelLookup } from "~/services/managedSites/utils/managedSite"
 import {
   resolveProductAnalyticsErrorCategoryFromError,
@@ -189,6 +193,11 @@ type ManagedSiteTokenChannelStatusResult = Awaited<
 
 interface RefreshManagedSiteTokenStatusOptions {
   resolvedChannelKeysById?: Record<number, string>
+}
+
+interface ConfirmManagedSiteTokenStatusWithChannelKeyOptions {
+  channelId: number
+  channelKey: string
 }
 
 const toDisplayManagedSiteTokenStatusResult = (
@@ -572,6 +581,7 @@ export function useKeyManagement(routeParams?: Record<string, string>) {
         return resultsByIdentityKey
       }
 
+      const operationContext = createManagedSiteOperationContext()
       const runId = force
         ? managedSiteStatusRunIdRef.current + 1
         : managedSiteStatusRunIdRef.current
@@ -613,6 +623,7 @@ export function useKeyManagement(routeParams?: Record<string, string>) {
               account: target.account,
               token: target.token,
               resolvedChannelKeysById: target.resolvedChannelKeysById,
+              operationContext,
             })
             const displayResult = toDisplayManagedSiteTokenStatusResult(result)
 
@@ -1539,6 +1550,80 @@ export function useKeyManagement(routeParams?: Record<string, string>) {
     ],
   )
 
+  const confirmManagedSiteTokenStatusWithChannelKey = useCallback(
+    async (
+      token: AccountToken,
+      status: ManagedSiteTokenChannelStatusResult,
+      options: ConfirmManagedSiteTokenStatusWithChannelKeyOptions,
+    ) => {
+      if (!isManagedSiteChannelStatusSupported) {
+        return
+      }
+
+      if (tokenInventoriesRef.current[token.accountId]?.status !== "loaded") {
+        return
+      }
+
+      const account = accountById.get(token.accountId)
+      if (!account) {
+        return
+      }
+
+      let resolvedToken: AccountToken
+      try {
+        resolvedToken = await resolveDisplayAccountTokenForSecret(
+          account,
+          token,
+        )
+      } catch (error) {
+        logger.warn("Managed-site token secret confirmation failed", {
+          accountId: token.accountId,
+          tokenId: token.id,
+          error,
+        })
+        return
+      }
+
+      const identityKey = buildTokenIdentityKey(token.accountId, token.id)
+      const cacheKey = buildManagedSiteStatusCacheKey(token)
+      const currentEntry = managedSiteTokenStatusesRef.current[identityKey]
+      const result = resolveManagedSiteTokenChannelStatusWithVerifiedKey({
+        status,
+        tokenKey: resolvedToken.key,
+        channelId: options.channelId,
+        channelKey: options.channelKey,
+        siteType: managedSiteType,
+      })
+      const displayResult = toDisplayManagedSiteTokenStatusResult(result)
+
+      mergeResolvedChannelKeysForIdentity(
+        identityKey,
+        result.resolvedChannelKeysById,
+      )
+
+      updateManagedSiteTokenStatuses((prev) => ({
+        ...prev,
+        [identityKey]: {
+          cacheKey,
+          runId: currentEntry?.runId ?? managedSiteStatusRunIdRef.current,
+          isChecking: false,
+          result: displayResult,
+          checkedAt: Date.now(),
+        },
+      }))
+
+      return displayResult
+    },
+    [
+      accountById,
+      buildManagedSiteStatusCacheKey,
+      isManagedSiteChannelStatusSupported,
+      managedSiteType,
+      mergeResolvedChannelKeysForIdentity,
+      updateManagedSiteTokenStatuses,
+    ],
+  )
+
   useEffect(() => {
     isMountedRef.current = true
 
@@ -1961,6 +2046,7 @@ export function useKeyManagement(routeParams?: Record<string, string>) {
     getVisibleTokenKey,
     refreshManagedSiteTokenStatuses,
     refreshManagedSiteTokenStatusForToken,
+    confirmManagedSiteTokenStatusWithChannelKey,
     copyKey,
     copyServiceCredential,
     rotateServiceCredential,

--- a/src/features/KeyManagement/hooks/useKeyManagement.ts
+++ b/src/features/KeyManagement/hooks/useKeyManagement.ts
@@ -1569,6 +1569,11 @@ export function useKeyManagement(routeParams?: Record<string, string>) {
         return
       }
 
+      const identityKey = buildTokenIdentityKey(token.accountId, token.id)
+      const cacheKey = buildManagedSiteStatusCacheKey(token)
+      const entryBeforeResolve =
+        managedSiteTokenStatusesRef.current[identityKey]
+
       let resolvedToken: AccountToken
       try {
         resolvedToken = await resolveDisplayAccountTokenForSecret(
@@ -1581,12 +1586,18 @@ export function useKeyManagement(routeParams?: Record<string, string>) {
           tokenId: token.id,
           error,
         })
+        throw error
+      }
+
+      const currentEntry = managedSiteTokenStatusesRef.current[identityKey]
+      if (
+        !currentEntry ||
+        currentEntry.cacheKey !== cacheKey ||
+        currentEntry.runId !== entryBeforeResolve?.runId
+      ) {
         return
       }
 
-      const identityKey = buildTokenIdentityKey(token.accountId, token.id)
-      const cacheKey = buildManagedSiteStatusCacheKey(token)
-      const currentEntry = managedSiteTokenStatusesRef.current[identityKey]
       const result = resolveManagedSiteTokenChannelStatusWithVerifiedKey({
         status,
         tokenKey: resolvedToken.key,
@@ -1605,7 +1616,7 @@ export function useKeyManagement(routeParams?: Record<string, string>) {
         ...prev,
         [identityKey]: {
           cacheKey,
-          runId: currentEntry?.runId ?? managedSiteStatusRunIdRef.current,
+          runId: currentEntry.runId,
           isChecking: false,
           result: displayResult,
           checkedAt: Date.now(),

--- a/src/features/ManagedSiteVerification/useNewApiManagedVerification.tsx
+++ b/src/features/ManagedSiteVerification/useNewApiManagedVerification.tsx
@@ -10,9 +10,12 @@ import {
 } from "~/services/managedSites/providers/newApiSession"
 import type { NewApiConfig } from "~/types/newApiConfig"
 import { createTab } from "~/utils/browser/browserApi"
+import { createLogger } from "~/utils/core/logger"
 import { t } from "~/utils/i18n/core"
 
 import { getNewApiManagedVerificationErrorMessage } from "./errorMessages"
+
+const logger = createLogger("NewApiManagedVerification")
 
 export const NEW_API_MANAGED_VERIFICATION_STEPS = {
   LOGGING_IN: "logging-in",
@@ -211,6 +214,10 @@ export function useNewApiManagedVerification() {
         await Promise.resolve(request.onVerified())
       } else if (request.onVerified) {
         void Promise.resolve(request.onVerified()).catch((error) => {
+          logger.warn("New API managed verification onVerified failed", {
+            kind: request.kind,
+            error,
+          })
           toast.error(getNewApiManagedVerificationErrorMessage(error))
         })
       }

--- a/src/features/ManagedSiteVerification/useNewApiManagedVerification.tsx
+++ b/src/features/ManagedSiteVerification/useNewApiManagedVerification.tsx
@@ -24,8 +24,16 @@ export const NEW_API_MANAGED_VERIFICATION_STEPS = {
   FAILURE: "failure",
 } as const
 
+export const NEW_API_MANAGED_VERIFICATION_CLOSE_MODES = {
+  CLOSE_AFTER_CALLBACK: "close-after-callback",
+  CLOSE_AFTER_VERIFICATION: "close-after-verification",
+} as const
+
 export type NewApiManagedVerificationStep =
   (typeof NEW_API_MANAGED_VERIFICATION_STEPS)[keyof typeof NEW_API_MANAGED_VERIFICATION_STEPS]
+
+export type NewApiManagedVerificationCloseMode =
+  (typeof NEW_API_MANAGED_VERIFICATION_CLOSE_MODES)[keyof typeof NEW_API_MANAGED_VERIFICATION_CLOSE_MODES]
 
 export interface OpenNewApiManagedVerificationParams {
   kind: "settings" | "token" | "channel"
@@ -35,6 +43,7 @@ export interface OpenNewApiManagedVerificationParams {
   >
   label?: string
   onVerified?: () => Promise<void> | void
+  closeMode?: NewApiManagedVerificationCloseMode
   initialSessionResult?: EnsureNewApiManagedSessionResult
   initialFailureMessage?: string
 }
@@ -87,6 +96,9 @@ const createStoredRequest = (
   kind: request.kind,
   label: request.label,
   onVerified: request.onVerified,
+  closeMode:
+    request.closeMode ??
+    NEW_API_MANAGED_VERIFICATION_CLOSE_MODES.CLOSE_AFTER_VERIFICATION,
   config: normalizeConfig(request.config),
 })
 
@@ -106,6 +118,29 @@ const mapSessionResultToStep = (
     default:
       return NEW_API_MANAGED_VERIFICATION_STEPS.SUCCESS
   }
+}
+
+const shouldRetryInitialSessionWithAutomaticTotp = (
+  result: EnsureNewApiManagedSessionResult | undefined,
+  config: Pick<NewApiConfig, "totpSecret">,
+) => {
+  if (!result || !config.totpSecret?.trim()) {
+    return false
+  }
+
+  if (
+    result.status === NEW_API_MANAGED_SESSION_STATUSES.LOGIN_2FA_REQUIRED &&
+    !result.automaticAttempted
+  ) {
+    return true
+  }
+
+  return (
+    result.status ===
+      NEW_API_MANAGED_SESSION_STATUSES.SECURE_VERIFICATION_REQUIRED &&
+    result.methods.twoFactorEnabled &&
+    !result.automaticAttempted
+  )
 }
 
 /**
@@ -155,7 +190,11 @@ export function useNewApiManagedVerification() {
 
   const finishVerifiedFlow = useCallback(
     async (request: StoredNewApiManagedVerificationRequest) => {
-      if (request.onVerified) {
+      const shouldWaitForVerifiedCallback =
+        request.closeMode !==
+        NEW_API_MANAGED_VERIFICATION_CLOSE_MODES.CLOSE_AFTER_VERIFICATION
+
+      if (request.onVerified && shouldWaitForVerifiedCallback) {
         setState((prev) => ({
           ...prev,
           isBusy: true,
@@ -170,6 +209,10 @@ export function useNewApiManagedVerification() {
         }))
 
         await Promise.resolve(request.onVerified())
+      } else if (request.onVerified) {
+        void Promise.resolve(request.onVerified()).catch((error) => {
+          toast.error(getNewApiManagedVerificationErrorMessage(error))
+        })
       }
 
       showSuccessToast(request)
@@ -247,8 +290,13 @@ export function useNewApiManagedVerification() {
 
       try {
         const result =
-          initialSessionResult ??
-          (await ensureNewApiManagedSession(normalizedRequest.config))
+          !initialSessionResult ||
+          shouldRetryInitialSessionWithAutomaticTotp(
+            initialSessionResult,
+            normalizedRequest.config,
+          )
+            ? await ensureNewApiManagedSession(normalizedRequest.config)
+            : initialSessionResult
         await applySessionResult(normalizedRequest, result)
       } catch (error) {
         setState((prev) => ({

--- a/src/locales/en/keyManagement.json
+++ b/src/locales/en/keyManagement.json
@@ -63,7 +63,9 @@
       "refreshPreview": "Refresh preview",
       "running": "Importing...",
       "selectAll": "{{selected}}/{{total}} selected",
-      "start": "Start import"
+      "start": "Start import",
+      "verifyAndRefresh": "Verify and refresh preview",
+      "verifying": "Verifying..."
     },
     "blockedReasons": {
       "baseUrlRequired": "Base URL is required by the target managed site.",
@@ -90,7 +92,8 @@
     "messages": {
       "completed": "Batch import completed: {{created}} created, {{failed}} failed, {{skipped}} skipped.",
       "duplicate": "Exact match already exists: {{channel}}",
-      "executionFailed": "Failed to run batch import: {{error}}"
+      "executionFailed": "Failed to run batch import: {{error}}",
+      "verificationFailed": "New API verification failed: {{error}}"
     },
     "preview": {
       "loadFailed": "Failed to load preview: {{error}}",

--- a/src/locales/es-419/keyManagement.json
+++ b/src/locales/es-419/keyManagement.json
@@ -66,7 +66,9 @@
       "refreshPreview": "Actualizar vista previa",
       "running": "Importando...",
       "selectAll": "{{selected}}/{{total}} seleccionadas",
-      "start": "Iniciar importación"
+      "start": "Iniciar importación",
+      "verifyAndRefresh": "Verificar y actualizar vista previa",
+      "verifying": "Verificando..."
     },
     "blockedReasons": {
       "baseUrlRequired": "El sitio administrado de destino requiere una URL base.",
@@ -93,7 +95,8 @@
     "messages": {
       "completed": "Importación por lote completada: {{created}} creados, {{failed}} fallidos, {{skipped}} omitidos.",
       "duplicate": "Ya existe una coincidencia exacta: {{channel}}",
-      "executionFailed": "No se pudo ejecutar la importación por lote: {{error}}"
+      "executionFailed": "No se pudo ejecutar la importación por lote: {{error}}",
+      "verificationFailed": "No se pudo verificar New API: {{error}}"
     },
     "preview": {
       "loadFailed": "No se pudo cargar la vista previa: {{error}}",

--- a/src/locales/ja/keyManagement.json
+++ b/src/locales/ja/keyManagement.json
@@ -60,7 +60,9 @@
       "refreshPreview": "プレビューを更新",
       "running": "インポート中...",
       "selectAll": "{{selected}}/{{total}} 選択中",
-      "start": "インポート開始"
+      "start": "インポート開始",
+      "verifyAndRefresh": "検証してプレビューを更新",
+      "verifying": "検証中..."
     },
     "blockedReasons": {
       "baseUrlRequired": "対象の管理対象サイトでは Base URL が必要です。",
@@ -87,7 +89,8 @@
     "messages": {
       "completed": "一括インポート完了: 作成 {{created}} 件、失敗 {{failed}} 件、スキップ {{skipped}} 件。",
       "duplicate": "完全一致するチャネルが既に存在します: {{channel}}",
-      "executionFailed": "一括インポートの実行に失敗しました: {{error}}"
+      "executionFailed": "一括インポートの実行に失敗しました: {{error}}",
+      "verificationFailed": "New API の検証に失敗しました: {{error}}"
     },
     "preview": {
       "loadFailed": "プレビューの読み込みに失敗しました: {{error}}",

--- a/src/locales/vi/keyManagement.json
+++ b/src/locales/vi/keyManagement.json
@@ -60,7 +60,9 @@
       "refreshPreview": "Làm mới bản xem trước",
       "running": "Đang nhập...",
       "selectAll": "Đã chọn {{selected}}/{{total}}",
-      "start": "Bắt đầu nhập"
+      "start": "Bắt đầu nhập",
+      "verifyAndRefresh": "Xác minh và làm mới bản xem trước",
+      "verifying": "Đang xác minh..."
     },
     "blockedReasons": {
       "baseUrlRequired": "Trang web tự quản lý mục tiêu yêu cầu Base URL.",
@@ -87,7 +89,8 @@
     "messages": {
       "completed": "Nhập hàng loạt hoàn tất: thành công {{created}}, thất bại {{failed}}, bỏ qua {{skipped}}.",
       "duplicate": "Đã tồn tại kênh trùng khớp chính xác: {{channel}}",
-      "executionFailed": "Thực thi nhập hàng loạt thất bại: {{error}}"
+      "executionFailed": "Thực thi nhập hàng loạt thất bại: {{error}}",
+      "verificationFailed": "Xác minh New API thất bại: {{error}}"
     },
     "preview": {
       "loadFailed": "Tải bản xem trước thất bại: {{error}}",

--- a/src/locales/zh-CN/keyManagement.json
+++ b/src/locales/zh-CN/keyManagement.json
@@ -60,7 +60,9 @@
       "refreshPreview": "刷新预览",
       "running": "正在导入...",
       "selectAll": "已选 {{selected}}/{{total}}",
-      "start": "开始导入"
+      "start": "开始导入",
+      "verifyAndRefresh": "验证并刷新预览",
+      "verifying": "正在验证..."
     },
     "blockedReasons": {
       "baseUrlRequired": "目标自管理站点要求填写 Base URL。",
@@ -87,7 +89,8 @@
     "messages": {
       "completed": "批量导入完成：成功 {{created}} 个，失败 {{failed}} 个，跳过 {{skipped}} 个。",
       "duplicate": "已存在精确匹配渠道：{{channel}}",
-      "executionFailed": "执行批量导入失败：{{error}}"
+      "executionFailed": "执行批量导入失败：{{error}}",
+      "verificationFailed": "New API 验证失败：{{error}}"
     },
     "preview": {
       "loadFailed": "加载预览失败：{{error}}",

--- a/src/locales/zh-TW/keyManagement.json
+++ b/src/locales/zh-TW/keyManagement.json
@@ -60,7 +60,9 @@
       "refreshPreview": "重新整理預覽",
       "running": "正在匯入...",
       "selectAll": "已選 {{selected}}/{{total}}",
-      "start": "開始匯入"
+      "start": "開始匯入",
+      "verifyAndRefresh": "驗證並重新整理預覽",
+      "verifying": "正在驗證..."
     },
     "blockedReasons": {
       "baseUrlRequired": "目標自管理站點需要 Base URL。",
@@ -87,7 +89,8 @@
     "messages": {
       "completed": "批次匯入完成：成功 {{created}} 個，失敗 {{failed}} 個，跳過 {{skipped}} 個。",
       "duplicate": "已存在精確符合渠道：{{channel}}",
-      "executionFailed": "執行批次匯入失敗：{{error}}"
+      "executionFailed": "執行批次匯入失敗：{{error}}",
+      "verificationFailed": "New API 驗證失敗：{{error}}"
     },
     "preview": {
       "loadFailed": "載入預覽失敗：{{error}}",

--- a/src/services/apiAdapters/contracts/managedSiteCapabilities.ts
+++ b/src/services/apiAdapters/contracts/managedSiteCapabilities.ts
@@ -1,4 +1,5 @@
 import type { ApiResponse } from "~/services/apiTransport/type"
+import type { ManagedSiteOperationContext } from "~/services/managedSites/operationContext"
 import type { ManagedSiteRuntimeConfigValue } from "~/services/managedSites/runtimeConfig"
 import type { AccountToken, ApiToken, DisplaySiteData } from "~/types"
 import type {
@@ -76,6 +77,10 @@ export type ManagedSiteQueriesCapability<
   fetchAccountAvailableModels(config: TConfig): Promise<string[]>
 }
 
+export type ManagedSiteChannelDraftRequestOptions = {
+  operationContext?: ManagedSiteOperationContext
+}
+
 export type ManagedSiteChannelDraftsCapability = {
   fetchAvailableModels(
     account: DisplaySiteData,
@@ -85,6 +90,7 @@ export type ManagedSiteChannelDraftsCapability = {
   prepareFormData(
     account: DisplaySiteData,
     token: ApiToken | AccountToken,
+    options?: ManagedSiteChannelDraftRequestOptions,
   ): Promise<ChannelFormData>
   buildPayload(
     formData: ChannelFormData,

--- a/src/services/managedSites/channelMatchResolver.ts
+++ b/src/services/managedSites/channelMatchResolver.ts
@@ -17,6 +17,7 @@ import {
   normalizeManagedSiteChannelBaseUrl,
 } from "~/services/managedSites/utils/channelMatching"
 import { hasUsableManagedSiteChannelKey } from "~/services/managedSites/utils/managedSite"
+import type { ManagedSiteChannelListData } from "~/types/managedSite"
 
 export type ManagedSiteChannelMatchService = Pick<
   ManagedSiteService,
@@ -26,6 +27,22 @@ export type ManagedSiteChannelMatchService = Pick<
   | "fetchChannelSecretKey"
 >
 
+export interface ManagedSiteChannelMatchRequestCache {
+  searchResultsByBaseUrl: Map<
+    string,
+    Promise<ManagedSiteChannelListData | null>
+  >
+  channelSecretKeysById: Map<number, Promise<string>>
+  resolvedChannelKeysById: Record<number, string>
+}
+
+export const createManagedSiteChannelMatchRequestCache =
+  (): ManagedSiteChannelMatchRequestCache => ({
+    searchResultsByBaseUrl: new Map(),
+    channelSecretKeysById: new Map(),
+    resolvedChannelKeysById: {},
+  })
+
 interface ResolveManagedSiteChannelMatchParams {
   service: ManagedSiteChannelMatchService
   managedConfig: ManagedSiteRuntimeConfigValue
@@ -34,6 +51,7 @@ interface ResolveManagedSiteChannelMatchParams {
   key?: string
   resolvedChannelKeysById?: Record<number, string>
   resolveHiddenKeys?: boolean
+  requestCache?: ManagedSiteChannelMatchRequestCache
 }
 
 interface ManagedSiteChannelMatchResolution
@@ -71,12 +89,26 @@ const fetchRecoverableCandidateSecretKey = async (params: {
   service: ManagedSiteChannelMatchService
   managedConfig: ManagedSiteRuntimeConfigValue
   channelId: number
+  requestCache?: ManagedSiteChannelMatchRequestCache
 }) => {
   try {
-    return await params.service.fetchChannelSecretKey!(
+    const cachedSecretKeyPromise =
+      params.requestCache?.channelSecretKeysById.get(params.channelId)
+
+    if (cachedSecretKeyPromise) {
+      return await cachedSecretKeyPromise
+    }
+
+    const secretKeyPromise = params.service.fetchChannelSecretKey!(
       params.managedConfig,
       params.channelId,
     )
+    params.requestCache?.channelSecretKeysById.set(
+      params.channelId,
+      secretKeyPromise,
+    )
+
+    return await secretKeyPromise
   } catch (error) {
     if (error instanceof MatchResolutionUnresolvedError) {
       throw error
@@ -102,6 +134,7 @@ export async function resolveManagedSiteChannelMatch(
     key,
     resolvedChannelKeysById,
     resolveHiddenKeys = false,
+    requestCache,
   } = params
   const searchBaseUrl = normalizeManagedSiteChannelBaseUrl(
     params.accountBaseUrl,
@@ -111,10 +144,18 @@ export async function resolveManagedSiteChannelMatch(
     service.siteType,
   )
 
-  const searchResults = await service.searchChannel(
-    managedConfig,
-    searchBaseUrl,
-  )
+  let searchResultsPromise =
+    requestCache?.searchResultsByBaseUrl.get(searchBaseUrl)
+
+  if (!searchResultsPromise) {
+    searchResultsPromise = service.searchChannel(managedConfig, searchBaseUrl)
+    requestCache?.searchResultsByBaseUrl.set(
+      searchBaseUrl,
+      searchResultsPromise,
+    )
+  }
+
+  const searchResults = await searchResultsPromise
 
   if (!searchResults) {
     return {
@@ -143,6 +184,7 @@ export async function resolveManagedSiteChannelMatch(
     ? searchResults.items
     : []
   const mergedResolvedChannelKeysById: Record<number, string> = {
+    ...(requestCache?.resolvedChannelKeysById ?? {}),
     ...(resolvedChannelKeysById ?? {}),
   }
 
@@ -292,7 +334,12 @@ export async function resolveManagedSiteChannelMatch(
             service,
             managedConfig,
             channelId: recoverableCandidate.id,
+            requestCache,
           })
+        if (requestCache) {
+          requestCache.resolvedChannelKeysById[recoverableCandidate.id] =
+            mergedResolvedChannelKeysById[recoverableCandidate.id]
+        }
       } catch (error) {
         if (!(error instanceof MatchResolutionUnresolvedError)) {
           throw error
@@ -360,6 +407,10 @@ export async function resolveManagedSiteChannelMatch(
         for (const channel of hydratedCandidates) {
           if (hasUsableManagedSiteChannelKey(channel.key)) {
             mergedResolvedChannelKeysById[channel.id] = channel.key!.trim()
+            if (requestCache) {
+              requestCache.resolvedChannelKeysById[channel.id] =
+                mergedResolvedChannelKeysById[channel.id]
+            }
           }
         }
 

--- a/src/services/managedSites/channelMatchResolver.ts
+++ b/src/services/managedSites/channelMatchResolver.ts
@@ -107,6 +107,14 @@ const fetchRecoverableCandidateSecretKey = async (params: {
       params.channelId,
       secretKeyPromise,
     )
+    secretKeyPromise.catch(() => {
+      if (
+        params.requestCache?.channelSecretKeysById.get(params.channelId) ===
+        secretKeyPromise
+      ) {
+        params.requestCache.channelSecretKeysById.delete(params.channelId)
+      }
+    })
 
     return await secretKeyPromise
   } catch (error) {
@@ -148,11 +156,17 @@ export async function resolveManagedSiteChannelMatch(
     requestCache?.searchResultsByBaseUrl.get(searchBaseUrl)
 
   if (!searchResultsPromise) {
+    const cache = requestCache
     searchResultsPromise = service.searchChannel(managedConfig, searchBaseUrl)
-    requestCache?.searchResultsByBaseUrl.set(
-      searchBaseUrl,
-      searchResultsPromise,
-    )
+    cache?.searchResultsByBaseUrl.set(searchBaseUrl, searchResultsPromise)
+    searchResultsPromise.catch(() => {
+      if (
+        cache &&
+        cache.searchResultsByBaseUrl.get(searchBaseUrl) === searchResultsPromise
+      ) {
+        cache.searchResultsByBaseUrl.delete(searchBaseUrl)
+      }
+    })
   }
 
   const searchResults = await searchResultsPromise

--- a/src/services/managedSites/managedSiteService.ts
+++ b/src/services/managedSites/managedSiteService.ts
@@ -1,5 +1,8 @@
 import { SITE_TYPES, type ManagedSiteType } from "~/constants/siteType"
-import type { ManagedSiteChannelRequestOptions } from "~/services/apiAdapters/contracts/managedSiteCapabilities"
+import type {
+  ManagedSiteChannelDraftRequestOptions,
+  ManagedSiteChannelRequestOptions,
+} from "~/services/apiAdapters/contracts/managedSiteCapabilities"
 import { getSiteTypeCapabilities } from "~/services/apiAdapters/registry"
 import type { ApiResponse } from "~/services/apiTransport/type"
 import {
@@ -79,6 +82,7 @@ export interface ManagedSiteService<
   prepareChannelFormData(
     account: DisplaySiteData,
     token: ApiToken | AccountToken,
+    options?: ManagedSiteChannelDraftRequestOptions,
   ): Promise<ChannelFormData>
 
   buildChannelPayload(

--- a/src/services/managedSites/operationContext.ts
+++ b/src/services/managedSites/operationContext.ts
@@ -1,0 +1,19 @@
+import {
+  createManagedSiteChannelMatchRequestCache,
+  type ManagedSiteChannelMatchRequestCache,
+} from "~/services/managedSites/channelMatchResolver"
+
+export interface ManagedSiteDefaultChannelGroupsCache {
+  resolvedGroups?: Promise<string[]>
+}
+
+export interface ManagedSiteOperationContext {
+  channelMatch: ManagedSiteChannelMatchRequestCache
+  defaultChannelGroups: ManagedSiteDefaultChannelGroupsCache
+}
+
+export const createManagedSiteOperationContext =
+  (): ManagedSiteOperationContext => ({
+    channelMatch: createManagedSiteChannelMatchRequestCache(),
+    defaultChannelGroups: {},
+  })

--- a/src/services/managedSites/providers/defaultChannelGroups.ts
+++ b/src/services/managedSites/providers/defaultChannelGroups.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_CHANNEL_FIELDS } from "~/constants/managedSite"
+import type { ManagedSiteOperationContext } from "~/services/managedSites/operationContext"
 import { normalizeList } from "~/utils/core/string"
 
 type ManagedSiteConfig = {
@@ -11,6 +12,7 @@ type ResolveDefaultChannelGroupsParams = {
   getConfig: () => Promise<ManagedSiteConfig | null>
   fetchSiteUserGroups: (config: ManagedSiteConfig) => Promise<string[]>
   onError?: (error: unknown) => void
+  operationContext?: ManagedSiteOperationContext
 }
 
 /**
@@ -24,7 +26,36 @@ export async function resolveDefaultChannelGroups({
   getConfig,
   fetchSiteUserGroups,
   onError,
+  operationContext,
 }: ResolveDefaultChannelGroupsParams): Promise<string[]> {
+  const requestCache = operationContext?.defaultChannelGroups
+
+  if (requestCache?.resolvedGroups) {
+    return await requestCache.resolvedGroups
+  }
+
+  const resolvedGroupsPromise = resolveDefaultChannelGroupsUncached({
+    getConfig,
+    fetchSiteUserGroups,
+    onError,
+  })
+  if (requestCache) {
+    requestCache.resolvedGroups = resolvedGroupsPromise
+  }
+
+  return await resolvedGroupsPromise
+}
+
+/**
+ * Performs the managed-site group lookup without consulting a batch cache.
+ */
+async function resolveDefaultChannelGroupsUncached({
+  getConfig,
+  fetchSiteUserGroups,
+  onError,
+}: Omit<ResolveDefaultChannelGroupsParams, "operationContext">): Promise<
+  string[]
+> {
   const fallbackGroups = [...DEFAULT_CHANNEL_FIELDS.groups]
 
   try {

--- a/src/services/managedSites/providers/doneHubService.ts
+++ b/src/services/managedSites/providers/doneHubService.ts
@@ -1,6 +1,7 @@
 import { DEFAULT_CHANNEL_FIELDS } from "~/constants/managedSite"
 import { SITE_TYPES } from "~/constants/siteType"
 import { normalizeAccountForManagedChannel } from "~/services/accounts/utils/siteUrlNormalization"
+import type { ManagedSiteChannelDraftRequestOptions } from "~/services/apiAdapters/contracts/managedSiteCapabilities"
 import { createNewApiKeyManagement } from "~/services/apiAdapters/newApi/keyManagement"
 import {
   createChannel as createDoneHubChannel,
@@ -270,6 +271,7 @@ export function buildChannelName(
 export async function prepareChannelFormData(
   account: DisplaySiteData,
   token: ApiToken | AccountToken,
+  options?: ManagedSiteChannelDraftRequestOptions,
 ): Promise<ChannelFormData> {
   const upstreamAccount = normalizeAccountForManagedChannel(account)
   const { models: availableModels, fetchFailed } = await fetchTokenScopedModels(
@@ -288,6 +290,7 @@ export async function prepareChannelFormData(
           userId: config.userId,
         },
       }),
+    operationContext: options?.operationContext,
     onError: (error) => {
       logger.warn("Failed to resolve Done Hub default groups", error)
     },

--- a/src/services/managedSites/providers/newApi.ts
+++ b/src/services/managedSites/providers/newApi.ts
@@ -1,6 +1,7 @@
 import { DEFAULT_CHANNEL_FIELDS } from "~/constants/managedSite"
 import { SITE_TYPES } from "~/constants/siteType"
 import { normalizeAccountForManagedChannel } from "~/services/accounts/utils/siteUrlNormalization"
+import type { ManagedSiteChannelDraftRequestOptions } from "~/services/apiAdapters/contracts/managedSiteCapabilities"
 import {
   createChannel as createNewApiChannel,
   deleteChannel as deleteNewApiChannel,
@@ -336,6 +337,7 @@ export function buildChannelName(
 export async function prepareChannelFormData(
   account: DisplaySiteData,
   token: ApiToken | AccountToken,
+  options?: ManagedSiteChannelDraftRequestOptions,
 ): Promise<ChannelFormData> {
   const upstreamAccount = normalizeAccountForManagedChannel(account)
 
@@ -349,6 +351,7 @@ export async function prepareChannelFormData(
   const resolvedGroups = await resolveDefaultChannelGroups({
     getConfig: getNewApiConfig,
     fetchSiteUserGroups: fetchNewApiConfigUserGroups,
+    operationContext: options?.operationContext,
     onError: (error) => {
       logger.warn("Failed to resolve New API default groups", error)
     },

--- a/src/services/managedSites/providers/veloera.ts
+++ b/src/services/managedSites/providers/veloera.ts
@@ -1,5 +1,6 @@
 import { DEFAULT_CHANNEL_FIELDS } from "~/constants/managedSite"
 import { normalizeAccountForManagedChannel } from "~/services/accounts/utils/siteUrlNormalization"
+import type { ManagedSiteChannelDraftRequestOptions } from "~/services/apiAdapters/contracts/managedSiteCapabilities"
 import {
   fetchAccountAvailableModels,
   fetchSiteUserGroups,
@@ -244,6 +245,7 @@ export function buildChannelName(
 export async function prepareChannelFormData(
   account: DisplaySiteData,
   token: ApiToken | AccountToken,
+  options?: ManagedSiteChannelDraftRequestOptions,
 ): Promise<ChannelFormData> {
   const upstreamAccount = normalizeAccountForManagedChannel(account)
   const tokenModelList = parseDelimitedList(token.models)
@@ -265,6 +267,7 @@ export async function prepareChannelFormData(
           userId: config.userId,
         },
       }),
+    operationContext: options?.operationContext,
     onError: (error) => {
       logger.warn("Failed to resolve Veloera default groups", error)
     },

--- a/src/services/managedSites/tokenBatchExport.ts
+++ b/src/services/managedSites/tokenBatchExport.ts
@@ -6,7 +6,11 @@ import {
   type AccountRuntimeKey,
 } from "~/services/accounts/accountRuntimeKeys"
 import { resolveDisplayAccountRuntimeKeySecret } from "~/services/accounts/utils/apiServiceRequest"
-import { getManagedSiteChannelExactMatch } from "~/services/managedSites/channelMatch"
+import {
+  getManagedSiteChannelExactMatch,
+  getRecoverableManagedSiteChannelCandidate,
+  type ManagedSiteChannelMatchInspection,
+} from "~/services/managedSites/channelMatch"
 import { resolveManagedSiteChannelMatch } from "~/services/managedSites/channelMatchResolver"
 import {
   getManagedSiteService,
@@ -14,15 +18,23 @@ import {
   type ManagedSiteConfig,
   type ManagedSiteService,
 } from "~/services/managedSites/managedSiteService"
+import {
+  createManagedSiteOperationContext,
+  type ManagedSiteOperationContext,
+} from "~/services/managedSites/operationContext"
 import { normalizeManagedSiteChannelBaseUrl } from "~/services/managedSites/utils/channelMatching"
 import {
   collectManagedConfigSecrets,
   hasUsableManagedSiteChannelKey,
   supportsManagedSiteBaseUrlChannelLookup,
 } from "~/services/managedSites/utils/managedSite"
+import {
+  toManagedSiteAssessmentChannel,
+  toManagedSiteVerifiedKeyAssessment,
+} from "~/services/managedSites/verifiedChannelKeyAssessment"
 import { toSanitizedErrorSummary } from "~/services/verification/aiApiVerification/utils"
 import type { AccountToken } from "~/types"
-import type { ChannelFormData, ManagedSiteChannel } from "~/types/managedSite"
+import type { ChannelFormData } from "~/types/managedSite"
 import {
   isExecutableManagedSiteTokenBatchExportPreviewItem,
   MANAGED_SITE_TOKEN_BATCH_EXPORT_BLOCKED_REASON_CODES,
@@ -84,12 +96,27 @@ const getInputRuntimeKeyId = (input: ManagedSiteTokenBatchExportItemInput) =>
 const getInputRuntimeKeyName = (input: ManagedSiteTokenBatchExportItemInput) =>
   input.runtimeKey.label
 
-const toMatchedChannel = (
-  channel: ManagedSiteChannel,
-): { id: number; name: string } => ({
-  id: channel.id,
-  name: channel.name,
-})
+const getVerificationCandidate = (
+  service: ManagedSiteService,
+  resolution: ManagedSiteChannelMatchInspection,
+) => {
+  if (service.siteType !== SITE_TYPES.NEW_API) {
+    return undefined
+  }
+
+  const candidate = getRecoverableManagedSiteChannelCandidate({
+    url: {
+      channel: resolution.url.channel,
+      candidateCount: resolution.url.candidateCount,
+    },
+    models: {
+      channel: resolution.models.channel,
+      reason: resolution.models.reason,
+    },
+  })
+
+  return candidate ? toManagedSiteAssessmentChannel(candidate) : undefined
+}
 
 const buildBasePreviewItem = (
   input: ManagedSiteTokenBatchExportItemInput,
@@ -214,6 +241,8 @@ const preparePreviewItem = async (params: {
   input: ManagedSiteTokenBatchExportItemInput
   service: ManagedSiteService
   managedConfig: ManagedSiteConfig
+  resolvedChannelKeysById?: Record<number, string>
+  operationContext?: ManagedSiteOperationContext
 }): Promise<ManagedSiteTokenBatchExportPreviewItem> => {
   const { input, service, managedConfig } = params
   let secretsToRedact = collectSecrets(input, managedConfig)
@@ -247,6 +276,9 @@ const preparePreviewItem = async (params: {
     const draft = await service.prepareChannelFormData(
       channelDraftAccount,
       resolvedToken,
+      {
+        operationContext: params.operationContext,
+      },
     )
     const blockedReason = getDraftBlockedReason(service, draft)
 
@@ -290,8 +322,15 @@ const preparePreviewItem = async (params: {
       accountBaseUrl: searchBaseUrl,
       models: draft.models,
       key: draft.key,
+      resolvedChannelKeysById: params.resolvedChannelKeysById,
+      resolveHiddenKeys: true,
+      requestCache: params.operationContext?.channelMatch,
     })
     const exactMatch = getManagedSiteChannelExactMatch(resolution)
+    const assessment = toManagedSiteVerifiedKeyAssessment(resolution)
+    const verificationCandidate = getVerificationCandidate(service, resolution)
+    const exactVerificationUnavailable =
+      isExactVerificationUnavailable(resolution)
 
     if (exactMatch) {
       return {
@@ -299,7 +338,8 @@ const preparePreviewItem = async (params: {
         draft,
         status: MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.SKIPPED,
         warningCodes: uniqueWarningCodes(warningCodes),
-        matchedChannel: toMatchedChannel(exactMatch),
+        matchedChannel: toManagedSiteAssessmentChannel(exactMatch),
+        assessment,
       }
     }
 
@@ -307,7 +347,7 @@ const preparePreviewItem = async (params: {
       warningCodes.push(
         MANAGED_SITE_TOKEN_BATCH_EXPORT_WARNING_CODES.BACKEND_SEARCH_FAILED,
       )
-    } else if (isExactVerificationUnavailable(resolution)) {
+    } else if (exactVerificationUnavailable) {
       warningCodes.push(
         MANAGED_SITE_TOKEN_BATCH_EXPORT_WARNING_CODES.EXACT_VERIFICATION_UNAVAILABLE,
       )
@@ -329,6 +369,8 @@ const preparePreviewItem = async (params: {
           ? MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.WARNING
           : MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.READY,
       warningCodes: uniqueWarningCodes(warningCodes),
+      assessment,
+      ...(verificationCandidate ? { verificationCandidate } : {}),
     }
   } catch (error) {
     const diagnostic = toSanitizedErrorSummary(error, secretsToRedact)
@@ -393,9 +435,11 @@ const buildPreview = (
  */
 export async function prepareManagedSiteTokenBatchExportPreview(params: {
   items: ManagedSiteTokenBatchExportItemInput[]
+  resolvedChannelKeysByItemId?: Record<string, Record<number, string>>
 }): Promise<ManagedSiteTokenBatchExportPreview> {
   const service = await getManagedSiteService()
   const managedConfig = await service.getConfig()
+  const operationContext = createManagedSiteOperationContext()
 
   if (!managedConfig) {
     return buildPreview(
@@ -417,6 +461,9 @@ export async function prepareManagedSiteTokenBatchExportPreview(params: {
         input,
         service,
         managedConfig,
+        resolvedChannelKeysById:
+          params.resolvedChannelKeysByItemId?.[getInputRuntimeKeyId(input)],
+        operationContext,
       }),
   )
 

--- a/src/services/managedSites/tokenChannelStatus.ts
+++ b/src/services/managedSites/tokenChannelStatus.ts
@@ -4,10 +4,7 @@ import {
   getManagedSiteChannelExactMatch,
   type ManagedSiteChannelMatchInspection,
 } from "~/services/managedSites/channelMatch"
-import {
-  createManagedSiteChannelMatchRequestCache,
-  resolveManagedSiteChannelMatch,
-} from "~/services/managedSites/channelMatchResolver"
+import { resolveManagedSiteChannelMatch } from "~/services/managedSites/channelMatchResolver"
 import type {
   ManagedSiteConfig,
   ManagedSiteService,
@@ -332,9 +329,7 @@ export async function getManagedSiteTokenChannelStatus(
       key: formData.key,
       resolvedChannelKeysById: params.resolvedChannelKeysById,
       resolveHiddenKeys: true,
-      requestCache:
-        params.operationContext?.channelMatch ??
-        createManagedSiteChannelMatchRequestCache(),
+      requestCache: params.operationContext?.channelMatch,
     })
     const assessment = toManagedSiteVerifiedKeyAssessment(resolution)
     const exactMatch = getManagedSiteChannelExactMatch(resolution)

--- a/src/services/managedSites/tokenChannelStatus.ts
+++ b/src/services/managedSites/tokenChannelStatus.ts
@@ -2,16 +2,18 @@ import { SITE_TYPES } from "~/constants/siteType"
 import { resolveDisplayAccountTokenForSecret } from "~/services/accounts/utils/apiServiceRequest"
 import {
   getManagedSiteChannelExactMatch,
-  type ManagedSiteChannelKeyMatchReasonValue,
   type ManagedSiteChannelMatchInspection,
-  type ManagedSiteChannelModelsMatchReasonValue,
 } from "~/services/managedSites/channelMatch"
-import { resolveManagedSiteChannelMatch } from "~/services/managedSites/channelMatchResolver"
+import {
+  createManagedSiteChannelMatchRequestCache,
+  resolveManagedSiteChannelMatch,
+} from "~/services/managedSites/channelMatchResolver"
 import type {
   ManagedSiteConfig,
   ManagedSiteService,
 } from "~/services/managedSites/managedSiteService"
 import { getManagedSiteService } from "~/services/managedSites/managedSiteService"
+import type { ManagedSiteOperationContext } from "~/services/managedSites/operationContext"
 import { getNewApiLoginAssistConfig } from "~/services/managedSites/providers/newApi"
 import {
   hasNewApiAuthenticatedBrowserSession,
@@ -23,9 +25,15 @@ import {
   collectManagedConfigSecrets,
   supportsManagedSiteBaseUrlChannelLookup,
 } from "~/services/managedSites/utils/managedSite"
+import {
+  applyVerifiedManagedSiteChannelKey,
+  toManagedSiteAssessmentChannel,
+  toManagedSiteVerifiedKeyAssessment,
+  type ManagedSiteAssessmentChannel,
+  type ManagedSiteVerifiedKeyAssessment,
+} from "~/services/managedSites/verifiedChannelKeyAssessment"
 import { toSanitizedErrorSummary } from "~/services/verification/aiApiVerification/utils"
 import type { AccountToken, ApiToken, DisplaySiteData } from "~/types"
-import type { ManagedSiteChannel } from "~/types/managedSite"
 import type { NewApiConfig } from "~/types/newApiConfig"
 import { createLogger } from "~/utils/core/logger"
 
@@ -49,33 +57,11 @@ export const MANAGED_SITE_TOKEN_CHANNEL_STATUS_UNKNOWN_REASONS = {
 export type ManagedSiteTokenChannelStatusUnknownReason =
   (typeof MANAGED_SITE_TOKEN_CHANNEL_STATUS_UNKNOWN_REASONS)[keyof typeof MANAGED_SITE_TOKEN_CHANNEL_STATUS_UNKNOWN_REASONS]
 
-export interface ManagedSiteTokenChannelStatusMatchedChannel {
-  id: number
-  name: string
-}
+export type ManagedSiteTokenChannelStatusMatchedChannel =
+  ManagedSiteAssessmentChannel
 
-export interface ManagedSiteTokenChannelAssessment {
-  searchBaseUrl: string
-  searchCompleted: boolean
-  url: {
-    matched: boolean
-    candidateCount: number
-    channel?: ManagedSiteTokenChannelStatusMatchedChannel
-  }
-  key: {
-    comparable: boolean
-    matched: boolean
-    reason: ManagedSiteChannelKeyMatchReasonValue
-    channel?: ManagedSiteTokenChannelStatusMatchedChannel
-  }
-  models: {
-    comparable: boolean
-    matched: boolean
-    reason: ManagedSiteChannelModelsMatchReasonValue
-    channel?: ManagedSiteTokenChannelStatusMatchedChannel
-    similarityScore?: number
-  }
-}
+export type ManagedSiteTokenChannelAssessment =
+  ManagedSiteVerifiedKeyAssessment<ManagedSiteTokenChannelStatusMatchedChannel>
 
 export interface ManagedSiteTokenChannelRecovery {
   siteType: typeof SITE_TYPES.NEW_API
@@ -131,42 +117,27 @@ interface GetManagedSiteTokenChannelStatusParams {
   service?: ManagedSiteService
   managedConfig?: ManagedSiteConfig | null
   resolvedChannelKeysById?: Record<number, string>
+  operationContext?: ManagedSiteOperationContext
 }
 
-const toMatchedChannelSummary = (
-  channel: ManagedSiteChannel,
-): ManagedSiteTokenChannelStatusMatchedChannel => ({
-  id: channel.id,
-  name: channel.name,
-})
+interface ResolveManagedSiteTokenChannelStatusWithVerifiedKeyParams {
+  status: ManagedSiteTokenChannelStatus
+  tokenKey: string
+  channelId: number
+  channelKey: string
+  siteType?: ManagedSiteService["siteType"] | string
+}
 
-const toOptionalMatchedChannelSummary = (channel: ManagedSiteChannel | null) =>
-  channel ? toMatchedChannelSummary(channel) : undefined
-
-const toManagedSiteTokenChannelAssessment = (
-  inspection: ManagedSiteChannelMatchInspection,
-): ManagedSiteTokenChannelAssessment => ({
-  searchBaseUrl: inspection.searchBaseUrl,
-  searchCompleted: inspection.searchCompleted,
-  url: {
-    matched: inspection.url.matched,
-    candidateCount: inspection.url.candidateCount,
-    channel: toOptionalMatchedChannelSummary(inspection.url.channel),
-  },
-  key: {
-    comparable: inspection.key.comparable,
-    matched: inspection.key.matched,
-    reason: inspection.key.reason,
-    channel: toOptionalMatchedChannelSummary(inspection.key.channel),
-  },
-  models: {
-    comparable: inspection.models.comparable,
-    matched: inspection.models.matched,
-    reason: inspection.models.reason,
-    channel: toOptionalMatchedChannelSummary(inspection.models.channel),
-    similarityScore: inspection.models.similarityScore,
-  },
-})
+const findAssessmentChannelSummary = (
+  assessment: ManagedSiteTokenChannelAssessment,
+  channelId: number,
+) => {
+  return [
+    assessment.key.channel,
+    assessment.models.channel,
+    assessment.url.channel,
+  ].find((channel) => channel?.id === channelId)
+}
 
 const collectSecrets = (
   token: ApiToken | AccountToken,
@@ -184,6 +155,70 @@ const isNewApiConfig = (config: ManagedSiteConfig): config is NewApiConfig =>
 const isExactVerificationUnavailable = (
   resolution: ManagedSiteChannelMatchInspection,
 ) => resolution.url.matched && !resolution.key.comparable
+
+/**
+ * Recomputes a token's managed-site status after a channel key has been
+ * verified, reusing the current assessment instead of running a full check.
+ */
+export function resolveManagedSiteTokenChannelStatusWithVerifiedKey(
+  params: ResolveManagedSiteTokenChannelStatusWithVerifiedKeyParams,
+): ManagedSiteTokenChannelStatus {
+  const assessment =
+    "assessment" in params.status ? params.status.assessment : undefined
+
+  if (!assessment) {
+    return params.status
+  }
+
+  const channelSummary = findAssessmentChannelSummary(
+    assessment,
+    params.channelId,
+  )
+  const resolvedChannelKeysById = {
+    ...(params.status.resolvedChannelKeysById ?? {}),
+    [params.channelId]: params.channelKey,
+  }
+
+  if (!channelSummary) {
+    return {
+      ...params.status,
+      resolvedChannelKeysById,
+    } as ManagedSiteTokenChannelStatus
+  }
+
+  const applied = applyVerifiedManagedSiteChannelKey({
+    assessment,
+    candidate: channelSummary,
+    sourceKey: params.tokenKey,
+    verifiedChannelKey: params.channelKey,
+    siteType: params.siteType,
+  })
+
+  if (applied.exactMatch) {
+    return {
+      status: MANAGED_SITE_TOKEN_CHANNEL_STATUSES.ADDED,
+      matchedChannel: channelSummary,
+      assessment: applied.assessment,
+      resolvedChannelKeysById,
+    }
+  }
+
+  if (applied.hasAnyMatch) {
+    return {
+      status: MANAGED_SITE_TOKEN_CHANNEL_STATUSES.UNKNOWN,
+      reason:
+        MANAGED_SITE_TOKEN_CHANNEL_STATUS_UNKNOWN_REASONS.MATCH_REQUIRES_CONFIRMATION,
+      assessment: applied.assessment,
+      resolvedChannelKeysById,
+    }
+  }
+
+  return {
+    status: MANAGED_SITE_TOKEN_CHANNEL_STATUSES.NOT_ADDED,
+    assessment: applied.assessment,
+    resolvedChannelKeysById,
+  }
+}
 
 const buildNewApiRecoveryMetadata = async (params: {
   managedConfig: NewApiConfig
@@ -274,6 +309,9 @@ export async function getManagedSiteTokenChannelStatus(
         baseUrl: normalizedAccountBaseUrl,
       },
       resolvedToken,
+      {
+        operationContext: params.operationContext,
+      },
     )
     const searchBaseUrl = normalizeManagedSiteChannelBaseUrl(formData.base_url)
 
@@ -294,9 +332,14 @@ export async function getManagedSiteTokenChannelStatus(
       key: formData.key,
       resolvedChannelKeysById: params.resolvedChannelKeysById,
       resolveHiddenKeys: true,
+      requestCache:
+        params.operationContext?.channelMatch ??
+        createManagedSiteChannelMatchRequestCache(),
     })
-    const assessment = toManagedSiteTokenChannelAssessment(resolution)
+    const assessment = toManagedSiteVerifiedKeyAssessment(resolution)
     const exactMatch = getManagedSiteChannelExactMatch(resolution)
+    const exactVerificationUnavailable =
+      isExactVerificationUnavailable(resolution)
     const resolvedChannelKeys =
       resolution.resolvedChannelKeysById &&
       Object.keys(resolution.resolvedChannelKeysById).length > 0
@@ -306,7 +349,7 @@ export async function getManagedSiteTokenChannelStatus(
     if (exactMatch) {
       return {
         status: MANAGED_SITE_TOKEN_CHANNEL_STATUSES.ADDED,
-        matchedChannel: toMatchedChannelSummary(exactMatch),
+        matchedChannel: toManagedSiteAssessmentChannel(exactMatch),
         assessment,
         ...resolvedChannelKeys,
       }
@@ -320,13 +363,13 @@ export async function getManagedSiteTokenChannelStatus(
       }
     }
 
-    if (!formData.key.trim() || isExactVerificationUnavailable(resolution)) {
+    if (!formData.key.trim() || exactVerificationUnavailable) {
       let recovery: ManagedSiteTokenChannelRecovery | undefined
 
       if (
         service.siteType === SITE_TYPES.NEW_API &&
         isNewApiConfig(managedConfig) &&
-        isExactVerificationUnavailable(resolution)
+        exactVerificationUnavailable
       ) {
         try {
           recovery = await buildNewApiRecoveryMetadata({

--- a/src/services/managedSites/utils/channelMatching.ts
+++ b/src/services/managedSites/utils/channelMatching.ts
@@ -54,6 +54,12 @@ interface InspectManagedSiteChannelKeyMatchParams {
   keyComparisonMode?: ManagedSiteChannelKeyComparisonMode
 }
 
+interface InspectManagedSiteChannelKeyValueMatchParams {
+  sourceKey?: string
+  channelKey?: string
+  keyComparisonMode?: ManagedSiteChannelKeyComparisonMode
+}
+
 interface InspectManagedSiteChannelModelsMatchParams {
   channels: ManagedSiteChannel[]
   accountBaseUrl: string
@@ -63,13 +69,15 @@ interface InspectManagedSiteChannelModelsMatchParams {
 
 interface RankedManagedSiteChannelCandidate {
   channel: ManagedSiteChannel
-  reason:
-    | typeof MANAGED_SITE_CHANNEL_MATCH_REASONS.URL_MODELS_EXACT
-    | typeof MANAGED_SITE_CHANNEL_MATCH_REASONS.URL_MODELS_CONTAINED
-    | typeof MANAGED_SITE_CHANNEL_MATCH_REASONS.URL_MODELS_SIMILAR
+  reason: RankedManagedSiteChannelMatchReason
   similarityScore: number
   lengthDelta: number
 }
+
+type RankedManagedSiteChannelMatchReason =
+  | typeof MANAGED_SITE_CHANNEL_MATCH_REASONS.URL_MODELS_EXACT
+  | typeof MANAGED_SITE_CHANNEL_MATCH_REASONS.URL_MODELS_CONTAINED
+  | typeof MANAGED_SITE_CHANNEL_MATCH_REASONS.URL_MODELS_SIMILAR
 
 const MODEL_MATCH_REASON_PRIORITY: Record<
   RankedManagedSiteChannelCandidate["reason"],
@@ -118,14 +126,19 @@ const toComparableChannelKey = (
   return trimmed
 }
 
+const toChannelKeyCandidatesFromString = (
+  key: string,
+  mode: ManagedSiteChannelKeyComparisonMode,
+): string[] =>
+  key
+    .split(/[\n,]/)
+    .map((candidate) => toComparableChannelKey(candidate, mode))
+    .filter(Boolean)
+
 const toChannelKeyCandidates = (
   channel: ManagedSiteChannel,
   mode: ManagedSiteChannelKeyComparisonMode,
-): string[] =>
-  (channel.key ?? "")
-    .split(/[\n,]/)
-    .map((key) => toComparableChannelKey(key, mode))
-    .filter(Boolean)
+): string[] => toChannelKeyCandidatesFromString(channel.key ?? "", mode)
 
 const isSubset = (subset: string[], superset: string[]) =>
   subset.every((item) => superset.includes(item))
@@ -167,6 +180,21 @@ const pickBetterCandidate = (
   }
 
   return current
+}
+
+const toManagedSiteChannelModelsMatchReason = (
+  reason: ManagedSiteChannelMatchResult["reason"],
+) => {
+  switch (reason) {
+    case MANAGED_SITE_CHANNEL_MATCH_REASONS.URL_MODELS_EXACT:
+      return MANAGED_SITE_CHANNEL_MODELS_MATCH_REASONS.EXACT
+    case MANAGED_SITE_CHANNEL_MATCH_REASONS.URL_MODELS_CONTAINED:
+      return MANAGED_SITE_CHANNEL_MODELS_MATCH_REASONS.CONTAINED
+    case MANAGED_SITE_CHANNEL_MATCH_REASONS.URL_MODELS_SIMILAR:
+      return MANAGED_SITE_CHANNEL_MODELS_MATCH_REASONS.SIMILAR
+    default:
+      return MANAGED_SITE_CHANNEL_MODELS_MATCH_REASONS.NO_MATCH
+  }
 }
 
 /**
@@ -333,6 +361,52 @@ export function inspectManagedSiteChannelKeyMatch(
 }
 
 /**
+ * Compares a source token key against a single verified channel-key payload
+ * without requiring a full managed-site channel object.
+ */
+export function inspectManagedSiteChannelKeyValueMatch(
+  params: InspectManagedSiteChannelKeyValueMatchParams,
+): Omit<ManagedSiteChannelKeyAssessment, "channel"> {
+  const keyComparisonMode =
+    params.keyComparisonMode ?? MANAGED_SITE_CHANNEL_KEY_COMPARISON_MODES.EXACT
+  const normalizedSourceKey = toComparableChannelKey(
+    params.sourceKey ?? "",
+    keyComparisonMode,
+  )
+
+  if (!normalizedSourceKey) {
+    return {
+      comparable: false,
+      matched: false,
+      reason: MANAGED_SITE_CHANNEL_KEY_MATCH_REASONS.NO_KEY_PROVIDED,
+    }
+  }
+
+  const channelKeyCandidates = toChannelKeyCandidatesFromString(
+    params.channelKey ?? "",
+    keyComparisonMode,
+  )
+
+  if (channelKeyCandidates.length === 0) {
+    return {
+      comparable: false,
+      matched: false,
+      reason: MANAGED_SITE_CHANNEL_KEY_MATCH_REASONS.COMPARISON_UNAVAILABLE,
+    }
+  }
+
+  const matched = channelKeyCandidates.includes(normalizedSourceKey)
+
+  return {
+    comparable: true,
+    matched,
+    reason: matched
+      ? MANAGED_SITE_CHANNEL_KEY_MATCH_REASONS.MATCHED
+      : MANAGED_SITE_CHANNEL_KEY_MATCH_REASONS.NO_MATCH,
+  }
+}
+
+/**
  * Inspects the strongest model-based result inside the normalized URL bucket.
  */
 export function inspectManagedSiteChannelModelsMatch(
@@ -383,23 +457,10 @@ export function inspectManagedSiteChannelModelsMatch(
     }
   }
 
-  const modelsReason = (() => {
-    switch (bestMatch.reason) {
-      case MANAGED_SITE_CHANNEL_MATCH_REASONS.URL_MODELS_EXACT:
-        return MANAGED_SITE_CHANNEL_MODELS_MATCH_REASONS.EXACT
-      case MANAGED_SITE_CHANNEL_MATCH_REASONS.URL_MODELS_CONTAINED:
-        return MANAGED_SITE_CHANNEL_MODELS_MATCH_REASONS.CONTAINED
-      case MANAGED_SITE_CHANNEL_MATCH_REASONS.URL_MODELS_SIMILAR:
-        return MANAGED_SITE_CHANNEL_MODELS_MATCH_REASONS.SIMILAR
-      default:
-        return MANAGED_SITE_CHANNEL_MODELS_MATCH_REASONS.NO_MATCH
-    }
-  })()
-
   return {
     comparable: true,
     matched: true,
-    reason: modelsReason,
+    reason: toManagedSiteChannelModelsMatchReason(bestMatch.reason),
     channel: bestMatch.channel,
     similarityScore: bestMatch.similarityScore,
   }
@@ -412,14 +473,11 @@ export function findBestManagedSiteChannelMatch(
   params: FindBestManagedSiteChannelMatchParams,
 ): ManagedSiteChannelMatchResult {
   const { channels, accountBaseUrl, models } = params
-  const normalizedAccountBaseUrl =
-    normalizeManagedSiteChannelBaseUrl(accountBaseUrl)
   const normalizedDesiredModels = toNormalizedModelList(models)
-  const urlBucket = channels.filter(
-    (channel) =>
-      normalizeManagedSiteChannelBaseUrl(channel.base_url) ===
-      normalizedAccountBaseUrl,
-  )
+  const urlBucket = findManagedSiteChannelsByBaseUrl({
+    channels,
+    accountBaseUrl,
+  })
 
   if (urlBucket.length === 0) {
     return {

--- a/src/services/managedSites/utils/channelMatching.ts
+++ b/src/services/managedSites/utils/channelMatching.ts
@@ -183,7 +183,7 @@ const pickBetterCandidate = (
 }
 
 const toManagedSiteChannelModelsMatchReason = (
-  reason: ManagedSiteChannelMatchResult["reason"],
+  reason: RankedManagedSiteChannelMatchReason,
 ) => {
   switch (reason) {
     case MANAGED_SITE_CHANNEL_MATCH_REASONS.URL_MODELS_EXACT:
@@ -192,8 +192,6 @@ const toManagedSiteChannelModelsMatchReason = (
       return MANAGED_SITE_CHANNEL_MODELS_MATCH_REASONS.CONTAINED
     case MANAGED_SITE_CHANNEL_MATCH_REASONS.URL_MODELS_SIMILAR:
       return MANAGED_SITE_CHANNEL_MODELS_MATCH_REASONS.SIMILAR
-    default:
-      return MANAGED_SITE_CHANNEL_MODELS_MATCH_REASONS.NO_MATCH
   }
 }
 
@@ -460,7 +458,9 @@ export function inspectManagedSiteChannelModelsMatch(
   return {
     comparable: true,
     matched: true,
-    reason: toManagedSiteChannelModelsMatchReason(bestMatch.reason),
+    reason: toManagedSiteChannelModelsMatchReason(
+      bestMatch.reason as RankedManagedSiteChannelMatchReason,
+    ),
     channel: bestMatch.channel,
     similarityScore: bestMatch.similarityScore,
   }

--- a/src/services/managedSites/verifiedChannelKeyAssessment.ts
+++ b/src/services/managedSites/verifiedChannelKeyAssessment.ts
@@ -1,0 +1,126 @@
+import {
+  MANAGED_SITE_CHANNEL_MODELS_MATCH_REASONS,
+  type ManagedSiteChannelKeyMatchReasonValue,
+  type ManagedSiteChannelMatchInspection,
+  type ManagedSiteChannelModelsMatchReasonValue,
+} from "~/services/managedSites/channelMatch"
+import {
+  getManagedSiteChannelKeyComparisonMode,
+  inspectManagedSiteChannelKeyValueMatch,
+} from "~/services/managedSites/utils/channelMatching"
+import type { ManagedSiteChannel } from "~/types/managedSite"
+
+export interface ManagedSiteAssessmentChannel {
+  id: number
+  name: string
+}
+
+export interface ManagedSiteVerifiedKeyAssessment<
+  TChannel extends ManagedSiteAssessmentChannel,
+> {
+  searchBaseUrl: string
+  searchCompleted: boolean
+  url: {
+    matched: boolean
+    candidateCount: number
+    channel?: TChannel
+  }
+  key: {
+    comparable: boolean
+    matched: boolean
+    reason: ManagedSiteChannelKeyMatchReasonValue
+    channel?: TChannel
+  }
+  models: {
+    comparable: boolean
+    matched: boolean
+    reason: ManagedSiteChannelModelsMatchReasonValue
+    channel?: TChannel
+    similarityScore?: number
+  }
+}
+
+export const toManagedSiteAssessmentChannel = (
+  channel: ManagedSiteChannel,
+): ManagedSiteAssessmentChannel => ({
+  id: channel.id,
+  name: channel.name,
+})
+
+const toOptionalManagedSiteAssessmentChannel = (
+  channel: ManagedSiteChannel | null,
+) => (channel ? toManagedSiteAssessmentChannel(channel) : undefined)
+
+export const toManagedSiteVerifiedKeyAssessment = (
+  inspection: ManagedSiteChannelMatchInspection,
+): ManagedSiteVerifiedKeyAssessment<ManagedSiteAssessmentChannel> => ({
+  searchBaseUrl: inspection.searchBaseUrl,
+  searchCompleted: inspection.searchCompleted,
+  url: {
+    matched: inspection.url.matched,
+    candidateCount: inspection.url.candidateCount,
+    channel: toOptionalManagedSiteAssessmentChannel(inspection.url.channel),
+  },
+  key: {
+    comparable: inspection.key.comparable,
+    matched: inspection.key.matched,
+    reason: inspection.key.reason,
+    channel: toOptionalManagedSiteAssessmentChannel(inspection.key.channel),
+  },
+  models: {
+    comparable: inspection.models.comparable,
+    matched: inspection.models.matched,
+    reason: inspection.models.reason,
+    channel: toOptionalManagedSiteAssessmentChannel(inspection.models.channel),
+    similarityScore: inspection.models.similarityScore,
+  },
+})
+
+/**
+ * Applies a verified managed-site channel key to an existing local assessment
+ * without reloading channel lists or rebuilding channel drafts.
+ */
+export function applyVerifiedManagedSiteChannelKey<
+  TChannel extends ManagedSiteAssessmentChannel,
+  TAssessment extends ManagedSiteVerifiedKeyAssessment<TChannel>,
+>(params: {
+  assessment: TAssessment
+  candidate: TChannel
+  sourceKey: string
+  verifiedChannelKey: string
+  siteType?: string
+}): {
+  assessment: TAssessment
+  exactMatch: boolean
+  hasAnyMatch: boolean
+} {
+  const keyAssessment = inspectManagedSiteChannelKeyValueMatch({
+    sourceKey: params.sourceKey,
+    channelKey: params.verifiedChannelKey,
+    keyComparisonMode: getManagedSiteChannelKeyComparisonMode(params.siteType),
+  })
+  const assessment = {
+    ...params.assessment,
+    key: {
+      comparable: keyAssessment.comparable,
+      matched: keyAssessment.matched,
+      reason: keyAssessment.reason,
+      channel: keyAssessment.matched ? params.candidate : undefined,
+    },
+  } as TAssessment
+  const exactMatch =
+    assessment.key.matched &&
+    assessment.models.matched &&
+    assessment.models.reason ===
+      MANAGED_SITE_CHANNEL_MODELS_MATCH_REASONS.EXACT &&
+    assessment.models.channel?.id === params.candidate.id
+
+  return {
+    assessment,
+    exactMatch,
+    hasAnyMatch:
+      assessment.url.matched ||
+      assessment.key.matched ||
+      assessment.models.matched,
+  }
+}

--- a/src/types/managedSiteTokenBatchExport.ts
+++ b/src/types/managedSiteTokenBatchExport.ts
@@ -1,5 +1,9 @@
 import type { ManagedSiteType } from "~/constants/siteType"
 import type { AccountRuntimeKey } from "~/services/accounts/accountRuntimeKeys"
+import type {
+  ManagedSiteAssessmentChannel,
+  ManagedSiteVerifiedKeyAssessment,
+} from "~/services/managedSites/verifiedChannelKeyAssessment"
 import type { DisplaySiteData } from "~/types"
 
 import type { ChannelFormData } from "./managedSite"
@@ -44,10 +48,11 @@ export type ManagedSiteTokenBatchExportItemInput = {
   runtimeKey: AccountRuntimeKey
 }
 
-export interface ManagedSiteTokenBatchExportMatchedChannel {
-  id: number
-  name: string
-}
+export type ManagedSiteTokenBatchExportMatchedChannel =
+  ManagedSiteAssessmentChannel
+
+export type ManagedSiteTokenBatchExportAssessment =
+  ManagedSiteVerifiedKeyAssessment<ManagedSiteTokenBatchExportMatchedChannel>
 
 export interface ManagedSiteTokenBatchExportPreviewItem {
   id: string
@@ -61,6 +66,8 @@ export interface ManagedSiteTokenBatchExportPreviewItem {
   blockingReasonCode?: ManagedSiteTokenBatchExportBlockedReasonCode
   blockingMessage?: string
   matchedChannel?: ManagedSiteTokenBatchExportMatchedChannel
+  verificationCandidate?: ManagedSiteTokenBatchExportMatchedChannel
+  assessment?: ManagedSiteTokenBatchExportAssessment
 }
 
 export type ExecutableManagedSiteTokenBatchExportPreviewItem =

--- a/tests/entrypoints/options/pages/KeyManagement/KeyManagement.managedSiteStatusSupport.test.tsx
+++ b/tests/entrypoints/options/pages/KeyManagement/KeyManagement.managedSiteStatusSupport.test.tsx
@@ -135,6 +135,7 @@ const baseHookResult = {
   ],
   refreshManagedSiteTokenStatuses: vi.fn(),
   refreshManagedSiteTokenStatusForToken: vi.fn(),
+  confirmManagedSiteTokenStatusWithChannelKey: vi.fn(),
   copyKey: vi.fn(),
   toggleKeyVisibility: vi.fn(),
   retryFailedAccounts: vi.fn(),
@@ -218,14 +219,30 @@ describe("KeyManagement managed-site status support", () => {
 
   it("tries the concrete channel key before opening verification when a candidate channel is known", async () => {
     sendRuntimeActionMessageMock.mockResolvedValue({ success: false })
-    loadNewApiChannelKeyWithVerificationMock.mockResolvedValue(true)
+    loadNewApiChannelKeyWithVerificationMock.mockImplementation(
+      async ({ setKey, onLoaded }) => {
+        setKey("token-1-secret")
+        await onLoaded()
+        return true
+      },
+    )
 
     const refreshManagedSiteTokenStatusForToken = vi.fn()
+    const confirmManagedSiteTokenStatusWithChannelKey = vi
+      .fn()
+      .mockResolvedValue({
+        status: MANAGED_SITE_TOKEN_CHANNEL_STATUSES.ADDED,
+        matchedChannel: {
+          id: 88,
+          name: "Managed Channel 88",
+        },
+      })
 
     useKeyManagementMock.mockReturnValue({
       ...baseHookResult,
       isManagedSiteChannelStatusSupported: true,
       refreshManagedSiteTokenStatusForToken,
+      confirmManagedSiteTokenStatusWithChannelKey,
     })
 
     render(<KeyManagement />)
@@ -290,6 +307,17 @@ describe("KeyManagement managed-site status support", () => {
           totpSecret: "JBSWY3DPEHPK3PXP",
         }),
       }),
+    )
+    expect(confirmManagedSiteTokenStatusWithChannelKey).toHaveBeenCalledWith(
+      baseHookResult.tokens[0],
+      expect.objectContaining({
+        reason:
+          MANAGED_SITE_TOKEN_CHANNEL_STATUS_UNKNOWN_REASONS.EXACT_VERIFICATION_UNAVAILABLE,
+      }),
+      {
+        channelId: 88,
+        channelKey: "token-1-secret",
+      },
     )
     expect(refreshManagedSiteTokenStatusForToken).not.toHaveBeenCalled()
     expect(openNewApiManagedVerificationMock).not.toHaveBeenCalled()

--- a/tests/entrypoints/options/pages/KeyManagement/TokenHeader.saveToApiProfiles.test.tsx
+++ b/tests/entrypoints/options/pages/KeyManagement/TokenHeader.saveToApiProfiles.test.tsx
@@ -925,6 +925,82 @@ describe("TokenHeader save to API profiles", () => {
     )
   })
 
+  it("shows loading and ignores duplicate clicks while managed-site verification retry is pending", async () => {
+    const user = userEvent.setup()
+    const account = createAccountStub()
+    let resolveRetry: () => void = () => {}
+    const retryPromise = new Promise<void>((resolve) => {
+      resolveRetry = resolve
+    })
+    const onManagedSiteVerificationRetry = vi.fn(() => retryPromise)
+
+    const token = {
+      id: 8_2,
+      user_id: 1,
+      key: "sk-verification-pending",
+      status: 1,
+      name: "Verification Pending Token",
+      created_time: 0,
+      accessed_time: 0,
+      expired_time: 0,
+      remain_quota: 0,
+      unlimited_quota: false,
+      used_quota: 0,
+      accountId: account.id,
+      accountName: account.name,
+    }
+
+    render(
+      <TokenHeader
+        token={token as any}
+        copyKey={vi.fn()}
+        handleEditToken={vi.fn()}
+        handleDeleteToken={vi.fn()}
+        account={account}
+        onManagedSiteVerificationRetry={onManagedSiteVerificationRetry}
+        managedSiteStatus={{
+          status: MANAGED_SITE_TOKEN_CHANNEL_STATUSES.UNKNOWN,
+          reason:
+            MANAGED_SITE_TOKEN_CHANNEL_STATUS_UNKNOWN_REASONS.EXACT_VERIFICATION_UNAVAILABLE,
+          assessment: createManagedSiteAssessment({
+            key: {
+              comparable: false,
+              matched: false,
+              reason:
+                MANAGED_SITE_CHANNEL_KEY_MATCH_REASONS.COMPARISON_UNAVAILABLE,
+            },
+          }),
+          recovery: {
+            siteType: "new-api",
+            managedBaseUrl: "https://managed.example",
+            searchBaseUrl: "https://example.com",
+            loginCredentialsConfigured: true,
+            authenticatedBrowserSessionExists: false,
+            automaticCodeConfigured: true,
+          },
+        }}
+      />,
+    )
+
+    const retryButton = screen.getByRole("button", {
+      name: "keyManagement:managedSiteStatus.actions.verifyNow",
+    })
+
+    await user.click(retryButton)
+
+    expect(onManagedSiteVerificationRetry).toHaveBeenCalledTimes(1)
+    await waitFor(() => expect(retryButton).toBeDisabled())
+    expect(
+      screen.getByRole("status", { name: "common:status.loading" }),
+    ).toBeInTheDocument()
+
+    await user.click(retryButton)
+    expect(onManagedSiteVerificationRetry).toHaveBeenCalledTimes(1)
+
+    resolveRetry()
+    await waitFor(() => expect(retryButton).not.toBeDisabled())
+  })
+
   it("directs the user to Settings instead of showing retry when login-assist credentials are missing", () => {
     const account = createAccountStub()
 

--- a/tests/entrypoints/options/pages/KeyManagement/useKeyManagement.test.tsx
+++ b/tests/entrypoints/options/pages/KeyManagement/useKeyManagement.test.tsx
@@ -2941,6 +2941,106 @@ describe("useKeyManagement enabled account filtering", () => {
     )
   })
 
+  it("skips managed-site confirmation when the selected managed site does not support status lookup", async () => {
+    const mockedUseAccountData = vi.mocked(useAccountData)
+    const account = createDisplayAccount({
+      id: "unsupported-confirm-acc",
+    })
+    mockedUseUserPreferencesContext.mockReturnValue({
+      managedSiteType: "Veloera",
+      newApiBaseUrl: "",
+      newApiAdminToken: "",
+      newApiUserId: "",
+      newApiUsername: "",
+      newApiPassword: "",
+      newApiTotpSecret: "",
+      doneHubBaseUrl: "",
+      doneHubAdminToken: "",
+      doneHubUserId: "",
+      veloeraBaseUrl: "https://veloera.example",
+      veloeraAdminToken: "veloera-admin-token",
+      veloeraUserId: "1",
+      octopusBaseUrl: "",
+      octopusUsername: "",
+      octopusPassword: "",
+    })
+    mockedUseAccountData.mockReturnValue({
+      enabledDisplayData: [account],
+    } as any)
+    const resolveTokenKey = vi.fn()
+    vi.mocked(getSiteTypeCapabilities).mockReturnValue(
+      createAdapterWithKeyManagement({
+        resolveTokenKey,
+      }) as any,
+    )
+
+    const { result } = renderHook(() => useKeyManagement(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      await result.current.confirmManagedSiteTokenStatusWithChannelKey(
+        createToken({
+          accountId: account.id,
+          id: 610,
+        }),
+        {
+          status: managedSiteTokenChannelStatuses.UNKNOWN,
+        } as any,
+        {
+          channelId: 90,
+          channelKey: "verified-channel-key",
+        },
+      )
+    })
+
+    expect(resolveTokenKey).not.toHaveBeenCalled()
+    expect(
+      resolveManagedSiteTokenChannelStatusWithVerifiedKeyMock,
+    ).not.toHaveBeenCalled()
+  })
+
+  it("skips managed-site confirmation before the token inventory has loaded", async () => {
+    const mockedUseAccountData = vi.mocked(useAccountData)
+    const account = createDisplayAccount({
+      id: "unloaded-confirm-acc",
+    })
+    mockedUseAccountData.mockReturnValue({
+      enabledDisplayData: [account],
+    } as any)
+    const resolveTokenKey = vi.fn()
+    vi.mocked(getSiteTypeCapabilities).mockReturnValue(
+      createAdapterWithKeyManagement({
+        resolveTokenKey,
+      }) as any,
+    )
+
+    const { result } = renderHook(() => useKeyManagement(), {
+      wrapper: createWrapper(),
+    })
+
+    await act(async () => {
+      await result.current.confirmManagedSiteTokenStatusWithChannelKey(
+        createToken({
+          accountId: account.id,
+          id: 611,
+        }),
+        {
+          status: managedSiteTokenChannelStatuses.UNKNOWN,
+        } as any,
+        {
+          channelId: 91,
+          channelKey: "verified-channel-key",
+        },
+      )
+    })
+
+    expect(resolveTokenKey).not.toHaveBeenCalled()
+    expect(
+      resolveManagedSiteTokenChannelStatusWithVerifiedKeyMock,
+    ).not.toHaveBeenCalled()
+  })
+
   it("rejects managed-site confirmation when token secret resolution fails", async () => {
     const mockedUseAccountData = vi.mocked(useAccountData)
     const account = createDisplayAccount({

--- a/tests/entrypoints/options/pages/KeyManagement/useKeyManagement.test.tsx
+++ b/tests/entrypoints/options/pages/KeyManagement/useKeyManagement.test.tsx
@@ -29,6 +29,7 @@ const {
   getManagedSiteTokenChannelStatusMock,
   managedSiteTokenChannelStatuses,
   mockedUseUserPreferencesContext,
+  resolveManagedSiteTokenChannelStatusWithVerifiedKeyMock,
   startProductAnalyticsActionMock,
   trackerCompleteMock,
 } = vi.hoisted(() => ({
@@ -39,6 +40,7 @@ const {
     UNKNOWN: "unknown",
   },
   mockedUseUserPreferencesContext: vi.fn(),
+  resolveManagedSiteTokenChannelStatusWithVerifiedKeyMock: vi.fn(),
   startProductAnalyticsActionMock: vi.fn(),
   trackerCompleteMock: vi.fn(),
 }))
@@ -55,6 +57,8 @@ vi.mock("~/services/managedSites/tokenChannelStatus", () => ({
   MANAGED_SITE_TOKEN_CHANNEL_STATUSES: managedSiteTokenChannelStatuses,
   getManagedSiteTokenChannelStatus: (...args: unknown[]) =>
     getManagedSiteTokenChannelStatusMock(...args),
+  resolveManagedSiteTokenChannelStatusWithVerifiedKey: (...args: unknown[]) =>
+    resolveManagedSiteTokenChannelStatusWithVerifiedKeyMock(...args),
 }))
 
 vi.mock("~/contexts/UserPreferencesContext", () => ({
@@ -194,6 +198,10 @@ describe("useKeyManagement enabled account filtering", () => {
     getManagedSiteTokenChannelStatusMock.mockResolvedValue({
       status: managedSiteTokenChannelStatuses.NOT_ADDED,
     })
+    resolveManagedSiteTokenChannelStatusWithVerifiedKeyMock.mockReset()
+    resolveManagedSiteTokenChannelStatusWithVerifiedKeyMock.mockImplementation(
+      ({ status }) => status,
+    )
     startProductAnalyticsActionMock.mockReset()
     trackerCompleteMock.mockReset()
     startProductAnalyticsActionMock.mockReturnValue({
@@ -1990,6 +1998,61 @@ describe("useKeyManagement enabled account filtering", () => {
     expect(getManagedSiteTokenChannelStatusMock).toHaveBeenCalledTimes(1)
   })
 
+  it("shares a managed-site match request cache across status checks in the same batch", async () => {
+    const mockedUseAccountData = vi.mocked(useAccountData)
+    const account = createDisplayAccount({
+      id: "managed-cache-acc",
+      name: "Managed Cache Account",
+    })
+
+    mockedUseAccountData.mockReturnValue({
+      enabledDisplayData: [account],
+    } as any)
+
+    const fetchAccountTokens = vi.fn().mockResolvedValue([
+      createToken({
+        id: 111,
+        key: "token-111",
+        name: "Token 111",
+        expired_time: 0,
+      }),
+      createToken({
+        id: 112,
+        key: "token-112",
+        name: "Token 112",
+        expired_time: 0,
+      }),
+    ])
+    vi.mocked(getSiteTypeCapabilities).mockReturnValue(
+      createAdapterWithKeyManagement({
+        fetchTokens: fetchAccountTokens,
+      }) as any,
+    )
+
+    const { result } = renderHook(() => useKeyManagement(), {
+      wrapper: createWrapper(),
+    })
+
+    act(() => {
+      result.current.setSelectedAccount(account.id)
+    })
+
+    await waitFor(() =>
+      expect(getManagedSiteTokenChannelStatusMock).toHaveBeenCalledTimes(2),
+    )
+
+    const [firstCall, secondCall] =
+      getManagedSiteTokenChannelStatusMock.mock.calls
+    const firstParams = firstCall?.[0] as
+      | { operationContext?: unknown }
+      | undefined
+    const secondParams = secondCall?.[0] as
+      | { operationContext?: unknown }
+      | undefined
+    expect(firstParams).toHaveProperty("operationContext")
+    expect(firstParams?.operationContext).toBe(secondParams?.operationContext)
+  })
+
   it("reveals the resolved full key when the inventory value is masked", async () => {
     const mockedUseAccountData = vi.mocked(useAccountData)
     const account = createDisplayAccount({
@@ -2747,6 +2810,132 @@ describe("useKeyManagement enabled account filtering", () => {
       expect.objectContaining({
         resolvedChannelKeysById: {
           55: "resolved-channel-key",
+        },
+      }),
+    )
+  })
+
+  it("confirms a managed-site token status with a verified channel key without a full refresh", async () => {
+    const mockedUseAccountData = vi.mocked(useAccountData)
+    const account = createDisplayAccount({
+      id: "verified-key-acc",
+      name: "Verified Key Account",
+    })
+    const initialStatus = {
+      status: managedSiteTokenChannelStatuses.UNKNOWN,
+      reason: "exact-verification-unavailable",
+      assessment: {
+        searchBaseUrl: "https://example.com",
+        searchCompleted: true,
+        url: {
+          matched: true,
+          candidateCount: 1,
+          channel: {
+            id: 77,
+            name: "Managed Channel 77",
+          },
+        },
+        key: {
+          comparable: false,
+          matched: false,
+          reason: "comparison-unavailable",
+        },
+        models: {
+          comparable: true,
+          matched: true,
+          reason: "exact",
+          channel: {
+            id: 77,
+            name: "Managed Channel 77",
+          },
+        },
+      },
+    }
+
+    mockedUseAccountData.mockReturnValue({
+      enabledDisplayData: [account],
+    } as any)
+
+    const fetchAccountTokens = vi.fn().mockResolvedValue([
+      createToken({
+        id: 607,
+        key: "masked-token-607",
+        name: "Token 607",
+        expired_time: 0,
+      }),
+    ])
+    const resolveTokenKey = vi.fn().mockResolvedValue("token-607-secret")
+    vi.mocked(getSiteTypeCapabilities).mockReturnValue(
+      createAdapterWithKeyManagement({
+        fetchTokens: fetchAccountTokens,
+        resolveTokenKey,
+      }) as any,
+    )
+    getManagedSiteTokenChannelStatusMock
+      .mockResolvedValueOnce(initialStatus)
+      .mockResolvedValueOnce({
+        status: managedSiteTokenChannelStatuses.ADDED,
+        matchedChannel: { id: 77, name: "Managed Channel 77" },
+      })
+    resolveManagedSiteTokenChannelStatusWithVerifiedKeyMock.mockReturnValue({
+      status: managedSiteTokenChannelStatuses.ADDED,
+      matchedChannel: { id: 77, name: "Managed Channel 77" },
+      resolvedChannelKeysById: {
+        77: "verified-channel-key",
+      },
+    })
+
+    const { result } = renderHook(() => useKeyManagement(), {
+      wrapper: createWrapper(),
+    })
+
+    act(() => {
+      result.current.setSelectedAccount(account.id)
+    })
+
+    await waitFor(() =>
+      expect(getManagedSiteTokenChannelStatusMock).toHaveBeenCalledTimes(1),
+    )
+
+    await act(async () => {
+      await result.current.confirmManagedSiteTokenStatusWithChannelKey(
+        result.current.tokens[0]!,
+        initialStatus as any,
+        {
+          channelId: 77,
+          channelKey: "verified-channel-key",
+        },
+      )
+    })
+
+    expect(getManagedSiteTokenChannelStatusMock).toHaveBeenCalledTimes(1)
+    expect(
+      resolveManagedSiteTokenChannelStatusWithVerifiedKeyMock,
+    ).toHaveBeenCalledWith({
+      status: initialStatus,
+      tokenKey: "token-607-secret",
+      channelId: 77,
+      channelKey: "verified-channel-key",
+      siteType: "new-api",
+    })
+    expect(
+      result.current.managedSiteTokenStatuses["verified-key-acc:607"]?.result,
+    ).toEqual({
+      status: managedSiteTokenChannelStatuses.ADDED,
+      matchedChannel: { id: 77, name: "Managed Channel 77" },
+    })
+
+    await act(async () => {
+      await result.current.refreshManagedSiteTokenStatusForToken(
+        result.current.tokens[0]!,
+      )
+    })
+
+    expect(getManagedSiteTokenChannelStatusMock).toHaveBeenCalledTimes(2)
+    expect(getManagedSiteTokenChannelStatusMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        resolvedChannelKeysById: {
+          77: "verified-channel-key",
         },
       }),
     )

--- a/tests/entrypoints/options/pages/KeyManagement/useKeyManagement.test.tsx
+++ b/tests/entrypoints/options/pages/KeyManagement/useKeyManagement.test.tsx
@@ -2941,6 +2941,197 @@ describe("useKeyManagement enabled account filtering", () => {
     )
   })
 
+  it("rejects managed-site confirmation when token secret resolution fails", async () => {
+    const mockedUseAccountData = vi.mocked(useAccountData)
+    const account = createDisplayAccount({
+      id: "secret-failure-acc",
+      siteType: SITE_TYPES.NEW_API,
+      baseUrl: "https://api.example.invalid",
+    })
+    const initialStatus = {
+      status: managedSiteTokenChannelStatuses.UNKNOWN,
+      assessment: {
+        searchBaseUrl: "https://api.example.invalid",
+        searchCompleted: true,
+        url: {
+          matched: true,
+          candidateCount: 1,
+          channel: { id: 88, name: "Managed Channel 88" },
+        },
+        key: {
+          comparable: false,
+          matched: false,
+          reason: "comparison-unavailable",
+        },
+        models: {
+          comparable: true,
+          matched: true,
+          reason: "exact",
+          channel: { id: 88, name: "Managed Channel 88" },
+        },
+      },
+    }
+
+    mockedUseAccountData.mockReturnValue({
+      enabledDisplayData: [account],
+    } as any)
+    vi.mocked(getSiteTypeCapabilities).mockReturnValue(
+      createAdapterWithKeyManagement({
+        fetchTokens: vi.fn().mockResolvedValue([
+          createToken({
+            id: 608,
+            key: "masked-token-608",
+            name: "Token 608",
+            expired_time: 0,
+          }),
+        ]),
+        resolveTokenKey: vi
+          .fn()
+          .mockRejectedValue(new Error("secret unavailable")),
+      }) as any,
+    )
+    getManagedSiteTokenChannelStatusMock.mockResolvedValue(initialStatus)
+
+    const { result } = renderHook(() => useKeyManagement(), {
+      wrapper: createWrapper(),
+    })
+
+    act(() => {
+      result.current.setSelectedAccount(account.id)
+    })
+
+    await waitFor(() =>
+      expect(getManagedSiteTokenChannelStatusMock).toHaveBeenCalledTimes(1),
+    )
+
+    await expect(
+      result.current.confirmManagedSiteTokenStatusWithChannelKey(
+        result.current.tokens[0]!,
+        initialStatus as any,
+        {
+          channelId: 88,
+          channelKey: "verified-channel-key",
+        },
+      ),
+    ).rejects.toThrow("secret unavailable")
+    expect(
+      resolveManagedSiteTokenChannelStatusWithVerifiedKeyMock,
+    ).not.toHaveBeenCalled()
+  })
+
+  it("does not overwrite a newer managed-site status after resolving a token secret", async () => {
+    const mockedUseAccountData = vi.mocked(useAccountData)
+    const account = createDisplayAccount({
+      id: "stale-confirm-acc",
+      siteType: SITE_TYPES.NEW_API,
+      baseUrl: "https://api.example.invalid",
+    })
+    const initialStatus = {
+      status: managedSiteTokenChannelStatuses.UNKNOWN,
+      assessment: {
+        searchBaseUrl: "https://api.example.invalid",
+        searchCompleted: true,
+        url: {
+          matched: true,
+          candidateCount: 1,
+          channel: { id: 89, name: "Managed Channel 89" },
+        },
+        key: {
+          comparable: false,
+          matched: false,
+          reason: "comparison-unavailable",
+        },
+        models: {
+          comparable: true,
+          matched: true,
+          reason: "exact",
+          channel: { id: 89, name: "Managed Channel 89" },
+        },
+      },
+    }
+    const refreshedStatus = {
+      status: managedSiteTokenChannelStatuses.NOT_ADDED,
+    }
+    let resolveSecret: (value: string) => void = () => {}
+    const resolveTokenKey = vi.fn(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveSecret = resolve
+        }),
+    )
+
+    mockedUseAccountData.mockReturnValue({
+      enabledDisplayData: [account],
+    } as any)
+    vi.mocked(getSiteTypeCapabilities).mockReturnValue(
+      createAdapterWithKeyManagement({
+        fetchTokens: vi.fn().mockResolvedValue([
+          createToken({
+            id: 609,
+            key: "masked-token-609",
+            name: "Token 609",
+            expired_time: 0,
+          }),
+        ]),
+        resolveTokenKey,
+      }) as any,
+    )
+    getManagedSiteTokenChannelStatusMock
+      .mockResolvedValueOnce(initialStatus)
+      .mockResolvedValueOnce(refreshedStatus)
+    resolveManagedSiteTokenChannelStatusWithVerifiedKeyMock.mockReturnValue({
+      status: managedSiteTokenChannelStatuses.ADDED,
+      matchedChannel: { id: 89, name: "Managed Channel 89" },
+    })
+
+    const { result } = renderHook(() => useKeyManagement(), {
+      wrapper: createWrapper(),
+    })
+
+    act(() => {
+      result.current.setSelectedAccount(account.id)
+    })
+
+    await waitFor(() =>
+      expect(getManagedSiteTokenChannelStatusMock).toHaveBeenCalledTimes(1),
+    )
+
+    const confirmationPromise =
+      result.current.confirmManagedSiteTokenStatusWithChannelKey(
+        result.current.tokens[0]!,
+        initialStatus as any,
+        {
+          channelId: 89,
+          channelKey: "verified-channel-key",
+        },
+      )
+
+    await waitFor(() => expect(resolveTokenKey).toHaveBeenCalledTimes(1))
+    await act(async () => {
+      await result.current.refreshManagedSiteTokenStatusForToken(
+        result.current.tokens[0]!,
+      )
+    })
+    await waitFor(() =>
+      expect(
+        result.current.managedSiteTokenStatuses["stale-confirm-acc:609"]
+          ?.result,
+      ).toEqual(refreshedStatus),
+    )
+
+    await act(async () => {
+      resolveSecret("token-609-secret")
+      await confirmationPromise
+    })
+
+    expect(
+      resolveManagedSiteTokenChannelStatusWithVerifiedKeyMock,
+    ).not.toHaveBeenCalled()
+    expect(
+      result.current.managedSiteTokenStatuses["stale-confirm-acc:609"]?.result,
+    ).toEqual(refreshedStatus)
+  })
+
   it("does not return stale managed-site status results from superseded forced refreshes", async () => {
     const mockedUseAccountData = vi.mocked(useAccountData)
     const account = createDisplayAccount({

--- a/tests/entrypoints/options/pages/KeyManagement/useKeyManagement.test.tsx
+++ b/tests/entrypoints/options/pages/KeyManagement/useKeyManagement.test.tsx
@@ -3041,6 +3041,64 @@ describe("useKeyManagement enabled account filtering", () => {
     ).not.toHaveBeenCalled()
   })
 
+  it("skips managed-site confirmation when the account disappears after inventory load", async () => {
+    const mockedUseAccountData = vi.mocked(useAccountData)
+    const account = createDisplayAccount({
+      id: "missing-confirm-acc",
+    })
+    const token = createToken({
+      accountId: account.id,
+      id: 612,
+    })
+    mockedUseAccountData.mockReturnValue({
+      enabledDisplayData: [account],
+    } as any)
+    const resolveTokenKey = vi.fn().mockResolvedValue("token-612-secret")
+    vi.mocked(getSiteTypeCapabilities).mockReturnValue(
+      createAdapterWithKeyManagement({
+        fetchTokens: vi.fn().mockResolvedValue([token]),
+        resolveTokenKey,
+      }) as any,
+    )
+
+    const { result, rerender } = renderHook(() => useKeyManagement(), {
+      wrapper: createWrapper(),
+    })
+
+    act(() => {
+      result.current.setSelectedAccount(account.id)
+    })
+
+    await waitFor(() =>
+      expect(result.current.tokenInventories[account.id]?.status).toBe(
+        "loaded",
+      ),
+    )
+
+    mockedUseAccountData.mockReturnValue({
+      enabledDisplayData: [],
+    } as any)
+    rerender()
+
+    await act(async () => {
+      await result.current.confirmManagedSiteTokenStatusWithChannelKey(
+        token,
+        {
+          status: managedSiteTokenChannelStatuses.UNKNOWN,
+        } as any,
+        {
+          channelId: 92,
+          channelKey: "verified-channel-key",
+        },
+      )
+    })
+
+    expect(resolveTokenKey).not.toHaveBeenCalled()
+    expect(
+      resolveManagedSiteTokenChannelStatusWithVerifiedKeyMock,
+    ).not.toHaveBeenCalled()
+  })
+
   it("rejects managed-site confirmation when token secret resolution fails", async () => {
     const mockedUseAccountData = vi.mocked(useAccountData)
     const account = createDisplayAccount({

--- a/tests/features/KeyManagement/components/ManagedSiteTokenBatchExportDialog.test.tsx
+++ b/tests/features/KeyManagement/components/ManagedSiteTokenBatchExportDialog.test.tsx
@@ -1,9 +1,11 @@
+import { act } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import type { ReactNode } from "react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { SITE_TYPES } from "~/constants/siteType"
 import { ManagedSiteTokenBatchExportDialog } from "~/features/KeyManagement/components/ManagedSiteTokenBatchExportDialog"
+import { NEW_API_MANAGED_VERIFICATION_CLOSE_MODES } from "~/features/ManagedSiteVerification/useNewApiManagedVerification"
 import { buildAccountTokenRuntimeKey } from "~/services/accounts/accountRuntimeKeys"
 import {
   PRODUCT_ANALYTICS_ACTION_IDS,
@@ -27,12 +29,16 @@ import { render, screen, waitFor } from "~~/tests/test-utils/render"
 
 const {
   mockExecuteBatchExport,
+  mockLoadNewApiChannelKeyWithVerification,
+  mockOpenNewApiManagedVerification,
   mockPreparePreview,
   mockTrackProductAnalyticsActionCompleted,
   mockTrackProductAnalyticsActionStarted,
   mockToastSuccess,
 } = vi.hoisted(() => ({
   mockExecuteBatchExport: vi.fn(),
+  mockLoadNewApiChannelKeyWithVerification: vi.fn(),
+  mockOpenNewApiManagedVerification: vi.fn(),
   mockPreparePreview: vi.fn(),
   mockTrackProductAnalyticsActionCompleted: vi.fn(),
   mockTrackProductAnalyticsActionStarted: vi.fn(),
@@ -43,6 +49,68 @@ vi.mock("~/services/managedSites/tokenBatchExport", () => ({
   prepareManagedSiteTokenBatchExportPreview: mockPreparePreview,
   executeManagedSiteTokenBatchExport: mockExecuteBatchExport,
 }))
+
+vi.mock(
+  "~/features/ManagedSiteVerification/loadNewApiChannelKeyWithVerification",
+  () => ({
+    loadNewApiChannelKeyWithVerification:
+      mockLoadNewApiChannelKeyWithVerification,
+  }),
+)
+
+vi.mock(
+  "~/features/ManagedSiteVerification/useNewApiManagedVerification",
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import("~/features/ManagedSiteVerification/useNewApiManagedVerification")
+      >()
+
+    return {
+      ...actual,
+      useNewApiManagedVerification: () => ({
+        dialogState: {
+          isOpen: false,
+          step: actual.NEW_API_MANAGED_VERIFICATION_STEPS.LOGGING_IN,
+          request: null,
+          code: "",
+          isBusy: false,
+        },
+        setCode: vi.fn(),
+        closeDialog: vi.fn(),
+        openBaseUrl: vi.fn(),
+        openNewApiManagedVerification: mockOpenNewApiManagedVerification,
+        submitCode: vi.fn(),
+        retryVerification: vi.fn(),
+        patchRequestConfig: vi.fn(),
+      }),
+    }
+  },
+)
+
+vi.mock(
+  "~/features/ManagedSiteVerification/NewApiManagedVerificationDialog",
+  () => ({
+    NewApiManagedVerificationDialog: ({ isOpen }: { isOpen: boolean }) =>
+      isOpen ? <div role="dialog">New API verification</div> : null,
+  }),
+)
+
+vi.mock("~/contexts/UserPreferencesContext", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("~/contexts/UserPreferencesContext")>()
+
+  return {
+    ...actual,
+    useUserPreferencesContext: () => ({
+      newApiBaseUrl: "https://managed.example",
+      newApiUserId: "1",
+      newApiUsername: "admin",
+      newApiPassword: "secret",
+      newApiTotpSecret: "JBSWY3DPEHPK3PXP",
+    }),
+  }
+})
 
 vi.mock("~/services/productAnalytics/actions", () => ({
   trackProductAnalyticsActionStarted: mockTrackProductAnalyticsActionStarted,
@@ -199,6 +267,40 @@ const buildDialogPreviewItem = (
     ...fields,
   }
 }
+
+const buildRecoverablePreviewItem = (
+  item: ManagedSiteTokenBatchExportPreviewItem,
+  channel: { id: number; name: string },
+): ManagedSiteTokenBatchExportPreviewItem => ({
+  ...item,
+  status: MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.WARNING,
+  warningCodes: [
+    MANAGED_SITE_TOKEN_BATCH_EXPORT_WARNING_CODES.EXACT_VERIFICATION_UNAVAILABLE,
+  ],
+  matchedChannel: channel,
+  verificationCandidate: channel,
+  assessment: {
+    searchBaseUrl: "https://example.com",
+    searchCompleted: true,
+    url: {
+      matched: true,
+      candidateCount: 1,
+      channel,
+    },
+    key: {
+      comparable: false,
+      matched: false,
+      reason: "comparison-unavailable",
+    },
+    models: {
+      comparable: true,
+      matched: true,
+      reason: "exact",
+      channel,
+      similarityScore: 1,
+    },
+  },
+})
 
 const preview: ManagedSiteTokenBatchExportPreview = {
   siteType: SITE_TYPES.NEW_API,
@@ -362,6 +464,15 @@ const renderDialog = (props?: {
 describe("ManagedSiteTokenBatchExportDialog", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockExecuteBatchExport.mockReset()
+    mockLoadNewApiChannelKeyWithVerification.mockReset()
+    mockPreparePreview.mockReset()
+    mockLoadNewApiChannelKeyWithVerification.mockImplementation(
+      async (params) => {
+        await Promise.resolve(params.onLoaded?.())
+        return true
+      },
+    )
   })
 
   it("shows preview load errors and retries preview preparation", async () => {
@@ -544,6 +655,194 @@ describe("ManagedSiteTokenBatchExportDialog", () => {
         "keyManagement:batchManagedSiteExport.results.summary",
       ),
     ).toBeInTheDocument()
+  })
+
+  it("does not auto-select warning rows that need duplicate-risk confirmation", async () => {
+    mockPreparePreview.mockResolvedValue(richPreview)
+
+    renderDialog()
+
+    expect(await screen.findByText("Account 1 / Token 2")).toBeInTheDocument()
+    expect(
+      screen.getByRole("checkbox", {
+        name: "Account 1 / Token 1",
+      }),
+    ).toHaveAttribute("aria-checked", "true")
+    expect(
+      screen.getByRole("checkbox", {
+        name: "Account 1 / Token 2",
+      }),
+    ).toHaveAttribute("aria-checked", "false")
+  })
+
+  it("lets users verify recoverable warning rows and update the preview locally", async () => {
+    const user = userEvent.setup()
+    mockLoadNewApiChannelKeyWithVerification.mockImplementation(
+      async (params) => {
+        const keyByChannelId: Record<number, string> = {
+          7: "test-key",
+          8: "test-key-2",
+        }
+        await Promise.resolve(params.setKey(keyByChannelId[params.channelId]))
+        await Promise.resolve(params.onLoaded?.())
+        return true
+      },
+    )
+    const recoverablePreview: ManagedSiteTokenBatchExportPreview = {
+      ...preview,
+      totalCount: 2,
+      readyCount: 0,
+      warningCount: 2,
+      skippedCount: 0,
+      blockedCount: 0,
+      items: [
+        buildRecoverablePreviewItem(preview.items[0], {
+          id: 7,
+          name: "Potential channel",
+        }),
+        buildRecoverablePreviewItem(preview.items[1], {
+          id: 8,
+          name: "Second potential channel",
+        }),
+      ],
+    }
+    mockPreparePreview.mockResolvedValueOnce(recoverablePreview)
+
+    renderDialog()
+
+    expect(await screen.findByText("Account 1 / Token 1")).toBeInTheDocument()
+    await user.click(
+      screen.getAllByRole("button", {
+        name: "keyManagement:batchManagedSiteExport.actions.verifyAndRefresh",
+      })[0],
+    )
+
+    await waitFor(() => {
+      expect(mockLoadNewApiChannelKeyWithVerification).toHaveBeenCalledWith(
+        expect.objectContaining({
+          channelId: 7,
+          label: "Potential channel",
+          requestKind: "channel",
+          config: {
+            baseUrl: "https://managed.example",
+            userId: "1",
+            username: "admin",
+            password: "secret",
+            totpSecret: "JBSWY3DPEHPK3PXP",
+          },
+          openVerification: expect.any(Function),
+        }),
+      )
+    })
+    await waitFor(() => {
+      expect(
+        screen.getAllByText(
+          "keyManagement:batchManagedSiteExport.status.skipped",
+        ),
+      ).toHaveLength(2)
+    })
+    expect(mockLoadNewApiChannelKeyWithVerification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channelId: 8,
+        label: "Second potential channel",
+      }),
+    )
+    expect(mockLoadNewApiChannelKeyWithVerification).toHaveBeenCalledTimes(2)
+    expect(mockPreparePreview).toHaveBeenCalledTimes(1)
+  })
+
+  it("continues verifying remaining warning rows after two-step verification completes", async () => {
+    const user = userEvent.setup()
+    mockLoadNewApiChannelKeyWithVerification
+      .mockImplementationOnce(async (params) => {
+        await Promise.resolve(
+          params.openVerification({
+            kind: "channel",
+            label: "Potential channel",
+            config: {
+              baseUrl: "https://managed.example",
+              userId: "1",
+              username: "admin",
+              password: "secret",
+              totpSecret: "JBSWY3DPEHPK3PXP",
+            },
+            onVerified: async () => {
+              await Promise.resolve(params.setKey("test-key"))
+              await Promise.resolve(params.onLoaded?.())
+            },
+          }),
+        )
+        return false
+      })
+      .mockImplementationOnce(async (params) => {
+        await Promise.resolve(params.setKey("test-key-2"))
+        await Promise.resolve(params.onLoaded?.())
+        return true
+      })
+    const recoverablePreview: ManagedSiteTokenBatchExportPreview = {
+      ...preview,
+      totalCount: 2,
+      readyCount: 0,
+      warningCount: 2,
+      skippedCount: 0,
+      blockedCount: 0,
+      items: [
+        buildRecoverablePreviewItem(preview.items[0], {
+          id: 7,
+          name: "Potential channel",
+        }),
+        buildRecoverablePreviewItem(preview.items[1], {
+          id: 8,
+          name: "Second potential channel",
+        }),
+      ],
+    }
+    mockPreparePreview.mockResolvedValueOnce(recoverablePreview)
+
+    renderDialog()
+
+    expect(await screen.findByText("Account 1 / Token 1")).toBeInTheDocument()
+    await user.click(
+      screen.getAllByRole("button", {
+        name: "keyManagement:batchManagedSiteExport.actions.verifyAndRefresh",
+      })[0],
+    )
+
+    await waitFor(() => {
+      expect(mockLoadNewApiChannelKeyWithVerification).toHaveBeenCalledTimes(1)
+    })
+    expect(mockLoadNewApiChannelKeyWithVerification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channelId: 7,
+      }),
+    )
+
+    const openedVerificationRequest =
+      mockOpenNewApiManagedVerification.mock.calls[0]?.[0]
+    expect(openedVerificationRequest?.closeMode).toBe(
+      NEW_API_MANAGED_VERIFICATION_CLOSE_MODES.CLOSE_AFTER_VERIFICATION,
+    )
+    await act(async () => {
+      await openedVerificationRequest?.onVerified?.()
+    })
+
+    await waitFor(() => {
+      expect(mockLoadNewApiChannelKeyWithVerification).toHaveBeenCalledWith(
+        expect.objectContaining({
+          channelId: 8,
+          label: "Second potential channel",
+        }),
+      )
+    })
+    await waitFor(() => {
+      expect(
+        screen.getAllByText(
+          "keyManagement:batchManagedSiteExport.status.skipped",
+        ),
+      ).toHaveLength(2)
+    })
+    expect(mockLoadNewApiChannelKeyWithVerification).toHaveBeenCalledTimes(2)
+    expect(mockPreparePreview).toHaveBeenCalledTimes(1)
   })
 
   it("tracks analytics only around confirmed batch export execution success", async () => {

--- a/tests/features/KeyManagement/components/ManagedSiteTokenBatchExportDialog.test.tsx
+++ b/tests/features/KeyManagement/components/ManagedSiteTokenBatchExportDialog.test.tsx
@@ -29,20 +29,26 @@ import { render, screen, waitFor } from "~~/tests/test-utils/render"
 
 const {
   mockExecuteBatchExport,
+  mockCloseNewApiManagedVerification,
   mockLoadNewApiChannelKeyWithVerification,
   mockOpenNewApiManagedVerification,
   mockPreparePreview,
   mockTrackProductAnalyticsActionCompleted,
   mockTrackProductAnalyticsActionStarted,
   mockToastSuccess,
+  mockVerificationDialogState,
 } = vi.hoisted(() => ({
   mockExecuteBatchExport: vi.fn(),
+  mockCloseNewApiManagedVerification: vi.fn(),
   mockLoadNewApiChannelKeyWithVerification: vi.fn(),
   mockOpenNewApiManagedVerification: vi.fn(),
   mockPreparePreview: vi.fn(),
   mockTrackProductAnalyticsActionCompleted: vi.fn(),
   mockTrackProductAnalyticsActionStarted: vi.fn(),
   mockToastSuccess: vi.fn(),
+  mockVerificationDialogState: {
+    isOpen: false,
+  },
 }))
 
 vi.mock("~/services/managedSites/tokenBatchExport", () => ({
@@ -70,14 +76,14 @@ vi.mock(
       ...actual,
       useNewApiManagedVerification: () => ({
         dialogState: {
-          isOpen: false,
+          isOpen: mockVerificationDialogState.isOpen,
           step: actual.NEW_API_MANAGED_VERIFICATION_STEPS.LOGGING_IN,
           request: null,
           code: "",
           isBusy: false,
         },
         setCode: vi.fn(),
-        closeDialog: vi.fn(),
+        closeDialog: mockCloseNewApiManagedVerification,
         openBaseUrl: vi.fn(),
         openNewApiManagedVerification: mockOpenNewApiManagedVerification,
         submitCode: vi.fn(),
@@ -140,11 +146,22 @@ vi.mock("~/components/ui", async (importOriginal) => {
       disabled?: boolean
       onClick?: () => void
       type?: "button" | "submit" | "reset"
-    }) => (
-      <button type={type} disabled={disabled} onClick={onClick}>
-        {children}
-      </button>
-    ),
+    }) => {
+      const isVerificationButton =
+        children ===
+          "keyManagement:batchManagedSiteExport.actions.verifyAndRefresh" ||
+        children === "keyManagement:batchManagedSiteExport.actions.verifying"
+
+      return (
+        <button
+          type={type}
+          disabled={isVerificationButton ? false : disabled}
+          onClick={onClick}
+        >
+          {children}
+        </button>
+      )
+    },
     Checkbox: ({
       checked,
       disabled,
@@ -465,8 +482,10 @@ describe("ManagedSiteTokenBatchExportDialog", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockExecuteBatchExport.mockReset()
+    mockCloseNewApiManagedVerification.mockReset()
     mockLoadNewApiChannelKeyWithVerification.mockReset()
     mockPreparePreview.mockReset()
+    mockVerificationDialogState.isOpen = false
     mockLoadNewApiChannelKeyWithVerification.mockImplementation(
       async (params) => {
         await Promise.resolve(params.onLoaded?.())
@@ -843,6 +862,139 @@ describe("ManagedSiteTokenBatchExportDialog", () => {
     })
     expect(mockLoadNewApiChannelKeyWithVerification).toHaveBeenCalledTimes(2)
     expect(mockPreparePreview).toHaveBeenCalledTimes(1)
+  })
+
+  it("closes an open verification dialog before closing the batch dialog", async () => {
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+    mockVerificationDialogState.isOpen = true
+    mockPreparePreview.mockResolvedValue(preview)
+
+    renderDialog({ onClose })
+
+    expect(await screen.findByText("Account 1 / Token 1")).toBeInTheDocument()
+    await user.click(
+      screen.getByRole("button", {
+        name: "common:actions.cancel",
+      }),
+    )
+
+    expect(mockCloseNewApiManagedVerification).toHaveBeenCalledTimes(1)
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it("shows a verification error when channel key loading fails", async () => {
+    const user = userEvent.setup()
+    const recoverablePreview: ManagedSiteTokenBatchExportPreview = {
+      ...preview,
+      totalCount: 1,
+      readyCount: 0,
+      warningCount: 1,
+      skippedCount: 0,
+      blockedCount: 0,
+      items: [
+        buildRecoverablePreviewItem(preview.items[0], {
+          id: 7,
+          name: "Potential channel",
+        }),
+      ],
+    }
+    mockPreparePreview.mockResolvedValueOnce(recoverablePreview)
+    mockLoadNewApiChannelKeyWithVerification.mockRejectedValue(
+      new Error("verification failed"),
+    )
+
+    renderDialog()
+
+    expect(await screen.findByText("Account 1 / Token 1")).toBeInTheDocument()
+    await user.click(
+      screen.getByRole("button", {
+        name: "keyManagement:batchManagedSiteExport.actions.verifyAndRefresh",
+      }),
+    )
+
+    expect(
+      await screen.findByText(
+        "keyManagement:batchManagedSiteExport.messages.executionFailed",
+      ),
+    ).toBeInTheDocument()
+  })
+
+  it("ignores verify clicks while the verification dialog is already open", async () => {
+    const user = userEvent.setup()
+    const recoverablePreview: ManagedSiteTokenBatchExportPreview = {
+      ...preview,
+      totalCount: 1,
+      readyCount: 0,
+      warningCount: 1,
+      skippedCount: 0,
+      blockedCount: 0,
+      items: [
+        buildRecoverablePreviewItem(preview.items[0], {
+          id: 7,
+          name: "Potential channel",
+        }),
+      ],
+    }
+    mockVerificationDialogState.isOpen = true
+    mockPreparePreview.mockResolvedValueOnce(recoverablePreview)
+
+    renderDialog()
+
+    expect(await screen.findByText("Account 1 / Token 1")).toBeInTheDocument()
+    await user.click(
+      screen.getByRole("button", {
+        name: "keyManagement:batchManagedSiteExport.actions.verifyAndRefresh",
+      }),
+    )
+
+    expect(mockLoadNewApiChannelKeyWithVerification).not.toHaveBeenCalled()
+  })
+
+  it("shows a fallback verification error when a verification target cannot be read", async () => {
+    const user = userEvent.setup()
+    const recoverablePreview: ManagedSiteTokenBatchExportPreview = {
+      ...preview,
+      totalCount: 1,
+      readyCount: 0,
+      warningCount: 1,
+      skippedCount: 0,
+      blockedCount: 0,
+      items: [
+        buildRecoverablePreviewItem(preview.items[0], {
+          id: 7,
+          name: "Potential channel",
+        }),
+      ],
+    }
+    mockPreparePreview.mockResolvedValueOnce(recoverablePreview)
+
+    renderDialog()
+
+    expect(await screen.findByText("Account 1 / Token 1")).toBeInTheDocument()
+    const originalItemId = recoverablePreview.items[0].id
+    Object.defineProperty(recoverablePreview.items[0], "id", {
+      configurable: true,
+      get: () => {
+        const stack = new Error().stack ?? ""
+        if (stack.includes("verifyTargetsFromIndex")) {
+          throw new Error("target unavailable")
+        }
+        return originalItemId
+      },
+    })
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "keyManagement:batchManagedSiteExport.actions.verifyAndRefresh",
+      }),
+    )
+
+    expect(
+      await screen.findByText(
+        "keyManagement:batchManagedSiteExport.messages.executionFailed",
+      ),
+    ).toBeInTheDocument()
   })
 
   it("tracks analytics only around confirmed batch export execution success", async () => {

--- a/tests/features/KeyManagement/components/ManagedSiteTokenBatchExportDialog.test.tsx
+++ b/tests/features/KeyManagement/components/ManagedSiteTokenBatchExportDialog.test.tsx
@@ -28,8 +28,10 @@ import {
 import { render, screen, waitFor } from "~~/tests/test-utils/render"
 
 const {
+  mockAllowDisabledVerificationButtonClicks,
   mockExecuteBatchExport,
   mockCloseNewApiManagedVerification,
+  mockGetPreviewVerificationTargets,
   mockLoadNewApiChannelKeyWithVerification,
   mockOpenNewApiManagedVerification,
   mockPreparePreview,
@@ -38,8 +40,12 @@ const {
   mockToastSuccess,
   mockVerificationDialogState,
 } = vi.hoisted(() => ({
+  mockAllowDisabledVerificationButtonClicks: {
+    current: false,
+  },
   mockExecuteBatchExport: vi.fn(),
   mockCloseNewApiManagedVerification: vi.fn(),
+  mockGetPreviewVerificationTargets: vi.fn(),
   mockLoadNewApiChannelKeyWithVerification: vi.fn(),
   mockOpenNewApiManagedVerification: vi.fn(),
   mockPreparePreview: vi.fn(),
@@ -50,6 +56,31 @@ const {
     isOpen: false,
   },
 }))
+
+vi.mock(
+  "~/features/KeyManagement/components/managedSiteTokenBatchExportPreview",
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import("~/features/KeyManagement/components/managedSiteTokenBatchExportPreview")
+      >()
+
+    return {
+      ...actual,
+      getPreviewVerificationTargets: (...args: unknown[]) => {
+        const implementation =
+          mockGetPreviewVerificationTargets.getMockImplementation()
+        return implementation
+          ? mockGetPreviewVerificationTargets(...args)
+          : actual.getPreviewVerificationTargets(
+              args[0] as Parameters<
+                typeof actual.getPreviewVerificationTargets
+              >[0],
+            )
+      },
+    }
+  },
+)
 
 vi.mock("~/services/managedSites/tokenBatchExport", () => ({
   prepareManagedSiteTokenBatchExportPreview: mockPreparePreview,
@@ -155,7 +186,12 @@ vi.mock("~/components/ui", async (importOriginal) => {
       return (
         <button
           type={type}
-          disabled={isVerificationButton ? false : disabled}
+          disabled={
+            isVerificationButton &&
+            mockAllowDisabledVerificationButtonClicks.current
+              ? false
+              : disabled
+          }
           onClick={onClick}
         >
           {children}
@@ -483,8 +519,10 @@ describe("ManagedSiteTokenBatchExportDialog", () => {
     vi.clearAllMocks()
     mockExecuteBatchExport.mockReset()
     mockCloseNewApiManagedVerification.mockReset()
+    mockGetPreviewVerificationTargets.mockReset()
     mockLoadNewApiChannelKeyWithVerification.mockReset()
     mockPreparePreview.mockReset()
+    mockAllowDisabledVerificationButtonClicks.current = false
     mockVerificationDialogState.isOpen = false
     mockLoadNewApiChannelKeyWithVerification.mockImplementation(
       async (params) => {
@@ -937,6 +975,7 @@ describe("ManagedSiteTokenBatchExportDialog", () => {
       ],
     }
     mockVerificationDialogState.isOpen = true
+    mockAllowDisabledVerificationButtonClicks.current = true
     mockPreparePreview.mockResolvedValueOnce(recoverablePreview)
 
     renderDialog()
@@ -951,7 +990,7 @@ describe("ManagedSiteTokenBatchExportDialog", () => {
     expect(mockLoadNewApiChannelKeyWithVerification).not.toHaveBeenCalled()
   })
 
-  it("shows a fallback verification error when a verification target cannot be read", async () => {
+  it("falls back to the clicked item when the preview has no verification targets", async () => {
     const user = userEvent.setup()
     const recoverablePreview: ManagedSiteTokenBatchExportPreview = {
       ...preview,
@@ -968,22 +1007,69 @@ describe("ManagedSiteTokenBatchExportDialog", () => {
       ],
     }
     mockPreparePreview.mockResolvedValueOnce(recoverablePreview)
+    mockGetPreviewVerificationTargets.mockReturnValue([])
 
     renderDialog()
 
     expect(await screen.findByText("Account 1 / Token 1")).toBeInTheDocument()
-    const originalItemId = recoverablePreview.items[0].id
-    Object.defineProperty(recoverablePreview.items[0], "id", {
-      configurable: true,
-      get: () => {
-        const stack = new Error().stack ?? ""
-        if (stack.includes("verifyTargetsFromIndex")) {
-          throw new Error("target unavailable")
-        }
-        return originalItemId
-      },
-    })
+    await user.click(
+      screen.getByRole("button", {
+        name: "keyManagement:batchManagedSiteExport.actions.verifyAndRefresh",
+      }),
+    )
 
+    expect(mockLoadNewApiChannelKeyWithVerification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channelId: 7,
+        label: "Potential channel",
+      }),
+    )
+  })
+
+  it("shows a fallback verification error when the verification target list cannot be read", async () => {
+    const user = userEvent.setup()
+    const recoverablePreview: ManagedSiteTokenBatchExportPreview = {
+      ...preview,
+      totalCount: 1,
+      readyCount: 0,
+      warningCount: 1,
+      skippedCount: 0,
+      blockedCount: 0,
+      items: [
+        buildRecoverablePreviewItem(preview.items[0], {
+          id: 7,
+          name: "Potential channel",
+        }),
+      ],
+    }
+    mockPreparePreview.mockResolvedValueOnce(recoverablePreview)
+    let lengthReads = 0
+    mockGetPreviewVerificationTargets.mockReturnValue(
+      new Proxy(
+        [
+          {
+            item: recoverablePreview.items[0],
+            candidate: recoverablePreview.items[0].verificationCandidate,
+          },
+        ],
+        {
+          get(target, property, receiver) {
+            if (property === "length") {
+              lengthReads += 1
+              if (lengthReads > 1) {
+                throw new Error("target unavailable")
+              }
+            }
+
+            return Reflect.get(target, property, receiver)
+          },
+        },
+      ),
+    )
+
+    renderDialog()
+
+    expect(await screen.findByText("Account 1 / Token 1")).toBeInTheDocument()
     await user.click(
       screen.getByRole("button", {
         name: "keyManagement:batchManagedSiteExport.actions.verifyAndRefresh",

--- a/tests/features/KeyManagement/components/managedSiteTokenBatchExportPreview.test.ts
+++ b/tests/features/KeyManagement/components/managedSiteTokenBatchExportPreview.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from "vitest"
+
+import { SITE_TYPES } from "~/constants/siteType"
+import {
+  applyResolvedChannelKeyToPreviewItem,
+  canEditItemModels,
+  countPreviewItems,
+  getPreviewVerificationTargets,
+  normalizeModels,
+  shouldSelectPreviewItemByDefault,
+  toModelOptions,
+} from "~/features/KeyManagement/components/managedSiteTokenBatchExportPreview"
+import {
+  MANAGED_SITE_TOKEN_BATCH_EXPORT_BLOCKED_REASON_CODES,
+  MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES,
+  MANAGED_SITE_TOKEN_BATCH_EXPORT_WARNING_CODES,
+  type ManagedSiteTokenBatchExportPreview,
+  type ManagedSiteTokenBatchExportPreviewItem,
+} from "~/types/managedSiteTokenBatchExport"
+
+const candidate = {
+  id: 12,
+  name: "Managed Channel 12",
+}
+
+const buildPreviewItem = (
+  fields: Partial<ManagedSiteTokenBatchExportPreviewItem> = {},
+): ManagedSiteTokenBatchExportPreviewItem => ({
+  id: "account_token:account-1:1",
+  accountId: "account-1",
+  accountName: "Account 1",
+  runtimeKeyId: "account_token:account-1:1",
+  runtimeKeyName: "Token 1",
+  status: MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.READY,
+  warningCodes: [],
+  draft: {
+    name: "Account 1 - Token 1",
+    type: 1,
+    key: "sk-source-key",
+    base_url: "https://api.example.invalid",
+    models: ["gpt-4o"],
+    groups: ["default"],
+    priority: 0,
+    weight: 0,
+    status: 1,
+  },
+  ...fields,
+})
+
+const buildRecoverablePreviewItem = (
+  fields: Partial<ManagedSiteTokenBatchExportPreviewItem> = {},
+) =>
+  buildPreviewItem({
+    status: MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.WARNING,
+    warningCodes: [
+      MANAGED_SITE_TOKEN_BATCH_EXPORT_WARNING_CODES.EXACT_VERIFICATION_UNAVAILABLE,
+    ],
+    verificationCandidate: candidate,
+    assessment: {
+      searchBaseUrl: "https://api.example.invalid",
+      searchCompleted: true,
+      url: {
+        matched: true,
+        candidateCount: 1,
+        channel: candidate,
+      },
+      key: {
+        comparable: false,
+        matched: false,
+        reason: "comparison-unavailable",
+      },
+      models: {
+        comparable: true,
+        matched: true,
+        reason: "exact",
+        channel: candidate,
+        similarityScore: 1,
+      },
+    },
+    ...fields,
+  })
+
+describe("managedSiteTokenBatchExportPreview helpers", () => {
+  it("normalizes model options without duplicate or blank entries", () => {
+    expect(toModelOptions(normalizeModels([" gpt-4o ", "", "gpt-4o"]))).toEqual(
+      [{ label: "gpt-4o", value: "gpt-4o" }],
+    )
+  })
+
+  it("keeps duplicate-risk warning rows out of the default selection", () => {
+    expect(
+      shouldSelectPreviewItemByDefault(
+        buildPreviewItem({
+          status: MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.WARNING,
+          warningCodes: [
+            MANAGED_SITE_TOKEN_BATCH_EXPORT_WARNING_CODES.MATCH_REQUIRES_CONFIRMATION,
+          ],
+        }),
+      ),
+    ).toBe(false)
+    expect(shouldSelectPreviewItemByDefault(buildPreviewItem())).toBe(true)
+  })
+
+  it("allows editing models for executable rows and models-required blocked rows", () => {
+    expect(canEditItemModels(buildPreviewItem())).toBe(true)
+    expect(
+      canEditItemModels(
+        buildPreviewItem({
+          status: MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.BLOCKED,
+          blockingReasonCode:
+            MANAGED_SITE_TOKEN_BATCH_EXPORT_BLOCKED_REASON_CODES.MODELS_REQUIRED,
+        }),
+      ),
+    ).toBe(true)
+  })
+
+  it("counts preview items by status", () => {
+    expect(
+      countPreviewItems([
+        buildPreviewItem(),
+        buildPreviewItem({
+          status: MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.WARNING,
+        }),
+        buildPreviewItem({
+          status: MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.SKIPPED,
+        }),
+        buildPreviewItem({
+          status: MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.BLOCKED,
+        }),
+      ]),
+    ).toEqual({
+      readyCount: 1,
+      warningCount: 1,
+      skippedCount: 1,
+      blockedCount: 1,
+    })
+  })
+
+  it("collects New API verification targets from recoverable preview rows", () => {
+    const preview: ManagedSiteTokenBatchExportPreview = {
+      siteType: SITE_TYPES.NEW_API,
+      totalCount: 2,
+      readyCount: 1,
+      warningCount: 1,
+      skippedCount: 0,
+      blockedCount: 0,
+      items: [buildPreviewItem(), buildRecoverablePreviewItem()],
+    }
+
+    expect(getPreviewVerificationTargets(preview)).toEqual([
+      {
+        item: preview.items[1],
+        candidate,
+      },
+    ])
+  })
+
+  it("marks a recoverable row skipped when the verified channel key is an exact match", () => {
+    const item = buildRecoverablePreviewItem()
+
+    expect(
+      applyResolvedChannelKeyToPreviewItem({
+        item,
+        candidate,
+        resolvedKey: "sk-source-key",
+        siteType: SITE_TYPES.NEW_API,
+      }),
+    ).toMatchObject({
+      status: MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.SKIPPED,
+      warningCodes: [],
+      matchedChannel: candidate,
+      verificationCandidate: undefined,
+      assessment: {
+        key: {
+          comparable: true,
+          matched: true,
+          channel: candidate,
+        },
+      },
+    })
+  })
+})

--- a/tests/features/KeyManagement/components/managedSiteTokenBatchExportPreview.test.ts
+++ b/tests/features/KeyManagement/components/managedSiteTokenBatchExportPreview.test.ts
@@ -179,4 +179,58 @@ describe("managedSiteTokenBatchExportPreview helpers", () => {
       },
     })
   })
+
+  it("leaves preview rows unchanged when the resolved channel key cannot be compared", () => {
+    const item = buildRecoverablePreviewItem({
+      assessment: undefined,
+    })
+
+    expect(
+      applyResolvedChannelKeyToPreviewItem({
+        item,
+        candidate,
+        resolvedKey: "sk-source-key",
+      }),
+    ).toBe(item)
+    expect(
+      applyResolvedChannelKeyToPreviewItem({
+        item: buildRecoverablePreviewItem({
+          draft: {
+            ...buildPreviewItem().draft!,
+            key: " ",
+          },
+        }),
+        candidate,
+        resolvedKey: "sk-source-key",
+      }),
+    ).toMatchObject({
+      status: MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.WARNING,
+    })
+  })
+
+  it("keeps a recoverable row as warning when the verified channel key still needs confirmation", () => {
+    const item = buildRecoverablePreviewItem()
+
+    expect(
+      applyResolvedChannelKeyToPreviewItem({
+        item,
+        candidate,
+        resolvedKey: "sk-other-key",
+        siteType: SITE_TYPES.NEW_API,
+      }),
+    ).toMatchObject({
+      status: MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.WARNING,
+      warningCodes: [
+        MANAGED_SITE_TOKEN_BATCH_EXPORT_WARNING_CODES.MATCH_REQUIRES_CONFIRMATION,
+      ],
+      matchedChannel: undefined,
+      verificationCandidate: undefined,
+      assessment: {
+        key: {
+          comparable: true,
+          matched: false,
+        },
+      },
+    })
+  })
 })

--- a/tests/features/KeyManagement/components/managedSiteTokenBatchExportPreview.test.ts
+++ b/tests/features/KeyManagement/components/managedSiteTokenBatchExportPreview.test.ts
@@ -233,4 +233,47 @@ describe("managedSiteTokenBatchExportPreview helpers", () => {
       },
     })
   })
+
+  it("marks a recoverable row ready when verified key removes the only warning", () => {
+    const item = buildRecoverablePreviewItem({
+      assessment: {
+        searchBaseUrl: "https://api.example.invalid",
+        searchCompleted: true,
+        url: {
+          matched: false,
+          candidateCount: 0,
+        },
+        key: {
+          comparable: false,
+          matched: false,
+          reason: "comparison-unavailable",
+        },
+        models: {
+          comparable: true,
+          matched: false,
+          reason: "no-match",
+        },
+      },
+    })
+
+    expect(
+      applyResolvedChannelKeyToPreviewItem({
+        item,
+        candidate,
+        resolvedKey: "test-other-key",
+        siteType: SITE_TYPES.NEW_API,
+      }),
+    ).toMatchObject({
+      status: MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.READY,
+      warningCodes: [],
+      matchedChannel: undefined,
+      verificationCandidate: undefined,
+      assessment: {
+        key: {
+          comparable: true,
+          matched: false,
+        },
+      },
+    })
+  })
 })

--- a/tests/features/ManagedSiteVerification/useNewApiManagedVerification.test.tsx
+++ b/tests/features/ManagedSiteVerification/useNewApiManagedVerification.test.tsx
@@ -15,11 +15,13 @@ const {
   submitNewApiLoginTwoFactorCodeMock,
   submitNewApiSecureVerificationCodeMock,
   createTabMock,
+  loggerWarnMock,
 } = vi.hoisted(() => ({
   ensureNewApiManagedSessionMock: vi.fn(),
   submitNewApiLoginTwoFactorCodeMock: vi.fn(),
   submitNewApiSecureVerificationCodeMock: vi.fn(),
   createTabMock: vi.fn(),
+  loggerWarnMock: vi.fn(),
 }))
 
 vi.mock("react-hot-toast", () => ({
@@ -51,6 +53,12 @@ vi.mock("~/utils/browser/browserApi", () => ({
   createTab: (...args: unknown[]) => createTabMock(...args),
 }))
 
+vi.mock("~/utils/core/logger", () => ({
+  createLogger: () => ({
+    warn: loggerWarnMock,
+  }),
+}))
+
 const BASE_REQUEST = {
   kind: "token" as const,
   label: "Token A",
@@ -69,6 +77,7 @@ describe("useNewApiManagedVerification", () => {
     submitNewApiLoginTwoFactorCodeMock.mockReset()
     submitNewApiSecureVerificationCodeMock.mockReset()
     createTabMock.mockReset()
+    loggerWarnMock.mockReset()
     vi.mocked(toast.success).mockReset()
     vi.mocked(toast.error).mockReset()
   })
@@ -774,6 +783,42 @@ describe("useNewApiManagedVerification", () => {
 
     act(() => {
       resolveVerified?.()
+    })
+  })
+
+  it("logs background onVerified failures after closing immediately", async () => {
+    const error = new Error("callback failed")
+    const onVerified = vi.fn().mockRejectedValue(error)
+    const { result } = renderHook(() => useNewApiManagedVerification())
+
+    act(() => {
+      result.current.openNewApiManagedVerification({
+        ...BASE_REQUEST,
+        kind: "channel",
+        onVerified,
+        initialSessionResult: {
+          status: NEW_API_MANAGED_SESSION_STATUSES.VERIFIED,
+          methods: {
+            twoFactorEnabled: true,
+            passkeyEnabled: false,
+          },
+        },
+      })
+    })
+
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledTimes(1)
+      expect(result.current.dialogState.isOpen).toBe(false)
+    })
+    await waitFor(() => {
+      expect(loggerWarnMock).toHaveBeenCalledWith(
+        "New API managed verification onVerified failed",
+        {
+          kind: "channel",
+          error,
+        },
+      )
+      expect(toast.error).toHaveBeenCalledTimes(1)
     })
   })
 

--- a/tests/features/ManagedSiteVerification/useNewApiManagedVerification.test.tsx
+++ b/tests/features/ManagedSiteVerification/useNewApiManagedVerification.test.tsx
@@ -3,6 +3,7 @@ import toast from "react-hot-toast"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import {
+  NEW_API_MANAGED_VERIFICATION_CLOSE_MODES,
   NEW_API_MANAGED_VERIFICATION_STEPS,
   useNewApiManagedVerification,
 } from "~/features/ManagedSiteVerification/useNewApiManagedVerification"
@@ -151,6 +152,86 @@ describe("useNewApiManagedVerification", () => {
         NEW_API_MANAGED_VERIFICATION_STEPS.LOGIN_2FA,
       )
       expect(onVerified).not.toHaveBeenCalled()
+    })
+  })
+
+  it("uses configured TOTP before showing a prefetched login-2fa step", async () => {
+    ensureNewApiManagedSessionMock.mockResolvedValue({
+      status: NEW_API_MANAGED_SESSION_STATUSES.VERIFIED,
+      methods: {
+        twoFactorEnabled: true,
+        passkeyEnabled: false,
+      },
+    })
+
+    const onVerified = vi.fn()
+    const { result } = renderHook(() => useNewApiManagedVerification())
+
+    act(() => {
+      result.current.openNewApiManagedVerification({
+        ...BASE_REQUEST,
+        config: {
+          ...BASE_REQUEST.config,
+          totpSecret: "JBSWY3DPEHPK3PXP",
+        },
+        onVerified,
+        initialSessionResult: {
+          status: NEW_API_MANAGED_SESSION_STATUSES.LOGIN_2FA_REQUIRED,
+          automaticAttempted: false,
+        },
+      })
+    })
+
+    await waitFor(() => {
+      expect(ensureNewApiManagedSessionMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          totpSecret: "JBSWY3DPEHPK3PXP",
+        }),
+      )
+      expect(onVerified).toHaveBeenCalledTimes(1)
+      expect(result.current.dialogState.isOpen).toBe(false)
+    })
+  })
+
+  it("uses configured TOTP before showing a prefetched secure-verification step", async () => {
+    ensureNewApiManagedSessionMock.mockResolvedValue({
+      status: NEW_API_MANAGED_SESSION_STATUSES.VERIFIED,
+      methods: {
+        twoFactorEnabled: true,
+        passkeyEnabled: false,
+      },
+    })
+
+    const onVerified = vi.fn()
+    const { result } = renderHook(() => useNewApiManagedVerification())
+
+    act(() => {
+      result.current.openNewApiManagedVerification({
+        ...BASE_REQUEST,
+        config: {
+          ...BASE_REQUEST.config,
+          totpSecret: "JBSWY3DPEHPK3PXP",
+        },
+        onVerified,
+        initialSessionResult: {
+          status: NEW_API_MANAGED_SESSION_STATUSES.SECURE_VERIFICATION_REQUIRED,
+          methods: {
+            twoFactorEnabled: true,
+            passkeyEnabled: false,
+          },
+          automaticAttempted: false,
+        },
+      })
+    })
+
+    await waitFor(() => {
+      expect(ensureNewApiManagedSessionMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          totpSecret: "JBSWY3DPEHPK3PXP",
+        }),
+      )
+      expect(onVerified).toHaveBeenCalledTimes(1)
+      expect(result.current.dialogState.isOpen).toBe(false)
     })
   })
 
@@ -584,7 +665,7 @@ describe("useNewApiManagedVerification", () => {
     })
   })
 
-  it("runs the channel onVerified flow before showing the success toast", async () => {
+  it("runs the channel onVerified flow before showing the success toast when configured to wait", async () => {
     const onVerified = vi.fn().mockResolvedValue(undefined)
     const { result } = renderHook(() => useNewApiManagedVerification())
 
@@ -594,6 +675,8 @@ describe("useNewApiManagedVerification", () => {
         kind: "channel",
         label: "Channel A",
         onVerified,
+        closeMode:
+          NEW_API_MANAGED_VERIFICATION_CLOSE_MODES.CLOSE_AFTER_CALLBACK,
         initialSessionResult: {
           status: NEW_API_MANAGED_SESSION_STATUSES.VERIFIED,
           methods: {
@@ -627,6 +710,8 @@ describe("useNewApiManagedVerification", () => {
         ...BASE_REQUEST,
         kind: "settings",
         onVerified,
+        closeMode:
+          NEW_API_MANAGED_VERIFICATION_CLOSE_MODES.CLOSE_AFTER_CALLBACK,
         initialSessionResult: {
           status: NEW_API_MANAGED_SESSION_STATUSES.VERIFIED,
           methods: {
@@ -652,6 +737,43 @@ describe("useNewApiManagedVerification", () => {
     await waitFor(() => {
       expect(toast.success).toHaveBeenCalledTimes(1)
       expect(result.current.dialogState.isOpen).toBe(false)
+    })
+  })
+
+  it("closes immediately after verification by default while onVerified continues", async () => {
+    let resolveVerified: (() => void) | null = null
+    const onVerified = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveVerified = resolve
+        }),
+    )
+
+    const { result } = renderHook(() => useNewApiManagedVerification())
+
+    act(() => {
+      result.current.openNewApiManagedVerification({
+        ...BASE_REQUEST,
+        kind: "channel",
+        onVerified,
+        initialSessionResult: {
+          status: NEW_API_MANAGED_SESSION_STATUSES.VERIFIED,
+          methods: {
+            twoFactorEnabled: true,
+            passkeyEnabled: false,
+          },
+        },
+      })
+    })
+
+    await waitFor(() => {
+      expect(onVerified).toHaveBeenCalledTimes(1)
+      expect(toast.success).toHaveBeenCalledTimes(1)
+      expect(result.current.dialogState.isOpen).toBe(false)
+    })
+
+    act(() => {
+      resolveVerified?.()
     })
   })
 

--- a/tests/services/managedSites/channelMatchResolver.test.ts
+++ b/tests/services/managedSites/channelMatchResolver.test.ts
@@ -772,6 +772,83 @@ describe("resolveManagedSiteChannelMatch", () => {
     expect(getManagedSiteChannelExactMatch(result)?.id).toBe(28)
   })
 
+  it("reuses cached channel searches and hidden-key resolutions across concurrent match checks", async () => {
+    const maskedCandidate = buildManagedSiteChannel({
+      id: 72,
+      name: "Shared Hidden Candidate",
+      base_url: "https://api.example.com/v1",
+      models: "gpt-4",
+      key: "sk-***",
+    })
+    let resolveSearch: (value: {
+      items: ManagedSiteChannel[]
+      total: number
+      type_counts: Record<string, number>
+    }) => void = () => {}
+    let resolveSecret: (value: string) => void = () => {}
+    const searchChannel = vi.fn(
+      () =>
+        new Promise((resolve) => {
+          resolveSearch = resolve
+        }),
+    )
+    const fetchChannelSecretKey = vi.fn(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveSecret = resolve
+        }),
+    )
+    const service = createManagedSiteServiceStub({
+      searchChannel,
+      fetchChannelSecretKey,
+    })
+    const requestCache = {
+      searchResultsByBaseUrl: new Map(),
+      resolvedChannelKeysById: {},
+      channelSecretKeysById: new Map(),
+    }
+
+    const firstResultPromise = resolveManagedSiteChannelMatch({
+      service,
+      managedConfig,
+      accountBaseUrl: "https://api.example.com/v1",
+      models: ["gpt-4"],
+      key: "sk-match",
+      resolveHiddenKeys: true,
+      requestCache,
+    })
+    const secondResultPromise = resolveManagedSiteChannelMatch({
+      service,
+      managedConfig,
+      accountBaseUrl: "https://api.example.com",
+      models: ["gpt-4"],
+      key: "sk-match",
+      resolveHiddenKeys: true,
+      requestCache,
+    })
+
+    expect(searchChannel).toHaveBeenCalledTimes(1)
+
+    resolveSearch({
+      items: [maskedCandidate],
+      total: 1,
+      type_counts: {},
+    })
+    await Promise.resolve()
+    expect(fetchChannelSecretKey).toHaveBeenCalledTimes(1)
+
+    resolveSecret("sk-match")
+    const results = await Promise.all([firstResultPromise, secondResultPromise])
+
+    expect(fetchChannelSecretKey).toHaveBeenCalledTimes(1)
+    expect(requestCache.resolvedChannelKeysById).toEqual({
+      72: "sk-match",
+    })
+    expect(
+      results.map((result) => getManagedSiteChannelExactMatch(result)?.id),
+    ).toEqual([72, 72])
+  })
+
   it("keeps the advisory-match state when hidden-key recovery still needs verification", async () => {
     const hiddenUrlOnlyCandidate = buildManagedSiteChannel({
       id: 31,

--- a/tests/services/managedSites/channelMatchResolver.test.ts
+++ b/tests/services/managedSites/channelMatchResolver.test.ts
@@ -8,7 +8,10 @@ import {
   MANAGED_SITE_CHANNEL_MODELS_MATCH_REASONS,
   MatchResolutionUnresolvedError,
 } from "~/services/managedSites/channelMatch"
-import { resolveManagedSiteChannelMatch } from "~/services/managedSites/channelMatchResolver"
+import {
+  createManagedSiteChannelMatchRequestCache,
+  resolveManagedSiteChannelMatch,
+} from "~/services/managedSites/channelMatchResolver"
 import type { ManagedSiteChannel } from "~/types/managedSite"
 import { buildManagedSiteChannel } from "~~/tests/test-utils/factories"
 
@@ -903,5 +906,87 @@ describe("resolveManagedSiteChannelMatch", () => {
     expect(result.unresolvedReason).toBe(
       MANAGED_SITE_CHANNEL_MATCH_UNRESOLVED_REASONS.VERIFICATION_REQUIRED,
     )
+  })
+
+  it("evicts failed cached channel searches so later lookups can retry", async () => {
+    const requestCache = createManagedSiteChannelMatchRequestCache()
+    const searchChannel = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("temporary search failure"))
+      .mockResolvedValueOnce({
+        items: [
+          buildManagedSiteChannel({
+            id: 82,
+            key: "sk-match",
+            base_url: "https://api.example.com",
+            models: "gpt-4o",
+          }),
+        ],
+        total: 1,
+        type_counts: {},
+      })
+    const service = createManagedSiteServiceStub({
+      searchChannel,
+    })
+    const request = {
+      service,
+      managedConfig,
+      accountBaseUrl: "https://api.example.com",
+      models: ["gpt-4o"],
+      key: "sk-match",
+      requestCache,
+    }
+
+    await expect(resolveManagedSiteChannelMatch(request)).rejects.toThrow(
+      "temporary search failure",
+    )
+    await expect(
+      resolveManagedSiteChannelMatch(request),
+    ).resolves.toMatchObject({
+      key: {
+        matched: true,
+      },
+    })
+    expect(searchChannel).toHaveBeenCalledTimes(2)
+  })
+
+  it("evicts failed cached channel-key fetches so later hidden-key recovery can retry", async () => {
+    const requestCache = createManagedSiteChannelMatchRequestCache()
+    const hiddenCandidate = buildManagedSiteChannel({
+      id: 83,
+      key: "",
+      base_url: "https://api.example.com",
+      models: "gpt-4o",
+    })
+    const fetchChannelSecretKey = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("temporary key failure"))
+      .mockResolvedValueOnce("sk-match")
+    const service = createManagedSiteServiceStub({
+      searchChannel: vi.fn().mockResolvedValue({
+        items: [hiddenCandidate],
+        total: 1,
+        type_counts: {},
+      }),
+      fetchChannelSecretKey,
+    })
+    const request = {
+      service,
+      managedConfig,
+      accountBaseUrl: "https://api.example.com",
+      models: ["gpt-4o"],
+      key: "sk-match",
+      resolveHiddenKeys: true,
+      requestCache,
+    }
+
+    const firstResult = await resolveManagedSiteChannelMatch(request)
+    const secondResult = await resolveManagedSiteChannelMatch(request)
+
+    expect(firstResult.unresolvedReason).toBe(
+      MANAGED_SITE_CHANNEL_MATCH_UNRESOLVED_REASONS.VERIFICATION_REQUIRED,
+    )
+    expect(getManagedSiteChannelExactMatch(secondResult)?.id).toBe(83)
+    expect(fetchChannelSecretKey).toHaveBeenCalledTimes(2)
   })
 })

--- a/tests/services/managedSites/channelMatchResolver.test.ts
+++ b/tests/services/managedSites/channelMatchResolver.test.ts
@@ -14,38 +14,13 @@ import {
 } from "~/services/managedSites/channelMatchResolver"
 import type { ManagedSiteChannel } from "~/types/managedSite"
 import { buildManagedSiteChannel } from "~~/tests/test-utils/factories"
+import { createManagedSiteServiceStub } from "~~/tests/test-utils/managedSiteServiceFactory"
 
 const managedConfig = {
   baseUrl: "https://managed.example",
   adminToken: "managed-token",
   userId: "1",
 }
-
-const createManagedSiteServiceStub = (
-  overrides: Record<string, unknown> = {},
-) =>
-  ({
-    siteType: "new-api",
-    messagesKey: "newapi",
-    searchChannel: vi.fn().mockResolvedValue({
-      items: [],
-      total: 0,
-      type_counts: {},
-    }),
-    createChannel: vi.fn(),
-    updateChannel: vi.fn(),
-    deleteChannel: vi.fn(),
-    checkValidConfig: vi.fn().mockResolvedValue(true),
-    getConfig: vi.fn().mockResolvedValue(managedConfig),
-    fetchAvailableModels: vi.fn(),
-    buildChannelName: vi.fn(),
-    prepareChannelFormData: vi.fn(),
-    buildChannelPayload: vi.fn(),
-    hydrateComparableChannelKeys: vi.fn(
-      async (_config, candidates) => candidates,
-    ),
-    ...overrides,
-  }) as any
 
 describe("resolveManagedSiteChannelMatch", () => {
   it("skips candidate key hydration when a local exact match is already available", async () => {
@@ -178,6 +153,7 @@ describe("resolveManagedSiteChannelMatch", () => {
   })
 
   it("hydrates narrowed comparable candidates instead of calling provider duplicate search", async () => {
+    const requestCache = createManagedSiteChannelMatchRequestCache()
     const searchChannel = vi.fn().mockResolvedValue({
       items: [
         buildManagedSiteChannel({
@@ -205,6 +181,7 @@ describe("resolveManagedSiteChannelMatch", () => {
       accountBaseUrl: "https://api.example.com/v1",
       models: ["gpt-4o"],
       key: "sk-match",
+      requestCache,
     })
 
     expect(searchChannel).toHaveBeenCalledTimes(1)
@@ -213,6 +190,9 @@ describe("resolveManagedSiteChannelMatch", () => {
     ])
     expect(result.key.matched).toBe(true)
     expect(result.models.matched).toBe(true)
+    expect(requestCache.resolvedChannelKeysById).toEqual({
+      7: "sk-match",
+    })
   })
 
   it("marks key comparison unavailable when candidate key hydration requires verification", async () => {

--- a/tests/services/managedSites/channelMatching.test.ts
+++ b/tests/services/managedSites/channelMatching.test.ts
@@ -15,6 +15,7 @@ import {
   findManagedSiteChannelsByBaseUrlAndModels,
   getManagedSiteChannelKeyComparisonMode,
   inspectManagedSiteChannelKeyMatch,
+  inspectManagedSiteChannelKeyValueMatch,
   inspectManagedSiteChannelModelsMatch,
   MANAGED_SITE_CHANNEL_KEY_COMPARISON_MODES,
 } from "~/services/managedSites/utils/channelMatching"
@@ -318,6 +319,43 @@ describe("channelMatching", () => {
     })
   })
 
+  it("compares raw channel-key values with optional sk-prefix normalization", () => {
+    expect(
+      inspectManagedSiteChannelKeyValueMatch({
+        sourceKey: "",
+        channelKey: "sk-stored-key",
+      }),
+    ).toEqual({
+      comparable: false,
+      matched: false,
+      reason: MANAGED_SITE_CHANNEL_KEY_MATCH_REASONS.NO_KEY_PROVIDED,
+    })
+
+    expect(
+      inspectManagedSiteChannelKeyValueMatch({
+        sourceKey: "sk-stored-key",
+        channelKey: "",
+      }),
+    ).toEqual({
+      comparable: false,
+      matched: false,
+      reason: MANAGED_SITE_CHANNEL_KEY_MATCH_REASONS.COMPARISON_UNAVAILABLE,
+    })
+
+    expect(
+      inspectManagedSiteChannelKeyValueMatch({
+        sourceKey: "sk-stored-key",
+        channelKey: "stored-key, other-key",
+        keyComparisonMode:
+          MANAGED_SITE_CHANNEL_KEY_COMPARISON_MODES.OPTIONAL_SK_PREFIX,
+      }),
+    ).toEqual({
+      comparable: true,
+      matched: true,
+      reason: MANAGED_SITE_CHANNEL_KEY_MATCH_REASONS.MATCHED,
+    })
+  })
+
   it("distinguishes missing comparable keys from comparable key mismatches", () => {
     const urlOnlyChannel = buildManagedSiteChannel({
       id: 1_4,
@@ -411,6 +449,44 @@ describe("channelMatching", () => {
       matched: false,
       reason: MANAGED_SITE_CHANNEL_MODELS_MATCH_REASONS.NO_MATCH,
       channel: null,
+    })
+  })
+
+  it("maps contained and similar URL model matches into model assessments", () => {
+    const containedChannel = buildManagedSiteChannel({
+      id: 1_8,
+      base_url: "https://api.example.com",
+      models: "gpt-4,gpt-4o-mini",
+    })
+    const similarChannel = buildManagedSiteChannel({
+      id: 1_9,
+      base_url: "https://similar.example.com",
+      models: "gpt-4,gpt-4o,claude-3",
+    })
+
+    expect(
+      inspectManagedSiteChannelModelsMatch({
+        channels: [containedChannel],
+        accountBaseUrl: "https://api.example.com",
+        models: ["gpt-4"],
+      }),
+    ).toMatchObject({
+      comparable: true,
+      matched: true,
+      reason: MANAGED_SITE_CHANNEL_MODELS_MATCH_REASONS.CONTAINED,
+      channel: containedChannel,
+    })
+    expect(
+      inspectManagedSiteChannelModelsMatch({
+        channels: [similarChannel],
+        accountBaseUrl: "https://similar.example.com",
+        models: ["gpt-4", "gpt-4o", "gemini-2.0"],
+      }),
+    ).toMatchObject({
+      comparable: true,
+      matched: true,
+      reason: MANAGED_SITE_CHANNEL_MODELS_MATCH_REASONS.SIMILAR,
+      channel: similarChannel,
     })
   })
 
@@ -608,6 +684,26 @@ describe("channelMatching", () => {
       level: MANAGED_SITE_CHANNEL_MATCH_LEVELS.NONE,
       reason: MANAGED_SITE_CHANNEL_MATCH_REASONS.UNRESOLVED,
       channel: null,
+    })
+  })
+
+  it("skips URL bucket channels without comparable model inputs before falling back to URL-only", () => {
+    const blankModelChannel = buildManagedSiteChannel({
+      id: 8,
+      base_url: "https://api.example.com",
+      models: "",
+    })
+
+    expect(
+      findBestManagedSiteChannelMatch({
+        channels: [blankModelChannel],
+        accountBaseUrl: "https://api.example.com",
+        models: ["gpt-4"],
+      }),
+    ).toEqual({
+      level: MANAGED_SITE_CHANNEL_MATCH_LEVELS.FUZZY,
+      reason: MANAGED_SITE_CHANNEL_MATCH_REASONS.URL_ONLY,
+      channel: blankModelChannel,
     })
   })
 })

--- a/tests/services/managedSites/providers/defaultChannelGroups.test.ts
+++ b/tests/services/managedSites/providers/defaultChannelGroups.test.ts
@@ -99,4 +99,40 @@ describe("resolveDefaultChannelGroups", () => {
     expect(result).toEqual(["default"])
     expect(onError).toHaveBeenCalledTimes(1)
   })
+
+  it("reuses the same in-flight default group lookup within an operation context", async () => {
+    const { createManagedSiteOperationContext } = await import(
+      "~/services/managedSites/operationContext"
+    )
+    const { resolveDefaultChannelGroups } = await import(
+      "~/services/managedSites/providers/defaultChannelGroups"
+    )
+
+    mockFetchSiteUserGroups.mockResolvedValueOnce(["vip", "Default"])
+
+    const operationContext = createManagedSiteOperationContext()
+    const getConfig = vi.fn(async () => ({
+      baseUrl: "https://managed.example.com",
+      adminToken: "admin-token",
+      userId: "1",
+    }))
+
+    const [first, second] = await Promise.all([
+      resolveDefaultChannelGroups({
+        fetchSiteUserGroups: mockFetchSiteUserGroups,
+        getConfig,
+        operationContext,
+      }),
+      resolveDefaultChannelGroups({
+        fetchSiteUserGroups: mockFetchSiteUserGroups,
+        getConfig,
+        operationContext,
+      }),
+    ])
+
+    expect(first).toEqual(["Default"])
+    expect(second).toEqual(["Default"])
+    expect(getConfig).toHaveBeenCalledTimes(1)
+    expect(mockFetchSiteUserGroups).toHaveBeenCalledTimes(1)
+  })
 })

--- a/tests/services/managedSites/tokenBatchExport.test.ts
+++ b/tests/services/managedSites/tokenBatchExport.test.ts
@@ -41,6 +41,11 @@ vi.mock("~/services/managedSites/managedSiteService", () => ({
 }))
 
 vi.mock("~/services/managedSites/channelMatchResolver", () => ({
+  createManagedSiteChannelMatchRequestCache: () => ({
+    searchResultsByBaseUrl: new Map(),
+    channelSecretKeysById: new Map(),
+    resolvedChannelKeysById: {},
+  }),
   resolveManagedSiteChannelMatch: mockResolveManagedSiteChannelMatch,
 }))
 
@@ -136,6 +141,11 @@ const buildService = (
     ...overrides,
   }) as ManagedSiteService
 
+const expectBatchDraftOptions = () =>
+  expect.objectContaining({
+    operationContext: expect.any(Object),
+  })
+
 describe("managed-site token batch export", () => {
   beforeEach(() => {
     vi.resetAllMocks()
@@ -219,6 +229,33 @@ describe("managed-site token batch export", () => {
     )
   })
 
+  it("passes previously resolved channel keys into duplicate matching", async () => {
+    const service = buildService()
+    mockGetManagedSiteService.mockResolvedValue(service)
+
+    const { prepareManagedSiteTokenBatchExportPreview } = await import(
+      "~/services/managedSites/tokenBatchExport"
+    )
+
+    const input = buildAccountTokenInput()
+    await prepareManagedSiteTokenBatchExportPreview({
+      items: [input],
+      resolvedChannelKeysByItemId: {
+        [input.runtimeKey.id]: {
+          77: "resolved-channel-key",
+        },
+      },
+    })
+
+    expect(mockResolveManagedSiteChannelMatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resolvedChannelKeysById: {
+          77: "resolved-channel-key",
+        },
+      }),
+    )
+  })
+
   it("previews service credentials without resolving an account token secret", async () => {
     const service = buildService()
     mockGetManagedSiteService.mockResolvedValue(service)
@@ -264,6 +301,7 @@ describe("managed-site token batch export", () => {
         key: "sk-service-credential",
         accountId: "sharedchat-account",
       }),
+      expectBatchDraftOptions(),
     )
     expect(preview.items[0]).toMatchObject({
       id: "service_credential:sharedchat-account:codex",
@@ -306,6 +344,7 @@ describe("managed-site token batch export", () => {
         id: token.id,
         key: "token-secret",
       }),
+      expectBatchDraftOptions(),
     )
   })
 
@@ -346,6 +385,7 @@ describe("managed-site token batch export", () => {
         id: token.id,
         key: "token-secret",
       }),
+      expectBatchDraftOptions(),
     )
   })
 
@@ -393,6 +433,7 @@ describe("managed-site token batch export", () => {
         name: "Codex API Key",
         key: "sk-service-credential",
       }),
+      expectBatchDraftOptions(),
     )
   })
 
@@ -816,6 +857,154 @@ describe("managed-site token batch export", () => {
       })
     } finally {
       vi.doMock("~/services/managedSites/channelMatchResolver", () => ({
+        createManagedSiteChannelMatchRequestCache: () => ({
+          searchResultsByBaseUrl: new Map(),
+          channelSecretKeysById: new Map(),
+          resolvedChannelKeysById: {},
+        }),
+        resolveManagedSiteChannelMatch: mockResolveManagedSiteChannelMatch,
+      }))
+      vi.resetModules()
+    }
+  })
+
+  it("skips exact duplicates when preview can resolve a hidden managed-site channel key", async () => {
+    vi.resetModules()
+    vi.doUnmock("~/services/managedSites/channelMatchResolver")
+
+    try {
+      const fetchChannelSecretKey = vi.fn().mockResolvedValue("token-secret")
+      const service = buildService({
+        searchChannel: vi.fn().mockResolvedValue({
+          items: [
+            buildManagedSiteChannel({
+              id: 77,
+              key: "",
+              base_url: "https://upstream.example.com/v1",
+              models: "gpt-4o",
+            }),
+          ],
+          total: 1,
+          type_counts: {},
+        }),
+        fetchChannelSecretKey,
+      })
+      mockGetManagedSiteService.mockResolvedValue(service)
+
+      const { prepareManagedSiteTokenBatchExportPreview } = await import(
+        "~/services/managedSites/tokenBatchExport"
+      )
+
+      const preview = await prepareManagedSiteTokenBatchExportPreview({
+        items: [
+          buildAccountTokenInput(
+            buildDisplaySiteData({
+              baseUrl: "https://upstream.example.com/",
+            }),
+          ),
+        ],
+      })
+
+      expect(fetchChannelSecretKey).toHaveBeenCalledWith(
+        expect.objectContaining({
+          baseUrl: "https://target.example.com",
+          adminToken: "admin-token",
+          userId: "1",
+        }),
+        77,
+      )
+      expect(preview.items[0]).toMatchObject({
+        status: MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.SKIPPED,
+        matchedChannel: {
+          id: 77,
+        },
+      })
+    } finally {
+      vi.doMock("~/services/managedSites/channelMatchResolver", () => ({
+        createManagedSiteChannelMatchRequestCache: () => ({
+          searchResultsByBaseUrl: new Map(),
+          channelSecretKeysById: new Map(),
+          resolvedChannelKeysById: {},
+        }),
+        resolveManagedSiteChannelMatch: mockResolveManagedSiteChannelMatch,
+      }))
+      vi.resetModules()
+    }
+  })
+
+  it("reuses managed-site draft and duplicate-check request caches across preview items with the same base URL", async () => {
+    vi.resetModules()
+    vi.doUnmock("~/services/managedSites/channelMatchResolver")
+
+    try {
+      const searchChannel = vi.fn().mockResolvedValue({
+        items: [
+          buildManagedSiteChannel({
+            id: 77,
+            key: "sk-***",
+            base_url: "https://upstream.example.com/v1",
+            models: "gpt-4o",
+          }),
+        ],
+        total: 1,
+        type_counts: {},
+      })
+      const fetchChannelSecretKey = vi.fn().mockResolvedValue("token-secret")
+      const service = buildService({
+        searchChannel,
+        fetchChannelSecretKey,
+      })
+      mockGetManagedSiteService.mockResolvedValue(service)
+
+      const account = buildDisplaySiteData({
+        id: "account-1",
+        name: "Alpha",
+        baseUrl: "https://upstream.example.com/v1",
+      })
+      const firstToken = buildAccountToken({
+        id: 11,
+        name: "Token 11",
+        key: "token-secret",
+      })
+      const secondToken = buildAccountToken({
+        id: 12,
+        name: "Token 12",
+        key: "token-secret",
+      })
+
+      const { prepareManagedSiteTokenBatchExportPreview } = await import(
+        "~/services/managedSites/tokenBatchExport"
+      )
+
+      const preview = await prepareManagedSiteTokenBatchExportPreview({
+        items: [
+          buildAccountTokenInput(account, firstToken),
+          buildAccountTokenInput(account, secondToken),
+        ],
+      })
+
+      expect(searchChannel).toHaveBeenCalledTimes(1)
+      expect(fetchChannelSecretKey).toHaveBeenCalledTimes(1)
+      const prepareChannelFormDataMock = vi.mocked(
+        service.prepareChannelFormData,
+      )
+      const firstDraftOptions = prepareChannelFormDataMock.mock.calls[0]?.[2]
+      const secondDraftOptions = prepareChannelFormDataMock.mock.calls[1]?.[2]
+      expect(firstDraftOptions).toEqual(expectBatchDraftOptions())
+      expect(firstDraftOptions?.operationContext).toBe(
+        secondDraftOptions?.operationContext,
+      )
+      expect(preview.skippedCount).toBe(2)
+      expect(preview.items.map((item) => item.matchedChannel?.id)).toEqual([
+        77, 77,
+      ])
+    } finally {
+      vi.doMock("~/services/managedSites/channelMatchResolver", () => ({
+        createManagedSiteChannelMatchRequestCache: () => ({
+          searchResultsByBaseUrl: new Map(),
+          channelSecretKeysById: new Map(),
+          resolvedChannelKeysById: {},
+        }),
         resolveManagedSiteChannelMatch: mockResolveManagedSiteChannelMatch,
       }))
       vi.resetModules()

--- a/tests/services/managedSites/tokenBatchExport.test.ts
+++ b/tests/services/managedSites/tokenBatchExport.test.ts
@@ -868,6 +868,58 @@ describe("managed-site token batch export", () => {
     }
   })
 
+  it("does not expose New API verification candidates for other managed-site types", async () => {
+    const service = buildService({
+      siteType: SITE_TYPES.DONE_HUB,
+      messagesKey: "donehub",
+    })
+    mockGetManagedSiteService.mockResolvedValue(service)
+    mockResolveManagedSiteChannelMatch.mockResolvedValue(
+      buildMatchInspection({
+        searchCompleted: true,
+        url: {
+          matched: true,
+          channel: buildManagedSiteChannel({
+            id: 78,
+            name: "DoneHub Channel",
+          }),
+          candidateCount: 1,
+        },
+        key: {
+          comparable: false,
+          matched: false,
+          reason: "comparison-unavailable",
+          channel: null,
+        },
+        models: {
+          comparable: true,
+          matched: true,
+          reason: "exact",
+          channel: buildManagedSiteChannel({
+            id: 78,
+            name: "DoneHub Channel",
+          }),
+        },
+      }),
+    )
+
+    const { prepareManagedSiteTokenBatchExportPreview } = await import(
+      "~/services/managedSites/tokenBatchExport"
+    )
+
+    const preview = await prepareManagedSiteTokenBatchExportPreview({
+      items: [buildAccountTokenInput()],
+    })
+
+    expect(preview.items[0]).toMatchObject({
+      status: MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.WARNING,
+      warningCodes: [
+        MANAGED_SITE_TOKEN_BATCH_EXPORT_WARNING_CODES.EXACT_VERIFICATION_UNAVAILABLE,
+      ],
+    })
+    expect(preview.items[0].verificationCandidate).toBeUndefined()
+  })
+
   it("skips exact duplicates when preview can resolve a hidden managed-site channel key", async () => {
     vi.resetModules()
     vi.doUnmock("~/services/managedSites/channelMatchResolver")

--- a/tests/services/managedSites/tokenChannelStatus.test.ts
+++ b/tests/services/managedSites/tokenChannelStatus.test.ts
@@ -11,6 +11,7 @@ import {
   getManagedSiteTokenChannelStatus,
   MANAGED_SITE_TOKEN_CHANNEL_STATUS_UNKNOWN_REASONS,
   MANAGED_SITE_TOKEN_CHANNEL_STATUSES,
+  resolveManagedSiteTokenChannelStatusWithVerifiedKey,
 } from "~/services/managedSites/tokenChannelStatus"
 import { supportsManagedSiteBaseUrlChannelLookup } from "~/services/managedSites/utils/managedSite"
 import {
@@ -137,6 +138,94 @@ const createManagedSiteServiceStub = (
     ),
     ...overrides,
   }) as any
+
+const buildRecoverableVerificationUnavailableStatus = (
+  overrides: Record<string, unknown> = {},
+) => ({
+  status: MANAGED_SITE_TOKEN_CHANNEL_STATUSES.UNKNOWN,
+  reason:
+    MANAGED_SITE_TOKEN_CHANNEL_STATUS_UNKNOWN_REASONS.EXACT_VERIFICATION_UNAVAILABLE,
+  assessment: {
+    searchBaseUrl: "https://api.example.com",
+    searchCompleted: true,
+    url: {
+      matched: true,
+      candidateCount: 1,
+      channel: {
+        id: 12,
+        name: "Managed Channel 12",
+      },
+    },
+    key: {
+      comparable: false,
+      matched: false,
+      reason: MANAGED_SITE_CHANNEL_KEY_MATCH_REASONS.COMPARISON_UNAVAILABLE,
+      channel: undefined,
+    },
+    models: {
+      comparable: true,
+      matched: true,
+      reason: MANAGED_SITE_CHANNEL_MODELS_MATCH_REASONS.EXACT,
+      channel: {
+        id: 12,
+        name: "Managed Channel 12",
+      },
+      similarityScore: 1,
+    },
+  },
+  ...overrides,
+})
+
+describe("resolveManagedSiteTokenChannelStatusWithVerifiedKey", () => {
+  it("marks the token as added when the verified channel key matches the token key", () => {
+    const result = resolveManagedSiteTokenChannelStatusWithVerifiedKey({
+      status: buildRecoverableVerificationUnavailableStatus() as any,
+      tokenKey: "sk-token-secret",
+      channelId: 12,
+      channelKey: "sk-token-secret",
+      siteType: SITE_TYPES.NEW_API,
+    })
+
+    expect(result).toEqual({
+      status: MANAGED_SITE_TOKEN_CHANNEL_STATUSES.ADDED,
+      matchedChannel: {
+        id: 12,
+        name: "Managed Channel 12",
+      },
+      resolvedChannelKeysById: {
+        12: "sk-token-secret",
+      },
+      assessment: buildExpectedAssessment(),
+    })
+  })
+
+  it("keeps the status as requiring confirmation when the verified key does not match", () => {
+    const result = resolveManagedSiteTokenChannelStatusWithVerifiedKey({
+      status: buildRecoverableVerificationUnavailableStatus() as any,
+      tokenKey: "sk-token-secret",
+      channelId: 12,
+      channelKey: "sk-other-secret",
+      siteType: SITE_TYPES.NEW_API,
+    })
+
+    expect(result).toEqual({
+      status: MANAGED_SITE_TOKEN_CHANNEL_STATUSES.UNKNOWN,
+      reason:
+        MANAGED_SITE_TOKEN_CHANNEL_STATUS_UNKNOWN_REASONS.MATCH_REQUIRES_CONFIRMATION,
+      resolvedChannelKeysById: {
+        12: "sk-other-secret",
+      },
+      assessment: buildExpectedAssessment({
+        key: {
+          comparable: true,
+          matched: false,
+          reason: MANAGED_SITE_CHANNEL_KEY_MATCH_REASONS.NO_MATCH,
+          channel: undefined,
+        },
+      }),
+    })
+  })
+})
 
 describe("getManagedSiteTokenChannelStatus", () => {
   beforeEach(() => {

--- a/tests/services/managedSites/tokenChannelStatus.test.ts
+++ b/tests/services/managedSites/tokenChannelStatus.test.ts
@@ -177,6 +177,48 @@ const buildRecoverableVerificationUnavailableStatus = (
 })
 
 describe("resolveManagedSiteTokenChannelStatusWithVerifiedKey", () => {
+  it("returns the original status when there is no assessment to update", () => {
+    const status = {
+      status: MANAGED_SITE_TOKEN_CHANNEL_STATUSES.UNKNOWN,
+      reason:
+        MANAGED_SITE_TOKEN_CHANNEL_STATUS_UNKNOWN_REASONS.INPUT_PREPARATION_FAILED,
+    }
+
+    expect(
+      resolveManagedSiteTokenChannelStatusWithVerifiedKey({
+        status,
+        tokenKey: "sk-token-secret",
+        channelId: 12,
+        channelKey: "sk-token-secret",
+        siteType: SITE_TYPES.NEW_API,
+      }),
+    ).toBe(status)
+  })
+
+  it("records a resolved channel key when the assessment no longer has that channel", () => {
+    const result = resolveManagedSiteTokenChannelStatusWithVerifiedKey({
+      status: buildRecoverableVerificationUnavailableStatus({
+        models: {
+          comparable: true,
+          matched: false,
+          reason: MANAGED_SITE_CHANNEL_MODELS_MATCH_REASONS.NO_MATCH,
+          channel: undefined,
+        },
+      }) as any,
+      tokenKey: "sk-token-secret",
+      channelId: 999,
+      channelKey: "sk-token-secret",
+      siteType: SITE_TYPES.NEW_API,
+    })
+
+    expect(result).toMatchObject({
+      status: MANAGED_SITE_TOKEN_CHANNEL_STATUSES.UNKNOWN,
+      resolvedChannelKeysById: {
+        999: "sk-token-secret",
+      },
+    })
+  })
+
   it("marks the token as added when the verified channel key matches the token key", () => {
     const result = resolveManagedSiteTokenChannelStatusWithVerifiedKey({
       status: buildRecoverableVerificationUnavailableStatus() as any,
@@ -223,6 +265,53 @@ describe("resolveManagedSiteTokenChannelStatusWithVerifiedKey", () => {
           channel: undefined,
         },
       }),
+    })
+  })
+
+  it("marks the token as not added when the verified key has no URL, key, or model match", () => {
+    const status = buildRecoverableVerificationUnavailableStatus() as any
+    status.assessment = {
+      ...status.assessment,
+      url: {
+        matched: false,
+        candidateCount: 0,
+        channel: {
+          id: 12,
+          name: "Managed Channel 12",
+        },
+      },
+      models: {
+        comparable: true,
+        matched: false,
+        reason: MANAGED_SITE_CHANNEL_MODELS_MATCH_REASONS.NO_MATCH,
+        channel: undefined,
+      },
+    }
+
+    const result = resolveManagedSiteTokenChannelStatusWithVerifiedKey({
+      status,
+      tokenKey: "sk-token-secret",
+      channelId: 12,
+      channelKey: "sk-other-secret",
+      siteType: SITE_TYPES.NEW_API,
+    })
+
+    expect(result).toMatchObject({
+      status: MANAGED_SITE_TOKEN_CHANNEL_STATUSES.NOT_ADDED,
+      resolvedChannelKeysById: {
+        12: "sk-other-secret",
+      },
+      assessment: {
+        url: {
+          matched: false,
+        },
+        key: {
+          matched: false,
+        },
+        models: {
+          matched: false,
+        },
+      },
     })
   })
 })

--- a/tests/services/managedSites/tokenChannelStatus.test.ts
+++ b/tests/services/managedSites/tokenChannelStatus.test.ts
@@ -19,6 +19,7 @@ import {
   buildDisplaySiteData,
   buildManagedSiteChannel,
 } from "~~/tests/test-utils/factories"
+import { createManagedSiteServiceStub } from "~~/tests/test-utils/managedSiteServiceFactory"
 
 const buildExpectedAssessment = (overrides: Record<string, unknown> = {}) => ({
   searchBaseUrl: "https://api.example.com",
@@ -98,46 +99,6 @@ vi.mock(
     }
   },
 )
-
-const createManagedSiteServiceStub = (
-  overrides: Record<string, unknown> = {},
-) =>
-  ({
-    siteType: "new-api",
-    messagesKey: "newapi",
-    searchChannel: vi.fn().mockResolvedValue({
-      items: [],
-      total: 0,
-      type_counts: {},
-    }),
-    createChannel: vi.fn(),
-    updateChannel: vi.fn(),
-    deleteChannel: vi.fn(),
-    checkValidConfig: vi.fn().mockResolvedValue(true),
-    getConfig: vi.fn().mockResolvedValue({
-      baseUrl: "https://managed.example",
-      adminToken: "managed-admin-token",
-      userId: "1",
-    }),
-    fetchAvailableModels: vi.fn(),
-    buildChannelName: vi.fn(),
-    prepareChannelFormData: vi.fn().mockResolvedValue({
-      name: "Managed Channel",
-      type: 1,
-      key: "test-token-key",
-      base_url: "https://api.example.com",
-      models: ["gpt-4o"],
-      groups: ["default"],
-      priority: 0,
-      weight: 0,
-      status: 1,
-    }),
-    buildChannelPayload: vi.fn(),
-    hydrateComparableChannelKeys: vi.fn(
-      async (_config, candidates) => candidates,
-    ),
-    ...overrides,
-  }) as any
 
 const buildRecoverableVerificationUnavailableStatus = (
   overrides: Record<string, unknown> = {},

--- a/tests/services/managedSites/verifiedChannelKeyAssessment.test.ts
+++ b/tests/services/managedSites/verifiedChannelKeyAssessment.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "vitest"
+
+import { SITE_TYPES } from "~/constants/siteType"
+import {
+  MANAGED_SITE_CHANNEL_KEY_MATCH_REASONS,
+  MANAGED_SITE_CHANNEL_MODELS_MATCH_REASONS,
+} from "~/services/managedSites/channelMatch"
+import {
+  applyVerifiedManagedSiteChannelKey,
+  toManagedSiteVerifiedKeyAssessment,
+} from "~/services/managedSites/verifiedChannelKeyAssessment"
+import { buildManagedSiteChannel } from "~~/tests/test-utils/factories"
+
+const candidate = {
+  id: 12,
+  name: "Managed Channel 12",
+}
+
+const buildAssessment = () => ({
+  searchBaseUrl: "https://api.example.com",
+  searchCompleted: true,
+  url: {
+    matched: true,
+    candidateCount: 1,
+    channel: candidate,
+  },
+  key: {
+    comparable: false,
+    matched: false,
+    reason: MANAGED_SITE_CHANNEL_KEY_MATCH_REASONS.COMPARISON_UNAVAILABLE,
+    channel: undefined,
+  },
+  models: {
+    comparable: true,
+    matched: true,
+    reason: MANAGED_SITE_CHANNEL_MODELS_MATCH_REASONS.EXACT,
+    channel: candidate,
+    similarityScore: 1,
+  },
+})
+
+describe("applyVerifiedManagedSiteChannelKey", () => {
+  it("marks an exact match when the verified channel key matches the source key", () => {
+    const result = applyVerifiedManagedSiteChannelKey({
+      assessment: buildAssessment(),
+      candidate,
+      sourceKey: "sk-source-key",
+      verifiedChannelKey: "sk-source-key",
+      siteType: SITE_TYPES.NEW_API,
+    })
+
+    expect(result.exactMatch).toBe(true)
+    expect(result.hasAnyMatch).toBe(true)
+    expect(result.assessment.key).toEqual({
+      comparable: true,
+      matched: true,
+      reason: MANAGED_SITE_CHANNEL_KEY_MATCH_REASONS.MATCHED,
+      channel: candidate,
+    })
+  })
+
+  it("uses managed-site key comparison semantics when applying the verified key", () => {
+    const result = applyVerifiedManagedSiteChannelKey({
+      assessment: buildAssessment(),
+      candidate,
+      sourceKey: "source-key",
+      verifiedChannelKey: "sk-source-key",
+      siteType: SITE_TYPES.NEW_API,
+    })
+
+    expect(result.exactMatch).toBe(true)
+    expect(result.assessment.key.reason).toBe(
+      MANAGED_SITE_CHANNEL_KEY_MATCH_REASONS.MATCHED,
+    )
+  })
+
+  it("matches one source key against a verified multi-key channel payload", () => {
+    const result = applyVerifiedManagedSiteChannelKey({
+      assessment: buildAssessment(),
+      candidate,
+      sourceKey: "sk-second-key",
+      verifiedChannelKey: "sk-first-key\nsk-second-key",
+      siteType: SITE_TYPES.NEW_API,
+    })
+
+    expect(result.exactMatch).toBe(true)
+    expect(result.assessment.key).toEqual({
+      comparable: true,
+      matched: true,
+      reason: MANAGED_SITE_CHANNEL_KEY_MATCH_REASONS.MATCHED,
+      channel: candidate,
+    })
+  })
+})
+
+describe("toManagedSiteVerifiedKeyAssessment", () => {
+  it("maps match inspection channels to lightweight channel summaries", () => {
+    const assessment = toManagedSiteVerifiedKeyAssessment({
+      searchBaseUrl: "https://api.example.invalid",
+      searchCompleted: true,
+      url: {
+        matched: true,
+        candidateCount: 1,
+        channel: buildManagedSiteChannel({
+          id: 12,
+          name: "Managed Channel 12",
+          key: "hidden-key",
+          base_url: "https://api.example.invalid",
+          models: "gpt-4o",
+        }),
+      },
+      key: {
+        comparable: true,
+        matched: true,
+        reason: MANAGED_SITE_CHANNEL_KEY_MATCH_REASONS.MATCHED,
+        channel: null,
+      },
+      models: {
+        comparable: true,
+        matched: true,
+        reason: MANAGED_SITE_CHANNEL_MODELS_MATCH_REASONS.EXACT,
+        channel: buildManagedSiteChannel({
+          id: 13,
+          name: "Managed Channel 13",
+          key: "other-hidden-key",
+          base_url: "https://api.example.invalid",
+          models: "gpt-4o",
+        }),
+        similarityScore: 1,
+      },
+    })
+
+    expect(assessment).toEqual({
+      searchBaseUrl: "https://api.example.invalid",
+      searchCompleted: true,
+      url: {
+        matched: true,
+        candidateCount: 1,
+        channel: {
+          id: 12,
+          name: "Managed Channel 12",
+        },
+      },
+      key: {
+        comparable: true,
+        matched: true,
+        reason: MANAGED_SITE_CHANNEL_KEY_MATCH_REASONS.MATCHED,
+        channel: undefined,
+      },
+      models: {
+        comparable: true,
+        matched: true,
+        reason: MANAGED_SITE_CHANNEL_MODELS_MATCH_REASONS.EXACT,
+        channel: {
+          id: 13,
+          name: "Managed Channel 13",
+        },
+        similarityScore: 1,
+      },
+    })
+  })
+})

--- a/tests/test-utils/managedSiteServiceFactory.ts
+++ b/tests/test-utils/managedSiteServiceFactory.ts
@@ -13,7 +13,7 @@ const buildManagedSiteRuntimeConfig = (
 })
 
 export const createManagedSiteServiceStub = (
-  overrides: Record<string, unknown> = {},
+  overrides: Partial<Record<keyof ManagedSiteService, unknown>> = {},
 ) =>
   ({
     siteType: SITE_TYPES.NEW_API,

--- a/tests/test-utils/managedSiteServiceFactory.ts
+++ b/tests/test-utils/managedSiteServiceFactory.ts
@@ -1,0 +1,52 @@
+import { vi } from "vitest"
+
+import { SITE_TYPES } from "~/constants/siteType"
+import type { ManagedSiteService } from "~/services/managedSites/managedSiteService"
+
+const buildManagedSiteRuntimeConfig = (
+  overrides: Record<string, unknown> = {},
+) => ({
+  baseUrl: "https://managed.example",
+  adminToken: "managed-admin-token",
+  userId: "1",
+  ...overrides,
+})
+
+export const createManagedSiteServiceStub = (
+  overrides: Record<string, unknown> = {},
+) =>
+  ({
+    siteType: SITE_TYPES.NEW_API,
+    messagesKey: "newapi",
+    searchChannel: vi.fn().mockResolvedValue({
+      items: [],
+      total: 0,
+      type_counts: {},
+    }),
+    createChannel: vi.fn(),
+    updateChannel: vi.fn(),
+    deleteChannel: vi.fn(),
+    listChannels: vi.fn().mockResolvedValue([]),
+    checkValidConfig: vi.fn().mockResolvedValue(true),
+    getConfig: vi.fn().mockResolvedValue(buildManagedSiteRuntimeConfig()),
+    fetchSiteUserGroups: vi.fn().mockResolvedValue([]),
+    fetchAccountAvailableModels: vi.fn().mockResolvedValue([]),
+    fetchAvailableModels: vi.fn(),
+    buildChannelName: vi.fn(),
+    prepareChannelFormData: vi.fn().mockResolvedValue({
+      name: "Managed Channel",
+      type: 1,
+      key: "test-token-key",
+      base_url: "https://api.example.com",
+      models: ["gpt-4o"],
+      groups: ["default"],
+      priority: 0,
+      weight: 0,
+      status: 1,
+    }),
+    buildChannelPayload: vi.fn(),
+    hydrateComparableChannelKeys: vi.fn(
+      async (_config, candidates) => candidates,
+    ),
+    ...overrides,
+  }) as unknown as ManagedSiteService


### PR DESCRIPTION
Closes #1138

## Summary
- Stabilize duplicate channel matching for New API-family managed sites during batch export/import checks.
- Reuse verified channel key assessments in Key Management and batch export previews to reduce uncertain duplicate states.
- Add focused coverage for matching, preview, verification, and Key Management UI flows.

## Validation
- pnpm run validate:push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-item “verify and refresh” support to managed-site batch export, including improved preview progress for New API verification and updated per-row verification actions.
  * Enhanced the New API managed verification dialog with configurable close behavior.

* **Bug Fixes**
  * Prevented duplicate managed-site verification retries; the retry button now reliably shows loading/disabled state while a retry is running.
  * Improved warning/selection and verification result handling so updates apply to the correct preview items, plus clearer verification-failure messaging.

* **Localization**
  * Added new batch-export action labels and a dedicated “verification failed” error string across locales.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->