### PR TITLE
fix(sponsors): prioritize fallback actions

### DIFF
--- a/src/features/AccountManagement/sponsors/SponsorRecommendationCard.tsx
+++ b/src/features/AccountManagement/sponsors/SponsorRecommendationCard.tsx
@@ -80,26 +80,18 @@ function getSupportBadgeVariant(
   }
 }
 
-/** Picks the compact row action without changing multi-fallback choice behavior. */
+/** Picks the compact row action, preferring plugin workflows over a plain visit. */
 function getMainActionKind(item: SponsorRecommendation): SponsorMainActionKind {
   if (item.actions.addAccount) {
     return SPONSOR_MAIN_ACTION_KINDS.ContinueAddAccount
   }
 
-  const fallbackActionKinds: SponsorMainActionKind[] = []
+  if (item.actions.apiCredentialProfileFallback) {
+    return SPONSOR_MAIN_ACTION_KINDS.ApiCredentialProfilesFallback
+  }
 
   if (item.actions.bookmarkFallback) {
-    fallbackActionKinds.push(SPONSOR_MAIN_ACTION_KINDS.BookmarkFallback)
-  }
-
-  if (item.actions.apiCredentialProfileFallback) {
-    fallbackActionKinds.push(
-      SPONSOR_MAIN_ACTION_KINDS.ApiCredentialProfilesFallback,
-    )
-  }
-
-  if (fallbackActionKinds.length === 1) {
-    return fallbackActionKinds[0]
+    return SPONSOR_MAIN_ACTION_KINDS.BookmarkFallback
   }
 
   return SPONSOR_MAIN_ACTION_KINDS.VisitProvider

--- a/src/features/AccountManagement/sponsors/SponsorRecommendationCard.tsx
+++ b/src/features/AccountManagement/sponsors/SponsorRecommendationCard.tsx
@@ -31,6 +31,16 @@ interface SponsorRecommendationCardProps {
   ) => void
 }
 
+const SPONSOR_MAIN_ACTION_KINDS = {
+  ContinueAddAccount: "continue-add-account",
+  VisitProvider: "visit-provider",
+  BookmarkFallback: "bookmark-fallback",
+  ApiCredentialProfilesFallback: "api-credential-profiles-fallback",
+} as const
+
+type SponsorMainActionKind =
+  (typeof SPONSOR_MAIN_ACTION_KINDS)[keyof typeof SPONSOR_MAIN_ACTION_KINDS]
+
 /** Returns the translated badge label for a sponsor recommendation. */
 function getSupportLabel(t: TFunction<"account">, item: SponsorRecommendation) {
   if (
@@ -67,6 +77,66 @@ function getSupportBadgeVariant(
     case SPONSOR_SUPPORT_STATUS.Unsupported:
     default:
       return "info"
+  }
+}
+
+/** Picks the compact row action without changing multi-fallback choice behavior. */
+function getMainActionKind(item: SponsorRecommendation): SponsorMainActionKind {
+  if (item.actions.addAccount) {
+    return SPONSOR_MAIN_ACTION_KINDS.ContinueAddAccount
+  }
+
+  const fallbackActionKinds: SponsorMainActionKind[] = []
+
+  if (item.actions.bookmarkFallback) {
+    fallbackActionKinds.push(SPONSOR_MAIN_ACTION_KINDS.BookmarkFallback)
+  }
+
+  if (item.actions.apiCredentialProfileFallback) {
+    fallbackActionKinds.push(
+      SPONSOR_MAIN_ACTION_KINDS.ApiCredentialProfilesFallback,
+    )
+  }
+
+  if (fallbackActionKinds.length === 1) {
+    return fallbackActionKinds[0]
+  }
+
+  return SPONSOR_MAIN_ACTION_KINDS.VisitProvider
+}
+
+/** Returns the translated action label for the compact row action. */
+function getMainActionLabel(
+  t: TFunction<"account">,
+  actionKind: SponsorMainActionKind,
+) {
+  switch (actionKind) {
+    case SPONSOR_MAIN_ACTION_KINDS.ContinueAddAccount:
+      return t("sponsor.actions.continueAddAccount")
+    case SPONSOR_MAIN_ACTION_KINDS.BookmarkFallback:
+      return t("sponsor.actions.openBookmarkManagerFallback")
+    case SPONSOR_MAIN_ACTION_KINDS.ApiCredentialProfilesFallback:
+      return t("sponsor.actions.openApiCredentialProfilesFallback")
+    case SPONSOR_MAIN_ACTION_KINDS.VisitProvider:
+    default:
+      return t("sponsor.actions.visitProvider")
+  }
+}
+
+/** Renders the compact row icon that matches its current action. */
+function renderMainActionIcon(actionKind: SponsorMainActionKind) {
+  switch (actionKind) {
+    case SPONSOR_MAIN_ACTION_KINDS.ContinueAddAccount:
+      return <Plus aria-hidden="true" className="h-3.5 w-3.5" />
+    case SPONSOR_MAIN_ACTION_KINDS.BookmarkFallback:
+      return <Bookmark aria-hidden="true" className="h-3.5 w-3.5" />
+    case SPONSOR_MAIN_ACTION_KINDS.ApiCredentialProfilesFallback:
+      return (
+        <ApiCredentialLibraryIcon aria-hidden="true" className="h-3.5 w-3.5" />
+      )
+    case SPONSOR_MAIN_ACTION_KINDS.VisitProvider:
+    default:
+      return <ExternalLink aria-hidden="true" className="h-3.5 w-3.5" />
   }
 }
 
@@ -149,12 +219,27 @@ export function SponsorRecommendationCard({
     })
   }
 
-  const primaryLabel = t("sponsor.actions.visitProvider")
-  const continueLabel = t("sponsor.actions.continueAddAccount")
-  const isSupported = Boolean(item.actions.addAccount)
-  const handleMainAction = isSupported
-    ? handleContinueAddAccount
-    : handlePrimaryClick
+  const mainActionKind = getMainActionKind(item)
+  const mainActionLabel = getMainActionLabel(t, mainActionKind)
+  const hasAddAccountAction = Boolean(item.actions.addAccount)
+  const isIntegratedMainAction =
+    mainActionKind !== SPONSOR_MAIN_ACTION_KINDS.VisitProvider
+  const handleMainAction = () => {
+    switch (mainActionKind) {
+      case SPONSOR_MAIN_ACTION_KINDS.ContinueAddAccount:
+        handleContinueAddAccount()
+        return
+      case SPONSOR_MAIN_ACTION_KINDS.BookmarkFallback:
+        handleOpenBookmarkManager()
+        return
+      case SPONSOR_MAIN_ACTION_KINDS.ApiCredentialProfilesFallback:
+        handleOpenApiCredentialProfiles()
+        return
+      case SPONSOR_MAIN_ACTION_KINDS.VisitProvider:
+      default:
+        handlePrimaryClick()
+    }
+  }
   const hasFallbackActions =
     Boolean(item.actions.bookmarkFallback) ||
     Boolean(item.actions.apiCredentialProfileFallback)
@@ -169,18 +254,14 @@ export function SponsorRecommendationCard({
         type="button"
         className={cn(
           "focus-visible:ring-ring/50 flex min-h-9 min-w-0 flex-1 items-center gap-2 rounded-md px-2.5 py-1.5 text-left transition-colors outline-none focus-visible:ring-[3px]",
-          isSupported
+          isIntegratedMainAction
             ? "text-blue-700 hover:bg-blue-100/70 dark:text-blue-300 dark:hover:bg-blue-900/30"
             : "dark:text-dark-text-primary dark:hover:bg-dark-bg-tertiary/70 text-gray-800 hover:bg-gray-100",
         )}
         onClick={handleMainAction}
-        aria-label={
-          isSupported
-            ? `${continueLabel}: ${item.name}`
-            : `${primaryLabel}: ${item.name}`
-        }
+        aria-label={`${mainActionLabel}: ${item.name}`}
         data-testid={
-          isSupported
+          mainActionKind === SPONSOR_MAIN_ACTION_KINDS.ContinueAddAccount
             ? ACCOUNT_MANAGEMENT_TEST_IDS.sponsorContinueAddAccountAction
             : ACCOUNT_MANAGEMENT_TEST_IDS.sponsorPrimaryAction
         }
@@ -188,16 +269,12 @@ export function SponsorRecommendationCard({
         <span
           className={cn(
             "flex h-6 w-6 shrink-0 items-center justify-center rounded-md",
-            isSupported
+            isIntegratedMainAction
               ? "bg-blue-600 text-white shadow-sm dark:bg-blue-500"
               : "dark:bg-dark-bg-tertiary dark:text-dark-text-secondary bg-gray-100 text-gray-600",
           )}
         >
-          {isSupported ? (
-            <Plus aria-hidden="true" className="h-3.5 w-3.5" />
-          ) : (
-            <ExternalLink aria-hidden="true" className="h-3.5 w-3.5" />
-          )}
+          {renderMainActionIcon(mainActionKind)}
         </span>
         <span className="min-w-0 flex-1">
           <span className="flex min-w-0 items-center gap-1.5">
@@ -209,7 +286,7 @@ export function SponsorRecommendationCard({
             {item.tagline}
           </span>
         </span>
-        {!isSupported ? (
+        {!hasAddAccountAction ? (
           <Badge
             variant={getSupportBadgeVariant(item.supportStatus)}
             size="sm"

--- a/src/features/AccountManagement/sponsors/SponsorRecommendationCard.tsx
+++ b/src/features/AccountManagement/sponsors/SponsorRecommendationCard.tsx
@@ -132,6 +132,21 @@ function renderMainActionIcon(actionKind: SponsorMainActionKind) {
   }
 }
 
+/** Returns the stable test id for the compact row action currently promoted. */
+function getMainActionTestId(actionKind: SponsorMainActionKind) {
+  switch (actionKind) {
+    case SPONSOR_MAIN_ACTION_KINDS.ContinueAddAccount:
+      return ACCOUNT_MANAGEMENT_TEST_IDS.sponsorContinueAddAccountAction
+    case SPONSOR_MAIN_ACTION_KINDS.BookmarkFallback:
+      return ACCOUNT_MANAGEMENT_TEST_IDS.sponsorPrimaryBookmarkAction
+    case SPONSOR_MAIN_ACTION_KINDS.ApiCredentialProfilesFallback:
+      return ACCOUNT_MANAGEMENT_TEST_IDS.sponsorPrimaryApiCredentialProfilesAction
+    case SPONSOR_MAIN_ACTION_KINDS.VisitProvider:
+    default:
+      return ACCOUNT_MANAGEMENT_TEST_IDS.sponsorPrimaryAction
+  }
+}
+
 /** Renders one compact sponsor recommendation with primary, continue, and fallback actions. */
 export function SponsorRecommendationCard({
   item,
@@ -252,11 +267,7 @@ export function SponsorRecommendationCard({
         )}
         onClick={handleMainAction}
         aria-label={`${mainActionLabel}: ${item.name}`}
-        data-testid={
-          mainActionKind === SPONSOR_MAIN_ACTION_KINDS.ContinueAddAccount
-            ? ACCOUNT_MANAGEMENT_TEST_IDS.sponsorContinueAddAccountAction
-            : ACCOUNT_MANAGEMENT_TEST_IDS.sponsorPrimaryAction
-        }
+        data-testid={getMainActionTestId(mainActionKind)}
       >
         <span
           className={cn(

--- a/src/features/AccountManagement/testIds.ts
+++ b/src/features/AccountManagement/testIds.ts
@@ -83,6 +83,10 @@ export const ACCOUNT_MANAGEMENT_TEST_IDS = {
   sponsorPrimaryAction: "account-management-sponsor-primary-action",
   sponsorContinueAddAccountAction:
     "account-management-sponsor-continue-add-account-action",
+  sponsorPrimaryBookmarkAction:
+    "account-management-sponsor-primary-bookmark-action",
+  sponsorPrimaryApiCredentialProfilesAction:
+    "account-management-sponsor-primary-api-credential-profiles-action",
   sponsorPostClickNote: "account-management-sponsor-post-click-note",
   sponsorFallbackBookmarkAction:
     "account-management-sponsor-fallback-bookmark-action",

--- a/tests/features/AccountManagement/sponsors/SponsorRecommendationsSection.test.tsx
+++ b/tests/features/AccountManagement/sponsors/SponsorRecommendationsSection.test.tsx
@@ -275,6 +275,34 @@ describe("SponsorRecommendationsSection", () => {
     )
   })
 
+  it("promotes API credential fallback over bookmark fallback when both are available", async () => {
+    const user = userEvent.setup()
+    const openSpy = vi.fn()
+    vi.stubGlobal("open", openSpy)
+
+    renderSection([createUnsupportedSponsor()])
+
+    await user.click(
+      screen.getByRole("button", {
+        name: /account:sponsor.actions.openApiCredentialProfilesFallback: Manual Provider/u,
+      }),
+    )
+
+    expect(onOpenApiCredentialProfiles).toHaveBeenCalledWith({
+      name: "Manual Provider",
+      baseUrl: "https://api.manual.example.invalid/v1",
+      apiKeyCreateUrl: "https://console.manual.example.invalid/keys",
+      apiKeyCreateHint: "Create a key in the example console.",
+    })
+    expect(onOpenBookmarkManager).not.toHaveBeenCalled()
+    expect(onContinueAddAccount).not.toHaveBeenCalled()
+    expect(openSpy).toHaveBeenCalledWith(
+      "https://manual.example.invalid/register",
+      "_blank",
+      "noopener,noreferrer",
+    )
+  })
+
   it("opens the provider URL directly when unsupported sponsors have no fallback actions", async () => {
     const user = userEvent.setup()
     const openSpy = vi.fn()
@@ -576,8 +604,8 @@ describe("SponsorRecommendationsSection", () => {
       2,
       PRODUCT_ANALYTICS_EVENTS.FeatureActionCompleted,
       expect.objectContaining({
-        action_id: "open_sponsor_provider",
-        sponsor_action_kind: "visit_provider",
+        action_id: "open_sponsor_api_credentials_followup",
+        sponsor_action_kind: "api_credential_profiles_fallback",
         sponsor_support_status: "unsupported",
         sponsor_catalog_source: "remote",
         sponsor_rank: 2,

--- a/tests/features/AccountManagement/sponsors/SponsorRecommendationsSection.test.tsx
+++ b/tests/features/AccountManagement/sponsors/SponsorRecommendationsSection.test.tsx
@@ -365,6 +365,80 @@ describe("SponsorRecommendationsSection", () => {
     expect(openSpy).toHaveBeenCalledTimes(2)
   })
 
+  it("promotes the only fallback action to the compact row action", async () => {
+    const user = userEvent.setup()
+    const openSpy = vi.fn()
+    vi.stubGlobal("open", openSpy)
+
+    renderSection([
+      createUnsupportedSponsor({
+        id: "bookmark-provider",
+        name: "Bookmark Provider",
+        tagline: "Bookmark first.",
+        links: {
+          primary: "https://bookmark.example.invalid/register",
+        },
+        actions: {
+          bookmarkFallback: {
+            url: "https://docs.bookmark.example.invalid/get-started",
+          },
+        },
+        postClickNote: undefined,
+      }),
+      createUnsupportedSponsor({
+        id: "api-provider",
+        name: "API Provider",
+        tagline: "API credential first.",
+        links: {
+          primary: "https://api.example.invalid/register",
+        },
+        actions: {
+          apiCredentialProfileFallback: {
+            baseUrl: "https://api.example.invalid/v1",
+          },
+        },
+        postClickNote: undefined,
+        rank: 3,
+      }),
+    ])
+
+    await user.click(
+      screen.getByRole("button", {
+        name: /account:sponsor.actions.openBookmarkManagerFallback: Bookmark Provider/u,
+      }),
+    )
+    await user.click(
+      screen.getByRole("button", {
+        name: /account:sponsor.actions.openApiCredentialProfilesFallback: API Provider/u,
+      }),
+    )
+
+    expect(onOpenBookmarkManager).toHaveBeenCalledWith({
+      name: "Bookmark Provider",
+      url: "https://docs.bookmark.example.invalid/get-started",
+    })
+    expect(onOpenApiCredentialProfiles).toHaveBeenCalledWith({
+      name: "API Provider",
+      baseUrl: "https://api.example.invalid/v1",
+      apiKeyCreateUrl: undefined,
+      apiKeyCreateHint: undefined,
+    })
+    expect(onContinueAddAccount).not.toHaveBeenCalled()
+    expect(openSpy).toHaveBeenCalledTimes(2)
+    expect(openSpy).toHaveBeenNthCalledWith(
+      1,
+      "https://bookmark.example.invalid/register",
+      "_blank",
+      "noopener,noreferrer",
+    )
+    expect(openSpy).toHaveBeenNthCalledWith(
+      2,
+      "https://api.example.invalid/register",
+      "_blank",
+      "noopener,noreferrer",
+    )
+  })
+
   it("renders nothing when no recommendations are available", () => {
     renderSection([])
 

--- a/tests/features/AccountManagement/sponsors/SponsorRecommendationsSection.test.tsx
+++ b/tests/features/AccountManagement/sponsors/SponsorRecommendationsSection.test.tsx
@@ -232,7 +232,9 @@ describe("SponsorRecommendationsSection", () => {
     ).not.toBeInTheDocument()
 
     expect(
-      screen.getByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.sponsorPrimaryAction),
+      screen.getByTestId(
+        ACCOUNT_MANAGEMENT_TEST_IDS.sponsorPrimaryApiCredentialProfilesAction,
+      ),
     ).toHaveAttribute("type", "button")
 
     const bookmarkAction = screen.getByRole("button", {
@@ -431,14 +433,14 @@ describe("SponsorRecommendationsSection", () => {
     ])
 
     await user.click(
-      screen.getByRole("button", {
-        name: /account:sponsor.actions.openBookmarkManagerFallback: Bookmark Provider/u,
-      }),
+      screen.getByTestId(
+        ACCOUNT_MANAGEMENT_TEST_IDS.sponsorPrimaryBookmarkAction,
+      ),
     )
     await user.click(
-      screen.getByRole("button", {
-        name: /account:sponsor.actions.openApiCredentialProfilesFallback: API Provider/u,
-      }),
+      screen.getByTestId(
+        ACCOUNT_MANAGEMENT_TEST_IDS.sponsorPrimaryApiCredentialProfilesAction,
+      ),
     )
 
     expect(onOpenBookmarkManager).toHaveBeenCalledWith({
@@ -571,7 +573,9 @@ describe("SponsorRecommendationsSection", () => {
       ),
     )
     await user.click(
-      screen.getByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.sponsorPrimaryAction),
+      screen.getByTestId(
+        ACCOUNT_MANAGEMENT_TEST_IDS.sponsorPrimaryApiCredentialProfilesAction,
+      ),
     )
     await user.click(
       screen.getByTestId(


### PR DESCRIPTION
## Summary
- Promote single sponsor fallback actions to the compact row primary action.
- Prefer plugin workflows over plain provider links: add account, API credential, bookmark, then visit provider.
- Update sponsor card tests and analytics assertions for single and multi-fallback behavior.

## Validation
- pnpm vitest --run tests/features/AccountManagement/sponsors/SponsorRecommendationsSection.test.tsx
- pnpm run validate:staged
- pnpm run validate:push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced sponsor recommendation “primary” action selection to consistently choose the most relevant option, updating labels, icons, accessibility text, and primary-action test identifiers.
  * Improved click routing so the correct follow-up behavior runs for continue-add-account, API credential fallback, or bookmark fallback (with provider visit as the default).
* **Bug Fixes**
  * Adjusted support badge visibility rules to align with available actions.
* **Tests**
  * Added/updated tests for unsupported-sponsor fallback promotion, compact action behavior, and revised analytics expectations for API credential follow-ups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->