### PR TITLE
feat(sponsors): add v5 catalog visibility controls

### DIFF
--- a/e2e/utils/commonUserFlows.ts
+++ b/e2e/utils/commonUserFlows.ts
@@ -2,6 +2,10 @@ import type { BrowserContext, Page, Worker } from "@playwright/test"
 
 import { SITE_TYPES } from "~/constants/siteType"
 import {
+  SPONSOR_CATALOG_SCHEMA_VERSION,
+  SPONSOR_REMOTE_CATALOG_V5_URL,
+} from "~/features/AccountManagement/sponsors/constants"
+import {
   createDefaultAccountStorageConfig,
   normalizeAccountStorageConfigForWrite,
   normalizeSiteAccount,
@@ -81,10 +85,8 @@ export type ExtensionPageGuardOptions = {
   ignoreConsoleErrorPatterns?: RegExp[]
 }
 
-const E2E_SPONSOR_REMOTE_CATALOG_URL =
-  "https://raw.githubusercontent.com/qixing-jk/all-api-hub/main/public/sponsor-catalog.v5.json"
 const E2E_SPONSOR_CATALOG_PAYLOAD = {
-  schemaVersion: 5,
+  schemaVersion: SPONSOR_CATALOG_SCHEMA_VERSION,
   items: [],
 }
 
@@ -162,7 +164,7 @@ export async function stubLlmMetadataIndex(context: BrowserContext) {
  * refreshes do not depend on a PR branch asset already existing on main.
  */
 export async function stubSponsorRemoteCatalog(context: BrowserContext) {
-  await context.route(E2E_SPONSOR_REMOTE_CATALOG_URL, (route) =>
+  await context.route(SPONSOR_REMOTE_CATALOG_V5_URL, (route) =>
     route.fulfill({
       status: 200,
       contentType: "application/json",

--- a/e2e/utils/commonUserFlows.ts
+++ b/e2e/utils/commonUserFlows.ts
@@ -82,9 +82,9 @@ export type ExtensionPageGuardOptions = {
 }
 
 const E2E_SPONSOR_REMOTE_CATALOG_URL =
-  "https://raw.githubusercontent.com/qixing-jk/all-api-hub/main/public/sponsor-catalog.v4.json"
+  "https://raw.githubusercontent.com/qixing-jk/all-api-hub/main/public/sponsor-catalog.v5.json"
 const E2E_SPONSOR_CATALOG_PAYLOAD = {
-  schemaVersion: 4,
+  schemaVersion: 5,
   items: [],
 }
 

--- a/public/sponsor-catalog.v5.json
+++ b/public/sponsor-catalog.v5.json
@@ -1,0 +1,610 @@
+{
+  "schemaVersion": 5,
+  "items": [
+    {
+      "id": "packycode",
+      "locales": {
+        "zh-CN": {
+          "enabled": true,
+          "rank": 95,
+          "supportStatus": "supported",
+          "name": "PackyCode",
+          "tagline": "稳定高效的 API 中转服务，支持 Claude Code、Codex、Gemini 等多种工具场景。",
+          "links": {
+            "primary": "https://www.packyapi.com/register?aff=all-api-hub"
+          },
+          "postClickNote": "使用 all-api-hub 优惠码完成首次充值，可享受 9 折优惠。",
+          "actions": {
+            "addAccount": {
+              "siteType": "new-api",
+              "siteUrl": "https://www.packyapi.com",
+              "authType": "access_token"
+            }
+          }
+        },
+        "zh-TW": {
+          "enabled": true,
+          "rank": 95,
+          "supportStatus": "supported",
+          "name": "PackyCode",
+          "tagline": "穩定高效的 API 中轉服務，支援 Claude Code、Codex、Gemini 等多種工具場景。",
+          "links": {
+            "primary": "https://www.packyapi.com/register?aff=all-api-hub"
+          },
+          "postClickNote": "使用 all-api-hub 優惠碼完成首次儲值，可享 9 折優惠。",
+          "actions": {
+            "addAccount": {
+              "siteType": "new-api",
+              "siteUrl": "https://www.packyapi.com",
+              "authType": "access_token"
+            }
+          }
+        },
+        "en": {
+          "enabled": true,
+          "rank": 95,
+          "supportStatus": "supported",
+          "name": "PackyCode",
+          "tagline": "A stable and efficient API relay service for Claude Code, Codex, Gemini, and more.",
+          "links": {
+            "primary": "https://www.packyapi.com/register?aff=all-api-hub"
+          },
+          "postClickNote": "Use promo code all-api-hub on your first recharge to get 10% off.",
+          "actions": {
+            "addAccount": {
+              "siteType": "new-api",
+              "siteUrl": "https://www.packyapi.com",
+              "authType": "access_token"
+            }
+          }
+        },
+        "ja": {
+          "enabled": true,
+          "rank": 95,
+          "supportStatus": "supported",
+          "name": "PackyCode",
+          "tagline": "Claude Code、Codex、Gemini などで使える、安定した高速な API リレーサービスです。",
+          "links": {
+            "primary": "https://www.packyapi.com/register?aff=all-api-hub"
+          },
+          "postClickNote": "初回チャージ時にプロモコード all-api-hub を入力すると、10% オフになります。",
+          "actions": {
+            "addAccount": {
+              "siteType": "new-api",
+              "siteUrl": "https://www.packyapi.com",
+              "authType": "access_token"
+            }
+          }
+        },
+        "vi": {
+          "enabled": true,
+          "rank": 95,
+          "supportStatus": "supported",
+          "name": "PackyCode",
+          "tagline": "Dich vu chuyen tiep API on dinh, hieu qua cho Claude Code, Codex, Gemini va nhieu cong cu khac.",
+          "links": {
+            "primary": "https://www.packyapi.com/register?aff=all-api-hub"
+          },
+          "postClickNote": "Dung ma uu dai all-api-hub trong lan nap dau tien de duoc giam 10%.",
+          "actions": {
+            "addAccount": {
+              "siteType": "new-api",
+              "siteUrl": "https://www.packyapi.com",
+              "authType": "access_token"
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": "xingchen-ai",
+      "locales": {
+        "zh-CN": {
+          "enabled": true,
+          "rank": 100,
+          "supportStatus": "supported",
+          "name": "星辰AI",
+          "tagline": "稳定高效的 API 中转服务商，提供 Claude Code、Codex、Gemini 等多种中转服务。",
+          "links": {
+            "primary": "https://ai.centos.hk"
+          },
+          "postClickNote": "充值比例 1:1，可开发票；Claude 低至 4 折。",
+          "actions": {
+            "addAccount": {
+              "siteType": "new-api",
+              "siteUrl": "https://ai.centos.hk",
+              "authType": "access_token"
+            }
+          }
+        },
+        "zh-TW": {
+          "enabled": true,
+          "rank": 100,
+          "supportStatus": "supported",
+          "name": "星辰AI",
+          "tagline": "穩定高效的 API 中轉服務商，提供 Claude Code、Codex、Gemini 等多種中轉服務。",
+          "links": {
+            "primary": "https://ai.centos.hk"
+          },
+          "postClickNote": "儲值比例 1:1，可開發票；Claude 低至 4 折。",
+          "actions": {
+            "addAccount": {
+              "siteType": "new-api",
+              "siteUrl": "https://ai.centos.hk",
+              "authType": "access_token"
+            }
+          }
+        },
+        "en": {
+          "enabled": true,
+          "rank": 100,
+          "supportStatus": "supported",
+          "name": "Xingchen AI",
+          "tagline": "A stable and efficient API relay provider for Claude Code, Codex, Gemini, and more.",
+          "links": {
+            "primary": "https://ai.centos.hk"
+          },
+          "postClickNote": "1:1 recharge ratio with invoice support and Claude from 40% pricing.",
+          "actions": {
+            "addAccount": {
+              "siteType": "new-api",
+              "siteUrl": "https://ai.centos.hk",
+              "authType": "access_token"
+            }
+          }
+        },
+        "ja": {
+          "enabled": true,
+          "rank": 100,
+          "supportStatus": "supported",
+          "name": "Xingchen AI",
+          "tagline": "Claude Code、Codex、Gemini などの中継サービスを提供する、安定した高速な API 中継プロバイダーです。",
+          "links": {
+            "primary": "https://ai.centos.hk"
+          },
+          "postClickNote": "チャージ比率は 1:1、請求書発行に対応。Claude は 40% 価格から利用できます。",
+          "actions": {
+            "addAccount": {
+              "siteType": "new-api",
+              "siteUrl": "https://ai.centos.hk",
+              "authType": "access_token"
+            }
+          }
+        },
+        "vi": {
+          "enabled": true,
+          "rank": 100,
+          "supportStatus": "supported",
+          "name": "Xingchen AI",
+          "tagline": "Nha cung cap chuyen tiep API on dinh, hieu qua cho Claude Code, Codex, Gemini va nhieu dich vu khac.",
+          "links": {
+            "primary": "https://ai.centos.hk"
+          },
+          "postClickNote": "Ty le nap 1:1, ho tro xuat hoa don va Claude tu 40% gia.",
+          "actions": {
+            "addAccount": {
+              "siteType": "new-api",
+              "siteUrl": "https://ai.centos.hk",
+              "authType": "access_token"
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": "runapi",
+      "locales": {
+        "zh-CN": {
+          "enabled": true,
+          "rank": 110,
+          "supportStatus": "supported",
+          "name": "RunAPI",
+          "tagline": "高效稳定的 API OpenRouter 平替平台，一个 API Key 可访问 OpenAI、Claude、Gemini、DeepSeek、Grok 等 150+ 主流模型，低至 1 折，兼容 Claude Code、OpenClaw 等工具。",
+          "links": {
+            "primary": "https://runapi.co/register?aff=cvDm"
+          },
+          "postClickNote": "All API Hub 用户注册后联系 RunAPI 管理员，即可领取 ¥7 免费额度。",
+          "actions": {
+            "addAccount": {
+              "siteType": "new-api",
+              "siteUrl": "https://runapi.co",
+              "authType": "access_token"
+            }
+          }
+        },
+        "zh-TW": {
+          "enabled": true,
+          "rank": 110,
+          "supportStatus": "supported",
+          "name": "RunAPI",
+          "tagline": "高效穩定的 API OpenRouter 平替平台，一個 API Key 可存取 OpenAI、Claude、Gemini、DeepSeek、Grok 等 150+ 主流模型，低至 1 折，兼容 Claude Code、OpenClaw 等工具。",
+          "links": {
+            "primary": "https://runapi.co/register?aff=cvDm"
+          },
+          "postClickNote": "All API Hub 使用者註冊後聯絡管理員，即可領取 ¥7 免費額度。",
+          "actions": {
+            "addAccount": {
+              "siteType": "new-api",
+              "siteUrl": "https://runapi.co",
+              "authType": "access_token"
+            }
+          }
+        },
+        "en": {
+          "enabled": true,
+          "rank": 110,
+          "supportStatus": "supported",
+          "name": "RunAPI",
+          "tagline": "A stable OpenRouter alternative API platform: one API key for 150+ mainstream models including OpenAI, Claude, Gemini, DeepSeek, and Grok, from 10% of standard pricing, with Claude Code and OpenClaw compatibility.",
+          "links": {
+            "primary": "https://runapi.co/register?aff=cvDm"
+          },
+          "postClickNote": "All API Hub users can register and contact the administrator to claim ¥7 in free credits.",
+          "actions": {
+            "addAccount": {
+              "siteType": "new-api",
+              "siteUrl": "https://runapi.co",
+              "authType": "access_token"
+            }
+          }
+        },
+        "ja": {
+          "enabled": true,
+          "rank": 110,
+          "supportStatus": "supported",
+          "name": "RunAPI",
+          "tagline": "OpenRouter の代替として使える安定した API プラットフォームです。1 つの API Key で OpenAI、Claude、Gemini、DeepSeek、Grok など 150 以上の主要モデルを利用でき、Claude Code や OpenClaw にも対応します。",
+          "links": {
+            "primary": "https://runapi.co/register?aff=cvDm"
+          },
+          "postClickNote": "All API Hub ユーザーは登録後に管理者へ連絡すると、¥7 の無料クレジットを受け取れます。",
+          "actions": {
+            "addAccount": {
+              "siteType": "new-api",
+              "siteUrl": "https://runapi.co",
+              "authType": "access_token"
+            }
+          }
+        },
+        "vi": {
+          "enabled": true,
+          "rank": 110,
+          "supportStatus": "supported",
+          "name": "RunAPI",
+          "tagline": "Nen tang API on dinh thay the OpenRouter: mot API Key truy cap hon 150 mo hinh pho bien nhu OpenAI, Claude, Gemini, DeepSeek va Grok, gia tu 10%, tuong thich Claude Code va OpenClaw.",
+          "links": {
+            "primary": "https://runapi.co/register?aff=cvDm"
+          },
+          "postClickNote": "Nguoi dung All API Hub co the dang ky va lien he quan tri vien de nhan ¥7 han muc mien phi.",
+          "actions": {
+            "addAccount": {
+              "siteType": "new-api",
+              "siteUrl": "https://runapi.co",
+              "authType": "access_token"
+            }
+          }
+        }
+      }
+    },
+    {
+      "id": "volcengine-coding-plan",
+      "locales": {
+        "zh-CN": {
+          "enabled": true,
+          "rank": 120,
+          "supportStatus": "unsupported",
+          "name": "火山引擎 - 方舟Coding-Plan",
+          "tagline": "字节跳动旗下开发者生产力计划，Lite 套餐仅需 9.9 元/月。支持豆包、DeepSeek、GLM 等顶级模型，完美适配 Cursor、Claude Code 等工具，尊享高并发稳定性与模型自动切换体验。",
+          "links": {
+            "primary": "https://dis.chatdesks.cn/chatdesk/hsyqallapihub.html"
+          },
+          "postClickNote": "全场 Lite 套餐 9.9 元/月起，更有邀请好友首单 9.5 折优惠及充值券返利。",
+          "actions": {
+            "apiCredentialProfileFallback": {
+              "baseUrl": "https://ark.cn-beijing.volces.com/api/v3",
+              "apiKeyCreateUrl": "https://console.volcengine.com/ark/region:ark+cn-beijing/apiKey",
+              "apiKeyCreateHint": "全场 Lite 套餐 9.9 元/月起，更有邀请好友首单 9.5 折优惠及充值券返利。"
+            }
+          }
+        },
+        "zh-TW": {
+          "enabled": true,
+          "rank": 120,
+          "supportStatus": "unsupported",
+          "name": "火山引擎 - 方舟Coding-Plan",
+          "tagline": "字節跳動旗下開發者生產力計劃，Lite 套餐僅需 9.9 元/月。支持豆包、DeepSeek、GLM 等頂級模型，完美适配 Cursor、Claude Code 等工具，尊享高併發穩定性與模型自動切換體驗。",
+          "links": {
+            "primary": "https://dis.chatdesks.cn/chatdesk/hsyqallapihub.html"
+          },
+          "postClickNote": "全場 Lite 套餐 9.9 元/月起，更有邀請好友首單 9.5 折優惠及充值券返利。",
+          "actions": {
+            "apiCredentialProfileFallback": {
+              "baseUrl": "https://ark.cn-beijing.volces.com/api/v3",
+              "apiKeyCreateUrl": "https://console.volcengine.com/ark/region:ark+cn-beijing/apiKey",
+              "apiKeyCreateHint": "全場 Lite 套餐 9.9 元/月起，更有邀請好友首單 9.5 折優惠及充值券返利。"
+            }
+          }
+        },
+        "en": {
+          "enabled": true,
+          "rank": 120,
+          "supportStatus": "unsupported",
+          "name": "Dola Seed on BytePlus ModelArk",
+          "tagline": "Dola Seed 2.0 is ByteDance's full-modal general large model for the global market, available through BytePlus ModelArk with multimodal understanding and generation, agent collaboration, reasoning, tool integration, and coding capabilities.",
+          "links": {
+            "primary": "https://www.byteplus.com/en/product/modelark?utm_campaign=hw&utm_content=all-api-hub&utm_medium=devrel_tool_web&utm_source=OWO&utm_term=all-api-hub"
+          },
+          "postClickNote": "Register via BytePlus ModelArk to get 500,000 tokens of free inference quota per model. Developers in mainland China can use https://dis.chatdesks.cn/chatdesk/hsyqallapihub.html instead.",
+          "actions": {
+            "apiCredentialProfileFallback": {
+              "baseUrl": "https://ark.ap-southeast.bytepluses.com/api/v3",
+              "apiKeyCreateUrl": "https://console.byteplus.com/ark/region:ark+ap-southeast-1/apiKey",
+              "apiKeyCreateHint": "Create a BytePlus ModelArk API key in the same region as your inference endpoint. The prefilled Base URL uses the AP region; switch it if your endpoint is in another region."
+            }
+          }
+        },
+        "ja": {
+          "enabled": true,
+          "rank": 120,
+          "supportStatus": "unsupported",
+          "name": "Dola Seed on BytePlus ModelArk",
+          "tagline": "Dola Seed 2.0 は ByteDance がグローバル市場向けに開発したフルモーダル汎用大規模モデルです。BytePlus ModelArk から、マルチモーダル理解と生成、エージェント協調、推論、ツール連携、コーディング機能を利用できます。",
+          "links": {
+            "primary": "https://www.byteplus.com/en/product/modelark?utm_campaign=hw&utm_content=all-api-hub&utm_medium=devrel_tool_web&utm_source=OWO&utm_term=all-api-hub"
+          },
+          "postClickNote": "BytePlus ModelArk から登録すると、各モデルにつき 500,000 トークン分の無料推論枠を受け取れます。中国大陆地区の開発者は https://dis.chatdesks.cn/chatdesk/hsyqallapihub.html を利用してください。",
+          "actions": {
+            "apiCredentialProfileFallback": {
+              "baseUrl": "https://ark.ap-southeast.bytepluses.com/api/v3",
+              "apiKeyCreateUrl": "https://console.byteplus.com/ark/region:ark+ap-southeast-1/apiKey",
+              "apiKeyCreateHint": "推論エンドポイントと同じリージョンで BytePlus ModelArk API Key を作成してください。事前入力される Base URL は AP リージョン用です。別リージョンのエンドポイントを使う場合は変更してください。"
+            }
+          }
+        },
+        "vi": {
+          "enabled": true,
+          "rank": 120,
+          "supportStatus": "unsupported",
+          "name": "Dola Seed on BytePlus ModelArk",
+          "tagline": "Dola Seed 2.0 la mo hinh lon tong quat full-modal cua ByteDance cho thi truong toan cau, co tren BytePlus ModelArk voi kha nang hieu va tao noi dung da phuong thuc, phoi hop agent, suy luan, tich hop cong cu va lap trinh.",
+          "links": {
+            "primary": "https://www.byteplus.com/en/product/modelark?utm_campaign=hw&utm_content=all-api-hub&utm_medium=devrel_tool_web&utm_source=OWO&utm_term=all-api-hub"
+          },
+          "postClickNote": "Dang ky qua BytePlus ModelArk de nhan 500.000 token suy luan mien phi cho moi mo hinh. Lap trinh vien o Trung Quoc dai luc co the dung https://dis.chatdesks.cn/chatdesk/hsyqallapihub.html.",
+          "actions": {
+            "apiCredentialProfileFallback": {
+              "baseUrl": "https://ark.ap-southeast.bytepluses.com/api/v3",
+              "apiKeyCreateUrl": "https://console.byteplus.com/ark/region:ark+ap-southeast-1/apiKey",
+              "apiKeyCreateHint": "Tao API key BytePlus ModelArk trong cung khu vuc voi inference endpoint cua ban. Base URL duoc dien san dung khu vuc AP; hay doi lai neu endpoint cua ban nam o khu vuc khac."
+            }
+          }
+        }
+      }
+    }
+  ],
+  "_examples": {
+    "devSponsors": [
+      {
+        "id": "dev-supported-direct",
+        "locales": {
+          "zh-CN": {
+            "enabled": true,
+            "rank": 9000,
+            "supportStatus": "supported",
+            "name": "[DEV] 可直接添加",
+            "tagline": "测试 Cookie 认证的 accountPrefill 主按钮和添加账号预填。",
+            "links": {
+              "primary": "https://dev-supported.example.test/register?utm_source=all-api-hub"
+            },
+            "postClickNote": "测试 Cookie 认证预填后的提示，会显示在新建账号 URL 下方。",
+            "actions": {
+              "addAccount": {
+                "siteType": "new-api",
+                "siteUrl": "https://dev-supported.example.test",
+                "authType": "cookie"
+              }
+            }
+          },
+          "en": {
+            "enabled": true,
+            "rank": 9000,
+            "supportStatus": "supported",
+            "name": "[DEV] Direct account",
+            "tagline": "Tests cookie accountPrefill primary action and add-account prefill.",
+            "links": {
+              "primary": "https://dev-supported.example.test/register?utm_source=all-api-hub"
+            },
+            "postClickNote": "Tests the post-click note shown below the add-account URL after cookie prefill.",
+            "actions": {
+              "addAccount": {
+                "siteType": "new-api",
+                "siteUrl": "https://dev-supported.example.test",
+                "authType": "cookie"
+              }
+            }
+          }
+        }
+      },
+      {
+        "id": "dev-supported-access-token",
+        "locales": {
+          "zh-CN": {
+            "enabled": true,
+            "rank": 9010,
+            "supportStatus": "supported",
+            "name": "[DEV] 访问令牌直连",
+            "tagline": "测试访问令牌认证的 accountPrefill 和 API Key 创建入口。",
+            "links": {
+              "primary": "https://dev-token.example.test/register?utm_source=all-api-hub"
+            },
+            "postClickNote": "测试访问令牌认证预填后的提示，会显示在新建账号 URL 下方。",
+            "actions": {
+              "addAccount": {
+                "siteType": "new-api",
+                "siteUrl": "https://dev-token.example.test",
+                "authType": "access_token"
+              }
+            }
+          },
+          "en": {
+            "enabled": true,
+            "rank": 9010,
+            "supportStatus": "supported",
+            "name": "[DEV] Access token account",
+            "tagline": "Tests access-token accountPrefill and API key creation URL normalization.",
+            "links": {
+              "primary": "https://dev-token.example.test/register?utm_source=all-api-hub"
+            },
+            "postClickNote": "Tests the post-click note shown below the add-account URL after access-token prefill.",
+            "actions": {
+              "addAccount": {
+                "siteType": "new-api",
+                "siteUrl": "https://dev-token.example.test",
+                "authType": "access_token"
+              }
+            }
+          }
+        }
+      },
+      {
+        "id": "dev-unsupported-bookmark",
+        "locales": {
+          "zh-CN": {
+            "enabled": true,
+            "rank": 9020,
+            "supportStatus": "unsupported",
+            "name": "[DEV] 保存书签",
+            "tagline": "测试仅显示书签 fallback。",
+            "links": {
+              "primary": "https://dev-bookmark.example.test"
+            },
+            "actions": {
+              "bookmarkFallback": {
+                "url": "https://dev-bookmark.example.test"
+              }
+            }
+          },
+          "en": {
+            "enabled": true,
+            "rank": 9020,
+            "supportStatus": "unsupported",
+            "name": "[DEV] Bookmark",
+            "tagline": "Tests the bookmark fallback only.",
+            "links": {
+              "primary": "https://dev-bookmark.example.test"
+            },
+            "actions": {
+              "bookmarkFallback": {
+                "url": "https://dev-bookmark.example.test"
+              }
+            }
+          }
+        }
+      },
+      {
+        "id": "dev-unsupported-api-profile",
+        "locales": {
+          "zh-CN": {
+            "enabled": true,
+            "rank": 9030,
+            "supportStatus": "unsupported",
+            "name": "[DEV] API 凭证",
+            "tagline": "测试仅显示 API 凭证配置 fallback。",
+            "links": {
+              "primary": "https://dev-api-profile.example.test"
+            },
+            "actions": {
+              "apiCredentialProfileFallback": {
+                "baseUrl": "https://dev-api-profile.example.test",
+                "apiKeyCreateUrl": "https://dev-api-profile.example.test/dashboard/api-keys?utm_source=all-api-hub"
+              }
+            }
+          },
+          "en": {
+            "enabled": true,
+            "rank": 9030,
+            "supportStatus": "unsupported",
+            "name": "[DEV] API profile",
+            "tagline": "Tests the API credential profile fallback only.",
+            "links": {
+              "primary": "https://dev-api-profile.example.test"
+            },
+            "actions": {
+              "apiCredentialProfileFallback": {
+                "baseUrl": "https://dev-api-profile.example.test",
+                "apiKeyCreateUrl": "https://dev-api-profile.example.test/dashboard/api-keys?utm_source=all-api-hub"
+              }
+            }
+          }
+        }
+      },
+      {
+        "id": "dev-unsupported-all-fallbacks",
+        "locales": {
+          "zh-CN": {
+            "enabled": true,
+            "rank": 9040,
+            "supportStatus": "unsupported",
+            "name": "[DEV] 全部 fallback",
+            "tagline": "测试 fallback 按钮和活动提示同时出现。",
+            "links": {
+              "primary": "https://dev-all-fallbacks.example.test/register"
+            },
+            "postClickNote": "测试赞助商提供的活动提示，可同时显示在添加账号和获取 API Key 的引导中。",
+            "actions": {
+              "bookmarkFallback": {
+                "url": "https://dev-all-fallbacks.example.test"
+              },
+              "apiCredentialProfileFallback": {
+                "baseUrl": "https://dev-all-fallbacks.example.test",
+                "apiKeyCreateUrl": "https://dev-all-fallbacks.example.test/dashboard/api-keys?utm_source=all-api-hub",
+                "apiKeyCreateHint": "测试赞助商提供的活动提示，可同时显示在添加账号和获取 API Key 的引导中。"
+              }
+            }
+          },
+          "en": {
+            "enabled": true,
+            "rank": 9040,
+            "supportStatus": "unsupported",
+            "name": "[DEV] All fallbacks",
+            "tagline": "Tests fallback buttons and campaign copy together.",
+            "links": {
+              "primary": "https://dev-all-fallbacks.example.test/register"
+            },
+            "postClickNote": "Tests sponsor-provided campaign copy in both add-account and API key guidance.",
+            "actions": {
+              "bookmarkFallback": {
+                "url": "https://dev-all-fallbacks.example.test"
+              },
+              "apiCredentialProfileFallback": {
+                "baseUrl": "https://dev-all-fallbacks.example.test",
+                "apiKeyCreateUrl": "https://dev-all-fallbacks.example.test/dashboard/api-keys?utm_source=all-api-hub",
+                "apiKeyCreateHint": "Tests sponsor-provided campaign copy in both add-account and API key guidance."
+              }
+            }
+          }
+        }
+      },
+      {
+        "id": "dev-locale-fallback",
+        "locales": {
+          "en": {
+            "enabled": true,
+            "rank": 9050,
+            "supportStatus": "unsupported",
+            "name": "[DEV] Locale fallback",
+            "tagline": "Tests fallback from the active locale to English.",
+            "links": {
+              "primary": "https://dev-locale-fallback.example.test"
+            },
+            "actions": {
+              "bookmarkFallback": {
+                "url": "https://dev-locale-fallback.example.test"
+              }
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/src/features/AccountManagement/sponsors/bundledCatalog.ts
+++ b/src/features/AccountManagement/sponsors/bundledCatalog.ts
@@ -1,5 +1,5 @@
 import { isDevelopmentMode } from "~/utils/core/environment"
-import sponsorCatalog from "~~/public/sponsor-catalog.v4.json"
+import sponsorCatalog from "~~/public/sponsor-catalog.v5.json"
 
 import type { RawSponsorCatalog } from "./types"
 

--- a/src/features/AccountManagement/sponsors/catalog.ts
+++ b/src/features/AccountManagement/sponsors/catalog.ts
@@ -14,8 +14,7 @@ import {
   getUnknownKeys,
   isActiveInDateRange,
   isValidSponsorId,
-  trimOptionalNonEmptyString,
-  trimRequiredString,
+  trimNonEmptyString,
   validateObjectKeys,
 } from "./catalogValidation"
 import {
@@ -367,8 +366,8 @@ function normalizeLocaleCampaign(
     }
   }
 
-  const name = trimRequiredString(campaign.name)
-  const tagline = trimRequiredString(campaign.tagline)
+  const name = trimNonEmptyString(campaign.name)
+  const tagline = trimNonEmptyString(campaign.tagline)
 
   if (!name || !tagline) {
     return {
@@ -392,7 +391,7 @@ function normalizeLocaleCampaign(
     }
   }
 
-  const postClickNote = trimOptionalNonEmptyString(campaign.postClickNote)
+  const postClickNote = trimNonEmptyString(campaign.postClickNote)
 
   return {
     recommendation: {

--- a/src/features/AccountManagement/sponsors/catalog.ts
+++ b/src/features/AccountManagement/sponsors/catalog.ts
@@ -4,6 +4,7 @@ import {
   type AccountSiteType,
 } from "~/constants/siteType"
 import { normalizeOptionalAccountAuthType } from "~/features/AccountManagement/utils/accountAuthType"
+import { isVersionInRange } from "~/services/productAnnouncements/versionRange"
 import type { AuthTypeEnum } from "~/types"
 
 import {
@@ -12,23 +13,27 @@ import {
 } from "./constants"
 import {
   SPONSOR_SUPPORT_STATUS,
-  type RawSponsorLocaleCampaignV4,
+  SPONSOR_VISIBILITY_BROWSER_FAMILIES,
+  type RawSponsorLocaleCampaign,
   type SponsorCatalogNormalizationResult,
   type SponsorCatalogSource,
   type SponsorRecommendation,
   type SponsorRecommendationActions,
   type SponsorSupportStatus,
+  type SponsorVisibilityBrowserFamily,
 } from "./types"
 
-interface NormalizeSponsorCatalogV4Options {
+interface NormalizeSponsorCatalogOptions {
   locale: string
   now?: number
   source: SponsorCatalogSource
+  currentVersion?: string
+  browserFamily?: SponsorVisibilityBrowserFamily | string
 }
 
-const V4_SCHEMA_VERSION = 4
-const V4_ITEM_KEYS = new Set(["id", "locales"])
-const V4_LOCALE_KEYS = new Set([
+const SPONSOR_CATALOG_SCHEMA_VERSION = 5
+const ITEM_KEYS = new Set(["id", "locales"])
+const LOCALE_KEYS = new Set([
   "enabled",
   "rank",
   "supportStatus",
@@ -39,15 +44,20 @@ const V4_LOCALE_KEYS = new Set([
   "postClickNote",
   "links",
   "actions",
+  "visibility",
 ])
-const V4_ACTION_KEYS = new Set([
+const VISIBILITY_KEYS = new Set([
+  "extensionVersions",
+  "excludedBrowserFamilies",
+])
+const ACTION_KEYS = new Set([
   "addAccount",
   "bookmarkFallback",
   "apiCredentialProfileFallback",
 ])
-const V4_ADD_ACCOUNT_KEYS = new Set(["siteType", "siteUrl", "authType"])
-const V4_BOOKMARK_FALLBACK_KEYS = new Set(["url"])
-const V4_API_CREDENTIAL_PROFILE_FALLBACK_KEYS = new Set([
+const ADD_ACCOUNT_KEYS = new Set(["siteType", "siteUrl", "authType"])
+const BOOKMARK_FALLBACK_KEYS = new Set(["url"])
+const API_CREDENTIAL_PROFILE_FALLBACK_KEYS = new Set([
   "baseUrl",
   "apiKeyCreateUrl",
   "apiKeyCreateHint",
@@ -55,11 +65,14 @@ const V4_API_CREDENTIAL_PROFILE_FALLBACK_KEYS = new Set([
 const SPONSOR_SUPPORT_STATUS_VALUES = new Set<string>(
   Object.values(SPONSOR_SUPPORT_STATUS),
 )
+const SPONSOR_VISIBILITY_BROWSER_FAMILY_VALUES = new Set<string>(
+  Object.values(SPONSOR_VISIBILITY_BROWSER_FAMILIES),
+)
 
-/** Normalizes a v4 locale-campaign sponsor catalog into UI recommendations. */
+/** Normalizes a v5 locale-campaign sponsor catalog into UI recommendations. */
 export function normalizeSponsorCatalog(
   catalog: unknown,
-  options: NormalizeSponsorCatalogV4Options,
+  options: NormalizeSponsorCatalogOptions,
 ): SponsorCatalogNormalizationResult {
   if (!isRecord(catalog)) {
     return {
@@ -69,7 +82,9 @@ export function normalizeSponsorCatalog(
     }
   }
 
-  if (catalog.schemaVersion !== V4_SCHEMA_VERSION) {
+  const schemaVersion =
+    typeof catalog.schemaVersion === "number" ? catalog.schemaVersion : null
+  if (schemaVersion !== SPONSOR_CATALOG_SCHEMA_VERSION) {
     return {
       ok: false,
       items: [],
@@ -88,7 +103,7 @@ export function normalizeSponsorCatalog(
   const now = options.now ?? Date.now()
   const errors: string[] = []
   const items = catalog.items.flatMap((item) => {
-    const normalized = normalizeSponsorItemV4(item, options, now, errors)
+    const normalized = normalizeSponsorItem(item, options, now, errors)
     return normalized ? [normalized] : []
   })
 
@@ -110,10 +125,10 @@ export function selectSponsorRecommendations(
   return items
 }
 
-/** Validates one v4 item and resolves its best locale campaign. */
-function normalizeSponsorItemV4(
+/** Validates one item and resolves its best locale campaign. */
+function normalizeSponsorItem(
   item: unknown,
-  options: NormalizeSponsorCatalogV4Options,
+  options: NormalizeSponsorCatalogOptions,
   now: number,
   errors: string[],
 ): SponsorRecommendation | undefined {
@@ -129,7 +144,7 @@ function normalizeSponsorItemV4(
     return undefined
   }
 
-  const extraItemKeys = getUnknownKeys(item, V4_ITEM_KEYS)
+  const extraItemKeys = getUnknownKeys(item, ITEM_KEYS)
   if (extraItemKeys.length > 0) {
     errors.push(
       `item ${itemId} has unsupported top-level fields: ${extraItemKeys.join(
@@ -178,7 +193,7 @@ function normalizeSponsorItemV4(
 function resolveLocaleCampaign(
   itemId: string,
   locales: Record<string, unknown>,
-  options: NormalizeSponsorCatalogV4Options,
+  options: NormalizeSponsorCatalogOptions,
   now: number,
 ): {
   recommendation?: Omit<SponsorRecommendation, "id">
@@ -236,13 +251,22 @@ function validateLocaleCampaignShape(
     return [`item ${itemId} locale ${locale} has invalid shape`]
   }
 
-  const unknownLocaleKeys = getUnknownKeys(campaign, V4_LOCALE_KEYS)
+  const unknownLocaleKeys = getUnknownKeys(campaign, LOCALE_KEYS)
   if (unknownLocaleKeys.length > 0) {
     return [
       `item ${itemId} locale ${locale} has unsupported locale fields: ${unknownLocaleKeys.join(
         ", ",
       )}`,
     ]
+  }
+
+  if (campaign.visibility !== undefined) {
+    const visibilityShapeErrors = validateVisibilityShape(
+      itemId,
+      locale,
+      campaign.visibility,
+    )
+    if (visibilityShapeErrors.length > 0) return visibilityShapeErrors
   }
 
   if (campaign.links !== undefined) {
@@ -261,7 +285,7 @@ function validateLocaleCampaignShape(
       return [`item ${itemId} locale ${locale} has invalid actions`]
     }
 
-    const unknownActionKeys = getUnknownKeys(campaign.actions, V4_ACTION_KEYS)
+    const unknownActionKeys = getUnknownKeys(campaign.actions, ACTION_KEYS)
     if (unknownActionKeys.length > 0) {
       return [
         `item ${itemId} locale ${locale} has unsupported action fields: ${unknownActionKeys.join(
@@ -285,11 +309,11 @@ function validateLocaleCampaignShape(
 function validateAllLocaleCampaignSemantics(
   itemId: string,
   locales: Record<string, unknown>,
-  options: NormalizeSponsorCatalogV4Options,
+  options: NormalizeSponsorCatalogOptions,
   now: number,
 ): string[] {
   return Object.entries(locales).flatMap(([locale, campaign]) => {
-    if (!isActiveEnabledCampaign(campaign, now)) return []
+    if (!isActiveEnabledCampaign(campaign, now, options)) return []
 
     const result = normalizeLocaleCampaign(
       itemId,
@@ -303,12 +327,12 @@ function validateAllLocaleCampaignSemantics(
   })
 }
 
-/** Converts a single strict v4 locale campaign into the shared UI contract. */
+/** Converts a single strict v5 locale campaign into the shared UI contract. */
 function normalizeLocaleCampaign(
   itemId: string,
   selectedLocale: string,
   campaign: unknown,
-  options: NormalizeSponsorCatalogV4Options,
+  options: NormalizeSponsorCatalogOptions,
   now: number,
 ): {
   recommendation?: Omit<SponsorRecommendation, "id">
@@ -348,6 +372,22 @@ function normalizeLocaleCampaign(
     }
   }
 
+  const visibility = getCampaignVisibilityState(campaign.visibility, options)
+  if (visibility === "invalid") {
+    return {
+      errors: [
+        `item ${itemId} locale ${selectedLocale} has invalid visibility`,
+      ],
+    }
+  }
+  if (visibility === "hidden") {
+    return {
+      errors: [
+        `item ${itemId} locale ${selectedLocale} is outside its visibility constraints`,
+      ],
+    }
+  }
+
   const name = trimRequiredString(campaign.name)
   const tagline = trimRequiredString(campaign.tagline)
 
@@ -382,7 +422,7 @@ function normalizeLocaleCampaign(
       links,
       actions,
       selectedLocale,
-      schemaVersion: V4_SCHEMA_VERSION,
+      schemaVersion: SPONSOR_CATALOG_SCHEMA_VERSION,
       name,
       tagline,
       postClickNote,
@@ -392,7 +432,7 @@ function normalizeLocaleCampaign(
   }
 }
 
-/** Validates and trims the v4 campaign primary link payload. */
+/** Validates and trims the campaign primary link payload. */
 function normalizeLinks(
   value: unknown,
 ): SponsorRecommendation["links"] | false {
@@ -404,7 +444,7 @@ function normalizeLinks(
   }
 }
 
-/** Validates and normalizes every supported v4 action payload. */
+/** Validates and normalizes every supported action payload. */
 function normalizeActions(
   value: unknown,
 ): SponsorRecommendationActions | false {
@@ -511,17 +551,110 @@ function getLocaleCandidates(locale: string): string[] {
 }
 
 /** Checks whether a campaign should be semantically validated as selectable content. */
-function isActiveEnabledCampaign(campaign: unknown, now: number): boolean {
+function isActiveEnabledCampaign(
+  campaign: unknown,
+  now: number,
+  options: NormalizeSponsorCatalogOptions,
+): boolean {
   if (!isRecord(campaign) || campaign.enabled !== true) return false
 
   const startsAt = parseOptionalDate(campaign.startsAt)
   const endsAt = parseOptionalDate(campaign.endsAt)
   if (startsAt === false || endsAt === false) return true
 
-  return (
+  const isActiveInTimeRange =
     (startsAt === undefined || now >= startsAt) &&
     (endsAt === undefined || now <= endsAt)
-  )
+  if (!isActiveInTimeRange) return false
+
+  return getCampaignVisibilityState(campaign.visibility, options) !== "hidden"
+}
+
+/** Validates the optional V5 campaign visibility object shape. */
+function validateVisibilityShape(
+  itemId: string,
+  locale: string,
+  value: unknown,
+): string[] {
+  if (!isRecord(value)) {
+    return [`item ${itemId} locale ${locale} has invalid visibility`]
+  }
+
+  const unknownVisibilityKeys = getUnknownKeys(value, VISIBILITY_KEYS)
+  if (unknownVisibilityKeys.length > 0) {
+    return [
+      `item ${itemId} locale ${locale} has unsupported visibility fields: ${unknownVisibilityKeys.join(
+        ", ",
+      )}`,
+    ]
+  }
+
+  if (
+    value.extensionVersions !== undefined &&
+    typeof value.extensionVersions !== "string"
+  ) {
+    return [`item ${itemId} locale ${locale} has invalid visibility`]
+  }
+
+  if (
+    value.excludedBrowserFamilies !== undefined &&
+    !isStringArray(value.excludedBrowserFamilies)
+  ) {
+    return [`item ${itemId} locale ${locale} has invalid visibility`]
+  }
+
+  return []
+}
+
+/** Evaluates whether a V5 visibility object allows the current runtime context. */
+function getCampaignVisibilityState(
+  value: unknown,
+  options: NormalizeSponsorCatalogOptions,
+): "visible" | "hidden" | "invalid" {
+  if (value === undefined) {
+    return "visible"
+  }
+  if (!isRecord(value)) return "invalid"
+
+  const extensionVersions = value.extensionVersions
+  if (extensionVersions !== undefined) {
+    if (typeof extensionVersions !== "string") return "invalid"
+    const currentVersion = options.currentVersion?.trim()
+    if (
+      !currentVersion ||
+      !isVersionInRange(currentVersion, extensionVersions)
+    ) {
+      return "hidden"
+    }
+  }
+
+  const excludedBrowserFamilies = value.excludedBrowserFamilies
+  if (excludedBrowserFamilies !== undefined) {
+    if (!isStringArray(excludedBrowserFamilies)) return "invalid"
+    if (
+      excludedBrowserFamilies.some(
+        (family) => !SPONSOR_VISIBILITY_BROWSER_FAMILY_VALUES.has(family),
+      )
+    ) {
+      return "invalid"
+    }
+
+    const browserFamily = options.browserFamily?.trim()
+    if (!browserFamily) return "hidden"
+    if (!SPONSOR_VISIBILITY_BROWSER_FAMILY_VALUES.has(browserFamily)) {
+      return "invalid"
+    }
+    if (excludedBrowserFamilies.includes(browserFamily)) {
+      return "hidden"
+    }
+  }
+
+  return "visible"
+}
+
+/** Checks whether a value is an array of strings. */
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === "string")
 }
 
 /** Validates the shape of every known action object. */
@@ -534,7 +667,7 @@ function validateActionPayloadShapes(
     itemId,
     locale,
     actions.addAccount,
-    V4_ADD_ACCOUNT_KEYS,
+    ADD_ACCOUNT_KEYS,
     "addAccount action",
   )
   if (addAccountErrors.length > 0) return addAccountErrors
@@ -543,7 +676,7 @@ function validateActionPayloadShapes(
     itemId,
     locale,
     actions.bookmarkFallback,
-    V4_BOOKMARK_FALLBACK_KEYS,
+    BOOKMARK_FALLBACK_KEYS,
     "bookmarkFallback action",
   )
   if (bookmarkErrors.length > 0) return bookmarkErrors
@@ -552,7 +685,7 @@ function validateActionPayloadShapes(
     itemId,
     locale,
     actions.apiCredentialProfileFallback,
-    V4_API_CREDENTIAL_PROFILE_FALLBACK_KEYS,
+    API_CREDENTIAL_PROFILE_FALLBACK_KEYS,
     "apiCredentialProfileFallback action",
   )
 }
@@ -616,7 +749,7 @@ function isSponsorSupportStatus(value: unknown): value is SponsorSupportStatus {
 
 /** Checks whether a campaign is active at the provided timestamp. */
 function isActiveInDateRange(
-  campaign: RawSponsorLocaleCampaignV4 | Record<string, unknown>,
+  campaign: RawSponsorLocaleCampaign | Record<string, unknown>,
   now: number,
 ): boolean {
   const startsAt = parseOptionalDate(campaign.startsAt)

--- a/src/features/AccountManagement/sponsors/catalog.ts
+++ b/src/features/AccountManagement/sponsors/catalog.ts
@@ -1,73 +1,46 @@
-import {
-  isAccountSiteType,
-  SITE_TYPES,
-  type AccountSiteType,
-} from "~/constants/siteType"
-import { normalizeOptionalAccountAuthType } from "~/features/AccountManagement/utils/accountAuthType"
-import { isVersionInRange } from "~/services/productAnnouncements/versionRange"
-import type { AuthTypeEnum } from "~/types"
+import { parseOptionalDate } from "~/utils/core/date"
+import { isRecord } from "~/utils/core/object"
+import { isHttpUrl } from "~/utils/core/urlParsing"
 
+import { normalizeActions, validateActionPayloadShapes } from "./catalogActions"
 import {
+  SPONSOR_CAMPAIGN_ACTION_FIELDS,
+  SPONSOR_CAMPAIGN_LINK_FIELDS,
+  SPONSOR_CATALOG_ITEM_FIELDS,
+  SPONSOR_LOCALE_CAMPAIGN_FIELDS,
+  SPONSOR_SUPPORT_STATUS_VALUES,
+} from "./catalogSchema"
+import {
+  getUnknownKeys,
+  isActiveInDateRange,
+  isValidSponsorId,
+  trimOptionalNonEmptyString,
+  trimRequiredString,
+  validateObjectKeys,
+} from "./catalogValidation"
+import {
+  getCampaignVisibilityState,
+  SPONSOR_CAMPAIGN_VISIBILITY_STATES,
+  validateVisibilityShape,
+  type SponsorVisibilityContext,
+} from "./catalogVisibility"
+import {
+  SPONSOR_CATALOG_SCHEMA_VERSION,
   SPONSOR_LOCALE_FALLBACKS,
   type SponsorRecommendationSurface,
 } from "./constants"
 import {
-  SPONSOR_SUPPORT_STATUS,
-  SPONSOR_VISIBILITY_BROWSER_FAMILIES,
-  type RawSponsorLocaleCampaign,
   type SponsorCatalogNormalizationResult,
   type SponsorCatalogSource,
   type SponsorRecommendation,
-  type SponsorRecommendationActions,
   type SponsorSupportStatus,
-  type SponsorVisibilityBrowserFamily,
 } from "./types"
 
-interface NormalizeSponsorCatalogOptions {
+interface NormalizeSponsorCatalogOptions extends SponsorVisibilityContext {
   locale: string
   now?: number
   source: SponsorCatalogSource
-  currentVersion?: string
-  browserFamily?: SponsorVisibilityBrowserFamily | string
 }
-
-const SPONSOR_CATALOG_SCHEMA_VERSION = 5
-const ITEM_KEYS = new Set(["id", "locales"])
-const LOCALE_KEYS = new Set([
-  "enabled",
-  "rank",
-  "supportStatus",
-  "startsAt",
-  "endsAt",
-  "name",
-  "tagline",
-  "postClickNote",
-  "links",
-  "actions",
-  "visibility",
-])
-const VISIBILITY_KEYS = new Set([
-  "extensionVersions",
-  "excludedBrowserFamilies",
-])
-const ACTION_KEYS = new Set([
-  "addAccount",
-  "bookmarkFallback",
-  "apiCredentialProfileFallback",
-])
-const ADD_ACCOUNT_KEYS = new Set(["siteType", "siteUrl", "authType"])
-const BOOKMARK_FALLBACK_KEYS = new Set(["url"])
-const API_CREDENTIAL_PROFILE_FALLBACK_KEYS = new Set([
-  "baseUrl",
-  "apiKeyCreateUrl",
-  "apiKeyCreateHint",
-])
-const SPONSOR_SUPPORT_STATUS_VALUES = new Set<string>(
-  Object.values(SPONSOR_SUPPORT_STATUS),
-)
-const SPONSOR_VISIBILITY_BROWSER_FAMILY_VALUES = new Set<string>(
-  Object.values(SPONSOR_VISIBILITY_BROWSER_FAMILIES),
-)
 
 /** Normalizes a v5 locale-campaign sponsor catalog into UI recommendations. */
 export function normalizeSponsorCatalog(
@@ -144,7 +117,7 @@ function normalizeSponsorItem(
     return undefined
   }
 
-  const extraItemKeys = getUnknownKeys(item, ITEM_KEYS)
+  const extraItemKeys = getUnknownKeys(item, SPONSOR_CATALOG_ITEM_FIELDS)
   if (extraItemKeys.length > 0) {
     errors.push(
       `item ${itemId} has unsupported top-level fields: ${extraItemKeys.join(
@@ -241,7 +214,7 @@ function validateAllLocaleCampaignShapes(
   )
 }
 
-/** Checks locale, link, and action objects for unknown fields. */
+/** Checks locale, link, visibility, and action objects for unknown fields. */
 function validateLocaleCampaignShape(
   itemId: string,
   locale: string,
@@ -251,7 +224,10 @@ function validateLocaleCampaignShape(
     return [`item ${itemId} locale ${locale} has invalid shape`]
   }
 
-  const unknownLocaleKeys = getUnknownKeys(campaign, LOCALE_KEYS)
+  const unknownLocaleKeys = getUnknownKeys(
+    campaign,
+    SPONSOR_LOCALE_CAMPAIGN_FIELDS,
+  )
   if (unknownLocaleKeys.length > 0) {
     return [
       `item ${itemId} locale ${locale} has unsupported locale fields: ${unknownLocaleKeys.join(
@@ -274,7 +250,7 @@ function validateLocaleCampaignShape(
       itemId,
       locale,
       campaign.links,
-      new Set(["primary"]),
+      SPONSOR_CAMPAIGN_LINK_FIELDS,
       "link",
     )
     if (linkShapeErrors.length > 0) return linkShapeErrors
@@ -285,7 +261,10 @@ function validateLocaleCampaignShape(
       return [`item ${itemId} locale ${locale} has invalid actions`]
     }
 
-    const unknownActionKeys = getUnknownKeys(campaign.actions, ACTION_KEYS)
+    const unknownActionKeys = getUnknownKeys(
+      campaign.actions,
+      SPONSOR_CAMPAIGN_ACTION_FIELDS,
+    )
     if (unknownActionKeys.length > 0) {
       return [
         `item ${itemId} locale ${locale} has unsupported action fields: ${unknownActionKeys.join(
@@ -373,14 +352,14 @@ function normalizeLocaleCampaign(
   }
 
   const visibility = getCampaignVisibilityState(campaign.visibility, options)
-  if (visibility === "invalid") {
+  if (visibility === SPONSOR_CAMPAIGN_VISIBILITY_STATES.Invalid) {
     return {
       errors: [
         `item ${itemId} locale ${selectedLocale} has invalid visibility`,
       ],
     }
   }
-  if (visibility === "hidden") {
+  if (visibility === SPONSOR_CAMPAIGN_VISIBILITY_STATES.Hidden) {
     return {
       errors: [
         `item ${itemId} locale ${selectedLocale} is outside its visibility constraints`,
@@ -437,109 +416,10 @@ function normalizeLinks(
   value: unknown,
 ): SponsorRecommendation["links"] | false {
   if (!isRecord(value)) return false
-  if (!isSafeHttpUrl(value.primary)) return false
+  if (!isHttpUrl(value.primary)) return false
 
   return {
     primary: value.primary.trim(),
-  }
-}
-
-/** Validates and normalizes every supported action payload. */
-function normalizeActions(
-  value: unknown,
-): SponsorRecommendationActions | false {
-  if (value === undefined) return {}
-  if (!isRecord(value)) return false
-
-  const addAccount = normalizeAddAccountAction(value.addAccount)
-  if (addAccount === false) return false
-
-  const bookmarkFallback = normalizeBookmarkFallbackAction(
-    value.bookmarkFallback,
-  )
-  if (bookmarkFallback === false) return false
-
-  const apiCredentialProfileFallback =
-    normalizeApiCredentialProfileFallbackAction(
-      value.apiCredentialProfileFallback,
-    )
-  if (apiCredentialProfileFallback === false) return false
-
-  return {
-    ...(addAccount ? { addAccount } : {}),
-    ...(bookmarkFallback ? { bookmarkFallback } : {}),
-    ...(apiCredentialProfileFallback ? { apiCredentialProfileFallback } : {}),
-  }
-}
-
-/** Validates sponsor-provided add-account prefill metadata. */
-function normalizeAddAccountAction(value: unknown):
-  | false
-  | undefined
-  | {
-      siteType: AccountSiteType
-      siteUrl: string
-      authType?: AuthTypeEnum
-    } {
-  if (value === undefined) return undefined
-  if (!isRecord(value)) return false
-
-  const { siteType, siteUrl, authType } = value
-  const normalizedAuthType = normalizeOptionalAccountAuthType(authType)
-  if (
-    !isAccountSiteType(siteType) ||
-    siteType === SITE_TYPES.UNKNOWN ||
-    !isSafeHttpUrl(siteUrl) ||
-    normalizedAuthType === false
-  ) {
-    return false
-  }
-
-  return {
-    siteType,
-    siteUrl: siteUrl.trim(),
-    ...(normalizedAuthType ? { authType: normalizedAuthType } : {}),
-  }
-}
-
-/** Validates the bookmark-manager fallback action payload. */
-function normalizeBookmarkFallbackAction(
-  value: unknown,
-): SponsorRecommendationActions["bookmarkFallback"] | false | undefined {
-  if (value === undefined) return undefined
-  if (!isRecord(value)) return false
-  if (!isSafeHttpUrl(value.url)) return false
-
-  return {
-    url: value.url.trim(),
-  }
-}
-
-/** Validates the API credential profile fallback action payload. */
-function normalizeApiCredentialProfileFallbackAction(
-  value: unknown,
-):
-  | SponsorRecommendationActions["apiCredentialProfileFallback"]
-  | false
-  | undefined {
-  if (value === undefined) return undefined
-  if (!isRecord(value)) return false
-  if (!isSafeHttpUrl(value.baseUrl)) return false
-  if (
-    value.apiKeyCreateUrl !== undefined &&
-    !isSafeHttpUrl(value.apiKeyCreateUrl)
-  ) {
-    return false
-  }
-
-  const apiKeyCreateHint = trimOptionalNonEmptyString(value.apiKeyCreateHint)
-
-  return {
-    baseUrl: value.baseUrl.trim(),
-    ...(value.apiKeyCreateUrl
-      ? { apiKeyCreateUrl: value.apiKeyCreateUrl.trim() }
-      : {}),
-    ...(apiKeyCreateHint ? { apiKeyCreateHint } : {}),
   }
 }
 
@@ -567,226 +447,13 @@ function isActiveEnabledCampaign(
     (endsAt === undefined || now <= endsAt)
   if (!isActiveInTimeRange) return false
 
-  return getCampaignVisibilityState(campaign.visibility, options) !== "hidden"
-}
-
-/** Validates the optional V5 campaign visibility object shape. */
-function validateVisibilityShape(
-  itemId: string,
-  locale: string,
-  value: unknown,
-): string[] {
-  if (!isRecord(value)) {
-    return [`item ${itemId} locale ${locale} has invalid visibility`]
-  }
-
-  const unknownVisibilityKeys = getUnknownKeys(value, VISIBILITY_KEYS)
-  if (unknownVisibilityKeys.length > 0) {
-    return [
-      `item ${itemId} locale ${locale} has unsupported visibility fields: ${unknownVisibilityKeys.join(
-        ", ",
-      )}`,
-    ]
-  }
-
-  if (
-    value.extensionVersions !== undefined &&
-    typeof value.extensionVersions !== "string"
-  ) {
-    return [`item ${itemId} locale ${locale} has invalid visibility`]
-  }
-
-  if (
-    value.excludedBrowserFamilies !== undefined &&
-    !isStringArray(value.excludedBrowserFamilies)
-  ) {
-    return [`item ${itemId} locale ${locale} has invalid visibility`]
-  }
-
-  return []
-}
-
-/** Evaluates whether a V5 visibility object allows the current runtime context. */
-function getCampaignVisibilityState(
-  value: unknown,
-  options: NormalizeSponsorCatalogOptions,
-): "visible" | "hidden" | "invalid" {
-  if (value === undefined) {
-    return "visible"
-  }
-  if (!isRecord(value)) return "invalid"
-
-  const extensionVersions = value.extensionVersions
-  if (extensionVersions !== undefined) {
-    if (typeof extensionVersions !== "string") return "invalid"
-    const currentVersion = options.currentVersion?.trim()
-    if (
-      !currentVersion ||
-      !isVersionInRange(currentVersion, extensionVersions)
-    ) {
-      return "hidden"
-    }
-  }
-
-  const excludedBrowserFamilies = value.excludedBrowserFamilies
-  if (excludedBrowserFamilies !== undefined) {
-    if (!isStringArray(excludedBrowserFamilies)) return "invalid"
-    if (
-      excludedBrowserFamilies.some(
-        (family) => !SPONSOR_VISIBILITY_BROWSER_FAMILY_VALUES.has(family),
-      )
-    ) {
-      return "invalid"
-    }
-
-    const browserFamily = options.browserFamily?.trim()
-    if (!browserFamily) return "hidden"
-    if (!SPONSOR_VISIBILITY_BROWSER_FAMILY_VALUES.has(browserFamily)) {
-      return "invalid"
-    }
-    if (excludedBrowserFamilies.includes(browserFamily)) {
-      return "hidden"
-    }
-  }
-
-  return "visible"
-}
-
-/** Checks whether a value is an array of strings. */
-function isStringArray(value: unknown): value is string[] {
-  return Array.isArray(value) && value.every((item) => typeof item === "string")
-}
-
-/** Validates the shape of every known action object. */
-function validateActionPayloadShapes(
-  itemId: string,
-  locale: string,
-  actions: Record<string, unknown>,
-): string[] {
-  const addAccountErrors = validateObjectKeys(
-    itemId,
-    locale,
-    actions.addAccount,
-    ADD_ACCOUNT_KEYS,
-    "addAccount action",
+  return (
+    getCampaignVisibilityState(campaign.visibility, options) !==
+    SPONSOR_CAMPAIGN_VISIBILITY_STATES.Hidden
   )
-  if (addAccountErrors.length > 0) return addAccountErrors
-
-  const bookmarkErrors = validateObjectKeys(
-    itemId,
-    locale,
-    actions.bookmarkFallback,
-    BOOKMARK_FALLBACK_KEYS,
-    "bookmarkFallback action",
-  )
-  if (bookmarkErrors.length > 0) return bookmarkErrors
-
-  return validateObjectKeys(
-    itemId,
-    locale,
-    actions.apiCredentialProfileFallback,
-    API_CREDENTIAL_PROFILE_FALLBACK_KEYS,
-    "apiCredentialProfileFallback action",
-  )
-}
-
-/** Validates optional object keys against a strict allow-list. */
-function validateObjectKeys(
-  itemId: string,
-  locale: string,
-  value: unknown,
-  allowedKeys: Set<string>,
-  label: string,
-): string[] {
-  if (value === undefined) return []
-  if (!isRecord(value)) {
-    return [`item ${itemId} locale ${locale} has invalid ${label}`]
-  }
-
-  const unknownKeys = getUnknownKeys(value, allowedKeys)
-  if (unknownKeys.length === 0) return []
-
-  return [
-    `item ${itemId} locale ${locale} has unsupported ${label} fields: ${unknownKeys.join(
-      ", ",
-    )}`,
-  ]
-}
-
-/** Returns object keys that are outside a strict allow-list. */
-function getUnknownKeys(
-  value: Record<string, unknown>,
-  allowedKeys: Set<string>,
-): string[] {
-  return Object.keys(value).filter((key) => !allowedKeys.has(key))
-}
-
-/** Trims a required non-empty string field. */
-function trimRequiredString(value: unknown): string | undefined {
-  if (typeof value !== "string") return undefined
-
-  const trimmed = value.trim()
-  return trimmed.length > 0 ? trimmed : undefined
-}
-
-/** Trims optional display copy and omits blanks or malformed values. */
-function trimOptionalNonEmptyString(value: unknown): string | undefined {
-  if (typeof value !== "string") return undefined
-
-  const trimmed = value.trim()
-  return trimmed.length > 0 ? trimmed : undefined
-}
-
-/** Checks whether a sponsor id uses the supported stable slug format. */
-function isValidSponsorId(value: unknown): value is string {
-  return typeof value === "string" && /^[a-z0-9][a-z0-9-]*$/.test(value)
 }
 
 /** Checks whether a value is a known sponsor support status. */
 function isSponsorSupportStatus(value: unknown): value is SponsorSupportStatus {
   return typeof value === "string" && SPONSOR_SUPPORT_STATUS_VALUES.has(value)
-}
-
-/** Checks whether a campaign is active at the provided timestamp. */
-function isActiveInDateRange(
-  campaign: RawSponsorLocaleCampaign | Record<string, unknown>,
-  now: number,
-): boolean {
-  const startsAt = parseOptionalDate(campaign.startsAt)
-  const endsAt = parseOptionalDate(campaign.endsAt)
-
-  if (startsAt === false || endsAt === false) {
-    return false
-  }
-
-  return (
-    (startsAt === undefined || now >= startsAt) &&
-    (endsAt === undefined || now <= endsAt)
-  )
-}
-
-/** Parses an optional date string for campaign active-window checks. */
-function parseOptionalDate(value: unknown): number | false | undefined {
-  if (value === undefined) return undefined
-  if (typeof value !== "string") return false
-
-  const timestamp = Date.parse(value)
-  return Number.isNaN(timestamp) ? false : timestamp
-}
-
-/** Checks whether a URL is parseable and restricted to HTTP or HTTPS. */
-function isSafeHttpUrl(value: unknown): value is string {
-  if (typeof value !== "string") return false
-
-  try {
-    const url = new URL(value.trim())
-    return url.protocol === "http:" || url.protocol === "https:"
-  } catch {
-    return false
-  }
-}
-
-/** Checks whether a remote JSON value is a non-null object record. */
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value)
 }

--- a/src/features/AccountManagement/sponsors/catalogActions.ts
+++ b/src/features/AccountManagement/sponsors/catalogActions.ts
@@ -13,10 +13,7 @@ import {
   SPONSOR_API_CREDENTIAL_PROFILE_FALLBACK_ACTION_FIELDS,
   SPONSOR_BOOKMARK_FALLBACK_ACTION_FIELDS,
 } from "./catalogSchema"
-import {
-  trimOptionalNonEmptyString,
-  validateObjectKeys,
-} from "./catalogValidation"
+import { trimNonEmptyString, validateObjectKeys } from "./catalogValidation"
 import type { SponsorRecommendationActions } from "./types"
 
 /** Validates the shape of every known action object. */
@@ -140,7 +137,7 @@ function normalizeApiCredentialProfileFallbackAction(
     return false
   }
 
-  const apiKeyCreateHint = trimOptionalNonEmptyString(value.apiKeyCreateHint)
+  const apiKeyCreateHint = trimNonEmptyString(value.apiKeyCreateHint)
 
   return {
     baseUrl: value.baseUrl.trim(),

--- a/src/features/AccountManagement/sponsors/catalogActions.ts
+++ b/src/features/AccountManagement/sponsors/catalogActions.ts
@@ -1,0 +1,152 @@
+import {
+  isAccountSiteType,
+  SITE_TYPES,
+  type AccountSiteType,
+} from "~/constants/siteType"
+import { normalizeOptionalAccountAuthType } from "~/features/AccountManagement/utils/accountAuthType"
+import type { AuthTypeEnum } from "~/types"
+import { isRecord } from "~/utils/core/object"
+import { isHttpUrl } from "~/utils/core/urlParsing"
+
+import {
+  SPONSOR_ADD_ACCOUNT_ACTION_FIELDS,
+  SPONSOR_API_CREDENTIAL_PROFILE_FALLBACK_ACTION_FIELDS,
+  SPONSOR_BOOKMARK_FALLBACK_ACTION_FIELDS,
+} from "./catalogSchema"
+import {
+  trimOptionalNonEmptyString,
+  validateObjectKeys,
+} from "./catalogValidation"
+import type { SponsorRecommendationActions } from "./types"
+
+/** Validates the shape of every known action object. */
+export function validateActionPayloadShapes(
+  itemId: string,
+  locale: string,
+  actions: Record<string, unknown>,
+): string[] {
+  const addAccountErrors = validateObjectKeys(
+    itemId,
+    locale,
+    actions.addAccount,
+    SPONSOR_ADD_ACCOUNT_ACTION_FIELDS,
+    "addAccount action",
+  )
+  if (addAccountErrors.length > 0) return addAccountErrors
+
+  const bookmarkErrors = validateObjectKeys(
+    itemId,
+    locale,
+    actions.bookmarkFallback,
+    SPONSOR_BOOKMARK_FALLBACK_ACTION_FIELDS,
+    "bookmarkFallback action",
+  )
+  if (bookmarkErrors.length > 0) return bookmarkErrors
+
+  return validateObjectKeys(
+    itemId,
+    locale,
+    actions.apiCredentialProfileFallback,
+    SPONSOR_API_CREDENTIAL_PROFILE_FALLBACK_ACTION_FIELDS,
+    "apiCredentialProfileFallback action",
+  )
+}
+
+/** Validates and normalizes every supported action payload. */
+export function normalizeActions(
+  value: unknown,
+): SponsorRecommendationActions | false {
+  if (value === undefined) return {}
+  if (!isRecord(value)) return false
+
+  const addAccount = normalizeAddAccountAction(value.addAccount)
+  if (addAccount === false) return false
+
+  const bookmarkFallback = normalizeBookmarkFallbackAction(
+    value.bookmarkFallback,
+  )
+  if (bookmarkFallback === false) return false
+
+  const apiCredentialProfileFallback =
+    normalizeApiCredentialProfileFallbackAction(
+      value.apiCredentialProfileFallback,
+    )
+  if (apiCredentialProfileFallback === false) return false
+
+  return {
+    ...(addAccount ? { addAccount } : {}),
+    ...(bookmarkFallback ? { bookmarkFallback } : {}),
+    ...(apiCredentialProfileFallback ? { apiCredentialProfileFallback } : {}),
+  }
+}
+
+/** Validates sponsor-provided add-account prefill metadata. */
+function normalizeAddAccountAction(value: unknown):
+  | false
+  | undefined
+  | {
+      siteType: AccountSiteType
+      siteUrl: string
+      authType?: AuthTypeEnum
+    } {
+  if (value === undefined) return undefined
+  if (!isRecord(value)) return false
+
+  const { siteType, siteUrl, authType } = value
+  const normalizedAuthType = normalizeOptionalAccountAuthType(authType)
+  if (
+    !isAccountSiteType(siteType) ||
+    siteType === SITE_TYPES.UNKNOWN ||
+    !isHttpUrl(siteUrl) ||
+    normalizedAuthType === false
+  ) {
+    return false
+  }
+
+  return {
+    siteType,
+    siteUrl: siteUrl.trim(),
+    ...(normalizedAuthType ? { authType: normalizedAuthType } : {}),
+  }
+}
+
+/** Validates the bookmark-manager fallback action payload. */
+function normalizeBookmarkFallbackAction(
+  value: unknown,
+): SponsorRecommendationActions["bookmarkFallback"] | false | undefined {
+  if (value === undefined) return undefined
+  if (!isRecord(value)) return false
+  if (!isHttpUrl(value.url)) return false
+
+  return {
+    url: value.url.trim(),
+  }
+}
+
+/** Validates the API credential profile fallback action payload. */
+function normalizeApiCredentialProfileFallbackAction(
+  value: unknown,
+):
+  | SponsorRecommendationActions["apiCredentialProfileFallback"]
+  | false
+  | undefined {
+  if (value === undefined) return undefined
+  if (!isRecord(value)) return false
+  if (!isHttpUrl(value.baseUrl)) return false
+  if (
+    value.apiKeyCreateUrl !== undefined &&
+    !isHttpUrl(value.apiKeyCreateUrl)
+  ) {
+    return false
+  }
+
+  const apiKeyCreateHint = trimOptionalNonEmptyString(value.apiKeyCreateHint)
+
+  return {
+    baseUrl: value.baseUrl.trim(),
+    ...(value.apiKeyCreateUrl
+      ? { apiKeyCreateUrl: value.apiKeyCreateUrl.trim() }
+      : {}),
+    ...(apiKeyCreateHint ? { apiKeyCreateHint } : {}),
+  }
+}

--- a/src/features/AccountManagement/sponsors/catalogSchema.ts
+++ b/src/features/AccountManagement/sponsors/catalogSchema.ts
@@ -1,9 +1,27 @@
 import {
   SPONSOR_SUPPORT_STATUS,
   SPONSOR_VISIBILITY_BROWSER_FAMILIES,
+  type RawSponsorCatalogItem,
+  type RawSponsorLocaleCampaign,
 } from "./types"
 
 type StringEnum = Record<string, string>
+type RawSponsorCampaignLinks = RawSponsorLocaleCampaign["links"]
+type RawSponsorCampaignVisibility = NonNullable<
+  RawSponsorLocaleCampaign["visibility"]
+>
+type RawSponsorCampaignActions = NonNullable<
+  RawSponsorLocaleCampaign["actions"]
+>
+type RawSponsorAddAccountAction = NonNullable<
+  RawSponsorCampaignActions["addAccount"]
+>
+type RawSponsorBookmarkFallbackAction = NonNullable<
+  RawSponsorCampaignActions["bookmarkFallback"]
+>
+type RawSponsorApiCredentialProfileFallbackAction = NonNullable<
+  RawSponsorCampaignActions["apiCredentialProfileFallback"]
+>
 
 /** Builds a reusable lookup set from a string enum-like constant object. */
 function createValueSet(values: StringEnum): ReadonlySet<string> {
@@ -13,7 +31,7 @@ function createValueSet(values: StringEnum): ReadonlySet<string> {
 const SPONSOR_CATALOG_ITEM_FIELD = {
   Id: "id",
   Locales: "locales",
-} as const
+} as const satisfies Record<string, keyof RawSponsorCatalogItem>
 
 const SPONSOR_LOCALE_CAMPAIGN_FIELD = {
   Enabled: "enabled",
@@ -27,38 +45,41 @@ const SPONSOR_LOCALE_CAMPAIGN_FIELD = {
   Links: "links",
   Actions: "actions",
   Visibility: "visibility",
-} as const
+} as const satisfies Record<string, keyof RawSponsorLocaleCampaign>
 
 const SPONSOR_CAMPAIGN_LINK_FIELD = {
   Primary: "primary",
-} as const
+} as const satisfies Record<string, keyof RawSponsorCampaignLinks>
 
 const SPONSOR_CAMPAIGN_VISIBILITY_FIELD = {
   ExtensionVersions: "extensionVersions",
   ExcludedBrowserFamilies: "excludedBrowserFamilies",
-} as const
+} as const satisfies Record<string, keyof RawSponsorCampaignVisibility>
 
 const SPONSOR_CAMPAIGN_ACTION_FIELD = {
   AddAccount: "addAccount",
   BookmarkFallback: "bookmarkFallback",
   ApiCredentialProfileFallback: "apiCredentialProfileFallback",
-} as const
+} as const satisfies Record<string, keyof RawSponsorCampaignActions>
 
 const SPONSOR_ADD_ACCOUNT_ACTION_FIELD = {
   SiteType: "siteType",
   SiteUrl: "siteUrl",
   AuthType: "authType",
-} as const
+} as const satisfies Record<string, keyof RawSponsorAddAccountAction>
 
 const SPONSOR_BOOKMARK_FALLBACK_ACTION_FIELD = {
   Url: "url",
-} as const
+} as const satisfies Record<string, keyof RawSponsorBookmarkFallbackAction>
 
 const SPONSOR_API_CREDENTIAL_PROFILE_FALLBACK_ACTION_FIELD = {
   BaseUrl: "baseUrl",
   ApiKeyCreateUrl: "apiKeyCreateUrl",
   ApiKeyCreateHint: "apiKeyCreateHint",
-} as const
+} as const satisfies Record<
+  string,
+  keyof RawSponsorApiCredentialProfileFallbackAction
+>
 
 export const SPONSOR_CATALOG_ITEM_FIELDS = createValueSet(
   SPONSOR_CATALOG_ITEM_FIELD,

--- a/src/features/AccountManagement/sponsors/catalogSchema.ts
+++ b/src/features/AccountManagement/sponsors/catalogSchema.ts
@@ -1,0 +1,100 @@
+import {
+  SPONSOR_SUPPORT_STATUS,
+  SPONSOR_VISIBILITY_BROWSER_FAMILIES,
+} from "./types"
+
+type StringEnum = Record<string, string>
+
+/** Builds a reusable lookup set from a string enum-like constant object. */
+function createValueSet(values: StringEnum): ReadonlySet<string> {
+  return new Set(Object.values(values))
+}
+
+const SPONSOR_CATALOG_ITEM_FIELD = {
+  Id: "id",
+  Locales: "locales",
+} as const
+
+const SPONSOR_LOCALE_CAMPAIGN_FIELD = {
+  Enabled: "enabled",
+  Rank: "rank",
+  SupportStatus: "supportStatus",
+  StartsAt: "startsAt",
+  EndsAt: "endsAt",
+  Name: "name",
+  Tagline: "tagline",
+  PostClickNote: "postClickNote",
+  Links: "links",
+  Actions: "actions",
+  Visibility: "visibility",
+} as const
+
+const SPONSOR_CAMPAIGN_LINK_FIELD = {
+  Primary: "primary",
+} as const
+
+const SPONSOR_CAMPAIGN_VISIBILITY_FIELD = {
+  ExtensionVersions: "extensionVersions",
+  ExcludedBrowserFamilies: "excludedBrowserFamilies",
+} as const
+
+const SPONSOR_CAMPAIGN_ACTION_FIELD = {
+  AddAccount: "addAccount",
+  BookmarkFallback: "bookmarkFallback",
+  ApiCredentialProfileFallback: "apiCredentialProfileFallback",
+} as const
+
+const SPONSOR_ADD_ACCOUNT_ACTION_FIELD = {
+  SiteType: "siteType",
+  SiteUrl: "siteUrl",
+  AuthType: "authType",
+} as const
+
+const SPONSOR_BOOKMARK_FALLBACK_ACTION_FIELD = {
+  Url: "url",
+} as const
+
+const SPONSOR_API_CREDENTIAL_PROFILE_FALLBACK_ACTION_FIELD = {
+  BaseUrl: "baseUrl",
+  ApiKeyCreateUrl: "apiKeyCreateUrl",
+  ApiKeyCreateHint: "apiKeyCreateHint",
+} as const
+
+export const SPONSOR_CATALOG_ITEM_FIELDS = createValueSet(
+  SPONSOR_CATALOG_ITEM_FIELD,
+)
+
+export const SPONSOR_LOCALE_CAMPAIGN_FIELDS = createValueSet(
+  SPONSOR_LOCALE_CAMPAIGN_FIELD,
+)
+
+export const SPONSOR_CAMPAIGN_LINK_FIELDS = createValueSet(
+  SPONSOR_CAMPAIGN_LINK_FIELD,
+)
+
+export const SPONSOR_CAMPAIGN_VISIBILITY_FIELDS = createValueSet(
+  SPONSOR_CAMPAIGN_VISIBILITY_FIELD,
+)
+
+export const SPONSOR_CAMPAIGN_ACTION_FIELDS = createValueSet(
+  SPONSOR_CAMPAIGN_ACTION_FIELD,
+)
+
+export const SPONSOR_ADD_ACCOUNT_ACTION_FIELDS = createValueSet(
+  SPONSOR_ADD_ACCOUNT_ACTION_FIELD,
+)
+
+export const SPONSOR_BOOKMARK_FALLBACK_ACTION_FIELDS = createValueSet(
+  SPONSOR_BOOKMARK_FALLBACK_ACTION_FIELD,
+)
+
+export const SPONSOR_API_CREDENTIAL_PROFILE_FALLBACK_ACTION_FIELDS =
+  createValueSet(SPONSOR_API_CREDENTIAL_PROFILE_FALLBACK_ACTION_FIELD)
+
+export const SPONSOR_SUPPORT_STATUS_VALUES = createValueSet(
+  SPONSOR_SUPPORT_STATUS,
+)
+
+export const SPONSOR_VISIBILITY_BROWSER_FAMILY_VALUES = createValueSet(
+  SPONSOR_VISIBILITY_BROWSER_FAMILIES,
+)

--- a/src/features/AccountManagement/sponsors/catalogValidation.ts
+++ b/src/features/AccountManagement/sponsors/catalogValidation.ts
@@ -35,13 +35,8 @@ export function getUnknownKeys(
   return Object.keys(value).filter((key) => !allowedKeys.has(key))
 }
 
-/** Trims a required non-empty string field. */
-export function trimRequiredString(value: unknown): string | undefined {
-  return trimToNull(value) ?? undefined
-}
-
-/** Trims optional display copy and omits blanks or malformed values. */
-export function trimOptionalNonEmptyString(value: unknown): string | undefined {
+/** Trims display copy and omits blanks or malformed values. */
+export function trimNonEmptyString(value: unknown): string | undefined {
   return trimToNull(value) ?? undefined
 }
 

--- a/src/features/AccountManagement/sponsors/catalogValidation.ts
+++ b/src/features/AccountManagement/sponsors/catalogValidation.ts
@@ -1,0 +1,69 @@
+import { parseOptionalDate } from "~/utils/core/date"
+import { isRecord } from "~/utils/core/object"
+import { trimToNull } from "~/utils/core/string"
+
+import type { RawSponsorLocaleCampaign } from "./types"
+
+/** Validates optional object keys against a strict allow-list. */
+export function validateObjectKeys(
+  itemId: string,
+  locale: string,
+  value: unknown,
+  allowedKeys: ReadonlySet<string>,
+  label: string,
+): string[] {
+  if (value === undefined) return []
+  if (!isRecord(value)) {
+    return [`item ${itemId} locale ${locale} has invalid ${label}`]
+  }
+
+  const unknownKeys = getUnknownKeys(value, allowedKeys)
+  if (unknownKeys.length === 0) return []
+
+  return [
+    `item ${itemId} locale ${locale} has unsupported ${label} fields: ${unknownKeys.join(
+      ", ",
+    )}`,
+  ]
+}
+
+/** Returns object keys that are outside a strict allow-list. */
+export function getUnknownKeys(
+  value: Record<string, unknown>,
+  allowedKeys: ReadonlySet<string>,
+): string[] {
+  return Object.keys(value).filter((key) => !allowedKeys.has(key))
+}
+
+/** Trims a required non-empty string field. */
+export function trimRequiredString(value: unknown): string | undefined {
+  return trimToNull(value) ?? undefined
+}
+
+/** Trims optional display copy and omits blanks or malformed values. */
+export function trimOptionalNonEmptyString(value: unknown): string | undefined {
+  return trimToNull(value) ?? undefined
+}
+
+/** Checks whether a sponsor id uses the supported stable slug format. */
+export function isValidSponsorId(value: unknown): value is string {
+  return typeof value === "string" && /^[a-z0-9][a-z0-9-]*$/.test(value)
+}
+
+/** Checks whether a campaign is active at the provided timestamp. */
+export function isActiveInDateRange(
+  campaign: RawSponsorLocaleCampaign | Record<string, unknown>,
+  now: number,
+): boolean {
+  const startsAt = parseOptionalDate(campaign.startsAt)
+  const endsAt = parseOptionalDate(campaign.endsAt)
+
+  if (startsAt === false || endsAt === false) {
+    return false
+  }
+
+  return (
+    (startsAt === undefined || now >= startsAt) &&
+    (endsAt === undefined || now <= endsAt)
+  )
+}

--- a/src/features/AccountManagement/sponsors/catalogVisibility.ts
+++ b/src/features/AccountManagement/sponsors/catalogVisibility.ts
@@ -1,0 +1,112 @@
+import { isVersionInRange } from "~/services/productAnnouncements/versionRange"
+import { isRecord, isStringArray } from "~/utils/core/object"
+
+import {
+  SPONSOR_CAMPAIGN_VISIBILITY_FIELDS,
+  SPONSOR_VISIBILITY_BROWSER_FAMILY_VALUES,
+} from "./catalogSchema"
+import { getUnknownKeys } from "./catalogValidation"
+import type { SponsorVisibilityBrowserFamily } from "./types"
+
+export interface SponsorVisibilityContext {
+  currentVersion?: string
+  browserFamily?: SponsorVisibilityBrowserFamily | string
+}
+
+export const SPONSOR_CAMPAIGN_VISIBILITY_STATES = {
+  Visible: "visible",
+  Hidden: "hidden",
+  Invalid: "invalid",
+} as const
+
+type SponsorCampaignVisibilityState =
+  (typeof SPONSOR_CAMPAIGN_VISIBILITY_STATES)[keyof typeof SPONSOR_CAMPAIGN_VISIBILITY_STATES]
+
+/** Validates the optional V5 campaign visibility object shape. */
+export function validateVisibilityShape(
+  itemId: string,
+  locale: string,
+  value: unknown,
+): string[] {
+  if (!isRecord(value)) {
+    return [`item ${itemId} locale ${locale} has invalid visibility`]
+  }
+
+  const unknownVisibilityKeys = getUnknownKeys(
+    value,
+    SPONSOR_CAMPAIGN_VISIBILITY_FIELDS,
+  )
+  if (unknownVisibilityKeys.length > 0) {
+    return [
+      `item ${itemId} locale ${locale} has unsupported visibility fields: ${unknownVisibilityKeys.join(
+        ", ",
+      )}`,
+    ]
+  }
+
+  if (
+    value.extensionVersions !== undefined &&
+    typeof value.extensionVersions !== "string"
+  ) {
+    return [`item ${itemId} locale ${locale} has invalid visibility`]
+  }
+
+  if (
+    value.excludedBrowserFamilies !== undefined &&
+    !isStringArray(value.excludedBrowserFamilies)
+  ) {
+    return [`item ${itemId} locale ${locale} has invalid visibility`]
+  }
+
+  return []
+}
+
+/** Evaluates whether a V5 visibility object allows the current runtime context. */
+export function getCampaignVisibilityState(
+  value: unknown,
+  context: SponsorVisibilityContext,
+): SponsorCampaignVisibilityState {
+  if (value === undefined) {
+    return SPONSOR_CAMPAIGN_VISIBILITY_STATES.Visible
+  }
+  if (!isRecord(value)) return SPONSOR_CAMPAIGN_VISIBILITY_STATES.Invalid
+
+  const extensionVersions = value.extensionVersions
+  if (extensionVersions !== undefined) {
+    if (typeof extensionVersions !== "string") {
+      return SPONSOR_CAMPAIGN_VISIBILITY_STATES.Invalid
+    }
+    const currentVersion = context.currentVersion?.trim()
+    if (
+      !currentVersion ||
+      !isVersionInRange(currentVersion, extensionVersions)
+    ) {
+      return SPONSOR_CAMPAIGN_VISIBILITY_STATES.Hidden
+    }
+  }
+
+  const excludedBrowserFamilies = value.excludedBrowserFamilies
+  if (excludedBrowserFamilies !== undefined) {
+    if (!isStringArray(excludedBrowserFamilies)) {
+      return SPONSOR_CAMPAIGN_VISIBILITY_STATES.Invalid
+    }
+    if (
+      excludedBrowserFamilies.some(
+        (family) => !SPONSOR_VISIBILITY_BROWSER_FAMILY_VALUES.has(family),
+      )
+    ) {
+      return SPONSOR_CAMPAIGN_VISIBILITY_STATES.Invalid
+    }
+
+    const browserFamily = context.browserFamily?.trim()
+    if (!browserFamily) return SPONSOR_CAMPAIGN_VISIBILITY_STATES.Hidden
+    if (!SPONSOR_VISIBILITY_BROWSER_FAMILY_VALUES.has(browserFamily)) {
+      return SPONSOR_CAMPAIGN_VISIBILITY_STATES.Invalid
+    }
+    if (excludedBrowserFamilies.includes(browserFamily)) {
+      return SPONSOR_CAMPAIGN_VISIBILITY_STATES.Hidden
+    }
+  }
+
+  return SPONSOR_CAMPAIGN_VISIBILITY_STATES.Visible
+}

--- a/src/features/AccountManagement/sponsors/catalogVisibility.ts
+++ b/src/features/AccountManagement/sponsors/catalogVisibility.ts
@@ -22,6 +22,18 @@ export const SPONSOR_CAMPAIGN_VISIBILITY_STATES = {
 type SponsorCampaignVisibilityState =
   (typeof SPONSOR_CAMPAIGN_VISIBILITY_STATES)[keyof typeof SPONSOR_CAMPAIGN_VISIBILITY_STATES]
 
+/** Normalizes a runtime browser family before visibility evaluation. */
+function normalizeBrowserFamily(
+  value: SponsorVisibilityContext["browserFamily"],
+): SponsorVisibilityBrowserFamily | undefined {
+  const normalized = value?.trim().toLowerCase()
+  if (!normalized) return undefined
+  if (!SPONSOR_VISIBILITY_BROWSER_FAMILY_VALUES.has(normalized)) {
+    return undefined
+  }
+  return normalized as SponsorVisibilityBrowserFamily
+}
+
 /** Validates the optional V5 campaign visibility object shape. */
 export function validateVisibilityShape(
   itemId: string,
@@ -98,11 +110,8 @@ export function getCampaignVisibilityState(
       return SPONSOR_CAMPAIGN_VISIBILITY_STATES.Invalid
     }
 
-    const browserFamily = context.browserFamily?.trim()
+    const browserFamily = normalizeBrowserFamily(context.browserFamily)
     if (!browserFamily) return SPONSOR_CAMPAIGN_VISIBILITY_STATES.Hidden
-    if (!SPONSOR_VISIBILITY_BROWSER_FAMILY_VALUES.has(browserFamily)) {
-      return SPONSOR_CAMPAIGN_VISIBILITY_STATES.Invalid
-    }
     if (excludedBrowserFamilies.includes(browserFamily)) {
       return SPONSOR_CAMPAIGN_VISIBILITY_STATES.Hidden
     }

--- a/src/features/AccountManagement/sponsors/constants.ts
+++ b/src/features/AccountManagement/sponsors/constants.ts
@@ -1,6 +1,4 @@
-import sponsorCatalog from "~~/public/sponsor-catalog.v5.json"
-
-export const SPONSOR_CATALOG_SCHEMA_VERSION = sponsorCatalog.schemaVersion
+export const SPONSOR_CATALOG_SCHEMA_VERSION = 5
 
 export const SPONSOR_REMOTE_CATALOG_V5_URL =
   "https://raw.githubusercontent.com/qixing-jk/all-api-hub/main/public/sponsor-catalog.v5.json"

--- a/src/features/AccountManagement/sponsors/constants.ts
+++ b/src/features/AccountManagement/sponsors/constants.ts
@@ -1,9 +1,9 @@
-import sponsorCatalog from "~~/public/sponsor-catalog.v4.json"
+import sponsorCatalog from "~~/public/sponsor-catalog.v5.json"
 
 export const SPONSOR_CATALOG_SCHEMA_VERSION = sponsorCatalog.schemaVersion
 
-export const SPONSOR_REMOTE_CATALOG_V4_URL =
-  "https://raw.githubusercontent.com/qixing-jk/all-api-hub/main/public/sponsor-catalog.v4.json"
+export const SPONSOR_REMOTE_CATALOG_V5_URL =
+  "https://raw.githubusercontent.com/qixing-jk/all-api-hub/main/public/sponsor-catalog.v5.json"
 
 export const SPONSOR_LOCALE_FALLBACKS = ["zh-CN", "en"] as const
 

--- a/src/features/AccountManagement/sponsors/loader.ts
+++ b/src/features/AccountManagement/sponsors/loader.ts
@@ -1,3 +1,5 @@
+import { getExtensionVersion } from "~/utils/browser/browserApi"
+import { detectBrowserFamily } from "~/utils/browser/userAgent"
 import { createLogger } from "~/utils/core/logger"
 
 import {
@@ -7,7 +9,7 @@ import {
 import { normalizeSponsorCatalog } from "./catalog"
 import {
   SPONSOR_CATALOG_SCHEMA_VERSION,
-  SPONSOR_REMOTE_CATALOG_V4_URL,
+  SPONSOR_REMOTE_CATALOG_V5_URL,
 } from "./constants"
 import { sponsorCatalogStorage } from "./storage"
 import {
@@ -22,6 +24,8 @@ const logger = createLogger("SponsorCatalogLoader")
 interface LoadSponsorRecommendationsOptions {
   locale: string
   now?: number
+  currentVersion?: string
+  browserFamily?: string
 }
 
 export interface LoadSponsorRecommendationsResult {
@@ -56,17 +60,17 @@ function mergeDevelopmentSponsorRecommendations(
   )
 }
 
-/** Fetches the current V4 sponsor catalog as a best-effort JSON payload. */
+/** Fetches the current V5 sponsor catalog as a best-effort JSON payload. */
 async function fetchRemoteSponsorCatalog(): Promise<unknown | null> {
   try {
-    const response = await fetch(SPONSOR_REMOTE_CATALOG_V4_URL, {
+    const response = await fetch(SPONSOR_REMOTE_CATALOG_V5_URL, {
       cache: "no-store",
     })
 
     if (!response.ok) {
       logger.warn("Failed to fetch sponsor catalog resource", {
         status: response.status,
-        url: SPONSOR_REMOTE_CATALOG_V4_URL,
+        url: SPONSOR_REMOTE_CATALOG_V5_URL,
       })
       return null
     }
@@ -75,38 +79,42 @@ async function fetchRemoteSponsorCatalog(): Promise<unknown | null> {
   } catch (error) {
     logger.warn("Failed to fetch sponsor catalog resource", {
       error,
-      url: SPONSOR_REMOTE_CATALOG_V4_URL,
+      url: SPONSOR_REMOTE_CATALOG_V5_URL,
     })
     return null
   }
 }
 
-/** Normalizes one V4 catalog payload for a result source. */
+/** Normalizes one V5 catalog payload for a result source. */
 function normalizeCatalog(
   catalog: unknown,
   options: LoadSponsorRecommendationsOptions & { source: SponsorCatalogSource },
 ): SponsorCatalogNormalizationResult {
-  return normalizeSponsorCatalog(catalog, options)
+  return normalizeSponsorCatalog(catalog, {
+    ...options,
+    currentVersion: options.currentVersion?.trim() || getExtensionVersion(),
+    browserFamily: options.browserFamily?.trim() || detectBrowserFamily(),
+  })
 }
 
-/** Reads the fixed V4 remote cache. */
+/** Reads the fixed V5 remote cache. */
 async function readCachedSponsorCatalog(): Promise<unknown | null> {
   try {
     const cached = await sponsorCatalogStorage.getCachedVersionedCatalog({
       schemaVersion: SPONSOR_CATALOG_SCHEMA_VERSION,
-      sourceUrl: SPONSOR_REMOTE_CATALOG_V4_URL,
+      sourceUrl: SPONSOR_REMOTE_CATALOG_V5_URL,
     })
     return cached?.payload ?? null
   } catch (error) {
     logger.warn("Failed to read sponsor catalog cache", {
       error,
-      url: SPONSOR_REMOTE_CATALOG_V4_URL,
+      url: SPONSOR_REMOTE_CATALOG_V5_URL,
     })
     return null
   }
 }
 
-/** Persists the fixed V4 remote cache. */
+/** Persists the fixed V5 remote cache. */
 async function persistCachedSponsorCatalog(
   payload: unknown,
   options: LoadSponsorRecommendationsOptions,
@@ -114,20 +122,20 @@ async function persistCachedSponsorCatalog(
   try {
     await sponsorCatalogStorage.setCachedVersionedCatalog({
       schemaVersion: SPONSOR_CATALOG_SCHEMA_VERSION,
-      sourceUrl: SPONSOR_REMOTE_CATALOG_V4_URL,
+      sourceUrl: SPONSOR_REMOTE_CATALOG_V5_URL,
       fetchedAt: options.now ?? Date.now(),
       payload,
     })
   } catch (error) {
     logger.warn("Failed to persist sponsor catalog cache", {
       error,
-      url: SPONSOR_REMOTE_CATALOG_V4_URL,
+      url: SPONSOR_REMOTE_CATALOG_V5_URL,
     })
   }
 }
 
 /**
- * Fetches, validates, and caches the current remote V4 sponsor recommendations.
+ * Fetches, validates, and caches the current remote V5 sponsor recommendations.
  */
 export async function refreshSponsorRecommendations(
   options: LoadSponsorRecommendationsOptions,
@@ -158,7 +166,7 @@ export async function refreshSponsorRecommendations(
 }
 
 /**
- * Loads cached V4 remote recommendations when valid, falling back to bundled data.
+ * Loads cached V5 remote recommendations when valid, falling back to bundled data.
  */
 export async function loadSponsorRecommendations(
   options: LoadSponsorRecommendationsOptions,

--- a/src/features/AccountManagement/sponsors/loader.ts
+++ b/src/features/AccountManagement/sponsors/loader.ts
@@ -43,7 +43,7 @@ function mergeDevelopmentSponsorRecommendations(
     return items
   }
 
-  const normalized = normalizeSponsorCatalog(developmentCatalog, {
+  const normalized = normalizeCatalog(developmentCatalog, {
     ...options,
     source: SPONSOR_CATALOG_SOURCES.Bundled,
   })

--- a/src/features/AccountManagement/sponsors/loader.ts
+++ b/src/features/AccountManagement/sponsors/loader.ts
@@ -20,6 +20,7 @@ import {
 } from "./types"
 
 const logger = createLogger("SponsorCatalogLoader")
+const REMOTE_SPONSOR_CATALOG_FETCH_TIMEOUT_MS = 15_000
 
 interface LoadSponsorRecommendationsOptions {
   locale: string
@@ -62,9 +63,15 @@ function mergeDevelopmentSponsorRecommendations(
 
 /** Fetches the current V5 sponsor catalog as a best-effort JSON payload. */
 async function fetchRemoteSponsorCatalog(): Promise<unknown | null> {
+  const abortController = new AbortController()
+  const timeoutId = globalThis.setTimeout(() => {
+    abortController.abort()
+  }, REMOTE_SPONSOR_CATALOG_FETCH_TIMEOUT_MS)
+
   try {
     const response = await fetch(SPONSOR_REMOTE_CATALOG_V5_URL, {
       cache: "no-store",
+      signal: abortController.signal,
     })
 
     if (!response.ok) {
@@ -82,6 +89,8 @@ async function fetchRemoteSponsorCatalog(): Promise<unknown | null> {
       url: SPONSOR_REMOTE_CATALOG_V5_URL,
     })
     return null
+  } finally {
+    globalThis.clearTimeout(timeoutId)
   }
 }
 

--- a/src/features/AccountManagement/sponsors/pendingAddAccountIntent.ts
+++ b/src/features/AccountManagement/sponsors/pendingAddAccountIntent.ts
@@ -8,6 +8,8 @@ import {
 } from "~/services/accounts/accountSiteProfile"
 import { STORAGE_KEYS } from "~/services/core/storageKeys"
 import { createLogger } from "~/utils/core/logger"
+import { isRecord } from "~/utils/core/object"
+import { isHttpUrl, tryParseHttpUrl } from "~/utils/core/urlParsing"
 
 import {
   BOOKMARK_IMPORT_ADD_ACCOUNT_PREFILL_SOURCE,
@@ -175,25 +177,23 @@ function normalizeSponsorAddAccountPrefillPayload(
   const normalizedAuthType = normalizeOptionalAccountAuthType(value.authType)
   if (normalizedAuthType === false) return null
 
-  try {
-    const url = new URL(value.siteUrl)
-    if (url.protocol !== "https:" && url.protocol !== "http:") return null
-    const siteUrl = normalizeAccountSiteProfileUrlForStorage({
-      siteType,
-      url: value.siteUrl,
-    })
-
-    return {
-      source: SPONSOR_ADD_ACCOUNT_PREFILL_SOURCE,
-      sponsorId: value.sponsorId.trim(),
-      siteType,
-      siteUrl,
-      authType:
-        normalizedAuthType ??
-        resolveAccountSiteDefaultAuthType({ siteType, url: siteUrl }),
-    }
-  } catch {
+  if (!isHttpUrl(value.siteUrl)) {
     return null
+  }
+
+  const siteUrl = normalizeAccountSiteProfileUrlForStorage({
+    siteType,
+    url: value.siteUrl,
+  })
+
+  return {
+    source: SPONSOR_ADD_ACCOUNT_PREFILL_SOURCE,
+    sponsorId: value.sponsorId.trim(),
+    siteType,
+    siteUrl,
+    authType:
+      normalizedAuthType ??
+      resolveAccountSiteDefaultAuthType({ siteType, url: siteUrl }),
   }
 }
 
@@ -210,31 +210,23 @@ function normalizeBookmarkImportAddAccountPrefillPayload(
     ? value.siteType
     : SITE_TYPES.UNKNOWN
 
-  try {
-    const url = new URL(value.siteUrl)
-    if (url.protocol !== "https:" && url.protocol !== "http:") return null
-    const siteUrl =
-      siteType !== SITE_TYPES.UNKNOWN
-        ? normalizeAccountSiteProfileUrlForStorage({
-            siteType,
-            url: value.siteUrl,
-          })
-        : url.origin
-
-    return {
-      source: BOOKMARK_IMPORT_ADD_ACCOUNT_PREFILL_SOURCE,
-      siteUrl,
-      ...(siteType !== SITE_TYPES.UNKNOWN ? { siteType } : {}),
-      ...(normalizedAuthType ? { authType: normalizedAuthType } : {}),
-    }
-  } catch {
+  const url = tryParseHttpUrl(value.siteUrl)
+  if (!url) {
     return null
   }
-}
 
-/**
- * Narrows unknown JSON-like values before field-level validation.
- */
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value)
+  const siteUrl =
+    siteType !== SITE_TYPES.UNKNOWN
+      ? normalizeAccountSiteProfileUrlForStorage({
+          siteType,
+          url: value.siteUrl,
+        })
+      : url.origin
+
+  return {
+    source: BOOKMARK_IMPORT_ADD_ACCOUNT_PREFILL_SOURCE,
+    siteUrl,
+    ...(siteType !== SITE_TYPES.UNKNOWN ? { siteType } : {}),
+    ...(normalizedAuthType ? { authType: normalizedAuthType } : {}),
+  }
 }

--- a/src/features/AccountManagement/sponsors/types.ts
+++ b/src/features/AccountManagement/sponsors/types.ts
@@ -18,6 +18,17 @@ export const SPONSOR_CATALOG_SOURCES = {
 export type SponsorCatalogSource =
   (typeof SPONSOR_CATALOG_SOURCES)[keyof typeof SPONSOR_CATALOG_SOURCES]
 
+export const SPONSOR_VISIBILITY_BROWSER_FAMILIES = {
+  Chromium: "chromium",
+  Edge: "edge",
+  Firefox: "firefox",
+  Safari: "safari",
+  Unknown: "unknown",
+} as const
+
+export type SponsorVisibilityBrowserFamily =
+  (typeof SPONSOR_VISIBILITY_BROWSER_FAMILIES)[keyof typeof SPONSOR_VISIBILITY_BROWSER_FAMILIES]
+
 export const SPONSOR_ADD_ACCOUNT_PREFILL_SOURCE = "sponsor" as const
 export const BOOKMARK_IMPORT_ADD_ACCOUNT_PREFILL_SOURCE =
   "bookmark-import" as const
@@ -64,15 +75,19 @@ export interface RawSponsorCatalog {
 
 export interface RawSponsorCatalogItem {
   id: string
-  locales: Record<string, RawSponsorLocaleCampaignV4>
+  locales: Record<string, RawSponsorLocaleCampaign>
 }
 
-export interface RawSponsorLocaleCampaignV4 {
+export interface RawSponsorLocaleCampaign {
   enabled: boolean
   rank: number
   supportStatus: SponsorSupportStatus | string
   startsAt?: string
   endsAt?: string
+  visibility?: {
+    extensionVersions?: string
+    excludedBrowserFamilies?: SponsorVisibilityBrowserFamily[] | string[]
+  }
   name: string
   tagline: string
   postClickNote?: string

--- a/src/utils/core/date.ts
+++ b/src/utils/core/date.ts
@@ -1,0 +1,13 @@
+/**
+ * Parses an optional date string into a timestamp.
+ *
+ * Returns `undefined` for omitted fields and `false` for malformed fields so
+ * callers can distinguish absence from invalid data without throwing.
+ */
+export function parseOptionalDate(value: unknown): number | false | undefined {
+  if (value === undefined) return undefined
+  if (typeof value !== "string") return false
+
+  const timestamp = Date.parse(value)
+  return Number.isNaN(timestamp) ? false : timestamp
+}

--- a/src/utils/core/object.ts
+++ b/src/utils/core/object.ts
@@ -15,3 +15,21 @@ export function isPlainObject(
 
   return prototype === Object.prototype || prototype === null
 }
+
+/**
+ * Determine whether an unknown value can be inspected as an object record.
+ *
+ * This is intentionally broader than `isPlainObject`: JSON-like validation
+ * often only needs to reject primitives, null, and arrays while preserving
+ * field-level checks for the object itself.
+ */
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+/**
+ * Determine whether an unknown value is an array containing only strings.
+ */
+export function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === "string")
+}

--- a/src/utils/core/urlParsing.ts
+++ b/src/utils/core/urlParsing.ts
@@ -48,9 +48,23 @@ export function tryParseOrigin(
 /**
  * Returns whether the value is an absolute HTTP(S) URL.
  */
-export function isHttpUrl(value: string | undefined | null): boolean {
+export function isHttpUrl(value: unknown): value is string {
+  return tryParseHttpUrl(value) !== null
+}
+
+/**
+ * Best-effort parse for absolute HTTP(S) URL strings.
+ * Returns `null` when the input is empty, malformed, or uses another scheme.
+ */
+export function tryParseHttpUrl(value: unknown): URL | null {
+  if (typeof value !== "string") return null
+
   const parsed = tryParseUrl(value)
-  return parsed?.protocol === "http:" || parsed?.protocol === "https:"
+  if (parsed?.protocol !== "http:" && parsed?.protocol !== "https:") {
+    return null
+  }
+
+  return parsed
 }
 
 /**

--- a/tests/features/AccountManagement/sponsors/catalog.test.ts
+++ b/tests/features/AccountManagement/sponsors/catalog.test.ts
@@ -10,11 +10,146 @@ import { AuthTypeEnum } from "~/types"
 
 const now = Date.parse("2026-06-11T00:00:00.000Z")
 
-describe("sponsor catalog v4 normalization", () => {
-  it("selects one whole valid locale campaign", () => {
+describe("sponsor catalog v5 normalization", () => {
+  it("rejects legacy V4 payloads in the current runtime parser", () => {
     const result = normalizeSponsorCatalog(
       {
         schemaVersion: 4,
+        items: [],
+      },
+      {
+        locale: "en",
+        now,
+        source: SPONSOR_CATALOG_SOURCES.Remote,
+      },
+    )
+
+    expect(result.ok).toBe(false)
+    expect(result.items).toEqual([])
+    expect(result.errors).toEqual(["unsupported schemaVersion 4"])
+  })
+
+  it("filters V5 campaigns by extension version and excluded browser families", () => {
+    const result = normalizeSponsorCatalog(
+      {
+        schemaVersion: 5,
+        items: [
+          {
+            id: "visible-version-campaign",
+            locales: {
+              en: {
+                enabled: true,
+                rank: 10,
+                supportStatus: SPONSOR_SUPPORT_STATUS.Unsupported,
+                name: "Visible Version Campaign",
+                tagline: "Visible for the current extension version.",
+                visibility: {
+                  extensionVersions: ">=3.52.0 <3.53.0",
+                },
+                links: {
+                  primary: "https://visible.example.invalid/signup",
+                },
+              },
+            },
+          },
+          {
+            id: "future-version-campaign",
+            locales: {
+              en: {
+                enabled: true,
+                rank: 20,
+                supportStatus: SPONSOR_SUPPORT_STATUS.Unsupported,
+                name: "Future Version Campaign",
+                tagline: "Hidden until a later extension version.",
+                visibility: {
+                  extensionVersions: ">=3.53.0",
+                },
+                links: {
+                  primary: "https://future.example.invalid/signup",
+                },
+              },
+            },
+          },
+          {
+            id: "excluded-browser-campaign",
+            locales: {
+              en: {
+                enabled: true,
+                rank: 30,
+                supportStatus: SPONSOR_SUPPORT_STATUS.Unsupported,
+                name: "Excluded Browser Campaign",
+                tagline: "Hidden for the current browser family.",
+                visibility: {
+                  excludedBrowserFamilies: ["firefox"],
+                },
+                links: {
+                  primary: "https://browser.example.invalid/signup",
+                },
+              },
+            },
+          },
+        ],
+      },
+      {
+        locale: "en",
+        now,
+        source: SPONSOR_CATALOG_SOURCES.Remote,
+        currentVersion: "3.52.1",
+        browserFamily: "firefox",
+      },
+    )
+
+    expect(result.ok).toBe(true)
+    expect(result.items.map((item) => item.id)).toEqual([
+      "visible-version-campaign",
+    ])
+  })
+
+  it("rejects malformed V5 visibility constraints", () => {
+    const result = normalizeSponsorCatalog(
+      {
+        schemaVersion: 5,
+        items: [
+          {
+            id: "invalid-visibility-campaign",
+            locales: {
+              en: {
+                enabled: true,
+                rank: 10,
+                supportStatus: SPONSOR_SUPPORT_STATUS.Unsupported,
+                name: "Invalid Visibility Campaign",
+                tagline: "Visibility has an unsupported browser family.",
+                visibility: {
+                  excludedBrowserFamilies: ["brave"],
+                },
+                links: {
+                  primary: "https://invalid-visibility.example.invalid/signup",
+                },
+              },
+            },
+          },
+        ],
+      },
+      {
+        locale: "en",
+        now,
+        source: SPONSOR_CATALOG_SOURCES.Remote,
+        currentVersion: "3.52.1",
+        browserFamily: "chromium",
+      },
+    )
+
+    expect(result.ok).toBe(false)
+    expect(result.items).toEqual([])
+    expect(result.errors.join("\n")).toContain(
+      "locale en has invalid visibility",
+    )
+  })
+
+  it("selects one whole valid locale campaign", () => {
+    const result = normalizeSponsorCatalog(
+      {
+        schemaVersion: 5,
         items: [
           {
             id: "locale-campaign",
@@ -68,7 +203,7 @@ describe("sponsor catalog v4 normalization", () => {
     expect(result.items).toHaveLength(1)
     expect(result.items[0]).toMatchObject({
       selectedLocale: "en",
-      schemaVersion: 4,
+      schemaVersion: 5,
       links: {
         primary: "https://en.example.invalid/signup",
       },
@@ -86,7 +221,7 @@ describe("sponsor catalog v4 normalization", () => {
   it("falls back when the candidate locale campaign is disabled", () => {
     const result = normalizeSponsorCatalog(
       {
-        schemaVersion: 4,
+        schemaVersion: 5,
         items: [
           {
             id: "fallback-campaign",
@@ -134,7 +269,7 @@ describe("sponsor catalog v4 normalization", () => {
   it("does not fall back to arbitrary unrelated locale campaigns", () => {
     const result = normalizeSponsorCatalog(
       {
-        schemaVersion: 4,
+        schemaVersion: 5,
         items: [
           {
             id: "unrelated-locale-campaign",
@@ -167,10 +302,10 @@ describe("sponsor catalog v4 normalization", () => {
     )
   })
 
-  it("normalizes every supported v4 action payload", () => {
+  it("normalizes every supported action payload", () => {
     const result = normalizeSponsorCatalog(
       {
-        schemaVersion: 4,
+        schemaVersion: 5,
         items: [
           {
             id: "action-campaign",
@@ -230,10 +365,10 @@ describe("sponsor catalog v4 normalization", () => {
     })
   })
 
-  it("keeps API key creation data on the explicit V4 action", () => {
+  it("keeps API key creation data on the explicit action", () => {
     const result = normalizeSponsorCatalog(
       {
-        schemaVersion: 4,
+        schemaVersion: 5,
         items: [
           {
             id: "api-key-bridge-campaign",
@@ -278,7 +413,7 @@ describe("sponsor catalog v4 normalization", () => {
   it("rejects malformed unselected locale campaigns", () => {
     const result = normalizeSponsorCatalog(
       {
-        schemaVersion: 4,
+        schemaVersion: 5,
         items: [
           {
             id: "unselected-malformed-campaign",
@@ -329,7 +464,7 @@ describe("sponsor catalog v4 normalization", () => {
   it("rejects unsafe links in unselected locale campaigns", () => {
     const result = normalizeSponsorCatalog(
       {
-        schemaVersion: 4,
+        schemaVersion: 5,
         items: [
           {
             id: "unselected-unsafe-link-campaign",
@@ -373,7 +508,7 @@ describe("sponsor catalog v4 normalization", () => {
   it("rejects invalid nested actions in unselected locale campaigns", () => {
     const result = normalizeSponsorCatalog(
       {
-        schemaVersion: 4,
+        schemaVersion: 5,
         items: [
           {
             id: "unselected-invalid-action-campaign",
@@ -426,7 +561,7 @@ describe("sponsor catalog v4 normalization", () => {
   it("rejects invalid rank and date values in unselected locale campaigns", () => {
     const result = normalizeSponsorCatalog(
       {
-        schemaVersion: 4,
+        schemaVersion: 5,
         items: [
           {
             id: "unselected-invalid-values-campaign",
@@ -471,7 +606,7 @@ describe("sponsor catalog v4 normalization", () => {
   it("rejects top-level campaign fields", () => {
     const result = normalizeSponsorCatalog(
       {
-        schemaVersion: 4,
+        schemaVersion: 5,
         items: [
           {
             id: "strict-campaign",
@@ -507,7 +642,7 @@ describe("sponsor catalog v4 normalization", () => {
   it("rejects unknown locale fields", () => {
     const result = normalizeSponsorCatalog(
       {
-        schemaVersion: 4,
+        schemaVersion: 5,
         items: [
           {
             id: "unknown-locale-field-campaign",
@@ -544,7 +679,7 @@ describe("sponsor catalog v4 normalization", () => {
   it("rejects malformed locale and action containers before semantic selection", () => {
     const result = normalizeSponsorCatalog(
       {
-        schemaVersion: 4,
+        schemaVersion: 5,
         items: [
           {
             id: "invalid-locales-campaign",
@@ -597,7 +732,7 @@ describe("sponsor catalog v4 normalization", () => {
   it("rejects selected locale campaigns with invalid semantic fields", () => {
     const result = normalizeSponsorCatalog(
       {
-        schemaVersion: 4,
+        schemaVersion: 5,
         items: [
           {
             id: "invalid-shape-selected-campaign",
@@ -698,7 +833,7 @@ describe("sponsor catalog v4 normalization", () => {
   it("rejects invalid fallback action URLs and malformed action payloads", () => {
     const result = normalizeSponsorCatalog(
       {
-        schemaVersion: 4,
+        schemaVersion: 5,
         items: [
           {
             id: "invalid-api-key-url-campaign",
@@ -761,7 +896,7 @@ describe("sponsor catalog v4 normalization", () => {
   it("rejects unknown nested link and action fields", () => {
     const result = normalizeSponsorCatalog(
       {
-        schemaVersion: 4,
+        schemaVersion: 5,
         items: [
           {
             id: "unknown-link-field-campaign",

--- a/tests/features/AccountManagement/sponsors/catalogVisibility.test.ts
+++ b/tests/features/AccountManagement/sponsors/catalogVisibility.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  getCampaignVisibilityState,
+  SPONSOR_CAMPAIGN_VISIBILITY_STATES,
+  validateVisibilityShape,
+} from "~/features/AccountManagement/sponsors/catalogVisibility"
+
+describe("sponsor catalog visibility helpers", () => {
+  it("reports strict shape errors for malformed visibility payloads", () => {
+    expect(validateVisibilityShape("example", "en", null)).toEqual([
+      "item example locale en has invalid visibility",
+    ])
+
+    expect(
+      validateVisibilityShape("example", "en", {
+        unsupported: true,
+      }),
+    ).toEqual([
+      "item example locale en has unsupported visibility fields: unsupported",
+    ])
+
+    expect(
+      validateVisibilityShape("example", "en", {
+        extensionVersions: 1,
+      }),
+    ).toEqual(["item example locale en has invalid visibility"])
+
+    expect(
+      validateVisibilityShape("example", "en", {
+        excludedBrowserFamilies: ["firefox", 1],
+      }),
+    ).toEqual(["item example locale en has invalid visibility"])
+
+    expect(
+      validateVisibilityShape("example", "en", {
+        extensionVersions: ">=3.52.0",
+        excludedBrowserFamilies: ["firefox"],
+      }),
+    ).toEqual([])
+  })
+
+  it("classifies malformed catalog visibility constraints as invalid", () => {
+    expect(
+      getCampaignVisibilityState(null, {
+        currentVersion: "3.52.1",
+        browserFamily: "firefox",
+      }),
+    ).toBe(SPONSOR_CAMPAIGN_VISIBILITY_STATES.Invalid)
+
+    expect(
+      getCampaignVisibilityState(
+        {
+          extensionVersions: 1,
+        },
+        {
+          currentVersion: "3.52.1",
+          browserFamily: "firefox",
+        },
+      ),
+    ).toBe(SPONSOR_CAMPAIGN_VISIBILITY_STATES.Invalid)
+
+    expect(
+      getCampaignVisibilityState(
+        {
+          excludedBrowserFamilies: ["firefox", 1],
+        },
+        {
+          currentVersion: "3.52.1",
+          browserFamily: "firefox",
+        },
+      ),
+    ).toBe(SPONSOR_CAMPAIGN_VISIBILITY_STATES.Invalid)
+
+    expect(
+      getCampaignVisibilityState(
+        {
+          excludedBrowserFamilies: ["brave"],
+        },
+        {
+          currentVersion: "3.52.1",
+          browserFamily: "firefox",
+        },
+      ),
+    ).toBe(SPONSOR_CAMPAIGN_VISIBILITY_STATES.Invalid)
+
+    expect(
+      getCampaignVisibilityState(
+        {
+          excludedBrowserFamilies: ["firefox"],
+        },
+        {
+          currentVersion: "3.52.1",
+          browserFamily: "brave",
+        },
+      ),
+    ).toBe(SPONSOR_CAMPAIGN_VISIBILITY_STATES.Hidden)
+  })
+
+  it("evaluates version and browser constraints against normalized runtime context", () => {
+    expect(
+      getCampaignVisibilityState(undefined, {
+        currentVersion: "3.52.1",
+        browserFamily: "firefox",
+      }),
+    ).toBe(SPONSOR_CAMPAIGN_VISIBILITY_STATES.Visible)
+
+    expect(
+      getCampaignVisibilityState(
+        {
+          extensionVersions: ">=3.52.0 <3.53.0",
+        },
+        {
+          currentVersion: "3.52.1",
+          browserFamily: "firefox",
+        },
+      ),
+    ).toBe(SPONSOR_CAMPAIGN_VISIBILITY_STATES.Visible)
+
+    expect(
+      getCampaignVisibilityState(
+        {
+          extensionVersions: ">=3.52.0 <3.53.0",
+        },
+        {
+          currentVersion: "3.51.0",
+          browserFamily: "firefox",
+        },
+      ),
+    ).toBe(SPONSOR_CAMPAIGN_VISIBILITY_STATES.Hidden)
+
+    expect(
+      getCampaignVisibilityState(
+        {
+          extensionVersions: ">=3.52.0",
+        },
+        {
+          browserFamily: "firefox",
+        },
+      ),
+    ).toBe(SPONSOR_CAMPAIGN_VISIBILITY_STATES.Hidden)
+
+    expect(
+      getCampaignVisibilityState(
+        {
+          excludedBrowserFamilies: ["firefox"],
+        },
+        {
+          currentVersion: "3.52.1",
+          browserFamily: " Firefox ",
+        },
+      ),
+    ).toBe(SPONSOR_CAMPAIGN_VISIBILITY_STATES.Hidden)
+
+    expect(
+      getCampaignVisibilityState(
+        {
+          excludedBrowserFamilies: ["firefox"],
+        },
+        {
+          currentVersion: "3.52.1",
+        },
+      ),
+    ).toBe(SPONSOR_CAMPAIGN_VISIBILITY_STATES.Hidden)
+
+    expect(
+      getCampaignVisibilityState(
+        {
+          excludedBrowserFamilies: ["firefox"],
+        },
+        {
+          currentVersion: "3.52.1",
+          browserFamily: "chromium",
+        },
+      ),
+    ).toBe(SPONSOR_CAMPAIGN_VISIBILITY_STATES.Visible)
+  })
+})

--- a/tests/features/AccountManagement/sponsors/loader.test.ts
+++ b/tests/features/AccountManagement/sponsors/loader.test.ts
@@ -86,6 +86,28 @@ const sponsorLoaderFixtures = vi.hoisted(() => ({
                 },
               },
             },
+            en: {
+              enabled: true,
+              rank: 9000,
+              supportStatus: "supported",
+              name: "[DEV] Direct add",
+              tagline: "Tests account prefill visibility defaults.",
+              visibility: {
+                extensionVersions: ">=3.51.0",
+                excludedBrowserFamilies: ["firefox"],
+              },
+              links: {
+                primary:
+                  "https://dev-supported.example.test/register?utm_source=all-api-hub",
+              },
+              actions: {
+                addAccount: {
+                  siteType: "new-api",
+                  siteUrl: "https://dev-supported.example.test",
+                  authType: "cookie",
+                },
+              },
+            },
           },
         },
         {
@@ -321,6 +343,25 @@ describe("sponsor recommendation loader", () => {
         },
       },
     })
+  })
+
+  it("uses runtime visibility defaults when merging development examples", async () => {
+    vi.stubEnv("MODE", "development")
+    vi.stubGlobal("fetch", vi.fn())
+    vi.mocked(
+      sponsorCatalogStorage.getCachedVersionedCatalog,
+    ).mockResolvedValue({
+      schemaVersion: 5,
+      sourceUrl: SPONSOR_REMOTE_CATALOG_V5_URL,
+      fetchedAt: now,
+      payload: createV5Catalog("cached-v5"),
+    })
+
+    const result = await loadSponsorRecommendations({ locale: "en", now })
+
+    expect(result.items.map((item) => item.id)).toContain(
+      "dev-supported-direct",
+    )
   })
 
   it("refreshes and caches valid remote V5 recommendations", async () => {

--- a/tests/features/AccountManagement/sponsors/loader.test.ts
+++ b/tests/features/AccountManagement/sponsors/loader.test.ts
@@ -222,6 +222,7 @@ describe("sponsor recommendation loader", () => {
   beforeEach(() => {
     vi.unstubAllGlobals()
     vi.unstubAllEnvs()
+    vi.useRealTimers()
     vi.mocked(sponsorCatalogStorage.getCachedVersionedCatalog).mockReset()
     vi.mocked(sponsorCatalogStorage.setCachedVersionedCatalog).mockReset()
   })
@@ -375,6 +376,7 @@ describe("sponsor recommendation loader", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock).toHaveBeenCalledWith(SPONSOR_REMOTE_CATALOG_V5_URL, {
       cache: "no-store",
+      signal: expect.any(AbortSignal),
     })
     expect(
       sponsorCatalogStorage.setCachedVersionedCatalog,
@@ -385,6 +387,35 @@ describe("sponsor recommendation loader", () => {
         payload: remoteCatalog,
       }),
     )
+  })
+
+  it("aborts stalled remote catalog fetches and keeps the refresh best effort", async () => {
+    vi.useFakeTimers()
+    const fetchMock = vi.fn(
+      (_url: string, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () => {
+            reject(new DOMException("Aborted", "AbortError"))
+          })
+        }),
+    )
+    vi.stubGlobal("fetch", fetchMock)
+
+    const resultPromise = refreshSponsorRecommendations({ locale: "en", now })
+
+    expect(fetchMock).toHaveBeenCalledWith(SPONSOR_REMOTE_CATALOG_V5_URL, {
+      cache: "no-store",
+      signal: expect.any(AbortSignal),
+    })
+    vi.advanceTimersByTime(15_000)
+    await expect(resultPromise).resolves.toBeNull()
+    expect(
+      (fetchMock.mock.calls[0]?.[1] as RequestInit | undefined)?.signal
+        ?.aborted,
+    ).toBe(true)
+    expect(
+      sponsorCatalogStorage.setCachedVersionedCatalog,
+    ).not.toHaveBeenCalled()
   })
 
   it("falls back to bundled recommendations when cache is invalid", async () => {
@@ -456,6 +487,7 @@ describe("sponsor recommendation loader", () => {
 
     expect(fetchMock).toHaveBeenCalledWith(SPONSOR_REMOTE_CATALOG_V5_URL, {
       cache: "no-store",
+      signal: expect.any(AbortSignal),
     })
     expect(
       sponsorCatalogStorage.setCachedVersionedCatalog,

--- a/tests/features/AccountManagement/sponsors/loader.test.ts
+++ b/tests/features/AccountManagement/sponsors/loader.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import { SITE_TYPES } from "~/constants/siteType"
 import {
   SPONSOR_CATALOG_SCHEMA_VERSION,
-  SPONSOR_REMOTE_CATALOG_V4_URL,
+  SPONSOR_REMOTE_CATALOG_V5_URL,
 } from "~/features/AccountManagement/sponsors/constants"
 import {
   loadSponsorRecommendations,
@@ -18,7 +18,7 @@ import { AuthTypeEnum } from "~/types"
 
 const sponsorLoaderFixtures = vi.hoisted(() => ({
   bundledCatalog: {
-    schemaVersion: 4,
+    schemaVersion: 5,
     items: [
       {
         id: "bundled-provider",
@@ -122,7 +122,7 @@ const sponsorLoaderFixtures = vi.hoisted(() => ({
   },
 }))
 
-vi.mock("~~/public/sponsor-catalog.v4.json", () => ({
+vi.mock("~~/public/sponsor-catalog.v5.json", () => ({
   default: sponsorLoaderFixtures.bundledCatalog,
 }))
 
@@ -135,7 +135,7 @@ vi.mock("~/features/AccountManagement/sponsors/storage", () => ({
 
 const now = Date.UTC(2026, 4, 25)
 
-function createV4Catalog(
+function createV5Catalog(
   id: string,
   primary = `https://${id}.example.invalid`,
 ) {
@@ -204,29 +204,91 @@ describe("sponsor recommendation loader", () => {
     vi.mocked(sponsorCatalogStorage.setCachedVersionedCatalog).mockReset()
   })
 
-  it("returns cached V4 recommendations without waiting for remote refresh", async () => {
+  it("returns cached V5 recommendations without waiting for remote refresh", async () => {
     const fetchMock = vi.fn()
     vi.stubGlobal("fetch", fetchMock)
     vi.mocked(
       sponsorCatalogStorage.getCachedVersionedCatalog,
     ).mockResolvedValue({
-      schemaVersion: 4,
-      sourceUrl: SPONSOR_REMOTE_CATALOG_V4_URL,
+      schemaVersion: 5,
+      sourceUrl: SPONSOR_REMOTE_CATALOG_V5_URL,
       fetchedAt: now,
-      payload: createV4Catalog("cached-v4"),
+      payload: createV5Catalog("cached-v5"),
     })
 
     const result = await loadSponsorRecommendations({ locale: "en", now })
 
-    expect(result.items.map((item) => item.id)).toEqual(["cached-v4"])
+    expect(result.items.map((item) => item.id)).toEqual(["cached-v5"])
     expect(result.source).toBe(SPONSOR_CATALOG_SOURCES.Cached)
     expect(fetchMock).not.toHaveBeenCalled()
     expect(
       sponsorCatalogStorage.getCachedVersionedCatalog,
     ).toHaveBeenCalledWith({
       schemaVersion: SPONSOR_CATALOG_SCHEMA_VERSION,
-      sourceUrl: SPONSOR_REMOTE_CATALOG_V4_URL,
+      sourceUrl: SPONSOR_REMOTE_CATALOG_V5_URL,
     })
+  })
+
+  it("applies runtime visibility context when loading cached recommendations", async () => {
+    vi.stubGlobal("fetch", vi.fn())
+    vi.mocked(
+      sponsorCatalogStorage.getCachedVersionedCatalog,
+    ).mockResolvedValue({
+      schemaVersion: 5,
+      sourceUrl: SPONSOR_REMOTE_CATALOG_V5_URL,
+      fetchedAt: now,
+      payload: {
+        schemaVersion: SPONSOR_CATALOG_SCHEMA_VERSION,
+        items: [
+          {
+            id: "visible-provider",
+            locales: {
+              en: {
+                enabled: true,
+                rank: 1,
+                supportStatus: SPONSOR_SUPPORT_STATUS.Unsupported,
+                name: "Visible Provider",
+                tagline: "Visible in the current runtime context.",
+                visibility: {
+                  extensionVersions: ">=3.52.0 <3.53.0",
+                  excludedBrowserFamilies: ["firefox"],
+                },
+                links: {
+                  primary: "https://visible-provider.example.invalid",
+                },
+              },
+            },
+          },
+          {
+            id: "hidden-provider",
+            locales: {
+              en: {
+                enabled: true,
+                rank: 2,
+                supportStatus: SPONSOR_SUPPORT_STATUS.Unsupported,
+                name: "Hidden Provider",
+                tagline: "Hidden for the current runtime context.",
+                visibility: {
+                  extensionVersions: ">=3.53.0",
+                },
+                links: {
+                  primary: "https://hidden-provider.example.invalid",
+                },
+              },
+            },
+          },
+        ],
+      },
+    })
+
+    const result = await loadSponsorRecommendations({
+      locale: "en",
+      now,
+      currentVersion: "3.52.1",
+      browserFamily: "chromium",
+    })
+
+    expect(result.items.map((item) => item.id)).toEqual(["visible-provider"])
   })
 
   it("merges development examples with cached recommendations in development", async () => {
@@ -235,17 +297,17 @@ describe("sponsor recommendation loader", () => {
     vi.mocked(
       sponsorCatalogStorage.getCachedVersionedCatalog,
     ).mockResolvedValue({
-      schemaVersion: 4,
-      sourceUrl: SPONSOR_REMOTE_CATALOG_V4_URL,
+      schemaVersion: 5,
+      sourceUrl: SPONSOR_REMOTE_CATALOG_V5_URL,
       fetchedAt: now,
-      payload: createV4Catalog("cached-v4"),
+      payload: createV5Catalog("cached-v5"),
     })
 
     const result = await loadSponsorRecommendations({ locale: "zh-CN", now })
 
     expect(result.source).toBe(SPONSOR_CATALOG_SOURCES.Cached)
     expect(result.items.map((item) => item.id)).toEqual([
-      "cached-v4",
+      "cached-v5",
       "dev-supported-direct",
       "dev-unsupported-all-fallbacks",
     ])
@@ -261,16 +323,16 @@ describe("sponsor recommendation loader", () => {
     })
   })
 
-  it("refreshes and caches valid remote V4 recommendations", async () => {
-    const remoteCatalog = createV4Catalog("remote-v4")
+  it("refreshes and caches valid remote V5 recommendations", async () => {
+    const remoteCatalog = createV5Catalog("remote-v5")
     const fetchMock = mockFetchJson(remoteCatalog)
 
     const result = await refreshSponsorRecommendations({ locale: "en", now })
 
-    expect(result?.items.map((item) => item.id)).toEqual(["remote-v4"])
+    expect(result?.items.map((item) => item.id)).toEqual(["remote-v5"])
     expect(result?.source).toBe(SPONSOR_CATALOG_SOURCES.Remote)
     expect(fetchMock).toHaveBeenCalledTimes(1)
-    expect(fetchMock).toHaveBeenCalledWith(SPONSOR_REMOTE_CATALOG_V4_URL, {
+    expect(fetchMock).toHaveBeenCalledWith(SPONSOR_REMOTE_CATALOG_V5_URL, {
       cache: "no-store",
     })
     expect(
@@ -278,7 +340,7 @@ describe("sponsor recommendation loader", () => {
     ).toHaveBeenCalledWith(
       expect.objectContaining({
         schemaVersion: SPONSOR_CATALOG_SCHEMA_VERSION,
-        sourceUrl: SPONSOR_REMOTE_CATALOG_V4_URL,
+        sourceUrl: SPONSOR_REMOTE_CATALOG_V5_URL,
         payload: remoteCatalog,
       }),
     )
@@ -289,11 +351,11 @@ describe("sponsor recommendation loader", () => {
     vi.mocked(
       sponsorCatalogStorage.getCachedVersionedCatalog,
     ).mockResolvedValue({
-      schemaVersion: 4,
-      sourceUrl: SPONSOR_REMOTE_CATALOG_V4_URL,
+      schemaVersion: 5,
+      sourceUrl: SPONSOR_REMOTE_CATALOG_V5_URL,
       fetchedAt: now,
       payload: {
-        schemaVersion: 4,
+        schemaVersion: 5,
         items: [],
       },
     })
@@ -303,7 +365,7 @@ describe("sponsor recommendation loader", () => {
     expectBundledSponsorFallback(result)
   })
 
-  it("ignores legacy V3 cache and falls back to bundled V4 recommendations", async () => {
+  it("ignores legacy cache and falls back to bundled V5 recommendations", async () => {
     vi.stubGlobal("fetch", vi.fn())
     vi.mocked(
       sponsorCatalogStorage.getCachedVersionedCatalog,
@@ -327,7 +389,7 @@ describe("sponsor recommendation loader", () => {
 
   it("rejects invalid remote payloads without replacing cache", async () => {
     mockFetchJson({
-      ...createV4Catalog("invalid-v4"),
+      ...createV5Catalog("invalid-v5"),
       schemaVersion: 999,
     })
 
@@ -351,7 +413,7 @@ describe("sponsor recommendation loader", () => {
       refreshSponsorRecommendations({ locale: "en", now }),
     ).resolves.toBeNull()
 
-    expect(fetchMock).toHaveBeenCalledWith(SPONSOR_REMOTE_CATALOG_V4_URL, {
+    expect(fetchMock).toHaveBeenCalledWith(SPONSOR_REMOTE_CATALOG_V5_URL, {
       cache: "no-store",
     })
     expect(
@@ -360,7 +422,7 @@ describe("sponsor recommendation loader", () => {
   })
 
   it("returns refreshed recommendations when cache persistence fails", async () => {
-    const remoteCatalog = createV4Catalog("remote-v4")
+    const remoteCatalog = createV5Catalog("remote-v5")
     mockFetchJson(remoteCatalog)
     vi.mocked(
       sponsorCatalogStorage.setCachedVersionedCatalog,
@@ -368,7 +430,7 @@ describe("sponsor recommendation loader", () => {
 
     const result = await refreshSponsorRecommendations({ locale: "en", now })
 
-    expect(result?.items.map((item) => item.id)).toEqual(["remote-v4"])
+    expect(result?.items.map((item) => item.id)).toEqual(["remote-v5"])
     expect(result?.source).toBe(SPONSOR_CATALOG_SOURCES.Remote)
   })
 

--- a/tests/features/AccountManagement/sponsors/publicCatalog.test.ts
+++ b/tests/features/AccountManagement/sponsors/publicCatalog.test.ts
@@ -7,12 +7,13 @@ import { bundledSponsorCatalog } from "~/features/AccountManagement/sponsors/bun
 import { normalizeSponsorCatalog } from "~/features/AccountManagement/sponsors/catalog"
 import {
   SPONSOR_CATALOG_SCHEMA_VERSION,
-  SPONSOR_REMOTE_CATALOG_V4_URL,
+  SPONSOR_REMOTE_CATALOG_V5_URL,
 } from "~/features/AccountManagement/sponsors/constants"
 import { SPONSOR_CATALOG_SOURCES } from "~/features/AccountManagement/sponsors/types"
 import { AuthTypeEnum } from "~/types"
 import legacySponsorCatalog from "~~/public/sponsor-catalog.json"
 import publicSponsorCatalogV4 from "~~/public/sponsor-catalog.v4.json"
+import publicSponsorCatalogV5 from "~~/public/sponsor-catalog.v5.json"
 
 const now = Date.UTC(2026, 4, 25)
 
@@ -28,7 +29,12 @@ describe("public sponsor catalog artifacts", () => {
     expect(legacySponsorCatalog.items.length).toBeGreaterThan(0)
   })
 
-  it("does not publish a runtime manifest artifact for V4-only clients", () => {
+  it("keeps the V4 public catalog as a legacy artifact for old clients", () => {
+    expect(publicSponsorCatalogV4.schemaVersion).toBe(4)
+    expect(publicSponsorCatalogV4.items.length).toBeGreaterThan(0)
+  })
+
+  it("does not publish a runtime manifest artifact for catalog clients", () => {
     expect(
       existsSync(
         resolve(process.cwd(), "public/sponsor-catalog-manifest.json"),
@@ -36,18 +42,20 @@ describe("public sponsor catalog artifacts", () => {
     ).toBe(false)
   })
 
-  it("uses the V4 public catalog as the runtime source", () => {
-    expect(publicSponsorCatalogV4.schemaVersion).toBe(
+  it("uses the V5 public catalog as the runtime source", () => {
+    expect(publicSponsorCatalogV5.schemaVersion).toBe(
       SPONSOR_CATALOG_SCHEMA_VERSION,
     )
-    expect(new URL(SPONSOR_REMOTE_CATALOG_V4_URL).pathname).toBe(
-      "/qixing-jk/all-api-hub/main/public/sponsor-catalog.v4.json",
+    expect(new URL(SPONSOR_REMOTE_CATALOG_V5_URL).pathname).toBe(
+      "/qixing-jk/all-api-hub/main/public/sponsor-catalog.v5.json",
     )
 
-    const productionResult = normalizeSponsorCatalog(publicSponsorCatalogV4, {
+    const productionResult = normalizeSponsorCatalog(publicSponsorCatalogV5, {
       locale: "zh-CN",
       now,
       source: SPONSOR_CATALOG_SOURCES.Remote,
+      currentVersion: "3.52.0",
+      browserFamily: "chromium",
     })
 
     expect(productionResult.errors).toEqual([])
@@ -75,19 +83,21 @@ describe("public sponsor catalog artifacts", () => {
       }
     })
 
-    expect(bundledSponsorCatalog).toBe(publicSponsorCatalogV4)
+    expect(bundledSponsorCatalog).toBe(publicSponsorCatalogV5)
   })
 
-  it("validates V4 development examples", () => {
+  it("validates V5 development examples", () => {
     const examplesResult = normalizeSponsorCatalog(
       {
-        schemaVersion: publicSponsorCatalogV4.schemaVersion,
-        items: publicSponsorCatalogV4._examples?.devSponsors ?? [],
+        schemaVersion: publicSponsorCatalogV5.schemaVersion,
+        items: publicSponsorCatalogV5._examples?.devSponsors ?? [],
       },
       {
         locale: "zh-CN",
         now,
         source: SPONSOR_CATALOG_SOURCES.Bundled,
+        currentVersion: "3.52.0",
+        browserFamily: "chromium",
       },
     )
 

--- a/tests/features/AccountManagement/sponsors/storage.test.ts
+++ b/tests/features/AccountManagement/sponsors/storage.test.ts
@@ -6,7 +6,7 @@ import { sponsorCatalogStorage } from "~/features/AccountManagement/sponsors/sto
 import { STORAGE_KEYS } from "~/services/core/storageKeys"
 
 const storage = new Storage({ area: "local" })
-const sourceUrl = "https://example.invalid/sponsors/catalog.v4.json"
+const sourceUrl = "https://example.invalid/sponsors/catalog.v5.json"
 
 describe("sponsor catalog storage", () => {
   beforeEach(async () => {
@@ -14,28 +14,28 @@ describe("sponsor catalog storage", () => {
     await storage.remove(STORAGE_KEYS.SPONSOR_CATALOG_VERSIONED_CACHE)
   })
 
-  it("persists and reads V4 catalog cache envelopes", async () => {
+  it("persists and reads catalog cache envelopes", async () => {
     await sponsorCatalogStorage.setCachedVersionedCatalog({
-      schemaVersion: 4,
+      schemaVersion: 5,
       sourceUrl,
       fetchedAt: Date.parse("2026-06-11T00:00:00.000Z"),
       payload: {
-        schemaVersion: 4,
+        schemaVersion: 5,
         items: [],
       },
     })
 
     await expect(
       sponsorCatalogStorage.getCachedVersionedCatalog({
-        schemaVersion: 4,
+        schemaVersion: 5,
         sourceUrl,
       }),
     ).resolves.toEqual({
-      schemaVersion: 4,
+      schemaVersion: 5,
       sourceUrl,
       fetchedAt: Date.parse("2026-06-11T00:00:00.000Z"),
       payload: {
-        schemaVersion: 4,
+        schemaVersion: 5,
         items: [],
       },
     })
@@ -43,11 +43,11 @@ describe("sponsor catalog storage", () => {
 
   it("does not return cache entries for mismatched schema or URL", async () => {
     await sponsorCatalogStorage.setCachedVersionedCatalog({
-      schemaVersion: 4,
+      schemaVersion: 5,
       sourceUrl,
       fetchedAt: 1,
       payload: {
-        schemaVersion: 4,
+        schemaVersion: 5,
         items: [],
       },
     })
@@ -60,7 +60,7 @@ describe("sponsor catalog storage", () => {
     ).resolves.toBeNull()
     await expect(
       sponsorCatalogStorage.getCachedVersionedCatalog({
-        schemaVersion: 4,
+        schemaVersion: 5,
         sourceUrl: "https://example.invalid/sponsors/other.json",
       }),
     ).resolves.toBeNull()
@@ -68,21 +68,21 @@ describe("sponsor catalog storage", () => {
 
   it("returns null for malformed matching cache entries", async () => {
     await storage.set(STORAGE_KEYS.SPONSOR_CATALOG_VERSIONED_CACHE, {
-      [`4:${sourceUrl}`]: {
-        schemaVersion: 4,
+      [`5:${sourceUrl}`]: {
+        schemaVersion: 5,
         sourceUrl,
         payload: {
-          schemaVersion: 4,
+          schemaVersion: 5,
           items: [],
         },
       },
-      "4:https://example.invalid/sponsors/catalog-with-invalid-date.v4.json": {
-        schemaVersion: 4,
+      "5:https://example.invalid/sponsors/catalog-with-invalid-date.v5.json": {
+        schemaVersion: 5,
         sourceUrl:
-          "https://example.invalid/sponsors/catalog-with-invalid-date.v4.json",
+          "https://example.invalid/sponsors/catalog-with-invalid-date.v5.json",
         fetchedAt: "2026-06-11T00:00:00.000Z",
         payload: {
-          schemaVersion: 4,
+          schemaVersion: 5,
           items: [],
         },
       },
@@ -90,15 +90,15 @@ describe("sponsor catalog storage", () => {
 
     await expect(
       sponsorCatalogStorage.getCachedVersionedCatalog({
-        schemaVersion: 4,
+        schemaVersion: 5,
         sourceUrl,
       }),
     ).resolves.toBeNull()
     await expect(
       sponsorCatalogStorage.getCachedVersionedCatalog({
-        schemaVersion: 4,
+        schemaVersion: 5,
         sourceUrl:
-          "https://example.invalid/sponsors/catalog-with-invalid-date.v4.json",
+          "https://example.invalid/sponsors/catalog-with-invalid-date.v5.json",
       }),
     ).resolves.toBeNull()
   })
@@ -110,7 +110,7 @@ describe("sponsor catalog storage", () => {
 
     await expect(
       sponsorCatalogStorage.getCachedVersionedCatalog({
-        schemaVersion: 4,
+        schemaVersion: 5,
         sourceUrl,
       }),
     ).resolves.toBeNull()


### PR DESCRIPTION
## Summary
- Add v5 sponsor catalog visibility controls for extension-version and browser-family filtering.
- Keep the runtime sponsor catalog on the strict v5 path while preserving the legacy artifact for old clients.
- Split sponsor catalog normalization into schema, visibility, action, and validation helpers, and reuse shared core utilities.

## Validation
- pnpm vitest run tests/features/AccountManagement/sponsors/catalog.test.ts tests/features/AccountManagement/sponsors/loader.test.ts tests/features/AccountManagement/sponsors/publicCatalog.test.ts tests/features/AccountManagement/sponsors/storage.test.ts tests/features/AccountManagement/sponsors/pendingAddAccountIntent.test.ts
- pnpm compile
- pnpm run validate:staged
- pnpm run validate:push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rolled out the latest sponsor catalog format (v5), including enhanced per-locale campaign metadata and support for additional action types.
  * Added/expanded sponsor action handling, including API credential fallback behavior and improved link validation.
  * Introduced stronger campaign visibility rules that filter sponsors by runtime version and browser constraints.

* **Bug Fixes**
  * Improved sponsor recommendation selection to better honor locale status, active date windows, and visibility constraints.
  * Updated remote loading and caching so bundled, remote, and cached recommendations consistently use the v5 catalog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->