### PR TITLE
refactor(key-management): split managed site batch export dialog

### DIFF
--- a/src/features/KeyManagement/components/ManagedSiteTokenBatchExportDialog.tsx
+++ b/src/features/KeyManagement/components/ManagedSiteTokenBatchExportDialog.tsx
@@ -1,186 +1,16 @@
-import type { TFunction } from "i18next"
-import { Loader2, RefreshCcw, SendToBack } from "lucide-react"
-import { useEffect, useMemo, useRef, useState } from "react"
-import toast from "react-hot-toast"
 import { useTranslation } from "react-i18next"
 
-import { ManagedSiteChannelAssessmentSignalsRow } from "~/components/ManagedSiteChannelAssessmentSignals"
-import {
-  Badge,
-  Button,
-  Checkbox,
-  CompactMultiSelect,
-  DestructiveConfirmDialog,
-  Modal,
-} from "~/components/ui"
-import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
-import { loadNewApiChannelKeyWithVerification } from "~/features/ManagedSiteVerification/loadNewApiChannelKeyWithVerification"
+import { DestructiveConfirmDialog, Modal } from "~/components/ui"
 import { NewApiManagedVerificationDialog } from "~/features/ManagedSiteVerification/NewApiManagedVerificationDialog"
-import {
-  NEW_API_MANAGED_VERIFICATION_CLOSE_MODES,
-  useNewApiManagedVerification,
-} from "~/features/ManagedSiteVerification/useNewApiManagedVerification"
-import {
-  executeManagedSiteTokenBatchExport,
-  prepareManagedSiteTokenBatchExportPreview,
-} from "~/services/managedSites/tokenBatchExport"
 import { getManagedSiteLabel } from "~/services/managedSites/utils/managedSite"
+
+import { ManagedSiteTokenBatchExportFooter } from "./ManagedSiteTokenBatchExportDialog/ManagedSiteTokenBatchExportFooter"
+import { ManagedSiteTokenBatchExportPreviewList } from "./ManagedSiteTokenBatchExportDialog/ManagedSiteTokenBatchExportPreviewList"
+import { ManagedSiteTokenBatchExportStatusPanels } from "./ManagedSiteTokenBatchExportDialog/ManagedSiteTokenBatchExportStatusPanels"
 import {
-  trackProductAnalyticsActionCompleted,
-  trackProductAnalyticsActionStarted,
-} from "~/services/productAnalytics/actions"
-import {
-  PRODUCT_ANALYTICS_ACTION_IDS,
-  PRODUCT_ANALYTICS_ENTRYPOINTS,
-  PRODUCT_ANALYTICS_ERROR_CATEGORIES,
-  PRODUCT_ANALYTICS_FEATURE_IDS,
-  PRODUCT_ANALYTICS_RESULTS,
-} from "~/services/productAnalytics/contracts"
-import type {
-  ManagedSiteTokenBatchExportExecutionResult,
-  ManagedSiteTokenBatchExportItemInput,
-  ManagedSiteTokenBatchExportMatchedChannel,
-  ManagedSiteTokenBatchExportPreview,
-  ManagedSiteTokenBatchExportPreviewItem,
-} from "~/types/managedSiteTokenBatchExport"
-import {
-  isExecutableManagedSiteTokenBatchExportPreviewItem as isExecutablePreviewItem,
-  MANAGED_SITE_TOKEN_BATCH_EXPORT_BLOCKED_REASON_CODES,
-  MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES,
-  MANAGED_SITE_TOKEN_BATCH_EXPORT_WARNING_CODES,
-} from "~/types/managedSiteTokenBatchExport"
-import { getErrorMessage } from "~/utils/core/error"
-
-import {
-  applyResolvedChannelKeyToPreviewItem,
-  canEditItemModels,
-  countPreviewItems,
-  getPreviewItemVerificationCandidate,
-  getPreviewVerificationTargets,
-  normalizeModels,
-  shouldSelectPreviewItemByDefault,
-  toModelOptions,
-} from "./managedSiteTokenBatchExportPreview"
-
-interface ManagedSiteTokenBatchExportDialogProps {
-  isOpen: boolean
-  onClose: () => void
-  items: ManagedSiteTokenBatchExportItemInput[]
-  onCompleted?: (result: ManagedSiteTokenBatchExportExecutionResult) => void
-}
-
-const formatValues = (items: string[] | undefined) =>
-  items && items.length > 0 ? items.join(", ") : "-"
-
-const getWarningText = (t: TFunction, code: string) => {
-  switch (code) {
-    case MANAGED_SITE_TOKEN_BATCH_EXPORT_WARNING_CODES.MODEL_PREFILL_FAILED:
-      return t(
-        "keyManagement:batchManagedSiteExport.warnings.modelPrefillFailed",
-      )
-    case MANAGED_SITE_TOKEN_BATCH_EXPORT_WARNING_CODES.MATCH_REQUIRES_CONFIRMATION:
-      return t(
-        "keyManagement:batchManagedSiteExport.warnings.matchRequiresConfirmation",
-      )
-    case MANAGED_SITE_TOKEN_BATCH_EXPORT_WARNING_CODES.EXACT_VERIFICATION_UNAVAILABLE:
-      return t(
-        "keyManagement:batchManagedSiteExport.warnings.exactVerificationUnavailable",
-      )
-    case MANAGED_SITE_TOKEN_BATCH_EXPORT_WARNING_CODES.BACKEND_SEARCH_FAILED:
-      return t(
-        "keyManagement:batchManagedSiteExport.warnings.backendSearchFailed",
-      )
-    case MANAGED_SITE_TOKEN_BATCH_EXPORT_WARNING_CODES.DEDUPE_UNSUPPORTED:
-    default:
-      return t(
-        "keyManagement:batchManagedSiteExport.warnings.dedupeUnsupported",
-      )
-  }
-}
-
-const getBlockedReasonText = (
-  t: TFunction,
-  code?: string | null | undefined,
-) => {
-  switch (code) {
-    case MANAGED_SITE_TOKEN_BATCH_EXPORT_BLOCKED_REASON_CODES.CONFIG_MISSING:
-      return t(
-        "keyManagement:batchManagedSiteExport.blockedReasons.configMissing",
-      )
-    case MANAGED_SITE_TOKEN_BATCH_EXPORT_BLOCKED_REASON_CODES.SECRET_RESOLUTION_FAILED:
-      return t(
-        "keyManagement:batchManagedSiteExport.blockedReasons.secretResolutionFailed",
-      )
-    case MANAGED_SITE_TOKEN_BATCH_EXPORT_BLOCKED_REASON_CODES.NAME_REQUIRED:
-      return t(
-        "keyManagement:batchManagedSiteExport.blockedReasons.nameRequired",
-      )
-    case MANAGED_SITE_TOKEN_BATCH_EXPORT_BLOCKED_REASON_CODES.KEY_REQUIRED:
-      return t(
-        "keyManagement:batchManagedSiteExport.blockedReasons.keyRequired",
-      )
-    case MANAGED_SITE_TOKEN_BATCH_EXPORT_BLOCKED_REASON_CODES.REAL_KEY_REQUIRED:
-      return t(
-        "keyManagement:batchManagedSiteExport.blockedReasons.realKeyRequired",
-      )
-    case MANAGED_SITE_TOKEN_BATCH_EXPORT_BLOCKED_REASON_CODES.BASE_URL_REQUIRED:
-      return t(
-        "keyManagement:batchManagedSiteExport.blockedReasons.baseUrlRequired",
-      )
-    case MANAGED_SITE_TOKEN_BATCH_EXPORT_BLOCKED_REASON_CODES.MODELS_REQUIRED:
-      return t(
-        "keyManagement:batchManagedSiteExport.blockedReasons.modelsRequired",
-      )
-    case MANAGED_SITE_TOKEN_BATCH_EXPORT_BLOCKED_REASON_CODES.INPUT_PREPARATION_FAILED:
-      return t(
-        "keyManagement:batchManagedSiteExport.blockedReasons.inputPreparationFailed",
-      )
-    default:
-      return null
-  }
-}
-
-const getExecutionErrorText = (t: TFunction, error?: string | null) => {
-  const blockedReasonText = getBlockedReasonText(t, error)
-  if (blockedReasonText) {
-    return blockedReasonText
-  }
-
-  const trimmedError = error?.trim()
-  return (
-    trimmedError ||
-    t("keyManagement:batchManagedSiteExport.results.channelCreationFailed")
-  )
-}
-
-const getStatusBadge = (
-  t: TFunction,
-  item: ManagedSiteTokenBatchExportPreviewItem,
-) => {
-  switch (item.status) {
-    case MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.READY:
-      return {
-        label: t("keyManagement:batchManagedSiteExport.status.ready"),
-        variant: "success" as const,
-      }
-    case MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.WARNING:
-      return {
-        label: t("keyManagement:batchManagedSiteExport.status.warning"),
-        variant: "warning" as const,
-      }
-    case MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.SKIPPED:
-      return {
-        label: t("keyManagement:batchManagedSiteExport.status.skipped"),
-        variant: "secondary" as const,
-      }
-    case MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.BLOCKED:
-    default:
-      return {
-        label: t("keyManagement:batchManagedSiteExport.status.blocked"),
-        variant: "danger" as const,
-      }
-  }
-}
+  useManagedSiteTokenBatchExportDialog,
+  type ManagedSiteTokenBatchExportDialogProps,
+} from "./ManagedSiteTokenBatchExportDialog/useManagedSiteTokenBatchExportDialog"
 
 /**
  * Preview and execute selected Key Management tokens as managed-site channels.
@@ -197,523 +27,23 @@ export function ManagedSiteTokenBatchExportDialog({
     "common",
     "channelDialog",
   ])
-  const {
-    newApiBaseUrl,
-    newApiUserId,
-    newApiUsername,
-    newApiPassword,
-    newApiTotpSecret,
-  } = useUserPreferencesContext()
-  const verification = useNewApiManagedVerification()
-  const [preview, setPreview] =
-    useState<ManagedSiteTokenBatchExportPreview | null>(null)
-  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
-  const [isLoadingPreview, setIsLoadingPreview] = useState(false)
-  const [previewError, setPreviewError] = useState<string | null>(null)
-  const [executionError, setExecutionError] = useState<string | null>(null)
-  const [isConfirmOpen, setIsConfirmOpen] = useState(false)
-  const [isRunning, setIsRunning] = useState(false)
-  const [executionResult, setExecutionResult] =
-    useState<ManagedSiteTokenBatchExportExecutionResult | null>(null)
-  const [refreshKey, setRefreshKey] = useState(0)
-  const [verifyingItemId, setVerifyingItemId] = useState<string | null>(null)
-  const resolvedChannelKeysByItemIdRef = useRef<
-    Record<string, Record<number, string>>
-  >({})
-
-  useEffect(() => {
-    if (!isOpen) {
-      setPreview(null)
-      setSelectedIds(new Set())
-      setIsLoadingPreview(false)
-      setPreviewError(null)
-      setExecutionError(null)
-      setIsConfirmOpen(false)
-      setIsRunning(false)
-      setExecutionResult(null)
-      setRefreshKey(0)
-      setVerifyingItemId(null)
-      resolvedChannelKeysByItemIdRef.current = {}
-      return
-    }
-
-    let cancelled = false
-    setPreview(null)
-    setSelectedIds(new Set())
-    setPreviewError(null)
-    setExecutionError(null)
-    setExecutionResult(null)
-    setIsLoadingPreview(true)
-
-    void (async () => {
-      try {
-        const nextPreview = await prepareManagedSiteTokenBatchExportPreview({
-          items,
-          resolvedChannelKeysByItemId: resolvedChannelKeysByItemIdRef.current,
-        })
-        if (cancelled) return
-        setPreview(nextPreview)
-        setSelectedIds(
-          new Set(
-            nextPreview.items
-              .filter(shouldSelectPreviewItemByDefault)
-              .map((item) => item.id),
-          ),
-        )
-      } catch (error) {
-        if (cancelled) return
-        setPreviewError(getErrorMessage(error))
-      } finally {
-        if (!cancelled) {
-          setIsLoadingPreview(false)
-        }
-      }
-    })()
-
-    return () => {
-      cancelled = true
-    }
-  }, [isOpen, items, refreshKey])
-
-  const executableItems = useMemo(
-    () => preview?.items.filter(isExecutablePreviewItem) ?? [],
-    [preview],
-  )
-  const selectedExecutableCount = executableItems.filter((item) =>
-    selectedIds.has(item.id),
-  ).length
-  const allExecutableSelected =
-    executableItems.length > 0 &&
-    selectedExecutableCount === executableItems.length
-  const executableSelectionChecked =
-    selectedExecutableCount === 0
-      ? false
-      : selectedExecutableCount === executableItems.length
-        ? true
-        : "indeterminate"
-
-  const selectedExecutionIds = useMemo(
-    () => Array.from(selectedIds),
-    [selectedIds],
-  )
-  const modelOptions = useMemo(
-    () =>
-      toModelOptions(
-        normalizeModels(
-          preview?.items.flatMap((item) => item.draft?.models ?? []) ?? [],
-        ),
-      ),
-    [preview],
-  )
-
-  const handleClose = () => {
-    if (isRunning) return
-    if (verification.dialogState.isOpen) {
-      verification.closeDialog()
-    }
-    onClose()
-  }
-
-  const handleRefreshPreview = () => {
-    if (isLoadingPreview || isRunning) return
-    setExecutionError(null)
-    setRefreshKey((value) => value + 1)
-  }
-
-  const mergeResolvedChannelKeyForItem = (
-    itemId: string,
-    channelId: number,
-    key: string,
-  ) => {
-    resolvedChannelKeysByItemIdRef.current = {
-      ...resolvedChannelKeysByItemIdRef.current,
-      [itemId]: {
-        ...(resolvedChannelKeysByItemIdRef.current[itemId] ?? {}),
-        [channelId]: key,
-      },
-    }
-  }
-
-  const applyResolvedChannelKeyForItem = (
-    item: ManagedSiteTokenBatchExportPreviewItem,
-    candidate: ManagedSiteTokenBatchExportMatchedChannel,
-    resolvedKey: string,
-  ) => {
-    setPreview((currentPreview) => {
-      if (!currentPreview) return currentPreview
-
-      const nextItems = currentPreview.items.map((previewItem) =>
-        previewItem.id === item.id
-          ? applyResolvedChannelKeyToPreviewItem({
-              item: previewItem,
-              candidate,
-              resolvedKey,
-              siteType: currentPreview.siteType,
-            })
-          : previewItem,
-      )
-
-      return {
-        ...currentPreview,
-        items: nextItems,
-        ...countPreviewItems(nextItems),
-      }
-    })
-    setSelectedIds((currentSelectedIds) => {
-      const nextSelectedIds = new Set(currentSelectedIds)
-      const updatedItem = applyResolvedChannelKeyToPreviewItem({
-        item,
-        candidate,
-        resolvedKey,
-        siteType: preview?.siteType,
-      })
-
-      if (
-        updatedItem.status ===
-        MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.SKIPPED
-      ) {
-        nextSelectedIds.delete(item.id)
-      }
-
-      return nextSelectedIds
-    })
-  }
-
-  const handleVerifyAndRefresh = async (
-    requestedItem: ManagedSiteTokenBatchExportPreviewItem,
-    requestedCandidate: ManagedSiteTokenBatchExportMatchedChannel,
-  ) => {
-    if (
-      verifyingItemId ||
-      verification.dialogState.isOpen ||
-      isLoadingPreview ||
-      isRunning
-    ) {
-      return
-    }
-
-    const verificationTargets = preview
-      ? getPreviewVerificationTargets(preview)
-      : []
-    const targets =
-      verificationTargets.length > 0
-        ? verificationTargets
-        : [{ item: requestedItem, candidate: requestedCandidate }]
-    const failureMessages: string[] = []
-
-    setExecutionError(null)
-
-    const verifyTargetsFromIndex = async (startIndex: number) => {
-      for (let index = startIndex; index < targets.length; index += 1) {
-        const { item, candidate } = targets[index]
-        let resolvedChannelKey = ""
-        let shouldContinueAfterDeferredLoad = false
-        let loadCompleted = false
-
-        setVerifyingItemId(item.id)
-
-        const handleLoaded = async () => {
-          loadCompleted = true
-          if (resolvedChannelKey) {
-            mergeResolvedChannelKeyForItem(
-              item.id,
-              candidate.id,
-              resolvedChannelKey,
-            )
-            applyResolvedChannelKeyForItem(item, candidate, resolvedChannelKey)
-          }
-          setExecutionError(null)
-          if (shouldContinueAfterDeferredLoad) {
-            await verifyTargetsFromIndex(index + 1)
-          }
-        }
-
-        try {
-          const loadedImmediately = await loadNewApiChannelKeyWithVerification({
-            channelId: candidate.id,
-            label: candidate.name,
-            requestKind: "channel",
-            config: {
-              baseUrl: newApiBaseUrl,
-              userId: newApiUserId,
-              username: newApiUsername,
-              password: newApiPassword,
-              totpSecret: newApiTotpSecret,
-            },
-            setKey: (key) => {
-              resolvedChannelKey = key
-            },
-            onLoaded: handleLoaded,
-            openVerification: (request) =>
-              verification.openNewApiManagedVerification({
-                ...request,
-                closeMode:
-                  NEW_API_MANAGED_VERIFICATION_CLOSE_MODES.CLOSE_AFTER_VERIFICATION,
-              }),
-          })
-
-          if (!loadedImmediately) {
-            if (!loadCompleted) {
-              shouldContinueAfterDeferredLoad = true
-              setVerifyingItemId(null)
-              return
-            }
-          }
-        } catch (error) {
-          failureMessages.push(getErrorMessage(error))
-        }
-      }
-
-      setVerifyingItemId(null)
-      if (failureMessages.length > 0) {
-        setExecutionError(
-          t(
-            "keyManagement:batchManagedSiteExport.messages.verificationFailed",
-            {
-              error: failureMessages.join("; "),
-            },
-          ),
-        )
-      }
-    }
-
-    try {
-      await verifyTargetsFromIndex(0)
-    } catch (error) {
-      setVerifyingItemId(null)
-      setExecutionError(
-        t("keyManagement:batchManagedSiteExport.messages.verificationFailed", {
-          error: getErrorMessage(error),
-        }),
-      )
-    }
-  }
-
-  const handleToggleAll = () => {
-    if (!preview || executionResult) return
-    setSelectedIds(
-      allExecutableSelected
-        ? new Set()
-        : new Set(executableItems.map((item) => item.id)),
-    )
-  }
-
-  const handleToggleItem = (item: ManagedSiteTokenBatchExportPreviewItem) => {
-    if (!isExecutablePreviewItem(item) || executionResult) return
-    setSelectedIds((prev) => {
-      const next = new Set(prev)
-      if (next.has(item.id)) {
-        next.delete(item.id)
-      } else {
-        next.add(item.id)
-      }
-      return next
-    })
-  }
-
-  const handleItemModelsChange = (
-    item: ManagedSiteTokenBatchExportPreviewItem,
-    models: string[],
-  ) => {
-    if (!item.draft || executionResult || isRunning) return
-
-    const normalizedModels = normalizeModels(models)
-
-    setPreview((currentPreview) => {
-      if (!currentPreview) return currentPreview
-
-      const nextItems = currentPreview.items.map((previewItem) => {
-        if (previewItem.id !== item.id || !previewItem.draft) {
-          return previewItem
-        }
-
-        if (normalizedModels.length === 0) {
-          return {
-            ...previewItem,
-            draft: {
-              ...previewItem.draft,
-              models: [],
-            },
-            status: MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.BLOCKED,
-            blockingReasonCode:
-              MANAGED_SITE_TOKEN_BATCH_EXPORT_BLOCKED_REASON_CODES.MODELS_REQUIRED,
-          }
-        }
-
-        if (
-          canEditItemModels(previewItem) &&
-          !isExecutablePreviewItem(previewItem)
-        ) {
-          // Manually supplied models make a models-required blocked row executable,
-          // but keep it as WARNING after clearing the blocking fields for confirmation.
-          return {
-            ...previewItem,
-            draft: {
-              ...previewItem.draft,
-              models: normalizedModels,
-            },
-            status: MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.WARNING,
-            blockingReasonCode: undefined,
-            blockingMessage: undefined,
-          }
-        }
-
-        return {
-          ...previewItem,
-          draft: {
-            ...previewItem.draft,
-            models: normalizedModels,
-          },
-        }
-      })
-
-      return {
-        ...currentPreview,
-        items: nextItems,
-        ...countPreviewItems(nextItems),
-      }
-    })
-
-    setSelectedIds((currentSelectedIds) => {
-      const nextSelectedIds = new Set(currentSelectedIds)
-      if (normalizedModels.length === 0) {
-        nextSelectedIds.delete(item.id)
-      } else if (
-        item.status ===
-          MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.BLOCKED &&
-        item.blockingReasonCode ===
-          MANAGED_SITE_TOKEN_BATCH_EXPORT_BLOCKED_REASON_CODES.MODELS_REQUIRED
-      ) {
-        nextSelectedIds.add(item.id)
-      }
-      return nextSelectedIds
-    })
-  }
-
-  const handleConfirm = async () => {
-    if (!preview || selectedExecutionIds.length === 0) return
-
-    setIsConfirmOpen(false)
-    setIsRunning(true)
-    setExecutionError(null)
-    const analyticsContext = {
-      featureId: PRODUCT_ANALYTICS_FEATURE_IDS.ManagedSiteChannels,
-      actionId: PRODUCT_ANALYTICS_ACTION_IDS.ExportManagedSiteTokenChannels,
-      entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Options,
-    }
-    void trackProductAnalyticsActionStarted(analyticsContext)
-    try {
-      const result = await executeManagedSiteTokenBatchExport({
-        preview,
-        selectedItemIds: selectedExecutionIds,
-      })
-      void trackProductAnalyticsActionCompleted({
-        ...analyticsContext,
-        result: PRODUCT_ANALYTICS_RESULTS.Success,
-        insights: {
-          selectedCount: result.totalSelected,
-          itemCount: result.attemptedCount,
-          successCount: result.createdCount,
-          failureCount: result.failedCount,
-        },
-      })
-      setExecutionResult(result)
-      onCompleted?.(result)
-      toast.success(
-        t("keyManagement:batchManagedSiteExport.messages.completed", {
-          created: result.createdCount,
-          failed: result.failedCount,
-          skipped: result.skippedCount,
-        }),
-      )
-    } catch (error) {
-      void trackProductAnalyticsActionCompleted({
-        ...analyticsContext,
-        result: PRODUCT_ANALYTICS_RESULTS.Failure,
-        errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
-        insights: {
-          selectedCount: selectedExecutionIds.length,
-          itemCount: selectedExecutionIds.length,
-        },
-      })
-      setExecutionError(getErrorMessage(error))
-    } finally {
-      setIsRunning(false)
-    }
-  }
-
-  const footer = executionResult ? (
-    <div className="flex items-center justify-between gap-3">
-      <div className="text-muted-foreground text-sm">
-        {t("keyManagement:batchManagedSiteExport.results.summary", {
-          created: executionResult.createdCount,
-          failed: executionResult.failedCount,
-          skipped: executionResult.skippedCount,
-          total: executionResult.items.length,
-        })}
-      </div>
-      <Button type="button" onClick={handleClose}>
-        {t("common:actions.close")}
-      </Button>
-    </div>
-  ) : (
-    <div className="flex items-center justify-between gap-3">
-      <div className="text-muted-foreground text-sm">
-        {preview
-          ? t("keyManagement:batchManagedSiteExport.preview.summary", {
-              ready: preview.readyCount,
-              warning: preview.warningCount,
-              skipped: preview.skippedCount,
-              blocked: preview.blockedCount,
-              total: preview.totalCount,
-            })
-          : t("keyManagement:batchManagedSiteExport.preview.selected", {
-              selectedCount: items.length,
-            })}
-      </div>
-      <div className="flex items-center gap-2">
-        <Button
-          type="button"
-          variant="outline"
-          onClick={handleClose}
-          disabled={isRunning}
-        >
-          {t("common:actions.cancel")}
-        </Button>
-        <Button
-          type="button"
-          leftIcon={
-            isRunning || isLoadingPreview ? (
-              <Loader2 className="h-4 w-4 animate-spin" />
-            ) : (
-              <SendToBack className="h-4 w-4" />
-            )
-          }
-          disabled={
-            isRunning ||
-            isLoadingPreview ||
-            !preview ||
-            selectedExecutableCount === 0 ||
-            Boolean(previewError)
-          }
-          onClick={() => setIsConfirmOpen(true)}
-        >
-          {isRunning
-            ? t("keyManagement:batchManagedSiteExport.actions.running")
-            : t("keyManagement:batchManagedSiteExport.actions.start")}
-        </Button>
-      </div>
-    </div>
-  )
+  const dialog = useManagedSiteTokenBatchExportDialog({
+    isOpen,
+    onClose,
+    items,
+    onCompleted,
+    t,
+  })
+  const verificationState = dialog.verification.dialogState
 
   return (
     <>
       <Modal
         isOpen={isOpen}
-        onClose={handleClose}
-        closeOnBackdropClick={!isRunning}
-        closeOnEsc={!isRunning}
-        showCloseButton={!isRunning}
+        onClose={dialog.actions.close}
+        closeOnBackdropClick={!dialog.isRunning}
+        closeOnEsc={!dialog.isRunning}
+        showCloseButton={!dialog.isRunning}
         size="lg"
         header={
           <div className="space-y-1">
@@ -721,10 +51,10 @@ export function ManagedSiteTokenBatchExportDialog({
               {t("keyManagement:batchManagedSiteExport.title")}
             </div>
             <div className="text-muted-foreground text-sm">
-              {preview
+              {dialog.preview
                 ? t("keyManagement:batchManagedSiteExport.description", {
-                    site: getManagedSiteLabel(t, preview.siteType),
-                    selectedCount: preview.totalCount,
+                    site: getManagedSiteLabel(t, dialog.preview.siteType),
+                    selectedCount: dialog.preview.totalCount,
                   })
                 : t("keyManagement:batchManagedSiteExport.loadingDescription", {
                     selectedCount: items.length,
@@ -732,326 +62,82 @@ export function ManagedSiteTokenBatchExportDialog({
             </div>
           </div>
         }
-        footer={footer}
+        footer={
+          <ManagedSiteTokenBatchExportFooter
+            t={t}
+            selectedItemCount={items.length}
+            preview={dialog.preview}
+            previewError={dialog.previewError}
+            executionResult={dialog.executionResult}
+            isLoadingPreview={dialog.isLoadingPreview}
+            isRunning={dialog.isRunning}
+            selectedExecutableCount={dialog.executableSelection.selectedCount}
+            onClose={dialog.actions.close}
+            onStart={dialog.actions.openConfirm}
+          />
+        }
       >
         <div className="space-y-4">
-          {previewError ? (
-            <div className="space-y-2 rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:border-red-900/40 dark:bg-red-950/30 dark:text-red-300">
-              <div>
-                {t("keyManagement:batchManagedSiteExport.preview.loadFailed", {
-                  error: previewError,
-                })}
-              </div>
-              <Button
-                type="button"
-                size="sm"
-                variant="outline"
-                leftIcon={<RefreshCcw className="h-4 w-4" />}
-                disabled={isLoadingPreview || isRunning}
-                onClick={handleRefreshPreview}
-              >
-                {t(
-                  "keyManagement:batchManagedSiteExport.actions.refreshPreview",
-                )}
-              </Button>
-            </div>
-          ) : null}
+          <ManagedSiteTokenBatchExportStatusPanels
+            t={t}
+            previewError={dialog.previewError}
+            executionError={dialog.executionError}
+            isLoadingPreview={dialog.isLoadingPreview}
+            isRunning={dialog.isRunning}
+            onRefreshPreview={dialog.actions.refreshPreview}
+          />
 
-          {executionError ? (
-            <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:border-red-900/40 dark:bg-red-950/30 dark:text-red-300">
-              {t(
-                "keyManagement:batchManagedSiteExport.messages.executionFailed",
-                {
-                  error: executionError,
-                },
-              )}
-            </div>
-          ) : null}
-
-          {isLoadingPreview ? (
-            <div className="text-muted-foreground rounded-md border p-3 text-sm">
-              <div className="flex items-center gap-2">
-                <Loader2 className="h-4 w-4 animate-spin" />
-                {t("keyManagement:batchManagedSiteExport.preview.loading")}
-              </div>
-            </div>
-          ) : null}
-
-          {preview && !executionResult ? (
-            <div className="flex flex-wrap items-center justify-between gap-2 rounded-md border p-3">
-              <label className="flex items-center gap-2 text-sm">
-                <Checkbox
-                  checked={executableSelectionChecked}
-                  disabled={executableItems.length === 0}
-                  aria-label={t(
-                    "keyManagement:batchManagedSiteExport.actions.selectAll",
-                    {
-                      selected: selectedExecutableCount,
-                      total: executableItems.length,
-                    },
-                  )}
-                  onCheckedChange={handleToggleAll}
-                />
-                {t("keyManagement:batchManagedSiteExport.actions.selectAll", {
-                  selected: selectedExecutableCount,
-                  total: executableItems.length,
-                })}
-              </label>
-              <Button
-                type="button"
-                size="sm"
-                variant="outline"
-                leftIcon={<RefreshCcw className="h-4 w-4" />}
-                disabled={isLoadingPreview || isRunning}
-                onClick={handleRefreshPreview}
-              >
-                {t(
-                  "keyManagement:batchManagedSiteExport.actions.refreshPreview",
-                )}
-              </Button>
-            </div>
-          ) : null}
-
-          {preview ? (
-            <div className="max-h-[60vh] space-y-3 overflow-y-auto rounded-md border p-3 md:max-h-[min(70vh,48rem)]">
-              {preview.items.map((item) => {
-                const badge = getStatusBadge(t, item)
-                const verificationCandidate =
-                  getPreviewItemVerificationCandidate(item, preview.siteType)
-                const result = executionResult?.items.find(
-                  (resultItem) => resultItem.id === item.id,
-                )
-                const verificationButton = verificationCandidate ? (
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant="outline"
-                    leftIcon={
-                      verifyingItemId === item.id ? (
-                        <Loader2 className="h-4 w-4 animate-spin" />
-                      ) : (
-                        <RefreshCcw className="h-4 w-4" />
-                      )
-                    }
-                    disabled={
-                      isLoadingPreview ||
-                      isRunning ||
-                      Boolean(executionResult) ||
-                      verification.dialogState.isOpen ||
-                      Boolean(verifyingItemId)
-                    }
-                    onClick={() =>
-                      void handleVerifyAndRefresh(item, verificationCandidate)
-                    }
-                  >
-                    {verifyingItemId === item.id
-                      ? t(
-                          "keyManagement:batchManagedSiteExport.actions.verifying",
-                        )
-                      : t(
-                          "keyManagement:batchManagedSiteExport.actions.verifyAndRefresh",
-                        )}
-                  </Button>
-                ) : null
-
-                return (
-                  <div
-                    key={item.id}
-                    className="space-y-2 rounded-md border p-3"
-                  >
-                    <div className="flex items-start justify-between gap-3">
-                      <label className="flex min-w-0 items-start gap-2">
-                        <Checkbox
-                          className="mt-0.5"
-                          checked={selectedIds.has(item.id)}
-                          aria-label={`${item.accountName} / ${item.runtimeKeyName}`}
-                          disabled={
-                            !isExecutablePreviewItem(item) || !!executionResult
-                          }
-                          onCheckedChange={() => handleToggleItem(item)}
-                        />
-                        <span className="min-w-0">
-                          <span className="block truncate text-sm font-medium">
-                            {item.accountName} / {item.runtimeKeyName}
-                          </span>
-                          <span className="text-muted-foreground block truncate text-xs">
-                            {item.draft?.name ?? "-"}
-                          </span>
-                        </span>
-                      </label>
-                      <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">
-                        {result ? (
-                          <Badge
-                            variant={
-                              result.success
-                                ? "success"
-                                : result.skipped
-                                  ? "secondary"
-                                  : "danger"
-                            }
-                            size="sm"
-                          >
-                            {result.success
-                              ? t(
-                                  "keyManagement:batchManagedSiteExport.results.status.success",
-                                )
-                              : result.skipped
-                                ? t(
-                                    "keyManagement:batchManagedSiteExport.results.status.skipped",
-                                  )
-                                : t(
-                                    "keyManagement:batchManagedSiteExport.results.status.failed",
-                                  )}
-                          </Badge>
-                        ) : (
-                          <Badge variant={badge.variant} size="sm">
-                            {badge.label}
-                          </Badge>
-                        )}
-                        {verificationButton}
-                      </div>
-                    </div>
-
-                    <div className="grid gap-2 text-xs md:grid-cols-2">
-                      <div>
-                        <span className="text-muted-foreground">
-                          {t(
-                            "keyManagement:batchManagedSiteExport.fields.baseUrl",
-                          )}
-                        </span>
-                        <span className="ml-2 break-all">
-                          {item.draft?.base_url || "-"}
-                        </span>
-                      </div>
-                      <div>
-                        <span className="text-muted-foreground">
-                          {t(
-                            "keyManagement:batchManagedSiteExport.fields.groups",
-                          )}
-                        </span>
-                        <span className="ml-2">
-                          {formatValues(item.draft?.groups)}
-                        </span>
-                      </div>
-                      <div className="md:col-span-2">
-                        <span className="text-muted-foreground">
-                          {t(
-                            "keyManagement:batchManagedSiteExport.fields.models",
-                          )}
-                        </span>
-                        {item.draft &&
-                        !executionResult &&
-                        canEditItemModels(item) ? (
-                          <div className="mt-1">
-                            <CompactMultiSelect
-                              options={modelOptions}
-                              selected={item.draft.models}
-                              onChange={(models) =>
-                                handleItemModelsChange(item, models)
-                              }
-                              size="default"
-                              placeholder={t(
-                                "channelDialog:fields.models.placeholder",
-                              )}
-                              aria-label={t(
-                                "keyManagement:batchManagedSiteExport.fields.editModelsLabel",
-                                {
-                                  name: `${item.accountName} / ${item.runtimeKeyName}`,
-                                },
-                              )}
-                              allowCustom
-                              disabled={isRunning}
-                            />
-                          </div>
-                        ) : (
-                          <span className="ml-2 break-words">
-                            {formatValues(item.draft?.models)}
-                          </span>
-                        )}
-                      </div>
-                    </div>
-
-                    {item.matchedChannel ? (
-                      <div className="text-muted-foreground dark:bg-dark-bg-tertiary rounded-md bg-gray-50 p-2 text-xs">
-                        {t(
-                          "keyManagement:batchManagedSiteExport.messages.duplicate",
-                          {
-                            channel: item.matchedChannel.name,
-                          },
-                        )}
-                      </div>
-                    ) : null}
-
-                    {item.warningCodes.length > 0 ? (
-                      <div className="space-y-2 rounded-md border border-amber-200/70 bg-amber-50/55 p-2 text-xs text-amber-900 dark:border-amber-900/40 dark:bg-amber-950/20 dark:text-amber-100">
-                        <ul className="list-disc space-y-1 pl-4 leading-5">
-                          {item.warningCodes.map((code) => (
-                            <li key={code}>{getWarningText(t, code)}</li>
-                          ))}
-                        </ul>
-                        {item.assessment ? (
-                          <ManagedSiteChannelAssessmentSignalsRow
-                            assessment={item.assessment}
-                            managedSiteType={preview.siteType}
-                          />
-                        ) : null}
-                      </div>
-                    ) : null}
-
-                    {item.blockingReasonCode ? (
-                      <div className="rounded-md bg-red-50 p-2 text-xs text-red-700 dark:bg-red-950/30 dark:text-red-300">
-                        {getBlockedReasonText(t, item.blockingReasonCode) ??
-                          t(
-                            "keyManagement:batchManagedSiteExport.blockedReasons.inputPreparationFailed",
-                          )}
-                        {item.blockingMessage
-                          ? `: ${item.blockingMessage}`
-                          : ""}
-                      </div>
-                    ) : null}
-
-                    {result?.error ? (
-                      <div className="rounded-md bg-red-50 p-2 text-xs text-red-700 dark:bg-red-950/30 dark:text-red-300">
-                        {getExecutionErrorText(t, result.error)}
-                      </div>
-                    ) : null}
-                  </div>
-                )
-              })}
-            </div>
+          {dialog.preview ? (
+            <ManagedSiteTokenBatchExportPreviewList
+              t={t}
+              preview={dialog.preview}
+              selectedIds={dialog.selectedIds}
+              executableSelection={dialog.executableSelection}
+              modelOptions={dialog.modelOptions}
+              executionResult={dialog.executionResult}
+              isLoadingPreview={dialog.isLoadingPreview}
+              isRunning={dialog.isRunning}
+              verifyingItemId={dialog.verifyingItemId}
+              isVerificationDialogOpen={verificationState.isOpen}
+              onToggleAll={dialog.actions.toggleAll}
+              onRefreshPreview={dialog.actions.refreshPreview}
+              onToggleItem={dialog.actions.toggleItem}
+              onItemModelsChange={dialog.actions.changeItemModels}
+              onVerifyAndRefresh={dialog.actions.verifyAndRefresh}
+            />
           ) : null}
         </div>
       </Modal>
 
       <DestructiveConfirmDialog
-        isOpen={isConfirmOpen}
-        onClose={() => setIsConfirmOpen(false)}
-        onConfirm={handleConfirm}
+        isOpen={dialog.isConfirmOpen}
+        onClose={dialog.actions.closeConfirm}
+        onConfirm={dialog.actions.confirm}
         title={t("keyManagement:batchManagedSiteExport.confirm.title")}
         description={t(
           "keyManagement:batchManagedSiteExport.confirm.description",
           {
-            selectedCount: selectedExecutableCount,
+            selectedCount: dialog.executableSelection.selectedCount,
           },
         )}
         confirmLabel={t("keyManagement:batchManagedSiteExport.actions.start")}
         cancelLabel={t("common:actions.cancel")}
-        isWorking={isRunning}
+        isWorking={dialog.isRunning}
       />
       <NewApiManagedVerificationDialog
-        isOpen={verification.dialogState.isOpen}
-        step={verification.dialogState.step}
-        request={verification.dialogState.request}
-        code={verification.dialogState.code}
-        errorMessage={verification.dialogState.errorMessage}
-        isBusy={verification.dialogState.isBusy}
-        busyMessage={verification.dialogState.busyMessage}
-        onCodeChange={verification.setCode}
-        onClose={verification.closeDialog}
-        onSubmit={verification.submitCode}
-        onRetry={verification.retryVerification}
-        onOpenSite={verification.openBaseUrl}
-        onUpdateRequestConfig={verification.patchRequestConfig}
+        isOpen={verificationState.isOpen}
+        step={verificationState.step}
+        request={verificationState.request}
+        code={verificationState.code}
+        errorMessage={verificationState.errorMessage}
+        isBusy={verificationState.isBusy}
+        busyMessage={verificationState.busyMessage}
+        onCodeChange={dialog.verification.setCode}
+        onClose={dialog.verification.closeDialog}
+        onSubmit={dialog.verification.submitCode}
+        onRetry={dialog.verification.retryVerification}
+        onOpenSite={dialog.verification.openBaseUrl}
+        onUpdateRequestConfig={dialog.verification.patchRequestConfig}
       />
     </>
   )

--- a/src/features/KeyManagement/components/ManagedSiteTokenBatchExportDialog/ManagedSiteTokenBatchExportFooter.tsx
+++ b/src/features/KeyManagement/components/ManagedSiteTokenBatchExportDialog/ManagedSiteTokenBatchExportFooter.tsx
@@ -1,0 +1,105 @@
+import type { TFunction } from "i18next"
+import { Loader2, SendToBack } from "lucide-react"
+
+import { Button } from "~/components/ui"
+import type {
+  ManagedSiteTokenBatchExportExecutionResult,
+  ManagedSiteTokenBatchExportPreview,
+} from "~/types/managedSiteTokenBatchExport"
+
+interface ManagedSiteTokenBatchExportFooterProps {
+  t: TFunction
+  selectedItemCount: number
+  preview: ManagedSiteTokenBatchExportPreview | null
+  previewError: string | null
+  executionResult: ManagedSiteTokenBatchExportExecutionResult | null
+  isLoadingPreview: boolean
+  isRunning: boolean
+  selectedExecutableCount: number
+  onClose: () => void
+  onStart: () => void
+}
+
+/**
+ * Renders the batch export dialog footer summary and primary actions.
+ */
+export function ManagedSiteTokenBatchExportFooter({
+  t,
+  selectedItemCount,
+  preview,
+  previewError,
+  executionResult,
+  isLoadingPreview,
+  isRunning,
+  selectedExecutableCount,
+  onClose,
+  onStart,
+}: ManagedSiteTokenBatchExportFooterProps) {
+  if (executionResult) {
+    return (
+      <div className="flex items-center justify-between gap-3">
+        <div className="text-muted-foreground text-sm">
+          {t("keyManagement:batchManagedSiteExport.results.summary", {
+            created: executionResult.createdCount,
+            failed: executionResult.failedCount,
+            skipped: executionResult.skippedCount,
+            total: executionResult.items.length,
+          })}
+        </div>
+        <Button type="button" onClick={onClose}>
+          {t("common:actions.close")}
+        </Button>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <div className="text-muted-foreground text-sm">
+        {preview
+          ? t("keyManagement:batchManagedSiteExport.preview.summary", {
+              ready: preview.readyCount,
+              warning: preview.warningCount,
+              skipped: preview.skippedCount,
+              blocked: preview.blockedCount,
+              total: preview.totalCount,
+            })
+          : t("keyManagement:batchManagedSiteExport.preview.selected", {
+              selectedCount: selectedItemCount,
+            })}
+      </div>
+      <div className="flex items-center gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          onClick={onClose}
+          disabled={isRunning}
+        >
+          {t("common:actions.cancel")}
+        </Button>
+        <Button
+          type="button"
+          leftIcon={
+            isRunning || isLoadingPreview ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <SendToBack className="h-4 w-4" />
+            )
+          }
+          disabled={
+            isRunning ||
+            isLoadingPreview ||
+            !preview ||
+            selectedExecutableCount === 0 ||
+            Boolean(previewError)
+          }
+          onClick={onStart}
+        >
+          {isRunning
+            ? t("keyManagement:batchManagedSiteExport.actions.running")
+            : t("keyManagement:batchManagedSiteExport.actions.start")}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/features/KeyManagement/components/ManagedSiteTokenBatchExportDialog/ManagedSiteTokenBatchExportFooter.tsx
+++ b/src/features/KeyManagement/components/ManagedSiteTokenBatchExportDialog/ManagedSiteTokenBatchExportFooter.tsx
@@ -2,6 +2,7 @@ import type { TFunction } from "i18next"
 import { Loader2, SendToBack } from "lucide-react"
 
 import { Button } from "~/components/ui"
+import { KEY_MANAGEMENT_TEST_IDS } from "~/features/KeyManagement/testIds"
 import type {
   ManagedSiteTokenBatchExportExecutionResult,
   ManagedSiteTokenBatchExportPreview,
@@ -46,7 +47,13 @@ export function ManagedSiteTokenBatchExportFooter({
             total: executionResult.items.length,
           })}
         </div>
-        <Button type="button" onClick={onClose}>
+        <Button
+          type="button"
+          onClick={onClose}
+          data-testid={
+            KEY_MANAGEMENT_TEST_IDS.managedSiteBatchExportCloseButton
+          }
+        >
           {t("common:actions.close")}
         </Button>
       </div>
@@ -65,7 +72,7 @@ export function ManagedSiteTokenBatchExportFooter({
               total: preview.totalCount,
             })
           : t("keyManagement:batchManagedSiteExport.preview.selected", {
-              selectedCount: selectedItemCount,
+              count: selectedItemCount,
             })}
       </div>
       <div className="flex items-center gap-2">
@@ -74,6 +81,9 @@ export function ManagedSiteTokenBatchExportFooter({
           variant="outline"
           onClick={onClose}
           disabled={isRunning}
+          data-testid={
+            KEY_MANAGEMENT_TEST_IDS.managedSiteBatchExportCancelButton
+          }
         >
           {t("common:actions.cancel")}
         </Button>
@@ -94,6 +104,9 @@ export function ManagedSiteTokenBatchExportFooter({
             Boolean(previewError)
           }
           onClick={onStart}
+          data-testid={
+            KEY_MANAGEMENT_TEST_IDS.managedSiteBatchExportStartButton
+          }
         >
           {isRunning
             ? t("keyManagement:batchManagedSiteExport.actions.running")

--- a/src/features/KeyManagement/components/ManagedSiteTokenBatchExportDialog/ManagedSiteTokenBatchExportPreviewList.tsx
+++ b/src/features/KeyManagement/components/ManagedSiteTokenBatchExportDialog/ManagedSiteTokenBatchExportPreviewList.tsx
@@ -65,6 +65,8 @@ export function ManagedSiteTokenBatchExportPreviewList({
   onVerifyAndRefresh,
 }: ManagedSiteTokenBatchExportPreviewListProps) {
   const hasExecutionResult = Boolean(executionResult)
+  const isVerificationPending =
+    isVerificationDialogOpen || Boolean(verifyingItemId)
   const selectAllId = useId()
 
   return (
@@ -75,7 +77,7 @@ export function ManagedSiteTokenBatchExportPreviewList({
             <Checkbox
               id={selectAllId}
               checked={executableSelection.checked}
-              disabled={executableSelection.itemCount === 0}
+              disabled={isRunning || executableSelection.itemCount === 0}
               aria-label={t(
                 "keyManagement:batchManagedSiteExport.actions.selectAll",
                 {
@@ -97,7 +99,7 @@ export function ManagedSiteTokenBatchExportPreviewList({
             size="sm"
             variant="outline"
             leftIcon={<RefreshCcw className="h-4 w-4" />}
-            disabled={isLoadingPreview || isRunning}
+            disabled={isLoadingPreview || isRunning || isVerificationPending}
             onClick={onRefreshPreview}
           >
             {t("keyManagement:batchManagedSiteExport.actions.refreshPreview")}

--- a/src/features/KeyManagement/components/ManagedSiteTokenBatchExportDialog/ManagedSiteTokenBatchExportPreviewList.tsx
+++ b/src/features/KeyManagement/components/ManagedSiteTokenBatchExportDialog/ManagedSiteTokenBatchExportPreviewList.tsx
@@ -1,0 +1,133 @@
+import type { TFunction } from "i18next"
+import { RefreshCcw } from "lucide-react"
+import { useId } from "react"
+
+import {
+  Button,
+  Checkbox,
+  type CompactMultiSelectOption,
+} from "~/components/ui"
+import type {
+  ManagedSiteTokenBatchExportExecutionResult,
+  ManagedSiteTokenBatchExportMatchedChannel,
+  ManagedSiteTokenBatchExportPreview,
+  ManagedSiteTokenBatchExportPreviewItem,
+} from "~/types/managedSiteTokenBatchExport"
+
+import { ManagedSiteTokenBatchExportPreviewRow } from "./ManagedSiteTokenBatchExportPreviewRow"
+
+interface ManagedSiteTokenBatchExportPreviewListProps {
+  t: TFunction
+  preview: ManagedSiteTokenBatchExportPreview
+  selectedIds: Set<string>
+  executableSelection: {
+    checked: boolean | "indeterminate"
+    itemCount: number
+    selectedCount: number
+  }
+  modelOptions: CompactMultiSelectOption[]
+  executionResult: ManagedSiteTokenBatchExportExecutionResult | null
+  isLoadingPreview: boolean
+  isRunning: boolean
+  verifyingItemId: string | null
+  isVerificationDialogOpen: boolean
+  onToggleAll: () => void
+  onRefreshPreview: () => void
+  onToggleItem: (item: ManagedSiteTokenBatchExportPreviewItem) => void
+  onItemModelsChange: (
+    item: ManagedSiteTokenBatchExportPreviewItem,
+    models: string[],
+  ) => void
+  onVerifyAndRefresh: (
+    item: ManagedSiteTokenBatchExportPreviewItem,
+    candidate: ManagedSiteTokenBatchExportMatchedChannel,
+  ) => void
+}
+
+/**
+ * Renders preview selection controls and the list of batch export rows.
+ */
+export function ManagedSiteTokenBatchExportPreviewList({
+  t,
+  preview,
+  selectedIds,
+  executableSelection,
+  modelOptions,
+  executionResult,
+  isLoadingPreview,
+  isRunning,
+  verifyingItemId,
+  isVerificationDialogOpen,
+  onToggleAll,
+  onRefreshPreview,
+  onToggleItem,
+  onItemModelsChange,
+  onVerifyAndRefresh,
+}: ManagedSiteTokenBatchExportPreviewListProps) {
+  const hasExecutionResult = Boolean(executionResult)
+  const selectAllId = useId()
+
+  return (
+    <>
+      {!executionResult ? (
+        <div className="flex flex-wrap items-center justify-between gap-2 rounded-md border p-3">
+          <div className="flex items-center gap-2 text-sm">
+            <Checkbox
+              id={selectAllId}
+              checked={executableSelection.checked}
+              disabled={executableSelection.itemCount === 0}
+              aria-label={t(
+                "keyManagement:batchManagedSiteExport.actions.selectAll",
+                {
+                  selected: executableSelection.selectedCount,
+                  total: executableSelection.itemCount,
+                },
+              )}
+              onCheckedChange={onToggleAll}
+            />
+            <label htmlFor={selectAllId}>
+              {t("keyManagement:batchManagedSiteExport.actions.selectAll", {
+                selected: executableSelection.selectedCount,
+                total: executableSelection.itemCount,
+              })}
+            </label>
+          </div>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            leftIcon={<RefreshCcw className="h-4 w-4" />}
+            disabled={isLoadingPreview || isRunning}
+            onClick={onRefreshPreview}
+          >
+            {t("keyManagement:batchManagedSiteExport.actions.refreshPreview")}
+          </Button>
+        </div>
+      ) : null}
+
+      <div className="max-h-[60vh] space-y-3 overflow-y-auto rounded-md border p-3 md:max-h-[min(70vh,48rem)]">
+        {preview.items.map((item) => (
+          <ManagedSiteTokenBatchExportPreviewRow
+            key={item.id}
+            t={t}
+            item={item}
+            siteType={preview.siteType}
+            result={executionResult?.items.find(
+              (resultItem) => resultItem.id === item.id,
+            )}
+            modelOptions={modelOptions}
+            isSelected={selectedIds.has(item.id)}
+            hasExecutionResult={hasExecutionResult}
+            isLoadingPreview={isLoadingPreview}
+            isRunning={isRunning}
+            verifyingItemId={verifyingItemId}
+            isVerificationDialogOpen={isVerificationDialogOpen}
+            onToggleItem={onToggleItem}
+            onItemModelsChange={onItemModelsChange}
+            onVerifyAndRefresh={onVerifyAndRefresh}
+          />
+        ))}
+      </div>
+    </>
+  )
+}

--- a/src/features/KeyManagement/components/ManagedSiteTokenBatchExportDialog/ManagedSiteTokenBatchExportPreviewRow.tsx
+++ b/src/features/KeyManagement/components/ManagedSiteTokenBatchExportDialog/ManagedSiteTokenBatchExportPreviewRow.tsx
@@ -11,6 +11,7 @@ import {
   type CompactMultiSelectOption,
 } from "~/components/ui"
 import type { ManagedSiteType } from "~/constants/siteType"
+import { KEY_MANAGEMENT_TEST_IDS } from "~/features/KeyManagement/testIds"
 import type {
   ManagedSiteTokenBatchExportExecutionItem,
   ManagedSiteTokenBatchExportMatchedChannel,
@@ -114,6 +115,7 @@ export function ManagedSiteTokenBatchExportPreviewRow({
         Boolean(verifyingItemId)
       }
       onClick={() => onVerifyAndRefresh(item, verificationCandidate)}
+      data-testid={KEY_MANAGEMENT_TEST_IDS.managedSiteBatchExportVerifyButton}
     >
       {isCurrentItemVerifying
         ? t("keyManagement:batchManagedSiteExport.actions.verifying")
@@ -130,8 +132,13 @@ export function ManagedSiteTokenBatchExportPreviewRow({
             className="mt-0.5"
             checked={isSelected}
             aria-label={`${item.accountName} / ${item.runtimeKeyName}`}
-            disabled={!isExecutablePreviewItem(item) || hasExecutionResult}
+            disabled={
+              !isExecutablePreviewItem(item) || hasExecutionResult || isRunning
+            }
             onCheckedChange={() => onToggleItem(item)}
+            data-testid={
+              KEY_MANAGEMENT_TEST_IDS.managedSiteBatchExportRowSelectCheckbox
+            }
           />
           <label htmlFor={checkboxId} className="min-w-0">
             <span className="block truncate text-sm font-medium">

--- a/src/features/KeyManagement/components/ManagedSiteTokenBatchExportDialog/ManagedSiteTokenBatchExportPreviewRow.tsx
+++ b/src/features/KeyManagement/components/ManagedSiteTokenBatchExportDialog/ManagedSiteTokenBatchExportPreviewRow.tsx
@@ -1,0 +1,245 @@
+import type { TFunction } from "i18next"
+import { Loader2, RefreshCcw } from "lucide-react"
+import { useId } from "react"
+
+import { ManagedSiteChannelAssessmentSignalsRow } from "~/components/ManagedSiteChannelAssessmentSignals"
+import {
+  Badge,
+  Button,
+  Checkbox,
+  CompactMultiSelect,
+  type CompactMultiSelectOption,
+} from "~/components/ui"
+import type { ManagedSiteType } from "~/constants/siteType"
+import type {
+  ManagedSiteTokenBatchExportExecutionItem,
+  ManagedSiteTokenBatchExportMatchedChannel,
+  ManagedSiteTokenBatchExportPreviewItem,
+} from "~/types/managedSiteTokenBatchExport"
+import { isExecutableManagedSiteTokenBatchExportPreviewItem as isExecutablePreviewItem } from "~/types/managedSiteTokenBatchExport"
+
+import {
+  canEditItemModels,
+  getPreviewItemVerificationCandidate,
+} from "../managedSiteTokenBatchExportPreview"
+import {
+  formatBatchExportValues,
+  getBatchExportBlockedReasonText,
+  getBatchExportExecutionErrorText,
+  getBatchExportStatusBadge,
+  getBatchExportWarningText,
+} from "./batchExportDialogText"
+
+interface ManagedSiteTokenBatchExportPreviewRowProps {
+  t: TFunction
+  item: ManagedSiteTokenBatchExportPreviewItem
+  siteType: ManagedSiteType
+  result?: ManagedSiteTokenBatchExportExecutionItem
+  modelOptions: CompactMultiSelectOption[]
+  isSelected: boolean
+  hasExecutionResult: boolean
+  isLoadingPreview: boolean
+  isRunning: boolean
+  verifyingItemId: string | null
+  isVerificationDialogOpen: boolean
+  onToggleItem: (item: ManagedSiteTokenBatchExportPreviewItem) => void
+  onItemModelsChange: (
+    item: ManagedSiteTokenBatchExportPreviewItem,
+    models: string[],
+  ) => void
+  onVerifyAndRefresh: (
+    item: ManagedSiteTokenBatchExportPreviewItem,
+    candidate: ManagedSiteTokenBatchExportMatchedChannel,
+  ) => void
+}
+
+const getExecutionResultVariant = (
+  result: ManagedSiteTokenBatchExportExecutionItem,
+) => (result.success ? "success" : result.skipped ? "secondary" : "danger")
+
+const getExecutionResultLabel = (
+  t: TFunction,
+  result: ManagedSiteTokenBatchExportExecutionItem,
+) =>
+  result.success
+    ? t("keyManagement:batchManagedSiteExport.results.status.success")
+    : result.skipped
+      ? t("keyManagement:batchManagedSiteExport.results.status.skipped")
+      : t("keyManagement:batchManagedSiteExport.results.status.failed")
+
+/**
+ * Renders a single managed-site token batch export preview row.
+ */
+export function ManagedSiteTokenBatchExportPreviewRow({
+  t,
+  item,
+  siteType,
+  result,
+  modelOptions,
+  isSelected,
+  hasExecutionResult,
+  isLoadingPreview,
+  isRunning,
+  verifyingItemId,
+  isVerificationDialogOpen,
+  onToggleItem,
+  onItemModelsChange,
+  onVerifyAndRefresh,
+}: ManagedSiteTokenBatchExportPreviewRowProps) {
+  const badge = getBatchExportStatusBadge(t, item)
+  const checkboxId = useId()
+  const verificationCandidate = getPreviewItemVerificationCandidate(
+    item,
+    siteType,
+  )
+  const isCurrentItemVerifying = verifyingItemId === item.id
+
+  const verificationButton = verificationCandidate ? (
+    <Button
+      type="button"
+      size="sm"
+      variant="outline"
+      leftIcon={
+        isCurrentItemVerifying ? (
+          <Loader2 className="h-4 w-4 animate-spin" />
+        ) : (
+          <RefreshCcw className="h-4 w-4" />
+        )
+      }
+      disabled={
+        isLoadingPreview ||
+        isRunning ||
+        hasExecutionResult ||
+        isVerificationDialogOpen ||
+        Boolean(verifyingItemId)
+      }
+      onClick={() => onVerifyAndRefresh(item, verificationCandidate)}
+    >
+      {isCurrentItemVerifying
+        ? t("keyManagement:batchManagedSiteExport.actions.verifying")
+        : t("keyManagement:batchManagedSiteExport.actions.verifyAndRefresh")}
+    </Button>
+  ) : null
+
+  return (
+    <div className="space-y-2 rounded-md border p-3">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex min-w-0 items-start gap-2">
+          <Checkbox
+            id={checkboxId}
+            className="mt-0.5"
+            checked={isSelected}
+            aria-label={`${item.accountName} / ${item.runtimeKeyName}`}
+            disabled={!isExecutablePreviewItem(item) || hasExecutionResult}
+            onCheckedChange={() => onToggleItem(item)}
+          />
+          <label htmlFor={checkboxId} className="min-w-0">
+            <span className="block truncate text-sm font-medium">
+              {item.accountName} / {item.runtimeKeyName}
+            </span>
+            <span className="text-muted-foreground block truncate text-xs">
+              {item.draft?.name ?? "-"}
+            </span>
+          </label>
+        </div>
+        <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">
+          {result ? (
+            <Badge variant={getExecutionResultVariant(result)} size="sm">
+              {getExecutionResultLabel(t, result)}
+            </Badge>
+          ) : (
+            <Badge variant={badge.variant} size="sm">
+              {badge.label}
+            </Badge>
+          )}
+          {verificationButton}
+        </div>
+      </div>
+
+      <div className="grid gap-2 text-xs md:grid-cols-2">
+        <div>
+          <span className="text-muted-foreground">
+            {t("keyManagement:batchManagedSiteExport.fields.baseUrl")}
+          </span>
+          <span className="ml-2 break-all">{item.draft?.base_url || "-"}</span>
+        </div>
+        <div>
+          <span className="text-muted-foreground">
+            {t("keyManagement:batchManagedSiteExport.fields.groups")}
+          </span>
+          <span className="ml-2">
+            {formatBatchExportValues(item.draft?.groups)}
+          </span>
+        </div>
+        <div className="md:col-span-2">
+          <span className="text-muted-foreground">
+            {t("keyManagement:batchManagedSiteExport.fields.models")}
+          </span>
+          {item.draft && !hasExecutionResult && canEditItemModels(item) ? (
+            <div className="mt-1">
+              <CompactMultiSelect
+                options={modelOptions}
+                selected={item.draft.models}
+                onChange={(models) => onItemModelsChange(item, models)}
+                size="default"
+                placeholder={t("channelDialog:fields.models.placeholder")}
+                aria-label={t(
+                  "keyManagement:batchManagedSiteExport.fields.editModelsLabel",
+                  {
+                    name: `${item.accountName} / ${item.runtimeKeyName}`,
+                  },
+                )}
+                allowCustom
+                disabled={isRunning}
+              />
+            </div>
+          ) : (
+            <span className="ml-2 break-words">
+              {formatBatchExportValues(item.draft?.models)}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {item.matchedChannel ? (
+        <div className="text-muted-foreground dark:bg-dark-bg-tertiary rounded-md bg-gray-50 p-2 text-xs">
+          {t("keyManagement:batchManagedSiteExport.messages.duplicate", {
+            channel: item.matchedChannel.name,
+          })}
+        </div>
+      ) : null}
+
+      {item.warningCodes.length > 0 ? (
+        <div className="space-y-2 rounded-md border border-amber-200/70 bg-amber-50/55 p-2 text-xs text-amber-900 dark:border-amber-900/40 dark:bg-amber-950/20 dark:text-amber-100">
+          <ul className="list-disc space-y-1 pl-4 leading-5">
+            {item.warningCodes.map((code) => (
+              <li key={code}>{getBatchExportWarningText(t, code)}</li>
+            ))}
+          </ul>
+          {item.assessment ? (
+            <ManagedSiteChannelAssessmentSignalsRow
+              assessment={item.assessment}
+              managedSiteType={siteType}
+            />
+          ) : null}
+        </div>
+      ) : null}
+
+      {item.blockingReasonCode ? (
+        <div className="rounded-md bg-red-50 p-2 text-xs text-red-700 dark:bg-red-950/30 dark:text-red-300">
+          {getBatchExportBlockedReasonText(t, item.blockingReasonCode) ??
+            t(
+              "keyManagement:batchManagedSiteExport.blockedReasons.inputPreparationFailed",
+            )}
+          {item.blockingMessage ? `: ${item.blockingMessage}` : ""}
+        </div>
+      ) : null}
+
+      {result?.error ? (
+        <div className="rounded-md bg-red-50 p-2 text-xs text-red-700 dark:bg-red-950/30 dark:text-red-300">
+          {getBatchExportExecutionErrorText(t, result.error)}
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/src/features/KeyManagement/components/ManagedSiteTokenBatchExportDialog/ManagedSiteTokenBatchExportStatusPanels.tsx
+++ b/src/features/KeyManagement/components/ManagedSiteTokenBatchExportDialog/ManagedSiteTokenBatchExportStatusPanels.tsx
@@ -1,0 +1,66 @@
+import type { TFunction } from "i18next"
+import { Loader2, RefreshCcw } from "lucide-react"
+
+import { Button } from "~/components/ui"
+
+interface ManagedSiteTokenBatchExportStatusPanelsProps {
+  t: TFunction
+  previewError: string | null
+  executionError: string | null
+  isLoadingPreview: boolean
+  isRunning: boolean
+  onRefreshPreview: () => void
+}
+
+/**
+ * Renders preview loading, preview failure, and execution failure panels.
+ */
+export function ManagedSiteTokenBatchExportStatusPanels({
+  t,
+  previewError,
+  executionError,
+  isLoadingPreview,
+  isRunning,
+  onRefreshPreview,
+}: ManagedSiteTokenBatchExportStatusPanelsProps) {
+  return (
+    <>
+      {previewError ? (
+        <div className="space-y-2 rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:border-red-900/40 dark:bg-red-950/30 dark:text-red-300">
+          <div>
+            {t("keyManagement:batchManagedSiteExport.preview.loadFailed", {
+              error: previewError,
+            })}
+          </div>
+          <Button
+            type="button"
+            size="sm"
+            variant="outline"
+            leftIcon={<RefreshCcw className="h-4 w-4" />}
+            disabled={isLoadingPreview || isRunning}
+            onClick={onRefreshPreview}
+          >
+            {t("keyManagement:batchManagedSiteExport.actions.refreshPreview")}
+          </Button>
+        </div>
+      ) : null}
+
+      {executionError ? (
+        <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:border-red-900/40 dark:bg-red-950/30 dark:text-red-300">
+          {t("keyManagement:batchManagedSiteExport.messages.executionFailed", {
+            error: executionError,
+          })}
+        </div>
+      ) : null}
+
+      {isLoadingPreview ? (
+        <div className="text-muted-foreground rounded-md border p-3 text-sm">
+          <div className="flex items-center gap-2">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            {t("keyManagement:batchManagedSiteExport.preview.loading")}
+          </div>
+        </div>
+      ) : null}
+    </>
+  )
+}

--- a/src/features/KeyManagement/components/ManagedSiteTokenBatchExportDialog/batchExportDialogText.ts
+++ b/src/features/KeyManagement/components/ManagedSiteTokenBatchExportDialog/batchExportDialogText.ts
@@ -1,0 +1,130 @@
+import type { TFunction } from "i18next"
+
+import type { ManagedSiteTokenBatchExportPreviewItem } from "~/types/managedSiteTokenBatchExport"
+import {
+  MANAGED_SITE_TOKEN_BATCH_EXPORT_BLOCKED_REASON_CODES,
+  MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES,
+  MANAGED_SITE_TOKEN_BATCH_EXPORT_WARNING_CODES,
+} from "~/types/managedSiteTokenBatchExport"
+
+export type BatchExportBadgeVariant =
+  | "success"
+  | "warning"
+  | "secondary"
+  | "danger"
+
+export const formatBatchExportValues = (items: string[] | undefined) =>
+  items && items.length > 0 ? items.join(", ") : "-"
+
+export const getBatchExportWarningText = (t: TFunction, code: string) => {
+  switch (code) {
+    case MANAGED_SITE_TOKEN_BATCH_EXPORT_WARNING_CODES.MODEL_PREFILL_FAILED:
+      return t(
+        "keyManagement:batchManagedSiteExport.warnings.modelPrefillFailed",
+      )
+    case MANAGED_SITE_TOKEN_BATCH_EXPORT_WARNING_CODES.MATCH_REQUIRES_CONFIRMATION:
+      return t(
+        "keyManagement:batchManagedSiteExport.warnings.matchRequiresConfirmation",
+      )
+    case MANAGED_SITE_TOKEN_BATCH_EXPORT_WARNING_CODES.EXACT_VERIFICATION_UNAVAILABLE:
+      return t(
+        "keyManagement:batchManagedSiteExport.warnings.exactVerificationUnavailable",
+      )
+    case MANAGED_SITE_TOKEN_BATCH_EXPORT_WARNING_CODES.BACKEND_SEARCH_FAILED:
+      return t(
+        "keyManagement:batchManagedSiteExport.warnings.backendSearchFailed",
+      )
+    case MANAGED_SITE_TOKEN_BATCH_EXPORT_WARNING_CODES.DEDUPE_UNSUPPORTED:
+    default:
+      return t(
+        "keyManagement:batchManagedSiteExport.warnings.dedupeUnsupported",
+      )
+  }
+}
+
+export const getBatchExportBlockedReasonText = (
+  t: TFunction,
+  code?: string | null | undefined,
+) => {
+  switch (code) {
+    case MANAGED_SITE_TOKEN_BATCH_EXPORT_BLOCKED_REASON_CODES.CONFIG_MISSING:
+      return t(
+        "keyManagement:batchManagedSiteExport.blockedReasons.configMissing",
+      )
+    case MANAGED_SITE_TOKEN_BATCH_EXPORT_BLOCKED_REASON_CODES.SECRET_RESOLUTION_FAILED:
+      return t(
+        "keyManagement:batchManagedSiteExport.blockedReasons.secretResolutionFailed",
+      )
+    case MANAGED_SITE_TOKEN_BATCH_EXPORT_BLOCKED_REASON_CODES.NAME_REQUIRED:
+      return t(
+        "keyManagement:batchManagedSiteExport.blockedReasons.nameRequired",
+      )
+    case MANAGED_SITE_TOKEN_BATCH_EXPORT_BLOCKED_REASON_CODES.KEY_REQUIRED:
+      return t(
+        "keyManagement:batchManagedSiteExport.blockedReasons.keyRequired",
+      )
+    case MANAGED_SITE_TOKEN_BATCH_EXPORT_BLOCKED_REASON_CODES.REAL_KEY_REQUIRED:
+      return t(
+        "keyManagement:batchManagedSiteExport.blockedReasons.realKeyRequired",
+      )
+    case MANAGED_SITE_TOKEN_BATCH_EXPORT_BLOCKED_REASON_CODES.BASE_URL_REQUIRED:
+      return t(
+        "keyManagement:batchManagedSiteExport.blockedReasons.baseUrlRequired",
+      )
+    case MANAGED_SITE_TOKEN_BATCH_EXPORT_BLOCKED_REASON_CODES.MODELS_REQUIRED:
+      return t(
+        "keyManagement:batchManagedSiteExport.blockedReasons.modelsRequired",
+      )
+    case MANAGED_SITE_TOKEN_BATCH_EXPORT_BLOCKED_REASON_CODES.INPUT_PREPARATION_FAILED:
+      return t(
+        "keyManagement:batchManagedSiteExport.blockedReasons.inputPreparationFailed",
+      )
+    default:
+      return null
+  }
+}
+
+export const getBatchExportExecutionErrorText = (
+  t: TFunction,
+  error?: string | null,
+) => {
+  const blockedReasonText = getBatchExportBlockedReasonText(t, error)
+  if (blockedReasonText) {
+    return blockedReasonText
+  }
+
+  const trimmedError = error?.trim()
+  return (
+    trimmedError ||
+    t("keyManagement:batchManagedSiteExport.results.channelCreationFailed")
+  )
+}
+
+export const getBatchExportStatusBadge = (
+  t: TFunction,
+  item: ManagedSiteTokenBatchExportPreviewItem,
+): { label: string; variant: BatchExportBadgeVariant } => {
+  switch (item.status) {
+    case MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.READY:
+      return {
+        label: t("keyManagement:batchManagedSiteExport.status.ready"),
+        variant: "success",
+      }
+    case MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.WARNING:
+      return {
+        label: t("keyManagement:batchManagedSiteExport.status.warning"),
+        variant: "warning",
+      }
+    case MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.SKIPPED:
+      return {
+        label: t("keyManagement:batchManagedSiteExport.status.skipped"),
+        variant: "secondary",
+      }
+    case MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.BLOCKED:
+    default:
+      return {
+        label: t("keyManagement:batchManagedSiteExport.status.blocked"),
+        variant: "danger",
+      }
+  }
+}

--- a/src/features/KeyManagement/components/ManagedSiteTokenBatchExportDialog/useManagedSiteTokenBatchExportDialog.ts
+++ b/src/features/KeyManagement/components/ManagedSiteTokenBatchExportDialog/useManagedSiteTokenBatchExportDialog.ts
@@ -1,0 +1,520 @@
+import type { TFunction } from "i18next"
+import { useEffect, useMemo, useRef, useState } from "react"
+import toast from "react-hot-toast"
+
+import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
+import { loadNewApiChannelKeyWithVerification } from "~/features/ManagedSiteVerification/loadNewApiChannelKeyWithVerification"
+import {
+  NEW_API_MANAGED_VERIFICATION_CLOSE_MODES,
+  useNewApiManagedVerification,
+} from "~/features/ManagedSiteVerification/useNewApiManagedVerification"
+import {
+  executeManagedSiteTokenBatchExport,
+  prepareManagedSiteTokenBatchExportPreview,
+} from "~/services/managedSites/tokenBatchExport"
+import {
+  trackProductAnalyticsActionCompleted,
+  trackProductAnalyticsActionStarted,
+} from "~/services/productAnalytics/actions"
+import {
+  PRODUCT_ANALYTICS_ACTION_IDS,
+  PRODUCT_ANALYTICS_ENTRYPOINTS,
+  PRODUCT_ANALYTICS_ERROR_CATEGORIES,
+  PRODUCT_ANALYTICS_FEATURE_IDS,
+  PRODUCT_ANALYTICS_RESULTS,
+} from "~/services/productAnalytics/contracts"
+import type {
+  ManagedSiteTokenBatchExportExecutionResult,
+  ManagedSiteTokenBatchExportItemInput,
+  ManagedSiteTokenBatchExportMatchedChannel,
+  ManagedSiteTokenBatchExportPreview,
+  ManagedSiteTokenBatchExportPreviewItem,
+} from "~/types/managedSiteTokenBatchExport"
+import {
+  isExecutableManagedSiteTokenBatchExportPreviewItem as isExecutablePreviewItem,
+  MANAGED_SITE_TOKEN_BATCH_EXPORT_BLOCKED_REASON_CODES,
+  MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES,
+} from "~/types/managedSiteTokenBatchExport"
+import { getErrorMessage } from "~/utils/core/error"
+
+import {
+  applyNormalizedModelsToPreviewItem,
+  applyResolvedChannelKeyToPreviewItem,
+  countPreviewItems,
+  getPreviewVerificationTargets,
+  normalizeModels,
+  shouldSelectPreviewItemByDefault,
+  toModelOptions,
+} from "../managedSiteTokenBatchExportPreview"
+
+export interface ManagedSiteTokenBatchExportDialogProps {
+  isOpen: boolean
+  onClose: () => void
+  items: ManagedSiteTokenBatchExportItemInput[]
+  onCompleted?: (result: ManagedSiteTokenBatchExportExecutionResult) => void
+}
+
+interface UseManagedSiteTokenBatchExportDialogParams
+  extends ManagedSiteTokenBatchExportDialogProps {
+  t: TFunction
+}
+
+const getBatchExportAnalyticsContext = () => ({
+  featureId: PRODUCT_ANALYTICS_FEATURE_IDS.ManagedSiteChannels,
+  actionId: PRODUCT_ANALYTICS_ACTION_IDS.ExportManagedSiteTokenChannels,
+  entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Options,
+})
+
+/**
+ * Builds the workflow state and view actions for the token batch export dialog.
+ */
+export function useManagedSiteTokenBatchExportDialog({
+  isOpen,
+  onClose,
+  items,
+  onCompleted,
+  t,
+}: UseManagedSiteTokenBatchExportDialogParams) {
+  const {
+    newApiBaseUrl,
+    newApiUserId,
+    newApiUsername,
+    newApiPassword,
+    newApiTotpSecret,
+  } = useUserPreferencesContext()
+  const verification = useNewApiManagedVerification()
+  const [preview, setPreview] =
+    useState<ManagedSiteTokenBatchExportPreview | null>(null)
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
+  const [isLoadingPreview, setIsLoadingPreview] = useState(false)
+  const [previewError, setPreviewError] = useState<string | null>(null)
+  const [executionError, setExecutionError] = useState<string | null>(null)
+  const [isConfirmOpen, setIsConfirmOpen] = useState(false)
+  const [isRunning, setIsRunning] = useState(false)
+  const [executionResult, setExecutionResult] =
+    useState<ManagedSiteTokenBatchExportExecutionResult | null>(null)
+  const [refreshKey, setRefreshKey] = useState(0)
+  const [verifyingItemId, setVerifyingItemId] = useState<string | null>(null)
+  const resolvedChannelKeysByItemIdRef = useRef<
+    Record<string, Record<number, string>>
+  >({})
+  const latestItemsRef = useRef(items)
+  const openedItemsRef = useRef(items)
+  const wasOpenRef = useRef(false)
+
+  latestItemsRef.current = items
+
+  useEffect(() => {
+    if (!isOpen) {
+      setPreview(null)
+      setSelectedIds(new Set())
+      setIsLoadingPreview(false)
+      setPreviewError(null)
+      setExecutionError(null)
+      setIsConfirmOpen(false)
+      setIsRunning(false)
+      setExecutionResult(null)
+      setRefreshKey(0)
+      setVerifyingItemId(null)
+      wasOpenRef.current = false
+      resolvedChannelKeysByItemIdRef.current = {}
+      return
+    }
+
+    if (!wasOpenRef.current) {
+      openedItemsRef.current = latestItemsRef.current
+      wasOpenRef.current = true
+    }
+
+    let cancelled = false
+    setPreview(null)
+    setSelectedIds(new Set())
+    setPreviewError(null)
+    setExecutionError(null)
+    setExecutionResult(null)
+    setIsLoadingPreview(true)
+
+    void (async () => {
+      try {
+        const nextPreview = await prepareManagedSiteTokenBatchExportPreview({
+          items: openedItemsRef.current,
+          resolvedChannelKeysByItemId: resolvedChannelKeysByItemIdRef.current,
+        })
+        if (cancelled) return
+        setPreview(nextPreview)
+        setSelectedIds(
+          new Set(
+            nextPreview.items
+              .filter(shouldSelectPreviewItemByDefault)
+              .map((item) => item.id),
+          ),
+        )
+      } catch (error) {
+        if (cancelled) return
+        setPreviewError(getErrorMessage(error))
+      } finally {
+        if (!cancelled) {
+          setIsLoadingPreview(false)
+        }
+      }
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  }, [isOpen, refreshKey])
+
+  const executableItems = useMemo(
+    () => preview?.items.filter(isExecutablePreviewItem) ?? [],
+    [preview],
+  )
+  const selectedExecutableCount = executableItems.filter((item) =>
+    selectedIds.has(item.id),
+  ).length
+  const allExecutableSelected =
+    executableItems.length > 0 &&
+    selectedExecutableCount === executableItems.length
+  const executableSelectionChecked: boolean | "indeterminate" =
+    selectedExecutableCount === 0
+      ? false
+      : selectedExecutableCount === executableItems.length
+        ? true
+        : "indeterminate"
+
+  const selectedExecutionIds = useMemo(
+    () => Array.from(selectedIds),
+    [selectedIds],
+  )
+  const modelOptions = useMemo(
+    () =>
+      toModelOptions(
+        normalizeModels(
+          preview?.items.flatMap((item) => item.draft?.models ?? []) ?? [],
+        ),
+      ),
+    [preview],
+  )
+
+  const handleClose = () => {
+    if (isRunning) return
+    if (verification.dialogState.isOpen) {
+      verification.closeDialog()
+    }
+    onClose()
+  }
+
+  const handleRefreshPreview = () => {
+    if (isLoadingPreview || isRunning) return
+    setExecutionError(null)
+    setRefreshKey((value) => value + 1)
+  }
+
+  const mergeResolvedChannelKeyForItem = (
+    itemId: string,
+    channelId: number,
+    key: string,
+  ) => {
+    resolvedChannelKeysByItemIdRef.current = {
+      ...resolvedChannelKeysByItemIdRef.current,
+      [itemId]: {
+        ...(resolvedChannelKeysByItemIdRef.current[itemId] ?? {}),
+        [channelId]: key,
+      },
+    }
+  }
+
+  const applyResolvedChannelKeyForItem = (
+    item: ManagedSiteTokenBatchExportPreviewItem,
+    candidate: ManagedSiteTokenBatchExportMatchedChannel,
+    resolvedKey: string,
+  ) => {
+    setPreview((currentPreview) => {
+      if (!currentPreview) return currentPreview
+
+      const nextItems = currentPreview.items.map((previewItem) =>
+        previewItem.id === item.id
+          ? applyResolvedChannelKeyToPreviewItem({
+              item: previewItem,
+              candidate,
+              resolvedKey,
+              siteType: currentPreview.siteType,
+            })
+          : previewItem,
+      )
+
+      return {
+        ...currentPreview,
+        items: nextItems,
+        ...countPreviewItems(nextItems),
+      }
+    })
+    setSelectedIds((currentSelectedIds) => {
+      const nextSelectedIds = new Set(currentSelectedIds)
+      const updatedItem = applyResolvedChannelKeyToPreviewItem({
+        item,
+        candidate,
+        resolvedKey,
+        siteType: preview?.siteType,
+      })
+
+      if (
+        updatedItem.status ===
+        MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.SKIPPED
+      ) {
+        nextSelectedIds.delete(item.id)
+      }
+
+      return nextSelectedIds
+    })
+  }
+
+  const handleVerifyAndRefresh = async (
+    requestedItem: ManagedSiteTokenBatchExportPreviewItem,
+    requestedCandidate: ManagedSiteTokenBatchExportMatchedChannel,
+  ) => {
+    if (
+      verifyingItemId ||
+      verification.dialogState.isOpen ||
+      isLoadingPreview ||
+      isRunning
+    ) {
+      return
+    }
+
+    const verificationTargets = preview
+      ? getPreviewVerificationTargets(preview)
+      : []
+    const targets =
+      verificationTargets.length > 0
+        ? verificationTargets
+        : [{ item: requestedItem, candidate: requestedCandidate }]
+    const failureMessages: string[] = []
+
+    setExecutionError(null)
+
+    const verifyTargetsFromIndex = async (startIndex: number) => {
+      for (let index = startIndex; index < targets.length; index += 1) {
+        const { item, candidate } = targets[index]
+        let resolvedChannelKey = ""
+        let shouldContinueAfterDeferredLoad = false
+        let loadCompleted = false
+
+        setVerifyingItemId(item.id)
+
+        const handleLoaded = async () => {
+          loadCompleted = true
+          if (resolvedChannelKey) {
+            mergeResolvedChannelKeyForItem(
+              item.id,
+              candidate.id,
+              resolvedChannelKey,
+            )
+            applyResolvedChannelKeyForItem(item, candidate, resolvedChannelKey)
+          }
+          setExecutionError(null)
+          if (shouldContinueAfterDeferredLoad) {
+            await verifyTargetsFromIndex(index + 1)
+          }
+        }
+
+        try {
+          const loadedImmediately = await loadNewApiChannelKeyWithVerification({
+            channelId: candidate.id,
+            label: candidate.name,
+            requestKind: "channel",
+            config: {
+              baseUrl: newApiBaseUrl,
+              userId: newApiUserId,
+              username: newApiUsername,
+              password: newApiPassword,
+              totpSecret: newApiTotpSecret,
+            },
+            setKey: (key) => {
+              resolvedChannelKey = key
+            },
+            onLoaded: handleLoaded,
+            openVerification: (request) =>
+              verification.openNewApiManagedVerification({
+                ...request,
+                closeMode:
+                  NEW_API_MANAGED_VERIFICATION_CLOSE_MODES.CLOSE_AFTER_VERIFICATION,
+              }),
+          })
+
+          if (!loadedImmediately) {
+            if (!loadCompleted) {
+              shouldContinueAfterDeferredLoad = true
+              setVerifyingItemId(null)
+              return
+            }
+          }
+        } catch (error) {
+          failureMessages.push(getErrorMessage(error))
+        }
+      }
+
+      setVerifyingItemId(null)
+      if (failureMessages.length > 0) {
+        setExecutionError(
+          t(
+            "keyManagement:batchManagedSiteExport.messages.verificationFailed",
+            {
+              error: failureMessages.join("; "),
+            },
+          ),
+        )
+      }
+    }
+
+    try {
+      await verifyTargetsFromIndex(0)
+    } catch (error) {
+      setVerifyingItemId(null)
+      setExecutionError(
+        t("keyManagement:batchManagedSiteExport.messages.verificationFailed", {
+          error: getErrorMessage(error),
+        }),
+      )
+    }
+  }
+
+  const handleToggleAll = () => {
+    if (!preview || executionResult) return
+    setSelectedIds(
+      allExecutableSelected
+        ? new Set()
+        : new Set(executableItems.map((item) => item.id)),
+    )
+  }
+
+  const handleToggleItem = (item: ManagedSiteTokenBatchExportPreviewItem) => {
+    if (!isExecutablePreviewItem(item) || executionResult) return
+    setSelectedIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(item.id)) {
+        next.delete(item.id)
+      } else {
+        next.add(item.id)
+      }
+      return next
+    })
+  }
+
+  const handleItemModelsChange = (
+    item: ManagedSiteTokenBatchExportPreviewItem,
+    models: string[],
+  ) => {
+    if (!item.draft || executionResult || isRunning) return
+
+    const normalizedModels = normalizeModels(models)
+
+    setPreview((currentPreview) => {
+      if (!currentPreview) return currentPreview
+
+      const nextItems = currentPreview.items.map((previewItem) =>
+        previewItem.id === item.id && previewItem.draft
+          ? applyNormalizedModelsToPreviewItem(previewItem, normalizedModels)
+          : previewItem,
+      )
+
+      return {
+        ...currentPreview,
+        items: nextItems,
+        ...countPreviewItems(nextItems),
+      }
+    })
+
+    setSelectedIds((currentSelectedIds) => {
+      const nextSelectedIds = new Set(currentSelectedIds)
+      if (normalizedModels.length === 0) {
+        nextSelectedIds.delete(item.id)
+      } else if (
+        item.status ===
+          MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.BLOCKED &&
+        item.blockingReasonCode ===
+          MANAGED_SITE_TOKEN_BATCH_EXPORT_BLOCKED_REASON_CODES.MODELS_REQUIRED
+      ) {
+        nextSelectedIds.add(item.id)
+      }
+      return nextSelectedIds
+    })
+  }
+
+  const handleConfirm = async () => {
+    if (!preview || selectedExecutionIds.length === 0) return
+
+    setIsConfirmOpen(false)
+    setIsRunning(true)
+    setExecutionError(null)
+    const analyticsContext = getBatchExportAnalyticsContext()
+    void trackProductAnalyticsActionStarted(analyticsContext)
+    try {
+      const result = await executeManagedSiteTokenBatchExport({
+        preview,
+        selectedItemIds: selectedExecutionIds,
+      })
+      void trackProductAnalyticsActionCompleted({
+        ...analyticsContext,
+        result: PRODUCT_ANALYTICS_RESULTS.Success,
+        insights: {
+          selectedCount: result.totalSelected,
+          itemCount: result.attemptedCount,
+          successCount: result.createdCount,
+          failureCount: result.failedCount,
+        },
+      })
+      setExecutionResult(result)
+      onCompleted?.(result)
+      toast.success(
+        t("keyManagement:batchManagedSiteExport.messages.completed", {
+          created: result.createdCount,
+          failed: result.failedCount,
+          skipped: result.skippedCount,
+        }),
+      )
+    } catch (error) {
+      void trackProductAnalyticsActionCompleted({
+        ...analyticsContext,
+        result: PRODUCT_ANALYTICS_RESULTS.Failure,
+        errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
+        insights: {
+          selectedCount: selectedExecutionIds.length,
+          itemCount: selectedExecutionIds.length,
+        },
+      })
+      setExecutionError(getErrorMessage(error))
+    } finally {
+      setIsRunning(false)
+    }
+  }
+
+  return {
+    preview,
+    selectedIds,
+    modelOptions,
+    previewError,
+    executionError,
+    isLoadingPreview,
+    isRunning,
+    executionResult,
+    isConfirmOpen,
+    verifyingItemId,
+    verification,
+    executableSelection: {
+      checked: executableSelectionChecked,
+      itemCount: executableItems.length,
+      selectedCount: selectedExecutableCount,
+    },
+    actions: {
+      close: handleClose,
+      refreshPreview: handleRefreshPreview,
+      toggleAll: handleToggleAll,
+      toggleItem: handleToggleItem,
+      changeItemModels: handleItemModelsChange,
+      verifyAndRefresh: handleVerifyAndRefresh,
+      openConfirm: () => setIsConfirmOpen(true),
+      closeConfirm: () => setIsConfirmOpen(false),
+      confirm: handleConfirm,
+    },
+  }
+}

--- a/src/features/KeyManagement/components/ManagedSiteTokenBatchExportDialog/useManagedSiteTokenBatchExportDialog.ts
+++ b/src/features/KeyManagement/components/ManagedSiteTokenBatchExportDialog/useManagedSiteTokenBatchExportDialog.ts
@@ -98,10 +98,12 @@ export function useManagedSiteTokenBatchExportDialog({
   const resolvedChannelKeysByItemIdRef = useRef<
     Record<string, Record<number, string>>
   >({})
+  const previewRef = useRef<ManagedSiteTokenBatchExportPreview | null>(null)
   const latestItemsRef = useRef(items)
   const openedItemsRef = useRef(items)
   const wasOpenRef = useRef(false)
 
+  previewRef.current = preview
   latestItemsRef.current = items
 
   useEffect(() => {
@@ -251,11 +253,15 @@ export function useManagedSiteTokenBatchExportDialog({
     })
     setSelectedIds((currentSelectedIds) => {
       const nextSelectedIds = new Set(currentSelectedIds)
+      const currentPreviewItem =
+        previewRef.current?.items.find(
+          (previewItem) => previewItem.id === item.id,
+        ) ?? item
       const updatedItem = applyResolvedChannelKeyToPreviewItem({
-        item,
+        item: currentPreviewItem,
         candidate,
         resolvedKey,
-        siteType: preview?.siteType,
+        siteType: previewRef.current?.siteType,
       })
 
       if (

--- a/src/features/KeyManagement/components/ManagedSiteTokenBatchExportDialog/useManagedSiteTokenBatchExportDialog.ts
+++ b/src/features/KeyManagement/components/ManagedSiteTokenBatchExportDialog/useManagedSiteTokenBatchExportDialog.ts
@@ -204,7 +204,8 @@ export function useManagedSiteTokenBatchExportDialog({
   }
 
   const handleRefreshPreview = () => {
-    if (isLoadingPreview || isRunning) return
+    if (isLoadingPreview || isRunning || verifyingItemId) return
+    if (verification.dialogState.isOpen) return
     setExecutionError(null)
     setRefreshKey((value) => value + 1)
   }
@@ -281,9 +282,7 @@ export function useManagedSiteTokenBatchExportDialog({
       return
     }
 
-    const verificationTargets = preview
-      ? getPreviewVerificationTargets(preview)
-      : []
+    const verificationTargets = getPreviewVerificationTargets(preview!)
     const targets =
       verificationTargets.length > 0
         ? verificationTargets
@@ -379,7 +378,7 @@ export function useManagedSiteTokenBatchExportDialog({
   }
 
   const handleToggleAll = () => {
-    if (!preview || executionResult) return
+    if (!preview || executionResult || isRunning) return
     setSelectedIds(
       allExecutableSelected
         ? new Set()
@@ -388,7 +387,7 @@ export function useManagedSiteTokenBatchExportDialog({
   }
 
   const handleToggleItem = (item: ManagedSiteTokenBatchExportPreviewItem) => {
-    if (!isExecutablePreviewItem(item) || executionResult) return
+    if (!isExecutablePreviewItem(item) || executionResult || isRunning) return
     setSelectedIds((prev) => {
       const next = new Set(prev)
       if (next.has(item.id)) {

--- a/src/features/KeyManagement/components/managedSiteTokenBatchExportPreview.ts
+++ b/src/features/KeyManagement/components/managedSiteTokenBatchExportPreview.ts
@@ -28,6 +28,55 @@ export const toModelOptions = (models: string[]) =>
 export const normalizeModels = (models: string[]) =>
   Array.from(new Set(models.map((model) => model.trim()).filter(Boolean)))
 
+export const applyNormalizedModelsToPreviewItem = (
+  item: ManagedSiteTokenBatchExportPreviewItem,
+  models: string[],
+): ManagedSiteTokenBatchExportPreviewItem => {
+  if (!item.draft) {
+    return item
+  }
+
+  if (models.length === 0) {
+    return {
+      ...item,
+      draft: {
+        ...item.draft,
+        models: [],
+      },
+      status: MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.BLOCKED,
+      blockingReasonCode:
+        MANAGED_SITE_TOKEN_BATCH_EXPORT_BLOCKED_REASON_CODES.MODELS_REQUIRED,
+    }
+  }
+
+  if (canEditItemModels(item) && !isExecutablePreviewItem(item)) {
+    return {
+      ...item,
+      draft: {
+        ...item.draft,
+        models,
+      },
+      status: MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.WARNING,
+      blockingReasonCode: undefined,
+      blockingMessage: undefined,
+    }
+  }
+
+  return {
+    ...item,
+    draft: {
+      ...item.draft,
+      models,
+    },
+  }
+}
+
+export const applyModelsToPreviewItem = (
+  item: ManagedSiteTokenBatchExportPreviewItem,
+  models: string[],
+): ManagedSiteTokenBatchExportPreviewItem =>
+  applyNormalizedModelsToPreviewItem(item, normalizeModels(models))
+
 const hasDuplicateRiskWarning = (
   item: ManagedSiteTokenBatchExportPreviewItem,
 ) =>

--- a/src/features/KeyManagement/components/managedSiteTokenBatchExportPreview.ts
+++ b/src/features/KeyManagement/components/managedSiteTokenBatchExportPreview.ts
@@ -46,6 +46,7 @@ export const applyNormalizedModelsToPreviewItem = (
       status: MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.BLOCKED,
       blockingReasonCode:
         MANAGED_SITE_TOKEN_BATCH_EXPORT_BLOCKED_REASON_CODES.MODELS_REQUIRED,
+      blockingMessage: undefined,
     }
   }
 

--- a/src/features/KeyManagement/testIds.ts
+++ b/src/features/KeyManagement/testIds.ts
@@ -12,6 +12,16 @@ export const KEY_MANAGEMENT_TEST_IDS = {
   tokenRowActions: "key-management-token-row-actions",
   managedSiteStatusBadge: "key-management-managed-site-status-badge",
   importToManagedSiteButton: "key-management-import-to-managed-site-button",
+  managedSiteBatchExportCancelButton:
+    "key-management-managed-site-batch-export-cancel-button",
+  managedSiteBatchExportCloseButton:
+    "key-management-managed-site-batch-export-close-button",
+  managedSiteBatchExportStartButton:
+    "key-management-managed-site-batch-export-start-button",
+  managedSiteBatchExportRowSelectCheckbox:
+    "key-management-managed-site-batch-export-row-select-checkbox",
+  managedSiteBatchExportVerifyButton:
+    "key-management-managed-site-batch-export-verify-button",
   managedSiteChannelLinkButton:
     "key-management-managed-site-channel-link-button",
   managedSiteVerificationRetryButton:

--- a/src/locales/en/keyManagement.json
+++ b/src/locales/en/keyManagement.json
@@ -98,7 +98,8 @@
     "preview": {
       "loadFailed": "Failed to load preview: {{error}}",
       "loading": "Preparing channel preview...",
-      "selected": "{{selectedCount}} keys selected",
+      "selected_one": "{{count}} key selected",
+      "selected_other": "{{count}} keys selected",
       "summary": "Preview: {{ready}} ready, {{warning}} warnings, {{skipped}} skipped, {{blocked}} blocked, {{total}} total."
     },
     "results": {

--- a/src/locales/es-419/keyManagement.json
+++ b/src/locales/es-419/keyManagement.json
@@ -101,7 +101,9 @@
     "preview": {
       "loadFailed": "No se pudo cargar la vista previa: {{error}}",
       "loading": "Preparando vista previa de canales...",
-      "selected": "{{selectedCount}} claves seleccionadas",
+      "selected_one": "{{count}} clave seleccionada",
+      "selected_many": "{{count}} claves seleccionadas",
+      "selected_other": "{{count}} claves seleccionadas",
       "summary": "Vista previa: {{ready}} listas, {{warning}} advertencias, {{skipped}} omitidas, {{blocked}} bloqueadas, {{total}} en total."
     },
     "results": {

--- a/src/locales/ja/keyManagement.json
+++ b/src/locales/ja/keyManagement.json
@@ -95,7 +95,7 @@
     "preview": {
       "loadFailed": "プレビューの読み込みに失敗しました: {{error}}",
       "loading": "チャネルプレビューを準備中...",
-      "selected": "{{selectedCount}} 件のキーを選択中",
+      "selected_other": "{{count}} 件のキーを選択中",
       "summary": "プレビュー: 作成可能 {{ready}} 件、警告 {{warning}} 件、スキップ {{skipped}} 件、ブロック {{blocked}} 件、合計 {{total}} 件。"
     },
     "results": {

--- a/src/locales/vi/keyManagement.json
+++ b/src/locales/vi/keyManagement.json
@@ -95,7 +95,7 @@
     "preview": {
       "loadFailed": "Tải bản xem trước thất bại: {{error}}",
       "loading": "Đang chuẩn bị xem trước kênh...",
-      "selected": "Đã chọn {{selectedCount}} khóa",
+      "selected_other": "Đã chọn {{count}} khóa",
       "summary": "Xem trước: Có thể tạo {{ready}}, cảnh báo {{warning}}, bỏ qua {{skipped}}, bị chặn {{blocked}}, tổng cộng {{total}}."
     },
     "results": {

--- a/src/locales/zh-CN/keyManagement.json
+++ b/src/locales/zh-CN/keyManagement.json
@@ -95,7 +95,7 @@
     "preview": {
       "loadFailed": "加载预览失败：{{error}}",
       "loading": "正在准备渠道预览...",
-      "selected": "已选择 {{selectedCount}} 个密钥",
+      "selected": "已选择 {{count}} 个密钥",
       "summary": "预览：可创建 {{ready}} 个，警告 {{warning}} 个，跳过 {{skipped}} 个，阻塞 {{blocked}} 个，共 {{total}} 个。"
     },
     "results": {

--- a/src/locales/zh-TW/keyManagement.json
+++ b/src/locales/zh-TW/keyManagement.json
@@ -95,7 +95,7 @@
     "preview": {
       "loadFailed": "載入預覽失敗：{{error}}",
       "loading": "正在準備渠道預覽...",
-      "selected": "已選擇 {{selectedCount}} 個金鑰",
+      "selected_other": "已選擇 {{count}} 個金鑰",
       "summary": "預覽：可建立 {{ready}} 個，警告 {{warning}} 個，跳過 {{skipped}} 個，阻擋 {{blocked}} 個，共 {{total}} 個。"
     },
     "results": {

--- a/tests/features/KeyManagement/components/ManagedSiteTokenBatchExportDialog.test.tsx
+++ b/tests/features/KeyManagement/components/ManagedSiteTokenBatchExportDialog.test.tsx
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { SITE_TYPES } from "~/constants/siteType"
 import { ManagedSiteTokenBatchExportDialog } from "~/features/KeyManagement/components/ManagedSiteTokenBatchExportDialog"
+import { ManagedSiteTokenBatchExportFooter } from "~/features/KeyManagement/components/ManagedSiteTokenBatchExportDialog/ManagedSiteTokenBatchExportFooter"
 import { NEW_API_MANAGED_VERIFICATION_CLOSE_MODES } from "~/features/ManagedSiteVerification/useNewApiManagedVerification"
 import { buildAccountTokenRuntimeKey } from "~/services/accounts/accountRuntimeKeys"
 import {
@@ -743,6 +744,80 @@ describe("ManagedSiteTokenBatchExportDialog", () => {
     ).toBeInTheDocument()
   })
 
+  it("passes count to the selected-key summary so i18next can pluralize it", () => {
+    const t = vi.fn((key: string) => key)
+
+    ManagedSiteTokenBatchExportFooter({
+      t: t as any,
+      selectedItemCount: 1,
+      preview: null,
+      previewError: null,
+      executionResult: null,
+      isLoadingPreview: false,
+      isRunning: false,
+      selectedExecutableCount: 0,
+      onClose: vi.fn(),
+      onStart: vi.fn(),
+    })
+
+    expect(t).toHaveBeenCalledWith(
+      "keyManagement:batchManagedSiteExport.preview.selected",
+      { count: 1 },
+    )
+  })
+
+  it("disables selection controls while an export is running", async () => {
+    const user = userEvent.setup()
+    let resolveExport:
+      | ((result: Awaited<ReturnType<typeof mockExecuteBatchExport>>) => void)
+      | undefined
+    mockPreparePreview.mockResolvedValue(preview)
+    mockExecuteBatchExport.mockReturnValue(
+      new Promise((resolve) => {
+        resolveExport = resolve
+      }),
+    )
+
+    renderDialog()
+
+    expect(await screen.findByText("Account 1 / Token 1")).toBeInTheDocument()
+    await user.click(
+      screen.getByRole("button", {
+        name: "keyManagement:batchManagedSiteExport.actions.start",
+      }),
+    )
+    await user.click(
+      screen.getAllByRole("button", {
+        name: "keyManagement:batchManagedSiteExport.actions.start",
+      })[1],
+    )
+
+    await waitFor(() => {
+      expect(mockExecuteBatchExport).toHaveBeenCalledTimes(1)
+    })
+    expect(
+      screen.getByRole("checkbox", {
+        name: "keyManagement:batchManagedSiteExport.actions.selectAll",
+      }),
+    ).toBeDisabled()
+    expect(
+      screen.getByRole("checkbox", {
+        name: "Account 1 / Token 1",
+      }),
+    ).toBeDisabled()
+
+    await act(async () => {
+      resolveExport?.({
+        totalSelected: 2,
+        attemptedCount: 2,
+        createdCount: 2,
+        failedCount: 0,
+        skippedCount: 0,
+        items: [],
+      })
+    })
+  })
+
   it("does not auto-select warning rows that need duplicate-risk confirmation", async () => {
     mockPreparePreview.mockResolvedValue(richPreview)
 
@@ -1017,6 +1092,20 @@ describe("ManagedSiteTokenBatchExportDialog", () => {
     )
 
     expect(mockLoadNewApiChannelKeyWithVerification).not.toHaveBeenCalled()
+  })
+
+  it("disables preview refresh while the verification dialog is open", async () => {
+    mockVerificationDialogState.isOpen = true
+    mockPreparePreview.mockResolvedValue(preview)
+
+    renderDialog()
+
+    expect(await screen.findByText("Account 1 / Token 1")).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", {
+        name: "keyManagement:batchManagedSiteExport.actions.refreshPreview",
+      }),
+    ).toBeDisabled()
   })
 
   it("falls back to the clicked item when the preview has no verification targets", async () => {

--- a/tests/features/KeyManagement/components/ManagedSiteTokenBatchExportDialog.test.tsx
+++ b/tests/features/KeyManagement/components/ManagedSiteTokenBatchExportDialog.test.tsx
@@ -624,6 +624,35 @@ describe("ManagedSiteTokenBatchExportDialog", () => {
     ).toBeNull()
   })
 
+  it("keeps the opened item batch stable across parent rerenders while open", async () => {
+    mockPreparePreview.mockResolvedValue(preview)
+
+    const { rerender } = render(
+      <ManagedSiteTokenBatchExportDialog
+        isOpen={true}
+        onClose={vi.fn()}
+        items={[{ account, runtimeKey }]}
+      />,
+    )
+
+    expect(await screen.findByText("Account 1 / Token 1")).toBeInTheDocument()
+    expect(mockPreparePreview).toHaveBeenCalledTimes(1)
+    mockPreparePreview.mockClear()
+
+    rerender(
+      <ManagedSiteTokenBatchExportDialog
+        isOpen={true}
+        onClose={vi.fn()}
+        items={[{ account, runtimeKey }]}
+      />,
+    )
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(mockPreparePreview).not.toHaveBeenCalled()
+  })
+
   it("executes selected preview rows and reports success", async () => {
     const user = userEvent.setup()
     mockPreparePreview.mockResolvedValue(preview)

--- a/tests/features/KeyManagement/components/ManagedSiteTokenBatchExportDialog.test.tsx
+++ b/tests/features/KeyManagement/components/ManagedSiteTokenBatchExportDialog.test.tsx
@@ -912,6 +912,95 @@ describe("ManagedSiteTokenBatchExportDialog", () => {
     expect(mockPreparePreview).toHaveBeenCalledTimes(1)
   })
 
+  it("removes verified skipped rows from execution selection using the current preview item", async () => {
+    const user = userEvent.setup()
+    mockLoadNewApiChannelKeyWithVerification.mockImplementation(
+      async (params) => {
+        await Promise.resolve(params.setKey("test-key"))
+        await Promise.resolve(params.onLoaded?.())
+        return true
+      },
+    )
+    const recoverableItem = buildRecoverablePreviewItem(preview.items[0], {
+      id: 7,
+      name: "Potential channel",
+    })
+    const staleVerificationTarget = {
+      ...recoverableItem,
+      assessment: undefined,
+    }
+    const recoverablePreview: ManagedSiteTokenBatchExportPreview = {
+      ...preview,
+      totalCount: 2,
+      readyCount: 1,
+      warningCount: 1,
+      skippedCount: 0,
+      blockedCount: 0,
+      items: [recoverableItem, preview.items[1]],
+    }
+    mockGetPreviewVerificationTargets.mockReturnValue([
+      {
+        item: staleVerificationTarget,
+        candidate: recoverableItem.verificationCandidate,
+      },
+    ])
+    mockPreparePreview.mockResolvedValueOnce(recoverablePreview)
+    mockExecuteBatchExport.mockResolvedValue({
+      totalSelected: 1,
+      attemptedCount: 1,
+      createdCount: 1,
+      failedCount: 0,
+      skippedCount: 1,
+      items: [
+        {
+          id: "account_token:account-1:2",
+          accountName: "Account 1",
+          runtimeKeyName: "Token 2",
+          success: true,
+          skipped: false,
+        },
+      ],
+    })
+
+    renderDialog()
+
+    expect(await screen.findByText("Account 1 / Token 1")).toBeInTheDocument()
+    await user.click(
+      screen.getByRole("checkbox", {
+        name: "Account 1 / Token 1",
+      }),
+    )
+    await user.click(
+      screen.getByRole("button", {
+        name: "keyManagement:batchManagedSiteExport.actions.verifyAndRefresh",
+      }),
+    )
+    await waitFor(() => {
+      expect(
+        screen.getByText("keyManagement:batchManagedSiteExport.status.skipped"),
+      ).toBeInTheDocument()
+    })
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "keyManagement:batchManagedSiteExport.actions.start",
+      }),
+    )
+    await user.click(
+      screen.getAllByRole("button", {
+        name: "keyManagement:batchManagedSiteExport.actions.start",
+      })[1],
+    )
+
+    await waitFor(() => {
+      expect(mockExecuteBatchExport).toHaveBeenCalledWith(
+        expect.objectContaining({
+          selectedItemIds: ["account_token:account-1:2"],
+        }),
+      )
+    })
+  })
+
   it("continues verifying remaining warning rows after two-step verification completes", async () => {
     const user = userEvent.setup()
     mockLoadNewApiChannelKeyWithVerification

--- a/tests/features/KeyManagement/components/managedSiteTokenBatchExportPreview.test.ts
+++ b/tests/features/KeyManagement/components/managedSiteTokenBatchExportPreview.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest"
 
 import { SITE_TYPES } from "~/constants/siteType"
 import {
+  applyModelsToPreviewItem,
   applyResolvedChannelKeyToPreviewItem,
   canEditItemModels,
   countPreviewItems,
@@ -112,6 +113,53 @@ describe("managedSiteTokenBatchExportPreview helpers", () => {
         }),
       ),
     ).toBe(true)
+  })
+
+  it("updates editable preview item models and normalizes duplicate values", () => {
+    expect(
+      applyModelsToPreviewItem(buildPreviewItem(), [
+        " gpt-4o-mini ",
+        "",
+        "gpt-4o-mini",
+      ]),
+    ).toMatchObject({
+      draft: {
+        models: ["gpt-4o-mini"],
+      },
+      status: MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.READY,
+    })
+  })
+
+  it("moves models-required blocked rows between blocked and warning states as models change", () => {
+    const item = buildPreviewItem({
+      status: MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.BLOCKED,
+      blockingReasonCode:
+        MANAGED_SITE_TOKEN_BATCH_EXPORT_BLOCKED_REASON_CODES.MODELS_REQUIRED,
+      blockingMessage: "models missing",
+      draft: {
+        ...buildPreviewItem().draft!,
+        models: [],
+      },
+    })
+
+    const unblocked = applyModelsToPreviewItem(item, ["gpt-4o-mini"])
+    expect(unblocked).toMatchObject({
+      status: MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.WARNING,
+      blockingReasonCode: undefined,
+      blockingMessage: undefined,
+      draft: {
+        models: ["gpt-4o-mini"],
+      },
+    })
+
+    expect(applyModelsToPreviewItem(unblocked, [])).toMatchObject({
+      status: MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.BLOCKED,
+      blockingReasonCode:
+        MANAGED_SITE_TOKEN_BATCH_EXPORT_BLOCKED_REASON_CODES.MODELS_REQUIRED,
+      draft: {
+        models: [],
+      },
+    })
   })
 
   it("counts preview items by status", () => {

--- a/tests/features/KeyManagement/components/managedSiteTokenBatchExportPreview.test.ts
+++ b/tests/features/KeyManagement/components/managedSiteTokenBatchExportPreview.test.ts
@@ -130,6 +130,14 @@ describe("managedSiteTokenBatchExportPreview helpers", () => {
     })
   })
 
+  it("leaves rows without editable drafts unchanged when applying models", () => {
+    const item = buildPreviewItem({
+      draft: null,
+    })
+
+    expect(applyModelsToPreviewItem(item, ["gpt-4o-mini"])).toBe(item)
+  })
+
   it("moves models-required blocked rows between blocked and warning states as models change", () => {
     const item = buildPreviewItem({
       status: MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.BLOCKED,
@@ -156,6 +164,26 @@ describe("managedSiteTokenBatchExportPreview helpers", () => {
       status: MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.BLOCKED,
       blockingReasonCode:
         MANAGED_SITE_TOKEN_BATCH_EXPORT_BLOCKED_REASON_CODES.MODELS_REQUIRED,
+      blockingMessage: undefined,
+      draft: {
+        models: [],
+      },
+    })
+  })
+
+  it("clears stale blocking details when an edited row becomes models-required again", () => {
+    const item = buildPreviewItem({
+      status: MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.BLOCKED,
+      blockingReasonCode:
+        MANAGED_SITE_TOKEN_BATCH_EXPORT_BLOCKED_REASON_CODES.CONFIG_MISSING,
+      blockingMessage: "previous configuration detail",
+    })
+
+    expect(applyModelsToPreviewItem(item, [])).toMatchObject({
+      status: MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES.BLOCKED,
+      blockingReasonCode:
+        MANAGED_SITE_TOKEN_BATCH_EXPORT_BLOCKED_REASON_CODES.MODELS_REQUIRED,
+      blockingMessage: undefined,
       draft: {
         models: [],
       },


### PR DESCRIPTION
## Summary
- Split ManagedSiteTokenBatchExportDialog into a view-model hook and focused presentational components
- Move dialog text/status mapping into local helpers
- Extract model-edit preview transitions into tested preview helpers

## Validation
- pnpm vitest run tests/features/KeyManagement/components/ManagedSiteTokenBatchExportDialog.test.tsx tests/features/KeyManagement/components/managedSiteTokenBatchExportPreview.test.ts tests/entrypoints/options/pages/KeyManagement/TokenList.batchExport.test.tsx
- pnpm run validate:staged
- pnpm run validate:push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked the managed site token batch export dialog into dedicated preview, status, footer, and row components.
  * Centralized dialog state (preview loading, selection, verification progress, and execution flow) for more consistent button enablement.
  * Improved preview editing behavior and display of warnings/blocking reasons and execution outcomes.
* **Localization**
  * Updated the “keys selected” preview text to use pluralized variants across supported languages.
* **Tests**
  * Added coverage for dialog stability, pluralization inputs, disabled controls during execution, and selection cleanup after verification.
* **Chores**
  * Added additional test identifiers for the batch export flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->