### PR TITLE
test(e2e): split real-site flows and cover external stubs

### DIFF
--- a/e2e/changelogOnUpdate.spec.ts
+++ b/e2e/changelogOnUpdate.spec.ts
@@ -41,7 +41,7 @@ async function findPageWithUpdateLogDialog(
  */
 async function waitForUpdateLogDialogPage(
   context: BrowserContext,
-  timeoutMs = 60_000,
+  timeoutMs = 30_000,
 ): Promise<Page> {
   const start = Date.now()
   while (Date.now() - start < timeoutMs) {
@@ -129,7 +129,7 @@ test("shows update log inline once on first UI open after update", async ({
     timeout: 30_000,
   })
 
-  const dialogPage = await waitForUpdateLogDialogPage(context, 60_000)
+  const dialogPage = await waitForUpdateLogDialogPage(context)
   await expect(dialogPage.locator(UPDATE_LOG_DIALOG_SELECTOR)).toBeVisible()
 
   await expect
@@ -233,7 +233,7 @@ test("shows update log inline in popup once on first UI open after update", asyn
 
   await page.goto(`chrome-extension://${extensionId}/${POPUP_PAGE_PATH}`)
 
-  const dialogPage = await waitForUpdateLogDialogPage(context, 60_000)
+  const dialogPage = await waitForUpdateLogDialogPage(context)
   await expect(dialogPage.locator(UPDATE_LOG_DIALOG_SELECTOR)).toBeVisible()
 
   await expect

--- a/e2e/realSite/doneHubAccountAdd.spec.ts
+++ b/e2e/realSite/doneHubAccountAdd.spec.ts
@@ -18,84 +18,86 @@ import {
 } from "~~/e2e/utils/realSite/doneHub"
 
 test.describe("real-site E2E: DoneHub account add flow", () => {
-  test.setTimeout(180_000)
-
   test.beforeEach(async ({ context, page }) => {
     await forceExtensionLanguage(page, "en")
     await stubLlmMetadataIndex(context)
   })
 
-  test("logs into a real DoneHub site, saves the account, then verifies account usage workflows", async ({
-    context,
-    extensionId,
-    page,
-  }, testInfo) => {
-    const realSite = resolveDoneHubRealSiteConfig()
-    test.skip(
-      !realSite.config,
-      getDoneHubRealSiteSkipReason(realSite.missingEnvKeys),
-    )
-
-    const config = realSite.config!
-    const serviceWorker = await getServiceWorker(context)
-
-    await seedUserPreferences(serviceWorker, {
-      managedSiteType: SITE_TYPES.DONE_HUB,
-      autoFillCurrentSiteUrlOnAccountAdd: false,
-      autoProvisionKeyOnAccountAdd: false,
-      openChangelogOnUpdate: false,
-    })
-
-    const accountFixture =
-      await test.step("save account from real site auto-detect", async () => {
-        const sitePage = await context.newPage()
-        try {
-          return await runCompatibleRealSiteAccountSaveFlow({
-            page,
-            extensionId,
-            serviceWorker,
-            sitePage,
-            config,
-            siteType: SITE_TYPES.DONE_HUB,
-            expectedDetectedSiteType: SITE_TYPES.DONE_HUB,
-            login: loginToRealDoneHubSite,
-          })
-        } finally {
-          if (!sitePage.isClosed()) {
-            await sitePage.close()
-          }
-        }
-      })
-    await runRealSiteAccountFixtureUsageChecks(
-      {
-        testInfo,
-        page,
-        extensionId,
-        serviceWorker,
-        account: accountFixture,
-        label: "DoneHub",
+  const usageChecks = [
+    realSiteAccountUsageChecks.keyLifecycle(),
+    realSiteAccountUsageChecks.keyToApiProfileAndPopupModels({
+      popupModelsProbe: {
+        expectedStatus: "fail",
+        expectedSummaryText: "No models returned",
       },
-      [
-        realSiteAccountUsageChecks.keyLifecycle(),
-        realSiteAccountUsageChecks.keyToApiProfileAndPopupModels({
-          popupModelsProbe: {
-            expectedStatus: "fail",
-            expectedSummaryText: "No models returned",
-          },
-        }),
-        realSiteAccountUsageChecks.providerDestinations({
-          validateDestinationPages: true,
-        }),
-        realSiteAccountUsageChecks.modelCatalog({
-          expectations: {
-            allowEmptyCatalog: true,
-          },
-        }),
-        realSiteAccountUsageChecks.modelToKey({
-          envPrefix: "DONE_HUB",
-          hasAvailableModel: false,
-        }),
-      ],
-    )
-  })
+    }),
+    realSiteAccountUsageChecks.providerDestinations({
+      validateDestinationPages: true,
+    }),
+    realSiteAccountUsageChecks.modelCatalog({
+      expectations: {
+        allowEmptyCatalog: true,
+      },
+    }),
+    realSiteAccountUsageChecks.modelToKey({
+      envPrefix: "DONE_HUB",
+      hasAvailableModel: false,
+    }),
+  ] as const
+
+  for (const usageCheck of usageChecks) {
+    test(`logs into a real DoneHub site, saves the account, then ${usageCheck.name}`, async ({
+      context,
+      extensionId,
+      page,
+    }, testInfo) => {
+      const realSite = resolveDoneHubRealSiteConfig()
+      test.skip(
+        !realSite.config,
+        getDoneHubRealSiteSkipReason(realSite.missingEnvKeys),
+      )
+
+      const config = realSite.config!
+      const serviceWorker = await getServiceWorker(context)
+
+      await seedUserPreferences(serviceWorker, {
+        managedSiteType: SITE_TYPES.DONE_HUB,
+        autoFillCurrentSiteUrlOnAccountAdd: false,
+        autoProvisionKeyOnAccountAdd: false,
+        openChangelogOnUpdate: false,
+      })
+
+      const accountFixture =
+        await test.step("save account from real site auto-detect", async () => {
+          const sitePage = await context.newPage()
+          try {
+            return await runCompatibleRealSiteAccountSaveFlow({
+              page,
+              extensionId,
+              serviceWorker,
+              sitePage,
+              config,
+              siteType: SITE_TYPES.DONE_HUB,
+              expectedDetectedSiteType: SITE_TYPES.DONE_HUB,
+              login: loginToRealDoneHubSite,
+            })
+          } finally {
+            if (!sitePage.isClosed()) {
+              await sitePage.close()
+            }
+          }
+        })
+      await runRealSiteAccountFixtureUsageChecks(
+        {
+          testInfo,
+          page,
+          extensionId,
+          serviceWorker,
+          account: accountFixture,
+          label: "DoneHub",
+        },
+        [usageCheck],
+      )
+    })
+  }
 })

--- a/e2e/realSite/managedSiteChannels.spec.ts
+++ b/e2e/realSite/managedSiteChannels.spec.ts
@@ -91,7 +91,6 @@ if (selectedManagedSiteTarget && selectedManagedSiteTargets.length === 0) {
 
 test.describe.configure({
   mode: selectedManagedSiteTarget ? "parallel" : "serial",
-  timeout: 600_000,
 })
 
 test.describe("real-site E2E: managed-site channel management", () => {
@@ -104,20 +103,68 @@ test.describe("real-site E2E: managed-site channel management", () => {
     const managedSite = target.resolveConfig()
 
     if (!managedSite.config) {
-      test.skip(`${target.label} covers channel CRUD/search and token channel status when supported`, async () => {
-        getManagedSiteRealSiteSkipReason({
-          label: target.label,
-          missingEnvKeys: managedSite.missingEnvKeys,
-        })
+      const skipReason = getManagedSiteRealSiteSkipReason({
+        label: target.label,
+        missingEnvKeys: managedSite.missingEnvKeys,
       })
+
+      test.skip(
+        `${target.label} covers channel CRUD/search`,
+        { annotation: { type: "skip", description: skipReason } },
+        async () => {},
+      )
+      test.skip(
+        `${target.label} covers token channel status when supported`,
+        { annotation: { type: "skip", description: skipReason } },
+        async () => {},
+      )
       continue
     }
 
-    test(`${target.label} covers channel CRUD/search and token channel status when supported`, async ({
+    test(`${target.label} covers channel CRUD/search`, async ({
+      context,
+      extensionId,
+      page,
+    }) => {
+      const serviceWorker = await getServiceWorker(context)
+      const config = managedSite.config
+      const runId = buildRealSiteRunId()
+      const runPrefix = buildManagedSiteE2ePrefix({
+        label: target.label.replace(/\s+/g, ""),
+        runId,
+      })
+      const cleanupPrefix = buildManagedSiteE2ePrefix({
+        label: target.label.replace(/\s+/g, ""),
+      })
+
+      await seedUserPreferences(serviceWorker, {
+        managedSiteType: target.siteType,
+        [target.preferenceKey]: config,
+        autoFillCurrentSiteUrlOnAccountAdd: false,
+        autoProvisionKeyOnAccountAdd: false,
+        openChangelogOnUpdate: false,
+      })
+
+      await runManagedSiteChannelsCrudScenario({
+        page,
+        extensionId,
+        siteType: target.siteType,
+        label: target.label,
+        runPrefix,
+        cleanupPrefix,
+      })
+    })
+
+    test(`${target.label} covers token channel status when supported`, async ({
       context,
       extensionId,
       page,
     }, testInfo) => {
+      test.skip(
+        target.siteType !== SITE_TYPES.NEW_API,
+        `${target.label} token channel status is not covered by this real-site E2E`,
+      )
+
       const serviceWorker = await getServiceWorker(context)
       const config = managedSite.config
       const runId = buildRealSiteRunId()
@@ -149,18 +196,19 @@ test.describe("real-site E2E: managed-site channel management", () => {
         openChangelogOnUpdate: false,
       })
 
-      try {
-        await test.step(`${target.label}: channel CRUD/search`, async () => {
-          await runManagedSiteChannelsCrudScenario({
-            page,
-            extensionId,
-            siteType: target.siteType,
-            label: target.label,
-            runPrefix,
-            cleanupPrefix,
-          })
+      if (!sourceAccountResult.sourceAccount) {
+        testInfo.annotations.push({
+          type: "skip",
+          description:
+            sourceAccountResult.skipReason ??
+            `${target.label} source account E2E env is missing`,
         })
+        return
+      }
 
+      const sourceAccount = sourceAccountResult.sourceAccount
+
+      try {
         const statusResult =
           await test.step(`${target.label}: token channel status`, async () =>
             await runManagedSiteTokenChannelStatusScenario({
@@ -170,7 +218,7 @@ test.describe("real-site E2E: managed-site channel management", () => {
               label: target.label,
               runPrefix,
               cleanupPrefix,
-              sourceAccount: sourceAccountResult.sourceAccount ?? undefined,
+              sourceAccount,
               tokenName: buildRealSiteTestTokenName({
                 label: "channel",
                 runId,
@@ -186,7 +234,7 @@ test.describe("real-site E2E: managed-site channel management", () => {
           })
         }
       } finally {
-        await sourceAccountResult.sourceAccount?.cleanup()
+        await sourceAccount.cleanup()
       }
     })
   }

--- a/e2e/realSite/managedSiteChannels.spec.ts
+++ b/e2e/realSite/managedSiteChannels.spec.ts
@@ -197,13 +197,12 @@ test.describe("real-site E2E: managed-site channel management", () => {
       })
 
       if (!sourceAccountResult.sourceAccount) {
-        testInfo.annotations.push({
-          type: "skip",
-          description:
-            sourceAccountResult.skipReason ??
+        test.skip(
+          true,
+          sourceAccountResult.skipReason ??
             `${target.label} source account E2E env is missing`,
-        })
-        return
+        )
+        throw new Error("Skipped test continued without a source account")
       }
 
       const sourceAccount = sourceAccountResult.sourceAccount

--- a/e2e/realSite/newApiAccountAdd.spec.ts
+++ b/e2e/realSite/newApiAccountAdd.spec.ts
@@ -18,71 +18,73 @@ import {
 } from "~~/e2e/utils/realSite/newApi"
 
 test.describe("real-site E2E: New API account add flow", () => {
-  test.setTimeout(180_000)
-
   test.beforeEach(async ({ context, page }) => {
     await forceExtensionLanguage(page, "en")
     await stubLlmMetadataIndex(context)
   })
 
-  test("logs into a real New API site, saves the account, then verifies account usage workflows", async ({
-    context,
-    extensionId,
-    page,
-  }, testInfo) => {
-    const realSite = resolveNewApiRealSiteConfig()
-    test.skip(
-      !realSite.config,
-      getNewApiRealSiteSkipReason(realSite.missingEnvKeys),
-    )
+  const usageChecks = [
+    realSiteAccountUsageChecks.keyLifecycle(),
+    realSiteAccountUsageChecks.keyToApiProfileAndPopupModels(),
+    realSiteAccountUsageChecks.providerDestinations({
+      validateDestinationPages: true,
+    }),
+    realSiteAccountUsageChecks.modelCatalog(),
+    realSiteAccountUsageChecks.modelToKey({ envPrefix: "NEW_API" }),
+  ] as const
 
-    const config = realSite.config!
-    const serviceWorker = await getServiceWorker(context)
+  for (const usageCheck of usageChecks) {
+    test(`logs into a real New API site, saves the account, then ${usageCheck.name}`, async ({
+      context,
+      extensionId,
+      page,
+    }, testInfo) => {
+      const realSite = resolveNewApiRealSiteConfig()
+      test.skip(
+        !realSite.config,
+        getNewApiRealSiteSkipReason(realSite.missingEnvKeys),
+      )
 
-    await seedUserPreferences(serviceWorker, {
-      managedSiteType: SITE_TYPES.NEW_API,
-      autoFillCurrentSiteUrlOnAccountAdd: false,
-      autoProvisionKeyOnAccountAdd: false,
-      openChangelogOnUpdate: false,
-    })
+      const config = realSite.config!
+      const serviceWorker = await getServiceWorker(context)
 
-    const accountFixture =
-      await test.step("save account from real site auto-detect", async () => {
-        const sitePage = await context.newPage()
-        try {
-          return await runCompatibleRealSiteAccountSaveFlow({
-            page,
-            extensionId,
-            serviceWorker,
-            sitePage,
-            config,
-            siteType: SITE_TYPES.NEW_API,
-            login: loginToRealNewApiSite,
-          })
-        } finally {
-          if (!sitePage.isClosed()) {
-            await sitePage.close()
-          }
-        }
+      await seedUserPreferences(serviceWorker, {
+        managedSiteType: SITE_TYPES.NEW_API,
+        autoFillCurrentSiteUrlOnAccountAdd: false,
+        autoProvisionKeyOnAccountAdd: false,
+        openChangelogOnUpdate: false,
       })
-    await runRealSiteAccountFixtureUsageChecks(
-      {
-        testInfo,
-        page,
-        extensionId,
-        serviceWorker,
-        account: accountFixture,
-        label: "New API",
-      },
-      [
-        realSiteAccountUsageChecks.keyLifecycle(),
-        realSiteAccountUsageChecks.keyToApiProfileAndPopupModels(),
-        realSiteAccountUsageChecks.providerDestinations({
-          validateDestinationPages: true,
-        }),
-        realSiteAccountUsageChecks.modelCatalog(),
-        realSiteAccountUsageChecks.modelToKey({ envPrefix: "NEW_API" }),
-      ],
-    )
-  })
+
+      const accountFixture =
+        await test.step("save account from real site auto-detect", async () => {
+          const sitePage = await context.newPage()
+          try {
+            return await runCompatibleRealSiteAccountSaveFlow({
+              page,
+              extensionId,
+              serviceWorker,
+              sitePage,
+              config,
+              siteType: SITE_TYPES.NEW_API,
+              login: loginToRealNewApiSite,
+            })
+          } finally {
+            if (!sitePage.isClosed()) {
+              await sitePage.close()
+            }
+          }
+        })
+      await runRealSiteAccountFixtureUsageChecks(
+        {
+          testInfo,
+          page,
+          extensionId,
+          serviceWorker,
+          account: accountFixture,
+          label: "New API",
+        },
+        [usageCheck],
+      )
+    })
+  }
 })

--- a/e2e/realSite/oneHubAccountAdd.spec.ts
+++ b/e2e/realSite/oneHubAccountAdd.spec.ts
@@ -18,71 +18,73 @@ import {
 } from "~~/e2e/utils/realSite/oneHub"
 
 test.describe("real-site E2E: OneHub account add flow", () => {
-  test.setTimeout(180_000)
-
   test.beforeEach(async ({ context, page }) => {
     await forceExtensionLanguage(page, "en")
     await stubLlmMetadataIndex(context)
   })
 
-  test("logs into a real OneHub site, saves the account, then verifies account usage workflows", async ({
-    context,
-    extensionId,
-    page,
-  }, testInfo) => {
-    const realSite = resolveOneHubRealSiteConfig()
-    test.skip(
-      !realSite.config,
-      getOneHubRealSiteSkipReason(realSite.missingEnvKeys),
-    )
+  const usageChecks = [
+    realSiteAccountUsageChecks.keyLifecycle(),
+    realSiteAccountUsageChecks.keyToApiProfileAndPopupModels(),
+    realSiteAccountUsageChecks.providerDestinations({
+      validateDestinationPages: true,
+    }),
+    realSiteAccountUsageChecks.modelCatalog(),
+    realSiteAccountUsageChecks.modelToKey({ envPrefix: "ONE_HUB" }),
+  ] as const
 
-    const config = realSite.config!
-    const serviceWorker = await getServiceWorker(context)
+  for (const usageCheck of usageChecks) {
+    test(`logs into a real OneHub site, saves the account, then ${usageCheck.name}`, async ({
+      context,
+      extensionId,
+      page,
+    }, testInfo) => {
+      const realSite = resolveOneHubRealSiteConfig()
+      test.skip(
+        !realSite.config,
+        getOneHubRealSiteSkipReason(realSite.missingEnvKeys),
+      )
 
-    await seedUserPreferences(serviceWorker, {
-      autoFillCurrentSiteUrlOnAccountAdd: false,
-      autoProvisionKeyOnAccountAdd: false,
-      openChangelogOnUpdate: false,
-    })
+      const config = realSite.config!
+      const serviceWorker = await getServiceWorker(context)
 
-    const accountFixture =
-      await test.step("save account from real site auto-detect", async () => {
-        const sitePage = await context.newPage()
-        try {
-          return await runCompatibleRealSiteAccountSaveFlow({
-            page,
-            extensionId,
-            serviceWorker,
-            sitePage,
-            config,
-            siteType: SITE_TYPES.ONE_HUB,
-            expectedDetectedSiteType: SITE_TYPES.ONE_HUB,
-            login: loginToRealOneHubSite,
-          })
-        } finally {
-          if (!sitePage.isClosed()) {
-            await sitePage.close()
-          }
-        }
+      await seedUserPreferences(serviceWorker, {
+        autoFillCurrentSiteUrlOnAccountAdd: false,
+        autoProvisionKeyOnAccountAdd: false,
+        openChangelogOnUpdate: false,
       })
-    await runRealSiteAccountFixtureUsageChecks(
-      {
-        testInfo,
-        page,
-        extensionId,
-        serviceWorker,
-        account: accountFixture,
-        label: "OneHub",
-      },
-      [
-        realSiteAccountUsageChecks.keyLifecycle(),
-        realSiteAccountUsageChecks.keyToApiProfileAndPopupModels(),
-        realSiteAccountUsageChecks.providerDestinations({
-          validateDestinationPages: true,
-        }),
-        realSiteAccountUsageChecks.modelCatalog(),
-        realSiteAccountUsageChecks.modelToKey({ envPrefix: "ONE_HUB" }),
-      ],
-    )
-  })
+
+      const accountFixture =
+        await test.step("save account from real site auto-detect", async () => {
+          const sitePage = await context.newPage()
+          try {
+            return await runCompatibleRealSiteAccountSaveFlow({
+              page,
+              extensionId,
+              serviceWorker,
+              sitePage,
+              config,
+              siteType: SITE_TYPES.ONE_HUB,
+              expectedDetectedSiteType: SITE_TYPES.ONE_HUB,
+              login: loginToRealOneHubSite,
+            })
+          } finally {
+            if (!sitePage.isClosed()) {
+              await sitePage.close()
+            }
+          }
+        })
+      await runRealSiteAccountFixtureUsageChecks(
+        {
+          testInfo,
+          page,
+          extensionId,
+          serviceWorker,
+          account: accountFixture,
+          label: "OneHub",
+        },
+        [usageCheck],
+      )
+    })
+  }
 })

--- a/e2e/realSite/sub2apiAccountAdd.spec.ts
+++ b/e2e/realSite/sub2apiAccountAdd.spec.ts
@@ -17,137 +17,151 @@ import {
   resolveSub2ApiRealSiteConfig,
 } from "~~/e2e/utils/realSite/sub2api"
 
-test.describe("real-site E2E: Sub2API auto-detect account add flow", () => {
-  test.setTimeout(180_000)
+const ACCOUNT_BACKED_MODEL_CATALOG_UNAVAILABLE_REASON =
+  "Sub2API account model catalog skipped because this site type does not expose an account-backed model catalog."
 
+test.describe("real-site E2E: Sub2API auto-detect account add flow", () => {
   test.beforeEach(async ({ context, page }) => {
     await forceExtensionLanguage(page, "en")
     await stubLlmMetadataIndex(context)
   })
 
-  test("logs into a real Sub2API site, saves the account, then verifies account usage", async ({
-    context,
-    extensionId,
-    page,
-  }, testInfo) => {
-    const realSite = resolveSub2ApiRealSiteConfig()
-    test.skip(
-      !realSite.config,
-      getSub2ApiRealSiteSkipReason(realSite.missingEnvKeys),
-    )
+  const usageChecks = [
+    realSiteAccountUsageChecks.keyLifecycle(),
+    realSiteAccountUsageChecks.keyToApiProfileAndPopupModels(),
+    realSiteAccountUsageChecks.providerDestinations({
+      validateDestinationPages: true,
+    }),
+    realSiteAccountUsageChecks.modelToKey({ envPrefix: "SUB2API" }),
+  ] as const
 
-    const config = realSite.config!
-    const serviceWorker = await getServiceWorker(context)
-
-    await seedUserPreferences(serviceWorker, {
-      autoFillCurrentSiteUrlOnAccountAdd: false,
-      autoProvisionKeyOnAccountAdd: false,
-      openChangelogOnUpdate: false,
-      tempWindowFallback: {
-        enabled: false,
+  test.skip(
+    "skips account model catalog because it is unavailable",
+    {
+      annotation: {
+        type: "skip",
+        description: ACCOUNT_BACKED_MODEL_CATALOG_UNAVAILABLE_REASON,
       },
-    })
+    },
+    async () => {},
+  )
 
-    const accountFixture =
-      await test.step("save account from real site auto-detect", async () => {
-        const sitePage = await context.newPage()
-        try {
-          return await runRealSiteAccountSaveFlow({
-            page,
-            extensionId,
-            serviceWorker,
-            sitePage,
-            baseUrl: config.baseUrl,
-            siteType: SITE_TYPES.SUB2API,
-            expectedDetectedSiteType: SITE_TYPES.SUB2API,
-            login: async (realSitePage) => {
-              const loginResult = await loginToRealSub2ApiSite(
-                realSitePage,
-                config,
-              )
-              expect(loginResult.authState.accessToken).not.toBe("")
+  for (const usageCheck of usageChecks) {
+    test(`logs into a real Sub2API site, saves the account, then ${usageCheck.name}`, async ({
+      context,
+      extensionId,
+      page,
+    }, testInfo) => {
+      const realSite = resolveSub2ApiRealSiteConfig()
+      test.skip(
+        !realSite.config,
+        getSub2ApiRealSiteSkipReason(realSite.missingEnvKeys),
+      )
 
-              return {
-                prepareDetectedDialog: async (dialog) => {
-                  await expect(dialog.siteNameInput).toHaveValue(/.+/, {
-                    timeout: 60_000,
-                  })
+      const config = realSite.config!
+      const serviceWorker = await getServiceWorker(context)
 
-                  await expect(dialog.userIdInput).toHaveValue(/.+/, {
-                    timeout: 60_000,
-                  })
-                  await expect
-                    .poll(
-                      async () =>
-                        (await dialog.accessTokenInput.inputValue()) ===
-                        loginResult.authState.accessToken,
-                      { timeout: 60_000 },
-                    )
-                    .toBe(true)
-                  await expect(
-                    dialog.sub2apiRefreshTokenSwitch,
-                  ).toHaveAttribute("aria-checked", "false")
-                  await expect(dialog.sub2apiImportSessionButton).toHaveCount(0)
-
-                  if (!loginResult.authState.refreshToken) {
-                    return
-                  }
-
-                  await dialog.sub2apiRefreshTokenSwitch.click()
-                  await expect(
-                    dialog.sub2apiRefreshTokenSwitch,
-                  ).toHaveAttribute("aria-checked", "true")
-
-                  const importSessionButtonVisible =
-                    await dialog.sub2apiImportSessionButton
-                      .waitFor({ state: "visible", timeout: 5_000 })
-                      .then(() => true)
-                      .catch(() => false)
-
-                  if (!importSessionButtonVisible) {
-                    return
-                  }
-
-                  await dialog.sub2apiImportSessionButton.click()
-                  await expect
-                    .poll(
-                      async () =>
-                        (await dialog.sub2apiRefreshTokenInput.inputValue()) ===
-                        loginResult.authState.refreshToken,
-                      { timeout: 60_000 },
-                    )
-                    .toBe(true)
-                },
-              }
-            },
-          })
-        } finally {
-          if (!sitePage.isClosed()) {
-            await sitePage.close()
-          }
-        }
+      await seedUserPreferences(serviceWorker, {
+        autoFillCurrentSiteUrlOnAccountAdd: false,
+        autoProvisionKeyOnAccountAdd: false,
+        openChangelogOnUpdate: false,
+        tempWindowFallback: {
+          enabled: false,
+        },
       })
-    await runRealSiteAccountFixtureUsageChecks(
-      {
-        testInfo,
-        page,
-        extensionId,
-        serviceWorker,
-        account: accountFixture,
-        label: "Sub2API",
-      },
-      [
-        realSiteAccountUsageChecks.keyLifecycle(),
-        realSiteAccountUsageChecks.keyToApiProfileAndPopupModels(),
-        realSiteAccountUsageChecks.providerDestinations({
-          validateDestinationPages: true,
-        }),
-        realSiteAccountUsageChecks.accountBackedModelCatalogUnavailable({
-          reason:
-            "Sub2API account model catalog skipped because this site type does not expose an account-backed model catalog.",
-        }),
-        realSiteAccountUsageChecks.modelToKey({ envPrefix: "SUB2API" }),
-      ],
-    )
-  })
+
+      const accountFixture =
+        await test.step("save account from real site auto-detect", async () => {
+          const sitePage = await context.newPage()
+          try {
+            return await runRealSiteAccountSaveFlow({
+              page,
+              extensionId,
+              serviceWorker,
+              sitePage,
+              baseUrl: config.baseUrl,
+              siteType: SITE_TYPES.SUB2API,
+              expectedDetectedSiteType: SITE_TYPES.SUB2API,
+              login: async (realSitePage) => {
+                const loginResult = await loginToRealSub2ApiSite(
+                  realSitePage,
+                  config,
+                )
+                expect(loginResult.authState.accessToken).not.toBe("")
+
+                return {
+                  prepareDetectedDialog: async (dialog) => {
+                    await expect(dialog.siteNameInput).toHaveValue(/.+/, {
+                      timeout: 30_000,
+                    })
+
+                    await expect(dialog.userIdInput).toHaveValue(/.+/, {
+                      timeout: 30_000,
+                    })
+                    await expect
+                      .poll(
+                        async () =>
+                          (await dialog.accessTokenInput.inputValue()) ===
+                          loginResult.authState.accessToken,
+                        { timeout: 30_000 },
+                      )
+                      .toBe(true)
+                    await expect(
+                      dialog.sub2apiRefreshTokenSwitch,
+                    ).toHaveAttribute("aria-checked", "false")
+                    await expect(dialog.sub2apiImportSessionButton).toHaveCount(
+                      0,
+                    )
+
+                    if (!loginResult.authState.refreshToken) {
+                      return
+                    }
+
+                    await dialog.sub2apiRefreshTokenSwitch.click()
+                    await expect(
+                      dialog.sub2apiRefreshTokenSwitch,
+                    ).toHaveAttribute("aria-checked", "true")
+
+                    const importSessionButtonVisible =
+                      await dialog.sub2apiImportSessionButton
+                        .waitFor({ state: "visible", timeout: 5_000 })
+                        .then(() => true)
+                        .catch(() => false)
+
+                    if (!importSessionButtonVisible) {
+                      return
+                    }
+
+                    await dialog.sub2apiImportSessionButton.click()
+                    await expect
+                      .poll(
+                        async () =>
+                          (await dialog.sub2apiRefreshTokenInput.inputValue()) ===
+                          loginResult.authState.refreshToken,
+                        { timeout: 30_000 },
+                      )
+                      .toBe(true)
+                  },
+                }
+              },
+            })
+          } finally {
+            if (!sitePage.isClosed()) {
+              await sitePage.close()
+            }
+          }
+        })
+      await runRealSiteAccountFixtureUsageChecks(
+        {
+          testInfo,
+          page,
+          extensionId,
+          serviceWorker,
+          account: accountFixture,
+          label: "Sub2API",
+        },
+        [usageCheck],
+      )
+    })
+  }
 })

--- a/e2e/realSite/veloeraAccountAdd.spec.ts
+++ b/e2e/realSite/veloeraAccountAdd.spec.ts
@@ -18,75 +18,77 @@ import {
 } from "~~/e2e/utils/realSite/veloera"
 
 test.describe("real-site E2E: Veloera account add flow", () => {
-  test.setTimeout(180_000)
-
   test.beforeEach(async ({ context, page }) => {
     await forceExtensionLanguage(page, "en")
     await stubLlmMetadataIndex(context)
   })
 
-  test("logs into a real Veloera site, saves the account, then verifies account usage workflows", async ({
-    context,
-    extensionId,
-    page,
-  }, testInfo) => {
-    const realSite = resolveVeloeraRealSiteConfig()
-    test.skip(
-      !realSite.config,
-      getVeloeraRealSiteSkipReason(realSite.missingEnvKeys),
-    )
-
-    const config = realSite.config!
-    const serviceWorker = await getServiceWorker(context)
-
-    await seedUserPreferences(serviceWorker, {
-      managedSiteType: SITE_TYPES.VELOERA,
-      autoFillCurrentSiteUrlOnAccountAdd: false,
-      autoProvisionKeyOnAccountAdd: false,
-      openChangelogOnUpdate: false,
-    })
-
-    const accountFixture =
-      await test.step("save account from real site auto-detect", async () => {
-        const sitePage = await context.newPage()
-        try {
-          return await runCompatibleRealSiteAccountSaveFlow({
-            page,
-            extensionId,
-            serviceWorker,
-            sitePage,
-            config,
-            siteType: SITE_TYPES.VELOERA,
-            expectedDetectedSiteType: SITE_TYPES.VELOERA,
-            login: loginToRealVeloeraSite,
-          })
-        } finally {
-          if (!sitePage.isClosed()) {
-            await sitePage.close()
-          }
-        }
-      })
-    await runRealSiteAccountFixtureUsageChecks(
-      {
-        testInfo,
-        page,
-        extensionId,
-        serviceWorker,
-        account: accountFixture,
-        label: "Veloera",
+  const usageChecks = [
+    realSiteAccountUsageChecks.keyLifecycle(),
+    realSiteAccountUsageChecks.keyToApiProfileAndPopupModels(),
+    realSiteAccountUsageChecks.providerDestinations({
+      validateDestinationPages: {
+        usage: true,
+        redeem: false,
       },
-      [
-        realSiteAccountUsageChecks.keyLifecycle(),
-        realSiteAccountUsageChecks.keyToApiProfileAndPopupModels(),
-        realSiteAccountUsageChecks.providerDestinations({
-          validateDestinationPages: {
-            usage: true,
-            redeem: false,
-          },
-        }),
-        realSiteAccountUsageChecks.modelCatalog(),
-        realSiteAccountUsageChecks.modelToKey({ envPrefix: "VELOERA" }),
-      ],
-    )
-  })
+    }),
+    realSiteAccountUsageChecks.modelCatalog(),
+    realSiteAccountUsageChecks.modelToKey({ envPrefix: "VELOERA" }),
+  ] as const
+
+  for (const usageCheck of usageChecks) {
+    test(`logs into a real Veloera site, saves the account, then ${usageCheck.name}`, async ({
+      context,
+      extensionId,
+      page,
+    }, testInfo) => {
+      const realSite = resolveVeloeraRealSiteConfig()
+      test.skip(
+        !realSite.config,
+        getVeloeraRealSiteSkipReason(realSite.missingEnvKeys),
+      )
+
+      const config = realSite.config!
+      const serviceWorker = await getServiceWorker(context)
+
+      await seedUserPreferences(serviceWorker, {
+        managedSiteType: SITE_TYPES.VELOERA,
+        autoFillCurrentSiteUrlOnAccountAdd: false,
+        autoProvisionKeyOnAccountAdd: false,
+        openChangelogOnUpdate: false,
+      })
+
+      const accountFixture =
+        await test.step("save account from real site auto-detect", async () => {
+          const sitePage = await context.newPage()
+          try {
+            return await runCompatibleRealSiteAccountSaveFlow({
+              page,
+              extensionId,
+              serviceWorker,
+              sitePage,
+              config,
+              siteType: SITE_TYPES.VELOERA,
+              expectedDetectedSiteType: SITE_TYPES.VELOERA,
+              login: loginToRealVeloeraSite,
+            })
+          } finally {
+            if (!sitePage.isClosed()) {
+              await sitePage.close()
+            }
+          }
+        })
+      await runRealSiteAccountFixtureUsageChecks(
+        {
+          testInfo,
+          page,
+          extensionId,
+          serviceWorker,
+          account: accountFixture,
+          label: "Veloera",
+        },
+        [usageCheck],
+      )
+    })
+  }
 })

--- a/e2e/scenarios/accountManualAdd.ts
+++ b/e2e/scenarios/accountManualAdd.ts
@@ -90,9 +90,9 @@ export async function saveManualAccountFromApp(params: {
     account: params.account,
   })
 
-  await expect(dialog.confirmAddButton).toBeEnabled({ timeout: 60_000 })
+  await expect(dialog.confirmAddButton).toBeEnabled({ timeout: 30_000 })
   await dialog.confirmAddButton.click()
-  await expect(dialog.dialog).toBeHidden({ timeout: 60_000 })
+  await expect(dialog.dialog).toBeHidden({ timeout: 30_000 })
 
   const savedAccount = await waitForManualSavedAccount({
     serviceWorker: params.serviceWorker,
@@ -200,7 +200,7 @@ async function waitForManualSavedAccount(params: {
 
         return savedAccount
       },
-      { timeout: 60_000 },
+      { timeout: 30_000 },
     )
     .not.toBeNull()
 

--- a/e2e/scenarios/managedSiteChannels.ts
+++ b/e2e/scenarios/managedSiteChannels.ts
@@ -102,7 +102,7 @@ export async function runManagedSiteChannelsCrudScenario<
     await waitForExtensionRoot(context.page)
     await expect(
       context.page.getByTestId(MANAGED_SITE_CHANNELS_TEST_IDS.addChannelButton),
-    ).toBeVisible({ timeout: 60_000 })
+    ).toBeVisible({ timeout: 30_000 })
 
     await createManagedSiteChannelFromUi(context.page, {
       name: channelName,
@@ -119,7 +119,7 @@ export async function runManagedSiteChannelsCrudScenario<
       .getByTestId(MANAGED_SITE_CHANNELS_TEST_IDS.searchInput)
       .fill(channelName)
     await expect(channelRowByName(context.page, channelName)).toBeVisible({
-      timeout: 60_000,
+      timeout: 30_000,
     })
     await expectPaginationSummary(context.page, "1", "1", "1")
 
@@ -132,7 +132,7 @@ export async function runManagedSiteChannelsCrudScenario<
 
     await expect(channelRowByName(context.page, editedChannelName)).toBeVisible(
       {
-        timeout: 60_000,
+        timeout: 30_000,
       },
     )
 
@@ -141,7 +141,7 @@ export async function runManagedSiteChannelsCrudScenario<
       .fill(editedChannelName)
     await expect(channelRowByName(context.page, editedChannelName)).toBeVisible(
       {
-        timeout: 60_000,
+        timeout: 30_000,
       },
     )
     await expect(channelRowByName(context.page, channelName)).toHaveCount(0)
@@ -215,7 +215,7 @@ export async function runManagedSiteTokenChannelStatusScenario<
 
     await expect(
       row.getByTestId(KEY_MANAGEMENT_TEST_IDS.managedSiteStatusBadge),
-    ).toBeVisible({ timeout: 90_000 })
+    ).toBeVisible({ timeout: 30_000 })
     await openManagedSiteImportDialogFromTokenRow({
       page: keyManagementPage,
       row,
@@ -276,7 +276,7 @@ async function openManagedSiteImportDialogFromTokenRow(params: {
     ).toBeVisible({ timeout: 30_000 })
   }).toPass({
     intervals: [1_000, 3_000, 5_000],
-    timeout: 90_000,
+    timeout: 30_000,
   })
 }
 
@@ -355,7 +355,7 @@ async function expectManagedSiteChannelVisibleAfterRefresh(params: {
     await expect(row).toBeVisible({ timeout: 20_000 })
   }).toPass({
     intervals: [1_000, 3_000, 5_000],
-    timeout: 90_000,
+    timeout: 30_000,
   })
 }
 
@@ -375,7 +375,7 @@ async function expectManagedSiteImportStatusAfterChannelCreate(row: Locator) {
     await expect(verificationRetryButton).toBeVisible({ timeout: 10_000 })
   }).toPass({
     intervals: [1_000, 3_000, 5_000],
-    timeout: 90_000,
+    timeout: 30_000,
   })
 }
 
@@ -425,7 +425,7 @@ async function deleteVisibleChannelByName(page: Page, channelName: string) {
   await page
     .getByTestId(MANAGED_SITE_CHANNELS_TEST_IDS.deleteChannelConfirmButton)
     .click()
-  await expect(row).toHaveCount(0, { timeout: 60_000 })
+  await expect(row).toHaveCount(0, { timeout: 30_000 })
 }
 
 async function createManagedSiteChannelFromUi(
@@ -443,7 +443,7 @@ async function createManagedSiteChannelFromUi(
   await expect(
     page.getByTestId(CHANNEL_DIALOG_TEST_IDS.submitButton),
   ).toBeVisible({
-    timeout: 60_000,
+    timeout: 30_000,
   })
   await page.getByTestId(CHANNEL_DIALOG_TEST_IDS.nameInput).fill(params.name)
   await page.getByTestId(CHANNEL_DIALOG_TEST_IDS.keyInput).fill(params.key)
@@ -495,7 +495,7 @@ async function openSingleVisibleChannelEditDialog(page: Page, rowText: string) {
     })
   }).toPass({
     intervals: [1_000, 3_000, 5_000],
-    timeout: 60_000,
+    timeout: 30_000,
   })
 }
 
@@ -521,13 +521,13 @@ async function expectPaginationSummary(
 ) {
   await expect(
     page.getByTestId(MANAGED_SITE_CHANNELS_TEST_IDS.paginationSummary),
-  ).toHaveAttribute("data-start", start, { timeout: 60_000 })
+  ).toHaveAttribute("data-start", start, { timeout: 30_000 })
   await expect(
     page.getByTestId(MANAGED_SITE_CHANNELS_TEST_IDS.paginationSummary),
-  ).toHaveAttribute("data-end", end, { timeout: 60_000 })
+  ).toHaveAttribute("data-end", end, { timeout: 30_000 })
   await expect(
     page.getByTestId(MANAGED_SITE_CHANNELS_TEST_IDS.paginationSummary),
-  ).toHaveAttribute("data-total", total, { timeout: 60_000 })
+  ).toHaveAttribute("data-total", total, { timeout: 30_000 })
 }
 
 function channelRowByName(page: Page, channelName: string) {

--- a/e2e/scenarios/managedSiteChannels.ts
+++ b/e2e/scenarios/managedSiteChannels.ts
@@ -349,7 +349,7 @@ async function expectManagedSiteChannelVisibleAfterRefresh(params: {
       MANAGED_SITE_CHANNELS_REFRESH_STATE_ATTRIBUTE,
       MANAGED_SITE_CHANNELS_REFRESH_STATES.Idle,
       {
-        timeout: 30_000,
+        timeout: 10_000,
       },
     )
     await expect(row).toBeVisible({ timeout: 20_000 })

--- a/e2e/scenarios/managedSiteChannels.ts
+++ b/e2e/scenarios/managedSiteChannels.ts
@@ -276,7 +276,7 @@ async function openManagedSiteImportDialogFromTokenRow(params: {
     ).toBeVisible({ timeout: 30_000 })
   }).toPass({
     intervals: [1_000, 3_000, 5_000],
-    timeout: 30_000,
+    timeout: 60_000,
   })
 }
 
@@ -349,13 +349,13 @@ async function expectManagedSiteChannelVisibleAfterRefresh(params: {
       MANAGED_SITE_CHANNELS_REFRESH_STATE_ATTRIBUTE,
       MANAGED_SITE_CHANNELS_REFRESH_STATES.Idle,
       {
-        timeout: 10_000,
+        timeout: 30_000,
       },
     )
     await expect(row).toBeVisible({ timeout: 20_000 })
   }).toPass({
     intervals: [1_000, 3_000, 5_000],
-    timeout: 30_000,
+    timeout: 60_000,
   })
 }
 

--- a/e2e/scenarios/modelListCatalog.ts
+++ b/e2e/scenarios/modelListCatalog.ts
@@ -67,7 +67,7 @@ async function expectModelListCatalog(params: {
   const { page, expectations } = params
 
   await expect(page.getByTestId(MODEL_LIST_TEST_IDS.controlPanel)).toBeVisible({
-    timeout: 60_000,
+    timeout: 30_000,
   })
   if (!expectations?.allowEmptyCatalog) {
     await expect(

--- a/e2e/scenarios/modelToKeyManagement.ts
+++ b/e2e/scenarios/modelToKeyManagement.ts
@@ -79,7 +79,7 @@ async function resolveCreatedKeyManagementToken(params: {
       }),
     })
 
-  await expect(tokenRows).toHaveCount(1, { timeout: 60_000 })
+  await expect(tokenRows).toHaveCount(1, { timeout: 30_000 })
 
   const row = tokenRows.first()
   const testId = await row.getAttribute("data-testid")

--- a/e2e/utils/accountLifecycle.ts
+++ b/e2e/utils/accountLifecycle.ts
@@ -142,15 +142,15 @@ export async function saveAutoDetectedAccountFromApp(params: {
     await expect(dialog.siteTypeTrigger).toHaveAttribute(
       "data-site-type",
       params.expectedSiteType,
-      { timeout: 60_000 },
+      { timeout: 30_000 },
     )
   }
 
   await params.prepareDetectedDialog?.(dialog)
 
-  await expect(dialog.confirmAddButton).toBeEnabled({ timeout: 60_000 })
+  await expect(dialog.confirmAddButton).toBeEnabled({ timeout: 30_000 })
   await dialog.confirmAddButton.click()
-  await expect(dialog.dialog).toBeHidden({ timeout: 60_000 })
+  await expect(dialog.dialog).toBeHidden({ timeout: 30_000 })
 
   await expectAccountListItemVisibleBySite(params.page, {
     siteType: params.siteType,
@@ -294,7 +294,7 @@ async function expectTokenVisibleInKeyManagementPage(params: {
   tokenName: string
 }): Promise<Locator> {
   const heading = params.page.getByRole("heading", { name: params.tokenName })
-  await expect(heading).toBeVisible({ timeout: 60_000 })
+  await expect(heading).toBeVisible({ timeout: 30_000 })
   return heading.locator("xpath=ancestor::*[@data-testid][1]")
 }
 
@@ -311,13 +311,13 @@ export async function deleteTokenFromKeyManagementPage(params: {
           tokenName: params.token,
         })
       : params.page.getByTestId(getKeyManagementTokenRowTestId(params.token.id))
-  await expect(row).toBeVisible({ timeout: 60_000 })
+  await expect(row).toBeVisible({ timeout: 30_000 })
 
   await row.getByRole("button", { name: "Delete Key" }).click()
   await params.page
     .getByTestId(KEY_MANAGEMENT_TEST_IDS.deleteTokenConfirmButton)
     .click()
-  await expect(row).toHaveCount(0, { timeout: 60_000 })
+  await expect(row).toHaveCount(0, { timeout: 30_000 })
 }
 
 export async function openKeyManagementForAccount(params: {

--- a/e2e/utils/realSite/accountAdd.ts
+++ b/e2e/utils/realSite/accountAdd.ts
@@ -105,7 +105,7 @@ export async function waitForSavedAccount(params: {
         return savedAccount
       },
       {
-        timeout: params.timeoutMs ?? 60_000,
+        timeout: params.timeoutMs ?? 30_000,
       },
     )
     .not.toBeNull()
@@ -116,7 +116,7 @@ export async function waitForSavedAccount(params: {
 export async function expectAccountListItemVisible(
   page: Page,
   accountId: string,
-  timeoutMs = 60_000,
+  timeoutMs = 30_000,
 ) {
   const row = page.getByTestId(getAccountManagementListItemTestId(accountId))
   await expect(row).toBeVisible({ timeout: timeoutMs })
@@ -139,7 +139,7 @@ export async function expectAccountListItemVisibleBySite(
     ].join(""),
   )
 
-  await expect(row).toBeVisible({ timeout: params.timeoutMs ?? 60_000 })
+  await expect(row).toBeVisible({ timeout: params.timeoutMs ?? 30_000 })
   return row
 }
 

--- a/tests/utils/commonUserFlows.test.ts
+++ b/tests/utils/commonUserFlows.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it, vi } from "vitest"
 
-import { installExtensionPageGuards } from "~~/e2e/utils/commonUserFlows"
+import {
+  SPONSOR_CATALOG_SCHEMA_VERSION,
+  SPONSOR_REMOTE_CATALOG_V5_URL,
+} from "~/features/AccountManagement/sponsors/constants"
+import {
+  installExtensionPageGuards,
+  stubLlmMetadataIndex,
+  stubSponsorRemoteCatalog,
+} from "~~/e2e/utils/commonUserFlows"
 
 describe("installExtensionPageGuards", () => {
   it("throws on extension console errors, including resource-load failures", () => {
@@ -57,5 +65,48 @@ describe("installExtensionPageGuards", () => {
         text: () => "ResizeObserver loop limit exceeded",
       }),
     ).not.toThrow()
+  })
+})
+
+describe("E2E external route stubs", () => {
+  it("stubs both metadata and sponsor catalog endpoints used by extension pages", async () => {
+    const context = {
+      route: vi.fn(),
+    } as any
+
+    await stubLlmMetadataIndex(context)
+
+    expect(context.route).toHaveBeenCalledWith(
+      "https://llm-metadata.pages.dev/api/index.json",
+      expect.any(Function),
+    )
+    expect(context.route).toHaveBeenCalledWith(
+      SPONSOR_REMOTE_CATALOG_V5_URL,
+      expect.any(Function),
+    )
+  })
+
+  it("serves a deterministic empty sponsor catalog for E2E pages", async () => {
+    const context = {
+      route: vi.fn(),
+    } as any
+
+    await stubSponsorRemoteCatalog(context)
+
+    const [, handler] = context.route.mock.calls[0]!
+    const route = {
+      fulfill: vi.fn(),
+    }
+
+    await handler(route)
+
+    expect(route.fulfill).toHaveBeenCalledWith({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        schemaVersion: SPONSOR_CATALOG_SCHEMA_VERSION,
+        items: [],
+      }),
+    })
   })
 })


### PR DESCRIPTION
## Summary
- split long real-site account and managed-site E2E flows into focused usage checks
- remove custom long Playwright timeouts in favor of suite defaults
- add coverage for external metadata/sponsor catalog route stubs

## Validation
- pnpm run validate:push
- GitHub Actions E2E: success
- GitHub Actions Real-Site E2E: dispatched

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved end-to-end reliability by splitting account-add and managed-site channel-management checks into smaller, per-usage-check/per-scenario runs.
  * Added clearer skip behavior when required configuration or prerequisites aren’t available, preventing unintended test execution.
* **Tests**
  * Reduced Playwright wait/timeout values across multiple flows (commonly 60s → 30s), including dialog confirmations, polling, and UI assertions.
  * Expanded coverage for sponsor-catalog and external route stubbing with deterministic assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->