### PR TITLE
fix(key-management): prefill auto token name

### DIFF
--- a/src/features/TokenProvisioning/components/AddTokenDialog/TokenForm/index.tsx
+++ b/src/features/TokenProvisioning/components/AddTokenDialog/TokenForm/index.tsx
@@ -4,6 +4,7 @@ import {
 } from "~/services/accounts/accountSiteProfile"
 import type { UserGroupInfo } from "~/services/accountTokens/tokenProvisioningModel"
 
+import { applyDefaultTokenCreateGroupSelection } from "../defaultTokenCreatePrefill"
 import type { FormData } from "../hooks/useTokenForm"
 import type { Account } from "./AccountSelection"
 import { AdvancedSettingsSection } from "./AdvancedSettingsSection"
@@ -43,7 +44,13 @@ export function TokenForm({
     }
 
   const handleSelectChange = (field: keyof FormData) => (value: string) => {
-    setFormData((prev) => ({ ...prev, [field]: value }))
+    setFormData((prev) => {
+      if (field !== "group") {
+        return { ...prev, [field]: value }
+      }
+
+      return applyDefaultTokenCreateGroupSelection(prev, value)
+    })
   }
 
   const handleSwitchChange = (field: keyof FormData) => (checked: boolean) => {

--- a/src/features/TokenProvisioning/components/AddTokenDialog/defaultTokenCreatePrefill.ts
+++ b/src/features/TokenProvisioning/components/AddTokenDialog/defaultTokenCreatePrefill.ts
@@ -10,6 +10,11 @@ export interface DefaultTokenCreatePrefill {
   allowedGroups: string[]
 }
 
+type DefaultTokenGroupSelectionData = {
+  group: string
+  name: string
+}
+
 /**
  * Builds the AddTokenDialog prefill for constrained default-token creation.
  */
@@ -26,5 +31,22 @@ export function buildDefaultTokenCreatePrefill(
     defaultName: tokenRequest.name,
     group: tokenRequest.group,
     allowedGroups: [...allowedGroups],
+  }
+}
+
+/**
+ * Applies a token group change while keeping extension-generated auto names in sync.
+ */
+export function applyDefaultTokenCreateGroupSelection<
+  T extends DefaultTokenGroupSelectionData,
+>(formData: T, nextGroup: string): T {
+  const normalizedGroup = nextGroup.trim()
+  const previousAutoName = buildGroupDefaultTokenRequest(formData.group).name
+  const nextAutoName = buildGroupDefaultTokenRequest(normalizedGroup).name
+
+  return {
+    ...formData,
+    group: normalizedGroup,
+    name: formData.name === previousAutoName ? nextAutoName : formData.name,
   }
 }

--- a/src/features/TokenProvisioning/components/AddTokenDialog/hooks/useTokenData.ts
+++ b/src/features/TokenProvisioning/components/AddTokenDialog/hooks/useTokenData.ts
@@ -16,6 +16,7 @@ import type { DisplaySiteData } from "~/types"
 import { getErrorMessage } from "~/utils/core/error"
 import { createLogger } from "~/utils/core/logger"
 
+import { applyDefaultTokenCreateGroupSelection } from "../defaultTokenCreatePrefill"
 import type { FormData } from "./useTokenForm"
 
 /**
@@ -113,7 +114,10 @@ export function useTokenData(
             (!canValidateGroupMembership ||
               resolvedGroupsData[DEFAULT_USER_GROUP_NAME])
           ) {
-            return { ...prev, group: DEFAULT_USER_GROUP_NAME }
+            return applyDefaultTokenCreateGroupSelection(
+              prev,
+              DEFAULT_USER_GROUP_NAME,
+            )
           }
 
           const firstAllowedGroup = normalizedAllowedGroups.find(
@@ -121,16 +125,21 @@ export function useTokenData(
           )
 
           return firstAllowedGroup
-            ? { ...prev, group: firstAllowedGroup }
+            ? applyDefaultTokenCreateGroupSelection(prev, firstAllowedGroup)
             : prev
         }
 
         if (resolvedGroupsData[DEFAULT_USER_GROUP_NAME]) {
-          return { ...prev, group: DEFAULT_USER_GROUP_NAME }
+          return applyDefaultTokenCreateGroupSelection(
+            prev,
+            DEFAULT_USER_GROUP_NAME,
+          )
         }
 
         const firstGroup = Object.keys(resolvedGroupsData)[0]
-        return firstGroup ? { ...prev, group: firstGroup } : prev
+        return firstGroup
+          ? applyDefaultTokenCreateGroupSelection(prev, firstGroup)
+          : prev
       })
     } catch (error) {
       logger.error("Failed to load initial data", error)

--- a/src/features/TokenProvisioning/components/AddTokenDialog/hooks/useTokenForm.ts
+++ b/src/features/TokenProvisioning/components/AddTokenDialog/hooks/useTokenForm.ts
@@ -3,7 +3,10 @@ import { useTranslation } from "react-i18next"
 
 import type { AccountSiteType } from "~/constants/siteType"
 import { UI_CONSTANTS } from "~/constants/ui"
-import { DEFAULT_USER_GROUP_NAME } from "~/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken"
+import {
+  DEFAULT_AUTO_PROVISION_TOKEN_NAME,
+  DEFAULT_USER_GROUP_NAME,
+} from "~/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken"
 import {
   ACCOUNT_SITE_TOKEN_FORM_NETWORK_LIMIT_POLICIES,
   resolveAccountSiteTokenFormNetworkLimitPolicy,
@@ -182,7 +185,7 @@ export function useTokenForm({
             ? createPrefill.defaultName
             : shouldPrefillModel
               ? `model ${normalizedModelId}`
-              : ""
+              : DEFAULT_AUTO_PROVISION_TOKEN_NAME
 
         const normalizedGroup =
           typeof createPrefill?.group === "string"

--- a/tests/features/AccountManagement/components/CopyKeyDialog.test.tsx
+++ b/tests/features/AccountManagement/components/CopyKeyDialog.test.tsx
@@ -1480,10 +1480,11 @@ describe("CopyKeyDialog", () => {
     })
     await user.click(customCreateButton)
 
-    await user.type(
-      await screen.findByLabelText(/keyManagement:dialog\.tokenName/),
-      "My Key",
+    const tokenNameInput = await screen.findByLabelText(
+      /keyManagement:dialog\.tokenName/,
     )
+    await user.clear(tokenNameInput)
+    await user.type(tokenNameInput, "My Key")
 
     await user.click(
       screen.getByRole("button", { name: "keyManagement:dialog.createToken" }),
@@ -1538,10 +1539,11 @@ describe("CopyKeyDialog", () => {
         name: "ui:dialog.copyKey.createCustomKey",
       }),
     )
-    await user.type(
-      await screen.findByLabelText(/keyManagement:dialog\.tokenName/),
-      "My Key",
+    const tokenNameInput = await screen.findByLabelText(
+      /keyManagement:dialog\.tokenName/,
     )
+    await user.clear(tokenNameInput)
+    await user.type(tokenNameInput, "My Key")
     await user.click(
       screen.getByRole("button", { name: "keyManagement:dialog.createToken" }),
     )
@@ -1600,10 +1602,11 @@ describe("CopyKeyDialog", () => {
         name: "ui:dialog.copyKey.createCustomKey",
       }),
     )
-    await user.type(
-      await screen.findByLabelText(/keyManagement:dialog\.tokenName/),
-      "My Key",
+    const tokenNameInput = await screen.findByLabelText(
+      /keyManagement:dialog\.tokenName/,
     )
+    await user.clear(tokenNameInput)
+    await user.type(tokenNameInput, "My Key")
     await user.click(
       screen.getByRole("button", { name: "keyManagement:dialog.createToken" }),
     )

--- a/tests/features/TokenProvisioning/components/AddTokenDialog/hooks/useTokenData.test.tsx
+++ b/tests/features/TokenProvisioning/components/AddTokenDialog/hooks/useTokenData.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { SITE_TYPES } from "~/constants/siteType"
 import { useTokenData } from "~/features/TokenProvisioning/components/AddTokenDialog/hooks/useTokenData"
+import { DEFAULT_AUTO_PROVISION_TOKEN_NAME } from "~/services/accounts/defaultTokenLifecycle"
 import { AuthTypeEnum } from "~/types"
 import { renderHook, waitFor } from "~~/tests/test-utils/render"
 
@@ -75,6 +76,7 @@ type RenderSubjectProps = {
   isOpen: boolean
   currentAccount?: typeof ACCOUNT
   initialGroup?: string
+  initialName?: string
   allowedGroups?: string[]
 }
 
@@ -84,10 +86,12 @@ const renderSubject = (props: RenderSubjectProps) =>
       isOpen,
       currentAccount,
       initialGroup = "",
+      initialName = "",
       allowedGroups,
     }: RenderSubjectProps) => {
       const [formData, setFormData] = useState({
         group: initialGroup,
+        name: initialName,
       } as any)
 
       return {
@@ -246,6 +250,24 @@ describe("useTokenData", () => {
     await waitFor(() => {
       expect(result.current.formData.group).toBe("beta")
     })
+  })
+
+  it("keeps the default auto token name aligned with the fetched fallback group", async () => {
+    fetchAccountAvailableModelsMock.mockResolvedValue(["gpt-4o-mini"])
+    fetchUserGroupsMock.mockResolvedValue(createGroups(["beta", "alpha"]))
+
+    const { result } = renderSubject({
+      isOpen: true,
+      currentAccount: ACCOUNT,
+      initialGroup: "default",
+      initialName: DEFAULT_AUTO_PROVISION_TOKEN_NAME,
+    })
+
+    await waitFor(() => {
+      expect(result.current.formData.group).toBe("beta")
+    })
+
+    expect(result.current.formData.name).toBe("beta group (auto)")
   })
 
   it("treats missing group capability as no group selection without showing an error", async () => {

--- a/tests/features/TokenProvisioning/components/AddTokenDialog/prefill.test.tsx
+++ b/tests/features/TokenProvisioning/components/AddTokenDialog/prefill.test.tsx
@@ -113,6 +113,15 @@ const ACCOUNT = {
   tagIds: ["tag-a"],
 } as any
 
+const SECOND_ACCOUNT = {
+  ...ACCOUNT,
+  id: "acc-2",
+  name: "Second Example",
+  baseUrl: "https://second.example.com",
+  token: "second-token",
+  userId: "2",
+}
+
 const AIHUBMIX_ACCOUNT = {
   ...ACCOUNT,
   id: "aihubmix-1",
@@ -231,6 +240,49 @@ describe("AddTokenDialog prefill", () => {
 
     expect(createApiTokenMock.mock.calls[0]?.[1]).toMatchObject({
       name: DEFAULT_AUTO_PROVISION_TOKEN_NAME,
+    })
+  })
+
+  it("allows selecting a different account before creating a token", async () => {
+    fetchAccountAvailableModelsMock.mockResolvedValue([])
+    fetchUserGroupsMock.mockResolvedValue({
+      default: { desc: "default", ratio: 1 },
+    })
+    createApiTokenMock.mockResolvedValueOnce(true)
+
+    const user = userEvent.setup()
+
+    render(
+      <AddTokenDialog
+        isOpen={true}
+        onClose={() => {}}
+        availableAccounts={[ACCOUNT, SECOND_ACCOUNT]}
+        preSelectedAccountId={ACCOUNT.id}
+      />,
+    )
+
+    await screen.findByLabelText(/keyManagement:dialog\.tokenName/)
+
+    const accountTrigger = screen
+      .getAllByRole("combobox")
+      .find((element) => element.textContent?.includes(ACCOUNT.name))
+    expect(accountTrigger).toBeTruthy()
+
+    await user.click(accountTrigger as HTMLElement)
+    await user.click(await screen.findByText(SECOND_ACCOUNT.name))
+
+    expect(accountTrigger).toHaveTextContent(SECOND_ACCOUNT.name)
+
+    await user.click(
+      screen.getByRole("button", { name: "keyManagement:dialog.createToken" }),
+    )
+
+    await waitFor(() => {
+      expect(createApiTokenMock).toHaveBeenCalledTimes(1)
+    })
+
+    expect(createApiTokenMock.mock.calls[0]?.[0]).toMatchObject({
+      baseUrl: SECOND_ACCOUNT.baseUrl,
     })
   })
 

--- a/tests/features/TokenProvisioning/components/AddTokenDialog/prefill.test.tsx
+++ b/tests/features/TokenProvisioning/components/AddTokenDialog/prefill.test.tsx
@@ -199,6 +199,41 @@ describe("AddTokenDialog prefill", () => {
     )
   })
 
+  it("prefills the default auto token name for manual create", async () => {
+    fetchAccountAvailableModelsMock.mockResolvedValueOnce([])
+    fetchUserGroupsMock.mockResolvedValueOnce({
+      default: { desc: "default", ratio: 1 },
+    })
+    createApiTokenMock.mockResolvedValueOnce(true)
+
+    const user = userEvent.setup()
+
+    render(
+      <AddTokenDialog
+        isOpen={true}
+        onClose={() => {}}
+        availableAccounts={[ACCOUNT]}
+        preSelectedAccountId={ACCOUNT.id}
+      />,
+    )
+
+    expect(
+      await screen.findByLabelText(/keyManagement:dialog\.tokenName/),
+    ).toHaveValue(DEFAULT_AUTO_PROVISION_TOKEN_NAME)
+
+    await user.click(
+      screen.getByRole("button", { name: "keyManagement:dialog.createToken" }),
+    )
+
+    await waitFor(() => {
+      expect(createApiTokenMock).toHaveBeenCalledTimes(1)
+    })
+
+    expect(createApiTokenMock.mock.calls[0]?.[1]).toMatchObject({
+      name: DEFAULT_AUTO_PROVISION_TOKEN_NAME,
+    })
+  })
+
   it("keeps a successful create flow successful when analytics completion rejects", async () => {
     fetchAccountAvailableModelsMock.mockResolvedValueOnce([])
     fetchUserGroupsMock.mockResolvedValueOnce({
@@ -1242,10 +1277,11 @@ describe("AddTokenDialog prefill", () => {
       />,
     )
 
-    await user.type(
-      await screen.findByLabelText(/keyManagement:dialog\.tokenName/),
-      "AIHubMix subnet test",
+    const tokenNameInput = await screen.findByLabelText(
+      /keyManagement:dialog\.tokenName/,
     )
+    await user.clear(tokenNameInput)
+    await user.type(tokenNameInput, "AIHubMix subnet test")
     await user.type(
       screen.getByLabelText("keyManagement:dialog.subnetLimits"),
       "111",
@@ -1399,7 +1435,9 @@ describe("AddTokenDialog prefill", () => {
       />,
     )
 
-    await screen.findByLabelText(/keyManagement:dialog\.tokenName/)
+    const tokenNameInput = await screen.findByLabelText(
+      /keyManagement:dialog\.tokenName/,
+    )
 
     const groupField = screen
       .getByText("keyManagement:dialog.groupLabel")
@@ -1411,6 +1449,8 @@ describe("AddTokenDialog prefill", () => {
     await user.click(
       await screen.findByText("vip - VIP (keyManagement:dialog.groupRate 2)"),
     )
+
+    expect(tokenNameInput).toHaveValue("vip group (auto)")
 
     await user.click(
       screen.getByRole("button", { name: "keyManagement:dialog.createToken" }),

--- a/tests/features/TokenProvisioning/defaultTokenCreatePrefill.test.ts
+++ b/tests/features/TokenProvisioning/defaultTokenCreatePrefill.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest"
 
-import { buildDefaultTokenCreatePrefill } from "~/features/TokenProvisioning/components/AddTokenDialog/defaultTokenCreatePrefill"
+import {
+  applyDefaultTokenCreateGroupSelection,
+  buildDefaultTokenCreatePrefill,
+} from "~/features/TokenProvisioning/components/AddTokenDialog/defaultTokenCreatePrefill"
 import { DEFAULT_AUTO_PROVISION_TOKEN_NAME } from "~/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken"
 
 describe("buildDefaultTokenCreatePrefill", () => {
@@ -25,5 +28,37 @@ describe("buildDefaultTokenCreatePrefill", () => {
   it("returns undefined without selectable groups", () => {
     expect(buildDefaultTokenCreatePrefill([])).toBeUndefined()
     expect(buildDefaultTokenCreatePrefill(undefined)).toBeUndefined()
+  })
+
+  it("updates generated auto names when the token group changes", () => {
+    expect(
+      applyDefaultTokenCreateGroupSelection(
+        {
+          name: DEFAULT_AUTO_PROVISION_TOKEN_NAME,
+          group: "default",
+          untouched: true,
+        },
+        "vip",
+      ),
+    ).toEqual({
+      name: "vip group (auto)",
+      group: "vip",
+      untouched: true,
+    })
+  })
+
+  it("preserves custom token names when the token group changes", () => {
+    expect(
+      applyDefaultTokenCreateGroupSelection(
+        {
+          name: "custom key",
+          group: "default",
+        },
+        "vip",
+      ),
+    ).toEqual({
+      name: "custom key",
+      group: "vip",
+    })
   })
 })


### PR DESCRIPTION
Summary:
- prefill manual Add Token default names with the auto-provision token name
- keep generated token names in sync with selected user group
- centralize AddTokenDialog default-token prefill/group-selection helper logic
- update coverage for default-name, constrained group, fallback group, and custom-name flows

Validation:
- pnpm run validate:staged
- pnpm run validate:push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Token creation now pre-fills a default auto-provision token name in more manual and edge-case flows.
  * When changing the token group, auto-generated names stay synchronized with the selected (including fallback) group, while custom names are preserved.

* **Bug Fixes**
  * Improved consistency of group selection and token details updates when previously selected groups become unavailable or restricted.
  * Creation tests and flows now more reliably interact with the token name field and ensure the submitted payload matches the currently selected account.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->