### PR TITLE
feat(site-announcements): support New API structured notices

### DIFF
--- a/src/services/apiAdapters/contracts/siteStructuredAnnouncements.ts
+++ b/src/services/apiAdapters/contracts/siteStructuredAnnouncements.ts
@@ -1,11 +1,15 @@
 import type { ApiServiceRequest } from "~/services/apiTransport/type"
 
+export const SITE_STRUCTURED_ANNOUNCEMENT_TYPES = [
+  "default",
+  "ongoing",
+  "success",
+  "warning",
+  "error",
+] as const
+
 export type SiteStructuredAnnouncementType =
-  | "default"
-  | "ongoing"
-  | "success"
-  | "warning"
-  | "error"
+  (typeof SITE_STRUCTURED_ANNOUNCEMENT_TYPES)[number]
 
 export type SiteStructuredAnnouncement = {
   id?: string | number

--- a/src/services/apiAdapters/contracts/siteStructuredAnnouncements.ts
+++ b/src/services/apiAdapters/contracts/siteStructuredAnnouncements.ts
@@ -1,0 +1,20 @@
+import type { ApiServiceRequest } from "~/services/apiTransport/type"
+
+export type SiteStructuredAnnouncementType =
+  | "default"
+  | "ongoing"
+  | "success"
+  | "warning"
+  | "error"
+
+export type SiteStructuredAnnouncement = {
+  id?: string | number
+  content: string
+  publishDate?: string
+  type?: SiteStructuredAnnouncementType
+  extra?: string
+}
+
+export type SiteStructuredAnnouncementsCapability = {
+  fetch(request: ApiServiceRequest): Promise<SiteStructuredAnnouncement[]>
+}

--- a/src/services/apiAdapters/contracts/siteTypeCapabilities.ts
+++ b/src/services/apiAdapters/contracts/siteTypeCapabilities.ts
@@ -18,6 +18,7 @@ import type { RedemptionCapability } from "./redemption"
 import type { ServiceCredentialCapability } from "./serviceCredential"
 import type { SiteAnnouncementsCapability } from "./siteAnnouncements"
 import type { SiteNoticeCapability } from "./siteNotice"
+import type { SiteStructuredAnnouncementsCapability } from "./siteStructuredAnnouncements"
 import type { TokenProvisioningCapability } from "./tokenProvisioning"
 
 export type SiteType = AccountSiteType | ManagedSiteType
@@ -28,6 +29,7 @@ export type SiteTypeCapabilities = {
   siteType: SiteType
   family?: SiteBackendFamily
   site?: {
+    announcements?: SiteStructuredAnnouncementsCapability
     notice?: SiteNoticeCapability
   }
   account?: {

--- a/src/services/apiAdapters/newApi/index.ts
+++ b/src/services/apiAdapters/newApi/index.ts
@@ -13,6 +13,7 @@ import { createNewApiKeyManagement } from "./keyManagement"
 import { createNewApiModelPricing } from "./modelPricing"
 import { createNewApiRedemption } from "./redemption"
 import { newApiSiteNotice } from "./siteNotice"
+import { newApiSiteStructuredAnnouncements } from "./siteStructuredAnnouncements"
 import { createNewApiTokenProvisioning } from "./tokenProvisioning"
 
 export const createNewApiCapabilities = (
@@ -20,7 +21,10 @@ export const createNewApiCapabilities = (
 ): SiteTypeCapabilities => ({
   siteType,
   family: ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily,
-  site: { notice: newApiSiteNotice },
+  site: {
+    announcements: newApiSiteStructuredAnnouncements,
+    notice: newApiSiteNotice,
+  },
   account: {
     data: createNewApiAccountData(siteType),
     bootstrap: createNewApiAccountBootstrap(siteType),

--- a/src/services/apiAdapters/newApi/siteStructuredAnnouncements.ts
+++ b/src/services/apiAdapters/newApi/siteStructuredAnnouncements.ts
@@ -1,0 +1,8 @@
+import { fetchSiteAnnouncements } from "~/services/apiService/newApiFamily/default/siteAnnouncements"
+
+import type { SiteStructuredAnnouncementsCapability } from "../contracts/siteStructuredAnnouncements"
+
+export const newApiSiteStructuredAnnouncements: SiteStructuredAnnouncementsCapability =
+  {
+    fetch: fetchSiteAnnouncements,
+  }

--- a/src/services/apiService/newApiFamily/default/siteAnnouncements.ts
+++ b/src/services/apiService/newApiFamily/default/siteAnnouncements.ts
@@ -1,4 +1,8 @@
-import type { SiteStructuredAnnouncement } from "~/services/apiAdapters/contracts/siteStructuredAnnouncements"
+import {
+  SITE_STRUCTURED_ANNOUNCEMENT_TYPES,
+  type SiteStructuredAnnouncement,
+  type SiteStructuredAnnouncementType,
+} from "~/services/apiAdapters/contracts/siteStructuredAnnouncements"
 import { fetchApiData } from "~/services/apiTransport/request"
 import type { ApiServiceRequest } from "~/services/apiTransport/type"
 import { AuthTypeEnum } from "~/types"
@@ -11,13 +15,16 @@ type NewApiStatusAnnouncementsResponse = {
   announcements?: unknown
 }
 
-const VALID_ANNOUNCEMENT_TYPES = new Set([
-  "default",
-  "ongoing",
-  "success",
-  "warning",
-  "error",
-])
+const VALID_ANNOUNCEMENT_TYPES = new Set(SITE_STRUCTURED_ANNOUNCEMENT_TYPES)
+
+/**
+ * Checks whether an upstream announcement type is supported locally.
+ */
+function isSiteStructuredAnnouncementType(
+  value: string,
+): value is SiteStructuredAnnouncementType {
+  return VALID_ANNOUNCEMENT_TYPES.has(value as SiteStructuredAnnouncementType)
+}
 
 /**
  * Keep only New API announcement fields the extension can safely display.
@@ -44,7 +51,7 @@ function normalizeStructuredAnnouncement(
       ? item.publishDate
       : undefined
   const type =
-    typeof item.type === "string" && VALID_ANNOUNCEMENT_TYPES.has(item.type)
+    typeof item.type === "string" && isSiteStructuredAnnouncementType(item.type)
       ? item.type
       : undefined
   const extra =
@@ -54,7 +61,7 @@ function normalizeStructuredAnnouncement(
     ...(id === undefined ? {} : { id }),
     content,
     ...(publishDate ? { publishDate } : {}),
-    ...(type ? { type: type as SiteStructuredAnnouncement["type"] } : {}),
+    ...(type ? { type } : {}),
     ...(extra ? { extra } : {}),
   }
 }

--- a/src/services/apiService/newApiFamily/default/siteAnnouncements.ts
+++ b/src/services/apiService/newApiFamily/default/siteAnnouncements.ts
@@ -1,0 +1,94 @@
+import type { SiteStructuredAnnouncement } from "~/services/apiAdapters/contracts/siteStructuredAnnouncements"
+import { fetchApiData } from "~/services/apiTransport/request"
+import type { ApiServiceRequest } from "~/services/apiTransport/type"
+import { AuthTypeEnum } from "~/types"
+import { createLogger } from "~/utils/core/logger"
+
+const logger = createLogger("NewApiFamilySiteAnnouncements")
+
+type NewApiStatusAnnouncementsResponse = {
+  announcements_enabled?: boolean
+  announcements?: unknown
+}
+
+const VALID_ANNOUNCEMENT_TYPES = new Set([
+  "default",
+  "ongoing",
+  "success",
+  "warning",
+  "error",
+])
+
+/**
+ * Keep only New API announcement fields the extension can safely display.
+ */
+function normalizeStructuredAnnouncement(
+  value: unknown,
+): SiteStructuredAnnouncement | null {
+  if (!value || typeof value !== "object") {
+    return null
+  }
+
+  const item = value as Record<string, unknown>
+  const content = typeof item.content === "string" ? item.content : ""
+  if (!content.trim()) {
+    return null
+  }
+
+  const id =
+    typeof item.id === "string" || typeof item.id === "number"
+      ? item.id
+      : undefined
+  const publishDate =
+    typeof item.publishDate === "string" && item.publishDate.trim()
+      ? item.publishDate
+      : undefined
+  const type =
+    typeof item.type === "string" && VALID_ANNOUNCEMENT_TYPES.has(item.type)
+      ? item.type
+      : undefined
+  const extra =
+    typeof item.extra === "string" && item.extra.trim() ? item.extra : undefined
+
+  return {
+    ...(id === undefined ? {} : { id }),
+    content,
+    ...(publishDate ? { publishDate } : {}),
+    ...(type ? { type: type as SiteStructuredAnnouncement["type"] } : {}),
+    ...(extra ? { extra } : {}),
+  }
+}
+
+/**
+ * Fetch New API structured system announcements from /api/status.
+ * Upstream contract: QuantumNous/new-api GetStatus injects
+ * console_setting.announcements when announcements_enabled is true.
+ */
+export async function fetchSiteAnnouncements(
+  request: ApiServiceRequest,
+): Promise<SiteStructuredAnnouncement[]> {
+  try {
+    const response = await fetchApiData<NewApiStatusAnnouncementsResponse>(
+      {
+        ...request,
+        auth: { authType: AuthTypeEnum.None },
+      },
+      { endpoint: "/api/status" },
+    )
+
+    if (response?.announcements_enabled === false) {
+      return []
+    }
+
+    if (!Array.isArray(response?.announcements)) {
+      return []
+    }
+
+    return response.announcements
+      .map(normalizeStructuredAnnouncement)
+      .filter((item): item is SiteStructuredAnnouncement => Boolean(item))
+  } catch (error) {
+    logger.warn("获取站点系统公告失败", error)
+    return []
+  }
+}

--- a/src/services/siteAnnouncements/providers.ts
+++ b/src/services/siteAnnouncements/providers.ts
@@ -1,4 +1,5 @@
 import { SITE_TYPES, type AccountSiteType } from "~/constants/siteType"
+import type { SiteStructuredAnnouncement } from "~/services/apiAdapters/contracts/siteStructuredAnnouncements"
 import { getSiteTypeCapabilities } from "~/services/apiAdapters/registry"
 import type { Sub2ApiAnnouncementData } from "~/services/apiService/sub2api/type"
 import type {
@@ -19,8 +20,12 @@ import { fingerprintAnnouncement, normalizeAnnouncementText } from "./text"
 
 const logger = createLogger("SiteAnnouncementProviders")
 
-const createMissingSiteNoticeCapabilityError = (siteType: AccountSiteType) =>
-  new Error(`siteNotice is not implemented for ${siteType}`)
+const createMissingCommonSiteAnnouncementCapabilitiesError = (
+  siteType: AccountSiteType,
+) =>
+  new Error(
+    `site announcement capabilities are not implemented for ${siteType}`,
+  )
 
 const createMissingSiteAnnouncementsCapabilityError = (
   siteType: AccountSiteType,
@@ -114,6 +119,40 @@ function normalizeSub2ApiAnnouncement(
   }
 }
 
+/**
+ * Converts New API-family structured announcement payloads into the local
+ * announcement contract while preserving optional extra text in the body.
+ */
+function normalizeStructuredSiteAnnouncement(
+  item: SiteStructuredAnnouncement,
+): SiteAnnouncement | null {
+  const content = normalizeAnnouncementText(item.content)
+  const extra = normalizeAnnouncementText(item.extra)
+
+  if (!content) {
+    return null
+  }
+
+  const upstreamId =
+    item.id === null || item.id === undefined ? undefined : String(item.id)
+  const createdAt = parseTimestamp(item.publishDate)
+  const fullContent = extra ? `${content}\n\n${extra}` : content
+  const fingerprint = fingerprintAnnouncement([
+    upstreamId ?? "",
+    item.type ?? "",
+    item.publishDate ?? "",
+    content,
+    extra,
+  ])
+
+  return {
+    id: upstreamId,
+    content: fullContent,
+    createdAt,
+    fingerprint,
+  }
+}
+
 export const commonSiteAnnouncementProvider: SiteAnnouncementProvider = {
   id: SITE_ANNOUNCEMENT_PROVIDER_IDS.Common,
   createSiteKey: createCommonSiteAnnouncementKey,
@@ -122,26 +161,44 @@ export const commonSiteAnnouncementProvider: SiteAnnouncementProvider = {
   ): Promise<SiteAnnouncementProviderResult> {
     const siteKey = createCommonSiteAnnouncementKey(request)
     try {
-      const noticeCapability = getSiteTypeCapabilities(request.siteType).site
-        ?.notice
-      if (!noticeCapability) {
-        throw createMissingSiteNoticeCapabilityError(request.siteType)
+      const siteCapabilities = getSiteTypeCapabilities(request.siteType).site
+      const structuredAnnouncementsCapability = siteCapabilities?.announcements
+      const noticeCapability = siteCapabilities?.notice
+
+      if (!structuredAnnouncementsCapability && !noticeCapability) {
+        throw createMissingCommonSiteAnnouncementCapabilitiesError(
+          request.siteType,
+        )
       }
 
-      const notice = await noticeCapability.fetch(request.apiRequest)
+      const structuredAnnouncements = structuredAnnouncementsCapability
+        ? await structuredAnnouncementsCapability
+            .fetch(request.apiRequest)
+            .then((items) =>
+              items
+                .map(normalizeStructuredSiteAnnouncement)
+                .filter((item): item is SiteAnnouncement => Boolean(item)),
+            )
+        : []
+      const notice = noticeCapability
+        ? await noticeCapability.fetch(request.apiRequest)
+        : null
       const content = normalizeAnnouncementText(notice)
       return {
         providerId: SITE_ANNOUNCEMENT_PROVIDER_IDS.Common,
         siteKey,
         status: SITE_ANNOUNCEMENT_STATUS.Success,
-        announcements: content
-          ? [
-              {
-                content,
-                fingerprint: fingerprintAnnouncement([content]),
-              },
-            ]
-          : [],
+        announcements: [
+          ...structuredAnnouncements,
+          ...(content
+            ? [
+                {
+                  content,
+                  fingerprint: fingerprintAnnouncement([content]),
+                },
+              ]
+            : []),
+        ],
       }
     } catch (error) {
       return {

--- a/src/services/siteAnnouncements/providers.ts
+++ b/src/services/siteAnnouncements/providers.ts
@@ -180,9 +180,20 @@ export const commonSiteAnnouncementProvider: SiteAnnouncementProvider = {
                 .filter((item): item is SiteAnnouncement => Boolean(item)),
             )
         : []
-      const notice = noticeCapability
-        ? await noticeCapability.fetch(request.apiRequest)
-        : null
+      let notice: string | null = null
+      if (noticeCapability && structuredAnnouncementsCapability) {
+        try {
+          notice = await noticeCapability.fetch(request.apiRequest)
+        } catch (error) {
+          logger.warn("Failed to fetch site notice", {
+            siteType: request.siteType,
+            baseUrl: request.baseUrl,
+            error: getErrorMessage(error),
+          })
+        }
+      } else if (noticeCapability) {
+        notice = await noticeCapability.fetch(request.apiRequest)
+      }
       const content = normalizeAnnouncementText(notice)
       return {
         providerId: SITE_ANNOUNCEMENT_PROVIDER_IDS.Common,

--- a/tests/services/apiAdapters/newApi/siteNotice.test.ts
+++ b/tests/services/apiAdapters/newApi/siteNotice.test.ts
@@ -1,10 +1,19 @@
 import { describe, expect, it, vi } from "vitest"
 
 import { newApiSiteNotice } from "~/services/apiAdapters/newApi/siteNotice"
+import { newApiSiteStructuredAnnouncements } from "~/services/apiAdapters/newApi/siteStructuredAnnouncements"
 import { AuthTypeEnum } from "~/types"
 
-const { newApiFamilyFetchSiteNoticeMock } = vi.hoisted(() => ({
+const {
+  newApiFamilyFetchSiteAnnouncementsMock,
+  newApiFamilyFetchSiteNoticeMock,
+} = vi.hoisted(() => ({
+  newApiFamilyFetchSiteAnnouncementsMock: vi.fn(),
   newApiFamilyFetchSiteNoticeMock: vi.fn(),
+}))
+
+vi.mock("~/services/apiService/newApiFamily/default/siteAnnouncements", () => ({
+  fetchSiteAnnouncements: newApiFamilyFetchSiteAnnouncementsMock,
 }))
 
 vi.mock("~/services/apiService/newApiFamily/default/siteNotice", () => ({
@@ -26,5 +35,37 @@ describe("newApiSiteNotice", () => {
 
     await expect(newApiSiteNotice.fetch(request)).resolves.toBe("Notice body")
     expect(newApiFamilyFetchSiteNoticeMock).toHaveBeenCalledWith(request)
+  })
+})
+
+describe("newApiSiteStructuredAnnouncements", () => {
+  it("delegates structured announcement fetches through the New API-family implementation", async () => {
+    newApiFamilyFetchSiteAnnouncementsMock.mockResolvedValueOnce([
+      {
+        content: "Maintenance",
+        publishDate: "2026-07-01T12:00:00Z",
+        type: "warning",
+      },
+    ])
+
+    const request = {
+      baseUrl: "https://example.invalid",
+      accountId: "account-1",
+      auth: {
+        authType: AuthTypeEnum.AccessToken,
+        accessToken: "token",
+      },
+    }
+
+    await expect(
+      newApiSiteStructuredAnnouncements.fetch(request),
+    ).resolves.toEqual([
+      {
+        content: "Maintenance",
+        publishDate: "2026-07-01T12:00:00Z",
+        type: "warning",
+      },
+    ])
+    expect(newApiFamilyFetchSiteAnnouncementsMock).toHaveBeenCalledWith(request)
   })
 })

--- a/tests/services/apiAdapters/registry.test.ts
+++ b/tests/services/apiAdapters/registry.test.ts
@@ -146,6 +146,9 @@ describe("apiAdapters registry", () => {
       expect(capabilities.site?.notice).toEqual({
         fetch: expect.any(Function),
       })
+      expect(capabilities.site?.announcements).toEqual({
+        fetch: expect.any(Function),
+      })
       expectAccountDataCapability(capabilities)
       expectAccountBootstrapCapability(capabilities)
       expectAccountCompletionCapability(capabilities)

--- a/tests/services/apiService/newApiFamily/siteAnnouncements.test.ts
+++ b/tests/services/apiService/newApiFamily/siteAnnouncements.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { fetchSiteAnnouncements } from "~/services/apiService/newApiFamily/default/siteAnnouncements"
+import { AuthTypeEnum } from "~/types"
+
+const { fetchApiDataMock, loggerWarnMock } = vi.hoisted(() => ({
+  fetchApiDataMock: vi.fn(),
+  loggerWarnMock: vi.fn(),
+}))
+
+vi.mock("~/services/apiTransport/request", () => ({
+  fetchApiData: fetchApiDataMock,
+}))
+
+vi.mock("~/utils/core/logger", () => ({
+  createLogger: () => ({
+    warn: loggerWarnMock,
+  }),
+}))
+
+const request = {
+  baseUrl: "https://announcements.example.invalid",
+  accountId: "account-1",
+  auth: {
+    authType: AuthTypeEnum.AccessToken,
+    accessToken: "token",
+  },
+}
+
+describe("newApiFamily siteAnnouncements", () => {
+  it("returns structured announcements from public status responses", async () => {
+    fetchApiDataMock.mockResolvedValueOnce({
+      announcements_enabled: true,
+      announcements: [
+        {
+          content: " Maintenance window ",
+          publishDate: "2026-07-01T12:00:00Z",
+          type: "warning",
+          extra: " Expect brief interruptions ",
+        },
+        {
+          content: "   ",
+          publishDate: "2026-07-02T12:00:00Z",
+          type: "success",
+        },
+      ],
+    })
+
+    await expect(fetchSiteAnnouncements(request)).resolves.toEqual([
+      {
+        content: " Maintenance window ",
+        publishDate: "2026-07-01T12:00:00Z",
+        type: "warning",
+        extra: " Expect brief interruptions ",
+      },
+    ])
+
+    expect(fetchApiDataMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        auth: { authType: AuthTypeEnum.None },
+      }),
+      { endpoint: "/api/status" },
+    )
+  })
+
+  it("returns an empty list when announcements are disabled or malformed", async () => {
+    fetchApiDataMock.mockResolvedValueOnce({
+      announcements_enabled: false,
+      announcements: [{ content: "Hidden" }],
+    })
+    await expect(fetchSiteAnnouncements(request)).resolves.toEqual([])
+
+    fetchApiDataMock.mockResolvedValueOnce({
+      announcements_enabled: true,
+      announcements: "not-an-array",
+    })
+    await expect(fetchSiteAnnouncements(request)).resolves.toEqual([])
+  })
+
+  it("returns an empty list when the status request throws", async () => {
+    fetchApiDataMock.mockRejectedValueOnce(new TypeError("network failed"))
+
+    await expect(fetchSiteAnnouncements(request)).resolves.toEqual([])
+    expect(loggerWarnMock).toHaveBeenCalledWith(
+      "获取站点系统公告失败",
+      expect.any(TypeError),
+    )
+  })
+})

--- a/tests/services/apiService/newApiFamily/siteAnnouncements.test.ts
+++ b/tests/services/apiService/newApiFamily/siteAnnouncements.test.ts
@@ -77,6 +77,40 @@ describe("newApiFamily siteAnnouncements", () => {
     await expect(fetchSiteAnnouncements(request)).resolves.toEqual([])
   })
 
+  it("keeps valid items while omitting invalid optional fields", async () => {
+    fetchApiDataMock.mockResolvedValueOnce({
+      announcements_enabled: true,
+      announcements: [
+        null,
+        "not-an-object",
+        42,
+        {
+          id: 7,
+          content: "Valid content",
+          publishDate: 123,
+          type: "critical",
+          extra: 456,
+        },
+        {
+          id: "announcement-2",
+          content: "Also valid",
+          type: 123,
+        },
+      ],
+    })
+
+    await expect(fetchSiteAnnouncements(request)).resolves.toEqual([
+      {
+        id: 7,
+        content: "Valid content",
+      },
+      {
+        id: "announcement-2",
+        content: "Also valid",
+      },
+    ])
+  })
+
   it("returns an empty list when the status request throws", async () => {
     fetchApiDataMock.mockRejectedValueOnce(new TypeError("network failed"))
 

--- a/tests/services/siteAnnouncements/providers.test.ts
+++ b/tests/services/siteAnnouncements/providers.test.ts
@@ -47,6 +47,22 @@ const createNoticeAdapter = (fetch = vi.fn().mockResolvedValue(null)) => ({
   },
 })
 
+const createCommonAdapter = (overrides?: {
+  notice?: ReturnType<typeof vi.fn>
+  announcements?: ReturnType<typeof vi.fn>
+}) => ({
+  siteType: SITE_TYPES.NEW_API,
+  family: "newApiFamily" as const,
+  site: {
+    notice: {
+      fetch: overrides?.notice ?? vi.fn().mockResolvedValue(null),
+    },
+    announcements: {
+      fetch: overrides?.announcements ?? vi.fn().mockResolvedValue([]),
+    },
+  },
+})
+
 const createSub2ApiAdapter = (overrides?: {
   fetch?: ReturnType<typeof vi.fn>
   markRead?: ReturnType<typeof vi.fn>
@@ -109,6 +125,45 @@ describe("site announcement providers", () => {
     })
   })
 
+  it("normalizes New API structured announcements alongside site notices", async () => {
+    getSiteTypeCapabilitiesMock.mockReturnValueOnce(
+      createCommonAdapter({
+        notice: vi.fn().mockResolvedValue(" Site notice "),
+        announcements: vi.fn().mockResolvedValue([
+          {
+            id: 7,
+            content: " Maintenance ",
+            publishDate: "2026-07-01T12:00:00Z",
+            type: "warning",
+            extra: " Brief interruption ",
+          },
+          {
+            content: "",
+            publishDate: "2026-07-02T12:00:00Z",
+            type: "success",
+          },
+        ]),
+      }),
+    )
+
+    const result = await commonSiteAnnouncementProvider.fetch(baseRequest)
+
+    expect(result.status).toBe(SITE_ANNOUNCEMENT_STATUS.Success)
+    expect(result.announcements).toEqual([
+      {
+        content: "Maintenance\n\nBrief interruption",
+        createdAt: Date.parse("2026-07-01T12:00:00Z"),
+        id: "7",
+        fingerprint:
+          "1:7|7:warning|20:2026-07-01T12:00:00Z|11:Maintenance|18:Brief interruption",
+      },
+      {
+        content: "Site notice",
+        fingerprint: "11:Site notice",
+      },
+    ])
+  })
+
   it("marks common provider failures as unsupported with the upstream error text", async () => {
     getSiteTypeCapabilitiesMock.mockReturnValueOnce(
       createNoticeAdapter(
@@ -125,7 +180,7 @@ describe("site announcement providers", () => {
     })
   })
 
-  it("marks common provider missing siteNotice capability as unsupported", async () => {
+  it("marks common provider missing site announcement capabilities as unsupported", async () => {
     getSiteTypeCapabilitiesMock.mockReturnValueOnce({
       siteType: SITE_TYPES.AIHUBMIX,
     })
@@ -138,7 +193,7 @@ describe("site announcement providers", () => {
     expect(result).toMatchObject({
       status: SITE_ANNOUNCEMENT_STATUS.Unsupported,
       announcements: [],
-      error: "siteNotice is not implemented for AIHubMix",
+      error: "site announcement capabilities are not implemented for AIHubMix",
     })
   })
 

--- a/tests/services/siteAnnouncements/providers.test.ts
+++ b/tests/services/siteAnnouncements/providers.test.ts
@@ -164,6 +164,33 @@ describe("site announcement providers", () => {
     ])
   })
 
+  it("keeps structured announcements when the site notice fetch fails", async () => {
+    getSiteTypeCapabilitiesMock.mockReturnValueOnce(
+      createCommonAdapter({
+        notice: vi.fn().mockRejectedValue(new Error("notice unavailable")),
+        announcements: vi.fn().mockResolvedValue([
+          {
+            content: "Structured",
+            publishDate: "2026-07-01T12:00:00Z",
+          },
+        ]),
+      }),
+    )
+
+    const result = await commonSiteAnnouncementProvider.fetch(baseRequest)
+
+    expect(result).toMatchObject({
+      status: SITE_ANNOUNCEMENT_STATUS.Success,
+      announcements: [
+        {
+          content: "Structured",
+          createdAt: Date.parse("2026-07-01T12:00:00Z"),
+          fingerprint: "0:|0:|20:2026-07-01T12:00:00Z|10:Structured|0:",
+        },
+      ],
+    })
+  })
+
   it("marks common provider failures as unsupported with the upstream error text", async () => {
     getSiteTypeCapabilitiesMock.mockReturnValueOnce(
       createNoticeAdapter(


### PR DESCRIPTION
## Summary
- add a site-level fetch-only capability for New API structured announcements from `/api/status`
- wire New API-family adapters to expose both `/api/notice` and structured status announcements
- normalize structured announcements into the existing site-announcement storage/notification pipeline without reusing Sub2API account-scoped mark-read semantics

Closes #1097

## Validation
- pnpm vitest run tests/services/apiService/newApiFamily/siteAnnouncements.test.ts tests/services/apiAdapters/newApi/siteNotice.test.ts tests/services/siteAnnouncements/providers.test.ts tests/services/apiAdapters/registry.test.ts
- pnpm compile
- pnpm run validate:staged
- pnpm run validate:push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end support for structured site announcements (content, publish date, type, and optional extra fields).
  * Exposed structured announcements as a site capability where supported.
* **Bug Fixes**
  * Improved announcement handling to ignore malformed/invalid items and return an empty result on failures instead of breaking.
  * When both structured announcements and site notices are available, the app now combines them into a single announcements feed.
* **Tests**
  * Expanded test coverage for fetching, normalization, capability wiring, and provider composition behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->