### PR TITLE
fix(ui): prevent modal select interactions from closing dialog

### DIFF
--- a/src/components/dialogs/ChannelDialog/components/DuplicateChannelWarningDialog.tsx
+++ b/src/components/dialogs/ChannelDialog/components/DuplicateChannelWarningDialog.tsx
@@ -1,4 +1,3 @@
-import { DialogTitle } from "@headlessui/react"
 import { ExclamationTriangleIcon } from "@heroicons/react/24/outline"
 import { useTranslation } from "react-i18next"
 
@@ -29,14 +28,15 @@ export function DuplicateChannelWarningDialog({
     <Modal
       isOpen={isOpen}
       onClose={onCancel}
+      title={t("channelDialog:warnings.channelExists.title")}
       size="sm"
       header={
         <div className="flex items-center justify-between">
           <div className="flex items-center space-x-3">
             <ExclamationTriangleIcon className="h-5 w-5 text-yellow-600 dark:text-yellow-400" />
-            <DialogTitle className="dark:text-dark-text-primary text-lg font-semibold text-gray-900">
+            <h2 className="dark:text-dark-text-primary text-lg font-semibold text-gray-900">
               {t("channelDialog:warnings.channelExists.title")}
-            </DialogTitle>
+            </h2>
           </div>
         </div>
       }

--- a/src/components/ui/Dialog/DestructiveConfirmDialog.tsx
+++ b/src/components/ui/Dialog/DestructiveConfirmDialog.tsx
@@ -1,4 +1,3 @@
-import { DialogTitle } from "@headlessui/react"
 import { TrashIcon } from "@heroicons/react/24/outline"
 import type { ReactNode } from "react"
 
@@ -81,6 +80,7 @@ export function DestructiveConfirmDialog({
     <Modal
       isOpen={isOpen}
       onClose={onClose}
+      title={title}
       closeOnBackdropClick={!isWorking}
       closeOnEsc={!isWorking}
       showCloseButton={!isWorking}
@@ -89,9 +89,9 @@ export function DestructiveConfirmDialog({
         <div className="flex items-center justify-between">
           <div className="flex items-center space-x-3">
             <TrashIcon className="h-5 w-5 text-red-600 dark:text-red-400" />
-            <DialogTitle className="dark:text-dark-text-primary text-lg font-semibold text-gray-900">
+            <h2 className="dark:text-dark-text-primary text-lg font-semibold text-gray-900">
               {title}
-            </DialogTitle>
+            </h2>
           </div>
         </div>
       }

--- a/src/components/ui/Dialog/Modal.tsx
+++ b/src/components/ui/Dialog/Modal.tsx
@@ -1,12 +1,6 @@
 import { XIcon } from "lucide-react"
 import { Dialog as DialogPrimitive } from "radix-ui"
-import {
-  ReactNode,
-  useEffect,
-  useId,
-  useSyncExternalStore,
-  type MouseEvent,
-} from "react"
+import { ReactNode, useRef, type MouseEvent } from "react"
 
 import { Z_INDEX } from "~/constants/designTokens"
 import { cn } from "~/lib/utils"
@@ -40,34 +34,22 @@ const sizeMap: Record<Size, string> = {
   xl: "max-w-5xl",
 }
 
-let activeModalStack: string[] = []
-const modalStackListeners = new Set<() => void>()
+const openFloatingLayerSelector = [
+  '[data-slot="select-content"][data-state="open"]',
+  '[data-slot="popover-content"][data-state="open"]',
+  '[data-slot="combobox-content"][data-open]',
+].join(",")
 
-const emitModalStackChange = () => {
-  modalStackListeners.forEach((listener) => listener())
+/**
+ * Detects nested select, popover, or combobox layers that should handle Escape
+ * before the legacy Modal treats it as a dialog dismissal request.
+ */
+function hasOpenFloatingLayer() {
+  return (
+    typeof document !== "undefined" &&
+    document.querySelector(openFloatingLayerSelector) !== null
+  )
 }
-
-const getModalStackSnapshot = () => activeModalStack.join("|")
-
-const subscribeModalStack = (listener: () => void) => {
-  modalStackListeners.add(listener)
-  return () => modalStackListeners.delete(listener)
-}
-
-const registerModal = (id: string) => {
-  if (activeModalStack.includes(id)) return
-  activeModalStack = [...activeModalStack, id]
-  emitModalStackChange()
-}
-
-const unregisterModal = (id: string) => {
-  if (!activeModalStack.includes(id)) return
-  activeModalStack = activeModalStack.filter((activeId) => activeId !== id)
-  emitModalStackChange()
-}
-
-const isModalTopmost = (id: string) =>
-  activeModalStack[activeModalStack.length - 1] === id
 
 /**
  * Modal renders a Radix/shadcn-compatible dialog with the legacy slot API.
@@ -90,38 +72,26 @@ export function Modal({
   closeOnBackdropClick = true,
   size = "md",
 }: ModalProps) {
-  const modalId = useId()
-  const modalStackSnapshot = useSyncExternalStore(
-    subscribeModalStack,
-    getModalStackSnapshot,
-    getModalStackSnapshot,
-  )
-  const topmostModalId = modalStackSnapshot.split("|").filter(Boolean).at(-1)
-  const isTopmostModal = isOpen && topmostModalId === modalId
-
-  useEffect(() => {
-    if (!isOpen) {
-      unregisterModal(modalId)
-      return
-    }
-
-    registerModal(modalId)
-    return () => unregisterModal(modalId)
-  }, [isOpen, modalId])
-
-  const handleOpenChange = (open: boolean) => {
-    if (!open && isModalTopmost(modalId)) onClose()
-  }
+  const contentRef = useRef<HTMLDivElement>(null)
 
   const handleBackdropClick = (event: MouseEvent<HTMLDivElement>) => {
-    if (
-      event.target !== event.currentTarget ||
-      !closeOnBackdropClick ||
-      !isModalTopmost(modalId)
-    ) {
-      return
-    }
+    if (event.target !== event.currentTarget || !closeOnBackdropClick) return
     onClose()
+  }
+
+  const shouldCloseOnEscape = () => {
+    if (!closeOnEsc) return false
+    if (hasOpenFloatingLayer()) return false
+    const activeElement = document.activeElement
+    return (
+      activeElement instanceof Node &&
+      contentRef.current?.contains(activeElement) === true
+    )
+  }
+
+  const handleEscapeKeyDown = (event: KeyboardEvent) => {
+    event.preventDefault()
+    if (shouldCloseOnEscape()) onClose()
   }
 
   const panelBaseClass = cn(
@@ -130,21 +100,16 @@ export function Modal({
   )
 
   return (
-    <DialogPrimitive.Root
-      open={isOpen}
-      onOpenChange={handleOpenChange}
-      modal={isTopmostModal}
-    >
+    <DialogPrimitive.Root open={isOpen} modal={false}>
       <DialogPrimitive.Portal>
-        <DialogPrimitive.Overlay
+        <div
           data-slot="modal-overlay"
+          data-state={isOpen ? "open" : "closed"}
           className={cn(
             "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 bg-black/30 backdrop-blur-sm",
             Z_INDEX.modal,
           )}
-          onPointerDown={(event) => {
-            if (!closeOnBackdropClick) event.preventDefault()
-          }}
+          onClick={handleBackdropClick}
         />
 
         <ToasterPortalHost />
@@ -152,25 +117,18 @@ export function Modal({
 
         <FloatingLayerProvider layer="modal-contained">
           <DialogPrimitive.Content
+            ref={contentRef}
             aria-describedby={undefined}
             className={cn(
               "fixed top-[50%] left-[50%] w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] outline-none",
               Z_INDEX.modal,
             )}
-            onEscapeKeyDown={(event) => {
-              if (!closeOnEsc || !isModalTopmost(modalId)) {
-                event.preventDefault()
-              }
-            }}
+            onEscapeKeyDown={handleEscapeKeyDown}
             onPointerDownOutside={(event) => {
-              if (!closeOnBackdropClick || !isModalTopmost(modalId)) {
-                event.preventDefault()
-              }
+              event.preventDefault()
             }}
             onInteractOutside={(event) => {
-              if (!closeOnBackdropClick || !isModalTopmost(modalId)) {
-                event.preventDefault()
-              }
+              event.preventDefault()
             }}
           >
             <DialogPrimitive.Title asChild>

--- a/src/components/ui/Dialog/Modal.tsx
+++ b/src/components/ui/Dialog/Modal.tsx
@@ -1,6 +1,6 @@
-import { Dialog, Transition } from "@headlessui/react"
-import { XMarkIcon } from "@heroicons/react/24/outline"
-import { Fragment, ReactNode } from "react"
+import { XIcon } from "lucide-react"
+import { Dialog as DialogPrimitive } from "radix-ui"
+import { ReactNode, type MouseEvent } from "react"
 
 import { Z_INDEX } from "~/constants/designTokens"
 import { cn } from "~/lib/utils"
@@ -14,6 +14,7 @@ type Size = "sm" | "md" | "lg" | "xl"
 interface ModalProps {
   isOpen: boolean
   onClose: () => void
+  title?: string
   children?: ReactNode
   header?: ReactNode
   footer?: ReactNode
@@ -34,11 +35,15 @@ const sizeMap: Record<Size, string> = {
 }
 
 /**
- * Modal renders a HeadlessUI dialog with configurable size, close behavior, and slots for header/footer.
+ * Modal renders a Radix/shadcn-compatible dialog with the legacy slot API.
+ * @deprecated Use the shadcn-style primitives from `~/components/ui/dialog`
+ * for new dialogs. Keep this wrapper only for existing dialogs that still
+ * depend on its legacy slots or project-specific dismissal guards.
  */
 export function Modal({
   isOpen,
   onClose,
+  title = "Dialog",
   children,
   header,
   footer,
@@ -50,21 +55,13 @@ export function Modal({
   closeOnBackdropClick = true,
   size = "md",
 }: ModalProps) {
-  // Intercept onKeyDown to optionally prevent Escape from closing
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === "Escape" && !closeOnEsc) {
-      e.stopPropagation()
-      e.preventDefault()
-    }
+  const handleOpenChange = (open: boolean) => {
+    if (!open) onClose()
   }
 
-  const overlayClickHandler = (e: React.MouseEvent) => {
-    if (!closeOnBackdropClick) {
-      // prevent Dialog from calling onClose via overlay click
-      e.stopPropagation()
-    } else {
-      onClose()
-    }
+  const handleBackdropClick = (event: MouseEvent<HTMLDivElement>) => {
+    if (event.target !== event.currentTarget || !closeOnBackdropClick) return
+    onClose()
   }
 
   const panelBaseClass = cn(
@@ -73,45 +70,52 @@ export function Modal({
   )
 
   return (
-    <Transition show={isOpen} as={Fragment}>
-      <Dialog
-        onClose={onClose}
-        className={cn("relative", Z_INDEX.modal)}
-        onKeyDown={handleKeyDown}
-      >
-        {/* backdrop */}
-        <Transition.Child
-          as={Fragment}
-          enter="ease-out duration-300"
-          enterFrom="opacity-0"
-          enterTo="opacity-100"
-          leave="ease-in duration-200"
-          leaveFrom="opacity-100"
-          leaveTo="opacity-0"
-        >
-          <div
-            className="fixed inset-0 bg-black/30 backdrop-blur-sm"
-            aria-hidden="true"
-            onClick={overlayClickHandler}
-          />
-        </Transition.Child>
+    <DialogPrimitive.Root open={isOpen} onOpenChange={handleOpenChange}>
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Overlay
+          data-slot="modal-overlay"
+          className={cn(
+            "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 bg-black/30 backdrop-blur-sm",
+            Z_INDEX.modal,
+          )}
+          onPointerDown={(event) => {
+            if (!closeOnBackdropClick) event.preventDefault()
+          }}
+        />
 
         <ToasterPortalHost />
         {floatingContent}
 
-        <div className="fixed inset-0 flex items-center justify-center p-4">
-          <Transition.Child
-            as={Fragment}
-            enter="ease-out duration-300"
-            enterFrom="opacity-0 scale-95 translate-y-4"
-            enterTo="opacity-100 scale-100 translate-y-0"
-            leave="ease-in duration-200"
-            leaveFrom="opacity-100 scale-100 translate-y-0"
-            leaveTo="opacity-0 scale-95 translate-y-4"
+        <FloatingLayerProvider layer="modal-contained">
+          <DialogPrimitive.Content
+            aria-describedby={undefined}
+            className={cn(
+              "fixed top-[50%] left-[50%] w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] outline-none",
+              Z_INDEX.modal,
+            )}
+            onEscapeKeyDown={(event) => {
+              if (!closeOnEsc) event.preventDefault()
+            }}
+            onPointerDownOutside={(event) => {
+              if (!closeOnBackdropClick) event.preventDefault()
+            }}
+            onInteractOutside={(event) => {
+              if (!closeOnBackdropClick) event.preventDefault()
+            }}
           >
-            <Dialog.Panel className={panelBaseClass} data-testid={panelTestId}>
-              <FloatingLayerProvider layer="modal-contained">
-                {/* close button */}
+            <DialogPrimitive.Title className="sr-only">
+              {title}
+            </DialogPrimitive.Title>
+            <div
+              className="flex items-center justify-center p-4"
+              data-slot="modal-positioner"
+              onClick={handleBackdropClick}
+            >
+              <div
+                className={panelBaseClass}
+                data-testid={panelTestId}
+                role="presentation"
+              >
                 {showCloseButton && (
                   <button
                     type="button"
@@ -119,11 +123,10 @@ export function Modal({
                     aria-label={t("common:actions.close")}
                     className="dark:hover:bg-dark-bg-tertiary dark:hover:text-dark-text-secondary absolute top-3 right-3 z-10 rounded-lg p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600 sm:top-4 sm:right-4"
                   >
-                    <XMarkIcon className="h-5 w-5" />
+                    <XIcon className="h-5 w-5" />
                   </button>
                 )}
 
-                {/* header area - 固定不滚动 */}
                 {header && (
                   <div className="dark:border-dark-bg-tertiary shrink-0 border-b border-gray-100 px-4 py-3 sm:px-6 sm:py-4">
                     <div className="flex items-start justify-between">
@@ -132,22 +135,20 @@ export function Modal({
                   </div>
                 )}
 
-                {/* content area - 可滚动 */}
                 <div className="flex min-h-0 flex-1 flex-col space-y-3 overflow-y-auto p-4 sm:space-y-4 sm:p-6">
                   {children}
                 </div>
 
-                {/* footer area - 固定不滚动 */}
                 {footer && (
                   <div className="dark:border-dark-bg-tertiary shrink-0 border-t border-gray-100 px-4 py-3 sm:px-6 sm:py-4">
                     {footer}
                   </div>
                 )}
-              </FloatingLayerProvider>
-            </Dialog.Panel>
-          </Transition.Child>
-        </div>
-      </Dialog>
-    </Transition>
+              </div>
+            </div>
+          </DialogPrimitive.Content>
+        </FloatingLayerProvider>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
   )
 }

--- a/src/components/ui/Dialog/Modal.tsx
+++ b/src/components/ui/Dialog/Modal.tsx
@@ -1,6 +1,12 @@
 import { XIcon } from "lucide-react"
 import { Dialog as DialogPrimitive } from "radix-ui"
-import { ReactNode, type MouseEvent } from "react"
+import {
+  ReactNode,
+  useEffect,
+  useId,
+  useSyncExternalStore,
+  type MouseEvent,
+} from "react"
 
 import { Z_INDEX } from "~/constants/designTokens"
 import { cn } from "~/lib/utils"
@@ -34,6 +40,35 @@ const sizeMap: Record<Size, string> = {
   xl: "max-w-5xl",
 }
 
+let activeModalStack: string[] = []
+const modalStackListeners = new Set<() => void>()
+
+const emitModalStackChange = () => {
+  modalStackListeners.forEach((listener) => listener())
+}
+
+const getModalStackSnapshot = () => activeModalStack.join("|")
+
+const subscribeModalStack = (listener: () => void) => {
+  modalStackListeners.add(listener)
+  return () => modalStackListeners.delete(listener)
+}
+
+const registerModal = (id: string) => {
+  if (activeModalStack.includes(id)) return
+  activeModalStack = [...activeModalStack, id]
+  emitModalStackChange()
+}
+
+const unregisterModal = (id: string) => {
+  if (!activeModalStack.includes(id)) return
+  activeModalStack = activeModalStack.filter((activeId) => activeId !== id)
+  emitModalStackChange()
+}
+
+const isModalTopmost = (id: string) =>
+  activeModalStack[activeModalStack.length - 1] === id
+
 /**
  * Modal renders a Radix/shadcn-compatible dialog with the legacy slot API.
  * @deprecated Use the shadcn-style primitives from `~/components/ui/dialog`
@@ -55,12 +90,37 @@ export function Modal({
   closeOnBackdropClick = true,
   size = "md",
 }: ModalProps) {
+  const modalId = useId()
+  const modalStackSnapshot = useSyncExternalStore(
+    subscribeModalStack,
+    getModalStackSnapshot,
+    getModalStackSnapshot,
+  )
+  const topmostModalId = modalStackSnapshot.split("|").filter(Boolean).at(-1)
+  const isTopmostModal = isOpen && topmostModalId === modalId
+
+  useEffect(() => {
+    if (!isOpen) {
+      unregisterModal(modalId)
+      return
+    }
+
+    registerModal(modalId)
+    return () => unregisterModal(modalId)
+  }, [isOpen, modalId])
+
   const handleOpenChange = (open: boolean) => {
-    if (!open) onClose()
+    if (!open && isModalTopmost(modalId)) onClose()
   }
 
   const handleBackdropClick = (event: MouseEvent<HTMLDivElement>) => {
-    if (event.target !== event.currentTarget || !closeOnBackdropClick) return
+    if (
+      event.target !== event.currentTarget ||
+      !closeOnBackdropClick ||
+      !isModalTopmost(modalId)
+    ) {
+      return
+    }
     onClose()
   }
 
@@ -70,7 +130,11 @@ export function Modal({
   )
 
   return (
-    <DialogPrimitive.Root open={isOpen} onOpenChange={handleOpenChange}>
+    <DialogPrimitive.Root
+      open={isOpen}
+      onOpenChange={handleOpenChange}
+      modal={isTopmostModal}
+    >
       <DialogPrimitive.Portal>
         <DialogPrimitive.Overlay
           data-slot="modal-overlay"
@@ -94,17 +158,23 @@ export function Modal({
               Z_INDEX.modal,
             )}
             onEscapeKeyDown={(event) => {
-              if (!closeOnEsc) event.preventDefault()
+              if (!closeOnEsc || !isModalTopmost(modalId)) {
+                event.preventDefault()
+              }
             }}
             onPointerDownOutside={(event) => {
-              if (!closeOnBackdropClick) event.preventDefault()
+              if (!closeOnBackdropClick || !isModalTopmost(modalId)) {
+                event.preventDefault()
+              }
             }}
             onInteractOutside={(event) => {
-              if (!closeOnBackdropClick) event.preventDefault()
+              if (!closeOnBackdropClick || !isModalTopmost(modalId)) {
+                event.preventDefault()
+              }
             }}
           >
-            <DialogPrimitive.Title className="sr-only">
-              {title}
+            <DialogPrimitive.Title asChild>
+              <span className="sr-only" aria-label={title} />
             </DialogPrimitive.Title>
             <div
               className="flex items-center justify-center p-4"

--- a/src/components/ui/Dialog/README.md
+++ b/src/components/ui/Dialog/README.md
@@ -1,0 +1,13 @@
+# Dialog Module
+
+Use `~/components/ui/dialog` for new dialogs. It is the preferred shadcn-style
+primitive interface: compose `Dialog`, `DialogContent`, `DialogHeader`,
+`DialogFooter`, `DialogTitle`, and `DialogDescription` directly at the call
+site.
+
+`Modal` is a deprecated compatibility wrapper for existing dialogs that still
+depend on the legacy slot interface (`header`, `footer`, `size`,
+`panelClassName`) or project-specific dismissal guards (`closeOnEsc`,
+`closeOnBackdropClick`). Do not add new call sites or new capabilities to
+`Modal`; migrate old dialogs only when they are already being touched for a
+feature or behavior change.

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -10,7 +10,7 @@ import { ToasterPortalHost } from "../toast/ToasterPortal"
 import { FloatingLayerProvider } from "./floating-layer"
 
 /**
- * Dialog provides a Radix-based modal root to manage open/close state.
+ * Dialog provides the preferred Radix/shadcn modal root for new dialogs.
  */
 function Dialog({
   ...props

--- a/src/features/AccountManagement/components/AccountDialog/AihubmixDefaultKeyPromptDialog.tsx
+++ b/src/features/AccountManagement/components/AccountDialog/AihubmixDefaultKeyPromptDialog.tsx
@@ -1,4 +1,3 @@
-import { DialogTitle } from "@headlessui/react"
 import { KeyIcon } from "@heroicons/react/24/outline"
 import { useTranslation } from "react-i18next"
 
@@ -31,15 +30,16 @@ export function AihubmixDefaultKeyPromptDialog({
     <Modal
       isOpen={isOpen}
       onClose={isCreating ? () => {} : onCancel}
+      title={t("accountDialog:aihubmixDefaultKeyPrompt.title")}
       closeOnBackdropClick={false}
       size="sm"
       header={
         <div className="flex items-center justify-between">
           <div className="flex items-center space-x-3">
             <KeyIcon className="h-5 w-5 text-yellow-600 dark:text-yellow-400" />
-            <DialogTitle className="dark:text-dark-text-primary text-lg font-semibold text-gray-900">
+            <h2 className="dark:text-dark-text-primary text-lg font-semibold text-gray-900">
               {t("accountDialog:aihubmixDefaultKeyPrompt.title")}
-            </DialogTitle>
+            </h2>
           </div>
         </div>
       }

--- a/src/features/AccountManagement/components/AccountDialog/DialogHeader.tsx
+++ b/src/features/AccountManagement/components/AccountDialog/DialogHeader.tsx
@@ -1,4 +1,3 @@
-import { DialogTitle } from "@headlessui/react"
 import { PencilIcon, SparklesIcon } from "@heroicons/react/24/outline"
 import { useTranslation } from "react-i18next"
 
@@ -26,9 +25,9 @@ export default function DialogHeader({ mode }: DialogHeaderProps) {
     <div className="flex items-center justify-between">
       <div className="flex items-center space-x-3">
         <Icon className={`h-5 w-5 ${iconClass}`} />
-        <DialogTitle className="dark:text-dark-text-primary text-lg font-semibold text-gray-900">
+        <h2 className="dark:text-dark-text-primary text-lg font-semibold text-gray-900">
           {title}
-        </DialogTitle>
+        </h2>
       </div>
       {/* Modal provides close button */}
     </div>

--- a/src/features/AccountManagement/components/AccountDialog/DuplicateAccountWarningDialog.tsx
+++ b/src/features/AccountManagement/components/AccountDialog/DuplicateAccountWarningDialog.tsx
@@ -1,4 +1,3 @@
-import { DialogTitle } from "@headlessui/react"
 import { ExclamationTriangleIcon } from "@heroicons/react/24/outline"
 import { useTranslation } from "react-i18next"
 
@@ -42,14 +41,15 @@ export function DuplicateAccountWarningDialog({
     <Modal
       isOpen={isOpen}
       onClose={onCancel}
+      title={t("accountDialog:warnings.duplicateAccount.title")}
       size="sm"
       header={
         <div className="flex items-center justify-between">
           <div className="flex items-center space-x-3">
             <ExclamationTriangleIcon className="h-5 w-5 text-yellow-600 dark:text-yellow-400" />
-            <DialogTitle className="dark:text-dark-text-primary text-lg font-semibold text-gray-900">
+            <h2 className="dark:text-dark-text-primary text-lg font-semibold text-gray-900">
               {t("accountDialog:warnings.duplicateAccount.title")}
-            </DialogTitle>
+            </h2>
           </div>
         </div>
       }

--- a/src/features/AccountManagement/components/AccountDialog/ManagedSiteConfigPromptDialog.tsx
+++ b/src/features/AccountManagement/components/AccountDialog/ManagedSiteConfigPromptDialog.tsx
@@ -1,4 +1,3 @@
-import { DialogTitle } from "@headlessui/react"
 import { ExclamationTriangleIcon } from "@heroicons/react/24/outline"
 import { useTranslation } from "react-i18next"
 
@@ -31,16 +30,19 @@ export function ManagedSiteConfigPromptDialog({
     <Modal
       isOpen={isOpen}
       onClose={onClose}
+      title={t("accountDialog:warnings.managedSiteConfig.title", {
+        managedSite: managedSiteLabel,
+      })}
       size="sm"
       header={
         <div className="flex items-center justify-between">
           <div className="flex items-center space-x-3">
             <ExclamationTriangleIcon className="h-5 w-5 text-yellow-600 dark:text-yellow-400" />
-            <DialogTitle className="dark:text-dark-text-primary text-lg font-semibold text-gray-900">
+            <h2 className="dark:text-dark-text-primary text-lg font-semibold text-gray-900">
               {t("accountDialog:warnings.managedSiteConfig.title", {
                 managedSite: managedSiteLabel,
               })}
-            </DialogTitle>
+            </h2>
           </div>
         </div>
       }

--- a/src/features/AccountManagement/components/AccountDialog/index.tsx
+++ b/src/features/AccountManagement/components/AccountDialog/index.tsx
@@ -148,6 +148,10 @@ export default function AccountDialog({
     onRequestCookieAuthPermissions: handlers.handleRequestCookieAuthPermissions,
   }
   const currentSitePolicy = getAccountDialogSitePolicy(state.siteType)
+  const dialogTitle =
+    mode === DIALOG_MODES.ADD
+      ? tAccountDialog("title.add")
+      : tAccountDialog("title.edit")
   const siteInfoInputProps: ComponentProps<typeof SiteInfoInput> =
     showEntryAuthTypeSelector
       ? {
@@ -206,6 +210,7 @@ export default function AccountDialog({
         isOpen={isOpen}
         onClose={handlers.handleClose}
         size="lg"
+        title={dialogTitle}
         panelTestId={ACCOUNT_MANAGEMENT_TEST_IDS.accountDialog}
         header={<DialogHeader mode={mode} />}
         footer={

--- a/src/features/AccountManagement/components/CopyKeyDialog/DialogHeader.tsx
+++ b/src/features/AccountManagement/components/CopyKeyDialog/DialogHeader.tsx
@@ -1,4 +1,3 @@
-import { DialogTitle } from "@headlessui/react"
 import { KeyIcon } from "@heroicons/react/24/outline"
 import { useTranslation } from "react-i18next"
 
@@ -19,9 +18,9 @@ export function DialogHeader({ account }: DialogHeaderProps) {
       <div className="flex items-center space-x-3">
         <KeyIcon className="h-5 w-5 text-blue-600 dark:text-blue-400" />
         <div>
-          <DialogTitle className="dark:text-dark-text-primary text-lg font-semibold text-gray-900">
+          <h2 className="dark:text-dark-text-primary text-lg font-semibold text-gray-900">
             {t("dialog.copyKey.title")}
-          </DialogTitle>
+          </h2>
           <p className="dark:text-dark-text-secondary mt-0.5 text-xs text-gray-500">
             {account?.name}
           </p>

--- a/src/features/AccountManagement/components/DedupeAccountsDialog/index.tsx
+++ b/src/features/AccountManagement/components/DedupeAccountsDialog/index.tsx
@@ -1,4 +1,3 @@
-import { DialogTitle } from "@headlessui/react"
 import { Trash2 } from "lucide-react"
 import { useMemo, useState } from "react"
 import toast from "react-hot-toast"
@@ -242,13 +241,14 @@ export default function DedupeAccountsDialog({
         closeOnEsc={!isWorking}
         showCloseButton={!isWorking}
         size="lg"
+        title={t("ui:dialog.dedupeAccounts.title")}
         header={
           <div className="flex min-w-0 flex-col gap-1 pr-8">
             <div className="flex items-center gap-2">
               <Trash2 className="h-5 w-5 text-red-600 dark:text-red-400" />
-              <DialogTitle className="dark:text-dark-text-primary text-lg font-semibold text-gray-900">
+              <h2 className="dark:text-dark-text-primary text-lg font-semibold text-gray-900">
                 {t("ui:dialog.dedupeAccounts.title")}
-              </DialogTitle>
+              </h2>
             </div>
             <p className="dark:text-dark-text-secondary text-sm text-gray-500">
               {t("ui:dialog.dedupeAccounts.description")}

--- a/src/features/ApiCredentialProfiles/components/ApiCredentialProfileDialog.tsx
+++ b/src/features/ApiCredentialProfiles/components/ApiCredentialProfileDialog.tsx
@@ -1,4 +1,3 @@
-import { DialogTitle } from "@headlessui/react"
 import {
   ArrowTopRightOnSquareIcon,
   KeyIcon,
@@ -172,6 +171,9 @@ export function ApiCredentialProfileDialog({
   ])
 
   const isEditMode = Boolean(profile)
+  const dialogTitle = isEditMode
+    ? t("apiCredentialProfiles:dialog.editTitle")
+    : t("apiCredentialProfiles:dialog.addTitle")
 
   const [name, setName] = useState("")
   const [apiType, setApiType] = useState<ApiVerificationApiType>(
@@ -449,6 +451,7 @@ export function ApiCredentialProfileDialog({
         closeOnEsc={!isSaving}
         showCloseButton={!isSaving}
         size="lg"
+        title={dialogTitle}
         panelTestId={API_CREDENTIAL_PROFILES_TEST_IDS.dialog}
         header={
           <div className="flex min-w-0 items-center gap-3">
@@ -457,11 +460,9 @@ export function ApiCredentialProfileDialog({
             ) : (
               <PlusIcon className="h-5 w-5 text-blue-600 dark:text-blue-400" />
             )}
-            <DialogTitle className="dark:text-dark-text-primary truncate text-lg font-semibold text-gray-900">
-              {isEditMode
-                ? t("apiCredentialProfiles:dialog.editTitle")
-                : t("apiCredentialProfiles:dialog.addTitle")}
-            </DialogTitle>
+            <h2 className="dark:text-dark-text-primary truncate text-lg font-semibold text-gray-900">
+              {dialogTitle}
+            </h2>
           </div>
         }
         footer={

--- a/src/features/ImportExport/components/WebDAVSettings.tsx
+++ b/src/features/ImportExport/components/WebDAVSettings.tsx
@@ -516,12 +516,12 @@ export default function WebDAVSettings() {
   }
 
   const handleConfirmRebuildBackup = async () => {
-    setRebuildDialogOpen(false)
     setRebuildPending(true)
     try {
       await uploadWebdavBackup({ forceFullRebuild: true })
     } finally {
       setRebuildPending(false)
+      setRebuildDialogOpen(false)
     }
   }
 

--- a/src/features/TokenProvisioning/components/AddTokenDialog/DialogHeader.tsx
+++ b/src/features/TokenProvisioning/components/AddTokenDialog/DialogHeader.tsx
@@ -1,4 +1,3 @@
-import { Dialog } from "@headlessui/react"
 import { KeyIcon } from "@heroicons/react/24/outline"
 import { useTranslation } from "react-i18next"
 
@@ -18,9 +17,9 @@ export function DialogHeader({ isEditMode }: DialogHeaderProps) {
     <div className="flex items-center justify-between">
       <div className="flex items-center space-x-2">
         <KeyIcon className="h-6 w-6 text-blue-600 dark:text-blue-400" />
-        <Dialog.Title className="dark:text-dark-text-primary text-lg font-semibold text-gray-900">
+        <h2 className="dark:text-dark-text-primary text-lg font-semibold text-gray-900">
           {isEditMode ? t("dialog.editToken") : t("dialog.addToken")}
-        </Dialog.Title>
+        </h2>
       </div>
       {/* Modal provides close button */}
     </div>

--- a/src/features/TokenProvisioning/components/AddTokenDialog/index.tsx
+++ b/src/features/TokenProvisioning/components/AddTokenDialog/index.tsx
@@ -290,6 +290,7 @@ export default function AddTokenDialog(props: AddTokenDialogProps) {
         isOpen={isOpen}
         onClose={handleClose}
         size="lg"
+        title={isEditMode ? t("dialog.editToken") : t("dialog.addToken")}
         header={<DialogHeader isEditMode={isEditMode} />}
         panelTestId={TOKEN_PROVISIONING_TEST_IDS.addTokenDialog}
         footer={

--- a/tests/components/FloatingLayerPrimitives.test.tsx
+++ b/tests/components/FloatingLayerPrimitives.test.tsx
@@ -116,6 +116,44 @@ function ModalComboboxHarness() {
   )
 }
 
+function ModalComboboxEscapeHarness({ onClose }: { onClose: () => void }) {
+  const items = React.useMemo(
+    () => [
+      { value: "alpha", label: "Alpha" },
+      { value: "beta", label: "Beta" },
+    ],
+    [],
+  )
+  const [value, setValue] = React.useState<(typeof items)[number] | null>(null)
+  const [open, setOpen] = React.useState(true)
+
+  return (
+    <Modal isOpen={true} onClose={onClose}>
+      <Combobox
+        items={items}
+        value={value}
+        onValueChange={setValue}
+        open={open}
+        onOpenChange={setOpen}
+      >
+        <ComboboxInput
+          aria-label="Escaped combobox in modal"
+          className="w-48"
+        />
+        <ComboboxContent>
+          <ComboboxList>
+            {(item) => (
+              <ComboboxItem key={item.value} value={item}>
+                {item.label}
+              </ComboboxItem>
+            )}
+          </ComboboxList>
+        </ComboboxContent>
+      </Combobox>
+    </Modal>
+  )
+}
+
 describe("floating layer primitives inside dialogs", () => {
   it("keeps Modal open when Escape closing is disabled", async () => {
     const user = userEvent.setup()
@@ -132,6 +170,24 @@ describe("floating layer primitives inside dialogs", () => {
     await user.keyboard("{Escape}")
 
     expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it("requests Modal close when Escape starts inside the dialog", async () => {
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+
+    render(
+      <Modal isOpen={true} onClose={onClose}>
+        <button type="button">Inside modal</button>
+      </Modal>,
+    )
+
+    await user.click(
+      await screen.findByRole("button", { name: "Inside modal" }),
+    )
+    await user.keyboard("{Escape}")
+
+    expect(onClose).toHaveBeenCalledTimes(1)
   })
 
   it("keeps Modal open when backdrop closing is disabled", async () => {
@@ -364,5 +420,23 @@ describe("floating layer primitives inside dialogs", () => {
     expect(positioner).toBeInTheDocument()
     expect(positioner).toHaveClass(Z_INDEX.modalFloating)
     expect(positioner).not.toHaveClass(Z_INDEX.floating)
+  })
+
+  it("keeps Modal open when Escape closes a nested combobox popup", async () => {
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+
+    render(<ModalComboboxEscapeHarness onClose={onClose} />)
+
+    await user.click(
+      await screen.findByRole("combobox", {
+        name: "Escaped combobox in modal",
+      }),
+    )
+    await screen.findByText("Alpha")
+
+    await user.keyboard("{Escape}")
+
+    expect(onClose).not.toHaveBeenCalled()
   })
 })

--- a/tests/components/FloatingLayerPrimitives.test.tsx
+++ b/tests/components/FloatingLayerPrimitives.test.tsx
@@ -1,6 +1,6 @@
 import userEvent from "@testing-library/user-event"
 import * as React from "react"
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 
 import {
   Modal,
@@ -117,6 +117,94 @@ function ModalComboboxHarness() {
 }
 
 describe("floating layer primitives inside dialogs", () => {
+  it("keeps Modal open when Escape closing is disabled", async () => {
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+
+    render(
+      <Modal isOpen={true} onClose={onClose} closeOnEsc={false}>
+        <button type="button">Inside modal</button>
+      </Modal>,
+    )
+
+    await screen.findByRole("dialog")
+
+    await user.keyboard("{Escape}")
+
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it("keeps Modal open when backdrop closing is disabled", async () => {
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+
+    render(
+      <Modal isOpen={true} onClose={onClose} closeOnBackdropClick={false}>
+        <button type="button">Inside modal</button>
+      </Modal>,
+    )
+
+    await screen.findByRole("dialog")
+
+    const overlay = document.querySelector('[data-slot="modal-overlay"]')
+    expect(overlay).toBeInTheDocument()
+
+    await user.click(overlay as HTMLElement)
+
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it("requests Modal close when clicking the visual backdrop around the panel", async () => {
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+
+    render(
+      <Modal isOpen={true} onClose={onClose}>
+        <button type="button">Inside modal</button>
+      </Modal>,
+    )
+
+    await screen.findByRole("dialog")
+
+    const positioner = document.querySelector('[data-slot="modal-positioner"]')
+    expect(positioner).toBeInTheDocument()
+
+    await user.click(positioner as HTMLElement)
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not request Modal close when selecting an item from a nested Select", async () => {
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+
+    render(
+      <Modal isOpen={true} onClose={onClose}>
+        <Select defaultValue="alpha">
+          <SelectTrigger
+            aria-label="Select without modal close"
+            className="w-48"
+          >
+            <SelectValue placeholder="Choose a value" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="alpha">Alpha</SelectItem>
+            <SelectItem value="beta">Beta</SelectItem>
+          </SelectContent>
+        </Select>
+      </Modal>,
+    )
+
+    await user.click(
+      await screen.findByRole("combobox", {
+        name: "Select without modal close",
+      }),
+    )
+    await user.click(await screen.findByRole("option", { name: "Beta" }))
+
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
   it("uses the modal-contained layer for select content inside Modal", async () => {
     const user = userEvent.setup()
 

--- a/tests/components/FloatingLayerPrimitives.test.tsx
+++ b/tests/components/FloatingLayerPrimitives.test.tsx
@@ -174,6 +174,111 @@ describe("floating layer primitives inside dialogs", () => {
     expect(onClose).toHaveBeenCalledTimes(1)
   })
 
+  it("uses Modal title as the dialog name without duplicating visible headings", async () => {
+    render(
+      <Modal
+        isOpen={true}
+        onClose={vi.fn()}
+        title="Duplicate account cleanup"
+        header={<h2>Duplicate account cleanup</h2>}
+      >
+        <button type="button">Inside modal</button>
+      </Modal>,
+    )
+
+    expect(
+      await screen.findByRole("dialog", {
+        name: "Duplicate account cleanup",
+      }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getAllByRole("heading", {
+        name: "Duplicate account cleanup",
+      }),
+    ).toHaveLength(1)
+  })
+
+  it("keeps the topmost Modal accessible when multiple legacy modals are open", async () => {
+    const user = userEvent.setup()
+    const onChildAction = vi.fn()
+
+    render(
+      <>
+        <Modal
+          isOpen={true}
+          onClose={vi.fn()}
+          title="Parent dialog"
+          header={<h2>Parent dialog</h2>}
+        >
+          <button type="button">Parent action</button>
+        </Modal>
+        <Modal
+          isOpen={true}
+          onClose={vi.fn()}
+          title="Child dialog"
+          header={<h2>Child dialog</h2>}
+        >
+          <button type="button" onClick={onChildAction}>
+            Child action
+          </button>
+        </Modal>
+      </>,
+    )
+
+    await user.click(
+      await screen.findByRole("button", { name: "Child action" }),
+    )
+
+    expect(onChildAction).toHaveBeenCalledTimes(1)
+  })
+
+  it("keeps a parent Modal open when a child Modal is opened from inside it", async () => {
+    const user = userEvent.setup()
+    const onParentClose = vi.fn()
+    const onChildAction = vi.fn()
+
+    function NestedModalHarness() {
+      const [isChildOpen, setIsChildOpen] = React.useState(false)
+
+      return (
+        <>
+          <Modal
+            isOpen={true}
+            onClose={onParentClose}
+            title="Parent dialog"
+            header={<h2>Parent dialog</h2>}
+          >
+            <button type="button" onClick={() => setIsChildOpen(true)}>
+              Open child dialog
+            </button>
+          </Modal>
+          <Modal
+            isOpen={isChildOpen}
+            onClose={() => setIsChildOpen(false)}
+            title="Child dialog"
+            header={<h2>Child dialog</h2>}
+          >
+            <button type="button" onClick={onChildAction}>
+              Child action
+            </button>
+          </Modal>
+        </>
+      )
+    }
+
+    render(<NestedModalHarness />)
+
+    await user.click(
+      await screen.findByRole("button", { name: "Open child dialog" }),
+    )
+    await user.click(
+      await screen.findByRole("button", { name: "Child action" }),
+    )
+
+    expect(onParentClose).not.toHaveBeenCalled()
+    expect(onChildAction).toHaveBeenCalledTimes(1)
+  })
+
   it("does not request Modal close when selecting an item from a nested Select", async () => {
     const user = userEvent.setup()
     const onClose = vi.fn()

--- a/tests/features/AccountManagement/components/AccountDialog.test.tsx
+++ b/tests/features/AccountManagement/components/AccountDialog.test.tsx
@@ -283,7 +283,10 @@ vi.mock("~/features/TokenProvisioning/components/OneTimeApiKeyDialog", () => ({
       onSave: () => Promise<void>
     }
   }) => (
-    <div data-testid="post-save-one-time-key-dialog">
+    <div
+      data-testid="post-save-one-time-key-dialog"
+      style={{ pointerEvents: "auto" }}
+    >
       <div data-testid="post-save-one-time-key-open">
         {String(props.isOpen)}
       </div>


### PR DESCRIPTION
## Summary
- migrate the deprecated legacy `Modal` wrapper from Headless UI to Radix/shadcn-compatible Dialog primitives
- keep the legacy slot API while preserving nested Select/Popover/Combobox and child-dialog interactions
- document shadcn Dialog primitives as the path for new dialogs and keep the wrapper as compatibility-only
- fix WebDAV forced rebuild confirmation so the dialog stays open while the rebuild is pending

## Root Cause
The original bug was caused by this project's custom legacy `Modal` wrapper, not by a generic Headless UI/Radix incompatibility. The wrapper exposed `closeOnBackdropClick` / `closeOnEsc` style behavior, but only guarded part of the dismissal surface; nested shadcn/Radix/Base UI floating layers could still be interpreted as outside interaction and close the parent dialog.

During PR feedback, the first Radix migration also showed why the old wrapper cannot use Radix's blocking modal mode as-is: existing legacy call sites include sibling-rendered child dialogs, test doubles, and non-Radix/Base UI portals. Radix modal mode applies modality effects such as sibling hiding and body pointer locking, which broke those compatibility assumptions.

## Fix
The new shadcn-style `Dialog` primitives remain the preferred path for new UI. The deprecated legacy `Modal` wrapper now acts as a compatibility layer:
- uses Radix Dialog root in non-blocking mode for legacy portal/sibling compatibility
- renders its own visual overlay so the legacy backdrop contract remains intact
- owns close requests explicitly through the close button, backdrop/positioner click, and Escape from inside the dialog
- prevents Radix outside-interaction dismissal so nested floating controls do not close the parent dialog
- lets open nested Select/Popover/Combobox layers consume Escape before the parent Modal closes

## Validation
- `pnpm vitest --run tests/components/FloatingLayerPrimitives.test.tsx`
- `pnpm vitest --run tests/components/ClaudeCodeRouterImportDialog.test.tsx --testNamePattern "prefills provider fields"`
- focused reruns for the previously failing KiloCodeExportDialog, WebDAVSettings, ManagedSiteChannels, and AutoCheckinSettings cases
- broader related suite: 13 files, 255 tests passed
- `pnpm run validate:staged`
- `pnpm run validate:push`
- pre-push `pnpm run validate:push` hook passed
- PR head `4d8f844` checks are green: quality, unit shards, unit merge, E2E default, E2E dnr-required, build artifact, notify