### PR TITLE
refactor(ui): standardize workflow transition icons

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -74,6 +74,30 @@ const newApiAdapterLegacyApiServiceImportPattern = {
   message:
     "New API adapters may import ~/services/apiService/newApiFamily only. Do not depend on the legacy apiService facade or other apiService modules.",
 }
+const workflowTransitionIconRestrictedImports = [
+  {
+    name: "lucide-react",
+    importNames: ["ExternalLink"],
+    message:
+      "Use `~/components/icons/WorkflowTransitionIcon` for arrow-up-right workflow/link affordances so the app keeps a single transition glyph.",
+  },
+  {
+    name: "@heroicons/react/24/outline",
+    importNames: ["ArrowTopRightOnSquareIcon"],
+    message:
+      "Use `~/components/icons/WorkflowTransitionIcon` for arrow-up-right workflow/link affordances so the app keeps a single transition glyph.",
+  },
+]
+
+function restrictedImports(...patterns) {
+  return [
+    "error",
+    {
+      paths: workflowTransitionIconRestrictedImports,
+      ...(patterns.length > 0 ? { patterns } : {}),
+    },
+  ]
+}
 
 export default defineConfig([
   {
@@ -212,19 +236,16 @@ export default defineConfig([
   {
     files: [srcJsFamilyFilePattern],
     rules: {
-      "no-restricted-imports": [
-        "error",
-        {
-          patterns: [optionsPageImportRestrictionPattern],
-        },
-      ],
+      "no-restricted-imports": restrictedImports(
+        optionsPageImportRestrictionPattern,
+      ),
     },
   },
   // Allow options entrypoint code to depend on options pages.
   {
     files: ["src/entrypoints/options/**/*.{js,cjs,mjs,jsx,ts,tsx}"],
     rules: {
-      "no-restricted-imports": "off",
+      "no-restricted-imports": restrictedImports(),
     },
   },
   // Guardrails: migrated New API adapters depend on the newApiFamily bridge,
@@ -232,15 +253,10 @@ export default defineConfig([
   {
     files: ["src/services/apiAdapters/newApi/**/*.{js,cjs,mjs,jsx,ts,tsx}"],
     rules: {
-      "no-restricted-imports": [
-        "error",
-        {
-          patterns: [
-            optionsPageImportRestrictionPattern,
-            newApiAdapterLegacyApiServiceImportPattern,
-          ],
-        },
-      ],
+      "no-restricted-imports": restrictedImports(
+        optionsPageImportRestrictionPattern,
+        newApiAdapterLegacyApiServiceImportPattern,
+      ),
     },
   },
   // Guardrails: keep direct backend-specific apiService imports behind adapters
@@ -256,12 +272,9 @@ export default defineConfig([
       "src/features/BasicSettings/components/tabs/ManagedSite/**/*.{js,cjs,mjs,jsx,ts,tsx}",
     ],
     rules: {
-      "no-restricted-imports": [
-        "error",
-        {
-          patterns: [apiServiceBackendImplementationImportPattern],
-        },
-      ],
+      "no-restricted-imports": restrictedImports(
+        apiServiceBackendImplementationImportPattern,
+      ),
     },
   },
   // Guardrails: account-mainline product flows must not import the legacy apiService facade.
@@ -278,39 +291,29 @@ export default defineConfig([
       "src/services/accounts/**/*.{js,cjs,mjs,jsx,ts,tsx}",
     ],
     rules: {
-      "no-restricted-imports": [
-        "error",
-        {
-          patterns: [
-            apiServiceBackendImplementationImportPattern,
-            accountSiteMainlineApiServiceFacadeImportPattern,
-          ],
-        },
-      ],
+      "no-restricted-imports": restrictedImports(
+        apiServiceBackendImplementationImportPattern,
+        accountSiteMainlineApiServiceFacadeImportPattern,
+      ),
     },
   },
   // Guardrails: AI API protocol modules must not depend on account-site apiService internals.
   {
     files: ["src/services/aiApi/**/*.{js,cjs,mjs,jsx,ts,tsx}"],
     rules: {
-      "no-restricted-imports": [
-        "error",
+      "no-restricted-imports": restrictedImports(
+        optionsPageImportRestrictionPattern,
         {
-          patterns: [
-            optionsPageImportRestrictionPattern,
-            {
-              group: [
-                "~/services/apiService/**",
-                "../apiService/**",
-                "../../apiService/**",
-                "../../../apiService/**",
-              ],
-              message:
-                "AI API protocol modules must not depend on the account-site apiService layer. Use ~/services/apiTransport/** for shared transport code.",
-            },
+          group: [
+            "~/services/apiService/**",
+            "../apiService/**",
+            "../../apiService/**",
+            "../../../apiService/**",
           ],
+          message:
+            "AI API protocol modules must not depend on the account-site apiService layer. Use ~/services/apiTransport/** for shared transport code.",
         },
-      ],
+      ),
     },
   },
   { rules },

--- a/src/components/ReleaseUpdateStatusPanel.tsx
+++ b/src/components/ReleaseUpdateStatusPanel.tsx
@@ -1,13 +1,13 @@
 import {
   ArrowDownTrayIcon,
   ArrowPathIcon,
-  ArrowTopRightOnSquareIcon,
   CloudArrowDownIcon,
 } from "@heroicons/react/24/outline"
 import type { TFunction } from "i18next"
 import toast from "react-hot-toast"
 import { useTranslation } from "react-i18next"
 
+import { WorkflowTransitionIcon } from "~/components/icons/WorkflowTransitionIcon"
 import { RELEASE_UPDATE_STATUS_PANEL_TEST_IDS } from "~/components/ReleaseUpdateStatusPanel.testIds"
 import { BodySmall, Button, Card, CardItem, CardList } from "~/components/ui"
 import { useReleaseUpdateStatus } from "~/contexts/ReleaseUpdateStatusContext"
@@ -218,7 +218,7 @@ export function ReleaseUpdateStatusPanel() {
       <ArrowDownTrayIcon className="h-4 w-4" />
     )
   ) : (
-    <ArrowTopRightOnSquareIcon className="h-4 w-4" />
+    <WorkflowTransitionIcon className="h-4 w-4" />
   )
 
   const handleCheckNow = async () => {

--- a/src/components/RootErrorBoundary.tsx
+++ b/src/components/RootErrorBoundary.tsx
@@ -1,7 +1,8 @@
-import { AlertTriangle, ExternalLink, RefreshCw } from "lucide-react"
+import { AlertTriangle, RefreshCw } from "lucide-react"
 import { Component, type ErrorInfo, type ReactNode } from "react"
 import { useTranslation } from "react-i18next"
 
+import { WorkflowTransitionIcon } from "~/components/icons/WorkflowTransitionIcon"
 import { Button } from "~/components/ui/button"
 import { createLogger } from "~/utils/core/logger"
 import { getFeedbackDestinationUrls } from "~/utils/navigation/feedbackLinks"
@@ -84,7 +85,9 @@ function RootErrorFallback({
           <Button
             asChild
             variant="outline"
-            leftIcon={<ExternalLink className="size-4" aria-hidden="true" />}
+            leftIcon={
+              <WorkflowTransitionIcon className="size-4" aria-hidden="true" />
+            }
           >
             <a
               href={

--- a/src/components/icons/WorkflowTransitionIcon.tsx
+++ b/src/components/icons/WorkflowTransitionIcon.tsx
@@ -2,9 +2,8 @@ import { ArrowUpRight } from "lucide-react"
 import type { ComponentProps } from "react"
 
 /**
- * WorkflowTransitionIcon marks actions that move the user into a different
- * page-level workflow, even when the destination still lives inside the
- * extension rather than a separate browser tab.
+ * WorkflowTransitionIcon marks actions that move the user out of the current
+ * surface into another workflow or destination.
  */
 export function WorkflowTransitionIcon(
   props: ComponentProps<typeof ArrowUpRight>,

--- a/src/features/AccountManagement/sponsors/SponsorRecommendationCard.tsx
+++ b/src/features/AccountManagement/sponsors/SponsorRecommendationCard.tsx
@@ -1,8 +1,9 @@
 import type { TFunction } from "i18next"
-import { Bookmark, ExternalLink, Plus } from "lucide-react"
+import { Bookmark, Plus } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import { ApiCredentialLibraryIcon } from "~/components/icons/productIcons"
+import { WorkflowTransitionIcon } from "~/components/icons/WorkflowTransitionIcon"
 import { Badge, IconButton } from "~/components/ui"
 import {
   SPONSOR_RECOMMENDATION_ACTION_KINDS,
@@ -128,7 +129,9 @@ function renderMainActionIcon(actionKind: SponsorMainActionKind) {
       )
     case SPONSOR_MAIN_ACTION_KINDS.VisitProvider:
     default:
-      return <ExternalLink aria-hidden="true" className="h-3.5 w-3.5" />
+      return (
+        <WorkflowTransitionIcon aria-hidden="true" className="h-3.5 w-3.5" />
+      )
   }
 }
 

--- a/src/features/ApiCredentialProfiles/components/ApiCredentialProfileDialog.tsx
+++ b/src/features/ApiCredentialProfiles/components/ApiCredentialProfileDialog.tsx
@@ -1,14 +1,10 @@
-import {
-  ArrowTopRightOnSquareIcon,
-  KeyIcon,
-  PencilIcon,
-  PlusIcon,
-} from "@heroicons/react/24/outline"
+import { KeyIcon, PencilIcon, PlusIcon } from "@heroicons/react/24/outline"
 import type { ChangeEvent } from "react"
 import { useEffect, useMemo, useState } from "react"
 import toast from "react-hot-toast"
 import { useTranslation } from "react-i18next"
 
+import { WorkflowTransitionIcon } from "~/components/icons/WorkflowTransitionIcon"
 import {
   Button,
   FormField,
@@ -595,7 +591,7 @@ export function ApiCredentialProfileDialog({
                     {t(
                       "apiCredentialProfiles:dialog.actions.openApiKeyCreateUrl",
                     )}
-                    <ArrowTopRightOnSquareIcon
+                    <WorkflowTransitionIcon
                       aria-hidden="true"
                       className="h-4 w-4"
                     />

--- a/src/features/BasicSettings/components/tabs/General/SiteAnnouncementNotificationSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/General/SiteAnnouncementNotificationSettings.tsx
@@ -1,11 +1,8 @@
-import {
-  ArrowTopRightOnSquareIcon,
-  ClockIcon,
-  MegaphoneIcon,
-} from "@heroicons/react/24/outline"
+import { ClockIcon, MegaphoneIcon } from "@heroicons/react/24/outline"
 import { useEffect, useState } from "react"
 import { useTranslation } from "react-i18next"
 
+import { WorkflowTransitionIcon } from "~/components/icons/WorkflowTransitionIcon"
 import { SettingSection } from "~/components/SettingSection"
 import {
   Button,
@@ -140,7 +137,7 @@ export default function SiteAnnouncementNotificationSettings() {
           <CardItem
             id={SETTINGS_ANCHORS.SITE_ANNOUNCEMENT_NOTIFICATIONS_PAGE}
             icon={
-              <ArrowTopRightOnSquareIcon className="h-5 w-5 text-sky-600 dark:text-sky-400" />
+              <WorkflowTransitionIcon className="h-5 w-5 text-sky-600 dark:text-sky-400" />
             }
             title={t("siteAnnouncementNotifications.page.title")}
             description={t("siteAnnouncementNotifications.page.description", {

--- a/src/features/ModelList/components/ModelItem/index.tsx
+++ b/src/features/ModelList/components/ModelItem/index.tsx
@@ -1,8 +1,9 @@
-import { Copy, ExternalLink } from "lucide-react"
+import { Copy } from "lucide-react"
 import { useEffect, useState } from "react"
 import toast from "react-hot-toast"
 import { useTranslation } from "react-i18next"
 
+import { WorkflowTransitionIcon } from "~/components/icons/WorkflowTransitionIcon"
 import { Badge, Card, CardContent, IconButton } from "~/components/ui"
 import {
   MODEL_LIST_GROUP_SELECTION_SCOPES,
@@ -323,7 +324,7 @@ export default function ModelItem(props: ModelItemProps) {
               : undefined
           }
         >
-          <ExternalLink className="h-3 w-3 text-gray-600 sm:h-3.5 sm:w-3.5 dark:text-gray-300" />
+          <WorkflowTransitionIcon className="h-3 w-3 text-gray-600 sm:h-3.5 sm:w-3.5 dark:text-gray-300" />
         </IconButton>
       ) : null}
     </>

--- a/src/features/ProductAnnouncements/ProductAnnouncementList.tsx
+++ b/src/features/ProductAnnouncements/ProductAnnouncementList.tsx
@@ -1,7 +1,7 @@
-import { ExternalLink } from "lucide-react"
 import type { ComponentProps } from "react"
 import { useTranslation } from "react-i18next"
 
+import { WorkflowTransitionIcon } from "~/components/icons/WorkflowTransitionIcon"
 import { Badge, Button } from "~/components/ui"
 import { cn } from "~/lib/utils"
 import type { ProductAnnouncement } from "~/services/productAnnouncements/types"
@@ -176,7 +176,7 @@ export function ProductAnnouncementList({
                 onClick={() => onOpenCta?.(notice)}
               >
                 <span className="min-w-0 break-words">{cta.label}</span>
-                <ExternalLink className="h-3 w-3 shrink-0" />
+                <WorkflowTransitionIcon className="h-3 w-3 shrink-0" />
               </a>
             ) : null}
           </article>

--- a/src/features/SiteAnnouncements/components/SiteAnnouncementCard.tsx
+++ b/src/features/SiteAnnouncements/components/SiteAnnouncementCard.tsx
@@ -3,12 +3,12 @@ import {
   CheckCircle2,
   ChevronDown,
   ChevronUp,
-  ExternalLink,
   Inbox,
 } from "lucide-react"
 import { type KeyboardEvent, type MouseEvent } from "react"
 import { useTranslation } from "react-i18next"
 
+import { WorkflowTransitionIcon } from "~/components/icons/WorkflowTransitionIcon"
 import { Badge, Button, Card } from "~/components/ui"
 import { ProductAnalyticsScope } from "~/contexts/ProductAnalyticsScopeContext"
 import { cn } from "~/lib/utils"
@@ -146,7 +146,7 @@ export function SiteAnnouncementCard({
                       aria-label={t("actions.viewSource")}
                       onClick={(event) => event.stopPropagation()}
                     >
-                      <ExternalLink className="h-5 w-5" />
+                      <WorkflowTransitionIcon className="h-5 w-5" />
                     </a>
                   </Button>
                   {!expanded && !record.read && (
@@ -223,7 +223,7 @@ export function SiteAnnouncementCard({
                   asChild
                   size="sm"
                   variant="outline"
-                  leftIcon={<ExternalLink className="h-4 w-4" />}
+                  leftIcon={<WorkflowTransitionIcon className="h-4 w-4" />}
                   analyticsAction={
                     PRODUCT_ANALYTICS_ACTION_IDS.OpenAnnouncementSource
                   }
@@ -274,7 +274,7 @@ export function SiteAnnouncementCard({
                 size="sm"
                 variant="ghost"
                 className="h-7 text-xs text-blue-600 hover:bg-blue-50 dark:text-blue-400 dark:hover:bg-blue-400/10"
-                leftIcon={<ExternalLink className="h-3.5 w-3.5" />}
+                leftIcon={<WorkflowTransitionIcon className="h-3.5 w-3.5" />}
                 analyticsAction={
                   PRODUCT_ANALYTICS_ACTION_IDS.OpenAnnouncementSource
                 }


### PR DESCRIPTION
## Summary
- Replace direct ExternalLink / ArrowTopRightOnSquareIcon affordances with the shared WorkflowTransitionIcon
- Broaden WorkflowTransitionIcon docs to cover internal workflows and external destinations
- Add ESLint restricted-import guardrails so future arrow-up-right affordances use the shared icon

## Validation
- pnpm run validate:staged
- pnpm compile
- pnpm run validate:push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized link/action icons across several screens for a more consistent look and feel.
* **Refactor**
  * Consolidated icon-related configuration and replaced scattered icon usage with a shared transition icon in multiple UI areas.
* **Bug Fixes**
  * Improved consistency in buttons and cards that open external pages or workflows, reducing visual mismatch across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->