### PR TITLE
test(e2e): reuse real-site account fixtures

### DIFF
--- a/e2e/realSite/doneHubAccountAdd.spec.ts
+++ b/e2e/realSite/doneHubAccountAdd.spec.ts
@@ -10,14 +10,21 @@ import {
   realSiteAccountUsageChecks,
   runRealSiteAccountFixtureUsageChecks,
 } from "~~/e2e/utils/realSite/accountUsage"
-import { runCompatibleRealSiteAccountSaveFlow } from "~~/e2e/utils/realSite/compatibleAccountSaveFlow"
+import { createCompatibleRealSiteAccountFixturePreparer } from "~~/e2e/utils/realSite/compatibleAccountSaveFlow"
 import {
   getDoneHubRealSiteSkipReason,
   loginToRealDoneHubSite,
   resolveDoneHubRealSiteConfig,
 } from "~~/e2e/utils/realSite/doneHub"
+import {
+  createReusedRealSiteAccountFixturePreparer,
+  createSharedRealSiteAccountFixtureCache,
+  resolveSharedRealSiteAccountFixture,
+} from "~~/e2e/utils/realSite/sharedAccountFixture"
 
 test.describe("real-site E2E: DoneHub account add flow", () => {
+  const sharedAccountCache = createSharedRealSiteAccountFixtureCache()
+
   test.beforeEach(async ({ context, page }) => {
     await forceExtensionLanguage(page, "en")
     await stubLlmMetadataIndex(context)
@@ -68,25 +75,27 @@ test.describe("real-site E2E: DoneHub account add flow", () => {
       })
 
       const accountFixture =
-        await test.step("save account from real site auto-detect", async () => {
-          const sitePage = await context.newPage()
-          try {
-            return await runCompatibleRealSiteAccountSaveFlow({
-              page,
-              extensionId,
-              serviceWorker,
-              sitePage,
-              config,
-              siteType: SITE_TYPES.DONE_HUB,
-              expectedDetectedSiteType: SITE_TYPES.DONE_HUB,
-              login: loginToRealDoneHubSite,
-            })
-          } finally {
-            if (!sitePage.isClosed()) {
-              await sitePage.close()
-            }
-          }
-        })
+        await test.step("save or reuse account from real site auto-detect", async () =>
+          await resolveSharedRealSiteAccountFixture({
+            cache: sharedAccountCache,
+            serviceWorker,
+            prepareReusedAccountFixture:
+              createReusedRealSiteAccountFixturePreparer({
+                page,
+                extensionId,
+              }),
+            prepareAccountFixture:
+              createCompatibleRealSiteAccountFixturePreparer({
+                context,
+                page,
+                extensionId,
+                serviceWorker,
+                config,
+                siteType: SITE_TYPES.DONE_HUB,
+                expectedDetectedSiteType: SITE_TYPES.DONE_HUB,
+                login: loginToRealDoneHubSite,
+              }),
+          }))
       await runRealSiteAccountFixtureUsageChecks(
         {
           testInfo,

--- a/e2e/realSite/newApiAccountAdd.spec.ts
+++ b/e2e/realSite/newApiAccountAdd.spec.ts
@@ -10,14 +10,21 @@ import {
   realSiteAccountUsageChecks,
   runRealSiteAccountFixtureUsageChecks,
 } from "~~/e2e/utils/realSite/accountUsage"
-import { runCompatibleRealSiteAccountSaveFlow } from "~~/e2e/utils/realSite/compatibleAccountSaveFlow"
+import { createCompatibleRealSiteAccountFixturePreparer } from "~~/e2e/utils/realSite/compatibleAccountSaveFlow"
 import {
   getNewApiRealSiteSkipReason,
   loginToRealNewApiSite,
   resolveNewApiRealSiteConfig,
 } from "~~/e2e/utils/realSite/newApi"
+import {
+  createReusedRealSiteAccountFixturePreparer,
+  createSharedRealSiteAccountFixtureCache,
+  resolveSharedRealSiteAccountFixture,
+} from "~~/e2e/utils/realSite/sharedAccountFixture"
 
 test.describe("real-site E2E: New API account add flow", () => {
+  const sharedAccountCache = createSharedRealSiteAccountFixtureCache()
+
   test.beforeEach(async ({ context, page }) => {
     await forceExtensionLanguage(page, "en")
     await stubLlmMetadataIndex(context)
@@ -56,24 +63,26 @@ test.describe("real-site E2E: New API account add flow", () => {
       })
 
       const accountFixture =
-        await test.step("save account from real site auto-detect", async () => {
-          const sitePage = await context.newPage()
-          try {
-            return await runCompatibleRealSiteAccountSaveFlow({
-              page,
-              extensionId,
-              serviceWorker,
-              sitePage,
-              config,
-              siteType: SITE_TYPES.NEW_API,
-              login: loginToRealNewApiSite,
-            })
-          } finally {
-            if (!sitePage.isClosed()) {
-              await sitePage.close()
-            }
-          }
-        })
+        await test.step("save or reuse account from real site auto-detect", async () =>
+          await resolveSharedRealSiteAccountFixture({
+            cache: sharedAccountCache,
+            serviceWorker,
+            prepareReusedAccountFixture:
+              createReusedRealSiteAccountFixturePreparer({
+                page,
+                extensionId,
+              }),
+            prepareAccountFixture:
+              createCompatibleRealSiteAccountFixturePreparer({
+                context,
+                page,
+                extensionId,
+                serviceWorker,
+                config,
+                siteType: SITE_TYPES.NEW_API,
+                login: loginToRealNewApiSite,
+              }),
+          }))
       await runRealSiteAccountFixtureUsageChecks(
         {
           testInfo,

--- a/e2e/realSite/oneHubAccountAdd.spec.ts
+++ b/e2e/realSite/oneHubAccountAdd.spec.ts
@@ -10,14 +10,21 @@ import {
   realSiteAccountUsageChecks,
   runRealSiteAccountFixtureUsageChecks,
 } from "~~/e2e/utils/realSite/accountUsage"
-import { runCompatibleRealSiteAccountSaveFlow } from "~~/e2e/utils/realSite/compatibleAccountSaveFlow"
+import { createCompatibleRealSiteAccountFixturePreparer } from "~~/e2e/utils/realSite/compatibleAccountSaveFlow"
 import {
   getOneHubRealSiteSkipReason,
   loginToRealOneHubSite,
   resolveOneHubRealSiteConfig,
 } from "~~/e2e/utils/realSite/oneHub"
+import {
+  createReusedRealSiteAccountFixturePreparer,
+  createSharedRealSiteAccountFixtureCache,
+  resolveSharedRealSiteAccountFixture,
+} from "~~/e2e/utils/realSite/sharedAccountFixture"
 
 test.describe("real-site E2E: OneHub account add flow", () => {
+  const sharedAccountCache = createSharedRealSiteAccountFixtureCache()
+
   test.beforeEach(async ({ context, page }) => {
     await forceExtensionLanguage(page, "en")
     await stubLlmMetadataIndex(context)
@@ -55,25 +62,27 @@ test.describe("real-site E2E: OneHub account add flow", () => {
       })
 
       const accountFixture =
-        await test.step("save account from real site auto-detect", async () => {
-          const sitePage = await context.newPage()
-          try {
-            return await runCompatibleRealSiteAccountSaveFlow({
-              page,
-              extensionId,
-              serviceWorker,
-              sitePage,
-              config,
-              siteType: SITE_TYPES.ONE_HUB,
-              expectedDetectedSiteType: SITE_TYPES.ONE_HUB,
-              login: loginToRealOneHubSite,
-            })
-          } finally {
-            if (!sitePage.isClosed()) {
-              await sitePage.close()
-            }
-          }
-        })
+        await test.step("save or reuse account from real site auto-detect", async () =>
+          await resolveSharedRealSiteAccountFixture({
+            cache: sharedAccountCache,
+            serviceWorker,
+            prepareReusedAccountFixture:
+              createReusedRealSiteAccountFixturePreparer({
+                page,
+                extensionId,
+              }),
+            prepareAccountFixture:
+              createCompatibleRealSiteAccountFixturePreparer({
+                context,
+                page,
+                extensionId,
+                serviceWorker,
+                config,
+                siteType: SITE_TYPES.ONE_HUB,
+                expectedDetectedSiteType: SITE_TYPES.ONE_HUB,
+                login: loginToRealOneHubSite,
+              }),
+          }))
       await runRealSiteAccountFixtureUsageChecks(
         {
           testInfo,

--- a/e2e/realSite/sub2apiAccountAdd.spec.ts
+++ b/e2e/realSite/sub2apiAccountAdd.spec.ts
@@ -12,6 +12,11 @@ import {
   runRealSiteAccountFixtureUsageChecks,
 } from "~~/e2e/utils/realSite/accountUsage"
 import {
+  createReusedRealSiteAccountFixturePreparer,
+  createSharedRealSiteAccountFixtureCache,
+  resolveSharedRealSiteAccountFixture,
+} from "~~/e2e/utils/realSite/sharedAccountFixture"
+import {
   getSub2ApiRealSiteSkipReason,
   loginToRealSub2ApiSite,
   resolveSub2ApiRealSiteConfig,
@@ -21,6 +26,8 @@ const ACCOUNT_BACKED_MODEL_CATALOG_UNAVAILABLE_REASON =
   "Sub2API account model catalog skipped because this site type does not expose an account-backed model catalog."
 
 test.describe("real-site E2E: Sub2API auto-detect account add flow", () => {
+  const sharedAccountCache = createSharedRealSiteAccountFixtureCache()
+
   test.beforeEach(async ({ context, page }) => {
     await forceExtensionLanguage(page, "en")
     await stubLlmMetadataIndex(context)
@@ -71,86 +78,96 @@ test.describe("real-site E2E: Sub2API auto-detect account add flow", () => {
       })
 
       const accountFixture =
-        await test.step("save account from real site auto-detect", async () => {
-          const sitePage = await context.newPage()
-          try {
-            return await runRealSiteAccountSaveFlow({
-              page,
-              extensionId,
-              serviceWorker,
-              sitePage,
-              baseUrl: config.baseUrl,
-              siteType: SITE_TYPES.SUB2API,
-              expectedDetectedSiteType: SITE_TYPES.SUB2API,
-              login: async (realSitePage) => {
-                const loginResult = await loginToRealSub2ApiSite(
-                  realSitePage,
-                  config,
-                )
-                expect(loginResult.authState.accessToken).not.toBe("")
-
-                return {
-                  prepareDetectedDialog: async (dialog) => {
-                    await expect(dialog.siteNameInput).toHaveValue(/.+/, {
-                      timeout: 30_000,
-                    })
-
-                    await expect(dialog.userIdInput).toHaveValue(/.+/, {
-                      timeout: 30_000,
-                    })
-                    await expect
-                      .poll(
-                        async () =>
-                          (await dialog.accessTokenInput.inputValue()) ===
-                          loginResult.authState.accessToken,
-                        { timeout: 30_000 },
-                      )
-                      .toBe(true)
-                    await expect(
-                      dialog.sub2apiRefreshTokenSwitch,
-                    ).toHaveAttribute("aria-checked", "false")
-                    await expect(dialog.sub2apiImportSessionButton).toHaveCount(
-                      0,
+        await test.step("save or reuse account from real site auto-detect", async () =>
+          await resolveSharedRealSiteAccountFixture({
+            cache: sharedAccountCache,
+            serviceWorker,
+            prepareReusedAccountFixture:
+              createReusedRealSiteAccountFixturePreparer({
+                page,
+                extensionId,
+              }),
+            prepareAccountFixture: async () => {
+              const sitePage = await context.newPage()
+              try {
+                return await runRealSiteAccountSaveFlow({
+                  page,
+                  extensionId,
+                  serviceWorker,
+                  sitePage,
+                  baseUrl: config.baseUrl,
+                  siteType: SITE_TYPES.SUB2API,
+                  expectedDetectedSiteType: SITE_TYPES.SUB2API,
+                  login: async (realSitePage) => {
+                    const loginResult = await loginToRealSub2ApiSite(
+                      realSitePage,
+                      config,
                     )
+                    expect(loginResult.authState.accessToken).not.toBe("")
 
-                    if (!loginResult.authState.refreshToken) {
-                      return
+                    return {
+                      prepareDetectedDialog: async (dialog) => {
+                        await expect(dialog.siteNameInput).toHaveValue(/.+/, {
+                          timeout: 30_000,
+                        })
+
+                        await expect(dialog.userIdInput).toHaveValue(/.+/, {
+                          timeout: 30_000,
+                        })
+                        await expect
+                          .poll(
+                            async () =>
+                              (await dialog.accessTokenInput.inputValue()) ===
+                              loginResult.authState.accessToken,
+                            { timeout: 30_000 },
+                          )
+                          .toBe(true)
+                        await expect(
+                          dialog.sub2apiRefreshTokenSwitch,
+                        ).toHaveAttribute("aria-checked", "false")
+                        await expect(
+                          dialog.sub2apiImportSessionButton,
+                        ).toHaveCount(0)
+
+                        if (!loginResult.authState.refreshToken) {
+                          return
+                        }
+
+                        await dialog.sub2apiRefreshTokenSwitch.click()
+                        await expect(
+                          dialog.sub2apiRefreshTokenSwitch,
+                        ).toHaveAttribute("aria-checked", "true")
+
+                        const importSessionButtonVisible =
+                          await dialog.sub2apiImportSessionButton
+                            .waitFor({ state: "visible", timeout: 5_000 })
+                            .then(() => true)
+                            .catch(() => false)
+
+                        if (!importSessionButtonVisible) {
+                          return
+                        }
+
+                        await dialog.sub2apiImportSessionButton.click()
+                        await expect
+                          .poll(
+                            async () =>
+                              (await dialog.sub2apiRefreshTokenInput.inputValue()) ===
+                              loginResult.authState.refreshToken,
+                            { timeout: 30_000 },
+                          )
+                          .toBe(true)
+                      },
                     }
-
-                    await dialog.sub2apiRefreshTokenSwitch.click()
-                    await expect(
-                      dialog.sub2apiRefreshTokenSwitch,
-                    ).toHaveAttribute("aria-checked", "true")
-
-                    const importSessionButtonVisible =
-                      await dialog.sub2apiImportSessionButton
-                        .waitFor({ state: "visible", timeout: 5_000 })
-                        .then(() => true)
-                        .catch(() => false)
-
-                    if (!importSessionButtonVisible) {
-                      return
-                    }
-
-                    await dialog.sub2apiImportSessionButton.click()
-                    await expect
-                      .poll(
-                        async () =>
-                          (await dialog.sub2apiRefreshTokenInput.inputValue()) ===
-                          loginResult.authState.refreshToken,
-                        { timeout: 30_000 },
-                      )
-                      .toBe(true)
                   },
+                })
+              } finally {
+                if (!sitePage.isClosed()) {
+                  await sitePage.close()
                 }
-              },
-            })
-          } finally {
-            if (!sitePage.isClosed()) {
-              await sitePage.close()
-            }
-          }
-        })
+              }
+            },
+          }))
       await runRealSiteAccountFixtureUsageChecks(
         {
           testInfo,

--- a/e2e/realSite/veloeraAccountAdd.spec.ts
+++ b/e2e/realSite/veloeraAccountAdd.spec.ts
@@ -10,7 +10,12 @@ import {
   realSiteAccountUsageChecks,
   runRealSiteAccountFixtureUsageChecks,
 } from "~~/e2e/utils/realSite/accountUsage"
-import { runCompatibleRealSiteAccountSaveFlow } from "~~/e2e/utils/realSite/compatibleAccountSaveFlow"
+import { createCompatibleRealSiteAccountFixturePreparer } from "~~/e2e/utils/realSite/compatibleAccountSaveFlow"
+import {
+  createReusedRealSiteAccountFixturePreparer,
+  createSharedRealSiteAccountFixtureCache,
+  resolveSharedRealSiteAccountFixture,
+} from "~~/e2e/utils/realSite/sharedAccountFixture"
 import {
   getVeloeraRealSiteSkipReason,
   loginToRealVeloeraSite,
@@ -18,6 +23,8 @@ import {
 } from "~~/e2e/utils/realSite/veloera"
 
 test.describe("real-site E2E: Veloera account add flow", () => {
+  const sharedAccountCache = createSharedRealSiteAccountFixtureCache()
+
   test.beforeEach(async ({ context, page }) => {
     await forceExtensionLanguage(page, "en")
     await stubLlmMetadataIndex(context)
@@ -59,25 +66,27 @@ test.describe("real-site E2E: Veloera account add flow", () => {
       })
 
       const accountFixture =
-        await test.step("save account from real site auto-detect", async () => {
-          const sitePage = await context.newPage()
-          try {
-            return await runCompatibleRealSiteAccountSaveFlow({
-              page,
-              extensionId,
-              serviceWorker,
-              sitePage,
-              config,
-              siteType: SITE_TYPES.VELOERA,
-              expectedDetectedSiteType: SITE_TYPES.VELOERA,
-              login: loginToRealVeloeraSite,
-            })
-          } finally {
-            if (!sitePage.isClosed()) {
-              await sitePage.close()
-            }
-          }
-        })
+        await test.step("save or reuse account from real site auto-detect", async () =>
+          await resolveSharedRealSiteAccountFixture({
+            cache: sharedAccountCache,
+            serviceWorker,
+            prepareReusedAccountFixture:
+              createReusedRealSiteAccountFixturePreparer({
+                page,
+                extensionId,
+              }),
+            prepareAccountFixture:
+              createCompatibleRealSiteAccountFixturePreparer({
+                context,
+                page,
+                extensionId,
+                serviceWorker,
+                config,
+                siteType: SITE_TYPES.VELOERA,
+                expectedDetectedSiteType: SITE_TYPES.VELOERA,
+                login: loginToRealVeloeraSite,
+              }),
+          }))
       await runRealSiteAccountFixtureUsageChecks(
         {
           testInfo,

--- a/e2e/scenarios/accountUsagePlan.ts
+++ b/e2e/scenarios/accountUsagePlan.ts
@@ -3,6 +3,7 @@ import type { AccountFixture } from "~~/e2e/scenarios/accountFixtures"
 export type AccountUsagePlanCheck<TContext> = {
   name: string
   run: (context: TContext) => Promise<void>
+  timeoutMs?: number
 }
 
 type AccountUsagePlanStep = (

--- a/e2e/utils/realSite/accountUsage.ts
+++ b/e2e/utils/realSite/accountUsage.ts
@@ -47,6 +47,8 @@ type RealSiteAccountUsagePlanContext = RealSiteAccountUsageContext & {
 type RealSiteAccountUsageCheck =
   AccountUsagePlanCheck<RealSiteAccountUsagePlanContext>
 
+const REAL_SITE_ACCOUNT_REMOTE_WRITE_TIMEOUT_MS = 120_000
+
 type ApiProfilePopupModelsProbeExpectation = {
   expectedStatus?: "pass" | "fail" | "handled"
   expectedSummaryText?: string
@@ -205,6 +207,7 @@ export const realSiteAccountUsageChecks = {
   keyLifecycle(): RealSiteAccountUsageCheck {
     return {
       name: "create and delete an account API key",
+      timeoutMs: REAL_SITE_ACCOUNT_REMOTE_WRITE_TIMEOUT_MS,
       run: async (context) => {
         await verifyRealSiteAccountKeyLifecycleUsage(context)
       },
@@ -220,6 +223,7 @@ export const realSiteAccountUsageChecks = {
   ): RealSiteAccountUsageCheck {
     return {
       name: "create an account key, save it to API profiles, and verify it from the popup",
+      timeoutMs: REAL_SITE_ACCOUNT_REMOTE_WRITE_TIMEOUT_MS,
       run: async (context) => {
         await verifyRealSiteApiProfilePopupModelsUsage({
           ...context,
@@ -279,6 +283,7 @@ export const realSiteAccountUsageChecks = {
   }): RealSiteAccountUsageCheck {
     return {
       name: "create a key from the model catalog",
+      timeoutMs: REAL_SITE_ACCOUNT_REMOTE_WRITE_TIMEOUT_MS,
       run: async (context) => {
         await maybeVerifyRealSiteModelToKeyUsage({
           ...context,
@@ -294,6 +299,14 @@ export async function runRealSiteAccountFixtureUsageChecks(
   context: RealSiteAccountUsagePlanContext,
   checks: readonly RealSiteAccountUsageCheck[],
 ) {
+  const timeoutMs = checks.reduce(
+    (total, check) => total + (check.timeoutMs ?? 0),
+    0,
+  )
+  if (timeoutMs > context.testInfo.timeout) {
+    context.testInfo.setTimeout(timeoutMs)
+  }
+
   await runAccountFixtureUsagePlan(context, checks, {
     step: async (name, run) => {
       await test.step(name, run)

--- a/e2e/utils/realSite/compatibleAccountSaveFlow.ts
+++ b/e2e/utils/realSite/compatibleAccountSaveFlow.ts
@@ -1,4 +1,4 @@
-import type { Page } from "@playwright/test"
+import type { BrowserContext, Page } from "@playwright/test"
 
 import type { AccountSiteType } from "~/constants/siteType"
 import { expect } from "~~/e2e/fixtures/extensionTest"
@@ -42,4 +42,40 @@ export async function runCompatibleRealSiteAccountSaveFlow(params: {
       expect(loginResult.user).toBeTruthy()
     },
   })
+}
+
+export function createCompatibleRealSiteAccountFixturePreparer(params: {
+  context: BrowserContext
+  page: Page
+  extensionId: string
+  serviceWorker: ServiceWorker
+  config: CompatibleApiRealSiteConfig
+  siteType: AccountSiteType
+  expectedDetectedSiteType?: AccountSiteType
+  extensionPageGuardOptions?: ExtensionPageGuardOptions
+  login: (
+    page: Page,
+    config: CompatibleApiRealSiteConfig,
+  ) => Promise<CompatibleRealSiteLoginResult>
+}) {
+  return async () => {
+    const sitePage = await params.context.newPage()
+    try {
+      return await runCompatibleRealSiteAccountSaveFlow({
+        page: params.page,
+        extensionId: params.extensionId,
+        serviceWorker: params.serviceWorker,
+        sitePage,
+        config: params.config,
+        siteType: params.siteType,
+        expectedDetectedSiteType: params.expectedDetectedSiteType,
+        extensionPageGuardOptions: params.extensionPageGuardOptions,
+        login: params.login,
+      })
+    } finally {
+      if (!sitePage.isClosed()) {
+        await sitePage.close()
+      }
+    }
+  }
 }

--- a/e2e/utils/realSite/sharedAccountFixture.ts
+++ b/e2e/utils/realSite/sharedAccountFixture.ts
@@ -1,0 +1,84 @@
+import type { Page, Worker } from "@playwright/test"
+
+import type { SiteAccount } from "~/types"
+import {
+  createAccountFixture,
+  createNoopAccountFixtureCleanup,
+  type AccountFixture,
+} from "~~/e2e/scenarios/accountFixtures"
+import { readStoredAccounts } from "~~/e2e/scenarios/accountManualAdd"
+import { seedStoredAccounts } from "~~/e2e/utils/commonUserFlows"
+import {
+  expectAccountListItemVisible,
+  openAccountManagementPage,
+} from "~~/e2e/utils/realSite/accountAdd"
+
+type SharedRealSiteAccountFixtureCache = {
+  storedAccount?: SiteAccount
+  storedAccountPromise?: Promise<SiteAccount>
+}
+
+export function createSharedRealSiteAccountFixtureCache(): SharedRealSiteAccountFixtureCache {
+  return {}
+}
+
+export function createReusedRealSiteAccountFixturePreparer(params: {
+  page: Page
+  extensionId: string
+}) {
+  return async (fixture: AccountFixture) => {
+    await openAccountManagementPage(params)
+    await expectAccountListItemVisible(params.page, fixture.accountId)
+  }
+}
+
+function createFixtureFromStoredAccount(account: SiteAccount): AccountFixture {
+  return createAccountFixture({
+    accountId: account.id,
+    siteType: account.site_type,
+    baseUrl: account.site_url,
+    cleanup: createNoopAccountFixtureCleanup(),
+  })
+}
+
+async function resolvePreparedStoredAccount(params: {
+  serviceWorker: Worker
+  prepareAccountFixture: () => Promise<AccountFixture>
+}) {
+  const fixture = await params.prepareAccountFixture()
+  const accounts = await readStoredAccounts(params.serviceWorker)
+  const storedAccount = accounts.find(
+    (account) => account.id === fixture.accountId,
+  )
+
+  if (!storedAccount) {
+    throw new Error(
+      `Real-site account fixture ${fixture.accountId} was not found in extension storage.`,
+    )
+  }
+
+  return storedAccount
+}
+
+export async function resolveSharedRealSiteAccountFixture(params: {
+  cache: SharedRealSiteAccountFixtureCache
+  serviceWorker: Worker
+  prepareAccountFixture: () => Promise<AccountFixture>
+  prepareReusedAccountFixture?: (fixture: AccountFixture) => Promise<void>
+}): Promise<AccountFixture> {
+  if (params.cache.storedAccount) {
+    await seedStoredAccounts(params.serviceWorker, [params.cache.storedAccount])
+    const fixture = createFixtureFromStoredAccount(params.cache.storedAccount)
+    await params.prepareReusedAccountFixture?.(fixture)
+    return fixture
+  }
+
+  if (!params.cache.storedAccountPromise) {
+    params.cache.storedAccountPromise = resolvePreparedStoredAccount(params)
+  }
+
+  const storedAccount = await params.cache.storedAccountPromise
+  params.cache.storedAccount = storedAccount
+
+  return createFixtureFromStoredAccount(storedAccount)
+}

--- a/tests/utils/realSiteAccountUsage.test.ts
+++ b/tests/utils/realSiteAccountUsage.test.ts
@@ -252,6 +252,62 @@ describe("real-site account usage adapters", () => {
     expect(cleanup).toHaveBeenCalledOnce()
   })
 
+  it("raises the timeout only for real-site account checks that perform remote writes", async () => {
+    vi.mocked(maybeRunRealSiteModelToKeyScenario).mockResolvedValue(undefined)
+    vi.mocked(verifyAccountModelCatalogUsage).mockResolvedValue(undefined)
+    const testInfo = {
+      annotations: [],
+      timeout: 60_000,
+      setTimeout: vi.fn(),
+    } as any
+
+    await runRealSiteAccountFixtureUsageChecks(
+      {
+        testInfo,
+        page,
+        extensionId: "extension-id",
+        serviceWorker,
+        account,
+        label: "New API",
+      },
+      [
+        realSiteAccountUsageChecks.modelToKey({ envPrefix: "NEW_API" }),
+        realSiteAccountUsageChecks.modelCatalog(),
+      ],
+    )
+
+    expect(testInfo.setTimeout).toHaveBeenCalledOnce()
+    expect(testInfo.setTimeout).toHaveBeenCalledWith(120_000)
+  })
+
+  it("sums timeout budgets when multiple real-site remote-write checks run together", async () => {
+    vi.mocked(verifyAccountKeyLifecycleUsage).mockResolvedValue(undefined)
+    vi.mocked(maybeRunRealSiteModelToKeyScenario).mockResolvedValue(undefined)
+    const testInfo = {
+      annotations: [],
+      timeout: 60_000,
+      setTimeout: vi.fn(),
+    } as any
+
+    await runRealSiteAccountFixtureUsageChecks(
+      {
+        testInfo,
+        page,
+        extensionId: "extension-id",
+        serviceWorker,
+        account,
+        label: "New API",
+      },
+      [
+        realSiteAccountUsageChecks.keyLifecycle(),
+        realSiteAccountUsageChecks.modelToKey({ envPrefix: "NEW_API" }),
+      ],
+    )
+
+    expect(testInfo.setTimeout).toHaveBeenCalledOnce()
+    expect(testInfo.setTimeout).toHaveBeenCalledWith(240_000)
+  })
+
   it("verifies key-to-profile usage from the popup and closes the popup page", async () => {
     const popupPage = {
       close: vi.fn().mockResolvedValue(undefined),

--- a/tests/utils/realSiteSharedAccountFixture.test.ts
+++ b/tests/utils/realSiteSharedAccountFixture.test.ts
@@ -1,0 +1,162 @@
+import { readFileSync } from "node:fs"
+import path from "node:path"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { SITE_TYPES } from "~/constants/siteType"
+import { AuthTypeEnum, SiteHealthStatus, type SiteAccount } from "~/types"
+import type { AccountFixture } from "~~/e2e/scenarios/accountFixtures"
+import { readStoredAccounts } from "~~/e2e/scenarios/accountManualAdd"
+import { seedStoredAccounts } from "~~/e2e/utils/commonUserFlows"
+import {
+  createSharedRealSiteAccountFixtureCache,
+  resolveSharedRealSiteAccountFixture,
+} from "~~/e2e/utils/realSite/sharedAccountFixture"
+
+const mocks = vi.hoisted(() => ({
+  readStoredAccounts: vi.fn(),
+  seedStoredAccounts: vi.fn(),
+}))
+
+vi.mock("~~/e2e/scenarios/accountManualAdd", () => ({
+  readStoredAccounts: mocks.readStoredAccounts,
+}))
+
+vi.mock("~~/e2e/utils/commonUserFlows", () => ({
+  seedStoredAccounts: mocks.seedStoredAccounts,
+}))
+
+describe("shared real-site account fixture cache", () => {
+  const storedAccount: SiteAccount = {
+    id: "account-1",
+    site_name: "Real Veloera",
+    site_url: "https://veloera.example.invalid",
+    site_type: SITE_TYPES.VELOERA,
+    account_info: {
+      id: "user-1",
+      username: "tester",
+      access_token: "token",
+      quota: 100,
+      today_prompt_tokens: 0,
+      today_completion_tokens: 0,
+      today_quota_consumption: 0,
+      today_requests_count: 0,
+      today_income: 0,
+    },
+    health: { status: SiteHealthStatus.Healthy },
+    exchange_rate: 7,
+    last_sync_time: 1,
+    created_at: 1,
+    updated_at: 1,
+    user_updated_at: 1,
+    disabled: false,
+    excludeFromTotalBalance: false,
+    excludeFromTodayIncome: false,
+    tagIds: [],
+    notes: "",
+    authType: AuthTypeEnum.AccessToken,
+    checkIn: {
+      enableDetection: false,
+    },
+  }
+
+  const createdFixture: AccountFixture = {
+    accountId: storedAccount.id,
+    siteType: SITE_TYPES.VELOERA,
+    baseUrl: storedAccount.site_url,
+    cleanup: vi.fn().mockResolvedValue(undefined),
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(readStoredAccounts).mockResolvedValue([storedAccount])
+    vi.mocked(seedStoredAccounts).mockResolvedValue(undefined)
+  })
+
+  it("creates the real-site account once and reuses storage for later split checks", async () => {
+    const cache = createSharedRealSiteAccountFixtureCache()
+    const serviceWorkerA = {} as any
+    const serviceWorkerB = {} as any
+    const prepareAccountFixture = vi.fn().mockResolvedValue(createdFixture)
+    const prepareReusedAccountFixture = vi.fn().mockResolvedValue(undefined)
+
+    const firstFixture = await resolveSharedRealSiteAccountFixture({
+      cache,
+      serviceWorker: serviceWorkerA,
+      prepareAccountFixture,
+      prepareReusedAccountFixture,
+    })
+    const secondFixture = await resolveSharedRealSiteAccountFixture({
+      cache,
+      serviceWorker: serviceWorkerB,
+      prepareAccountFixture,
+      prepareReusedAccountFixture,
+    })
+
+    expect(prepareAccountFixture).toHaveBeenCalledOnce()
+    expect(prepareReusedAccountFixture).toHaveBeenCalledOnce()
+    expect(prepareReusedAccountFixture).toHaveBeenCalledWith(secondFixture)
+    expect(readStoredAccounts).toHaveBeenCalledOnce()
+    expect(seedStoredAccounts).toHaveBeenCalledOnce()
+    expect(seedStoredAccounts).toHaveBeenCalledWith(serviceWorkerB, [
+      storedAccount,
+    ])
+    expect(firstFixture).toMatchObject({
+      accountId: "account-1",
+      siteType: SITE_TYPES.VELOERA,
+      baseUrl: "https://veloera.example.invalid",
+    })
+    expect(secondFixture).toMatchObject({
+      accountId: "account-1",
+      siteType: SITE_TYPES.VELOERA,
+      baseUrl: "https://veloera.example.invalid",
+    })
+  })
+
+  it("does not retry real-site preparation after a shared preparation failure", async () => {
+    const cache = createSharedRealSiteAccountFixtureCache()
+    const error = new Error("Veloera login returned HTTP 429")
+    const prepareAccountFixture = vi.fn().mockRejectedValue(error)
+
+    await expect(
+      resolveSharedRealSiteAccountFixture({
+        cache,
+        serviceWorker: {} as any,
+        prepareAccountFixture,
+      }),
+    ).rejects.toThrow(error)
+    await expect(
+      resolveSharedRealSiteAccountFixture({
+        cache,
+        serviceWorker: {} as any,
+        prepareAccountFixture,
+      }),
+    ).rejects.toThrow(error)
+
+    expect(prepareAccountFixture).toHaveBeenCalledOnce()
+    expect(readStoredAccounts).not.toHaveBeenCalled()
+    expect(seedStoredAccounts).not.toHaveBeenCalled()
+  })
+})
+
+describe("real-site account spec structure", () => {
+  const splitAccountSpecs = [
+    "doneHubAccountAdd.spec.ts",
+    "newApiAccountAdd.spec.ts",
+    "oneHubAccountAdd.spec.ts",
+    "sub2apiAccountAdd.spec.ts",
+    "veloeraAccountAdd.spec.ts",
+  ] as const
+
+  it("uses shared account fixture caching for split real-site account specs", () => {
+    const specsWithoutSharedFixture = splitAccountSpecs.filter((fileName) => {
+      const source = readFileSync(
+        path.join(process.cwd(), "e2e", "realSite", fileName),
+        "utf8",
+      )
+
+      return !source.includes("resolveSharedRealSiteAccountFixture")
+    })
+
+    expect(specsWithoutSharedFixture).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary
- reuse real-site account fixtures across split account usage checks
- restore the account-management page state when cached fixtures are reused
- apply a scoped 120s timeout only to real-site account checks that perform remote key writes

## Validation
- pnpm exec vitest --run tests/utils/realSiteSharedAccountFixture.test.ts tests/utils/realSiteAccountUsage.test.ts tests/utils/accountUsagePlan.test.ts
- pnpm compile
- pnpm knip
- pnpm run e2e:real-site:account
- pnpm run validate:staged
- pre-push validate:push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-site E2E account add flows now reuse shared account fixtures across runs to reduce repeated setup.
  * Account usage checks support configurable timeouts to better accommodate longer remote operations.
* **Bug Fixes**
  * Improved lifecycle handling for temporary pages during account saving and reuse.
  * Added safer memoization for shared-fixture preparation failures to prevent repeated retries.
* **Tests**
  * Added coverage for shared fixture reuse, failure memoization, and aggregated timeout behavior for remote-write checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->