### PR TITLE
feat(model-list): add metadata-backed capability filters and badges

### DIFF
--- a/e2e/utils/commonUserFlows.ts
+++ b/e2e/utils/commonUserFlows.ts
@@ -16,6 +16,7 @@ import {
 } from "~/services/core/storageKeys"
 import { USAGE_HISTORY_STORAGE_KEYS } from "~/services/history/usageHistory/constants"
 import type { ModelPricing } from "~/services/modelList/pricingModel"
+import { MODEL_METADATA_URL } from "~/services/models/modelMetadata/constants"
 import { SITE_ANNOUNCEMENTS_STORE_SCHEMA_VERSION } from "~/services/siteAnnouncements/constants"
 import { API_TYPES } from "~/services/verification/aiApiVerification/types"
 import {
@@ -147,14 +148,12 @@ export async function forceExtensionLanguage(page: Page, language = "en") {
  * refreshes do not reach the network during these user-flow specs.
  */
 export async function stubLlmMetadataIndex(context: BrowserContext) {
-  await context.route(
-    "https://llm-metadata.pages.dev/api/index.json",
-    (route) =>
-      route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify({ models: [] }),
-      }),
+  await context.route(MODEL_METADATA_URL, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ models: [] }),
+    }),
   )
   await stubSponsorRemoteCatalog(context)
 }

--- a/src/components/ui/CompactMultiSelect.tsx
+++ b/src/components/ui/CompactMultiSelect.tsx
@@ -102,6 +102,17 @@ const getOptionAccessibleLabel = (option: CompactMultiSelectOption) =>
     ? `${option.label} ${option.count}`
     : option.label
 
+const OptionCountBadge = ({ count }: { count?: number }) =>
+  typeof count === "number" ? (
+    <Badge
+      variant="secondary"
+      size="sm"
+      className="ml-auto shrink-0 tabular-nums"
+    >
+      {count}
+    </Badge>
+  ) : null
+
 /**
  * CompactMultiSelect
  *
@@ -530,15 +541,7 @@ export function CompactMultiSelect({
                   aria-label={getOptionAccessibleLabel(item)}
                 >
                   <span className="min-w-0 flex-1 truncate">{item.label}</span>
-                  {typeof item.count === "number" && (
-                    <Badge
-                      variant="secondary"
-                      size="sm"
-                      className="ml-auto shrink-0 tabular-nums"
-                    >
-                      {item.count}
-                    </Badge>
-                  )}
+                  <OptionCountBadge count={item.count} />
                 </ComboboxItem>
               )}
             </ComboboxList>
@@ -695,15 +698,7 @@ export function CompactMultiSelect({
                         <span className="min-w-0 flex-1 truncate">
                           {option.label}
                         </span>
-                        {typeof option.count === "number" && (
-                          <Badge
-                            variant="secondary"
-                            size="sm"
-                            className="ml-auto shrink-0 tabular-nums"
-                          >
-                            {option.count}
-                          </Badge>
-                        )}
+                        <OptionCountBadge count={option.count} />
                       </CommandItem>
                     )
                   })}

--- a/src/components/ui/CompactMultiSelect.tsx
+++ b/src/components/ui/CompactMultiSelect.tsx
@@ -41,6 +41,7 @@ const logger = createLogger("CompactMultiSelect")
 export interface CompactMultiSelectOption {
   value: string
   label: string
+  count?: number
   disabled?: boolean
 }
 
@@ -95,6 +96,11 @@ export interface CompactMultiSelectProps
    */
   inputTestId?: string
 }
+
+const getOptionAccessibleLabel = (option: CompactMultiSelectOption) =>
+  typeof option.count === "number"
+    ? `${option.label} ${option.count}`
+    : option.label
 
 /**
  * CompactMultiSelect
@@ -521,8 +527,18 @@ export function CompactMultiSelect({
                   key={item.value}
                   value={item}
                   disabled={disabled || Boolean(item.disabled)}
+                  aria-label={getOptionAccessibleLabel(item)}
                 >
-                  <span className="truncate">{item.label}</span>
+                  <span className="min-w-0 flex-1 truncate">{item.label}</span>
+                  {typeof item.count === "number" && (
+                    <Badge
+                      variant="secondary"
+                      size="sm"
+                      className="ml-auto shrink-0 tabular-nums"
+                    >
+                      {item.count}
+                    </Badge>
+                  )}
                 </ComboboxItem>
               )}
             </ComboboxList>
@@ -667,6 +683,7 @@ export function CompactMultiSelect({
                         value={option.value}
                         keywords={[option.label]}
                         disabled={isOptionDisabled}
+                        aria-label={getOptionAccessibleLabel(option)}
                         onSelect={() => toggleValue(option.value)}
                       >
                         <CheckIcon
@@ -675,7 +692,18 @@ export function CompactMultiSelect({
                             isSelected ? "opacity-100" : "opacity-0",
                           )}
                         />
-                        <span className="truncate">{option.label}</span>
+                        <span className="min-w-0 flex-1 truncate">
+                          {option.label}
+                        </span>
+                        {typeof option.count === "number" && (
+                          <Badge
+                            variant="secondary"
+                            size="sm"
+                            className="ml-auto shrink-0 tabular-nums"
+                          >
+                            {option.count}
+                          </Badge>
+                        )}
                       </CommandItem>
                     )
                   })}

--- a/src/features/ModelList/ModelList.tsx
+++ b/src/features/ModelList/ModelList.tsx
@@ -112,6 +112,8 @@ export default function ModelList(props: {
     setSortMode,
     selectedBillingMode,
     setSelectedBillingMode,
+    selectedModelCapabilities,
+    setSelectedModelCapabilities,
     selectedGroups,
     setSelectedGroups,
     allAccountsExcludedGroupsByAccountId,
@@ -146,6 +148,8 @@ export default function ModelList(props: {
     availableGroups,
     availableAccountGroupsByAccountId,
     availableAccountGroupOptionsByAccountId,
+    supportsModelCapabilityFilter,
+    modelCapabilityMetadataCoverage,
 
     // Operations
     loadPricingData,
@@ -700,6 +704,10 @@ export default function ModelList(props: {
             setSortMode={setSortMode}
             selectedBillingMode={selectedBillingMode}
             setSelectedBillingMode={setSelectedBillingMode}
+            supportsModelCapabilityFilter={supportsModelCapabilityFilter}
+            modelCapabilityMetadataCoverage={modelCapabilityMetadataCoverage}
+            selectedModelCapabilities={selectedModelCapabilities}
+            setSelectedModelCapabilities={setSelectedModelCapabilities}
             selectedGroups={selectedGroups}
             setSelectedGroups={setSelectedGroups}
             availableGroups={availableGroups}

--- a/src/features/ModelList/components/ControlPanel.tsx
+++ b/src/features/ModelList/components/ControlPanel.tsx
@@ -32,6 +32,7 @@ import {
   resolveGroupRatio,
 } from "~/features/ModelList/groupLabels"
 import {
+  MODEL_CAPABILITY_FILTER_LABEL_TRANSLATORS,
   MODEL_CAPABILITY_FILTER_VALUES,
   type ModelCapabilityMetadataCoverage,
   type ModelCapabilitySelectionValue,
@@ -200,6 +201,8 @@ export function ControlPanel({
     !!modelCapabilityMetadataCoverage &&
     modelCapabilityMetadataCoverage.total > 0 &&
     modelCapabilityMetadataCoverage.unmatched > 0
+  const unmatchedCapabilityMetadataCount =
+    modelCapabilityMetadataCoverage?.unmatched ?? 0
   const groupOptions = availableGroups.map((group) => ({
     value: group,
     label: formatGroupLabel(
@@ -279,10 +282,7 @@ export function ControlPanel({
         selectedVerificationResults,
       })
     }
-    const buildCapabilityOption = (
-      value: ModelCapabilitySelectionValue,
-      label: string,
-    ) => {
+    const buildCapabilityOption = (value: ModelCapabilitySelectionValue) => {
       const count = supportsModelCapabilityFilter
         ? resolveCapabilityCount(value)
         : undefined
@@ -290,57 +290,24 @@ export function ControlPanel({
 
       return {
         value,
-        label,
+        label: MODEL_CAPABILITY_FILTER_LABEL_TRANSLATORS[value](t),
         count,
         disabled: !isSelected && count === 0,
       }
     }
 
     const capabilityOptions = [
-      buildCapabilityOption(
-        MODEL_CAPABILITY_FILTER_VALUES.IMAGE_INPUT,
-        t("modelCapabilityFilter.options.imageInput"),
-      ),
-      buildCapabilityOption(
-        MODEL_CAPABILITY_FILTER_VALUES.IMAGE_OUTPUT,
-        t("modelCapabilityFilter.options.imageOutput"),
-      ),
-      buildCapabilityOption(
-        MODEL_CAPABILITY_FILTER_VALUES.AUDIO_INPUT,
-        t("modelCapabilityFilter.options.audioInput"),
-      ),
-      buildCapabilityOption(
-        MODEL_CAPABILITY_FILTER_VALUES.AUDIO_OUTPUT,
-        t("modelCapabilityFilter.options.audioOutput"),
-      ),
-      buildCapabilityOption(
-        MODEL_CAPABILITY_FILTER_VALUES.VIDEO_INPUT,
-        t("modelCapabilityFilter.options.videoInput"),
-      ),
-      buildCapabilityOption(
-        MODEL_CAPABILITY_FILTER_VALUES.VIDEO_OUTPUT,
-        t("modelCapabilityFilter.options.videoOutput"),
-      ),
-      buildCapabilityOption(
-        MODEL_CAPABILITY_FILTER_VALUES.PDF,
-        t("modelCapabilityFilter.options.pdf"),
-      ),
-      buildCapabilityOption(
-        MODEL_CAPABILITY_FILTER_VALUES.REASONING,
-        t("modelCapabilityFilter.options.reasoning"),
-      ),
-      buildCapabilityOption(
-        MODEL_CAPABILITY_FILTER_VALUES.TOOL_CALL,
-        t("modelCapabilityFilter.options.toolCall"),
-      ),
-      buildCapabilityOption(
-        MODEL_CAPABILITY_FILTER_VALUES.STRUCTURED_OUTPUT,
-        t("modelCapabilityFilter.options.structuredOutput"),
-      ),
-      buildCapabilityOption(
-        MODEL_CAPABILITY_FILTER_VALUES.ATTACHMENT,
-        t("modelCapabilityFilter.options.attachment"),
-      ),
+      buildCapabilityOption(MODEL_CAPABILITY_FILTER_VALUES.IMAGE_INPUT),
+      buildCapabilityOption(MODEL_CAPABILITY_FILTER_VALUES.IMAGE_OUTPUT),
+      buildCapabilityOption(MODEL_CAPABILITY_FILTER_VALUES.AUDIO_INPUT),
+      buildCapabilityOption(MODEL_CAPABILITY_FILTER_VALUES.AUDIO_OUTPUT),
+      buildCapabilityOption(MODEL_CAPABILITY_FILTER_VALUES.VIDEO_INPUT),
+      buildCapabilityOption(MODEL_CAPABILITY_FILTER_VALUES.VIDEO_OUTPUT),
+      buildCapabilityOption(MODEL_CAPABILITY_FILTER_VALUES.PDF),
+      buildCapabilityOption(MODEL_CAPABILITY_FILTER_VALUES.REASONING),
+      buildCapabilityOption(MODEL_CAPABILITY_FILTER_VALUES.TOOL_CALL),
+      buildCapabilityOption(MODEL_CAPABILITY_FILTER_VALUES.STRUCTURED_OUTPUT),
+      buildCapabilityOption(MODEL_CAPABILITY_FILTER_VALUES.ATTACHMENT),
     ]
 
     return [
@@ -594,9 +561,10 @@ export function ControlPanel({
                   <>
                     {" "}
                     {t("modelCapabilityFilter.coverageHint", {
+                      count: unmatchedCapabilityMetadataCount,
                       matched: modelCapabilityMetadataCoverage.matched,
                       total: modelCapabilityMetadataCoverage.total,
-                      unmatched: modelCapabilityMetadataCoverage.unmatched,
+                      unmatched: unmatchedCapabilityMetadataCount,
                     })}
                   </>
                 )}

--- a/src/features/ModelList/components/ControlPanel.tsx
+++ b/src/features/ModelList/components/ControlPanel.tsx
@@ -5,6 +5,7 @@ import {
   MagnifyingGlassIcon,
 } from "@heroicons/react/24/outline"
 import { Copy, TrendingDown } from "lucide-react"
+import { useMemo } from "react"
 import toast from "react-hot-toast"
 import { useTranslation } from "react-i18next"
 
@@ -30,6 +31,11 @@ import {
   formatGroupLabel,
   resolveGroupRatio,
 } from "~/features/ModelList/groupLabels"
+import {
+  MODEL_CAPABILITY_FILTER_VALUES,
+  type ModelCapabilityMetadataCoverage,
+  type ModelCapabilitySelectionValue,
+} from "~/features/ModelList/modelCapabilityFilters"
 import {
   ALL_ACCOUNTS_SOURCE_VALUE,
   MODEL_MANAGEMENT_SOURCE_KINDS,
@@ -72,6 +78,12 @@ interface ControlPanelProps {
   ) => void
   selectedBillingMode: ModelListBillingMode
   setSelectedBillingMode: (mode: ModelListBillingMode) => void
+  supportsModelCapabilityFilter?: boolean
+  modelCapabilityMetadataCoverage?: ModelCapabilityMetadataCoverage
+  selectedModelCapabilities?: ModelCapabilitySelectionValue[]
+  setSelectedModelCapabilities?: (
+    capabilities: ModelCapabilitySelectionValue[],
+  ) => void
   selectedGroups: string[]
   setSelectedGroups: (groups: string[]) => void
   availableGroups: string[]
@@ -88,6 +100,7 @@ interface ControlPanelProps {
     searchTerm?: string
     sortMode?: ModelListSortMode
     selectedBillingMode?: ModelListBillingMode
+    selectedModelCapabilities?: ModelCapabilitySelectionValue[]
     selectedGroups?: string[]
     selectedVerificationResults?: ModelListVerificationResultFilter[]
   }) => number
@@ -109,6 +122,10 @@ interface ControlPanelProps {
  * @param props.setSelectedVerificationResults Setter for verification-result filters.
  * @param props.selectedBillingMode Active billing-mode filter value.
  * @param props.setSelectedBillingMode Setter for billing-mode filter.
+ * @param props.supportsModelCapabilityFilter Whether metadata-backed capability filters are available.
+ * @param props.modelCapabilityMetadataCoverage Metadata match coverage for models before capability filters.
+ * @param props.selectedModelCapabilities Active model capability filter values.
+ * @param props.setSelectedModelCapabilities Setter for model capability filters.
  * @param props.selectedGroups Active candidate group filter set.
  * @param props.setSelectedGroups Setter for candidate group filter set.
  * @param props.availableGroups Available group options.
@@ -138,6 +155,10 @@ export function ControlPanel({
   setSelectedVerificationResults = () => {},
   selectedBillingMode,
   setSelectedBillingMode,
+  supportsModelCapabilityFilter = false,
+  modelCapabilityMetadataCoverage,
+  selectedModelCapabilities = [],
+  setSelectedModelCapabilities = () => {},
   selectedGroups,
   setSelectedGroups,
   availableGroups,
@@ -174,6 +195,11 @@ export function ControlPanel({
     sourceCapabilities.supportsPricing &&
     !isProfileSource &&
     !isPriceComparisonActive
+  const shouldShowModelCapabilityCoverageHint =
+    supportsModelCapabilityFilter &&
+    !!modelCapabilityMetadataCoverage &&
+    modelCapabilityMetadataCoverage.total > 0 &&
+    modelCapabilityMetadataCoverage.unmatched > 0
   const groupOptions = availableGroups.map((group) => ({
     value: group,
     label: formatGroupLabel(
@@ -229,6 +255,109 @@ export function ControlPanel({
       label: t("ui:billing.perCall"),
     },
   ]
+  const modelCapabilityOptions = useMemo(() => {
+    const selectedCapabilitySet = new Set(selectedModelCapabilities)
+    const resolveCapabilityCount = (
+      capability: ModelCapabilitySelectionValue,
+    ) => {
+      if (!getFilteredResultCount) {
+        return undefined
+      }
+
+      const selectedModelCapabilitiesForCount = selectedCapabilitySet.has(
+        capability,
+      )
+        ? selectedModelCapabilities
+        : [...selectedModelCapabilities, capability]
+
+      return getFilteredResultCount({
+        searchTerm,
+        sortMode,
+        selectedBillingMode,
+        selectedModelCapabilities: selectedModelCapabilitiesForCount,
+        selectedGroups,
+        selectedVerificationResults,
+      })
+    }
+    const buildCapabilityOption = (
+      value: ModelCapabilitySelectionValue,
+      label: string,
+    ) => {
+      const count = supportsModelCapabilityFilter
+        ? resolveCapabilityCount(value)
+        : undefined
+      const isSelected = selectedCapabilitySet.has(value)
+
+      return {
+        value,
+        label,
+        count,
+        disabled: !isSelected && count === 0,
+      }
+    }
+
+    const capabilityOptions = [
+      buildCapabilityOption(
+        MODEL_CAPABILITY_FILTER_VALUES.IMAGE_INPUT,
+        t("modelCapabilityFilter.options.imageInput"),
+      ),
+      buildCapabilityOption(
+        MODEL_CAPABILITY_FILTER_VALUES.IMAGE_OUTPUT,
+        t("modelCapabilityFilter.options.imageOutput"),
+      ),
+      buildCapabilityOption(
+        MODEL_CAPABILITY_FILTER_VALUES.AUDIO_INPUT,
+        t("modelCapabilityFilter.options.audioInput"),
+      ),
+      buildCapabilityOption(
+        MODEL_CAPABILITY_FILTER_VALUES.AUDIO_OUTPUT,
+        t("modelCapabilityFilter.options.audioOutput"),
+      ),
+      buildCapabilityOption(
+        MODEL_CAPABILITY_FILTER_VALUES.VIDEO_INPUT,
+        t("modelCapabilityFilter.options.videoInput"),
+      ),
+      buildCapabilityOption(
+        MODEL_CAPABILITY_FILTER_VALUES.VIDEO_OUTPUT,
+        t("modelCapabilityFilter.options.videoOutput"),
+      ),
+      buildCapabilityOption(
+        MODEL_CAPABILITY_FILTER_VALUES.PDF,
+        t("modelCapabilityFilter.options.pdf"),
+      ),
+      buildCapabilityOption(
+        MODEL_CAPABILITY_FILTER_VALUES.REASONING,
+        t("modelCapabilityFilter.options.reasoning"),
+      ),
+      buildCapabilityOption(
+        MODEL_CAPABILITY_FILTER_VALUES.TOOL_CALL,
+        t("modelCapabilityFilter.options.toolCall"),
+      ),
+      buildCapabilityOption(
+        MODEL_CAPABILITY_FILTER_VALUES.STRUCTURED_OUTPUT,
+        t("modelCapabilityFilter.options.structuredOutput"),
+      ),
+      buildCapabilityOption(
+        MODEL_CAPABILITY_FILTER_VALUES.ATTACHMENT,
+        t("modelCapabilityFilter.options.attachment"),
+      ),
+    ]
+
+    return [
+      ...capabilityOptions.filter((option) => !option.disabled),
+      ...capabilityOptions.filter((option) => option.disabled),
+    ]
+  }, [
+    getFilteredResultCount,
+    searchTerm,
+    selectedBillingMode,
+    selectedGroups,
+    selectedModelCapabilities,
+    selectedVerificationResults,
+    sortMode,
+    supportsModelCapabilityFilter,
+    t,
+  ])
   const verificationResultOptions = [
     {
       value: "pass",
@@ -261,6 +390,7 @@ export function ControlPanel({
       searchTerm: string
       sortMode: ModelListSortMode
       selectedBillingMode: ModelListBillingMode
+      selectedModelCapabilities: ModelCapabilitySelectionValue[]
       selectedGroups: string[]
       selectedVerificationResults: ModelListVerificationResultFilter[]
     }> = {},
@@ -269,6 +399,9 @@ export function ControlPanel({
     const nextSortMode = nextFilters.sortMode ?? sortMode
     const nextSelectedBillingMode =
       nextFilters.selectedBillingMode ?? selectedBillingMode
+    const nextSelectedModelCapabilities = supportsModelCapabilityFilter
+      ? nextFilters.selectedModelCapabilities ?? selectedModelCapabilities
+      : []
     const nextSelectedGroups = nextFilters.selectedGroups ?? selectedGroups
     const nextSelectedVerificationResults =
       nextFilters.selectedVerificationResults ?? selectedVerificationResults
@@ -276,6 +409,7 @@ export function ControlPanel({
       (nextSearchTerm.trim() ? 1 : 0) +
       (nextSortMode !== MODEL_LIST_SORT_MODES.DEFAULT ? 1 : 0) +
       (nextSelectedBillingMode !== MODEL_LIST_BILLING_MODES.ALL ? 1 : 0) +
+      nextSelectedModelCapabilities.length +
       nextSelectedGroups.length +
       (nextSelectedVerificationResults.length ===
       verificationResultOptions.length
@@ -286,6 +420,7 @@ export function ControlPanel({
         searchTerm: nextSearchTerm,
         sortMode: nextSortMode,
         selectedBillingMode: nextSelectedBillingMode,
+        selectedModelCapabilities: nextSelectedModelCapabilities,
         selectedGroups: nextSelectedGroups,
         selectedVerificationResults: nextSelectedVerificationResults,
       }) ?? filteredModels.length
@@ -322,6 +457,13 @@ export function ControlPanel({
     setSelectedBillingMode(nextBillingMode)
     trackFilterChange(PRODUCT_ANALYTICS_MODE_IDS.BillingFilter, {
       selectedBillingMode: nextBillingMode,
+    })
+  }
+  const handleModelCapabilityChange = (values: string[]) => {
+    const nextCapabilities = values as ModelCapabilitySelectionValue[]
+    setSelectedModelCapabilities(nextCapabilities)
+    trackFilterChange(PRODUCT_ANALYTICS_MODE_IDS.ModelCapabilityFilter, {
+      selectedModelCapabilities: nextCapabilities,
     })
   }
   const handleGroupSelectionChange = (groups: string[]) => {
@@ -431,6 +573,36 @@ export function ControlPanel({
                 </p>
               </FormField>
             )}
+
+          {supportsModelCapabilityFilter && (
+            <FormField
+              label={t("modelCapabilityFilter.label")}
+              className="w-full lg:w-64"
+            >
+              <CompactMultiSelect
+                options={modelCapabilityOptions}
+                selected={selectedModelCapabilities}
+                onChange={handleModelCapabilityChange}
+                size="default"
+                displayMode="summary"
+                placeholder={t("modelCapabilityFilter.options.all")}
+                emptyMessage={t("modelCapabilityFilter.options.all")}
+              />
+              <p className="dark:text-dark-text-tertiary mt-1 text-xs text-gray-500">
+                {t("modelCapabilityFilter.selectionHint")}
+                {shouldShowModelCapabilityCoverageHint && (
+                  <>
+                    {" "}
+                    {t("modelCapabilityFilter.coverageHint", {
+                      matched: modelCapabilityMetadataCoverage.matched,
+                      total: modelCapabilityMetadataCoverage.total,
+                      unmatched: modelCapabilityMetadataCoverage.unmatched,
+                    })}
+                  </>
+                )}
+              </p>
+            </FormField>
+          )}
 
           <FormField
             label={t("verificationResults.label")}

--- a/src/features/ModelList/components/ModelDisplay.tsx
+++ b/src/features/ModelList/components/ModelDisplay.tsx
@@ -197,6 +197,7 @@ export function ModelDisplay(props: ModelDisplayProps) {
           return (
             <ModelItem
               model={item.model}
+              modelMetadata={item.modelMetadata}
               calculatedPrice={item.calculatedPrice}
               exchangeRate={exchangeRate}
               showRealPrice={showRealPrice}

--- a/src/features/ModelList/components/ModelItem/ModelCapabilityBadges.tsx
+++ b/src/features/ModelList/components/ModelItem/ModelCapabilityBadges.tsx
@@ -1,0 +1,178 @@
+import {
+  Braces,
+  Brain,
+  Eye,
+  FileText,
+  Image as ImageIcon,
+  Paperclip,
+  Video,
+  Volume2,
+  Wrench,
+  type LucideIcon,
+} from "lucide-react"
+import { useTranslation } from "react-i18next"
+
+import { Badge } from "~/components/ui"
+import {
+  getModelCapabilityBadges,
+  MODEL_CAPABILITY_FILTER_LABEL_KEYS,
+  MODEL_CAPABILITY_FILTER_VALUES,
+  type ModelCapabilitySelectionValue,
+} from "~/features/ModelList/modelCapabilityFilters"
+import { cn } from "~/lib/utils"
+import type { ModelMetadata } from "~/services/models/modelMetadata/types"
+
+interface ModelCapabilityBadgesProps {
+  modelMetadata?: ModelMetadata
+  className?: string
+}
+
+const CAPABILITY_ICONS: Record<ModelCapabilitySelectionValue, LucideIcon> = {
+  [MODEL_CAPABILITY_FILTER_VALUES.IMAGE_INPUT]: Eye,
+  [MODEL_CAPABILITY_FILTER_VALUES.IMAGE_OUTPUT]: ImageIcon,
+  [MODEL_CAPABILITY_FILTER_VALUES.AUDIO_INPUT]: Volume2,
+  [MODEL_CAPABILITY_FILTER_VALUES.AUDIO_OUTPUT]: Volume2,
+  [MODEL_CAPABILITY_FILTER_VALUES.VIDEO_INPUT]: Video,
+  [MODEL_CAPABILITY_FILTER_VALUES.VIDEO_OUTPUT]: Video,
+  [MODEL_CAPABILITY_FILTER_VALUES.PDF]: FileText,
+  [MODEL_CAPABILITY_FILTER_VALUES.REASONING]: Brain,
+  [MODEL_CAPABILITY_FILTER_VALUES.TOOL_CALL]: Wrench,
+  [MODEL_CAPABILITY_FILTER_VALUES.STRUCTURED_OUTPUT]: Braces,
+  [MODEL_CAPABILITY_FILTER_VALUES.ATTACHMENT]: Paperclip,
+}
+
+const CAPABILITY_GROUPS: Array<{
+  id: "input" | "output" | "capabilities"
+  capabilities: ModelCapabilitySelectionValue[]
+}> = [
+  {
+    id: "input",
+    capabilities: [
+      MODEL_CAPABILITY_FILTER_VALUES.IMAGE_INPUT,
+      MODEL_CAPABILITY_FILTER_VALUES.AUDIO_INPUT,
+      MODEL_CAPABILITY_FILTER_VALUES.VIDEO_INPUT,
+      MODEL_CAPABILITY_FILTER_VALUES.PDF,
+    ],
+  },
+  {
+    id: "output",
+    capabilities: [
+      MODEL_CAPABILITY_FILTER_VALUES.IMAGE_OUTPUT,
+      MODEL_CAPABILITY_FILTER_VALUES.AUDIO_OUTPUT,
+      MODEL_CAPABILITY_FILTER_VALUES.VIDEO_OUTPUT,
+    ],
+  },
+  {
+    id: "capabilities",
+    capabilities: [
+      MODEL_CAPABILITY_FILTER_VALUES.REASONING,
+      MODEL_CAPABILITY_FILTER_VALUES.TOOL_CALL,
+      MODEL_CAPABILITY_FILTER_VALUES.STRUCTURED_OUTPUT,
+      MODEL_CAPABILITY_FILTER_VALUES.ATTACHMENT,
+    ],
+  },
+]
+
+/**
+ * Shows metadata-backed model capabilities as a compact row-level badge group.
+ */
+export function ModelCapabilityBadges({
+  modelMetadata,
+  className,
+}: ModelCapabilityBadgesProps) {
+  const { t } = useTranslation("modelList")
+  const capabilityBadges = getModelCapabilityBadges(modelMetadata)
+  const capabilityDescriptions: Record<ModelCapabilitySelectionValue, string> =
+    {
+      [MODEL_CAPABILITY_FILTER_VALUES.IMAGE_INPUT]: t(
+        "modelCapabilityFilter.descriptions.imageInput",
+      ),
+      [MODEL_CAPABILITY_FILTER_VALUES.IMAGE_OUTPUT]: t(
+        "modelCapabilityFilter.descriptions.imageOutput",
+      ),
+      [MODEL_CAPABILITY_FILTER_VALUES.AUDIO_INPUT]: t(
+        "modelCapabilityFilter.descriptions.audioInput",
+      ),
+      [MODEL_CAPABILITY_FILTER_VALUES.AUDIO_OUTPUT]: t(
+        "modelCapabilityFilter.descriptions.audioOutput",
+      ),
+      [MODEL_CAPABILITY_FILTER_VALUES.VIDEO_INPUT]: t(
+        "modelCapabilityFilter.descriptions.videoInput",
+      ),
+      [MODEL_CAPABILITY_FILTER_VALUES.VIDEO_OUTPUT]: t(
+        "modelCapabilityFilter.descriptions.videoOutput",
+      ),
+      [MODEL_CAPABILITY_FILTER_VALUES.PDF]: t(
+        "modelCapabilityFilter.descriptions.pdf",
+      ),
+      [MODEL_CAPABILITY_FILTER_VALUES.REASONING]: t(
+        "modelCapabilityFilter.descriptions.reasoning",
+      ),
+      [MODEL_CAPABILITY_FILTER_VALUES.TOOL_CALL]: t(
+        "modelCapabilityFilter.descriptions.toolCall",
+      ),
+      [MODEL_CAPABILITY_FILTER_VALUES.STRUCTURED_OUTPUT]: t(
+        "modelCapabilityFilter.descriptions.structuredOutput",
+      ),
+      [MODEL_CAPABILITY_FILTER_VALUES.ATTACHMENT]: t(
+        "modelCapabilityFilter.descriptions.attachment",
+      ),
+    }
+  const groupLabels: Record<(typeof CAPABILITY_GROUPS)[number]["id"], string> =
+    {
+      input: t("modelCapabilityFilter.groups.input"),
+      output: t("modelCapabilityFilter.groups.output"),
+      capabilities: t("modelCapabilityFilter.groups.capabilities"),
+    }
+
+  if (capabilityBadges.length === 0) {
+    return null
+  }
+
+  return (
+    <div
+      className={cn(
+        "flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1.5 sm:justify-end",
+        className,
+      )}
+    >
+      {CAPABILITY_GROUPS.map(({ id, capabilities }) => {
+        const visibleCapabilities = capabilities.filter((capability) =>
+          capabilityBadges.includes(capability),
+        )
+
+        if (visibleCapabilities.length === 0) {
+          return null
+        }
+
+        return (
+          <div key={id} className="flex min-w-0 flex-wrap items-center gap-1.5">
+            <span className="dark:text-dark-text-tertiary shrink-0 text-[10px] font-medium text-gray-500 sm:text-xs">
+              {groupLabels[id]}
+            </span>
+            {visibleCapabilities.map((capability) => {
+              const Icon = CAPABILITY_ICONS[capability]
+              const label = t(MODEL_CAPABILITY_FILTER_LABEL_KEYS[capability])
+              const description = capabilityDescriptions[capability]
+              const accessibleLabel = `${label}: ${description}`
+
+              return (
+                <Badge
+                  key={capability}
+                  variant="outline"
+                  size="sm"
+                  className="border-slate-300 bg-slate-50 text-[10px] text-slate-700 sm:text-xs dark:border-slate-600 dark:bg-slate-800/70 dark:text-slate-200"
+                  title={accessibleLabel}
+                  aria-label={accessibleLabel}
+                >
+                  <Icon aria-hidden="true" className="h-3 w-3" />
+                  {label}
+                </Badge>
+              )
+            })}
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/features/ModelList/components/ModelItem/index.tsx
+++ b/src/features/ModelList/components/ModelItem/index.tsx
@@ -21,6 +21,7 @@ import {
   type ModelPricing,
 } from "~/services/modelList/pricingModel"
 import { DEFAULT_MODEL_GROUP } from "~/services/models/constants"
+import type { ModelMetadata } from "~/services/models/modelMetadata/types"
 import type { CalculatedPrice } from "~/services/models/utils/modelPricing"
 import {
   PRODUCT_ANALYTICS_ACTION_IDS,
@@ -35,6 +36,7 @@ import { createLogger } from "~/utils/core/logger"
 import { tryParseUrl } from "~/utils/core/urlParsing"
 
 import { formatGroupLabelFromRatios } from "../../groupLabels"
+import { ModelCapabilityBadges } from "./ModelCapabilityBadges"
 import { ModelItemDescription } from "./ModelItemDescription"
 import { ModelItemDetails } from "./ModelItemDetails"
 import { ModelItemExpandButton } from "./ModelItemExpandButton"
@@ -45,6 +47,7 @@ const logger = createLogger("ModelItem")
 
 interface ModelItemProps {
   model: ModelPricing
+  modelMetadata?: ModelMetadata
   calculatedPrice: CalculatedPrice
   exchangeRate: number
   showRealPrice: boolean
@@ -92,6 +95,7 @@ interface ModelItemProps {
 export default function ModelItem(props: ModelItemProps) {
   const {
     model,
+    modelMetadata,
     calculatedPrice,
     exchangeRate,
     showRealPrice,
@@ -405,22 +409,30 @@ export default function ModelItem(props: ModelItemProps) {
           model={model}
           isAvailableForUser={isAvailableForUser}
         />
-        <ModelItemPricing
-          model={model}
-          calculatedPrice={calculatedPrice}
-          exchangeRate={exchangeRate}
-          showRealPrice={showRealPrice}
-          showPricing={showPricing}
-          showRatioColumn={
-            showRatioColumn && effectiveCapabilities.supportsRatioDisplay
-          }
-          isAvailableForUser={isAvailableForUser}
-          isLowestPrice={isLowestPrice}
-          effectiveGroup={effectiveGroup}
-          groupRatios={groupRatios}
-          showsOptimalGroup={showsOptimalGroup}
-          groupSelectionScope={groupSelectionScope}
-        />
+        <div className="flex min-w-0 flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+          <div className="min-w-0 flex-1">
+            <ModelItemPricing
+              model={model}
+              calculatedPrice={calculatedPrice}
+              exchangeRate={exchangeRate}
+              showRealPrice={showRealPrice}
+              showPricing={showPricing}
+              showRatioColumn={
+                showRatioColumn && effectiveCapabilities.supportsRatioDisplay
+              }
+              isAvailableForUser={isAvailableForUser}
+              isLowestPrice={isLowestPrice}
+              effectiveGroup={effectiveGroup}
+              groupRatios={groupRatios}
+              showsOptimalGroup={showsOptimalGroup}
+              groupSelectionScope={groupSelectionScope}
+            />
+          </div>
+          <ModelCapabilityBadges
+            modelMetadata={modelMetadata}
+            className="mt-1 sm:ml-auto sm:max-w-[48%]"
+          />
+        </div>
 
         {isExpanded &&
           source.kind === MODEL_MANAGEMENT_SOURCE_KINDS.ACCOUNT && (

--- a/src/features/ModelList/hooks/useFilteredModels.ts
+++ b/src/features/ModelList/hooks/useFilteredModels.ts
@@ -3,6 +3,14 @@ import { useCallback, useMemo } from "react"
 import { UI_CONSTANTS } from "~/constants/ui"
 import { applyAihubmixModelListCapabilities } from "~/features/ModelList/aihubmixModelList"
 import {
+  createModelMetadataIndex,
+  hasFilterableModelCapabilityMetadata,
+  matchesModelCapabilityFilters,
+  resolveModelMetadata,
+  type ModelCapabilityMetadataCoverage,
+  type ModelCapabilitySelectionValue,
+} from "~/features/ModelList/modelCapabilityFilters"
+import {
   createAccountSource,
   deriveModelListSourceCapabilities,
   MODEL_MANAGEMENT_SOURCE_KINDS,
@@ -19,6 +27,7 @@ import {
   type PricingResponse,
 } from "~/services/modelList/pricingModel"
 import { DEFAULT_MODEL_GROUP } from "~/services/models/constants"
+import type { ModelMetadata } from "~/services/models/modelMetadata/types"
 import {
   calculateModelPrice,
   isTokenBillingType,
@@ -45,6 +54,8 @@ interface UseFilteredModelsProps {
   allAccountsExcludedGroupsByAccountId?: Record<string, string[]>
   searchTerm: string
   selectedProvider: ModelProviderFilterValue
+  selectedModelCapabilities: ModelCapabilitySelectionValue[]
+  modelMetadata: ModelMetadata[]
   sortMode: ModelListSortMode
   showRealPrice: boolean
   accountFilterAccountIds?: string[]
@@ -71,6 +82,7 @@ interface RawModelItem {
   sourceIdentity?: ModelListSourceIdentity
   groupRatios: Record<string, number>
   exchangeRate: number
+  modelMetadata?: ModelMetadata
 }
 
 export interface AccountGroupOption {
@@ -90,6 +102,7 @@ export type CalculatedModelItem = {
   sourceIdentity?: ModelListSourceIdentity
   groupRatios: Record<string, number>
   effectiveGroup?: string
+  modelMetadata?: ModelMetadata
   hasAutoSelectedGroup?: boolean
   isLowestPrice?: boolean
 }
@@ -371,6 +384,7 @@ function resolveBestCalculatedItem(
       sourceIdentity: rawItem.sourceIdentity,
       groupRatios: rawItem.groupRatios,
       effectiveGroup: supportsGroupFiltering ? group : undefined,
+      modelMetadata: rawItem.modelMetadata,
       hasAutoSelectedGroup: groupsToEvaluate.length > 1,
     }
     const candidateKey = getComparablePriceKey(candidateItem, showRealPrice)
@@ -428,7 +442,11 @@ function resolveCalculatedModels(params: {
 type FilterOverrides = Partial<
   Pick<
     UseFilteredModelsProps,
-    "searchTerm" | "sortMode" | "selectedBillingMode" | "selectedGroups"
+    | "searchTerm"
+    | "sortMode"
+    | "selectedBillingMode"
+    | "selectedGroups"
+    | "selectedModelCapabilities"
   >
 >
 
@@ -456,10 +474,21 @@ export function useFilteredModels(params: UseFilteredModelsProps) {
     allAccountsExcludedGroupsByAccountId = {},
     searchTerm,
     selectedProvider,
+    selectedModelCapabilities,
+    modelMetadata,
     sortMode,
     showRealPrice,
     accountFilterAccountIds = [],
   } = params
+
+  const modelMetadataIndex = useMemo(
+    () => createModelMetadataIndex(modelMetadata),
+    [modelMetadata],
+  )
+  const supportsModelCapabilityFilter = useMemo(
+    () => hasFilterableModelCapabilityMetadata(modelMetadata),
+    [modelMetadata],
+  )
 
   const rawModelItems = useMemo<RawModelItem[]>(() => {
     if (pricingContexts && pricingContexts.length > 0) {
@@ -498,6 +527,10 @@ export function useFilteredModels(params: UseFilteredModelsProps) {
           sourceIdentity,
           groupRatios: pricing.group_ratio ?? {},
           exchangeRate,
+          modelMetadata: resolveModelMetadata(
+            modelMetadataIndex,
+            model.model_name,
+          ),
         }))
       })
     }
@@ -512,6 +545,10 @@ export function useFilteredModels(params: UseFilteredModelsProps) {
         source: selectedSource,
         groupRatios: {},
         exchangeRate: 1,
+        modelMetadata: resolveModelMetadata(
+          modelMetadataIndex,
+          model.model_name,
+        ),
       }))
     }
 
@@ -541,8 +578,9 @@ export function useFilteredModels(params: UseFilteredModelsProps) {
       source,
       groupRatios: pricingData.group_ratio ?? {},
       exchangeRate,
+      modelMetadata: resolveModelMetadata(modelMetadataIndex, model.model_name),
     }))
-  }, [pricingContexts, pricingData, selectedSource])
+  }, [modelMetadataIndex, pricingContexts, pricingData, selectedSource])
 
   const availableGroups = useMemo(() => {
     if (
@@ -808,6 +846,8 @@ export function useFilteredModels(params: UseFilteredModelsProps) {
       const nextSelectedBillingMode =
         overrides.selectedBillingMode ?? selectedBillingMode
       const nextSelectedGroups = overrides.selectedGroups ?? selectedGroups
+      const nextSelectedModelCapabilities =
+        overrides.selectedModelCapabilities ?? selectedModelCapabilities
 
       if (nextSearchTerm) {
         const searchLower = nextSearchTerm.toLowerCase()
@@ -849,6 +889,18 @@ export function useFilteredModels(params: UseFilteredModelsProps) {
         )
       }
 
+      if (
+        supportsModelCapabilityFilter &&
+        nextSelectedModelCapabilities.length > 0
+      ) {
+        filtered = filtered.filter((item) =>
+          matchesModelCapabilityFilters({
+            metadata: item.modelMetadata,
+            filters: nextSelectedModelCapabilities,
+          }),
+        )
+      }
+
       return filtered
     },
     [
@@ -856,8 +908,10 @@ export function useFilteredModels(params: UseFilteredModelsProps) {
       rawModelItems,
       searchTerm,
       selectedBillingMode,
+      selectedModelCapabilities,
       selectedGroups,
       selectedSource?.capabilities.supportsGroupFiltering,
+      supportsModelCapabilityFilter,
     ],
   )
 
@@ -932,6 +986,23 @@ export function useFilteredModels(params: UseFilteredModelsProps) {
     (overrides: FilterOverrides = {}) => getFilteredModels(overrides).length,
     [getFilteredModels],
   )
+
+  const modelCapabilityMetadataCoverage =
+    useMemo<ModelCapabilityMetadataCoverage>(() => {
+      const modelsBeforeCapabilityFilters = getFilteredModels({
+        selectedModelCapabilities: [],
+      })
+      const matched = modelsBeforeCapabilityFilters.filter(
+        (item) => !!item.modelMetadata,
+      ).length
+      const total = modelsBeforeCapabilityFilters.length
+
+      return {
+        matched,
+        total,
+        unmatched: total - matched,
+      }
+    }, [getFilteredModels])
 
   const accountSummaryCountsByAccountId = useMemo(() => {
     if (selectedSource?.kind !== MODEL_MANAGEMENT_SOURCE_KINDS.ALL_ACCOUNTS) {
@@ -1171,8 +1242,10 @@ export function useFilteredModels(params: UseFilteredModelsProps) {
     getProviderFilteredCount,
     getFilteredModels,
     getFilteredResultCount,
+    modelCapabilityMetadataCoverage,
     availableGroups,
     availableAccountGroupsByAccountId,
     availableAccountGroupOptionsByAccountId,
+    supportsModelCapabilityFilter,
   }
 }

--- a/src/features/ModelList/hooks/useModelListData.ts
+++ b/src/features/ModelList/hooks/useModelListData.ts
@@ -1,7 +1,9 @@
-import { useEffect, useMemo } from "react"
+import { useEffect, useMemo, useState } from "react"
 
 import { useApiCredentialProfiles } from "~/features/ApiCredentialProfiles/hooks/useApiCredentialProfiles"
 import { useAccountData } from "~/hooks/useAccountData"
+import { modelMetadataService } from "~/services/models/modelMetadata"
+import type { ModelMetadata } from "~/services/models/modelMetadata/types"
 
 import {
   isAihubmixCatalogFallbackPricing,
@@ -51,6 +53,7 @@ export function useModelListData(routeParams?: Record<string, string>) {
     setAllAccountsExcludedGroupsByAccountId,
     searchTerm,
     selectedProvider,
+    selectedModelCapabilities,
     sortMode,
     setSortMode,
     showRealPrice,
@@ -180,6 +183,30 @@ export function useModelListData(routeParams?: Record<string, string>) {
     selectedSource,
     accounts,
   })
+  const [modelMetadata, setModelMetadata] = useState<ModelMetadata[]>([])
+
+  useEffect(() => {
+    let isMounted = true
+
+    const loadModelMetadata = async () => {
+      try {
+        await modelMetadataService.initialize()
+        if (isMounted) {
+          setModelMetadata(modelMetadataService.getAllMetadata())
+        }
+      } catch {
+        if (isMounted) {
+          setModelMetadata([])
+        }
+      }
+    }
+
+    void loadModelMetadata()
+
+    return () => {
+      isMounted = false
+    }
+  }, [])
 
   const isFallbackCatalogActive = modelData.accountFallback?.isActive === true
   const isSelectedAccountAihubmixCatalogFallback =
@@ -261,6 +288,8 @@ export function useModelListData(routeParams?: Record<string, string>) {
     allAccountsExcludedGroupsByAccountId,
     searchTerm,
     selectedProvider,
+    selectedModelCapabilities,
+    modelMetadata,
     sortMode,
     showRealPrice,
     accountFilterAccountIds: allAccountsFilterAccountIds,

--- a/src/features/ModelList/hooks/useModelListState.ts
+++ b/src/features/ModelList/hooks/useModelListState.ts
@@ -17,6 +17,7 @@ import {
   MODEL_LIST_BILLING_MODES,
   type ModelListBillingMode,
 } from "../billingModes"
+import type { ModelCapabilitySelectionValue } from "../modelCapabilityFilters"
 
 /**
  * Manages view state for the model list page.
@@ -29,6 +30,9 @@ export function useModelListState() {
   const [searchTerm, setSearchTerm] = useState("") // 搜索关键词
   const [selectedProvider, setSelectedProvider] =
     useState<ModelProviderFilterValue>(MODEL_PROVIDER_FILTER_VALUES.ALL) // 当前选中的模型提供商
+  const [selectedModelCapabilities, setSelectedModelCapabilities] = useState<
+    ModelCapabilitySelectionValue[]
+  >([])
   const [sortMode, setSortMode] = useState<ModelListSortMode>(
     MODEL_LIST_SORT_MODES.DEFAULT,
   )
@@ -58,6 +62,8 @@ export function useModelListState() {
     setSearchTerm,
     selectedProvider,
     setSelectedProvider,
+    selectedModelCapabilities,
+    setSelectedModelCapabilities,
     sortMode,
     setSortMode,
     selectedBillingMode,

--- a/src/features/ModelList/modelCapabilityFilters.ts
+++ b/src/features/ModelList/modelCapabilityFilters.ts
@@ -1,0 +1,253 @@
+import type { ModelMetadata } from "~/services/models/modelMetadata/types"
+import { extractActualModel } from "~/services/models/modelRedirect/modelNormalization"
+import { toModelTokenKey } from "~/services/models/utils/modelName"
+
+export const MODEL_CAPABILITY_FILTER_VALUES = {
+  ALL: "all",
+  IMAGE_INPUT: "image_input",
+  IMAGE_OUTPUT: "image_output",
+  AUDIO_INPUT: "audio_input",
+  AUDIO_OUTPUT: "audio_output",
+  VIDEO_INPUT: "video_input",
+  VIDEO_OUTPUT: "video_output",
+  PDF: "pdf",
+  REASONING: "reasoning",
+  TOOL_CALL: "tool_call",
+  STRUCTURED_OUTPUT: "structured_output",
+  ATTACHMENT: "attachment",
+} as const
+
+export type ModelCapabilityFilterValue =
+  (typeof MODEL_CAPABILITY_FILTER_VALUES)[keyof typeof MODEL_CAPABILITY_FILTER_VALUES]
+export type ModelCapabilitySelectionValue = Exclude<
+  ModelCapabilityFilterValue,
+  typeof MODEL_CAPABILITY_FILTER_VALUES.ALL
+>
+
+/**
+ * Counts metadata matches after other active filters but before capability filters.
+ */
+export interface ModelCapabilityMetadataCoverage {
+  matched: number
+  total: number
+  unmatched: number
+}
+
+export const MODEL_CAPABILITY_FILTER_LABEL_KEYS: Record<
+  ModelCapabilityFilterValue,
+  string
+> = {
+  [MODEL_CAPABILITY_FILTER_VALUES.ALL]: "modelCapabilityFilter.options.all",
+  [MODEL_CAPABILITY_FILTER_VALUES.IMAGE_INPUT]:
+    "modelCapabilityFilter.options.imageInput",
+  [MODEL_CAPABILITY_FILTER_VALUES.IMAGE_OUTPUT]:
+    "modelCapabilityFilter.options.imageOutput",
+  [MODEL_CAPABILITY_FILTER_VALUES.AUDIO_INPUT]:
+    "modelCapabilityFilter.options.audioInput",
+  [MODEL_CAPABILITY_FILTER_VALUES.AUDIO_OUTPUT]:
+    "modelCapabilityFilter.options.audioOutput",
+  [MODEL_CAPABILITY_FILTER_VALUES.VIDEO_INPUT]:
+    "modelCapabilityFilter.options.videoInput",
+  [MODEL_CAPABILITY_FILTER_VALUES.VIDEO_OUTPUT]:
+    "modelCapabilityFilter.options.videoOutput",
+  [MODEL_CAPABILITY_FILTER_VALUES.PDF]: "modelCapabilityFilter.options.pdf",
+  [MODEL_CAPABILITY_FILTER_VALUES.REASONING]:
+    "modelCapabilityFilter.options.reasoning",
+  [MODEL_CAPABILITY_FILTER_VALUES.TOOL_CALL]:
+    "modelCapabilityFilter.options.toolCall",
+  [MODEL_CAPABILITY_FILTER_VALUES.STRUCTURED_OUTPUT]:
+    "modelCapabilityFilter.options.structuredOutput",
+  [MODEL_CAPABILITY_FILTER_VALUES.ATTACHMENT]:
+    "modelCapabilityFilter.options.attachment",
+}
+
+type ModelCapabilityMatchInput = {
+  metadata: ModelMetadata | undefined
+  filter: ModelCapabilitySelectionValue
+}
+
+const MODEL_METADATA_TOKEN_KEY_PREFIX = "token:"
+
+/**
+ * Normalizes model ids and names for metadata lookup.
+ */
+function normalizeModelKey(value: string) {
+  return value.trim().toLowerCase()
+}
+
+/**
+ * Builds a deterministic token lookup key without fuzzy model-name matching.
+ */
+function toMetadataTokenLookupKey(value: string) {
+  const tokenKey = toModelTokenKey(extractActualModel(value))
+  return tokenKey ? `${MODEL_METADATA_TOKEN_KEY_PREFIX}${tokenKey}` : null
+}
+
+/**
+ * Builds lookup keys for provider-prefixed and plain model ids.
+ */
+export function createModelMetadataIndex(modelMetadata: ModelMetadata[]) {
+  const index = new Map<string, ModelMetadata>()
+  const tokenIndex = new Map<string, ModelMetadata | null>()
+
+  modelMetadata.forEach((metadata) => {
+    const candidateKeys = [
+      metadata.id,
+      metadata.name,
+      extractActualModel(metadata.id),
+      extractActualModel(metadata.name),
+    ]
+
+    candidateKeys.forEach((key) => {
+      const normalized = normalizeModelKey(key)
+      if (normalized && !index.has(normalized)) {
+        index.set(normalized, metadata)
+      }
+
+      const tokenLookupKey = toMetadataTokenLookupKey(key)
+      if (!tokenLookupKey) return
+
+      const existingTokenMatch = tokenIndex.get(tokenLookupKey)
+      if (existingTokenMatch === undefined) {
+        tokenIndex.set(tokenLookupKey, metadata)
+      } else if (existingTokenMatch !== metadata) {
+        tokenIndex.set(tokenLookupKey, null)
+      }
+    })
+  })
+
+  tokenIndex.forEach((metadata, key) => {
+    if (metadata && !index.has(key)) {
+      index.set(key, metadata)
+    }
+  })
+
+  return index
+}
+
+/**
+ * Finds metadata for a displayed model name using exact and normalized keys.
+ */
+export function resolveModelMetadata(
+  index: Map<string, ModelMetadata>,
+  modelName: string,
+) {
+  const normalized = normalizeModelKey(modelName)
+  return (
+    index.get(normalized) ??
+    index.get(normalizeModelKey(extractActualModel(modelName))) ??
+    index.get(toMetadataTokenLookupKey(modelName) ?? "")
+  )
+}
+
+/**
+ * Checks whether one model metadata record satisfies a capability filter.
+ */
+function matchesModelCapabilityFilter({
+  metadata,
+  filter,
+}: ModelCapabilityMatchInput) {
+  if (!metadata) {
+    return false
+  }
+
+  if (filter === MODEL_CAPABILITY_FILTER_VALUES.IMAGE_INPUT) {
+    return metadata.modalities?.input.includes("image") === true
+  }
+
+  if (filter === MODEL_CAPABILITY_FILTER_VALUES.IMAGE_OUTPUT) {
+    return metadata.modalities?.output.includes("image") === true
+  }
+
+  if (filter === MODEL_CAPABILITY_FILTER_VALUES.AUDIO_INPUT) {
+    return metadata.modalities?.input.includes("audio") === true
+  }
+
+  if (filter === MODEL_CAPABILITY_FILTER_VALUES.AUDIO_OUTPUT) {
+    return metadata.modalities?.output.includes("audio") === true
+  }
+
+  if (filter === MODEL_CAPABILITY_FILTER_VALUES.VIDEO_INPUT) {
+    return metadata.modalities?.input.includes("video") === true
+  }
+
+  if (filter === MODEL_CAPABILITY_FILTER_VALUES.VIDEO_OUTPUT) {
+    return metadata.modalities?.output.includes("video") === true
+  }
+
+  if (filter === MODEL_CAPABILITY_FILTER_VALUES.PDF) {
+    return metadata.modalities?.input.includes("pdf") === true
+  }
+
+  if (filter === MODEL_CAPABILITY_FILTER_VALUES.REASONING) {
+    return metadata.capabilities?.reasoning === true
+  }
+
+  if (filter === MODEL_CAPABILITY_FILTER_VALUES.TOOL_CALL) {
+    return metadata.capabilities?.toolCall === true
+  }
+
+  if (filter === MODEL_CAPABILITY_FILTER_VALUES.STRUCTURED_OUTPUT) {
+    return metadata.capabilities?.structuredOutput === true
+  }
+
+  return metadata.capabilities?.attachment === true
+}
+
+/**
+ * Applies selected capability filters as an intersection.
+ */
+export function matchesModelCapabilityFilters({
+  metadata,
+  filters,
+}: {
+  metadata: ModelMetadata | undefined
+  filters: ModelCapabilitySelectionValue[]
+}) {
+  if (filters.length === 0) {
+    return true
+  }
+
+  return filters.every((filter) =>
+    matchesModelCapabilityFilter({ metadata, filter }),
+  )
+}
+
+/**
+ * Detects whether loaded metadata can safely drive capability filtering.
+ */
+export function hasFilterableModelCapabilityMetadata(
+  modelMetadata: ModelMetadata[],
+) {
+  return modelMetadata.some(
+    (metadata) => getModelCapabilityBadges(metadata).length > 0,
+  )
+}
+
+/**
+ * Returns the capability badges that should be shown for one model row.
+ */
+export function getModelCapabilityBadges(metadata?: ModelMetadata) {
+  if (!metadata) {
+    return []
+  }
+
+  return [
+    MODEL_CAPABILITY_FILTER_VALUES.IMAGE_INPUT,
+    MODEL_CAPABILITY_FILTER_VALUES.IMAGE_OUTPUT,
+    MODEL_CAPABILITY_FILTER_VALUES.AUDIO_INPUT,
+    MODEL_CAPABILITY_FILTER_VALUES.AUDIO_OUTPUT,
+    MODEL_CAPABILITY_FILTER_VALUES.VIDEO_INPUT,
+    MODEL_CAPABILITY_FILTER_VALUES.VIDEO_OUTPUT,
+    MODEL_CAPABILITY_FILTER_VALUES.PDF,
+    MODEL_CAPABILITY_FILTER_VALUES.REASONING,
+    MODEL_CAPABILITY_FILTER_VALUES.TOOL_CALL,
+    MODEL_CAPABILITY_FILTER_VALUES.STRUCTURED_OUTPUT,
+    MODEL_CAPABILITY_FILTER_VALUES.ATTACHMENT,
+  ].filter((filter) =>
+    matchesModelCapabilityFilter({
+      metadata,
+      filter,
+    }),
+  )
+}

--- a/src/features/ModelList/modelCapabilityFilters.ts
+++ b/src/features/ModelList/modelCapabilityFilters.ts
@@ -1,3 +1,5 @@
+import type { TFunction } from "i18next"
+
 import type { ModelMetadata } from "~/services/models/modelMetadata/types"
 import { extractActualModel } from "~/services/models/modelRedirect/modelNormalization"
 import { toModelTokenKey } from "~/services/models/utils/modelName"
@@ -61,6 +63,34 @@ export const MODEL_CAPABILITY_FILTER_LABEL_KEYS: Record<
     "modelCapabilityFilter.options.attachment",
 }
 
+export const MODEL_CAPABILITY_FILTER_LABEL_TRANSLATORS: Record<
+  ModelCapabilitySelectionValue,
+  (t: TFunction) => string
+> = {
+  [MODEL_CAPABILITY_FILTER_VALUES.IMAGE_INPUT]: (t) =>
+    t("modelCapabilityFilter.options.imageInput", { ns: "modelList" }),
+  [MODEL_CAPABILITY_FILTER_VALUES.IMAGE_OUTPUT]: (t) =>
+    t("modelCapabilityFilter.options.imageOutput", { ns: "modelList" }),
+  [MODEL_CAPABILITY_FILTER_VALUES.AUDIO_INPUT]: (t) =>
+    t("modelCapabilityFilter.options.audioInput", { ns: "modelList" }),
+  [MODEL_CAPABILITY_FILTER_VALUES.AUDIO_OUTPUT]: (t) =>
+    t("modelCapabilityFilter.options.audioOutput", { ns: "modelList" }),
+  [MODEL_CAPABILITY_FILTER_VALUES.VIDEO_INPUT]: (t) =>
+    t("modelCapabilityFilter.options.videoInput", { ns: "modelList" }),
+  [MODEL_CAPABILITY_FILTER_VALUES.VIDEO_OUTPUT]: (t) =>
+    t("modelCapabilityFilter.options.videoOutput", { ns: "modelList" }),
+  [MODEL_CAPABILITY_FILTER_VALUES.PDF]: (t) =>
+    t("modelCapabilityFilter.options.pdf", { ns: "modelList" }),
+  [MODEL_CAPABILITY_FILTER_VALUES.REASONING]: (t) =>
+    t("modelCapabilityFilter.options.reasoning", { ns: "modelList" }),
+  [MODEL_CAPABILITY_FILTER_VALUES.TOOL_CALL]: (t) =>
+    t("modelCapabilityFilter.options.toolCall", { ns: "modelList" }),
+  [MODEL_CAPABILITY_FILTER_VALUES.STRUCTURED_OUTPUT]: (t) =>
+    t("modelCapabilityFilter.options.structuredOutput", { ns: "modelList" }),
+  [MODEL_CAPABILITY_FILTER_VALUES.ATTACHMENT]: (t) =>
+    t("modelCapabilityFilter.options.attachment", { ns: "modelList" }),
+}
+
 type ModelCapabilityMatchInput = {
   metadata: ModelMetadata | undefined
   filter: ModelCapabilitySelectionValue
@@ -87,7 +117,7 @@ function toMetadataTokenLookupKey(value: string) {
  * Builds lookup keys for provider-prefixed and plain model ids.
  */
 export function createModelMetadataIndex(modelMetadata: ModelMetadata[]) {
-  const index = new Map<string, ModelMetadata>()
+  const index = new Map<string, ModelMetadata | null>()
   const tokenIndex = new Map<string, ModelMetadata | null>()
 
   modelMetadata.forEach((metadata) => {
@@ -100,8 +130,13 @@ export function createModelMetadataIndex(modelMetadata: ModelMetadata[]) {
 
     candidateKeys.forEach((key) => {
       const normalized = normalizeModelKey(key)
-      if (normalized && !index.has(normalized)) {
-        index.set(normalized, metadata)
+      if (normalized) {
+        const existingMatch = index.get(normalized)
+        if (existingMatch === undefined) {
+          index.set(normalized, metadata)
+        } else if (existingMatch !== metadata) {
+          index.set(normalized, null)
+        }
       }
 
       const tokenLookupKey = toMetadataTokenLookupKey(key)
@@ -122,7 +157,11 @@ export function createModelMetadataIndex(modelMetadata: ModelMetadata[]) {
     }
   })
 
-  return index
+  return new Map(
+    Array.from(index.entries()).filter(
+      (entry): entry is [string, ModelMetadata] => entry[1] !== null,
+    ),
+  )
 }
 
 /**

--- a/src/locales/en/modelList.json
+++ b/src/locales/en/modelList.json
@@ -169,6 +169,43 @@
     "modelNamesCopied": "Model names copied",
     "siteUrlCopied": "Site URL copied"
   },
+  "modelCapabilityFilter": {
+    "coverageHint": "{{unmatched}} models in this list do not have capability details yet, so capability filters skip them.",
+    "descriptions": {
+      "attachment": "Supports uploaded attachments as input context.",
+      "audioInput": "Supports audio input.",
+      "audioOutput": "Supports audio output.",
+      "imageInput": "Supports uploaded images for recognition, analysis, or visual understanding.",
+      "imageOutput": "Supports generating images directly as model output.",
+      "pdf": "Supports PDF document input.",
+      "reasoning": "Supports explicit reasoning or thinking steps.",
+      "structuredOutput": "Supports structured output or JSON schema constraints.",
+      "toolCall": "Supports tool calling or function calling.",
+      "videoInput": "Supports video input.",
+      "videoOutput": "Supports video output."
+    },
+    "groups": {
+      "capabilities": "Capabilities:",
+      "input": "Input:",
+      "output": "Output:"
+    },
+    "label": "Model Capabilities",
+    "options": {
+      "all": "All Capabilities",
+      "attachment": "Attachments",
+      "audioInput": "Audio Input",
+      "audioOutput": "Audio Output",
+      "imageInput": "Image Input",
+      "imageOutput": "Image Generation",
+      "pdf": "PDF",
+      "reasoning": "Reasoning",
+      "structuredOutput": "Structured Output",
+      "toolCall": "Tool Calling",
+      "videoInput": "Video Input",
+      "videoOutput": "Video Output"
+    },
+    "selectionHint": "When multiple capabilities are selected, models must match all selected capabilities."
+  },
   "noMatchingModels": "No matching models found",
   "noSourcesDescription": "Add a site account or API credential before viewing the model list.",
   "noSourcesTitle": "No model sources yet",

--- a/src/locales/en/modelList.json
+++ b/src/locales/en/modelList.json
@@ -170,7 +170,8 @@
     "siteUrlCopied": "Site URL copied"
   },
   "modelCapabilityFilter": {
-    "coverageHint": "{{unmatched}} models in this list do not have capability details yet, so capability filters skip them.",
+    "coverageHint_one": "{{count}} model in this list does not have capability details yet, so capability filters skip it.",
+    "coverageHint_other": "{{count}} models in this list do not have capability details yet, so capability filters skip them.",
     "descriptions": {
       "attachment": "Supports uploaded attachments as input context.",
       "audioInput": "Supports audio input.",

--- a/src/locales/es-419/modelList.json
+++ b/src/locales/es-419/modelList.json
@@ -176,7 +176,9 @@
     "siteUrlCopied": "URL del sitio copiada"
   },
   "modelCapabilityFilter": {
-    "coverageHint": "{{unmatched}} modelos de esta lista aún no tienen detalles de capacidades, por eso los filtros de capacidades los omiten.",
+    "coverageHint_one": "{{count}} modelo de esta lista aún no tiene detalles de capacidades, por eso los filtros de capacidades lo omiten.",
+    "coverageHint_many": "{{count}} modelos de esta lista aún no tienen detalles de capacidades, por eso los filtros de capacidades los omiten.",
+    "coverageHint_other": "{{count}} modelos de esta lista aún no tienen detalles de capacidades, por eso los filtros de capacidades los omiten.",
     "descriptions": {
       "attachment": "Admite adjuntos cargados como contexto de entrada.",
       "audioInput": "Admite entrada de audio.",

--- a/src/locales/es-419/modelList.json
+++ b/src/locales/es-419/modelList.json
@@ -175,6 +175,43 @@
     "modelNamesCopied": "Nombres de modelos copiados",
     "siteUrlCopied": "URL del sitio copiada"
   },
+  "modelCapabilityFilter": {
+    "coverageHint": "{{unmatched}} modelos de esta lista aún no tienen detalles de capacidades, por eso los filtros de capacidades los omiten.",
+    "descriptions": {
+      "attachment": "Admite adjuntos cargados como contexto de entrada.",
+      "audioInput": "Admite entrada de audio.",
+      "audioOutput": "Admite salida de audio.",
+      "imageInput": "Admite imágenes cargadas para reconocimiento, análisis o comprensión visual.",
+      "imageOutput": "Admite generar imágenes directamente como salida del modelo.",
+      "pdf": "Admite entrada de documentos PDF.",
+      "reasoning": "Admite razonamiento explícito o pasos de pensamiento.",
+      "structuredOutput": "Admite salida estructurada o restricciones de esquema JSON.",
+      "toolCall": "Admite llamadas a herramientas o funciones.",
+      "videoInput": "Admite entrada de video.",
+      "videoOutput": "Admite salida de video."
+    },
+    "groups": {
+      "capabilities": "Capacidades:",
+      "input": "Entrada:",
+      "output": "Salida:"
+    },
+    "label": "Capacidades del modelo",
+    "options": {
+      "all": "Todas las capacidades",
+      "attachment": "Adjuntos",
+      "audioInput": "Entrada de audio",
+      "audioOutput": "Salida de audio",
+      "imageInput": "Entrada de imagen",
+      "imageOutput": "Generación de imagen",
+      "pdf": "PDF",
+      "reasoning": "Razonamiento",
+      "structuredOutput": "Salida estructurada",
+      "toolCall": "Llamada a herramientas",
+      "videoInput": "Entrada de video",
+      "videoOutput": "Salida de video"
+    },
+    "selectionHint": "Cuando se seleccionan varias capacidades, los modelos deben coincidir con todas las capacidades seleccionadas."
+  },
   "noMatchingModels": "No se encontraron modelos coincidentes",
   "noSourcesDescription": "Agrega una cuenta de sitio o una credencial de API antes de ver la lista de modelos.",
   "noSourcesTitle": "Aún no hay fuentes de modelos",

--- a/src/locales/ja/modelList.json
+++ b/src/locales/ja/modelList.json
@@ -164,7 +164,8 @@
     "siteUrlCopied": "サイト URL をコピーしました"
   },
   "modelCapabilityFilter": {
-    "coverageHint": "この一覧には能力説明がまだないモデルが {{unmatched}} 件あり、能力フィルターでは一時的に除外されます。",
+    "coverageHint_one": "この一覧には能力説明がまだないモデルが {{count}} 件あり、能力フィルターでは一時的に除外されます。",
+    "coverageHint_other": "この一覧には能力説明がまだないモデルが {{count}} 件あり、能力フィルターでは一時的に除外されます。",
     "descriptions": {
       "attachment": "アップロードした添付ファイルを入力コンテキストとして利用できます。",
       "audioInput": "音声入力に対応します。",

--- a/src/locales/ja/modelList.json
+++ b/src/locales/ja/modelList.json
@@ -163,6 +163,43 @@
     "modelNamesCopied": "モデル名をコピーしました",
     "siteUrlCopied": "サイト URL をコピーしました"
   },
+  "modelCapabilityFilter": {
+    "coverageHint": "この一覧には能力説明がまだないモデルが {{unmatched}} 件あり、能力フィルターでは一時的に除外されます。",
+    "descriptions": {
+      "attachment": "アップロードした添付ファイルを入力コンテキストとして利用できます。",
+      "audioInput": "音声入力に対応します。",
+      "audioOutput": "音声出力に対応します。",
+      "imageInput": "画像のアップロードによる認識、分析、視覚理解に対応します。",
+      "imageOutput": "モデル出力として画像を直接生成できます。",
+      "pdf": "PDF ドキュメント入力に対応します。",
+      "reasoning": "明示的な推論または思考ステップに対応します。",
+      "structuredOutput": "構造化出力または JSON スキーマ制約に対応します。",
+      "toolCall": "ツール呼び出しまたは関数呼び出しに対応します。",
+      "videoInput": "動画入力に対応します。",
+      "videoOutput": "動画出力に対応します。"
+    },
+    "groups": {
+      "capabilities": "能力:",
+      "input": "入力:",
+      "output": "出力:"
+    },
+    "label": "モデル能力",
+    "options": {
+      "all": "すべての能力",
+      "attachment": "添付",
+      "audioInput": "音声入力",
+      "audioOutput": "音声出力",
+      "imageInput": "画像理解",
+      "imageOutput": "画像生成",
+      "pdf": "PDF",
+      "reasoning": "推論",
+      "structuredOutput": "構造化出力",
+      "toolCall": "ツール呼び出し",
+      "videoInput": "動画入力",
+      "videoOutput": "動画出力"
+    },
+    "selectionHint": "複数の能力を選択すると、モデルは選択したすべての能力を満たす必要があります。"
+  },
   "noMatchingModels": "一致するモデルが見つかりません",
   "noSourcesDescription": "モデル一覧を表示するには、先にサイトアカウントまたは API 認証情報を追加してください。",
   "noSourcesTitle": "利用できるデータソースがありません",

--- a/src/locales/vi/modelList.json
+++ b/src/locales/vi/modelList.json
@@ -164,7 +164,8 @@
     "siteUrlCopied": "Đã sao chép URL trang"
   },
   "modelCapabilityFilter": {
-    "coverageHint": "{{unmatched}} mô hình trong danh sách này chưa có mô tả năng lực, nên bộ lọc năng lực sẽ tạm bỏ qua chúng.",
+    "coverageHint_one": "{{count}} mô hình trong danh sách này chưa có mô tả năng lực, nên bộ lọc năng lực sẽ tạm bỏ qua mô hình này.",
+    "coverageHint_other": "{{count}} mô hình trong danh sách này chưa có mô tả năng lực, nên bộ lọc năng lực sẽ tạm bỏ qua chúng.",
     "descriptions": {
       "attachment": "Hỗ trợ tệp đính kèm đã tải lên làm ngữ cảnh đầu vào.",
       "audioInput": "Hỗ trợ đầu vào âm thanh.",

--- a/src/locales/vi/modelList.json
+++ b/src/locales/vi/modelList.json
@@ -163,6 +163,43 @@
     "modelNamesCopied": "Đã sao chép tên các mô hình",
     "siteUrlCopied": "Đã sao chép URL trang"
   },
+  "modelCapabilityFilter": {
+    "coverageHint": "{{unmatched}} mô hình trong danh sách này chưa có mô tả năng lực, nên bộ lọc năng lực sẽ tạm bỏ qua chúng.",
+    "descriptions": {
+      "attachment": "Hỗ trợ tệp đính kèm đã tải lên làm ngữ cảnh đầu vào.",
+      "audioInput": "Hỗ trợ đầu vào âm thanh.",
+      "audioOutput": "Hỗ trợ đầu ra âm thanh.",
+      "imageInput": "Hỗ trợ tải hình ảnh lên để nhận dạng, phân tích hoặc hiểu thị giác.",
+      "imageOutput": "Hỗ trợ tạo hình ảnh trực tiếp dưới dạng đầu ra của mô hình.",
+      "pdf": "Hỗ trợ đầu vào tài liệu PDF.",
+      "reasoning": "Hỗ trợ suy luận rõ ràng hoặc các bước suy nghĩ.",
+      "structuredOutput": "Hỗ trợ đầu ra có cấu trúc hoặc ràng buộc JSON Schema.",
+      "toolCall": "Hỗ trợ gọi công cụ hoặc gọi hàm.",
+      "videoInput": "Hỗ trợ đầu vào video.",
+      "videoOutput": "Hỗ trợ đầu ra video."
+    },
+    "groups": {
+      "capabilities": "Năng lực:",
+      "input": "Đầu vào:",
+      "output": "Đầu ra:"
+    },
+    "label": "Năng lực mô hình",
+    "options": {
+      "all": "Tất cả năng lực",
+      "attachment": "Tệp đính kèm",
+      "audioInput": "Đầu vào âm thanh",
+      "audioOutput": "Đầu ra âm thanh",
+      "imageInput": "Đầu vào hình ảnh",
+      "imageOutput": "Tạo hình ảnh",
+      "pdf": "PDF",
+      "reasoning": "Suy luận",
+      "structuredOutput": "Đầu ra có cấu trúc",
+      "toolCall": "Gọi công cụ",
+      "videoInput": "Đầu vào video",
+      "videoOutput": "Đầu ra video"
+    },
+    "selectionHint": "Khi chọn nhiều năng lực, mô hình phải khớp với tất cả năng lực đã chọn."
+  },
   "noMatchingModels": "Không tìm thấy mô hình nào phù hợp",
   "noSourcesDescription": "Vui lòng thêm tài khoản trang web hoặc thông tin xác thực API trước, sau đó xem danh sách mô hình.",
   "noSourcesTitle": "Hiện chưa có nguồn dữ liệu khả dụng",

--- a/src/locales/zh-CN/modelList.json
+++ b/src/locales/zh-CN/modelList.json
@@ -163,6 +163,43 @@
     "modelNamesCopied": "模型名称已复制",
     "siteUrlCopied": "站点 URL 已复制"
   },
+  "modelCapabilityFilter": {
+    "coverageHint": "当前列表中有 {{unmatched}} 个模型暂无能力说明，选择能力筛选时会先跳过。",
+    "descriptions": {
+      "attachment": "支持上传附件作为输入上下文。",
+      "audioInput": "支持音频输入。",
+      "audioOutput": "支持音频输出。",
+      "imageInput": "支持上传图片进行识别、分析或视觉理解。",
+      "imageOutput": "支持直接生成图片输出。",
+      "pdf": "支持 PDF 文档输入。",
+      "reasoning": "支持显式推理或思考过程。",
+      "structuredOutput": "支持结构化输出或 JSON Schema 约束。",
+      "toolCall": "支持工具调用或函数调用。",
+      "videoInput": "支持视频输入。",
+      "videoOutput": "支持视频输出。"
+    },
+    "groups": {
+      "capabilities": "能力:",
+      "input": "输入:",
+      "output": "输出:"
+    },
+    "label": "模型能力",
+    "options": {
+      "all": "全部能力",
+      "attachment": "附件",
+      "audioInput": "音频输入",
+      "audioOutput": "音频输出",
+      "imageInput": "图片理解",
+      "imageOutput": "图片生成",
+      "pdf": "PDF",
+      "reasoning": "思考",
+      "structuredOutput": "结构化输出",
+      "toolCall": "工具调用",
+      "videoInput": "视频输入",
+      "videoOutput": "视频输出"
+    },
+    "selectionHint": "选择多个能力时，模型需要同时满足所有条件。"
+  },
   "noMatchingModels": "没有找到匹配的模型",
   "noSourcesDescription": "请先添加站点账号或 API 凭据，然后查看模型列表。",
   "noSourcesTitle": "暂无可用数据源",

--- a/src/locales/zh-CN/modelList.json
+++ b/src/locales/zh-CN/modelList.json
@@ -164,7 +164,7 @@
     "siteUrlCopied": "站点 URL 已复制"
   },
   "modelCapabilityFilter": {
-    "coverageHint": "当前列表中有 {{unmatched}} 个模型暂无能力说明，选择能力筛选时会先跳过。",
+    "coverageHint": "当前列表中有 {{count}} 个模型暂无能力说明，选择能力筛选时会先跳过。",
     "descriptions": {
       "attachment": "支持上传附件作为输入上下文。",
       "audioInput": "支持音频输入。",

--- a/src/locales/zh-TW/modelList.json
+++ b/src/locales/zh-TW/modelList.json
@@ -163,6 +163,43 @@
     "modelNamesCopied": "模型名稱已複製",
     "siteUrlCopied": "站點 URL 已複製"
   },
+  "modelCapabilityFilter": {
+    "coverageHint": "目前列表中有 {{unmatched}} 個模型暫無能力說明，選擇能力篩選時會先略過。",
+    "descriptions": {
+      "attachment": "支援上傳附件作為輸入上下文。",
+      "audioInput": "支援音訊輸入。",
+      "audioOutput": "支援音訊輸出。",
+      "imageInput": "支援上傳圖片進行辨識、分析或視覺理解。",
+      "imageOutput": "支援直接生成圖片輸出。",
+      "pdf": "支援 PDF 文件輸入。",
+      "reasoning": "支援明確推理或思考過程。",
+      "structuredOutput": "支援結構化輸出或 JSON Schema 約束。",
+      "toolCall": "支援工具呼叫或函式呼叫。",
+      "videoInput": "支援影片輸入。",
+      "videoOutput": "支援影片輸出。"
+    },
+    "groups": {
+      "capabilities": "能力:",
+      "input": "輸入:",
+      "output": "輸出:"
+    },
+    "label": "模型能力",
+    "options": {
+      "all": "全部能力",
+      "attachment": "附件",
+      "audioInput": "音訊輸入",
+      "audioOutput": "音訊輸出",
+      "imageInput": "圖片理解",
+      "imageOutput": "圖片生成",
+      "pdf": "PDF",
+      "reasoning": "思考",
+      "structuredOutput": "結構化輸出",
+      "toolCall": "工具呼叫",
+      "videoInput": "影片輸入",
+      "videoOutput": "影片輸出"
+    },
+    "selectionHint": "選擇多個能力時，模型需要同時符合所有條件。"
+  },
   "noMatchingModels": "沒有找到匹配的模型",
   "noSourcesDescription": "請先新增站點帳號或 API 憑據，然後查看模型列表。",
   "noSourcesTitle": "暫無可用資料來源",

--- a/src/locales/zh-TW/modelList.json
+++ b/src/locales/zh-TW/modelList.json
@@ -164,7 +164,8 @@
     "siteUrlCopied": "站點 URL 已複製"
   },
   "modelCapabilityFilter": {
-    "coverageHint": "目前列表中有 {{unmatched}} 個模型暫無能力說明，選擇能力篩選時會先略過。",
+    "coverageHint_one": "目前列表中有 {{count}} 個模型暫無能力說明，選擇能力篩選時會先略過。",
+    "coverageHint_other": "目前列表中有 {{count}} 個模型暫無能力說明，選擇能力篩選時會先略過。",
     "descriptions": {
       "attachment": "支援上傳附件作為輸入上下文。",
       "audioInput": "支援音訊輸入。",

--- a/src/services/models/modelMetadata/ModelMetadataService.ts
+++ b/src/services/models/modelMetadata/ModelMetadataService.ts
@@ -9,7 +9,14 @@ import {
   MODEL_METADATA_REFRESH_INTERVAL,
   MODEL_METADATA_URL,
 } from "./constants"
-import type { ModelMetadata, ModelMetadataCache, VendorRule } from "./types"
+import type {
+  ModelMetadata,
+  ModelMetadataCache,
+  ModelMetadataCapabilities,
+  ModelMetadataLimits,
+  ModelMetadataModalities,
+  VendorRule,
+} from "./types"
 
 const logger = createLogger("ModelMetadata")
 
@@ -33,6 +40,251 @@ const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
   alibaba: "阿里巴巴",
   "alibaba-cn": "通义千问",
   doubao: "豆包",
+}
+
+const MODELS_DEV_MODEL_ID_PATTERN = /^[^/]+\/[^/]+$/
+
+/**
+ * Normalizes optional array fields from the remote metadata payload.
+ */
+function normalizeStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return value
+    .filter((item): item is string => typeof item === "string")
+    .map((item) => item.trim())
+    .filter(Boolean)
+}
+
+/**
+ * Keeps non-empty string fields and drops missing or blank values.
+ */
+function normalizeOptionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value : undefined
+}
+
+/**
+ * Keeps boolean metadata flags without coercing truthy or falsy strings.
+ */
+function normalizeOptionalBoolean(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined
+}
+
+/**
+ * Keeps finite numeric metadata limits.
+ */
+function normalizeOptionalNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined
+}
+
+/**
+ * Resolves provider ids from explicit fields or models.dev path-style ids.
+ */
+function deriveProviderId(item: any, id: string): string {
+  const explicitProviderId =
+    normalizeOptionalString(item.providerId) ??
+    normalizeOptionalString(item.provider_id) ??
+    normalizeOptionalString(item.provider)
+
+  if (explicitProviderId) {
+    return explicitProviderId
+  }
+
+  if (MODELS_DEV_MODEL_ID_PATTERN.test(id)) {
+    return id.slice(0, id.indexOf("/"))
+  }
+
+  return ""
+}
+
+/**
+ * Converts models.dev modality arrays into the internal metadata shape.
+ */
+function normalizeModalities(
+  value: unknown,
+): ModelMetadataModalities | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined
+  }
+
+  const record = value as Record<string, unknown>
+  const input = normalizeStringArray(record.input)
+  const output = normalizeStringArray(record.output)
+
+  if (input.length === 0 && output.length === 0) {
+    return undefined
+  }
+
+  return { input, output }
+}
+
+/**
+ * Converts models.dev capability flags into camelCase internal fields.
+ */
+function normalizeCapabilities(
+  item: any,
+): ModelMetadataCapabilities | undefined {
+  const flags = item.flags && typeof item.flags === "object" ? item.flags : {}
+  const capabilities: ModelMetadataCapabilities = {}
+  const attachment =
+    normalizeOptionalBoolean(item.attachment) ??
+    normalizeOptionalBoolean(flags.attachment)
+  const reasoning =
+    normalizeOptionalBoolean(item.reasoning) ??
+    normalizeOptionalBoolean(flags.reasoning)
+  const toolCall =
+    normalizeOptionalBoolean(item.tool_call) ??
+    normalizeOptionalBoolean(item.toolCall) ??
+    normalizeOptionalBoolean(flags.tool_call) ??
+    normalizeOptionalBoolean(flags.toolCall)
+  const structuredOutput =
+    normalizeOptionalBoolean(item.structured_output) ??
+    normalizeOptionalBoolean(item.structuredOutput) ??
+    normalizeOptionalBoolean(flags.structured_output) ??
+    normalizeOptionalBoolean(flags.structuredOutput)
+  const temperature =
+    normalizeOptionalBoolean(item.temperature) ??
+    normalizeOptionalBoolean(flags.temperature)
+
+  if (attachment !== undefined) {
+    capabilities.attachment = attachment
+  }
+  if (reasoning !== undefined) {
+    capabilities.reasoning = reasoning
+  }
+  if (toolCall !== undefined) {
+    capabilities.toolCall = toolCall
+  }
+  if (structuredOutput !== undefined) {
+    capabilities.structuredOutput = structuredOutput
+  }
+  if (temperature !== undefined) {
+    capabilities.temperature = temperature
+  }
+
+  return Object.keys(capabilities).length > 0 ? capabilities : undefined
+}
+
+/**
+ * Converts context/input/output limit fields into the internal metadata shape.
+ */
+function normalizeLimits(value: unknown): ModelMetadataLimits | undefined {
+  if (!value || typeof value !== "object") {
+    return undefined
+  }
+
+  const record = value as Record<string, unknown>
+  const limits: ModelMetadataLimits = {}
+  const context = normalizeOptionalNumber(record.context)
+  const input = normalizeOptionalNumber(record.input)
+  const output = normalizeOptionalNumber(record.output)
+
+  if (context !== undefined) {
+    limits.context = context
+  }
+  if (input !== undefined) {
+    limits.input = input
+  }
+  if (output !== undefined) {
+    limits.output = output
+  }
+
+  return Object.keys(limits).length > 0 ? limits : undefined
+}
+
+/**
+ * Converts one remote metadata record into the cached internal shape.
+ */
+function normalizeModelMetadataItem(item: any, key?: string): ModelMetadata {
+  const id = item.id || key || ""
+  const metadata: ModelMetadata = {
+    id,
+    name: item.name || id,
+    provider_id: deriveProviderId(item, id),
+  }
+  const description = normalizeOptionalString(item.description)
+  const capabilities = normalizeCapabilities(item)
+  const modalities = normalizeModalities(item.modalities)
+  const openWeights = normalizeOptionalBoolean(item.open_weights)
+  const limits = normalizeLimits(item.limit ?? item.limits)
+  const releaseDate = normalizeOptionalString(item.release_date)
+  const lastUpdated =
+    normalizeOptionalString(item.last_updated) ??
+    normalizeOptionalString(item.updated)
+
+  if (description) {
+    metadata.description = description
+  }
+  if (capabilities) {
+    metadata.capabilities = capabilities
+  }
+  if (modalities) {
+    metadata.modalities = modalities
+  }
+  if (openWeights !== undefined) {
+    metadata.open_weights = openWeights
+  }
+  if (limits) {
+    metadata.limits = limits
+  }
+  if (releaseDate) {
+    metadata.release_date = releaseDate
+  }
+  if (lastUpdated) {
+    metadata.last_updated = lastUpdated
+  }
+
+  return metadata
+}
+
+/**
+ * Accepts both legacy array payloads and models.dev object-map payloads.
+ */
+function normalizeMetadataPayload(data: any): ModelMetadata[] {
+  const modelsPayload = data.models || data
+
+  if (Array.isArray(modelsPayload)) {
+    return modelsPayload.map((item: any) => normalizeModelMetadataItem(item))
+  }
+
+  if (modelsPayload && typeof modelsPayload === "object") {
+    const entries = Object.entries(modelsPayload)
+    if (
+      entries.length === 0 ||
+      entries.some(
+        ([, item]) => !item || typeof item !== "object" || Array.isArray(item),
+      )
+    ) {
+      throw new Error(
+        "Invalid metadata format: model map values should be objects",
+      )
+    }
+
+    return entries.map(([key, item]) => normalizeModelMetadataItem(item, key))
+  }
+
+  throw new Error("Invalid metadata format: models should be array or object")
+}
+
+/**
+ * Returns defensive copies of nested metadata objects exposed to consumers.
+ */
+function cloneMetadata(model: ModelMetadata): ModelMetadata {
+  return {
+    ...model,
+    ...(model.capabilities ? { capabilities: { ...model.capabilities } } : {}),
+    ...(model.modalities
+      ? {
+          modalities: {
+            input: [...model.modalities.input],
+            output: [...model.modalities.output],
+          },
+        }
+      : {}),
+    ...(model.limits ? { limits: { ...model.limits } } : {}),
+  }
 }
 
 /**
@@ -111,16 +363,7 @@ class ModelMetadataService {
         throw new Error("Invalid metadata format: expected object")
       }
 
-      const modelsArray = data.models || data
-      if (!Array.isArray(modelsArray)) {
-        throw new Error("Invalid metadata format: models should be array")
-      }
-
-      const models: ModelMetadata[] = modelsArray.map((item: any) => ({
-        id: item.id || "",
-        name: item.name || item.id || "",
-        provider_id: item.providerId || item.provider_id || "",
-      }))
+      const models = normalizeMetadataPayload(data)
 
       this.cache = {
         models,
@@ -180,8 +423,9 @@ class ModelMetadataService {
         providerPrefixes.set(model.provider_id, new Set())
       }
 
+      const actualModel = extractActualModel(model.id)
       // 提取前缀（取第一个 '-' 前的部分）
-      const parts = model.id.split("-")
+      const parts = actualModel.split("-")
       if (parts.length > 0) {
         const prefix = parts[0].toLowerCase().trim()
         if (prefix) {
@@ -190,8 +434,8 @@ class ModelMetadataService {
       }
 
       // 如果没有 '-'，使用完整ID作为前缀（某些简短模型名）
-      if (!model.id.includes("-")) {
-        const prefix = model.id.toLowerCase().trim()
+      if (!actualModel.includes("-")) {
+        const prefix = actualModel.toLowerCase().trim()
         if (prefix && prefix.length <= 15) {
           providerPrefixes.get(model.provider_id)!.add(prefix)
         }
@@ -468,7 +712,7 @@ class ModelMetadataService {
     if (!this.cache) {
       return []
     }
-    return [...this.cache.models]
+    return this.cache.models.map(cloneMetadata)
   }
 
   /**

--- a/src/services/models/modelMetadata/ModelMetadataService.ts
+++ b/src/services/models/modelMetadata/ModelMetadataService.ts
@@ -42,7 +42,7 @@ const PROVIDER_DISPLAY_NAMES: Record<string, string> = {
   doubao: "豆包",
 }
 
-const MODELS_DEV_MODEL_ID_PATTERN = /^[^/]+\/[^/]+$/
+const MODELS_DEV_MODEL_ID_PATTERN = /^[^/]+\/.+$/
 
 /**
  * Normalizes optional array fields from the remote metadata payload.
@@ -92,6 +92,7 @@ function deriveProviderId(item: any, id: string): string {
     return explicitProviderId
   }
 
+  // models.dev ids are provider-prefixed paths; nested model ids keep the first path segment as provider.
   if (MODELS_DEV_MODEL_ID_PATTERN.test(id)) {
     return id.slice(0, id.indexOf("/"))
   }
@@ -301,6 +302,18 @@ class ModelMetadataService {
   private initPromise: Promise<void> | null = null
   private lastFetch: number = 0
 
+  private addMetadataLookupKeys(model: ModelMetadata): void {
+    const normalizedId = model.id.trim().toLowerCase()
+    if (normalizedId) {
+      this.metadataMap.set(normalizedId, model)
+    }
+
+    const actualModel = extractActualModel(model.id)
+    if (actualModel) {
+      this.metadataMap.set(actualModel, model)
+    }
+  }
+
   /**
    * Initialize metadata (idempotent). Reuses in-flight init promise.
    * @returns Promise that resolves when initialization completes or reuses the in-flight promise.
@@ -395,10 +408,7 @@ class ModelMetadataService {
     this.metadataMap.clear()
 
     for (const model of this.cache.models) {
-      const actualModel = extractActualModel(model.id)
-      if (actualModel) {
-        this.metadataMap.set(actualModel, model)
-      }
+      this.addMetadataLookupKeys(model)
     }
   }
 
@@ -586,10 +596,7 @@ class ModelMetadataService {
 
     this.metadataMap.clear()
     for (const model of defaultMetadata) {
-      const actualModel = extractActualModel(model.id)
-      if (actualModel) {
-        this.metadataMap.set(actualModel, model)
-      }
+      this.addMetadataLookupKeys(model)
     }
 
     this.vendorRules = defaultRules

--- a/src/services/models/modelMetadata/constants.ts
+++ b/src/services/models/modelMetadata/constants.ts
@@ -1,4 +1,3 @@
-export const MODEL_METADATA_URL =
-  "https://llm-metadata.pages.dev/api/index.json"
+export const MODEL_METADATA_URL = "https://models.dev/models.json"
 
 export const MODEL_METADATA_REFRESH_INTERVAL = 24 * 60 * 60 * 1000

--- a/src/services/models/modelMetadata/types.ts
+++ b/src/services/models/modelMetadata/types.ts
@@ -2,6 +2,13 @@ export interface ModelMetadata {
   id: string
   name: string
   provider_id: string
+  description?: string
+  capabilities?: ModelMetadataCapabilities
+  modalities?: ModelMetadataModalities
+  open_weights?: boolean
+  limits?: ModelMetadataLimits
+  release_date?: string
+  last_updated?: string
 }
 
 export interface ModelMetadataCache {
@@ -14,4 +21,23 @@ export interface VendorRule {
   providerID: string
   displayName: string
   pattern: RegExp
+}
+
+export interface ModelMetadataCapabilities {
+  attachment?: boolean
+  reasoning?: boolean
+  toolCall?: boolean
+  structuredOutput?: boolean
+  temperature?: boolean
+}
+
+export interface ModelMetadataModalities {
+  input: string[]
+  output: string[]
+}
+
+export interface ModelMetadataLimits {
+  context?: number
+  input?: number
+  output?: number
 }

--- a/src/services/productAnalytics/contracts.ts
+++ b/src/services/productAnalytics/contracts.ts
@@ -180,6 +180,7 @@ export const PRODUCT_ANALYTICS_MODE_IDS = {
   Export: "export",
   SearchFilter: "search_filter",
   ProviderFilter: "provider_filter",
+  ModelCapabilityFilter: "model_capability_filter",
   SortFilter: "sort_filter",
   BillingFilter: "billing_filter",
   GroupFilter: "group_filter",

--- a/tests/components/CompactMultiSelect.test.tsx
+++ b/tests/components/CompactMultiSelect.test.tsx
@@ -89,6 +89,26 @@ describe("CompactMultiSelect", () => {
     expect(onChange).toHaveBeenCalledWith(["id-alpha"])
   })
 
+  it("shows option counts in chips display mode", async () => {
+    const user = userEvent.setup()
+
+    renderCompact(
+      <CompactMultiSelect
+        displayMode="chips"
+        options={[{ value: "id-alpha", label: "Alpha", count: 3 }]}
+        selected={[]}
+        onChange={vi.fn()}
+        placeholder="Pick"
+      />,
+    )
+
+    await user.click(await screen.findByPlaceholderText("Pick"))
+
+    expect(screen.getByRole("option", { name: "Alpha 3" })).toHaveTextContent(
+      "3",
+    )
+  })
+
   it("copies chip text when the selected chip label is clicked", async () => {
     const user = userEvent.setup()
     const onChange = vi.fn()

--- a/tests/components/CompactMultiSelect.test.tsx
+++ b/tests/components/CompactMultiSelect.test.tsx
@@ -481,6 +481,30 @@ describe("CompactMultiSelect", () => {
     expect(onChange).toHaveBeenCalledWith([])
   })
 
+  it("renders option counts without adding them to the selected summary", async () => {
+    const user = userEvent.setup()
+
+    renderCompact(
+      <CompactMultiSelect
+        displayMode="summary"
+        options={[
+          { value: "alpha", label: "Alpha", count: 12 },
+          { value: "beta", label: "Beta", count: 0 },
+        ]}
+        selected={["alpha"]}
+        onChange={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByRole("combobox")).toHaveTextContent("Alpha")
+    expect(screen.getByRole("combobox")).not.toHaveTextContent("12")
+
+    await user.click(screen.getByRole("combobox"))
+
+    expect(screen.getByRole("option", { name: "Alpha 12" })).toBeInTheDocument()
+    expect(screen.getByRole("option", { name: "Beta 0" })).toBeInTheDocument()
+  })
+
   it("keeps duplicate custom batches as a no-op and clears the search term", async () => {
     const user = userEvent.setup()
     const onChange = vi.fn()

--- a/tests/entrypoints/options/pages/ModelList/ControlPanel.capabilities.test.tsx
+++ b/tests/entrypoints/options/pages/ModelList/ControlPanel.capabilities.test.tsx
@@ -725,6 +725,7 @@ describe("ControlPanel profile capabilities", () => {
       searchTerm: "private-search",
       sortMode: MODEL_LIST_SORT_MODES.DEFAULT,
       selectedBillingMode: MODEL_LIST_BILLING_MODES.TOKEN_BASED,
+      selectedModelCapabilities: [],
       selectedGroups: [],
       selectedVerificationResults: ["pass", "fail", "unverified"],
     })

--- a/tests/entrypoints/options/pages/ModelList/useFilteredModels.test.ts
+++ b/tests/entrypoints/options/pages/ModelList/useFilteredModels.test.ts
@@ -4,6 +4,7 @@ import { SITE_TYPES } from "~/constants/siteType"
 import { UI_CONSTANTS } from "~/constants/ui"
 import { MODEL_LIST_BILLING_MODES } from "~/features/ModelList/billingModes"
 import { useFilteredModels } from "~/features/ModelList/hooks/useFilteredModels"
+import { MODEL_CAPABILITY_FILTER_VALUES } from "~/features/ModelList/modelCapabilityFilters"
 import {
   createAccountSource,
   createAccountTokenModelListSourceIdentity,
@@ -20,6 +21,7 @@ import {
   type PricingResponse,
 } from "~/services/modelList/pricingModel"
 import { DEFAULT_MODEL_GROUP } from "~/services/models/constants"
+import type { ModelMetadata } from "~/services/models/modelMetadata/types"
 import { MODEL_PROVIDER_FILTER_VALUES } from "~/services/models/utils/modelProviders"
 import { API_TYPES } from "~/services/verification/aiApiVerification"
 import { AuthTypeEnum, SiteHealthStatus, type DisplaySiteData } from "~/types"
@@ -86,6 +88,8 @@ function renderUseFilteredModels(
         selectedGroups: [],
         searchTerm: "",
         selectedProvider: MODEL_PROVIDER_FILTER_VALUES.ALL,
+        selectedModelCapabilities: [],
+        modelMetadata: [],
         sortMode: MODEL_LIST_SORT_MODES.DEFAULT,
         showRealPrice: false,
         ...overrides,
@@ -374,6 +378,209 @@ describe("useFilteredModels", () => {
     expect(result.current.getFilteredResultCount({ searchTerm: "batch" })).toBe(
       1,
     )
+  })
+
+  it("filters models by explicit metadata capabilities and modalities", async () => {
+    const account = createDisplayAccount({
+      id: "account-model-capability-filter",
+      balance: { USD: 5, CNY: 35 },
+    })
+    const modelMetadata: ModelMetadata[] = [
+      {
+        id: "openai/gpt-4o",
+        name: "GPT-4o",
+        provider_id: "openai",
+        capabilities: {
+          reasoning: false,
+          toolCall: true,
+        },
+        modalities: {
+          input: ["text", "image"],
+          output: ["text"],
+        },
+      },
+      {
+        id: "deepseek/deepseek-reasoner",
+        name: "DeepSeek Reasoner",
+        provider_id: "deepseek",
+        capabilities: {
+          reasoning: true,
+          toolCall: false,
+        },
+        modalities: {
+          input: ["text"],
+          output: ["text"],
+        },
+      },
+      {
+        id: "openai/gpt-image-1",
+        name: "GPT Image 1",
+        provider_id: "openai",
+        modalities: {
+          input: ["text"],
+          output: ["image"],
+        },
+      },
+      {
+        id: "example/media-model",
+        name: "Media Model",
+        provider_id: "example",
+        modalities: {
+          input: ["text", "audio", "video"],
+          output: ["text", "audio", "video"],
+        },
+      },
+    ]
+
+    const { result, rerender } = renderUseFilteredModels({
+      pricingData: createPricingResponse([
+        "gpt-4o",
+        "gpt-image-1",
+        "deepseek-reasoner",
+        "media-model",
+        "unknown-audio-model",
+      ]),
+      selectedSource: createAccountSource(account),
+      modelMetadata,
+      selectedModelCapabilities: [MODEL_CAPABILITY_FILTER_VALUES.IMAGE_INPUT],
+    })
+
+    await waitFor(() =>
+      expect(
+        result.current.filteredModels.map((item) => item.model.model_name),
+      ).toEqual(["gpt-4o"]),
+    )
+
+    rerender({
+      pricingData: createPricingResponse([
+        "gpt-4o",
+        "gpt-image-1",
+        "deepseek-reasoner",
+        "media-model",
+        "unknown-audio-model",
+      ]),
+      selectedSource: createAccountSource(account),
+      modelMetadata,
+      selectedModelCapabilities: [MODEL_CAPABILITY_FILTER_VALUES.REASONING],
+    })
+
+    expect(
+      result.current.filteredModels.map((item) => item.model.model_name),
+    ).toEqual(["deepseek-reasoner"])
+    expect(
+      result.current
+        .getFilteredModels({
+          selectedModelCapabilities: [
+            MODEL_CAPABILITY_FILTER_VALUES.IMAGE_INPUT,
+            MODEL_CAPABILITY_FILTER_VALUES.TOOL_CALL,
+          ],
+        })
+        .map((item) => item.model.model_name),
+    ).toEqual(["gpt-4o"])
+    expect(
+      result.current
+        .getFilteredModels({
+          selectedModelCapabilities: [
+            MODEL_CAPABILITY_FILTER_VALUES.IMAGE_OUTPUT,
+          ],
+        })
+        .map((item) => item.model.model_name),
+    ).toEqual(["gpt-image-1"])
+    expect(
+      result.current
+        .getFilteredModels({
+          selectedModelCapabilities: [
+            MODEL_CAPABILITY_FILTER_VALUES.AUDIO_OUTPUT,
+            MODEL_CAPABILITY_FILTER_VALUES.VIDEO_INPUT,
+          ],
+        })
+        .map((item) => item.model.model_name),
+    ).toEqual(["media-model"])
+  })
+
+  it("reports capability metadata coverage before applying capability filters", async () => {
+    const account = createDisplayAccount({
+      id: "account-model-capability-coverage",
+      balance: { USD: 5, CNY: 35 },
+    })
+    const modelMetadata: ModelMetadata[] = [
+      {
+        id: "openai/gpt-4o",
+        name: "GPT-4o",
+        provider_id: "openai",
+        modalities: {
+          input: ["text", "image"],
+          output: ["text"],
+        },
+      },
+      {
+        id: "anthropic/claude-sonnet-4-5",
+        name: "Claude Sonnet 4.5",
+        provider_id: "anthropic",
+        capabilities: {
+          reasoning: true,
+        },
+        modalities: {
+          input: ["text"],
+          output: ["text"],
+        },
+      },
+    ]
+
+    const { result } = renderUseFilteredModels({
+      pricingData: createPricingResponse([
+        "gpt-4o",
+        "claude-4.5-sonnet-20250929",
+        "unknown-custom-model",
+      ]),
+      selectedSource: createAccountSource(account),
+      modelMetadata,
+      selectedModelCapabilities: [MODEL_CAPABILITY_FILTER_VALUES.IMAGE_INPUT],
+    })
+
+    await waitFor(() =>
+      expect(
+        result.current.filteredModels.map((item) => item.model.model_name),
+      ).toEqual(["gpt-4o"]),
+    )
+
+    expect(result.current.modelCapabilityMetadataCoverage).toEqual({
+      matched: 2,
+      total: 3,
+      unmatched: 1,
+    })
+    expect(
+      result.current
+        .getFilteredModels({
+          selectedModelCapabilities: [MODEL_CAPABILITY_FILTER_VALUES.REASONING],
+        })
+        .map((item) => item.model.model_name),
+    ).toEqual(["claude-4.5-sonnet-20250929"])
+  })
+
+  it("does not apply capability filters when capability metadata is unavailable", async () => {
+    const account = createDisplayAccount({
+      id: "account-missing-model-capability-metadata",
+      balance: { USD: 5, CNY: 35 },
+    })
+
+    const { result } = renderUseFilteredModels({
+      pricingData: createPricingResponse([
+        "gpt-4o",
+        "deepseek-reasoner",
+        "unknown-audio-model",
+      ]),
+      selectedSource: createAccountSource(account),
+      modelMetadata: [],
+      selectedModelCapabilities: [MODEL_CAPABILITY_FILTER_VALUES.IMAGE_INPUT],
+    })
+
+    await waitFor(() =>
+      expect(
+        result.current.filteredModels.map((item) => item.model.model_name),
+      ).toEqual(["gpt-4o", "deepseek-reasoner", "unknown-audio-model"]),
+    )
+    expect(result.current.supportsModelCapabilityFilter).toBe(false)
   })
 
   it("skips malformed account pricing payloads while keeping valid account models and groups", async () => {

--- a/tests/entrypoints/options/pages/ModelList/useFilteredModels.test.ts
+++ b/tests/entrypoints/options/pages/ModelList/useFilteredModels.test.ts
@@ -4,7 +4,13 @@ import { SITE_TYPES } from "~/constants/siteType"
 import { UI_CONSTANTS } from "~/constants/ui"
 import { MODEL_LIST_BILLING_MODES } from "~/features/ModelList/billingModes"
 import { useFilteredModels } from "~/features/ModelList/hooks/useFilteredModels"
-import { MODEL_CAPABILITY_FILTER_VALUES } from "~/features/ModelList/modelCapabilityFilters"
+import {
+  createModelMetadataIndex,
+  getModelCapabilityBadges,
+  matchesModelCapabilityFilters,
+  MODEL_CAPABILITY_FILTER_VALUES,
+  resolveModelMetadata,
+} from "~/features/ModelList/modelCapabilityFilters"
 import {
   createAccountSource,
   createAccountTokenModelListSourceIdentity,
@@ -496,6 +502,41 @@ describe("useFilteredModels", () => {
         })
         .map((item) => item.model.model_name),
     ).toEqual(["media-model"])
+  })
+
+  it("skips ambiguous bare aliases while preserving exact provider aliases", () => {
+    const metadata: ModelMetadata[] = [
+      {
+        id: "provider-a/shared-model",
+        name: "Shared Model A",
+        provider_id: "provider-a",
+      },
+      {
+        id: "provider-b/shared-model",
+        name: "Shared Model B",
+        provider_id: "provider-b",
+      },
+    ]
+
+    const index = createModelMetadataIndex(metadata)
+
+    expect(resolveModelMetadata(index, "shared-model")).toBeUndefined()
+    expect(resolveModelMetadata(index, "provider-a/shared-model")).toBe(
+      metadata[0],
+    )
+  })
+
+  it("matches every model when no capability filters are selected", () => {
+    expect(
+      matchesModelCapabilityFilters({
+        metadata: undefined,
+        filters: [],
+      }),
+    ).toBe(true)
+  })
+
+  it("returns no capability badges when metadata is missing", () => {
+    expect(getModelCapabilityBadges()).toEqual([])
   })
 
   it("reports capability metadata coverage before applying capability filters", async () => {

--- a/tests/entrypoints/options/pages/ModelList/useModelListData.test.tsx
+++ b/tests/entrypoints/options/pages/ModelList/useModelListData.test.tsx
@@ -18,6 +18,12 @@ const mockUseAccountData = vi.fn()
 const mockUseApiCredentialProfiles = vi.fn()
 const mockUseModelData = vi.fn()
 const mockUseFilteredModels = vi.fn()
+const { mockModelMetadataService } = vi.hoisted(() => ({
+  mockModelMetadataService: {
+    initialize: vi.fn(),
+    getAllMetadata: vi.fn(),
+  },
+}))
 
 vi.mock("~/hooks/useAccountData", () => ({
   useAccountData: (...args: unknown[]) => mockUseAccountData(...args),
@@ -37,6 +43,10 @@ vi.mock("~/features/ModelList/hooks/useModelData", () => ({
 
 vi.mock("~/features/ModelList/hooks/useFilteredModels", () => ({
   useFilteredModels: (...args: unknown[]) => mockUseFilteredModels(...args),
+}))
+
+vi.mock("~/services/models/modelMetadata", () => ({
+  modelMetadataService: mockModelMetadataService,
 }))
 
 const ACCOUNT: DisplaySiteData = {
@@ -97,6 +107,48 @@ describe("useModelListData", () => {
       baseFilteredModels: [],
       getProviderFilteredCount: vi.fn(() => 0),
       availableGroups: [],
+    })
+    mockModelMetadataService.initialize.mockResolvedValue(undefined)
+    mockModelMetadataService.getAllMetadata.mockReturnValue([])
+  })
+
+  it("passes loaded model metadata into the filter pipeline", async () => {
+    mockModelMetadataService.getAllMetadata.mockReturnValue([
+      {
+        id: "openai/gpt-4o",
+        name: "GPT-4o",
+        provider_id: "openai",
+      },
+    ])
+
+    renderHook(() => useModelListData())
+
+    await waitFor(() => {
+      expect(mockUseFilteredModels).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          modelMetadata: [
+            {
+              id: "openai/gpt-4o",
+              name: "GPT-4o",
+              provider_id: "openai",
+            },
+          ],
+        }),
+      )
+    })
+  })
+
+  it("falls back to empty model metadata when metadata loading fails", async () => {
+    mockModelMetadataService.initialize.mockRejectedValue(new Error("offline"))
+
+    renderHook(() => useModelListData())
+
+    await waitFor(() => {
+      expect(mockUseFilteredModels).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          modelMetadata: [],
+        }),
+      )
     })
   })
 

--- a/tests/features/ModelList/components/ControlPanel.test.tsx
+++ b/tests/features/ModelList/components/ControlPanel.test.tsx
@@ -476,6 +476,27 @@ describe("ControlPanel", () => {
     ).not.toBeInTheDocument()
   })
 
+  it("renders capability options without counts when count lookup is unavailable", async () => {
+    const user = userEvent.setup()
+
+    renderControlPanel({
+      supportsModelCapabilityFilter: true,
+      modelCapabilityMetadataCoverage: {
+        matched: 1,
+        total: 1,
+        unmatched: 0,
+      },
+      getFilteredResultCount: undefined,
+    })
+
+    const imageInput = screen.getByLabelText(
+      "modelCapabilityFilter.options.imageInput",
+    )
+
+    expect(imageInput.closest("label")).not.toHaveTextContent("7")
+    await user.click(imageInput)
+  })
+
   it("hides the prompt when price comparison is already active", () => {
     renderControlPanel({
       selectedSource: ALL_ACCOUNTS_SOURCE,

--- a/tests/features/ModelList/components/ControlPanel.test.tsx
+++ b/tests/features/ModelList/components/ControlPanel.test.tsx
@@ -6,6 +6,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import { MODEL_LIST_BILLING_MODES } from "~/features/ModelList/billingModes"
 import { ControlPanel } from "~/features/ModelList/components/ControlPanel"
 import {
+  MODEL_CAPABILITY_FILTER_VALUES,
+  type ModelCapabilitySelectionValue,
+} from "~/features/ModelList/modelCapabilityFilters"
+import {
   ALL_ACCOUNTS_SOURCE_VALUE,
   MODEL_MANAGEMENT_SOURCE_KINDS,
   type ModelManagementSourceCapabilities,
@@ -17,6 +21,7 @@ import {
 } from "~/features/ModelList/verificationResultFilters"
 import {
   PRODUCT_ANALYTICS_ACTION_IDS,
+  PRODUCT_ANALYTICS_MODE_IDS,
   PRODUCT_ANALYTICS_RESULTS,
 } from "~/services/productAnalytics/contracts"
 
@@ -98,7 +103,12 @@ vi.mock("~/components/ui", () => ({
     placeholder,
     size = "sm",
   }: {
-    options: Array<{ value: string; label: string }>
+    options: Array<{
+      value: string
+      label: string
+      count?: number
+      disabled?: boolean
+    }>
     selected: string[]
     onChange: (selected: string[]) => void
     placeholder?: string
@@ -108,9 +118,12 @@ vi.mock("~/components/ui", () => ({
       {options.map((option) => (
         <label key={option.value}>
           {option.label}
+          {typeof option.count === "number" && <span>{option.count}</span>}
           <input
             type="checkbox"
+            aria-label={option.label}
             checked={selected.includes(option.value)}
+            disabled={option.disabled}
             onChange={(event) => {
               onChange(
                 event.target.checked
@@ -313,6 +326,154 @@ describe("ControlPanel", () => {
         }),
       }),
     )
+  })
+
+  it("applies model capability filters through the control panel", async () => {
+    const user = userEvent.setup()
+    const setSelectedModelCapabilities = vi.fn()
+    const getFilteredResultCount = vi.fn(() => 3)
+
+    renderControlPanel({
+      supportsModelCapabilityFilter: true,
+      selectedModelCapabilities: [MODEL_CAPABILITY_FILTER_VALUES.IMAGE_INPUT],
+      setSelectedModelCapabilities,
+      getFilteredResultCount,
+    })
+
+    await user.click(
+      screen.getByLabelText("modelCapabilityFilter.options.toolCall"),
+    )
+
+    expect(setSelectedModelCapabilities).toHaveBeenLastCalledWith(
+      expect.arrayContaining([
+        MODEL_CAPABILITY_FILTER_VALUES.IMAGE_INPUT,
+        MODEL_CAPABILITY_FILTER_VALUES.TOOL_CALL,
+      ]),
+    )
+    expect(getFilteredResultCount).toHaveBeenCalledWith(
+      expect.objectContaining({
+        selectedModelCapabilities: [
+          MODEL_CAPABILITY_FILTER_VALUES.IMAGE_INPUT,
+          MODEL_CAPABILITY_FILTER_VALUES.TOOL_CALL,
+        ],
+      }),
+    )
+    expect(trackProductAnalyticsActionCompletedMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actionId: PRODUCT_ANALYTICS_ACTION_IDS.FilterModelList,
+        result: PRODUCT_ANALYTICS_RESULTS.Success,
+        insights: expect.objectContaining({
+          mode: PRODUCT_ANALYTICS_MODE_IDS.ModelCapabilityFilter,
+          filterCount: 4,
+          resultCount: 3,
+        }),
+      }),
+    )
+  })
+
+  it("shows capability result counts and disables unavailable unselected capabilities", () => {
+    const getFilteredResultCount = vi.fn(
+      (filters: {
+        selectedModelCapabilities?: ModelCapabilitySelectionValue[]
+      }) => {
+        const capabilities = filters.selectedModelCapabilities ?? []
+
+        if (capabilities.includes(MODEL_CAPABILITY_FILTER_VALUES.TOOL_CALL)) {
+          return 2
+        }
+
+        return 0
+      },
+    )
+
+    renderControlPanel({
+      supportsModelCapabilityFilter: true,
+      searchTerm: "vision",
+      selectedVerificationResults: [
+        MODEL_LIST_VERIFICATION_RESULT_FILTERS.PASS,
+      ],
+      selectedModelCapabilities: [MODEL_CAPABILITY_FILTER_VALUES.IMAGE_INPUT],
+      getFilteredResultCount,
+    })
+
+    expect(
+      screen.getByLabelText("modelCapabilityFilter.options.imageInput"),
+    ).not.toBeDisabled()
+    expect(
+      screen.getByLabelText("modelCapabilityFilter.options.audioOutput"),
+    ).toBeDisabled()
+    expect(
+      screen.getByLabelText("modelCapabilityFilter.options.toolCall"),
+    ).not.toBeDisabled()
+
+    expect(
+      screen.getByText("modelCapabilityFilter.options.imageInput"),
+    ).toHaveTextContent("0")
+    expect(
+      screen.getByText("modelCapabilityFilter.options.audioOutput"),
+    ).toHaveTextContent("0")
+    expect(
+      screen.getByText("modelCapabilityFilter.options.toolCall"),
+    ).toHaveTextContent("2")
+    expect(
+      screen
+        .getByText("modelCapabilityFilter.options.imageInput")
+        .compareDocumentPosition(
+          screen.getByText("modelCapabilityFilter.options.toolCall"),
+        ) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy()
+    expect(
+      screen
+        .getByText("modelCapabilityFilter.options.toolCall")
+        .compareDocumentPosition(
+          screen.getByText("modelCapabilityFilter.options.audioOutput"),
+        ) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy()
+    expect(getFilteredResultCount).toHaveBeenCalledWith(
+      expect.objectContaining({
+        searchTerm: "vision",
+        selectedVerificationResults: [
+          MODEL_LIST_VERIFICATION_RESULT_FILTERS.PASS,
+        ],
+        selectedModelCapabilities: [
+          MODEL_CAPABILITY_FILTER_VALUES.IMAGE_INPUT,
+          MODEL_CAPABILITY_FILTER_VALUES.TOOL_CALL,
+        ],
+      }),
+    )
+  })
+
+  it("explains capability metadata coverage when some models lack capability details", () => {
+    renderControlPanel({
+      supportsModelCapabilityFilter: true,
+      modelCapabilityMetadataCoverage: {
+        matched: 2,
+        total: 5,
+        unmatched: 3,
+      },
+    })
+
+    const capabilityHint = screen
+      .getByText("modelCapabilityFilter.selectionHint", { exact: false })
+      .closest("p")
+
+    expect(capabilityHint).toHaveTextContent(
+      "modelCapabilityFilter.selectionHint",
+    )
+    expect(capabilityHint).toHaveTextContent(
+      "modelCapabilityFilter.coverageHint",
+    )
+  })
+
+  it("hides model capability filters until capability metadata is available", () => {
+    renderControlPanel({
+      supportsModelCapabilityFilter: false,
+      selectedModelCapabilities: [MODEL_CAPABILITY_FILTER_VALUES.IMAGE_INPUT],
+    })
+
+    expect(
+      screen.queryByLabelText("modelCapabilityFilter.options.all"),
+    ).not.toBeInTheDocument()
   })
 
   it("hides the prompt when price comparison is already active", () => {

--- a/tests/features/ModelList/components/ModelCapabilityBadges.test.tsx
+++ b/tests/features/ModelList/components/ModelCapabilityBadges.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import { ModelCapabilityBadges } from "~/features/ModelList/components/ModelItem/ModelCapabilityBadges"
+
+vi.mock("react-i18next", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-i18next")>()
+
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string) => key,
+    }),
+  }
+})
+
+describe("ModelCapabilityBadges", () => {
+  it("renders granular model capability badges with explanations", () => {
+    render(
+      <ModelCapabilityBadges
+        modelMetadata={{
+          id: "openai/gpt-image-1",
+          name: "GPT Image 1",
+          provider_id: "openai",
+          capabilities: {
+            reasoning: true,
+            toolCall: true,
+            structuredOutput: true,
+          },
+          modalities: {
+            input: ["text", "image", "audio", "video", "pdf"],
+            output: ["text", "image", "audio", "video"],
+          },
+        }}
+      />,
+    )
+
+    expect(
+      screen.getByText("modelCapabilityFilter.groups.input"),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText("modelCapabilityFilter.groups.output"),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText("modelCapabilityFilter.groups.capabilities"),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText("modelCapabilityFilter.options.imageInput"),
+    ).toHaveAttribute(
+      "title",
+      "modelCapabilityFilter.options.imageInput: modelCapabilityFilter.descriptions.imageInput",
+    )
+    expect(
+      screen.getByText("modelCapabilityFilter.options.imageOutput"),
+    ).toHaveAttribute(
+      "title",
+      "modelCapabilityFilter.options.imageOutput: modelCapabilityFilter.descriptions.imageOutput",
+    )
+    expect(
+      screen.getByText("modelCapabilityFilter.options.audioInput"),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText("modelCapabilityFilter.options.audioOutput"),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText("modelCapabilityFilter.options.videoInput"),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText("modelCapabilityFilter.options.videoOutput"),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText("modelCapabilityFilter.options.pdf"),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText("modelCapabilityFilter.options.reasoning"),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText("modelCapabilityFilter.options.toolCall"),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByText("modelCapabilityFilter.options.structuredOutput"),
+    ).toBeInTheDocument()
+  })
+})

--- a/tests/features/ModelList/components/ModelCapabilityBadges.test.tsx
+++ b/tests/features/ModelList/components/ModelCapabilityBadges.test.tsx
@@ -15,6 +15,59 @@ vi.mock("react-i18next", async (importOriginal) => {
 })
 
 describe("ModelCapabilityBadges", () => {
+  it("does not render groups when the model has no displayable capabilities", () => {
+    const { container } = render(
+      <ModelCapabilityBadges
+        modelMetadata={{
+          id: "example/text-only",
+          name: "Text Only",
+          provider_id: "example",
+          modalities: {
+            input: ["text"],
+            output: ["text"],
+          },
+        }}
+      />,
+    )
+
+    expect(container).toBeEmptyDOMElement()
+    expect(
+      screen.queryByText("modelCapabilityFilter.groups.input"),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByText("modelCapabilityFilter.groups.output"),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByText("modelCapabilityFilter.groups.capabilities"),
+    ).not.toBeInTheDocument()
+  })
+
+  it("skips empty capability groups while rendering populated groups", () => {
+    render(
+      <ModelCapabilityBadges
+        modelMetadata={{
+          id: "example/image-input",
+          name: "Image Input",
+          provider_id: "example",
+          modalities: {
+            input: ["text", "image"],
+            output: ["text"],
+          },
+        }}
+      />,
+    )
+
+    expect(
+      screen.getByText("modelCapabilityFilter.groups.input"),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByText("modelCapabilityFilter.groups.output"),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByText("modelCapabilityFilter.groups.capabilities"),
+    ).not.toBeInTheDocument()
+  })
+
   it("renders granular model capability badges with explanations", () => {
     render(
       <ModelCapabilityBadges

--- a/tests/services/modelMetadata/ModelMetadataService.test.ts
+++ b/tests/services/modelMetadata/ModelMetadataService.test.ts
@@ -258,6 +258,69 @@ describe("ModelMetadataService", () => {
     })
   })
 
+  it("normalizes models.dev model metadata without dropping capability fields", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        "openai/gpt-4o": {
+          id: "openai/gpt-4o",
+          name: "GPT-4o",
+          description: "Multimodal model",
+          attachment: true,
+          reasoning: false,
+          tool_call: true,
+          structured_output: true,
+          temperature: true,
+          release_date: "2024-05-13",
+          last_updated: "2024-08-06",
+          modalities: {
+            input: ["text", "image", "pdf"],
+            output: ["text"],
+          },
+          open_weights: false,
+          limit: {
+            context: 128000,
+            output: 16384,
+          },
+        },
+      }),
+    })
+
+    const modelMetadataService = await loadService()
+    await modelMetadataService.initialize()
+
+    expect(modelMetadataService.getAllMetadata()).toEqual([
+      {
+        id: "openai/gpt-4o",
+        name: "GPT-4o",
+        provider_id: "openai",
+        description: "Multimodal model",
+        capabilities: {
+          attachment: true,
+          reasoning: false,
+          toolCall: true,
+          structuredOutput: true,
+          temperature: true,
+        },
+        modalities: {
+          input: ["text", "image", "pdf"],
+          output: ["text"],
+        },
+        open_weights: false,
+        limits: {
+          context: 128000,
+          output: 16384,
+        },
+        release_date: "2024-05-13",
+        last_updated: "2024-08-06",
+      },
+    ])
+    expect(modelMetadataService.findStandardModelName("gpt-4o")).toEqual({
+      standardName: "openai/gpt-4o",
+      vendorName: "OpenAI",
+    })
+  })
+
   it("falls back to bundled metadata when the remote payload is not an object", async () => {
     global.fetch = vi.fn().mockResolvedValue({
       ok: true,

--- a/tests/services/modelMetadata/ModelMetadataService.test.ts
+++ b/tests/services/modelMetadata/ModelMetadataService.test.ts
@@ -280,8 +280,21 @@ describe("ModelMetadataService", () => {
           open_weights: false,
           limit: {
             context: 128000,
+            input: 64000,
             output: 16384,
           },
+        },
+        "example/metadata-with-empty-modalities": {
+          name: "Metadata With Empty Modalities",
+          provider_id: "example",
+          modalities: {
+            input: "text",
+            output: [],
+          },
+        },
+        "openai/family/gpt-4o-mini": {
+          id: "openai/family/gpt-4o-mini",
+          name: "Nested GPT-4o mini",
         },
       }),
     })
@@ -309,14 +322,31 @@ describe("ModelMetadataService", () => {
         open_weights: false,
         limits: {
           context: 128000,
+          input: 64000,
           output: 16384,
         },
         release_date: "2024-05-13",
         last_updated: "2024-08-06",
       },
+      {
+        id: "example/metadata-with-empty-modalities",
+        name: "Metadata With Empty Modalities",
+        provider_id: "example",
+      },
+      {
+        id: "openai/family/gpt-4o-mini",
+        name: "Nested GPT-4o mini",
+        provider_id: "openai",
+      },
     ])
     expect(modelMetadataService.findStandardModelName("gpt-4o")).toEqual({
       standardName: "openai/gpt-4o",
+      vendorName: "OpenAI",
+    })
+    expect(
+      modelMetadataService.findStandardModelName("openai/family/gpt-4o-mini"),
+    ).toEqual({
+      standardName: "openai/family/gpt-4o-mini",
       vendorName: "OpenAI",
     })
   })
@@ -347,6 +377,23 @@ describe("ModelMetadataService", () => {
         models: {
           id: "gpt-4o",
         },
+      }),
+    })
+
+    const modelMetadataService = await loadService()
+    await modelMetadataService.initialize()
+
+    expect(modelMetadataService.findStandardModelName("gpt-4o")).toEqual({
+      standardName: "gpt-4o",
+      vendorName: "OpenAI",
+    })
+  })
+
+  it("falls back to bundled metadata when the models field is primitive", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        models: "invalid models",
       }),
     })
 

--- a/tests/utils/commonUserFlows.test.ts
+++ b/tests/utils/commonUserFlows.test.ts
@@ -4,6 +4,7 @@ import {
   SPONSOR_CATALOG_SCHEMA_VERSION,
   SPONSOR_REMOTE_CATALOG_V5_URL,
 } from "~/features/AccountManagement/sponsors/constants"
+import { MODEL_METADATA_URL } from "~/services/models/modelMetadata/constants"
 import {
   installExtensionPageGuards,
   stubLlmMetadataIndex,
@@ -77,7 +78,7 @@ describe("E2E external route stubs", () => {
     await stubLlmMetadataIndex(context)
 
     expect(context.route).toHaveBeenCalledWith(
-      "https://llm-metadata.pages.dev/api/index.json",
+      MODEL_METADATA_URL,
       expect.any(Function),
     )
     expect(context.route).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary
- normalize models.dev model capability metadata for Model List consumers
- add metadata-backed capability filters with localized copy, counts, and analytics payload typing
- show per-model capability badges in the Model List rows

## Validation
- pnpm vitest --run tests/services/modelMetadata/ModelMetadataService.test.ts tests/entrypoints/options/pages/ModelList/useFilteredModels.test.ts tests/features/ModelList/components/ControlPanel.test.tsx tests/features/ModelList/components/ModelCapabilityBadges.test.tsx tests/components/CompactMultiSelect.test.tsx tests/entrypoints/options/pages/ModelList/ControlPanel.capabilities.test.tsx
- pnpm run i18n:extract:ci
- pnpm run validate:push
- git push pre-push hook: validate:push

## E2E Decision
- No new E2E added; the changed behavior is covered by focused service, hook, component, and shared multiselect tests. Browser-level coverage can be added later if row/dropdown wrapping becomes a real integration risk.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added model capability filtering to the Model List (image, audio, video, PDF, reasoning, tool calling, structured output).
  * Models can now display capability badges, and filter options show result counts (counts appear in chips; summary view hides them).
  * Added a coverage hint when some models lack capability details.
* **Localization**
  * Added “Model Capabilities” filter UI text and descriptions across multiple languages.
* **Accessibility**
  * Improved accessible labeling for capability badges and filter options, including count-aware labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->