### PR TITLE
fix(background): close completed composite temp windows

### DIFF
--- a/docs/superpowers/plans/2026-07-13-composite-temp-window-cleanup.md
+++ b/docs/superpowers/plans/2026-07-13-composite-temp-window-cleanup.md
@@ -1,0 +1,512 @@
+# Composite Temp Window Cleanup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close an extension-owned composite window explicitly when its final temp tab finishes, preserve other tabs and concurrent opens, and warn when an unknown browser handle falls back from window removal to tab removal.
+
+**Architecture:** Preserve the actual temp-context mode and composite owner window ID instead of collapsing all composite contexts to an untyped tab handle. Route known handles through explicit `removeWindow` and `removeTab` adapters, serialize composite window creation/removal with a global operation queue, and reserve `removeTabOrWindow` for genuinely unknown legacy handles with warning-level fallback logging.
+
+**Tech Stack:** TypeScript, WXT Manifest V3 background service worker, WebExtension `windows`/`tabs` APIs, Vitest browser API mocks.
+
+---
+
+### Task 1: Make Browser Removal APIs Explicit and Observable
+
+**Files:**
+
+- Modify: `src/utils/browser/browserApi.ts:149-173`
+- Test: `tests/utils/browserApi.test.ts:1-85`
+- Test: `tests/utils/browserApi.test.ts:1218-1264`
+
+- [ ] **Step 1: Write failing adapter and warning tests**
+
+Import `removeTab` and `removeWindow` beside `removeTabOrWindow`, then replace the existing fallback test with the following assertions and add direct adapter tests:
+
+```ts
+it("warns before falling back to tab removal", async () => {
+  const error = new Error("not a window")
+  const removeWindowMock = vi.fn().mockRejectedValueOnce(error)
+  const removeTabMock = vi.fn().mockResolvedValue(undefined)
+  ;(globalThis as any).browser.windows.remove = removeWindowMock
+  ;(globalThis as any).browser.tabs.remove = removeTabMock
+
+  await removeTabOrWindow(42)
+
+  expect(removeWindowMock).toHaveBeenCalledWith(42)
+  expect(loggerMock.warn).toHaveBeenCalledWith(
+    "removeTabOrWindow: Failed to remove as window, falling back to tab",
+    { id: 42, error },
+  )
+  expect(removeTabMock).toHaveBeenCalledWith(42)
+  expect(removeWindowMock.mock.invocationCallOrder[0]).toBeLessThan(
+    removeTabMock.mock.invocationCallOrder[0],
+  )
+})
+
+it("removes a known tab without probing the windows API", async () => {
+  const removeTabMock = vi.fn().mockResolvedValue(undefined)
+  const removeWindowMock = vi.fn().mockResolvedValue(undefined)
+  ;(globalThis as any).browser.tabs.remove = removeTabMock
+  ;(globalThis as any).browser.windows.remove = removeWindowMock
+
+  await removeTab(43)
+
+  expect(removeTabMock).toHaveBeenCalledWith(43)
+  expect(removeWindowMock).not.toHaveBeenCalled()
+  expect(loggerMock.warn).not.toHaveBeenCalled()
+})
+
+it("removes a known window without probing the tabs API", async () => {
+  const removeTabMock = vi.fn().mockResolvedValue(undefined)
+  const removeWindowMock = vi.fn().mockResolvedValue(undefined)
+  ;(globalThis as any).browser.tabs.remove = removeTabMock
+  ;(globalThis as any).browser.windows.remove = removeWindowMock
+
+  await removeWindow(44)
+
+  expect(removeWindowMock).toHaveBeenCalledWith(44)
+  expect(removeTabMock).not.toHaveBeenCalled()
+})
+```
+
+- [ ] **Step 2: Run the focused tests and verify RED**
+
+Run:
+
+```powershell
+pnpm exec vitest run tests/utils/browserApi.test.ts -t "warns before falling back|removes a known"
+```
+
+Expected: failure because `removeTab` and `removeWindow` are not exported and the fallback currently logs at debug level.
+
+- [ ] **Step 3: Implement explicit adapters and warning-level fallback**
+
+Replace the ambiguous removal block with:
+
+```ts
+export async function removeTab(tabId: number): Promise<void> {
+  await browser.tabs.remove(tabId)
+}
+
+export async function removeWindow(windowId: number): Promise<void> {
+  if (!hasWindowsAPI()) {
+    throw new Error("browser.windows.remove is unavailable")
+  }
+
+  await browser.windows.remove(windowId)
+}
+
+export async function removeTabOrWindow(id: number): Promise<void> {
+  if (hasWindowsAPI()) {
+    try {
+      await removeWindow(id)
+      return
+    } catch (error) {
+      logger.warn(
+        "removeTabOrWindow: Failed to remove as window, falling back to tab",
+        { id, error },
+      )
+    }
+  }
+
+  await removeTab(id)
+}
+```
+
+- [ ] **Step 4: Run the focused tests and verify GREEN**
+
+Run the Step 2 command again.
+
+Expected: all selected tests pass and the warning assertion contains the original error object.
+
+- [ ] **Step 5: Commit the adapter slice**
+
+```powershell
+git add -- src/utils/browser/browserApi.ts tests/utils/browserApi.test.ts
+git commit -m "fix(browser): warn on cleanup fallback"
+```
+
+### Task 2: Preserve Typed Temp Handles and Close the Final Composite Window
+
+**Files:**
+
+- Modify: `src/entrypoints/background/tempWindowPool.ts:428-447`
+- Modify: `src/entrypoints/background/tempWindowPool.ts:687-702`
+- Modify: `src/entrypoints/background/tempWindowPool.ts:788-985`
+- Modify: `src/entrypoints/background/tempWindowPool.ts:2012-2316`
+- Modify: `src/entrypoints/background/tempWindowPool.ts:2547-2712`
+- Test: `tests/entrypoints/background/tempWindowPoolOpenClose.test.ts`
+- Test: `tests/entrypoints/background/tempWindowPoolWindowFallback.test.ts`
+
+- [ ] **Step 1: Add failing final-window and multi-tab tests**
+
+Extend the browser API mocks in both test files with `removeTabMock` and `removeWindowMock`. In the open/close test, add:
+
+```ts
+it("closes the owner window for the final manual composite tab", async () => {
+  tempContextMode = "composite"
+  createWindowMock.mockResolvedValueOnce({ id: 901 })
+  tabsQueryMock.mockResolvedValue([{ id: 902 }])
+
+  const { handleCloseTempWindow, handleOpenTempWindow } = await import(
+    "~/entrypoints/background/tempWindowPool"
+  )
+  await handleOpenTempWindow(
+    {
+      requestId: "req-composite-final",
+      url: "https://example.invalid/composite/final",
+    },
+    vi.fn(),
+  )
+
+  const closeResponse = vi.fn()
+  await handleCloseTempWindow(
+    { requestId: "req-composite-final" },
+    closeResponse,
+  )
+
+  expect(removeWindowMock).toHaveBeenCalledWith(901)
+  expect(removeTabMock).not.toHaveBeenCalled()
+  expect(removeTabOrWindowMock).not.toHaveBeenCalled()
+  expect(closeResponse).toHaveBeenCalledWith({ success: true })
+})
+
+it("removes only the completed composite tab when another tab exists", async () => {
+  tempContextMode = "composite"
+  createWindowMock.mockResolvedValueOnce({ id: 911 })
+  tabsQueryMock
+    .mockResolvedValueOnce([{ id: 912 }])
+    .mockResolvedValueOnce([{ id: 912 }, { id: 913 }])
+
+  const { handleCloseTempWindow, handleOpenTempWindow } = await import(
+    "~/entrypoints/background/tempWindowPool"
+  )
+  await handleOpenTempWindow(
+    {
+      requestId: "req-composite-shared",
+      url: "https://example.invalid/composite/shared",
+    },
+    vi.fn(),
+  )
+
+  await handleCloseTempWindow(
+    { requestId: "req-composite-shared" },
+    vi.fn(),
+  )
+
+  expect(removeTabMock).toHaveBeenCalledWith(912)
+  expect(removeWindowMock).not.toHaveBeenCalled()
+  expect(removeTabOrWindowMock).not.toHaveBeenCalled()
+})
+```
+
+Add a pooled-context regression in `tempWindowPoolWindowFallback.test.ts` by adapting the existing composite fetch cleanup scenario to assert that `windowId=305` is removed when `tabId=306` is the only tab:
+
+```ts
+await vi.advanceTimersByTimeAsync(2500)
+expect(removeWindowMock).toHaveBeenCalledWith(305)
+expect(removeTabMock).not.toHaveBeenCalledWith(306)
+expect(removeTabOrWindowMock).not.toHaveBeenCalledWith(306)
+```
+
+- [ ] **Step 2: Run the three selected tests and verify RED**
+
+Run:
+
+```powershell
+pnpm exec vitest run tests/entrypoints/background/tempWindowPoolOpenClose.test.ts tests/entrypoints/background/tempWindowPoolWindowFallback.test.ts -t "final manual composite|another tab exists|continues composite temp-window fetches"
+```
+
+Expected: the current code calls `removeTabOrWindow(tabId)` and does not retain the composite owner window ID.
+
+- [ ] **Step 3: Add typed handles and preserve actual open mode**
+
+Introduce these shapes near the existing temp context types:
+
+```ts
+type TempWindowHandle =
+  | { kind: "window"; windowId: number }
+  | { kind: "tab"; tabId: number }
+  | { kind: "composite"; tabId: number; windowId: number }
+
+type TempContext = {
+  id: number
+  tabId: number
+  origin: string
+  type: "window" | "tab"
+  mode: TempContextOpenMode
+  ownerWindowId?: number
+  currentUrl?: string
+  activeRequestIds: Set<string>
+  lastUsed: number
+  downloadBlockRuleId?: number | null
+  firefoxDownloadBlockTabId?: number | null
+  releaseTimer?: ReturnType<typeof setTimeout>
+}
+
+type TempContextOpenResult = {
+  id: number
+  tabId: number
+  type: "window" | "tab"
+  mode: TempContextOpenMode
+  ownerWindowId?: number
+}
+```
+
+Change `tempWindows` to `Map<string, TempWindowHandle>`. Make popup, plain-tab,
+and composite open paths save the matching discriminated handle. Return
+`mode: "window"`, `mode: "tab"`, or `mode: "composite"` from the actual open
+path so a window-creation rollback records `tab`.
+
+- [ ] **Step 4: Add a shared known-handle cleanup helper**
+
+Add a composite-aware removal function and route both manual handles and pooled
+contexts through it:
+
+```ts
+async function removeCompositeTab(windowId: number, tabId: number) {
+  let tabs: browser.tabs.Tab[]
+
+  try {
+    tabs = await queryTabs({ windowId })
+  } catch (error) {
+    logger.warn("Failed to inspect composite temp window; removing tab only", {
+      windowId,
+      tabId,
+      error,
+    })
+    await removeTab(tabId)
+    return
+  }
+
+  const isOnlyTab = tabs.length === 1 && tabs[0]?.id === tabId
+  if (!isOnlyTab) {
+    await removeTab(tabId)
+    return
+  }
+
+  if (compositeWindowId === windowId) {
+    compositeWindowId = null
+  }
+
+  try {
+    await removeWindow(windowId)
+  } catch (error) {
+    logger.warn(
+      "Failed to remove final composite temp window; falling back to tab",
+      { windowId, tabId, error },
+    )
+    await removeTab(tabId)
+  }
+}
+
+async function removeTempWindowHandle(handle: TempWindowHandle) {
+  switch (handle.kind) {
+    case "window":
+      await removeWindow(handle.windowId)
+      return
+    case "composite":
+      await removeCompositeTab(handle.windowId, handle.tabId)
+      return
+    case "tab":
+      await removeTab(handle.tabId)
+  }
+}
+```
+
+Update listener comparisons to inspect the discriminated fields and remove all
+manual handles belonging to a removed composite window. Replace known-ID
+creation-error and stale-window cleanup calls with explicit window/tab helpers.
+
+- [ ] **Step 5: Run the selected tests and verify GREEN**
+
+Run the Step 2 command again.
+
+Expected: sole composite tabs close their owner window, shared windows keep
+other tabs, and no known-handle path calls `removeTabOrWindow`.
+
+- [ ] **Step 6: Commit the ownership slice**
+
+```powershell
+git add -- src/entrypoints/background/tempWindowPool.ts tests/entrypoints/background/tempWindowPoolOpenClose.test.ts tests/entrypoints/background/tempWindowPoolWindowFallback.test.ts
+git commit -m "fix(background): close final composite temp window"
+```
+
+### Task 3: Serialize Composite Open and Close Operations
+
+**Files:**
+
+- Modify: `src/entrypoints/background/tempWindowPool.ts:698-702`
+- Modify: `src/entrypoints/background/tempWindowPool.ts:2366-2545`
+- Modify: `src/entrypoints/background/tempWindowPool.ts` composite cleanup helper from Task 2
+- Test: `tests/entrypoints/background/tempWindowPoolOpenClose.test.ts`
+
+- [ ] **Step 1: Write the failing open-versus-close race test**
+
+Add a test that holds final-window inspection pending while another composite
+open begins:
+
+```ts
+it("serializes final composite cleanup with a concurrent open", async () => {
+  tempContextMode = "composite"
+  createWindowMock
+    .mockResolvedValueOnce({ id: 921 })
+    .mockResolvedValueOnce({ id: 925 })
+  tabsQueryMock.mockResolvedValueOnce([{ id: 922 }])
+
+  let resolveCleanupQuery!: (tabs: browser.tabs.Tab[]) => void
+  tabsQueryMock.mockReturnValueOnce(
+    new Promise<browser.tabs.Tab[]>((resolve) => {
+      resolveCleanupQuery = resolve
+    }),
+  )
+  tabsQueryMock.mockResolvedValueOnce([{ id: 926 }])
+
+  const { handleCloseTempWindow, handleOpenTempWindow } = await import(
+    "~/entrypoints/background/tempWindowPool"
+  )
+  await handleOpenTempWindow(
+    {
+      requestId: "req-composite-race-old",
+      url: "https://example.invalid/composite/race/old",
+    },
+    vi.fn(),
+  )
+
+  const closePromise = handleCloseTempWindow(
+    { requestId: "req-composite-race-old" },
+    vi.fn(),
+  )
+  const nextResponse = vi.fn()
+  const nextOpenPromise = handleOpenTempWindow(
+    {
+      requestId: "req-composite-race-new",
+      url: "https://example.invalid/composite/race/new",
+    },
+    nextResponse,
+  )
+
+  expect(createWindowMock).toHaveBeenCalledTimes(1)
+  resolveCleanupQuery([{ id: 922 } as browser.tabs.Tab])
+  await Promise.all([closePromise, nextOpenPromise])
+
+  expect(removeWindowMock).toHaveBeenCalledWith(921)
+  expect(createWindowMock).toHaveBeenCalledTimes(2)
+  expect(nextResponse).toHaveBeenCalledWith({
+    success: true,
+    windowId: 925,
+    tabId: 926,
+  })
+})
+```
+
+- [ ] **Step 2: Run the race test and verify RED**
+
+Run:
+
+```powershell
+pnpm exec vitest run tests/entrypoints/background/tempWindowPoolOpenClose.test.ts -t "serializes final composite cleanup"
+```
+
+Expected: the second open reuses or races with window `921` before cleanup has
+finished because only initial window creation is currently coordinated.
+
+- [ ] **Step 3: Implement the composite operation queue**
+
+Replace the creation-only promise with a queue that survives rejected
+operations:
+
+```ts
+let compositeWindowOperationQueue: Promise<void> = Promise.resolve()
+
+async function withCompositeWindowLock<T>(
+  operation: () => Promise<T>,
+): Promise<T> {
+  const result = compositeWindowOperationQueue.then(operation, operation)
+  compositeWindowOperationQueue = result.then(
+    () => undefined,
+    () => undefined,
+  )
+  return await result
+}
+```
+
+Move the existing body of `openTabInCompositeWindow()` into
+`openTabInCompositeWindowLocked()` and make the public helper call it through
+`withCompositeWindowLock`. Run `removeCompositeTab()` through the same lock.
+Keep partial-window cleanup inside the already-locked function so it never
+recursively acquires the queue.
+
+- [ ] **Step 4: Run the race and existing concurrency tests**
+
+Run:
+
+```powershell
+pnpm exec vitest run tests/entrypoints/background/tempWindowPoolOpenClose.test.ts -t "serializes final composite cleanup|shares an in-flight composite window creation|surfaces a concurrent composite-tab creation failure"
+```
+
+Expected: all selected tests pass; concurrent opens still share one window,
+while an open that begins during final cleanup waits and uses the next window.
+
+- [ ] **Step 5: Commit the synchronization slice**
+
+```powershell
+git add -- src/entrypoints/background/tempWindowPool.ts tests/entrypoints/background/tempWindowPoolOpenClose.test.ts
+git commit -m "fix(background): serialize composite window cleanup"
+```
+
+### Task 4: Validate the Integrated Fix
+
+**Files:**
+
+- Verify: `src/utils/browser/browserApi.ts`
+- Verify: `src/entrypoints/background/tempWindowPool.ts`
+- Verify: `tests/utils/browserApi.test.ts`
+- Verify: `tests/entrypoints/background/tempWindowPoolOpenClose.test.ts`
+- Verify: `tests/entrypoints/background/tempWindowPoolWindowFallback.test.ts`
+
+- [ ] **Step 1: Run all affected tests**
+
+```powershell
+pnpm exec vitest run tests/utils/browserApi.test.ts tests/entrypoints/background/tempWindowPoolOpenClose.test.ts tests/entrypoints/background/tempWindowPoolWindowFallback.test.ts
+```
+
+Expected: all tests in the three files pass.
+
+- [ ] **Step 2: Run related-test discovery for production changes**
+
+```powershell
+pnpm exec vitest related --run src/utils/browser/browserApi.ts src/entrypoints/background/tempWindowPool.ts
+```
+
+Expected: all discovered related tests pass.
+
+- [ ] **Step 3: Stage only implementation files and run the commit gate**
+
+```powershell
+git add -- src/utils/browser/browserApi.ts src/entrypoints/background/tempWindowPool.ts tests/utils/browserApi.test.ts tests/entrypoints/background/tempWindowPoolOpenClose.test.ts tests/entrypoints/background/tempWindowPoolWindowFallback.test.ts
+pnpm run validate:staged
+```
+
+Expected: lint-staged, focused Vitest, formatting, and staged i18n checks pass.
+
+- [ ] **Step 4: Run the shared-runtime push gate**
+
+```powershell
+pnpm run validate:push
+```
+
+Expected: `compile` and `knip` pass.
+
+- [ ] **Step 5: Inspect the final diff and commit any validation-only formatting**
+
+```powershell
+git diff --check
+git status --short
+git diff --cached --stat
+git commit -m "test(background): cover composite cleanup compatibility"
+```
+
+Expected: no debug artifacts, temporary Playwright specs, unrelated files, or
+unstaged task changes remain. Skip the final commit if the preceding task
+commits already contain every validated change.

--- a/docs/superpowers/specs/2026-07-13-composite-temp-window-cleanup-design.md
+++ b/docs/superpowers/specs/2026-07-13-composite-temp-window-cleanup-design.md
@@ -1,0 +1,129 @@
+# Composite Temp Window Cleanup Design
+
+## Problem
+
+Composite mode creates a dedicated normal browser window but stores each temp
+context as a tab-backed context. Normal cleanup therefore passes the tab ID to
+`removeTabOrWindow()`, which first attempts `windows.remove(tabId)` and then
+falls back to `tabs.remove(tabId)`.
+
+Chromium closes a normal window after its final tab is removed, which hides the
+missing window ownership in the current model. Browsers that keep the window
+alive by inserting a new tab can leave the extension-created window behind.
+
+## Goals
+
+- Explicitly close an extension-created composite window when its current temp
+  tab is the only tab left in that window.
+- Preserve concurrent composite work and any additional tabs by removing only
+  the completed temp tab when the window contains more than one tab.
+- Make unknown-ID window-to-tab fallback visible through warning-level logs.
+- Cover the cleanup decision and warning contract with focused tests.
+
+## Non-Goals
+
+- Detect or special-case a specific Chromium fork.
+- Change popup-window or plain-tab user preferences.
+- Add product analytics for an internal cleanup correction.
+- Keep the temporary Playwright diagnostic as permanent E2E coverage.
+
+## Design
+
+### Preserve Composite Window Ownership
+
+`TempContextOpenResult` and `TempContext` will retain the actual open mode and
+the owning `windowId` for composite contexts. Popup contexts continue to
+identify themselves by their window ID, while plain tabs have no owning
+temp-window ID. A window-creation fallback must record its resulting mode as
+`tab`, not the originally requested mode.
+
+The composite open path already receives both handles from
+`openTabInCompositeWindow()`. The change carries that existing `windowId`
+through context creation instead of discarding it. The `tempWindows` map used
+by manual open/close messages will likewise store a typed handle rather than an
+unclassified number, so manual composite tabs retain both IDs.
+
+### Serialize Shared Window Mutations
+
+The current origin locks cannot protect a composite window because different
+origins share that window. A dedicated composite operation lock will serialize:
+
+- creation or reuse of the shared window;
+- creation of a tab inside the shared window;
+- inspection before closing a composite context; and
+- removal of a composite tab or its owning window.
+
+This prevents a cleanup operation from observing one remaining tab and closing
+the window while another origin is concurrently adding a new tab to the same
+window. Ordinary page loading and fetch work remain outside this lock.
+
+### Use Explicit Removal for Known Handles
+
+The browser API adapter will expose explicit `removeTab(tabId)` and
+`removeWindow(windowId)` helpers. Cleanup paths that already know the handle
+kind will use those helpers instead of `removeTabOrWindow()`.
+
+For a composite context, cleanup will query the owning window inside the
+composite operation lock immediately before removal:
+
+1. If the window contains exactly the current temp tab, clear the matching
+   cached `compositeWindowId` and close the window explicitly.
+2. If the window contains other tabs, remove only the current temp tab.
+3. If window inspection fails, log a warning and use the conservative tab-only
+   cleanup so an uncertain window is not closed.
+
+Clearing the cached composite window ID before awaiting window removal routes
+later opens to a fresh window. The lock closes the create-versus-remove race,
+while querying the real window tab list protects other concurrent temp tabs and
+user-added tabs from being closed.
+
+### Warn on Unknown-ID Fallback
+
+`removeTabOrWindow()` remains a compatibility helper for callers whose stored
+handle kind is not available. When `windows.remove(id)` fails and the helper
+falls back to `tabs.remove(id)`, it will emit a `logger.warn` entry containing
+the ID and the original error.
+
+Known tab cleanup must not call this helper merely to trigger the fallback;
+otherwise routine operation would generate misleading warnings.
+
+## Error Handling
+
+- Failure to inspect a composite window produces a warning and falls back to
+  removing only the known tab.
+- Failure of the selected browser removal API remains caught by the existing
+  temp-context cleanup boundary and is logged without masking the completed
+  request result.
+- Browser `onRemoved` listeners remain the source of truth for externally
+  closed windows and tabs.
+
+## Tests
+
+Focused Vitest coverage will prove:
+
+- a single-tab composite context closes its owning window ID rather than
+  sending its tab ID through the unknown-kind fallback;
+- a composite window with another tracked or untracked tab removes only the
+  completed temp tab;
+- concurrent composite open and final cleanup operations cannot close the tab
+  being opened;
+- manual composite open/close retains the owner window and follows the same
+  final-window decision;
+- a composite window inspection failure uses conservative tab cleanup;
+- `removeTabOrWindow()` warns with the ID and error before falling back from
+  `windows.remove` to `tabs.remove`;
+- popup-window and plain-tab cleanup behavior remains unchanged and does not
+  emit an expected-operation fallback warning.
+
+The prior Playwright diagnostic already established the real Chromium API
+behavior: `windows.remove(tabId)` rejects, the tab survives that attempt, and
+removing the final tab closes the normal Chromium window. The regression itself
+belongs in Vitest because the defect is the extension's handle ownership and
+branching logic, not Chromium's API implementation.
+
+## Validation
+
+Run the two affected test files first, followed by related Vitest coverage and
+the repository's staged validation gate. Because the change affects shared
+browser helpers and background runtime behavior, also run `validate:push`
+before handoff.

--- a/src/constants/tempContextMode.ts
+++ b/src/constants/tempContextMode.ts
@@ -1,0 +1,8 @@
+export const TEMP_CONTEXT_MODES = {
+  Window: "window",
+  Composite: "composite",
+  Tab: "tab",
+} as const
+
+export type TempContextMode =
+  (typeof TEMP_CONTEXT_MODES)[keyof typeof TEMP_CONTEXT_MODES]

--- a/src/entrypoints/background/tempWindowPool.ts
+++ b/src/entrypoints/background/tempWindowPool.ts
@@ -9,8 +9,10 @@ import {
 } from "~/services/apiTransport/errors"
 import {
   DEFAULT_PREFERENCES,
+  TEMP_CONTEXT_MODES,
   TempWindowFallbackPreferences,
   userPreferences,
+  type TempContextMode,
 } from "~/services/preferences/userPreferences"
 import { trackProductAnalyticsActionCompleted } from "~/services/productAnalytics/actions"
 import {
@@ -97,8 +99,12 @@ const logger = createLogger("TempWindowPool")
 const TEMP_CONTEXT_IDLE_TIMEOUT = 5000
 const TEMP_CONTEXT_INITIAL_URL = "about:blank"
 const QUIET_WINDOW_IDLE_TIMEOUT = 3000
+const TEMP_CONTEXT_TYPES = {
+  Window: "window",
+  Tab: "tab",
+} as const
 const DEFAULT_TEMP_CONTEXT_MODE: TempWindowFallbackPreferences["tempContextMode"] =
-  "composite"
+  TEMP_CONTEXT_MODES.Composite
 
 const TEMP_WINDOW_FETCH_NO_RESPONSE_ERROR = "No response from temp window fetch"
 const TURNSTILE_TOKEN_UNAVAILABLE_ERROR = "Turnstile token not available"
@@ -426,13 +432,10 @@ function logTempWindow(event: string, details?: Record<string, unknown>) {
   }
 }
 
-type TempContext = {
+type TempContextSharedFields = {
   id: number
   tabId: number
   origin: string
-  type: "window" | "tab"
-  mode: TempContextOpenMode
-  ownerWindowId?: number
   currentUrl?: string
   activeRequestIds: Set<string>
   lastUsed: number
@@ -441,20 +444,58 @@ type TempContext = {
   releaseTimer?: ReturnType<typeof setTimeout>
 }
 
-type TempContextOpenMode = "window" | "composite" | "tab"
+type TempContextOpenMode = TempContextMode
+
+type TempContextOwnership =
+  | {
+      type: typeof TEMP_CONTEXT_TYPES.Window
+      mode: typeof TEMP_CONTEXT_MODES.Window
+      ownerWindowId: number
+    }
+  | {
+      type: typeof TEMP_CONTEXT_TYPES.Tab
+      mode: typeof TEMP_CONTEXT_MODES.Composite
+      ownerWindowId: number
+    }
+  | {
+      type: typeof TEMP_CONTEXT_TYPES.Tab
+      mode: typeof TEMP_CONTEXT_MODES.Tab
+      ownerWindowId?: never
+    }
+
+type TempContext = TempContextSharedFields & TempContextOwnership
 
 type TempWindowHandle =
-  | { kind: "window"; windowId: number }
-  | { kind: "tab"; tabId: number }
-  | { kind: "composite"; tabId: number; windowId: number }
+  | { kind: typeof TEMP_CONTEXT_MODES.Window; windowId: number }
+  | { kind: typeof TEMP_CONTEXT_MODES.Tab; tabId: number }
+  | {
+      kind: typeof TEMP_CONTEXT_MODES.Composite
+      tabId: number
+      windowId: number
+    }
 
-type TempContextOpenResult = {
-  id: number
-  tabId: number
-  type: "window" | "tab"
-  mode: TempContextOpenMode
-  ownerWindowId?: number
-}
+type TempContextOpenResult =
+  | {
+      id: number
+      tabId: number
+      type: typeof TEMP_CONTEXT_TYPES.Window
+      mode: typeof TEMP_CONTEXT_MODES.Window
+      ownerWindowId: number
+    }
+  | {
+      id: number
+      tabId: number
+      type: typeof TEMP_CONTEXT_TYPES.Tab
+      mode: typeof TEMP_CONTEXT_MODES.Composite
+      ownerWindowId: number
+    }
+  | {
+      id: number
+      tabId: number
+      type: typeof TEMP_CONTEXT_TYPES.Tab
+      mode: typeof TEMP_CONTEXT_MODES.Tab
+      ownerWindowId?: never
+    }
 
 type RecoverableWindowCreationError = Error & {
   reason: WindowCreationFailureReason
@@ -709,7 +750,6 @@ type CompositeWindowCreationResult = { windowId: number; tabId: number }
 
 let compositeWindowId: number | null = null
 let compositeWindowOperationQueue: Promise<void> = Promise.resolve()
-let compositeWindowOperationPending = false
 
 /**
  * Serialize composite temp-window open and close operations.
@@ -718,17 +758,11 @@ async function withCompositeWindowLock<T>(
   operation: () => Promise<T>,
 ): Promise<T> {
   const result = compositeWindowOperationQueue.then(operation, operation)
-  compositeWindowOperationPending = true
   const nextQueue = result.then(
     () => undefined,
     () => undefined,
   )
   compositeWindowOperationQueue = nextQueue
-  void nextQueue.finally(() => {
-    if (compositeWindowOperationQueue === nextQueue) {
-      compositeWindowOperationPending = false
-    }
-  })
   return await result
 }
 
@@ -785,14 +819,58 @@ async function removeCompositeTabLocked(windowId: number, tabId: number) {
  */
 async function removeTempWindowHandle(handle: TempWindowHandle) {
   switch (handle.kind) {
-    case "window":
+    case TEMP_CONTEXT_MODES.Window:
       await removeWindow(handle.windowId)
       return
-    case "composite":
+    case TEMP_CONTEXT_MODES.Composite:
       await removeCompositeTab(handle.windowId, handle.tabId)
       return
-    case "tab":
+    case TEMP_CONTEXT_MODES.Tab:
       await removeTab(handle.tabId)
+  }
+}
+
+/**
+ * Builds the browser-removal handle for an already registered temp context.
+ */
+function getTempContextHandle(context: TempContext): TempWindowHandle {
+  switch (context.mode) {
+    case TEMP_CONTEXT_MODES.Window:
+      return {
+        kind: TEMP_CONTEXT_MODES.Window,
+        windowId: context.ownerWindowId,
+      }
+    case TEMP_CONTEXT_MODES.Composite:
+      return {
+        kind: TEMP_CONTEXT_MODES.Composite,
+        windowId: context.ownerWindowId,
+        tabId: context.tabId,
+      }
+    case TEMP_CONTEXT_MODES.Tab:
+      return { kind: TEMP_CONTEXT_MODES.Tab, tabId: context.tabId }
+  }
+}
+
+/**
+ * Builds the browser-removal handle for a partially opened temp context.
+ */
+function getTempContextOpenResultHandle(
+  opened: TempContextOpenResult,
+): TempWindowHandle {
+  switch (opened.mode) {
+    case TEMP_CONTEXT_MODES.Window:
+      return {
+        kind: TEMP_CONTEXT_MODES.Window,
+        windowId: opened.ownerWindowId,
+      }
+    case TEMP_CONTEXT_MODES.Composite:
+      return {
+        kind: TEMP_CONTEXT_MODES.Composite,
+        windowId: opened.ownerWindowId,
+        tabId: opened.tabId,
+      }
+    case TEMP_CONTEXT_MODES.Tab:
+      return { kind: TEMP_CONTEXT_MODES.Tab, tabId: opened.tabId }
   }
 }
 
@@ -889,8 +967,10 @@ function handleTempWindowRemoved(windowId: number) {
   let removedRequestId: string | undefined
   for (const [requestId, handle] of tempWindows.entries()) {
     const belongsToRemovedWindow =
-      (handle.kind === "window" && handle.windowId === windowId) ||
-      (handle.kind === "composite" && handle.windowId === windowId)
+      (handle.kind === TEMP_CONTEXT_MODES.Window &&
+        handle.windowId === windowId) ||
+      (handle.kind === TEMP_CONTEXT_MODES.Composite &&
+        handle.windowId === windowId)
 
     if (belongsToRemovedWindow) {
       tempWindows.delete(requestId)
@@ -904,7 +984,7 @@ function handleTempWindowRemoved(windowId: number) {
   })
 
   const context = tempContextById.get(windowId)
-  if (context && context.type === "window") {
+  if (context && context.type === TEMP_CONTEXT_TYPES.Window) {
     withOriginLock(context.origin, () =>
       destroyContext(context, {
         skipBrowserRemoval: true,
@@ -923,8 +1003,8 @@ function handleTempTabRemoved(tabId: number) {
   let removedRequestId: string | undefined
   for (const [requestId, handle] of tempWindows.entries()) {
     const belongsToRemovedTab =
-      (handle.kind === "tab" && handle.tabId === tabId) ||
-      (handle.kind === "composite" && handle.tabId === tabId)
+      (handle.kind === TEMP_CONTEXT_MODES.Tab && handle.tabId === tabId) ||
+      (handle.kind === TEMP_CONTEXT_MODES.Composite && handle.tabId === tabId)
 
     if (belongsToRemovedTab) {
       tempWindows.delete(requestId)
@@ -939,7 +1019,7 @@ function handleTempTabRemoved(tabId: number) {
   })
 
   const context = tempContextByTabId.get(tabId)
-  if (context && context.type === "tab") {
+  if (context && context.type === TEMP_CONTEXT_TYPES.Tab) {
     withOriginLock(context.origin, () =>
       destroyContext(context, {
         skipBrowserRemoval: true,
@@ -970,8 +1050,10 @@ export async function handleOpenTempWindow(
       preferredMode,
     })
 
-    const shouldUseWindow = preferredMode === "window" && hasWindowsAPI()
-    const shouldUseComposite = preferredMode === "composite" && hasWindowsAPI()
+    const shouldUseWindow =
+      preferredMode === TEMP_CONTEXT_MODES.Window && hasWindowsAPI()
+    const shouldUseComposite =
+      preferredMode === TEMP_CONTEXT_MODES.Composite && hasWindowsAPI()
 
     if (shouldUseComposite) {
       const { windowId, tabId } = await openTabInCompositeWindow({
@@ -981,7 +1063,11 @@ export async function handleOpenTempWindow(
         suppressMinimize: true,
       })
 
-      tempWindows.set(requestId, { kind: "composite", windowId, tabId })
+      tempWindows.set(requestId, {
+        kind: TEMP_CONTEXT_MODES.Composite,
+        windowId,
+        tabId,
+      })
       logTempWindow("openTempCompositeTabSuccess", {
         requestId,
         windowId,
@@ -1000,7 +1086,10 @@ export async function handleOpenTempWindow(
 
       if (window?.id) {
         // 记录窗口ID
-        tempWindows.set(requestId, { kind: "window", windowId: window.id })
+        tempWindows.set(requestId, {
+          kind: TEMP_CONTEXT_MODES.Window,
+          windowId: window.id,
+        })
         logTempWindow("openTempWindowSuccess", {
           requestId,
           windowId: window.id,
@@ -1021,7 +1110,10 @@ export async function handleOpenTempWindow(
       // 使用标签页
       const tab = await createTab(url, false)
       if (tab?.id) {
-        tempWindows.set(requestId, { kind: "tab", tabId: tab.id })
+        tempWindows.set(requestId, {
+          kind: TEMP_CONTEXT_MODES.Tab,
+          tabId: tab.id,
+        })
         logTempWindow("openTempTabSuccess", {
           requestId,
           tabId: tab.id,
@@ -2082,18 +2174,18 @@ function resolveTempContextOpenMode(params: {
   incognito?: boolean
 }): TempContextOpenMode {
   if (params.incognito) {
-    return "window"
+    return TEMP_CONTEXT_MODES.Window
   }
 
-  if (params.preferredMode === "window") {
-    return "window"
+  if (params.preferredMode === TEMP_CONTEXT_MODES.Window) {
+    return TEMP_CONTEXT_MODES.Window
   }
 
-  if (params.preferredMode === "composite") {
-    return "composite"
+  if (params.preferredMode === TEMP_CONTEXT_MODES.Composite) {
+    return TEMP_CONTEXT_MODES.Composite
   }
 
-  return "tab"
+  return TEMP_CONTEXT_MODES.Tab
 }
 
 /**
@@ -2129,8 +2221,8 @@ async function openPlainTabTempContext(
   return {
     id: tab.id,
     tabId: tab.id,
-    type: "tab",
-    mode: "tab",
+    type: TEMP_CONTEXT_TYPES.Tab,
+    mode: TEMP_CONTEXT_MODES.Tab,
   }
 }
 
@@ -2216,8 +2308,8 @@ async function openPopupWindowTempContext(params: {
     return {
       id: windowId,
       tabId,
-      type: "window",
-      mode: "window",
+      type: TEMP_CONTEXT_TYPES.Window,
+      mode: TEMP_CONTEXT_MODES.Window,
       ownerWindowId: windowId,
     }
   } catch (error) {
@@ -2249,12 +2341,12 @@ async function openFallbackAwareTempContext(params: {
   suppressMinimize?: boolean
   incognito?: boolean
 }): Promise<TempContextOpenResult> {
-  if (params.requestedMode === "tab") {
+  if (params.requestedMode === TEMP_CONTEXT_MODES.Tab) {
     return await openPlainTabTempContext()
   }
 
   try {
-    if (params.requestedMode === "composite") {
+    if (params.requestedMode === TEMP_CONTEXT_MODES.Composite) {
       const opened = await openTabInCompositeWindow({
         origin: params.origin,
         requestId: params.requestId,
@@ -2264,8 +2356,8 @@ async function openFallbackAwareTempContext(params: {
       return {
         id: opened.tabId,
         tabId: opened.tabId,
-        type: "tab",
-        mode: "composite",
+        type: TEMP_CONTEXT_TYPES.Tab,
+        mode: TEMP_CONTEXT_MODES.Composite,
         ownerWindowId: opened.windowId,
       }
     }
@@ -2318,14 +2410,10 @@ async function createTempContextInstance(
   preferredMode: TempWindowFallbackPreferences["tempContextMode"] = DEFAULT_TEMP_CONTEXT_MODE,
   suppressMinimize = false,
   options: { incognito?: boolean } = {},
-) {
-  let contextId: number | undefined
-  let tabId: number | undefined
+): Promise<TempContext> {
+  let opened: TempContextOpenResult | undefined
   let downloadBlockRuleId: number | null = null
   let firefoxDownloadBlockTabId: number | null = null
-  let type: "window" | "tab" = "window"
-  let mode: TempContextOpenMode = "window"
-  let ownerWindowId: number | undefined
   const useIncognito = Boolean(options.incognito)
   const requestedMode = resolveTempContextOpenMode({
     preferredMode,
@@ -2333,10 +2421,11 @@ async function createTempContextInstance(
   })
   // Incognito/private temp contexts must stay window-backed so storage/session
   // isolation does not silently collapse back into the regular profile.
-  const allowWindowRollback = !useIncognito && requestedMode !== "tab"
+  const allowWindowRollback =
+    !useIncognito && requestedMode !== TEMP_CONTEXT_MODES.Tab
 
   try {
-    const opened = await openFallbackAwareTempContext({
+    opened = await openFallbackAwareTempContext({
       url,
       origin,
       requestId,
@@ -2345,32 +2434,26 @@ async function createTempContextInstance(
       suppressMinimize,
       incognito: useIncognito,
     })
-
-    contextId = opened.id
-    tabId = opened.tabId
-    type = opened.type
-    mode = opened.mode
-    ownerWindowId = opened.ownerWindowId
     ;[downloadBlockRuleId, firefoxDownloadBlockTabId] = await Promise.all([
-      applyTempWindowDownloadBlockRule(tabId),
-      applyFirefoxTempWindowDownloadBlockRule(tabId),
+      applyTempWindowDownloadBlockRule(opened.tabId),
+      applyFirefoxTempWindowDownloadBlockRule(opened.tabId),
     ])
     if (downloadBlockRuleId == null && firefoxDownloadBlockTabId == null) {
       logger.warn(
         "No temp-window download block rule could be installed before navigation",
-        { requestId, origin, tabId },
+        { requestId, origin, tabId: opened.tabId },
       )
     }
-    await updateTab(tabId, { url })
+    await updateTab(opened.tabId, { url })
 
     logTempWindow("createTempContextInstance", {
       requestId,
       origin,
-      contextId,
-      tabId,
-      type,
-      mode,
-      ownerWindowId: ownerWindowId ?? null,
+      contextId: opened.id,
+      tabId: opened.tabId,
+      type: opened.type,
+      mode: opened.mode,
+      ownerWindowId: opened.ownerWindowId ?? null,
       downloadBlockRuleInstalled: downloadBlockRuleId != null,
       firefoxDownloadBlockRuleInstalled: firefoxDownloadBlockTabId != null,
       preferredMode,
@@ -2379,30 +2462,26 @@ async function createTempContextInstance(
     })
 
     // Best-effort: annotate the temporary window/tab so users understand why it opened.
-    void showShieldBypassUiInTab({ tabId, origin, requestId })
+    void showShieldBypassUiInTab({ tabId: opened.tabId, origin, requestId })
 
-    await waitForTabComplete(tabId, { requestId, origin })
-    const readyTab = await getTempContextTabSnapshot(tabId)
+    await waitForTabComplete(opened.tabId, { requestId, origin })
+    const readyTab = await getTempContextTabSnapshot(opened.tabId)
 
     logTempWindow("createTempContextInstanceReady", {
       requestId,
       origin,
-      contextId,
-      tabId,
-      type,
-      mode,
-      ownerWindowId: ownerWindowId ?? null,
+      contextId: opened.id,
+      tabId: opened.tabId,
+      type: opened.type,
+      mode: opened.mode,
+      ownerWindowId: opened.ownerWindowId ?? null,
       preferredMode,
       requestedMode,
     })
 
     return {
-      id: contextId,
-      tabId,
+      ...opened,
       origin,
-      type,
-      mode,
-      ...(ownerWindowId != null ? { ownerWindowId } : {}),
       currentUrl: readyTab?.url ?? url,
       activeRequestIds: new Set<string>(),
       lastUsed: Date.now(),
@@ -2415,24 +2494,18 @@ async function createTempContextInstance(
     logTempWindow("createTempContextInstanceError", {
       requestId,
       origin,
-      contextId: contextId ?? null,
-      tabId: tabId ?? null,
-      type,
-      mode,
-      ownerWindowId: ownerWindowId ?? null,
+      contextId: opened?.id ?? null,
+      tabId: opened?.tabId ?? null,
+      type: opened?.type ?? TEMP_CONTEXT_TYPES.Window,
+      mode: opened?.mode ?? TEMP_CONTEXT_MODES.Window,
+      ownerWindowId: opened?.ownerWindowId ?? null,
       error: getErrorMessage(error),
       preferredMode,
       requestedMode,
     })
-    if (contextId) {
+    if (opened) {
       try {
-        await removeTempWindowHandle(
-          mode === "composite" && ownerWindowId != null && tabId != null
-            ? { kind: "composite", windowId: ownerWindowId, tabId }
-            : type === "window"
-              ? { kind: "window", windowId: contextId }
-              : { kind: "tab", tabId: contextId },
-        )
+        await removeTempWindowHandle(getTempContextOpenResultHandle(opened))
       } catch (cleanupError) {
         logger.warn(
           "Failed to cleanup temp context after creation error",
@@ -2498,24 +2571,20 @@ async function openTabInCompositeWindow(params: {
   requestId: string
   suppressMinimize?: boolean
 }): Promise<{ windowId: number; tabId: number }> {
-  const wasQueuedBehindCompositeOperation = compositeWindowOperationPending
   return await withCompositeWindowLock(() =>
-    openTabInCompositeWindowLocked(params, wasQueuedBehindCompositeOperation),
+    openTabInCompositeWindowLocked(params),
   )
 }
 
 /**
  * Open a composite temp tab after the composite operation lock is held.
  */
-async function openTabInCompositeWindowLocked(
-  params: {
-    initialUrl?: string
-    origin: string
-    requestId: string
-    suppressMinimize?: boolean
-  },
-  wasQueuedBehindCompositeOperation: boolean,
-): Promise<CompositeWindowCreationResult> {
+async function openTabInCompositeWindowLocked(params: {
+  initialUrl?: string
+  origin: string
+  requestId: string
+  suppressMinimize?: boolean
+}): Promise<CompositeWindowCreationResult> {
   const initialUrl = params.initialUrl ?? TEMP_CONTEXT_INITIAL_URL
   if (!hasWindowsAPI()) {
     throw createRecoverableWindowCreationError(
@@ -2559,18 +2628,7 @@ async function openTabInCompositeWindowLocked(
       })
 
       if (existingCompositeWindowConfirmed) {
-        if (wasQueuedBehindCompositeOperation) {
-          throw error
-        }
-
-        try {
-          await removeWindow(previousCompositeWindowId)
-        } catch (cleanupError) {
-          logger.warn(
-            "Failed to cleanup stale composite temp window after reuse error",
-            cleanupError,
-          )
-        }
+        throw error
       }
 
       compositeWindowId = null
@@ -2729,7 +2787,7 @@ function scheduleContextCleanup(context: TempContext) {
   clearContextReleaseTimer(context)
 
   const idleTimeoutMs =
-    context.type === "window"
+    context.type === TEMP_CONTEXT_TYPES.Window
       ? QUIET_WINDOW_IDLE_TIMEOUT
       : TEMP_CONTEXT_IDLE_TIMEOUT
 
@@ -2827,17 +2885,7 @@ async function destroyContext(
 
   if (!options.skipBrowserRemoval) {
     try {
-      await removeTempWindowHandle(
-        context.mode === "composite" && context.ownerWindowId != null
-          ? {
-              kind: "composite",
-              windowId: context.ownerWindowId,
-              tabId: context.tabId,
-            }
-          : context.type === "window"
-            ? { kind: "window", windowId: context.id }
-            : { kind: "tab", tabId: context.tabId },
-      )
+      await removeTempWindowHandle(getTempContextHandle(context))
     } catch (error) {
       logger.warn("Failed to remove temp context", error)
     }

--- a/src/entrypoints/background/tempWindowPool.ts
+++ b/src/entrypoints/background/tempWindowPool.ts
@@ -102,8 +102,8 @@ const TEMP_CONTEXT_IDLE_TIMEOUT = 5000
 const TEMP_CONTEXT_INITIAL_URL = "about:blank"
 const QUIET_WINDOW_IDLE_TIMEOUT = 3000
 const TEMP_CONTEXT_TYPES = {
-  Window: "window",
-  Tab: "tab",
+  Window: TEMP_CONTEXT_MODES.Window,
+  Tab: TEMP_CONTEXT_MODES.Tab,
 } as const
 const DEFAULT_TEMP_CONTEXT_MODE: TempWindowFallbackPreferences["tempContextMode"] =
   TEMP_CONTEXT_MODES.Composite
@@ -832,47 +832,28 @@ async function removeTempWindowHandle(handle: TempWindowHandle) {
   }
 }
 
-/**
- * Builds the browser-removal handle for an already registered temp context.
- */
-function getTempContextHandle(context: TempContext): TempWindowHandle {
-  switch (context.mode) {
-    case TEMP_CONTEXT_MODES.Window:
-      return {
-        kind: TEMP_CONTEXT_MODES.Window,
-        windowId: context.ownerWindowId,
-      }
-    case TEMP_CONTEXT_MODES.Composite:
-      return {
-        kind: TEMP_CONTEXT_MODES.Composite,
-        windowId: context.ownerWindowId,
-        tabId: context.tabId,
-      }
-    case TEMP_CONTEXT_MODES.Tab:
-      return { kind: TEMP_CONTEXT_MODES.Tab, tabId: context.tabId }
-  }
-}
+type TempContextHandleSource = TempContext | TempContextOpenResult
 
 /**
- * Builds the browser-removal handle for a partially opened temp context.
+ * Builds the browser-removal handle for a registered or partially opened temp context.
  */
-function getTempContextOpenResultHandle(
-  opened: TempContextOpenResult,
+function getTempContextHandle(
+  source: TempContextHandleSource,
 ): TempWindowHandle {
-  switch (opened.mode) {
+  switch (source.mode) {
     case TEMP_CONTEXT_MODES.Window:
       return {
         kind: TEMP_CONTEXT_MODES.Window,
-        windowId: opened.ownerWindowId,
+        windowId: source.ownerWindowId,
       }
     case TEMP_CONTEXT_MODES.Composite:
       return {
         kind: TEMP_CONTEXT_MODES.Composite,
-        windowId: opened.ownerWindowId,
-        tabId: opened.tabId,
+        windowId: source.ownerWindowId,
+        tabId: source.tabId,
       }
     case TEMP_CONTEXT_MODES.Tab:
-      return { kind: TEMP_CONTEXT_MODES.Tab, tabId: opened.tabId }
+      return { kind: TEMP_CONTEXT_MODES.Tab, tabId: source.tabId }
   }
 }
 
@@ -2507,7 +2488,7 @@ async function createTempContextInstance(
     })
     if (opened) {
       try {
-        await removeTempWindowHandle(getTempContextOpenResultHandle(opened))
+        await removeTempWindowHandle(getTempContextHandle(opened))
       } catch (cleanupError) {
         logger.warn(
           "Failed to cleanup temp context after creation error",

--- a/src/entrypoints/background/tempWindowPool.ts
+++ b/src/entrypoints/background/tempWindowPool.ts
@@ -1,5 +1,9 @@
 import { RuntimeActionIds } from "~/constants/runtimeActions"
 import { isAccountSiteType, type AccountSiteType } from "~/constants/siteType"
+import {
+  TEMP_CONTEXT_MODES,
+  type TempContextMode,
+} from "~/constants/tempContextMode"
 import { TURNSTILE_DEFAULT_QUERY_PARAM_NAME } from "~/constants/turnstile"
 import { normalizeAccountIdentity } from "~/services/accounts/accountIdentity"
 import { accountStorage } from "~/services/accounts/accountStorage"
@@ -9,10 +13,8 @@ import {
 } from "~/services/apiTransport/errors"
 import {
   DEFAULT_PREFERENCES,
-  TEMP_CONTEXT_MODES,
   TempWindowFallbackPreferences,
   userPreferences,
-  type TempContextMode,
 } from "~/services/preferences/userPreferences"
 import { trackProductAnalyticsActionCompleted } from "~/services/productAnalytics/actions"
 import {

--- a/src/entrypoints/background/tempWindowPool.ts
+++ b/src/entrypoints/background/tempWindowPool.ts
@@ -2639,14 +2639,10 @@ async function openTabInCompositeWindowLocked(params: {
       throw error
     }
 
-    const missingWindowReason = classifyWindowCreationFailure({
-      missingHandle: !compositeWindow?.id,
-    })
     const compositeWindowHandle = compositeWindow?.id
-    if (missingWindowReason || compositeWindowHandle == null) {
+    if (compositeWindowHandle == null) {
       throw createRecoverableWindowCreationError(
-        missingWindowReason ??
-          WINDOW_CREATION_FAILURE_REASONS.WINDOW_HANDLE_UNAVAILABLE,
+        WINDOW_CREATION_FAILURE_REASONS.WINDOW_HANDLE_UNAVAILABLE,
       )
     }
 
@@ -2677,13 +2673,9 @@ async function openTabInCompositeWindowLocked(params: {
     })
     const tabId = tabs[0]?.id
 
-    const missingTabReason = classifyWindowCreationFailure({
-      missingHandle: !tabId,
-    })
-    if (missingTabReason || tabId == null) {
+    if (tabId == null) {
       throw createRecoverableWindowCreationError(
-        missingTabReason ??
-          WINDOW_CREATION_FAILURE_REASONS.WINDOW_HANDLE_UNAVAILABLE,
+        WINDOW_CREATION_FAILURE_REASONS.WINDOW_HANDLE_UNAVAILABLE,
       )
     }
 

--- a/src/entrypoints/background/tempWindowPool.ts
+++ b/src/entrypoints/background/tempWindowPool.ts
@@ -54,7 +54,8 @@ import {
   onTabRemoved,
   onWindowRemoved,
   queryTabs,
-  removeTabOrWindow,
+  removeTab,
+  removeWindow,
   sendTabMessageWithRetry,
   updateTab,
   updateWindow,
@@ -430,6 +431,8 @@ type TempContext = {
   tabId: number
   origin: string
   type: "window" | "tab"
+  mode: TempContextOpenMode
+  ownerWindowId?: number
   currentUrl?: string
   activeRequestIds: Set<string>
   lastUsed: number
@@ -440,10 +443,17 @@ type TempContext = {
 
 type TempContextOpenMode = "window" | "composite" | "tab"
 
+type TempWindowHandle =
+  | { kind: "window"; windowId: number }
+  | { kind: "tab"; tabId: number }
+  | { kind: "composite"; tabId: number; windowId: number }
+
 type TempContextOpenResult = {
   id: number
   tabId: number
   type: "window" | "tab"
+  mode: TempContextOpenMode
+  ownerWindowId?: number
 }
 
 type RecoverableWindowCreationError = Error & {
@@ -685,7 +695,7 @@ function trackTempWindowFetchCompleted(input: {
 }
 
 // 手动打开的临时窗口/标签页
-const tempWindows = new Map<string, number>()
+const tempWindows = new Map<string, TempWindowHandle>()
 
 const tempRequestContextMap = new Map<string, TempContext>()
 const tempContextById = new Map<number, TempContext>()
@@ -698,8 +708,93 @@ const destroyingOrigins = new Set<string>()
 type CompositeWindowCreationResult = { windowId: number; tabId: number }
 
 let compositeWindowId: number | null = null
-let compositeWindowCreatePromise: Promise<CompositeWindowCreationResult> | null =
-  null
+let compositeWindowOperationQueue: Promise<void> = Promise.resolve()
+let compositeWindowOperationPending = false
+
+/**
+ * Serialize composite temp-window open and close operations.
+ */
+async function withCompositeWindowLock<T>(
+  operation: () => Promise<T>,
+): Promise<T> {
+  const result = compositeWindowOperationQueue.then(operation, operation)
+  compositeWindowOperationPending = true
+  const nextQueue = result.then(
+    () => undefined,
+    () => undefined,
+  )
+  compositeWindowOperationQueue = nextQueue
+  void nextQueue.finally(() => {
+    if (compositeWindowOperationQueue === nextQueue) {
+      compositeWindowOperationPending = false
+    }
+  })
+  return await result
+}
+
+/**
+ * Remove a composite tab while closing the shared owner window when it is the
+ * final remaining tab.
+ */
+async function removeCompositeTab(windowId: number, tabId: number) {
+  await withCompositeWindowLock(() => removeCompositeTabLocked(windowId, tabId))
+}
+
+/**
+ * Remove a composite tab after the composite operation lock is held.
+ */
+async function removeCompositeTabLocked(windowId: number, tabId: number) {
+  let tabs: browser.tabs.Tab[]
+
+  try {
+    tabs = await queryTabs({ windowId })
+  } catch (error) {
+    logger.warn("Failed to inspect composite temp window; removing tab only", {
+      windowId,
+      tabId,
+      error,
+    })
+    await removeTab(tabId)
+    return
+  }
+
+  const isOnlyTab = tabs.length === 1 && tabs[0]?.id === tabId
+  if (!isOnlyTab) {
+    await removeTab(tabId)
+    return
+  }
+
+  if (compositeWindowId === windowId) {
+    compositeWindowId = null
+  }
+
+  try {
+    await removeWindow(windowId)
+  } catch (error) {
+    logger.warn(
+      "Failed to remove final composite temp window; falling back to tab",
+      { windowId, tabId, error },
+    )
+    await removeTab(tabId)
+  }
+}
+
+/**
+ * Remove a known temp-window handle through the typed browser adapter that
+ * matches the handle owner.
+ */
+async function removeTempWindowHandle(handle: TempWindowHandle) {
+  switch (handle.kind) {
+    case "window":
+      await removeWindow(handle.windowId)
+      return
+    case "composite":
+      await removeCompositeTab(handle.windowId, handle.tabId)
+      return
+    case "tab":
+      await removeTab(handle.tabId)
+  }
+}
 
 /**
  * 设置临时窗口/标签页相关的浏览器事件监听器。
@@ -792,11 +887,14 @@ function handleTempWindowRemoved(windowId: number) {
   }
 
   let removedRequestId: string | undefined
-  for (const [requestId, storedId] of tempWindows.entries()) {
-    if (storedId === windowId) {
+  for (const [requestId, handle] of tempWindows.entries()) {
+    const belongsToRemovedWindow =
+      (handle.kind === "window" && handle.windowId === windowId) ||
+      (handle.kind === "composite" && handle.windowId === windowId)
+
+    if (belongsToRemovedWindow) {
       tempWindows.delete(requestId)
-      removedRequestId = requestId
-      break
+      removedRequestId ??= requestId
     }
   }
 
@@ -823,8 +921,12 @@ function handleTempWindowRemoved(windowId: number) {
  */
 function handleTempTabRemoved(tabId: number) {
   let removedRequestId: string | undefined
-  for (const [requestId, storedId] of tempWindows.entries()) {
-    if (storedId === tabId) {
+  for (const [requestId, handle] of tempWindows.entries()) {
+    const belongsToRemovedTab =
+      (handle.kind === "tab" && handle.tabId === tabId) ||
+      (handle.kind === "composite" && handle.tabId === tabId)
+
+    if (belongsToRemovedTab) {
       tempWindows.delete(requestId)
       removedRequestId = requestId
       break
@@ -879,7 +981,7 @@ export async function handleOpenTempWindow(
         suppressMinimize: true,
       })
 
-      tempWindows.set(requestId, tabId)
+      tempWindows.set(requestId, { kind: "composite", windowId, tabId })
       logTempWindow("openTempCompositeTabSuccess", {
         requestId,
         windowId,
@@ -898,7 +1000,7 @@ export async function handleOpenTempWindow(
 
       if (window?.id) {
         // 记录窗口ID
-        tempWindows.set(requestId, window.id)
+        tempWindows.set(requestId, { kind: "window", windowId: window.id })
         logTempWindow("openTempWindowSuccess", {
           requestId,
           windowId: window.id,
@@ -919,7 +1021,7 @@ export async function handleOpenTempWindow(
       // 使用标签页
       const tab = await createTab(url, false)
       if (tab?.id) {
-        tempWindows.set(requestId, tab.id)
+        tempWindows.set(requestId, { kind: "tab", tabId: tab.id })
         logTempWindow("openTempTabSuccess", {
           requestId,
           tabId: tab.id,
@@ -956,22 +1058,22 @@ export async function handleCloseTempWindow(
 ) {
   try {
     const { requestId } = request
-    const id = tempWindows.get(requestId)
+    const handle = tempWindows.get(requestId)
 
     logTempWindow(RuntimeActionIds.CloseTempWindow, {
       requestId,
-      mappedId: id ?? null,
+      mappedHandle: handle ?? null,
       hasRequestContext: requestId
         ? tempRequestContextMap.has(requestId)
         : false,
     })
 
-    if (id) {
-      await removeTabOrWindow(id)
+    if (handle) {
+      await removeTempWindowHandle(handle)
       tempWindows.delete(requestId)
       logTempWindow("closeTempWindowSuccess", {
         requestId,
-        removedId: id,
+        removedHandle: handle,
       })
       sendResponse({ success: true })
       return
@@ -2028,6 +2130,7 @@ async function openPlainTabTempContext(
     id: tab.id,
     tabId: tab.id,
     type: "tab",
+    mode: "tab",
   }
 }
 
@@ -2114,11 +2217,13 @@ async function openPopupWindowTempContext(params: {
       id: windowId,
       tabId,
       type: "window",
+      mode: "window",
+      ownerWindowId: windowId,
     }
   } catch (error) {
     if (windowId != null) {
       try {
-        await removeTabOrWindow(windowId)
+        await removeWindow(windowId)
       } catch (cleanupError) {
         logger.warn(
           "Failed to cleanup temp context after popup creation error",
@@ -2160,6 +2265,8 @@ async function openFallbackAwareTempContext(params: {
         id: opened.tabId,
         tabId: opened.tabId,
         type: "tab",
+        mode: "composite",
+        ownerWindowId: opened.windowId,
       }
     }
 
@@ -2217,6 +2324,8 @@ async function createTempContextInstance(
   let downloadBlockRuleId: number | null = null
   let firefoxDownloadBlockTabId: number | null = null
   let type: "window" | "tab" = "window"
+  let mode: TempContextOpenMode = "window"
+  let ownerWindowId: number | undefined
   const useIncognito = Boolean(options.incognito)
   const requestedMode = resolveTempContextOpenMode({
     preferredMode,
@@ -2240,6 +2349,8 @@ async function createTempContextInstance(
     contextId = opened.id
     tabId = opened.tabId
     type = opened.type
+    mode = opened.mode
+    ownerWindowId = opened.ownerWindowId
     ;[downloadBlockRuleId, firefoxDownloadBlockTabId] = await Promise.all([
       applyTempWindowDownloadBlockRule(tabId),
       applyFirefoxTempWindowDownloadBlockRule(tabId),
@@ -2258,6 +2369,8 @@ async function createTempContextInstance(
       contextId,
       tabId,
       type,
+      mode,
+      ownerWindowId: ownerWindowId ?? null,
       downloadBlockRuleInstalled: downloadBlockRuleId != null,
       firefoxDownloadBlockRuleInstalled: firefoxDownloadBlockTabId != null,
       preferredMode,
@@ -2277,6 +2390,8 @@ async function createTempContextInstance(
       contextId,
       tabId,
       type,
+      mode,
+      ownerWindowId: ownerWindowId ?? null,
       preferredMode,
       requestedMode,
     })
@@ -2286,6 +2401,8 @@ async function createTempContextInstance(
       tabId,
       origin,
       type,
+      mode,
+      ...(ownerWindowId != null ? { ownerWindowId } : {}),
       currentUrl: readyTab?.url ?? url,
       activeRequestIds: new Set<string>(),
       lastUsed: Date.now(),
@@ -2301,13 +2418,21 @@ async function createTempContextInstance(
       contextId: contextId ?? null,
       tabId: tabId ?? null,
       type,
+      mode,
+      ownerWindowId: ownerWindowId ?? null,
       error: getErrorMessage(error),
       preferredMode,
       requestedMode,
     })
     if (contextId) {
       try {
-        await removeTabOrWindow(contextId)
+        await removeTempWindowHandle(
+          mode === "composite" && ownerWindowId != null && tabId != null
+            ? { kind: "composite", windowId: ownerWindowId, tabId }
+            : type === "window"
+              ? { kind: "window", windowId: contextId }
+              : { kind: "tab", tabId: contextId },
+        )
       } catch (cleanupError) {
         logger.warn(
           "Failed to cleanup temp context after creation error",
@@ -2373,6 +2498,24 @@ async function openTabInCompositeWindow(params: {
   requestId: string
   suppressMinimize?: boolean
 }): Promise<{ windowId: number; tabId: number }> {
+  const wasQueuedBehindCompositeOperation = compositeWindowOperationPending
+  return await withCompositeWindowLock(() =>
+    openTabInCompositeWindowLocked(params, wasQueuedBehindCompositeOperation),
+  )
+}
+
+/**
+ * Open a composite temp tab after the composite operation lock is held.
+ */
+async function openTabInCompositeWindowLocked(
+  params: {
+    initialUrl?: string
+    origin: string
+    requestId: string
+    suppressMinimize?: boolean
+  },
+  wasQueuedBehindCompositeOperation: boolean,
+): Promise<CompositeWindowCreationResult> {
   const initialUrl = params.initialUrl ?? TEMP_CONTEXT_INITIAL_URL
   if (!hasWindowsAPI()) {
     throw createRecoverableWindowCreationError(
@@ -2416,8 +2559,12 @@ async function openTabInCompositeWindow(params: {
       })
 
       if (existingCompositeWindowConfirmed) {
+        if (wasQueuedBehindCompositeOperation) {
+          throw error
+        }
+
         try {
-          await removeTabOrWindow(previousCompositeWindowId)
+          await removeWindow(previousCompositeWindowId)
         } catch (cleanupError) {
           logger.warn(
             "Failed to cleanup stale composite temp window after reuse error",
@@ -2430,10 +2577,65 @@ async function openTabInCompositeWindow(params: {
     }
   }
 
-  if (compositeWindowCreatePromise) {
-    const { windowId } = await compositeWindowCreatePromise
-    const tab = await createTab(initialUrl, false, { windowId })
-    const tabId = tab?.id
+  let windowId: number | null = null
+
+  try {
+    let compositeWindow: browser.windows.Window | null = null
+
+    try {
+      compositeWindow = await createWindow({
+        url: initialUrl,
+        type: "normal",
+        width: 420,
+        height: 520,
+        focused: false,
+      })
+    } catch (error) {
+      const reason = classifyWindowCreationFailure({ error })
+      if (reason) {
+        throw createRecoverableWindowCreationError(reason, error)
+      }
+      throw error
+    }
+
+    const missingWindowReason = classifyWindowCreationFailure({
+      missingHandle: !compositeWindow?.id,
+    })
+    const compositeWindowHandle = compositeWindow?.id
+    if (missingWindowReason || compositeWindowHandle == null) {
+      throw createRecoverableWindowCreationError(
+        missingWindowReason ??
+          WINDOW_CREATION_FAILURE_REASONS.WINDOW_HANDLE_UNAVAILABLE,
+      )
+    }
+
+    windowId = compositeWindowHandle
+    compositeWindowId = windowId
+
+    if (!params.suppressMinimize) {
+      try {
+        await updateWindow(windowId, { state: "minimized" })
+        logTempWindow("compositeWindowMinimized", {
+          requestId: params.requestId,
+          origin: params.origin,
+          windowId,
+        })
+      } catch (minErr) {
+        logTempWindow("compositeWindowMinimizeFailed", {
+          requestId: params.requestId,
+          origin: params.origin,
+          windowId,
+          error: getErrorMessage(minErr),
+        })
+      }
+    }
+
+    const tabs = await queryTabs({
+      windowId,
+      active: true,
+    })
+    const tabId = tabs[0]?.id
+
     const missingTabReason = classifyWindowCreationFailure({
       missingHandle: !tabId,
     })
@@ -2445,102 +2647,21 @@ async function openTabInCompositeWindow(params: {
     }
 
     return { windowId, tabId }
-  }
-
-  compositeWindowCreatePromise = (async () => {
-    let windowId: number | null = null
-
-    try {
-      let compositeWindow: browser.windows.Window | null = null
+  } catch (error) {
+    if (windowId != null) {
+      compositeWindowId = null
 
       try {
-        compositeWindow = await createWindow({
-          url: initialUrl,
-          type: "normal",
-          width: 420,
-          height: 520,
-          focused: false,
-        })
-      } catch (error) {
-        const reason = classifyWindowCreationFailure({ error })
-        if (reason) {
-          throw createRecoverableWindowCreationError(reason, error)
-        }
-        throw error
-      }
-
-      const missingWindowReason = classifyWindowCreationFailure({
-        missingHandle: !compositeWindow?.id,
-      })
-      const compositeWindowHandle = compositeWindow?.id
-      if (missingWindowReason || compositeWindowHandle == null) {
-        throw createRecoverableWindowCreationError(
-          missingWindowReason ??
-            WINDOW_CREATION_FAILURE_REASONS.WINDOW_HANDLE_UNAVAILABLE,
+        await removeWindow(windowId)
+      } catch (cleanupError) {
+        logger.warn(
+          "Failed to cleanup composite temp context after creation error",
+          cleanupError,
         )
       }
-
-      windowId = compositeWindowHandle
-      compositeWindowId = windowId
-
-      if (!params.suppressMinimize) {
-        try {
-          await updateWindow(windowId, { state: "minimized" })
-          logTempWindow("compositeWindowMinimized", {
-            requestId: params.requestId,
-            origin: params.origin,
-            windowId,
-          })
-        } catch (minErr) {
-          logTempWindow("compositeWindowMinimizeFailed", {
-            requestId: params.requestId,
-            origin: params.origin,
-            windowId,
-            error: getErrorMessage(minErr),
-          })
-        }
-      }
-
-      const tabs = await queryTabs({
-        windowId,
-        active: true,
-      })
-      const tabId = tabs[0]?.id
-
-      const missingTabReason = classifyWindowCreationFailure({
-        missingHandle: !tabId,
-      })
-      if (missingTabReason || tabId == null) {
-        throw createRecoverableWindowCreationError(
-          missingTabReason ??
-            WINDOW_CREATION_FAILURE_REASONS.WINDOW_HANDLE_UNAVAILABLE,
-        )
-      }
-
-      return { windowId, tabId }
-    } catch (error) {
-      if (windowId != null) {
-        compositeWindowId = null
-
-        try {
-          await removeTabOrWindow(windowId)
-        } catch (cleanupError) {
-          logger.warn(
-            "Failed to cleanup composite temp context after creation error",
-            cleanupError,
-          )
-        }
-      }
-
-      throw error
     }
-  })()
 
-  try {
-    const { windowId, tabId } = await compositeWindowCreatePromise
-    return { windowId, tabId }
-  } finally {
-    compositeWindowCreatePromise = null
+    throw error
   }
 }
 
@@ -2669,6 +2790,8 @@ async function destroyContext(
     contextId: context.id,
     tabId: context.tabId,
     type: context.type,
+    mode: context.mode,
+    ownerWindowId: context.ownerWindowId ?? null,
     skipBrowserRemoval: Boolean(options.skipBrowserRemoval),
     reason: options.reason ?? null,
   })
@@ -2704,7 +2827,17 @@ async function destroyContext(
 
   if (!options.skipBrowserRemoval) {
     try {
-      await removeTabOrWindow(context.id)
+      await removeTempWindowHandle(
+        context.mode === "composite" && context.ownerWindowId != null
+          ? {
+              kind: "composite",
+              windowId: context.ownerWindowId,
+              tabId: context.tabId,
+            }
+          : context.type === "window"
+            ? { kind: "window", windowId: context.id }
+            : { kind: "tab", tabId: context.tabId },
+      )
     } catch (error) {
       logger.warn("Failed to remove temp context", error)
     }

--- a/src/features/BasicSettings/components/tabs/Refresh/ShieldSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/Refresh/ShieldSettings.tsx
@@ -71,8 +71,7 @@ export default function ShieldSettings() {
   const shieldOptions = tempWindowFallback.useInOptions
   const shieldAutoRefresh = tempWindowFallback.useForAutoRefresh
   const shieldManualRefresh = tempWindowFallback.useForManualRefresh
-  const shieldTempContextMode =
-    tempWindowFallback.tempContextMode ?? TEMP_CONTEXT_MODES.Composite
+  const shieldTempContextMode = tempWindowFallback.tempContextMode
 
   const disableShieldUI = !canUseTempWindowFallback
   const shieldMethodHint =

--- a/src/features/BasicSettings/components/tabs/Refresh/ShieldSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/Refresh/ShieldSettings.tsx
@@ -19,8 +19,8 @@ import {
   Switch,
   WorkflowTransitionButton,
 } from "~/components/ui"
+import { TEMP_CONTEXT_MODES } from "~/constants/tempContextMode"
 import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
-import { TEMP_CONTEXT_MODES } from "~/services/preferences/userPreferences"
 import {
   getProtectionBypassUiVariant,
   isProtectionBypassFirefoxEnv,

--- a/src/features/BasicSettings/components/tabs/Refresh/ShieldSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/Refresh/ShieldSettings.tsx
@@ -20,6 +20,7 @@ import {
   WorkflowTransitionButton,
 } from "~/components/ui"
 import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
+import { TEMP_CONTEXT_MODES } from "~/services/preferences/userPreferences"
 import {
   getProtectionBypassUiVariant,
   isProtectionBypassFirefoxEnv,
@@ -71,13 +72,13 @@ export default function ShieldSettings() {
   const shieldAutoRefresh = tempWindowFallback.useForAutoRefresh
   const shieldManualRefresh = tempWindowFallback.useForManualRefresh
   const shieldTempContextMode =
-    tempWindowFallback.tempContextMode ?? "composite"
+    tempWindowFallback.tempContextMode ?? TEMP_CONTEXT_MODES.Composite
 
   const disableShieldUI = !canUseTempWindowFallback
   const shieldMethodHint =
-    shieldTempContextMode === "window"
+    shieldTempContextMode === TEMP_CONTEXT_MODES.Window
       ? t("refresh.shieldMethodHintWindow")
-      : shieldTempContextMode === "composite"
+      : shieldTempContextMode === TEMP_CONTEXT_MODES.Composite
         ? t("refresh.shieldMethodHintComposite")
         : t("refresh.shieldMethodHintTab")
 
@@ -145,7 +146,7 @@ export default function ShieldSettings() {
                   <Button
                     size="sm"
                     variant={
-                      shieldTempContextMode === "composite"
+                      shieldTempContextMode === TEMP_CONTEXT_MODES.Composite
                         ? "default"
                         : "outline"
                     }
@@ -155,7 +156,9 @@ export default function ShieldSettings() {
                       (isFirefoxEnv && !canUseTempWindowFallback)
                     }
                     onClick={() =>
-                      updateTempWindowFallback({ tempContextMode: "composite" })
+                      updateTempWindowFallback({
+                        tempContextMode: TEMP_CONTEXT_MODES.Composite,
+                      })
                     }
                     leftIcon={
                       <StarIcon className="h-4 w-4 text-amber-500 dark:text-amber-400" />
@@ -167,11 +170,15 @@ export default function ShieldSettings() {
                   <Button
                     size="sm"
                     variant={
-                      shieldTempContextMode === "tab" ? "default" : "outline"
+                      shieldTempContextMode === TEMP_CONTEXT_MODES.Tab
+                        ? "default"
+                        : "outline"
                     }
                     disabled={disableShieldUI || !shieldEnabled}
                     onClick={() =>
-                      updateTempWindowFallback({ tempContextMode: "tab" })
+                      updateTempWindowFallback({
+                        tempContextMode: TEMP_CONTEXT_MODES.Tab,
+                      })
                     }
                     className={responsiveButtonGroupItemClassName}
                   >
@@ -180,7 +187,9 @@ export default function ShieldSettings() {
                   <Button
                     size="sm"
                     variant={
-                      shieldTempContextMode === "window" ? "default" : "outline"
+                      shieldTempContextMode === TEMP_CONTEXT_MODES.Window
+                        ? "default"
+                        : "outline"
                     }
                     disabled={
                       disableShieldUI ||
@@ -188,7 +197,9 @@ export default function ShieldSettings() {
                       (isFirefoxEnv && !canUseTempWindowFallback)
                     }
                     onClick={() =>
-                      updateTempWindowFallback({ tempContextMode: "window" })
+                      updateTempWindowFallback({
+                        tempContextMode: TEMP_CONTEXT_MODES.Window,
+                      })
                     }
                     className={responsiveButtonGroupItemClassName}
                   >

--- a/src/services/preferences/userPreferences.ts
+++ b/src/services/preferences/userPreferences.ts
@@ -3,6 +3,10 @@ import { Storage } from "@plasmohq/storage"
 import { DATA_TYPE_BALANCE, DATA_TYPE_CASHFLOW } from "~/constants"
 import { SITE_TYPES, type ManagedSiteType } from "~/constants/siteType"
 import {
+  TEMP_CONTEXT_MODES,
+  type TempContextMode,
+} from "~/constants/tempContextMode"
+import {
   STORAGE_LOCKS,
   USER_PREFERENCES_STORAGE_KEYS,
 } from "~/services/core/storageKeys"
@@ -100,15 +104,6 @@ import { createLogger } from "~/utils/core/logger"
 import { normalizeAppLanguage } from "~/utils/i18n/language"
 
 const logger = createLogger("UserPreferences")
-
-export const TEMP_CONTEXT_MODES = {
-  Window: "window",
-  Composite: "composite",
-  Tab: "tab",
-} as const
-
-export type TempContextMode =
-  (typeof TEMP_CONTEXT_MODES)[keyof typeof TEMP_CONTEXT_MODES]
 
 export interface TempWindowFallbackPreferences {
   enabled: boolean

--- a/src/services/preferences/userPreferences.ts
+++ b/src/services/preferences/userPreferences.ts
@@ -101,6 +101,15 @@ import { normalizeAppLanguage } from "~/utils/i18n/language"
 
 const logger = createLogger("UserPreferences")
 
+export const TEMP_CONTEXT_MODES = {
+  Window: "window",
+  Composite: "composite",
+  Tab: "tab",
+} as const
+
+export type TempContextMode =
+  (typeof TEMP_CONTEXT_MODES)[keyof typeof TEMP_CONTEXT_MODES]
+
 export interface TempWindowFallbackPreferences {
   enabled: boolean
   useInPopup: boolean
@@ -114,7 +123,7 @@ export interface TempWindowFallbackPreferences {
    * - "window": Open a popup window
    * - "composite": Open temporary tabs inside a shared window
    */
-  tempContextMode: "tab" | "window" | "composite"
+  tempContextMode: TempContextMode
 }
 
 export interface TempWindowFallbackReminderPreferences {
@@ -623,7 +632,7 @@ export const DEFAULT_PREFERENCES: UserPreferences = {
     useInOptions: true,
     useForAutoRefresh: true,
     useForManualRefresh: true,
-    tempContextMode: "composite",
+    tempContextMode: TEMP_CONTEXT_MODES.Composite,
   },
   tempWindowFallbackReminder: {
     dismissed: false,

--- a/src/services/productAnalytics/settings.ts
+++ b/src/services/productAnalytics/settings.ts
@@ -1,8 +1,8 @@
 /* eslint-disable jsdoc/require-jsdoc */
 import { SITE_TYPES } from "~/constants/siteType"
+import { TEMP_CONTEXT_MODES } from "~/constants/tempContextMode"
 import {
   DEFAULT_PREFERENCES,
-  TEMP_CONTEXT_MODES,
   TOOLBAR_ACTION_CLICK_BEHAVIORS,
   type RedemptionAssistPreferences,
   type TempWindowFallbackPreferences,

--- a/src/services/productAnalytics/settings.ts
+++ b/src/services/productAnalytics/settings.ts
@@ -2,6 +2,7 @@
 import { SITE_TYPES } from "~/constants/siteType"
 import {
   DEFAULT_PREFERENCES,
+  TEMP_CONTEXT_MODES,
   TOOLBAR_ACTION_CLICK_BEHAVIORS,
   type RedemptionAssistPreferences,
   type TempWindowFallbackPreferences,
@@ -99,8 +100,12 @@ function getUsageHistoryScheduleMode(mode: string | undefined) {
 function getTempWindowMode(
   mode: TempWindowFallbackPreferences["tempContextMode"] | undefined,
 ): ProductAnalyticsModeId {
-  if (mode === "window") return PRODUCT_ANALYTICS_MODE_IDS.TempWindowModeWindow
-  if (mode === "tab") return PRODUCT_ANALYTICS_MODE_IDS.TempWindowModeTab
+  if (mode === TEMP_CONTEXT_MODES.Window) {
+    return PRODUCT_ANALYTICS_MODE_IDS.TempWindowModeWindow
+  }
+  if (mode === TEMP_CONTEXT_MODES.Tab) {
+    return PRODUCT_ANALYTICS_MODE_IDS.TempWindowModeTab
+  }
   return PRODUCT_ANALYTICS_MODE_IDS.TempWindowModeComposite
 }
 

--- a/src/services/productAnalytics/settings.ts
+++ b/src/services/productAnalytics/settings.ts
@@ -98,7 +98,7 @@ function getUsageHistoryScheduleMode(mode: string | undefined) {
 }
 
 function getTempWindowMode(
-  mode: TempWindowFallbackPreferences["tempContextMode"] | undefined,
+  mode: TempWindowFallbackPreferences["tempContextMode"],
 ): ProductAnalyticsModeId {
   if (mode === TEMP_CONTEXT_MODES.Window) {
     return PRODUCT_ANALYTICS_MODE_IDS.TempWindowModeWindow

--- a/src/utils/browser/browserApi.ts
+++ b/src/utils/browser/browserApi.ts
@@ -147,29 +147,40 @@ export async function queryTabs(
 }
 
 /**
- * 移除标签页或窗口
- * 自动检测平台能力并选择合适的 API
- * @param id 目标窗口或标签页的 ID。
+ * Removes a known browser tab without probing other removal APIs.
+ */
+export async function removeTab(tabId: number): Promise<void> {
+  await browser.tabs.remove(tabId)
+}
+
+/**
+ * Removes a known browser window when the windows API is available.
+ */
+export async function removeWindow(windowId: number): Promise<void> {
+  if (!hasWindowsAPI()) {
+    throw new Error("browser.windows.remove is unavailable")
+  }
+
+  await browser.windows.remove(windowId)
+}
+
+/**
+ * Removes an id that may refer to a window first, then falls back to tab removal.
  */
 export async function removeTabOrWindow(id: number): Promise<void> {
   if (hasWindowsAPI()) {
     try {
-      await browser.windows.remove(id)
+      await removeWindow(id)
       return
     } catch (error) {
-      // 如果不是窗口 ID，尝试作为标签页 ID
-      logger.debug(
-        "removeTabOrWindow: Failed to remove as window, trying as tab",
-        {
-          id,
-          error,
-        },
+      logger.warn(
+        "removeTabOrWindow: Failed to remove as window, falling back to tab",
+        { id, error },
       )
     }
   }
 
-  // Firefox Android 或窗口 API 失败：使用标签页 API
-  await browser.tabs.remove(id)
+  await removeTab(id)
 }
 
 /**

--- a/tests/entrypoints/background/tempWindowPoolNativeCheckin.test.ts
+++ b/tests/entrypoints/background/tempWindowPoolNativeCheckin.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { RuntimeActionIds } from "~/constants/runtimeActions"
 import { SITE_TYPES } from "~/constants/siteType"
+import { TEMP_CONTEXT_MODES } from "~/services/preferences/userPreferences"
 import { AuthTypeEnum } from "~/types"
 
 const originalBrowser = (globalThis as any).browser
@@ -116,13 +117,14 @@ describe("tempWindowPool native check-in page action", () => {
     vi.doMock("~/services/preferences/userPreferences", () => ({
       DEFAULT_PREFERENCES: {
         tempWindowFallback: {
-          tempContextMode: "tab",
+          tempContextMode: TEMP_CONTEXT_MODES.Tab,
         },
       },
+      TEMP_CONTEXT_MODES,
       userPreferences: {
         getPreferences: vi.fn().mockResolvedValue({
           tempWindowFallback: {
-            tempContextMode: "tab",
+            tempContextMode: TEMP_CONTEXT_MODES.Tab,
           },
         }),
       },

--- a/tests/entrypoints/background/tempWindowPoolNativeCheckin.test.ts
+++ b/tests/entrypoints/background/tempWindowPoolNativeCheckin.test.ts
@@ -2,7 +2,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { RuntimeActionIds } from "~/constants/runtimeActions"
 import { SITE_TYPES } from "~/constants/siteType"
-import { TEMP_CONTEXT_MODES } from "~/services/preferences/userPreferences"
 import { AuthTypeEnum } from "~/types"
 
 const originalBrowser = (globalThis as any).browser
@@ -117,14 +116,13 @@ describe("tempWindowPool native check-in page action", () => {
     vi.doMock("~/services/preferences/userPreferences", () => ({
       DEFAULT_PREFERENCES: {
         tempWindowFallback: {
-          tempContextMode: TEMP_CONTEXT_MODES.Tab,
+          tempContextMode: "tab",
         },
       },
-      TEMP_CONTEXT_MODES,
       userPreferences: {
         getPreferences: vi.fn().mockResolvedValue({
           tempWindowFallback: {
-            tempContextMode: TEMP_CONTEXT_MODES.Tab,
+            tempContextMode: "tab",
           },
         }),
       },

--- a/tests/entrypoints/background/tempWindowPoolOpenClose.test.ts
+++ b/tests/entrypoints/background/tempWindowPoolOpenClose.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import {
   TEMP_CONTEXT_MODES,
   type TempContextMode,
-} from "~/services/preferences/userPreferences"
+} from "~/constants/tempContextMode"
 
 const originalBrowser = (globalThis as any).browser
 
@@ -70,7 +70,6 @@ describe("tempWindowPool open/close handlers", () => {
           tempContextMode,
         },
       },
-      TEMP_CONTEXT_MODES,
       userPreferences: {
         getPreferences: vi.fn().mockImplementation(() =>
           Promise.resolve({

--- a/tests/entrypoints/background/tempWindowPoolOpenClose.test.ts
+++ b/tests/entrypoints/background/tempWindowPoolOpenClose.test.ts
@@ -250,6 +250,63 @@ describe("tempWindowPool open/close handlers", () => {
     expect(removeTabOrWindowMock).not.toHaveBeenCalled()
   })
 
+  it("removes only the composite tab when tab inspection fails during close", async () => {
+    tempContextMode = TEMP_CONTEXT_MODES.Composite
+    createWindowMock.mockResolvedValueOnce({ id: 921 })
+    tabsQueryMock
+      .mockResolvedValueOnce([{ id: 922 }])
+      .mockRejectedValueOnce(new Error("tab query failed"))
+
+    const { handleCloseTempWindow, handleOpenTempWindow } = await import(
+      "~/entrypoints/background/tempWindowPool"
+    )
+    await handleOpenTempWindow(
+      {
+        requestId: "req-composite-query-failed",
+        url: "https://example.invalid/composite/query-failed",
+      },
+      vi.fn(),
+    )
+
+    await handleCloseTempWindow(
+      { requestId: "req-composite-query-failed" },
+      vi.fn(),
+    )
+
+    expect(removeTabMock).toHaveBeenCalledWith(922)
+    expect(removeWindowMock).not.toHaveBeenCalled()
+    expect(removeTabOrWindowMock).not.toHaveBeenCalled()
+  })
+
+  it("falls back to removing the composite tab when final window removal fails", async () => {
+    tempContextMode = TEMP_CONTEXT_MODES.Composite
+    createWindowMock.mockResolvedValueOnce({ id: 931 })
+    tabsQueryMock
+      .mockResolvedValueOnce([{ id: 932 }])
+      .mockResolvedValueOnce([{ id: 932 }])
+    removeWindowMock.mockRejectedValueOnce(new Error("window remove failed"))
+
+    const { handleCloseTempWindow, handleOpenTempWindow } = await import(
+      "~/entrypoints/background/tempWindowPool"
+    )
+    await handleOpenTempWindow(
+      {
+        requestId: "req-composite-remove-window-failed",
+        url: "https://example.invalid/composite/remove-window-failed",
+      },
+      vi.fn(),
+    )
+
+    await handleCloseTempWindow(
+      { requestId: "req-composite-remove-window-failed" },
+      vi.fn(),
+    )
+
+    expect(removeWindowMock).toHaveBeenCalledWith(931)
+    expect(removeTabMock).toHaveBeenCalledWith(932)
+    expect(removeTabOrWindowMock).not.toHaveBeenCalled()
+  })
+
   it("preserves a confirmed composite window when tab creation fails", async () => {
     tempContextMode = TEMP_CONTEXT_MODES.Composite
     createWindowMock.mockResolvedValueOnce({ id: 901 })
@@ -814,6 +871,50 @@ describe("tempWindowPool open/close handlers", () => {
 
     const closeResponse = vi.fn()
     await handleCloseTempWindow({ requestId: "req-tab-removed" }, closeResponse)
+
+    expect(closeResponse).toHaveBeenCalledWith({
+      success: false,
+      error: "messages:background.windowNotFound",
+    })
+    expect(removeTabOrWindowMock).not.toHaveBeenCalled()
+  })
+
+  it("drops tracked composite-tab mappings when the browser reports the temp tab was closed", async () => {
+    tempContextMode = TEMP_CONTEXT_MODES.Composite
+    createWindowMock.mockResolvedValueOnce({ id: 941 })
+    tabsQueryMock.mockResolvedValueOnce([{ id: 942 }])
+
+    const {
+      handleCloseTempWindow,
+      handleOpenTempWindow,
+      setupTempWindowListeners,
+    } = await import("~/entrypoints/background/tempWindowPool")
+
+    setupTempWindowListeners()
+    const onTabRemoved = onTabRemovedMock.mock.calls[0]?.[0]
+
+    const openResponse = vi.fn()
+    await handleOpenTempWindow(
+      {
+        requestId: "req-composite-tab-removed",
+        url: "https://example.com/composite-tab-removed",
+      },
+      openResponse,
+    )
+
+    expect(openResponse).toHaveBeenCalledWith({
+      success: true,
+      windowId: 941,
+      tabId: 942,
+    })
+
+    await onTabRemoved?.(942)
+
+    const closeResponse = vi.fn()
+    await handleCloseTempWindow(
+      { requestId: "req-composite-tab-removed" },
+      closeResponse,
+    )
 
     expect(closeResponse).toHaveBeenCalledWith({
       success: false,

--- a/tests/entrypoints/background/tempWindowPoolOpenClose.test.ts
+++ b/tests/entrypoints/background/tempWindowPoolOpenClose.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
+import {
+  TEMP_CONTEXT_MODES,
+  type TempContextMode,
+} from "~/services/preferences/userPreferences"
+
 const originalBrowser = (globalThis as any).browser
 
 describe("tempWindowPool open/close handlers", () => {
@@ -13,7 +18,7 @@ describe("tempWindowPool open/close handlers", () => {
   let removeTabOrWindowMock: ReturnType<typeof vi.fn>
   let tabsQueryMock: ReturnType<typeof vi.fn>
   let windowsGetMock: ReturnType<typeof vi.fn>
-  let tempContextMode: "window" | "composite" | "tab"
+  let tempContextMode: TempContextMode
 
   beforeEach(() => {
     createTabMock = vi.fn()
@@ -26,7 +31,7 @@ describe("tempWindowPool open/close handlers", () => {
     removeTabOrWindowMock = vi.fn().mockResolvedValue(undefined)
     tabsQueryMock = vi.fn().mockResolvedValue([{ id: 902 }])
     windowsGetMock = vi.fn().mockResolvedValue({ id: 901 })
-    tempContextMode = "window"
+    tempContextMode = TEMP_CONTEXT_MODES.Window
 
     vi.useFakeTimers()
     vi.resetModules()
@@ -65,6 +70,7 @@ describe("tempWindowPool open/close handlers", () => {
           tempContextMode,
         },
       },
+      TEMP_CONTEXT_MODES,
       userPreferences: {
         getPreferences: vi.fn().mockImplementation(() =>
           Promise.resolve({
@@ -91,7 +97,7 @@ describe("tempWindowPool open/close handlers", () => {
   })
 
   it("opens and closes a popup temp window in window mode", async () => {
-    tempContextMode = "window"
+    tempContextMode = TEMP_CONTEXT_MODES.Window
     createWindowMock.mockResolvedValueOnce({ id: 801 })
 
     const { handleCloseTempWindow, handleOpenTempWindow } = await import(
@@ -121,7 +127,7 @@ describe("tempWindowPool open/close handlers", () => {
   })
 
   it("opens a composite temp tab when composite mode is enabled", async () => {
-    tempContextMode = "composite"
+    tempContextMode = TEMP_CONTEXT_MODES.Composite
     createWindowMock.mockResolvedValueOnce({ id: 901 })
 
     const { handleOpenTempWindow } = await import(
@@ -152,7 +158,7 @@ describe("tempWindowPool open/close handlers", () => {
   })
 
   it("reuses the existing composite window for later temp opens", async () => {
-    tempContextMode = "composite"
+    tempContextMode = TEMP_CONTEXT_MODES.Composite
     createWindowMock.mockResolvedValueOnce({ id: 901 })
     createTabMock.mockResolvedValueOnce({ id: 903 })
 
@@ -193,7 +199,7 @@ describe("tempWindowPool open/close handlers", () => {
   })
 
   it("closes the owner window for the final manual composite tab", async () => {
-    tempContextMode = "composite"
+    tempContextMode = TEMP_CONTEXT_MODES.Composite
     createWindowMock.mockResolvedValueOnce({ id: 901 })
     tabsQueryMock.mockResolvedValue([{ id: 902 }])
 
@@ -221,7 +227,7 @@ describe("tempWindowPool open/close handlers", () => {
   })
 
   it("removes only the completed composite tab when another tab exists", async () => {
-    tempContextMode = "composite"
+    tempContextMode = TEMP_CONTEXT_MODES.Composite
     createWindowMock.mockResolvedValueOnce({ id: 911 })
     tabsQueryMock
       .mockResolvedValueOnce([{ id: 912 }])
@@ -245,15 +251,13 @@ describe("tempWindowPool open/close handlers", () => {
     expect(removeTabOrWindowMock).not.toHaveBeenCalled()
   })
 
-  it("recreates the composite window after a stale reuse failure", async () => {
-    tempContextMode = "composite"
-    createWindowMock
-      .mockResolvedValueOnce({ id: 901 })
-      .mockResolvedValueOnce({ id: 905 })
+  it("preserves a confirmed composite window when tab creation fails", async () => {
+    tempContextMode = TEMP_CONTEXT_MODES.Composite
+    createWindowMock.mockResolvedValueOnce({ id: 901 })
     createTabMock.mockResolvedValueOnce({})
     tabsQueryMock
       .mockResolvedValueOnce([{ id: 902 }])
-      .mockResolvedValueOnce([{ id: 906 }])
+      .mockResolvedValueOnce([{ id: 902 }, { id: 905 }])
 
     const { handleOpenTempWindow } = await import(
       "~/entrypoints/background/tempWindowPool"
@@ -268,27 +272,48 @@ describe("tempWindowPool open/close handlers", () => {
       firstResponse,
     )
 
-    const secondResponse = vi.fn()
+    const failedResponse = vi.fn()
     await handleOpenTempWindow(
       {
-        requestId: "req-composite-recreated",
-        url: "https://example.com/composite/recreated",
+        requestId: "req-composite-tab-failure",
+        url: "https://example.com/composite/tab-failure",
       },
-      secondResponse,
+      failedResponse,
     )
 
-    expect(createWindowMock).toHaveBeenCalledTimes(2)
-    expect(removeWindowMock).toHaveBeenCalledWith(901)
+    expect(createWindowMock).toHaveBeenCalledTimes(1)
+    expect(removeWindowMock).not.toHaveBeenCalled()
     expect(removeTabOrWindowMock).not.toHaveBeenCalled()
-    expect(secondResponse).toHaveBeenCalledWith({
+    expect(failedResponse).toHaveBeenCalledWith({
+      success: false,
+      error: "messages:background.windowCreationUnavailable",
+    })
+
+    createTabMock.mockResolvedValueOnce({ id: 905 })
+    const reusedResponse = vi.fn()
+    await handleOpenTempWindow(
+      {
+        requestId: "req-composite-reused-after-tab-failure",
+        url: "https://example.com/composite/reused-after-tab-failure",
+      },
+      reusedResponse,
+    )
+
+    expect(createWindowMock).toHaveBeenCalledTimes(1)
+    expect(createTabMock).toHaveBeenLastCalledWith(
+      "https://example.com/composite/reused-after-tab-failure",
+      false,
+      { windowId: 901 },
+    )
+    expect(reusedResponse).toHaveBeenCalledWith({
       success: true,
-      windowId: 905,
-      tabId: 906,
+      windowId: 901,
+      tabId: 905,
     })
   })
 
   it("recreates the composite window when the existing window handle is unavailable", async () => {
-    tempContextMode = "composite"
+    tempContextMode = TEMP_CONTEXT_MODES.Composite
     createWindowMock
       .mockResolvedValueOnce({ id: 901 })
       .mockResolvedValueOnce({ id: 905 })
@@ -329,15 +354,11 @@ describe("tempWindowPool open/close handlers", () => {
     })
   })
 
-  it("recreates the composite window even when stale-window cleanup fails", async () => {
-    tempContextMode = "composite"
-    createWindowMock
-      .mockResolvedValueOnce({ id: 901 })
-      .mockResolvedValueOnce({ id: 905 })
+  it("does not remove a confirmed composite window when tab creation fails", async () => {
+    tempContextMode = TEMP_CONTEXT_MODES.Composite
+    createWindowMock.mockResolvedValueOnce({ id: 901 })
     createTabMock.mockResolvedValueOnce({})
-    tabsQueryMock
-      .mockResolvedValueOnce([{ id: 902 }])
-      .mockResolvedValueOnce([{ id: 906 }])
+    tabsQueryMock.mockResolvedValueOnce([{ id: 902 }])
 
     const { handleOpenTempWindow } = await import(
       "~/entrypoints/background/tempWindowPool"
@@ -352,29 +373,26 @@ describe("tempWindowPool open/close handlers", () => {
       firstResponse,
     )
 
-    removeWindowMock.mockRejectedValueOnce(new Error("cleanup failed"))
-
     const secondResponse = vi.fn()
     await handleOpenTempWindow(
       {
-        requestId: "req-composite-cleanup-failure-second",
-        url: "https://example.com/composite/cleanup-failure/second",
+        requestId: "req-composite-preserve-after-tab-failure",
+        url: "https://example.com/composite/preserve-after-tab-failure",
       },
       secondResponse,
     )
 
-    expect(createWindowMock).toHaveBeenCalledTimes(2)
-    expect(removeWindowMock).toHaveBeenNthCalledWith(1, 901)
+    expect(createWindowMock).toHaveBeenCalledTimes(1)
+    expect(removeWindowMock).not.toHaveBeenCalled()
     expect(removeTabOrWindowMock).not.toHaveBeenCalled()
     expect(secondResponse).toHaveBeenCalledWith({
-      success: true,
-      windowId: 905,
-      tabId: 906,
+      success: false,
+      error: "messages:background.windowCreationUnavailable",
     })
   })
 
   it("shares an in-flight composite window creation across concurrent opens", async () => {
-    tempContextMode = "composite"
+    tempContextMode = TEMP_CONTEXT_MODES.Composite
 
     let resolveWindow!: (value: { id: number }) => void
     const windowCreated = new Promise<{ id: number }>((resolve) => {
@@ -430,7 +448,7 @@ describe("tempWindowPool open/close handlers", () => {
   })
 
   it("surfaces a concurrent composite-tab creation failure after the shared window is created", async () => {
-    tempContextMode = "composite"
+    tempContextMode = TEMP_CONTEXT_MODES.Composite
 
     let resolveWindow!: (value: { id: number }) => void
     const windowCreated = new Promise<{ id: number }>((resolve) => {
@@ -485,7 +503,7 @@ describe("tempWindowPool open/close handlers", () => {
   })
 
   it("serializes final composite cleanup with a concurrent open", async () => {
-    tempContextMode = "composite"
+    tempContextMode = TEMP_CONTEXT_MODES.Composite
     createWindowMock
       .mockResolvedValueOnce({ id: 921 })
       .mockResolvedValueOnce({ id: 925 })
@@ -538,7 +556,7 @@ describe("tempWindowPool open/close handlers", () => {
   })
 
   it("falls back to a plain tab when window mode is unavailable", async () => {
-    tempContextMode = "window"
+    tempContextMode = TEMP_CONTEXT_MODES.Window
     hasWindowsApiMock.mockReturnValue(false)
     createTabMock.mockResolvedValueOnce({ id: 701 })
 
@@ -563,7 +581,7 @@ describe("tempWindowPool open/close handlers", () => {
   })
 
   it("returns an error when window mode cannot provide a window id", async () => {
-    tempContextMode = "window"
+    tempContextMode = TEMP_CONTEXT_MODES.Window
     createWindowMock.mockResolvedValueOnce({})
 
     const { handleOpenTempWindow } = await import(
@@ -586,7 +604,7 @@ describe("tempWindowPool open/close handlers", () => {
   })
 
   it("returns an error when tab mode cannot provide a tab id", async () => {
-    tempContextMode = "tab"
+    tempContextMode = TEMP_CONTEXT_MODES.Tab
     createTabMock.mockResolvedValueOnce({})
 
     const { handleOpenTempWindow } = await import(
@@ -609,7 +627,7 @@ describe("tempWindowPool open/close handlers", () => {
   })
 
   it("surfaces unexpected popup-window creation failures to the caller", async () => {
-    tempContextMode = "window"
+    tempContextMode = TEMP_CONTEXT_MODES.Window
     createWindowMock.mockRejectedValueOnce(new Error("window blocked"))
 
     const { handleOpenTempWindow } = await import(
@@ -632,7 +650,7 @@ describe("tempWindowPool open/close handlers", () => {
   })
 
   it("surfaces unexpected plain-tab creation failures to the caller", async () => {
-    tempContextMode = "tab"
+    tempContextMode = TEMP_CONTEXT_MODES.Tab
     createTabMock.mockRejectedValueOnce(new Error("tab blocked"))
 
     const { handleOpenTempWindow } = await import(
@@ -681,7 +699,7 @@ describe("tempWindowPool open/close handlers", () => {
   })
 
   it("drops tracked popup-window mappings when the browser reports the temp window was closed", async () => {
-    tempContextMode = "window"
+    tempContextMode = TEMP_CONTEXT_MODES.Window
     createWindowMock.mockResolvedValueOnce({ id: 811 })
 
     const {
@@ -723,7 +741,7 @@ describe("tempWindowPool open/close handlers", () => {
   })
 
   it("recreates the composite window after the browser reports the shared window was closed", async () => {
-    tempContextMode = "composite"
+    tempContextMode = TEMP_CONTEXT_MODES.Composite
     createWindowMock
       .mockResolvedValueOnce({ id: 901 })
       .mockResolvedValueOnce({ id: 905 })
@@ -767,7 +785,7 @@ describe("tempWindowPool open/close handlers", () => {
   })
 
   it("drops tracked plain-tab mappings when the browser reports the temp tab was closed", async () => {
-    tempContextMode = "tab"
+    tempContextMode = TEMP_CONTEXT_MODES.Tab
     createTabMock.mockResolvedValueOnce({ id: 711 })
 
     const {

--- a/tests/entrypoints/background/tempWindowPoolOpenClose.test.ts
+++ b/tests/entrypoints/background/tempWindowPoolOpenClose.test.ts
@@ -8,6 +8,8 @@ describe("tempWindowPool open/close handlers", () => {
   let hasWindowsApiMock: ReturnType<typeof vi.fn>
   let onTabRemovedMock: ReturnType<typeof vi.fn>
   let onWindowRemovedMock: ReturnType<typeof vi.fn>
+  let removeTabMock: ReturnType<typeof vi.fn>
+  let removeWindowMock: ReturnType<typeof vi.fn>
   let removeTabOrWindowMock: ReturnType<typeof vi.fn>
   let tabsQueryMock: ReturnType<typeof vi.fn>
   let windowsGetMock: ReturnType<typeof vi.fn>
@@ -19,6 +21,8 @@ describe("tempWindowPool open/close handlers", () => {
     hasWindowsApiMock = vi.fn(() => true)
     onTabRemovedMock = vi.fn(() => () => {})
     onWindowRemovedMock = vi.fn(() => () => {})
+    removeTabMock = vi.fn().mockResolvedValue(undefined)
+    removeWindowMock = vi.fn().mockResolvedValue(undefined)
     removeTabOrWindowMock = vi.fn().mockResolvedValue(undefined)
     tabsQueryMock = vi.fn().mockResolvedValue([{ id: 902 }])
     windowsGetMock = vi.fn().mockResolvedValue({ id: 901 })
@@ -50,7 +54,9 @@ describe("tempWindowPool open/close handlers", () => {
         hasWindowsAPI: hasWindowsApiMock,
         onTabRemoved: onTabRemovedMock,
         onWindowRemoved: onWindowRemovedMock,
+        removeTab: removeTabMock,
         removeTabOrWindow: removeTabOrWindowMock,
+        removeWindow: removeWindowMock,
       }
     })
     vi.doMock("~/services/preferences/userPreferences", () => ({
@@ -109,7 +115,8 @@ describe("tempWindowPool open/close handlers", () => {
     const closeResponse = vi.fn()
     await handleCloseTempWindow({ requestId: "req-window" }, closeResponse)
 
-    expect(removeTabOrWindowMock).toHaveBeenCalledWith(801)
+    expect(removeWindowMock).toHaveBeenCalledWith(801)
+    expect(removeTabOrWindowMock).not.toHaveBeenCalled()
     expect(closeResponse).toHaveBeenCalledWith({ success: true })
   })
 
@@ -185,6 +192,59 @@ describe("tempWindowPool open/close handlers", () => {
     })
   })
 
+  it("closes the owner window for the final manual composite tab", async () => {
+    tempContextMode = "composite"
+    createWindowMock.mockResolvedValueOnce({ id: 901 })
+    tabsQueryMock.mockResolvedValue([{ id: 902 }])
+
+    const { handleCloseTempWindow, handleOpenTempWindow } = await import(
+      "~/entrypoints/background/tempWindowPool"
+    )
+    await handleOpenTempWindow(
+      {
+        requestId: "req-composite-final",
+        url: "https://example.invalid/composite/final",
+      },
+      vi.fn(),
+    )
+
+    const closeResponse = vi.fn()
+    await handleCloseTempWindow(
+      { requestId: "req-composite-final" },
+      closeResponse,
+    )
+
+    expect(removeWindowMock).toHaveBeenCalledWith(901)
+    expect(removeTabMock).not.toHaveBeenCalled()
+    expect(removeTabOrWindowMock).not.toHaveBeenCalled()
+    expect(closeResponse).toHaveBeenCalledWith({ success: true })
+  })
+
+  it("removes only the completed composite tab when another tab exists", async () => {
+    tempContextMode = "composite"
+    createWindowMock.mockResolvedValueOnce({ id: 911 })
+    tabsQueryMock
+      .mockResolvedValueOnce([{ id: 912 }])
+      .mockResolvedValueOnce([{ id: 912 }, { id: 913 }])
+
+    const { handleCloseTempWindow, handleOpenTempWindow } = await import(
+      "~/entrypoints/background/tempWindowPool"
+    )
+    await handleOpenTempWindow(
+      {
+        requestId: "req-composite-shared",
+        url: "https://example.invalid/composite/shared",
+      },
+      vi.fn(),
+    )
+
+    await handleCloseTempWindow({ requestId: "req-composite-shared" }, vi.fn())
+
+    expect(removeTabMock).toHaveBeenCalledWith(912)
+    expect(removeWindowMock).not.toHaveBeenCalled()
+    expect(removeTabOrWindowMock).not.toHaveBeenCalled()
+  })
+
   it("recreates the composite window after a stale reuse failure", async () => {
     tempContextMode = "composite"
     createWindowMock
@@ -218,7 +278,8 @@ describe("tempWindowPool open/close handlers", () => {
     )
 
     expect(createWindowMock).toHaveBeenCalledTimes(2)
-    expect(removeTabOrWindowMock).toHaveBeenCalledWith(901)
+    expect(removeWindowMock).toHaveBeenCalledWith(901)
+    expect(removeTabOrWindowMock).not.toHaveBeenCalled()
     expect(secondResponse).toHaveBeenCalledWith({
       success: true,
       windowId: 905,
@@ -291,7 +352,7 @@ describe("tempWindowPool open/close handlers", () => {
       firstResponse,
     )
 
-    removeTabOrWindowMock.mockRejectedValueOnce(new Error("cleanup failed"))
+    removeWindowMock.mockRejectedValueOnce(new Error("cleanup failed"))
 
     const secondResponse = vi.fn()
     await handleOpenTempWindow(
@@ -303,7 +364,8 @@ describe("tempWindowPool open/close handlers", () => {
     )
 
     expect(createWindowMock).toHaveBeenCalledTimes(2)
-    expect(removeTabOrWindowMock).toHaveBeenNthCalledWith(1, 901)
+    expect(removeWindowMock).toHaveBeenNthCalledWith(1, 901)
+    expect(removeTabOrWindowMock).not.toHaveBeenCalled()
     expect(secondResponse).toHaveBeenCalledWith({
       success: true,
       windowId: 905,
@@ -419,6 +481,59 @@ describe("tempWindowPool open/close handlers", () => {
     expect(secondResponse).toHaveBeenCalledWith({
       success: false,
       error: "messages:background.windowCreationUnavailable",
+    })
+  })
+
+  it("serializes final composite cleanup with a concurrent open", async () => {
+    tempContextMode = "composite"
+    createWindowMock
+      .mockResolvedValueOnce({ id: 921 })
+      .mockResolvedValueOnce({ id: 925 })
+    createTabMock.mockResolvedValueOnce({ id: 923 })
+    tabsQueryMock.mockResolvedValueOnce([{ id: 922 }])
+
+    let resolveCleanupQuery!: (tabs: browser.tabs.Tab[]) => void
+    tabsQueryMock.mockReturnValueOnce(
+      new Promise<browser.tabs.Tab[]>((resolve) => {
+        resolveCleanupQuery = resolve
+      }),
+    )
+    tabsQueryMock.mockResolvedValueOnce([{ id: 926 }])
+
+    const { handleCloseTempWindow, handleOpenTempWindow } = await import(
+      "~/entrypoints/background/tempWindowPool"
+    )
+    await handleOpenTempWindow(
+      {
+        requestId: "req-composite-race-old",
+        url: "https://example.invalid/composite/race/old",
+      },
+      vi.fn(),
+    )
+
+    const closePromise = handleCloseTempWindow(
+      { requestId: "req-composite-race-old" },
+      vi.fn(),
+    )
+    const nextResponse = vi.fn()
+    const nextOpenPromise = handleOpenTempWindow(
+      {
+        requestId: "req-composite-race-new",
+        url: "https://example.invalid/composite/race/new",
+      },
+      nextResponse,
+    )
+
+    expect(createWindowMock).toHaveBeenCalledTimes(1)
+    resolveCleanupQuery([{ id: 922 } as browser.tabs.Tab])
+    await Promise.all([closePromise, nextOpenPromise])
+
+    expect(removeWindowMock).toHaveBeenCalledWith(921)
+    expect(createWindowMock).toHaveBeenCalledTimes(2)
+    expect(nextResponse).toHaveBeenCalledWith({
+      success: true,
+      windowId: 925,
+      tabId: 926,
     })
   })
 

--- a/tests/entrypoints/background/tempWindowPoolSuspendCleanup.test.ts
+++ b/tests/entrypoints/background/tempWindowPoolSuspendCleanup.test.ts
@@ -6,6 +6,7 @@ const originalBrowser = (globalThis as any).browser
 
 describe("cleanupTempContextsOnSuspend", () => {
   let createTabMock: ReturnType<typeof vi.fn>
+  let removeTabMock: ReturnType<typeof vi.fn>
   let removeTabOrWindowMock: ReturnType<typeof vi.fn>
 
   beforeEach(() => {
@@ -13,6 +14,7 @@ describe("cleanupTempContextsOnSuspend", () => {
       .fn()
       .mockResolvedValueOnce({ id: 101 })
       .mockResolvedValueOnce({ id: 202 })
+    removeTabMock = vi.fn().mockResolvedValue(undefined)
     removeTabOrWindowMock = vi.fn().mockResolvedValue(undefined)
 
     vi.useFakeTimers()
@@ -53,6 +55,7 @@ describe("cleanupTempContextsOnSuspend", () => {
         isAllowedIncognitoAccess: vi.fn().mockResolvedValue(true),
         onTabRemoved: vi.fn(() => () => {}),
         onWindowRemoved: vi.fn(() => () => {}),
+        removeTab: removeTabMock,
         removeTabOrWindow: removeTabOrWindowMock,
       }
     })
@@ -113,7 +116,8 @@ describe("cleanupTempContextsOnSuspend", () => {
 
     await cleanupTempContextsOnSuspend()
 
-    expect(removeTabOrWindowMock).toHaveBeenCalledWith(101)
+    expect(removeTabMock).toHaveBeenCalledWith(101)
+    expect(removeTabOrWindowMock).not.toHaveBeenCalled()
 
     const closeResponse = vi.fn()
     await handleCloseTempWindow({ requestId: "req-1" }, closeResponse)
@@ -123,7 +127,8 @@ describe("cleanupTempContextsOnSuspend", () => {
     )
 
     await vi.advanceTimersByTimeAsync(2000)
-    expect(removeTabOrWindowMock).toHaveBeenCalledTimes(1)
+    expect(removeTabMock).toHaveBeenCalledTimes(1)
+    expect(removeTabOrWindowMock).not.toHaveBeenCalled()
 
     const secondResponse = vi.fn()
     const secondRequest = handleTempWindowGetRenderedTitle(
@@ -146,8 +151,9 @@ describe("cleanupTempContextsOnSuspend", () => {
     await cleanupTempContextsOnSuspend()
     await vi.advanceTimersByTimeAsync(2000)
 
-    expect(removeTabOrWindowMock).toHaveBeenCalledTimes(2)
-    expect(removeTabOrWindowMock).toHaveBeenLastCalledWith(202)
+    expect(removeTabMock).toHaveBeenCalledTimes(2)
+    expect(removeTabMock).toHaveBeenLastCalledWith(202)
+    expect(removeTabOrWindowMock).not.toHaveBeenCalled()
   })
 
   it("resolves without closing anything when no temp contexts are tracked", async () => {
@@ -156,6 +162,7 @@ describe("cleanupTempContextsOnSuspend", () => {
     )
 
     await expect(cleanupTempContextsOnSuspend()).resolves.toBeUndefined()
+    expect(removeTabMock).not.toHaveBeenCalled()
     expect(removeTabOrWindowMock).not.toHaveBeenCalled()
   })
 })

--- a/tests/entrypoints/background/tempWindowPoolSuspendCleanup.test.ts
+++ b/tests/entrypoints/background/tempWindowPoolSuspendCleanup.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { RuntimeActionIds } from "~/constants/runtimeActions"
+import { TEMP_CONTEXT_MODES } from "~/services/preferences/userPreferences"
 
 const originalBrowser = (globalThis as any).browser
 
@@ -62,13 +63,14 @@ describe("cleanupTempContextsOnSuspend", () => {
     vi.doMock("~/services/preferences/userPreferences", () => ({
       DEFAULT_PREFERENCES: {
         tempWindowFallback: {
-          tempContextMode: "tab",
+          tempContextMode: TEMP_CONTEXT_MODES.Tab,
         },
       },
+      TEMP_CONTEXT_MODES,
       userPreferences: {
         getPreferences: vi.fn().mockResolvedValue({
           tempWindowFallback: {
-            tempContextMode: "tab",
+            tempContextMode: TEMP_CONTEXT_MODES.Tab,
           },
         }),
       },

--- a/tests/entrypoints/background/tempWindowPoolSuspendCleanup.test.ts
+++ b/tests/entrypoints/background/tempWindowPoolSuspendCleanup.test.ts
@@ -1,7 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { RuntimeActionIds } from "~/constants/runtimeActions"
-import { TEMP_CONTEXT_MODES } from "~/services/preferences/userPreferences"
 
 const originalBrowser = (globalThis as any).browser
 
@@ -63,14 +62,13 @@ describe("cleanupTempContextsOnSuspend", () => {
     vi.doMock("~/services/preferences/userPreferences", () => ({
       DEFAULT_PREFERENCES: {
         tempWindowFallback: {
-          tempContextMode: TEMP_CONTEXT_MODES.Tab,
+          tempContextMode: "tab",
         },
       },
-      TEMP_CONTEXT_MODES,
       userPreferences: {
         getPreferences: vi.fn().mockResolvedValue({
           tempWindowFallback: {
-            tempContextMode: TEMP_CONTEXT_MODES.Tab,
+            tempContextMode: "tab",
           },
         }),
       },

--- a/tests/entrypoints/background/tempWindowPoolWindowFallback.test.ts
+++ b/tests/entrypoints/background/tempWindowPoolWindowFallback.test.ts
@@ -64,6 +64,8 @@ const createDeferred = <T>() => {
 describe("tempWindowPool window fallback", () => {
   let createTabMock: ReturnType<typeof vi.fn>
   let createWindowMock: ReturnType<typeof vi.fn>
+  let removeTabMock: ReturnType<typeof vi.fn>
+  let removeWindowMock: ReturnType<typeof vi.fn>
   let removeTabOrWindowMock: ReturnType<typeof vi.fn>
   let hasWindowsApiMock: ReturnType<typeof vi.fn>
   let isAllowedIncognitoAccessMock: ReturnType<typeof vi.fn>
@@ -91,6 +93,8 @@ describe("tempWindowPool window fallback", () => {
   beforeEach(() => {
     createTabMock = vi.fn()
     createWindowMock = vi.fn()
+    removeTabMock = vi.fn().mockResolvedValue(undefined)
+    removeWindowMock = vi.fn().mockResolvedValue(undefined)
     removeTabOrWindowMock = vi.fn().mockResolvedValue(undefined)
     hasWindowsApiMock = vi.fn(() => true)
     isAllowedIncognitoAccessMock = vi.fn().mockResolvedValue(true)
@@ -197,7 +201,9 @@ describe("tempWindowPool window fallback", () => {
         isAllowedIncognitoAccess: isAllowedIncognitoAccessMock,
         onTabRemoved: onTabRemovedMock,
         onWindowRemoved: onWindowRemovedMock,
+        removeTab: removeTabMock,
         removeTabOrWindow: removeTabOrWindowMock,
+        removeWindow: removeWindowMock,
       }
     })
     vi.doMock("~/services/accounts/accountStorage", () => ({
@@ -319,7 +325,7 @@ describe("tempWindowPool window fallback", () => {
     })
 
     await vi.advanceTimersByTimeAsync(2500)
-    expect(removeTabOrWindowMock).toHaveBeenCalledWith(101)
+    expect(removeTabMock).toHaveBeenCalledWith(101)
   })
 
   it("installs and removes a temp-context download block rule for the owned tab", async () => {
@@ -379,7 +385,7 @@ describe("tempWindowPool window fallback", () => {
     expect(removeTempWindowDownloadBlockRuleMock).toHaveBeenCalledWith(
       2_000_601,
     )
-    expect(removeTabOrWindowMock).toHaveBeenCalledWith(601)
+    expect(removeTabMock).toHaveBeenCalledWith(601)
   })
 
   it("installs and removes a Firefox temp-context download block rule for the owned tab", async () => {
@@ -414,7 +420,7 @@ describe("tempWindowPool window fallback", () => {
     expect(removeFirefoxTempWindowDownloadBlockRuleMock).toHaveBeenCalledWith(
       602,
     )
-    expect(removeTabOrWindowMock).toHaveBeenCalledWith(602)
+    expect(removeTabMock).toHaveBeenCalledWith(602)
   })
 
   it("warns when no temp-context download blocker can be installed before navigation", async () => {
@@ -497,7 +503,7 @@ describe("tempWindowPool window fallback", () => {
     })
 
     await vi.advanceTimersByTimeAsync(2500)
-    expect(removeTabOrWindowMock).toHaveBeenCalledWith(202)
+    expect(removeTabMock).toHaveBeenCalledWith(202)
   })
 
   it("cleans up a half-created composite window before rolling back to a plain tab", async () => {
@@ -532,20 +538,22 @@ describe("tempWindowPool window fallback", () => {
         data: "ok",
       },
     })
-    expect(removeTabOrWindowMock).toHaveBeenNthCalledWith(1, 303)
+    expect(removeWindowMock).toHaveBeenCalledWith(303)
     expect(createTabMock).toHaveBeenCalledWith("about:blank", false)
     expect(tabsUpdateMock).toHaveBeenCalledWith(304, {
       url: "https://example.com",
     })
 
     await vi.advanceTimersByTimeAsync(2500)
-    expect(removeTabOrWindowMock).toHaveBeenNthCalledWith(2, 304)
+    expect(removeTabMock).toHaveBeenCalledWith(304)
   })
 
   it("continues composite temp-window fetches when minimizing the shared window fails", async () => {
     tempContextMode = "composite"
     createWindowMock.mockResolvedValueOnce({ id: 305 })
-    tabsQueryMock.mockResolvedValueOnce([{ id: 306 }])
+    tabsQueryMock
+      .mockResolvedValueOnce([{ id: 306 }])
+      .mockResolvedValueOnce([{ id: 306 }])
     ;(globalThis as any).browser.windows.update.mockRejectedValueOnce(
       new Error("minimize failed"),
     )
@@ -584,7 +592,9 @@ describe("tempWindowPool window fallback", () => {
     })
 
     await vi.advanceTimersByTimeAsync(2500)
-    expect(removeTabOrWindowMock).toHaveBeenCalledWith(306)
+    expect(removeWindowMock).toHaveBeenCalledWith(305)
+    expect(removeTabMock).not.toHaveBeenCalledWith(306)
+    expect(removeTabOrWindowMock).not.toHaveBeenCalledWith(306)
   })
 
   it("preserves a structured unsupported result for incognito temp contexts", async () => {
@@ -682,7 +692,7 @@ describe("tempWindowPool window fallback", () => {
     )
 
     expect(createTabMock).not.toHaveBeenCalled()
-    expect(removeTabOrWindowMock).toHaveBeenCalledWith(404)
+    expect(removeWindowMock).toHaveBeenCalledWith(404)
     expect(sendResponse).toHaveBeenCalledWith({
       success: false,
       error: "messages:background.windowCreationUnavailable",
@@ -964,7 +974,7 @@ describe("tempWindowPool window fallback", () => {
     expect(closeResponse).toHaveBeenCalledWith({ success: true })
 
     await vi.advanceTimersByTimeAsync(2000)
-    expect(removeTabOrWindowMock).toHaveBeenCalledWith(493)
+    expect(removeTabMock).toHaveBeenCalledWith(493)
 
     deferredFetch.reject(new Error("manual close canceled the fetch"))
     await request
@@ -976,7 +986,7 @@ describe("tempWindowPool window fallback", () => {
     })
 
     await vi.advanceTimersByTimeAsync(2000)
-    expect(removeTabOrWindowMock).toHaveBeenCalledTimes(1)
+    expect(removeTabMock).toHaveBeenCalledTimes(1)
   })
 
   it("rejects invalid temp-window fetch requests before opening any context", async () => {
@@ -1073,7 +1083,7 @@ describe("tempWindowPool window fallback", () => {
     })
 
     await vi.advanceTimersByTimeAsync(2500)
-    expect(removeTabOrWindowMock).toHaveBeenCalledWith(508)
+    expect(removeTabMock).toHaveBeenCalledWith(508)
   })
 
   it("uses an incognito temp context for incognito auto-detect requests", async () => {
@@ -1289,7 +1299,7 @@ describe("tempWindowPool window fallback", () => {
     })
 
     await vi.advanceTimersByTimeAsync(2500)
-    expect(removeTabOrWindowMock).toHaveBeenCalledWith(509)
+    expect(removeTabMock).toHaveBeenCalledWith(509)
   })
 
   it("surfaces auto-detect failures when site-type detection throws", async () => {
@@ -1363,7 +1373,7 @@ describe("tempWindowPool window fallback", () => {
     })
 
     await vi.advanceTimersByTimeAsync(2100)
-    expect(removeTabOrWindowMock).toHaveBeenCalledWith(514)
+    expect(removeTabMock).toHaveBeenCalledWith(514)
   })
 
   it("returns a failure response when rendered-title content never answers and still cleans up the temp context", async () => {
@@ -1407,8 +1417,8 @@ describe("tempWindowPool window fallback", () => {
     })
 
     await vi.advanceTimersByTimeAsync(2100)
-    expect(removeTabOrWindowMock).toHaveBeenCalledTimes(1)
-    expect(removeTabOrWindowMock).toHaveBeenCalledWith(511)
+    expect(removeTabMock).toHaveBeenCalledTimes(1)
+    expect(removeTabMock).toHaveBeenCalledWith(511)
   })
 
   it("keeps rendered-title fetches working when popup window minimization fails", async () => {
@@ -1447,7 +1457,7 @@ describe("tempWindowPool window fallback", () => {
     })
 
     await vi.advanceTimersByTimeAsync(2100)
-    expect(removeTabOrWindowMock).toHaveBeenCalledWith(612)
+    expect(removeWindowMock).toHaveBeenCalledWith(612)
   })
 
   it("allows manual close while a rendered-title request is still in delayed-release state", async () => {
@@ -1483,8 +1493,8 @@ describe("tempWindowPool window fallback", () => {
     expect(closeResponse).toHaveBeenCalledWith({ success: true })
 
     await vi.advanceTimersByTimeAsync(2100)
-    expect(removeTabOrWindowMock).toHaveBeenCalledTimes(1)
-    expect(removeTabOrWindowMock).toHaveBeenCalledWith(512)
+    expect(removeTabMock).toHaveBeenCalledTimes(1)
+    expect(removeTabMock).toHaveBeenCalledWith(512)
   })
 
   it("returns a structured close failure when browser removal throws for an open temp window", async () => {
@@ -1509,7 +1519,7 @@ describe("tempWindowPool window fallback", () => {
       tabId: 5120,
     })
 
-    removeTabOrWindowMock.mockRejectedValueOnce(new Error("close failed"))
+    removeTabMock.mockRejectedValueOnce(new Error("close failed"))
 
     const closeResponse = vi.fn()
     await handleCloseTempWindow({ requestId: "req-close-error" }, closeResponse)
@@ -1659,11 +1669,11 @@ describe("tempWindowPool window fallback", () => {
 
     await cleanupTempContextsOnSuspend()
 
-    expect(removeTabOrWindowMock).toHaveBeenCalledTimes(1)
-    expect(removeTabOrWindowMock).toHaveBeenCalledWith(615)
+    expect(removeTabMock).toHaveBeenCalledTimes(1)
+    expect(removeTabMock).toHaveBeenCalledWith(615)
 
     await vi.advanceTimersByTimeAsync(2500)
-    expect(removeTabOrWindowMock).toHaveBeenCalledTimes(1)
+    expect(removeTabMock).toHaveBeenCalledTimes(1)
 
     const secondResponse = vi.fn()
     const secondRequest = handleTempWindowFetch(
@@ -1725,11 +1735,11 @@ describe("tempWindowPool window fallback", () => {
 
     await cleanupTempContextsOnSuspend()
 
-    expect(removeTabOrWindowMock).toHaveBeenCalledTimes(1)
-    expect(removeTabOrWindowMock).toHaveBeenCalledWith(617)
+    expect(removeWindowMock).toHaveBeenCalledTimes(1)
+    expect(removeWindowMock).toHaveBeenCalledWith(617)
 
     await vi.advanceTimersByTimeAsync(2500)
-    expect(removeTabOrWindowMock).toHaveBeenCalledTimes(1)
+    expect(removeWindowMock).toHaveBeenCalledTimes(1)
 
     const secondResponse = vi.fn()
     const secondRequest = handleTempWindowGetRenderedTitle(
@@ -1775,7 +1785,7 @@ describe("tempWindowPool window fallback", () => {
       error: "tab disappeared",
       code: undefined,
     })
-    expect(removeTabOrWindowMock).toHaveBeenCalledWith(506)
+    expect(removeTabMock).toHaveBeenCalledWith(506)
     expect(sendMessageMock).not.toHaveBeenCalledWith(
       506,
       expect.objectContaining({
@@ -1812,7 +1822,7 @@ describe("tempWindowPool window fallback", () => {
       error: "messages:background.pageLoadTimeout",
       code: undefined,
     })
-    expect(removeTabOrWindowMock).toHaveBeenCalledWith(507)
+    expect(removeTabMock).toHaveBeenCalledWith(507)
     expect(sendMessageMock).not.toHaveBeenCalledWith(
       507,
       expect.objectContaining({
@@ -1865,7 +1875,7 @@ describe("tempWindowPool window fallback", () => {
       success: false,
       error: "No response from temp window fetch",
     })
-    expect(removeTabOrWindowMock).toHaveBeenCalledWith(505)
+    expect(removeTabMock).toHaveBeenCalledWith(505)
   })
 
   it("classifies downstream unsuccessful temp fetch responses by status and code", async () => {
@@ -1929,7 +1939,7 @@ describe("tempWindowPool window fallback", () => {
         statusKind: PRODUCT_ANALYTICS_STATUS_KINDS.Error,
       },
     })
-    expect(removeTabOrWindowMock).toHaveBeenCalledWith(510)
+    expect(removeTabMock).toHaveBeenCalledWith(510)
   })
 
   it("waits for protection guards to pass before issuing the temp fetch", async () => {
@@ -2114,7 +2124,7 @@ describe("tempWindowPool window fallback", () => {
     expect(fetchCallsBeforeCleanup).toHaveLength(2)
 
     await vi.advanceTimersByTimeAsync(2500)
-    expect(removeTabOrWindowMock).toHaveBeenCalledWith(606)
+    expect(removeTabMock).toHaveBeenCalledWith(606)
 
     const thirdResponse = vi.fn()
     const thirdRequest = handleTempWindowFetch(
@@ -2239,8 +2249,8 @@ describe("tempWindowPool window fallback", () => {
     await secondRequest
 
     await vi.advanceTimersByTimeAsync(2500)
-    expect(removeTabOrWindowMock).toHaveBeenCalledTimes(1)
-    expect(removeTabOrWindowMock).toHaveBeenCalledWith(608)
+    expect(removeTabMock).toHaveBeenCalledTimes(1)
+    expect(removeTabMock).toHaveBeenCalledWith(608)
     expect(secondResponse).toHaveBeenCalledWith({
       success: true,
       data: {
@@ -2350,8 +2360,8 @@ describe("tempWindowPool window fallback", () => {
     expect(closeResponse).toHaveBeenCalledWith({ success: true })
 
     await vi.advanceTimersByTimeAsync(2000)
-    expect(removeTabOrWindowMock).toHaveBeenCalledTimes(1)
-    expect(removeTabOrWindowMock).toHaveBeenCalledWith(650)
+    expect(removeTabMock).toHaveBeenCalledTimes(1)
+    expect(removeTabMock).toHaveBeenCalledWith(650)
 
     const otherCloseResponse = vi.fn()
     await handleCloseTempWindow(
@@ -2380,7 +2390,7 @@ describe("tempWindowPool window fallback", () => {
     })
 
     await vi.advanceTimersByTimeAsync(2000)
-    expect(removeTabOrWindowMock).toHaveBeenCalledTimes(1)
+    expect(removeTabMock).toHaveBeenCalledTimes(1)
 
     const thirdResponse = vi.fn()
     const thirdRequest = handleTempWindowFetch(
@@ -2449,7 +2459,7 @@ describe("tempWindowPool window fallback", () => {
     await secondRequest
 
     expect(createTabMock).toHaveBeenCalledTimes(2)
-    expect(removeTabOrWindowMock).not.toHaveBeenCalledWith(708)
+    expect(removeTabMock).not.toHaveBeenCalledWith(708)
     const fetchCalls = sendMessageMock.mock.calls.filter(
       ([, message]) =>
         message.action === RuntimeActionIds.ContentPerformTempWindowFetch,
@@ -3274,7 +3284,7 @@ describe("tempWindowPool window fallback", () => {
       PRODUCT_ANALYTICS_RESULTS.Failure,
     )
     await new Promise((resolve) => setTimeout(resolve, 2500))
-    expect(removeTabOrWindowMock).toHaveBeenCalledWith(809)
+    expect(removeTabMock).toHaveBeenCalledWith(809)
     expect(removeTempWindowCookieRuleMock).not.toHaveBeenCalled()
   })
 
@@ -3372,7 +3382,7 @@ describe("tempWindowPool window fallback", () => {
     )
     expect(analyticsCallsJson).not.toContain("cf_clearance=1")
     expect(removeTempWindowCookieRuleMock).toHaveBeenCalledWith(1_000_810)
-    expect(removeTabOrWindowMock).toHaveBeenCalledWith(810)
+    expect(removeTabMock).toHaveBeenCalledWith(810)
   })
 
   it("classifies downstream unsuccessful turnstile temp fetch responses by status and code", async () => {
@@ -3452,6 +3462,6 @@ describe("tempWindowPool window fallback", () => {
         statusKind: PRODUCT_ANALYTICS_STATUS_KINDS.Error,
       },
     })
-    expect(removeTabOrWindowMock).toHaveBeenCalledWith(813)
+    expect(removeTabMock).toHaveBeenCalledWith(813)
   })
 })

--- a/tests/entrypoints/background/tempWindowPoolWindowFallback.test.ts
+++ b/tests/entrypoints/background/tempWindowPoolWindowFallback.test.ts
@@ -328,6 +328,43 @@ describe("tempWindowPool window fallback", () => {
     expect(removeTabMock).toHaveBeenCalledWith(101)
   })
 
+  it("cleans up a successful popup temp-context fetch after the quiet idle timeout", async () => {
+    tempContextMode = "window"
+    createWindowMock.mockResolvedValueOnce({ id: 111 })
+    tabsQueryMock.mockResolvedValueOnce([{ id: 112 }])
+
+    const { handleTempWindowFetch } = await import(
+      "~/entrypoints/background/tempWindowPool"
+    )
+
+    const sendResponse = vi.fn()
+    const request = handleTempWindowFetch(
+      {
+        originUrl: "https://example.com",
+        fetchUrl: "https://example.com/api/window-success",
+        fetchOptions: { method: "GET" },
+        requestId: "req-window-success",
+      },
+      sendResponse,
+    )
+
+    await vi.advanceTimersByTimeAsync(500)
+    await request
+
+    expect(sendResponse).toHaveBeenCalledWith({
+      success: true,
+      data: {
+        success: true,
+        message: "",
+        data: "ok",
+      },
+    })
+
+    await vi.advanceTimersByTimeAsync(3000)
+    expect(removeWindowMock).toHaveBeenCalledWith(111)
+    expect(removeTabMock).not.toHaveBeenCalledWith(112)
+  })
+
   it("installs and removes a temp-context download block rule for the owned tab", async () => {
     tempContextMode = "tab"
     const setupOrder: string[] = []
@@ -546,6 +583,88 @@ describe("tempWindowPool window fallback", () => {
 
     await vi.advanceTimersByTimeAsync(2500)
     expect(removeTabMock).toHaveBeenCalledWith(304)
+  })
+
+  it("rolls back composite temp-context creation when the window handle is missing", async () => {
+    tempContextMode = "composite"
+    createWindowMock.mockResolvedValueOnce({})
+    createTabMock.mockResolvedValueOnce({ id: 307 })
+
+    const { handleTempWindowFetch } = await import(
+      "~/entrypoints/background/tempWindowPool"
+    )
+
+    const sendResponse = vi.fn()
+    const request = handleTempWindowFetch(
+      {
+        originUrl: "https://example.com",
+        fetchUrl: "https://example.com/api/composite-missing-window",
+        fetchOptions: { method: "GET" },
+        requestId: "req-composite-missing-window",
+      },
+      sendResponse,
+    )
+
+    await vi.advanceTimersByTimeAsync(500)
+    await request
+
+    expect(sendResponse).toHaveBeenCalledWith({
+      success: true,
+      data: {
+        success: true,
+        message: "",
+        data: "ok",
+      },
+    })
+    expect(removeWindowMock).not.toHaveBeenCalled()
+    expect(createTabMock).toHaveBeenCalledWith("about:blank", false)
+    expect(tabsUpdateMock).toHaveBeenCalledWith(307, {
+      url: "https://example.com",
+    })
+  })
+
+  it("still rolls back composite creation when half-created window cleanup fails", async () => {
+    tempContextMode = "composite"
+    createWindowMock.mockResolvedValueOnce({ id: 308 })
+    tabsQueryMock.mockResolvedValueOnce([])
+    removeWindowMock.mockRejectedValueOnce(new Error("cleanup failed"))
+    createTabMock.mockResolvedValueOnce({ id: 309 })
+
+    const { handleTempWindowFetch } = await import(
+      "~/entrypoints/background/tempWindowPool"
+    )
+
+    const sendResponse = vi.fn()
+    const request = handleTempWindowFetch(
+      {
+        originUrl: "https://example.com",
+        fetchUrl: "https://example.com/api/composite-cleanup-failed",
+        fetchOptions: { method: "GET" },
+        requestId: "req-composite-cleanup-failed",
+      },
+      sendResponse,
+    )
+
+    await vi.advanceTimersByTimeAsync(500)
+    await request
+
+    expect(sendResponse).toHaveBeenCalledWith({
+      success: true,
+      data: {
+        success: true,
+        message: "",
+        data: "ok",
+      },
+    })
+    expect(removeWindowMock).toHaveBeenCalledWith(308)
+    expect(loggerWarnMock).toHaveBeenCalledWith(
+      "Failed to cleanup composite temp context after creation error",
+      expect.any(Error),
+    )
+    expect(createTabMock).toHaveBeenCalledWith("about:blank", false)
+    expect(tabsUpdateMock).toHaveBeenCalledWith(309, {
+      url: "https://example.com",
+    })
   })
 
   it("continues composite temp-window fetches when minimizing the shared window fails", async () => {

--- a/tests/entrypoints/background/tempWindowPoolWindowFallback.test.ts
+++ b/tests/entrypoints/background/tempWindowPoolWindowFallback.test.ts
@@ -2,7 +2,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { RuntimeActionIds } from "~/constants/runtimeActions"
 import { API_ERROR_CODES } from "~/services/apiTransport/errors"
-import { TEMP_CONTEXT_MODES } from "~/services/preferences/userPreferences"
 import {
   PRODUCT_ANALYTICS_ACTION_IDS,
   PRODUCT_ANALYTICS_ENTRYPOINTS,
@@ -246,7 +245,6 @@ describe("tempWindowPool window fallback", () => {
           tempContextMode: defaultTempContextMode,
         },
       },
-      TEMP_CONTEXT_MODES,
       userPreferences: {
         getPreferences: getPreferencesMock,
       },

--- a/tests/entrypoints/background/tempWindowPoolWindowFallback.test.ts
+++ b/tests/entrypoints/background/tempWindowPoolWindowFallback.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { RuntimeActionIds } from "~/constants/runtimeActions"
 import { API_ERROR_CODES } from "~/services/apiTransport/errors"
+import { TEMP_CONTEXT_MODES } from "~/services/preferences/userPreferences"
 import {
   PRODUCT_ANALYTICS_ACTION_IDS,
   PRODUCT_ANALYTICS_ENTRYPOINTS,
@@ -245,6 +246,7 @@ describe("tempWindowPool window fallback", () => {
           tempContextMode: defaultTempContextMode,
         },
       },
+      TEMP_CONTEXT_MODES,
       userPreferences: {
         getPreferences: getPreferencesMock,
       },

--- a/tests/utils/browserApi.test.ts
+++ b/tests/utils/browserApi.test.ts
@@ -63,7 +63,9 @@ import {
   removeContextMenu,
   removePermissions,
   removePermissionsDetailed,
+  removeTab,
   removeTabOrWindow,
+  removeWindow,
   requestPermissions,
   requestPermissionsDetailed,
   requestRuntimeUpdateCheck,
@@ -1241,10 +1243,9 @@ describe("browserApi window and manifest helpers", () => {
     ;(globalThis as any).chrome = originalChrome
   })
 
-  it("falls back to removing a tab when removing a window fails", async () => {
-    const removeWindowMock = vi
-      .fn()
-      .mockRejectedValueOnce(new Error("not a window"))
+  it("warns before falling back to tab removal", async () => {
+    const error = new Error("not a window")
+    const removeWindowMock = vi.fn().mockRejectedValueOnce(error)
     const removeTabMock = vi.fn().mockResolvedValue(undefined)
     ;(globalThis as any).browser.windows.remove = removeWindowMock
     ;(globalThis as any).browser.tabs.remove = removeTabMock
@@ -1252,7 +1253,39 @@ describe("browserApi window and manifest helpers", () => {
     await removeTabOrWindow(42)
 
     expect(removeWindowMock).toHaveBeenCalledWith(42)
+    expect(loggerMock.warn).toHaveBeenCalledWith(
+      "removeTabOrWindow: Failed to remove as window, falling back to tab",
+      { id: 42, error },
+    )
     expect(removeTabMock).toHaveBeenCalledWith(42)
+    expect(removeWindowMock.mock.invocationCallOrder[0]).toBeLessThan(
+      removeTabMock.mock.invocationCallOrder[0],
+    )
+  })
+
+  it("removes a known tab without probing the windows API", async () => {
+    const removeTabMock = vi.fn().mockResolvedValue(undefined)
+    const removeWindowMock = vi.fn().mockResolvedValue(undefined)
+    ;(globalThis as any).browser.tabs.remove = removeTabMock
+    ;(globalThis as any).browser.windows.remove = removeWindowMock
+
+    await removeTab(43)
+
+    expect(removeTabMock).toHaveBeenCalledWith(43)
+    expect(removeWindowMock).not.toHaveBeenCalled()
+    expect(loggerMock.warn).not.toHaveBeenCalled()
+  })
+
+  it("removes a known window without probing the tabs API", async () => {
+    const removeTabMock = vi.fn().mockResolvedValue(undefined)
+    const removeWindowMock = vi.fn().mockResolvedValue(undefined)
+    ;(globalThis as any).browser.tabs.remove = removeTabMock
+    ;(globalThis as any).browser.windows.remove = removeWindowMock
+
+    await removeWindow(44)
+
+    expect(removeWindowMock).toHaveBeenCalledWith(44)
+    expect(removeTabMock).not.toHaveBeenCalled()
   })
 
   it("returns null from createWindow when the windows API is unavailable", async () => {

--- a/tests/utils/browserApi.test.ts
+++ b/tests/utils/browserApi.test.ts
@@ -1288,6 +1288,14 @@ describe("browserApi window and manifest helpers", () => {
     expect(removeTabMock).not.toHaveBeenCalled()
   })
 
+  it("rejects known-window removal when the windows API is unavailable", async () => {
+    ;(globalThis as any).browser.windows = undefined
+
+    await expect(removeWindow(45)).rejects.toThrow(
+      "browser.windows.remove is unavailable",
+    )
+  })
+
   it("returns null from createWindow when the windows API is unavailable", async () => {
     ;(globalThis as any).browser.windows = undefined
 


### PR DESCRIPTION
## Summary
- Preserve the owner window for composite temp contexts so the final completed temp tab closes the extension-owned window.
- Keep shared composite windows open when other temp tabs still exist, and remove only the completed tab.
- Add explicit tab/window cleanup helpers and serialize composite cleanup/open operations to avoid race-related orphan windows.

## Test Plan
- pnpm exec vitest run tests/utils/browserApi.test.ts tests/entrypoints/background/tempWindowPoolOpenClose.test.ts tests/entrypoints/background/tempWindowPoolWindowFallback.test.ts tests/entrypoints/background/tempWindowPoolSuspendCleanup.test.ts
- pnpm run validate:push

Closes #1171
Closes #873

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized temporary context mode definitions used across settings, analytics, and the temp-context UI.
* **Bug Fixes**
  * Improved cleanup for tab, window, and composite temporary contexts, closing the owner window only after the final composite temp tab is removed while preserving other tabs.
  * Added safer tab/window removal with warning-level fallback when window removal isn’t available.
  * Reduced race issues during concurrent composite open/close and strengthened suspend cleanup behavior.
* **Documentation**
  * Added planning and design documentation for the composite temp-window cleanup approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->