### PR TITLE
feat(options): preserve key and model selections in history

### DIFF
--- a/e2e/accountActionShortcuts.spec.ts
+++ b/e2e/accountActionShortcuts.spec.ts
@@ -302,9 +302,6 @@ test("opens per-account key and model management from the row menu", async ({
   )
   await waitForExtensionRoot(page)
 
-  const targetUrl = new URL(page.url())
-  expect(targetUrl.hash).toBe(`#${MENU_ITEM_IDS.MODELS}`)
-  expect(targetUrl.searchParams.get("accountId")).toBe("shortcut-account")
   await expect(
     page.getByRole("heading", { name: "gpt-shortcut" }),
   ).toBeVisible()

--- a/e2e/accountActionShortcuts.spec.ts
+++ b/e2e/accountActionShortcuts.spec.ts
@@ -20,7 +20,6 @@ import {
   seedStoredAccounts,
   stubLlmMetadataIndex,
   stubNewApiSiteRoutes,
-  waitForExtensionPage,
 } from "~~/e2e/utils/commonUserFlows"
 import {
   expectPermissionOnboardingHidden,
@@ -275,49 +274,39 @@ test("opens per-account key and model management from the row menu", async ({
   await waitForExtensionRoot(page)
   await expectPermissionOnboardingHidden(page)
 
-  const keysPagePromise = waitForExtensionPage(context, {
-    extensionId,
-    path: OPTIONS_PAGE_PATH,
-    hash: `#${MENU_ITEM_IDS.KEYS}`,
-    searchParams: { accountId: "shortcut-account" },
-  })
-
   await openAccountActionsMenu(page, "Shortcut Account")
   await page
     .getByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.rowKeyManagementMenuItem)
     .click()
 
-  const keysPage = await keysPagePromise
-  installExtensionPageGuards(keysPage)
-  await waitForExtensionRoot(keysPage)
-  await expect(keysPage).toHaveURL(
+  await expect(page).toHaveURL(
     /options\.html\?accountId=shortcut-account#keys$/,
   )
-  await keysPage.close()
+  await waitForExtensionRoot(page)
 
-  await page.bringToFront()
-
-  const modelsPagePromise = waitForExtensionPage(context, {
-    extensionId,
-    path: OPTIONS_PAGE_PATH,
-    hash: `#${MENU_ITEM_IDS.MODELS}`,
-    searchParams: { accountId: "shortcut-account" },
-  })
+  await page.goBack()
+  await expect(page).toHaveURL(
+    new RegExp(`options\\.html#${MENU_ITEM_IDS.ACCOUNT}$`, "u"),
+  )
+  await expect(
+    page.getByTestId(getAccountManagementListItemTestId("shortcut-account")),
+  ).toBeVisible()
 
   await openAccountActionsMenu(page, "Shortcut Account")
   await page
     .getByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.rowModelManagementMenuItem)
     .click()
 
-  const modelsPage = await modelsPagePromise
-  installExtensionPageGuards(modelsPage)
-  await waitForExtensionRoot(modelsPage)
+  await expect(page).toHaveURL(
+    /options\.html\?accountId=shortcut-account#models$/,
+  )
+  await waitForExtensionRoot(page)
 
-  const targetUrl = new URL(modelsPage.url())
+  const targetUrl = new URL(page.url())
   expect(targetUrl.hash).toBe(`#${MENU_ITEM_IDS.MODELS}`)
   expect(targetUrl.searchParams.get("accountId")).toBe("shortcut-account")
   await expect(
-    modelsPage.getByRole("heading", { name: "gpt-shortcut" }),
+    page.getByRole("heading", { name: "gpt-shortcut" }),
   ).toBeVisible()
 })
 

--- a/e2e/apiCredentialProfilesOptionsActions.spec.ts
+++ b/e2e/apiCredentialProfilesOptionsActions.spec.ts
@@ -267,9 +267,6 @@ test("opens model management for an options-page API credential profile", async 
   })
   await waitForExtensionRoot(page)
 
-  const targetUrl = new URL(page.url())
-  expect(targetUrl.hash).toBe(`#${MENU_ITEM_IDS.MODELS}`)
-  expect(targetUrl.searchParams.get("profileId")).toBe("profile-models")
   await expect(page.getByText("gpt-options-model")).toBeVisible()
 })
 

--- a/e2e/apiCredentialProfilesOptionsActions.spec.ts
+++ b/e2e/apiCredentialProfilesOptionsActions.spec.ts
@@ -14,7 +14,6 @@ import {
   seedApiCredentialProfiles,
   seedUserPreferences,
   stubLlmMetadataIndex,
-  waitForExtensionPage,
 } from "~~/e2e/utils/commonUserFlows"
 import {
   expectPermissionOnboardingHidden,
@@ -256,27 +255,22 @@ test("opens model management for an options-page API credential profile", async 
 
   await openProfilesPage(page, extensionId)
 
-  const targetPagePromise = waitForExtensionPage(context, {
-    extensionId,
-    path: OPTIONS_PAGE_PATH,
-    hash: `#${MENU_ITEM_IDS.MODELS}`,
-    searchParams: {
-      profileId: "profile-models",
-    },
-  })
-
   await page
     .getByTestId(API_CREDENTIAL_PROFILES_TEST_IDS.openModelManagementButton)
     .click()
 
-  const targetPage = await targetPagePromise
-  installExtensionPageGuards(targetPage)
-  await waitForExtensionRoot(targetPage)
+  await expect(page).toHaveURL((url) => {
+    return (
+      url.hash === `#${MENU_ITEM_IDS.MODELS}` &&
+      url.searchParams.get("profileId") === "profile-models"
+    )
+  })
+  await waitForExtensionRoot(page)
 
-  const targetUrl = new URL(targetPage.url())
+  const targetUrl = new URL(page.url())
   expect(targetUrl.hash).toBe(`#${MENU_ITEM_IDS.MODELS}`)
   expect(targetUrl.searchParams.get("profileId")).toBe("profile-models")
-  await expect(targetPage.getByText("gpt-options-model")).toBeVisible()
+  await expect(page.getByText("gpt-options-model")).toBeVisible()
 })
 
 test("opens the CC Switch model picker for an API credential profile", async ({

--- a/e2e/modelListCommonFlows.spec.ts
+++ b/e2e/modelListCommonFlows.spec.ts
@@ -15,7 +15,6 @@ import {
   seedStoredAccounts,
   stubLlmMetadataIndex,
   stubNewApiSiteRoutes,
-  waitForExtensionPage,
 } from "~~/e2e/utils/commonUserFlows"
 import {
   expectPermissionOnboardingHidden,
@@ -240,40 +239,33 @@ test("creates an API profile from the empty model list and loads models from it"
 
   expect(profileId).toBeTruthy()
 
-  const modelsPagePromise = waitForExtensionPage(context, {
-    extensionId,
-    path: OPTIONS_PAGE_PATH,
-    hash: `#${MENU_ITEM_IDS.MODELS}`,
-    searchParams: { profileId: profileId! },
-  })
-
   await page
     .getByTestId(API_CREDENTIAL_PROFILES_TEST_IDS.openModelManagementButton)
     .click()
 
-  const modelsPage = await modelsPagePromise
-  installExtensionPageGuards(modelsPage)
-  await waitForExtensionRoot(modelsPage)
+  await expect(page).toHaveURL((url) => {
+    return (
+      url.hash === `#${MENU_ITEM_IDS.MODELS}` &&
+      url.searchParams.get("profileId") === profileId
+    )
+  })
+  await waitForExtensionRoot(page)
 
-  const targetUrl = new URL(modelsPage.url())
+  const targetUrl = new URL(page.url())
   expect(targetUrl.hash).toBe(`#${MENU_ITEM_IDS.MODELS}`)
   expect(targetUrl.searchParams.get("profileId")).toBe(profileId)
 
+  await expect(page.getByRole("heading", { name: "Model List" })).toBeVisible()
   await expect(
-    modelsPage.getByRole("heading", { name: "Model List" }),
-  ).toBeVisible()
-  await expect(
-    modelsPage.getByRole("heading", {
+    page.getByRole("heading", {
       name: "gpt-first-profile",
       exact: true,
     }),
   ).toBeVisible()
   await expect(
-    modelsPage.getByRole("heading", { name: "gpt-first-profile-pro" }),
+    page.getByRole("heading", { name: "gpt-first-profile-pro" }),
   ).toBeVisible()
   await expect(
-    modelsPage
-      .getByText("Profile: First Model Profile", { exact: false })
-      .first(),
+    page.getByText("Profile: First Model Profile", { exact: false }).first(),
   ).toBeVisible()
 })

--- a/e2e/modelListCommonFlows.spec.ts
+++ b/e2e/modelListCommonFlows.spec.ts
@@ -251,10 +251,6 @@ test("creates an API profile from the empty model list and loads models from it"
   })
   await waitForExtensionRoot(page)
 
-  const targetUrl = new URL(page.url())
-  expect(targetUrl.hash).toBe(`#${MENU_ITEM_IDS.MODELS}`)
-  expect(targetUrl.searchParams.get("profileId")).toBe(profileId)
-
   await expect(page.getByRole("heading", { name: "Model List" })).toBeVisible()
   await expect(
     page.getByRole("heading", {

--- a/e2e/scenarios/modelToKeyManagement.ts
+++ b/e2e/scenarios/modelToKeyManagement.ts
@@ -11,7 +11,6 @@ import {
   type ModelListCatalogExpectations,
 } from "~~/e2e/scenarios/modelListCatalog"
 import { deleteTokenFromKeyManagementPage } from "~~/e2e/utils/accountLifecycle"
-import { waitForExtensionPage } from "~~/e2e/utils/commonUserFlows"
 import { expectPermissionOnboardingHidden } from "~~/e2e/utils/extensionState"
 import { waitForExtensionRoot } from "~~/e2e/utils/lazyLoading"
 
@@ -185,19 +184,18 @@ export async function runModelToKeyManagementScenario(
     await expect(keyDialog.getByText(createdCompatibleKeyLabel)).toBeVisible()
   }
 
-  const keysPagePromise = waitForExtensionPage(page.context(), {
-    extensionId: params.extensionId,
-    path: OPTIONS_PAGE_PATH,
-    hash: `#${MENU_ITEM_IDS.KEYS}`,
-    searchParams: { accountId: params.accountId },
-    reuseExistingPage: false,
-  })
-
   await keyDialog
     .getByTestId(MODEL_LIST_TEST_IDS.openKeyManagementButton)
     .click()
 
-  const keysPage = await keysPagePromise
+  await expect(page).toHaveURL((url) => {
+    return (
+      url.pathname === `/${OPTIONS_PAGE_PATH}` &&
+      url.hash === `#${MENU_ITEM_IDS.KEYS}` &&
+      url.searchParams.get("accountId") === params.accountId
+    )
+  })
+  const keysPage = page
 
   try {
     await params.prepareKeyManagementPage?.(keysPage)

--- a/e2e/utils/accountLifecycle.ts
+++ b/e2e/utils/accountLifecycle.ts
@@ -15,7 +15,6 @@ import {
   type ApiCredentialProfile,
 } from "~/types/apiCredentialProfiles"
 import { expect } from "~~/e2e/fixtures/extensionTest"
-import { waitForExtensionPage } from "~~/e2e/utils/commonUserFlows"
 import {
   expectPermissionOnboardingHidden,
   getPlasmoStorageRawValue,
@@ -203,7 +202,6 @@ async function openKeyManagementPage(params: {
 
 async function openKeyManagementPageFromAccountRow(params: {
   page: Page
-  extensionId: string
   accountId?: string
   siteType?: AccountSiteType
   baseUrl?: string
@@ -217,11 +215,6 @@ async function openKeyManagementPageFromAccountRow(params: {
         })
 
   await row.hover()
-  const keyManagementPagePromise = waitForExtensionPage(params.page.context(), {
-    extensionId: params.extensionId,
-    path: OPTIONS_PAGE_PATH,
-    hash: `#${MENU_ITEM_IDS.KEYS}`,
-  })
   await row
     .getByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.rowMoreActionsButton)
     .click()
@@ -229,11 +222,17 @@ async function openKeyManagementPageFromAccountRow(params: {
     .getByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.rowKeyManagementMenuItem)
     .click()
 
-  const keyManagementPage = await keyManagementPagePromise
-  await keyManagementPage.waitForLoadState("domcontentloaded")
-  await waitForExtensionRoot(keyManagementPage)
-  await expectPermissionOnboardingHidden(keyManagementPage)
-  return keyManagementPage
+  await expect(params.page).toHaveURL((url) => {
+    return (
+      url.pathname === `/${OPTIONS_PAGE_PATH}` &&
+      url.hash === `#${MENU_ITEM_IDS.KEYS}` &&
+      (params.accountId === undefined ||
+        url.searchParams.get("accountId") === params.accountId)
+    )
+  })
+  await waitForExtensionRoot(params.page)
+  await expectPermissionOnboardingHidden(params.page)
+  return params.page
 }
 
 async function submitCreateTokenForm(params: {
@@ -331,7 +330,6 @@ export async function openKeyManagementForAccount(params: {
   if (params.openFromAccountRow) {
     return await openKeyManagementPageFromAccountRow({
       page: params.page,
-      extensionId: params.extensionId,
       accountId: params.accountId,
       siteType: params.siteType,
       baseUrl: params.baseUrl,

--- a/src/features/AccountManagement/components/AccountActionButtons/index.tsx
+++ b/src/features/AccountManagement/components/AccountActionButtons/index.tsx
@@ -272,6 +272,7 @@ export default function AccountActionButtons({
   } = useAccountDataContext()
   const { openEditAccount } = useDialogStateContext()
   const [isCheckingTokens, setIsCheckingTokens] = useState(false)
+  const [isMoreActionsOpen, setIsMoreActionsOpen] = useState(false)
 
   const isAccountDisabled = site.disabled === true
   const isQuickCheckinEligible =
@@ -403,12 +404,18 @@ export default function AccountActionButtons({
   }
 
   // Navigation functions for secondary menu items
+  const navigateAfterClosingMoreActions = (navigate: () => void) => {
+    setIsMoreActionsOpen(false)
+    // Let Radix release its scroll lock before the options route unmounts it.
+    window.requestAnimationFrame(navigate)
+  }
+
   const handleNavigateToKeyManagement = () => {
-    openKeysPage(site.id)
+    navigateAfterClosingMoreActions(() => openKeysPage(site.id))
   }
 
   const handleNavigateToModelManagement = () => {
-    openModelsPage(site.id)
+    navigateAfterClosingMoreActions(() => openModelsPage(site.id))
   }
 
   const handleNavigateToUsageManagement = () => {
@@ -843,7 +850,10 @@ export default function AccountActionButtons({
         </IconButton>
 
         {/* Secondary Level - Dropdown menu */}
-        <DropdownMenu>
+        <DropdownMenu
+          open={isMoreActionsOpen}
+          onOpenChange={setIsMoreActionsOpen}
+        >
           <DropdownMenuTrigger asChild>
             <IconButton
               variant="ghost"

--- a/src/features/KeyManagement/KeyManagement.tsx
+++ b/src/features/KeyManagement/KeyManagement.tsx
@@ -22,7 +22,11 @@ import {
 } from "~/services/managedSites/tokenChannelStatus"
 import type { AccountToken } from "~/types"
 import { ACCOUNT_KEY_REPAIR_JOB_STATES } from "~/types/accountKeyAutoProvisioning"
-import { openModelsPage, pushWithinOptionsPage } from "~/utils/navigation"
+import {
+  openModelsPage,
+  pushWithinOptionsPage,
+  replaceWithinOptionsPage,
+} from "~/utils/navigation"
 
 import { AccountSelectorPanel } from "./components/AccountSelectorPanel"
 import { AccountSummaryBar } from "./components/AccountSummaryBar"
@@ -219,6 +223,17 @@ export default function KeyManagement(props: {
     void openModelsPage(selectedAccount)
   }, [selectedAccount])
 
+  const handleSelectedAccountChange = useCallback(
+    (accountId: string) => {
+      setSelectedAccount(accountId)
+      replaceWithinOptionsPage(
+        `#${MENU_ITEM_IDS.KEYS}`,
+        accountId ? { accountId } : undefined,
+      )
+    },
+    [setSelectedAccount],
+  )
+
   const handleRequestAccountSelection = useCallback(() => {
     const selectorTrigger = accountSelectorTriggerRef.current
 
@@ -375,7 +390,7 @@ export default function KeyManagement(props: {
 
       <AccountSelectorPanel
         selectedAccount={selectedAccount}
-        setSelectedAccount={setSelectedAccount}
+        setSelectedAccount={handleSelectedAccountChange}
         displayData={displayData}
         selectorOpen={isAccountSelectorOpen}
         onSelectorOpenChange={setIsAccountSelectorOpen}

--- a/src/features/KeyManagement/hooks/useKeyManagement.ts
+++ b/src/features/KeyManagement/hooks/useKeyManagement.ts
@@ -1218,7 +1218,7 @@ export function useKeyManagement(routeParams?: Record<string, string>) {
       return
     }
 
-    const requestedAccountId = routeParams.accountId?.trim()
+    const requestedAccountId = routeParams?.accountId?.trim()
     if (!requestedAccountId) {
       setSelectedAccount("")
       return

--- a/src/features/KeyManagement/hooks/useKeyManagement.ts
+++ b/src/features/KeyManagement/hooks/useKeyManagement.ts
@@ -254,6 +254,7 @@ const hashStringForCache = (value: string) => {
  * @returns State, derived data, and handlers for token management UI.
  */
 export function useKeyManagement(routeParams?: Record<string, string>) {
+  const isRouteControlled = routeParams !== undefined
   const { t } = useTranslation(["keyManagement", "messages"])
   const { enabledDisplayData } = useAccountData()
   const {
@@ -1213,15 +1214,25 @@ export function useKeyManagement(routeParams?: Record<string, string>) {
   }, [accountById, allAccountsFilterAccountIds, selectedAccount])
 
   useEffect(() => {
-    if (routeParams?.accountId && enabledDisplayData.length > 0) {
-      const accountExists = enabledDisplayData.some(
-        (acc) => acc.id === routeParams.accountId,
-      )
-      if (accountExists) {
-        setSelectedAccount(routeParams.accountId)
-      }
+    if (!isRouteControlled) {
+      return
     }
-  }, [routeParams?.accountId, enabledDisplayData])
+
+    const requestedAccountId = routeParams.accountId?.trim()
+    if (!requestedAccountId) {
+      setSelectedAccount("")
+      return
+    }
+
+    if (enabledDisplayData.length === 0) {
+      return
+    }
+
+    const accountExists =
+      requestedAccountId === KEY_MANAGEMENT_ALL_ACCOUNTS_VALUE ||
+      enabledDisplayData.some((acc) => acc.id === requestedAccountId)
+    setSelectedAccount(accountExists ? requestedAccountId : "")
+  }, [routeParams?.accountId, enabledDisplayData, isRouteControlled])
 
   useEffect(() => {
     if (selectedAccount) {

--- a/src/features/ModelList/ModelList.tsx
+++ b/src/features/ModelList/ModelList.tsx
@@ -22,7 +22,9 @@ import {
   type BatchVerifyModelItem,
 } from "~/features/ModelList/batchVerification"
 import {
+  ALL_ACCOUNTS_SOURCE_VALUE,
   MODEL_MANAGEMENT_SOURCE_KINDS,
+  resolveModelManagementSource,
   type ModelManagementItemSource,
 } from "~/features/ModelList/modelManagementSources"
 import {
@@ -48,7 +50,11 @@ import {
 } from "~/services/verification/verificationResultHistory"
 import type { DisplaySiteData } from "~/types"
 import type { ApiCredentialProfile } from "~/types/apiCredentialProfiles"
-import { openKeysPage, pushWithinOptionsPage } from "~/utils/navigation"
+import {
+  openKeysPage,
+  pushWithinOptionsPage,
+  replaceWithinOptionsPage,
+} from "~/utils/navigation"
 
 import { sortModelListAccounts } from "./accountOrdering"
 import { AccountSelector } from "./components/AccountSelector"
@@ -177,6 +183,29 @@ export default function ModelList(props: {
         accountSummaryCountsByAccountId,
       }),
     [accountQueryStates, accountSummaryCountsByAccountId, accounts],
+  )
+
+  const handleSelectedSourceValueChange = useCallback(
+    (sourceValue: string) => {
+      setSelectedSourceValue(sourceValue)
+
+      const source = resolveModelManagementSource({
+        value: sourceValue,
+        accounts,
+        profiles,
+      })
+      const searchParams =
+        source?.kind === MODEL_MANAGEMENT_SOURCE_KINDS.ACCOUNT
+          ? { accountId: source.account.id }
+          : source?.kind === MODEL_MANAGEMENT_SOURCE_KINDS.PROFILE
+            ? { profileId: source.profile.id }
+            : source?.kind === MODEL_MANAGEMENT_SOURCE_KINDS.ALL_ACCOUNTS
+              ? { accountId: ALL_ACCOUNTS_SOURCE_VALUE }
+              : undefined
+
+      replaceWithinOptionsPage(`#${MENU_ITEM_IDS.MODELS}`, searchParams)
+    },
+    [accounts, profiles, setSelectedSourceValue],
   )
 
   const handleGroupClick = (group: string) => {
@@ -529,7 +558,7 @@ export default function ModelList(props: {
       />
       <AccountSelector
         selectedSourceValue={selectedSourceValue}
-        setSelectedSourceValue={setSelectedSourceValue}
+        setSelectedSourceValue={handleSelectedSourceValueChange}
         accounts={sortedAccounts}
         profiles={profiles}
         showAllAccountsGroupFilter={isAllAccountsScope}
@@ -697,7 +726,7 @@ export default function ModelList(props: {
             selectedSource={selectedSource}
             sourceCapabilities={sourceCapabilities}
             selectedSourceValue={selectedSourceValue}
-            setSelectedSourceValue={setSelectedSourceValue}
+            setSelectedSourceValue={handleSelectedSourceValueChange}
             searchTerm={searchTerm}
             setSearchTerm={setSearchTerm}
             sortMode={sortMode}

--- a/src/features/ModelList/hooks/useModelListData.ts
+++ b/src/features/ModelList/hooks/useModelListData.ts
@@ -10,6 +10,7 @@ import {
   isAihubmixModelListPricing,
 } from "../aihubmixModelList"
 import {
+  ALL_ACCOUNTS_SOURCE_VALUE,
   deriveModelListSourceCapabilities,
   EMPTY_MODEL_MANAGEMENT_CAPABILITIES,
   isProfileSourceValue,
@@ -30,6 +31,25 @@ import { useModelListState } from "./useModelListState"
 
 const ROUTE_SOURCE_PENDING = Symbol("route-source-pending")
 
+/** Resolves account routing after profile-route precedence has been settled. */
+function resolveRouteAccountSourceValue(
+  requestedAccountId: string | undefined,
+  accounts: readonly { id: string }[],
+): string {
+  if (requestedAccountId === ALL_ACCOUNTS_SOURCE_VALUE) {
+    return accounts.length > 0
+      ? ALL_ACCOUNTS_SOURCE_VALUE
+      : NO_MODEL_MANAGEMENT_SOURCE_VALUE
+  }
+
+  const matchedAccount = requestedAccountId
+    ? accounts.find((account) => account.id === requestedAccountId)
+    : null
+  return matchedAccount
+    ? toAccountSourceValue(matchedAccount.id)
+    : NO_MODEL_MANAGEMENT_SOURCE_VALUE
+}
+
 /**
  * Aggregates model list state, data loading, and filtering in one hook.
  * Route-driven source selection lives here so it can wait for profile storage
@@ -37,6 +57,7 @@ const ROUTE_SOURCE_PENDING = Symbol("route-source-pending")
  * @returns Combined account data, UI state, model data, and filtered results.
  */
 export function useModelListData(routeParams?: Record<string, string>) {
+  const isRouteControlled = routeParams !== undefined
   // Single source of account data
   const { enabledDisplayData } = useAccountData()
   const accounts = useMemo(() => enabledDisplayData || [], [enabledDisplayData])
@@ -79,24 +100,17 @@ export function useModelListData(routeParams?: Record<string, string>) {
         return ROUTE_SOURCE_PENDING
       }
 
-      const matchedAccount = requestedAccountId
-        ? accounts.find((account) => account.id === requestedAccountId)
-        : null
-      return matchedAccount
-        ? toAccountSourceValue(matchedAccount.id)
-        : NO_MODEL_MANAGEMENT_SOURCE_VALUE
+      return resolveRouteAccountSourceValue(requestedAccountId, accounts)
     }
 
     if (requestedAccountId) {
-      const matchedAccount = accounts.find(
-        (account) => account.id === requestedAccountId,
-      )
-      return matchedAccount ? toAccountSourceValue(matchedAccount.id) : null
+      return resolveRouteAccountSourceValue(requestedAccountId, accounts)
     }
 
-    return null
+    return isRouteControlled ? NO_MODEL_MANAGEMENT_SOURCE_VALUE : null
   }, [
     accounts,
+    isRouteControlled,
     profiles,
     profilesLoading,
     routeParams?.accountId,

--- a/src/utils/navigation/index.ts
+++ b/src/utils/navigation/index.ts
@@ -573,6 +573,14 @@ const _openApiCredentialProfilesPage = (
  * @param accountId Optional account id to prefill.
  */
 const _openKeysPage = async (accountId?: string) => {
+  const targetHash = `#${MENU_ITEM_IDS.KEYS}`
+  const searchParams = accountId ? { accountId } : undefined
+
+  if (isOnOptionsPage()) {
+    pushWithinOptionsPage(targetHash, searchParams)
+    return
+  }
+
   const baseUrl = getExtensionURL("options.html")
   const url = new URL(baseUrl)
 
@@ -580,7 +588,7 @@ const _openKeysPage = async (accountId?: string) => {
     url.searchParams.set("accountId", accountId)
   }
 
-  url.hash = MENU_ITEM_IDS.KEYS
+  url.hash = targetHash
   await createActiveTab(url.toString())
 }
 
@@ -599,6 +607,22 @@ type ModelManagementNavigationTarget =
  * Opens the Models page, optionally pre-selecting an account or stored profile.
  */
 const _openModelsPage = async (target?: ModelManagementNavigationTarget) => {
+  const targetHash = `#${MENU_ITEM_IDS.MODELS}`
+  const searchParams =
+    typeof target === "string"
+      ? { accountId: target }
+      : target
+        ? {
+            accountId: target.accountId,
+            profileId: target.profileId,
+          }
+        : undefined
+
+  if (isOnOptionsPage()) {
+    pushWithinOptionsPage(targetHash, searchParams)
+    return
+  }
+
   const baseUrl = getExtensionURL("options.html")
   const url = new URL(baseUrl)
 
@@ -614,7 +638,7 @@ const _openModelsPage = async (target?: ModelManagementNavigationTarget) => {
     }
   }
 
-  url.hash = MENU_ITEM_IDS.MODELS
+  url.hash = targetHash
   await createActiveTab(url.toString())
 }
 

--- a/tests/entrypoints/options/pages/KeyManagement/KeyManagement.emptyStateActions.test.tsx
+++ b/tests/entrypoints/options/pages/KeyManagement/KeyManagement.emptyStateActions.test.tsx
@@ -16,6 +16,7 @@ const {
   tokenListPropsSpy,
   useKeyManagementMock,
   pushWithinOptionsPageMock,
+  replaceWithinOptionsPageMock,
   openModelsPageMock,
   mockedUseUserPreferencesContext,
   addTokenDialogPropsSpy,
@@ -26,6 +27,7 @@ const {
   tokenListPropsSpy: vi.fn(),
   useKeyManagementMock: vi.fn(),
   pushWithinOptionsPageMock: vi.fn(),
+  replaceWithinOptionsPageMock: vi.fn(),
   openModelsPageMock: vi.fn(),
   mockedUseUserPreferencesContext: vi.fn(),
   addTokenDialogPropsSpy: vi.fn(),
@@ -49,6 +51,7 @@ vi.mock("~/utils/navigation", async (importOriginal) => {
   return {
     ...actual,
     pushWithinOptionsPage: pushWithinOptionsPageMock,
+    replaceWithinOptionsPage: replaceWithinOptionsPageMock,
     openModelsPage: openModelsPageMock,
   }
 })
@@ -106,13 +109,33 @@ vi.mock("~/contexts/UserPreferencesContext", async (importOriginal) => {
 })
 
 vi.mock("~/features/KeyManagement/components/AccountSelectorPanel", () => {
-  function MockAccountSelectorPanel(props: { selectorOpen?: boolean }) {
-    const { selectorOpen } = props
+  function MockAccountSelectorPanel(props: {
+    selectorOpen?: boolean
+    setSelectedAccount: (value: string) => void
+  }) {
+    const { selectorOpen, setSelectedAccount } = props
 
     return (
-      <button type="button" role="combobox" aria-expanded={selectorOpen}>
-        Mock account selector
-      </button>
+      <div>
+        <button type="button" role="combobox" aria-expanded={selectorOpen}>
+          Mock account selector
+        </button>
+        <button
+          type="button"
+          onClick={() => setSelectedAccount("selected-account")}
+        >
+          select-account
+        </button>
+        <button
+          type="button"
+          onClick={() => setSelectedAccount(KEY_MANAGEMENT_ALL_ACCOUNTS_VALUE)}
+        >
+          select-all-accounts
+        </button>
+        <button type="button" onClick={() => setSelectedAccount("")}>
+          clear-account
+        </button>
+      </div>
     )
   }
 
@@ -230,6 +253,7 @@ describe("KeyManagement empty-state actions", () => {
     tokenListPropsSpy.mockReset()
     useKeyManagementMock.mockReset()
     pushWithinOptionsPageMock.mockReset()
+    replaceWithinOptionsPageMock.mockReset()
     openModelsPageMock.mockReset()
     addTokenDialogPropsSpy.mockReset()
     accountSummaryBarPropsSpy.mockReset()
@@ -334,6 +358,35 @@ describe("KeyManagement empty-state actions", () => {
 
     expect(openModelsPageMock).toHaveBeenCalledWith(account.id)
   })
+
+  it.each([
+    ["select-account", "selected-account", { accountId: "selected-account" }],
+    [
+      "select-all-accounts",
+      KEY_MANAGEMENT_ALL_ACCOUNTS_VALUE,
+      { accountId: KEY_MANAGEMENT_ALL_ACCOUNTS_VALUE },
+    ],
+    ["clear-account", "", undefined],
+  ])(
+    "replaces the key-management route when the user chooses %s",
+    async (buttonName, selectedValue, expectedParams) => {
+      const user = userEvent.setup()
+      const setSelectedAccount = vi.fn()
+      useKeyManagementMock.mockReturnValue(
+        createHookResult({ setSelectedAccount }),
+      )
+
+      render(<KeyManagement />)
+
+      await user.click(await screen.findByRole("button", { name: buttonName }))
+
+      expect(setSelectedAccount).toHaveBeenCalledWith(selectedValue)
+      expect(replaceWithinOptionsPageMock).toHaveBeenCalledWith(
+        "#keys",
+        expectedParams,
+      )
+    },
+  )
 
   it("does not show the model-list title shortcut while viewing all accounts", async () => {
     const account = createAccount({

--- a/tests/entrypoints/options/pages/KeyManagement/useKeyManagement.test.tsx
+++ b/tests/entrypoints/options/pages/KeyManagement/useKeyManagement.test.tsx
@@ -3923,6 +3923,41 @@ describe("useKeyManagement enabled account filtering", () => {
     await waitFor(() => expect(fetchAccountTokens).toHaveBeenCalledTimes(1))
   })
 
+  it("waits for enabled accounts before selecting a routed account", async () => {
+    const mockedUseAccountData = vi.mocked(useAccountData)
+    const account = createDisplayAccount({
+      id: "hydrated-route-acc",
+      name: "Hydrated Route Account",
+    })
+
+    mockedUseAccountData.mockReturnValue({ enabledDisplayData: [] } as any)
+
+    const fetchAccountTokens = vi.fn().mockResolvedValue([])
+    vi.mocked(getSiteTypeCapabilities).mockReturnValue(
+      createAdapterWithKeyManagement({
+        fetchTokens: fetchAccountTokens,
+      }) as any,
+    )
+
+    const { result, rerender } = renderHook(
+      () => useKeyManagement({ accountId: account.id }),
+      {
+        wrapper: createWrapper(),
+      },
+    )
+
+    expect(result.current.selectedAccount).toBe("")
+    expect(fetchAccountTokens).not.toHaveBeenCalled()
+
+    mockedUseAccountData.mockReturnValue({
+      enabledDisplayData: [account],
+    } as any)
+    rerender()
+
+    await waitFor(() => expect(result.current.selectedAccount).toBe(account.id))
+    await waitFor(() => expect(fetchAccountTokens).toHaveBeenCalledTimes(1))
+  })
+
   it("restores all-accounts selection from routeParams.accountId", async () => {
     const mockedUseAccountData = vi.mocked(useAccountData)
     const account = createDisplayAccount({

--- a/tests/entrypoints/options/pages/KeyManagement/useKeyManagement.test.tsx
+++ b/tests/entrypoints/options/pages/KeyManagement/useKeyManagement.test.tsx
@@ -3923,6 +3923,87 @@ describe("useKeyManagement enabled account filtering", () => {
     await waitFor(() => expect(fetchAccountTokens).toHaveBeenCalledTimes(1))
   })
 
+  it("restores all-accounts selection from routeParams.accountId", async () => {
+    const mockedUseAccountData = vi.mocked(useAccountData)
+    const account = createDisplayAccount({
+      id: "route-acc",
+      name: "Route Account",
+    })
+
+    mockedUseAccountData.mockReturnValue({
+      enabledDisplayData: [account],
+    } as any)
+
+    const fetchAccountTokens = vi.fn().mockResolvedValue([])
+    vi.mocked(getSiteTypeCapabilities).mockReturnValue(
+      createAdapterWithKeyManagement({
+        fetchTokens: fetchAccountTokens,
+      }) as any,
+    )
+
+    const { result } = renderHook(
+      () =>
+        useKeyManagement({
+          accountId: KEY_MANAGEMENT_ALL_ACCOUNTS_VALUE,
+        }),
+      {
+        wrapper: createWrapper(),
+      },
+    )
+
+    await waitFor(() =>
+      expect(result.current.selectedAccount).toBe(
+        KEY_MANAGEMENT_ALL_ACCOUNTS_VALUE,
+      ),
+    )
+    await waitFor(() => expect(fetchAccountTokens).toHaveBeenCalledTimes(1))
+  })
+
+  it.each([
+    ["an empty route", {}],
+    ["an invalid account route", { accountId: "missing-account" }],
+  ] satisfies Array<[string, Record<string, string>]>)(
+    "clears the selected account when a controlled route changes to %s",
+    async (_label, nextRouteParams) => {
+      const mockedUseAccountData = vi.mocked(useAccountData)
+      const account = createDisplayAccount({
+        id: "route-acc",
+        name: "Route Account",
+      })
+
+      mockedUseAccountData.mockReturnValue({
+        enabledDisplayData: [account],
+      } as any)
+
+      vi.mocked(getSiteTypeCapabilities).mockReturnValue(
+        createAdapterWithKeyManagement({
+          fetchTokens: vi.fn().mockResolvedValue([]),
+        }) as any,
+      )
+
+      const { result, rerender } = renderHook(
+        ({ routeParams }: { routeParams: Record<string, string> }) =>
+          useKeyManagement(routeParams),
+        {
+          initialProps: {
+            routeParams: {
+              accountId: account.id,
+            } as Record<string, string>,
+          },
+          wrapper: createWrapper(),
+        },
+      )
+
+      await waitFor(() =>
+        expect(result.current.selectedAccount).toBe(account.id),
+      )
+
+      rerender({ routeParams: nextRouteParams })
+
+      await waitFor(() => expect(result.current.selectedAccount).toBe(""))
+    },
+  )
+
   it("clears all-accounts selection when enabled accounts disappear", async () => {
     const mockedUseAccountData = vi.mocked(useAccountData)
     const account = createDisplayAccount({

--- a/tests/entrypoints/options/pages/ModelList/useModelListData.test.tsx
+++ b/tests/entrypoints/options/pages/ModelList/useModelListData.test.tsx
@@ -300,6 +300,26 @@ describe("useModelListData", () => {
     )
   })
 
+  it("clears an all-accounts route when enabled accounts disappear", async () => {
+    const { result, rerender } = renderHook(() =>
+      useModelListData({ accountId: ALL_ACCOUNTS_SOURCE_VALUE }),
+    )
+
+    await waitFor(() => {
+      expect(result.current.selectedSourceValue).toBe(ALL_ACCOUNTS_SOURCE_VALUE)
+    })
+
+    mockUseAccountData.mockReturnValue({ enabledDisplayData: [] })
+    rerender()
+
+    await waitFor(() => {
+      expect(result.current.selectedSourceValue).toBe(
+        NO_MODEL_MANAGEMENT_SOURCE_VALUE,
+      )
+    })
+    expect(result.current.selectedSource).toBeNull()
+  })
+
   it.each([
     ["an empty route", {}],
     ["an invalid account route", { accountId: "missing-account" }],
@@ -349,6 +369,31 @@ describe("useModelListData", () => {
     expect(result.current.selectedSource?.kind).toBe(
       MODEL_MANAGEMENT_SOURCE_KINDS.PROFILE,
     )
+  })
+
+  it("clears a profile route without an account fallback when the profile is deleted", async () => {
+    const { result, rerender } = renderHook(() =>
+      useModelListData({ profileId: PROFILE.id }),
+    )
+
+    await waitFor(() => {
+      expect(result.current.selectedSourceValue).toBe(
+        toProfileSourceValue(PROFILE.id),
+      )
+    })
+
+    mockUseApiCredentialProfiles.mockReturnValue({
+      profiles: [],
+      isLoading: false,
+    })
+    rerender()
+
+    await waitFor(() => {
+      expect(result.current.selectedSourceValue).toBe(
+        NO_MODEL_MANAGEMENT_SOURCE_VALUE,
+      )
+    })
+    expect(result.current.selectedSource).toBeNull()
   })
 
   it("waits for profile storage before falling back from a stale profile deep link to accountId", async () => {

--- a/tests/entrypoints/options/pages/ModelList/useModelListData.test.tsx
+++ b/tests/entrypoints/options/pages/ModelList/useModelListData.test.tsx
@@ -286,6 +286,55 @@ describe("useModelListData", () => {
     )
   })
 
+  it("restores all-accounts selection from routeParams.accountId", async () => {
+    const { result } = renderHook(() =>
+      useModelListData({ accountId: ALL_ACCOUNTS_SOURCE_VALUE }),
+    )
+
+    await waitFor(() => {
+      expect(result.current.selectedSourceValue).toBe(ALL_ACCOUNTS_SOURCE_VALUE)
+    })
+
+    expect(result.current.selectedSource?.kind).toBe(
+      MODEL_MANAGEMENT_SOURCE_KINDS.ALL_ACCOUNTS,
+    )
+  })
+
+  it.each([
+    ["an empty route", {}],
+    ["an invalid account route", { accountId: "missing-account" }],
+  ] satisfies Array<[string, Record<string, string>]>)(
+    "clears the selected source when a controlled route changes to %s",
+    async (_label, nextRouteParams) => {
+      const { result, rerender } = renderHook(
+        ({ routeParams }: { routeParams: Record<string, string> }) =>
+          useModelListData(routeParams),
+        {
+          initialProps: {
+            routeParams: {
+              accountId: ACCOUNT.id,
+            } as Record<string, string>,
+          },
+        },
+      )
+
+      await waitFor(() =>
+        expect(result.current.selectedSourceValue).toBe(
+          toAccountSourceValue(ACCOUNT.id),
+        ),
+      )
+
+      rerender({ routeParams: nextRouteParams })
+
+      await waitFor(() =>
+        expect(result.current.selectedSourceValue).toBe(
+          NO_MODEL_MANAGEMENT_SOURCE_VALUE,
+        ),
+      )
+      expect(result.current.selectedSource).toBeNull()
+    },
+  )
+
   it("prefers a valid route profile over a simultaneous account target", async () => {
     const { result } = renderHook(() =>
       useModelListData({ profileId: "profile-1", accountId: "acc-1" }),
@@ -332,6 +381,40 @@ describe("useModelListData", () => {
 
     expect(result.current.selectedSource?.kind).toBe(
       MODEL_MANAGEMENT_SOURCE_KINDS.ACCOUNT,
+    )
+  })
+
+  it("waits for profile storage before falling back from a stale profile deep link to all accounts", async () => {
+    mockUseApiCredentialProfiles.mockReturnValue({
+      profiles: [],
+      isLoading: true,
+    })
+
+    const { result, rerender } = renderHook(() =>
+      useModelListData({
+        profileId: "missing-profile",
+        accountId: ALL_ACCOUNTS_SOURCE_VALUE,
+      }),
+    )
+
+    expect(result.current.selectedSourceValue).toBe(
+      NO_MODEL_MANAGEMENT_SOURCE_VALUE,
+    )
+    expect(result.current.selectedSource).toBeNull()
+
+    mockUseApiCredentialProfiles.mockReturnValue({
+      profiles: [],
+      isLoading: false,
+    })
+
+    rerender()
+
+    await waitFor(() => {
+      expect(result.current.selectedSourceValue).toBe(ALL_ACCOUNTS_SOURCE_VALUE)
+    })
+
+    expect(result.current.selectedSource?.kind).toBe(
+      MODEL_MANAGEMENT_SOURCE_KINDS.ALL_ACCOUNTS,
     )
   })
 

--- a/tests/features/AccountManagement/components/AccountActionButtons.test.tsx
+++ b/tests/features/AccountManagement/components/AccountActionButtons.test.tsx
@@ -450,45 +450,60 @@ describe("AccountActionButtons", () => {
     })
   })
 
-  it("closes the account action menu before starting in-page navigation", async () => {
-    const user = userEvent.setup()
-    const site = buildDisplaySiteData({
-      id: "acc-in-page-navigation",
-      disabled: false,
-      name: "In-page Navigation Site",
-    })
-    let menuExpandedWhenNavigationStarted: string | null = null
+  it.each([
+    {
+      actionLabel: "account:actions.keyManagement",
+      getOpenPageMock: () => openKeysPageMock,
+      destination: "key management",
+    },
+    {
+      actionLabel: "account:actions.modelManagement",
+      getOpenPageMock: () => openModelsPageMock,
+      destination: "model management",
+    },
+  ])(
+    "closes the account action menu before starting $destination navigation",
+    async ({ actionLabel, getOpenPageMock }) => {
+      const user = userEvent.setup()
+      const site = buildDisplaySiteData({
+        id: "acc-in-page-navigation",
+        disabled: false,
+        name: "In-page Navigation Site",
+      })
+      let menuExpandedWhenNavigationStarted: string | null = null
 
-    render(
-      <AccountActionButtons
-        site={site}
-        onCopyKey={vi.fn()}
-        onDeleteAccount={vi.fn()}
-      />,
-    )
+      render(
+        <AccountActionButtons
+          site={site}
+          onCopyKey={vi.fn()}
+          onDeleteAccount={vi.fn()}
+        />,
+      )
 
-    const moreActionsButton = screen.getByRole("button", {
-      name: "common:actions.more",
-    })
-    openKeysPageMock.mockImplementation(() => {
-      menuExpandedWhenNavigationStarted =
-        moreActionsButton.getAttribute("aria-expanded")
-    })
+      const moreActionsButton = screen.getByRole("button", {
+        name: "common:actions.more",
+      })
+      const openPageMock = getOpenPageMock()
+      openPageMock.mockImplementation(() => {
+        menuExpandedWhenNavigationStarted =
+          moreActionsButton.getAttribute("aria-expanded")
+      })
 
-    await user.click(moreActionsButton)
-    const menu = await screen.findByRole("menu")
-    const keyManagementButton = (
-      await within(menu).findByText("account:actions.keyManagement")
-    ).closest("button")
-    expect(keyManagementButton).not.toBeNull()
+      await user.click(moreActionsButton)
+      const menu = await screen.findByRole("menu")
+      const navigationButton = (
+        await within(menu).findByText(actionLabel)
+      ).closest("button")
+      expect(navigationButton).not.toBeNull()
 
-    await user.click(keyManagementButton!)
+      await user.click(navigationButton!)
 
-    await waitFor(() => {
-      expect(openKeysPageMock).toHaveBeenCalledWith(site.id)
-    })
-    expect(menuExpandedWhenNavigationStarted).toBe("false")
-  })
+      await waitFor(() => {
+        expect(openPageMock).toHaveBeenCalledWith(site.id)
+      })
+      expect(menuExpandedWhenNavigationStarted).toBe("false")
+    },
+  )
 
   it("does not track analytics for disabled account action menu entries", async () => {
     userPreferencesContextValue.preferences = {

--- a/tests/features/AccountManagement/components/AccountActionButtons.test.tsx
+++ b/tests/features/AccountManagement/components/AccountActionButtons.test.tsx
@@ -33,8 +33,10 @@ const {
   mockTogglePinAccount,
   fetchAccountTokensMock,
   getManagedSiteServiceMock,
+  openKeysPageMock,
   openManagedSiteChannelsForChannelMock,
   openManagedSiteChannelsPageMock,
+  openModelsPageMock,
   sendRuntimeMessageMock,
   loadAccountDataMock,
   exportShareSnapshotWithToastMock,
@@ -58,8 +60,10 @@ const {
   mockTogglePinAccount: vi.fn(),
   fetchAccountTokensMock: vi.fn(),
   getManagedSiteServiceMock: vi.fn(),
+  openKeysPageMock: vi.fn(),
   openManagedSiteChannelsForChannelMock: vi.fn(),
   openManagedSiteChannelsPageMock: vi.fn(),
+  openModelsPageMock: vi.fn(),
   sendRuntimeMessageMock: vi.fn(),
   loadAccountDataMock: vi.fn(),
   exportShareSnapshotWithToastMock: vi.fn(),
@@ -162,10 +166,10 @@ vi.mock("~/contexts/UserPreferencesContext", () => ({
 }))
 
 vi.mock("~/utils/navigation", () => ({
-  openKeysPage: vi.fn(),
+  openKeysPage: openKeysPageMock,
   openManagedSiteChannelsForChannel: openManagedSiteChannelsForChannelMock,
   openManagedSiteChannelsPage: openManagedSiteChannelsPageMock,
-  openModelsPage: vi.fn(),
+  openModelsPage: openModelsPageMock,
   openRedeemPage: vi.fn(),
   openUsagePage: vi.fn(),
 }))
@@ -444,6 +448,46 @@ describe("AccountActionButtons", () => {
         entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Options,
       })
     })
+  })
+
+  it("closes the account action menu before starting in-page navigation", async () => {
+    const user = userEvent.setup()
+    const site = buildDisplaySiteData({
+      id: "acc-in-page-navigation",
+      disabled: false,
+      name: "In-page Navigation Site",
+    })
+    let menuExpandedWhenNavigationStarted: string | null = null
+
+    render(
+      <AccountActionButtons
+        site={site}
+        onCopyKey={vi.fn()}
+        onDeleteAccount={vi.fn()}
+      />,
+    )
+
+    const moreActionsButton = screen.getByRole("button", {
+      name: "common:actions.more",
+    })
+    openKeysPageMock.mockImplementation(() => {
+      menuExpandedWhenNavigationStarted =
+        moreActionsButton.getAttribute("aria-expanded")
+    })
+
+    await user.click(moreActionsButton)
+    const menu = await screen.findByRole("menu")
+    const keyManagementButton = (
+      await within(menu).findByText("account:actions.keyManagement")
+    ).closest("button")
+    expect(keyManagementButton).not.toBeNull()
+
+    await user.click(keyManagementButton!)
+
+    await waitFor(() => {
+      expect(openKeysPageMock).toHaveBeenCalledWith(site.id)
+    })
+    expect(menuExpandedWhenNavigationStarted).toBe("false")
   })
 
   it("does not track analytics for disabled account action menu entries", async () => {

--- a/tests/features/AccountManagement/components/AccountActionButtons.test.tsx
+++ b/tests/features/AccountManagement/components/AccountActionButtons.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { SITE_TYPES } from "~/constants/siteType"
 import AccountActionButtons from "~/features/AccountManagement/components/AccountActionButtons"
+import { ACCOUNT_MANAGEMENT_TEST_IDS } from "~/features/AccountManagement/testIds"
 import type { ManagedUpstreamResourcesCapability } from "~/services/apiAdapters/contracts/managedUpstreamResources"
 import { MANAGED_UPSTREAM_RESOURCE_FEATURES } from "~/services/managedSites/managedUpstreamResourceMigration"
 import type { UserPreferences } from "~/services/preferences/userPreferences"
@@ -452,18 +453,18 @@ describe("AccountActionButtons", () => {
 
   it.each([
     {
-      actionLabel: "account:actions.keyManagement",
+      testId: ACCOUNT_MANAGEMENT_TEST_IDS.rowKeyManagementMenuItem,
       getOpenPageMock: () => openKeysPageMock,
       destination: "key management",
     },
     {
-      actionLabel: "account:actions.modelManagement",
+      testId: ACCOUNT_MANAGEMENT_TEST_IDS.rowModelManagementMenuItem,
       getOpenPageMock: () => openModelsPageMock,
       destination: "model management",
     },
   ])(
     "closes the account action menu before starting $destination navigation",
-    async ({ actionLabel, getOpenPageMock }) => {
+    async ({ testId, getOpenPageMock }) => {
       const user = userEvent.setup()
       const site = buildDisplaySiteData({
         id: "acc-in-page-navigation",
@@ -491,12 +492,9 @@ describe("AccountActionButtons", () => {
 
       await user.click(moreActionsButton)
       const menu = await screen.findByRole("menu")
-      const navigationButton = (
-        await within(menu).findByText(actionLabel)
-      ).closest("button")
-      expect(navigationButton).not.toBeNull()
+      const navigationButton = within(menu).getByTestId(testId)
 
-      await user.click(navigationButton!)
+      await user.click(navigationButton)
 
       await waitFor(() => {
         expect(openPageMock).toHaveBeenCalledWith(site.id)

--- a/tests/features/ModelList/ModelList.test.tsx
+++ b/tests/features/ModelList/ModelList.test.tsx
@@ -4,13 +4,18 @@ import type { ReactNode } from "react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import ModelList from "~/features/ModelList/ModelList"
-import { MODEL_MANAGEMENT_SOURCE_KINDS } from "~/features/ModelList/modelManagementSources"
+import {
+  ALL_ACCOUNTS_SOURCE_VALUE,
+  MODEL_MANAGEMENT_SOURCE_KINDS,
+} from "~/features/ModelList/modelManagementSources"
 import { MODEL_LIST_TEST_IDS } from "~/features/ModelList/testIds"
 
-const { mockUseModelListData, openKeysPageMock } = vi.hoisted(() => ({
-  mockUseModelListData: vi.fn(),
-  openKeysPageMock: vi.fn(),
-}))
+const { mockUseModelListData, openKeysPageMock, replaceWithinOptionsPageMock } =
+  vi.hoisted(() => ({
+    mockUseModelListData: vi.fn(),
+    openKeysPageMock: vi.fn(),
+    replaceWithinOptionsPageMock: vi.fn(),
+  }))
 
 vi.mock("react-i18next", async (importOriginal) => {
   const actual = await importOriginal<typeof import("react-i18next")>()
@@ -33,6 +38,7 @@ vi.mock("~/utils/navigation", async (importOriginal) => {
   return {
     ...actual,
     openKeysPage: openKeysPageMock,
+    replaceWithinOptionsPage: replaceWithinOptionsPageMock,
   }
 })
 
@@ -52,7 +58,35 @@ vi.mock(
 )
 
 vi.mock("~/features/ModelList/components/AccountSelector", () => ({
-  AccountSelector: () => <div data-testid="account-selector" />,
+  AccountSelector: ({
+    setSelectedSourceValue,
+  }: {
+    setSelectedSourceValue: (value: string) => void
+  }) => (
+    <div data-testid="account-selector">
+      <button
+        type="button"
+        onClick={() => setSelectedSourceValue("account:account-1")}
+      >
+        select-account-source
+      </button>
+      <button
+        type="button"
+        onClick={() => setSelectedSourceValue("profile:profile-1")}
+      >
+        select-profile-source
+      </button>
+      <button
+        type="button"
+        onClick={() => setSelectedSourceValue(ALL_ACCOUNTS_SOURCE_VALUE)}
+      >
+        select-all-sources
+      </button>
+      <button type="button" onClick={() => setSelectedSourceValue("")}>
+        clear-source
+      </button>
+    </div>
+  ),
 }))
 
 vi.mock("~/features/ModelList/components/AccountSummaryBar", () => ({
@@ -222,6 +256,18 @@ const ACCOUNT_SOURCE = {
   capabilities: CAPABILITIES,
 } as any
 
+const PROFILE = {
+  id: "profile-1",
+  name: "Reusable Key",
+  apiType: "openai-compatible",
+  baseUrl: "https://profile.example.com",
+  apiKey: "sk-example",
+  tagIds: [],
+  notes: "",
+  createdAt: 1,
+  updatedAt: 1,
+} as any
+
 function createModelListData() {
   return {
     accounts: [ACCOUNT],
@@ -307,6 +353,38 @@ describe("ModelList", () => {
 
     expect(openKeysPageMock).toHaveBeenCalledWith(ACCOUNT.id)
   })
+
+  it.each([
+    ["select-account-source", "account:account-1", { accountId: ACCOUNT.id }],
+    ["select-profile-source", "profile:profile-1", { profileId: PROFILE.id }],
+    [
+      "select-all-sources",
+      ALL_ACCOUNTS_SOURCE_VALUE,
+      { accountId: ALL_ACCOUNTS_SOURCE_VALUE },
+    ],
+    ["clear-source", "", undefined],
+  ])(
+    "replaces the model-list route when the user chooses %s",
+    async (buttonName, selectedValue, expectedParams) => {
+      const user = userEvent.setup()
+      const setSelectedSourceValue = vi.fn()
+      mockUseModelListData.mockReturnValue({
+        ...createModelListData(),
+        profiles: [PROFILE],
+        setSelectedSourceValue,
+      })
+
+      render(<ModelList />)
+
+      await user.click(screen.getByRole("button", { name: buttonName }))
+
+      expect(setSelectedSourceValue).toHaveBeenCalledWith(selectedValue)
+      expect(replaceWithinOptionsPageMock).toHaveBeenCalledWith(
+        "#models",
+        expectedParams,
+      )
+    },
+  )
 
   it("does not show the key-management title shortcut for non-account sources", () => {
     mockUseModelListData.mockReturnValue({

--- a/tests/utils/modelToKeyScenario.test.ts
+++ b/tests/utils/modelToKeyScenario.test.ts
@@ -20,7 +20,6 @@ const mocks = vi.hoisted(() => ({
     toBe: vi.fn(),
   })),
   runModelListCatalogScenario: vi.fn(),
-  waitForExtensionPage: vi.fn(),
   deleteTokenFromKeyManagementPage: vi.fn(),
   expectPermissionOnboardingHidden: vi.fn(),
   waitForExtensionRoot: vi.fn(),
@@ -32,10 +31,6 @@ vi.mock("~~/e2e/fixtures/extensionTest", () => ({
 
 vi.mock("~~/e2e/scenarios/modelListCatalog", () => ({
   runModelListCatalogScenario: mocks.runModelListCatalogScenario,
-}))
-
-vi.mock("~~/e2e/utils/commonUserFlows", () => ({
-  waitForExtensionPage: mocks.waitForExtensionPage,
 }))
 
 vi.mock("~~/e2e/utils/accountLifecycle", () => ({
@@ -53,24 +48,16 @@ vi.mock("~~/e2e/utils/lazyLoading", () => ({
 describe("model-to-key E2E scenario", () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    mocks.expect.mockImplementation((_locator?: unknown) => ({
-      toBeVisible: vi.fn().mockResolvedValue(undefined),
-      toHaveCount: vi.fn().mockResolvedValue(undefined),
-      toHaveValue: vi.fn().mockResolvedValue(undefined),
-      toHaveURL: vi.fn().mockResolvedValue(undefined),
-      toBe: vi.fn(),
-    }))
+    mocks.expect.mockImplementation(createE2eAssertions)
   })
 
   it("creates a model-scoped key from an account model catalog and opens Key Management", async () => {
-    const modelPage = createModelPage()
-    const keysPage = createKeysPage()
+    const page = createModelToKeyPage()
 
-    vi.mocked(runModelListCatalogScenario).mockResolvedValue(modelPage)
-    vi.mocked(mocks.waitForExtensionPage).mockResolvedValue(keysPage)
+    vi.mocked(runModelListCatalogScenario).mockResolvedValue(page)
 
-    await runModelToKeyManagementScenario({
-      page: {} as any,
+    const result = await runModelToKeyManagementScenario({
+      page,
       extensionId: "extension-id",
       accountId: "account-1",
       modelId: "gpt-model-key-mini",
@@ -81,48 +68,36 @@ describe("model-to-key E2E scenario", () => {
     })
 
     expect(runModelListCatalogScenario).toHaveBeenCalledWith({
-      page: {},
+      page,
       extensionId: "extension-id",
       source: { accountId: "account-1" },
       expectations: undefined,
     })
-    expect(mocks.waitForExtensionPage).toHaveBeenCalledWith(
-      "browser-context",
-      expect.objectContaining({
-        extensionId: "extension-id",
-        hash: "#keys",
-        reuseExistingPage: false,
-        searchParams: { accountId: "account-1" },
-      }),
+    expect(result).toBe(page)
+    expect(page.url()).toBe(
+      "chrome-extension://extension-id/options.html?accountId=account-1#keys",
     )
-    expect(waitForExtensionRoot).toHaveBeenCalledWith(keysPage)
-    expect(expectPermissionOnboardingHidden).toHaveBeenCalledWith(keysPage)
+    expect(waitForExtensionRoot).toHaveBeenCalledWith(page)
+    expect(expectPermissionOnboardingHidden).toHaveBeenCalledWith(page)
   })
 
   it("uses the first visible catalog model when no model id is configured", async () => {
-    const modelPage = createModelPage({
+    const page = createModelToKeyPage({
       inferredTokenName: "model gpt-visible-real-site-model",
-    })
-    const keysPage = createKeysPage({
       createdTokenName: "model gpt-visible-real-site-model",
-      url: vi.fn(
-        () =>
-          "chrome-extension://extension-id/options.html?accountId=account-1#keys",
-      ),
     })
 
-    vi.mocked(runModelListCatalogScenario).mockResolvedValue(modelPage)
-    vi.mocked(mocks.waitForExtensionPage).mockResolvedValue(keysPage)
+    vi.mocked(runModelListCatalogScenario).mockResolvedValue(page)
 
     await runModelToKeyManagementScenario({
-      page: {} as any,
+      page,
       extensionId: "extension-id",
       accountId: "account-1",
       cleanupCreatedKey: true,
     })
 
     expect(mocks.deleteTokenFromKeyManagementPage).toHaveBeenCalledWith({
-      page: keysPage,
+      page,
       token: {
         id: "created-token-id",
         name: "model gpt-visible-real-site-model",
@@ -131,26 +106,23 @@ describe("model-to-key E2E scenario", () => {
   })
 
   it("cleans up the actual Key Management token row when the backend normalizes the submitted name", async () => {
-    const modelPage = createModelPage({
+    const page = createModelToKeyPage({
       inferredTokenName: "model [official]claude-opus",
       selectedCompatibleKeyName: "model 【official】claude-opus",
-    })
-    const keysPage = createKeysPage({
       createdTokenName: "model 【official】claude-opus",
     })
 
-    vi.mocked(runModelListCatalogScenario).mockResolvedValue(modelPage)
-    vi.mocked(mocks.waitForExtensionPage).mockResolvedValue(keysPage)
+    vi.mocked(runModelListCatalogScenario).mockResolvedValue(page)
 
     await runModelToKeyManagementScenario({
-      page: {} as any,
+      page,
       extensionId: "extension-id",
       accountId: "account-1",
       cleanupCreatedKey: true,
     })
 
     expect(mocks.deleteTokenFromKeyManagementPage).toHaveBeenCalledWith({
-      page: keysPage,
+      page,
       token: {
         id: "created-token-id",
         name: "model 【official】claude-opus",
@@ -159,16 +131,14 @@ describe("model-to-key E2E scenario", () => {
   })
 
   it("ignores the compatible key select placeholder when resolving the created Key Management token", async () => {
-    const modelPage = createModelPage({
+    const page = createModelToKeyPage({
       selectedCompatibleKeyName: "Select a key",
     })
-    const keysPage = createKeysPage()
 
-    vi.mocked(runModelListCatalogScenario).mockResolvedValue(modelPage)
-    vi.mocked(mocks.waitForExtensionPage).mockResolvedValue(keysPage)
+    vi.mocked(runModelListCatalogScenario).mockResolvedValue(page)
 
     await runModelToKeyManagementScenario({
-      page: {} as any,
+      page,
       extensionId: "extension-id",
       accountId: "account-1",
       modelId: "gpt-model-key-mini",
@@ -176,38 +146,38 @@ describe("model-to-key E2E scenario", () => {
       cleanupCreatedKey: true,
     })
 
-    expect(keysPage.getByRole).toHaveBeenCalledWith("heading", {
+    expect(page.getByRole).toHaveBeenCalledWith("heading", {
       name: "model gpt-model-key-mini",
       exact: true,
     })
-    expect(keysPage.getByRole).not.toHaveBeenCalledWith("heading", {
+    expect(page.getByRole).not.toHaveBeenCalledWith("heading", {
       name: "Select a key",
       exact: true,
     })
   })
 
   it("still verifies the model key dialog leaves the empty state when the compatible key select shows a placeholder", async () => {
-    const modelPage = createModelPage({
+    const page = createModelToKeyPage({
       selectedCompatibleKeyName: "Select a key",
     })
-    const keysPage = createKeysPage()
 
-    vi.mocked(runModelListCatalogScenario).mockResolvedValue(modelPage)
-    vi.mocked(mocks.waitForExtensionPage).mockResolvedValue(keysPage)
+    vi.mocked(runModelListCatalogScenario).mockResolvedValue(page)
 
     await runModelToKeyManagementScenario({
-      page: {} as any,
+      page,
       extensionId: "extension-id",
       accountId: "account-1",
       modelId: "gpt-model-key-mini",
       createdKeyName: "model gpt-model-key-mini",
     })
 
-    expect(modelPage.keyDialog.getByText).toHaveBeenCalledWith(
+    expect(page.keyDialog.getByText).toHaveBeenCalledWith(
       "No compatible keys for gpt-model-key-mini",
     )
-    const keyDialogGetByTextCalls = modelPage.keyDialog.getByText.mock
-      .calls as [string, ...unknown[]][]
+    const keyDialogGetByTextCalls = page.keyDialog.getByText.mock.calls as [
+      string,
+      ...unknown[],
+    ][]
     expect(
       keyDialogGetByTextCalls.filter(
         ([text]) => text === "No compatible keys for gpt-model-key-mini",
@@ -216,14 +186,12 @@ describe("model-to-key E2E scenario", () => {
   })
 
   it("cleans up the created key when cleanup is enabled", async () => {
-    const modelPage = createModelPage()
-    const keysPage = createKeysPage()
+    const page = createModelToKeyPage()
 
-    vi.mocked(runModelListCatalogScenario).mockResolvedValue(modelPage)
-    vi.mocked(mocks.waitForExtensionPage).mockResolvedValue(keysPage)
+    vi.mocked(runModelListCatalogScenario).mockResolvedValue(page)
 
     await runModelToKeyManagementScenario({
-      page: {} as any,
+      page,
       extensionId: "extension-id",
       accountId: "account-1",
       modelId: "gpt-model-key-mini",
@@ -232,7 +200,7 @@ describe("model-to-key E2E scenario", () => {
     })
 
     expect(mocks.deleteTokenFromKeyManagementPage).toHaveBeenCalledWith({
-      page: keysPage,
+      page,
       token: {
         id: "created-token-id",
         name: "model gpt-model-key-mini",
@@ -242,8 +210,7 @@ describe("model-to-key E2E scenario", () => {
 
   it("cleans up the created key when post-creation verification fails", async () => {
     const error = new Error("post-create verification failed")
-    const modelPage = createModelPage()
-    const keysPage = createKeysPage({
+    const page = createModelToKeyPage({
       tokenRowGetByText: vi.fn((text: string) => {
         if (text === "vip") {
           throw error
@@ -255,12 +222,11 @@ describe("model-to-key E2E scenario", () => {
       }),
     })
 
-    vi.mocked(runModelListCatalogScenario).mockResolvedValue(modelPage)
-    vi.mocked(mocks.waitForExtensionPage).mockResolvedValue(keysPage)
+    vi.mocked(runModelListCatalogScenario).mockResolvedValue(page)
 
     await expect(
       runModelToKeyManagementScenario({
-        page: {} as any,
+        page,
         extensionId: "extension-id",
         accountId: "account-1",
         modelId: "gpt-model-key-mini",
@@ -271,7 +237,7 @@ describe("model-to-key E2E scenario", () => {
     ).rejects.toThrow(error)
 
     expect(mocks.deleteTokenFromKeyManagementPage).toHaveBeenCalledWith({
-      page: keysPage,
+      page,
       token: {
         id: "created-token-id",
         name: "model gpt-model-key-mini",
@@ -281,15 +247,13 @@ describe("model-to-key E2E scenario", () => {
 
   it("resolves the token row during cleanup when verification fails before recording it", async () => {
     const error = new Error("prepare failed")
-    const modelPage = createModelPage()
-    const keysPage = createKeysPage()
+    const page = createModelToKeyPage()
 
-    vi.mocked(runModelListCatalogScenario).mockResolvedValue(modelPage)
-    vi.mocked(mocks.waitForExtensionPage).mockResolvedValue(keysPage)
+    vi.mocked(runModelListCatalogScenario).mockResolvedValue(page)
 
     await expect(
       runModelToKeyManagementScenario({
-        page: {} as any,
+        page,
         extensionId: "extension-id",
         accountId: "account-1",
         modelId: "gpt-model-key-mini",
@@ -300,7 +264,7 @@ describe("model-to-key E2E scenario", () => {
     ).rejects.toThrow(error)
 
     expect(mocks.deleteTokenFromKeyManagementPage).toHaveBeenCalledWith({
-      page: keysPage,
+      page,
       token: {
         id: "created-token-id",
         name: "model gpt-model-key-mini",
@@ -309,17 +273,15 @@ describe("model-to-key E2E scenario", () => {
   })
 
   it("does not fall back to name-only cleanup when the created token row cannot be resolved", async () => {
-    const modelPage = createModelPage()
-    const keysPage = createKeysPage({
+    const page = createModelToKeyPage({
       tokenRowsCountError: new Error("no token rows"),
     })
 
-    vi.mocked(runModelListCatalogScenario).mockResolvedValue(modelPage)
-    vi.mocked(mocks.waitForExtensionPage).mockResolvedValue(keysPage)
+    vi.mocked(runModelListCatalogScenario).mockResolvedValue(page)
 
     await expect(
       runModelToKeyManagementScenario({
-        page: {} as any,
+        page,
         extensionId: "extension-id",
         accountId: "account-1",
         modelId: "gpt-model-key-mini",
@@ -385,12 +347,34 @@ describe("real-site model-to-key config", () => {
   })
 })
 
-function createModelPage(
+function createE2eAssertions(locator?: unknown) {
+  return {
+    toBeVisible: vi.fn().mockResolvedValue(undefined),
+    toHaveCount: vi.fn().mockResolvedValue(undefined),
+    toHaveValue: vi.fn().mockResolvedValue(undefined),
+    toHaveURL: vi.fn(async (matcher: unknown) => {
+      if (typeof matcher !== "function") return
+
+      const url = (locator as { url?: () => string } | undefined)?.url?.()
+      if (!url || !(matcher as (url: URL) => boolean)(new URL(url))) {
+        throw new Error(`Expected page URL to match, received ${url ?? "none"}`)
+      }
+    }),
+    toBe: vi.fn(),
+  }
+}
+
+function createModelToKeyPage(
   options: {
     inferredTokenName?: string
     selectedCompatibleKeyName?: string
+    createdTokenName?: string
+    tokenRowGetByText?: (text: string) => unknown
+    tokenRowsCountError?: Error
   } = {},
 ) {
+  let currentUrl =
+    "chrome-extension://extension-id/options.html?accountId=account-1#models"
   const tokenNameInput = {
     inputValue: vi
       .fn()
@@ -410,6 +394,12 @@ function createModelPage(
     })),
     toString: () => "add key dialog",
   }
+  const openKeyManagementButton = {
+    click: vi.fn(async () => {
+      currentUrl =
+        "chrome-extension://extension-id/options.html?accountId=account-1#keys"
+    }),
+  }
   const keyDialog = {
     getByRole: vi.fn(() => ({
       innerText: vi
@@ -419,16 +409,64 @@ function createModelPage(
     getByText: vi.fn(() => ({
       toString: () => "model key dialog text",
     })),
-    getByTestId: vi.fn((testId: string) => ({
-      click: vi.fn().mockResolvedValue(undefined),
-      testId,
-    })),
+    getByTestId: vi.fn((testId: string) => {
+      if (testId === MODEL_LIST_TEST_IDS.openKeyManagementButton) {
+        return openKeyManagementButton
+      }
+
+      return {
+        click: vi.fn().mockResolvedValue(undefined),
+        testId,
+      }
+    }),
     toString: () => "model key dialog",
+  }
+  const tokenHeading = {
+    innerText: vi
+      .fn()
+      .mockResolvedValue(
+        options.createdTokenName ?? "model gpt-model-key-mini",
+      ),
+    toString: () => "created token heading",
+  }
+  const tokenRow = {
+    getAttribute: vi
+      .fn()
+      .mockResolvedValue("key-management-token-row-created-token-id"),
+    getByText: options.tokenRowGetByText
+      ? vi.fn(options.tokenRowGetByText)
+      : vi.fn(() => ({
+          toString: () => "created token row text",
+        })),
+    locator: vi.fn(() => ({
+      first: vi.fn(() => tokenHeading),
+    })),
+    toString: () => "created token row",
+  }
+  const tokenRows = {
+    filter: vi.fn(() => tokenRows),
+    first: vi.fn(() => tokenRow),
+    toString: () => "created token rows",
+  }
+
+  if (options.tokenRowsCountError) {
+    mocks.expect.mockImplementation((locator?: unknown) => {
+      const assertions = createE2eAssertions(locator)
+      if (locator === tokenRows) {
+        return {
+          ...assertions,
+          toHaveCount: vi.fn().mockRejectedValue(options.tokenRowsCountError),
+        }
+      }
+
+      return assertions
+    })
   }
 
   return {
     keyDialog,
     context: vi.fn(() => "browser-context"),
+    url: vi.fn(() => currentUrl),
     getByTestId: vi.fn((testId: string) => {
       if (testId === MODEL_LIST_TEST_IDS.modelKeyDialog) return keyDialog
       if (testId === "key-management-add-token-dialog") return addKeyDialog
@@ -442,66 +480,6 @@ function createModelPage(
         testId,
       }
     }),
-  } as any
-}
-
-function createKeysPage(overrides: Record<string, unknown> = {}) {
-  const createdTokenName =
-    typeof overrides.createdTokenName === "string"
-      ? overrides.createdTokenName
-      : "model gpt-model-key-mini"
-  const tokenHeading = {
-    innerText: vi.fn().mockResolvedValue(createdTokenName),
-    toString: () => "created token heading",
-  }
-  const tokenRow = {
-    getAttribute: vi
-      .fn()
-      .mockResolvedValue("key-management-token-row-created-token-id"),
-    getByText:
-      typeof overrides.tokenRowGetByText === "function"
-        ? overrides.tokenRowGetByText
-        : vi.fn(() => ({
-            toString: () => "created token row text",
-          })),
-    locator: vi.fn(() => ({
-      first: vi.fn(() => tokenHeading),
-    })),
-    toString: () => "created token row",
-  }
-  const tokenRows = {
-    filter: vi.fn(() => tokenRows),
-    first: vi.fn(() => tokenRow),
-    toString: () => "created token rows",
-  }
-
-  if (overrides.tokenRowsCountError instanceof Error) {
-    mocks.expect.mockImplementation((locator?: unknown) => {
-      if (locator === tokenRows) {
-        return {
-          toHaveCount: vi.fn().mockRejectedValue(overrides.tokenRowsCountError),
-          toBeVisible: vi.fn().mockResolvedValue(undefined),
-          toHaveValue: vi.fn().mockResolvedValue(undefined),
-          toHaveURL: vi.fn().mockResolvedValue(undefined),
-          toBe: vi.fn(),
-        }
-      }
-
-      return {
-        toBeVisible: vi.fn().mockResolvedValue(undefined),
-        toHaveCount: vi.fn().mockResolvedValue(undefined),
-        toHaveValue: vi.fn().mockResolvedValue(undefined),
-        toHaveURL: vi.fn().mockResolvedValue(undefined),
-        toBe: vi.fn(),
-      }
-    })
-  }
-
-  return {
-    url: vi.fn(
-      () =>
-        "chrome-extension://extension-id/options.html?accountId=account-1#keys",
-    ),
     getByRole: vi.fn(() => ({
       toString: () => "created key heading",
     })),
@@ -509,10 +487,5 @@ function createKeysPage(overrides: Record<string, unknown> = {}) {
       toString: () => "keys page text",
     })),
     locator: vi.fn(() => tokenRows),
-    ...Object.fromEntries(
-      Object.entries(overrides).filter(
-        ([key]) => key !== "tokenRowsCountError" && key !== "tokenRowGetByText",
-      ),
-    ),
   } as any
 }

--- a/tests/utils/modelToKeyScenario.test.ts
+++ b/tests/utils/modelToKeyScenario.test.ts
@@ -18,9 +18,7 @@ const mocks = vi.hoisted(() => ({
     toHaveCount: vi.fn().mockResolvedValue(undefined),
     toHaveValue: vi.fn().mockResolvedValue(undefined),
     toHaveURL: vi.fn().mockResolvedValue(undefined),
-    toBe: vi.fn((expected: unknown) => {
-      expect(locator).toBe(expected)
-    }),
+    toBe: vi.fn(),
   })),
   runModelListCatalogScenario: vi.fn(),
   deleteTokenFromKeyManagementPage: vi.fn(),
@@ -363,7 +361,9 @@ function createE2eAssertions(locator?: unknown) {
         throw new Error(`Expected page URL to match, received ${url ?? "none"}`)
       }
     }),
-    toBe: vi.fn(),
+    toBe: vi.fn((expected: unknown) => {
+      expect(locator).toBe(expected)
+    }),
   }
 }
 

--- a/tests/utils/modelToKeyScenario.test.ts
+++ b/tests/utils/modelToKeyScenario.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { MODEL_LIST_TEST_IDS } from "~/features/ModelList/testIds"
+import { TOKEN_PROVISIONING_TEST_IDS } from "~/features/TokenProvisioning/testIds"
 import { runModelListCatalogScenario } from "~~/e2e/scenarios/modelListCatalog"
 import { runModelToKeyManagementScenario } from "~~/e2e/scenarios/modelToKeyManagement"
 import { expectPermissionOnboardingHidden } from "~~/e2e/utils/extensionState"
@@ -17,7 +18,9 @@ const mocks = vi.hoisted(() => ({
     toHaveCount: vi.fn().mockResolvedValue(undefined),
     toHaveValue: vi.fn().mockResolvedValue(undefined),
     toHaveURL: vi.fn().mockResolvedValue(undefined),
-    toBe: vi.fn(),
+    toBe: vi.fn((expected: unknown) => {
+      expect(locator).toBe(expected)
+    }),
   })),
   runModelListCatalogScenario: vi.fn(),
   deleteTokenFromKeyManagementPage: vi.fn(),
@@ -469,7 +472,9 @@ function createModelToKeyPage(
     url: vi.fn(() => currentUrl),
     getByTestId: vi.fn((testId: string) => {
       if (testId === MODEL_LIST_TEST_IDS.modelKeyDialog) return keyDialog
-      if (testId === "key-management-add-token-dialog") return addKeyDialog
+      if (testId === TOKEN_PROVISIONING_TEST_IDS.addTokenDialog) {
+        return addKeyDialog
+      }
 
       return {
         first: vi.fn(() => ({

--- a/tests/utils/navigation.test.ts
+++ b/tests/utils/navigation.test.ts
@@ -170,6 +170,19 @@ describe("navigation utilities", () => {
     )
   })
 
+  it("openKeysPage should push within the current options tab", async () => {
+    window.history.replaceState(null, "", `${OPTIONS_PAGE_URL}#models`)
+    const pushStateSpy = vi.spyOn(window.history, "pushState")
+
+    await openKeysPage("123")
+
+    expect(pushStateSpy).toHaveBeenCalledTimes(1)
+    expect(window.location.href).toBe(`${OPTIONS_PAGE_URL}?accountId=123#keys`)
+    expect(mockedCreateTab).not.toHaveBeenCalled()
+
+    pushStateSpy.mockRestore()
+  })
+
   it("openKeysPage should close popup after dispatching navigation", async () => {
     const closeSpy = vi.spyOn(window, "close").mockImplementation(() => {})
     mockedIsExtensionPopup.mockReturnValue(true)
@@ -250,6 +263,21 @@ describe("navigation utilities", () => {
     expect(closeSpy).toHaveBeenCalledTimes(1)
 
     closeSpy.mockRestore()
+  })
+
+  it("openModelsPage should push within the current options tab", async () => {
+    window.history.replaceState(null, "", `${OPTIONS_PAGE_URL}#keys`)
+    const pushStateSpy = vi.spyOn(window.history, "pushState")
+
+    await openModelsPage({ profileId: "profile-7" })
+
+    expect(pushStateSpy).toHaveBeenCalledTimes(1)
+    expect(window.location.href).toBe(
+      `${OPTIONS_PAGE_URL}?profileId=profile-7#models`,
+    )
+    expect(mockedCreateTab).not.toHaveBeenCalled()
+
+    pushStateSpy.mockRestore()
   })
 
   it("openAutoCheckinPage should omit undefined params and close popup", async () => {


### PR DESCRIPTION
## Summary

- Preserve Key Management and Model List selections in options-page URLs without persistent storage.
- Replace history entries for selector changes and push entries for in-options cross-page navigation while preserving popup and external-entry behavior.
- Restore account, API credential profile, and all-account selections during browser back/forward navigation, including controlled-route fallback handling.

## Testing

- `pnpm vitest run tests/utils/navigation.test.ts tests/entrypoints/options/pages/KeyManagement/useKeyManagement.test.tsx tests/entrypoints/options/pages/ModelList/useModelListData.test.tsx tests/entrypoints/options/pages/KeyManagement/KeyManagement.emptyStateActions.test.tsx tests/features/ModelList/ModelList.test.tsx`
- `pnpm run validate:staged`
- `pnpm run validate:push`

## E2E decision

- No Playwright test added; the affected history, routing, hook, and component behavior is covered by focused Vitest suites.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved Keys and Models selection to keep the options-page URL synchronized as users change account/source choices, including all-accounts and profile targets.
  - Enhanced in-page navigation for Keys and Models when already on the options page, reducing unnecessary new tabs.
- **Bug Fixes**
  - Fixed route-driven selection to correctly wait for enabled data, restore all-accounts when requested, and clear/fallback selections for invalid or missing targets.
  - Improved “more actions” dropdown behavior by controlling its open state and closing it before initiating in-page navigation.
- **Tests**
  - Expanded and updated unit, integration, and e2e coverage for URL/route transitions and navigation sequencing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->