### PR TITLE
fix(content): prevent temporary title feedback loops

### DIFF
--- a/docs/superpowers/specs/2026-07-15-bounded-temp-page-title-prefix-design.md
+++ b/docs/superpowers/specs/2026-07-15-bounded-temp-page-title-prefix-design.md
@@ -1,0 +1,83 @@
+# Bounded Temp Page Title Prefix Design
+
+## Problem
+
+The shield-bypass prompt currently keeps its temporary-page title prefix alive
+with both a `MutationObserver` and a one-second interval. A host page can also
+enforce its own title with an observer. When the two writers require
+incompatible titles, each title mutation triggers the other writer and creates
+an unbounded mutation feedback loop. The affected renderer can stop painting,
+consume sustained CPU, allocate rapidly, and prevent the background auto-detect
+request from completing.
+
+## Goals
+
+- Keep the temporary-context title cue resilient to ordinary page title updates.
+- Put a strict upper bound on extension-authored corrective title writes.
+- Yield title ownership permanently when a host repeatedly rejects the prefix.
+- Preserve the in-page shield-bypass prompt as the durable user explanation.
+- Cover a competing host title observer with focused component tests.
+
+## Non-Goals
+
+- Detect or special-case a site, domain, browser, or branding script.
+- Prevent host pages from changing their own titles.
+- Change temp-context creation, protection guards, or window cleanup.
+- Add product analytics for this internal compatibility safeguard.
+- Add Playwright coverage for behavior that jsdom can reproduce deterministically.
+
+## Design
+
+### Bound Corrective Writes
+
+`usePrefixedDocumentTitle()` will continue to apply the localized title prefix
+when the prompt mounts. The initial write does not consume the correction
+budget. The hook may then correct at most two later host-authored title changes
+during that mount.
+
+The title observer remains scoped to the existing `<title>` element. When it
+observes a title without the prefix, it increments the correction count and
+reapplies the prefix. After the second corrective write, it immediately
+disconnects. A host observer may then restore its preferred title once more,
+but the extension will not respond again. This gives ordinary applications two
+opportunities to retain the temporary-context cue while making a feedback loop
+finite by construction.
+
+The one-second interval will be removed. A timer would continue competing after
+the observer budget was exhausted and would weaken the bounded-write contract.
+
+### Preserve Host Ownership During Cleanup
+
+When the prompt unmounts, the hook will remove its prefix only if the current
+title still contains that prefix. If the host has already replaced the title,
+cleanup leaves it unchanged. This prevents stale extension state from
+overwriting a newer host-owned title.
+
+### Keep the Limit Local and Explicit
+
+The correction limit will be a small module-level constant next to the hook.
+It is an internal safety invariant, not a user preference. The behavior applies
+to every host page equally and does not inspect URLs, script names, or page
+content.
+
+## Tests
+
+Focused Vitest/Testing Library coverage will prove:
+
+- mounting applies the prefix without consuming the correction budget;
+- ordinary host title changes are corrected no more than twice;
+- a host observer that continually restores its own title cannot cause an
+  unbounded mutation loop, and its title wins after the budget is exhausted;
+- no interval is left running to rewrite the title later;
+- unmount removes a still-present prefix but does not overwrite a title the
+  host already owns;
+- the shield-bypass prompt remains rendered and interactive.
+
+## Validation
+
+Run the focused shield-bypass prompt test first, then related Vitest coverage.
+Stage only the task-scoped component, test, and design files and run
+`pnpm run validate:staged`. Because the executable change is isolated to a
+content-script React hook and does not alter exports or dependencies,
+`validate:push` is not required unless focused or staged validation exposes a
+shared-contract issue.

--- a/src/entrypoints/content/shieldBypassAssist/components/ShieldBypassPromptToast.tsx
+++ b/src/entrypoints/content/shieldBypassAssist/components/ShieldBypassPromptToast.tsx
@@ -21,6 +21,8 @@ import {
   recordShieldBypassSettingsVisited,
 } from "~/services/productAnalytics/shieldBypassSummary"
 
+const MAX_TITLE_CORRECTIONS = 2
+
 /** Removes a previously applied prefix from a title string. */
 function stripPrefixedTitle(title: string, prefix: string) {
   const trimmed = title.trim()
@@ -48,7 +50,7 @@ function usePrefixedDocumentTitle(prefix: string) {
     let applying = false
 
     const apply = () => {
-      if (disposed || applying) return
+      if (disposed || applying) return false
       applying = true
       try {
         const current = typeof document.title === "string" ? document.title : ""
@@ -56,7 +58,9 @@ function usePrefixedDocumentTitle(prefix: string) {
         const next = base ? `${normalizedPrefix} · ${base}` : normalizedPrefix
         if (document.title !== next) {
           document.title = next
+          return true
         }
+        return false
       } finally {
         applying = false
       }
@@ -65,27 +69,33 @@ function usePrefixedDocumentTitle(prefix: string) {
     apply()
 
     const titleEl = document.querySelector("title")
-    const observer = new MutationObserver(() => apply())
+    let correctionCount = 0
+    const observer = new MutationObserver(() => {
+      if (correctionCount >= MAX_TITLE_CORRECTIONS) {
+        observer.disconnect()
+        return
+      }
+
+      if (apply()) {
+        correctionCount += 1
+        if (correctionCount >= MAX_TITLE_CORRECTIONS) {
+          observer.disconnect()
+        }
+      }
+    })
     if (titleEl) {
       observer.observe(titleEl, { childList: true, subtree: true })
-    } else {
-      observer.observe(document.documentElement, {
-        childList: true,
-        subtree: true,
-      })
     }
-
-    const interval = window.setInterval(apply, 1000)
 
     return () => {
       disposed = true
       observer.disconnect()
-      window.clearInterval(interval)
 
       try {
         const current = typeof document.title === "string" ? document.title : ""
-        const base = stripPrefixedTitle(current || "", normalizedPrefix).trim()
-        if (base && document.title !== base) {
+        const stripped = stripPrefixedTitle(current || "", normalizedPrefix)
+        const base = stripped.trim()
+        if (stripped !== current && document.title !== base) {
           document.title = base
         }
       } catch {

--- a/src/entrypoints/content/shieldBypassAssist/components/ShieldBypassPromptToast.tsx
+++ b/src/entrypoints/content/shieldBypassAssist/components/ShieldBypassPromptToast.tsx
@@ -71,11 +71,6 @@ function usePrefixedDocumentTitle(prefix: string) {
     const titleEl = document.querySelector("title")
     let correctionCount = 0
     const observer = new MutationObserver(() => {
-      if (correctionCount >= MAX_TITLE_CORRECTIONS) {
-        observer.disconnect()
-        return
-      }
-
       if (apply()) {
         correctionCount += 1
         if (correctionCount >= MAX_TITLE_CORRECTIONS) {

--- a/tests/entrypoints/content/shieldBypassAssist/ShieldBypassPromptToast.test.tsx
+++ b/tests/entrypoints/content/shieldBypassAssist/ShieldBypassPromptToast.test.tsx
@@ -82,6 +82,55 @@ describe("ShieldBypassPromptToast", () => {
     expect(document.title).toBe("Host Changed Title")
   })
 
+  it("yields the document title after two corrections when the host keeps restoring its title", async () => {
+    document.title = "Host Owned Title"
+
+    const titleElement = document.querySelector("title")
+    expect(titleElement).not.toBeNull()
+
+    let hostRestoreCount = 0
+    const hostObserver = new MutationObserver(() => {
+      if (document.title.startsWith("Shield Mode") && hostRestoreCount < 5) {
+        hostRestoreCount += 1
+        document.title = "Host Owned Title"
+      }
+    })
+    hostObserver.observe(titleElement!, { childList: true, subtree: true })
+
+    try {
+      const { unmount } = render(
+        <ShieldBypassPromptToast
+          onDismiss={vi.fn()}
+          onOpenSettings={vi.fn()}
+        />,
+      )
+
+      await waitFor(() => {
+        expect(hostRestoreCount).toBeGreaterThan(0)
+      })
+
+      await new Promise((resolve) => window.setTimeout(resolve, 0))
+
+      expect(hostRestoreCount).toBe(3)
+      expect(document.title).toBe("Host Owned Title")
+
+      hostObserver.disconnect()
+      await new Promise((resolve) => window.setTimeout(resolve, 1100))
+
+      expect(document.title).toBe("Host Owned Title")
+      expect(screen.getByText("Shield Prompt")).toBeVisible()
+      expect(
+        screen.getByRole("button", { name: "Open settings" }),
+      ).toBeEnabled()
+
+      unmount()
+
+      expect(document.title).toBe("Host Owned Title")
+    } finally {
+      hostObserver.disconnect()
+    }
+  })
+
   it("normalizes an already-prefixed title and wires the dismiss/settings actions", async () => {
     const user = userEvent.setup()
     const onDismiss = vi.fn()
@@ -130,7 +179,7 @@ describe("ShieldBypassPromptToast", () => {
     expect(document.title).toBe("Existing Title")
   })
 
-  it("uses the prefix alone when the page starts without a title and leaves it unchanged on cleanup", async () => {
+  it("uses the prefix alone when the page starts without a title and restores the empty title on cleanup", async () => {
     document.title = ""
 
     const { unmount } = render(
@@ -143,7 +192,7 @@ describe("ShieldBypassPromptToast", () => {
 
     unmount()
 
-    expect(document.title).toBe("Shield Mode")
+    expect(document.title).toBe("")
   })
 
   it("does not modify the document title when the translated prefix is blank", async () => {


### PR DESCRIPTION
## Summary

- Bound temporary-context title corrections and permanently yield when a host repeatedly restores its own title.
- Remove interval polling and broad document observation so competing title writers cannot form an unbounded feedback loop.
- Preserve host-owned titles during cleanup while keeping the shield-bypass prompt rendered and interactive.
- Add deterministic component coverage for a competing host title observer and cleanup behavior.

## Issue context

The maintainer investigation in #1177 identified the browser freeze as a title-write feedback loop between the host page and the extension. This PR bounds that exact loop without adding domain-specific handling.

## Testing

- `pnpm vitest --run tests/entrypoints/content/shieldBypassAssist/ShieldBypassPromptToast.test.tsx` (5 passed)
- `pnpm vitest related --run src/entrypoints/content/shieldBypassAssist/components/ShieldBypassPromptToast.tsx` (28 passed)
- `pnpm run validate:staged`
- `pnpm run validate:push`

Fixes #1177

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bounded temporary page-title prefixing when host pages repeatedly update the title.
  * Capped subsequent title corrections to prevent continued overwrites after the limit.
  * Avoided overriding host-authored titles during cleanup.
  * Correctly restored an empty title on unmount when none existed initially.
* **Tests**
  * Added/updated coverage for repeated host title mutations, correction limiting, and post-unmount toast behavior.
* **Documentation**
  * Added a design specification for the bounded title prefix approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->