### PR TITLE
fix(temp-window): preserve source context across background flows

### DIFF
--- a/docs/superpowers/plans/2026-07-16-temp-window-source-context.md
+++ b/docs/superpowers/plans/2026-07-16-temp-window-source-context.md
@@ -1,0 +1,746 @@
+# Temp Window Source Context Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Preserve toolbar-popup-originated temporary-window work across background boundaries while allowing options, side-panel, and background work to minimize normally.
+
+**Architecture:** Introduce a transient `TempWindowRequestSource` contract plus one centralized launch-policy resolver. Capture source before delegation, propagate it through API transport and auto-checkin orchestration, and resolve the existing low-level `suppressMinimize` boolean only at the temporary-window boundary. Keep explicit open-window commands as intentional overrides and do not add popup liveness monitoring.
+
+**Tech Stack:** TypeScript, React, WXT Manifest V3 runtime messaging, WebExtension windows/tabs APIs, Vitest, Testing Library.
+
+---
+
+## File Structure
+
+- `src/types/tempWindowFetch.ts`: owns runtime source constants/types and temporary-window request contracts.
+- `src/utils/browser/tempWindowRequestSource.ts`: owns source detection, runtime normalization, launch-policy resolution, and Firefox popup safety classification.
+- `src/utils/browser/index.ts`: exposes options-page detection alongside existing popup/side-panel/background detection.
+- `src/utils/browser/tempWindowFetch.ts`: applies the centralized policy to fetch, Turnstile, native page action, rendered-title, and generic fallback requests.
+- `src/entrypoints/background/runtimeMessages.ts` and `src/entrypoints/background/tempWindowPool.ts`: normalize untrusted runtime payloads and apply the policy again at direct handler boundaries.
+- `src/services/apiTransport/type.ts` and `src/services/apiTransport/request.ts`: carry transient source metadata through generic API fallback.
+- `src/services/siteDetection/autoDetectService.ts`, `src/services/accountBrowserSession/**`, and `src/entrypoints/background/tempWindowPool.ts`: migrate auto-detect/session flows and validate background message sources.
+- `src/services/checkin/autoCheckin/**` plus UI callers: propagate source through UI-open/manual runs, scheduler, and providers.
+- `src/services/accounts/accountStorage.ts`: preserve the source during post-checkin account refresh.
+- `tests/**`: prove source resolution and each real propagation seam without relying on toolbar-popup E2E emulation.
+
+### Task 1: Add the Source Contract and Central Launch Policy
+
+**Files:**
+- Modify: `src/types/tempWindowFetch.ts`
+- Modify: `src/utils/browser/index.ts`
+- Create: `src/utils/browser/tempWindowRequestSource.ts`
+- Modify: `tests/utils/browser.test.ts`
+- Create: `tests/utils/tempWindowRequestSource.test.ts`
+
+- [ ] **Step 1: Write failing browser-surface and policy tests**
+
+Add an options-page detection case to `tests/utils/browser.test.ts`, and create `tests/utils/tempWindowRequestSource.test.ts` with the complete behavior matrix:
+
+```ts
+const context = vi.hoisted(() => ({
+  popup: false,
+  options: false,
+  sidepanel: false,
+  background: false,
+  firefox: false,
+}))
+
+vi.mock("~/utils/browser/index", () => ({
+  isExtensionPopup: () => context.popup,
+  isExtensionOptions: () => context.options,
+  isExtensionSidePanel: () => context.sidepanel,
+  isExtensionBackground: () => context.background,
+}))
+
+vi.mock("~/utils/browser/protectionBypass", () => ({
+  isProtectionBypassFirefoxEnv: () => context.firefox,
+}))
+
+describe("tempWindowRequestSource", () => {
+  it.each([
+    ["popup", "popup", true],
+    ["options", "options", false],
+    ["sidepanel", "sidepanel", false],
+    ["background", "background", false],
+  ])("resolves %s source", (_label, tempWindowRequestSource, suppressMinimize) => {
+    expect(
+      resolveTempWindowRequestPolicy({ tempWindowRequestSource }),
+    ).toMatchObject({
+      tempWindowRequestSource,
+      suppressMinimize,
+      blockedReason: null,
+    })
+  })
+
+  it("lets explicit booleans override source minimization", () => {
+    expect(
+      resolveTempWindowRequestPolicy({
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+        suppressMinimize: false,
+      }).suppressMinimize,
+    ).toBe(false)
+    expect(
+      resolveTempWindowRequestPolicy({
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Background,
+        suppressMinimize: true,
+      }).suppressMinimize,
+    ).toBe(true)
+  })
+
+  it("normalizes invalid runtime values to background", () => {
+    expect(normalizeTempWindowRequestSource("unknown")).toBe(
+      TEMP_WINDOW_REQUEST_SOURCES.Background,
+    )
+  })
+
+  it("captures the current surface only when source is omitted", () => {
+    context.popup = true
+    expect(resolveTempWindowRequestPolicy({}).tempWindowRequestSource).toBe(
+      TEMP_WINDOW_REQUEST_SOURCES.Popup,
+    )
+    expect(
+      resolveTempWindowRequestPolicy({ tempWindowRequestSource: "unknown" })
+        .tempWindowRequestSource,
+    ).toBe(
+      TEMP_WINDOW_REQUEST_SOURCES.Background,
+    )
+  })
+
+  it("blocks Firefox popup-source temporary windows", () => {
+    context.firefox = true
+    expect(
+      resolveTempWindowRequestPolicy({
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+      }).blockedReason,
+    ).toBe("firefox_popup_unsupported")
+  })
+})
+```
+
+- [ ] **Step 2: Run the tests and verify RED**
+
+Run:
+
+```bash
+pnpm vitest run tests/utils/browser.test.ts tests/utils/tempWindowRequestSource.test.ts
+```
+
+Expected: FAIL because `isExtensionOptions`, `TEMP_WINDOW_REQUEST_SOURCES`, and the request-policy helpers do not exist.
+
+- [ ] **Step 3: Add the source constants, type guard, and options detection**
+
+In `src/types/tempWindowFetch.ts` add:
+
+```ts
+export const TEMP_WINDOW_REQUEST_SOURCES = {
+  Popup: "popup",
+  Options: "options",
+  Sidepanel: "sidepanel",
+  Background: "background",
+} as const
+
+export type TempWindowRequestSource =
+  (typeof TEMP_WINDOW_REQUEST_SOURCES)[keyof typeof TEMP_WINDOW_REQUEST_SOURCES]
+
+export function isTempWindowRequestSource(
+  value: unknown,
+): value is TempWindowRequestSource {
+  return Object.values(TEMP_WINDOW_REQUEST_SOURCES).includes(
+    value as TempWindowRequestSource,
+  )
+}
+```
+
+In `src/utils/browser/index.ts`, add `isExtensionOptions()` using the same safe URL parsing as `isExtensionPopup()` and `OPTIONS_PAGE_PATH`.
+
+- [ ] **Step 4: Implement the centralized policy**
+
+Create `src/utils/browser/tempWindowRequestSource.ts`:
+
+```ts
+import {
+  isTempWindowRequestSource,
+  TEMP_WINDOW_REQUEST_SOURCES,
+  type TempWindowRequestSource,
+} from "~/types/tempWindowFetch"
+import {
+  isExtensionBackground,
+  isExtensionOptions,
+  isExtensionPopup,
+  isExtensionSidePanel,
+} from "~/utils/browser/index"
+import { isProtectionBypassFirefoxEnv } from "~/utils/browser/protectionBypass"
+
+export type TempWindowRequestBlockedReason =
+  | "firefox_popup_unsupported"
+  | null
+
+export function normalizeTempWindowRequestSource(
+  value: unknown,
+): TempWindowRequestSource {
+  return isTempWindowRequestSource(value)
+    ? value
+    : TEMP_WINDOW_REQUEST_SOURCES.Background
+}
+
+export function getCurrentTempWindowRequestSource(): TempWindowRequestSource {
+  if (isExtensionPopup()) return TEMP_WINDOW_REQUEST_SOURCES.Popup
+  if (isExtensionOptions()) return TEMP_WINDOW_REQUEST_SOURCES.Options
+  if (isExtensionSidePanel()) return TEMP_WINDOW_REQUEST_SOURCES.Sidepanel
+  if (isExtensionBackground()) return TEMP_WINDOW_REQUEST_SOURCES.Background
+  return TEMP_WINDOW_REQUEST_SOURCES.Background
+}
+
+export function resolveTempWindowRequestPolicy(params: {
+  tempWindowRequestSource?: unknown
+  suppressMinimize?: unknown
+}) {
+  const tempWindowRequestSource =
+    params.tempWindowRequestSource === undefined
+      ? getCurrentTempWindowRequestSource()
+      : normalizeTempWindowRequestSource(params.tempWindowRequestSource)
+  return {
+    tempWindowRequestSource,
+    suppressMinimize:
+      typeof params.suppressMinimize === "boolean"
+        ? params.suppressMinimize
+        : tempWindowRequestSource === TEMP_WINDOW_REQUEST_SOURCES.Popup,
+    blockedReason:
+      tempWindowRequestSource === TEMP_WINDOW_REQUEST_SOURCES.Popup &&
+      isProtectionBypassFirefoxEnv()
+        ? ("firefox_popup_unsupported" as const)
+        : null,
+  }
+}
+```
+
+- [ ] **Step 5: Run tests and verify GREEN**
+
+Run the Step 2 command. Expected: both files PASS with no warnings.
+
+- [ ] **Step 6: Commit the policy slice**
+
+```bash
+git add src/types/tempWindowFetch.ts src/utils/browser/index.ts src/utils/browser/tempWindowRequestSource.ts tests/utils/browser.test.ts tests/utils/tempWindowRequestSource.test.ts
+git commit -m "refactor(temp-window): centralize request source policy"
+```
+
+### Task 2: Apply Source Policy to Temporary-Window Wrappers and API Transport
+
+**Files:**
+- Modify: `src/types/tempWindowFetch.ts`
+- Modify: `src/services/apiTransport/type.ts`
+- Modify: `src/services/apiTransport/request.ts`
+- Modify: `src/utils/browser/tempWindowFetch.ts`
+- Modify: `src/entrypoints/background/runtimeMessages.ts`
+- Modify: `src/entrypoints/background/tempWindowPool.ts`
+- Modify: `tests/utils/tempWindowFetch.background.test.ts`
+- Modify: `tests/utils/tempWindowFetch.fallback.test.ts`
+- Modify: `tests/services/apiTransport/request.test.ts`
+- Modify: `tests/entrypoints/background/runtimeMessages.more.test.ts`
+- Modify: `tests/entrypoints/background/tempWindowPoolWindowFallback.test.ts`
+- Modify: `tests/entrypoints/background/tempWindowPoolOpenClose.test.ts`
+
+- [ ] **Step 1: Write failing wrapper and fallback tests**
+
+Extend the wrapper tests to prove all four helpers resolve the same source policy and include the resolved source in their background/runtime payloads:
+
+```ts
+it("uses popup source for fetch and rendered-title requests", async () => {
+  mocks.isExtensionPopupMock.mockReturnValue(true)
+  await tempWindowFetch({
+    originUrl: "https://example.invalid",
+    fetchUrl: "https://example.invalid/api/user/self",
+  })
+  await tempWindowGetRenderedTitle({
+    originUrl: "https://example.invalid",
+  })
+
+  expect(mocks.sendRuntimeMessageMock).toHaveBeenNthCalledWith(
+    1,
+    expect.objectContaining({
+      tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+      suppressMinimize: true,
+    }),
+  )
+  expect(mocks.sendRuntimeMessageMock).toHaveBeenNthCalledWith(
+    2,
+    expect.objectContaining({
+      tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+      suppressMinimize: true,
+    }),
+  )
+})
+
+it("keeps explicit false over a popup source", async () => {
+  await tempWindowTurnstileFetch({
+    originUrl: "https://example.invalid",
+    pageUrl: "https://example.invalid/console",
+    fetchUrl: "https://example.invalid/api/user/checkin",
+    tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+    suppressMinimize: false,
+  })
+  expect(mocks.sendRuntimeMessageMock).toHaveBeenCalledWith(
+    expect.objectContaining({
+      tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+      suppressMinimize: false,
+    }),
+  )
+})
+```
+
+Add a generic fallback case proving background source is no longer forced to `true`, and a popup-source API request remains protected:
+
+```ts
+expect(mockSendRuntimeMessage).toHaveBeenCalledWith(
+  expect.objectContaining({
+    action: RuntimeActionIds.TempWindowFetch,
+    tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Background,
+    suppressMinimize: false,
+  }),
+)
+```
+
+Add Firefox popup-source cases for fetch, Turnstile, page action, and rendered title that expect a structured failure and no runtime/background dispatch.
+
+- [ ] **Step 2: Run the tests and verify RED**
+
+```bash
+pnpm vitest run tests/utils/tempWindowFetch.background.test.ts tests/utils/tempWindowFetch.fallback.test.ts tests/services/apiTransport/request.test.ts tests/entrypoints/background/runtimeMessages.more.test.ts tests/entrypoints/background/tempWindowPoolWindowFallback.test.ts tests/entrypoints/background/tempWindowPoolOpenClose.test.ts
+```
+
+Expected: FAIL because request contracts do not carry `tempWindowRequestSource`, rendered-title still has a separate default, runtime handlers do not normalize the source, and generic fallback still forces suppression.
+
+- [ ] **Step 3: Extend request contracts and transport metadata**
+
+Add `tempWindowRequestSource?: TempWindowRequestSource` to `TempWindowFetchParams`, `TempWindowCheckinPageActionParams`, a new exported `TempWindowRenderedTitleParams`, and `TempWindowFallbackContext`. Add the same transient metadata to `ApiTransportRequest`:
+
+```ts
+/** Originating extension surface for temporary-window presentation policy. */
+tempWindowRequestSource?: TempWindowRequestSource
+```
+
+In `_fetchApi`, copy `request.tempWindowRequestSource` into `TempWindowFallbackContext`.
+
+- [ ] **Step 4: Route all wrappers through one policy resolver**
+
+Replace each `params.suppressMinimize ?? isExtensionPopup()` branch with:
+
+```ts
+const policy = resolveTempWindowRequestPolicy({
+  tempWindowRequestSource: params.tempWindowRequestSource,
+  suppressMinimize: params.suppressMinimize,
+})
+const payload = {
+  ...params,
+  tempWindowRequestSource: policy.tempWindowRequestSource,
+  suppressMinimize: policy.suppressMinimize,
+}
+```
+
+If `policy.blockedReason === "firefox_popup_unsupported"`, do not dispatch. Use one internal error constant and return each helper's existing result contract: fetch/title `{ success: false, error }`; Turnstile `{ success: false, error, turnstile: { status: "error", hasTurnstile: false } }`; page action `{ success: false, reason: "trigger_failed", error }`.
+
+Update `getTempWindowFallbackBlockStatus` to accept `tempWindowRequestSource?: unknown`. When present, derive popup/options/side-panel/background preference flags from the original source; when absent, retain its existing surface arguments for reminder UI and compatibility tests. The Firefox popup guard must prefer the original source even when execution is now in the background worker.
+
+- [ ] **Step 5: Normalize runtime messages and direct pool calls**
+
+For `AutoDetectSite`, `TempWindowFetch`, `TempWindowTurnstileFetch`, `TempWindowCheckinPageAction`, and `TempWindowGetRenderedTitle`, normalize missing or invalid runtime values to `Background` before dispatch. Preserve a valid source and preserve only actual boolean overrides (`typeof suppressMinimize === "boolean"`).
+
+Resolve the same policy again in the five corresponding `tempWindowPool` handlers so direct callers cannot bypass it; keep only the resolved boolean below `acquireTempContext`. Add parameterized runtime tests for valid popup, missing/invalid source, and explicit true/false overrides. Add pool tests proving popup skips minimization, background minimizes, and a reused pooled context is not state-mutated again.
+
+Do not route `OpenTempWindow` through this normalizer. Its composite path is an explicit visible-window command and must retain the existing fixed `suppressMinimize: true`; lock this contract with a `windows.update(... minimized)` negative assertion.
+
+- [ ] **Step 6: Remove the unconditional generic fallback override**
+
+Change `fetchViaTempWindow` from fixed `suppressMinimize: true` to source propagation:
+
+```ts
+const payload: TempWindowFetchParams = {
+  originUrl: context.baseUrl,
+  fetchUrl: context.url,
+  fetchOptions,
+  requestId,
+  responseType,
+  tempWindowRequestSource: context.tempWindowRequestSource,
+  accountId: context.accountId,
+  authType: context.authType,
+  cookieAuthSessionCookie: context.cookieAuthSessionCookie,
+  useIncognito: context.useIncognito,
+  cookieStoreId: context.cookieStoreId,
+}
+```
+
+The wrapper now captures a direct popup caller or resolves an explicit propagated source; background fallback resolves false.
+
+- [ ] **Step 7: Run tests and verify GREEN**
+
+Run the Step 2 command. Expected: all three files PASS.
+
+- [ ] **Step 8: Commit the transport slice**
+
+```bash
+git add src/types/tempWindowFetch.ts src/services/apiTransport/type.ts src/services/apiTransport/request.ts src/utils/browser/tempWindowFetch.ts src/entrypoints/background/runtimeMessages.ts src/entrypoints/background/tempWindowPool.ts tests/utils/tempWindowFetch.background.test.ts tests/utils/tempWindowFetch.fallback.test.ts tests/services/apiTransport/request.test.ts tests/entrypoints/background/runtimeMessages.more.test.ts tests/entrypoints/background/tempWindowPoolWindowFallback.test.ts tests/entrypoints/background/tempWindowPoolOpenClose.test.ts
+git commit -m "fix(temp-window): propagate source through fallbacks"
+```
+
+### Task 3: Migrate Auto-Detect and Browser-Session Requests
+
+**Files:**
+- Modify: `src/services/siteDetection/autoDetectService.ts`
+- Modify: `src/services/accountBrowserSession/types.ts`
+- Modify: `src/services/accountBrowserSession/sessionReader.ts`
+- Modify: `src/services/apiService/sub2api/tokenResync.ts`
+- Modify: `src/services/apiService/sub2api/index.ts`
+- Modify: `src/services/apiService/voapiV2/tokenResync.ts`
+- Modify: `src/services/apiService/voapiV2/index.ts`
+- Modify: `tests/services/autoDetectService.test.ts`
+- Modify: `tests/services/accountBrowserSession/sessionReader.test.ts`
+- Modify: `tests/services/apiService/sub2api/tokenResync.test.ts`
+- Modify: `tests/services/apiService/sub2api/index.test.ts`
+- Modify: `tests/services/apiService/voapiV2/tokenResync.test.ts`
+- Modify: `tests/services/apiService/voapiV2/index.test.ts`
+
+- [ ] **Step 1: Write failing source-propagation tests**
+
+Update the popup auto-detect expectation from a bare boolean to the semantic source:
+
+```ts
+expect(mockSendRuntimeMessage).toHaveBeenCalledWith(
+  expect.objectContaining({
+    action: RuntimeActionIds.AutoDetectSite,
+    tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+  }),
+)
+```
+
+Add session-reader coverage:
+
+```ts
+await resolveAccountBrowserSession({
+  baseUrl: "https://example.invalid",
+  siteType: SITE_TYPES.SUB2API,
+  useTempWindow: true,
+  tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+})
+expect(mockSendRuntimeMessage).toHaveBeenCalledWith(
+  expect.objectContaining({
+    tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+  }),
+)
+```
+
+Add a fallback case proving a popup auto-detect request keeps the same source when the background temp-context attempt fails and execution falls back to `getUserDataViaAPI`.
+
+- [ ] **Step 2: Run tests and verify RED**
+
+```bash
+pnpm vitest run tests/services/autoDetectService.test.ts tests/services/accountBrowserSession/sessionReader.test.ts tests/services/apiService/sub2api/tokenResync.test.ts tests/services/apiService/sub2api/index.test.ts tests/services/apiService/voapiV2/tokenResync.test.ts tests/services/apiService/voapiV2/index.test.ts -t "source|minimize|temp-window|resync"
+```
+
+Expected: FAIL because auto-detect/session and nested token-resync requests do not carry source.
+
+- [ ] **Step 3: Capture and send semantic source**
+
+In `autoDetectService`, replace popup-only boolean construction with:
+
+```ts
+tempWindowRequestSource: getCurrentTempWindowRequestSource(),
+```
+
+Capture once in `getUserDataViaBackground`, forward the same value to the runtime request and to `getUserDataViaAPI` after background failure, and include it in `accountBootstrap.fetchUserInfo()` requests so their own API fallback does not lose context.
+
+Add `tempWindowRequestSource?: TempWindowRequestSource` to `ResolveAccountBrowserSessionOptions`; preserve the existing low-level `suppressMinimize?: boolean` override for compatibility. Send both fields when present.
+
+- [ ] **Step 4: Preserve source in nested token-resync sessions**
+
+Thread `request.tempWindowRequestSource` from the Sub2API and VoAPI v2 adapter entrypoints into their token-resync helpers, then into `resolveAccountBrowserSession`. Test both the adapter-to-resync argument and the session-reader options. Keep the field optional so existing non-temporary requests remain unchanged.
+
+- [ ] **Step 5: Run tests and verify GREEN**
+
+Run the Step 2 command without `-t` after the focused assertions pass. Expected: all three files PASS.
+
+- [ ] **Step 6: Commit the auto-detect/session slice**
+
+```bash
+git add src/services/siteDetection/autoDetectService.ts src/services/accountBrowserSession/types.ts src/services/accountBrowserSession/sessionReader.ts src/services/apiService/sub2api/tokenResync.ts src/services/apiService/sub2api/index.ts src/services/apiService/voapiV2/tokenResync.ts src/services/apiService/voapiV2/index.ts tests/services/autoDetectService.test.ts tests/services/accountBrowserSession/sessionReader.test.ts tests/services/apiService/sub2api/tokenResync.test.ts tests/services/apiService/sub2api/index.test.ts tests/services/apiService/voapiV2/tokenResync.test.ts tests/services/apiService/voapiV2/index.test.ts
+git commit -m "refactor(autodetect): use temp window source context"
+```
+
+### Task 4: Propagate Source Through Auto-Checkin UI, Scheduler, and Providers
+
+**Files:**
+- Modify: `src/services/checkin/autoCheckin/messaging.ts`
+- Modify: `src/hooks/useAutoCheckinUiOpenPretrigger.ts`
+- Modify: `src/features/AutoCheckin/AutoCheckin.tsx`
+- Modify: `src/features/AccountManagement/components/AccountActionButtons/index.tsx`
+- Modify: `src/services/checkin/autoCheckin/providers/index.ts`
+- Modify: `src/services/checkin/autoCheckin/providers/newApi.ts`
+- Modify: `src/services/checkin/autoCheckin/providers/anyrouter.ts`
+- Modify: `src/services/checkin/autoCheckin/providers/veloera.ts`
+- Modify: `src/services/checkin/autoCheckin/providers/wong.ts`
+- Modify: `src/services/checkin/autoCheckin/providers/voapiV2.ts`
+- Modify: `src/services/checkin/autoCheckin/scheduler.ts`
+- Modify: `tests/components/AutoCheckinUiOpenPretrigger.test.tsx`
+- Modify: `tests/entrypoints/options/AutoCheckinQuickRun.test.tsx`
+- Modify: `tests/features/AccountManagement/components/AccountActionButtons.test.tsx`
+- Modify: `tests/services/autoCheckin/scheduler.test.ts`
+- Modify: `tests/services/autoCheckin/providers/newApi.test.ts`
+- Modify: `tests/services/autoCheckin/providers/anyrouter.test.ts`
+- Modify: `tests/services/autoCheckin/providers/veloera.test.ts`
+- Modify: `tests/services/autoCheckin/providers/wong.test.ts`
+- Modify: `tests/services/autoCheckin/providers/voapiV2.test.ts`
+
+- [ ] **Step 1: Write failing UI and scheduler propagation tests**
+
+Update UI-open pretrigger to require source in its typed message:
+
+```ts
+expect(sendRuntimeMessageSpy).toHaveBeenCalledWith(
+  AutoCheckinMessageTypes.PretriggerDailyOnUiOpen,
+  expect.objectContaining({
+    requestId: expect.any(String),
+    tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+  }),
+)
+```
+
+Add equivalent source expectations to manual `RunNow` callers. In scheduler tests, assert the provider receives a second context argument:
+
+```ts
+expect(provider.checkIn).toHaveBeenCalledWith(
+  expect.objectContaining({ id: "account-1" }),
+  {
+    tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+  },
+)
+```
+
+Add an alarm test asserting omitted source becomes `Background`, and a retry test asserting later retry alarms do not reuse an earlier popup source.
+
+- [ ] **Step 2: Write failing New API provider tests**
+
+Exercise both temporary paths with a popup context:
+
+```ts
+await newApiProvider.checkIn(mockAccount, {
+  tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+})
+expect(tempWindowTriggerCheckinPageAction).toHaveBeenCalledWith(
+  expect.objectContaining({
+    tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+  }),
+)
+expect(tempWindowTurnstileFetch).toHaveBeenCalledWith(
+  expect.objectContaining({
+    tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+  }),
+)
+```
+
+Also assert the initial API request, `checked_in_today` polling, and incognito Turnstile retry preserve the same source. In the AnyRouter, Veloera, Wong, and VoAPI v2 provider tests, pass popup context and assert each API request carries it; for VoAPI v2, assert the expired-auth resync and the retried request also retain it.
+
+- [ ] **Step 3: Run tests and verify RED**
+
+```bash
+pnpm vitest run tests/components/AutoCheckinUiOpenPretrigger.test.tsx tests/entrypoints/options/AutoCheckinQuickRun.test.tsx tests/features/AccountManagement/components/AccountActionButtons.test.tsx tests/services/autoCheckin/scheduler.test.ts tests/services/autoCheckin/providers/newApi.test.ts tests/services/autoCheckin/providers/anyrouter.test.ts tests/services/autoCheckin/providers/veloera.test.ts tests/services/autoCheckin/providers/wong.test.ts tests/services/autoCheckin/providers/voapiV2.test.ts -t "source|pretrigger|Turnstile|native page|retry"
+```
+
+Expected: FAIL because messages, provider contracts, and scheduler run options do not carry source.
+
+- [ ] **Step 4: Extend the typed auto-checkin contracts**
+
+Add optional transient source to `AutoCheckinRunNowRequest` and `AutoCheckinPretriggerDailyOnUiOpenRequest`:
+
+```ts
+tempWindowRequestSource?: TempWindowRequestSource
+```
+
+Add a provider context without changing provider results:
+
+```ts
+export interface AutoCheckinProviderContext {
+  tempWindowRequestSource: TempWindowRequestSource
+}
+
+checkIn(
+  account: SiteAccount | AnyrouterCheckInParams,
+  context?: AutoCheckinProviderContext,
+): Promise<AutoCheckinProviderResult>
+```
+
+Existing providers may ignore the optional second argument.
+
+- [ ] **Step 5: Capture source in UI callers**
+
+Use `getCurrentTempWindowRequestSource()` immediately before sending `RunNow` or UI-open pretrigger messages. Do not persist it in preferences or status.
+
+- [ ] **Step 6: Carry source through scheduler execution**
+
+Normalize source at the background message boundary, then add it to `pretriggerDailyOnUiOpen`, `handleDailyAlarm`, `runCheckins`, `runAccountCheckinsInBatches`, and `runAccountCheckin` options. Default alarm/debug/retry calls to `TEMP_WINDOW_REQUEST_SOURCES.Background`.
+
+Provider invocation becomes:
+
+```ts
+await provider.checkIn(account, {
+  tempWindowRequestSource,
+})
+```
+
+Do not write the source into `AutoCheckinStatus` or retry state.
+
+- [ ] **Step 7: Carry source through every provider request and New API temporary attempt**
+
+At each provider entry, normalize the optional context once to `Background`, then add the required value to every `ApiTransportRequest`. For New API, also add it to native page action params, `checked_in_today` polling, normal Turnstile params, preferred-incognito attempts, and fallback incognito attempts. For VoAPI v2, pass it to token resync and the retried request. Do not recompute source inside retry branches.
+
+- [ ] **Step 8: Run tests and verify GREEN**
+
+Run the Step 3 command without `-t`. Expected: all five files PASS.
+
+- [ ] **Step 9: Commit the auto-checkin execution slice**
+
+```bash
+git add src/services/checkin/autoCheckin/messaging.ts src/hooks/useAutoCheckinUiOpenPretrigger.ts src/features/AutoCheckin/AutoCheckin.tsx src/features/AccountManagement/components/AccountActionButtons/index.tsx src/services/checkin/autoCheckin/providers/index.ts src/services/checkin/autoCheckin/providers/newApi.ts src/services/checkin/autoCheckin/providers/anyrouter.ts src/services/checkin/autoCheckin/providers/veloera.ts src/services/checkin/autoCheckin/providers/wong.ts src/services/checkin/autoCheckin/providers/voapiV2.ts src/services/checkin/autoCheckin/scheduler.ts tests/components/AutoCheckinUiOpenPretrigger.test.tsx tests/entrypoints/options/AutoCheckinQuickRun.test.tsx tests/features/AccountManagement/components/AccountActionButtons.test.tsx tests/services/autoCheckin/scheduler.test.ts tests/services/autoCheckin/providers/newApi.test.ts tests/services/autoCheckin/providers/anyrouter.test.ts tests/services/autoCheckin/providers/veloera.test.ts tests/services/autoCheckin/providers/wong.test.ts tests/services/autoCheckin/providers/voapiV2.test.ts
+git commit -m "fix(auto-checkin): preserve temp window source"
+```
+
+### Task 5: Preserve Source Through Post-Checkin Account Refresh
+
+**Files:**
+- Modify: `src/services/accounts/accountStorage.ts`
+- Modify: `src/services/checkin/autoCheckin/scheduler.ts`
+- Modify: `tests/services/accountStorage.test.ts`
+- Modify: `tests/services/autoCheckin/scheduler.test.ts`
+- Modify: `tests/services/apiTransport/request.test.ts`
+
+- [ ] **Step 1: Write the failing account-storage propagation test**
+
+Add an account refresh case that supplies popup source and asserts both support detection and refresh receive it:
+
+```ts
+await accountStorage.refreshAccount("temp-window", true, {
+  tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+})
+
+expect(mockFetchCheckInSupport).toHaveBeenCalledWith(
+  expect.objectContaining({
+    tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+  }),
+)
+expect(mockRefreshAccountData).toHaveBeenCalledWith(
+  expect.objectContaining({
+    tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+  }),
+)
+```
+
+Add a transport assertion proving this metadata reaches `TempWindowFallbackContext` and resolves to `suppressMinimize: true` in the final runtime payload.
+
+- [ ] **Step 2: Write the failing scheduler post-refresh test**
+
+Extend `refreshAccountsAfterSuccessfulCheckins` coverage:
+
+```ts
+await (autoCheckinScheduler as any).refreshAccountsAfterSuccessfulCheckins({
+  accountIds: ["account-1"],
+  tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+})
+
+expect(mockedAccountStorage.refreshAccount).toHaveBeenCalledWith(
+  "account-1",
+  true,
+  {
+    tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+  },
+)
+```
+
+- [ ] **Step 3: Run tests and verify RED**
+
+```bash
+pnpm vitest run tests/services/accountStorage.test.ts tests/services/autoCheckin/scheduler.test.ts tests/services/apiTransport/request.test.ts -t "temp window source|post-checkin refresh|fallback"
+```
+
+Expected: FAIL because `RefreshAccountOptions` and account API requests drop source metadata.
+
+- [ ] **Step 4: Propagate source through the real refresh chain**
+
+Add `tempWindowRequestSource?: TempWindowRequestSource` to `RefreshAccountOptions`. Include it in the request objects passed to `fetchCheckInSupport` and `refreshAccount`. Extend `refreshAccountsAfterSuccessfulCheckins` to accept and pass the same source, and pass the run source from both normal and retry/manual success paths.
+
+Do not add source to persisted account data, storage migrations, or balance-history records.
+
+- [ ] **Step 5: Run tests and verify GREEN**
+
+Run the Step 3 command without `-t`. Expected: all three files PASS.
+
+- [ ] **Step 6: Commit the post-refresh slice**
+
+```bash
+git add src/services/accounts/accountStorage.ts src/services/checkin/autoCheckin/scheduler.ts tests/services/accountStorage.test.ts tests/services/autoCheckin/scheduler.test.ts tests/services/apiTransport/request.test.ts
+git commit -m "fix(accounts): preserve temp window source on refresh"
+```
+
+### Task 6: Integration, Maintainability, and Release Gates
+
+**Files:**
+- Verify: all files touched in Tasks 1-5
+- Verify existing behavior: `src/entrypoints/background/tempWindowPool.ts`
+- Verify existing tests: `tests/entrypoints/background/tempWindowPoolOpenClose.test.ts`
+
+- [ ] **Step 1: Run the complete focused regression set**
+
+```bash
+pnpm vitest run tests/utils/browser.test.ts tests/utils/tempWindowRequestSource.test.ts tests/utils/tempWindowFetch.background.test.ts tests/utils/tempWindowFetch.fallback.test.ts tests/services/apiTransport/request.test.ts tests/entrypoints/background/runtimeMessages.more.test.ts tests/entrypoints/background/tempWindowPoolWindowFallback.test.ts tests/entrypoints/background/tempWindowPoolOpenClose.test.ts tests/services/autoDetectService.test.ts tests/services/accountBrowserSession/sessionReader.test.ts tests/services/apiService/sub2api/tokenResync.test.ts tests/services/apiService/sub2api/index.test.ts tests/services/apiService/voapiV2/tokenResync.test.ts tests/services/apiService/voapiV2/index.test.ts tests/components/AutoCheckinUiOpenPretrigger.test.tsx tests/entrypoints/options/AutoCheckinQuickRun.test.tsx tests/features/AccountManagement/components/AccountActionButtons.test.tsx tests/services/autoCheckin/scheduler.test.ts tests/services/autoCheckin/providers/newApi.test.ts tests/services/autoCheckin/providers/anyrouter.test.ts tests/services/autoCheckin/providers/veloera.test.ts tests/services/autoCheckin/providers/wong.test.ts tests/services/autoCheckin/providers/voapiV2.test.ts tests/services/accountStorage.test.ts
+```
+
+Expected: PASS with no unhandled rejections or warnings.
+
+- [ ] **Step 2: Inspect the source-policy surface for duplicate rules**
+
+```bash
+rg -n "suppressMinimize|isExtensionPopup\(\)" src/types/tempWindowFetch.ts src/utils/browser src/services/apiTransport src/services/siteDetection src/services/accountBrowserSession src/services/checkin/autoCheckin src/services/accounts/accountStorage.ts src/entrypoints/background/tempWindowPool.ts
+```
+
+Expected:
+
+- ordinary fallback callers use source context rather than duplicating `tempWindowRequestSource === "popup"`;
+- no unconditional generic `suppressMinimize: true` remains;
+- the explicit `OpenTempWindow` visible-window override remains;
+- no popup liveness Port, polling, or storage state was added.
+
+- [ ] **Step 3: Run shared TypeScript and dependency gates**
+
+```bash
+pnpm compile
+pnpm run validate:push
+```
+
+Expected: PASS; `validate:push` completes both compile and knip successfully.
+
+- [ ] **Step 4: Run the commit-equivalent staged gate on any final cleanup**
+
+If Task 6 requires cleanup, stage only those task-scoped files and run:
+
+```bash
+pnpm run validate:staged
+```
+
+Expected: PASS. If no cleanup was needed, do not create a no-op commit.
+
+- [ ] **Step 5: Inspect final history and worktree**
+
+```bash
+git status --short
+git log --oneline -6
+git diff 45bdea78a..HEAD --stat
+```
+
+Expected: clean worktree; only source-context implementation/test files changed after the design commit; commits remain task-scoped.
+
+- [ ] **Step 6: Record the E2E and telemetry decisions in the handoff**
+
+State explicitly:
+
+- no new Playwright E2E was added because the current harness opens `popup.html` as a normal page and cannot reproduce toolbar-popup auto-hide;
+- focused runtime-message, wrapper, scheduler, and pool tests cover the controllable contract;
+- telemetry remains `none` because this is an internal correctness fix without a new user action or setting;
+- no dynamic popup monitoring was introduced.

--- a/docs/superpowers/specs/2026-07-16-temp-window-source-context-design.md
+++ b/docs/superpowers/specs/2026-07-16-temp-window-source-context-design.md
@@ -1,0 +1,222 @@
+# Temp Window Source Context Design
+
+Date: 2026-07-16
+
+## Purpose
+
+Preserve the toolbar popup when a popup-originated task opens a temporary
+browser context, without leaving background, options-page, or side-panel
+temporary windows unnecessarily unminimized.
+
+The current behavior is inconsistent. Some helpers infer popup state in the
+context where they execute, which fails after work has crossed into the
+background service worker. The generic API fallback also hard-codes
+`suppressMinimize: true`, so background work does not follow the historical
+"minimize unless a popup needs protection" policy.
+
+## Decision
+
+Carry an immutable source context with the task. Do not add live popup
+monitoring, polling, storage-backed liveness, or a runtime Port in this slice.
+
+The source context is captured when the task starts and remains valid even if
+the toolbar popup closes before the background work finishes. This avoids a
+check-then-act race between probing popup liveness and creating or minimizing a
+temporary window.
+
+## Historical Contract
+
+The established behavior from popup-launched auto-detect is:
+
+- toolbar popup source: do not minimize the temporary window;
+- options page, side panel, and background source: minimize the temporary
+  window to reduce disruption;
+- explicit user action whose purpose is to open a temporary window: keep that
+  window visible.
+
+`focused: false` remains unchanged. `suppressMinimize` controls the subsequent
+best-effort `windows.update(..., { state: "minimized" })`; it is not a focus
+request and only matters when a new window-backed context is created.
+
+## Goals
+
+- Preserve popup origin across runtime-message and scheduler boundaries.
+- Apply one source-to-minimization policy to generic API fallback,
+  Turnstile-assisted requests, native-page auto-checkin, and post-checkin
+  account refresh.
+- Remove the generic fallback's unconditional `suppressMinimize: true`.
+- Evaluate the existing Firefox popup safety rule from the task source rather
+  than the background worker's execution location.
+- Keep background alarms, retries, periodic refresh, options, and side-panel
+  work quiet by default.
+- Keep explicit open-window behavior unchanged.
+- Centralize the policy so business callers do not duplicate boolean rules.
+
+## Non-Goals
+
+- Do not dynamically monitor whether a popup is still open.
+- Do not add a popup/background Port or service-worker keepalive mechanism.
+- Do not change temporary-context pooling, cleanup timing, focus flags, window
+  dimensions, or window-versus-tab fallback behavior.
+- Do not change Firefox's existing popup safety gate.
+- Do not add a user setting, telemetry event, or user-facing copy.
+
+## Source Context
+
+Introduce `TEMP_WINDOW_REQUEST_SOURCES` as a runtime constant and derive the
+`TempWindowRequestSource` union from it in the temporary-window contract. It
+distinguishes:
+
+- `popup`
+- `options`
+- `sidepanel`
+- `background`
+
+Runtime message boundaries validate unknown source values with a type guard.
+The source is transient and must not be persisted.
+
+A single resolver converts the source into the low-level window policy:
+
+```ts
+shouldSuppressTempWindowMinimize(source) => source === "popup"
+```
+
+The launch policy also exposes whether the existing browser-specific safety
+rules allow a temporary window. In particular, a Firefox task whose source is
+the toolbar popup remains blocked even after that task has crossed into the
+background worker. Source context does not create a new Firefox policy; it
+prevents the existing policy from being bypassed by delegation.
+
+Resolution precedence is explicit:
+
+1. an intentional low-level `suppressMinimize` boolean override;
+2. a valid source supplied by the caller;
+3. source captured from the current extension surface before delegation;
+4. `background` when a runtime boundary receives a missing or invalid source.
+
+This distinguishes a high-level wrapper that is still able to capture its
+current popup surface from a background handler that must not guess where an
+already-delegated request originated.
+
+Explicit open-window operations remain an intentional low-level override and
+do not use the ordinary fallback resolver.
+
+## Data Flow
+
+### UI-open auto-checkin
+
+1. The shared UI hook determines its current source before sending the
+   pretrigger message.
+2. The typed auto-checkin message carries that source into the background.
+3. The scheduler carries it through the daily-run invocation without storing
+   it in scheduler status or retry state.
+4. The per-account provider context receives the source.
+5. New API native-page and Turnstile helpers derive `suppressMinimize` from the
+   source.
+6. Before opening a window, Firefox popup-source work applies the existing
+   popup safety gate even though execution is now in the background.
+7. Successful post-checkin account refresh receives the same source so its API
+   fallback cannot later close the originating popup.
+
+The post-checkin refresh propagation is end to end. The source travels through
+the scheduler refresh request, `RefreshAccountOptions`,
+`ApiServiceAccountRequest`/`ApiTransportRequest`, and
+`TempWindowFallbackContext` before the fallback wrapper resolves the final
+boolean. It must not stop at a scheduler-only option that downstream account
+refresh silently drops.
+
+Scheduled alarms and later retry alarms start with `background` source. They do
+not inherit the source of an earlier UI pretrigger.
+
+### Generic API fallback
+
+1. API transport accepts an optional temporary-window source as transient
+   request metadata.
+2. The fallback context carries it to the temporary-window wrapper.
+3. If an explicit source is present, the centralized resolver uses it.
+4. If no source was passed, the wrapper captures the current extension surface
+   before crossing into background. This preserves existing direct popup calls
+   while allowing direct background calls to minimize normally.
+
+The existing unconditional `suppressMinimize: true` is removed.
+
+### Auto-detect and browser-session reads
+
+Existing popup detection is routed through the same source resolver rather
+than maintaining a separate boolean rule. Browser-session callers that already
+know their source pass it explicitly. The background temp-window pool continues
+to receive the resolved boolean and remains independent of React/UI modules.
+
+### Rendered-title reads
+
+`tempWindowGetRenderedTitle` uses the same resolver and precedence as fetch,
+Turnstile, and page-action helpers. It must not retain a separate
+`params.suppressMinimize ?? isExtensionPopup()` implementation.
+
+### Explicit open-window action
+
+`OpenTempWindow` intentionally presents a window to the user. Its composite
+mode must continue suppressing minimization so it behaves like the standalone
+window mode. This is an explicit presentation command, not a fallback request.
+
+## Failure and Compatibility Behavior
+
+- A high-level wrapper with no explicit source captures its current extension
+  surface before delegation.
+- A runtime/background boundary that receives a missing or invalid source
+  falls back to `background`, which minimizes and preserves the previous
+  background default.
+- Firefox popup-source requests remain subject to the existing no-temp-window
+  safety behavior after crossing into background.
+- An explicit low-level `suppressMinimize` override remains supported where a
+  caller truly owns window presentation behavior and takes precedence over a
+  supplied or inferred source.
+- Tab-backed contexts ignore minimization as they do today.
+- Reused pooled contexts keep their existing window state; the policy affects
+  creation of a new window-backed context only.
+- Popup closure does not cancel background check-in work.
+
+## Testing
+
+Use TDD at the real propagation seams:
+
+- source-policy resolver matrix for popup, options, side panel, background,
+  missing, and invalid inputs;
+- UI-open pretrigger captures and sends the current source;
+- scheduler passes popup source to provider execution and successful
+  post-checkin refresh;
+- alarm and retry paths use background source;
+- native-page and Turnstile wrappers receive the derived suppression policy;
+- Firefox popup-source work is rejected by the existing safety gate even when
+  the helper executes in background;
+- popup-source post-checkin refresh carries the source through account storage,
+  API service/transport request metadata, and `TempWindowFallbackContext`, then
+  makes generic fallback suppress minimization at the final wrapper;
+- generic API fallback no longer forces suppression and resolves popup versus
+  background correctly;
+- auto-detect keeps its popup protection through the shared source path;
+- rendered-title reads use the same source resolver as the other temporary
+  helpers;
+- explicit `suppressMinimize: true` and `suppressMinimize: false` each override
+  a conflicting source, while missing or invalid runtime source defaults to
+  background;
+- standalone window and composite window modes both skip minimization only
+  when suppression resolves true;
+- explicit `OpenTempWindow` remains visible.
+
+Focused Vitest coverage is the correct primary layer because the contract is
+runtime-message and request-metadata propagation. Existing Playwright tests
+open `popup.html` as a normal page and cannot reproduce a real toolbar popup's
+auto-hide semantics, so no new E2E test is planned for this slice.
+
+Before handoff, run related Vitest suites, `pnpm run validate:staged`, and
+`pnpm run validate:push` because shared TypeScript contracts and runtime wiring
+will change.
+
+## Release Readiness
+
+- Telemetry: none. This is an internal correctness fix with no new user action,
+  setting, or privacy-safe product question that needs measurement.
+- Settings search/deep links: not applicable; no setting changes.
+- Maintainability: centralize source resolution and retain the pool as the
+  low-level window owner. Do not introduce popup-liveness state.

--- a/src/entrypoints/background/runtimeMessages.ts
+++ b/src/entrypoints/background/runtimeMessages.ts
@@ -34,6 +34,7 @@ import {
   hasCookieReadPermissionForUrl,
 } from "~/utils/browser/cookieHelper"
 import { extractSessionCookieHeader } from "~/utils/browser/cookieString"
+import { normalizeTempWindowRequestSource } from "~/utils/browser/tempWindowRequestSource"
 import { getErrorMessage } from "~/utils/core/error"
 import { createLogger } from "~/utils/core/logger"
 import {
@@ -56,6 +57,28 @@ import {
  * Unified logger scoped to background runtime message routing.
  */
 const logger = createLogger("RuntimeMessages")
+
+/** Normalizes untrusted temp-window presentation metadata at the runtime boundary. */
+function normalizeTempWindowRuntimeRequest<
+  T extends Record<string, unknown> & {
+    suppressMinimize?: unknown
+    tempWindowRequestSource?: unknown
+  },
+>(request: T) {
+  const normalizedRequest = Object.assign({}, request, {
+    tempWindowRequestSource: normalizeTempWindowRequestSource(
+      request.tempWindowRequestSource,
+    ),
+  })
+
+  if (typeof request.suppressMinimize === "boolean") {
+    normalizedRequest.suppressMinimize = request.suppressMinimize
+  } else {
+    delete normalizedRequest.suppressMinimize
+  }
+
+  return normalizedRequest
+}
 
 /**
  * Resolves the browser cookie store that should be used for a cookie import request.
@@ -164,27 +187,42 @@ export function setupRuntimeMessageListeners() {
       }
 
       if (request.action === RuntimeActionIds.AutoDetectSite) {
-        void handleAutoDetectSite(request, sendResponse)
+        void handleAutoDetectSite(
+          normalizeTempWindowRuntimeRequest(request),
+          sendResponse,
+        )
         return true
       }
 
       if (request.action === RuntimeActionIds.TempWindowFetch) {
-        void handleTempWindowFetch(request, sendResponse)
+        void handleTempWindowFetch(
+          normalizeTempWindowRuntimeRequest(request),
+          sendResponse,
+        )
         return true
       }
 
       if (request.action === RuntimeActionIds.TempWindowTurnstileFetch) {
-        void handleTempWindowTurnstileFetch(request, sendResponse)
+        void handleTempWindowTurnstileFetch(
+          normalizeTempWindowRuntimeRequest(request),
+          sendResponse,
+        )
         return true
       }
 
       if (request.action === RuntimeActionIds.TempWindowCheckinPageAction) {
-        void handleTempWindowCheckinPageAction(request, sendResponse)
+        void handleTempWindowCheckinPageAction(
+          normalizeTempWindowRuntimeRequest(request),
+          sendResponse,
+        )
         return true
       }
 
       if (request.action === RuntimeActionIds.TempWindowGetRenderedTitle) {
-        void handleTempWindowGetRenderedTitle(request, sendResponse)
+        void handleTempWindowGetRenderedTitle(
+          normalizeTempWindowRuntimeRequest(request),
+          sendResponse,
+        )
         return true
       }
 

--- a/src/entrypoints/background/tempWindowPool.ts
+++ b/src/entrypoints/background/tempWindowPool.ts
@@ -42,6 +42,7 @@ import type {
   TempWindowFetch,
   TempWindowFetchParams,
   TempWindowPageAccountIdentity,
+  TempWindowRenderedTitleParams,
   TempWindowTurnstileFetch,
   TempWindowTurnstileFetchParams,
   TempWindowTurnstileMeta,
@@ -85,6 +86,7 @@ import {
 } from "~/utils/browser/firefoxTempWindowDownloadBlocker"
 import { isProtectionBypassFirefoxEnv } from "~/utils/browser/protectionBypass"
 import { normalizeRequestInitForMessage } from "~/utils/browser/requestInitMessage"
+import { resolveTempWindowRequestPolicy } from "~/utils/browser/tempWindowRequestSource"
 import { resolveAuthTypeEnum } from "~/utils/core/authType"
 import { getErrorMessage } from "~/utils/core/error"
 import { safeRandomUUID } from "~/utils/core/identifier"
@@ -379,10 +381,19 @@ async function navigateTempContextToPage(
  * 在临时上下文中渲染页面并读取真实的 document.title。
  */
 export async function handleTempWindowGetRenderedTitle(
-  request: any,
+  request: TempWindowRenderedTitleParams,
   sendResponse: (response?: any) => void,
 ) {
-  const { originUrl, requestId, suppressMinimize } = request
+  const { originUrl, requestId } = request
+  const policy = resolveTempWindowRequestPolicy({
+    tempWindowRequestSource: request.tempWindowRequestSource,
+    suppressMinimize: request.suppressMinimize,
+  })
+  if (policy.blockedReason) {
+    sendResponse({ success: false, error: policy.blockedReason })
+    return
+  }
+  const { suppressMinimize } = policy
   const tempRequestId = requestId || `temp-title-${Date.now()}`
 
   logTempWindow("tempWindowGetRenderedTitleStart", {
@@ -1186,7 +1197,16 @@ export async function handleAutoDetectSite(
   request: any,
   sendResponse: (response?: any) => void,
 ) {
-  const { url, requestId, useIncognito, suppressMinimize } = request
+  const { url, requestId, useIncognito } = request
+  const policy = resolveTempWindowRequestPolicy({
+    tempWindowRequestSource: request.tempWindowRequestSource,
+    suppressMinimize: request.suppressMinimize,
+  })
+  if (policy.blockedReason) {
+    sendResponse({ success: false, error: policy.blockedReason })
+    return
+  }
+  const { suppressMinimize } = policy
 
   try {
     if (useIncognito) {
@@ -1246,13 +1266,21 @@ export async function handleTempWindowFetch(
     fetchOptions,
     responseType = "json",
     requestId,
-    suppressMinimize,
     accountId,
     authType,
     cookieAuthSessionCookie,
     useIncognito,
     cookieStoreId,
   } = request
+  const policy = resolveTempWindowRequestPolicy({
+    tempWindowRequestSource: request.tempWindowRequestSource,
+    suppressMinimize: request.suppressMinimize,
+  })
+  if (policy.blockedReason) {
+    sendResponse({ success: false, error: policy.blockedReason })
+    return
+  }
+  const { suppressMinimize } = policy
 
   if (!originUrl || !fetchUrl) {
     const error = t("messages:background.invalidFetchRequest")
@@ -1440,15 +1468,21 @@ export async function handleTempWindowCheckinPageAction(
   request: TempWindowCheckinPageActionParams,
   sendResponse: (response?: TempWindowCheckinPageAction) => void,
 ) {
-  const {
-    originUrl,
-    pageUrl,
-    requestId,
-    suppressMinimize,
-    siteType,
-    expectedUserId,
-    trigger,
-  } = request
+  const { originUrl, pageUrl, requestId, siteType, expectedUserId, trigger } =
+    request
+  const policy = resolveTempWindowRequestPolicy({
+    tempWindowRequestSource: request.tempWindowRequestSource,
+    suppressMinimize: request.suppressMinimize,
+  })
+  if (policy.blockedReason) {
+    sendResponse({
+      success: false,
+      reason: "trigger_failed",
+      error: policy.blockedReason,
+    })
+    return
+  }
+  const { suppressMinimize } = policy
 
   if (
     !originUrl ||
@@ -1593,7 +1627,6 @@ export async function handleTempWindowTurnstileFetch(
     fetchOptions,
     responseType = "json",
     requestId,
-    suppressMinimize,
     accountId,
     authType,
     cookieAuthSessionCookie,
@@ -1602,6 +1635,19 @@ export async function handleTempWindowTurnstileFetch(
     turnstileParamName,
     turnstilePreTrigger,
   } = request
+  const policy = resolveTempWindowRequestPolicy({
+    tempWindowRequestSource: request.tempWindowRequestSource,
+    suppressMinimize: request.suppressMinimize,
+  })
+  if (policy.blockedReason) {
+    sendResponse({
+      success: false,
+      error: policy.blockedReason,
+      turnstile: { status: "error", hasTurnstile: false },
+    })
+    return
+  }
+  const { suppressMinimize } = policy
 
   const turnstile: TempWindowTurnstileMeta = {
     status: "error",

--- a/src/features/AccountManagement/components/AccountActionButtons/index.tsx
+++ b/src/features/AccountManagement/components/AccountActionButtons/index.tsx
@@ -83,6 +83,7 @@ import { buildAccountShareSnapshotPayload } from "~/services/sharing/shareSnapsh
 import { toSanitizedErrorSummary } from "~/services/verification/aiApiVerification/utils"
 import type { DisplaySiteData } from "~/types"
 import { CHECKIN_RESULT_STATUS } from "~/types/autoCheckin"
+import { getCurrentTempWindowRequestSource } from "~/utils/browser/tempWindowRequestSource"
 import { getErrorMessage } from "~/utils/core/error"
 import { createLogger } from "~/utils/core/logger"
 import { showWarningToast } from "~/utils/core/toastHelpers"
@@ -704,10 +705,12 @@ export default function AccountActionButtons({
     try {
       toastId = toast.loading(t("autoCheckin:messages.loading.running"))
 
+      const tempWindowRequestSource = getCurrentTempWindowRequestSource()
       const response = await sendAutoCheckinMessage(
         AutoCheckinMessageTypes.RunNow,
         {
           accountIds: [site.id],
+          tempWindowRequestSource,
         },
       )
 

--- a/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
+++ b/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
@@ -113,6 +113,7 @@ import {
   type SiteAccount,
 } from "~/types"
 import type { AccountSaveResponse } from "~/types/serviceResponse"
+import type { TempWindowRequestSource } from "~/types/tempWindowFetch"
 import { deepOverride } from "~/utils"
 import { isExtensionPopup } from "~/utils/browser"
 import {
@@ -122,6 +123,7 @@ import {
   onTabUpdated,
   sendRuntimeMessage,
 } from "~/utils/browser/browserApi"
+import { getCurrentTempWindowRequestSource } from "~/utils/browser/tempWindowRequestSource"
 import { getErrorMessage } from "~/utils/core/error"
 import { createLogger } from "~/utils/core/logger"
 import { showUpdateToast, showWarningToast } from "~/utils/core/toastHelpers"
@@ -198,10 +200,11 @@ const logger = createLogger("AccountDialogHook")
  */
 function schedulePostSaveAccountRefresh(
   accountId: string,
+  tempWindowRequestSource: TempWindowRequestSource,
   onPostSaveAccountRefresh?: (accountIds: string[]) => Promise<void>,
 ) {
   void accountStorage
-    .refreshAccount(accountId, true)
+    .refreshAccount(accountId, true, { tempWindowRequestSource })
     .then(async (result) => {
       if (!result?.refreshed) {
         return
@@ -1542,6 +1545,7 @@ export function useAccountDialog({
       return
     }
 
+    const tempWindowRequestSource = getCurrentTempWindowRequestSource()
     setIsImportingSub2apiSession(true)
     try {
       const baseUrl = url.trim()
@@ -1563,6 +1567,7 @@ export function useAccountDialog({
         ...(currentTab ? { currentTab } : {}),
         useExistingTabs: true,
         useTempWindow: true,
+        tempWindowRequestSource,
         requestIdPrefix: "account-dialog-sub2api-import",
         isUsableSession: hasUsableSub2apiRefreshToken,
         onError: (error, context) => {
@@ -1880,6 +1885,7 @@ export function useAccountDialog({
     skipSub2ApiKeyPrompt?: boolean
     skipAutoProvisionKeyOnAccountAdd?: boolean
   }) => {
+    const tempWindowRequestSource = getCurrentTempWindowRequestSource()
     const analyticsAction = startProductAnalyticsAction({
       featureId: PRODUCT_ANALYTICS_FEATURE_IDS.AccountManagement,
       actionId:
@@ -1975,7 +1981,11 @@ export function useAccountDialog({
           : null
 
       if (savedAccountId) {
-        schedulePostSaveAccountRefresh(savedAccountId, onPostSaveAccountRefresh)
+        schedulePostSaveAccountRefresh(
+          savedAccountId,
+          tempWindowRequestSource,
+          onPostSaveAccountRefresh,
+        )
       }
 
       const feedbackMessage =
@@ -2011,9 +2021,12 @@ export function useAccountDialog({
                   )
 
                   try {
+                    const tempWindowRequestSource =
+                      getCurrentTempWindowRequestSource()
                     const refreshResult = await accountStorage.refreshAccount(
                       warningAccountId,
                       true,
+                      { tempWindowRequestSource },
                     )
 
                     if (!refreshResult?.refreshed) {

--- a/src/features/AccountManagement/hooks/AccountActionsContext.tsx
+++ b/src/features/AccountManagement/hooks/AccountActionsContext.tsx
@@ -26,6 +26,7 @@ import {
   PRODUCT_ANALYTICS_SURFACE_IDS,
 } from "~/services/productAnalytics/contracts"
 import type { DisplaySiteData } from "~/types"
+import { getCurrentTempWindowRequestSource } from "~/utils/browser/tempWindowRequestSource"
 import { getErrorMessage } from "~/utils/core/error"
 import { createLogger } from "~/utils/core/logger"
 import { t } from "~/utils/i18n/core"
@@ -91,6 +92,7 @@ export const AccountActionsProvider = ({
       if (refreshingAccountId) return
       if (account.disabled === true) return
 
+      const tempWindowRequestSource = getCurrentTempWindowRequestSource()
       setRefreshingAccountId(account.id)
       const tracker = startProductAnalyticsAction({
         featureId: PRODUCT_ANALYTICS_FEATURE_IDS.AccountManagement,
@@ -102,7 +104,9 @@ export const AccountActionsProvider = ({
       let analyticsCompleted = false
 
       const refreshPromise = async () => {
-        const result = await accountStorage.refreshAccount(account.id, force)
+        const result = await accountStorage.refreshAccount(account.id, force, {
+          tempWindowRequestSource,
+        })
         if (result) {
           await loadAccountData()
           return result

--- a/src/features/AccountManagement/hooks/AccountDataContext.tsx
+++ b/src/features/AccountManagement/hooks/AccountDataContext.tsx
@@ -66,6 +66,7 @@ import {
   onTabRemoved,
   onTabUpdated,
 } from "~/utils/browser/browserApi"
+import { getCurrentTempWindowRequestSource } from "~/utils/browser/tempWindowRequestSource"
 import { createLogger } from "~/utils/core/logger"
 
 /**
@@ -706,9 +707,12 @@ export const AccountDataProvider = ({
 
   const handleRefresh = useCallback(
     async (force: boolean = false) => {
+      const tempWindowRequestSource = getCurrentTempWindowRequestSource()
       setIsRefreshing(true)
       try {
-        const refreshResult = await accountStorage.refreshAllAccounts(force)
+        const refreshResult = await accountStorage.refreshAllAccounts(force, {
+          tempWindowRequestSource,
+        })
         await loadAccountData()
         if (refreshResult.latestSyncTime > 0) {
           setLastUpdateTime(new Date(refreshResult.latestSyncTime))
@@ -727,10 +731,13 @@ export const AccountDataProvider = ({
 
   const handleRefreshDisabledAccounts = useCallback(
     async (force: boolean = false) => {
+      const tempWindowRequestSource = getCurrentTempWindowRequestSource()
       setIsRefreshingDisabledAccounts(true)
       try {
-        const refreshResult =
-          await accountStorage.refreshDisabledAccounts(force)
+        const refreshResult = await accountStorage.refreshDisabledAccounts(
+          force,
+          { tempWindowRequestSource },
+        )
         await loadAccountData()
         if (refreshResult.latestSyncTime > 0) {
           setLastUpdateTime(new Date(refreshResult.latestSyncTime))

--- a/src/features/AutoCheckin/AutoCheckin.tsx
+++ b/src/features/AutoCheckin/AutoCheckin.tsx
@@ -50,6 +50,7 @@ import {
   CHECKIN_RESULT_STATUS,
 } from "~/types/autoCheckin"
 import { onRuntimeMessage } from "~/utils/browser/browserApi"
+import { getCurrentTempWindowRequestSource } from "~/utils/browser/tempWindowRequestSource"
 import { isDevelopmentMode } from "~/utils/core/environment"
 import { getErrorMessage } from "~/utils/core/error"
 import { safeRandomUUID } from "~/utils/core/identifier"
@@ -322,9 +323,10 @@ export default function AutoCheckin(props: {
       setIsRunning(true)
       toast.loading(t("messages.loading.running"))
 
+      const tempWindowRequestSource = getCurrentTempWindowRequestSource()
       const response = await sendAutoCheckinMessage(
         AutoCheckinMessageTypes.RunNow,
-        {},
+        { tempWindowRequestSource },
       )
 
       toast.dismiss()
@@ -474,11 +476,13 @@ export default function AutoCheckin(props: {
       )
       toast.loading(t("messages.loading.evaluatingUiOpenPretrigger"))
 
+      const tempWindowRequestSource = getCurrentTempWindowRequestSource()
       const response = await sendAutoCheckinMessage(
         AutoCheckinMessageTypes.PretriggerDailyOnUiOpen,
         {
           dryRun: true,
           debug: true,
+          tempWindowRequestSource,
         },
       )
 
@@ -538,11 +542,13 @@ export default function AutoCheckin(props: {
         }
       })
 
+      const tempWindowRequestSource = getCurrentTempWindowRequestSource()
       const response = await sendAutoCheckinMessage(
         AutoCheckinMessageTypes.PretriggerDailyOnUiOpen,
         {
           requestId,
           debug: true,
+          tempWindowRequestSource,
         },
       )
 
@@ -724,10 +730,12 @@ export default function AutoCheckin(props: {
 
     try {
       setRetryingAccountId(accountId)
+      const tempWindowRequestSource = getCurrentTempWindowRequestSource()
       const response = await sendAutoCheckinMessage(
         AutoCheckinMessageTypes.RetryAccount,
         {
           accountId,
+          tempWindowRequestSource,
         },
       )
 

--- a/src/hooks/useAutoCheckinUiOpenPretrigger.ts
+++ b/src/hooks/useAutoCheckinUiOpenPretrigger.ts
@@ -25,6 +25,7 @@ import type {
 } from "~/types/autoCheckin"
 import { AUTO_CHECKIN_RUN_RESULT } from "~/types/autoCheckin"
 import { onRuntimeMessage } from "~/utils/browser/browserApi"
+import { getCurrentTempWindowRequestSource } from "~/utils/browser/tempWindowRequestSource"
 import { safeRandomUUID } from "~/utils/core/identifier"
 import { createLogger } from "~/utils/core/logger"
 
@@ -134,10 +135,12 @@ export function useAutoCheckinUiOpenPretrigger(): {
 
     void (async () => {
       try {
+        const tempWindowRequestSource = getCurrentTempWindowRequestSource()
         const response = await sendAutoCheckinMessage(
           AutoCheckinMessageTypes.PretriggerDailyOnUiOpen,
           {
             requestId,
+            tempWindowRequestSource,
           },
         )
 

--- a/src/services/accountBrowserSession/sessionReader.ts
+++ b/src/services/accountBrowserSession/sessionReader.ts
@@ -281,7 +281,12 @@ const readAccountBrowserSessionFromTempWindow = async (
       action: RuntimeActionIds.AutoDetectSite,
       url: options.baseUrl,
       requestId: `${options.requestIdPrefix ?? "account-browser-session"}-${Date.now()}`,
-      ...(options.suppressMinimize ? { suppressMinimize: true } : {}),
+      ...(options.tempWindowRequestSource
+        ? { tempWindowRequestSource: options.tempWindowRequestSource }
+        : {}),
+      ...(typeof options.suppressMinimize === "boolean"
+        ? { suppressMinimize: options.suppressMinimize }
+        : {}),
       ...(options.currentTab?.incognito === true ? { useIncognito: true } : {}),
     })
 

--- a/src/services/accountBrowserSession/types.ts
+++ b/src/services/accountBrowserSession/types.ts
@@ -1,6 +1,7 @@
 import type { AccountSiteType } from "~/constants/siteType"
 import type { ApiServiceFetchContext } from "~/services/apiTransport/type"
 import type { Sub2ApiAuthConfig } from "~/types"
+import type { TempWindowRequestSource } from "~/types/tempWindowFetch"
 
 export const ACCOUNT_BROWSER_SESSION_SOURCES = {
   CURRENT_TAB: "current_tab",
@@ -71,6 +72,7 @@ export type ResolveAccountBrowserSessionOptions = {
   }
   useExistingTabs?: boolean
   useTempWindow?: boolean
+  tempWindowRequestSource?: TempWindowRequestSource
   suppressMinimize?: boolean
   requestIdPrefix?: string
   isUsableSession?: AccountBrowserSessionPredicate

--- a/src/services/accounts/accountStorage.ts
+++ b/src/services/accounts/accountStorage.ts
@@ -33,6 +33,7 @@ import {
   type SiteBookmark,
 } from "~/types"
 import type { DailyBalanceHistoryCaptureSource } from "~/types/dailyBalanceHistory"
+import type { TempWindowRequestSource } from "~/types/tempWindowFetch"
 import { DeepPartial } from "~/types/utils"
 import { deepOverride } from "~/utils"
 import { getErrorMessage } from "~/utils/core/error"
@@ -79,7 +80,13 @@ type RefreshAccountOptions = {
   balanceHistoryCaptureSource?: DailyBalanceHistoryCaptureSource
   allowDisabled?: boolean
   reEnableOnSuccess?: boolean
+  tempWindowRequestSource?: TempWindowRequestSource
 }
+
+type RefreshAccountsOptions = Pick<
+  RefreshAccountOptions,
+  "tempWindowRequestSource"
+>
 
 type UpdateAccountOptions = {
   userTimestampMode: AccountUpdateUserTimestampMode
@@ -1084,6 +1091,7 @@ class AccountStorageService {
       }
       const accountRefresh = getSiteTypeCapabilities(account.site_type).account
         ?.refresh
+      const tempWindowRequestSource = options?.tempWindowRequestSource
 
       // Refresh check-in support status together with account refresh.
       const currentCheckIn = account.checkIn
@@ -1096,6 +1104,7 @@ class AccountStorageService {
             accountId: account.id,
             cookieAuthSessionCookie: account.cookieAuth?.sessionCookie,
             auth,
+            ...(tempWindowRequestSource ? { tempWindowRequestSource } : {}),
           })
 
           if (typeof support === "boolean") {
@@ -1125,6 +1134,7 @@ class AccountStorageService {
             exchangeRate: account.exchange_rate,
             auth,
             includeTodayCashflow,
+            ...(tempWindowRequestSource ? { tempWindowRequestSource } : {}),
           })
         : createMissingAccountRefreshResult(account.site_type)
 
@@ -1313,10 +1323,14 @@ class AccountStorageService {
   /**
    * Refresh all accounts concurrently; summarizes results.
    */
-  async refreshAllAccounts(force: boolean = false) {
+  async refreshAllAccounts(
+    force: boolean = false,
+    options?: RefreshAccountsOptions,
+  ) {
     const accounts = await this.getEnabledAccounts()
     const includeTodayCashflow =
       (await userPreferences.getPreferences()).showTodayCashflow ?? true
+    const tempWindowRequestSource = options?.tempWindowRequestSource
     let successCount = 0
     let failedCount = 0
     let refreshedCount = 0
@@ -1325,7 +1339,10 @@ class AccountStorageService {
     // 使用 Promise.allSettled 来并发刷新，避免单个失败影响其他账号
     const results = await Promise.allSettled(
       accounts.map((account) =>
-        this.refreshAccount(account.id, force, { includeTodayCashflow }),
+        this.refreshAccount(account.id, force, {
+          includeTodayCashflow,
+          ...(tempWindowRequestSource ? { tempWindowRequestSource } : {}),
+        }),
       ),
     )
 
@@ -1361,12 +1378,16 @@ class AccountStorageService {
    * Re-probe disabled accounts and automatically re-enable the ones whose
    * account data can be refreshed successfully.
    */
-  async refreshDisabledAccounts(force: boolean = false) {
+  async refreshDisabledAccounts(
+    force: boolean = false,
+    options?: RefreshAccountsOptions,
+  ) {
     const accounts = (await this.getAllAccounts()).filter((account) =>
       AccountStorageService.isAccountDisabled(account),
     )
     const includeTodayCashflow =
       (await userPreferences.getPreferences()).showTodayCashflow ?? true
+    const tempWindowRequestSource = options?.tempWindowRequestSource
     let processedCount = 0
     let failedCount = 0
     let reEnabledCount = 0
@@ -1378,6 +1399,7 @@ class AccountStorageService {
           includeTodayCashflow,
           allowDisabled: true,
           reEnableOnSuccess: true,
+          ...(tempWindowRequestSource ? { tempWindowRequestSource } : {}),
         }),
       ),
     )

--- a/src/services/apiAdapters/contracts/accountRefresh.ts
+++ b/src/services/apiAdapters/contracts/accountRefresh.ts
@@ -6,7 +6,11 @@ import type { ApiServiceRequest } from "~/services/apiTransport/type"
 
 export type AccountRefreshSupportRequest = Pick<
   ApiServiceRequest,
-  "baseUrl" | "auth" | "accountId" | "cookieAuthSessionCookie"
+  | "baseUrl"
+  | "auth"
+  | "accountId"
+  | "cookieAuthSessionCookie"
+  | "tempWindowRequestSource"
 >
 
 export type AccountRefreshRequest = ApiServiceAccountRequest

--- a/src/services/apiService/newApiFamily/variants/anyrouter.ts
+++ b/src/services/apiService/newApiFamily/variants/anyrouter.ts
@@ -14,6 +14,7 @@ import type { ApiServiceRequest } from "~/services/apiTransport/type"
 import { anyrouterProvider } from "~/services/checkin/autoCheckin/providers/anyrouter"
 import { SiteHealthStatus, type CheckInConfig } from "~/types"
 import { CHECKIN_RESULT_STATUS } from "~/types/autoCheckin"
+import { normalizeTempWindowRequestSource } from "~/utils/browser/tempWindowRequestSource"
 import { createLogger } from "~/utils/core/logger"
 import { t } from "~/utils/i18n/core"
 
@@ -42,13 +43,19 @@ export async function fetchCheckInStatus(
       return undefined
     }
 
-    const checkInData = await anyrouterProvider.checkIn({
-      site_url: request.baseUrl,
-      id: request.accountId,
-      cookieAuthSessionCookie:
-        request.cookieAuthSessionCookie ?? request.auth.cookie,
-      account_info: { id: numericUserId },
-    })
+    const tempWindowRequestSource = normalizeTempWindowRequestSource(
+      request.tempWindowRequestSource,
+    )
+    const checkInData = await anyrouterProvider.checkIn(
+      {
+        site_url: request.baseUrl,
+        id: request.accountId,
+        cookieAuthSessionCookie:
+          request.cookieAuthSessionCookie ?? request.auth.cookie,
+        account_info: { id: numericUserId },
+      },
+      { tempWindowRequestSource },
+    )
     return checkInData.status !== CHECKIN_RESULT_STATUS.ALREADY_CHECKED
   } catch (error) {
     logger.warn("获取签到状态失败", error)

--- a/src/services/apiService/sub2api/index.ts
+++ b/src/services/apiService/sub2api/index.ts
@@ -393,12 +393,10 @@ const resyncSub2ApiRequestAuth = async <
       return latestRequest
     }
 
-    const resynced = latestRequest.tempWindowRequestSource
-      ? await resyncSub2ApiAuthToken(
-          latestRequest.baseUrl,
-          latestRequest.tempWindowRequestSource,
-        )
-      : await resyncSub2ApiAuthToken(latestRequest.baseUrl)
+    const resynced = await resyncSub2ApiAuthToken(
+      latestRequest.baseUrl,
+      latestRequest.tempWindowRequestSource,
+    )
     if (!resynced) {
       throw createLoginRequiredError(params.endpoint)
     }

--- a/src/services/apiService/sub2api/index.ts
+++ b/src/services/apiService/sub2api/index.ts
@@ -393,7 +393,12 @@ const resyncSub2ApiRequestAuth = async <
       return latestRequest
     }
 
-    const resynced = await resyncSub2ApiAuthToken(latestRequest.baseUrl)
+    const resynced = latestRequest.tempWindowRequestSource
+      ? await resyncSub2ApiAuthToken(
+          latestRequest.baseUrl,
+          latestRequest.tempWindowRequestSource,
+        )
+      : await resyncSub2ApiAuthToken(latestRequest.baseUrl)
     if (!resynced) {
       throw createLoginRequiredError(params.endpoint)
     }

--- a/src/services/apiService/sub2api/tokenResync.ts
+++ b/src/services/apiService/sub2api/tokenResync.ts
@@ -4,6 +4,7 @@ import {
   resolveAccountBrowserSession,
   type AccountBrowserSession,
 } from "~/services/accountBrowserSession"
+import type { TempWindowRequestSource } from "~/types/tempWindowFetch"
 
 type Sub2ApiResyncedToken = {
   accessToken: string
@@ -42,6 +43,7 @@ const mapResyncSource = (
  */
 export async function resyncSub2ApiAuthToken(
   baseUrl: string,
+  tempWindowRequestSource?: TempWindowRequestSource,
 ): Promise<Sub2ApiResyncedToken | null> {
   const session = await resolveAccountBrowserSession({
     baseUrl,
@@ -49,6 +51,7 @@ export async function resyncSub2ApiAuthToken(
     useExistingTabs: true,
     useTempWindow: true,
     requestIdPrefix: "sub2api-token-resync",
+    ...(tempWindowRequestSource ? { tempWindowRequestSource } : {}),
     isUsableSession: hasUsableAccessToken,
   })
 

--- a/src/services/apiService/voapiV2/index.ts
+++ b/src/services/apiService/voapiV2/index.ts
@@ -382,7 +382,12 @@ export async function refreshAccountData(
     }
   } catch (error) {
     if (isVoApiV2AuthExpiredError(error)) {
-      const resynced = await resyncVoApiV2AuthToken(request.baseUrl)
+      const resynced = request.tempWindowRequestSource
+        ? await resyncVoApiV2AuthToken(
+            request.baseUrl,
+            request.tempWindowRequestSource,
+          )
+        : await resyncVoApiV2AuthToken(request.baseUrl)
       if (resynced) {
         const resyncedRequest: ApiServiceAccountRequest = {
           ...request,

--- a/src/services/apiService/voapiV2/tokenResync.ts
+++ b/src/services/apiService/voapiV2/tokenResync.ts
@@ -4,6 +4,7 @@ import {
   resolveAccountBrowserSession,
   type AccountBrowserSession,
 } from "~/services/accountBrowserSession"
+import type { TempWindowRequestSource } from "~/types/tempWindowFetch"
 
 type VoApiV2ResyncedToken = {
   accessToken: string
@@ -51,6 +52,7 @@ const resolveUsername = (session: AccountBrowserSession): string | undefined =>
  */
 export async function resyncVoApiV2AuthToken(
   baseUrl: string,
+  tempWindowRequestSource?: TempWindowRequestSource,
 ): Promise<VoApiV2ResyncedToken | null> {
   const session = await resolveAccountBrowserSession({
     baseUrl,
@@ -58,6 +60,7 @@ export async function resyncVoApiV2AuthToken(
     useExistingTabs: true,
     useTempWindow: true,
     requestIdPrefix: "voapi-v2-token-resync",
+    ...(tempWindowRequestSource ? { tempWindowRequestSource } : {}),
     isUsableSession: hasUsableDashboardJwt,
   })
 

--- a/src/services/apiTransport/request.ts
+++ b/src/services/apiTransport/request.ts
@@ -573,6 +573,7 @@ const _fetchApi = async <T>(
     fetchOptions,
     onlyData,
     responseType,
+    tempWindowRequestSource: request.tempWindowRequestSource,
     tempWindowFallback: options.tempWindowFallback,
     accountId,
     authType: resolvedAuth.authType,

--- a/src/services/apiTransport/type.ts
+++ b/src/services/apiTransport/type.ts
@@ -1,6 +1,7 @@
 import { AuthTypeEnum } from "~/types"
 import type {
   TempWindowFallbackAllowlist,
+  TempWindowRequestSource,
   TempWindowResponseType,
 } from "~/types/tempWindowFetch"
 
@@ -95,6 +96,8 @@ export interface ApiTransportRequest {
   abortSignal?: AbortSignal
   cookieAuthSessionCookie?: string
   fetchContext?: ApiTransportFetchContext
+  /** Originating extension surface for temporary-window presentation policy. */
+  tempWindowRequestSource?: TempWindowRequestSource
   /** Skip the generic per-site limiter when the caller already applies a narrower limiter. */
   bypassSiteRequestLimit?: boolean
 }

--- a/src/services/checkin/autoCheckin/messaging.ts
+++ b/src/services/checkin/autoCheckin/messaging.ts
@@ -8,9 +8,11 @@ import type {
   AutoCheckinRunSummary,
   AutoCheckinStatus,
 } from "~/types/autoCheckin"
+import type { TempWindowRequestSource } from "~/types/tempWindowFetch"
 
 export interface AutoCheckinRunNowRequest {
   accountIds?: string[]
+  tempWindowRequestSource?: TempWindowRequestSource
 }
 
 export interface AutoCheckinDebugScheduleDailyAlarmForTodayRequest {
@@ -21,6 +23,7 @@ export interface AutoCheckinPretriggerDailyOnUiOpenRequest {
   requestId?: string
   dryRun?: boolean
   debug?: boolean
+  tempWindowRequestSource?: TempWindowRequestSource
 }
 
 type AutoCheckinPretriggerDailyOnUiOpenResponse =
@@ -41,6 +44,7 @@ type AutoCheckinPretriggerDailyOnUiOpenResponse =
 
 interface AutoCheckinRetryAccountRequest {
   accountId?: string
+  tempWindowRequestSource?: TempWindowRequestSource
 }
 
 export interface AutoCheckinGetAccountInfoRequest {

--- a/src/services/checkin/autoCheckin/providers/anyrouter.ts
+++ b/src/services/checkin/autoCheckin/providers/anyrouter.ts
@@ -9,8 +9,9 @@ import type { AutoCheckinProviderResult } from "~/services/checkin/autoCheckin/p
 import type { SiteAccount } from "~/types"
 import { AuthTypeEnum } from "~/types"
 import { CHECKIN_RESULT_STATUS } from "~/types/autoCheckin"
+import { normalizeTempWindowRequestSource } from "~/utils/browser/tempWindowRequestSource"
 
-import type { AutoCheckinProvider } from "./index"
+import type { AutoCheckinProvider, AutoCheckinProviderContext } from "./index"
 
 export type AnyrouterCheckInParams = {
   id?: string
@@ -40,7 +41,11 @@ function isAnyrouterAlreadyCheckedMessage(message: string): boolean {
 
 const checkinAnyRouter = async (
   account: SiteAccount | AnyrouterCheckInParams,
+  context?: AutoCheckinProviderContext,
 ): Promise<AutoCheckinProviderResult> => {
+  const tempWindowRequestSource = normalizeTempWindowRequestSource(
+    context?.tempWindowRequestSource,
+  )
   const { site_url, account_info } = account
   const cookieAuthSessionCookie = isSiteAccount(account)
     ? account.cookieAuth?.sessionCookie
@@ -61,6 +66,7 @@ const checkinAnyRouter = async (
           authType: AuthTypeEnum.Cookie,
           userId: account_info.id,
         },
+        tempWindowRequestSource,
       },
       {
         endpoint: "/api/user/sign_in",

--- a/src/services/checkin/autoCheckin/providers/index.ts
+++ b/src/services/checkin/autoCheckin/providers/index.ts
@@ -3,6 +3,7 @@ import { newApiProvider } from "~/services/checkin/autoCheckin/providers/newApi"
 import type { AutoCheckinProviderResult } from "~/services/checkin/autoCheckin/providers/types"
 import { voApiV2Provider } from "~/services/checkin/autoCheckin/providers/voapiV2"
 import type { SiteAccount } from "~/types"
+import type { TempWindowRequestSource } from "~/types/tempWindowFetch"
 
 import { AnyrouterCheckInParams, anyrouterProvider } from "./anyrouter"
 import { veloeraProvider } from "./veloera"
@@ -19,7 +20,12 @@ export interface AutoCheckinProvider {
   canCheckIn(account: SiteAccount): boolean
   checkIn(
     account: SiteAccount | AnyrouterCheckInParams,
+    context?: AutoCheckinProviderContext,
   ): Promise<AutoCheckinProviderResult>
+}
+
+export interface AutoCheckinProviderContext {
+  tempWindowRequestSource: TempWindowRequestSource
 }
 
 const providers: Record<string, AutoCheckinProvider> = {

--- a/src/services/checkin/autoCheckin/providers/newApi.ts
+++ b/src/services/checkin/autoCheckin/providers/newApi.ts
@@ -13,7 +13,10 @@ import { buildCompatUserIdHeaders } from "~/services/apiTransport/compatHeaders"
 import { REQUEST_CONFIG } from "~/services/apiTransport/constant"
 import { ApiError } from "~/services/apiTransport/errors"
 import { fetchApi, fetchApiData } from "~/services/apiTransport/request"
-import type { AutoCheckinProvider } from "~/services/checkin/autoCheckin/providers/index"
+import type {
+  AutoCheckinProvider,
+  AutoCheckinProviderContext,
+} from "~/services/checkin/autoCheckin/providers/index"
 import {
   AUTO_CHECKIN_PROVIDER_FALLBACK_MESSAGE_KEYS,
   AUTO_CHECKIN_USER_CHECKIN_ENDPOINT,
@@ -28,6 +31,7 @@ import { AuthTypeEnum } from "~/types"
 import { CHECKIN_RESULT_STATUS } from "~/types/autoCheckin"
 import type {
   TempWindowCheckinPageAction,
+  TempWindowRequestSource,
   TempWindowTurnstileFetch,
 } from "~/types/tempWindowFetch"
 import type { TurnstilePreTrigger } from "~/types/turnstile"
@@ -36,6 +40,7 @@ import {
   tempWindowTriggerCheckinPageAction,
   tempWindowTurnstileFetch,
 } from "~/utils/browser/tempWindowFetch"
+import { normalizeTempWindowRequestSource } from "~/utils/browser/tempWindowRequestSource"
 import { safeRandomUUID } from "~/utils/core/identifier"
 import { joinUrl } from "~/utils/core/url"
 
@@ -257,6 +262,7 @@ function resolveStandardCheckinResult(params: {
  */
 async function fetchCheckedInTodayStatus(
   account: SiteAccount,
+  tempWindowRequestSource: TempWindowRequestSource,
 ): Promise<boolean | undefined> {
   const currentMonth = new Date()
     .toISOString()
@@ -273,6 +279,7 @@ async function fetchCheckedInTodayStatus(
           userId: account.account_info.id,
           accessToken: account.account_info.access_token,
         },
+        tempWindowRequestSource,
       },
       {
         endpoint: `${ENDPOINT}?month=${currentMonth}`,
@@ -297,12 +304,16 @@ async function fetchCheckedInTodayStatus(
  */
 async function pollCheckedInTodayStatus(
   account: SiteAccount,
+  tempWindowRequestSource: TempWindowRequestSource,
 ): Promise<boolean | undefined> {
   const deadline = Date.now() + NATIVE_PAGE_STATUS_POLL_TIMEOUT_MS
   let lastStatus: boolean | undefined
 
   while (Date.now() <= deadline) {
-    lastStatus = await fetchCheckedInTodayStatus(account)
+    lastStatus = await fetchCheckedInTodayStatus(
+      account,
+      tempWindowRequestSource,
+    )
     if (lastStatus === true) return true
 
     const remainingMs = deadline - Date.now()
@@ -366,6 +377,7 @@ function getTurnstileAssistedFetchOptions(account: SiteAccount): RequestInit {
 function buildTurnstileAssistedParams(
   account: SiteAccount,
   checkInUrl: string,
+  tempWindowRequestSource: TempWindowRequestSource,
 ) {
   const fetchUrl = joinUrl(account.site_url, ENDPOINT)
 
@@ -380,6 +392,7 @@ function buildTurnstileAssistedParams(
     cookieAuthSessionCookie: account.cookieAuth?.sessionCookie,
     turnstileTimeoutMs: TURNSTILE_ASSIST_TIMEOUT_MS,
     turnstilePreTrigger: resolveTurnstilePreTrigger(account),
+    tempWindowRequestSource,
   } as const
 }
 
@@ -483,6 +496,7 @@ function resolveNativePageFailureResult(params: {
 async function resolveNativePageCheckinResult(params: {
   account: SiteAccount
   responseMessage: string
+  tempWindowRequestSource: TempWindowRequestSource
 }): Promise<CheckinResult> {
   const checkInUrl = await resolveCheckInUrl(params.account)
   const expectedUserId = normalizeAccountIdentity(
@@ -509,6 +523,7 @@ async function resolveNativePageCheckinResult(params: {
       siteType: params.account.site_type,
       expectedUserId,
       trigger: resolveTurnstilePreTrigger(params.account),
+      tempWindowRequestSource: params.tempWindowRequestSource,
     })
   } catch (error: unknown) {
     const errorMessage = getProviderErrorMessage(error)
@@ -527,7 +542,10 @@ async function resolveNativePageCheckinResult(params: {
     })
   }
 
-  const checkedInToday = await pollCheckedInTodayStatus(params.account)
+  const checkedInToday = await pollCheckedInTodayStatus(
+    params.account,
+    params.tempWindowRequestSource,
+  )
   if (checkedInToday === true) {
     return {
       status: CHECKIN_RESULT_STATUS.ALREADY_CHECKED,
@@ -605,11 +623,13 @@ async function runPreferredTurnstileAssistedAttempt(params: {
 async function resolveTurnstileAssistedCheckinResult(params: {
   account: SiteAccount
   responseMessage: string
+  tempWindowRequestSource: TempWindowRequestSource
 }): Promise<CheckinResult> {
   const checkInUrl = await resolveCheckInUrl(params.account)
   const assistedParams = buildTurnstileAssistedParams(
     params.account,
     checkInUrl,
+    params.tempWindowRequestSource,
   )
 
   const initialAttempt = await runPreferredTurnstileAssistedAttempt({
@@ -629,7 +649,10 @@ async function resolveTurnstileAssistedCheckinResult(params: {
 
   if (!assisted.success) {
     if (assisted.turnstile?.status !== "token_obtained") {
-      const checkedInToday = await fetchCheckedInTodayStatus(params.account)
+      const checkedInToday = await fetchCheckedInTodayStatus(
+        params.account,
+        params.tempWindowRequestSource,
+      )
       if (checkedInToday === true) {
         return {
           status: CHECKIN_RESULT_STATUS.ALREADY_CHECKED,
@@ -737,7 +760,10 @@ async function resolveTurnstileAssistedCheckinResult(params: {
     assisted.turnstile?.status &&
     assisted.turnstile.status !== "token_obtained"
   ) {
-    const checkedInToday = await fetchCheckedInTodayStatus(params.account)
+    const checkedInToday = await fetchCheckedInTodayStatus(
+      params.account,
+      params.tempWindowRequestSource,
+    )
     if (checkedInToday === true) {
       return {
         status: CHECKIN_RESULT_STATUS.ALREADY_CHECKED,
@@ -771,6 +797,7 @@ async function resolveTurnstileAssistedCheckinResult(params: {
  */
 async function performCheckin(
   account: SiteAccount,
+  tempWindowRequestSource: TempWindowRequestSource,
 ): Promise<NewApiCheckInResponse> {
   const { site_url, account_info } = account
 
@@ -784,6 +811,7 @@ async function performCheckin(
         userId: account_info.id,
         accessToken: account_info.access_token,
       },
+      tempWindowRequestSource,
     },
     {
       endpoint: ENDPOINT,
@@ -812,9 +840,18 @@ function getProviderErrorMessage(error: unknown): string {
 /**
  * Provider entry: execute check-in directly and normalize the response.
  */
-async function checkinNewApi(account: SiteAccount): Promise<CheckinResult> {
+async function checkinNewApi(
+  account: SiteAccount,
+  context?: AutoCheckinProviderContext,
+): Promise<CheckinResult> {
+  const tempWindowRequestSource = normalizeTempWindowRequestSource(
+    context?.tempWindowRequestSource,
+  )
   try {
-    const checkinResponse = await performCheckin(account)
+    const checkinResponse = await performCheckin(
+      account,
+      tempWindowRequestSource,
+    )
     const responseMessage = normalizeCheckinMessage(checkinResponse.message)
 
     const standardResult = resolveStandardCheckinResult({
@@ -833,6 +870,7 @@ async function checkinNewApi(account: SiteAccount): Promise<CheckinResult> {
       return await resolveTurnstileAssistedCheckinResult({
         account,
         responseMessage,
+        tempWindowRequestSource,
       })
     }
 
@@ -845,6 +883,7 @@ async function checkinNewApi(account: SiteAccount): Promise<CheckinResult> {
       return await resolveNativePageCheckinResult({
         account,
         responseMessage,
+        tempWindowRequestSource,
       })
     }
 
@@ -868,6 +907,7 @@ async function checkinNewApi(account: SiteAccount): Promise<CheckinResult> {
       return await resolveNativePageCheckinResult({
         account,
         responseMessage: errorMessage,
+        tempWindowRequestSource,
       })
     }
 

--- a/src/services/checkin/autoCheckin/providers/veloera.ts
+++ b/src/services/checkin/autoCheckin/providers/veloera.ts
@@ -15,9 +15,10 @@ import type { AutoCheckinProviderResult } from "~/services/checkin/autoCheckin/p
 import type { SiteAccount } from "~/types"
 import { AuthTypeEnum } from "~/types"
 import { CHECKIN_RESULT_STATUS } from "~/types/autoCheckin"
+import { normalizeTempWindowRequestSource } from "~/utils/browser/tempWindowRequestSource"
 import { getErrorMessage } from "~/utils/core/error"
 
-import type { AutoCheckinProvider } from "./index"
+import type { AutoCheckinProvider, AutoCheckinProviderContext } from "./index"
 
 type CheckinResult = AutoCheckinProviderResult
 
@@ -28,7 +29,13 @@ const ENDPOINT = "/api/user/check_in"
  * @param account - The site account to check in
  * @returns Check-in result with status and message
  */
-async function checkinVeloera(account: SiteAccount): Promise<CheckinResult> {
+async function checkinVeloera(
+  account: SiteAccount,
+  context?: AutoCheckinProviderContext,
+): Promise<CheckinResult> {
+  const tempWindowRequestSource = normalizeTempWindowRequestSource(
+    context?.tempWindowRequestSource,
+  )
   const { site_url, account_info, authType } = account
 
   try {
@@ -43,6 +50,7 @@ async function checkinVeloera(account: SiteAccount): Promise<CheckinResult> {
           userId: account_info.id,
           accessToken: account_info.access_token,
         },
+        tempWindowRequestSource,
       },
       {
         endpoint: ENDPOINT,

--- a/src/services/checkin/autoCheckin/providers/voapiV2.ts
+++ b/src/services/checkin/autoCheckin/providers/voapiV2.ts
@@ -8,7 +8,10 @@ import {
 import { isVoApiV2AuthExpiredError } from "~/services/apiService/voapiV2/parsing"
 import { resyncVoApiV2AuthToken } from "~/services/apiService/voapiV2/tokenResync"
 import type { ApiServiceRequest } from "~/services/apiTransport/type"
-import type { AutoCheckinProvider } from "~/services/checkin/autoCheckin/providers"
+import type {
+  AutoCheckinProvider,
+  AutoCheckinProviderContext,
+} from "~/services/checkin/autoCheckin/providers"
 import {
   AUTO_CHECKIN_PROVIDER_FALLBACK_MESSAGE_KEYS,
   resolveProviderErrorResult,
@@ -16,8 +19,13 @@ import {
 import type { AutoCheckinProviderResult } from "~/services/checkin/autoCheckin/providers/types"
 import { AuthTypeEnum, type SiteAccount } from "~/types"
 import { CHECKIN_RESULT_STATUS } from "~/types/autoCheckin"
+import type { TempWindowRequestSource } from "~/types/tempWindowFetch"
+import { normalizeTempWindowRequestSource } from "~/utils/browser/tempWindowRequestSource"
 
-const createRequest = (account: SiteAccount): ApiServiceRequest => ({
+const createRequest = (
+  account: SiteAccount,
+  tempWindowRequestSource: TempWindowRequestSource,
+): ApiServiceRequest => ({
   baseUrl: account.site_url,
   accountId: account.id,
   auth: {
@@ -25,6 +33,7 @@ const createRequest = (account: SiteAccount): ApiServiceRequest => ({
     accessToken: account.account_info.access_token,
     userId: account.account_info.id,
   },
+  tempWindowRequestSource,
 })
 
 const isVoApiV2Account = (account: SiteAccount): boolean =>
@@ -91,7 +100,13 @@ export const voApiV2Provider: AutoCheckinProvider = {
         account.account_info?.access_token,
     )
   },
-  async checkIn(account): Promise<AutoCheckinProviderResult> {
+  async checkIn(
+    account,
+    context?: AutoCheckinProviderContext,
+  ): Promise<AutoCheckinProviderResult> {
+    const tempWindowRequestSource = normalizeTempWindowRequestSource(
+      context?.tempWindowRequestSource,
+    )
     try {
       if (!this.canCheckIn(account as SiteAccount)) {
         return {
@@ -101,7 +116,7 @@ export const voApiV2Provider: AutoCheckinProvider = {
       }
 
       const siteAccount = account as SiteAccount
-      const request = createRequest(siteAccount)
+      const request = createRequest(siteAccount, tempWindowRequestSource)
       try {
         return await runCheckIn(request)
       } catch (error) {
@@ -109,7 +124,10 @@ export const voApiV2Provider: AutoCheckinProvider = {
           throw error
         }
 
-        const resynced = await resyncVoApiV2AuthToken(siteAccount.site_url)
+        const resynced = await resyncVoApiV2AuthToken(
+          siteAccount.site_url,
+          tempWindowRequestSource,
+        )
         if (!resynced) {
           throw error
         }

--- a/src/services/checkin/autoCheckin/providers/wong.ts
+++ b/src/services/checkin/autoCheckin/providers/wong.ts
@@ -13,7 +13,10 @@ import type {
   WongCheckinStatusData,
 } from "~/services/apiService/wong"
 import { fetchApi } from "~/services/apiTransport/request"
-import type { AutoCheckinProvider } from "~/services/checkin/autoCheckin/providers/index"
+import type {
+  AutoCheckinProvider,
+  AutoCheckinProviderContext,
+} from "~/services/checkin/autoCheckin/providers/index"
 import {
   AUTO_CHECKIN_PROVIDER_FALLBACK_MESSAGE_KEYS,
   AUTO_CHECKIN_USER_CHECKIN_ENDPOINT,
@@ -26,6 +29,8 @@ import type { AutoCheckinProviderResult } from "~/services/checkin/autoCheckin/p
 import type { SiteAccount } from "~/types"
 import { AuthTypeEnum } from "~/types"
 import { CHECKIN_RESULT_STATUS } from "~/types/autoCheckin"
+import type { TempWindowRequestSource } from "~/types/tempWindowFetch"
+import { normalizeTempWindowRequestSource } from "~/utils/browser/tempWindowRequestSource"
 
 /**
  * WONG daily check-in endpoint.
@@ -40,6 +45,7 @@ const ENDPOINT = AUTO_CHECKIN_USER_CHECKIN_ENDPOINT
  */
 async function performCheckin(
   account: SiteAccount,
+  tempWindowRequestSource: TempWindowRequestSource,
 ): Promise<WongCheckinApiResponse> {
   const { site_url, account_info } = account
 
@@ -53,6 +59,7 @@ async function performCheckin(
         userId: account_info.id,
         accessToken: account_info.access_token,
       },
+      tempWindowRequestSource,
     },
     {
       endpoint: ENDPOINT,
@@ -70,9 +77,16 @@ async function performCheckin(
  */
 async function checkinWongGongyi(
   account: SiteAccount,
+  context?: AutoCheckinProviderContext,
 ): Promise<AutoCheckinProviderResult> {
+  const tempWindowRequestSource = normalizeTempWindowRequestSource(
+    context?.tempWindowRequestSource,
+  )
   try {
-    const checkinResponse = await performCheckin(account)
+    const checkinResponse = await performCheckin(
+      account,
+      tempWindowRequestSource,
+    )
     const responseMessage = normalizeCheckinMessage(checkinResponse.message)
 
     if (checkinResponse.data?.enabled === false) {

--- a/src/services/checkin/autoCheckin/scheduler.ts
+++ b/src/services/checkin/autoCheckin/scheduler.ts
@@ -59,6 +59,10 @@ import {
   TASK_NOTIFICATION_TASKS,
 } from "~/types/taskNotifications"
 import {
+  TEMP_WINDOW_REQUEST_SOURCES,
+  type TempWindowRequestSource,
+} from "~/types/tempWindowFetch"
+import {
   clearAlarm,
   createAlarm,
   getAlarm,
@@ -67,6 +71,7 @@ import {
   onAlarm,
   sendRuntimeMessage,
 } from "~/utils/browser/browserApi"
+import { normalizeTempWindowRequestSource } from "~/utils/browser/tempWindowRequestSource"
 import { isDevelopmentMode, isTestMode } from "~/utils/core/environment"
 import { getErrorMessage } from "~/utils/core/error"
 import { createLogger } from "~/utils/core/logger"
@@ -175,6 +180,7 @@ class AutoCheckinScheduler {
   private async refreshAccountsAfterSuccessfulCheckins(params: {
     accountIds: string[]
     force?: boolean
+    tempWindowRequestSource?: TempWindowRequestSource
   }): Promise<void> {
     try {
       const uniqueAccountIds = Array.from(new Set(params.accountIds)).filter(
@@ -196,7 +202,11 @@ class AutoCheckinScheduler {
         items: uniqueAccountIds,
         batchSize: AutoCheckinScheduler.CHECKIN_EXECUTION_BATCH_SIZE,
         processItem: async (accountId) => {
-          const result = await accountStorage.refreshAccount(accountId, force)
+          const result = params.tempWindowRequestSource
+            ? await accountStorage.refreshAccount(accountId, force, {
+                tempWindowRequestSource: params.tempWindowRequestSource,
+              })
+            : await accountStorage.refreshAccount(accountId, force)
           if (result?.refreshed === true) return "refreshed"
           if (result == null) return "failed"
           return "unchanged"
@@ -936,6 +946,7 @@ class AutoCheckinScheduler {
   private async runAccountCheckin(
     account: SiteAccount,
     accountName: string,
+    tempWindowRequestSource: TempWindowRequestSource = TEMP_WINDOW_REQUEST_SOURCES.Background,
   ): Promise<{
     result: CheckinAccountResult
     successful: boolean
@@ -974,7 +985,9 @@ class AutoCheckinScheduler {
         }
       }
 
-      const providerResult = await provider.checkIn(account)
+      const providerResult = await provider.checkIn(account, {
+        tempWindowRequestSource,
+      })
       const result = buildResult(providerResult.status, {
         messageKey: providerResult.messageKey,
         messageParams: providerResult.messageParams,
@@ -1063,6 +1076,7 @@ class AutoCheckinScheduler {
   private async runAccountCheckinsInBatches(params: {
     accounts: SiteAccount[]
     accountDisplayNameById: Map<string, string>
+    tempWindowRequestSource: TempWindowRequestSource
   }): Promise<
     Array<{
       result: CheckinAccountResult
@@ -1089,6 +1103,7 @@ class AutoCheckinScheduler {
         this.runAccountCheckin(
           account,
           params.accountDisplayNameById.get(account.id) ?? account.id,
+          params.tempWindowRequestSource,
         ),
     })
   }
@@ -1111,7 +1126,10 @@ class AutoCheckinScheduler {
           if (alarm.name === AutoCheckinScheduler.DAILY_ALARM_NAME) {
             // Await to keep the MV3 service worker alive for the full daily run.
             try {
-              await this.handleDailyAlarm(alarm)
+              await this.handleDailyAlarm(
+                alarm,
+                TEMP_WINDOW_REQUEST_SOURCES.Background,
+              )
             } catch (error) {
               logger.error("Daily alarm execution failed", error)
             }
@@ -1508,7 +1526,10 @@ class AutoCheckinScheduler {
    * - the next daily run for the next day window
    * - any required retry alarm (without overriding the daily schedule)
    */
-  private async handleDailyAlarm(alarm: browser.alarms.Alarm) {
+  private async handleDailyAlarm(
+    alarm: browser.alarms.Alarm,
+    tempWindowRequestSource: TempWindowRequestSource = TEMP_WINDOW_REQUEST_SOURCES.Background,
+  ) {
     const now = new Date()
     const today = this.getLocalDay(now)
 
@@ -1537,7 +1558,10 @@ class AutoCheckinScheduler {
 
       logger.info("Daily alarm triggered; starting check-in execution")
       try {
-        await this.runCheckins({ runType: AUTO_CHECKIN_RUN_TYPE.DAILY })
+        await this.runCheckins({
+          runType: AUTO_CHECKIN_RUN_TYPE.DAILY,
+          tempWindowRequestSource,
+        })
       } catch (error) {
         logger.error("Error during daily check-in execution", error)
       } finally {
@@ -1566,6 +1590,7 @@ class AutoCheckinScheduler {
    */
   async pretriggerDailyOnUiOpen(params?: {
     requestId?: string
+    tempWindowRequestSource?: TempWindowRequestSource
     /**
      * When true, evaluates eligibility but does not execute the daily run.
      * Intended for UI diagnostics so users can understand why a pre-trigger did
@@ -1729,10 +1754,13 @@ class AutoCheckinScheduler {
       }
     }
 
-    await this.handleDailyAlarm({
-      name: AutoCheckinScheduler.DAILY_ALARM_NAME,
-      scheduledTime: dailyAlarm.scheduledTime,
-    } as browser.alarms.Alarm)
+    await this.handleDailyAlarm(
+      {
+        name: AutoCheckinScheduler.DAILY_ALARM_NAME,
+        scheduledTime: dailyAlarm.scheduledTime,
+      } as browser.alarms.Alarm,
+      params?.tempWindowRequestSource ?? TEMP_WINDOW_REQUEST_SOURCES.Background,
+    )
 
     const updatedStatus = await autoCheckinStorage.getStatus()
     const summary =
@@ -1795,10 +1823,13 @@ class AutoCheckinScheduler {
    * `chrome.alarms` without waiting for the scheduled time.
    */
   async debugTriggerDailyAlarmNow(): Promise<void> {
-    await this.handleDailyAlarm({
-      name: AutoCheckinScheduler.DAILY_ALARM_NAME,
-      scheduledTime: Date.now(),
-    } as browser.alarms.Alarm)
+    await this.handleDailyAlarm(
+      {
+        name: AutoCheckinScheduler.DAILY_ALARM_NAME,
+        scheduledTime: Date.now(),
+      } as browser.alarms.Alarm,
+      TEMP_WINDOW_REQUEST_SOURCES.Background,
+    )
   }
 
   /**
@@ -1881,11 +1912,14 @@ class AutoCheckinScheduler {
   async runCheckins(options?: {
     runType?: AutoCheckinRunType
     targetAccountIds?: string[]
+    tempWindowRequestSource?: TempWindowRequestSource
   }): Promise<void> {
     // Default to manual runs for UI-triggered or debug entry points.
     const runType = options?.runType ?? AUTO_CHECKIN_RUN_TYPE.MANUAL
     const isDailyRun = runType === AUTO_CHECKIN_RUN_TYPE.DAILY
     const targetAccountIds = options?.targetAccountIds
+    const tempWindowRequestSource =
+      options?.tempWindowRequestSource ?? TEMP_WINDOW_REQUEST_SOURCES.Background
     const targetAccountIdSet =
       !isDailyRun &&
       Array.isArray(targetAccountIds) &&
@@ -2123,6 +2157,7 @@ class AutoCheckinScheduler {
       const checkinOutcomes = await this.runAccountCheckinsInBatches({
         accounts: runnableAccounts,
         accountDisplayNameById,
+        tempWindowRequestSource,
       })
 
       for (const outcome of checkinOutcomes) {
@@ -2239,6 +2274,7 @@ class AutoCheckinScheduler {
       await this.refreshAccountsAfterSuccessfulCheckins({
         accountIds: accountIdsToRefresh,
         force: true,
+        tempWindowRequestSource,
       })
 
       if (notifyUiOnCompletion) {
@@ -2337,7 +2373,9 @@ class AutoCheckinScheduler {
    * - Each automatic retry increments the count.
    * - Retries stop once `attempts >= retryStrategy.maxAttemptsPerDay`.
    */
-  private async runRetryCheckins(): Promise<void> {
+  private async runRetryCheckins(
+    tempWindowRequestSource: TempWindowRequestSource = TEMP_WINDOW_REQUEST_SOURCES.Background,
+  ): Promise<void> {
     const startTime = Date.now()
     const now = new Date()
     const today = this.getLocalDay(now)
@@ -2432,6 +2470,7 @@ class AutoCheckinScheduler {
       const outcome = await this.runAccountCheckin(
         account,
         accountDisplayNameById.get(account.id) ?? account.id,
+        tempWindowRequestSource,
       )
       // Persist that we've attempted one more time for this account today, regardless of outcome.
       attemptsByAccount[accountId] = attempts + 1
@@ -2497,6 +2536,7 @@ class AutoCheckinScheduler {
     await this.refreshAccountsAfterSuccessfulCheckins({
       accountIds: accountIdsToRefresh,
       force: true,
+      tempWindowRequestSource,
     })
 
     if (notifyUiOnCompletion) {
@@ -2601,7 +2641,10 @@ class AutoCheckinScheduler {
    * If this account is currently in today's retry queue, a successful manual retry removes it
    * from the pending list (and may clear the retry alarm if nothing else remains).
    */
-  async retryAccount(accountId: string) {
+  async retryAccount(
+    accountId: string,
+    tempWindowRequestSource: TempWindowRequestSource = TEMP_WINDOW_REQUEST_SOURCES.Background,
+  ) {
     const today = this.getLocalDay()
     const allAccounts = await accountStorage.getAllAccounts()
     const account = allAccounts.find((item) => item.id === accountId)
@@ -2627,6 +2670,7 @@ class AutoCheckinScheduler {
             await this.runAccountCheckin(
               account,
               accountDisplayNameById.get(account.id) ?? account.id,
+              tempWindowRequestSource,
             )
           ).result
 
@@ -2770,11 +2814,15 @@ export async function runAutoCheckinNow(data: AutoCheckinRunNowRequest = {}) {
   if (!targetIdsResult.success) {
     return { success: false as const, error: targetIdsResult.error }
   }
+  const tempWindowRequestSource = normalizeTempWindowRequestSource(
+    data.tempWindowRequestSource,
+  )
 
   try {
     await autoCheckinScheduler.runCheckins({
       runType: AUTO_CHECKIN_RUN_TYPE.MANUAL,
       targetAccountIds: targetIdsResult.targetAccountIds,
+      tempWindowRequestSource,
     })
     return { success: true as const }
   } catch (e) {
@@ -2863,10 +2911,14 @@ export async function scheduleAutoCheckinDailyAlarmForToday(
 export async function pretriggerAutoCheckinDailyOnUiOpen(
   data: AutoCheckinPretriggerDailyOnUiOpenRequest = {},
 ) {
+  const tempWindowRequestSource = normalizeTempWindowRequestSource(
+    data.tempWindowRequestSource,
+  )
   const result = await autoCheckinScheduler.pretriggerDailyOnUiOpen({
     requestId: data.requestId,
     dryRun: data.dryRun,
     debug: data.debug,
+    tempWindowRequestSource,
   })
   return { success: true as const, ...result }
 }
@@ -2874,11 +2926,17 @@ export async function pretriggerAutoCheckinDailyOnUiOpen(
 /**
  * Retry auto check-in for one failed account.
  */
-export async function retryAutoCheckinAccount(accountId?: string) {
+export async function retryAutoCheckinAccount(
+  accountId?: string,
+  tempWindowRequestSource?: unknown,
+) {
   if (!accountId) {
     return { success: false as const, error: "Missing accountId" }
   }
-  await autoCheckinScheduler.retryAccount(accountId)
+  await autoCheckinScheduler.retryAccount(
+    accountId,
+    normalizeTempWindowRequestSource(tempWindowRequestSource),
+  )
   return { success: true as const }
 }
 
@@ -2996,7 +3054,10 @@ export function setupAutoCheckinMessagingListeners() {
       AutoCheckinMessageTypes.RetryAccount,
       async ({ data }) => {
         try {
-          return await retryAutoCheckinAccount(data.accountId)
+          return await retryAutoCheckinAccount(
+            data.accountId,
+            data.tempWindowRequestSource,
+          )
         } catch (error) {
           return toAutoCheckinFailure(error)
         }

--- a/src/services/siteDetection/autoDetectService.ts
+++ b/src/services/siteDetection/autoDetectService.ts
@@ -33,13 +33,14 @@ import {
 } from "~/services/apiTransport/type"
 import type { ApiServiceFetchContext } from "~/services/apiTransport/type"
 import { AuthTypeEnum, type Sub2ApiAuthConfig } from "~/types"
+import type { TempWindowRequestSource } from "~/types/tempWindowFetch"
 import {
   getActiveOrAllTabs,
   getBrowserApiCapabilities,
   isMessageReceiverUnavailableError,
   sendRuntimeMessage,
 } from "~/utils/browser/browserApi"
-import { isExtensionPopup } from "~/utils/browser/index"
+import { getCurrentTempWindowRequestSource } from "~/utils/browser/tempWindowRequestSource"
 import { getErrorMessage } from "~/utils/core/error"
 import { createLogger } from "~/utils/core/logger"
 import { t } from "~/utils/i18n/core"
@@ -256,6 +257,7 @@ async function getUserDataViaAPI(
   url: string,
   siteType: AccountSiteType,
   fetchContext?: AutoDetectFetchContext,
+  tempWindowRequestSource?: TempWindowRequestSource,
 ): Promise<UserDataResult | null> {
   try {
     if (fetchContext) {
@@ -281,6 +283,7 @@ async function getUserDataViaAPI(
         authType: AuthTypeEnum.Cookie,
       },
       ...(fetchContext ? { fetchContext } : {}),
+      ...(tempWindowRequestSource ? { tempWindowRequestSource } : {}),
     })
     const userId = normalizeAccountIdentity(userInfo?.id)
     if (!userInfo || !userId) {
@@ -365,6 +368,8 @@ async function getUserDataViaBackground(
   siteType: AccountSiteType,
   fetchContext?: AutoDetectFetchContext,
 ): Promise<UserDataResult | null> {
+  const tempWindowRequestSource = getCurrentTempWindowRequestSource()
+
   try {
     const requestId = `auto-detect-${Date.now()}`
     logger.debug("Background auto-detect request prepared", {
@@ -375,13 +380,11 @@ async function getUserDataViaBackground(
       fetchContext: summarizeApiServiceFetchContext(fetchContext),
     })
 
-    const shouldSuppressMinimize = isExtensionPopup()
-
     const response = await sendRuntimeMessage({
       action: RuntimeActionIds.AutoDetectSite,
       url: url,
       requestId: requestId,
-      ...(shouldSuppressMinimize ? { suppressMinimize: true } : {}),
+      tempWindowRequestSource,
       ...(fetchContext?.incognito === true ? { useIncognito: true } : {}),
       ...(fetchContext?.cookieStoreId
         ? { cookieStoreId: fetchContext.cookieStoreId }
@@ -401,7 +404,12 @@ async function getUserDataViaBackground(
           fetchContext: summarizeApiServiceFetchContext(fetchContext),
         },
       )
-      return await getUserDataViaAPI(url, siteType, fetchContext)
+      return await getUserDataViaAPI(
+        url,
+        siteType,
+        fetchContext,
+        tempWindowRequestSource,
+      )
     }
 
     logger.debug("Background auto-detect returned user data", {
@@ -419,7 +427,12 @@ async function getUserDataViaBackground(
         siteType,
         requestId,
       })
-      return await getUserDataViaAPI(url, siteType, fetchContext)
+      return await getUserDataViaAPI(
+        url,
+        siteType,
+        fetchContext,
+        tempWindowRequestSource,
+      )
     }
 
     return {
@@ -437,7 +450,12 @@ async function getUserDataViaBackground(
       fetchContext: summarizeApiServiceFetchContext(fetchContext),
       error: getErrorMessage(error),
     })
-    return null
+    return await getUserDataViaAPI(
+      url,
+      siteType,
+      fetchContext,
+      tempWindowRequestSource,
+    )
   }
 }
 

--- a/src/types/tempWindowFetch.ts
+++ b/src/types/tempWindowFetch.ts
@@ -6,6 +6,25 @@ import type {
   TurnstilePreTrigger,
 } from "~/types/turnstile"
 
+export const TEMP_WINDOW_REQUEST_SOURCES = {
+  Popup: "popup",
+  Options: "options",
+  Sidepanel: "sidepanel",
+  Background: "background",
+} as const
+
+export type TempWindowRequestSource =
+  (typeof TEMP_WINDOW_REQUEST_SOURCES)[keyof typeof TEMP_WINDOW_REQUEST_SOURCES]
+
+/** Checks whether an untrusted value is a supported temp-window request source. */
+export function isTempWindowRequestSource(
+  value: unknown,
+): value is TempWindowRequestSource {
+  return Object.values(TEMP_WINDOW_REQUEST_SOURCES).includes(
+    value as TempWindowRequestSource,
+  )
+}
+
 export type TempWindowResponseType = "json" | "text" | "arrayBuffer" | "blob"
 
 export interface TempWindowFetchParams {
@@ -14,6 +33,7 @@ export interface TempWindowFetchParams {
   fetchOptions?: RequestInit
   requestId?: string
   responseType?: TempWindowResponseType
+  tempWindowRequestSource?: TempWindowRequestSource
   suppressMinimize?: boolean
   /** Account ID for per-request cookie isolation */
   accountId?: string
@@ -76,6 +96,7 @@ export interface TempWindowCheckinPageActionParams {
   originUrl: string
   pageUrl: string
   requestId?: string
+  tempWindowRequestSource?: TempWindowRequestSource
   suppressMinimize?: boolean
   siteType: AccountSiteType
   expectedUserId: string
@@ -114,6 +135,13 @@ export interface TempWindowRenderedTitleResponse {
   error?: string
 }
 
+export interface TempWindowRenderedTitleParams {
+  originUrl: string
+  requestId?: string
+  tempWindowRequestSource?: TempWindowRequestSource
+  suppressMinimize?: boolean
+}
+
 export interface TempWindowFallbackAllowlist {
   statusCodes?: number[]
   codes?: ApiErrorCode[]
@@ -126,6 +154,7 @@ export interface TempWindowFallbackContext {
   fetchOptions: RequestInit
   onlyData: boolean
   responseType: TempWindowResponseType
+  tempWindowRequestSource?: TempWindowRequestSource
   /**
    * Allowlist controlling which `ApiError.statusCode` and/or `ApiError.code` values can trigger temp-window fallback.
    * When provided, this fully overrides the default allowlist: omitted fields default to empty lists.

--- a/src/utils/browser/index.ts
+++ b/src/utils/browser/index.ts
@@ -1,4 +1,5 @@
 import {
+  OPTIONS_PAGE_PATH,
   POPUP_PAGE_PATH,
   SIDEPANEL_PAGE_PATH,
 } from "~/constants/extensionPages"
@@ -89,35 +90,42 @@ export function isExtensionPage(url: URL) {
   return url.protocol.includes("-extension:")
 }
 
-/**
- * Determines if current window is the browser action popup.
- * @returns True when running inside popup.html.
- */
-export function isExtensionPopup() {
+/** Checks whether the current window matches a specific extension page path. */
+function isCurrentExtensionPage(pagePath: string): boolean {
   if (typeof window === "undefined") {
     return false
   }
 
   try {
     const url = new URL(window.location.href)
-    return isExtensionPage(url) && url.pathname.endsWith(`/${POPUP_PAGE_PATH}`)
+    return isExtensionPage(url) && url.pathname.endsWith(`/${pagePath}`)
   } catch {
     return false
   }
 }
+
+/**
+ * Determines if current window is the browser action popup.
+ * @returns True when running inside popup.html.
+ */
+export function isExtensionPopup() {
+  return isCurrentExtensionPage(POPUP_PAGE_PATH)
+}
+
+/**
+ * Determines if the current window is the extension options page.
+ * @returns True when running inside options.html.
+ */
+export function isExtensionOptions() {
+  return isCurrentExtensionPage(OPTIONS_PAGE_PATH)
+}
+
 /**
  * Determines if the current page is loaded inside the extension side panel.
  * @returns True when sidepanel.html is detected in the URL path.
  */
 export function isExtensionSidePanel() {
-  try {
-    const url = new URL(window.location.href)
-    return (
-      isExtensionPage(url) && url.pathname.endsWith(`/${SIDEPANEL_PAGE_PATH}`)
-    )
-  } catch {
-    return false
-  }
+  return isCurrentExtensionPage(SIDEPANEL_PAGE_PATH)
 }
 
 /**

--- a/src/utils/browser/tempWindowFetch.ts
+++ b/src/utils/browser/tempWindowFetch.ts
@@ -29,16 +29,18 @@ import {
   TEMP_WINDOW_HEALTH_STATUS_CODES,
   type TempWindowHealthStatusCode,
 } from "~/types/tempWindow"
-import type {
-  TempWindowCheckinPageAction,
-  TempWindowCheckinPageActionParams,
-  TempWindowFallbackAllowlist,
-  TempWindowFallbackContext,
-  TempWindowFetch,
-  TempWindowFetchParams,
-  TempWindowRenderedTitleResponse,
-  TempWindowTurnstileFetch,
-  TempWindowTurnstileFetchParams,
+import {
+  TEMP_WINDOW_REQUEST_SOURCES,
+  type TempWindowCheckinPageAction,
+  type TempWindowCheckinPageActionParams,
+  type TempWindowFallbackAllowlist,
+  type TempWindowFallbackContext,
+  type TempWindowFetch,
+  type TempWindowFetchParams,
+  type TempWindowRenderedTitleParams,
+  type TempWindowRenderedTitleResponse,
+  type TempWindowTurnstileFetch,
+  type TempWindowTurnstileFetchParams,
 } from "~/types/tempWindowFetch"
 import { sendRuntimeMessage } from "~/utils/browser/browserApi"
 import { OPTIONS_PAGE_URL } from "~/utils/browser/extensionPageUrls"
@@ -49,6 +51,10 @@ import {
 } from "~/utils/browser/index"
 import { isProtectionBypassFirefoxEnv } from "~/utils/browser/protectionBypass"
 import { normalizeRequestInitForMessage } from "~/utils/browser/requestInitMessage"
+import {
+  normalizeTempWindowRequestSource,
+  resolveTempWindowRequestPolicy,
+} from "~/utils/browser/tempWindowRequestSource"
 import { safeRandomUUID } from "~/utils/core/identifier"
 import { createLogger } from "~/utils/core/logger"
 
@@ -56,6 +62,8 @@ import { createLogger } from "~/utils/core/logger"
  * Unified logger scoped to temp window fetch helpers and fallback behavior.
  */
 const logger = createLogger("TempWindowFetch")
+const FIREFOX_POPUP_TEMP_WINDOW_UNSUPPORTED_ERROR =
+  "Temporary-window operations are unavailable from the Firefox popup"
 
 /**
  * Type guard to validate the shape of a temp window rendered title response.
@@ -126,18 +134,35 @@ export async function getTempWindowFallbackBlockStatus(
     inPopup?: boolean
     inSidePanel?: boolean
     inOptions?: boolean
+    tempWindowRequestSource?: unknown
   } = {},
 ): Promise<TempWindowFallbackBlockStatus> {
   const preferences: TempWindowFallbackPreferences = {
     ...(DEFAULT_PREFERENCES.tempWindowFallback as TempWindowFallbackPreferences),
     ...(params.preferences ?? {}),
   }
-  const isBackground = params.isBackground ?? isExtensionBackground()
-  let inPopup = params.inPopup ?? false
-  let inSidePanel = params.inSidePanel ?? false
-  let inOptions = params.inOptions ?? false
+  const source =
+    params.tempWindowRequestSource === undefined
+      ? undefined
+      : normalizeTempWindowRequestSource(params.tempWindowRequestSource)
+  const isBackground =
+    source === undefined
+      ? params.isBackground ?? isExtensionBackground()
+      : source === TEMP_WINDOW_REQUEST_SOURCES.Background
+  let inPopup =
+    source === undefined
+      ? params.inPopup ?? false
+      : source === TEMP_WINDOW_REQUEST_SOURCES.Popup
+  let inSidePanel =
+    source === undefined
+      ? params.inSidePanel ?? false
+      : source === TEMP_WINDOW_REQUEST_SOURCES.Sidepanel
+  let inOptions =
+    source === undefined
+      ? params.inOptions ?? false
+      : source === TEMP_WINDOW_REQUEST_SOURCES.Options
 
-  if (!isBackground) {
+  if (source === undefined && !isBackground) {
     try {
       if (params.inPopup === undefined && isExtensionPopup()) {
         inPopup = true
@@ -157,7 +182,11 @@ export async function getTempWindowFallbackBlockStatus(
     }
   }
 
-  if (!isBackground && inPopup && isProtectionBypassFirefoxEnv()) {
+  if (
+    inPopup &&
+    (source !== undefined || !isBackground) &&
+    isProtectionBypassFirefoxEnv()
+  ) {
     return {
       kind: "not_applicable",
       code: null,
@@ -240,14 +269,25 @@ export async function getTempWindowFallbackBlockStatus(
 export async function tempWindowFetch(
   params: TempWindowFetchParams,
 ): Promise<TempWindowFetch> {
-  const suppressMinimize = params.suppressMinimize ?? isExtensionPopup()
+  const policy = resolveTempWindowRequestPolicy({
+    tempWindowRequestSource: params.tempWindowRequestSource,
+    suppressMinimize: params.suppressMinimize,
+  })
+
+  if (policy.blockedReason) {
+    return {
+      success: false,
+      error: FIREFOX_POPUP_TEMP_WINDOW_UNSUPPORTED_ERROR,
+    }
+  }
 
   const payload: TempWindowFetchParams = {
     ...params,
     ...(params.fetchOptions
       ? { fetchOptions: normalizeRequestInitForMessage(params.fetchOptions) }
       : {}),
-    suppressMinimize,
+    tempWindowRequestSource: policy.tempWindowRequestSource,
+    suppressMinimize: policy.suppressMinimize,
   }
 
   // Make sure works normally in all contexts, including background
@@ -289,14 +329,26 @@ export async function tempWindowFetch(
 export async function tempWindowTurnstileFetch(
   params: TempWindowTurnstileFetchParams,
 ): Promise<TempWindowTurnstileFetch> {
-  const suppressMinimize = params.suppressMinimize ?? isExtensionPopup()
+  const policy = resolveTempWindowRequestPolicy({
+    tempWindowRequestSource: params.tempWindowRequestSource,
+    suppressMinimize: params.suppressMinimize,
+  })
+
+  if (policy.blockedReason) {
+    return {
+      success: false,
+      error: FIREFOX_POPUP_TEMP_WINDOW_UNSUPPORTED_ERROR,
+      turnstile: { status: "error", hasTurnstile: false },
+    }
+  }
 
   const payload: TempWindowTurnstileFetchParams = {
     ...params,
     ...(params.fetchOptions
       ? { fetchOptions: normalizeRequestInitForMessage(params.fetchOptions) }
       : {}),
-    suppressMinimize,
+    tempWindowRequestSource: policy.tempWindowRequestSource,
+    suppressMinimize: policy.suppressMinimize,
   }
 
   // Make sure works normally in all contexts, including background
@@ -341,11 +393,23 @@ export async function tempWindowTurnstileFetch(
 export async function tempWindowTriggerCheckinPageAction(
   params: TempWindowCheckinPageActionParams,
 ): Promise<TempWindowCheckinPageAction> {
-  const suppressMinimize = params.suppressMinimize ?? isExtensionPopup()
+  const policy = resolveTempWindowRequestPolicy({
+    tempWindowRequestSource: params.tempWindowRequestSource,
+    suppressMinimize: params.suppressMinimize,
+  })
+
+  if (policy.blockedReason) {
+    return {
+      success: false,
+      reason: "trigger_failed",
+      error: FIREFOX_POPUP_TEMP_WINDOW_UNSUPPORTED_ERROR,
+    }
+  }
 
   const payload: TempWindowCheckinPageActionParams = {
     ...params,
-    suppressMinimize,
+    tempWindowRequestSource: policy.tempWindowRequestSource,
+    suppressMinimize: policy.suppressMinimize,
   }
 
   if (isExtensionBackground()) {
@@ -385,15 +449,26 @@ export async function tempWindowTriggerCheckinPageAction(
 /**
  * Reads the rendered document.title via the temp window flow.
  */
-export async function tempWindowGetRenderedTitle(params: {
-  originUrl: string
-  requestId?: string
-  suppressMinimize?: boolean
-}): Promise<TempWindowRenderedTitleResponse> {
+export async function tempWindowGetRenderedTitle(
+  params: TempWindowRenderedTitleParams,
+): Promise<TempWindowRenderedTitleResponse> {
+  const policy = resolveTempWindowRequestPolicy({
+    tempWindowRequestSource: params.tempWindowRequestSource,
+    suppressMinimize: params.suppressMinimize,
+  })
+
+  if (policy.blockedReason) {
+    return {
+      success: false,
+      error: FIREFOX_POPUP_TEMP_WINDOW_UNSUPPORTED_ERROR,
+    }
+  }
+
   const payload = {
     action: RuntimeActionIds.TempWindowGetRenderedTitle,
     ...params,
-    suppressMinimize: params.suppressMinimize ?? isExtensionPopup(),
+    tempWindowRequestSource: policy.tempWindowRequestSource,
+    suppressMinimize: policy.suppressMinimize,
   }
 
   // Make sure works normally in all contexts, including background
@@ -616,16 +691,15 @@ async function shouldUseTempWindowFallback(
     return false
   }
 
-  try {
-    if (isProtectionBypassFirefoxEnv() && isExtensionPopup()) {
-      logSkipTempWindowFallback(
-        "Running in Firefox popup; temp window fallback is forcibly disabled to avoid closing the popup.",
-        context,
-      )
-      return false
-    }
-  } catch {
-    // ignore environment detection errors
+  const policy = resolveTempWindowRequestPolicy({
+    tempWindowRequestSource: context.tempWindowRequestSource,
+  })
+  if (policy.blockedReason) {
+    logSkipTempWindowFallback(
+      "Running in Firefox popup; temp window fallback is forcibly disabled to avoid closing the popup.",
+      context,
+    )
+    return false
   }
 
   let prefsFallback: TempWindowFallbackPreferences | undefined
@@ -641,6 +715,7 @@ async function shouldUseTempWindowFallback(
 
   const blockStatus = await getTempWindowFallbackBlockStatus({
     preferences: prefsFallback,
+    tempWindowRequestSource: context.tempWindowRequestSource,
   })
 
   if (blockStatus.kind === "available") {
@@ -732,14 +807,13 @@ async function fetchViaTempWindow<T>(
   }
 
   const requestId = safeRandomUUID(`temp-fetch-${context.url}`)
-  const suppressMinimize = true
   const payload: TempWindowFetchParams = {
     originUrl: context.baseUrl,
     fetchUrl: context.url,
     fetchOptions,
     requestId,
     responseType,
-    suppressMinimize,
+    tempWindowRequestSource: context.tempWindowRequestSource,
     accountId: context.accountId,
     authType: context.authType,
     cookieAuthSessionCookie: context.cookieAuthSessionCookie,

--- a/src/utils/browser/tempWindowRequestSource.ts
+++ b/src/utils/browser/tempWindowRequestSource.ts
@@ -1,0 +1,69 @@
+import {
+  isTempWindowRequestSource,
+  TEMP_WINDOW_REQUEST_SOURCES,
+  type TempWindowRequestSource,
+} from "~/types/tempWindowFetch"
+import {
+  isExtensionBackground,
+  isExtensionOptions,
+  isExtensionPopup,
+  isExtensionSidePanel,
+} from "~/utils/browser"
+import { isProtectionBypassFirefoxEnv } from "~/utils/browser/protectionBypass"
+
+type TempWindowRequestBlockedReason = "firefox_popup_unsupported" | null
+
+/** Normalizes an untrusted request source to the safe background default. */
+export function normalizeTempWindowRequestSource(
+  value: unknown,
+): TempWindowRequestSource {
+  return isTempWindowRequestSource(value)
+    ? value
+    : TEMP_WINDOW_REQUEST_SOURCES.Background
+}
+
+/** Detects the current extension surface in semantic-priority order. */
+export function getCurrentTempWindowRequestSource(): TempWindowRequestSource {
+  if (isExtensionPopup()) {
+    return TEMP_WINDOW_REQUEST_SOURCES.Popup
+  }
+  if (isExtensionOptions()) {
+    return TEMP_WINDOW_REQUEST_SOURCES.Options
+  }
+  if (isExtensionSidePanel()) {
+    return TEMP_WINDOW_REQUEST_SOURCES.Sidepanel
+  }
+  if (isExtensionBackground()) {
+    return TEMP_WINDOW_REQUEST_SOURCES.Background
+  }
+  return TEMP_WINDOW_REQUEST_SOURCES.Background
+}
+
+/** Resolves source-aware minimization and browser compatibility policy. */
+export function resolveTempWindowRequestPolicy({
+  tempWindowRequestSource,
+  suppressMinimize,
+}: {
+  tempWindowRequestSource?: unknown
+  suppressMinimize?: unknown
+}) {
+  const resolvedSource =
+    tempWindowRequestSource === undefined
+      ? getCurrentTempWindowRequestSource()
+      : normalizeTempWindowRequestSource(tempWindowRequestSource)
+  const resolvedSuppressMinimize =
+    typeof suppressMinimize === "boolean"
+      ? suppressMinimize
+      : resolvedSource === TEMP_WINDOW_REQUEST_SOURCES.Popup
+  const blockedReason: TempWindowRequestBlockedReason =
+    resolvedSource === TEMP_WINDOW_REQUEST_SOURCES.Popup &&
+    isProtectionBypassFirefoxEnv()
+      ? "firefox_popup_unsupported"
+      : null
+
+  return {
+    tempWindowRequestSource: resolvedSource,
+    suppressMinimize: resolvedSuppressMinimize,
+    blockedReason,
+  }
+}

--- a/tests/components/AutoCheckinUiOpenPretrigger.test.tsx
+++ b/tests/components/AutoCheckinUiOpenPretrigger.test.tsx
@@ -19,6 +19,7 @@ import {
 } from "~/services/productAnalytics/contracts"
 import { AutoCheckinMessageTypes } from "~/services/runtimeMessaging/messageTypes"
 import { AUTO_CHECKIN_RUN_RESULT } from "~/types/autoCheckin"
+import { TEMP_WINDOW_REQUEST_SOURCES } from "~/types/tempWindowFetch"
 import { openAutoCheckinPage, pushWithinOptionsPage } from "~/utils/navigation"
 import { render, screen, waitFor } from "~~/tests/test-utils/render"
 
@@ -26,10 +27,16 @@ const {
   trackProductAnalyticsActionCompletedMock,
   trackProductAnalyticsActionStartedMock,
   trackProductAnalyticsEventMock,
+  getCurrentTempWindowRequestSourceMock,
 } = vi.hoisted(() => ({
   trackProductAnalyticsActionCompletedMock: vi.fn(),
   trackProductAnalyticsActionStartedMock: vi.fn(),
   trackProductAnalyticsEventMock: vi.fn(),
+  getCurrentTempWindowRequestSourceMock: vi.fn(),
+}))
+
+vi.mock("~/utils/browser/tempWindowRequestSource", () => ({
+  getCurrentTempWindowRequestSource: getCurrentTempWindowRequestSourceMock,
 }))
 
 vi.mock("react-hot-toast", () => ({
@@ -91,10 +98,13 @@ vi.mock("~/services/checkin/autoCheckin/messaging", async (importOriginal) => {
 describe("AutoCheckinUiOpenPretrigger", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    getCurrentTempWindowRequestSourceMock.mockReturnValue(
+      TEMP_WINDOW_REQUEST_SOURCES.Popup,
+    )
     window.history.replaceState(null, "", "/")
   })
 
-  it("shows a started toast and a completion dialog with a View details button", async () => {
+  it("captures the popup source for the pretrigger request before showing completion", async () => {
     const toast = (await import("react-hot-toast")).default
 
     /**
@@ -149,9 +159,18 @@ describe("AutoCheckinUiOpenPretrigger", () => {
     await waitFor(() => {
       expect(sendRuntimeMessageSpy).toHaveBeenCalledWith(
         AutoCheckinMessageTypes.PretriggerDailyOnUiOpen,
-        expect.objectContaining({ requestId: expect.any(String) }),
+        expect.objectContaining({
+          requestId: expect.any(String),
+          tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+        }),
       )
     })
+    expect(getCurrentTempWindowRequestSourceMock).toHaveBeenCalledTimes(1)
+    expect(
+      sendRuntimeMessageSpy.mock.calls.filter(
+        ([type]) => type === AutoCheckinMessageTypes.PretriggerDailyOnUiOpen,
+      ),
+    ).toHaveLength(1)
     expect(trackProductAnalyticsActionStartedMock).toHaveBeenCalledWith({
       featureId: PRODUCT_ANALYTICS_FEATURE_IDS.AutoCheckin,
       actionId: PRODUCT_ANALYTICS_ACTION_IDS.RunAutoCheckinNow,

--- a/tests/entrypoints/background/runtimeMessages.more.test.ts
+++ b/tests/entrypoints/background/runtimeMessages.more.test.ts
@@ -6,6 +6,7 @@ import { RuntimeActionIds } from "~/constants/runtimeActions"
 import { WEB_AI_API_CHECK_TARGET_IDS } from "~/features/BasicSettings/components/tabs/WebAiApiCheck/searchTargets"
 import { ProductAnalyticsMessageTypes } from "~/services/productAnalytics/messaging"
 import { RedemptionAssistMessageTypes } from "~/services/redemption/redemptionAssistMessaging"
+import { TEMP_WINDOW_REQUEST_SOURCES } from "~/types/tempWindowFetch"
 
 type RuntimeMessageListener = (
   request: any,
@@ -451,9 +452,107 @@ describe("setupRuntimeMessageListeners additional routing", () => {
       const result = listener(request, sender, sendResponse)
 
       expect(result).toBe(true)
-      expect(expected).toHaveBeenLastCalledWith(request, sendResponse)
+      expect(expected).toHaveBeenLastCalledWith(
+        request.action === RuntimeActionIds.TempWindowCheckinPageAction
+          ? {
+              ...request,
+              tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Background,
+            }
+          : request,
+        sendResponse,
+      )
     }
   })
+
+  it.each([
+    {
+      action: RuntimeActionIds.AutoDetectSite,
+      handler: mocks.handleAutoDetectSite,
+      fields: { url: "https://example.invalid/account" },
+    },
+    {
+      action: RuntimeActionIds.TempWindowFetch,
+      handler: mocks.handleTempWindowFetch,
+      fields: {
+        originUrl: "https://example.invalid",
+        fetchUrl: "https://example.invalid/api/models",
+      },
+    },
+    {
+      action: RuntimeActionIds.TempWindowTurnstileFetch,
+      handler: mocks.handleTempWindowTurnstileFetch,
+      fields: {
+        originUrl: "https://example.invalid",
+        pageUrl: "https://example.invalid/checkin",
+        fetchUrl: "https://example.invalid/api/checkin",
+      },
+    },
+    {
+      action: RuntimeActionIds.TempWindowCheckinPageAction,
+      handler: mocks.handleTempWindowCheckinPageAction,
+      fields: {
+        originUrl: "https://example.invalid",
+        pageUrl: "https://example.invalid/console/personal",
+        siteType: "new-api",
+        expectedUserId: "target-user",
+      },
+    },
+    {
+      action: RuntimeActionIds.TempWindowGetRenderedTitle,
+      handler: mocks.handleTempWindowGetRenderedTitle,
+      fields: { originUrl: "https://example.invalid" },
+    },
+  ])(
+    "normalizes source and boolean overrides for $action runtime requests",
+    async ({ action, handler, fields }) => {
+      const listener = await loadListener()
+      const sendResponse = vi.fn()
+
+      listener(
+        {
+          action,
+          ...fields,
+          tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+          suppressMinimize: "true",
+        },
+        {},
+        sendResponse,
+      )
+      let normalizedRequest = handler.mock.calls.at(-1)?.[0]
+      expect(normalizedRequest).toMatchObject({
+        action,
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+      })
+      expect(normalizedRequest).not.toHaveProperty("suppressMinimize")
+
+      listener({ action, ...fields, suppressMinimize: true }, {}, sendResponse)
+      normalizedRequest = handler.mock.calls.at(-1)?.[0]
+      expect(normalizedRequest).toMatchObject({
+        action,
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Background,
+        suppressMinimize: true,
+      })
+
+      listener(
+        {
+          action,
+          ...fields,
+          tempWindowRequestSource: "untrusted",
+          suppressMinimize: false,
+        },
+        {},
+        sendResponse,
+      )
+      expect(handler).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          action,
+          tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Background,
+          suppressMinimize: false,
+        }),
+        sendResponse,
+      )
+    },
+  )
 
   it("does not route typed Redemption Assist RPCs through the raw runtime listener", async () => {
     const listener = await loadListener()

--- a/tests/entrypoints/background/tempWindowPoolOpenClose.test.ts
+++ b/tests/entrypoints/background/tempWindowPoolOpenClose.test.ts
@@ -149,6 +149,10 @@ describe("tempWindowPool open/close handlers", () => {
         url: "https://example.com/composite",
       }),
     )
+    expect((globalThis as any).browser.windows.update).not.toHaveBeenCalledWith(
+      901,
+      { state: "minimized" },
+    )
     expect(sendResponse).toHaveBeenCalledWith({
       success: true,
       windowId: 901,

--- a/tests/entrypoints/background/tempWindowPoolWindowFallback.test.ts
+++ b/tests/entrypoints/background/tempWindowPoolWindowFallback.test.ts
@@ -12,6 +12,7 @@ import {
   PRODUCT_ANALYTICS_SURFACE_IDS,
 } from "~/services/productAnalytics/contracts"
 import { AuthTypeEnum } from "~/types"
+import { TEMP_WINDOW_REQUEST_SOURCES } from "~/types/tempWindowFetch"
 import {
   AUTH_MODE,
   COOKIE_SESSION_OVERRIDE_HEADER_NAME,
@@ -1538,6 +1539,72 @@ describe("tempWindowPool window fallback", () => {
     await vi.advanceTimersByTimeAsync(2100)
     expect(removeTabMock).toHaveBeenCalledTimes(1)
     expect(removeTabMock).toHaveBeenCalledWith(511)
+  })
+
+  it("keeps popup-source temp windows visible for direct pool callers", async () => {
+    tempContextMode = "window"
+    createWindowMock.mockResolvedValueOnce({ id: 620 })
+    tabsQueryMock.mockResolvedValueOnce([{ id: 621 }])
+
+    const { handleTempWindowGetRenderedTitle } = await import(
+      "~/entrypoints/background/tempWindowPool"
+    )
+
+    const request = handleTempWindowGetRenderedTitle(
+      {
+        originUrl: "https://example.invalid/rendered-title",
+        requestId: "req-popup-source-title",
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+      },
+      vi.fn(),
+    )
+
+    await vi.advanceTimersByTimeAsync(500)
+    await request
+
+    expect((globalThis as any).browser.windows.update).not.toHaveBeenCalledWith(
+      620,
+      { state: "minimized" },
+    )
+  })
+
+  it("minimizes background-source windows only when creating the pooled context", async () => {
+    tempContextMode = "window"
+    createWindowMock.mockResolvedValueOnce({ id: 622 })
+    tabsQueryMock.mockResolvedValueOnce([{ id: 623 }])
+
+    const { handleTempWindowGetRenderedTitle } = await import(
+      "~/entrypoints/background/tempWindowPool"
+    )
+
+    const firstRequest = handleTempWindowGetRenderedTitle(
+      {
+        originUrl: "https://example.invalid/rendered-title/first",
+        requestId: "req-background-source-title",
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Background,
+      },
+      vi.fn(),
+    )
+    await vi.advanceTimersByTimeAsync(500)
+    await firstRequest
+
+    const secondRequest = handleTempWindowGetRenderedTitle(
+      {
+        originUrl: "https://example.invalid/rendered-title/second",
+        requestId: "req-reused-popup-source-title",
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+      },
+      vi.fn(),
+    )
+    await vi.advanceTimersByTimeAsync(500)
+    await secondRequest
+
+    expect(createWindowMock).toHaveBeenCalledTimes(1)
+    expect((globalThis as any).browser.windows.update).toHaveBeenCalledTimes(1)
+    expect((globalThis as any).browser.windows.update).toHaveBeenCalledWith(
+      622,
+      { state: "minimized" },
+    )
   })
 
   it("keeps rendered-title fetches working when popup window minimization fails", async () => {

--- a/tests/entrypoints/background/tempWindowPoolWindowFallback.test.ts
+++ b/tests/entrypoints/background/tempWindowPoolWindowFallback.test.ts
@@ -272,6 +272,99 @@ describe("tempWindowPool window fallback", () => {
     vi.restoreAllMocks()
   })
 
+  it("blocks Firefox popup-source requests at every direct handler boundary without opening a context", async () => {
+    isProtectionBypassFirefoxEnvMock.mockReturnValue(true)
+
+    const {
+      handleAutoDetectSite,
+      handleTempWindowCheckinPageAction,
+      handleTempWindowFetch,
+      handleTempWindowGetRenderedTitle,
+      handleTempWindowTurnstileFetch,
+    } = await import("~/entrypoints/background/tempWindowPool")
+
+    const renderedTitleResponse = vi.fn()
+    await handleTempWindowGetRenderedTitle(
+      {
+        originUrl: "https://example.invalid/rendered-title",
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+      },
+      renderedTitleResponse,
+    )
+
+    const autoDetectResponse = vi.fn()
+    await handleAutoDetectSite(
+      {
+        url: "https://example.invalid/account",
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+      },
+      autoDetectResponse,
+    )
+
+    const fetchResponse = vi.fn()
+    await handleTempWindowFetch(
+      {
+        originUrl: "https://example.invalid",
+        fetchUrl: "https://example.invalid/api/user/self",
+        fetchOptions: { method: "GET" },
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+      },
+      fetchResponse,
+    )
+
+    const pageActionResponse = vi.fn()
+    await handleTempWindowCheckinPageAction(
+      {
+        originUrl: "https://example.invalid",
+        pageUrl: "https://example.invalid/console/personal",
+        expectedUserId: "example-user",
+        siteType: "new-api",
+        trigger: { kind: "checkinButton" },
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+      },
+      pageActionResponse,
+    )
+
+    const turnstileResponse = vi.fn()
+    await handleTempWindowTurnstileFetch(
+      {
+        originUrl: "https://example.invalid",
+        pageUrl: "https://example.invalid/checkin",
+        fetchUrl: "https://example.invalid/api/checkin",
+        fetchOptions: { method: "POST" },
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+      },
+      turnstileResponse,
+    )
+
+    expect(renderedTitleResponse).toHaveBeenCalledWith({
+      success: false,
+      error: "firefox_popup_unsupported",
+    })
+    expect(autoDetectResponse).toHaveBeenCalledWith({
+      success: false,
+      error: "firefox_popup_unsupported",
+    })
+    expect(fetchResponse).toHaveBeenCalledWith({
+      success: false,
+      error: "firefox_popup_unsupported",
+    })
+    expect(pageActionResponse).toHaveBeenCalledWith({
+      success: false,
+      reason: "trigger_failed",
+      error: "firefox_popup_unsupported",
+    })
+    expect(turnstileResponse).toHaveBeenCalledWith({
+      success: false,
+      error: "firefox_popup_unsupported",
+      turnstile: { status: "error", hasTurnstile: false },
+    })
+    expect(createWindowMock).not.toHaveBeenCalled()
+    expect(createTabMock).not.toHaveBeenCalled()
+    expect(tabsQueryMock).not.toHaveBeenCalled()
+    expect(sendMessageMock).not.toHaveBeenCalled()
+  })
+
   it("rolls back popup temp-context creation to a plain tab", async () => {
     tempContextMode = "window"
     createWindowMock.mockRejectedValueOnce(

--- a/tests/entrypoints/options/AutoCheckinAccountActions.test.tsx
+++ b/tests/entrypoints/options/AutoCheckinAccountActions.test.tsx
@@ -13,10 +13,11 @@ import {
 } from "~/services/productAnalytics/contracts"
 import { AutoCheckinMessageTypes } from "~/services/runtimeMessaging/messageTypes"
 import { CHECKIN_RESULT_STATUS } from "~/types/autoCheckin"
+import { TEMP_WINDOW_REQUEST_SOURCES } from "~/types/tempWindowFetch"
 import { openSettingsTab } from "~/utils/navigation"
 import { render, screen, waitFor, within } from "~~/tests/test-utils/render"
 
-const { toast } = vi.hoisted(() => ({
+const { toast, getCurrentTempWindowRequestSourceMock } = vi.hoisted(() => ({
   toast: {
     loading: vi.fn(),
     dismiss: vi.fn(),
@@ -49,6 +50,7 @@ const { toast } = vi.hoisted(() => ({
       },
     ),
   },
+  getCurrentTempWindowRequestSourceMock: vi.fn(),
 }))
 
 vi.mock("react-hot-toast", () => ({
@@ -113,6 +115,17 @@ vi.mock("~/services/checkin/autoCheckin/messaging", async (importOriginal) => {
   }
 })
 
+vi.mock("~/utils/browser/tempWindowRequestSource", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("~/utils/browser/tempWindowRequestSource")
+    >()
+  return {
+    ...actual,
+    getCurrentTempWindowRequestSource: getCurrentTempWindowRequestSourceMock,
+  }
+})
+
 afterEach(() => {
   vi.restoreAllMocks()
   vi.clearAllMocks()
@@ -120,6 +133,9 @@ afterEach(() => {
 
 describe("AutoCheckin account actions", () => {
   beforeEach(() => {
+    getCurrentTempWindowRequestSourceMock.mockReturnValue(
+      TEMP_WINDOW_REQUEST_SOURCES.Background,
+    )
     startProductAnalyticsActionMock.mockReturnValue({
       complete: completeProductAnalyticsActionMock,
     })
@@ -157,6 +173,9 @@ describe("AutoCheckin account actions", () => {
   })
 
   it("retries a failed account, reloads status, and hides row actions after success", async () => {
+    getCurrentTempWindowRequestSourceMock.mockReturnValue(
+      TEMP_WINDOW_REQUEST_SOURCES.Popup,
+    )
     const user = userEvent.setup()
     const browserApi = await import("~/utils/browser/browserApi")
 
@@ -204,9 +223,13 @@ describe("AutoCheckin account actions", () => {
     await waitFor(() => {
       expect(sendRuntimeMessageSpy).toHaveBeenCalledWith(
         AutoCheckinMessageTypes.RetryAccount,
-        { accountId: "alpha" },
+        {
+          accountId: "alpha",
+          tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+        },
       )
     })
+    expect(getCurrentTempWindowRequestSourceMock).toHaveBeenCalledTimes(1)
     await waitFor(() => {
       expect(toast.success).toHaveBeenCalledWith(
         "autoCheckin:messages.success.retryCompleted",
@@ -268,7 +291,10 @@ describe("AutoCheckin account actions", () => {
         }
 
         if (message === AutoCheckinMessageTypes.RetryAccount) {
-          expect(data).toEqual({ accountId: "alpha" })
+          expect(data).toEqual({
+            accountId: "alpha",
+            tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Background,
+          })
           return await new Promise<{ success: boolean; error?: string }>(
             (resolve) => {
               resolveRetry = resolve
@@ -292,7 +318,10 @@ describe("AutoCheckin account actions", () => {
     await waitFor(() => {
       expect(sendRuntimeMessageSpy).toHaveBeenCalledWith(
         AutoCheckinMessageTypes.RetryAccount,
-        { accountId: "alpha" },
+        {
+          accountId: "alpha",
+          tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Background,
+        },
       )
     })
 

--- a/tests/entrypoints/options/AutoCheckinQuickRun.test.tsx
+++ b/tests/entrypoints/options/AutoCheckinQuickRun.test.tsx
@@ -13,6 +13,7 @@ import {
 } from "~/services/productAnalytics/contracts"
 import { AutoCheckinMessageTypes } from "~/services/runtimeMessaging/messageTypes"
 import { CHECKIN_RESULT_STATUS } from "~/types/autoCheckin"
+import { TEMP_WINDOW_REQUEST_SOURCES } from "~/types/tempWindowFetch"
 import { render, screen, waitFor } from "~~/tests/test-utils/render"
 
 function createDeferred<T>() {
@@ -32,12 +33,18 @@ const {
   trackProductAnalyticsActionStartedMock,
   sendAutoCheckinMessageMock,
   pushWithinOptionsPageMock,
+  getCurrentTempWindowRequestSourceMock,
 } = vi.hoisted(() => ({
   startProductAnalyticsActionMock: vi.fn(),
   completeProductAnalyticsActionMock: vi.fn(),
   trackProductAnalyticsActionStartedMock: vi.fn(),
   sendAutoCheckinMessageMock: vi.fn(),
   pushWithinOptionsPageMock: vi.fn(),
+  getCurrentTempWindowRequestSourceMock: vi.fn(),
+}))
+
+vi.mock("~/utils/browser/tempWindowRequestSource", () => ({
+  getCurrentTempWindowRequestSource: getCurrentTempWindowRequestSourceMock,
 }))
 
 vi.mock("react-hot-toast", () => ({
@@ -98,6 +105,9 @@ afterEach(() => {
 
 describe("AutoCheckin quick run", () => {
   beforeEach(() => {
+    getCurrentTempWindowRequestSourceMock.mockReturnValue(
+      TEMP_WINDOW_REQUEST_SOURCES.Popup,
+    )
     startProductAnalyticsActionMock.mockReturnValue({
       complete: completeProductAnalyticsActionMock,
     })
@@ -220,7 +230,7 @@ describe("AutoCheckin quick run", () => {
     ).not.toBeInTheDocument()
   })
 
-  it("auto-triggers runNow when routeParams.runNow is present", async () => {
+  it("captures the popup source when routeParams.runNow triggers a run", async () => {
     const navigation = await import("~/utils/navigation")
     const navigateWithinOptionsPageSpy = vi
       .spyOn(navigation, "navigateWithinOptionsPage")
@@ -263,8 +273,16 @@ describe("AutoCheckin quick run", () => {
     )
     expect(sendAutoCheckinMessageMock).toHaveBeenCalledWith(
       AutoCheckinMessageTypes.RunNow,
-      {},
+      {
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+      },
     )
+    expect(getCurrentTempWindowRequestSourceMock).toHaveBeenCalledTimes(1)
+    expect(
+      sendAutoCheckinMessageMock.mock.calls.filter(
+        ([type]) => type === AutoCheckinMessageTypes.RunNow,
+      ),
+    ).toHaveLength(1)
     expect(navigateWithinOptionsPageSpy).toHaveBeenCalled()
     expect(startProductAnalyticsActionMock).toHaveBeenCalledWith({
       featureId: PRODUCT_ANALYTICS_FEATURE_IDS.AutoCheckin,

--- a/tests/entrypoints/options/AutoCheckinQuickRun.test.tsx
+++ b/tests/entrypoints/options/AutoCheckinQuickRun.test.tsx
@@ -368,6 +368,55 @@ describe("AutoCheckin quick run", () => {
     )
   })
 
+  it.each([
+    {
+      actionName: "autoCheckin:execution.debug.evaluateUiOpenPretrigger",
+      expectedRequest: {
+        dryRun: true,
+        debug: true,
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+      },
+    },
+    {
+      actionName: "autoCheckin:execution.debug.triggerUiOpenPretrigger",
+      expectedRequest: {
+        requestId: expect.any(String),
+        debug: true,
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+      },
+    },
+  ])(
+    "passes the popup source through $actionName",
+    async ({ actionName, expectedRequest }) => {
+      const user = userEvent.setup()
+
+      sendAutoCheckinMessageMock.mockImplementation(async (type: string) => {
+        if (type === AutoCheckinMessageTypes.GetStatus) {
+          return { success: true, data: { perAccount: {} } }
+        }
+        if (type === AutoCheckinMessageTypes.PretriggerDailyOnUiOpen) {
+          return { success: true, eligible: true, started: false }
+        }
+        return { success: true }
+      })
+
+      render(<AutoCheckin routeParams={{}} />)
+
+      await user.click(
+        await screen.findByRole("button", {
+          name: actionName,
+        }),
+      )
+
+      await waitFor(() => {
+        expect(sendAutoCheckinMessageMock).toHaveBeenCalledWith(
+          AutoCheckinMessageTypes.PretriggerDailyOnUiOpen,
+          expectedRequest,
+        )
+      })
+    },
+  )
+
   it("keeps run now busy through rejection cleanup and permits retry", async () => {
     const user = userEvent.setup()
     const firstAttempt = createDeferred<{ success: boolean }>()

--- a/tests/features/AccountManagement/components/AccountActionButtons.test.tsx
+++ b/tests/features/AccountManagement/components/AccountActionButtons.test.tsx
@@ -26,6 +26,7 @@ import {
   MANAGED_UPSTREAM_RESOURCE_STATUSES,
   type ManagedUpstreamResourceSummary,
 } from "~/types/managedUpstreamResource"
+import { TEMP_WINDOW_REQUEST_SOURCES } from "~/types/tempWindowFetch"
 import { buildDisplaySiteData } from "~~/tests/test-utils/factories"
 import { render } from "~~/tests/test-utils/render"
 
@@ -69,6 +70,7 @@ const {
   resolveProductAnalyticsErrorCategoryFromErrorMock,
   resolveDisplayAccountRuntimeKeySecretMock,
   resolveManagedUpstreamResourceFeatureCapabilitiesMock,
+  getCurrentTempWindowRequestSourceMock,
 } = vi.hoisted(() => ({
   mockHandleSetAccountDisabled: vi.fn(),
   mockHandleRefreshAccount: vi.fn(),
@@ -116,6 +118,11 @@ const {
   resolveProductAnalyticsErrorCategoryFromErrorMock: vi.fn(),
   resolveDisplayAccountRuntimeKeySecretMock: vi.fn(),
   resolveManagedUpstreamResourceFeatureCapabilitiesMock: vi.fn(),
+  getCurrentTempWindowRequestSourceMock: vi.fn(),
+}))
+
+vi.mock("~/utils/browser/tempWindowRequestSource", () => ({
+  getCurrentTempWindowRequestSource: getCurrentTempWindowRequestSourceMock,
 }))
 
 vi.mock("react-hot-toast", () => ({
@@ -272,6 +279,9 @@ vi.mock(
 
 describe("AccountActionButtons", () => {
   beforeEach(() => {
+    getCurrentTempWindowRequestSourceMock.mockReturnValue(
+      TEMP_WINDOW_REQUEST_SOURCES.Popup,
+    )
     Object.defineProperty(window.navigator, "clipboard", {
       configurable: true,
       value: {
@@ -1232,7 +1242,7 @@ describe("AccountActionButtons", () => {
     })
   })
 
-  it("sends a targeted autoCheckin:runNow payload when Quick check-in is clicked", async () => {
+  it("captures the popup source for a targeted Quick check-in request", async () => {
     toastLoadingMock.mockReturnValue("toast-quick-checkin")
     sendRuntimeMessageMock
       .mockResolvedValueOnce({ success: true })
@@ -1277,13 +1287,14 @@ describe("AccountActionButtons", () => {
       "autoCheckin:messages.loading.running",
     )
     await waitFor(() => {
-      expect(sendRuntimeMessageMock).toHaveBeenNthCalledWith(
-        1,
+      expect(sendRuntimeMessageMock).toHaveBeenCalledWith(
         AutoCheckinMessageTypes.RunNow,
-        { accountIds: ["acc-5"] },
+        {
+          accountIds: ["acc-5"],
+          tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+        },
       )
-      expect(sendRuntimeMessageMock).toHaveBeenNthCalledWith(
-        2,
+      expect(sendRuntimeMessageMock).toHaveBeenCalledWith(
         AutoCheckinMessageTypes.GetStatus,
         undefined,
       )
@@ -1308,6 +1319,17 @@ describe("AccountActionButtons", () => {
         },
       )
     })
+    expect(getCurrentTempWindowRequestSourceMock).toHaveBeenCalledTimes(1)
+    expect(
+      sendRuntimeMessageMock.mock.calls.filter(
+        ([type]) => type === AutoCheckinMessageTypes.RunNow,
+      ),
+    ).toHaveLength(1)
+    expect(
+      sendRuntimeMessageMock.mock.calls.filter(
+        ([type]) => type === AutoCheckinMessageTypes.GetStatus,
+      ),
+    ).toHaveLength(1)
   })
 
   it("shows a failure toast when quick check-in finishes without a per-account result", async () => {

--- a/tests/features/AccountManagement/hooks/AccountActionsContext.test.tsx
+++ b/tests/features/AccountManagement/hooks/AccountActionsContext.test.tsx
@@ -19,6 +19,7 @@ import {
   PRODUCT_ANALYTICS_SOURCE_KINDS,
   PRODUCT_ANALYTICS_SURFACE_IDS,
 } from "~/services/productAnalytics/contracts"
+import { TEMP_WINDOW_REQUEST_SOURCES } from "~/types/tempWindowFetch"
 
 // Verifies account action flows through the public context API, including
 // refresh, enable/disable, copy URL, custom check-in state, and external
@@ -35,6 +36,7 @@ const {
   mockLoggerError,
   mockStartProductAnalyticsAction,
   mockCompleteProductAnalyticsAction,
+  mockGetCurrentTempWindowRequestSource,
 } = vi.hoisted(() => ({
   mockLoadAccountData: vi.fn(),
   mockSendExternalCheckInMessage: vi.fn(),
@@ -51,6 +53,7 @@ const {
   mockLoggerError: vi.fn(),
   mockStartProductAnalyticsAction: vi.fn(),
   mockCompleteProductAnalyticsAction: vi.fn(),
+  mockGetCurrentTempWindowRequestSource: vi.fn(),
 }))
 
 vi.mock("react-hot-toast", () => ({
@@ -101,6 +104,17 @@ vi.mock("~/services/productAnalytics/actions", async (importOriginal) => {
     ...actual,
     startProductAnalyticsAction: (...args: unknown[]) =>
       mockStartProductAnalyticsAction(...args),
+  }
+})
+
+vi.mock("~/utils/browser/tempWindowRequestSource", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("~/utils/browser/tempWindowRequestSource")
+    >()
+  return {
+    ...actual,
+    getCurrentTempWindowRequestSource: mockGetCurrentTempWindowRequestSource,
   }
 })
 
@@ -169,6 +183,9 @@ const renderContext = async () => {
 
 beforeEach(() => {
   vi.clearAllMocks()
+  mockGetCurrentTempWindowRequestSource.mockReturnValue(
+    TEMP_WINDOW_REQUEST_SOURCES.Background,
+  )
   mockToast.promise.mockImplementation(
     async (promise: Promise<unknown>) => promise,
   )
@@ -385,6 +402,9 @@ describe("AccountActionsContext", () => {
   })
 
   it("refreshes enabled accounts, exposes the in-flight id, and skips concurrent refreshes", async () => {
+    mockGetCurrentTempWindowRequestSource.mockReturnValue(
+      TEMP_WINDOW_REQUEST_SOURCES.Popup,
+    )
     const { getContext } = await renderContext()
     let resolveRefresh: ((value: { refreshed: boolean }) => void) | undefined
     const refreshResult = new Promise<{ refreshed: boolean }>((resolve) => {
@@ -409,7 +429,10 @@ describe("AccountActionsContext", () => {
     })
 
     expect(mockRefreshAccount).toHaveBeenCalledTimes(1)
-    expect(mockRefreshAccount).toHaveBeenCalledWith("refresh-1", false)
+    expect(mockRefreshAccount).toHaveBeenCalledWith("refresh-1", false, {
+      tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+    })
+    expect(mockGetCurrentTempWindowRequestSource).toHaveBeenCalledTimes(1)
 
     const refreshToastPromise = mockToast.promise.mock.calls[0]?.[0]
     const toastConfig = mockToast.promise.mock.calls[0]?.[1]

--- a/tests/features/AccountManagement/hooks/AccountDataContext.test.tsx
+++ b/tests/features/AccountManagement/hooks/AccountDataContext.test.tsx
@@ -20,6 +20,7 @@ import type { SearchResult } from "~/services/search/accountSearch"
 import type { DisplaySiteData } from "~/types"
 import { DAILY_BALANCE_HISTORY_STORE_SCHEMA_VERSION } from "~/types/dailyBalanceHistory"
 import { SortingCriteriaType } from "~/types/sorting"
+import { TEMP_WINDOW_REQUEST_SOURCES } from "~/types/tempWindowFetch"
 import { testI18n } from "~~/tests/test-utils/i18n"
 
 type MockIndexedAccountSearchEntry = {
@@ -71,6 +72,7 @@ const {
   mockBuildAccountSearchIndex,
   mockSearchAccountSearchIndex,
   mockUpdateSortConfig,
+  mockGetCurrentTempWindowRequestSource,
 } = vi.hoisted(() => ({
   mockLogger: {
     debug: vi.fn(),
@@ -157,6 +159,7 @@ const {
     (accounts: MockIndexedAccountSearchEntry[], query: string) => SearchResult[]
   >(() => []),
   mockUpdateSortConfig: vi.fn(),
+  mockGetCurrentTempWindowRequestSource: vi.fn(),
 }))
 
 const mockUserPreferencesContext = vi.hoisted(() => ({
@@ -233,6 +236,17 @@ vi.mock("~/utils/core/logger", () => ({
   createLogger: () => mockLogger,
 }))
 
+vi.mock("~/utils/browser/tempWindowRequestSource", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("~/utils/browser/tempWindowRequestSource")
+    >()
+  return {
+    ...actual,
+    getCurrentTempWindowRequestSource: mockGetCurrentTempWindowRequestSource,
+  }
+})
+
 vi.mock("~/utils/browser/browserApi", () => ({
   getActiveTabs: mockGetActiveTabs,
   getAllTabs: mockGetAllTabs,
@@ -271,6 +285,9 @@ afterEach(() => {
 
 beforeEach(() => {
   vi.clearAllMocks()
+  mockGetCurrentTempWindowRequestSource.mockReturnValue(
+    TEMP_WINDOW_REQUEST_SOURCES.Background,
+  )
 
   mockUserPreferencesContext.current = {
     currencyType: "USD",
@@ -1742,6 +1759,9 @@ describe("AccountDataContext current tab detection", () => {
 
 describe("AccountDataContext refresh orchestration", () => {
   it("refreshes data on demand, exposes the pending state, and stores the returned sync time", async () => {
+    mockGetCurrentTempWindowRequestSource.mockReturnValue(
+      TEMP_WINDOW_REQUEST_SOURCES.Popup,
+    )
     let resolveRefresh!: (value: any) => void
     const refreshPromise = new Promise((resolve) => {
       resolveRefresh = resolve
@@ -1779,10 +1799,16 @@ describe("AccountDataContext refresh orchestration", () => {
       expect(getLatestCtx().lastUpdateTime?.getTime()).toBe(1_710_123_456_789)
     })
 
-    expect(mockRefreshAllAccounts).toHaveBeenCalledWith(true)
+    expect(mockRefreshAllAccounts).toHaveBeenCalledWith(true, {
+      tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+    })
+    expect(mockGetCurrentTempWindowRequestSource).toHaveBeenCalledTimes(1)
   })
 
   it("refreshes disabled accounts on demand and stores the returned sync time", async () => {
+    mockGetCurrentTempWindowRequestSource.mockReturnValue(
+      TEMP_WINDOW_REQUEST_SOURCES.Popup,
+    )
     let resolveRefresh!: (value: any) => void
     const refreshPromise = new Promise((resolve) => {
       resolveRefresh = resolve
@@ -1813,7 +1839,10 @@ describe("AccountDataContext refresh orchestration", () => {
       expect(getLatestCtx().lastUpdateTime?.getTime()).toBe(1_720_123_456_789)
     })
 
-    expect(mockRefreshDisabledAccounts).toHaveBeenCalledWith(true)
+    expect(mockRefreshDisabledAccounts).toHaveBeenCalledWith(true, {
+      tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+    })
+    expect(mockGetCurrentTempWindowRequestSource).toHaveBeenCalledTimes(1)
   })
 
   it("reloads account data after disabled-account refresh failures and clears the refreshing state", async () => {
@@ -1899,7 +1928,9 @@ describe("AccountDataContext refresh orchestration", () => {
 
     await waitFor(() => {
       expect(mockToastPromise).toHaveBeenCalledTimes(1)
-      expect(mockRefreshAllAccounts).toHaveBeenCalledWith(false)
+      expect(mockRefreshAllAccounts).toHaveBeenCalledWith(false, {
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Background,
+      })
     })
 
     const [, toastOptions] = mockToastPromise.mock.calls[0]

--- a/tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
+++ b/tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
@@ -35,6 +35,7 @@ import {
   type ApiToken,
   type DisplaySiteData,
 } from "~/types"
+import { TEMP_WINDOW_REQUEST_SOURCES } from "~/types/tempWindowFetch"
 import { buildSiteAccount } from "~~/tests/test-utils/factories"
 import { act, renderHook, waitFor } from "~~/tests/test-utils/render"
 
@@ -51,6 +52,7 @@ const {
   mockSendRuntimeMessage,
   mockStartProductAnalyticsAction,
   mockCompleteProductAnalyticsAction,
+  mockGetCurrentTempWindowRequestSource,
 } = vi.hoisted(() => ({
   mockToast: vi.fn(),
   mockValidateAndSaveAccount: vi.fn(),
@@ -64,6 +66,7 @@ const {
   mockSendRuntimeMessage: vi.fn().mockResolvedValue(undefined),
   mockStartProductAnalyticsAction: vi.fn(),
   mockCompleteProductAnalyticsAction: vi.fn(),
+  mockGetCurrentTempWindowRequestSource: vi.fn(),
 }))
 
 vi.mock("react-hot-toast", () => {
@@ -159,10 +162,24 @@ vi.mock("~/services/productAnalytics/actions", () => ({
   startProductAnalyticsAction: mockStartProductAnalyticsAction,
 }))
 
+vi.mock("~/utils/browser/tempWindowRequestSource", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("~/utils/browser/tempWindowRequestSource")
+    >()
+  return {
+    ...actual,
+    getCurrentTempWindowRequestSource: mockGetCurrentTempWindowRequestSource,
+  }
+})
+
 describe("useAccountDialog save and auto-config flows", () => {
   beforeEach(async () => {
     vi.clearAllMocks()
     vi.restoreAllMocks()
+    mockGetCurrentTempWindowRequestSource.mockReturnValue(
+      TEMP_WINDOW_REQUEST_SOURCES.Background,
+    )
     await accountStorage.clearAllData()
     mockValidateAndSaveAccount.mockResolvedValue({
       success: true,
@@ -308,6 +325,87 @@ describe("useAccountDialog save and auto-config flows", () => {
       result.current.setters.setSiteType(SITE_TYPES.NEW_API)
     })
   }
+
+  it("preserves the save surface for the scheduled post-save refresh", async () => {
+    mockGetCurrentTempWindowRequestSource.mockReturnValue(
+      TEMP_WINDOW_REQUEST_SOURCES.Popup,
+    )
+    const { result } = renderAddHook()
+
+    await waitFor(() => {
+      expect(result.current.state).toBeTruthy()
+    })
+    await fillStandardAddAccountDraft(result)
+
+    await act(async () => {
+      await result.current.handlers.handleSaveAccount()
+    })
+
+    await waitFor(() => {
+      expect(accountStorage.refreshAccount).toHaveBeenCalledWith(
+        "saved-account-id",
+        true,
+        { tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup },
+      )
+    })
+    expect(mockGetCurrentTempWindowRequestSource).toHaveBeenCalledTimes(1)
+  })
+
+  it("captures the current surface again when the warning refresh action is clicked", async () => {
+    mockGetCurrentTempWindowRequestSource
+      .mockReturnValueOnce(TEMP_WINDOW_REQUEST_SOURCES.Options)
+      .mockReturnValueOnce(TEMP_WINDOW_REQUEST_SOURCES.Popup)
+    mockValidateAndSaveAccount.mockResolvedValueOnce({
+      success: true,
+      accountId: "saved-account-id",
+      message: "Account saved, but latest metrics are placeholders.",
+      feedbackLevel: "warning",
+    })
+    const { result } = renderAddHook()
+
+    await waitFor(() => {
+      expect(result.current.state).toBeTruthy()
+    })
+    await fillStandardAddAccountDraft(result)
+
+    await act(async () => {
+      await result.current.handlers.handleSaveAccount()
+    })
+
+    const warningRenderer = vi.mocked(toast.custom).mock.calls[0]?.[0] as
+      | ((toastInstance: any) => any)
+      | undefined
+    const warningElement = warningRenderer?.({
+      id: "warning-toast-id",
+      type: "custom",
+      visible: true,
+      dismissed: false,
+      height: 0,
+      ariaProps: { role: "status", "aria-live": "polite" },
+      message: "",
+      createdAt: Date.now(),
+      pauseDuration: 0,
+      position: "bottom-center",
+    } as any)
+
+    await act(async () => {
+      await warningElement?.props.action.onClick()
+    })
+
+    expect(accountStorage.refreshAccount).toHaveBeenNthCalledWith(
+      1,
+      "saved-account-id",
+      true,
+      { tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Options },
+    )
+    expect(accountStorage.refreshAccount).toHaveBeenNthCalledWith(
+      2,
+      "saved-account-id",
+      true,
+      { tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup },
+    )
+    expect(mockGetCurrentTempWindowRequestSource).toHaveBeenCalledTimes(2)
+  })
 
   it("shows managed-site setup guidance before saving when auto-config prerequisites are missing", async () => {
     mockGetManagedSiteConfig.mockResolvedValue(null)
@@ -462,7 +560,9 @@ describe("useAccountDialog save and auto-config flows", () => {
       },
     )
     await waitFor(() => {
-      expect(refreshSpy).toHaveBeenCalledWith("saved-account-id", true)
+      expect(refreshSpy).toHaveBeenCalledWith("saved-account-id", true, {
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Background,
+      })
     })
   })
 
@@ -522,6 +622,9 @@ describe("useAccountDialog save and auto-config flows", () => {
       expect(accountStorage.refreshAccount).toHaveBeenCalledWith(
         "saved-account-id",
         true,
+        {
+          tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Background,
+        },
       )
     })
     expect(onPostSaveAccountRefresh).not.toHaveBeenCalled()
@@ -613,6 +716,9 @@ describe("useAccountDialog save and auto-config flows", () => {
       expect(accountStorage.refreshAccount).toHaveBeenCalledWith(
         "saved-account-id",
         true,
+        {
+          tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Background,
+        },
       )
     })
     expect(mockSendRuntimeMessage).not.toHaveBeenCalled()

--- a/tests/features/AccountManagement/hooks/useAccountDialog.sub2apiConstraints.test.tsx
+++ b/tests/features/AccountManagement/hooks/useAccountDialog.sub2apiConstraints.test.tsx
@@ -7,18 +7,21 @@ import { useAccountDialog } from "~/features/AccountManagement/components/Accoun
 import { ACCOUNT_BROWSER_SESSION_SOURCES } from "~/services/accountBrowserSession/types"
 import { accountStorage } from "~/services/accounts/accountStorage"
 import { AuthTypeEnum } from "~/types"
+import { TEMP_WINDOW_REQUEST_SOURCES } from "~/types/tempWindowFetch"
 import { act, renderHook, waitFor } from "~~/tests/test-utils/render"
 
 const {
   mockOpenWithAccount,
   mockOpenDefaultTokenQuickCreateDialogForAccount,
   mockResolveAccountBrowserSession,
+  mockGetCurrentTempWindowRequestSource,
   mockToastError,
   mockToastSuccess,
 } = vi.hoisted(() => ({
   mockOpenWithAccount: vi.fn(),
   mockOpenDefaultTokenQuickCreateDialogForAccount: vi.fn(),
   mockResolveAccountBrowserSession: vi.fn(),
+  mockGetCurrentTempWindowRequestSource: vi.fn(),
   mockToastError: vi.fn(),
   mockToastSuccess: vi.fn(),
 }))
@@ -68,10 +71,25 @@ vi.mock("~/utils/browser/browserApi", async (importOriginal) => {
   }
 })
 
+vi.mock("~/utils/browser/tempWindowRequestSource", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("~/utils/browser/tempWindowRequestSource")
+    >()
+
+  return {
+    ...actual,
+    getCurrentTempWindowRequestSource: mockGetCurrentTempWindowRequestSource,
+  }
+})
+
 describe("useAccountDialog Sub2API constraints", () => {
   beforeEach(async () => {
     vi.clearAllMocks()
     mockResolveAccountBrowserSession.mockResolvedValue(null)
+    mockGetCurrentTempWindowRequestSource.mockReturnValue(
+      TEMP_WINDOW_REQUEST_SOURCES.Background,
+    )
     await accountStorage.clearAllData()
     ;(globalThis.browser.tabs.sendMessage as any) = vi.fn()
   })
@@ -297,6 +315,41 @@ describe("useAccountDialog Sub2API constraints", () => {
     expect(result.current.state.userId).toBe("42")
     expect(result.current.state.username).toBe("tab-user")
     expect(mockToastSuccess).toHaveBeenCalled()
+  })
+
+  it("passes the initiating Popup source to the Sub2API browser-session import", async () => {
+    mockGetCurrentTempWindowRequestSource.mockReturnValue(
+      TEMP_WINDOW_REQUEST_SOURCES.Popup,
+    )
+
+    const { result } = renderHook(() =>
+      useAccountDialog({
+        mode: DIALOG_MODES.ADD,
+        isOpen: true,
+        onClose: vi.fn(),
+        onSuccess: vi.fn(),
+      }),
+    )
+
+    await waitFor(() => {
+      expect(result.current).toBeTruthy()
+    })
+
+    await act(async () => {
+      result.current.setters.setUrl("https://sub2.example.com")
+      result.current.setters.setSiteType(SITE_TYPES.SUB2API)
+    })
+
+    await act(async () => {
+      await result.current.handlers.handleImportSub2apiSession()
+    })
+
+    expect(mockGetCurrentTempWindowRequestSource).toHaveBeenCalledTimes(1)
+    expect(mockResolveAccountBrowserSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+      }),
+    )
   })
 
   it("passes the current private tab context to the Sub2API browser-session import", async () => {

--- a/tests/services/accountBrowserSession/sessionReader.test.ts
+++ b/tests/services/accountBrowserSession/sessionReader.test.ts
@@ -9,6 +9,7 @@ import {
   resolveAccountBrowserSession,
 } from "~/services/accountBrowserSession"
 import { API_SERVICE_FETCH_CONTEXT_KINDS } from "~/services/apiTransport/type"
+import { TEMP_WINDOW_REQUEST_SOURCES } from "~/types/tempWindowFetch"
 
 const {
   mockGetAllTabs,
@@ -392,6 +393,41 @@ describe("account browser-session reader", () => {
         requestId: expect.stringMatching(/^test-session-/),
       }),
     )
+    expect(mockSendRuntimeMessage).toHaveBeenCalledWith(
+      expect.not.objectContaining({
+        tempWindowRequestSource: expect.anything(),
+      }),
+    )
+  })
+
+  it("passes popup temp-window source and the explicit minimize override without persisting either", async () => {
+    mockSendRuntimeMessage.mockResolvedValueOnce({
+      success: true,
+      data: {
+        userId: "11",
+        user: { username: "temp-user" },
+        accessToken: "temp-token",
+      },
+    })
+
+    const session = await resolveAccountBrowserSession({
+      baseUrl: "https://example.invalid",
+      siteType: SITE_TYPES.SUB2API,
+      useTempWindow: true,
+      tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+      suppressMinimize: false,
+    })
+
+    expect(mockSendRuntimeMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: RuntimeActionIds.AutoDetectSite,
+        url: "https://example.invalid",
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+        suppressMinimize: false,
+      }),
+    )
+    expect(session).not.toHaveProperty("tempWindowRequestSource")
+    expect(session).not.toHaveProperty("suppressMinimize")
   })
 
   it("notifies callers about temp-window read errors without throwing", async () => {

--- a/tests/services/accountStorage.test.ts
+++ b/tests/services/accountStorage.test.ts
@@ -1,9 +1,12 @@
+import { http, HttpResponse } from "msw"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { SITE_TYPES } from "~/constants/siteType"
 import { UI_CONSTANTS } from "~/constants/ui"
+import { ACCOUNT_BROWSER_SESSION_SOURCES } from "~/services/accountBrowserSession"
 import { AccountUpdateUserTimestampMode } from "~/services/accounts/accountDefaults"
 import { accountStorage } from "~/services/accounts/accountStorage"
+import { refreshAccountData as refreshVoApiV2AccountData } from "~/services/apiService/voapiV2"
 import {
   ACCOUNT_STORAGE_KEYS,
   STORAGE_KEYS,
@@ -19,6 +22,8 @@ import {
   type SiteAccount,
   type SiteBookmark,
 } from "~/types"
+import { TEMP_WINDOW_REQUEST_SOURCES } from "~/types/tempWindowFetch"
+import { server } from "~~/tests/msw/server"
 
 const storageData = new Map<string, any>()
 
@@ -41,6 +46,7 @@ const {
   markAccountDisabledInStatusMock,
   markAccountsDisabledInStatusMock,
   pruneStatusForAccountIdsMock,
+  mockResolveAccountBrowserSession,
 } = vi.hoisted(() => ({
   mockFetchSupportCheckIn: vi.fn(),
   mockGetAccountSiteType: vi.fn(),
@@ -49,6 +55,7 @@ const {
   markAccountDisabledInStatusMock: vi.fn(),
   markAccountsDisabledInStatusMock: vi.fn(),
   pruneStatusForAccountIdsMock: vi.fn(),
+  mockResolveAccountBrowserSession: vi.fn(),
 }))
 
 vi.mock("@plasmohq/storage", () => {
@@ -77,6 +84,15 @@ vi.mock("@plasmohq/storage", () => {
 vi.mock("~/services/apiAdapters/registry", () => ({
   getSiteTypeCapabilities: mockgetSiteTypeCapabilities,
 }))
+
+vi.mock("~/services/accountBrowserSession", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("~/services/accountBrowserSession")>()
+  return {
+    ...actual,
+    resolveAccountBrowserSession: mockResolveAccountBrowserSession,
+  }
+})
 
 vi.mock("~/services/siteDetection/detectSiteType", () => ({
   getAccountSiteType: mockGetAccountSiteType,
@@ -176,6 +192,8 @@ describe("accountStorage core behaviors", () => {
     mockGetAccountSiteType.mockReset()
     mockgetSiteTypeCapabilities.mockReset()
     mockRefreshAccountData.mockReset()
+    mockResolveAccountBrowserSession.mockReset()
+    mockResolveAccountBrowserSession.mockResolvedValue(null)
     markAccountDisabledInStatusMock.mockReset()
     markAccountsDisabledInStatusMock.mockReset()
     pruneStatusForAccountIdsMock.mockReset()
@@ -926,16 +944,21 @@ describe("accountStorage core behaviors", () => {
       .mockRejectedValueOnce(new Error("refresh exploded"))
 
     try {
-      const result = await accountStorage.refreshAllAccounts()
+      const result = await accountStorage.refreshAllAccounts(false, {
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+      })
 
       expect(refreshAccountSpy).toHaveBeenNthCalledWith(1, "refresh-1", false, {
         includeTodayCashflow: false,
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
       })
       expect(refreshAccountSpy).toHaveBeenNthCalledWith(2, "refresh-2", false, {
         includeTodayCashflow: false,
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
       })
       expect(refreshAccountSpy).toHaveBeenNthCalledWith(3, "refresh-3", false, {
         includeTodayCashflow: false,
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
       })
       expect(result).toEqual({
         success: 2,
@@ -946,6 +969,84 @@ describe("accountStorage core behaviors", () => {
     } finally {
       refreshAccountSpy.mockRestore()
     }
+  })
+
+  it("carries a popup bulk-refresh source through VoAPI resync to the browser-session seam", async () => {
+    seedStorage([
+      createAccount({
+        id: "voapi-refresh",
+        site_type: SITE_TYPES.VO_API_V2,
+        site_url: "https://example.invalid",
+        account_info: {
+          id: "7",
+          username: "owner",
+          access_token: "expired-dashboard-token",
+          quota: 1_000_000,
+          today_prompt_tokens: 0,
+          today_completion_tokens: 0,
+          today_quota_consumption: 0,
+          today_requests_count: 0,
+          today_income: 0,
+        },
+      }),
+    ])
+    mockgetSiteTypeCapabilities.mockReturnValue({
+      siteType: SITE_TYPES.VO_API_V2,
+      account: {
+        refresh: {
+          refreshAccount: refreshVoApiV2AccountData,
+        },
+      },
+    })
+    mockResolveAccountBrowserSession.mockResolvedValueOnce({
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB,
+      siteType: SITE_TYPES.VO_API_V2,
+      siteTypeHint: SITE_TYPES.VO_API_V2,
+      userId: "8",
+      user: { username: "resynced-owner" },
+      accessToken: "resynced-dashboard-token",
+    })
+    server.use(
+      http.get("https://example.invalid/api/user/info", ({ request }) => {
+        if (
+          request.headers.get("authorization") === "expired-dashboard-token"
+        ) {
+          return HttpResponse.json({ code: 2, data: null, msg: "Auth expire" })
+        }
+        return HttpResponse.json({
+          code: 0,
+          data: {
+            id: 8,
+            username: "resynced-owner",
+            basicBalance: "2",
+            bindBalance: "0",
+          },
+        })
+      }),
+      http.get("https://example.invalid/api/dash/statistics", () =>
+        HttpResponse.json({
+          code: 0,
+          data: { d: { requests: 1, usedBasicBalance: "0" } },
+        }),
+      ),
+      http.get("https://example.invalid/api/check_in/stats", () =>
+        HttpResponse.json({
+          code: 0,
+          data: { todaySigned: false },
+        }),
+      ),
+    )
+
+    await accountStorage.refreshAllAccounts(true, {
+      tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+    })
+
+    expect(mockResolveAccountBrowserSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseUrl: "https://example.invalid",
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+      }),
+    )
   })
 
   it("refreshDisabledAccounts only probes disabled accounts and summarizes restored results", async () => {
@@ -972,18 +1073,22 @@ describe("accountStorage core behaviors", () => {
       } as any)
 
     try {
-      const result = await accountStorage.refreshDisabledAccounts(true)
+      const result = await accountStorage.refreshDisabledAccounts(true, {
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+      })
 
       expect(refreshAccountSpy).toHaveBeenCalledTimes(2)
       expect(refreshAccountSpy).toHaveBeenNthCalledWith(1, "disabled-a", true, {
         includeTodayCashflow: true,
         allowDisabled: true,
         reEnableOnSuccess: true,
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
       })
       expect(refreshAccountSpy).toHaveBeenNthCalledWith(2, "disabled-c", true, {
         includeTodayCashflow: true,
         allowDisabled: true,
         reEnableOnSuccess: true,
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
       })
       expect(result).toEqual({
         processedCount: 2,
@@ -2008,6 +2113,33 @@ describe("accountStorage core behaviors", () => {
     expect(mockRefreshAccountData).toHaveBeenCalledWith(
       expect.objectContaining({
         baseUrl: "https://pathful.example.com",
+      }),
+    )
+  })
+
+  it("refreshAccount preserves the temp window source across support detection and data refresh", async () => {
+    const account = createAccount({
+      id: "temp-window",
+      site_url: "https://refresh.example.invalid/dashboard",
+      site_type: SITE_TYPES.NEW_API,
+      checkIn: { enableDetection: true },
+    })
+    seedStorage([account])
+
+    await accountStorage.refreshAccount("temp-window", true, {
+      tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+    })
+
+    expect(mockFetchSupportCheckIn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountId: "temp-window",
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+      }),
+    )
+    expect(mockRefreshAccountData).toHaveBeenCalledWith(
+      expect.objectContaining({
+        accountId: "temp-window",
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
       }),
     )
   })

--- a/tests/services/apiService/anyrouter.index.test.ts
+++ b/tests/services/apiService/anyrouter.index.test.ts
@@ -8,6 +8,7 @@ import {
 } from "~/services/apiService/anyrouter"
 import { SiteHealthStatus } from "~/types"
 import { CHECKIN_RESULT_STATUS } from "~/types/autoCheckin"
+import { TEMP_WINDOW_REQUEST_SOURCES } from "~/types/tempWindowFetch"
 
 const {
   mockDetermineHealthStatus,
@@ -58,6 +59,9 @@ vi.mock("~/utils/i18n/core", () => ({
 }))
 
 describe("AnyRouter API service", () => {
+  const backgroundProviderContext = {
+    tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Background,
+  }
   const baseRequest = {
     baseUrl: "https://anyrouter.example.com",
     auth: {
@@ -123,11 +127,14 @@ describe("AnyRouter API service", () => {
       }),
     ).resolves.toBe(true)
 
-    expect(mockCheckIn).toHaveBeenCalledWith({
-      site_url: "https://anyrouter.example.com",
-      id: undefined,
-      account_info: { id: 42 },
-    })
+    expect(mockCheckIn).toHaveBeenCalledWith(
+      {
+        site_url: "https://anyrouter.example.com",
+        id: undefined,
+        account_info: { id: 42 },
+      },
+      backgroundProviderContext,
+    )
   })
 
   it("passes request account identity to the AnyRouter check-in provider", async () => {
@@ -143,12 +150,46 @@ describe("AnyRouter API service", () => {
       }),
     ).resolves.toBe(true)
 
-    expect(mockCheckIn).toHaveBeenCalledWith({
-      site_url: "https://anyrouter.example.com",
-      id: "stored-account-id",
-      cookieAuthSessionCookie: "stored-session-cookie",
-      account_info: { id: 42 },
+    expect(mockCheckIn).toHaveBeenCalledWith(
+      {
+        site_url: "https://anyrouter.example.com",
+        id: "stored-account-id",
+        cookieAuthSessionCookie: "stored-session-cookie",
+        account_info: { id: 42 },
+      },
+      backgroundProviderContext,
+    )
+  })
+
+  it("passes the Popup request source to the AnyRouter check-in provider", async () => {
+    mockCheckIn.mockResolvedValueOnce({
+      status: CHECKIN_RESULT_STATUS.SUCCESS,
     })
+
+    await fetchCheckInStatus({
+      ...baseRequest,
+      tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+    })
+
+    expect(mockCheckIn).toHaveBeenCalledWith(expect.any(Object), {
+      tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+    })
+  })
+
+  it("normalizes invalid AnyRouter request sources to Background", async () => {
+    mockCheckIn.mockResolvedValueOnce({
+      status: CHECKIN_RESULT_STATUS.SUCCESS,
+    })
+
+    await fetchCheckInStatus({
+      ...baseRequest,
+      tempWindowRequestSource: "invalid-source",
+    })
+
+    expect(mockCheckIn).toHaveBeenCalledWith(
+      expect.any(Object),
+      backgroundProviderContext,
+    )
   })
 
   it("maps provider check-in statuses into the account-facing boolean", async () => {
@@ -163,16 +204,24 @@ describe("AnyRouter API service", () => {
     await expect(fetchCheckInStatus(baseRequest)).resolves.toBe(true)
     await expect(fetchCheckInStatus(baseRequest)).resolves.toBe(false)
 
-    expect(mockCheckIn).toHaveBeenNthCalledWith(1, {
-      site_url: "https://anyrouter.example.com",
-      id: undefined,
-      account_info: { id: 42 },
-    })
-    expect(mockCheckIn).toHaveBeenNthCalledWith(2, {
-      site_url: "https://anyrouter.example.com",
-      id: undefined,
-      account_info: { id: 42 },
-    })
+    expect(mockCheckIn).toHaveBeenNthCalledWith(
+      1,
+      {
+        site_url: "https://anyrouter.example.com",
+        id: undefined,
+        account_info: { id: 42 },
+      },
+      backgroundProviderContext,
+    )
+    expect(mockCheckIn).toHaveBeenNthCalledWith(
+      2,
+      {
+        site_url: "https://anyrouter.example.com",
+        id: undefined,
+        account_info: { id: 42 },
+      },
+      backgroundProviderContext,
+    )
   })
 
   it("treats provider failures as unsupported check-in detection", async () => {

--- a/tests/services/apiService/sub2api/index.test.ts
+++ b/tests/services/apiService/sub2api/index.test.ts
@@ -47,6 +47,7 @@ import type {
 import { API_ERROR_CODES, ApiError } from "~/services/apiTransport/errors"
 import { fetchApi } from "~/services/apiTransport/request"
 import { AuthTypeEnum, SiteHealthStatus } from "~/types"
+import { TEMP_WINDOW_REQUEST_SOURCES } from "~/types/tempWindowFetch"
 
 const { mockGetLatestAuth, mockPersistAuthUpdate } = vi.hoisted(() => ({
   mockGetLatestAuth: vi.fn(),
@@ -609,7 +610,7 @@ describe("apiService sub2api refreshAccountData", () => {
     expect(fetchApi).toHaveBeenCalledTimes(1)
   })
 
-  it("re-syncs token and retries once on HTTP 401 (success)", async () => {
+  it("passes temp-window source to token resync and preserves it on the retry", async () => {
     vi.mocked(fetchApi)
       .mockRejectedValueOnce(
         new ApiError("Unauthorized", 401, "/api/v1/auth/me"),
@@ -625,12 +626,20 @@ describe("apiService sub2api refreshAccountData", () => {
       source: ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB,
     })
 
-    const request = createRequest()
+    const request = createRequest({
+      tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+    })
     const result = await refreshAccountData(request)
 
-    expect(resyncSub2ApiAuthToken).toHaveBeenCalledWith(request.baseUrl)
+    expect(resyncSub2ApiAuthToken).toHaveBeenCalledWith(
+      request.baseUrl,
+      TEMP_WINDOW_REQUEST_SOURCES.Popup,
+    )
     const retryRequest = vi.mocked(fetchApi).mock.calls[1]?.[0] as any
     expect(retryRequest?.auth?.accessToken).toBe("new-jwt")
+    expect(retryRequest?.tempWindowRequestSource).toBe(
+      TEMP_WINDOW_REQUEST_SOURCES.Popup,
+    )
 
     expect(result.success).toBe(true)
     expect(result.data?.quota).toBe(500_000)

--- a/tests/services/apiService/sub2api/index.test.ts
+++ b/tests/services/apiService/sub2api/index.test.ts
@@ -965,7 +965,10 @@ describe("apiService sub2api refreshAccountData", () => {
     const tokens = await fetchAccountTokens(request)
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
-    expect(resyncSub2ApiAuthToken).toHaveBeenCalledWith(request.baseUrl)
+    expect(resyncSub2ApiAuthToken).toHaveBeenCalledWith(
+      request.baseUrl,
+      undefined,
+    )
     expect(
       (vi.mocked(fetchApi).mock.calls[1]?.[0] as any)?.auth?.accessToken,
     ).toBe("resynced-jwt")
@@ -1067,7 +1070,10 @@ describe("apiService sub2api refreshAccountData", () => {
     const result = await refreshAccountData(request)
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
-    expect(resyncSub2ApiAuthToken).toHaveBeenCalledWith(request.baseUrl)
+    expect(resyncSub2ApiAuthToken).toHaveBeenCalledWith(
+      request.baseUrl,
+      undefined,
+    )
     expect(
       (vi.mocked(fetchApi).mock.calls[1]?.[0] as any)?.auth?.accessToken,
     ).toBe("resynced-jwt")
@@ -1107,7 +1113,10 @@ describe("apiService sub2api refreshAccountData", () => {
     const result = await refreshAccountData(request)
 
     expect(fetchMock).toHaveBeenCalledTimes(1)
-    expect(resyncSub2ApiAuthToken).toHaveBeenCalledWith(request.baseUrl)
+    expect(resyncSub2ApiAuthToken).toHaveBeenCalledWith(
+      request.baseUrl,
+      undefined,
+    )
     expect(fetchApi).toHaveBeenCalledTimes(1)
     expect(result.success).toBe(false)
     expect(result.healthStatus.status).toBe(SiteHealthStatus.Warning)
@@ -1407,6 +1416,7 @@ describe("apiService sub2api exported operations", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(resyncSub2ApiAuthToken).toHaveBeenCalledWith(
       "https://sub2.example.com",
+      undefined,
     )
     expect((vi.mocked(fetchApi).mock.calls[0]?.[0] as any)?.auth).toMatchObject(
       {
@@ -1515,6 +1525,7 @@ describe("apiService sub2api exported operations", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(resyncSub2ApiAuthToken).toHaveBeenCalledWith(
       "https://sub2.example.com",
+      undefined,
     )
     expect(fetchApi).toHaveBeenCalledTimes(2)
     expect(
@@ -1554,6 +1565,7 @@ describe("apiService sub2api exported operations", () => {
 
     expect(resyncSub2ApiAuthToken).toHaveBeenCalledWith(
       "https://sub2.example.com",
+      undefined,
     )
   })
 
@@ -1575,6 +1587,7 @@ describe("apiService sub2api exported operations", () => {
 
     expect(resyncSub2ApiAuthToken).toHaveBeenCalledWith(
       "https://sub2.example.com",
+      undefined,
     )
   })
 

--- a/tests/services/apiService/sub2api/keyManagement.test.ts
+++ b/tests/services/apiService/sub2api/keyManagement.test.ts
@@ -778,6 +778,7 @@ describe("apiService sub2api key management service", () => {
     expect(tokens).toHaveLength(1)
     expect(resyncSub2ApiAuthTokenMock).toHaveBeenCalledWith(
       "https://sub2.example.com",
+      undefined,
     )
     expect(persistAuthUpdateMock).toHaveBeenCalledWith("acc-1", {
       accessToken: "resynced-jwt",

--- a/tests/services/apiService/sub2api/tokenResync.test.ts
+++ b/tests/services/apiService/sub2api/tokenResync.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { ACCOUNT_BROWSER_SESSION_SOURCES } from "~/services/accountBrowserSession"
 import { resyncSub2ApiAuthToken } from "~/services/apiService/sub2api/tokenResync"
+import { TEMP_WINDOW_REQUEST_SOURCES } from "~/types/tempWindowFetch"
 
 const { mockResolveAccountBrowserSession } = vi.hoisted(() => ({
   mockResolveAccountBrowserSession: vi.fn(),
@@ -45,6 +46,27 @@ describe("Sub2API token re-sync", () => {
         useTempWindow: true,
         requestIdPrefix: "sub2api-token-resync",
         isUsableSession: expect.any(Function),
+      }),
+    )
+    expect(mockResolveAccountBrowserSession).toHaveBeenCalledWith(
+      expect.not.objectContaining({
+        tempWindowRequestSource: expect.anything(),
+      }),
+    )
+  })
+
+  it("passes popup source to the browser-session reader", async () => {
+    mockResolveAccountBrowserSession.mockResolvedValueOnce(null)
+
+    await resyncSub2ApiAuthToken(
+      "https://example.invalid",
+      TEMP_WINDOW_REQUEST_SOURCES.Popup,
+    )
+
+    expect(mockResolveAccountBrowserSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseUrl: "https://example.invalid",
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
       }),
     )
   })

--- a/tests/services/apiService/voapiV2/index.test.ts
+++ b/tests/services/apiService/voapiV2/index.test.ts
@@ -18,6 +18,7 @@ import {
   updateVoApiV2Token,
 } from "~/services/apiService/voapiV2"
 import { AuthTypeEnum, SiteHealthStatus } from "~/types"
+import { TEMP_WINDOW_REQUEST_SOURCES } from "~/types/tempWindowFetch"
 import { server } from "~~/tests/msw/server"
 
 const { mockResyncVoApiV2AuthToken } = vi.hoisted(() => ({
@@ -212,7 +213,7 @@ describe("apiService VoAPI v2", () => {
     })
   })
 
-  it("re-syncs the dashboard JWT from a logged-in browser session after auth expiry", async () => {
+  it("passes temp-window source to dashboard JWT resync after auth expiry", async () => {
     const authorizations: (string | null)[] = []
     mockResyncVoApiV2AuthToken.mockResolvedValueOnce({
       accessToken: "resynced-dashboard-token",
@@ -258,7 +259,12 @@ describe("apiService VoAPI v2", () => {
       ),
     )
 
-    await expect(refreshAccountData(createVoApiV2Request())).resolves.toEqual(
+    await expect(
+      refreshAccountData({
+        ...createVoApiV2Request(),
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+      }),
+    ).resolves.toEqual(
       expect.objectContaining({
         success: true,
         authUpdate: {
@@ -273,6 +279,7 @@ describe("apiService VoAPI v2", () => {
     expect(authorizations).toContain("resynced-dashboard-token")
     expect(mockResyncVoApiV2AuthToken).toHaveBeenCalledWith(
       "https://example.invalid",
+      TEMP_WINDOW_REQUEST_SOURCES.Popup,
     )
   })
 
@@ -319,6 +326,9 @@ describe("apiService VoAPI v2", () => {
         message: "account:healthStatus.httpError",
       },
     })
+    expect(mockResyncVoApiV2AuthToken).toHaveBeenCalledWith(
+      "https://example.invalid",
+    )
   })
 
   it("reports non-auth retry failures after dashboard JWT re-sync", async () => {

--- a/tests/services/apiService/voapiV2/tokenResync.test.ts
+++ b/tests/services/apiService/voapiV2/tokenResync.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { ACCOUNT_BROWSER_SESSION_SOURCES } from "~/services/accountBrowserSession"
 import { resyncVoApiV2AuthToken } from "~/services/apiService/voapiV2/tokenResync"
+import { TEMP_WINDOW_REQUEST_SOURCES } from "~/types/tempWindowFetch"
 
 const { mockResolveAccountBrowserSession } = vi.hoisted(() => ({
   mockResolveAccountBrowserSession: vi.fn(),
@@ -48,6 +49,27 @@ describe("VoAPI v2 token re-sync", () => {
         useTempWindow: true,
         requestIdPrefix: "voapi-v2-token-resync",
         isUsableSession: expect.any(Function),
+      }),
+    )
+    expect(mockResolveAccountBrowserSession).toHaveBeenCalledWith(
+      expect.not.objectContaining({
+        tempWindowRequestSource: expect.anything(),
+      }),
+    )
+  })
+
+  it("passes popup source to the browser-session reader", async () => {
+    mockResolveAccountBrowserSession.mockResolvedValueOnce(null)
+
+    await resyncVoApiV2AuthToken(
+      "https://example.invalid",
+      TEMP_WINDOW_REQUEST_SOURCES.Popup,
+    )
+
+    expect(mockResolveAccountBrowserSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseUrl: "https://example.invalid",
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
       }),
     )
   })

--- a/tests/services/apiTransport/request.test.ts
+++ b/tests/services/apiTransport/request.test.ts
@@ -7,6 +7,7 @@ import {
   API_TRANSPORT_FETCH_CONTEXT_KINDS,
 } from "~/services/apiTransport/type"
 import { AuthTypeEnum, TEMP_WINDOW_HEALTH_STATUS_CODES } from "~/types"
+import { TEMP_WINDOW_REQUEST_SOURCES } from "~/types/tempWindowFetch"
 import {
   COOKIE_AUTH_HEADER_NAME,
   COOKIE_SESSION_OVERRIDE_HEADER_NAME,
@@ -50,6 +51,10 @@ const { mockSendTabMessageWithRetry, mockSendRuntimeMessage } = vi.hoisted(
     mockSendRuntimeMessage: vi.fn(),
   }),
 )
+
+const { mockIsProtectionBypassFirefoxEnv } = vi.hoisted(() => ({
+  mockIsProtectionBypassFirefoxEnv: vi.fn(() => true),
+}))
 
 vi.mock("~/utils/browser/browserApi", async (importOriginal) => {
   const actual =
@@ -101,11 +106,12 @@ vi.mock("~/services/apiTransport/siteRequestLimiter", () => ({
 }))
 
 vi.mock("~/utils/browser/protectionBypass", () => ({
-  isProtectionBypassFirefoxEnv: vi.fn(() => true),
+  isProtectionBypassFirefoxEnv: mockIsProtectionBypassFirefoxEnv,
 }))
 
 vi.mock("~/utils/browser/index", () => ({
   isExtensionBackground: vi.fn(() => false),
+  isExtensionOptions: vi.fn(() => false),
   isExtensionPopup: vi.fn(() => false),
   isExtensionSidePanel: vi.fn(() => false),
 }))
@@ -194,6 +200,8 @@ describe("apiTransport request helpers", () => {
     mockSendTabMessageWithRetry.mockReset()
     mockSendRuntimeMessage.mockReset()
     mockSendRuntimeMessage.mockResolvedValue({ success: true })
+    mockIsProtectionBypassFirefoxEnv.mockReset()
+    mockIsProtectionBypassFirefoxEnv.mockReturnValue(true)
   })
 
   afterEach(() => {
@@ -846,7 +854,8 @@ describe("apiTransport request helpers", () => {
     expect(mockSendTabMessageWithRetry).toHaveBeenCalledTimes(1)
   })
 
-  it("fetchApiData skips normal fetch for incognito current-tab fallback and uses the temp context", async () => {
+  it("fetchApiData preserves the popup temp window source through fallback context", async () => {
+    mockIsProtectionBypassFirefoxEnv.mockReturnValue(false)
     mockGetPreferences.mockResolvedValueOnce({
       tempWindowFallback: {
         enabled: true,
@@ -893,6 +902,7 @@ describe("apiTransport request helpers", () => {
             cookie: "session=abc123",
             userId: "123",
           },
+          tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
           fetchContext: {
             kind: API_TRANSPORT_FETCH_CONTEXT_KINDS.CURRENT_TAB,
             tabId: 456,
@@ -911,6 +921,8 @@ describe("apiTransport request helpers", () => {
         action: RuntimeActionIds.TempWindowFetch,
         originUrl: BASE_URL,
         fetchUrl: API_URL,
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+        suppressMinimize: true,
         useIncognito: true,
         cookieStoreId: "1-incognito",
       }),

--- a/tests/services/autoCheckin/providers/anyrouter.test.ts
+++ b/tests/services/autoCheckin/providers/anyrouter.test.ts
@@ -6,6 +6,7 @@ import {
   type AnyrouterCheckInParams,
 } from "~/services/checkin/autoCheckin/providers/anyrouter"
 import { AuthTypeEnum, SiteHealthStatus, type SiteAccount } from "~/types"
+import { TEMP_WINDOW_REQUEST_SOURCES } from "~/types/tempWindowFetch"
 
 vi.mock("~/services/apiTransport/request", () => ({
   fetchApi: vi.fn(),
@@ -63,7 +64,7 @@ describe("anyrouterProvider", () => {
   })
 
   describe("checkIn", () => {
-    it("returns success on successful check-in (message includes 签到成功)", async () => {
+    it("propagates the popup source on a successful check-in", async () => {
       const { fetchApi } = await import("~/services/apiTransport/request")
       const mockedFetchApi = vi.mocked(
         fetchApi as unknown as (...args: any[]) => Promise<any>,
@@ -75,10 +76,13 @@ describe("anyrouterProvider", () => {
         message: "签到成功，获得 $25 额度",
       })
 
-      const result = await anyrouterProvider.checkIn(mockAccount)
+      const result = await anyrouterProvider.checkIn(mockAccount, {
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+      })
       expect(result.status).toBe("success")
       expect(mockedFetchApi.mock.calls[0]?.[0]).toMatchObject({
         accountId: "test-id",
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
       })
     })
 
@@ -112,6 +116,7 @@ describe("anyrouterProvider", () => {
         baseUrl: "https://anyrouter.top",
         accountId: "stored-account-id",
         cookieAuthSessionCookie: "session=stored-cookie",
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Background,
         auth: {
           authType: AuthTypeEnum.Cookie,
           userId: 12345,

--- a/tests/services/autoCheckin/providers/newApi.test.ts
+++ b/tests/services/autoCheckin/providers/newApi.test.ts
@@ -5,6 +5,7 @@ import { SITE_ROUTE_KINDS } from "~/services/accounts/utils/siteRouteResolver"
 import { ApiError } from "~/services/apiTransport/errors"
 import { newApiProvider } from "~/services/checkin/autoCheckin/providers/newApi"
 import { AuthTypeEnum, SiteHealthStatus } from "~/types"
+import { TEMP_WINDOW_REQUEST_SOURCES } from "~/types/tempWindowFetch"
 import { safeRandomUUID } from "~/utils/core/identifier"
 import { buildSiteAccount } from "~~/tests/test-utils/factories"
 
@@ -124,7 +125,7 @@ describe("newApiProvider", () => {
   })
 
   describe("checkIn", () => {
-    it("uses native page check-in for narrow dynamic signature failures", async () => {
+    it("preserves the popup source through native page check-in and status polling", async () => {
       const { fetchApi, fetchApiData } = await import(
         "~/services/apiTransport/request"
       )
@@ -157,7 +158,9 @@ describe("newApiProvider", () => {
         stats: { checked_in_today: true },
       } as any)
 
-      const result = await newApiProvider.checkIn(mockAccount)
+      const result = await newApiProvider.checkIn(mockAccount, {
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+      })
 
       expect(result).toEqual({
         status: "already_checked",
@@ -168,9 +171,11 @@ describe("newApiProvider", () => {
       })
       expect(vi.mocked(fetchApi).mock.calls[0]?.[0]).toMatchObject({
         accountId: "test-id",
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
       })
       expect(vi.mocked(fetchApiData).mock.calls[0]?.[0]).toMatchObject({
         accountId: "test-id",
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
       })
       expect(tempWindowTriggerCheckinPageAction).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -181,6 +186,7 @@ describe("newApiProvider", () => {
           accountId: "test-id",
           authType: AuthTypeEnum.AccessToken,
           trigger: { kind: "checkinButton" },
+          tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
         }),
       )
       expect(tempWindowTurnstileFetch).not.toHaveBeenCalled()
@@ -549,7 +555,9 @@ describe("newApiProvider", () => {
     })
 
     it("does not add native page identity matching to Turnstile replay failures", async () => {
-      const { fetchApi } = await import("~/services/apiTransport/request")
+      const { fetchApi, fetchApiData } = await import(
+        "~/services/apiTransport/request"
+      )
       const { tempWindowTriggerCheckinPageAction, tempWindowTurnstileFetch } =
         await import("~/utils/browser/tempWindowFetch")
       const { isAllowedIncognitoAccess } = await import(
@@ -567,6 +575,9 @@ describe("newApiProvider", () => {
         error: "Turnstile token not available",
         turnstile: { status: "timeout", hasTurnstile: true },
       })
+      vi.mocked(fetchApiData).mockResolvedValueOnce({
+        stats: { checked_in_today: false },
+      } as any)
 
       const result = await newApiProvider.checkIn(mockAccount)
 
@@ -630,7 +641,6 @@ describe("newApiProvider", () => {
         message: "",
         data: { checkin_date: "2026-01-01", quota_awarded: 1 },
       })
-
       const result = await newApiProvider.checkIn(mockAccount)
 
       expect(result).toEqual({
@@ -638,6 +648,9 @@ describe("newApiProvider", () => {
         rawMessage: undefined,
         messageKey: "autoCheckin:providerFallback.checkinSuccessful",
         data: { checkin_date: "2026-01-01", quota_awarded: 1 },
+      })
+      expect(vi.mocked(fetchApi).mock.calls[0]?.[0]).toMatchObject({
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Background,
       })
     })
 
@@ -1178,7 +1191,7 @@ describe("newApiProvider", () => {
       })
     })
 
-    it("falls back to the normal temp context when an incognito-first Turnstile attempt cannot obtain a token", async () => {
+    it("preserves the popup source across preferred and fallback Turnstile attempts", async () => {
       const { fetchApi, fetchApiData } = await import(
         "~/services/apiTransport/request"
       )
@@ -1220,18 +1233,34 @@ describe("newApiProvider", () => {
 
       vi.mocked(isAllowedIncognitoAccess).mockResolvedValueOnce(true)
 
-      const result = await newApiProvider.checkIn(mockAccount)
+      const result = await newApiProvider.checkIn(mockAccount, {
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+      })
 
       expect(result.status).toBe("success")
       expect(tempWindowTurnstileFetch).toHaveBeenCalledTimes(2)
       expect(tempWindowTurnstileFetch).toHaveBeenNthCalledWith(
         1,
-        expect.objectContaining({ useIncognito: true }),
+        expect.objectContaining({
+          useIncognito: true,
+          tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+        }),
       )
       expect(tempWindowTurnstileFetch).toHaveBeenNthCalledWith(
         2,
-        expect.not.objectContaining({ useIncognito: true }),
+        expect.objectContaining({
+          tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+        }),
       )
+      expect(
+        vi.mocked(tempWindowTurnstileFetch).mock.calls[1]?.[0].useIncognito,
+      ).toBeUndefined()
+      expect(vi.mocked(fetchApi).mock.calls[0]?.[0]).toMatchObject({
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+      })
+      expect(vi.mocked(fetchApiData).mock.calls[0]?.[0]).toMatchObject({
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+      })
     })
 
     it("falls back to manual verification when the incognito retry still cannot complete the assisted request", async () => {

--- a/tests/services/autoCheckin/providers/veloera.test.ts
+++ b/tests/services/autoCheckin/providers/veloera.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import { SITE_TYPES } from "~/constants/siteType"
 import { veloeraProvider } from "~/services/checkin/autoCheckin/providers/veloera"
 import { AuthTypeEnum, SiteHealthStatus, type SiteAccount } from "~/types"
+import { TEMP_WINDOW_REQUEST_SOURCES } from "~/types/tempWindowFetch"
 
 vi.mock("~/services/apiTransport/request", () => ({
   fetchApi: vi.fn(),
@@ -74,7 +75,7 @@ describe("veloeraProvider", () => {
   })
 
   describe("checkIn", () => {
-    it("returns the fallback success message key when the backend omits a message", async () => {
+    it("propagates the popup source when the backend omits a message", async () => {
       const { fetchApi } = await import("~/services/apiTransport/request")
       vi.mocked(fetchApi).mockResolvedValueOnce({
         success: true,
@@ -82,7 +83,9 @@ describe("veloeraProvider", () => {
         message: "",
       })
 
-      const result = await veloeraProvider.checkIn(mockAccount)
+      const result = await veloeraProvider.checkIn(mockAccount, {
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+      })
 
       expect(result).toEqual({
         status: "success",
@@ -92,6 +95,7 @@ describe("veloeraProvider", () => {
       })
       expect(vi.mocked(fetchApi).mock.calls[0]?.[0]).toMatchObject({
         accountId: "test-id",
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
       })
     })
 
@@ -105,6 +109,9 @@ describe("veloeraProvider", () => {
 
       const result = await veloeraProvider.checkIn(mockAccount)
       expect(result.status).toBe("success")
+      expect(vi.mocked(fetchApi).mock.calls[0]?.[0]).toMatchObject({
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Background,
+      })
     })
 
     it("returns already_checked when already checked in", async () => {

--- a/tests/services/autoCheckin/providers/voapiV2.test.ts
+++ b/tests/services/autoCheckin/providers/voapiV2.test.ts
@@ -9,12 +9,41 @@ import {
 import { voApiV2Provider } from "~/services/checkin/autoCheckin/providers/voapiV2"
 import type { SiteAccount } from "~/types"
 import { CHECKIN_RESULT_STATUS } from "~/types/autoCheckin"
+import { TEMP_WINDOW_REQUEST_SOURCES } from "~/types/tempWindowFetch"
 import { server } from "~~/tests/msw/server"
 
-const { mockResyncVoApiV2AuthToken, mockUpdateAccount } = vi.hoisted(() => ({
+const {
+  mockResyncVoApiV2AuthToken,
+  mockUpdateAccount,
+  mockSubmitVoApiV2CheckIn,
+  mockFetchVoApiV2CheckInStats,
+} = vi.hoisted(() => ({
   mockResyncVoApiV2AuthToken: vi.fn(),
   mockUpdateAccount: vi.fn(),
+  mockSubmitVoApiV2CheckIn: vi.fn(),
+  mockFetchVoApiV2CheckInStats: vi.fn(),
 }))
+
+vi.mock("~/services/apiService/voapiV2", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("~/services/apiService/voapiV2")>()
+
+  return {
+    ...actual,
+    submitVoApiV2CheckIn: (
+      ...args: Parameters<typeof actual.submitVoApiV2CheckIn>
+    ) => {
+      mockSubmitVoApiV2CheckIn(...args)
+      return actual.submitVoApiV2CheckIn(...args)
+    },
+    fetchVoApiV2CheckInStats: (
+      ...args: Parameters<typeof actual.fetchVoApiV2CheckInStats>
+    ) => {
+      mockFetchVoApiV2CheckInStats(...args)
+      return actual.fetchVoApiV2CheckInStats(...args)
+    },
+  }
+})
 
 vi.mock("~/services/apiService/voapiV2/tokenResync", () => ({
   resyncVoApiV2AuthToken: mockResyncVoApiV2AuthToken,
@@ -52,7 +81,7 @@ describe("voApiV2Provider", () => {
     )
   })
 
-  it("checks in through the VoAPI v2 API and confirms stats", async () => {
+  it("propagates the popup source through VoAPI v2 check-in and stats requests", async () => {
     server.use(
       http.post("https://example.invalid/api/check_in", ({ request }) => {
         expect(request.headers.get("authorization")).toBe("jwt-dashboard")
@@ -66,9 +95,21 @@ describe("voApiV2Provider", () => {
       ),
     )
 
-    await expect(voApiV2Provider.checkIn(account)).resolves.toMatchObject({
-      status: CHECKIN_RESULT_STATUS.SUCCESS,
-    })
+    await expect(
+      voApiV2Provider.checkIn(account, {
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+      }),
+    ).resolves.toMatchObject({ status: CHECKIN_RESULT_STATUS.SUCCESS })
+    expect(mockSubmitVoApiV2CheckIn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+      }),
+    )
+    expect(mockFetchVoApiV2CheckInStats).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+      }),
+    )
   })
 
   it("treats repeated same-day sign-in as already checked", async () => {
@@ -84,6 +125,11 @@ describe("voApiV2Provider", () => {
     await expect(voApiV2Provider.checkIn(account)).resolves.toMatchObject({
       status: CHECKIN_RESULT_STATUS.ALREADY_CHECKED,
     })
+    expect(mockSubmitVoApiV2CheckIn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Background,
+      }),
+    )
   })
 
   it("does not run without the saved dashboard JWT", () => {
@@ -153,6 +199,7 @@ describe("voApiV2Provider", () => {
     })
     expect(mockResyncVoApiV2AuthToken).toHaveBeenCalledWith(
       "https://example.invalid",
+      TEMP_WINDOW_REQUEST_SOURCES.Background,
     )
   })
 
@@ -205,9 +252,11 @@ describe("voApiV2Provider", () => {
       }),
     )
 
-    await expect(voApiV2Provider.checkIn(account)).resolves.toMatchObject({
-      status: CHECKIN_RESULT_STATUS.SUCCESS,
-    })
+    await expect(
+      voApiV2Provider.checkIn(account, {
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+      }),
+    ).resolves.toMatchObject({ status: CHECKIN_RESULT_STATUS.SUCCESS })
 
     expect(postAuthorizations).toEqual([
       "jwt-dashboard",
@@ -216,6 +265,18 @@ describe("voApiV2Provider", () => {
     expect(statsAuthorizations).toEqual(["resynced-dashboard-token"])
     expect(mockResyncVoApiV2AuthToken).toHaveBeenCalledWith(
       "https://example.invalid",
+      TEMP_WINDOW_REQUEST_SOURCES.Popup,
+    )
+    expect(mockSubmitVoApiV2CheckIn).toHaveBeenCalledTimes(2)
+    for (const [request] of mockSubmitVoApiV2CheckIn.mock.calls) {
+      expect(request).toMatchObject({
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+      })
+    }
+    expect(mockFetchVoApiV2CheckInStats).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+      }),
     )
     expect(mockUpdateAccount).toHaveBeenCalledWith(
       "account-1",

--- a/tests/services/autoCheckin/providers/wong.test.ts
+++ b/tests/services/autoCheckin/providers/wong.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import { SITE_TYPES } from "~/constants/siteType"
 import { wongGongyiProvider } from "~/services/checkin/autoCheckin/providers/wong"
 import { AuthTypeEnum, SiteHealthStatus, type SiteAccount } from "~/types"
+import { TEMP_WINDOW_REQUEST_SOURCES } from "~/types/tempWindowFetch"
 
 vi.mock("~/services/apiTransport/request", () => ({
   fetchApi: vi.fn(),
@@ -81,7 +82,7 @@ describe("wongGongyiProvider", () => {
   })
 
   describe("checkIn", () => {
-    it("returns already_checked when POST indicates checked_in true", async () => {
+    it("propagates the popup source when POST indicates checked_in true", async () => {
       const { fetchApi } = await import("~/services/apiTransport/request")
       const mockedFetchApi = vi.mocked(fetchApi)
 
@@ -91,10 +92,13 @@ describe("wongGongyiProvider", () => {
         data: { enabled: true, checked_in: true },
       })
 
-      const result = await wongGongyiProvider.checkIn(mockAccount)
+      const result = await wongGongyiProvider.checkIn(mockAccount, {
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+      })
       expect(result.status).toBe("already_checked")
       expect(mockedFetchApi.mock.calls[0]?.[0]).toMatchObject({
         accountId: "test-id",
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
       })
       expect(result.messageKey).toBe(
         "autoCheckin:providerFallback.alreadyCheckedToday",
@@ -113,6 +117,9 @@ describe("wongGongyiProvider", () => {
 
       const result = await wongGongyiProvider.checkIn(mockAccount)
       expect(result.status).toBe("already_checked")
+      expect(mockedFetchApi.mock.calls[0]?.[0]).toMatchObject({
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Background,
+      })
     })
 
     it("returns failed when POST indicates enabled false", async () => {

--- a/tests/services/autoCheckin/scheduler.test.ts
+++ b/tests/services/autoCheckin/scheduler.test.ts
@@ -37,6 +37,7 @@ import {
 } from "~/services/productAnalytics/contracts"
 import { trackProductAnalyticsEvent } from "~/services/productAnalytics/dispatch"
 import { AUTO_CHECKIN_RUN_TYPE } from "~/types/autoCheckin"
+import { TEMP_WINDOW_REQUEST_SOURCES } from "~/types/tempWindowFetch"
 import {
   clearAlarm,
   createAlarm,
@@ -304,7 +305,10 @@ describe("autoCheckinScheduler.initialize", () => {
     await alarmListener(dailyAlarm)
     await alarmListener(retryAlarm)
 
-    expect(handleDailyAlarmSpy).toHaveBeenCalledWith(dailyAlarm)
+    expect(handleDailyAlarmSpy).toHaveBeenCalledWith(
+      dailyAlarm,
+      TEMP_WINDOW_REQUEST_SOURCES.Background,
+    )
     expect(handleRetryAlarmSpy).toHaveBeenCalledWith(retryAlarm)
 
     handleDailyAlarmSpy.mockRestore()
@@ -1057,7 +1061,7 @@ describe("autoCheckinScheduler daily+retry behavior", () => {
 
     const provider = {
       canCheckIn: vi.fn(() => true),
-      checkIn: vi.fn(async (account: any) => {
+      checkIn: vi.fn(async (account: any, _context?: unknown) => {
         if (account.id === "a") {
           return { status: "already_checked" }
         }
@@ -1335,6 +1339,7 @@ describe("autoCheckinScheduler daily+retry behavior", () => {
       checkIn: { enableDetection: true },
     }
     mockedAccountStorage.getAccountById.mockResolvedValue(accountB)
+    mockedAccountStorage.getAllAccounts.mockResolvedValue([accountB])
 
     const provider = {
       canCheckIn: vi.fn(() => true),
@@ -1350,6 +1355,9 @@ describe("autoCheckinScheduler daily+retry behavior", () => {
     expect(provider.checkIn).toHaveBeenCalledTimes(1)
     expect(provider.checkIn).toHaveBeenCalledWith(
       expect.objectContaining({ id: "b" }),
+      {
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Background,
+      },
     )
     expect(storedStatus.retryState).toBeUndefined()
     expect(storedStatus.pendingRetry).toBe(false)
@@ -1800,7 +1808,7 @@ describe("autoCheckinScheduler daily+retry behavior", () => {
     vi.useRealTimers()
   })
 
-  it("processes mixed retry outcomes and keeps only failed accounts queued", async () => {
+  it("processes mixed retry outcomes and preserves the background post-checkin refresh source", async () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date(2024, 0, 1, 9, 30, 0))
 
@@ -1900,7 +1908,7 @@ describe("autoCheckinScheduler daily+retry behavior", () => {
 
     const provider = {
       canCheckIn: vi.fn(() => true),
-      checkIn: vi.fn(async (account: any) => {
+      checkIn: vi.fn(async (account: any, _context?: unknown) => {
         if (account.id === "success") {
           return { status: "success", rawMessage: "ok" }
         }
@@ -1917,6 +1925,11 @@ describe("autoCheckinScheduler daily+retry behavior", () => {
     await (autoCheckinScheduler as any).runRetryCheckins()
 
     expect(provider.checkIn).toHaveBeenCalledTimes(2)
+    for (const call of provider.checkIn.mock.calls) {
+      expect(call[1]).toEqual({
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Background,
+      })
+    }
     expect(storedStatus.perAccount.disabled).toMatchObject({
       status: "skipped",
       reasonCode: "account_disabled",
@@ -1934,10 +1947,14 @@ describe("autoCheckinScheduler daily+retry behavior", () => {
         failed: 2,
       },
     })
+    expect(storedStatus.retryState).not.toHaveProperty(
+      "tempWindowRequestSource",
+    )
     expect(storedStatus.pendingRetry).toBe(true)
     expect(refreshSpy).toHaveBeenCalledWith({
       accountIds: ["success"],
       force: true,
+      tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Background,
     })
     expect(mockedBrowserApi.sendRuntimeMessage).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -2959,6 +2976,9 @@ describe("autoCheckinScheduler targeting support", () => {
     expect(provider.checkIn).toHaveBeenCalledTimes(1)
     expect(provider.checkIn).toHaveBeenCalledWith(
       expect.objectContaining({ id: "target" }),
+      {
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Background,
+      },
     )
     expect(storedStatus.perAccount.target).toMatchObject({
       status: "success",
@@ -3123,6 +3143,9 @@ describe("autoCheckinScheduler targeting support", () => {
     expect(provider.checkIn).toHaveBeenCalledTimes(1)
     expect(provider.checkIn).toHaveBeenCalledWith(
       expect.objectContaining({ id: "a" }),
+      {
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Background,
+      },
     )
 
     vi.useRealTimers()
@@ -3239,7 +3262,7 @@ describe("autoCheckinScheduler run-completed notifications", () => {
     vi.clearAllMocks()
   })
 
-  it("emits autoCheckin:runCompleted when notifyUiOnCompletion is enabled", async () => {
+  it("emits run completion after preserving the popup source through post-checkin refresh", async () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date(2024, 0, 1, 9, 0, 0))
 
@@ -3307,9 +3330,16 @@ describe("autoCheckinScheduler run-completed notifications", () => {
 
     await autoCheckinScheduler.runCheckins({
       runType: AUTO_CHECKIN_RUN_TYPE.MANUAL,
+      tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
     })
 
-    expect(mockedAccountStorage.refreshAccount).toHaveBeenCalledWith("a", true)
+    expect(mockedAccountStorage.refreshAccount).toHaveBeenCalledWith(
+      "a",
+      true,
+      {
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+      },
+    )
     expect(mockedBrowserApi.sendRuntimeMessage).toHaveBeenCalledWith(
       expect.objectContaining({
         action: RuntimeActionIds.AutoCheckinRunCompleted,
@@ -3377,7 +3407,13 @@ describe("autoCheckinScheduler run-completed notifications", () => {
       runType: AUTO_CHECKIN_RUN_TYPE.MANUAL,
     })
 
-    expect(mockedAccountStorage.refreshAccount).toHaveBeenCalledWith("a", true)
+    expect(mockedAccountStorage.refreshAccount).toHaveBeenCalledWith(
+      "a",
+      true,
+      {
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Background,
+      },
+    )
     expect(mockedBrowserApi.sendRuntimeMessage).toHaveBeenCalledWith(
       expect.objectContaining({
         action: RuntimeActionIds.AutoCheckinRunCompleted,
@@ -3440,7 +3476,13 @@ describe("autoCheckinScheduler run-completed notifications", () => {
       runType: AUTO_CHECKIN_RUN_TYPE.MANUAL,
     })
 
-    expect(mockedAccountStorage.refreshAccount).toHaveBeenCalledWith("a", true)
+    expect(mockedAccountStorage.refreshAccount).toHaveBeenCalledWith(
+      "a",
+      true,
+      {
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Background,
+      },
+    )
     expect(mockedBrowserApi.sendRuntimeMessage).not.toHaveBeenCalledWith(
       expect.objectContaining({
         action: RuntimeActionIds.AutoCheckinRunCompleted,
@@ -3466,6 +3508,7 @@ describe("auto check-in operation helpers", () => {
     expect(runSpy).toHaveBeenCalledWith({
       runType: AUTO_CHECKIN_RUN_TYPE.MANUAL,
       targetAccountIds: undefined,
+      tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Background,
     })
   })
 
@@ -3480,6 +3523,7 @@ describe("auto check-in operation helpers", () => {
     expect(runSpy).toHaveBeenCalledWith({
       runType: AUTO_CHECKIN_RUN_TYPE.MANUAL,
       targetAccountIds: ["a"],
+      tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Background,
     })
   })
 
@@ -3494,6 +3538,7 @@ describe("auto check-in operation helpers", () => {
     expect(runSpy).toHaveBeenCalledWith({
       runType: AUTO_CHECKIN_RUN_TYPE.MANUAL,
       targetAccountIds: ["a", "b"],
+      tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Background,
     })
   })
 
@@ -3576,7 +3621,39 @@ describe("auto check-in operation helpers", () => {
       success: true,
     })
 
-    expect(retrySpy).toHaveBeenCalledWith("account-1")
+    expect(retrySpy).toHaveBeenCalledWith(
+      "account-1",
+      TEMP_WINDOW_REQUEST_SOURCES.Background,
+    )
+  })
+
+  it("passes valid popup source through the manual retry message boundary", async () => {
+    const retrySpy = vi
+      .spyOn(autoCheckinScheduler as any, "retryAccount")
+      .mockResolvedValueOnce(undefined)
+
+    await retryAutoCheckinAccount(
+      "account-1",
+      TEMP_WINDOW_REQUEST_SOURCES.Popup,
+    )
+
+    expect(retrySpy).toHaveBeenCalledWith(
+      "account-1",
+      TEMP_WINDOW_REQUEST_SOURCES.Popup,
+    )
+  })
+
+  it("normalizes invalid manual retry source to background", async () => {
+    const retrySpy = vi
+      .spyOn(autoCheckinScheduler as any, "retryAccount")
+      .mockResolvedValueOnce(undefined)
+
+    await retryAutoCheckinAccount("account-1", "invalid-source")
+
+    expect(retrySpy).toHaveBeenCalledWith(
+      "account-1",
+      TEMP_WINDOW_REQUEST_SOURCES.Background,
+    )
   })
 
   it("should surface retryAccount failures back to the caller", async () => {
@@ -3592,7 +3669,10 @@ describe("auto check-in operation helpers", () => {
       "retry failed",
     )
 
-    expect(retrySpy).toHaveBeenCalledWith("account-1")
+    expect(retrySpy).toHaveBeenCalledWith(
+      "account-1",
+      TEMP_WINDOW_REQUEST_SOURCES.Background,
+    )
   })
 
   it("should reject retry requests without an accountId", async () => {
@@ -3686,13 +3766,14 @@ describe("auto check-in operation helpers", () => {
     expect(updateSpy).toHaveBeenCalledWith(settings)
   })
 
-  it("should pretrigger daily run on autoCheckin:pretriggerDailyOnUiOpen", async () => {
+  it("normalizes a popup source at the pretrigger message boundary", async () => {
     const pretriggerSpy = vi
       .spyOn(autoCheckinScheduler as any, "pretriggerDailyOnUiOpen")
       .mockResolvedValueOnce({ started: false, eligible: false })
     await expect(
       pretriggerAutoCheckinDailyOnUiOpen({
         requestId: "req-1",
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
       }),
     ).resolves.toEqual({
       success: true,
@@ -3700,9 +3781,47 @@ describe("auto check-in operation helpers", () => {
       eligible: false,
     })
 
+    expect(pretriggerSpy).toHaveBeenCalledWith({
+      requestId: "req-1",
+      dryRun: undefined,
+      debug: undefined,
+      tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+    })
+  })
+
+  it("normalizes an invalid pretrigger source to background", async () => {
+    const pretriggerSpy = vi
+      .spyOn(autoCheckinScheduler as any, "pretriggerDailyOnUiOpen")
+      .mockResolvedValueOnce({ started: false, eligible: false })
+
+    await pretriggerAutoCheckinDailyOnUiOpen({
+      tempWindowRequestSource: "invalid-source",
+    } as any)
+
     expect(pretriggerSpy).toHaveBeenCalledWith(
-      expect.objectContaining({ requestId: "req-1" }),
+      expect.objectContaining({
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Background,
+      }),
     )
+  })
+
+  it("normalizes the manual run source once at the message boundary", async () => {
+    const runSpy = vi
+      .spyOn(autoCheckinScheduler as any, "runCheckins")
+      .mockResolvedValueOnce(undefined)
+    vi.spyOn(autoCheckinScheduler as any, "scheduleNextRun").mockResolvedValue(
+      undefined,
+    )
+
+    await runAutoCheckinNow({
+      tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+    })
+
+    expect(runSpy).toHaveBeenCalledWith({
+      runType: AUTO_CHECKIN_RUN_TYPE.MANUAL,
+      targetAccountIds: undefined,
+      tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+    })
   })
 
   it("should reset lastDailyRunDay on autoCheckin:debugResetLastDailyRunDay", async () => {
@@ -3783,6 +3902,7 @@ describe("auto check-in operation helpers", () => {
     expect(runSpy).toHaveBeenCalledWith({
       runType: AUTO_CHECKIN_RUN_TYPE.MANUAL,
       targetAccountIds: undefined,
+      tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Background,
     })
     expect(scheduleSpy).toHaveBeenCalledWith({ preserveExisting: true })
   })
@@ -3972,7 +4092,10 @@ describe("autoCheckinScheduler.retryAccount", () => {
       .spyOn(autoCheckinScheduler as any, "scheduleRetryAlarm")
       .mockResolvedValue(undefined)
 
-    const result = await autoCheckinScheduler.retryAccount("retry-1")
+    const result = await autoCheckinScheduler.retryAccount(
+      "retry-1",
+      TEMP_WINDOW_REQUEST_SOURCES.Popup,
+    )
 
     expect(result.result.status).toBe("success")
     expect(result.pendingRetry).toBe(false)
@@ -3983,6 +4106,9 @@ describe("autoCheckinScheduler.retryAccount", () => {
       successCount: 1,
       failedCount: 0,
       needsRetry: false,
+    })
+    expect(provider.checkIn).toHaveBeenCalledWith(account, {
+      tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
     })
     expect(scheduleRetrySpy).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -4852,6 +4978,28 @@ describe("autoCheckinScheduler daily alarm helpers", () => {
     vi.clearAllMocks()
   })
 
+  it("defaults daily alarm runs to the background source", async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-01-23T09:00:00"))
+    const runSpy = vi
+      .spyOn(autoCheckinScheduler as any, "runCheckins")
+      .mockResolvedValueOnce(undefined)
+    vi.spyOn(autoCheckinScheduler as any, "scheduleNextRun").mockResolvedValue(
+      undefined,
+    )
+
+    await (autoCheckinScheduler as any).handleDailyAlarm({
+      name: "autoCheckinDaily",
+      scheduledTime: Date.now(),
+    })
+
+    expect(runSpy).toHaveBeenCalledWith({
+      runType: AUTO_CHECKIN_RUN_TYPE.DAILY,
+      tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Background,
+    })
+    vi.useRealTimers()
+  })
+
   it("ignores duplicate daily alarms while a run for today is already in flight", async () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date("2026-01-23T09:00:00"))
@@ -5075,10 +5223,13 @@ describe("autoCheckinScheduler debug helpers", () => {
 
     await autoCheckinScheduler.debugTriggerDailyAlarmNow()
 
-    expect(handleDailyAlarmSpy).toHaveBeenCalledWith({
-      name: "autoCheckinDaily",
-      scheduledTime: Date.now(),
-    })
+    expect(handleDailyAlarmSpy).toHaveBeenCalledWith(
+      {
+        name: "autoCheckinDaily",
+        scheduledTime: Date.now(),
+      },
+      TEMP_WINDOW_REQUEST_SOURCES.Background,
+    )
 
     vi.useRealTimers()
   })
@@ -5205,7 +5356,7 @@ describe("autoCheckinScheduler private helpers", () => {
     vi.clearAllMocks()
   })
 
-  it("refreshes unique accounts in batches and preserves an explicit force flag", async () => {
+  it("preserves a temp window source through post-checkin refresh batches", async () => {
     mockedAccountStorage.refreshAccount
       .mockResolvedValueOnce({ refreshed: true })
       .mockResolvedValueOnce(null)
@@ -5215,6 +5366,7 @@ describe("autoCheckinScheduler private helpers", () => {
       (autoCheckinScheduler as any).refreshAccountsAfterSuccessfulCheckins({
         accountIds: ["a", "a", " ", "b", "c"],
         force: false,
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
       }),
     ).resolves.toBeUndefined()
 
@@ -5223,16 +5375,25 @@ describe("autoCheckinScheduler private helpers", () => {
       1,
       "a",
       false,
+      {
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+      },
     )
     expect(mockedAccountStorage.refreshAccount).toHaveBeenNthCalledWith(
       2,
       "b",
       false,
+      {
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+      },
     )
     expect(mockedAccountStorage.refreshAccount).toHaveBeenNthCalledWith(
       3,
       "c",
       false,
+      {
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+      },
     )
   })
 
@@ -5618,6 +5779,33 @@ describe("autoCheckinScheduler private helpers", () => {
       },
     })
     expect(throwingProvider.checkIn).toHaveBeenCalledTimes(1)
+  })
+
+  it("retains one normalized source across account batches", async () => {
+    const accounts = [
+      { id: "source-a", site_name: "Source A" },
+      { id: "source-b", site_name: "Source B" },
+    ] as any[]
+    const provider = {
+      checkIn: vi.fn().mockResolvedValue({ status: "success" }),
+    }
+    mockedProviders.resolveAutoCheckinProvider.mockReturnValue(provider as any)
+
+    await (autoCheckinScheduler as any).runAccountCheckinsInBatches({
+      accounts,
+      accountDisplayNameById: new Map([
+        ["source-a", "Source A"],
+        ["source-b", "Source B"],
+      ]),
+      tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+    })
+
+    expect(provider.checkIn).toHaveBeenCalledTimes(2)
+    for (const call of provider.checkIn.mock.calls) {
+      expect(call[1]).toEqual({
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+      })
+    }
   })
 
   it("marks accounts checked in for successful and already-checked outcomes", async () => {

--- a/tests/services/autoDetectService.test.ts
+++ b/tests/services/autoDetectService.test.ts
@@ -10,12 +10,14 @@ import { ACCOUNT_BROWSER_SESSION_SOURCES } from "~/services/accountBrowserSessio
 import { API_SERVICE_FETCH_CONTEXT_KINDS } from "~/services/apiTransport/type"
 import { autoDetectSmart } from "~/services/siteDetection/autoDetectService"
 import { AuthTypeEnum } from "~/types"
+import { TEMP_WINDOW_REQUEST_SOURCES } from "~/types/tempWindowFetch"
 
 const {
   mockFetchUserInfo,
   mockGetActiveOrAllTabs,
   mockGetActiveTabs,
   mockGetAccountSiteType,
+  mockGetCurrentTempWindowRequestSource,
   mockgetSiteTypeCapabilities,
   mockIsMessageReceiverUnavailableError,
   mockReadAccountBrowserSessionFromTab,
@@ -25,6 +27,7 @@ const {
   mockGetActiveOrAllTabs: vi.fn(),
   mockGetActiveTabs: vi.fn(),
   mockGetAccountSiteType: vi.fn(),
+  mockGetCurrentTempWindowRequestSource: vi.fn(),
   mockgetSiteTypeCapabilities: vi.fn(),
   mockIsMessageReceiverUnavailableError: vi.fn(),
   mockReadAccountBrowserSessionFromTab: vi.fn(),
@@ -62,6 +65,10 @@ vi.mock("~/utils/browser/browserApi", async (importOriginal) => {
   }
 })
 
+vi.mock("~/utils/browser/tempWindowRequestSource", () => ({
+  getCurrentTempWindowRequestSource: mockGetCurrentTempWindowRequestSource,
+}))
+
 describe("autoDetectSmart", () => {
   const browserAny = globalThis.browser as any
   const originalRuntime = browserAny.runtime
@@ -85,6 +92,9 @@ describe("autoDetectSmart", () => {
     }
 
     mockGetAccountSiteType.mockResolvedValue(SITE_TYPES.NEW_API)
+    mockGetCurrentTempWindowRequestSource.mockReturnValue(
+      TEMP_WINDOW_REQUEST_SOURCES.Background,
+    )
     mockGetActiveOrAllTabs.mockResolvedValue([])
     mockGetActiveTabs.mockResolvedValue([])
     mockIsMessageReceiverUnavailableError.mockReturnValue(false)
@@ -623,42 +633,40 @@ describe("autoDetectSmart", () => {
       action: expect.any(String),
       requestId: expect.any(String),
       url: "https://aihubmix.com",
+      tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Background,
     })
     expect(mockFetchUserInfo).not.toHaveBeenCalled()
   })
 
-  it("suppresses temp-window minimization when background detection starts from the extension popup", async () => {
-    ;(globalThis as any).window = {
-      location: {
-        href: "chrome-extension://extension-id/popup.html",
-      },
-    }
-    mockGetAccountSiteType.mockResolvedValue(SITE_TYPES.AIHUBMIX)
+  it("captures popup temp-window source once and propagates it through background and API fallback", async () => {
+    mockGetCurrentTempWindowRequestSource
+      .mockReturnValueOnce(TEMP_WINDOW_REQUEST_SOURCES.Popup)
+      .mockReturnValue(TEMP_WINDOW_REQUEST_SOURCES.Background)
     mockGetActiveOrAllTabs.mockResolvedValue([
       {
         id: 2,
         active: true,
-        url: "https://console.aihubmix.com/statistics",
+        url: "https://other.example.invalid/statistics",
       },
     ])
-    mockSendRuntimeMessage.mockResolvedValue({
-      success: true,
-      data: {
-        userId: "7",
-        user: { id: 7, username: "aihubmix-user" },
-        accessToken: "console-session-token",
-        siteTypeHint: SITE_TYPES.AIHUBMIX,
-      },
-    })
+    mockSendRuntimeMessage.mockResolvedValue(null)
 
-    const result = await autoDetectSmart("https://aihubmix.com")
+    const result = await autoDetectSmart("https://example.invalid")
 
     expect(result.success).toBe(true)
     expect(mockSendRuntimeMessage).toHaveBeenCalledWith({
       action: expect.any(String),
       requestId: expect.any(String),
-      url: "https://aihubmix.com",
-      suppressMinimize: true,
+      url: "https://example.invalid",
+      tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+    })
+    expect(mockGetCurrentTempWindowRequestSource).toHaveBeenCalledTimes(1)
+    expect(mockFetchUserInfo).toHaveBeenCalledWith({
+      baseUrl: "https://example.invalid",
+      auth: {
+        authType: AuthTypeEnum.Cookie,
+      },
+      tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
     })
   })
 
@@ -818,6 +826,7 @@ describe("autoDetectSmart", () => {
       action: expect.any(String),
       requestId: expect.any(String),
       url: "https://example.com/console",
+      tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Background,
       useIncognito: true,
       cookieStoreId: "1-incognito",
     })
@@ -861,6 +870,7 @@ describe("autoDetectSmart", () => {
       action: expect.any(String),
       requestId: expect.any(String),
       url: "https://example.com/console",
+      tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Background,
       useIncognito: true,
       cookieStoreId: "1-incognito",
     })
@@ -901,21 +911,24 @@ describe("autoDetectSmart", () => {
     expect(result.data).not.toHaveProperty("fetchContext")
   })
 
-  it("falls back to direct detection when background auto-detect throws", async () => {
+  it("preserves popup temp-window source when background auto-detect throws", async () => {
+    mockGetCurrentTempWindowRequestSource
+      .mockReturnValueOnce(TEMP_WINDOW_REQUEST_SOURCES.Popup)
+      .mockReturnValue(TEMP_WINDOW_REQUEST_SOURCES.Background)
     mockGetActiveOrAllTabs.mockResolvedValue([
       {
         id: 23,
         active: true,
-        url: "https://different.example.com/home",
+        url: "https://different.example.invalid/home",
       },
     ])
     mockSendRuntimeMessage.mockRejectedValueOnce(new Error("runtime failed"))
     mockFetchUserInfo.mockResolvedValueOnce({
       id: 23,
-      username: "direct-after-runtime-throw",
+      username: "api-after-runtime-throw",
     })
 
-    const result = await autoDetectSmart("https://example.com/console")
+    const result = await autoDetectSmart("https://example.invalid/console")
 
     expect(result).toMatchObject({
       success: true,
@@ -923,14 +936,22 @@ describe("autoDetectSmart", () => {
         userId: "23",
         user: {
           id: 23,
-          username: "direct-after-runtime-throw",
+          username: "api-after-runtime-throw",
         },
         siteType: SITE_TYPES.NEW_API,
         accessToken: undefined,
         sub2apiAuth: undefined,
       },
     })
+    expect(mockGetCurrentTempWindowRequestSource).toHaveBeenCalledTimes(1)
     expect(mockFetchUserInfo).toHaveBeenCalledTimes(1)
+    expect(mockFetchUserInfo).toHaveBeenCalledWith({
+      baseUrl: "https://example.invalid/console",
+      auth: {
+        authType: AuthTypeEnum.Cookie,
+      },
+      tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+    })
   })
 
   it("falls back to direct detection when API fallback after background data miss throws", async () => {
@@ -1020,6 +1041,7 @@ describe("autoDetectSmart", () => {
         incognito: true,
         cookieStoreId: "1-incognito",
       },
+      tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Background,
     })
   })
 

--- a/tests/services/autoDetectService.test.ts
+++ b/tests/services/autoDetectService.test.ts
@@ -670,6 +670,58 @@ describe("autoDetectSmart", () => {
     })
   })
 
+  it.each([
+    ["missing", undefined],
+    ["blank", "   "],
+  ])(
+    "uses API fallback for a successful background result with a %s user id and preserves Popup source",
+    async (_label, userId) => {
+      mockGetCurrentTempWindowRequestSource
+        .mockReturnValueOnce(TEMP_WINDOW_REQUEST_SOURCES.Popup)
+        .mockReturnValue(TEMP_WINDOW_REQUEST_SOURCES.Background)
+      mockGetActiveOrAllTabs.mockResolvedValue([
+        {
+          id: 3,
+          active: true,
+          url: "https://other.example.invalid/statistics",
+        },
+      ])
+      mockSendRuntimeMessage.mockResolvedValueOnce({
+        success: true,
+        data: {
+          userId,
+          user: { username: "background-user-without-id" },
+        },
+      })
+      mockFetchUserInfo.mockResolvedValueOnce({
+        id: 31,
+        username: "api-fallback-user",
+      })
+
+      const result = await autoDetectSmart("https://example.invalid")
+
+      expect(result).toMatchObject({
+        success: true,
+        data: {
+          userId: "31",
+          user: {
+            id: 31,
+            username: "api-fallback-user",
+          },
+          siteType: SITE_TYPES.NEW_API,
+        },
+      })
+      expect(mockGetCurrentTempWindowRequestSource).toHaveBeenCalledTimes(1)
+      expect(mockFetchUserInfo).toHaveBeenCalledWith({
+        baseUrl: "https://example.invalid",
+        auth: {
+          authType: AuthTypeEnum.Cookie,
+        },
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+      })
+    },
+  )
+
   it("uses current-tab detection for AIHubMix when the active tab is the API origin", async () => {
     mockGetAccountSiteType.mockResolvedValue(SITE_TYPES.AIHUBMIX)
     mockGetActiveOrAllTabs.mockResolvedValue([

--- a/tests/services/runtimeTypedMessagingSetup.test.ts
+++ b/tests/services/runtimeTypedMessagingSetup.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
+import { TEMP_WINDOW_REQUEST_SOURCES } from "~/types/tempWindowFetch"
+
 type RuntimeMessageHandler = (input?: { data?: unknown }) => Promise<unknown>
 type OnMessageMock = ReturnType<
   typeof vi.fn<(type: string, handler: RuntimeMessageHandler) => () => void>
@@ -1006,6 +1008,7 @@ describe("typed runtime messaging setup", () => {
     expect(runCheckins).toHaveBeenCalledWith({
       runType: "manual",
       targetAccountIds: ["a", "b"],
+      tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Background,
     })
     expect(scheduleNextRun).toHaveBeenCalledWith({ preserveExisting: true })
     expect(debugScheduleDailyAlarmForToday).toHaveBeenCalledWith({
@@ -1015,7 +1018,12 @@ describe("typed runtime messaging setup", () => {
       requestId: "request-1",
       dryRun: true,
       debug: undefined,
+      tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Background,
     })
+    expect(retryAccount).toHaveBeenCalledWith(
+      "account-1",
+      TEMP_WINDOW_REQUEST_SOURCES.Background,
+    )
     expect(getAccountDisplayData).toHaveBeenCalledWith("account-1", {
       includeDisabled: true,
     })

--- a/tests/utils/browser.test.ts
+++ b/tests/utils/browser.test.ts
@@ -6,6 +6,7 @@ import {
   getDeviceTypeInfo,
   isEdgeByUA,
   isExtensionBackground,
+  isExtensionOptions,
   isExtensionPopup,
   isExtensionSidePanel,
   isFirefoxByUA,
@@ -220,13 +221,23 @@ describe("browser", () => {
   })
 
   describe("extension page detection", () => {
-    it("detects popup and sidepanel extension URLs from window.location", () => {
+    it("detects popup, options, and sidepanel extension URLs from window.location", () => {
       vi.stubGlobal("window", {
         location: {
           href: "moz-extension://abc/popup.html",
         },
       })
       expect(isExtensionPopup()).toBe(true)
+      expect(isExtensionOptions()).toBe(false)
+      expect(isExtensionSidePanel()).toBe(false)
+
+      vi.stubGlobal("window", {
+        location: {
+          href: "moz-extension://abc/options.html",
+        },
+      })
+      expect(isExtensionPopup()).toBe(false)
+      expect(isExtensionOptions()).toBe(true)
       expect(isExtensionSidePanel()).toBe(false)
 
       vi.stubGlobal("window", {
@@ -235,6 +246,7 @@ describe("browser", () => {
         },
       })
       expect(isExtensionPopup()).toBe(false)
+      expect(isExtensionOptions()).toBe(false)
       expect(isExtensionSidePanel()).toBe(true)
     })
 
@@ -245,6 +257,7 @@ describe("browser", () => {
         },
       })
       expect(isExtensionPopup()).toBe(false)
+      expect(isExtensionOptions()).toBe(false)
       expect(isExtensionSidePanel()).toBe(false)
     })
 
@@ -252,6 +265,7 @@ describe("browser", () => {
       vi.stubGlobal("window", undefined)
 
       expect(isExtensionPopup()).toBe(false)
+      expect(isExtensionOptions()).toBe(false)
       expect(isExtensionSidePanel()).toBe(false)
     })
   })

--- a/tests/utils/tempWindowFetch.background.test.ts
+++ b/tests/utils/tempWindowFetch.background.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest"
 
 import { RuntimeActionIds } from "~/constants/runtimeActions"
+import { TEMP_WINDOW_REQUEST_SOURCES } from "~/types/tempWindowFetch"
 import {
   tempWindowFetch,
   tempWindowGetRenderedTitle,
@@ -64,6 +65,7 @@ describe("tempWindowFetch helpers (background context)", () => {
       expect.objectContaining({
         originUrl: "https://example.com",
         fetchUrl: "https://example.com/api/test",
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Background,
         suppressMinimize: false,
       }),
       expect.any(Function),
@@ -119,6 +121,7 @@ describe("tempWindowFetch helpers (background context)", () => {
         originUrl: "https://example.com",
         pageUrl: "https://example.com/checkin",
         fetchUrl: "https://example.com/api/checkin",
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Background,
         suppressMinimize: false,
       }),
       expect.any(Function),
@@ -162,6 +165,13 @@ describe("tempWindowFetch helpers (background context)", () => {
     })
 
     expect(handleTempWindowCheckinPageActionMock).toHaveBeenCalledTimes(1)
+    expect(handleTempWindowCheckinPageActionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Background,
+        suppressMinimize: false,
+      }),
+      expect.any(Function),
+    )
     expect(response).toMatchObject({
       success: true,
       reason: "clicked",
@@ -218,6 +228,7 @@ describe("tempWindowFetch helpers (background context)", () => {
       expect.objectContaining({
         action: RuntimeActionIds.TempWindowGetRenderedTitle,
         originUrl: "https://example.com",
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Background,
         suppressMinimize: false,
       }),
       expect.any(Function),

--- a/tests/utils/tempWindowFetch.fallback.test.ts
+++ b/tests/utils/tempWindowFetch.fallback.test.ts
@@ -3,7 +3,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { RuntimeActionIds } from "~/constants/runtimeActions"
 import { API_ERROR_CODES, ApiError } from "~/services/apiTransport/errors"
 import { AuthTypeEnum, TEMP_WINDOW_HEALTH_STATUS_CODES } from "~/types"
-import type { TempWindowFallbackContext } from "~/types/tempWindowFetch"
+import {
+  TEMP_WINDOW_REQUEST_SOURCES,
+  type TempWindowFallbackContext,
+} from "~/types/tempWindowFetch"
 import {
   canUseTempWindowFetch,
   executeWithTempWindowFallback,
@@ -17,11 +20,13 @@ import {
 const mocks = vi.hoisted(() => ({
   sendRuntimeMessageMock: vi.fn(),
   handleTempWindowFetchMock: vi.fn(),
+  handleTempWindowCheckinPageActionMock: vi.fn(),
   handleTempWindowTurnstileFetchMock: vi.fn(),
   handleTempWindowGetRenderedTitleMock: vi.fn(),
   hasCookieInterceptorPermissionsMock: vi.fn(),
   getPreferencesMock: vi.fn(),
   isExtensionBackgroundMock: vi.fn(),
+  isExtensionOptionsMock: vi.fn(),
   isExtensionPopupMock: vi.fn(),
   isExtensionSidePanelMock: vi.fn(),
   isProtectionBypassFirefoxEnvMock: vi.fn(),
@@ -49,6 +54,8 @@ vi.mock("~/utils/browser/browserApi", () => ({
 
 vi.mock("~/entrypoints/background/tempWindowPool", () => ({
   handleTempWindowFetch: mocks.handleTempWindowFetchMock,
+  handleTempWindowCheckinPageAction:
+    mocks.handleTempWindowCheckinPageActionMock,
   handleTempWindowTurnstileFetch: mocks.handleTempWindowTurnstileFetchMock,
   handleTempWindowGetRenderedTitle: mocks.handleTempWindowGetRenderedTitleMock,
 }))
@@ -69,6 +76,7 @@ vi.mock("~/services/preferences/userPreferences", () => ({
 
 vi.mock("~/utils/browser/index", () => ({
   isExtensionBackground: mocks.isExtensionBackgroundMock,
+  isExtensionOptions: mocks.isExtensionOptionsMock,
   isExtensionPopup: mocks.isExtensionPopupMock,
   isExtensionSidePanel: mocks.isExtensionSidePanelMock,
 }))
@@ -132,6 +140,7 @@ describe("tempWindowFetch runtime helpers and fallback gating", () => {
       tempWindowFallback: buildTempWindowPreferences(),
     })
     mocks.isExtensionBackgroundMock.mockReturnValue(false)
+    mocks.isExtensionOptionsMock.mockReturnValue(false)
     mocks.isExtensionPopupMock.mockReturnValue(false)
     mocks.isExtensionSidePanelMock.mockReturnValue(false)
     mocks.isProtectionBypassFirefoxEnvMock.mockReturnValue(false)
@@ -245,6 +254,7 @@ describe("tempWindowFetch runtime helpers and fallback gating", () => {
       originUrl: "https://example.com",
       fetchUrl: "https://example.com/api/models",
       fetchOptions: { method: "POST" },
+      tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
       suppressMinimize: true,
     })
   })
@@ -288,6 +298,7 @@ describe("tempWindowFetch runtime helpers and fallback gating", () => {
       action: RuntimeActionIds.TempWindowFetch,
       originUrl: "https://example.com",
       fetchUrl: "https://example.com/api/models",
+      tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Background,
       suppressMinimize: false,
     })
   })
@@ -306,6 +317,7 @@ describe("tempWindowFetch runtime helpers and fallback gating", () => {
       pageUrl: "https://example.com/checkin",
       fetchUrl: "https://example.com/api/checkin",
       fetchOptions: { method: "POST" },
+      tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
       suppressMinimize: false,
     })
 
@@ -320,6 +332,7 @@ describe("tempWindowFetch runtime helpers and fallback gating", () => {
       pageUrl: "https://example.com/checkin",
       fetchUrl: "https://example.com/api/checkin",
       fetchOptions: { method: "POST" },
+      tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
       suppressMinimize: false,
     })
   })
@@ -368,6 +381,7 @@ describe("tempWindowFetch runtime helpers and fallback gating", () => {
       originUrl: "https://example.com",
       pageUrl: "https://example.com/checkin",
       fetchUrl: "https://example.com/api/checkin",
+      tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Background,
       suppressMinimize: false,
     })
   })
@@ -386,6 +400,7 @@ describe("tempWindowFetch runtime helpers and fallback gating", () => {
       siteType: "new-api",
       expectedUserId: "target-user",
       requestId: "req-native-runtime",
+      tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Background,
       suppressMinimize: true,
     })
 
@@ -396,6 +411,7 @@ describe("tempWindowFetch runtime helpers and fallback gating", () => {
       siteType: "new-api",
       expectedUserId: "target-user",
       requestId: "req-native-runtime",
+      tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Background,
       suppressMinimize: true,
     })
     expect(response.reason).toBe("identity_mismatch")
@@ -420,9 +436,114 @@ describe("tempWindowFetch runtime helpers and fallback gating", () => {
     expect(mocks.sendRuntimeMessageMock).toHaveBeenCalledWith({
       action: RuntimeActionIds.TempWindowGetRenderedTitle,
       originUrl: "https://example.com",
+      tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
       suppressMinimize: true,
     })
   })
+
+  it("prefers the propagated popup source when fallback executes in background", async () => {
+    mocks.isProtectionBypassFirefoxEnvMock.mockReturnValue(true)
+
+    await expect(
+      getTempWindowFallbackBlockStatus({
+        preferences: buildTempWindowPreferences(),
+        isBackground: true,
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+      }),
+    ).resolves.toEqual({
+      kind: "not_applicable",
+      code: null,
+      reason: "firefox_popup_unsupported",
+    })
+  })
+
+  it("returns structured failures without dispatching Firefox popup requests", async () => {
+    mocks.isProtectionBypassFirefoxEnvMock.mockReturnValue(true)
+    const popupSource = {
+      tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+    }
+
+    await expect(
+      tempWindowFetch({
+        originUrl: "https://example.invalid",
+        fetchUrl: "https://example.invalid/api/models",
+        ...popupSource,
+      }),
+    ).resolves.toMatchObject({ success: false, error: expect.any(String) })
+    await expect(
+      tempWindowTurnstileFetch({
+        originUrl: "https://example.invalid",
+        pageUrl: "https://example.invalid/checkin",
+        fetchUrl: "https://example.invalid/api/checkin",
+        ...popupSource,
+      }),
+    ).resolves.toMatchObject({
+      success: false,
+      error: expect.any(String),
+      turnstile: { status: "error", hasTurnstile: false },
+    })
+    await expect(
+      tempWindowTriggerCheckinPageAction({
+        originUrl: "https://example.invalid",
+        pageUrl: "https://example.invalid/console/personal",
+        siteType: "new-api",
+        expectedUserId: "target-user",
+        ...popupSource,
+      }),
+    ).resolves.toMatchObject({
+      success: false,
+      reason: "trigger_failed",
+      error: expect.any(String),
+    })
+    await expect(
+      tempWindowGetRenderedTitle({
+        originUrl: "https://example.invalid",
+        ...popupSource,
+      }),
+    ).resolves.toMatchObject({ success: false, error: expect.any(String) })
+
+    expect(mocks.sendRuntimeMessageMock).not.toHaveBeenCalled()
+    expect(mocks.handleTempWindowFetchMock).not.toHaveBeenCalled()
+    expect(mocks.handleTempWindowTurnstileFetchMock).not.toHaveBeenCalled()
+    expect(mocks.handleTempWindowCheckinPageActionMock).not.toHaveBeenCalled()
+    expect(mocks.handleTempWindowGetRenderedTitleMock).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    {
+      source: TEMP_WINDOW_REQUEST_SOURCES.Background,
+      suppressMinimize: false,
+    },
+    {
+      source: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+      suppressMinimize: true,
+    },
+  ])(
+    "uses $source source policy for generic fallback",
+    async ({ source, suppressMinimize }) => {
+      mocks.sendRuntimeMessageMock.mockResolvedValue({
+        success: true,
+        status: 200,
+        data: { success: true, data: { ok: true }, message: "ok" },
+      })
+
+      await executeWithTempWindowFallback(
+        buildContext({
+          forceTempWindow: true,
+          tempWindowRequestSource: source,
+        }),
+        async () => ({ success: true, data: { ok: false }, message: "direct" }),
+      )
+
+      expect(mocks.sendRuntimeMessageMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: RuntimeActionIds.TempWindowFetch,
+          tempWindowRequestSource: source,
+          suppressMinimize,
+        }),
+      )
+    },
+  )
 
   it("rethrows non-ApiError failures without attempting temp-window fallback", async () => {
     const networkError = new TypeError("socket hang up")
@@ -487,7 +608,8 @@ describe("tempWindowFetch runtime helpers and fallback gating", () => {
         fetchUrl: "https://example.com/api/models",
         requestId: "uuid:temp-fetch-https://example.com/api/models",
         responseType: "json",
-        suppressMinimize: true,
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Background,
+        suppressMinimize: false,
         accountId: "acct-1",
         authType: AuthTypeEnum.Cookie,
         cookieAuthSessionCookie: "session=abc",

--- a/tests/utils/tempWindowRequestSource.test.ts
+++ b/tests/utils/tempWindowRequestSource.test.ts
@@ -1,0 +1,175 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { TEMP_WINDOW_REQUEST_SOURCES } from "~/types/tempWindowFetch"
+import {
+  isExtensionBackground,
+  isExtensionOptions,
+  isExtensionPopup,
+  isExtensionSidePanel,
+} from "~/utils/browser"
+import { isProtectionBypassFirefoxEnv } from "~/utils/browser/protectionBypass"
+import {
+  getCurrentTempWindowRequestSource,
+  normalizeTempWindowRequestSource,
+  resolveTempWindowRequestPolicy,
+} from "~/utils/browser/tempWindowRequestSource"
+
+vi.mock("~/utils/browser", () => ({
+  isExtensionBackground: vi.fn(),
+  isExtensionOptions: vi.fn(),
+  isExtensionPopup: vi.fn(),
+  isExtensionSidePanel: vi.fn(),
+}))
+
+vi.mock("~/utils/browser/protectionBypass", () => ({
+  isProtectionBypassFirefoxEnv: vi.fn(),
+}))
+
+const mockedIsExtensionBackground = vi.mocked(isExtensionBackground)
+const mockedIsExtensionOptions = vi.mocked(isExtensionOptions)
+const mockedIsExtensionPopup = vi.mocked(isExtensionPopup)
+const mockedIsExtensionSidePanel = vi.mocked(isExtensionSidePanel)
+const mockedIsProtectionBypassFirefoxEnv = vi.mocked(
+  isProtectionBypassFirefoxEnv,
+)
+
+describe("tempWindowRequestSource", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockedIsExtensionBackground.mockReturnValue(false)
+    mockedIsExtensionOptions.mockReturnValue(false)
+    mockedIsExtensionPopup.mockReturnValue(false)
+    mockedIsExtensionSidePanel.mockReturnValue(false)
+    mockedIsProtectionBypassFirefoxEnv.mockReturnValue(false)
+  })
+
+  it.each([
+    [TEMP_WINDOW_REQUEST_SOURCES.Popup, true],
+    [TEMP_WINDOW_REQUEST_SOURCES.Options, false],
+    [TEMP_WINDOW_REQUEST_SOURCES.Sidepanel, false],
+    [TEMP_WINDOW_REQUEST_SOURCES.Background, false],
+  ])(
+    "resolves an explicit %s source with its default minimize policy",
+    (tempWindowRequestSource, suppressMinimize) => {
+      expect(
+        resolveTempWindowRequestPolicy({ tempWindowRequestSource }),
+      ).toEqual({
+        tempWindowRequestSource,
+        suppressMinimize,
+        blockedReason: null,
+      })
+    },
+  )
+
+  it("lets an explicit boolean override the source default", () => {
+    expect(
+      resolveTempWindowRequestPolicy({
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+        suppressMinimize: false,
+      }),
+    ).toMatchObject({ suppressMinimize: false })
+
+    expect(
+      resolveTempWindowRequestPolicy({
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Background,
+        suppressMinimize: true,
+      }),
+    ).toMatchObject({ suppressMinimize: true })
+  })
+
+  it("ignores non-boolean minimize overrides and uses the source policy", () => {
+    expect(
+      resolveTempWindowRequestPolicy({
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+        suppressMinimize: "false",
+      }),
+    ).toMatchObject({ suppressMinimize: true })
+  })
+
+  it("normalizes invalid runtime values to the background source", () => {
+    expect(normalizeTempWindowRequestSource("invalid-source")).toBe(
+      TEMP_WINDOW_REQUEST_SOURCES.Background,
+    )
+  })
+
+  it("captures the current surface only when the source is omitted", () => {
+    mockedIsExtensionPopup.mockReturnValue(true)
+
+    expect(resolveTempWindowRequestPolicy({})).toMatchObject({
+      tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+      suppressMinimize: true,
+    })
+    expect(
+      resolveTempWindowRequestPolicy({
+        tempWindowRequestSource: "invalid-source",
+      }),
+    ).toMatchObject({
+      tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Background,
+      suppressMinimize: false,
+    })
+  })
+
+  it("detects the current surface in popup, options, sidepanel, background order", () => {
+    mockedIsExtensionPopup.mockReturnValue(true)
+    mockedIsExtensionOptions.mockReturnValue(true)
+    mockedIsExtensionSidePanel.mockReturnValue(true)
+    mockedIsExtensionBackground.mockReturnValue(true)
+
+    expect(getCurrentTempWindowRequestSource()).toBe(
+      TEMP_WINDOW_REQUEST_SOURCES.Popup,
+    )
+
+    mockedIsExtensionPopup.mockReturnValue(false)
+    expect(getCurrentTempWindowRequestSource()).toBe(
+      TEMP_WINDOW_REQUEST_SOURCES.Options,
+    )
+
+    mockedIsExtensionOptions.mockReturnValue(false)
+    expect(getCurrentTempWindowRequestSource()).toBe(
+      TEMP_WINDOW_REQUEST_SOURCES.Sidepanel,
+    )
+
+    mockedIsExtensionSidePanel.mockReturnValue(false)
+    expect(getCurrentTempWindowRequestSource()).toBe(
+      TEMP_WINDOW_REQUEST_SOURCES.Background,
+    )
+  })
+
+  it("defaults current-surface detection to background", () => {
+    expect(getCurrentTempWindowRequestSource()).toBe(
+      TEMP_WINDOW_REQUEST_SOURCES.Background,
+    )
+  })
+
+  it("blocks Firefox popup requests", () => {
+    mockedIsProtectionBypassFirefoxEnv.mockReturnValue(true)
+
+    expect(
+      resolveTempWindowRequestPolicy({
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+      }),
+    ).toEqual({
+      tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+      suppressMinimize: true,
+      blockedReason: "firefox_popup_unsupported",
+    })
+  })
+
+  it.each([
+    TEMP_WINDOW_REQUEST_SOURCES.Options,
+    TEMP_WINDOW_REQUEST_SOURCES.Sidepanel,
+    TEMP_WINDOW_REQUEST_SOURCES.Background,
+  ])(
+    "allows Firefox requests from the %s source",
+    (tempWindowRequestSource) => {
+      mockedIsProtectionBypassFirefoxEnv.mockReturnValue(true)
+
+      expect(
+        resolveTempWindowRequestPolicy({ tempWindowRequestSource }),
+      ).toMatchObject({
+        tempWindowRequestSource,
+        blockedReason: null,
+      })
+    },
+  )
+})


### PR DESCRIPTION
## Context

[PR #1032](https://github.com/qixing-jk/all-api-hub/pull/1032) introduced the native-page auto-check-in fallback for sites whose check-in API requires browser-generated signature headers.

That flow added a new delegation path:

1. a user starts auto-check-in from an extension surface;
2. the request enters the background scheduler and New API provider;
3. the provider opens a temporary native page;
4. the content script triggers the site's check-in action;
5. the provider confirms success through `checked_in_today` polling.

When the action originates from the toolbar popup, the originating surface is lost before the temporary window is created. Execution is already inside the background worker, where popup detection no longer describes the initiating context.

This can cause popup-originated native-page work to follow background minimization policy and can evaluate the existing Firefox popup safety rule against the wrong execution context. The same source-loss pattern also affected delegated API fallback, browser-session resync, account refresh, and retry paths.

This is the behavior previously handled specifically for auto-detection in [PR #901](https://github.com/qixing-jk/all-api-hub/pull/901). The native-page flow showed that passing individual `suppressMinimize` booleans does not scale across runtime and scheduler boundaries.

See the [source-context design](docs/superpowers/specs/2026-07-16-temp-window-source-context-design.md) and [implementation plan](docs/superpowers/plans/2026-07-16-temp-window-source-context.md).

## Related work

- Follow-up to [PR #1032](https://github.com/qixing-jk/all-api-hub/pull/1032), which introduced native-page auto-check-in fallback.
- Generalizes the popup temporary-window protection established by [PR #901](https://github.com/qixing-jk/all-api-hub/pull/901).
- The native-page fallback originally addressed [Issue #1002](https://github.com/qixing-jk/all-api-hub/issues/1002), where a New API-compatible site required signature headers unavailable to direct API check-in.

## Approach

Introduce a transient semantic request source—`popup`, `options`, `sidepanel`, or `background`—captured before delegation and carried with the task.

A centralized resolver converts that source into the existing low-level `suppressMinimize` behavior and applies the Firefox popup safeguard. Explicit low-level boolean overrides remain supported.

The source is immutable request metadata. It is not persisted, and this change does not add popup-liveness polling, runtime ports, or service-worker keepalive logic.

## Changes

- Centralize temporary-window source detection, validation, normalization, and launch policy.
- Propagate source through generic API fallback, runtime messages, temporary-window handlers, Turnstile requests, native-page actions, and rendered-title reads.
- Preserve source across auto-detection, browser-session reads, Sub2API/VoAPI token resync, and runtime-error fallbacks.
- Carry source through account refresh, import, save, and bulk-refresh actions.
- Carry source through auto-check-in UI actions, scheduler batches, providers, manual retries, and post-check-in refresh.
- Keep scheduled alarms and automatic retries explicitly background-owned.
- Preserve the explicit `OpenTempWindow` visible-window override.
- Reject Firefox popup-source temporary-window work before background dispatch.

## Behavioral boundaries

- Explicit `suppressMinimize` values take precedence over source-derived policy.
- Missing or invalid source at a runtime boundary becomes `background`.
- Reused pooled contexts retain their current window state.
- Popup closure does not cancel background work.
- No user settings, telemetry, persisted state, or user-facing copy were added.

## Validation

- 31 focused test files, 982 tests passed.
- Each rebuilt code commit passed `pnpm compile`.
- Every commit hook passed `pnpm run validate:staged`.
- Final and pre-push `pnpm run validate:push` passed, including TypeScript and Knip.
- Rewritten branch tree is identical to the pre-rewrite backup.

## Release decisions

No Playwright test was added because the current harness opens `popup.html` as a normal page and cannot reproduce real toolbar-popup auto-hide behavior. Runtime-message, wrapper, pool, scheduler, provider, and component tests cover the controllable contracts.

No telemetry or dynamic popup monitoring was added. A manual Chromium/Firefox toolbar-popup smoke check is still recommended before release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Temporary-window actions now preserve a validated “origin surface” across check-in, UI pretriggers, account refresh, session recovery, and API fallback, improving correct minimize/visibility behavior.
  * Firefox popup requests are now consistently blocked with clear failure details when unsupported.
  * Intentional “open” actions remain visible (no minimization).
* **Bug Fixes**
  * Prevents incorrect minimization/visibility by normalizing and safely handling temp-window request metadata at boundaries.
* **Tests**
  * Expanded coverage for propagation, policy decisions, and fallback routing.
* **Documentation**
  * Added new design and implementation plan for temp-window source context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->