### PR TITLE
refactor(managed-sites): add resource-native AxonHub substrate

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -36,6 +36,18 @@ _Avoid_: dedicated override, alias, fallback
 A normalized product-owned shape consumed by features after upstream backend payloads have been adapted.
 _Avoid_: upstream response, New API response
 
+**Managed Upstream Resource**:
+An upstream-native administrative resource managed through a Managed Site Type, such as a channel, provider, or outbound route.
+_Avoid_: managed site channel
+
+**Resource Display Facts**:
+A safe product-selected projection of a managed upstream resource for read-only display.
+_Avoid_: raw upstream payload, full native detail
+
+**Editable Resource Projection**:
+A product-selected subset of managed upstream resource fields that users can edit without exposing the complete upstream schema.
+_Avoid_: generated upstream form, full-field editor
+
 **Account Runtime Key**:
 A product canonical model for a key that can be used for account-scoped runtime
 requests such as verification, model probing, export, or CLI configuration,
@@ -54,6 +66,12 @@ _Avoid_: API token, token row
 - A **Product Canonical Model** may retain historical New API field names when
   those fields are now the product contract. Its owner is determined by product
   semantics, not by the upstream backend that originally shaped it.
+- A **Managed Upstream Resource** retains its upstream-native semantics while
+  exposing only **Resource Display Facts** and an explicit **Editable Resource
+  Projection** to product features.
+- An **Editable Resource Projection** may expand as user needs are verified, but
+  it does not imply that every field of a **Managed Upstream Resource** is
+  editable.
 - An **Account Runtime Key** is not necessarily an API token resource. API token
   CRUD, token metadata, and service-credential rotation remain source-specific
   behavior behind the account runtime key source.
@@ -62,6 +80,9 @@ _Avoid_: API token, token row
 
 > **Dev:** "Can we treat AIHubMix as a managed site because it supports accounts?"
 > **Domain expert:** "No. It is an **Account-Only Site Type** unless managed-site provider support is explicitly verified."
+>
+> **Dev:** "Does native editing mean rendering every upstream field?"
+> **Domain expert:** "No. The Adapter preserves the **Managed Upstream Resource**, while the product exposes only its **Editable Resource Projection**."
 
 ## Flagged ambiguities
 

--- a/docs/superpowers/plans/2026-07-16-axonhub-canonical-migration-capability.md
+++ b/docs/superpowers/plans/2026-07-16-axonhub-canonical-migration-capability.md
@@ -1,0 +1,658 @@
+# AxonHub Canonical Migration Capability Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox notation (`- [ ]`) for tracking.
+
+**Goal:** Route AxonHub migration as both source and target through a named, feature-owned canonical capability while preserving the current dialog and every observable migration behavior.
+
+**Architecture:** The migration feature owns canonical source, target projection, adjustment, command, and result models. A temporary legacy facade is the only new Module allowed to translate `ManagedSiteChannel` or `ChannelFormData`; the AxonHub capability consumes native refs and PR1 native operations, and the current dialog continues to receive its existing preview/result shape.
+
+**Tech Stack:** TypeScript 5.9, Vitest 4, existing managed-site migration orchestration, PR1 resource-native registry and AxonHub Adapter, React Testing Library regression tests.
+
+---
+
+## Source, prerequisite, and stop conditions
+
+Implement the second delivery slice from
+`docs/superpowers/specs/2026-07-16-managed-site-resource-native-extension-design.md`.
+
+Prerequisite: the PR1 plan
+`2026-07-16-managed-site-resource-native-substrate.md` is implemented and
+green. Execute this plan before the native UI cutover plan.
+
+Stop and split the PR if any of these becomes necessary:
+
+- more than eight production files;
+- moving a second Site Type to the named capability;
+- changing migration dialog props or rendered shape;
+- changing locales, analytics contracts, runtime messages, persistence, or
+  options routing;
+- changing numeric UI row identity to native resource identity;
+- adding protocol operations that belong in PR1;
+- changing more than roughly 300 lines inside `channelMigration.ts` instead of
+  extracting canonical orchestration.
+
+## File structure
+
+Create:
+
+- `src/types/managedSiteMigrationCapability.ts` — feature-owned canonical
+  migration types and named capability Interface.
+- `src/services/managedSites/channelMigrationCapabilityRegistry.ts` — explicit
+  migration capability lookup.
+- `src/services/managedSites/channelMigrationLegacyFacade.ts` — the only new
+  legacy row/draft translation seam.
+- `src/services/apiAdapters/managedResources/axonHubMigration.ts` — AxonHub
+  source/target capability built on PR1 native primitives.
+- `tests/services/managedSites/channelMigrationCapabilityRegistry.test.ts` —
+  registry and no-fallback tests.
+
+Modify:
+
+- `src/types/managedSiteMigration.ts` — optional internal canonical preparation
+  on existing preview rows.
+- `src/services/managedSites/channelMigration.ts` — canonical orchestration
+  while preserving exported signatures.
+- `src/services/managedSites/managedUpstreamResourceMigration.ts` — remove only
+  AxonHub's old channel-migration feature gate.
+- `src/services/apiAdapters/managedResources/axonHub.ts` — export the existing
+  native detail/create primitives for the named capability; do not add legacy
+  draft logic.
+- `tests/services/managedSites/channelMigration.test.ts` — source/target
+  equivalence and per-row outcomes.
+- `tests/services/apiAdapters/managedResources/axonHub.test.ts` — canonical
+  mapping and native mutation coverage.
+- `tests/services/managedSites/managedUpstreamResourceService.test.ts` — old
+  gate regression.
+
+Keep `ManagedSiteChannelMigrationDialog.tsx`, its locale keys, and analytics
+contracts unchanged. Modify its test only if TypeScript fixtures require the new
+optional property.
+
+### Task 1: Define canonical migration models and an explicit registry
+
+**Files:**
+
+- Create: `src/types/managedSiteMigrationCapability.ts`
+- Create: `src/services/managedSites/channelMigrationCapabilityRegistry.ts`
+- Create: `tests/services/managedSites/channelMigrationCapabilityRegistry.test.ts`
+
+- [ ] **Step 1: Write failing registry tests**
+
+Add:
+
+```ts
+describe("channelMigrationCapabilityRegistry", () => {
+  it("returns null when a Site Type has no named migration capability", () => {
+    expect(resolveManagedSiteMigrationCapability(SITE_TYPES.NEW_API)).toBeNull()
+  })
+
+  it("does not fall back to the old resource feature gate", () => {
+    expect(resolveManagedSiteMigrationCapability(SITE_TYPES.AXON_HUB)).toBeNull()
+    expect(resolveManagedUpstreamResourceFeatureCapabilities).not.toHaveBeenCalled()
+  })
+})
+```
+
+The first commit intentionally has no production registration.
+
+- [ ] **Step 2: Run the test and verify failure**
+
+```powershell
+pnpm exec vitest run tests/services/managedSites/channelMigrationCapabilityRegistry.test.ts
+```
+
+Expected: FAIL because the canonical type and registry modules do not exist.
+
+- [ ] **Step 3: Add the feature-owned canonical types**
+
+Create `managedSiteMigrationCapability.ts`:
+
+```ts
+import type { ChannelType } from "~/constants/managedSite"
+import type { ManagedSiteType } from "~/constants/siteType"
+import type {
+  ManagedResourceRef,
+  ResourceOperationOptions,
+} from "~/services/apiAdapters/contracts/managedResourceNative"
+
+import type {
+  ManagedSiteChannelMigrationBlockedReasonCode,
+  ManagedSiteChannelMigrationGeneralWarningCode,
+  ManagedSiteChannelMigrationItemWarningCode,
+} from "./managedSiteMigration"
+
+export type ManagedSiteMigrationSelection = {
+  selectionId: string
+  displayName: string
+  ref: ManagedResourceRef
+}
+
+export type ManagedSiteMigrationStatus = "enabled" | "disabled" | "other"
+
+export type ManagedSiteMigrationLossSignals = {
+  hasModelMapping: boolean
+  hasStatusCodeMapping: boolean
+  hasAdvancedSettings: boolean
+  hasMultiKeyState: boolean
+}
+
+export type ManagedSiteMigrationSource = {
+  sourceSiteType: ManagedSiteType
+  resourceType: ChannelType
+  baseUrl: string
+  models: string[]
+  groups: string[]
+  priority: number
+  weight: number
+  status: ManagedSiteMigrationStatus
+  lossSignals: ManagedSiteMigrationLossSignals
+}
+
+export type ManagedSiteMigrationPreviewProjection = {
+  name: string
+  type: ChannelType | string
+  baseUrl: string
+  models: string[]
+  groups: string[]
+  priority: number
+  weight: number
+  status: 1 | 2
+}
+
+export type ManagedSiteMigrationTargetAdjustments = {
+  remappedType: boolean
+  normalizedBaseUrl: boolean
+  forcedDefaultGroup: boolean
+  ignoredPriority: boolean
+  ignoredWeight: boolean
+  simplifiedStatus: boolean
+}
+
+export type ManagedSiteMigrationExecutionCommand = {
+  source: ManagedSiteMigrationSource
+  targetSiteType: ManagedSiteType
+  projection: ManagedSiteMigrationPreviewProjection
+  credential: string
+}
+
+export type ManagedSiteMigrationTargetPreparation = {
+  projection: ManagedSiteMigrationPreviewProjection
+  adjustments: ManagedSiteMigrationTargetAdjustments
+}
+
+export type ManagedSiteMigrationSourcePreparation =
+  | { status: "ready"; source: ManagedSiteMigrationSource }
+  | {
+      status: "blocked"
+      reasonCode: ManagedSiteChannelMigrationBlockedReasonCode
+    }
+
+export type ManagedSiteMigrationCredentialResolution =
+  | { status: "ready"; credential: string }
+  | {
+      status: "blocked"
+      reasonCode: ManagedSiteChannelMigrationBlockedReasonCode
+    }
+
+export const MANAGED_SITE_MIGRATION_EXECUTION_FAILURE_CODES = {
+  SourceUnavailable: "source_unavailable",
+  TargetUnavailable: "target_unavailable",
+  TargetRejected: "target_rejected",
+  MutationStateUncertain: "mutation_state_uncertain",
+  Unexpected: "unexpected",
+} as const
+
+export type ManagedSiteMigrationExecutionFailureCode =
+  (typeof MANAGED_SITE_MIGRATION_EXECUTION_FAILURE_CODES)[keyof typeof MANAGED_SITE_MIGRATION_EXECUTION_FAILURE_CODES]
+
+export type ManagedSiteMigrationCreateResult =
+  | { status: "created" }
+  | { status: "failed"; failureCode: ManagedSiteMigrationExecutionFailureCode }
+  | { status: "uncertain" }
+
+export type ManagedSiteMigrationCanonicalPreviewItem = {
+  selection: ManagedSiteMigrationSelection
+  status: "ready" | "blocked"
+  warningCodes: readonly ManagedSiteChannelMigrationItemWarningCode[]
+  blockingReasonCode?: ManagedSiteChannelMigrationBlockedReasonCode
+  source?: ManagedSiteMigrationSource
+  target?: ManagedSiteMigrationTargetPreparation
+}
+
+export type ManagedSiteMigrationCanonicalPreview = {
+  sourceSiteType: ManagedSiteType
+  targetSiteType: ManagedSiteType
+  generalWarningCodes: readonly ManagedSiteChannelMigrationGeneralWarningCode[]
+  items: readonly ManagedSiteMigrationCanonicalPreviewItem[]
+  totalCount: number
+  readyCount: number
+  blockedCount: number
+}
+
+export type ManagedSiteMigrationCanonicalExecutionResult = {
+  totalSelected: number
+  attemptedCount: number
+  createdCount: number
+  failedCount: number
+  skippedCount: number
+  uncertainCount: number
+  items: readonly {
+    selectionId: string
+    displayName: string
+    status: "created" | "failed" | "skipped" | "uncertain"
+    failureCode?: ManagedSiteMigrationExecutionFailureCode
+    blockingReasonCode?: ManagedSiteChannelMigrationBlockedReasonCode
+  }[]
+}
+
+export type ManagedSiteMigrationCapability = {
+  source?: {
+    prepare(
+      selection: ManagedSiteMigrationSelection,
+      options?: ResourceOperationOptions,
+    ): Promise<ManagedSiteMigrationSourcePreparation>
+    resolveCredential(
+      selection: ManagedSiteMigrationSelection,
+      options?: ResourceOperationOptions,
+    ): Promise<ManagedSiteMigrationCredentialResolution>
+  }
+  target?: {
+    prepare(
+      source: ManagedSiteMigrationSource,
+      options?: ResourceOperationOptions,
+    ): Promise<ManagedSiteMigrationTargetPreparation>
+    create(
+      command: ManagedSiteMigrationExecutionCommand,
+      options?: ResourceOperationOptions,
+    ): Promise<ManagedSiteMigrationCreateResult>
+  }
+}
+```
+
+Every preview and result type above is secret-free. The execution function
+calls `source.resolveCredential(selection)` immediately before target creation,
+constructs `ManagedSiteMigrationExecutionCommand` in local scope, awaits one
+`target.create(command)`, and then drops the command. The command must never be
+returned, cached, persisted, placed in React state, logged, or analyzed.
+If credential resolution is blocked after a ready preview, emit a skipped item
+with the controlled blocker and do not increment `attemptedCount`. A confirmed
+target rejection emits failed; possible/partial application emits uncertain.
+
+The canonical file must not import `ManagedSiteChannel`, `ChannelFormData`,
+editor descriptors, or the legacy runtime-config union.
+
+- [ ] **Step 4: Add an empty explicit registry**
+
+Create `channelMigrationCapabilityRegistry.ts` with a typed registration array
+and this lookup:
+
+```ts
+export function resolveManagedSiteMigrationCapability(
+  siteType: ManagedSiteType,
+): ManagedSiteMigrationCapability | null {
+  return registrations.find((entry) => entry.siteType === siteType)?.capability ?? null
+}
+```
+
+Do not import the old feature gates or create a generic capability bag.
+
+- [ ] **Step 5: Run tests and compile**
+
+```powershell
+pnpm exec vitest run tests/services/managedSites/channelMigrationCapabilityRegistry.test.ts
+pnpm compile
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit the canonical contract**
+
+```powershell
+git add src/types/managedSiteMigrationCapability.ts src/services/managedSites/channelMigrationCapabilityRegistry.ts tests/services/managedSites/channelMigrationCapabilityRegistry.test.ts
+pnpm run validate:staged
+git commit -m "refactor(managed-sites): define canonical migration capabilities"
+```
+
+### Task 2: Introduce the legacy compatibility facade without behavior changes
+
+**Files:**
+
+- Create: `src/services/managedSites/channelMigrationLegacyFacade.ts`
+- Modify: `src/types/managedSiteMigration.ts`
+- Modify: `src/services/managedSites/channelMigration.ts`
+- Test: `tests/services/managedSites/channelMigration.test.ts`
+
+- [ ] **Step 1: Add failing compatibility tests**
+
+Add tests proving:
+
+- non-Axon preview rows keep identical `channelId`, `channelName`, order,
+  warnings, `draft`, and counts;
+- source key hydration concurrency remains `5`;
+- target-config missing, empty response messages, thrown errors, blocked rows,
+  and successful-row retention remain unchanged;
+- current exported preview and execution function signatures remain usable.
+
+Also add failing tests for the new canonical entry points:
+
+```ts
+export function prepareManagedSiteMigrationPreview(params: {
+  sourceSiteType: ManagedSiteType
+  targetSiteType: ManagedSiteType
+  selections: readonly ManagedSiteMigrationSelection[]
+  options?: ResourceOperationOptions
+}): Promise<ManagedSiteMigrationCanonicalPreview>
+
+export function executeManagedSiteMigration(params: {
+  preview: ManagedSiteMigrationCanonicalPreview
+  options?: ResourceOperationOptions
+}): Promise<ManagedSiteMigrationCanonicalExecutionResult>
+```
+
+The canonical entry points use string `selectionId` and `ManagedResourceRef`;
+they never accept `ManagedSiteChannel` or return `ChannelFormData`.
+
+Add one test that calls the new facade directly and proves its product model is
+secret-free:
+
+```ts
+const source = toCanonicalMigrationSourceFromLegacyChannel({
+  sourceSiteType: SITE_TYPES.NEW_API,
+  channel: buildManagedSiteChannel({ id: 7, name: "Example" }),
+})
+expect(source).toMatchObject({
+  sourceSiteType: SITE_TYPES.NEW_API,
+})
+expect(source).not.toHaveProperty("credential")
+```
+
+- [ ] **Step 2: Run the migration test and verify failure**
+
+```powershell
+pnpm exec vitest run tests/services/managedSites/channelMigration.test.ts
+```
+
+Expected: FAIL because the legacy facade does not exist.
+
+- [ ] **Step 3: Add the optional canonical preparation to preview rows**
+
+In `managedSiteMigration.ts` add:
+
+```ts
+export type ManagedSiteMigrationCanonicalPreparation = {
+  selection: ManagedSiteMigrationSelection
+  source: ManagedSiteMigrationSource
+  target: ManagedSiteMigrationTargetPreparation
+}
+```
+
+Add `canonicalPreparation?: ManagedSiteMigrationCanonicalPreparation` to
+`ManagedSiteChannelMigrationPreviewItem`. Keep all existing fields and names.
+
+- [ ] **Step 4: Extract the permitted legacy translation functions**
+
+The new facade owns exactly:
+
+- `toCanonicalMigrationSourceFromLegacyChannel`
+- `toCanonicalMigrationSelectionFromLegacyAxonRow`
+- `resolveAxonHubMigrationResourceRefFromLegacyRow`
+- `toCanonicalTargetPreparationFromLegacyDraft`
+- `toLegacyChannelFormDataProjection`
+- `collectLegacyMigrationLossSignals`
+- `toLegacyMigrationWarningCodes`
+
+It is the only new Module allowed to accept `ManagedSiteChannel` or return
+`ChannelFormData`. Prefer an existing `resourceRef`; the temporary Axon fallback
+may use `_axonHubData.id`. Preserve numeric selection identity and native string
+resource identity separately. The canonical selection uses the native ref and
+a string `selectionId`; numeric `channelId` remains exclusively on the existing
+legacy preview/result shape.
+`toCanonicalTargetPreparationFromLegacyDraft` removes the credential and maps
+only preview projection/adjustment facts. `toLegacyChannelFormDataProjection`
+accepts the safe source, safe target projection, and an execution-time
+credential, and returns an ephemeral target draft only to the existing target
+create call.
+
+- [ ] **Step 5: Route legacy paths through the facade with no production registration**
+
+Add `prepareManagedSiteMigrationPreview` and `executeManagedSiteMigration` as
+the canonical orchestration entry points. Refactor `buildPreviewItem`, warning
+collection, target draft preparation, and execution to use them internally.
+Keep `prepareManagedSiteChannelMigrationPreview` and
+`executeManagedSiteChannelMigration` as legacy wrappers that translate through
+the facade and preserve every observable existing field, row order, count,
+warning, copy, and behavior. The optional canonical preparation is safe and
+contains no credential or execution command. Because the named registry is
+still empty, every production Site Type must finish on its current legacy or
+old resource path.
+
+The canonical orchestrator supports a named native source with a legacy target:
+preview translates the safe canonical source through the existing legacy target
+preparation and immediately converts that draft back to the secret-free target
+projection/adjustments. Execution resolves the source credential just in time,
+injects it into an ephemeral `ChannelFormData` inside
+`channelMigrationLegacyFacade.ts`, invokes the target's existing create path
+once, and discards both values. Neither the draft nor credential enters the
+canonical preview. This bridge is target compatibility, not a native source
+conversion to `ManagedSiteChannel`.
+
+- [ ] **Step 6: Run migration and dialog regression tests**
+
+```powershell
+pnpm exec vitest run tests/services/managedSites/channelMigration.test.ts tests/features/ManagedSiteChannels/components/ManagedSiteChannelMigrationDialog.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit the compatibility plumbing**
+
+```powershell
+git add src/services/managedSites/channelMigrationLegacyFacade.ts src/types/managedSiteMigration.ts src/services/managedSites/channelMigration.ts tests/services/managedSites/channelMigration.test.ts
+pnpm run validate:staged
+git commit -m "refactor(managed-sites): normalize migration through canonical models"
+```
+
+### Task 3: Route AxonHub source and target through the named capability
+
+**Files:**
+
+- Create: `src/services/apiAdapters/managedResources/axonHubMigration.ts`
+- Modify: `src/services/apiAdapters/managedResources/axonHub.ts`
+- Modify: `src/services/managedSites/channelMigrationCapabilityRegistry.ts`
+- Modify: `src/services/managedSites/channelMigration.ts`
+- Modify: `src/services/managedSites/managedUpstreamResourceMigration.ts`
+- Modify: `tests/services/apiAdapters/managedResources/axonHub.test.ts`
+- Modify: `tests/services/managedSites/channelMigrationCapabilityRegistry.test.ts`
+- Modify: `tests/services/managedSites/channelMigration.test.ts`
+- Modify: `tests/services/managedSites/managedUpstreamResourceService.test.ts`
+
+- [ ] **Step 1: Add failing named-capability registry and gate tests**
+
+Change the registry expectation to:
+
+```ts
+expect(resolveManagedSiteMigrationCapability(SITE_TYPES.AXON_HUB)).toMatchObject({
+  source: {
+    prepare: expect.any(Function),
+    resolveCredential: expect.any(Function),
+  },
+  target: { prepare: expect.any(Function), create: expect.any(Function) },
+})
+```
+
+In the old resource service test, assert that AxonHub channel migration returns
+`feature-slice-disabled`, while Axon core resource resolution and every other
+existing feature gate remain unchanged.
+
+- [ ] **Step 2: Add failing Axon source/target orchestration tests**
+
+Add these exact cases to `channelMigration.test.ts`:
+
+- `prepares an Axon target through the named capability and keeps the displayed legacy draft equivalent`
+- `resolves an Axon credential only at execution and creates exactly once without legacy payload builders`
+- `prepares an Axon source from its native string ref without old secret hydration`
+- `maps permission-hidden Axon credentials to the existing blocked row`
+- `preserves Axon source projection when targeting a legacy site`
+- `executes an Axon native selection into a legacy target with one just-in-time credential resolution and one create`
+- `blocks only the row whose named target preparation fails`
+- `continues after one named target create failure`
+- `preserves string selection identity and order across native preparation`
+- `maps uncertain target creation to an explicit non-replayable result`
+- `keeps canonical preview and result objects free of credentials and commands`
+- `returns the existing create-only no-dedupe and no-rollback general warnings`
+
+When `targetSiteType` is AxonHub, assert that the path does not call old
+`prepareImportDraft`, `resources.items.create`, legacy `buildChannelPayload`,
+or legacy `createChannel`. An Axon source targeting a non-Axon legacy site is
+expected to call that target's existing create path through the compatibility
+facade exactly once.
+
+- [ ] **Step 3: Run the focused tests and verify red state**
+
+```powershell
+pnpm exec vitest run tests/services/managedSites/channelMigrationCapabilityRegistry.test.ts tests/services/managedSites/channelMigration.test.ts tests/services/managedSites/managedUpstreamResourceService.test.ts
+```
+
+Expected: FAIL because Axon has not been registered in the named capability.
+
+- [ ] **Step 4: Export and reuse PR1 native primitives**
+
+In `managedResources/axonHub.ts`, reuse the exact PR1 export
+`openAxonHubNativeResourceOperations(options)`. Its returned
+`AxonHubNativeResourceOperations.get(ref, options)` and
+`.create(input, desiredStatus, options)` are the only native operations this
+capability needs. Do not export editor descriptors, configuration, or native
+detail through the public Workspace contract. Preserve the caller's signal.
+
+- [ ] **Step 5: Implement the Axon capability**
+
+`axonHubMigration.ts` must:
+
+- source: load native detail by `ManagedResourceRef`, require a usable regular
+  key during preview only to classify availability, discard its value, map
+  native string type to current `ChannelType`, preserve supported and manual
+  model semantics, and return existing blocker codes for unavailable
+  credentials; `resolveCredential` reloads detail at execution and returns the
+  usable key only to the orchestration call stack;
+- target prepare: map canonical type to Axon type, build the safe projection and
+  adjustment facts without a credential or command;
+- target create: build direct `AxonHubCreateChannelInput`, call the shared native
+  create primitive, and map confirmed success/failure to the controlled feature
+  result;
+- uncertain or partial creation: return `{ status: "uncertain" }`; canonical
+  execution emits the controlled `mutation_state_uncertain` category, increments
+  `uncertainCount`, refreshes, and never triggers replay.
+
+The file must not import `ManagedSiteChannel`, `ChannelFormData`, legacy provider
+builders, or the old resource capability.
+
+- [ ] **Step 6: Register Axon and remove only its old feature gate**
+
+Register:
+
+```ts
+{
+  siteType: SITE_TYPES.AXON_HUB,
+  capability: axonHubManagedSiteMigrationCapability,
+}
+```
+
+Delete only this old gate entry:
+
+```ts
+{
+  siteType: SITE_TYPES.AXON_HUB,
+  feature: MANAGED_UPSTREAM_RESOURCE_FEATURES.ChannelMigration,
+}
+```
+
+Do not remove Axon core gating or change another Site Type.
+
+- [ ] **Step 7: Route Axon orchestration through canonical preparation**
+
+For Axon source, call `source.prepare(selection, options)` with the string
+selection identity and native ref. For Axon target, call `target.prepare`,
+convert only its projection to the existing display `draft`, and store only the
+safe selection/source/target preparation. During execution, resolve the source
+credential just in time, construct the execution command locally, call
+`target.create(command, options)` once, and discard it. A legacy non-Axon source
+uses its existing key-resolution path at this same execution boundary; it does
+not copy the credential into canonical preparation. Keep the two legacy
+exported migration function signatures unchanged.
+For the unchanged legacy result shape, map canonical `uncertain` to one failed
+row with localized safe fallback text and include it in `failedCount`; do not
+retry it. The canonical result keeps `status: "uncertain"` and
+`uncertainCount` for the native UI.
+
+- [ ] **Step 8: Run capability, migration, Adapter, and dialog tests**
+
+```powershell
+pnpm exec vitest run tests/services/managedSites/channelMigrationCapabilityRegistry.test.ts tests/services/managedSites/channelMigration.test.ts tests/services/apiAdapters/managedResources/axonHub.test.ts tests/services/managedSites/managedUpstreamResourceService.test.ts tests/features/ManagedSiteChannels/components/ManagedSiteChannelMigrationDialog.test.tsx
+```
+
+Expected: PASS. Existing analytics assertions remain aggregate-only, and the
+dialog never renders canonical credentials or commands.
+
+- [ ] **Step 9: Commit the Axon route**
+
+```powershell
+git add src/services/apiAdapters/managedResources/axonHubMigration.ts src/services/apiAdapters/managedResources/axonHub.ts src/services/managedSites/channelMigrationCapabilityRegistry.ts src/services/managedSites/channelMigration.ts src/services/managedSites/managedUpstreamResourceMigration.ts tests/services/apiAdapters/managedResources/axonHub.test.ts tests/services/managedSites/channelMigrationCapabilityRegistry.test.ts tests/services/managedSites/channelMigration.test.ts tests/services/managedSites/managedUpstreamResourceService.test.ts
+pnpm run validate:staged
+git commit -m "refactor(axonhub): route migration through native capabilities"
+```
+
+## PR2 final verification
+
+- [ ] Run the affected migration surface:
+
+```powershell
+pnpm exec vitest related --run src/services/managedSites/channelMigration.ts src/services/apiAdapters/managedResources/axonHubMigration.ts src/types/managedSiteMigration.ts src/types/managedSiteMigrationCapability.ts
+pnpm compile
+```
+
+Expected: PASS.
+
+- [ ] Confirm every task commit ran `validate:staged` after its exact `git add`
+  and before `git commit`. Do not run a no-staged-files command as a substitute.
+
+- [ ] Run the remote handoff gate:
+
+```powershell
+pnpm run validate:push
+```
+
+Expected: compile and `knip` pass.
+
+- [ ] Inspect the PR against its prerequisite branch:
+
+```powershell
+$baseSha = git log -1 --format=%H --grep="^refactor(axonhub): register native resource adapter$"
+git diff --stat "$baseSha..HEAD"
+git diff --name-status "$baseSha..HEAD"
+git diff --check "$baseSha..HEAD"
+```
+
+Expected: `$baseSha` is non-empty; at most eight production files, the named tests, and no dialog,
+locale, analytics, runtime-message, storage, or routing changes.
+
+## Required preserved behavior
+
+- Current dialog props, copy, warning order, counts, loading, refresh, retry,
+  late-result cancellation, and close protection.
+- Numeric UI row identity and selection order; native string identity remains in
+  `ManagedResourceRef`.
+- `PREVIEW_BUILD_CONCURRENCY = 5`.
+- Existing New API, Veloera, DoneHub, Octopus, and Claude Code Hub paths.
+- Per-row failure continuation, no rollback, successful-row retention, local
+  empty-message fallback, and no replay of uncertain native creation.
+- Existing analytics action IDs and aggregate-only payloads.
+
+## Release-readiness decisions
+
+- Telemetry: `reuse existing`; the production dialog and analytics contract do
+  not change.
+- E2E: `none`; migration orchestration and unchanged dialog behavior are covered
+  more precisely with Vitest.
+- Maintainability: the compatibility facade localizes all permitted legacy
+  translation. Delete it only after the native UI no longer needs legacy preview
+  shapes; do not spread dual-model translation into the Adapter or dialog.

--- a/docs/superpowers/plans/2026-07-16-axonhub-resource-native-ui-cutover.md
+++ b/docs/superpowers/plans/2026-07-16-axonhub-resource-native-ui-cutover.md
@@ -10,8 +10,8 @@
 
 ## Required inputs and execution order
 
-Implement this plan only after both preceding plans are merged or present in
-the working tree:
+Implement this plan only after both preceding plans are merged or committed at
+the current `HEAD`:
 
 1. `docs/superpowers/plans/2026-07-16-managed-site-resource-native-substrate.md`
 2. `docs/superpowers/plans/2026-07-16-axonhub-canonical-migration-capability.md`
@@ -26,10 +26,27 @@ Before editing, run:
 ```powershell
 git status --short
 git log -3 --oneline
+$stagedPaths = @(git diff --cached --name-only)
+if ($stagedPaths.Count -gt 0) {
+  throw "Commit or otherwise reconcile pre-existing staged work before PR3"
+}
+$pr3BaseSha = git rev-parse HEAD
+if (-not $pr3BaseSha) { throw "PR3 base SHA is required" }
 ```
 
 Expected: understand and preserve all pre-existing index and worktree state.
 Confirm that the native registry and canonical migration entry points compile.
+If either prerequisite exists only as uncommitted work, stop and commit it in
+its owning slice before recording `$pr3BaseSha`; the base SHA must identify the
+immutable prerequisite tip, not merely a worktree that happens to contain it.
+Retain the recorded full `$pr3BaseSha` in the execution handoff and restore that
+exact value when resuming in another shell; do not rediscover it by commit
+subject.
+
+The empty-index check is a commit-safety invariant, not permission to unstage
+user work. Re-run `git diff --cached --quiet` immediately before every task's
+`git add`; if it reports staged content, stop and reconcile ownership instead
+of committing it with the task.
 
 ## Scope controls
 
@@ -127,10 +144,13 @@ introduced by PR 1. The AxonHub assertion is:
 
 ```ts
 expect(openSettingsTab).toHaveBeenCalledWith("managedSite", {
-  anchor: "axonhub",
+  anchor: SETTINGS_ANCHORS.AXON_HUB,
   preserveHistory: true,
 })
 ```
+
+Import `SETTINGS_ANCHORS` from the shared settings-anchor constants; do not
+duplicate the AxonHub anchor literal in the test or implementation.
 
 - [ ] **Step 3: Run both tests and verify they fail**
 
@@ -264,9 +284,11 @@ Expected: FAIL because both hooks are missing.
 
 Own only Workspace opening, query/cursor, rows, selection, abort generations,
 and load/retry/refresh state. Preserve current route precedence by normalizing
-`routeParams.channelId?.trim() ?? routeParams.search?.trim()` exactly once when
-either parameter changes. Treat that term as Workspace resource-wide search,
-which the Axon Adapter matches against opaque id and safe display facts. A user
+`routeParams.channelId?.trim() || routeParams.search?.trim() || undefined`
+exactly once when either parameter changes. Add a controller regression test
+that proves a whitespace-only `channelId` falls back to a valid search term.
+Treat that term as Workspace resource-wide search, which the Axon Adapter
+matches against opaque id and safe display facts. A user
 search updates the existing options hash with `navigateWithinOptionsPage`,
 sets only `search`, and thereby clears `channelId`. If search is unsupported,
 omit the control and query rather than locally filtering a loaded page.
@@ -460,12 +482,18 @@ Add behavior tests for:
 - `refreshes instead of replaying after an uncertain mutation`
 - `does not expose resource ids scope keys credentials or native detail`
 - `records only controlled analytics dimensions`
+- `reuses the existing action ids surfaces and Options entrypoint`
+- `starts and completes each analytics action exactly once`
 - `maps every ResourceFailure code to controlled copy without Error messages`
 - `treats aborted and superseded operations as silent cancellation`
 - `retains editor values for upstream_rejected but closes uncertain and not-found sessions`
 
 The page test should inspect analytics payloads and prove that names, URLs,
 models, tags, ids, refs, field values, and error messages are absent.
+For every retained action, assert the expected action id, toolbar or row-action
+surface, and Options entrypoint. Assert one `startProductAnalyticsAction` call
+and one returned tracker `complete` call for each terminal path, including
+failures and mixed migration outcomes.
 Cover `configuration_required`, `invalid_configuration`,
 `authentication_failed`, `permission_denied`, `validation_failed`, `not_found`,
 `mutation_state_uncertain`, `unavailable`, `upstream_rejected`, `aborted`, and
@@ -555,15 +583,31 @@ Reuse these existing analytics identifiers rather than adding new events:
   migration, open single/selected/filtered migration, and migrate managed-site
   channels.
 
-Completion payloads may include controlled site type, result, item count, and
-failure category only. They must omit all resource data and user-entered data.
-The button/row-action analytics integration emits the single start event. The
-page creates and passes the action context; the controller's terminal outcome
+The completion `result` argument must be a `ProductAnalyticsResult`. Its exact
+optional payload allowlist is `managedSiteType`, `itemCount`, `selectedCount`,
+`successCount`, `failureCount`, `errorCategory`, `failureReason`,
+`sourceManagedSiteType`, `targetManagedSiteType`, `readyCount`, `blockedCount`,
+`warningCount`, and `failureStage` only. The source/target site types and
+ready/blocked/warning counts are migration-only controlled dimensions retained
+from the legacy migration flow; `failureStage` is included only for a
+controlled migration failure.
+`durationMs` remains infrastructure-generated by `startProductAnalyticsAction`
+and is intentionally outside this caller-owned insights allowlist. Preserve it
+by completing through the returned action tracker instead of calling the raw
+completion event helper; do not derive or supply duration from resource data.
+`errorCategory` must be a `ProductAnalyticsErrorCategory`; `failureReason` must
+be a `ProductAnalyticsFailureReason` selected from
+`PRODUCT_ANALYTICS_FAILURE_REASONS`; `sourceManagedSiteType` and
+`targetManagedSiteType` must be `ProductAnalyticsManagedSiteType` values; and
+`failureStage` must be a `ProductAnalyticsFailureStage`. None may contain a raw
+error, backend message, resource value, or user-entered value. The
+button/row-action analytics integration emits the single start event. The page
+creates and passes the action context; the controller's terminal outcome
 callback completes it exactly once. Do not start or complete again inside both
-page and controller. Allow only `managedSiteType`, `itemCount`, `selectedCount`,
-`successCount`, `failureCount`, `errorCategory`, and `failureReason` controlled
-dimensions. Map uncertain mutation to the existing controlled failed/partial
-result category without resource data.
+page and controller. Map an uncertain single mutation to controlled `Failure`
+and `Unknown` values. Use the controlled `PartialSuccess` failure reason only
+when aggregate counts prove a mixed outcome. Tests must assert this exact key
+set and enum membership and must reject resource data or user-entered data.
 
 - [ ] **Step 7: Run related UI tests**
 
@@ -709,29 +753,37 @@ the canonical preview/execute entry points.
 Inspect the entire PR3 range, not only the last uncommitted slice:
 
 ```powershell
-$baseSha = git log -1 --format=%H --grep="^refactor(axonhub): route migration through native capabilities$"
-git diff --check $baseSha
-git diff --stat $baseSha
-git diff --name-status $baseSha
+git cat-file -e "$pr3BaseSha^{commit}"
+git diff --check $pr3BaseSha
+git diff --stat $pr3BaseSha
+git diff --name-status $pr3BaseSha
 ```
 
-Expected: `$baseSha` is non-empty and the diff contains only files named by
+Expected: `$pr3BaseSha` resolves to the exact prerequisite tip recorded before
+Task 1 and the diff contains only files named by
 this plan.
 
 If cleanup would exceed this touched surface, record it as follow-up rather
 than expanding the cutover.
 
-- [ ] **Step 7: Stage only task files and run the commit gate**
+- [ ] **Step 7: Stage only the remaining Task 6 files and run the commit gate**
+
+Tasks 1 through 4 must already be committed by their own explicit commit steps,
+and Task 5 deliberately leaves its two E2E files for this final static-cutover
+commit. Confirm the index is empty before staging; if an earlier task file is
+still uncommitted, stop and complete that task's commit instead of silently
+folding it into the cutover commit.
 
 ```powershell
 git status --short
 git diff --check
-git add src/features/ManagedSiteResources src/entrypoints/options/pages/ManagedSiteChannels/index.tsx src/components/ManagedSiteConfigRequiredState.tsx src/services/accountSiteDefinitions/definitions.ts src/locales/zh-CN/managedSiteResources.json src/locales/zh-TW/managedSiteResources.json src/locales/en/managedSiteResources.json src/locales/ja/managedSiteResources.json src/locales/es-419/managedSiteResources.json src/locales/vi/managedSiteResources.json tests/features/ManagedSiteResources tests/test-utils/managedResourceWorkspace.ts tests/components/ManagedSiteConfigRequiredState.test.tsx tests/services/accountSiteDefinitions/registry.test.ts e2e/managedSiteAxonHubNative.spec.ts e2e/scenarios/managedSiteChannels.ts
+git add src/services/accountSiteDefinitions/definitions.ts tests/services/accountSiteDefinitions/registry.test.ts e2e/managedSiteAxonHubNative.spec.ts e2e/scenarios/managedSiteChannels.ts
 pnpm run validate:staged
 ```
 
-Expected: PASS. Inspect `git diff --cached --stat` and
-`git diff --cached --check`; unrelated files must not be staged.
+Expected: PASS. These are the complete four files owned by the Task 6 commit.
+Inspect `git diff --cached --stat` and `git diff --cached --check`; unrelated
+files and files owned by prior task commits must not be staged.
 
 - [ ] **Step 8: Commit the static cutover**
 
@@ -744,9 +796,9 @@ git commit -m "feat(axonhub): switch channels to native workspace"
 ```powershell
 git status --short
 git log -1 --oneline
-$baseSha = git log -1 --format=%H --grep="^refactor(axonhub): route migration through native capabilities$"
-git diff --check "$baseSha..HEAD"
-git diff --stat "$baseSha..HEAD"
+git cat-file -e "$pr3BaseSha^{commit}"
+git diff --check "$pr3BaseSha..HEAD"
+git diff --stat "$pr3BaseSha..HEAD"
 ```
 
 Expected: the task-scoped work is committed and unrelated user state, if any,

--- a/docs/superpowers/plans/2026-07-16-axonhub-resource-native-ui-cutover.md
+++ b/docs/superpowers/plans/2026-07-16-axonhub-resource-native-ui-cutover.md
@@ -1,0 +1,787 @@
+# AxonHub Resource-Native UI Cutover Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox notation (`- [ ]`) for tracking.
+
+**Goal:** Add the shared resource-native managed-site UI, preserve the current AxonHub user workflow and analytics, and switch only AxonHub from the legacy channel page to its native Workspace.
+
+**Architecture:** The options entry point renders a small dispatcher using the static Managed Site Definition. Legacy definitions continue to render `ManagedSiteChannels`; a native definition must resolve a matching registration or render an integration failure without fallback. A feature-local page composes one list controller and one mutation controller, while the Workspace remains the only feature-facing data interface. Primitive field components render only the approved descriptor kinds. Native migration consumes the canonical capability API from the preceding plan and never creates `ManagedSiteChannel` or `ChannelFormData` values.
+
+**Tech Stack:** TypeScript, React, WXT, the existing options hash/search route parameters, shadcn/Radix UI primitives already in the repository, i18next, Vitest, Testing Library, Playwright, product analytics.
+
+## Required inputs and execution order
+
+Implement this plan only after both preceding plans are merged or present in
+the working tree:
+
+1. `docs/superpowers/plans/2026-07-16-managed-site-resource-native-substrate.md`
+2. `docs/superpowers/plans/2026-07-16-axonhub-canonical-migration-capability.md`
+
+The approved design is
+`docs/superpowers/specs/2026-07-16-managed-site-resource-native-extension-design.md`.
+The pinned AxonHub contract and source links in that design remain authoritative.
+Do not replace them with behavior inferred from the current default branch.
+
+Before editing, run:
+
+```powershell
+git status --short
+git log -3 --oneline
+```
+
+Expected: understand and preserve all pre-existing index and worktree state.
+Confirm that the native registry and canonical migration entry points compile.
+
+## Scope controls
+
+- Do not edit the large legacy
+  `src/features/ManagedSiteChannels/ManagedSiteChannels.tsx` or
+  `src/components/dialogs/ChannelDialog/**`.
+- Do not add a global resource provider, a general state-machine dependency, a
+  form generator, raw JSON fields, or a third controller hook that merely
+  combines the two feature hooks.
+- Do not convert a native `ManagedResourceRef` into a numeric id or a legacy
+  channel row. Selection identity is the serialized ref identity, not display
+  text or row position.
+- Do not display Adapter detail, raw backend messages, endpoints, resource ids,
+  scope keys, secrets, or mutation-certainty internals.
+- Do not replay an uncertain mutation. Close its editor, clear unsafe
+  selection, and require a fresh list/detail read.
+- Keep the existing static definition mode as the rollback switch. Missing
+  native registration is an integration error, never permission to fall back.
+- Keep existing user-facing “channel” terminology where it is already the
+  product language. The new locale namespace is for new native-only states and
+  field labels, not a broad copy rewrite.
+
+## File structure
+
+Create:
+
+- `src/features/ManagedSiteResources/ManagedResourceDispatcher.tsx`
+- `src/features/ManagedSiteResources/ManagedSiteResourcePage.tsx`
+- `src/features/ManagedSiteResources/hooks/useManagedResourceListController.ts`
+- `src/features/ManagedSiteResources/hooks/useManagedResourceMutationController.ts`
+- `src/features/ManagedSiteResources/components/ManagedResourceTable.tsx`
+- `src/features/ManagedSiteResources/components/ManagedResourceDetailDialog.tsx`
+- `src/features/ManagedSiteResources/components/ManagedResourceEditorDialog.tsx`
+- `src/features/ManagedSiteResources/components/ManagedResourceField.tsx`
+- `src/features/ManagedSiteResources/components/ManagedResourceMigrationDialog.tsx`
+- `src/features/ManagedSiteResources/copy.ts`
+- `src/features/ManagedSiteResources/testIds.ts`
+- `src/locales/{zh-CN,zh-TW,en,ja,es-419,vi}/managedSiteResources.json`
+- `tests/test-utils/managedResourceWorkspace.ts`
+- `tests/features/ManagedSiteResources/ManagedResourceDispatcher.test.tsx`
+- `tests/features/ManagedSiteResources/useManagedResourceControllers.test.tsx`
+- `tests/features/ManagedSiteResources/ManagedResourceEditorDialog.test.tsx`
+- `tests/features/ManagedSiteResources/ManagedSiteResourcePage.test.tsx`
+- `tests/features/ManagedSiteResources/ManagedResourceMigrationDialog.test.tsx`
+- `tests/components/ManagedSiteConfigRequiredState.test.tsx`
+- `e2e/managedSiteAxonHubNative.spec.ts`
+
+Modify:
+
+- `src/entrypoints/options/pages/ManagedSiteChannels/index.tsx`
+- `src/components/ManagedSiteConfigRequiredState.tsx`
+- `src/services/accountSiteDefinitions/definitions.ts`
+- `tests/services/accountSiteDefinitions/registry.test.ts`
+- `e2e/scenarios/managedSiteChannels.ts`
+
+If implementation needs to change the public Workspace contract or canonical
+migration model, stop and amend the preceding plan and its contract tests first.
+Do not work around contract gaps in React.
+
+### Task 1: Add explicit dispatch and definition-owned settings recovery
+
+**Files:**
+
+- Create: `src/features/ManagedSiteResources/ManagedResourceDispatcher.tsx`
+- Modify: `src/entrypoints/options/pages/ManagedSiteChannels/index.tsx`
+- Modify: `src/components/ManagedSiteConfigRequiredState.tsx`
+- Test: `tests/features/ManagedSiteResources/ManagedResourceDispatcher.test.tsx`
+- Test: `tests/components/ManagedSiteConfigRequiredState.test.tsx`
+
+- [ ] **Step 1: Write the failing dispatcher tests**
+
+Mock the user-preferences context, definition registry, native registration
+registry, the legacy page, and a native-page test double. Add these behavior
+tests:
+
+- `renders the legacy page for a legacy-channel definition`
+- `renders the native page for a native-resource definition`
+- `reports a native integration error when registration is missing`
+- `never falls back to the legacy page when native registration is missing`
+- `re-dispatches when the selected managed site type changes`
+- `forwards refreshKey and routeParams to the selected page`
+
+The missing-registration assertion must target controlled local copy and a
+retry/reload action; it must not expose a thrown error message.
+
+- [ ] **Step 2: Write the failing settings-target test**
+
+Add tests for `ManagedSiteConfigRequiredState`:
+
+- `opens managed-site settings with the default target when no target is supplied`
+- `opens the definition-owned settings anchor when supplied`
+
+Extend its props with an optional target using the same settings target type
+introduced by PR 1. The AxonHub assertion is:
+
+```ts
+expect(openSettingsTab).toHaveBeenCalledWith("managedSite", {
+  anchor: "axonhub",
+  preserveHistory: true,
+})
+```
+
+- [ ] **Step 3: Run both tests and verify they fail**
+
+```powershell
+pnpm exec vitest run tests/features/ManagedSiteResources/ManagedResourceDispatcher.test.tsx tests/components/ManagedSiteConfigRequiredState.test.tsx
+```
+
+Expected: FAIL because the dispatcher does not exist and the configuration
+state cannot receive a settings target.
+
+- [ ] **Step 4: Implement the small dispatcher**
+
+`ManagedResourceDispatcher` accepts the same page props as the legacy page:
+
+```ts
+export interface ManagedResourcePageRouteProps {
+  refreshKey?: number
+  routeParams?: Record<string, string>
+}
+```
+
+It reads `managedSiteType` from `useUserPreferencesContext()`, resolves the
+Managed Site Definition, and switches only on the definition's explicit mode:
+
+```tsx
+if (policy.mode === MANAGED_RESOURCE_MODES.LegacyChannel) {
+  return <ManagedSiteChannels {...props} />
+}
+
+const registration = getManagedResourceRegistration(
+  managedSiteType,
+  policy.primaryKind,
+)
+if (!registration) return <NativeRegistrationIntegrationError />
+
+return (
+  <ManagedSiteResourcePage
+    key={`${managedSiteType}:${policy.primaryKind}`}
+    definition={definition}
+    registration={registration}
+    {...props}
+  />
+)
+```
+
+The integration-error component is local to the dispatcher. It may reload the
+page, but it must not invoke the legacy UI. Update the options entry point to
+export the dispatcher. Update `ManagedSiteConfigRequiredState` to use its
+supplied target while preserving the current default.
+
+- [ ] **Step 5: Run the focused tests**
+
+```powershell
+pnpm exec vitest run tests/features/ManagedSiteResources/ManagedResourceDispatcher.test.tsx tests/components/ManagedSiteConfigRequiredState.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit the dispatch seam**
+
+```powershell
+git add src/features/ManagedSiteResources/ManagedResourceDispatcher.tsx src/entrypoints/options/pages/ManagedSiteChannels/index.tsx src/components/ManagedSiteConfigRequiredState.tsx tests/features/ManagedSiteResources/ManagedResourceDispatcher.test.tsx tests/components/ManagedSiteConfigRequiredState.test.tsx
+pnpm run validate:staged
+git commit -m "feat(managed-sites): dispatch native resource workspaces"
+```
+
+### Task 2: Implement list and mutation controllers
+
+**Files:**
+
+- Create: `src/features/ManagedSiteResources/hooks/useManagedResourceListController.ts`
+- Create: `src/features/ManagedSiteResources/hooks/useManagedResourceMutationController.ts`
+- Create: `tests/test-utils/managedResourceWorkspace.ts`
+- Test: `tests/features/ManagedSiteResources/useManagedResourceControllers.test.tsx`
+
+- [ ] **Step 1: Create a typed Workspace test builder**
+
+The builder returns a complete `ManagedResourceWorkspace` with overridable
+methods and uses reserved example data. Use an opaque id such as
+`channel_example_opaque`, `https://upstream.example.invalid`, and fake model
+names. Do not add Axon native DTOs to the helper.
+
+- [ ] **Step 2: Write failing list-controller tests**
+
+Use `renderHook` and deferred promises. Add these tests:
+
+- `opens a workspace and loads its first page`
+- `aborts the previous open and ignores a late site result`
+- `reloads and supersedes the active request when refreshKey changes`
+- `treats route channelId or search as a new first-page resource-wide query`
+- `supersedes an in-flight search without showing an aborted error`
+- `does not render a search state when supportsSearch is false`
+- `appends a cursor page without assuming a total`
+- `updates the managedSiteChannels URL and clears channelId when search changes`
+- `does not navigate when normalized route search is unchanged`
+- `keeps the current rows when a manual refresh fails`
+- `maps safe failure codes without reading raw error messages`
+- `retries workspace opening after configuration changes`
+- `clears row selection when site scope changes`
+
+The list state should distinguish initial loading, refreshing, empty, and safe
+failure. Do not expose a generic `unknown` error to the page.
+
+- [ ] **Step 3: Write failing mutation-controller tests**
+
+Add these tests:
+
+- `loads detail and ignores a late result after the selected ref changes`
+- `opens create and edit sessions through the Workspace`
+- `coalesces duplicate UI submit attempts while saving`
+- `upserts returned display facts after confirmed create or update`
+- `retains entered values after validation or confirmed pre-dispatch failure`
+- `closes the editor and requires refresh after mutation_state_uncertain`
+- `never automatically replays an uncertain mutation`
+- `refreshes after not_found closes a stale edit session`
+- `treats an already-missing delete as a successful desired state`
+- `returns per-ref successes and failures for bulk delete`
+
+Use serialized ref identity for sets and maps. Do not use `displayName`, array
+index, or numeric conversion as identity.
+
+- [ ] **Step 4: Run the controller test and verify it fails**
+
+```powershell
+pnpm exec vitest run tests/features/ManagedSiteResources/useManagedResourceControllers.test.tsx
+```
+
+Expected: FAIL because both hooks are missing.
+
+- [ ] **Step 5: Implement the list controller**
+
+Own only Workspace opening, query/cursor, rows, selection, abort generations,
+and load/retry/refresh state. Preserve current route precedence by normalizing
+`routeParams.channelId?.trim() ?? routeParams.search?.trim()` exactly once when
+either parameter changes. Treat that term as Workspace resource-wide search,
+which the Axon Adapter matches against opaque id and safe display facts. A user
+search updates the existing options hash with `navigateWithinOptionsPage`,
+sets only `search`, and thereby clears `channelId`. If search is unsupported,
+omit the control and query rather than locally filtering a loaded page.
+
+Abort every prior open/list request when site type, resource kind, search,
+`refreshKey`, or cursor changes. Use a monotonically increasing generation to
+ignore late results even when an Adapter does not observe abort promptly. A
+refresh error keeps the previous rows and exposes a safe retry state. Cursor UX
+is one-way “load more”: append unique rows and retain only `nextCursor`; do not
+build a previous-page cursor stack or page-number abstraction.
+
+- [ ] **Step 6: Implement the mutation controller**
+
+Own detail/editor/delete dialog state and one UI-level submit guard. Delegate
+validation and correctness to the Resource Editor. On confirmed success call a
+controller callback to upsert returned facts. On `mutation_state_uncertain` or
+`not_found`, close the editor, clear its ref, and request a list refresh. Never
+automatically invoke `submit` or `delete` again.
+
+Bulk delete may run requests independently, but its product result contains
+only safe per-ref success/failure codes. It must not add a generic batch method
+to the Workspace.
+
+- [ ] **Step 7: Run the controller tests**
+
+```powershell
+pnpm exec vitest run tests/features/ManagedSiteResources/useManagedResourceControllers.test.tsx
+```
+
+Expected: PASS, including abort, late-result, uncertain-mutation, and partial
+bulk-delete cases.
+
+- [ ] **Step 8: Commit the controllers**
+
+```powershell
+git add src/features/ManagedSiteResources/hooks/useManagedResourceListController.ts src/features/ManagedSiteResources/hooks/useManagedResourceMutationController.ts tests/test-utils/managedResourceWorkspace.ts tests/features/ManagedSiteResources/useManagedResourceControllers.test.tsx
+pnpm run validate:staged
+git commit -m "feat(managed-sites): control native resource workflows"
+```
+
+### Task 3: Render the approved primitive editor safely
+
+**Files:**
+
+- Create: `src/features/ManagedSiteResources/components/ManagedResourceField.tsx`
+- Create: `src/features/ManagedSiteResources/components/ManagedResourceEditorDialog.tsx`
+- Create: `src/features/ManagedSiteResources/copy.ts`
+- Create: `src/features/ManagedSiteResources/testIds.ts`
+- Create: `src/locales/{zh-CN,zh-TW,en,ja,es-419,vi}/managedSiteResources.json`
+- Test: `tests/features/ManagedSiteResources/ManagedResourceEditorDialog.test.tsx`
+
+- [ ] **Step 1: Define stable native test ids**
+
+Use constant ids for workflow-critical controls and ref-derived ids for rows:
+
+```ts
+export const MANAGED_SITE_RESOURCE_TEST_IDS = {
+  addButton: "managed-site-resource-add-button",
+  refreshButton: "managed-site-resource-refresh-button",
+  searchInput: "managed-site-resource-search-input",
+  editorDialog: "managed-site-resource-editor-dialog",
+  editorSubmit: "managed-site-resource-editor-submit",
+  deleteConfirm: "managed-site-resource-delete-confirm",
+  row: "managed-site-resource-row",
+  rowActions: "managed-site-resource-row-actions",
+} as const
+```
+
+Rows share the fixed `row` id and expose an accessible row name; actions inside
+the row use the fixed `rowActions` id. Tests locate the row by accessible name
+and then scope fixed action ids within it. Do not put a serialized ref,
+resource id, scope key, display name, or secret into a DOM attribute.
+
+- [ ] **Step 2: Write the failing editor tests**
+
+Create one descriptor for every approved kind and add these tests:
+
+- `renders text textarea number boolean select multi-select and secret fields`
+- `initializes only the safe editable projection`
+- `renders field issues and focuses the first invalid field`
+- `represents secrets with unchanged replace and allowed clear intents`
+- `does not render an input value for masked or unavailable secrets`
+- `does not offer clear when the descriptor forbids it`
+- `does not infer replacement from a masked placeholder`
+- `disables dismissal and repeated submission while saving`
+- `keeps values after a reusable validation failure`
+- `closes after a confirmed success or terminal recovery result`
+
+Assert labels and roles rather than wrapper structure or Tailwind classes.
+
+- [ ] **Step 3: Run the editor test and verify it fails**
+
+```powershell
+pnpm exec vitest run tests/features/ManagedSiteResources/ManagedResourceEditorDialog.test.tsx
+```
+
+Expected: FAIL because the renderer and dialog do not exist.
+
+- [ ] **Step 4: Implement the field renderer**
+
+Switch exhaustively on the seven descriptor kinds. Reuse repository UI
+primitives and existing accessible dialog/select/checkbox patterns. The
+renderer receives a descriptor, current value, field issue, and `onChange`; it
+does not receive a Workspace, native detail, or site type.
+
+For secret fields, render an explicit replace control and a separate clear
+choice only when allowed. Never write masked text into form state. Reject an
+unknown descriptor kind with a development integration error; do not render a
+raw JSON fallback.
+
+- [ ] **Step 5: Implement the editor dialog**
+
+React owns a copy of `editor.initialValues`. Call `editor.validate` before
+submit, focus the first returned issue, and then call the controller's guarded
+submit. Keep the dialog controlled by the page and block accidental dismissal
+while saving. `copy.ts` maps controlled failure code plus operation to locale
+keys and maps each approved field id to a literal localized label call. It never
+accepts a backend message. An unrecognized field id is a controlled integration
+error, not a raw-id label fallback.
+
+- [ ] **Step 6: Add the complete localized namespace with the editor**
+
+Create all six locale files with identical key shape. Include actions, states,
+all controlled failure and field-issue codes, editor/detail/table/secret copy,
+and labels for the exact 14 Axon fields. Chinese is the source wording; add
+natural `zh-TW`, `en`, `ja`, `es-419`, and `vi` translations now. Keep existing
+channel and migration terminology. Add no keys for deferred fields. Every key
+must have a real literal `t("managedSiteResources:...")` call in `copy.ts`;
+do not change extractor configuration or use `defaultValue`.
+
+The required families are:
+
+- actions: retry, refresh, add, view, edit, delete, delete selected, replace
+  secret, clear secret, load more, and open settings;
+- states: initial loading, refreshing, empty, filtered empty, integration
+  error, partial delete, and uncertain mutation;
+- failures: all eleven `ResourceFailure.code` values with actionable recovery;
+- validation: every controlled `ResourceFieldIssue.code`;
+- editor, detail, table, pagination, and secret-state labels;
+- fields: name, type, base URL, status, key, supported models, manual models,
+  default test model, automatic supported-model sync, automatic model pattern,
+  tags, ordering weight, remark, and extra model prefix.
+
+Do not add keys for endpoints, policies, settings JSON, revision conflicts, or
+other deferred fields.
+
+- [ ] **Step 7: Run locale extraction and editor tests**
+
+```powershell
+pnpm run i18n:extract:ci
+pnpm exec vitest run tests/features/ManagedSiteResources/ManagedResourceEditorDialog.test.tsx
+```
+
+Expected: PASS with no locale rewrite and all editor behavior green.
+
+- [ ] **Step 8: Commit the primitive editor and its copy atomically**
+
+```powershell
+git add src/features/ManagedSiteResources/components/ManagedResourceField.tsx src/features/ManagedSiteResources/components/ManagedResourceEditorDialog.tsx src/features/ManagedSiteResources/copy.ts src/features/ManagedSiteResources/testIds.ts src/locales/zh-CN/managedSiteResources.json src/locales/zh-TW/managedSiteResources.json src/locales/en/managedSiteResources.json src/locales/ja/managedSiteResources.json src/locales/es-419/managedSiteResources.json src/locales/vi/managedSiteResources.json tests/features/ManagedSiteResources/ManagedResourceEditorDialog.test.tsx
+pnpm run validate:staged
+git commit -m "feat(managed-sites): render localized native resource editors"
+```
+
+### Task 4: Build the list, detail, and canonical migration experience
+
+**Files:**
+
+- Create: `src/features/ManagedSiteResources/components/ManagedResourceTable.tsx`
+- Create: `src/features/ManagedSiteResources/components/ManagedResourceDetailDialog.tsx`
+- Create: `src/features/ManagedSiteResources/components/ManagedResourceMigrationDialog.tsx`
+- Create: `src/features/ManagedSiteResources/ManagedSiteResourcePage.tsx`
+- Test: `tests/features/ManagedSiteResources/ManagedSiteResourcePage.test.tsx`
+- Test: `tests/features/ManagedSiteResources/ManagedResourceMigrationDialog.test.tsx`
+
+- [ ] **Step 1: Write failing page tests**
+
+Add behavior tests for:
+
+- `shows the definition-owned configuration CTA and retries after setup`
+- `shows controlled authentication and permission recovery without raw detail`
+- `shows initial loading empty filtered-empty and refresh-failure states`
+- `renders search only when the Workspace supports resource-wide search`
+- `applies route search and resets the cursor`
+- `renders rows and loads safe detail facts on demand`
+- `renders all fourteen definition-selected safe Axon detail facts`
+- `opens create and edit editors from explicit actions`
+- `does not open an empty editor when session opening fails`
+- `confirms single and selected deletion before dispatch`
+- `loads every remaining search cursor before opening filtered migration`
+- `keeps successful rows and reports failed rows after bulk delete`
+- `refreshes instead of replaying after an uncertain mutation`
+- `does not expose resource ids scope keys credentials or native detail`
+- `records only controlled analytics dimensions`
+- `maps every ResourceFailure code to controlled copy without Error messages`
+- `treats aborted and superseded operations as silent cancellation`
+- `retains editor values for upstream_rejected but closes uncertain and not-found sessions`
+
+The page test should inspect analytics payloads and prove that names, URLs,
+models, tags, ids, refs, field values, and error messages are absent.
+Cover `configuration_required`, `invalid_configuration`,
+`authentication_failed`, `permission_denied`, `validation_failed`, `not_found`,
+`mutation_state_uncertain`, `unavailable`, `upstream_rejected`, `aborted`, and
+`unexpected` in a table-driven copy/recovery test.
+
+- [ ] **Step 2: Write failing canonical migration dialog tests**
+
+Mock only the canonical PR 2 entry points. Add:
+
+- `prepares preview from selected ManagedResourceRef values`
+- `preserves string selection identity and row ordering`
+- `renders existing warning and blocked-reason copy`
+- `blocks unavailable or compatibility-masked source credentials`
+- `renders created failed and skipped per-item results`
+- `keeps created rows when a later row fails and does not roll back`
+- `refreshes the source list after execution`
+- `cancels a late preview when the target changes`
+- `retries a failed preview without retaining stale rows`
+- `prevents closing while execution is running`
+- `resets preview and result when closed and reopened`
+- `renders uncertain results as refresh-required and never re-executes them`
+- `records the existing migration analytics action without resource data`
+- `never constructs ManagedSiteChannel or ChannelFormData`
+- `never receives or stores a credential or execution command in preview state`
+
+- [ ] **Step 3: Run the page and migration tests and verify they fail**
+
+```powershell
+pnpm exec vitest run tests/features/ManagedSiteResources/ManagedSiteResourcePage.test.tsx tests/features/ManagedSiteResources/ManagedResourceMigrationDialog.test.tsx
+```
+
+Expected: FAIL because the page components do not exist.
+
+- [ ] **Step 4: Implement the table and detail dialog**
+
+Render only `ResourceDisplayFacts` selected by the definition policy. Reuse the
+current managed-site toolbar/table visual language and row-action menu. The
+table receives callbacks and state; it does not call the Workspace. Detail
+renders safe facts only and uses the same safe failure mapping as the page.
+Render create, delete-selected, and migration controls only when their
+definition-owned product action is present; row update/delete remain controlled
+by each fact's safe action flags.
+
+Use explicit loading, empty, filtered-empty, error, partial-delete, and
+refreshing states. Optional `total` and cursors must remain optional in copy and
+pagination controls.
+
+- [ ] **Step 5: Implement the native migration dialog**
+
+Pass `ManagedSiteMigrationSelection[]` containing `selectionId`, `displayName`,
+and public `ref` to:
+
+```ts
+prepareManagedSiteMigrationPreview({
+  sourceSiteType,
+  targetSiteType,
+  selections,
+})
+
+executeManagedSiteMigration({ preview })
+```
+
+Reuse existing `managedSiteChannels:migration.*` copy and the existing target
+option helper. Do not duplicate migration projections or warning rules in UI.
+Preserve the current no-rollback explanation and concurrency behavior from PR
+2. For “filtered” migration, the list controller drains the current
+resource-wide search through every remaining cursor with abort and repeated-
+cursor protection before building selections; it must not silently migrate
+only the visible page. The dialog refreshes after execution even when some rows
+fail.
+
+- [ ] **Step 6: Implement the page by composing the two controllers**
+
+The page owns only view composition, dialogs, selected target, and analytics
+contexts. It uses the list controller for Workspace/list/search/selection and
+the mutation controller for detail/editor/delete. It does not introduce a
+third hook that re-exports their state.
+
+Reuse these existing analytics identifiers rather than adding new events:
+
+- feature: `PRODUCT_ANALYTICS_FEATURE_IDS.ManagedSiteChannels`
+- entry point: the existing Options entry id
+- surfaces:
+  `OptionsManagedSiteChannelsToolbar` and
+  `OptionsManagedSiteChannelsRowActions`
+- actions: create, view, update, delete, delete selected, refresh, toggle
+  migration, open single/selected/filtered migration, and migrate managed-site
+  channels.
+
+Completion payloads may include controlled site type, result, item count, and
+failure category only. They must omit all resource data and user-entered data.
+The button/row-action analytics integration emits the single start event. The
+page creates and passes the action context; the controller's terminal outcome
+callback completes it exactly once. Do not start or complete again inside both
+page and controller. Allow only `managedSiteType`, `itemCount`, `selectedCount`,
+`successCount`, `failureCount`, `errorCategory`, and `failureReason` controlled
+dimensions. Map uncertain mutation to the existing controlled failed/partial
+result category without resource data.
+
+- [ ] **Step 7: Run related UI tests**
+
+```powershell
+pnpm exec vitest run tests/features/ManagedSiteResources/ManagedSiteResourcePage.test.tsx tests/features/ManagedSiteResources/ManagedResourceMigrationDialog.test.tsx tests/features/ManagedSiteResources/useManagedResourceControllers.test.tsx tests/features/ManagedSiteResources/ManagedResourceEditorDialog.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit the complete native page**
+
+```powershell
+git add src/features/ManagedSiteResources/ManagedSiteResourcePage.tsx src/features/ManagedSiteResources/components/ManagedResourceTable.tsx src/features/ManagedSiteResources/components/ManagedResourceDetailDialog.tsx src/features/ManagedSiteResources/components/ManagedResourceMigrationDialog.tsx tests/features/ManagedSiteResources/ManagedSiteResourcePage.test.tsx tests/features/ManagedSiteResources/ManagedResourceMigrationDialog.test.tsx
+pnpm run validate:staged
+git commit -m "feat(managed-sites): add native resource management page"
+```
+
+### Task 5: Write the AxonHub browser proof without enabling it
+
+**Files:**
+
+- Create: `e2e/managedSiteAxonHubNative.spec.ts`
+- Modify: `e2e/scenarios/managedSiteChannels.ts`
+
+- [ ] **Step 1: Add native helpers without changing other site scenarios**
+
+Import the native test ids into `e2e/scenarios/managedSiteChannels.ts`. Route
+only `SITE_TYPES.AXON_HUB` through native row/editor helpers. The other five
+managed site types must continue using existing legacy test ids and
+`ChannelDialog` helpers.
+
+Do not modify the environment-backed multi-site scenarios to require live
+AxonHub credentials.
+
+- [ ] **Step 2: Write the targeted intercepted Chromium test**
+
+Test name:
+
+```ts
+test("routes AxonHub channel management through the native editor and refreshes the edited row", async ({ context, page, extensionId }) => {
+  // ...
+})
+```
+
+Import `test` from `~~/e2e/fixtures/extensionTest`. In `beforeEach`, call
+`installExtensionPageGuards(page)`, `forceExtensionLanguage(page, "en")`, and
+`stubLlmMetadataIndex(context)`. Obtain the service worker with
+`getServiceWorker(context)` and seed preferences through the existing
+`seedUserPreferences` helper.
+
+Seed valid AxonHub preferences with reserved example values. Use
+`context.route` so requests made by the extension service worker are also
+intercepted; handle sign-in and GraphQL operations. Return an opaque string id
+and cursor page without requiring a total. Open the options channel-management
+route with a `search` parameter, assert the native search and row selectors,
+edit only the channel name, and submit.
+
+Assert the intercepted `UpdateChannel` variables contain the required id and
+changed `name`, and omit credentials and every unchanged editable field. Return
+the updated row, wait for the subsequent list refresh, and assert the edited
+name is visible.
+
+Do not flip the definition, run this E2E, or commit these two files yet. They
+remain part of the final cutover commit in Task 6, so the definition test can
+still prove a red state first.
+
+### Task 6: Switch AxonHub and run release gates
+
+**Files:**
+
+- Modify: `src/services/accountSiteDefinitions/definitions.ts`
+- Modify: `tests/services/accountSiteDefinitions/registry.test.ts`
+- Create: `e2e/managedSiteAxonHubNative.spec.ts`
+- Modify: `e2e/scenarios/managedSiteChannels.ts`
+
+- [ ] **Step 1: Write the failing definition assertion**
+
+Update the registry test to assert:
+
+- AxonHub declares `native-resource` and its exact primary kind;
+- AxonHub has a matching production registration;
+- all five other Managed Site Types still declare `legacy-channel`;
+- every native definition has a matching registration;
+- mode is explicit and is never inferred from registration presence.
+
+- [ ] **Step 2: Run the registry test and verify it fails**
+
+```powershell
+pnpm exec vitest run tests/services/accountSiteDefinitions/registry.test.ts
+```
+
+Expected: FAIL because AxonHub still uses legacy mode.
+
+- [ ] **Step 3: Flip only the AxonHub static definition**
+
+Change AxonHub to `native-resource` with the registered channel kind. Do not
+delete the legacy AxonHub Adapter/provider/UI path in this plan. The one-line
+definition change is the rollback switch; reverting it restores the legacy
+page without a runtime flag.
+
+- [ ] **Step 4: Run all focused tests**
+
+```powershell
+pnpm exec vitest run tests/services/accountSiteDefinitions/registry.test.ts tests/features/ManagedSiteResources tests/components/ManagedSiteConfigRequiredState.test.tsx tests/services/apiAdapters/managedResources tests/services/managedSites/channelMigrationCapabilityRegistry.test.ts tests/services/managedSites/channelMigration.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run locale, targeted E2E, and repository gates**
+
+```powershell
+pnpm run i18n:extract:ci
+pnpm exec playwright test e2e/managedSiteAxonHubNative.spec.ts --project=chromium
+pnpm run validate:push
+```
+
+Expected: all PASS. `validate:push` must include successful compile and knip
+checks. Classify any failure before changing code; do not weaken a gate.
+
+- [ ] **Step 6: Inspect maintainability and privacy**
+
+Inspect the task diff and verify:
+
+- the page composes two substantive hooks and no shallow aggregation layer;
+- Workspace calls exist only in controllers, not table/field components;
+- no resource value reaches analytics, logs, or safe failure copy;
+- no legacy channel conversion exists in the native feature;
+- there is one field-kind switch and one failure-code-to-copy mapping;
+- route search is not duplicated as client-side current-page filtering;
+- uncertain mutations have no retry/replay branch;
+- no unsupported AxonHub field was added;
+- non-AxonHub modes and E2E paths remain unchanged.
+
+Run the static native/legacy boundary check:
+
+```powershell
+rg -n "ManagedSiteChannel|ChannelFormData|prepareManagedSiteChannelMigrationPreview|executeManagedSiteChannelMigration|channelMigrationLegacyFacade" src/features/ManagedSiteResources
+```
+
+Expected: no matches. The feature may import only canonical migration types and
+the canonical preview/execute entry points.
+
+Inspect the entire PR3 range, not only the last uncommitted slice:
+
+```powershell
+$baseSha = git log -1 --format=%H --grep="^refactor(axonhub): route migration through native capabilities$"
+git diff --check $baseSha
+git diff --stat $baseSha
+git diff --name-status $baseSha
+```
+
+Expected: `$baseSha` is non-empty and the diff contains only files named by
+this plan.
+
+If cleanup would exceed this touched surface, record it as follow-up rather
+than expanding the cutover.
+
+- [ ] **Step 7: Stage only task files and run the commit gate**
+
+```powershell
+git status --short
+git diff --check
+git add src/features/ManagedSiteResources src/entrypoints/options/pages/ManagedSiteChannels/index.tsx src/components/ManagedSiteConfigRequiredState.tsx src/services/accountSiteDefinitions/definitions.ts src/locales/zh-CN/managedSiteResources.json src/locales/zh-TW/managedSiteResources.json src/locales/en/managedSiteResources.json src/locales/ja/managedSiteResources.json src/locales/es-419/managedSiteResources.json src/locales/vi/managedSiteResources.json tests/features/ManagedSiteResources tests/test-utils/managedResourceWorkspace.ts tests/components/ManagedSiteConfigRequiredState.test.tsx tests/services/accountSiteDefinitions/registry.test.ts e2e/managedSiteAxonHubNative.spec.ts e2e/scenarios/managedSiteChannels.ts
+pnpm run validate:staged
+```
+
+Expected: PASS. Inspect `git diff --cached --stat` and
+`git diff --cached --check`; unrelated files must not be staged.
+
+- [ ] **Step 8: Commit the static cutover**
+
+```powershell
+git commit -m "feat(axonhub): switch channels to native workspace"
+```
+
+- [ ] **Step 9: Verify the committed state**
+
+```powershell
+git status --short
+git log -1 --oneline
+$baseSha = git log -1 --format=%H --grep="^refactor(axonhub): route migration through native capabilities$"
+git diff --check "$baseSha..HEAD"
+git diff --stat "$baseSha..HEAD"
+```
+
+Expected: the task-scoped work is committed and unrelated user state, if any,
+is untouched.
+
+## Release decisions
+
+- **Telemetry:** reuse existing Managed Site Channels action events and
+  controlled result categories. Add no passive impression or settings
+  snapshot. Tests prove resource and field values are excluded.
+- **Settings search/deep links:** add no search entry because no setting moves.
+  Preserve the definition-owned AxonHub `managedSite` anchor and test the CTA.
+- **E2E:** retain one intercepted Chromium workflow because the primary cutover
+  risk is route dispatch plus real dialog/browser integration. Keep state
+  matrices in Vitest.
+- **Maintainability:** reuse existing UI primitives, target selection, locale
+  copy, navigation, analytics ids, Workspace, and canonical migration API.
+  Extract only the two deep controllers, primitive field switch, and controlled
+  copy mapping. Leave legacy page deletion and migration of the other five site
+  types out of scope.
+- **Rollback:** revert only AxonHub's static `resourceMode` definition. Do not
+  add a runtime fallback, remote flag, or catch-and-fallback branch.
+
+## Completion criteria
+
+- AxonHub renders the resource-native page; the other five site types render
+  the unchanged legacy page.
+- The first 14 fields can be displayed and the Adapter-selected editable subset
+  can be edited without exposing or replacing hidden values.
+- Configuration, authentication, permission, empty, loading, refresh failure,
+  deletion partial failure, not-found, and uncertain mutation states have safe
+  actionable UI.
+- Resource-wide search is either delegated to the Workspace or absent.
+- Native migration uses canonical selections/results and preserves existing
+  warnings, partial outcomes, no rollback, refresh, copy, and analytics.
+- No native code constructs `ManagedSiteChannel` or `ChannelFormData`.
+- Focused tests, i18n extraction, targeted Chromium E2E,
+  `validate:staged`, and `validate:push` pass before remote handoff.

--- a/docs/superpowers/plans/2026-07-16-managed-site-resource-native-substrate.md
+++ b/docs/superpowers/plans/2026-07-16-managed-site-resource-native-substrate.md
@@ -1,0 +1,1010 @@
+# Managed Site Resource-Native Substrate Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox notation (`- [ ]`) for tracking.
+
+**Goal:** Add the resource-native contracts, factory, AxonHub protocol support, and an AxonHub native registration without changing production UI routing.
+
+**Architecture:** A typed per-kind factory closes over native config, locator, list, detail, create, and update types, then exposes a small non-generic Workspace. AxonHub is registered in a dedicated native registry, while every Managed Site Definition remains on `legacy-channel` until the later UI cutover.
+
+**Tech Stack:** TypeScript 5.9, Vitest 4, MSW, WXT browser-extension services, native `fetch`, GraphQL over HTTP, existing user-preferences storage.
+
+---
+
+## Source and execution order
+
+Implement the first delivery slice from
+`docs/superpowers/specs/2026-07-16-managed-site-resource-native-extension-design.md`.
+
+This plan starts from commit `7756a5f18`. Execute it before:
+
+1. `2026-07-16-axonhub-canonical-migration-capability.md`
+2. `2026-07-16-axonhub-resource-native-ui-cutover.md`
+
+At execution time, create or select an isolated worktree with
+`superpowers:using-git-worktrees`. Do not implement PR2 or PR3 in this branch.
+
+## File structure
+
+Create:
+
+- `src/services/apiAdapters/contracts/managedResourceNative.ts` — the only
+  feature-facing resource-native contract.
+- `src/services/apiAdapters/managedResources/factory.ts` — generic native
+  definition and non-generic Workspace/editor implementation.
+- `src/services/apiAdapters/managedResources/axonHub.ts` — AxonHub native
+  registration and field/payload projection.
+- `src/services/apiAdapters/managedResources/registry.ts` — explicit native
+  registration lookup, separate from legacy `SiteTypeCapabilities`.
+- `tests/services/apiAdapters/managedResources/factory.test.ts` — reusable
+  synthetic Adapter contract tests.
+- `tests/services/apiAdapters/managedResources/axonHub.test.ts` — AxonHub
+  projection, preservation, mutation-certainty, and registry tests.
+
+Modify:
+
+- `src/services/accountSiteDefinitions/contracts.ts` — definition-owned
+  resource mode, primary kind, labels, and settings target.
+- `src/services/accountSiteDefinitions/definitions.ts` — explicit legacy mode
+  for all six current Managed Site Types.
+- `src/services/accountSiteDefinitions/registry.ts` — defensive cloning for the
+  new policy object.
+- `src/types/axonHub.ts` — pinned beta5 native channel/input types.
+- `src/services/apiService/axonHub/index.ts` — native page/detail operations,
+  signal propagation, selections, inputs, and controlled protocol errors.
+- `tests/services/accountSiteDefinitions/registry.test.ts` — mode completeness
+  and defensive-copy tests.
+- `tests/services/apiService/axonHub/index.test.ts` — GraphQL contract tests.
+
+Do not modify the legacy resource contracts, legacy AxonHub adapter/provider,
+UI, migration, locale, analytics, or E2E files in this plan.
+
+### Task 1: Add explicit Managed Site resource policy and public contracts
+
+**Files:**
+
+- Create: `src/services/apiAdapters/contracts/managedResourceNative.ts`
+- Modify: `src/services/accountSiteDefinitions/contracts.ts`
+- Modify: `src/services/accountSiteDefinitions/definitions.ts`
+- Modify: `src/services/accountSiteDefinitions/registry.ts`
+- Test: `tests/services/accountSiteDefinitions/registry.test.ts`
+
+- [ ] **Step 1: Add failing definition-policy tests**
+
+Add these cases to `registry.test.ts`:
+
+```ts
+it("gives every managed site an explicit managed-resource policy", () => {
+  for (const siteType of MANAGED_SITE_TYPES) {
+    expect(getAccountSiteDefinition(siteType)?.managedResource).toMatchObject({
+      mode: "legacy-channel",
+      primaryKind: "channel",
+      settingsTarget: { tabId: "managedSite" },
+    })
+  }
+})
+
+it("keeps AxonHub on the legacy channel path until UI cutover", () => {
+  expect(
+    getAccountSiteDefinition(SITE_TYPES.AXON_HUB)?.managedResource,
+  ).toMatchObject({
+    mode: "legacy-channel",
+    primaryKind: "channel",
+    settingsTarget: { tabId: "managedSite", anchor: "axonhub" },
+    actions: ["create", "delete-selected", "migrate"],
+  })
+})
+
+it("returns defensive managed-resource policy copies", () => {
+  const first = getAccountSiteDefinition(SITE_TYPES.AXON_HUB)!
+  const mutableDetailFields = first.managedResource!.detailFieldIds as string[]
+  first.managedResource!.settingsTarget.anchor = "changed"
+  mutableDetailFields[0] = "changed"
+
+  expect(
+    getAccountSiteDefinition(SITE_TYPES.AXON_HUB)?.managedResource
+      ?.settingsTarget,
+  ).toEqual({ tabId: "managedSite", anchor: "axonhub" })
+  expect(
+    getAccountSiteDefinition(SITE_TYPES.AXON_HUB)?.managedResource
+      ?.detailFieldIds[0],
+  ).toBe("name")
+})
+```
+
+Also add `keeps managed-resource field and action policy values unique`, which
+checks each definition without freezing the whole definition object.
+
+- [ ] **Step 2: Run the tests and verify the expected failure**
+
+Run:
+
+```powershell
+pnpm exec vitest run tests/services/accountSiteDefinitions/registry.test.ts
+```
+
+Expected: FAIL because `managedResource` does not exist on the definition
+contract.
+
+- [ ] **Step 3: Add the definition policy contract**
+
+Add to `accountSiteDefinitions/contracts.ts`:
+
+```ts
+export const MANAGED_RESOURCE_MODES = {
+  LegacyChannel: "legacy-channel",
+  NativeResource: "native-resource",
+} as const
+
+export type ManagedResourceMode =
+  (typeof MANAGED_RESOURCE_MODES)[keyof typeof MANAGED_RESOURCE_MODES]
+
+export const MANAGED_RESOURCE_KINDS = {
+  Channel: "channel",
+} as const
+
+export type ManagedResourceKind =
+  (typeof MANAGED_RESOURCE_KINDS)[keyof typeof MANAGED_RESOURCE_KINDS]
+
+export const MANAGED_RESOURCE_PRODUCT_ACTIONS = {
+  Create: "create",
+  DeleteSelected: "delete-selected",
+  Migrate: "migrate",
+} as const
+
+export type ManagedResourceProductAction =
+  (typeof MANAGED_RESOURCE_PRODUCT_ACTIONS)[keyof typeof MANAGED_RESOURCE_PRODUCT_ACTIONS]
+
+export interface ManagedResourceProductPolicy {
+  mode: ManagedResourceMode
+  primaryKind: ManagedResourceKind
+  titleKey: "managedSiteChannels:title"
+  itemLabelKey: "managedSiteChannels:table.columns.name"
+  tableFieldIds: readonly string[]
+  detailFieldIds: readonly string[]
+  actions: readonly ManagedResourceProductAction[]
+  settingsTarget: {
+    tabId: "managedSite"
+    anchor?: string
+  }
+}
+```
+
+Add `managedResource?: ManagedResourceProductPolicy` to
+`AccountSiteDefinition`. Define one shared legacy policy in `definitions.ts`,
+spread it into every managed-scoped definition, and give AxonHub the
+`anchor: "axonhub"` settings target. Legacy policies may use empty field arrays
+because their existing page owns its columns. AxonHub declares
+`tableFieldIds` as `name`, `type`, `baseURL`, `status`, `supportedModels`, and
+`tags`, `detailFieldIds` as the exact 14-field allowlist in Task 4, and actions
+as create, delete-selected, and migrate. Clone the policy, both field arrays,
+the action array, and the nested target in `cloneDefinition`.
+
+- [ ] **Step 4: Add the non-generic feature-facing resource contract**
+
+Create `managedResourceNative.ts` with these runtime constants and types:
+
+```ts
+import type { ManagedSiteType } from "~/constants/siteType"
+import type { ManagedResourceKind } from "~/services/accountSiteDefinitions/contracts"
+
+export const MANAGED_RESOURCE_FIELD_TYPES = {
+  Text: "text",
+  Textarea: "textarea",
+  Number: "number",
+  Boolean: "boolean",
+  Select: "select",
+  MultiSelect: "multi-select",
+  Secret: "secret",
+} as const
+
+export const MANAGED_RESOURCE_FAILURE_CODES = {
+  ConfigurationRequired: "configuration_required",
+  InvalidConfiguration: "invalid_configuration",
+  AuthenticationFailed: "authentication_failed",
+  PermissionDenied: "permission_denied",
+  ValidationFailed: "validation_failed",
+  NotFound: "not_found",
+  MutationStateUncertain: "mutation_state_uncertain",
+  Unavailable: "unavailable",
+  UpstreamRejected: "upstream_rejected",
+  Aborted: "aborted",
+  Unexpected: "unexpected",
+} as const
+
+export const MANAGED_RESOURCE_FIELD_ISSUE_CODES = {
+  Required: "required",
+  InvalidValue: "invalid_value",
+  OutOfRange: "out_of_range",
+  UnsupportedOption: "unsupported_option",
+  InconsistentValue: "inconsistent_value",
+} as const
+
+export type ManagedResourceRef = {
+  siteType: ManagedSiteType
+  kind: ManagedResourceKind
+  scopeKey: string
+  resourceId: string
+}
+
+export type ResourceOperationOptions = { signal?: AbortSignal }
+
+export type ResourceListQuery = {
+  cursor?: string
+  limit?: number
+  search?: string
+}
+
+export type ResourceDisplayFacts = {
+  ref: ManagedResourceRef
+  displayName: string
+  status:
+    | "enabled"
+    | "disabled"
+    | "archived"
+    | "auto-disabled"
+    | "unknown"
+  fields: readonly ResourceDisplayFact[]
+  actions: { canUpdate: boolean; canDelete: boolean }
+}
+
+export type ResourceSecretState =
+  | "available"
+  | "masked"
+  | "unavailable"
+  | "permission-hidden"
+
+export type ResourceDisplayFact =
+  | { fieldId: string; kind: "text"; value: string }
+  | { fieldId: string; kind: "number"; value: number }
+  | { fieldId: string; kind: "boolean"; value: boolean }
+  | { fieldId: string; kind: "list"; value: readonly string[] }
+  | { fieldId: string; kind: "secret"; state: ResourceSecretState }
+
+export type ResourcePage = {
+  items: readonly ResourceDisplayFacts[]
+  total?: number
+  nextCursor?: string
+}
+
+export type SecretEditIntent =
+  | { kind: "unchanged" }
+  | { kind: "replace"; value: string }
+  | { kind: "clear" }
+
+export type ResourceFieldValue =
+  | string
+  | number
+  | boolean
+  | readonly string[]
+  | SecretEditIntent
+
+export type EditableResourceProjection = Readonly<
+  Record<string, ResourceFieldValue>
+>
+
+export type ResourceFieldIssue = {
+  fieldId: string
+  code: (typeof MANAGED_RESOURCE_FIELD_ISSUE_CODES)[keyof typeof MANAGED_RESOURCE_FIELD_ISSUE_CODES]
+}
+export type ResourceValidationResult =
+  | { valid: true }
+  | { valid: false; issues: readonly ResourceFieldIssue[] }
+
+type ResourceFieldDescriptorBase = {
+  fieldId: string
+  required?: boolean
+}
+
+export type ResourceFieldDescriptor =
+  | (ResourceFieldDescriptorBase & { type: "text" })
+  | (ResourceFieldDescriptorBase & { type: "textarea"; rows?: number })
+  | (ResourceFieldDescriptorBase & {
+      type: "number"
+      min?: number
+      max?: number
+      step?: number
+    })
+  | (ResourceFieldDescriptorBase & { type: "boolean" })
+  | (ResourceFieldDescriptorBase & {
+      type: "select"
+      options: readonly { value: string }[]
+    })
+  | (ResourceFieldDescriptorBase & {
+      type: "multi-select"
+      options: readonly { value: string }[]
+    })
+  | (ResourceFieldDescriptorBase & {
+      type: "secret"
+      secretState: ResourceSecretState
+      allowClear: boolean
+    })
+
+export type ResourceFailure = {
+  code: (typeof MANAGED_RESOURCE_FAILURE_CODES)[keyof typeof MANAGED_RESOURCE_FAILURE_CODES]
+  fieldIssues?: readonly ResourceFieldIssue[]
+}
+
+export class ManagedResourceError extends Error {
+  constructor(readonly failure: ResourceFailure) {
+    super(failure.code)
+    this.name = "ManagedResourceError"
+  }
+}
+
+export interface ResourceEditor {
+  readonly fields: readonly ResourceFieldDescriptor[]
+  readonly initialValues: EditableResourceProjection
+  validate(values: EditableResourceProjection): ResourceValidationResult
+  submit(
+    values: EditableResourceProjection,
+    options?: ResourceOperationOptions,
+  ): Promise<ResourceDisplayFacts>
+}
+
+export interface ManagedResourceWorkspace {
+  readonly supportsSearch: boolean
+  list(
+    query?: ResourceListQuery,
+    options?: ResourceOperationOptions,
+  ): Promise<ResourcePage>
+  get(
+    ref: ManagedResourceRef,
+    options?: ResourceOperationOptions,
+  ): Promise<ResourceDisplayFacts>
+  openCreateEditor(options?: ResourceOperationOptions): Promise<ResourceEditor>
+  openEditEditor(
+    ref: ManagedResourceRef,
+    options?: ResourceOperationOptions,
+  ): Promise<ResourceEditor>
+  delete(
+    ref: ManagedResourceRef,
+    options?: ResourceOperationOptions,
+  ): Promise<void>
+}
+
+export interface ManagedResourceRegistration {
+  readonly siteType: ManagedSiteType
+  readonly kind: ManagedResourceKind
+  open(options?: ResourceOperationOptions): Promise<ManagedResourceWorkspace>
+}
+```
+
+Keep native DTOs, config, commands, mutation certainty, and `unknown` out of this
+file.
+
+`ResourceDisplayFact` is safe product data, not an erased native value. It is
+the only extension point for displaying additional verified primitive fields.
+It deliberately has no object, nested, or JSON variant. The definition selects
+which ids appear in the table and detail surface; the Adapter may return fewer
+facts from `list` than from `get`. Reject duplicate fact ids and facts whose ids
+are absent from the active definition policy in focused definition/Adapter
+tests; the generic factory rejects duplicates without importing product policy.
+
+- [ ] **Step 5: Run the definition tests and compile**
+
+Run:
+
+```powershell
+pnpm exec vitest run tests/services/accountSiteDefinitions/registry.test.ts
+pnpm compile
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit the policy and public contract**
+
+```powershell
+git add src/services/apiAdapters/contracts/managedResourceNative.ts src/services/accountSiteDefinitions/contracts.ts src/services/accountSiteDefinitions/definitions.ts src/services/accountSiteDefinitions/registry.ts tests/services/accountSiteDefinitions/registry.test.ts
+pnpm run validate:staged
+git commit -m "refactor(managed-sites): define resource-native contracts"
+```
+
+### Task 2: Implement the typed native-resource factory
+
+**Files:**
+
+- Create: `src/services/apiAdapters/managedResources/factory.ts`
+- Create: `tests/services/apiAdapters/managedResources/factory.test.ts`
+
+- [ ] **Step 1: Write the synthetic Adapter contract tests**
+
+Create `factory.test.ts` with a test-only definition using:
+
+```ts
+type TestConfig = { scope: string }
+type TestLocator = { tenant: string; route: string }
+type TestDetail = {
+  id: TestLocator
+  name: string
+  secret: string
+  settings: { visible: string; hidden: string }
+}
+
+const encodeLocator = (locator: TestLocator) =>
+  `${encodeURIComponent(locator.tenant)}/${encodeURIComponent(locator.route)}`
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+  return { promise, resolve, reject }
+}
+```
+
+Add these exact tests:
+
+- `opens a ready workspace without exposing native config or detail types`
+- `supports an opaque nonnumeric resource id and cursor page without a total`
+- `rejects empty or over-512-character resource ids before native access`
+- `rejects refs with the wrong site type resource kind or scope`
+- `keeps hidden native detail in the edit-editor closure`
+- `preserves a hidden nested native field across an allowed edit`
+- `coalesces concurrent editor submits into one Adapter mutation`
+- `maps possible and partial mutation outcomes to mutation_state_uncertain`
+- `treats deletion of an already-missing resource as success`
+- `maps abort before dispatch to aborted and keeps the editor reusable`
+- `maps abort after dispatch to mutation_state_uncertain and closes the editor`
+- `maps every Adapter read and mutation failure to a controlled public code`
+
+- [ ] **Step 2: Run the contract test and verify the missing-module failure**
+
+```powershell
+pnpm exec vitest run tests/services/apiAdapters/managedResources/factory.test.ts
+```
+
+Expected: FAIL because `managedResources/factory.ts` does not exist.
+
+- [ ] **Step 3: Define the internal correlated Adapter contract**
+
+Keep the following result Adapter-facing: export it from `factory.ts` so a
+site Adapter and later named capabilities can share the native certainty
+contract, but do not add it to the feature-facing
+`managedResourceNative.ts` contract:
+
+```ts
+export type NativeResourceMutationResult<T, TFailure> =
+  | { certainty: "applied"; value: T }
+  | { certainty: "not-applied"; failure: TFailure }
+  | { certainty: "possibly-applied" }
+  | { certainty: "partially-applied" }
+```
+
+Also export `defineNativeResourceKind` and its strongly typed definition input.
+The registry still receives only the erased `ManagedResourceRegistration`:
+
+```ts
+export type NativeResourcePage<TItem> = {
+  items: readonly TItem[]
+  total?: number
+  nextCursor?: string
+}
+
+export type NativeResourceEditorDefinition<TCommand> = {
+  fields: readonly ResourceFieldDescriptor[]
+  initialValues: EditableResourceProjection
+  validate(values: EditableResourceProjection): ResourceValidationResult
+  buildCommand(values: EditableResourceProjection): TCommand
+}
+
+export type NativeResourceKindDefinition<
+  TConfig,
+  TLocator,
+  TListItem,
+  TDetail,
+  TCreateCommand,
+  TUpdateCommand,
+  TFailure,
+> = {
+  siteType: ManagedSiteType
+  kind: ManagedResourceKind
+  supportsSearch: boolean
+  openConfig(options?: ResourceOperationOptions): Promise<TConfig>
+  scopeKey(config: TConfig): string
+  encodeLocator(locator: TLocator): string
+  decodeLocator(resourceId: string): TLocator
+  locatorFromListItem(item: TListItem): TLocator
+  list(
+    config: TConfig,
+    query?: ResourceListQuery,
+    options?: ResourceOperationOptions,
+  ): Promise<NativeResourcePage<TListItem>>
+  get(
+    config: TConfig,
+    locator: TLocator,
+    options?: ResourceOperationOptions,
+  ): Promise<TDetail>
+  toListFacts(
+    item: TListItem,
+    ref: ManagedResourceRef,
+  ): ResourceDisplayFacts
+  toDetailFacts(
+    detail: TDetail,
+    ref: ManagedResourceRef,
+  ): ResourceDisplayFacts
+  createEditor(
+    config: TConfig,
+    options?: ResourceOperationOptions,
+  ): Promise<NativeResourceEditorDefinition<TCreateCommand>>
+  editEditor(
+    config: TConfig,
+    detail: TDetail,
+  ): NativeResourceEditorDefinition<TUpdateCommand>
+  create(
+    config: TConfig,
+    command: TCreateCommand,
+    options?: ResourceOperationOptions,
+  ): Promise<NativeResourceMutationResult<TDetail, TFailure>>
+  update(
+    config: TConfig,
+    detail: TDetail,
+    command: TUpdateCommand,
+    options?: ResourceOperationOptions,
+  ): Promise<NativeResourceMutationResult<TDetail, TFailure>>
+  delete(
+    config: TConfig,
+    locator: TLocator,
+    options?: ResourceOperationOptions,
+  ): Promise<NativeResourceMutationResult<void, TFailure>>
+  mapFailure(error: unknown): ResourceFailure
+}
+
+export function defineNativeResourceKind<
+  TConfig,
+  TLocator,
+  TListItem,
+  TDetail,
+  TCreateCommand,
+  TUpdateCommand,
+  TFailure,
+>(
+  definition: NativeResourceKindDefinition<
+    TConfig,
+    TLocator,
+    TListItem,
+    TDetail,
+    TCreateCommand,
+    TUpdateCommand,
+    TFailure
+  >,
+): ManagedResourceRegistration
+```
+
+The definition must provide `siteType`, `kind`, `supportsSearch`, `openConfig`,
+`scopeKey`, locator encode/decode, list/get/project functions, create/edit
+editor builders, mutation functions, and a failure mapper. Do not export an
+erased generic container or use registry-level casts.
+
+`TFailure` is the Adapter's controlled internal failure type. It is the only
+addition to the design sketch's correlated generics and is necessary to keep
+failure translation at the Workspace boundary; it never appears in the public
+Workspace or registry type.
+
+- [ ] **Step 4: Implement ref validation, editor closure, and certainty mapping**
+
+Use one normalization helper:
+
+```ts
+const toPublicMutation = async <T, TFailure>(
+  operation: () => Promise<NativeResourceMutationResult<T, TFailure>>,
+  mapFailure: (failure: TFailure) => ResourceFailure,
+): Promise<T> => {
+  const result = await operation()
+  if (result.certainty === "applied") return result.value
+  if (result.certainty === "not-applied") {
+    throw new ManagedResourceError(mapFailure(result.failure))
+  }
+  throw new ManagedResourceError({
+    code: MANAGED_RESOURCE_FAILURE_CODES.MutationStateUncertain,
+  })
+}
+```
+
+The editor closure stores native detail and one `inflight` Promise. A second
+submit returns the same Promise. Validation failure does not dispatch. Applied,
+possibly-applied, partially-applied, and not-found outcomes close the session;
+a confirmed pre-dispatch rejection leaves it reusable. Already-missing delete
+is normalized to success. Validate `resourceId` as a non-empty string of at most
+512 characters before locator decoding or native access.
+
+- [ ] **Step 5: Run the factory tests**
+
+```powershell
+pnpm exec vitest run tests/services/apiAdapters/managedResources/factory.test.ts
+```
+
+Expected: PASS with all twelve contract cases.
+
+- [ ] **Step 6: Commit the factory**
+
+```powershell
+git add src/services/apiAdapters/managedResources/factory.ts tests/services/apiAdapters/managedResources/factory.test.ts
+pnpm run validate:staged
+git commit -m "refactor(managed-sites): implement resource-native adapter factory"
+```
+
+### Task 3: Expose the pinned AxonHub native protocol
+
+**Files:**
+
+- Modify: `src/types/axonHub.ts`
+- Modify: `src/services/apiService/axonHub/index.ts`
+- Test: `tests/services/apiService/axonHub/index.test.ts`
+
+- [ ] **Step 1: Add failing GraphQL contract tests**
+
+Using the existing `AUTH_URL`, `GRAPHQL_URL`, `matchesGraphqlOperation`, and MSW
+helpers, add these tests:
+
+- `returns one native AxonHub channel page with its upstream cursor`
+- `loads native AxonHub detail by opaque GraphQL id`
+- `selects every pinned beta5 settings field required for replacement preservation`
+- `sends verified update and clear fields unchanged`
+- `classifies abort before mutation dispatch as not-dispatched`
+- `classifies abort after mutation dispatch as dispatched`
+- `retains controlled status and dispatch phase in AxonHub protocol failures`
+
+Assert operation names, variables, and required selections. Do not snapshot a
+whole GraphQL document.
+
+- [ ] **Step 2: Run the focused protocol tests and verify failure**
+
+```powershell
+pnpm exec vitest run tests/services/apiService/axonHub/index.test.ts
+```
+
+Expected: FAIL because native page/detail functions and beta5 fields are absent.
+
+- [ ] **Step 3: Complete the beta5 native types**
+
+Extend `AxonHubChannel`, `AxonHubChannelCredentials`,
+`AxonHubChannelSettings`, `AxonHubCreateChannelInput`, and
+`AxonHubUpdateChannelInput` with the pinned fields from the spec. The update
+type must represent `status`, append fields, and every verified `clearXxx`
+flag. Settings must explicitly type every beta5 `ChannelSettingsInput` member;
+do not rely on `[key: string]: unknown` for preservation.
+
+Use this pinned `d061ac7` settings matrix in both the detail selection and the
+replacement input. Every selected output object is mapped field-for-field to
+its input counterpart when only `extraModelPrefix` changes:
+
+| Setting field | Pinned output/input shape |
+| --- | --- |
+| `extraModelPrefix` | nullable string |
+| `modelMappings` | `{ from, to }[]` to `ModelMappingInput[]` |
+| `autoTrimedModelPrefixes` | string array |
+| `hideOriginalModels` | nullable boolean |
+| `hideMappedModels` | nullable boolean |
+| `lowercaseModelId` | nullable boolean |
+| `proxy` | `{ type, url, username, password }` to `ProxyConfigInput` |
+| `transformOptions` | `{ forceArrayInstructions, forceArrayInputs, replaceDeveloperRoleWithSystem, reasoningEffortMapping: { from, to }[] }` to matching input |
+| `headerOverrideOperations` | `{ op, path, from, to, value, condition, match: { path, eq }, index, splat }[]` to matching inputs |
+| `bodyOverrideOperations` | same override-operation shape |
+| `passThroughUserAgent` | nullable boolean |
+| `passThroughBody` | nullable boolean |
+| `rateLimit` | `{ rpm, tpm, maxConcurrent, queueSize, queueTimeoutMs }` to matching input |
+| `retryableStatusCodes` | integer array |
+| `retryableErrorPatterns` | `{ pattern, regex }[]` to matching inputs |
+| `providerQuota` | `{ opencodeGo: { workspaceId, authCookie } }` to matching input |
+
+The detail GraphQL selection must include every field and nested member in the
+table. Tests assert each member individually. Do not claim preservation for an
+unselected fork-specific field. Keep the pinned source URL and commit beside
+the selection and mapping code.
+
+- [ ] **Step 4: Add controlled internal protocol errors**
+
+In the AxonHub API module add:
+
+```ts
+export type AxonHubRequestFailureKind =
+  | "authentication"
+  | "permission"
+  | "not-found"
+  | "upstream-rejected"
+  | "protocol"
+  | "unavailable"
+  | "aborted"
+
+export class AxonHubRequestError extends Error {
+  constructor(
+    readonly kind: AxonHubRequestFailureKind,
+    readonly dispatch: "not-dispatched" | "dispatched",
+  ) {
+    super(kind)
+    this.name = "AxonHubRequestError"
+  }
+}
+```
+
+Wrap `AbortError` in `AxonHubRequestError` while preserving whether the native
+mutation was dispatched. A signal already aborted before mutation dispatch is
+`not-dispatched`; an abort from the in-flight mutation request is `dispatched`.
+Distinguish sign-in rejection from network failure, classify a post-refresh
+403 as permission denial, and never include response body text or credentials
+in the typed error.
+
+- [ ] **Step 5: Add native page/detail operations and signal-aware mutations**
+
+Add:
+
+```ts
+export type AxonHubChannelPage = {
+  items: AxonHubChannel[]
+  total?: number
+  nextCursor?: string
+}
+
+export async function listAxonHubChannelPage(
+  config: AxonHubConfig,
+  input: { cursor?: string; limit: number },
+  options?: Pick<RequestInit, "signal">,
+): Promise<AxonHubChannelPage>
+
+export async function getAxonHubChannel(
+  config: AxonHubConfig,
+  id: string,
+  options?: Pick<RequestInit, "signal">,
+): Promise<AxonHubChannel>
+```
+
+Make create, update, status update, and delete accept the same signal options.
+Keep current legacy list/cache/projection exports working by building them on
+the new page primitive where practical.
+
+Add the pinned commit URL beside the detail selection and update input logic,
+stating the settings-preservation, clear-flag, and permission-null contracts.
+
+- [ ] **Step 6: Run protocol and legacy AxonHub tests**
+
+```powershell
+pnpm exec vitest run tests/services/apiService/axonHub/index.test.ts tests/services/apiAdapters/managedSites/axonHub.test.ts tests/services/managedSites/providers/axonHub.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit the protocol slice**
+
+```powershell
+git add src/types/axonHub.ts src/services/apiService/axonHub/index.ts tests/services/apiService/axonHub/index.test.ts
+pnpm run validate:staged
+git commit -m "refactor(axonhub): expose native channel protocol"
+```
+
+### Task 4: Register the AxonHub native Adapter without UI cutover
+
+**Files:**
+
+- Create: `src/services/apiAdapters/managedResources/axonHub.ts`
+- Create: `src/services/apiAdapters/managedResources/registry.ts`
+- Create: `tests/services/apiAdapters/managedResources/axonHub.test.ts`
+
+- [ ] **Step 1: Write failing AxonHub registration tests**
+
+Add these exact cases:
+
+- `opens AxonHub with validated saved configuration`
+- `maps missing invalid authentication permission and aborted config failures safely`
+- `maps native list and detail responses to safe display facts`
+- `maps all fourteen approved fields to safe detail facts`
+- `returns only the definition-selected safe fact subset from list`
+- `searches across all AxonHub pages when supportsSearch is true`
+- `matches resource-wide search against opaque id and safe display facts`
+- `exposes only the approved first editable field set`
+- `keeps archived distinct from disabled`
+- `omits unchanged unavailable permission-hidden and masked credentials`
+- `emits a replacement credential only for explicit replace intent`
+- `emits only changed top-level fields and verified clear flags`
+- `preserves every selected pinned setting while updating extraModelPrefix`
+- `validates supported manual and default-model invariants`
+- `maps create plus failed status follow-up to mutation_state_uncertain without replay`
+- `registers AxonHub separately from legacy SiteTypeCapabilities`
+- `does not treat registration presence as native rollout mode`
+- `has a registration for every definition currently marked native-resource`
+
+Use `vi.hoisted` mocks and local placeholder builders. Never import legacy test
+builders or real service data.
+
+- [ ] **Step 2: Run the Adapter tests and verify failure**
+
+```powershell
+pnpm exec vitest run tests/services/apiAdapters/managedResources/axonHub.test.ts
+```
+
+Expected: FAIL because the registration and native registry do not exist.
+
+- [ ] **Step 3: Implement AxonHub config opening and failure mapping**
+
+`openConfig` must call `userPreferences.getPreferences()` directly, then pass
+the result to `resolveManagedSiteRuntimeConfigForType(preferences,
+SITE_TYPES.AXON_HUB)`. Missing fields map to `configuration_required`; storage
+errors remain `unavailable` or `unexpected` rather than becoming missing config.
+Validate sign-in with the caller signal.
+
+Keep configuration in a site-private session shared by the registration and
+later named Axon capabilities. Export these exact symbols from this Adapter
+module, not from the public Workspace contract:
+
+```ts
+export type AxonHubNativeFailure = {
+  code:
+    | "configuration_required"
+    | "invalid_configuration"
+    | "authentication_failed"
+    | "permission_denied"
+    | "not_found"
+    | "unavailable"
+    | "upstream_rejected"
+    | "aborted"
+    | "unexpected"
+  dispatch: "before" | "after"
+}
+
+export class AxonHubNativeError extends Error {
+  constructor(readonly failure: AxonHubNativeFailure) {
+    super(failure.code)
+    this.name = "AxonHubNativeError"
+  }
+}
+
+export interface AxonHubNativeResourceOperations {
+  readonly scopeKey: string
+  list(
+    query?: ResourceListQuery,
+    options?: ResourceOperationOptions,
+  ): Promise<{
+    items: readonly AxonHubChannel[]
+    nextCursor?: string
+  }>
+  get(
+    ref: ManagedResourceRef,
+    options?: ResourceOperationOptions,
+  ): Promise<AxonHubChannel>
+  create(
+    input: AxonHubCreateChannelInput,
+    desiredStatus: AxonHubChannelStatus,
+    options?: ResourceOperationOptions,
+  ): Promise<
+    NativeResourceMutationResult<AxonHubChannel, AxonHubNativeFailure>
+  >
+  update(
+    detail: AxonHubChannel,
+    input: AxonHubUpdateChannelInput,
+    options?: ResourceOperationOptions,
+  ): Promise<
+    NativeResourceMutationResult<AxonHubChannel, AxonHubNativeFailure>
+  >
+  delete(
+    ref: ManagedResourceRef,
+    options?: ResourceOperationOptions,
+  ): Promise<NativeResourceMutationResult<void, AxonHubNativeFailure>>
+}
+
+export function openAxonHubNativeResourceOperations(
+  options?: ResourceOperationOptions,
+): Promise<AxonHubNativeResourceOperations>
+```
+
+The session closes over validated `AxonHubConfig`; callers never receive it.
+Its non-secret normalized origin is exposed only as `scopeKey` for ref
+validation. Open/read failures throw `AxonHubNativeError`; mutation failures
+use the certainty result.
+Use it as the factory's correlated `TConfig` so list/detail/editor mutations and
+the named migration capability share one protocol implementation. Mutations
+always return the certainty union.
+Map the internal failure only at the Workspace or named-feature boundary.
+
+- [ ] **Step 4: Implement the approved AxonHub display/editor projection**
+
+Use this exact field-id allowlist:
+
+```ts
+const AXON_HUB_EDITABLE_FIELD_IDS = [
+  "name",
+  "type",
+  "baseURL",
+  "status",
+  "key",
+  "supportedModels",
+  "manualModels",
+  "defaultTestModel",
+  "autoSyncSupportedModels",
+  "autoSyncModelPattern",
+  "tags",
+  "orderingWeight",
+  "remark",
+  "extraModelPrefix",
+] as const
+```
+
+Regular-key type options must exclude pinned OAuth/AWS/GCP credential types and
+exclude unknown future types by default. Existing special-credential channels
+remain viewable and may edit safe non-credential fields, but cannot change type
+or credentials.
+
+Map every allowlisted id into a primitive `ResourceDisplayFact` returned by
+detail. The list projection returns only the definition's table ids. The `key`
+fact carries secret state and never a credential value. Resource-wide search
+loads all required upstream pages and compares the normalized term against the
+opaque resource id and safe textual/list facts only; it never searches native
+detail, credentials, or only the current cursor page.
+
+Top-level updates omit unchanged fields. Empty base URL, manual models, pattern,
+tags, and remark use verified clear flags. Clearing `extraModelPrefix` writes an
+empty prefix inside a settings object merged from every field selected by the
+pinned detail query; never send `clearSettings`.
+
+- [ ] **Step 5: Implement create/update/delete certainty**
+
+Create sends one native create command. If the requested status is enabled, run
+the dedicated status mutation once. A failure after confirmed creation returns
+`partially-applied`; a lost acknowledgement after dispatch returns
+`possibly-applied`. Neither path retries create. Edit uses
+`UpdateChannelInput.status` in the main mutation. Delete treats an upstream
+not-found as success.
+
+- [ ] **Step 6: Add the explicit native registry**
+
+`registry.ts` must import the production Axon registration and expose:
+
+```ts
+export function getManagedResourceRegistration(
+  siteType: ManagedSiteType,
+  kind: ManagedResourceKind,
+): ManagedResourceRegistration | null
+```
+
+Use a typed key helper and a fixed registration array. Do not add a property to
+`SiteTypeCapabilities.managedSites`, infer definition mode from registration
+presence, or fall back to the legacy adapter.
+
+- [ ] **Step 7: Run focused and legacy regression tests**
+
+```powershell
+pnpm exec vitest run tests/services/apiAdapters/managedResources/axonHub.test.ts tests/services/apiService/axonHub/index.test.ts tests/services/apiAdapters/managedSites/axonHub.test.ts tests/services/apiAdapters/registry.test.ts tests/services/managedSites/providers/axonHub.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit the registration slice**
+
+```powershell
+git add src/services/apiAdapters/managedResources/axonHub.ts src/services/apiAdapters/managedResources/registry.ts tests/services/apiAdapters/managedResources/axonHub.test.ts
+pnpm run validate:staged
+git commit -m "refactor(axonhub): register native resource adapter"
+```
+
+## PR1 final verification
+
+- [ ] Confirm every task commit ran `validate:staged` after its exact `git add`
+  and before `git commit`. Do not run a no-staged-files command as a substitute.
+
+- [ ] Run the shared-contract remote handoff gate:
+
+```powershell
+pnpm run validate:push
+```
+
+Expected: `pnpm compile` and `pnpm knip` both pass.
+
+- [ ] Inspect scope:
+
+```powershell
+git diff --stat 7756a5f18..HEAD
+git diff --name-status 7756a5f18..HEAD
+git diff --check 7756a5f18..HEAD
+```
+
+Expected: only the files named in this plan; no UI, migration, locale,
+analytics, E2E, legacy resource contract, or legacy AxonHub adapter changes.
+
+## Release-readiness decisions
+
+- Telemetry: `none`; no user-visible route changes in PR1.
+- E2E: `none`; protocol, factory, registration, and legacy regression tests
+  cover the changed risk.
+- Maintainability: reuse current Axon authentication, GraphQL transport, config
+  resolver, and preference storage. Keep the new native projection out of the
+  legacy Axon provider/adapter and do not split the entire Axon apiService.

--- a/docs/superpowers/specs/2026-07-16-managed-site-resource-native-extension-design.md
+++ b/docs/superpowers/specs/2026-07-16-managed-site-resource-native-extension-design.md
@@ -1,0 +1,747 @@
+# Managed Site Resource-Native Extension Design
+
+Date: 2026-07-16
+
+## Status and relationship to the 2026-07-03 design
+
+This design is the approved follow-up to
+`2026-07-03-managed-upstream-resource-design.md`.
+
+The earlier design correctly identified the New API-shaped channel dependency
+and the need to preserve upstream-native detail. Its migration-first interface,
+however, still exposed product code to generic native detail, draft machinery,
+and per-feature legacy fallback gates. That shape is useful as historical
+context, but it is not the preferred path for a new Managed Site Type.
+
+This design revises the direction as follows:
+
+- existing Managed Site Types may remain on the Legacy Channel Path until a
+  focused migration is justified;
+- every new non-New-API-family Managed Site Type uses the Resource-Native Path;
+- AxonHub is the first existing Managed Site Type migrated to prove the new
+  path with controlled change size;
+- native detail and mutation uncertainty stay behind the Adapter seam;
+- product code sees only Resource Display Facts, an Editable Resource
+  Projection, and named Product Canonical Models;
+- routing is explicit and never silently falls back from resource-native mode
+  to New API-shaped channel behavior.
+
+Where the two documents conflict, this document governs new resource-native
+work. The earlier document continues to describe why legacy compatibility
+exists and why migration remains staged.
+
+## Problem
+
+The current managed-site product surface can represent the six supported
+Managed Site Types, but its dominant contracts still assume New API-shaped
+channels. A new, unrelated Upstream Backend would otherwise need to translate
+native resources into `ManagedSiteChannel`, `ChannelFormData`, and associated
+feature-specific shapes even when those fields do not exist upstream.
+
+That translation has three costs:
+
+1. native fields cannot be displayed or edited without expanding a New
+   API-shaped product model;
+2. hidden upstream fields and permission-sensitive secrets are easy to erase
+   during update;
+3. internal features learn UI draft shapes instead of consuming stable Product
+   Canonical Models.
+
+The solution must not overcorrect by generating an editor for the entire
+upstream schema. The product should progressively expose common, verified
+fields. Unedited top-level fields are preserved by omission from partial
+updates; replacement objects are preserved only to the extent covered by the
+authoritative detail selection and pinned target contract.
+
+## Goals
+
+- Make a new non-New-API-family Managed Site Type implement one resource-native
+  Adapter instead of the Legacy Channel Path.
+- Display safe native facts without exposing raw upstream payloads.
+- Edit a product-selected field subset and expand it incrementally.
+- Preserve unedited top-level fields and every selected field of a replacement
+  native object, without rewriting permission-sensitive secrets.
+- Give migration and future internal features named, typed capabilities that do
+  not depend on editor descriptors or `ChannelFormData`.
+- Keep the public Interface small enough that callers do not learn GraphQL,
+  configuration, commit-certainty, or concurrency details.
+- Validate the design against a pinned real AxonHub release before relying on
+  protocol fields or update semantics.
+- Migrate AxonHub without forcing the other existing Managed Site Types to move
+  in the same change.
+
+## Non-goals
+
+- Editing every AxonHub channel field.
+- Generating forms from GraphQL or arbitrary upstream schemas.
+- A nested, array, conditional, or raw-JSON field DSL.
+- A generic feature bag such as `features: Record<string, unknown>`.
+- Generic batch CRUD, background-owned editor sessions, persisted drafts, or an
+  idempotency framework.
+- Pretending AxonHub provides ETag or compare-and-swap concurrency.
+- Migrating model sync, model redirect, channel filters, batch export, and every
+  existing Managed Site Type in one effort.
+- Renaming existing user-facing channel copy to internal resource terminology.
+- Expanding the closed legacy `ManagedSiteRuntimeConfig` union for every future
+  resource-native site.
+
+## Design principles
+
+### Keep the public Interface deep
+
+Callers should get list, safe detail, edit, create, and delete behavior from a
+small Interface. Protocol parsing, native DTOs, clear flags, configuration
+validation, secret preservation, and mutation reconciliation remain in the
+Adapter implementation.
+
+Deleting the resource-native Module should cause those concerns to reappear in
+multiple callers. This is the deletion test that justifies the seam.
+
+### Separate upstream facts from product policy
+
+The Adapter owns Upstream Backend facts: supported operations, native fields,
+authentication, pagination, clear behavior, secret availability, and protocol
+failure interpretation.
+
+The Managed Site Definition and feature Modules own product policy: which
+resource kind is primary, which fields are displayed or editable now, which
+actions appear, user-facing recovery, analytics taxonomy, and rollout mode.
+
+### Make native mode explicit
+
+Each Managed Site Definition declares exactly one resource mode:
+
+```ts
+type ManagedResourceMode = "legacy-channel" | "native-resource"
+```
+
+Native mode requires a matching registration. A missing registration is an
+integration error. It must never route to the Legacy Channel Path because a
+registration is absent, misconfigured, or temporarily unavailable.
+
+## Architecture
+
+```text
+Managed Site Definition
+  | resourceMode + primary resource kind + product policy
+  v
+Managed Resource Dispatcher
+  | legacy-channel ----------------------> existing channel UI and contracts
+  | native-resource
+  v
+Resource-Native Registration
+  | opens and validates site configuration
+  v
+Managed Resource Workspace
+  | list / get / create editor / edit editor / delete
+  v
+Site Adapter implementation
+  | native queries, mutations, detail, secrets, preservation, error mapping
+  v
+Upstream Backend
+
+Named internal feature
+  -> named Site Adapter Capability
+  -> feature-owned Product Canonical Model
+```
+
+### Managed Site Definition
+
+The definition owns static product decisions:
+
+- `resourceMode`;
+- the primary managed resource kind and user-facing label keys;
+- configuration/settings navigation target;
+- rollout readiness and product-visible actions.
+
+The definition does not own native DTOs, GraphQL operations, configuration
+loading, credentials, editor state, or feature implementation objects.
+
+### Resource-Native Registration
+
+The registry maps a Managed Site Type and resource kind to a registration.
+Registration is explicit production wiring. An exhaustive typed registry and a
+focused completeness test catch a definition whose registration is missing;
+`knip` remains the dead-export and dependency gate.
+
+Each registration opens its own configuration and returns a ready Workspace.
+New sites therefore do not have to join the central legacy six-site runtime
+configuration union.
+
+A strongly typed factory may correlate site-specific types:
+
+```ts
+defineNativeResourceKind<
+  TConfig,
+  TLocator,
+  TListItem,
+  TDetail,
+  TCreateCommand,
+  TUpdateCommand
+>(definition)
+```
+
+The factory erases those generics inside a closure before registry storage.
+There is no public `TNative = unknown`, registry-level cast, or conversion to
+`ChannelFormData`. If a site exposes multiple native resource kinds, each kind
+gets its own correlated factory instance. The definition owns validated
+`TLocator` encoding and decoding to the public opaque `resourceId`.
+
+### Public Workspace Interface
+
+The feature-facing Interface remains intentionally small:
+
+```ts
+type ResourceOperationOptions = {
+  signal?: AbortSignal
+}
+
+interface ManagedResourceWorkspace {
+  readonly supportsSearch: boolean
+
+  list(
+    query?: ResourceListQuery,
+    options?: ResourceOperationOptions,
+  ): Promise<ResourcePage>
+  get(
+    ref: ManagedResourceRef,
+    options?: ResourceOperationOptions,
+  ): Promise<ResourceDisplayFacts>
+  openCreateEditor(
+    options?: ResourceOperationOptions,
+  ): Promise<ResourceEditor>
+  openEditEditor(
+    ref: ManagedResourceRef,
+    options?: ResourceOperationOptions,
+  ): Promise<ResourceEditor>
+  delete(
+    ref: ManagedResourceRef,
+    options?: ResourceOperationOptions,
+  ): Promise<void>
+}
+
+interface ResourceEditor {
+  readonly fields: readonly ResourceFieldDescriptor[]
+  readonly initialValues: EditableResourceProjection
+
+  validate(values: EditableResourceProjection): ResourceValidationResult
+  submit(
+    values: EditableResourceProjection,
+    options?: ResourceOperationOptions,
+  ): Promise<ResourceDisplayFacts>
+}
+```
+
+`ManagedResourceRef` is serializable and contains the Managed Site Type,
+resource kind, non-secret scope key, and an Adapter-produced opaque string
+`resourceId`. The string is bounded, stable for the resource lifetime, and must
+not contain secrets. An Adapter that eventually needs composite identity owns
+canonical encoding and decoding behind the seam rather than exposing a JSON
+locator to callers.
+
+`ResourcePage.total` and cursors are optional. The Interface must not assume
+page-number pagination or a known total.
+
+A search term in `ResourceListQuery` always means resource-wide search, never
+filtering only the currently loaded page. An Adapter must perform upstream-wide
+search, load every required page before filtering, or explicitly declare search
+unsupported through `supportsSearch` so the product does not render the control.
+
+### Resource views and editor fields
+
+`ResourceDisplayFacts` are the single safe read-only projection for both list
+and detail surfaces. A list response may select fewer display facts than `get`,
+but both use the same product model and never contain raw native detail or
+credentials.
+
+The first renderer supports only common primitive field kinds:
+
+- text;
+- textarea;
+- number;
+- boolean;
+- select;
+- multi-select;
+- secret.
+
+Nested native values may be exposed as a flat product field, for example
+`settings.extraModelPrefix` as a text field. There is no raw JSON editor and no
+generic nested-field DSL in the first implementation. Omitting JSON is an
+approved first-slice simplification, not a statement that future site-specific
+editors can never validate a structured field.
+
+React owns mutable form values. The editor supplies immutable descriptors,
+initial safe values, validation, and submit behavior. Native detail remains in
+the editor closure.
+
+Secret fields use explicit intent rather than masked-string inference:
+
+```ts
+type SecretEditIntent =
+  | { kind: "unchanged" }
+  | { kind: "replace"; value: string }
+  | { kind: "clear" }
+```
+
+An Adapter exposes `clear` only when the verified Upstream Backend supports it.
+Masked, unavailable, or permission-hidden credentials can never become a
+replacement value.
+
+### Named internal capabilities
+
+Migration, model sync, matching, and future internal features do not consume
+the Workspace editor Interface. They use separately registered, named Site
+Adapter Capabilities and feature-owned Product Canonical Models.
+
+For example, migration owns canonical source, preview, command, and per-item
+result models. The AxonHub Adapter maps between those models and native channel
+operations. The compatibility facade may translate current
+`ManagedSiteChannel` inputs at the migration entry point while the old UI is
+being cut over, but native capabilities never accept `ChannelFormData`.
+
+Capabilities are added only when a feature is migrated. There is no anonymous
+capability bag and no inference from editor fields.
+
+## Errors, mutation certainty, and concurrency
+
+### Public failures stay actionable
+
+Opening a registration succeeds with a ready Workspace or throws a
+`ManagedResourceError` carrying the typed safe failure below. Every Workspace
+operation uses the same rejection contract. Loading/checking is UI state, not a
+shared configuration-state union.
+
+Reads and public mutations use one typed failure shape:
+
+```ts
+type ResourceFailure = {
+  code:
+    | "configuration_required"
+    | "invalid_configuration"
+    | "authentication_failed"
+    | "permission_denied"
+    | "validation_failed"
+    | "not_found"
+    | "mutation_state_uncertain"
+    | "unavailable"
+    | "upstream_rejected"
+    | "aborted"
+    | "unexpected"
+  fieldIssues?: readonly ResourceFieldIssue[]
+}
+```
+
+The failure contains no endpoint, raw backend message, cause, stack, secret,
+resource name, or other user-entered value. The Workspace is solely responsible
+for translating Adapter errors and mutation certainty into this failure. The UI
+controller combines the controlled code, operation context, and the
+definition-owned settings target to choose localized copy and actions such as
+retry, refresh, reload editor, or open settings.
+
+### Mutation certainty is implementation detail
+
+An Adapter may internally classify a mutation as applied, not applied, possibly
+applied, or partially applied. This is necessary for cases such as a lost
+response or AxonHub create followed by a status mutation. It is not part of the
+ordinary CRUD Interface.
+
+The Workspace maps certainty to a safe public success or failure:
+
+- confirmed success returns the new Resource Display Facts;
+- confirmed rejection may permit retry while retaining editor values;
+- possible or partial application becomes `mutation_state_uncertain`; the UI
+  controller requires refresh/reload confirmation and never automatically
+  replays it;
+- delete of an already missing resource is treated as achieving the desired
+  state.
+
+Batch migration is different: per-item success, failure, and skipped outcomes
+are a Product Canonical Model because users need them. That product-level
+partial result does not expose protocol steps.
+
+### Editor submission
+
+The editor implementation is single-flight. Concurrent calls return the same
+in-flight Promise or are rejected before dispatch. The UI also disables submit
+while saving, but correctness does not depend on the button state.
+
+Successful submissions close the native editor session and return Resource
+Display Facts that the controller may upsert; it refreshes instead if the
+returned facts are insufficient. Possibly applied, partially applied, and
+not-found submissions close the session and require a fresh read. A local
+validation failure or a confirmed pre-dispatch failure may keep the editor
+usable. The state machine is internal; callers do not learn its states.
+
+Abort before dispatch is a confirmed non-application. Abort after dispatch with
+no acknowledgement is possibly applied and requires refresh confirmation.
+
+### AxonHub concurrency
+
+The verified AxonHub release exposes `updatedAt` but its channel update mutation
+does not accept an expected version, ETag, or other precondition. A read-before-
+write comparison would still race with the subsequent write and must not be
+described as concurrency protection.
+
+The first AxonHub slice therefore:
+
+- sends only changed top-level fields and verified clear flags;
+- preserves hidden settings fields when updating `settings.extraModelPrefix`;
+- never sends unchanged credentials;
+- accepts the absence of client-enforced conflict detection; concurrent results
+  follow the Upstream Backend's mutation ordering and merge semantics;
+- does not expose revision or generic compare policy through the Interface.
+
+If a future Upstream Backend offers conditional mutation, add a controlled
+`conflict` failure code when that real Adapter needs it; no current public code
+or revision contract is reserved for the hypothetical case.
+
+## AxonHub reference implementation
+
+AxonHub is the first existing Managed Site Type migrated because it already has
+a dedicated GraphQL integration and is unrelated to the New API family. It
+tests string ids, cursor pagination, credential objects, native settings, and
+partial update semantics without requiring a new production Site Type in this
+effort.
+
+### Verified upstream baseline
+
+The baseline was retrieved on 2026-07-16:
+
+- repository: `looplj/axonhub`;
+- latest release: `v1.0.0-beta5`, published 2026-07-11;
+- release commit: `d061ac7df6aef0c5ec6cdfa9dc5002546a1c5a57`;
+- default branch: `unstable`;
+- forward-check commit:
+  `213b8c888ae6f7d297ff59126798914d34152b98`.
+
+Implementation source priority is:
+
+1. exact target-deployment evidence, fork, and build/version when supplied,
+   including sanitized introspection or traces;
+2. the exact release tag matching that target, or the explicitly selected
+   latest release when no target version is supplied;
+3. the default branch only as a non-binding forward drift check that never
+   silently overrides the first two sources;
+4. the current local Adapter as historical behavior, not upstream truth.
+
+Pinned primary sources:
+
+- [release](https://github.com/looplj/axonhub/releases/tag/v1.0.0-beta5);
+- [channel schema](https://github.com/looplj/axonhub/blob/d061ac7df6aef0c5ec6cdfa9dc5002546a1c5a57/internal/ent/schema/channel.go#L102-L155);
+- [CreateChannelInput](https://github.com/looplj/axonhub/blob/d061ac7df6aef0c5ec6cdfa9dc5002546a1c5a57/internal/server/gql/ent.graphql#L1558);
+- [UpdateChannelInput](https://github.com/looplj/axonhub/blob/d061ac7df6aef0c5ec6cdfa9dc5002546a1c5a57/internal/server/gql/ent.graphql#L5993);
+- [channel mutations](https://github.com/looplj/axonhub/blob/d061ac7df6aef0c5ec6cdfa9dc5002546a1c5a57/internal/server/gql/axonhub.graphql#L815);
+- [permission-sensitive credential field](https://github.com/looplj/axonhub/blob/d061ac7df6aef0c5ec6cdfa9dc5002546a1c5a57/internal/server/gql/axonhub.graphql#L667-L670);
+- [credential permission resolver](https://github.com/looplj/axonhub/blob/d061ac7df6aef0c5ec6cdfa9dc5002546a1c5a57/internal/server/gql/axonhub.resolvers.go#L50-L55);
+- [channel create/update validation](https://github.com/looplj/axonhub/blob/d061ac7df6aef0c5ec6cdfa9dc5002546a1c5a57/frontend/src/features/channels/data/schema.ts);
+- [upstream settings merge helper](https://github.com/looplj/axonhub/blob/d061ac7df6aef0c5ec6cdfa9dc5002546a1c5a57/frontend/src/features/channels/utils/merge.ts).
+
+Live network access is not a required PR validation gate. Tests use minimal
+handwritten fixtures derived from the pinned contract. A manual or scheduled
+forward check may report drift against `unstable`, but default-branch drift does
+not silently change release behavior.
+
+### First editable field set
+
+The first slice preserves current AxonHub parity and adds a limited set of
+commonly useful native fields.
+
+This allowlist is the approved first AxonHub cutover scope. It is intentionally
+larger than parity-only CRUD so the new path proves progressive native editing,
+but implementation must not add further fields opportunistically.
+
+| Field | Create | Update/clear behavior | First slice rule |
+| --- | --- | --- | --- |
+| `name` | required | optional update | display and edit |
+| `type` | required | optional update | display and edit only within verified regular-key-compatible types |
+| `baseURL` | optional | `clearBaseURL` | display and edit |
+| `status` | omitted; defaults to disabled | editor update uses `UpdateChannelInput.status`; enabled create uses a follow-up status mutation | display and edit; reconcile create follow-up failure |
+| regular API key | required only for first-slice regular-key create types | optional credentials replacement | secret intent; unchanged or unavailable omitted; no initial clear action |
+| `supportedModels` | required | optional replacement | display and edit; validate product invariants |
+| `manualModels` | optional | `clearManualModels` | display and edit |
+| `defaultTestModel` | required | optional update | display and edit |
+| `autoSyncSupportedModels` | optional | optional update | display and edit |
+| `autoSyncModelPattern` | optional | `clearAutoSyncModelPattern` | display and edit |
+| `tags` | optional | `clearTags` | display and edit |
+| `orderingWeight` | optional | optional update | display and edit |
+| `remark` | optional | `clearRemark` | display and edit |
+| `settings.extraModelPrefix` | inside optional settings | settings object update; empty string clears the prefix | expose as text; merge every pinned-contract settings field selected by the authoritative detail query; never use `clearSettings` |
+
+The release creates channels as `disabled` because status is excluded from
+`CreateChannelInput`. Creating an enabled channel may therefore require a
+second mutation. Partial or uncertain completion is handled internally and the
+UI is told to refresh before retrying.
+
+The first slice edits regular API-key credentials only. Create type options are
+limited to channel types whose pinned-release validation accepts regular API
+keys. Existing OAuth, AWS, or GCP credential channels remain viewable and may
+edit safe non-credential fields, but changing their type or credentials is
+deferred.
+
+The implementation field matrix must enumerate the exact regular-key type
+allowlist from the pinned release. The beta5 frontend validation identifies
+`codex`, `claudecode`, `antigravity`, and `github_copilot` as OAuth credential
+types, `anthropic_gcp` as GCP credentials, and `anthropic_aws` as a non-regular-
+key credential type. These types are excluded. Any type not explicitly
+enumerated with pinned validation evidence is excluded by default rather than
+falling back to the regular-key form.
+
+### Deferred AxonHub fields
+
+The Adapter selects these fields when they are needed to preserve a replacement
+object, but the first UI does not edit them:
+
+- model mappings and automatic trimmed prefixes;
+- endpoints;
+- policies;
+- rate limits and proxy configuration;
+- header/body overrides and pass-through settings;
+- AWS, GCP, and OAuth credentials;
+- disabled-key management;
+- provider-quota settings;
+- archived-status lifecycle beyond the product actions explicitly designed for
+  it.
+
+`archived` must not be collapsed into `disabled`. The pinned release returns
+`null` credentials when the caller lacks channel-write permission, which must
+not be interpreted as empty credentials. Defensive masked-string detection may
+remain as compatibility hardening for forks or deployments, but masking is not
+asserted as the beta5 protocol contract.
+
+Unedited top-level fields are omitted from partial update commands. When an
+edited field belongs to a replacement object such as `settings`, the Adapter
+merges every field defined by the pinned target contract and returned by the
+authoritative detail query. Preservation of unknown or unselected fork-specific
+fields is not claimed until target-deployment evidence extends that contract.
+
+Before implementation, the AxonHub Adapter work records a field matrix with:
+field, read selection, create input, update input, clear behavior, editable-now
+decision, and preservation rule. If the user's deployment differs from the
+pinned release, that deployment wins and the difference is documented near the
+protocol implementation.
+
+## Migration and compatibility
+
+The Legacy Channel Path remains available for existing non-migrated Managed
+Site Types. It may receive compatibility fixes and migration glue, but new
+features default to the Resource-Native Path.
+
+AxonHub cutover must include its currently exposed channel-migration workflow.
+Otherwise the new page would still depend on `ManagedSiteChannel` and
+`ChannelFormData`, undermining the seam. The migration feature receives a named
+canonical capability before the AxonHub UI switches modes.
+
+Other existing Managed Site Types do not need to migrate for AxonHub to use the
+new path. A static Managed Site Definition mode is the rollback switch: reverting
+AxonHub to `legacy-channel` restores the old path. Runtime errors never trigger
+that switch automatically.
+
+The following old shapes are legacy-only and must not be used by a new native
+registration:
+
+- `ManagedUpstreamResourceDetail<TNative = unknown>`;
+- generic `items`/`drafts` capability groups from the 2026-07-03 proposal;
+- a facade that casts native data to `ChannelFormData`;
+- feature gates inferred from registration presence;
+- the closed core-site migration gate as the long-term source of truth.
+
+## Testing strategy
+
+### Public Interface contract tests
+
+A reusable contract suite runs against AxonHub and a minimal test-only Adapter.
+The synthetic Adapter is not a production Site Type. It proves that the public
+Interface does not accidentally depend on AxonHub or New API assumptions by
+using:
+
+- a nonnumeric opaque string resource id;
+- cursor pagination without a total;
+- a masked secret state;
+- one hidden nested native field preserved across an allowed edit.
+
+PR 2 extends capability contract coverage with one test-only named capability;
+PR 1 does not introduce feature capability machinery only for a synthetic test.
+
+The contract suite tests the public Interface rather than registry casts or
+implementation call order.
+
+### AxonHub Adapter tests
+
+Focused tests cover:
+
+- operation names, variables, required selections, cursor handling, and string
+  ids without whole-document GraphQL snapshots;
+- mapping the first field set to Resource Display Facts and editable values;
+- nullable and permission-hidden credentials, with defensive masked-string
+  compatibility hardening tested separately from the beta5 contract;
+- editing one field emits only that top-level update plus required merged
+  native objects;
+- unchanged secret omission and replacement-secret emission;
+- verified clear flags for base URL, manual models, pattern, tags, and remark;
+- `settings.extraModelPrefix` updates preserve every pinned-beta5 settings
+  field selected by the authoritative detail query;
+- supported/manual model semantics and default-test-model validation;
+- `archived` remains distinct from disabled;
+- create plus status follow-up partial/uncertain application maps to
+  `mutation_state_uncertain` and is not automatically retried;
+- deferred credentials, endpoints, policies, and settings are not cleared.
+
+Fixtures use reserved example domains, fake ids, and fake model names. Real
+protocol field and enum names remain because they are the contract. Production
+response dumps and real credentials are prohibited.
+
+### Dispatcher and UI tests
+
+Vitest and Testing Library cover:
+
+- explicit native/legacy dispatch and native-registration-missing failure;
+- loading, configuration-required, authentication, permission, empty, list
+  error, retry, detail, create, edit, delete, and refresh-recovery states;
+- the configuration-required CTA uses the definition-owned settings deep link
+  and can retry after configuration changes;
+- primitive field renderers and field validation;
+- masked secret behavior;
+- double-submit prevention and late-result protection;
+- no automatic replay after possible or partial mutation application;
+- resource-wide search either spans multiple upstream pages or is not rendered
+  when the Adapter declares it unsupported;
+- existing route, search, localized copy, and analytics behavior.
+
+There is no UI test matrix for internal commit-certainty states. Controller
+tests assert only the corresponding product recovery action.
+
+### Migration tests
+
+Migration retains product-level per-item outcomes:
+
+- preview ready/blocked states;
+- successful, failed, and skipped rows with aggregate counts;
+- unavailable or compatibility-masked source secrets are blocked;
+- successful rows are not rolled back when another row fails;
+- AxonHub uses its named capability and never reads editor descriptors.
+
+Before PR 3, the existing migration dialog must run through the named
+capability for AxonHub as both source and target. Equivalence tests preserve row
+identity and selection, type mapping, warnings, masked/unavailable-secret
+blocking, per-row failure, aggregate counts, successful-row retention, and the
+post-execution refresh behavior.
+
+### E2E decision
+
+The substrate and canonical migration PRs do not add Playwright coverage because
+their risks are better exercised through contract and feature tests. The final
+AxonHub UI cutover adds or extends one stable Chromium options-page scenario
+covering route selection, a representative edit, intercepted GraphQL, and list
+refresh. It does not require a real AxonHub deployment in CI.
+
+## Delivery slices
+
+### PR 1: resource-native substrate and AxonHub registration
+
+Expected scope: approximately 6-9 production files and 2-4 test files.
+
+- add refs, display/editor contracts, safe failures, registration factory,
+  registry, and explicit dispatcher requirements;
+- add direct AxonHub native queries/mutations and field preservation;
+- keep current AxonHub legacy resources wired for existing callers;
+- add pinned upstream comments near protocol-dependent implementation;
+- add contract and Adapter tests;
+- do not change the production UI, migration dialog, locales, or analytics.
+
+Suggested commits:
+
+1. `refactor(managed-sites): add resource-native workspace contracts`
+2. `refactor(axonhub): register native resource adapter`
+
+### PR 2: canonical migration capability and AxonHub bridge
+
+Expected scope: approximately 5-8 production files and 3-5 test files.
+
+- define feature-owned migration source, preview, command, and result models;
+- add named AxonHub migration capability;
+- translate current legacy migration inputs only at the feature entry point;
+- route the existing dialog through the capability for AxonHub as source and
+  target, preserving row identity/selection, type mapping, warnings, copy,
+  analytics, unavailable-key blocking, per-row results, and refresh behavior;
+- remove AxonHub from the old generic migration gate after the named capability
+  becomes the production route.
+
+Suggested commits:
+
+1. `refactor(managed-sites): define canonical migration capabilities`
+2. `refactor(axonhub): route migration through native capabilities`
+
+If this slice exceeds eight production files or requires a migration-dialog
+rewrite, split capability core and compatibility UI facade into separate PRs.
+
+### PR 3: native UI and AxonHub cutover
+
+Expected scope: approximately 9-14 TypeScript/TSX files, relevant locale files,
+and 4-7 test files plus one targeted E2E scenario.
+
+- add the shared native resource list/view/editor UI and controller;
+- cover non-happy paths and safe recovery;
+- preserve route, settings navigation, search, localized copy, and analytics;
+- switch the AxonHub Managed Site Definition to `native-resource` in the last
+  commit;
+- retain the static definition mode as the rollback switch;
+- do not leave a long-term runtime feature flag or silent fallback.
+
+Suggested commits:
+
+1. `feat(managed-sites): add native resource editor and list`
+2. `test(axonhub): cover native resource UI parity`
+3. `feat(axonhub): switch managed resources to native workspace`
+
+The per-PR file estimates are gross touched-file counts and are not additive:
+the registry, AxonHub Adapter, migration entry point, and contract tests are
+expected to recur across slices. The expected unique total is approximately
+18-25 production TypeScript/TSX files before locale changes, 8-13 test files,
+and roughly 1,500-2,600 production lines. Existing AxonHub GraphQL,
+authentication, and provider logic should be reused; the current large legacy
+page and dialog should not absorb the new implementation.
+
+## Validation
+
+Each implementation slice starts with focused affected tests. Shared contracts,
+exports, and registry wiring require `pnpm compile` and `pnpm knip` through
+`pnpm run validate:push` before remote handoff. Task-scoped files are staged
+before `pnpm run validate:staged`. Locale changes also require
+`pnpm run i18n:extract:ci`.
+
+The final cutover additionally runs the targeted Chromium E2E scenario. A live
+AxonHub deployment remains a manual integration check because credentials,
+permissions, deployment version, and network availability are not stable CI
+inputs.
+
+## Observability and discoverability decisions
+
+The AxonHub cutover reuses every action currently visible for AxonHub: create,
+view, update, delete, delete selected, refresh, and migration open/toggle/execute.
+Unsupported model-sync and filter actions remain absent. Controlled
+result/error categories may be mapped from the new controller, but analytics
+must not record URLs, resource ids, locators, names, tags, models, field values,
+secrets, raw upstream messages, or other user-entered text. No passive
+impression event or new settings snapshot is required.
+
+The design does not add, rename, or move a setting. Existing AxonHub
+configuration navigation and search/deep-link targets must remain valid during
+cutover; no new settings-search entry is required unless implementation changes
+that surface.
+
+## Completion criteria
+
+The design is successfully implemented when:
+
+- a test-only unrelated Adapter and AxonHub both satisfy the same small public
+  resource Interface without `ManagedSiteChannel` or `ChannelFormData`;
+- AxonHub native fields in the first slice display and edit correctly;
+- unedited top-level fields, selected replacement-object fields, and
+  unchanged/masked credentials survive updates;
+- possible or partial mutation application is never automatically retried;
+- AxonHub migration uses a named Product Canonical Model capability;
+- native mode cannot silently fall back to legacy mode;
+- existing non-migrated Managed Site Types continue to use the Legacy Channel
+  Path unchanged;
+- focused tests, hook-equivalent validation, compile/knip validation, locale
+  extraction where applicable, and the targeted cutover E2E pass.

--- a/src/constants/basicSettingsTabs.ts
+++ b/src/constants/basicSettingsTabs.ts
@@ -63,6 +63,7 @@ export const BASIC_SETTINGS_ANCHOR_TO_TAB: Record<string, BasicSettingsTabId> =
     "new-api-model-sync": "managedSite",
     [SETTINGS_ANCHORS.MANAGED_SITE_MODEL_SYNC]: "managedSite",
     [SETTINGS_ANCHORS.MANAGED_SITE_SELECTOR]: "managedSite",
+    [SETTINGS_ANCHORS.AXON_HUB]: "managedSite",
     "cli-proxy": "cliProxy",
     "claude-code-router": "claudeCodeRouter",
     "dangerous-zone": "general",

--- a/src/constants/settingsAnchors.ts
+++ b/src/constants/settingsAnchors.ts
@@ -42,6 +42,7 @@ export const SETTINGS_ANCHORS = {
   BALANCE_HISTORY: "balance-history",
   MANAGED_SITE_MODEL_SYNC: "managed-site-model-sync",
   MANAGED_SITE_SELECTOR: "managed-site-selector",
+  AXON_HUB: "axonhub",
   PRODUCT_ANALYTICS: "product-analytics",
   PRODUCT_ANALYTICS_ENABLED: "product-analytics-enabled",
   USAGE_HISTORY_SYNC: "usage-history-sync",

--- a/src/features/BasicSettings/components/tabs/ManagedSite/AxonHubSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/ManagedSite/AxonHubSettings.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next"
 
 import { SettingSection } from "~/components/SettingSection"
 import { Button, Card, CardItem, CardList, Input } from "~/components/ui"
+import { SETTINGS_ANCHORS } from "~/constants/settingsAnchors"
 import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
 import { usePreferenceDraft } from "~/hooks/usePreferenceDraft"
 import { signIn } from "~/services/apiService/axonHub"
@@ -136,7 +137,7 @@ export default function AxonHubSettings() {
 
   return (
     <SettingSection
-      id="axonhub"
+      id={SETTINGS_ANCHORS.AXON_HUB}
       title={t("axonHub.title")}
       description={t("axonHub.description")}
       onReset={resetAxonHubConfig}

--- a/src/features/BasicSettings/components/tabs/ManagedSite/ManagedSiteAxonHub.search.ts
+++ b/src/features/BasicSettings/components/tabs/ManagedSite/ManagedSiteAxonHub.search.ts
@@ -1,3 +1,4 @@
+import { SETTINGS_ANCHORS } from "~/constants/settingsAnchors"
 import { SITE_TYPES } from "~/constants/siteType"
 import {
   buildControlDefinition,
@@ -10,7 +11,7 @@ export const managedSiteAxonHubSearchSections: OptionsSearchItemDefinition[] = [
   buildSectionDefinition(
     "section:axonhub",
     "managedSite",
-    "axonhub",
+    SETTINGS_ANCHORS.AXON_HUB,
     "settings:axonHub.title",
     345,
     {

--- a/src/services/accountSiteDefinitions/contracts.ts
+++ b/src/services/accountSiteDefinitions/contracts.ts
@@ -37,6 +37,44 @@ export const ACCOUNT_SITE_DEFINITION_SCOPES = {
 export type AccountSiteDefinitionScope =
   (typeof ACCOUNT_SITE_DEFINITION_SCOPES)[keyof typeof ACCOUNT_SITE_DEFINITION_SCOPES]
 
+export const MANAGED_RESOURCE_MODES = {
+  LegacyChannel: "legacy-channel",
+  NativeResource: "native-resource",
+} as const
+
+export type ManagedResourceMode =
+  (typeof MANAGED_RESOURCE_MODES)[keyof typeof MANAGED_RESOURCE_MODES]
+
+export const MANAGED_RESOURCE_KINDS = {
+  Channel: "channel",
+} as const
+
+export type ManagedResourceKind =
+  (typeof MANAGED_RESOURCE_KINDS)[keyof typeof MANAGED_RESOURCE_KINDS]
+
+export const MANAGED_RESOURCE_PRODUCT_ACTIONS = {
+  Create: "create",
+  DeleteSelected: "delete-selected",
+  Migrate: "migrate",
+} as const
+
+export type ManagedResourceProductAction =
+  (typeof MANAGED_RESOURCE_PRODUCT_ACTIONS)[keyof typeof MANAGED_RESOURCE_PRODUCT_ACTIONS]
+
+export interface ManagedResourceProductPolicy {
+  mode: ManagedResourceMode
+  primaryKind: ManagedResourceKind
+  titleKey: "managedSiteChannels:title"
+  itemLabelKey: "managedSiteChannels:table.columns.name"
+  tableFieldIds: readonly string[]
+  detailFieldIds: readonly string[]
+  actions: readonly ManagedResourceProductAction[]
+  settingsTarget: {
+    tabId: "managedSite"
+    anchor?: string
+  }
+}
+
 export interface AccountSiteDefinitionOnboardingMetadata {
   detection?: AccountSiteDetectionMetadata
   routes?: AccountSiteRouteConfig
@@ -61,6 +99,7 @@ export interface AccountSiteDefinition {
   siteType: SiteType
   scopes: readonly AccountSiteDefinitionScope[]
   adapterFamily: AccountSiteBackendFamily
+  managedResource?: ManagedResourceProductPolicy
   onboarding?: AccountSiteDefinitionOnboardingMetadata
   productProfile?: AccountSiteProductProfileOverride
   readiness?: AccountSiteDefinitionReadiness

--- a/src/services/accountSiteDefinitions/definitions.ts
+++ b/src/services/accountSiteDefinitions/definitions.ts
@@ -1,3 +1,4 @@
+import { SETTINGS_ANCHORS } from "~/constants/settingsAnchors"
 import {
   ACCOUNT_SITE_AUTH_SESSION_REFRESH_LOCK_SCOPES,
   ACCOUNT_SITE_CREATED_TOKEN_SECRET_HANDLING,
@@ -401,7 +402,7 @@ const MANAGED_ONLY_SITE_DEFINITIONS = [
       ],
       settingsTarget: {
         ...LEGACY_MANAGED_CHANNEL_POLICY.settingsTarget,
-        anchor: "axonhub",
+        anchor: SETTINGS_ANCHORS.AXON_HUB,
       },
     },
   },

--- a/src/services/accountSiteDefinitions/definitions.ts
+++ b/src/services/accountSiteDefinitions/definitions.ts
@@ -15,7 +15,11 @@ import {
   ACCOUNT_SITE_ADAPTER_FAMILIES,
   ACCOUNT_SITE_DEFINITION_SCOPES,
   ACCOUNT_SITE_MODEL_LIST_EXPECTED_ROUTES,
+  MANAGED_RESOURCE_KINDS,
+  MANAGED_RESOURCE_MODES,
+  MANAGED_RESOURCE_PRODUCT_ACTIONS,
   type AccountSiteDefinition,
+  type ManagedResourceProductPolicy,
 } from "./contracts"
 import {
   AIHUBMIX_API_ORIGIN,
@@ -52,6 +56,17 @@ const ACCOUNT_AND_MANAGED_SCOPES = [
   ACCOUNT_SITE_DEFINITION_SCOPES.Account,
   ACCOUNT_SITE_DEFINITION_SCOPES.Managed,
 ] as const
+
+const LEGACY_MANAGED_CHANNEL_POLICY = {
+  mode: MANAGED_RESOURCE_MODES.LegacyChannel,
+  primaryKind: MANAGED_RESOURCE_KINDS.Channel,
+  titleKey: "managedSiteChannels:title",
+  itemLabelKey: "managedSiteChannels:table.columns.name",
+  tableFieldIds: [],
+  detailFieldIds: [],
+  actions: [],
+  settingsTarget: { tabId: "managedSite" },
+} as const satisfies ManagedResourceProductPolicy
 
 const directPricingReadiness = {
   modelList: {
@@ -120,6 +135,7 @@ const ACCOUNT_SITE_DEFINITIONS = [
     siteType: SITE_TYPES.NEW_API,
     scopes: ACCOUNT_AND_MANAGED_SCOPES,
     adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily,
+    managedResource: { ...LEGACY_MANAGED_CHANNEL_POLICY },
     onboarding: {
       detection: {
         titlePatterns: [makeTitleRegex(SITE_TYPES.NEW_API)],
@@ -346,16 +362,54 @@ const MANAGED_ONLY_SITE_DEFINITIONS = [
     siteType: SITE_TYPES.OCTOPUS,
     scopes: MANAGED_SCOPE,
     adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.Unsupported,
+    managedResource: { ...LEGACY_MANAGED_CHANNEL_POLICY },
   },
   {
     siteType: SITE_TYPES.AXON_HUB,
     scopes: MANAGED_SCOPE,
     adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.Unsupported,
+    managedResource: {
+      ...LEGACY_MANAGED_CHANNEL_POLICY,
+      tableFieldIds: [
+        "name",
+        "type",
+        "baseURL",
+        "status",
+        "supportedModels",
+        "tags",
+      ],
+      detailFieldIds: [
+        "name",
+        "type",
+        "baseURL",
+        "status",
+        "key",
+        "supportedModels",
+        "manualModels",
+        "defaultTestModel",
+        "autoSyncSupportedModels",
+        "autoSyncModelPattern",
+        "tags",
+        "orderingWeight",
+        "remark",
+        "extraModelPrefix",
+      ],
+      actions: [
+        MANAGED_RESOURCE_PRODUCT_ACTIONS.Create,
+        MANAGED_RESOURCE_PRODUCT_ACTIONS.DeleteSelected,
+        MANAGED_RESOURCE_PRODUCT_ACTIONS.Migrate,
+      ],
+      settingsTarget: {
+        ...LEGACY_MANAGED_CHANNEL_POLICY.settingsTarget,
+        anchor: "axonhub",
+      },
+    },
   },
   {
     siteType: SITE_TYPES.CLAUDE_CODE_HUB,
     scopes: MANAGED_SCOPE,
     adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.Unsupported,
+    managedResource: { ...LEGACY_MANAGED_CHANNEL_POLICY },
   },
 ] as const satisfies readonly AccountSiteDefinition[]
 
@@ -364,6 +418,7 @@ const ACCOUNT_SITE_DEFINITION_OVERRIDES = [
     siteType: SITE_TYPES.VELOERA,
     scopes: ACCOUNT_AND_MANAGED_SCOPES,
     adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily,
+    managedResource: { ...LEGACY_MANAGED_CHANNEL_POLICY },
     onboarding: {
       detection: {
         titlePatterns: [makeTitleRegex(SITE_TYPES.VELOERA)],
@@ -382,6 +437,7 @@ const ACCOUNT_SITE_DEFINITION_OVERRIDES = [
     siteType: SITE_TYPES.DONE_HUB,
     scopes: ACCOUNT_AND_MANAGED_SCOPES,
     adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily,
+    managedResource: { ...LEGACY_MANAGED_CHANNEL_POLICY },
     onboarding: {
       detection: { titlePatterns: [makeTitleRegex(SITE_TYPES.DONE_HUB)] },
       routes: {

--- a/src/services/accountSiteDefinitions/registry.ts
+++ b/src/services/accountSiteDefinitions/registry.ts
@@ -124,6 +124,15 @@ function cloneDefinition(
   return {
     ...definition,
     scopes: [...definition.scopes],
+    managedResource: definition.managedResource
+      ? {
+          ...definition.managedResource,
+          tableFieldIds: [...definition.managedResource.tableFieldIds],
+          detailFieldIds: [...definition.managedResource.detailFieldIds],
+          actions: [...definition.managedResource.actions],
+          settingsTarget: { ...definition.managedResource.settingsTarget },
+        }
+      : undefined,
     onboarding: cloneOnboarding(definition.onboarding),
     productProfile: cloneProductProfile(definition.productProfile),
     readiness: cloneReadiness(definition.readiness),

--- a/src/services/apiAdapters/contracts/managedResourceNative.ts
+++ b/src/services/apiAdapters/contracts/managedResourceNative.ts
@@ -1,0 +1,179 @@
+import type { ManagedSiteType } from "~/constants/siteType"
+import type { ManagedResourceKind } from "~/services/accountSiteDefinitions/contracts"
+
+export const MANAGED_RESOURCE_FIELD_TYPES = {
+  Text: "text",
+  Textarea: "textarea",
+  Number: "number",
+  Boolean: "boolean",
+  Select: "select",
+  MultiSelect: "multi-select",
+  Secret: "secret",
+} as const
+
+export const MANAGED_RESOURCE_FAILURE_CODES = {
+  ConfigurationRequired: "configuration_required",
+  InvalidConfiguration: "invalid_configuration",
+  AuthenticationFailed: "authentication_failed",
+  PermissionDenied: "permission_denied",
+  ValidationFailed: "validation_failed",
+  NotFound: "not_found",
+  MutationStateUncertain: "mutation_state_uncertain",
+  Unavailable: "unavailable",
+  UpstreamRejected: "upstream_rejected",
+  Aborted: "aborted",
+  Unexpected: "unexpected",
+} as const
+
+export const MANAGED_RESOURCE_FIELD_ISSUE_CODES = {
+  Required: "required",
+  InvalidValue: "invalid_value",
+  OutOfRange: "out_of_range",
+  UnsupportedOption: "unsupported_option",
+  InconsistentValue: "inconsistent_value",
+} as const
+
+export type ManagedResourceRef = {
+  siteType: ManagedSiteType
+  kind: ManagedResourceKind
+  scopeKey: string
+  resourceId: string
+}
+
+export type ResourceOperationOptions = { signal?: AbortSignal }
+
+export type ResourceListQuery = {
+  cursor?: string
+  limit?: number
+  search?: string
+}
+
+export type ResourceDisplayFacts = {
+  ref: ManagedResourceRef
+  displayName: string
+  status: "enabled" | "disabled" | "archived" | "auto-disabled" | "unknown"
+  fields: readonly ResourceDisplayFact[]
+  actions: { canUpdate: boolean; canDelete: boolean }
+}
+
+export type ResourceSecretState =
+  | "available"
+  | "masked"
+  | "unavailable"
+  | "permission-hidden"
+
+export type ResourceDisplayFact =
+  | { fieldId: string; kind: "text"; value: string }
+  | { fieldId: string; kind: "number"; value: number }
+  | { fieldId: string; kind: "boolean"; value: boolean }
+  | { fieldId: string; kind: "list"; value: readonly string[] }
+  | { fieldId: string; kind: "secret"; state: ResourceSecretState }
+
+export type ResourcePage = {
+  items: readonly ResourceDisplayFacts[]
+  total?: number
+  nextCursor?: string
+}
+
+export type SecretEditIntent =
+  | { kind: "unchanged" }
+  | { kind: "replace"; value: string }
+  | { kind: "clear" }
+
+export type ResourceFieldValue =
+  | string
+  | number
+  | boolean
+  | readonly string[]
+  | SecretEditIntent
+
+export type EditableResourceProjection = Readonly<
+  Record<string, ResourceFieldValue>
+>
+
+export type ResourceFieldIssue = {
+  fieldId: string
+  code: (typeof MANAGED_RESOURCE_FIELD_ISSUE_CODES)[keyof typeof MANAGED_RESOURCE_FIELD_ISSUE_CODES]
+}
+
+export type ResourceValidationResult =
+  | { valid: true }
+  | { valid: false; issues: readonly ResourceFieldIssue[] }
+
+type ResourceFieldDescriptorBase = {
+  fieldId: string
+  required?: boolean
+}
+
+export type ResourceFieldDescriptor =
+  | (ResourceFieldDescriptorBase & { type: "text" })
+  | (ResourceFieldDescriptorBase & { type: "textarea"; rows?: number })
+  | (ResourceFieldDescriptorBase & {
+      type: "number"
+      min?: number
+      max?: number
+      step?: number
+    })
+  | (ResourceFieldDescriptorBase & { type: "boolean" })
+  | (ResourceFieldDescriptorBase & {
+      type: "select"
+      options: readonly { value: string }[]
+    })
+  | (ResourceFieldDescriptorBase & {
+      type: "multi-select"
+      options: readonly { value: string }[]
+    })
+  | (ResourceFieldDescriptorBase & {
+      type: "secret"
+      secretState: ResourceSecretState
+      allowClear: boolean
+    })
+
+export type ResourceFailure = {
+  code: (typeof MANAGED_RESOURCE_FAILURE_CODES)[keyof typeof MANAGED_RESOURCE_FAILURE_CODES]
+  fieldIssues?: readonly ResourceFieldIssue[]
+}
+
+export class ManagedResourceError extends Error {
+  constructor(readonly failure: ResourceFailure) {
+    super(failure.code)
+    this.name = "ManagedResourceError"
+  }
+}
+
+export interface ResourceEditor {
+  readonly fields: readonly ResourceFieldDescriptor[]
+  readonly initialValues: EditableResourceProjection
+  validate(values: EditableResourceProjection): ResourceValidationResult
+  submit(
+    values: EditableResourceProjection,
+    options?: ResourceOperationOptions,
+  ): Promise<ResourceDisplayFacts>
+}
+
+export interface ManagedResourceWorkspace {
+  readonly supportsSearch: boolean
+  list(
+    query?: ResourceListQuery,
+    options?: ResourceOperationOptions,
+  ): Promise<ResourcePage>
+  get(
+    ref: ManagedResourceRef,
+    options?: ResourceOperationOptions,
+  ): Promise<ResourceDisplayFacts>
+  openCreateEditor(options?: ResourceOperationOptions): Promise<ResourceEditor>
+  openEditEditor(
+    ref: ManagedResourceRef,
+    options?: ResourceOperationOptions,
+  ): Promise<ResourceEditor>
+  delete(
+    ref: ManagedResourceRef,
+    options?: ResourceOperationOptions,
+  ): Promise<void>
+}
+
+export interface ManagedResourceRegistration {
+  readonly siteType: ManagedSiteType
+  readonly kind: ManagedResourceKind
+  open(options?: ResourceOperationOptions): Promise<ManagedResourceWorkspace>
+}

--- a/src/services/apiAdapters/managedResources/axonHub.ts
+++ b/src/services/apiAdapters/managedResources/axonHub.ts
@@ -240,6 +240,7 @@ const mutationFailure = <T>(
     failure.dispatch === "after" &&
     (failure.code === "unavailable" ||
       failure.code === "aborted" ||
+      failure.code === "upstream_rejected" ||
       failure.code === "unexpected")
   return acknowledgementMayBeLost
     ? { certainty: "possibly-applied" }
@@ -650,12 +651,7 @@ const validateValues = (
       code: MANAGED_RESOURCE_FIELD_ISSUE_CODES.UnsupportedOption,
     })
   }
-  if (context.create && !baseURL) {
-    issues.push({
-      fieldId: "baseURL",
-      code: MANAGED_RESOURCE_FIELD_ISSUE_CODES.Required,
-    })
-  } else if (baseURL && !isHttpUrl(baseURL)) {
+  if (baseURL && !isHttpUrl(baseURL)) {
     issues.push({
       fieldId: "baseURL",
       code: MANAGED_RESOURCE_FIELD_ISSUE_CODES.InvalidValue,
@@ -774,7 +770,6 @@ const createFieldDescriptors = (
     {
       fieldId: "baseURL",
       type: MANAGED_RESOURCE_FIELD_TYPES.Text,
-      required: !detail,
     },
     {
       fieldId: "status",
@@ -872,6 +867,7 @@ const editInitialValues = (
 const buildCreateCommand = (
   values: EditableResourceProjection,
 ): AxonHubCreateCommand => {
+  const baseURL = readString(values, "baseURL")
   const secret = readSecretIntent(values)
   const credential = secret.kind === "replace" ? secret.value.trim() : ""
   const extraModelPrefix = readString(values, "extraModelPrefix")
@@ -883,7 +879,7 @@ const buildCreateCommand = (
     input: {
       type: readString(values, "type"),
       name: readString(values, "name"),
-      baseURL: readString(values, "baseURL"),
+      ...(baseURL ? { baseURL } : {}),
       credentials: { apiKeys: [credential] },
       supportedModels: normalizeList(readList(values, "supportedModels")),
       manualModels: normalizeList(readList(values, "manualModels")),

--- a/src/services/apiAdapters/managedResources/axonHub.ts
+++ b/src/services/apiAdapters/managedResources/axonHub.ts
@@ -1,0 +1,1095 @@
+import {
+  AXON_HUB_CHANNEL_STATUS,
+  AXON_HUB_CHANNEL_TYPE,
+  type AxonHubChannelStatus,
+} from "~/constants/axonHub"
+import { SITE_TYPES } from "~/constants/siteType"
+import { MANAGED_RESOURCE_KINDS } from "~/services/accountSiteDefinitions/contracts"
+import { getAccountSiteDefinition } from "~/services/accountSiteDefinitions/registry"
+import { hasUsableApiTokenKey } from "~/services/accountTokens/apiTokenKey"
+import {
+  MANAGED_RESOURCE_FIELD_ISSUE_CODES,
+  MANAGED_RESOURCE_FIELD_TYPES,
+  type EditableResourceProjection,
+  type ManagedResourceRef,
+  type ResourceDisplayFact,
+  type ResourceDisplayFacts,
+  type ResourceFailure,
+  type ResourceFieldDescriptor,
+  type ResourceFieldIssue,
+  type ResourceListQuery,
+  type ResourceOperationOptions,
+  type ResourceSecretState,
+  type ResourceValidationResult,
+  type SecretEditIntent,
+} from "~/services/apiAdapters/contracts/managedResourceNative"
+import {
+  defineNativeResourceKind,
+  type NativeResourceEditorDefinition,
+  type NativeResourceMutationResult,
+} from "~/services/apiAdapters/managedResources/factory"
+import {
+  AxonHubRequestError,
+  createAxonHubChannel,
+  deleteAxonHubChannel,
+  getAxonHubChannel,
+  listAxonHubChannelPage,
+  signIn,
+  updateAxonHubChannel,
+  updateAxonHubChannelStatus,
+  type AxonHubChannelPage,
+  type AxonHubRequestFailureKind,
+} from "~/services/apiService/axonHub"
+import { resolveManagedSiteRuntimeConfigForType } from "~/services/managedSites/runtimeConfig"
+import { userPreferences } from "~/services/preferences/userPreferences"
+import type {
+  AxonHubChannel,
+  AxonHubCreateChannelInput,
+  AxonHubUpdateChannelInput,
+} from "~/types/axonHub"
+import type { AxonHubConfig } from "~/types/axonHubConfig"
+
+export const AXON_HUB_EDITABLE_FIELD_IDS = [
+  "name",
+  "type",
+  "baseURL",
+  "status",
+  "key",
+  "supportedModels",
+  "manualModels",
+  "defaultTestModel",
+  "autoSyncSupportedModels",
+  "autoSyncModelPattern",
+  "tags",
+  "orderingWeight",
+  "remark",
+  "extraModelPrefix",
+] as const
+
+export type AxonHubNativeFailure = {
+  code:
+    | "configuration_required"
+    | "invalid_configuration"
+    | "authentication_failed"
+    | "permission_denied"
+    | "not_found"
+    | "unavailable"
+    | "upstream_rejected"
+    | "aborted"
+    | "unexpected"
+  dispatch: "before" | "after"
+}
+
+export class AxonHubNativeError extends Error {
+  constructor(readonly failure: AxonHubNativeFailure) {
+    super(failure.code)
+    this.name = "AxonHubNativeError"
+  }
+}
+
+type AxonHubNativeResourcePage = {
+  readonly items: readonly AxonHubChannelPage["items"][number][]
+  readonly nextCursor?: AxonHubChannelPage["nextCursor"]
+}
+
+export interface AxonHubNativeResourceOperations {
+  readonly scopeKey: string
+  list(
+    query?: ResourceListQuery,
+    options?: ResourceOperationOptions,
+  ): Promise<AxonHubNativeResourcePage>
+  get(
+    ref: ManagedResourceRef,
+    options?: ResourceOperationOptions,
+  ): Promise<AxonHubChannel>
+  create(
+    input: AxonHubCreateChannelInput,
+    desiredStatus: AxonHubChannelStatus,
+    options?: ResourceOperationOptions,
+  ): Promise<NativeResourceMutationResult<AxonHubChannel, AxonHubNativeFailure>>
+  update(
+    detail: AxonHubChannel,
+    input: AxonHubUpdateChannelInput,
+    options?: ResourceOperationOptions,
+  ): Promise<NativeResourceMutationResult<AxonHubChannel, AxonHubNativeFailure>>
+  delete(
+    ref: ManagedResourceRef,
+    options?: ResourceOperationOptions,
+  ): Promise<NativeResourceMutationResult<void, AxonHubNativeFailure>>
+}
+
+type AxonHubCreateCommand = {
+  input: AxonHubCreateChannelInput
+  desiredStatus: AxonHubChannelStatus
+}
+
+// beta5 requires apiKeys for these audited regular-key types; structured
+// AWS/GCP/OAuth and unknown future types stay excluded by default.
+// Source: https://github.com/looplj/axonhub/blob/d061ac7df6aef0c5ec6cdfa9dc5002546a1c5a57/frontend/src/features/channels/data/schema.ts
+const REGULAR_AXON_HUB_CHANNEL_TYPES = [
+  AXON_HUB_CHANNEL_TYPE.OPENAI,
+  AXON_HUB_CHANNEL_TYPE.OPENAI_RESPONSES,
+  AXON_HUB_CHANNEL_TYPE.ANTHROPIC,
+  AXON_HUB_CHANNEL_TYPE.GEMINI_OPENAI,
+  AXON_HUB_CHANNEL_TYPE.GEMINI,
+  AXON_HUB_CHANNEL_TYPE.GEMINI_VERTEX,
+  AXON_HUB_CHANNEL_TYPE.DEEPSEEK,
+  AXON_HUB_CHANNEL_TYPE.DEEPSEEK_ANTHROPIC,
+  AXON_HUB_CHANNEL_TYPE.OPENROUTER,
+  AXON_HUB_CHANNEL_TYPE.XAI,
+  AXON_HUB_CHANNEL_TYPE.SILICONFLOW,
+  AXON_HUB_CHANNEL_TYPE.VOLCENGINE,
+  AXON_HUB_CHANNEL_TYPE.NANOGPT,
+  AXON_HUB_CHANNEL_TYPE.OLLAMA,
+] as const
+
+const REGULAR_AXON_HUB_CHANNEL_TYPE_SET = new Set<string>(
+  REGULAR_AXON_HUB_CHANNEL_TYPES,
+)
+
+// Resource-wide search is client-side, so cap both upstream work and retained
+// input at conservative levels well above normal managed-site inventories.
+const AXON_HUB_SEARCH_PAGE_LIMIT = 100
+const AXON_HUB_SEARCH_ITEM_LIMIT = 5_000
+
+const normalizeOrigin = (value: string) => {
+  const url = new URL(value.trim())
+  if (
+    (url.protocol !== "https:" && url.protocol !== "http:") ||
+    url.username ||
+    url.password ||
+    url.search ||
+    url.hash
+  ) {
+    throw new Error("invalid origin")
+  }
+  return url.origin
+}
+
+const controlledNativeFailures = new WeakSet<object>()
+
+const createControlledNativeFailure = (
+  code: AxonHubNativeFailure["code"],
+  dispatch: AxonHubNativeFailure["dispatch"] = "before",
+) => {
+  const failure: AxonHubNativeFailure = { code, dispatch }
+  controlledNativeFailures.add(failure)
+  return failure
+}
+
+const createNativeFailure = (
+  code: AxonHubNativeFailure["code"],
+  dispatch: AxonHubNativeFailure["dispatch"] = "before",
+) => new AxonHubNativeError(createControlledNativeFailure(code, dispatch))
+
+const AXON_HUB_NATIVE_FAILURE_CODES = new Set<string>([
+  "configuration_required",
+  "invalid_configuration",
+  "authentication_failed",
+  "permission_denied",
+  "not_found",
+  "unavailable",
+  "upstream_rejected",
+  "aborted",
+  "unexpected",
+])
+
+const AXON_HUB_REQUEST_FAILURE_CODES = {
+  authentication: "authentication_failed",
+  permission: "permission_denied",
+  "not-found": "not_found",
+  "upstream-rejected": "upstream_rejected",
+  protocol: "unexpected",
+  unavailable: "unavailable",
+  aborted: "aborted",
+} as const satisfies Record<
+  AxonHubRequestFailureKind,
+  AxonHubNativeFailure["code"]
+>
+
+const isAxonHubNativeFailure = (
+  value: unknown,
+): value is AxonHubNativeFailure =>
+  typeof value === "object" &&
+  value !== null &&
+  controlledNativeFailures.has(value) &&
+  "code" in value &&
+  typeof value.code === "string" &&
+  AXON_HUB_NATIVE_FAILURE_CODES.has(value.code) &&
+  "dispatch" in value &&
+  (value.dispatch === "before" || value.dispatch === "after")
+
+const mapRequestFailure = (error: unknown): AxonHubNativeError => {
+  if (error instanceof AxonHubNativeError) return error
+  if (!(error instanceof AxonHubRequestError)) {
+    return createNativeFailure("unexpected")
+  }
+
+  const dispatch = error.dispatch === "dispatched" ? "after" : "before"
+  return createNativeFailure(
+    AXON_HUB_REQUEST_FAILURE_CODES[error.kind],
+    dispatch,
+  )
+}
+
+const mutationFailure = <T>(
+  error: unknown,
+): NativeResourceMutationResult<T, AxonHubNativeFailure> => {
+  const failure = mapRequestFailure(error).failure
+  const acknowledgementMayBeLost =
+    failure.dispatch === "after" &&
+    (failure.code === "unavailable" ||
+      failure.code === "aborted" ||
+      failure.code === "unexpected")
+  return acknowledgementMayBeLost
+    ? { certainty: "possibly-applied" }
+    : { certainty: "not-applied", failure }
+}
+
+const callRead = async <T>(operation: () => Promise<T>): Promise<T> => {
+  try {
+    return await operation()
+  } catch (error) {
+    throw mapRequestFailure(error)
+  }
+}
+
+/** Opens a validated, scope-bound AxonHub native resource session. */
+export async function openAxonHubNativeResourceOperations(
+  options?: ResourceOperationOptions,
+): Promise<AxonHubNativeResourceOperations> {
+  let preferences: Awaited<ReturnType<typeof userPreferences.getPreferences>>
+  try {
+    preferences = await userPreferences.getPreferences()
+  } catch (error) {
+    throw mapRequestFailure(error)
+  }
+
+  const resolved = resolveManagedSiteRuntimeConfigForType(
+    preferences,
+    SITE_TYPES.AXON_HUB,
+  )
+  if (!resolved) throw createNativeFailure("configuration_required")
+
+  let scopeKey: string
+  let config: AxonHubConfig
+  try {
+    scopeKey = normalizeOrigin(resolved.config.baseUrl)
+    const email = resolved.config.email.trim()
+    const password = resolved.config.password.trim()
+    if (!email || !password) throw new Error("invalid credentials")
+    config = {
+      baseUrl: resolved.config.baseUrl,
+      email,
+      password,
+    }
+  } catch {
+    throw createNativeFailure("invalid_configuration")
+  }
+
+  const requestOptions = (operationOptions?: ResourceOperationOptions) =>
+    operationOptions?.signal ? { signal: operationOptions.signal } : undefined
+
+  await callRead(() => signIn(config, requestOptions(options)))
+
+  const assertRef = (ref: ManagedResourceRef) => {
+    if (
+      ref.siteType !== SITE_TYPES.AXON_HUB ||
+      ref.kind !== MANAGED_RESOURCE_KINDS.Channel ||
+      ref.scopeKey !== scopeKey ||
+      !ref.resourceId
+    ) {
+      throw createNativeFailure("unexpected")
+    }
+  }
+
+  return {
+    scopeKey,
+    list: async (query, operationOptions) => {
+      const normalizedSearch = query?.search?.trim().toLowerCase() ?? ""
+      if (!normalizedSearch) {
+        return callRead(async () => {
+          const page = await listAxonHubChannelPage(
+            config,
+            {
+              ...(query?.cursor ? { cursor: query.cursor } : {}),
+              limit: query?.limit ?? 100,
+            },
+            requestOptions(operationOptions),
+          )
+          return {
+            items: page.items,
+            ...(page.nextCursor ? { nextCursor: page.nextCursor } : {}),
+          }
+        })
+      }
+
+      return callRead(async () => {
+        const items: AxonHubChannel[] = []
+        const seenCursors = new Set<string>()
+        let cursor: string | undefined
+        let pageCount = 0
+        let itemCount = 0
+        do {
+          if (pageCount >= AXON_HUB_SEARCH_PAGE_LIMIT) {
+            throw createNativeFailure("unexpected")
+          }
+          pageCount += 1
+          const page = await listAxonHubChannelPage(
+            config,
+            { ...(cursor ? { cursor } : {}), limit: 100 },
+            operationOptions?.signal
+              ? { signal: operationOptions.signal }
+              : undefined,
+          )
+          itemCount += page.items.length
+          if (itemCount > AXON_HUB_SEARCH_ITEM_LIMIT) {
+            throw createNativeFailure("unexpected")
+          }
+          items.push(
+            ...page.items.filter((item) =>
+              searchableValues(item).some((value) =>
+                value.toLowerCase().includes(normalizedSearch),
+              ),
+            ),
+          )
+          const nextCursor = page.nextCursor
+          if (nextCursor && seenCursors.has(nextCursor)) {
+            throw createNativeFailure("unexpected")
+          }
+          if (nextCursor) seenCursors.add(nextCursor)
+          cursor = nextCursor
+        } while (cursor)
+        return { items }
+      })
+    },
+    get: (ref, operationOptions) => {
+      assertRef(ref)
+      return callRead(() =>
+        getAxonHubChannel(
+          config,
+          ref.resourceId,
+          requestOptions(operationOptions),
+        ),
+      )
+    },
+    create: async (input, desiredStatus, operationOptions) => {
+      let created: AxonHubChannel
+      try {
+        created = await createAxonHubChannel(
+          config,
+          input,
+          requestOptions(operationOptions),
+        )
+      } catch (error) {
+        return mutationFailure(error)
+      }
+
+      if (desiredStatus !== AXON_HUB_CHANNEL_STATUS.ENABLED) {
+        return { certainty: "applied", value: created }
+      }
+
+      try {
+        await updateAxonHubChannelStatus(
+          config,
+          created.id,
+          desiredStatus,
+          requestOptions(operationOptions),
+        )
+        return {
+          certainty: "applied",
+          value: { ...created, status: desiredStatus },
+        }
+      } catch {
+        return { certainty: "partially-applied" }
+      }
+    },
+    update: async (detail, input, operationOptions) => {
+      try {
+        return {
+          certainty: "applied",
+          value: await updateAxonHubChannel(
+            config,
+            detail.id,
+            input,
+            requestOptions(operationOptions),
+          ),
+        }
+      } catch (error) {
+        return mutationFailure(error)
+      }
+    },
+    delete: async (ref, operationOptions) => {
+      assertRef(ref)
+      try {
+        const deleted = await deleteAxonHubChannel(
+          config,
+          ref.resourceId,
+          requestOptions(operationOptions),
+        )
+        if (!deleted) {
+          return {
+            certainty: "not-applied",
+            failure: createControlledNativeFailure(
+              "upstream_rejected",
+              "after",
+            ),
+          }
+        }
+        return { certainty: "applied", value: undefined }
+      } catch (error) {
+        const failure = mapRequestFailure(error).failure
+        if (failure.code === "not_found") {
+          return { certainty: "applied", value: undefined }
+        }
+        return mutationFailure(new AxonHubNativeError(failure))
+      }
+    },
+  }
+}
+
+const searchableValues = (channel: AxonHubChannel) => [
+  channel.id,
+  channel.name,
+  String(channel.type),
+  channel.baseURL ?? "",
+  String(channel.status),
+  ...(channel.supportedModels ?? []),
+  ...(channel.tags ?? []),
+]
+
+const toStatus = (status: string): ResourceDisplayFacts["status"] => {
+  switch (status) {
+    case AXON_HUB_CHANNEL_STATUS.ENABLED:
+      return "enabled"
+    case AXON_HUB_CHANNEL_STATUS.DISABLED:
+      return "disabled"
+    case AXON_HUB_CHANNEL_STATUS.ARCHIVED:
+      return "archived"
+    case "auto-disabled":
+      return "auto-disabled"
+    default:
+      return "unknown"
+  }
+}
+
+const getCredentialState = (channel: AxonHubChannel): ResourceSecretState => {
+  if (channel.credentials === null) return "permission-hidden"
+  const keys = [
+    ...(channel.credentials?.apiKeys ?? []),
+    ...(channel.credentials?.apiKey ? [channel.credentials.apiKey] : []),
+  ].map((key) => key.trim())
+  if (keys.some(hasUsableApiTokenKey)) return "available"
+  if (keys.some(Boolean)) return "masked"
+  return "unavailable"
+}
+
+const detailFacts = (
+  channel: AxonHubChannel,
+): readonly ResourceDisplayFact[] => [
+  { fieldId: "name", kind: "text", value: channel.name },
+  { fieldId: "type", kind: "text", value: String(channel.type) },
+  { fieldId: "baseURL", kind: "text", value: channel.baseURL ?? "" },
+  { fieldId: "status", kind: "text", value: String(channel.status) },
+  { fieldId: "key", kind: "secret", state: getCredentialState(channel) },
+  {
+    fieldId: "supportedModels",
+    kind: "list",
+    value: channel.supportedModels ?? [],
+  },
+  {
+    fieldId: "manualModels",
+    kind: "list",
+    value: channel.manualModels ?? [],
+  },
+  {
+    fieldId: "defaultTestModel",
+    kind: "text",
+    value: channel.defaultTestModel ?? "",
+  },
+  {
+    fieldId: "autoSyncSupportedModels",
+    kind: "boolean",
+    value: channel.autoSyncSupportedModels ?? false,
+  },
+  {
+    fieldId: "autoSyncModelPattern",
+    kind: "text",
+    value: channel.autoSyncModelPattern ?? "",
+  },
+  { fieldId: "tags", kind: "list", value: channel.tags ?? [] },
+  {
+    fieldId: "orderingWeight",
+    kind: "number",
+    value: channel.orderingWeight ?? 0,
+  },
+  { fieldId: "remark", kind: "text", value: channel.remark ?? "" },
+  {
+    fieldId: "extraModelPrefix",
+    kind: "text",
+    value: channel.settings?.extraModelPrefix ?? "",
+  },
+]
+
+const toFacts = (
+  channel: AxonHubChannel,
+  ref: ManagedResourceRef,
+  fields: readonly ResourceDisplayFact[],
+): ResourceDisplayFacts => {
+  const status = toStatus(channel.status)
+  const supportedState = status !== "unknown"
+  return {
+    ref,
+    displayName: channel.name,
+    status,
+    fields,
+    actions: { canUpdate: supportedState, canDelete: supportedState },
+  }
+}
+
+const toListFacts = (channel: AxonHubChannel, ref: ManagedResourceRef) => {
+  const selectedFieldIds = new Set(
+    getAccountSiteDefinition(SITE_TYPES.AXON_HUB)?.managedResource
+      ?.tableFieldIds ?? [],
+  )
+  return toFacts(
+    channel,
+    ref,
+    detailFacts(channel).filter((fact) => selectedFieldIds.has(fact.fieldId)),
+  )
+}
+
+const readString = (values: EditableResourceProjection, fieldId: string) => {
+  const value = values[fieldId]
+  return typeof value === "string" ? value.trim() : ""
+}
+
+const readBoolean = (values: EditableResourceProjection, fieldId: string) =>
+  values[fieldId] === true
+
+const readNumber = (values: EditableResourceProjection, fieldId: string) => {
+  const value = values[fieldId]
+  return typeof value === "number" && Number.isFinite(value) ? value : 0
+}
+
+const readList = (values: EditableResourceProjection, fieldId: string) => {
+  const value = values[fieldId]
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string")
+    : []
+}
+
+const readSecretIntent = (
+  values: EditableResourceProjection,
+): SecretEditIntent => {
+  const value = values.key
+  if (typeof value === "object" && value !== null && "kind" in value) {
+    if (value.kind === "unchanged") return { kind: "unchanged" }
+    if (value.kind === "clear") return { kind: "clear" }
+    if (value.kind === "replace" && typeof value.value === "string") {
+      return { kind: "replace", value: value.value }
+    }
+  }
+  return { kind: "unchanged" }
+}
+
+const normalizeList = (values: readonly string[]) =>
+  values.map((value) => value.trim()).filter(Boolean)
+
+const hasInvalidListValues = (values: readonly string[]) => {
+  const normalized = values.map((value) => value.trim())
+  return (
+    normalized.some((value) => !value) ||
+    new Set(normalized).size !== normalized.length
+  )
+}
+
+const isHttpUrl = (value: string) => {
+  try {
+    const url = new URL(value)
+    return url.protocol === "http:" || url.protocol === "https:"
+  } catch {
+    return false
+  }
+}
+
+const validateValues = (
+  values: EditableResourceProjection,
+  context: { create: boolean; detail?: AxonHubChannel },
+): ResourceValidationResult => {
+  const issues: ResourceFieldIssue[] = []
+  const name = readString(values, "name")
+  const type = readString(values, "type")
+  const baseURL = readString(values, "baseURL")
+  const supportedModels = readList(values, "supportedModels")
+  const manualModels = readList(values, "manualModels")
+  const defaultTestModel = readString(values, "defaultTestModel")
+  const secretIntent = readSecretIntent(values)
+  const status = readString(values, "status")
+  const specialCredentialType = context.detail
+    ? !REGULAR_AXON_HUB_CHANNEL_TYPE_SET.has(String(context.detail.type))
+    : false
+
+  if (!name) {
+    issues.push({
+      fieldId: "name",
+      code: MANAGED_RESOURCE_FIELD_ISSUE_CODES.Required,
+    })
+  }
+  if (!type) {
+    issues.push({
+      fieldId: "type",
+      code: MANAGED_RESOURCE_FIELD_ISSUE_CODES.Required,
+    })
+  } else if (
+    (!specialCredentialType && !REGULAR_AXON_HUB_CHANNEL_TYPE_SET.has(type)) ||
+    (specialCredentialType && type !== context.detail?.type)
+  ) {
+    issues.push({
+      fieldId: "type",
+      code: MANAGED_RESOURCE_FIELD_ISSUE_CODES.UnsupportedOption,
+    })
+  }
+  if (context.create && !baseURL) {
+    issues.push({
+      fieldId: "baseURL",
+      code: MANAGED_RESOURCE_FIELD_ISSUE_CODES.Required,
+    })
+  } else if (baseURL && !isHttpUrl(baseURL)) {
+    issues.push({
+      fieldId: "baseURL",
+      code: MANAGED_RESOURCE_FIELD_ISSUE_CODES.InvalidValue,
+    })
+  }
+  if (
+    (context.create &&
+      (secretIntent.kind !== "replace" || !secretIntent.value.trim())) ||
+    secretIntent.kind === "clear" ||
+    (secretIntent.kind === "replace" && !secretIntent.value.trim()) ||
+    (specialCredentialType && secretIntent.kind !== "unchanged")
+  ) {
+    issues.push({
+      fieldId: "key",
+      code: context.create
+        ? MANAGED_RESOURCE_FIELD_ISSUE_CODES.Required
+        : MANAGED_RESOURCE_FIELD_ISSUE_CODES.UnsupportedOption,
+    })
+  }
+  if (hasInvalidListValues(supportedModels)) {
+    issues.push({
+      fieldId: "supportedModels",
+      code: MANAGED_RESOURCE_FIELD_ISSUE_CODES.InvalidValue,
+    })
+  }
+  if (supportedModels.length === 0) {
+    issues.push({
+      fieldId: "supportedModels",
+      code: MANAGED_RESOURCE_FIELD_ISSUE_CODES.Required,
+    })
+  }
+  if (hasInvalidListValues(manualModels)) {
+    issues.push({
+      fieldId: "manualModels",
+      code: MANAGED_RESOURCE_FIELD_ISSUE_CODES.InvalidValue,
+    })
+  }
+  if (!defaultTestModel) {
+    issues.push({
+      fieldId: "defaultTestModel",
+      code: MANAGED_RESOURCE_FIELD_ISSUE_CODES.Required,
+    })
+  } else if (
+    defaultTestModel &&
+    !new Set([
+      ...normalizeList(supportedModels),
+      ...normalizeList(manualModels),
+    ]).has(defaultTestModel)
+  ) {
+    issues.push({
+      fieldId: "defaultTestModel",
+      code: MANAGED_RESOURCE_FIELD_ISSUE_CODES.InconsistentValue,
+    })
+  }
+  const supportedStatuses = context.create
+    ? [AXON_HUB_CHANNEL_STATUS.ENABLED, AXON_HUB_CHANNEL_STATUS.DISABLED]
+    : [
+        AXON_HUB_CHANNEL_STATUS.ENABLED,
+        AXON_HUB_CHANNEL_STATUS.DISABLED,
+        AXON_HUB_CHANNEL_STATUS.ARCHIVED,
+        ...(context.detail ? [String(context.detail.status)] : []),
+      ]
+  if (!supportedStatuses.includes(status)) {
+    issues.push({
+      fieldId: "status",
+      code: MANAGED_RESOURCE_FIELD_ISSUE_CODES.UnsupportedOption,
+    })
+  }
+  const orderingWeight = values.orderingWeight
+  if (!Number.isInteger(orderingWeight)) {
+    issues.push({
+      fieldId: "orderingWeight",
+      code: MANAGED_RESOURCE_FIELD_ISSUE_CODES.InvalidValue,
+    })
+  }
+
+  return issues.length ? { valid: false, issues } : { valid: true }
+}
+
+const createFieldDescriptors = (
+  detail?: AxonHubChannel,
+): readonly ResourceFieldDescriptor[] => {
+  const specialCredentialType = detail
+    ? !REGULAR_AXON_HUB_CHANNEL_TYPE_SET.has(String(detail.type))
+    : false
+  const typeOptions =
+    specialCredentialType && detail
+      ? [{ value: String(detail.type) }]
+      : REGULAR_AXON_HUB_CHANNEL_TYPES.map((value) => ({ value }))
+  const currentStatus = detail ? String(detail.status) : undefined
+  const statusValues = detail
+    ? [
+        AXON_HUB_CHANNEL_STATUS.ENABLED,
+        AXON_HUB_CHANNEL_STATUS.DISABLED,
+        AXON_HUB_CHANNEL_STATUS.ARCHIVED,
+        ...(currentStatus &&
+        currentStatus !== AXON_HUB_CHANNEL_STATUS.ENABLED &&
+        currentStatus !== AXON_HUB_CHANNEL_STATUS.DISABLED &&
+        currentStatus !== AXON_HUB_CHANNEL_STATUS.ARCHIVED
+          ? [currentStatus]
+          : []),
+      ]
+    : [AXON_HUB_CHANNEL_STATUS.ENABLED, AXON_HUB_CHANNEL_STATUS.DISABLED]
+  return [
+    {
+      fieldId: "name",
+      type: MANAGED_RESOURCE_FIELD_TYPES.Text,
+      required: true,
+    },
+    {
+      fieldId: "type",
+      type: MANAGED_RESOURCE_FIELD_TYPES.Select,
+      required: true,
+      options: typeOptions,
+    },
+    {
+      fieldId: "baseURL",
+      type: MANAGED_RESOURCE_FIELD_TYPES.Text,
+      required: !detail,
+    },
+    {
+      fieldId: "status",
+      type: MANAGED_RESOURCE_FIELD_TYPES.Select,
+      required: true,
+      options: statusValues.map((value) => ({ value })),
+    },
+    {
+      fieldId: "key",
+      type: MANAGED_RESOURCE_FIELD_TYPES.Secret,
+      secretState: detail ? getCredentialState(detail) : "unavailable",
+      allowClear: false,
+    },
+    {
+      fieldId: "supportedModels",
+      type: MANAGED_RESOURCE_FIELD_TYPES.MultiSelect,
+      options: [],
+    },
+    {
+      fieldId: "manualModels",
+      type: MANAGED_RESOURCE_FIELD_TYPES.MultiSelect,
+      options: [],
+    },
+    {
+      fieldId: "defaultTestModel",
+      type: MANAGED_RESOURCE_FIELD_TYPES.Text,
+      required: true,
+    },
+    {
+      fieldId: "autoSyncSupportedModels",
+      type: MANAGED_RESOURCE_FIELD_TYPES.Boolean,
+    },
+    {
+      fieldId: "autoSyncModelPattern",
+      type: MANAGED_RESOURCE_FIELD_TYPES.Text,
+    },
+    {
+      fieldId: "tags",
+      type: MANAGED_RESOURCE_FIELD_TYPES.MultiSelect,
+      options: [],
+    },
+    {
+      fieldId: "orderingWeight",
+      type: MANAGED_RESOURCE_FIELD_TYPES.Number,
+      step: 1,
+    },
+    {
+      fieldId: "remark",
+      type: MANAGED_RESOURCE_FIELD_TYPES.Textarea,
+      rows: 3,
+    },
+    {
+      fieldId: "extraModelPrefix",
+      type: MANAGED_RESOURCE_FIELD_TYPES.Text,
+    },
+  ]
+}
+
+const createInitialValues = (): EditableResourceProjection => ({
+  name: "",
+  type: AXON_HUB_CHANNEL_TYPE.OPENAI,
+  baseURL: "",
+  status: AXON_HUB_CHANNEL_STATUS.DISABLED,
+  key: { kind: "unchanged" },
+  supportedModels: [],
+  manualModels: [],
+  defaultTestModel: "",
+  autoSyncSupportedModels: false,
+  autoSyncModelPattern: "",
+  tags: [],
+  orderingWeight: 0,
+  remark: "",
+  extraModelPrefix: "",
+})
+
+const editInitialValues = (
+  detail: AxonHubChannel,
+): EditableResourceProjection => ({
+  name: detail.name,
+  type: String(detail.type),
+  baseURL: detail.baseURL ?? "",
+  status: String(detail.status),
+  key: { kind: "unchanged" },
+  supportedModels: [...(detail.supportedModels ?? [])],
+  manualModels: [...(detail.manualModels ?? [])],
+  defaultTestModel: detail.defaultTestModel ?? "",
+  autoSyncSupportedModels: detail.autoSyncSupportedModels ?? false,
+  autoSyncModelPattern: detail.autoSyncModelPattern ?? "",
+  tags: [...(detail.tags ?? [])],
+  orderingWeight: detail.orderingWeight ?? 0,
+  remark: detail.remark ?? "",
+  extraModelPrefix: detail.settings?.extraModelPrefix ?? "",
+})
+
+const buildCreateCommand = (
+  values: EditableResourceProjection,
+): AxonHubCreateCommand => {
+  const secret = readSecretIntent(values)
+  const credential = secret.kind === "replace" ? secret.value.trim() : ""
+  const extraModelPrefix = readString(values, "extraModelPrefix")
+  return {
+    desiredStatus:
+      readString(values, "status") === AXON_HUB_CHANNEL_STATUS.ENABLED
+        ? AXON_HUB_CHANNEL_STATUS.ENABLED
+        : AXON_HUB_CHANNEL_STATUS.DISABLED,
+    input: {
+      type: readString(values, "type"),
+      name: readString(values, "name"),
+      baseURL: readString(values, "baseURL"),
+      credentials: { apiKeys: [credential] },
+      supportedModels: normalizeList(readList(values, "supportedModels")),
+      manualModels: normalizeList(readList(values, "manualModels")),
+      autoSyncSupportedModels: readBoolean(values, "autoSyncSupportedModels"),
+      autoSyncModelPattern: readString(values, "autoSyncModelPattern") || null,
+      tags: normalizeList(readList(values, "tags")),
+      defaultTestModel: readString(values, "defaultTestModel"),
+      settings: { extraModelPrefix },
+      orderingWeight: readNumber(values, "orderingWeight"),
+      remark: readString(values, "remark") || null,
+    },
+  }
+}
+
+const arraysEqual = (first: readonly string[], second: readonly string[]) =>
+  first.length === second.length &&
+  first.every((value, index) => value === second[index])
+
+const fieldChanged = (
+  values: EditableResourceProjection,
+  baseline: EditableResourceProjection,
+  fieldId: string,
+) => {
+  const value = values[fieldId]
+  const initialValue = baseline[fieldId]
+  if (Array.isArray(value) && Array.isArray(initialValue)) {
+    return !arraysEqual(value, initialValue)
+  }
+  return value !== initialValue
+}
+
+const addNullableTextDiff = (
+  input: AxonHubUpdateChannelInput,
+  values: EditableResourceProjection,
+  baseline: EditableResourceProjection,
+  fieldId: "baseURL" | "autoSyncModelPattern" | "remark",
+  clearField: "clearBaseURL" | "clearAutoSyncModelPattern" | "clearRemark",
+) => {
+  if (!fieldChanged(values, baseline, fieldId)) return
+  const next = readString(values, fieldId)
+  if (next) input[fieldId] = next
+  else input[clearField] = true
+}
+
+const buildUpdateCommand = (
+  detail: AxonHubChannel,
+  baseline: EditableResourceProjection,
+  values: EditableResourceProjection,
+): AxonHubUpdateChannelInput => {
+  const input: AxonHubUpdateChannelInput = {}
+  const name = readString(values, "name")
+  const type = readString(values, "type")
+  const status = readString(values, "status")
+  if (fieldChanged(values, baseline, "name")) input.name = name
+  if (fieldChanged(values, baseline, "type")) input.type = type
+  if (fieldChanged(values, baseline, "status")) input.status = status
+
+  addNullableTextDiff(input, values, baseline, "baseURL", "clearBaseURL")
+  addNullableTextDiff(
+    input,
+    values,
+    baseline,
+    "autoSyncModelPattern",
+    "clearAutoSyncModelPattern",
+  )
+  addNullableTextDiff(input, values, baseline, "remark", "clearRemark")
+
+  const secret = readSecretIntent(values)
+  if (secret.kind === "replace") {
+    input.credentials = { apiKeys: [secret.value.trim()] }
+  }
+
+  const supportedModels = normalizeList(readList(values, "supportedModels"))
+  if (fieldChanged(values, baseline, "supportedModels")) {
+    input.supportedModels = supportedModels
+  }
+  const manualModels = normalizeList(readList(values, "manualModels"))
+  if (fieldChanged(values, baseline, "manualModels")) {
+    if (manualModels.length) input.manualModels = manualModels
+    else input.clearManualModels = true
+  }
+  const tags = normalizeList(readList(values, "tags"))
+  if (fieldChanged(values, baseline, "tags")) {
+    if (tags.length) input.tags = tags
+    else input.clearTags = true
+  }
+
+  const defaultTestModel = readString(values, "defaultTestModel")
+  if (fieldChanged(values, baseline, "defaultTestModel")) {
+    input.defaultTestModel = defaultTestModel
+  }
+  const autoSyncSupportedModels = readBoolean(values, "autoSyncSupportedModels")
+  if (fieldChanged(values, baseline, "autoSyncSupportedModels")) {
+    input.autoSyncSupportedModels = autoSyncSupportedModels
+  }
+  const orderingWeight = readNumber(values, "orderingWeight")
+  if (fieldChanged(values, baseline, "orderingWeight")) {
+    input.orderingWeight = orderingWeight
+  }
+
+  const extraModelPrefix = readString(values, "extraModelPrefix")
+  if (fieldChanged(values, baseline, "extraModelPrefix")) {
+    input.settings = {
+      ...(detail.settings ?? {}),
+      extraModelPrefix,
+    }
+  }
+  return input
+}
+
+const createEditor =
+  (): NativeResourceEditorDefinition<AxonHubCreateCommand> => ({
+    fields: createFieldDescriptors(),
+    initialValues: createInitialValues(),
+    validate: (values) => validateValues(values, { create: true }),
+    buildCommand: buildCreateCommand,
+  })
+
+const editEditor = (
+  detail: AxonHubChannel,
+): NativeResourceEditorDefinition<AxonHubUpdateChannelInput> => {
+  const initialValues = editInitialValues(detail)
+  return {
+    fields: createFieldDescriptors(detail),
+    initialValues,
+    validate: (values) => validateValues(values, { create: false, detail }),
+    buildCommand: (values) => buildUpdateCommand(detail, initialValues, values),
+  }
+}
+
+const mapFailure = (error: unknown): ResourceFailure => {
+  const failure =
+    error instanceof AxonHubNativeError
+      ? error.failure
+      : isAxonHubNativeFailure(error)
+        ? error
+        : mapRequestFailure(error).failure
+  return { code: failure.code }
+}
+
+const axonHubNativeDefinition = {
+  siteType: SITE_TYPES.AXON_HUB,
+  kind: MANAGED_RESOURCE_KINDS.Channel,
+  supportsSearch: true,
+  openConfig: openAxonHubNativeResourceOperations,
+  scopeKey: (operations: AxonHubNativeResourceOperations) =>
+    operations.scopeKey,
+  encodeLocator: (locator: string) => locator,
+  decodeLocator: (resourceId: string) => resourceId,
+  locatorFromListItem: (item: AxonHubChannel) => item.id,
+  locatorFromDetail: (detail: AxonHubChannel) => detail.id,
+  list: (
+    operations: AxonHubNativeResourceOperations,
+    query?: ResourceListQuery,
+    options?: ResourceOperationOptions,
+  ) => operations.list(query, options),
+  get: (
+    operations: AxonHubNativeResourceOperations,
+    locator: string,
+    options?: ResourceOperationOptions,
+  ) =>
+    operations.get(
+      {
+        siteType: SITE_TYPES.AXON_HUB,
+        kind: MANAGED_RESOURCE_KINDS.Channel,
+        scopeKey: operations.scopeKey,
+        resourceId: locator,
+      },
+      options,
+    ),
+  toListFacts,
+  toDetailFacts: (detail: AxonHubChannel, ref: ManagedResourceRef) =>
+    toFacts(detail, ref, detailFacts(detail)),
+  createEditor: async () => createEditor(),
+  editEditor: (
+    _operations: AxonHubNativeResourceOperations,
+    detail: AxonHubChannel,
+  ) => editEditor(detail),
+  create: (
+    operations: AxonHubNativeResourceOperations,
+    command: AxonHubCreateCommand,
+    options?: ResourceOperationOptions,
+  ) => operations.create(command.input, command.desiredStatus, options),
+  update: (
+    operations: AxonHubNativeResourceOperations,
+    detail: AxonHubChannel,
+    command: AxonHubUpdateChannelInput,
+    options?: ResourceOperationOptions,
+  ) => operations.update(detail, command, options),
+  delete: (
+    operations: AxonHubNativeResourceOperations,
+    locator: string,
+    options?: ResourceOperationOptions,
+  ) =>
+    operations.delete(
+      {
+        siteType: SITE_TYPES.AXON_HUB,
+        kind: MANAGED_RESOURCE_KINDS.Channel,
+        scopeKey: operations.scopeKey,
+        resourceId: locator,
+      },
+      options,
+    ),
+  mapFailure,
+}
+
+export const axonHubManagedResourceRegistration = defineNativeResourceKind(
+  axonHubNativeDefinition,
+)

--- a/src/services/apiAdapters/managedResources/factory.ts
+++ b/src/services/apiAdapters/managedResources/factory.ts
@@ -1,0 +1,438 @@
+import type { ManagedSiteType } from "~/constants/siteType"
+import type { ManagedResourceKind } from "~/services/accountSiteDefinitions/contracts"
+import {
+  MANAGED_RESOURCE_FAILURE_CODES,
+  ManagedResourceError,
+  type EditableResourceProjection,
+  type ManagedResourceRef,
+  type ManagedResourceRegistration,
+  type ManagedResourceWorkspace,
+  type ResourceDisplayFacts,
+  type ResourceEditor,
+  type ResourceFailure,
+  type ResourceFieldDescriptor,
+  type ResourceListQuery,
+  type ResourceOperationOptions,
+  type ResourceValidationResult,
+} from "~/services/apiAdapters/contracts/managedResourceNative"
+
+export type NativeResourceMutationResult<T, TFailure> =
+  | { certainty: "applied"; value: T }
+  | { certainty: "not-applied"; failure: TFailure }
+  | { certainty: "possibly-applied" }
+  | { certainty: "partially-applied" }
+
+export type NativeResourcePage<TItem> = {
+  items: readonly TItem[]
+  total?: number
+  nextCursor?: string
+}
+
+export type NativeResourceEditorDefinition<TCommand> = {
+  fields: readonly ResourceFieldDescriptor[]
+  initialValues: EditableResourceProjection
+  validate(values: EditableResourceProjection): ResourceValidationResult
+  buildCommand(values: EditableResourceProjection): TCommand
+}
+
+export type NativeResourceKindDefinition<
+  TConfig,
+  TLocator,
+  TListItem,
+  TDetail,
+  TCreateCommand,
+  TUpdateCommand,
+  TFailure,
+> = {
+  siteType: ManagedSiteType
+  kind: ManagedResourceKind
+  supportsSearch: boolean
+  openConfig(options?: ResourceOperationOptions): Promise<TConfig>
+  scopeKey(config: TConfig): string
+  encodeLocator(locator: TLocator): string
+  decodeLocator(resourceId: string): TLocator
+  locatorFromListItem(item: TListItem): TLocator
+  locatorFromDetail(detail: TDetail): TLocator
+  list(
+    config: TConfig,
+    query?: ResourceListQuery,
+    options?: ResourceOperationOptions,
+  ): Promise<NativeResourcePage<TListItem>>
+  get(
+    config: TConfig,
+    locator: TLocator,
+    options?: ResourceOperationOptions,
+  ): Promise<TDetail>
+  toListFacts(item: TListItem, ref: ManagedResourceRef): ResourceDisplayFacts
+  toDetailFacts(detail: TDetail, ref: ManagedResourceRef): ResourceDisplayFacts
+  createEditor(
+    config: TConfig,
+    options?: ResourceOperationOptions,
+  ): Promise<NativeResourceEditorDefinition<TCreateCommand>>
+  editEditor(
+    config: TConfig,
+    detail: TDetail,
+  ): NativeResourceEditorDefinition<TUpdateCommand>
+  create(
+    config: TConfig,
+    command: TCreateCommand,
+    options?: ResourceOperationOptions,
+  ): Promise<NativeResourceMutationResult<TDetail, TFailure>>
+  update(
+    config: TConfig,
+    detail: TDetail,
+    command: TUpdateCommand,
+    options?: ResourceOperationOptions,
+  ): Promise<NativeResourceMutationResult<TDetail, TFailure>>
+  delete(
+    config: TConfig,
+    locator: TLocator,
+    options?: ResourceOperationOptions,
+  ): Promise<NativeResourceMutationResult<void, TFailure>>
+  mapFailure(error: unknown): ResourceFailure
+}
+
+const invalidPublicInput = (fieldIssues?: ResourceFailure["fieldIssues"]) =>
+  new ManagedResourceError({
+    code: MANAGED_RESOURCE_FAILURE_CODES.ValidationFailed,
+    ...(fieldIssues === undefined ? {} : { fieldIssues }),
+  })
+
+const unexpectedDefinitionOutput = () =>
+  new ManagedResourceError({
+    code: MANAGED_RESOURCE_FAILURE_CODES.Unexpected,
+  })
+
+const toManagedError = (
+  error: unknown,
+  mapFailure: (error: unknown) => ResourceFailure,
+) => {
+  if (error instanceof ManagedResourceError) return error
+
+  try {
+    return new ManagedResourceError(mapFailure(error))
+  } catch {
+    return unexpectedDefinitionOutput()
+  }
+}
+
+const mapOperationFailure = async <T>(
+  operation: () => T | Promise<T>,
+  mapFailure: (error: unknown) => ResourceFailure,
+): Promise<T> => {
+  try {
+    return await operation()
+  } catch (error) {
+    throw toManagedError(error, mapFailure)
+  }
+}
+
+const toPublicMutation = async <T, TFailure>(
+  operation: () => Promise<NativeResourceMutationResult<T, TFailure>>,
+  mapFailure: (failure: TFailure) => ResourceFailure,
+): Promise<T> => {
+  const result = await operation()
+  if (result.certainty === "applied") return result.value
+  if (result.certainty === "not-applied") {
+    throw new ManagedResourceError(mapFailure(result.failure))
+  }
+  throw new ManagedResourceError({
+    code: MANAGED_RESOURCE_FAILURE_CODES.MutationStateUncertain,
+  })
+}
+
+const refsMatch = (
+  actualRef: ManagedResourceRef,
+  expectedRef: ManagedResourceRef,
+) =>
+  actualRef.siteType === expectedRef.siteType &&
+  actualRef.kind === expectedRef.kind &&
+  actualRef.scopeKey === expectedRef.scopeKey &&
+  actualRef.resourceId === expectedRef.resourceId
+
+const assertValidFacts = (
+  facts: ResourceDisplayFacts,
+  expectedRef: ManagedResourceRef,
+) => {
+  if (!refsMatch(facts.ref, expectedRef)) {
+    throw unexpectedDefinitionOutput()
+  }
+
+  const fieldIds = new Set<string>()
+  for (const field of facts.fields) {
+    if (fieldIds.has(field.fieldId)) throw unexpectedDefinitionOutput()
+    fieldIds.add(field.fieldId)
+  }
+  return facts
+}
+
+const isValidResourceId = (resourceId: unknown): resourceId is string =>
+  typeof resourceId === "string" &&
+  resourceId.length > 0 &&
+  resourceId.length <= 512
+
+/** Creates a public managed-resource registration from a correlated native Adapter definition. */
+export function defineNativeResourceKind<
+  TConfig,
+  TLocator,
+  TListItem,
+  TDetail,
+  TCreateCommand,
+  TUpdateCommand,
+  TFailure,
+>(
+  definition: NativeResourceKindDefinition<
+    TConfig,
+    TLocator,
+    TListItem,
+    TDetail,
+    TCreateCommand,
+    TUpdateCommand,
+    TFailure
+  >,
+): ManagedResourceRegistration {
+  const mapFailure = (error: unknown) => definition.mapFailure(error)
+
+  return {
+    siteType: definition.siteType,
+    kind: definition.kind,
+    open: (options) =>
+      mapOperationFailure(async () => {
+        const config = await definition.openConfig(options)
+        const scopeKey = definition.scopeKey(config)
+
+        const createRef = (locator: TLocator): ManagedResourceRef => {
+          const resourceId = definition.encodeLocator(locator)
+          if (!isValidResourceId(resourceId)) throw unexpectedDefinitionOutput()
+          return {
+            siteType: definition.siteType,
+            kind: definition.kind,
+            scopeKey,
+            resourceId,
+          }
+        }
+
+        const decodeRef = (candidate: unknown) => {
+          if (
+            typeof candidate !== "object" ||
+            candidate === null ||
+            Array.isArray(candidate)
+          ) {
+            throw invalidPublicInput()
+          }
+
+          const ref = candidate as Record<string, unknown>
+          const { siteType, kind, scopeKey: refScopeKey, resourceId } = ref
+          if (
+            typeof siteType !== "string" ||
+            siteType !== definition.siteType ||
+            typeof kind !== "string" ||
+            kind !== definition.kind ||
+            typeof refScopeKey !== "string" ||
+            refScopeKey !== scopeKey ||
+            !isValidResourceId(resourceId)
+          ) {
+            throw invalidPublicInput()
+          }
+
+          const canonicalRef: ManagedResourceRef = {
+            siteType: definition.siteType,
+            kind: definition.kind,
+            scopeKey,
+            resourceId,
+          }
+          return {
+            ref: canonicalRef,
+            locator: definition.decodeLocator(canonicalRef.resourceId),
+          }
+        }
+
+        const refFromDetail = (detail: TDetail) =>
+          createRef(definition.locatorFromDetail(detail))
+
+        const assertDetailIdentity = (
+          detail: TDetail,
+          expectedRef: ManagedResourceRef,
+        ) => {
+          if (!refsMatch(refFromDetail(detail), expectedRef)) {
+            throw unexpectedDefinitionOutput()
+          }
+        }
+
+        const readDetail = async (
+          candidate: unknown,
+          readOptions?: ResourceOperationOptions,
+        ) => {
+          const { ref, locator } = decodeRef(candidate)
+          const detail = await definition.get(config, locator, readOptions)
+          assertDetailIdentity(detail, ref)
+          return { ref, detail }
+        }
+
+        const projectCreatedDetail = (detail: TDetail) => {
+          const ref = refFromDetail(detail)
+          return assertValidFacts(definition.toDetailFacts(detail, ref), ref)
+        }
+
+        const projectDetailAtRef = (
+          detail: TDetail,
+          expectedRef: ManagedResourceRef,
+        ) => {
+          assertDetailIdentity(detail, expectedRef)
+          return assertValidFacts(
+            definition.toDetailFacts(detail, expectedRef),
+            expectedRef,
+          )
+        }
+
+        const createEditor = <TCommand>(
+          editorDefinition: NativeResourceEditorDefinition<TCommand>,
+          mutate: (
+            command: TCommand,
+            options?: ResourceOperationOptions,
+          ) => Promise<NativeResourceMutationResult<TDetail, TFailure>>,
+          projectResult: (detail: TDetail) => ResourceDisplayFacts,
+        ): ResourceEditor => {
+          let closed = false
+          let inflight: Promise<ResourceDisplayFacts> | undefined
+
+          const validate = (values: EditableResourceProjection) => {
+            try {
+              return editorDefinition.validate(values)
+            } catch (error) {
+              throw toManagedError(error, mapFailure)
+            }
+          }
+
+          const submit = (
+            values: EditableResourceProjection,
+            submitOptions?: ResourceOperationOptions,
+          ) => {
+            if (inflight !== undefined) return inflight
+            if (closed) return Promise.reject(invalidPublicInput())
+
+            const run = mapOperationFailure(async () => {
+              const validation = validate(values)
+              if (!validation.valid) throw invalidPublicInput(validation.issues)
+              const command = editorDefinition.buildCommand(values)
+              let detail: TDetail
+              try {
+                detail = await toPublicMutation(async () => {
+                  const result = await mutate(command, submitOptions)
+                  if (result.certainty !== "not-applied") closed = true
+                  return result
+                }, mapFailure)
+              } catch (error) {
+                const managedError = toManagedError(error, mapFailure)
+                if (
+                  managedError.failure.code ===
+                    MANAGED_RESOURCE_FAILURE_CODES.NotFound ||
+                  managedError.failure.code ===
+                    MANAGED_RESOURCE_FAILURE_CODES.MutationStateUncertain
+                ) {
+                  closed = true
+                }
+                throw managedError
+              }
+              return projectResult(detail)
+            }, mapFailure)
+
+            const tracked = run.finally(() => {
+              if (inflight === tracked) inflight = undefined
+            })
+            inflight = tracked
+            return tracked
+          }
+
+          return {
+            fields: editorDefinition.fields,
+            initialValues: editorDefinition.initialValues,
+            validate,
+            submit,
+          }
+        }
+
+        const workspace: ManagedResourceWorkspace = {
+          supportsSearch: definition.supportsSearch,
+          list: (query, listOptions) =>
+            mapOperationFailure(async () => {
+              const page = await definition.list(config, query, listOptions)
+              const items = page.items.map((item) => {
+                const ref = createRef(definition.locatorFromListItem(item))
+                return assertValidFacts(definition.toListFacts(item, ref), ref)
+              })
+              return {
+                items,
+                ...(page.total === undefined ? {} : { total: page.total }),
+                ...(page.nextCursor === undefined
+                  ? {}
+                  : { nextCursor: page.nextCursor }),
+              }
+            }, mapFailure),
+          get: (ref, getOptions) =>
+            mapOperationFailure(async () => {
+              const { ref: canonicalRef, detail } = await readDetail(
+                ref,
+                getOptions,
+              )
+              return assertValidFacts(
+                definition.toDetailFacts(detail, canonicalRef),
+                canonicalRef,
+              )
+            }, mapFailure),
+          openCreateEditor: (editorOptions) =>
+            mapOperationFailure(async () => {
+              const editorDefinition = await definition.createEditor(
+                config,
+                editorOptions,
+              )
+              return createEditor(
+                editorDefinition,
+                (command, submitOptions) =>
+                  definition.create(config, command, submitOptions),
+                projectCreatedDetail,
+              )
+            }, mapFailure),
+          openEditEditor: (ref, editorOptions) =>
+            mapOperationFailure(async () => {
+              const { ref: canonicalRef, detail } = await readDetail(
+                ref,
+                editorOptions,
+              )
+              const editorDefinition = definition.editEditor(config, detail)
+              return createEditor(
+                editorDefinition,
+                (command, submitOptions) =>
+                  definition.update(config, detail, command, submitOptions),
+                (updatedDetail) =>
+                  projectDetailAtRef(updatedDetail, canonicalRef),
+              )
+            }, mapFailure),
+          delete: (ref, deleteOptions) =>
+            mapOperationFailure(async () => {
+              const { locator } = decodeRef(ref)
+              try {
+                await mapOperationFailure(
+                  () =>
+                    toPublicMutation(
+                      () => definition.delete(config, locator, deleteOptions),
+                      mapFailure,
+                    ),
+                  mapFailure,
+                )
+              } catch (error) {
+                if (
+                  error instanceof ManagedResourceError &&
+                  error.failure.code === MANAGED_RESOURCE_FAILURE_CODES.NotFound
+                ) {
+                  return
+                }
+                throw error
+              }
+            }, mapFailure),
+        }
+
+        return workspace
+      }, mapFailure),
+  }
+}

--- a/src/services/apiAdapters/managedResources/registry.ts
+++ b/src/services/apiAdapters/managedResources/registry.ts
@@ -1,0 +1,28 @@
+import type { ManagedSiteType } from "~/constants/siteType"
+import type { ManagedResourceKind } from "~/services/accountSiteDefinitions/contracts"
+import type { ManagedResourceRegistration } from "~/services/apiAdapters/contracts/managedResourceNative"
+
+import { axonHubManagedResourceRegistration } from "./axonHub"
+
+const MANAGED_RESOURCE_REGISTRATIONS = [
+  axonHubManagedResourceRegistration,
+] satisfies readonly ManagedResourceRegistration[]
+
+const managedResourceKey = (
+  siteType: ManagedSiteType,
+  kind: ManagedResourceKind,
+) => `${siteType}:${kind}`
+
+/** Returns the native managed-resource registration for an exact site/kind. */
+export function getManagedResourceRegistration(
+  siteType: ManagedSiteType,
+  kind: ManagedResourceKind,
+): ManagedResourceRegistration | null {
+  const key = managedResourceKey(siteType, kind)
+  return (
+    MANAGED_RESOURCE_REGISTRATIONS.find(
+      (registration) =>
+        managedResourceKey(registration.siteType, registration.kind) === key,
+    ) ?? null
+  )
+}

--- a/src/services/apiAdapters/managedSites/axonHub.ts
+++ b/src/services/apiAdapters/managedSites/axonHub.ts
@@ -13,6 +13,7 @@ import type { ManagedUpstreamResourcesCapability } from "~/services/apiAdapters/
 import {
   createAxonHubChannel,
   deleteAxonHubChannel,
+  getAxonHubChannel,
   updateAxonHubChannel,
   updateAxonHubChannelStatus,
 } from "~/services/apiService/axonHub"
@@ -160,7 +161,7 @@ const toAxonHubResourceSummary = (
       AxonHubChannelTypeNames[
         channel.type as keyof typeof AxonHubChannelTypeNames
       ] ?? String(channel.type),
-    endpointLabel: channel.baseURL,
+    endpointLabel: channel.baseURL ?? "",
     modelCount: models.length,
     modelPreview: models.slice(0, 3),
     secretState: toAxonHubSecretState(channel),
@@ -201,17 +202,7 @@ const findAxonHubChannelByRef = async (
   ref: ManagedUpstreamResourceRef,
 ): Promise<AxonHubChannel> => {
   assertAxonHubResourceRef(config, ref)
-
-  const channels = await listChannels(config)
-  const channel = channels.items
-    .map(rowToAxonHubNativeChannel)
-    .find((item) => item.id === ref.resourceId)
-
-  if (!channel) {
-    throw new Error(`Channel ${ref.resourceId} was not found`)
-  }
-
-  return channel
+  return getAxonHubChannel(config, ref.resourceId)
 }
 
 const prepareAxonHubEditDraft = (
@@ -223,7 +214,7 @@ const prepareAxonHubEditDraft = (
     name: channel.name,
     type: channel.type,
     key: getAxonHubCredentialKey(channel.credentials),
-    base_url: channel.baseURL,
+    base_url: channel.baseURL ?? "",
     models: getAxonHubModelList(channel),
     groups: [],
     priority: 0,

--- a/src/services/apiService/axonHub/index.ts
+++ b/src/services/apiService/axonHub/index.ts
@@ -162,6 +162,64 @@ const AXON_HUB_CHANNEL_DETAIL_SELECTION = `
   }
 `
 
+// The legacy table still needs the primary API key and model mappings, but it
+// must not retain unrelated provider credentials or secret-bearing settings.
+const AXON_HUB_LEGACY_CHANNEL_SELECTION = `
+  __typename
+  id
+  createdAt
+  updatedAt
+  type
+  baseURL
+  name
+  status
+  credentials {
+    apiKey
+    apiKeys
+  }
+  supportedModels
+  manualModels
+  tags
+  defaultTestModel
+  settings {
+    extraModelPrefix
+    modelMappings {
+      from
+      to
+    }
+    autoTrimedModelPrefixes
+    hideOriginalModels
+    hideMappedModels
+    lowercaseModelId
+    transformOptions {
+      forceArrayInstructions
+      forceArrayInputs
+      replaceDeveloperRoleWithSystem
+      reasoningEffortMapping {
+        from
+        to
+      }
+    }
+    passThroughUserAgent
+    passThroughBody
+    rateLimit {
+      rpm
+      tpm
+      maxConcurrent
+      queueSize
+      queueTimeoutMs
+    }
+    retryableStatusCodes
+    retryableErrorPatterns {
+      pattern
+      regex
+    }
+  }
+  orderingWeight
+  errorMessage
+  remark
+`
+
 const QUERY_CHANNELS = `
   query QueryChannels($input: QueryChannelInput!) {
     queryChannels(input: $input) {
@@ -203,6 +261,16 @@ const GET_AXON_HUB_CHANNEL = `
     node(id: $id) {
       ... on Channel {
         ${AXON_HUB_CHANNEL_DETAIL_SELECTION}
+      }
+    }
+  }
+`
+
+const GET_AXON_HUB_LEGACY_CHANNEL = `
+  query GetAxonHubChannel($id: ID!) {
+    node(id: $id) {
+      ... on Channel {
+        ${AXON_HUB_LEGACY_CHANNEL_SELECTION}
       }
     }
   }
@@ -296,6 +364,7 @@ const safeChannelListCache = new Map<
 const numericIdToGraphqlId = new Map<number, string>()
 const CHANNEL_LIST_CACHE_TTL_MS = 15_000
 const MAX_LIST_CHANNEL_PAGES = 100
+const LEGACY_CHANNEL_DETAIL_CONCURRENCY = 4
 
 const normalizeBaseUrl = (baseUrl: string) => baseUrl.trim().replace(/\/+$/, "")
 
@@ -652,6 +721,138 @@ const isAuthoritativeAxonHubChannel = (
   isOutputNullableString(value.remark) &&
   isOutputEndpoints(value.endpoints) &&
   isOutputDisabledApiKeys(value.disabledAPIKeys)
+
+const isLegacyOutputCredentials = (value: unknown) =>
+  value === null ||
+  (isRecord(value) &&
+    isOutputNullableString(value.apiKey) &&
+    isOutputNullableStringArray(value.apiKeys))
+
+const isLegacyOutputSettings = (value: unknown) =>
+  value === null ||
+  (isRecord(value) &&
+    isOutputNullableString(value.extraModelPrefix) &&
+    isOutputModelMappings(value.modelMappings) &&
+    isOutputNullableStringArray(value.autoTrimedModelPrefixes) &&
+    isOutputNullableBoolean(value.hideOriginalModels) &&
+    isOutputNullableBoolean(value.hideMappedModels) &&
+    isOutputNullableBoolean(value.lowercaseModelId) &&
+    isOutputTransformOptions(value.transformOptions) &&
+    isOutputNullableBoolean(value.passThroughUserAgent) &&
+    isOutputNullableBoolean(value.passThroughBody) &&
+    isOutputRateLimit(value.rateLimit) &&
+    isOutputRetryableStatusCodes(value.retryableStatusCodes) &&
+    isOutputRetryableErrorPatterns(value.retryableErrorPatterns))
+
+const isLegacyAxonHubChannel = (
+  value: unknown,
+): value is AxonHubChannel & { __typename: "Channel" } =>
+  isRecord(value) &&
+  value.__typename === "Channel" &&
+  isNonEmptyString(value.id) &&
+  typeof value.createdAt === "string" &&
+  typeof value.updatedAt === "string" &&
+  typeof value.type === "string" &&
+  isOutputNullableString(value.baseURL) &&
+  typeof value.name === "string" &&
+  typeof value.status === "string" &&
+  isLegacyOutputCredentials(value.credentials) &&
+  isOutputStringArray(value.supportedModels) &&
+  isOutputNullableStringArray(value.manualModels) &&
+  isOutputNullableStringArray(value.tags) &&
+  typeof value.defaultTestModel === "string" &&
+  isLegacyOutputSettings(value.settings) &&
+  typeof value.orderingWeight === "number" &&
+  Number.isInteger(value.orderingWeight) &&
+  isOutputNullableString(value.errorMessage) &&
+  isOutputNullableString(value.remark)
+
+const sanitizeLegacyAxonHubChannel = (
+  value: AxonHubChannel,
+): AxonHubChannel => {
+  const primaryApiKey =
+    value.credentials?.apiKeys
+      ?.map((key) => key.trim())
+      .find((key) => key.length > 0) ?? value.credentials?.apiKey?.trim()
+  const settings = value.settings
+
+  return {
+    id: value.id,
+    type: value.type,
+    baseURL: value.baseURL,
+    name: value.name,
+    status: value.status,
+    credentials: primaryApiKey ? { apiKeys: [primaryApiKey] } : null,
+    supportedModels: value.supportedModels ? [...value.supportedModels] : null,
+    manualModels: value.manualModels ? [...value.manualModels] : null,
+    tags: value.tags ? [...value.tags] : null,
+    defaultTestModel: value.defaultTestModel ?? null,
+    settings:
+      settings == null
+        ? null
+        : {
+            extraModelPrefix: settings.extraModelPrefix ?? null,
+            modelMappings:
+              settings.modelMappings?.map(({ from, to }) => ({ from, to })) ??
+              null,
+            autoTrimedModelPrefixes:
+              settings.autoTrimedModelPrefixes == null
+                ? null
+                : [...settings.autoTrimedModelPrefixes],
+            hideOriginalModels: settings.hideOriginalModels ?? null,
+            hideMappedModels: settings.hideMappedModels ?? null,
+            lowercaseModelId: settings.lowercaseModelId ?? null,
+            transformOptions:
+              settings.transformOptions == null
+                ? null
+                : {
+                    forceArrayInstructions:
+                      settings.transformOptions.forceArrayInstructions ?? null,
+                    forceArrayInputs:
+                      settings.transformOptions.forceArrayInputs ?? null,
+                    replaceDeveloperRoleWithSystem:
+                      settings.transformOptions
+                        .replaceDeveloperRoleWithSystem ?? null,
+                    reasoningEffortMapping:
+                      settings.transformOptions.reasoningEffortMapping?.map(
+                        ({ from, to }) => ({ from, to }),
+                      ) ?? null,
+                  },
+            passThroughUserAgent: settings.passThroughUserAgent ?? null,
+            passThroughBody: settings.passThroughBody ?? null,
+            rateLimit:
+              settings.rateLimit == null
+                ? null
+                : {
+                    rpm: settings.rateLimit.rpm ?? null,
+                    tpm: settings.rateLimit.tpm ?? null,
+                    maxConcurrent: settings.rateLimit.maxConcurrent ?? null,
+                    queueSize: settings.rateLimit.queueSize ?? null,
+                    queueTimeoutMs: settings.rateLimit.queueTimeoutMs ?? null,
+                  },
+            retryableStatusCodes:
+              settings.retryableStatusCodes == null
+                ? null
+                : [...settings.retryableStatusCodes],
+            retryableErrorPatterns:
+              settings.retryableErrorPatterns?.map(({ pattern, regex }) => ({
+                pattern,
+                regex: regex ?? null,
+              })) ?? null,
+          },
+    createdAt: value.createdAt ?? null,
+    updatedAt: value.updatedAt ?? null,
+    orderingWeight: value.orderingWeight ?? null,
+    errorMessage: value.errorMessage ?? null,
+    remark: value.remark ?? null,
+  }
+}
+
+const toLegacyAxonHubChannel = (value: unknown): AxonHubChannel | null => {
+  if (!isLegacyAxonHubChannel(value)) return null
+
+  return sanitizeLegacyAxonHubChannel(value)
+}
 
 const toSafeAxonHubChannelSummary = (value: unknown): AxonHubChannel | null => {
   if (!isAxonHubChannelCore(value)) return null
@@ -1013,7 +1214,10 @@ export async function graphqlRequest<T>(
 /**
  * Convert an AxonHub GraphQL channel into the managed-site channel row shape.
  */
-export function axonHubChannelToManagedSite(channel: AxonHubChannel) {
+export function axonHubChannelToManagedSite(
+  authoritativeChannel: AxonHubChannel,
+) {
+  const channel = sanitizeLegacyAxonHubChannel(authoritativeChannel)
   const models = normalizeList([
     ...(channel.supportedModels ?? []),
     ...(channel.manualModels ?? []),
@@ -1203,6 +1407,76 @@ export async function getAxonHubChannel(
   return data.node
 }
 
+const getLegacyAxonHubChannel = async (
+  config: AxonHubConfig,
+  id: string,
+  options?: Pick<RequestInit, "signal">,
+): Promise<AxonHubChannel> => {
+  const data = await graphqlRequest<unknown>(
+    config,
+    GET_AXON_HUB_LEGACY_CHANNEL,
+    { id },
+    options,
+  )
+
+  if (!isRecord(data) || !("node" in data)) {
+    throw new AxonHubRequestError("protocol", "not-dispatched")
+  }
+  if (data.node === null) {
+    throw new AxonHubRequestError("not-found", "not-dispatched")
+  }
+
+  const channel = toLegacyAxonHubChannel(data.node)
+  if (!channel || channel.id !== id) {
+    throw new AxonHubRequestError("protocol", "not-dispatched")
+  }
+  return channel
+}
+
+const hydrateLegacyAxonHubChannels = async (
+  config: AxonHubConfig,
+  channels: readonly AxonHubChannel[],
+  options?: Pick<RequestInit, "signal">,
+): Promise<ManagedSiteChannelListData["items"]> => {
+  if (channels.length === 0) return []
+
+  const items = new Array<ManagedSiteChannelListData["items"][number]>(
+    channels.length,
+  )
+  let nextIndex = 0
+  let stopped = false
+
+  const worker = async () => {
+    while (!stopped) {
+      throwIfAborted(options?.signal)
+      const index = nextIndex
+      if (index >= channels.length) return
+      nextIndex += 1
+
+      try {
+        const channel = channels[index]
+        if (!channel) return
+        items[index] = axonHubChannelToManagedSite(
+          await getLegacyAxonHubChannel(config, channel.id, options),
+        )
+      } catch (error) {
+        stopped = true
+        throw error
+      }
+    }
+  }
+
+  await Promise.all(
+    Array.from(
+      {
+        length: Math.min(LEGACY_CHANNEL_DETAIL_CONCURRENCY, channels.length),
+      },
+      worker,
+    ),
+  )
+  return items
+}
+
 const listSafeAxonHubChannels = async (
   config: AxonHubConfig,
   options?: Pick<RequestInit, "signal">,
@@ -1269,12 +1543,10 @@ export async function listChannels(
   options?: Pick<RequestInit, "signal">,
 ): Promise<ManagedSiteChannelListData> {
   const safeChannels = await listSafeAxonHubChannels(config, options)
-  const items = await Promise.all(
-    safeChannels.items.map(async (channel) =>
-      axonHubChannelToManagedSite(
-        await getAxonHubChannel(config, channel.id, options),
-      ),
-    ),
+  const items = await hydrateLegacyAxonHubChannels(
+    config,
+    safeChannels.items,
+    options,
   )
 
   return {

--- a/src/services/apiService/axonHub/index.ts
+++ b/src/services/apiService/axonHub/index.ts
@@ -19,57 +19,155 @@ import { normalizeList } from "~/utils/core/string"
 
 const logger = createLogger("AxonHubApiService")
 
+// Channel list responses are cached briefly, so keep this selection limited to
+// non-secret summary fields and sanitize over-returned nodes before caching.
+const AXON_HUB_CHANNEL_LIST_SELECTION = `
+  id
+  type
+  baseURL
+  name
+  status
+  tags
+  supportedModels
+`
+
+// AxonHub v1.0.0-beta5 keeps ChannelSettingsInput as a replacement value, so
+// detail reads select every pinned settings member before callers rebuild it.
+// Its credential resolver may return null for an existing channel when the
+// caller lacks write scope. Sources: https://github.com/looplj/axonhub/blob/d061ac7df6aef0c5ec6cdfa9dc5002546a1c5a57/internal/server/gql/axonhub.graphql#L151-L205
+// and https://github.com/looplj/axonhub/blob/d061ac7df6aef0c5ec6cdfa9dc5002546a1c5a57/internal/server/gql/axonhub.resolvers.go#L50-L55
+const AXON_HUB_CHANNEL_DETAIL_SELECTION = `
+  __typename
+  id
+  createdAt
+  updatedAt
+  type
+  baseURL
+  name
+  status
+  policies {
+    stream
+  }
+  credentials {
+    apiKey
+    apiKeys
+    gcp {
+      region
+      projectID
+      jsonData
+    }
+    oauth {
+      accessToken
+      refreshToken
+      clientID
+      expiresAt
+      tokenType
+      scopes
+    }
+  }
+  supportedModels
+  autoSyncSupportedModels
+  autoSyncModelPattern
+  manualModels
+  tags
+  defaultTestModel
+  settings {
+    extraModelPrefix
+    modelMappings {
+      from
+      to
+    }
+    autoTrimedModelPrefixes
+    hideOriginalModels
+    hideMappedModels
+    lowercaseModelId
+    proxy {
+      type
+      url
+      username
+      password
+    }
+    transformOptions {
+      forceArrayInstructions
+      forceArrayInputs
+      replaceDeveloperRoleWithSystem
+      reasoningEffortMapping {
+        from
+        to
+      }
+    }
+    headerOverrideOperations {
+      op
+      path
+      from
+      to
+      value
+      condition
+      match {
+        path
+        eq
+      }
+      index
+      splat
+    }
+    bodyOverrideOperations {
+      op
+      path
+      from
+      to
+      value
+      condition
+      match {
+        path
+        eq
+      }
+      index
+      splat
+    }
+    passThroughUserAgent
+    passThroughBody
+    rateLimit {
+      rpm
+      tpm
+      maxConcurrent
+      queueSize
+      queueTimeoutMs
+    }
+    retryableStatusCodes
+    retryableErrorPatterns {
+      pattern
+      regex
+    }
+    providerQuota {
+      opencodeGo {
+        workspaceId
+        authCookie
+      }
+    }
+  }
+  orderingWeight
+  errorMessage
+  remark
+  endpoints {
+    apiFormat
+    path
+    baseURL
+    transport
+  }
+  disabledAPIKeys {
+    key
+    disabledAt
+    errorCode
+    reason
+  }
+`
+
 const QUERY_CHANNELS = `
   query QueryChannels($input: QueryChannelInput!) {
     queryChannels(input: $input) {
       edges {
         node {
-          id
-          createdAt
-          updatedAt
-          type
-          baseURL
-          name
-          status
-          credentials {
-            apiKey
-            apiKeys
-            gcp {
-              region
-              projectID
-              jsonData
-            }
-          }
-          supportedModels
-          manualModels
-          tags
-          defaultTestModel
-          settings {
-            extraModelPrefix
-            modelMappings {
-              from
-              to
-            }
-            autoTrimedModelPrefixes
-            hideOriginalModels
-            hideMappedModels
-            passThroughUserAgent
-            passThroughBody
-            rateLimit {
-              rpm
-              tpm
-              maxConcurrent
-            }
-          }
-          orderingWeight
-          errorMessage
-          remark
-          disabledAPIKeys {
-            key
-            disabledAt
-            errorCode
-            reason
-          }
+          ${AXON_HUB_CHANNEL_LIST_SELECTION}
         }
         cursor
       }
@@ -82,29 +180,38 @@ const QUERY_CHANNELS = `
   }
 `
 
+const LIST_AXON_HUB_CHANNEL_PAGE = `
+  query ListAxonHubChannelPage($input: QueryChannelInput!) {
+    queryChannels(input: $input) {
+      edges {
+        node {
+          ${AXON_HUB_CHANNEL_LIST_SELECTION}
+        }
+        cursor
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+      totalCount
+    }
+  }
+`
+
+const GET_AXON_HUB_CHANNEL = `
+  query GetAxonHubChannel($id: ID!) {
+    node(id: $id) {
+      ... on Channel {
+        ${AXON_HUB_CHANNEL_DETAIL_SELECTION}
+      }
+    }
+  }
+`
+
 const CREATE_CHANNEL = `
   mutation CreateChannel($input: CreateChannelInput!) {
     createChannel(input: $input) {
-      id
-      type
-      baseURL
-      name
-      status
-      credentials {
-        apiKey
-        apiKeys
-      }
-      supportedModels
-      manualModels
-      defaultTestModel
-      settings {
-        modelMappings {
-          from
-          to
-        }
-      }
-      orderingWeight
-      remark
+      ${AXON_HUB_CHANNEL_DETAIL_SELECTION}
     }
   }
 `
@@ -112,27 +219,7 @@ const CREATE_CHANNEL = `
 const UPDATE_CHANNEL = `
   mutation UpdateChannel($id: ID!, $input: UpdateChannelInput!) {
     updateChannel(id: $id, input: $input) {
-      id
-      type
-      baseURL
-      name
-      status
-      credentials {
-        apiKey
-        apiKeys
-      }
-      supportedModels
-      manualModels
-      defaultTestModel
-      settings {
-        modelMappings {
-          from
-          to
-        }
-      }
-      orderingWeight
-      errorMessage
-      remark
+      ${AXON_HUB_CHANNEL_DETAIL_SELECTION}
     }
   }
 `
@@ -140,6 +227,7 @@ const UPDATE_CHANNEL = `
 const UPDATE_CHANNEL_STATUS = `
   mutation UpdateChannelStatus($id: ID!, $status: ChannelStatus!) {
     updateChannelStatus(id: $id, status: $status) {
+      __typename
       id
       status
     }
@@ -157,25 +245,51 @@ const DELETE_CHANNEL = `
   }
 `
 
-interface GraphQLResponse<T> {
-  data?: T
-  errors?: Array<{ message?: string }>
-}
-
-interface QueryChannelsData {
-  queryChannels: {
-    edges: Array<{ node: AxonHubChannel; cursor?: string | null }>
-    pageInfo?: { hasNextPage?: boolean; endCursor?: string | null }
-    totalCount?: number
+interface GraphQLErrorPayload {
+  message?: string
+  extensions?: {
+    code?: string
   }
 }
 
+interface GraphQLResponseEnvelope {
+  data?: unknown
+  errors?: GraphQLErrorPayload[]
+}
+
+export type AxonHubRequestFailureKind =
+  | "authentication"
+  | "permission"
+  | "not-found"
+  | "upstream-rejected"
+  | "protocol"
+  | "unavailable"
+  | "aborted"
+
+export class AxonHubRequestError extends Error {
+  constructor(
+    readonly kind: AxonHubRequestFailureKind,
+    readonly dispatch: "not-dispatched" | "dispatched",
+  ) {
+    super(kind)
+    this.name = "AxonHubRequestError"
+  }
+}
+
+export type AxonHubChannelPage = {
+  items: AxonHubChannel[]
+  total?: number
+  nextCursor?: string
+}
+
+type AxonHubChannelStatusResult = Pick<AxonHubChannel, "id" | "status">
+
 const tokenCache = new Map<string, string>()
 const inflightSignIns = new Map<string, Promise<string>>()
-const channelListCache = new Map<
+const safeChannelListCache = new Map<
   string,
   {
-    data: ManagedSiteChannelListData
+    data: { items: AxonHubChannel[]; total: number }
     expiresAt: number
   }
 >()
@@ -189,13 +303,13 @@ const cacheKeyForConfig = (config: AxonHubConfig) =>
   `${normalizeBaseUrl(config.baseUrl)}|${config.email.trim().toLowerCase()}`
 
 const invalidateChannelListCache = (config: AxonHubConfig) => {
-  channelListCache.delete(cacheKeyForConfig(config))
+  safeChannelListCache.delete(cacheKeyForConfig(config))
 }
 
 export const __resetCachesForTesting = () => {
   tokenCache.clear()
   inflightSignIns.clear()
-  channelListCache.clear()
+  safeChannelListCache.clear()
   numericIdToGraphqlId.clear()
 }
 
@@ -267,6 +381,323 @@ const toSafeErrorMessage = (error: unknown, fallback: string) => {
   return message.replace(/Bearer\s+[A-Za-z0-9._-]+/g, "Bearer [redacted]")
 }
 
+const isAbortError = (error: unknown) =>
+  typeof error === "object" &&
+  error !== null &&
+  "name" in error &&
+  error.name === "AbortError"
+
+const throwIfAborted = (signal?: AbortSignal | null) => {
+  if (signal?.aborted) {
+    throw new AxonHubRequestError("aborted", "not-dispatched")
+  }
+}
+
+const toAxonHubRequestError = (
+  error: unknown,
+  dispatch: "not-dispatched" | "dispatched",
+  fallbackKind: AxonHubRequestFailureKind,
+) => {
+  if (error instanceof AxonHubRequestError) {
+    if (dispatch === "dispatched" && error.dispatch === "not-dispatched") {
+      return new AxonHubRequestError(error.kind, dispatch)
+    }
+    return error
+  }
+
+  return new AxonHubRequestError(
+    isAbortError(error) ? "aborted" : fallbackKind,
+    dispatch,
+  )
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+const isNonEmptyString = (value: unknown): value is string =>
+  typeof value === "string" && value.length > 0
+
+const isNullableString = (value: unknown) =>
+  value === undefined || value === null || typeof value === "string"
+
+const isNullableNumber = (value: unknown) =>
+  value === undefined ||
+  value === null ||
+  (typeof value === "number" && Number.isFinite(value))
+
+const isNullableStringArray = (value: unknown) =>
+  value === undefined ||
+  value === null ||
+  (Array.isArray(value) && value.every((item) => typeof item === "string"))
+
+const isAxonHubChannelCore = (value: unknown): value is AxonHubChannel =>
+  isRecord(value) &&
+  isNonEmptyString(value.id) &&
+  typeof value.name === "string" &&
+  typeof value.type === "string" &&
+  typeof value.status === "string" &&
+  (typeof value.baseURL === "string" || value.baseURL === null) &&
+  isNullableString(value.createdAt) &&
+  isNullableString(value.updatedAt) &&
+  isNullableStringArray(value.tags) &&
+  isNullableStringArray(value.supportedModels) &&
+  isNullableStringArray(value.manualModels) &&
+  isNullableString(value.defaultTestModel) &&
+  isNullableNumber(value.orderingWeight) &&
+  isNullableString(value.errorMessage) &&
+  isNullableString(value.remark)
+
+// Authoritative detail/mutation output nullability follows the pinned beta5
+// Channel schemas, not the more permissive input/TypeScript shapes:
+// https://github.com/looplj/axonhub/blob/d061ac7df6aef0c5ec6cdfa9dc5002546a1c5a57/internal/server/gql/ent.graphql
+// https://github.com/looplj/axonhub/blob/d061ac7df6aef0c5ec6cdfa9dc5002546a1c5a57/internal/server/gql/axonhub.graphql
+const isOutputNullableString = (value: unknown) =>
+  value === null || typeof value === "string"
+
+const isOutputNullableBoolean = (value: unknown) =>
+  value === null || typeof value === "boolean"
+
+const isOutputNullableInteger = (value: unknown) =>
+  value === null || (typeof value === "number" && Number.isInteger(value))
+
+const isOutputStringArray = (value: unknown) =>
+  Array.isArray(value) && value.every((item) => typeof item === "string")
+
+const isOutputNullableStringArray = (value: unknown) =>
+  value === null || isOutputStringArray(value)
+
+const isOutputOAuthCredentials = (value: unknown) =>
+  value === null ||
+  (isRecord(value) &&
+    isOutputNullableString(value.accessToken) &&
+    isOutputNullableString(value.refreshToken) &&
+    isOutputNullableString(value.clientID) &&
+    isOutputNullableString(value.expiresAt) &&
+    isOutputNullableString(value.tokenType) &&
+    isOutputNullableStringArray(value.scopes))
+
+const isOutputGcpCredential = (value: unknown) =>
+  value === null ||
+  (isRecord(value) &&
+    typeof value.region === "string" &&
+    typeof value.projectID === "string" &&
+    typeof value.jsonData === "string")
+
+const isOutputCredentials = (value: unknown) =>
+  value === null ||
+  (isRecord(value) &&
+    isOutputNullableString(value.apiKey) &&
+    isOutputNullableStringArray(value.apiKeys) &&
+    isOutputGcpCredential(value.gcp) &&
+    isOutputOAuthCredentials(value.oauth))
+
+const isOutputModelMappings = (value: unknown) =>
+  value === null ||
+  (Array.isArray(value) &&
+    value.every(
+      (mapping) =>
+        isRecord(mapping) &&
+        typeof mapping.from === "string" &&
+        typeof mapping.to === "string",
+    ))
+
+const isOutputOverrideMatch = (value: unknown) =>
+  value === null ||
+  (isRecord(value) &&
+    typeof value.path === "string" &&
+    typeof value.eq === "string")
+
+const isOutputOverrideOperations = (value: unknown) =>
+  Array.isArray(value) &&
+  value.every(
+    (operation) =>
+      isRecord(operation) &&
+      typeof operation.op === "string" &&
+      isOutputNullableString(operation.path) &&
+      isOutputNullableString(operation.from) &&
+      isOutputNullableString(operation.to) &&
+      isOutputNullableString(operation.value) &&
+      isOutputNullableString(operation.condition) &&
+      isOutputOverrideMatch(operation.match) &&
+      isOutputNullableInteger(operation.index) &&
+      isOutputNullableBoolean(operation.splat),
+  )
+
+const isOutputProxy = (value: unknown) =>
+  value === null ||
+  (isRecord(value) &&
+    typeof value.type === "string" &&
+    isOutputNullableString(value.url) &&
+    isOutputNullableString(value.username) &&
+    isOutputNullableString(value.password))
+
+const isOutputTransformOptions = (value: unknown) =>
+  value === null ||
+  (isRecord(value) &&
+    typeof value.forceArrayInstructions === "boolean" &&
+    typeof value.forceArrayInputs === "boolean" &&
+    typeof value.replaceDeveloperRoleWithSystem === "boolean" &&
+    (value.reasoningEffortMapping === null ||
+      (Array.isArray(value.reasoningEffortMapping) &&
+        value.reasoningEffortMapping.every(
+          (mapping) =>
+            isRecord(mapping) &&
+            typeof mapping.from === "string" &&
+            typeof mapping.to === "string",
+        ))))
+
+const isOutputRateLimit = (value: unknown) =>
+  value === null ||
+  (isRecord(value) &&
+    isOutputNullableInteger(value.rpm) &&
+    isOutputNullableInteger(value.tpm) &&
+    isOutputNullableInteger(value.maxConcurrent) &&
+    isOutputNullableInteger(value.queueSize) &&
+    isOutputNullableInteger(value.queueTimeoutMs))
+
+const isOutputRetryableStatusCodes = (value: unknown) =>
+  value === null ||
+  (Array.isArray(value) && value.every((code) => Number.isInteger(code)))
+
+const isOutputRetryableErrorPatterns = (value: unknown) =>
+  value === null ||
+  (Array.isArray(value) &&
+    value.every(
+      (entry) =>
+        isRecord(entry) &&
+        typeof entry.pattern === "string" &&
+        typeof entry.regex === "boolean",
+    ))
+
+const isOutputProviderQuota = (value: unknown) =>
+  value === null ||
+  (isRecord(value) &&
+    (value.opencodeGo === null ||
+      (isRecord(value.opencodeGo) &&
+        isOutputNullableString(value.opencodeGo.workspaceId) &&
+        isOutputNullableString(value.opencodeGo.authCookie))))
+
+const isOutputSettings = (value: unknown) =>
+  value === null ||
+  (isRecord(value) &&
+    isOutputNullableString(value.extraModelPrefix) &&
+    isOutputModelMappings(value.modelMappings) &&
+    isOutputNullableStringArray(value.autoTrimedModelPrefixes) &&
+    isOutputNullableBoolean(value.hideOriginalModels) &&
+    isOutputNullableBoolean(value.hideMappedModels) &&
+    isOutputNullableBoolean(value.lowercaseModelId) &&
+    isOutputProxy(value.proxy) &&
+    isOutputTransformOptions(value.transformOptions) &&
+    isOutputOverrideOperations(value.headerOverrideOperations) &&
+    isOutputOverrideOperations(value.bodyOverrideOperations) &&
+    isOutputNullableBoolean(value.passThroughUserAgent) &&
+    isOutputNullableBoolean(value.passThroughBody) &&
+    isOutputRateLimit(value.rateLimit) &&
+    isOutputRetryableStatusCodes(value.retryableStatusCodes) &&
+    isOutputRetryableErrorPatterns(value.retryableErrorPatterns) &&
+    isOutputProviderQuota(value.providerQuota))
+
+const isOutputPolicies = (value: unknown) =>
+  value === null || (isRecord(value) && isOutputNullableString(value.stream))
+
+const isOutputEndpoints = (value: unknown) =>
+  value === null ||
+  (Array.isArray(value) &&
+    value.every(
+      (endpoint) =>
+        isRecord(endpoint) &&
+        typeof endpoint.apiFormat === "string" &&
+        isOutputNullableString(endpoint.path) &&
+        isOutputNullableString(endpoint.baseURL) &&
+        isOutputNullableString(endpoint.transport),
+    ))
+
+const isOutputDisabledApiKeys = (value: unknown) =>
+  value === null ||
+  (Array.isArray(value) &&
+    value.every(
+      (entry) =>
+        isRecord(entry) &&
+        typeof entry.key === "string" &&
+        typeof entry.disabledAt === "string" &&
+        typeof entry.errorCode === "number" &&
+        Number.isInteger(entry.errorCode) &&
+        isOutputNullableString(entry.reason),
+    ))
+
+const isAuthoritativeAxonHubChannel = (
+  value: unknown,
+): value is AxonHubChannel & { __typename: "Channel" } =>
+  isRecord(value) &&
+  value.__typename === "Channel" &&
+  isNonEmptyString(value.id) &&
+  typeof value.createdAt === "string" &&
+  typeof value.updatedAt === "string" &&
+  typeof value.type === "string" &&
+  isOutputNullableString(value.baseURL) &&
+  typeof value.name === "string" &&
+  typeof value.status === "string" &&
+  isOutputPolicies(value.policies) &&
+  isOutputCredentials(value.credentials) &&
+  isOutputStringArray(value.supportedModels) &&
+  typeof value.autoSyncSupportedModels === "boolean" &&
+  isOutputNullableString(value.autoSyncModelPattern) &&
+  isOutputNullableStringArray(value.manualModels) &&
+  isOutputNullableStringArray(value.tags) &&
+  typeof value.defaultTestModel === "string" &&
+  isOutputSettings(value.settings) &&
+  typeof value.orderingWeight === "number" &&
+  Number.isInteger(value.orderingWeight) &&
+  isOutputNullableString(value.errorMessage) &&
+  isOutputNullableString(value.remark) &&
+  isOutputEndpoints(value.endpoints) &&
+  isOutputDisabledApiKeys(value.disabledAPIKeys)
+
+const toSafeAxonHubChannelSummary = (value: unknown): AxonHubChannel | null => {
+  if (!isAxonHubChannelCore(value)) return null
+
+  return {
+    id: value.id,
+    name: value.name,
+    type: value.type,
+    status: value.status,
+    baseURL: value.baseURL,
+    tags: value.tags as string[] | null | undefined,
+    supportedModels: value.supportedModels as string[] | null | undefined,
+  }
+}
+
+const parseGraphqlEnvelope = (
+  payload: unknown,
+  dispatch: "not-dispatched" | "dispatched",
+): GraphQLResponseEnvelope => {
+  if (!isRecord(payload)) {
+    throw new AxonHubRequestError("protocol", dispatch)
+  }
+
+  const errors = payload.errors
+  if (
+    errors !== undefined &&
+    (!Array.isArray(errors) ||
+      errors.some(
+        (error) =>
+          !isRecord(error) ||
+          (error.message !== undefined && typeof error.message !== "string") ||
+          (error.extensions !== undefined &&
+            (!isRecord(error.extensions) ||
+              (error.extensions.code !== undefined &&
+                typeof error.extensions.code !== "string"))),
+      ))
+  ) {
+    throw new AxonHubRequestError("protocol", dispatch)
+  }
+
+  return {
+    data: payload.data,
+    errors: errors as GraphQLErrorPayload[] | undefined,
+  }
+}
+
 /**
  * Sign in to AxonHub admin and cache the returned session token.
  */
@@ -275,9 +706,11 @@ export async function signIn(
   options?: Pick<RequestInit, "signal">,
 ): Promise<string> {
   const baseUrl = normalizeBaseUrl(config.baseUrl)
+  throwIfAborted(options?.signal)
 
+  let response: Response
   try {
-    const response = await fetch(`${baseUrl}/admin/auth/signin`, {
+    response = await fetch(`${baseUrl}/admin/auth/signin`, {
       method: "POST",
       signal: options?.signal,
       headers: {
@@ -288,27 +721,36 @@ export async function signIn(
         password: config.password,
       }),
     })
-
-    const data = (await response.json().catch(() => ({}))) as {
-      token?: string
-      message?: string
-      error?: string | { message?: string }
-    }
-
-    if (!response.ok || !data.token) {
-      const fallbackMessage = `AxonHub sign-in failed (HTTP ${response.status})`
-      const message =
-        data.message ||
-        (typeof data.error === "string" ? data.error : data.error?.message) ||
-        fallbackMessage
-      throw new Error(message)
-    }
-
-    tokenCache.set(cacheKeyForConfig(config), data.token)
-    return data.token
   } catch (error) {
-    throw new Error(toSafeErrorMessage(error, "AxonHub sign-in failed"))
+    throw toAxonHubRequestError(error, "not-dispatched", "unavailable")
   }
+
+  if (!response.ok) {
+    throw new AxonHubRequestError(
+      response.status >= 500 ? "unavailable" : "authentication",
+      "not-dispatched",
+    )
+  }
+
+  let data: unknown
+  try {
+    data = await response.json()
+  } catch (error) {
+    throw toAxonHubRequestError(error, "not-dispatched", "protocol")
+  }
+
+  if (
+    typeof data !== "object" ||
+    data === null ||
+    !("token" in data) ||
+    typeof data.token !== "string" ||
+    !data.token
+  ) {
+    throw new AxonHubRequestError("protocol", "not-dispatched")
+  }
+
+  tokenCache.set(cacheKeyForConfig(config), data.token)
+  return data.token
 }
 
 const getSessionToken = async (
@@ -360,10 +802,7 @@ const awaitSignInWithCallerCancellation = async (
       pendingSignIn,
       new Promise<string>((_resolve, reject) => {
         abort = () => {
-          reject(
-            callerSignal.reason ??
-              new DOMException("The operation was aborted", "AbortError"),
-          )
+          reject(new AxonHubRequestError("aborted", "not-dispatched"))
         }
 
         if (callerSignal.aborted) {
@@ -381,19 +820,66 @@ const awaitSignInWithCallerCancellation = async (
   }
 }
 
-const isUnauthorized = (
+const GRAPHQL_AUTHENTICATION_ERROR_PATTERN =
+  /unauthorized|unauthenticated|jwt expired|jwt invalid|invalid jwt|invalid token|expired token|session expired|access token expired|access token invalid|refresh token expired|refresh token invalid|malformed token|revoked token/i
+
+const containsGraphqlError = (
+  errors: GraphQLErrorPayload[] | undefined,
+  pattern: RegExp,
+) => errors?.some((error) => pattern.test(error.message ?? "")) ?? false
+
+const hasGraphqlAuthenticationError = (
+  errors: GraphQLErrorPayload[] | undefined,
+) => containsGraphqlError(errors, GRAPHQL_AUTHENTICATION_ERROR_PATTERN)
+
+const hasGraphqlErrorCode = (
+  errors: GraphQLErrorPayload[] | undefined,
+  code: string,
+) => errors?.some((error) => error.extensions?.code === code) ?? false
+
+const hasExplicitGraphqlErrorCode = (
+  errors: GraphQLErrorPayload[] | undefined,
+) => errors?.some((error) => error.extensions?.code !== undefined) ?? false
+
+const shouldRefreshAuthentication = (
   response: Response,
-  errors?: Array<{ message?: string }>,
-) =>
-  response.status === 401 ||
-  response.status === 403 ||
-  Boolean(
-    errors?.some((error) =>
-      /unauthorized|unauthenticated|jwt expired|jwt invalid|invalid jwt|invalid token|expired token|session expired|access token expired|access token invalid|refresh token expired|refresh token invalid|malformed token|revoked token/i.test(
-        error.message ?? "",
-      ),
-    ),
-  )
+  errors: GraphQLErrorPayload[] | undefined,
+) => {
+  if (response.status >= 500 || response.status === 403) return false
+  if (response.status === 401) return true
+  if (hasGraphqlErrorCode(errors, "FORBIDDEN")) return false
+  if (hasGraphqlErrorCode(errors, "UNAUTHENTICATED")) return true
+  return false
+}
+
+const classifyGraphqlFailure = (
+  response: Response,
+  errors: GraphQLErrorPayload[] | undefined,
+): AxonHubRequestFailureKind => {
+  if (response.status >= 500) return "unavailable"
+  if (response.status === 401) return "authentication"
+  if (response.status === 403) return "permission"
+  if (
+    response.status === 404 ||
+    containsGraphqlError(errors, /not found|no .* found/i)
+  ) {
+    return "not-found"
+  }
+  if (hasGraphqlErrorCode(errors, "FORBIDDEN")) return "permission"
+  if (hasGraphqlErrorCode(errors, "UNAUTHENTICATED")) return "authentication"
+  if (!hasExplicitGraphqlErrorCode(errors)) {
+    if (hasGraphqlAuthenticationError(errors)) return "authentication"
+    if (
+      containsGraphqlError(errors, /forbidden|permission denied|access denied/i)
+    ) {
+      return "permission"
+    }
+  }
+  if (errors?.length) {
+    return "upstream-rejected"
+  }
+  return "upstream-rejected"
+}
 
 /**
  * Execute an authenticated AxonHub admin GraphQL request with one auth retry.
@@ -406,60 +892,121 @@ export async function graphqlRequest<T>(
 ): Promise<T> {
   const baseUrl = normalizeBaseUrl(config.baseUrl)
   const retryAuth = options?.retryAuth ?? true
-  const token = await getSessionToken(config, false, options)
+  const isMutation = /^\s*mutation\b/.test(query)
+  let mutationDispatched = false
+
+  type GraphqlAttempt = { kind: "data"; data: T } | { kind: "retry-auth" }
+
+  const retryAuthentication = (): GraphqlAttempt => {
+    if (isMutation) mutationDispatched = false
+    return { kind: "retry-auth" }
+  }
 
   const execute = async (
     sessionToken: string,
     allowAuthRetry: boolean,
-  ): Promise<T | null> => {
-    const response = await fetch(`${baseUrl}/admin/graphql`, {
-      method: "POST",
-      signal: options?.signal,
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${sessionToken}`,
-      },
-      body: JSON.stringify({ query, variables }),
-    })
+  ): Promise<GraphqlAttempt> => {
+    throwIfAborted(options?.signal)
 
-    const payload = (await response
-      .json()
-      .catch(() => ({}))) as GraphQLResponse<T>
-    if (!response.ok || payload.errors?.length) {
-      if (allowAuthRetry && isUnauthorized(response, payload.errors)) {
-        return null
+    let response: Response
+    try {
+      if (isMutation) {
+        mutationDispatched = true
+      }
+      response = await fetch(`${baseUrl}/admin/graphql`, {
+        method: "POST",
+        signal: options?.signal,
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${sessionToken}`,
+        },
+        body: JSON.stringify({ query, variables }),
+      })
+    } catch (error) {
+      throw toAxonHubRequestError(
+        error,
+        isMutation ? "dispatched" : "not-dispatched",
+        "unavailable",
+      )
+    }
+
+    const dispatch = isMutation ? "dispatched" : "not-dispatched"
+    let payload: unknown
+    try {
+      payload = await response.json()
+    } catch (error) {
+      if (isAbortError(error)) {
+        throw toAxonHubRequestError(error, dispatch, "protocol")
+      }
+      if (allowAuthRetry && shouldRefreshAuthentication(response, undefined)) {
+        return retryAuthentication()
+      }
+      if (!response.ok) {
+        throw new AxonHubRequestError(
+          classifyGraphqlFailure(response, undefined),
+          dispatch,
+        )
+      }
+      throw new AxonHubRequestError("protocol", dispatch)
+    }
+
+    if (response.status >= 500) {
+      throw new AxonHubRequestError("unavailable", dispatch)
+    }
+    if (response.status === 401) {
+      if (allowAuthRetry) return retryAuthentication()
+      throw new AxonHubRequestError("authentication", dispatch)
+    }
+    if (response.status === 403) {
+      throw new AxonHubRequestError("permission", dispatch)
+    }
+
+    const graphqlPayload = parseGraphqlEnvelope(payload, dispatch)
+
+    if (!response.ok || graphqlPayload.errors?.length) {
+      if (
+        allowAuthRetry &&
+        shouldRefreshAuthentication(response, graphqlPayload.errors)
+      ) {
+        return retryAuthentication()
       }
 
-      const message =
-        payload.errors
-          ?.map((error) => error.message)
-          .filter(Boolean)
-          .join("; ") ||
-        `AxonHub GraphQL request failed with HTTP ${response.status}`
-      throw new Error(message)
+      throw new AxonHubRequestError(
+        classifyGraphqlFailure(response, graphqlPayload.errors),
+        dispatch,
+      )
     }
 
-    if (!payload.data) {
-      throw new Error("AxonHub GraphQL response did not include data")
+    if (graphqlPayload.data === undefined || graphqlPayload.data === null) {
+      throw new AxonHubRequestError("protocol", dispatch)
     }
 
-    return payload.data
+    return { kind: "data", data: graphqlPayload.data as T }
   }
 
   try {
+    throwIfAborted(options?.signal)
+    const token = await getSessionToken(config, false, options)
     const firstAttempt = await execute(token, retryAuth)
-    if (firstAttempt) return firstAttempt
+    if (firstAttempt.kind === "data") return firstAttempt.data
 
     // Cached admin JWTs are session-scoped and may expire while the extension
     // page remains open; retry once with fresh credentials before surfacing.
     const refreshedToken = await getSessionToken(config, true, options)
     const secondAttempt = await execute(refreshedToken, false)
-    if (!secondAttempt) {
-      throw new Error("AxonHub GraphQL request failed without data")
+    if (secondAttempt.kind !== "data") {
+      throw new AxonHubRequestError(
+        "protocol",
+        isMutation ? "dispatched" : "not-dispatched",
+      )
     }
-    return secondAttempt
+    return secondAttempt.data
   } catch (error) {
-    throw new Error(toSafeErrorMessage(error, "AxonHub GraphQL request failed"))
+    throw toAxonHubRequestError(
+      error,
+      isMutation && mutationDispatched ? "dispatched" : "not-dispatched",
+      "unavailable",
+    )
   }
 }
 
@@ -495,7 +1042,7 @@ export function axonHubChannelToManagedSite(channel: AxonHubChannel) {
     id: numericIdFromGraphqlId(channel.id),
     name: channel.name,
     type: channel.type,
-    base_url: channel.baseURL,
+    base_url: channel.baseURL ?? "",
     key: apiKey,
     models: models.join(","),
     status:
@@ -539,21 +1086,135 @@ export function axonHubChannelToManagedSite(channel: AxonHubChannel) {
   }
 }
 
+const requestAxonHubChannelPage = async (
+  config: AxonHubConfig,
+  input: { cursor?: string; limit: number },
+  query: string,
+  options?: Pick<RequestInit, "signal">,
+): Promise<AxonHubChannelPage> => {
+  const data = await graphqlRequest<unknown>(
+    config,
+    query,
+    {
+      input: {
+        first: input.limit,
+        ...(input.cursor ? { after: input.cursor } : {}),
+      },
+    },
+    options,
+  )
+
+  if (!isRecord(data) || !isRecord(data.queryChannels)) {
+    throw new AxonHubRequestError("protocol", "not-dispatched")
+  }
+  const connection = data.queryChannels
+  if (!Array.isArray(connection.edges) || !isRecord(connection.pageInfo)) {
+    throw new AxonHubRequestError("protocol", "not-dispatched")
+  }
+  if (
+    typeof connection.pageInfo.hasNextPage !== "boolean" ||
+    (connection.pageInfo.endCursor !== null &&
+      typeof connection.pageInfo.endCursor !== "string") ||
+    (connection.pageInfo.hasNextPage &&
+      !isNonEmptyString(connection.pageInfo.endCursor)) ||
+    (connection.totalCount !== undefined &&
+      (typeof connection.totalCount !== "number" ||
+        !Number.isInteger(connection.totalCount) ||
+        connection.totalCount < 0))
+  ) {
+    throw new AxonHubRequestError("protocol", "not-dispatched")
+  }
+
+  const items: AxonHubChannel[] = []
+  for (const edge of connection.edges) {
+    if (
+      !isRecord(edge) ||
+      (edge.cursor !== undefined &&
+        edge.cursor !== null &&
+        typeof edge.cursor !== "string")
+    ) {
+      throw new AxonHubRequestError("protocol", "not-dispatched")
+    }
+    const channel = toSafeAxonHubChannelSummary(edge.node)
+    if (!channel) {
+      throw new AxonHubRequestError("protocol", "not-dispatched")
+    }
+    items.push(channel)
+  }
+
+  const nextCursor = connection.pageInfo.hasNextPage
+    ? (connection.pageInfo.endCursor as string)
+    : undefined
+
+  return {
+    items,
+    ...(typeof connection.totalCount === "number"
+      ? { total: connection.totalCount }
+      : {}),
+    ...(nextCursor ? { nextCursor } : {}),
+  }
+}
+
 /**
- * List all AxonHub channels through the paginated admin GraphQL query.
+ * Return exactly one native AxonHub cursor page.
  */
-export async function listChannels(
+export async function listAxonHubChannelPage(
+  config: AxonHubConfig,
+  input: { cursor?: string; limit: number },
+  options?: Pick<RequestInit, "signal">,
+): Promise<AxonHubChannelPage> {
+  return requestAxonHubChannelPage(
+    config,
+    input,
+    LIST_AXON_HUB_CHANNEL_PAGE,
+    options,
+  )
+}
+
+/**
+ * Load one native AxonHub channel by its opaque GraphQL id.
+ */
+export async function getAxonHubChannel(
+  config: AxonHubConfig,
+  id: string,
+  options?: Pick<RequestInit, "signal">,
+): Promise<AxonHubChannel> {
+  const data = await graphqlRequest<unknown>(
+    config,
+    GET_AXON_HUB_CHANNEL,
+    { id },
+    options,
+  )
+
+  if (!isRecord(data) || !("node" in data)) {
+    throw new AxonHubRequestError("protocol", "not-dispatched")
+  }
+  if (data.node === null) {
+    throw new AxonHubRequestError("not-found", "not-dispatched")
+  }
+  if (
+    !isRecord(data.node) ||
+    !isAuthoritativeAxonHubChannel(data.node) ||
+    data.node.id !== id
+  ) {
+    throw new AxonHubRequestError("protocol", "not-dispatched")
+  }
+
+  return data.node
+}
+
+const listSafeAxonHubChannels = async (
   config: AxonHubConfig,
   options?: Pick<RequestInit, "signal">,
-): Promise<ManagedSiteChannelListData> {
+): Promise<{ items: AxonHubChannel[]; total: number }> => {
   const cacheKey = cacheKeyForConfig(config)
-  const cachedChannels = channelListCache.get(cacheKey)
+  const cachedChannels = safeChannelListCache.get(cacheKey)
   if (cachedChannels && cachedChannels.expiresAt > Date.now()) {
     return cachedChannels.data
   }
 
-  channelListCache.delete(cacheKey)
-  const items: ReturnType<typeof axonHubChannelToManagedSite>[] = []
+  safeChannelListCache.delete(cacheKey)
+  const items: AxonHubChannel[] = []
   let after: string | null | undefined
   let total = 0
   let pageCount = 0
@@ -565,27 +1226,19 @@ export async function listChannels(
     }
     pageCount += 1
 
-    const data = await graphqlRequest<QueryChannelsData>(
+    const page = await requestAxonHubChannelPage(
       config,
-      QUERY_CHANNELS,
       {
-        input: {
-          first: 100,
-          after,
-        },
+        cursor: after ?? undefined,
+        limit: 100,
       },
+      QUERY_CHANNELS,
       options,
     )
 
-    total = data.queryChannels.totalCount ?? total
-    items.push(
-      ...data.queryChannels.edges.map((edge) =>
-        axonHubChannelToManagedSite(edge.node),
-      ),
-    )
-    const nextCursor = data.queryChannels.pageInfo?.hasNextPage
-      ? data.queryChannels.pageInfo.endCursor
-      : null
+    total = page.total ?? total
+    items.push(...page.items)
+    const nextCursor = page.nextCursor
     if (nextCursor) {
       if (seenCursors.has(nextCursor)) {
         throw new Error("AxonHub channel pagination cursor repeated")
@@ -598,19 +1251,41 @@ export async function listChannels(
   const result = {
     items,
     total: total || items.length,
+  }
+
+  safeChannelListCache.set(cacheKey, {
+    data: result,
+    expiresAt: Date.now() + CHANNEL_LIST_CACHE_TTL_MS,
+  })
+
+  return result
+}
+
+/**
+ * List all AxonHub channels through the legacy managed-site contract.
+ */
+export async function listChannels(
+  config: AxonHubConfig,
+  options?: Pick<RequestInit, "signal">,
+): Promise<ManagedSiteChannelListData> {
+  const safeChannels = await listSafeAxonHubChannels(config, options)
+  const items = await Promise.all(
+    safeChannels.items.map(async (channel) =>
+      axonHubChannelToManagedSite(
+        await getAxonHubChannel(config, channel.id, options),
+      ),
+    ),
+  )
+
+  return {
+    items,
+    total: safeChannels.total,
     type_counts: items.reduce<Record<string, number>>((acc, channel) => {
       const key = String(channel.type)
       acc[key] = (acc[key] ?? 0) + 1
       return acc
     }, {}),
   }
-
-  channelListCache.set(cacheKey, {
-    data: result,
-    expiresAt: Date.now() + CHANNEL_LIST_CACHE_TTL_MS,
-  })
-
-  return result
 }
 
 /**
@@ -650,12 +1325,17 @@ export async function searchChannels(
 export async function createAxonHubChannel(
   config: AxonHubConfig,
   input: AxonHubCreateChannelInput,
+  options?: Pick<RequestInit, "signal">,
 ) {
-  const data = await graphqlRequest<{ createChannel: AxonHubChannel }>(
+  const data = await graphqlRequest<unknown>(
     config,
     CREATE_CHANNEL,
     { input },
+    options,
   )
+  if (!isRecord(data) || !isAuthoritativeAxonHubChannel(data.createChannel)) {
+    throw new AxonHubRequestError("protocol", "dispatched")
+  }
   invalidateChannelListCache(config)
   return data.createChannel
 }
@@ -667,12 +1347,24 @@ export async function updateAxonHubChannel(
   config: AxonHubConfig,
   id: string,
   input: AxonHubUpdateChannelInput,
+  options?: Pick<RequestInit, "signal">,
 ) {
-  const data = await graphqlRequest<{ updateChannel: AxonHubChannel }>(
+  // beta5 UpdateChannelInput treats settings as replacement data and exposes
+  // only these generated append/clear fields; forward the verified input
+  // unchanged. Source: https://github.com/looplj/axonhub/blob/d061ac7df6aef0c5ec6cdfa9dc5002546a1c5a57/internal/server/gql/ent.graphql#L5993-L6033
+  const data = await graphqlRequest<unknown>(
     config,
     UPDATE_CHANNEL,
     { id, input },
+    options,
   )
+  if (
+    !isRecord(data) ||
+    !isAuthoritativeAxonHubChannel(data.updateChannel) ||
+    data.updateChannel.id !== id
+  ) {
+    throw new AxonHubRequestError("protocol", "dispatched")
+  }
   invalidateChannelListCache(config)
   return data.updateChannel
 }
@@ -684,25 +1376,44 @@ export async function updateAxonHubChannelStatus(
   config: AxonHubConfig,
   id: string,
   status: string,
+  options?: Pick<RequestInit, "signal">,
 ) {
-  const data = await graphqlRequest<{ updateChannelStatus: AxonHubChannel }>(
+  const data = await graphqlRequest<unknown>(
     config,
     UPDATE_CHANNEL_STATUS,
     { id, status },
+    options,
   )
+  if (
+    !isRecord(data) ||
+    !isRecord(data.updateChannelStatus) ||
+    data.updateChannelStatus.__typename !== "Channel" ||
+    data.updateChannelStatus.id !== id ||
+    data.updateChannelStatus.status !== status
+  ) {
+    throw new AxonHubRequestError("protocol", "dispatched")
+  }
   invalidateChannelListCache(config)
-  return data.updateChannelStatus
+  return { id, status } as AxonHubChannelStatusResult
 }
 
 /**
  * Delete an AxonHub channel by GraphQL id.
  */
-export async function deleteAxonHubChannel(config: AxonHubConfig, id: string) {
-  const data = await graphqlRequest<{ deleteChannel: boolean }>(
+export async function deleteAxonHubChannel(
+  config: AxonHubConfig,
+  id: string,
+  options?: Pick<RequestInit, "signal">,
+) {
+  const data = await graphqlRequest<unknown>(
     config,
     DELETE_CHANNEL,
     { id },
+    options,
   )
+  if (!isRecord(data) || typeof data.deleteChannel !== "boolean") {
+    throw new AxonHubRequestError("protocol", "dispatched")
+  }
   invalidateChannelListCache(config)
   return data.deleteChannel
 }
@@ -767,7 +1478,10 @@ export async function createChannel(
  */
 export async function updateChannel(
   request: ApiServiceRequest,
-  channelData: AxonHubUpdateChannelInput & { id: number; status?: number },
+  channelData: Omit<AxonHubUpdateChannelInput, "status"> & {
+    id: number
+    status?: number
+  },
 ): Promise<ApiResponse<unknown>> {
   try {
     const config = extractRequestConfig(request)

--- a/src/services/managedSites/providers/axonHub.ts
+++ b/src/services/managedSites/providers/axonHub.ts
@@ -369,7 +369,7 @@ export function buildChannelPayload(
       name: input.name,
       type: input.type,
       key: input.credentials.apiKeys?.[0] ?? "",
-      base_url: input.baseURL,
+      base_url: input.baseURL ?? "",
       models: input.supportedModels.join(","),
       groups: [],
       priority: 0,

--- a/src/types/axonHub.ts
+++ b/src/types/axonHub.ts
@@ -4,23 +4,138 @@ import type {
 } from "~/constants/axonHub"
 
 export interface AxonHubModelMapping {
-  from?: string | null
+  from: string
   to: string
 }
 
+export interface AxonHubOverrideMatch {
+  path: string
+  eq: string
+}
+
+export interface AxonHubOverrideOperation {
+  op: string
+  path?: string | null
+  from?: string | null
+  to?: string | null
+  value?: string | null
+  condition?: string | null
+  match?: AxonHubOverrideMatch | null
+  index?: number | null
+  splat?: boolean | null
+}
+
+export interface AxonHubProxyConfig {
+  type: string
+  url?: string | null
+  username?: string | null
+  password?: string | null
+}
+
+export interface AxonHubReasoningEffortMapping {
+  from: string
+  to: string
+}
+
+export interface AxonHubTransformOptions {
+  forceArrayInstructions?: boolean | null
+  forceArrayInputs?: boolean | null
+  replaceDeveloperRoleWithSystem?: boolean | null
+  reasoningEffortMapping?: AxonHubReasoningEffortMapping[] | null
+}
+
+export interface AxonHubChannelRateLimit {
+  rpm?: number | null
+  tpm?: number | null
+  maxConcurrent?: number | null
+  queueSize?: number | null
+  queueTimeoutMs?: number | null
+}
+
+export interface AxonHubRetryableErrorPattern {
+  pattern: string
+  regex?: boolean | null
+}
+
+export interface AxonHubOpenCodeGoQuotaSettings {
+  workspaceId?: string | null
+  authCookie?: string | null
+}
+
+export interface AxonHubChannelProviderQuotaSettings {
+  opencodeGo?: AxonHubOpenCodeGoQuotaSettings | null
+}
+
 export interface AxonHubChannelSettings {
+  extraModelPrefix?: string | null
   modelMappings?: AxonHubModelMapping[] | null
   autoTrimedModelPrefixes?: string[] | null
-  extraModelPrefix?: string | null
   hideOriginalModels?: boolean | null
   hideMappedModels?: boolean | null
-  [key: string]: unknown
+  lowercaseModelId?: boolean | null
+  proxy?: AxonHubProxyConfig | null
+  transformOptions?: AxonHubTransformOptions | null
+  headerOverrideOperations?: AxonHubOverrideOperation[] | null
+  bodyOverrideOperations?: AxonHubOverrideOperation[] | null
+  passThroughUserAgent?: boolean | null
+  passThroughBody?: boolean | null
+  rateLimit?: AxonHubChannelRateLimit | null
+  retryableStatusCodes?: number[] | null
+  retryableErrorPatterns?: AxonHubRetryableErrorPattern[] | null
+  providerQuota?: AxonHubChannelProviderQuotaSettings | null
+}
+
+export interface AxonHubOAuthCredentials {
+  accessToken?: string | null
+  refreshToken?: string | null
+  clientID?: string | null
+  expiresAt?: string | null
+  tokenType?: string | null
+  scopes?: string[] | null
+}
+
+export interface AxonHubGCPCredential {
+  region: string
+  projectID: string
+  jsonData: string
 }
 
 export interface AxonHubChannelCredentials {
   apiKey?: string | null
   apiKeys?: string[] | null
-  [key: string]: unknown
+  gcp?: AxonHubGCPCredential | null
+  oauth?: AxonHubOAuthCredentials | null
+}
+
+export interface AxonHubChannelPolicies {
+  stream?: string | null
+}
+
+export interface AxonHubChannelEndpoint {
+  apiFormat: string
+  path?: string | null
+  baseURL?: string | null
+  transport?: string | null
+}
+
+export interface AxonHubDisabledAPIKey {
+  key: string
+  disabledAt: string
+  errorCode: number
+  reason?: string | null
+}
+
+export interface AxonHubChannelModelEntry {
+  requestModel: string
+  actualModel: string
+  source: string
+}
+
+export interface AxonHubChannelLimiterStats {
+  inFlight: number
+  waiting: number
+  capacity: number
+  queueSize: number
 }
 
 export interface AxonHubChannel {
@@ -28,35 +143,75 @@ export interface AxonHubChannel {
   name: string
   type: AxonHubChannelType | string
   status: AxonHubChannelStatus | string
-  baseURL: string
+  baseURL: string | null
   credentials?: AxonHubChannelCredentials | null
   supportedModels?: string[] | null
   manualModels?: string[] | null
+  autoSyncSupportedModels?: boolean | null
+  autoSyncModelPattern?: string | null
+  tags?: string[] | null
   defaultTestModel?: string | null
+  policies?: AxonHubChannelPolicies | null
   settings?: AxonHubChannelSettings | null
   createdAt?: string | null
   updatedAt?: string | null
   orderingWeight?: number | null
   remark?: string | null
   errorMessage?: string | null
+  endpoints?: AxonHubChannelEndpoint[] | null
+  defaultEndpoints?: AxonHubChannelEndpoint[] | null
+  disabledAPIKeys?: AxonHubDisabledAPIKey[] | null
+  allModelEntries?: AxonHubChannelModelEntry[] | null
+  liveLimiterStats?: AxonHubChannelLimiterStats | null
 }
 
 export interface AxonHubCreateChannelInput {
   type: AxonHubChannelType | string
   name: string
-  baseURL: string
+  baseURL?: string | null
   credentials: AxonHubChannelCredentials
   supportedModels: string[]
   manualModels?: string[] | null
+  autoSyncSupportedModels?: boolean | null
+  autoSyncModelPattern?: string | null
+  tags?: string[] | null
   defaultTestModel: string
+  policies?: AxonHubChannelPolicies | null
   settings?: AxonHubChannelSettings | null
   orderingWeight?: number | null
   remark?: string | null
+  endpoints?: AxonHubChannelEndpoint[] | null
 }
 
-export type AxonHubUpdateChannelInput = Partial<
-  Omit<AxonHubCreateChannelInput, "defaultTestModel" | "supportedModels">
-> & {
-  defaultTestModel?: string | null
+export interface AxonHubUpdateChannelInput {
+  type?: AxonHubChannelType | string
+  baseURL?: string | null
+  clearBaseURL?: boolean
+  name?: string
+  status?: AxonHubChannelStatus | string
+  credentials?: AxonHubChannelCredentials | null
   supportedModels?: string[] | null
+  appendSupportedModels?: string[] | null
+  manualModels?: string[] | null
+  appendManualModels?: string[] | null
+  clearManualModels?: boolean
+  autoSyncSupportedModels?: boolean | null
+  autoSyncModelPattern?: string | null
+  clearAutoSyncModelPattern?: boolean
+  tags?: string[] | null
+  appendTags?: string[] | null
+  clearTags?: boolean
+  defaultTestModel?: string | null
+  policies?: AxonHubChannelPolicies | null
+  clearPolicies?: boolean
+  settings?: AxonHubChannelSettings | null
+  clearSettings?: boolean
+  orderingWeight?: number | null
+  errorMessage?: string | null
+  clearErrorMessage?: boolean
+  remark?: string | null
+  clearRemark?: boolean
+  endpoints?: AxonHubChannelEndpoint[] | null
+  appendEndpoints?: AxonHubChannelEndpoint[] | null
+  clearEndpoints?: boolean
 }

--- a/tests/entrypoints/options/BasicSettings.lazyMount.test.tsx
+++ b/tests/entrypoints/options/BasicSettings.lazyMount.test.tsx
@@ -2,6 +2,7 @@ import userEvent from "@testing-library/user-event"
 import type { ReactNode } from "react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
+import { SETTINGS_ANCHORS } from "~/constants/settingsAnchors"
 import BasicSettings from "~/features/BasicSettings/BasicSettings"
 import { act, render, screen, waitFor } from "~~/tests/test-utils/render"
 
@@ -337,6 +338,21 @@ describe("BasicSettings tab mounting", () => {
 
     expect(
       await screen.findByTestId("checkin-redeem-tab-content"),
+    ).toBeInTheDocument()
+    expect(screen.queryByTestId("general-tab-content")).not.toBeInTheDocument()
+  })
+
+  it("routes the AxonHub settings anchor to the managed-site tab", async () => {
+    window.history.replaceState(
+      null,
+      "",
+      `/?anchor=${SETTINGS_ANCHORS.AXON_HUB}#basic`,
+    )
+
+    render(<BasicSettings />, { withReleaseUpdateStatusProvider: false })
+
+    expect(
+      await screen.findByTestId("managed-site-tab-content"),
     ).toBeInTheDocument()
     expect(screen.queryByTestId("general-tab-content")).not.toBeInTheDocument()
   })

--- a/tests/services/accountSiteDefinitions/registry.test.ts
+++ b/tests/services/accountSiteDefinitions/registry.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest"
 
+import { SETTINGS_ANCHORS } from "~/constants/settingsAnchors"
 import {
   getAccountSiteApiRouter,
   ACCOUNT_SITE_TYPE_VALUES as LEGACY_ACCOUNT_SITE_TYPE_VALUES,
@@ -291,7 +292,10 @@ describe("account site definition registry", () => {
     ).toMatchObject({
       mode: "legacy-channel",
       primaryKind: "channel",
-      settingsTarget: { tabId: "managedSite", anchor: "axonhub" },
+      settingsTarget: {
+        tabId: "managedSite",
+        anchor: SETTINGS_ANCHORS.AXON_HUB,
+      },
       actions: ["create", "delete-selected", "migrate"],
     })
   })
@@ -306,7 +310,10 @@ describe("account site definition registry", () => {
     expect(
       getAccountSiteDefinition(SITE_TYPES.AXON_HUB)?.managedResource
         ?.settingsTarget,
-    ).toEqual({ tabId: "managedSite", anchor: "axonhub" })
+    ).toEqual({
+      tabId: "managedSite",
+      anchor: SETTINGS_ANCHORS.AXON_HUB,
+    })
     expect(
       getAccountSiteDefinition(SITE_TYPES.AXON_HUB)?.managedResource
         ?.detailFieldIds[0],

--- a/tests/services/accountSiteDefinitions/registry.test.ts
+++ b/tests/services/accountSiteDefinitions/registry.test.ts
@@ -273,6 +273,60 @@ describe("account site definition registry", () => {
     }
   })
 
+  it("gives every managed site an explicit managed-resource policy", () => {
+    for (const siteType of MANAGED_SITE_TYPES) {
+      expect(getAccountSiteDefinition(siteType)?.managedResource).toMatchObject(
+        {
+          mode: "legacy-channel",
+          primaryKind: "channel",
+          settingsTarget: { tabId: "managedSite" },
+        },
+      )
+    }
+  })
+
+  it("keeps AxonHub on the legacy channel path until UI cutover", () => {
+    expect(
+      getAccountSiteDefinition(SITE_TYPES.AXON_HUB)?.managedResource,
+    ).toMatchObject({
+      mode: "legacy-channel",
+      primaryKind: "channel",
+      settingsTarget: { tabId: "managedSite", anchor: "axonhub" },
+      actions: ["create", "delete-selected", "migrate"],
+    })
+  })
+
+  it("returns defensive managed-resource policy copies", () => {
+    const first = getAccountSiteDefinition(SITE_TYPES.AXON_HUB)!
+    const mutableDetailFields = first.managedResource!
+      .detailFieldIds as string[]
+    first.managedResource!.settingsTarget.anchor = "changed"
+    mutableDetailFields[0] = "changed"
+
+    expect(
+      getAccountSiteDefinition(SITE_TYPES.AXON_HUB)?.managedResource
+        ?.settingsTarget,
+    ).toEqual({ tabId: "managedSite", anchor: "axonhub" })
+    expect(
+      getAccountSiteDefinition(SITE_TYPES.AXON_HUB)?.managedResource
+        ?.detailFieldIds[0],
+    ).toBe("name")
+  })
+
+  it("keeps managed-resource field and action policy values unique", () => {
+    for (const siteType of MANAGED_SITE_TYPES) {
+      const policy = getAccountSiteDefinition(siteType)?.managedResource
+
+      expect(new Set(policy?.tableFieldIds).size).toBe(
+        policy?.tableFieldIds.length,
+      )
+      expect(new Set(policy?.detailFieldIds).size).toBe(
+        policy?.detailFieldIds.length,
+      )
+      expect(new Set(policy?.actions).size).toBe(policy?.actions.length)
+    }
+  })
+
   it("projects representative adapter families", () => {
     expect(getAccountSiteDefinition(SITE_TYPES.NEW_API)?.adapterFamily).toBe(
       ACCOUNT_SITE_ADAPTER_FAMILIES.NewApiFamily,

--- a/tests/services/apiAdapters/managedResources/axonHub.test.ts
+++ b/tests/services/apiAdapters/managedResources/axonHub.test.ts
@@ -1,0 +1,863 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+  AXON_HUB_CHANNEL_STATUS,
+  AXON_HUB_CHANNEL_TYPE,
+} from "~/constants/axonHub"
+import { isManagedSiteType, SITE_TYPES } from "~/constants/siteType"
+import {
+  MANAGED_RESOURCE_KINDS,
+  MANAGED_RESOURCE_MODES,
+} from "~/services/accountSiteDefinitions/contracts"
+import {
+  getAccountSiteDefinition,
+  getAccountSiteDefinitions,
+} from "~/services/accountSiteDefinitions/registry"
+import {
+  MANAGED_RESOURCE_FAILURE_CODES,
+  ManagedResourceError,
+  type EditableResourceProjection,
+  type ManagedResourceRef,
+} from "~/services/apiAdapters/contracts/managedResourceNative"
+import {
+  AXON_HUB_EDITABLE_FIELD_IDS,
+  axonHubManagedResourceRegistration,
+  AxonHubNativeError,
+  openAxonHubNativeResourceOperations,
+  type AxonHubNativeFailure,
+  type AxonHubNativeResourceOperations,
+} from "~/services/apiAdapters/managedResources/axonHub"
+import { getManagedResourceRegistration } from "~/services/apiAdapters/managedResources/registry"
+import { getSiteTypeCapabilities } from "~/services/apiAdapters/registry"
+import type { AxonHubChannel } from "~/types/axonHub"
+
+const mocks = vi.hoisted(() => {
+  class RequestError extends Error {
+    constructor(
+      readonly kind:
+        | "authentication"
+        | "permission"
+        | "not-found"
+        | "upstream-rejected"
+        | "protocol"
+        | "unavailable"
+        | "aborted",
+      readonly dispatch: "not-dispatched" | "dispatched",
+    ) {
+      super(kind)
+      this.name = "AxonHubRequestError"
+    }
+  }
+
+  return {
+    RequestError,
+    getPreferences: vi.fn(),
+    resolveRuntimeConfig: vi.fn(),
+    signIn: vi.fn(),
+    listPage: vi.fn(),
+    getChannel: vi.fn(),
+    createChannel: vi.fn(),
+    updateChannel: vi.fn(),
+    updateStatus: vi.fn(),
+    deleteChannel: vi.fn(),
+  }
+})
+
+vi.mock("~/services/preferences/userPreferences", () => ({
+  userPreferences: { getPreferences: mocks.getPreferences },
+}))
+
+vi.mock("~/services/managedSites/runtimeConfig", () => ({
+  resolveManagedSiteRuntimeConfigForType: mocks.resolveRuntimeConfig,
+}))
+
+vi.mock("~/services/apiService/axonHub", () => ({
+  AxonHubRequestError: mocks.RequestError,
+  signIn: mocks.signIn,
+  listAxonHubChannelPage: mocks.listPage,
+  getAxonHubChannel: mocks.getChannel,
+  createAxonHubChannel: mocks.createChannel,
+  updateAxonHubChannel: mocks.updateChannel,
+  updateAxonHubChannelStatus: mocks.updateStatus,
+  deleteAxonHubChannel: mocks.deleteChannel,
+}))
+
+const config = {
+  baseUrl: "https://api.example.invalid/",
+  email: "admin@example.invalid",
+  password: "saved-password",
+}
+
+const buildListChannel = (
+  overrides: Partial<AxonHubChannel> = {},
+): AxonHubChannel => ({
+  id: "opaque-channel-1",
+  name: "Example channel",
+  type: AXON_HUB_CHANNEL_TYPE.OPENAI,
+  status: AXON_HUB_CHANNEL_STATUS.ENABLED,
+  baseURL: "https://gateway.example.invalid",
+  supportedModels: ["model-a"],
+  tags: ["primary"],
+  ...overrides,
+})
+
+const pinnedSettings = {
+  extraModelPrefix: "old-prefix",
+  modelMappings: [{ from: "model-a", to: "model-b" }],
+  autoTrimedModelPrefixes: ["vendor/"],
+  hideOriginalModels: true,
+  hideMappedModels: false,
+  lowercaseModelId: true,
+  proxy: {
+    type: "http",
+    url: "https://proxy.example.invalid",
+    username: "proxy-user",
+    password: "proxy-password",
+  },
+  transformOptions: {
+    forceArrayInstructions: true,
+    forceArrayInputs: false,
+    replaceDeveloperRoleWithSystem: true,
+    reasoningEffortMapping: [{ from: "high", to: "medium" }],
+  },
+  headerOverrideOperations: [
+    { op: "set", path: "x-example", value: "header-value" },
+  ],
+  bodyOverrideOperations: [{ op: "set", path: "example", value: "body-value" }],
+  passThroughUserAgent: true,
+  passThroughBody: false,
+  rateLimit: {
+    rpm: 10,
+    tpm: 20,
+    maxConcurrent: 3,
+    queueSize: 4,
+    queueTimeoutMs: 500,
+  },
+  retryableStatusCodes: [429, 503],
+  retryableErrorPatterns: [{ pattern: "retry", regex: false }],
+  providerQuota: {
+    opencodeGo: { workspaceId: "workspace-placeholder", authCookie: null },
+  },
+} satisfies NonNullable<AxonHubChannel["settings"]>
+
+const buildDetailChannel = (
+  overrides: Partial<AxonHubChannel> = {},
+): AxonHubChannel => ({
+  ...buildListChannel(),
+  credentials: { apiKeys: ["sk-placeholder-value"] },
+  manualModels: ["manual-model"],
+  defaultTestModel: "model-a",
+  autoSyncSupportedModels: true,
+  autoSyncModelPattern: "model-*",
+  orderingWeight: 7,
+  remark: "Example remark",
+  settings: structuredClone(pinnedSettings),
+  ...overrides,
+})
+
+const refFor = (channel = buildDetailChannel()): ManagedResourceRef => ({
+  siteType: SITE_TYPES.AXON_HUB,
+  kind: MANAGED_RESOURCE_KINDS.Channel,
+  scopeKey: "https://api.example.invalid",
+  resourceId: channel.id,
+})
+
+const expectFailureCode = async (promise: Promise<unknown>, code: string) => {
+  const error = await promise.catch((failure) => failure)
+  expect(error).toBeInstanceOf(ManagedResourceError)
+  expect((error as ManagedResourceError).failure).toEqual({ code })
+}
+
+const openWorkspace = () => axonHubManagedResourceRegistration.open()
+
+describe("AxonHub native managed-resource Adapter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    const preferences = { marker: "saved-preferences" }
+    mocks.getPreferences.mockResolvedValue(preferences)
+    mocks.resolveRuntimeConfig.mockReturnValue({
+      siteType: SITE_TYPES.AXON_HUB,
+      config,
+    })
+    mocks.signIn.mockResolvedValue("session-token")
+    mocks.listPage.mockResolvedValue({
+      items: [buildListChannel()],
+      total: 1,
+    })
+    mocks.getChannel.mockResolvedValue(buildDetailChannel())
+    mocks.createChannel.mockResolvedValue(
+      buildDetailChannel({ status: AXON_HUB_CHANNEL_STATUS.DISABLED }),
+    )
+    mocks.updateChannel.mockImplementation(async (_config, _id, input) => ({
+      ...buildDetailChannel(),
+      ...input,
+    }))
+    mocks.updateStatus.mockResolvedValue({
+      id: "opaque-channel-1",
+      status: AXON_HUB_CHANNEL_STATUS.ENABLED,
+    })
+    mocks.deleteChannel.mockResolvedValue(true)
+  })
+
+  it("opens AxonHub with validated saved configuration", async () => {
+    const controller = new AbortController()
+    const workspace = await axonHubManagedResourceRegistration.open({
+      signal: controller.signal,
+    })
+
+    expect(mocks.getPreferences).toHaveBeenCalledOnce()
+    expect(mocks.resolveRuntimeConfig).toHaveBeenCalledWith(
+      { marker: "saved-preferences" },
+      SITE_TYPES.AXON_HUB,
+    )
+    expect(mocks.signIn).toHaveBeenCalledWith(config, {
+      signal: controller.signal,
+    })
+    expect(workspace.supportsSearch).toBe(true)
+    const operations: AxonHubNativeResourceOperations =
+      await openAxonHubNativeResourceOperations()
+    expect(operations).toMatchObject({
+      scopeKey: "https://api.example.invalid",
+    })
+  })
+
+  it("maps missing invalid authentication permission and aborted config failures safely", async () => {
+    mocks.resolveRuntimeConfig.mockReturnValueOnce(null)
+    await expectFailureCode(
+      openWorkspace(),
+      MANAGED_RESOURCE_FAILURE_CODES.ConfigurationRequired,
+    )
+
+    mocks.resolveRuntimeConfig.mockReturnValueOnce({
+      siteType: SITE_TYPES.AXON_HUB,
+      config: { ...config, baseUrl: "not-an-origin" },
+    })
+    await expectFailureCode(
+      openWorkspace(),
+      MANAGED_RESOURCE_FAILURE_CODES.InvalidConfiguration,
+    )
+
+    mocks.signIn.mockRejectedValueOnce(
+      new mocks.RequestError("authentication", "not-dispatched"),
+    )
+    const nativeError = await openAxonHubNativeResourceOperations().catch(
+      (error) => error,
+    )
+    const expectedNativeFailure = {
+      code: "authentication_failed",
+      dispatch: "before",
+    } satisfies AxonHubNativeFailure
+    expect(nativeError).toBeInstanceOf(AxonHubNativeError)
+    expect((nativeError as AxonHubNativeError).failure).toEqual(
+      expectedNativeFailure,
+    )
+    expect(Object.keys((nativeError as AxonHubNativeError).failure)).toEqual([
+      "code",
+      "dispatch",
+    ])
+
+    for (const [kind, code] of [
+      ["authentication", MANAGED_RESOURCE_FAILURE_CODES.AuthenticationFailed],
+      ["permission", MANAGED_RESOURCE_FAILURE_CODES.PermissionDenied],
+      ["aborted", MANAGED_RESOURCE_FAILURE_CODES.Aborted],
+    ] as const) {
+      mocks.signIn.mockRejectedValueOnce(
+        new mocks.RequestError(kind, "not-dispatched"),
+      )
+      await expectFailureCode(openWorkspace(), code)
+    }
+
+    mocks.getPreferences.mockRejectedValueOnce(new Error("storage details"))
+    await expectFailureCode(
+      openWorkspace(),
+      MANAGED_RESOURCE_FAILURE_CODES.Unexpected,
+    )
+
+    for (const [kind, dispatch, code] of [
+      [
+        "authentication",
+        "dispatched",
+        MANAGED_RESOURCE_FAILURE_CODES.AuthenticationFailed,
+      ],
+      [
+        "permission",
+        "dispatched",
+        MANAGED_RESOURCE_FAILURE_CODES.PermissionDenied,
+      ],
+      [
+        "upstream-rejected",
+        "dispatched",
+        MANAGED_RESOURCE_FAILURE_CODES.UpstreamRejected,
+      ],
+      ["not-found", "dispatched", MANAGED_RESOURCE_FAILURE_CODES.NotFound],
+      ["aborted", "not-dispatched", MANAGED_RESOURCE_FAILURE_CODES.Aborted],
+    ] as const) {
+      mocks.updateChannel.mockRejectedValueOnce(
+        new mocks.RequestError(kind, dispatch),
+      )
+      const workspace = await openWorkspace()
+      const editor = await workspace.openEditEditor(refFor())
+      await expectFailureCode(
+        editor.submit({ ...editor.initialValues, name: "Renamed" }),
+        code,
+      )
+    }
+
+    const workspace = await openWorkspace()
+    const editor = await workspace.openCreateEditor()
+    const spoofedValues = { ...editor.initialValues }
+    Object.defineProperty(spoofedValues, "name", {
+      get() {
+        throw { code: "permission_denied", dispatch: "before" }
+      },
+    })
+    let spoofedFailure: unknown
+    try {
+      editor.validate(spoofedValues)
+    } catch (error) {
+      spoofedFailure = error
+    }
+    expect(spoofedFailure).toBeInstanceOf(ManagedResourceError)
+    expect((spoofedFailure as ManagedResourceError).failure).toEqual({
+      code: MANAGED_RESOURCE_FAILURE_CODES.Unexpected,
+    })
+  })
+
+  it("maps native list and detail responses to safe display facts", async () => {
+    const workspace = await openWorkspace()
+    const page = await workspace.list()
+    const detail = await workspace.get(refFor())
+
+    expect(page.items[0]).toMatchObject({
+      displayName: "Example channel",
+      status: "enabled",
+      actions: { canUpdate: true, canDelete: true },
+    })
+    expect(page.items[0]?.fields).not.toContainEqual(
+      expect.objectContaining({ fieldId: "key" }),
+    )
+    expect(detail.fields).toContainEqual({
+      fieldId: "key",
+      kind: "secret",
+      state: "available",
+    })
+    expect(JSON.stringify([page, detail])).not.toContain("sk-placeholder-value")
+    expect(JSON.stringify([page, detail])).not.toContain("proxy-password")
+  })
+
+  it("maps all fourteen approved fields to safe detail facts", async () => {
+    const workspace = await openWorkspace()
+    const detail = await workspace.get(refFor())
+
+    expect(detail.fields.map((field) => field.fieldId)).toEqual(
+      AXON_HUB_EDITABLE_FIELD_IDS,
+    )
+    expect(new Set(detail.fields.map((field) => field.fieldId)).size).toBe(14)
+    expect(
+      detail.fields.every((field) =>
+        ["text", "number", "boolean", "list", "secret"].includes(field.kind),
+      ),
+    ).toBe(true)
+  })
+
+  it("returns only the definition-selected safe fact subset from list", async () => {
+    const workspace = await openWorkspace()
+    const page = await workspace.list()
+
+    expect(page.items[0]?.fields.map((field) => field.fieldId)).toEqual([
+      "name",
+      "type",
+      "baseURL",
+      "status",
+      "supportedModels",
+      "tags",
+    ])
+  })
+
+  it("searches across all AxonHub pages when supportsSearch is true", async () => {
+    mocks.listPage.mockImplementation(async (_config, input) => {
+      if (!input.cursor) {
+        return {
+          items: [buildListChannel({ id: "first", name: "First" })],
+          nextCursor: "next-page",
+        }
+      }
+      return {
+        items: [buildListChannel({ id: "second", name: "Needle channel" })],
+      }
+    })
+    const workspace = await openWorkspace()
+
+    const page = await workspace.list({ search: "needle", limit: 1 })
+
+    expect(page.items.map((item) => item.ref.resourceId)).toEqual(["second"])
+    expect(mocks.listPage).toHaveBeenNthCalledWith(
+      1,
+      config,
+      { limit: 100 },
+      undefined,
+    )
+    expect(mocks.listPage).toHaveBeenNthCalledWith(
+      2,
+      config,
+      { cursor: "next-page", limit: 100 },
+      undefined,
+    )
+
+    mocks.listPage.mockClear()
+    mocks.listPage.mockResolvedValue({ items: [], nextCursor: "repeated" })
+    await expectFailureCode(
+      workspace.list({ search: "absent" }),
+      MANAGED_RESOURCE_FAILURE_CODES.Unexpected,
+    )
+    expect(mocks.listPage).toHaveBeenCalledTimes(2)
+    expect(mocks.getChannel).not.toHaveBeenCalled()
+
+    mocks.listPage.mockClear()
+    let uniqueCursor = 0
+    mocks.listPage.mockImplementation(async () => {
+      const nextCursor =
+        uniqueCursor < 150 ? `unique-${uniqueCursor++}` : "unique-149"
+      return { items: [], nextCursor }
+    })
+    await expectFailureCode(
+      workspace.list({ search: "absent" }),
+      MANAGED_RESOURCE_FAILURE_CODES.Unexpected,
+    )
+    expect(mocks.listPage).toHaveBeenCalledTimes(100)
+
+    mocks.listPage.mockClear()
+    mocks.listPage.mockResolvedValue({
+      items: Array.from({ length: 5_001 }, (_, index) =>
+        buildListChannel({ id: `bounded-item-${index}` }),
+      ),
+    })
+    await expectFailureCode(
+      workspace.list({ search: "absent" }),
+      MANAGED_RESOURCE_FAILURE_CODES.Unexpected,
+    )
+    expect(mocks.listPage).toHaveBeenCalledOnce()
+    expect(mocks.getChannel).not.toHaveBeenCalled()
+  })
+
+  it("matches resource-wide search against opaque id and safe display facts", async () => {
+    mocks.listPage.mockResolvedValue({
+      items: [
+        buildListChannel({
+          id: "opaque-search-id",
+          name: "Plain name",
+          supportedModels: ["model-searchable"],
+          tags: ["tag-searchable"],
+        }),
+      ],
+    })
+    const workspace = await openWorkspace()
+
+    for (const term of [
+      "opaque-search",
+      "plain name",
+      "model-searchable",
+      "tag-searchable",
+      "gateway.example.invalid",
+    ]) {
+      await expect(workspace.list({ search: term })).resolves.toMatchObject({
+        items: [{ ref: { resourceId: "opaque-search-id" } }],
+      })
+    }
+    await expect(
+      workspace.list({ search: "proxy-password" }),
+    ).resolves.toMatchObject({ items: [] })
+    expect(mocks.getChannel).not.toHaveBeenCalled()
+  })
+
+  it("exposes only the approved first editable field set", async () => {
+    const workspace = await openWorkspace()
+    const editor = await workspace.openCreateEditor()
+
+    expect(editor.fields.map((field) => field.fieldId)).toEqual(
+      AXON_HUB_EDITABLE_FIELD_IDS,
+    )
+    expect(editor.initialValues.key).toEqual({ kind: "unchanged" })
+    expect(JSON.stringify(editor.initialValues)).not.toContain("saved-password")
+    const typeField = editor.fields.find((field) => field.fieldId === "type")
+    expect(typeField).toMatchObject({ type: "select" })
+    if (typeField?.type !== "select") throw new Error("expected select")
+    expect(typeField.options.map((option) => option.value)).toEqual([
+      AXON_HUB_CHANNEL_TYPE.OPENAI,
+      AXON_HUB_CHANNEL_TYPE.OPENAI_RESPONSES,
+      AXON_HUB_CHANNEL_TYPE.ANTHROPIC,
+      AXON_HUB_CHANNEL_TYPE.GEMINI_OPENAI,
+      AXON_HUB_CHANNEL_TYPE.GEMINI,
+      AXON_HUB_CHANNEL_TYPE.GEMINI_VERTEX,
+      AXON_HUB_CHANNEL_TYPE.DEEPSEEK,
+      AXON_HUB_CHANNEL_TYPE.DEEPSEEK_ANTHROPIC,
+      AXON_HUB_CHANNEL_TYPE.OPENROUTER,
+      AXON_HUB_CHANNEL_TYPE.XAI,
+      AXON_HUB_CHANNEL_TYPE.SILICONFLOW,
+      AXON_HUB_CHANNEL_TYPE.VOLCENGINE,
+      AXON_HUB_CHANNEL_TYPE.NANOGPT,
+      AXON_HUB_CHANNEL_TYPE.OLLAMA,
+    ])
+
+    for (const type of [AXON_HUB_CHANNEL_TYPE.CLAUDECODE, "future_oauth"]) {
+      const specialDetail = buildDetailChannel({ type })
+      mocks.getChannel.mockResolvedValueOnce(specialDetail)
+      const specialEditor = await workspace.openEditEditor(
+        refFor(specialDetail),
+      )
+      const specialTypeField = specialEditor.fields.find(
+        (field) => field.fieldId === "type",
+      )
+      expect(specialTypeField).toMatchObject({
+        type: "select",
+        options: [{ value: type }],
+      })
+      expect(
+        specialEditor.validate({
+          ...specialEditor.initialValues,
+          name: "Safe rename",
+        }),
+      ).toEqual({ valid: true })
+      expect(
+        specialEditor.validate({
+          ...specialEditor.initialValues,
+          type: AXON_HUB_CHANNEL_TYPE.OPENAI,
+          key: { kind: "replace", value: "replacement-secret" },
+        }),
+      ).toEqual({
+        valid: false,
+        issues: expect.arrayContaining([
+          { fieldId: "type", code: "unsupported_option" },
+          { fieldId: "key", code: "unsupported_option" },
+        ]),
+      })
+    }
+  })
+
+  it("keeps archived distinct from disabled", async () => {
+    mocks.listPage.mockResolvedValue({
+      items: [
+        buildListChannel({ id: "archived", status: "archived" }),
+        buildListChannel({ id: "disabled", status: "disabled" }),
+        buildListChannel({ id: "auto", status: "auto-disabled" }),
+      ],
+    })
+    const workspace = await openWorkspace()
+    const page = await workspace.list()
+
+    expect(page.items.map((item) => item.status)).toEqual([
+      "archived",
+      "disabled",
+      "auto-disabled",
+    ])
+  })
+
+  it("omits unchanged unavailable permission-hidden and masked credentials", async () => {
+    const credentialShapes = [undefined, null, { apiKeys: ["sk-****masked"] }]
+
+    for (const credentials of credentialShapes) {
+      const detail = buildDetailChannel({ credentials })
+      mocks.getChannel.mockResolvedValueOnce(detail)
+      mocks.updateChannel.mockResolvedValueOnce({ ...detail, name: "Renamed" })
+      const workspace = await openWorkspace()
+      const editor = await workspace.openEditEditor(refFor(detail))
+      await editor.submit({ ...editor.initialValues, name: "Renamed" })
+    }
+
+    for (const call of mocks.updateChannel.mock.calls.slice(-3)) {
+      expect(call[2]).not.toHaveProperty("credentials")
+    }
+  })
+
+  it("emits a replacement credential only for explicit replace intent", async () => {
+    const detail = buildDetailChannel({ credentials: null })
+    mocks.getChannel.mockResolvedValue(detail)
+    mocks.updateChannel.mockResolvedValue({
+      ...detail,
+      credentials: { apiKeys: ["replacement-secret"] },
+    })
+    const workspace = await openWorkspace()
+    const editor = await workspace.openEditEditor(refFor(detail))
+
+    await editor.submit({
+      ...editor.initialValues,
+      key: { kind: "replace", value: "replacement-secret" },
+    })
+
+    expect(mocks.updateChannel).toHaveBeenCalledWith(
+      config,
+      detail.id,
+      { credentials: { apiKeys: ["replacement-secret"] } },
+      undefined,
+    )
+  })
+
+  it("emits only changed top-level fields and verified clear flags", async () => {
+    const detail = buildDetailChannel()
+    mocks.getChannel.mockResolvedValue(detail)
+    mocks.updateChannel.mockResolvedValue({ ...detail, name: "Renamed" })
+    const workspace = await openWorkspace()
+    const editor = await workspace.openEditEditor(refFor(detail))
+
+    await editor.submit({
+      ...editor.initialValues,
+      name: "Renamed",
+      baseURL: "",
+      status: AXON_HUB_CHANNEL_STATUS.DISABLED,
+      supportedModels: ["model-a", "model-b"],
+      manualModels: [],
+      autoSyncModelPattern: "",
+      tags: [],
+      orderingWeight: 9,
+      remark: "",
+    })
+
+    expect(mocks.updateChannel).toHaveBeenCalledWith(
+      config,
+      detail.id,
+      {
+        name: "Renamed",
+        clearBaseURL: true,
+        status: AXON_HUB_CHANNEL_STATUS.DISABLED,
+        supportedModels: ["model-a", "model-b"],
+        clearManualModels: true,
+        clearAutoSyncModelPattern: true,
+        clearTags: true,
+        orderingWeight: 9,
+        clearRemark: true,
+      },
+      undefined,
+    )
+    expect(mocks.updateStatus).not.toHaveBeenCalled()
+
+    const whitespaceDetail = buildDetailChannel({
+      name: "  Padded channel  ",
+      baseURL: "  https://gateway.example.invalid  ",
+      supportedModels: ["  model-a  "],
+      manualModels: ["  manual-model  "],
+      defaultTestModel: "  model-a  ",
+      autoSyncModelPattern: "  model-*  ",
+      tags: ["  primary  "],
+      remark: "  Example remark  ",
+      settings: { ...pinnedSettings, extraModelPrefix: "  old-prefix  " },
+    })
+    mocks.getChannel.mockResolvedValue(whitespaceDetail)
+    mocks.updateChannel.mockResolvedValue(whitespaceDetail)
+    const whitespaceWorkspace = await openWorkspace()
+    const whitespaceEditor = await whitespaceWorkspace.openEditEditor(
+      refFor(whitespaceDetail),
+    )
+
+    await whitespaceEditor.submit(whitespaceEditor.initialValues)
+
+    expect(mocks.updateChannel.mock.calls.at(-1)?.[2]).toEqual({})
+  })
+
+  it("preserves every selected pinned setting while updating extraModelPrefix", async () => {
+    const detail = buildDetailChannel()
+    const original = structuredClone(detail)
+    mocks.getChannel.mockResolvedValue(detail)
+    mocks.updateChannel.mockResolvedValue({
+      ...detail,
+      settings: { ...detail.settings, extraModelPrefix: "new-prefix" },
+    })
+    const workspace = await openWorkspace()
+    const editor = await workspace.openEditEditor(refFor(detail))
+
+    await editor.submit({
+      ...editor.initialValues,
+      extraModelPrefix: "new-prefix",
+    })
+
+    expect(mocks.updateChannel.mock.calls.at(-1)?.[2]).toEqual({
+      settings: { ...pinnedSettings, extraModelPrefix: "new-prefix" },
+    })
+    expect(mocks.updateChannel.mock.calls.at(-1)?.[2]).not.toHaveProperty(
+      "clearSettings",
+    )
+    expect(detail).toEqual(original)
+  })
+
+  it("validates supported manual and default-model invariants", async () => {
+    const workspace = await openWorkspace()
+    const editor = await workspace.openCreateEditor()
+    const validBase: EditableResourceProjection = {
+      ...editor.initialValues,
+      name: "Created channel",
+      type: AXON_HUB_CHANNEL_TYPE.OPENAI,
+      baseURL: "https://gateway.example.invalid",
+      key: { kind: "replace", value: "replacement-secret" },
+      supportedModels: ["model-a"],
+      manualModels: ["manual-model"],
+      defaultTestModel: "model-a",
+    }
+
+    expect(editor.validate(validBase)).toEqual({ valid: true })
+    expect(editor.validate({ ...validBase, orderingWeight: 1.5 })).toEqual({
+      valid: false,
+      issues: expect.arrayContaining([
+        { fieldId: "orderingWeight", code: "invalid_value" },
+      ]),
+    })
+    expect(mocks.createChannel).not.toHaveBeenCalled()
+    expect(
+      editor.validate({
+        ...validBase,
+        supportedModels: ["model-a", " model-a ", ""],
+        manualModels: ["manual-model", "manual-model"],
+        defaultTestModel: "missing-model",
+      }),
+    ).toEqual({
+      valid: false,
+      issues: expect.arrayContaining([
+        { fieldId: "supportedModels", code: "invalid_value" },
+        { fieldId: "manualModels", code: "invalid_value" },
+        { fieldId: "defaultTestModel", code: "inconsistent_value" },
+      ]),
+    })
+
+    const detail = buildDetailChannel()
+    mocks.getChannel.mockResolvedValue(detail)
+    const editEditor = await workspace.openEditEditor(refFor(detail))
+    expect(
+      editEditor.validate({
+        ...editEditor.initialValues,
+        orderingWeight: 2.25,
+      }),
+    ).toEqual({
+      valid: false,
+      issues: expect.arrayContaining([
+        { fieldId: "orderingWeight", code: "invalid_value" },
+      ]),
+    })
+    expect(mocks.updateChannel).not.toHaveBeenCalled()
+    expect(
+      editEditor.validate({
+        ...editEditor.initialValues,
+        supportedModels: [],
+      }),
+    ).toEqual({
+      valid: false,
+      issues: expect.arrayContaining([
+        { fieldId: "supportedModels", code: "required" },
+      ]),
+    })
+    expect(
+      editEditor.validate({
+        ...editEditor.initialValues,
+        defaultTestModel: "",
+      }),
+    ).toEqual({
+      valid: false,
+      issues: expect.arrayContaining([
+        { fieldId: "defaultTestModel", code: "required" },
+      ]),
+    })
+    expect(
+      editEditor.validate({
+        ...editEditor.initialValues,
+        manualModels: [],
+      }),
+    ).toEqual({ valid: true })
+  })
+
+  it("maps create plus failed status follow-up to mutation_state_uncertain without replay", async () => {
+    const created = buildDetailChannel({
+      id: "created-id",
+      status: AXON_HUB_CHANNEL_STATUS.DISABLED,
+    })
+    mocks.createChannel.mockResolvedValue(created)
+    mocks.updateStatus.mockRejectedValue(
+      new mocks.RequestError("unavailable", "dispatched"),
+    )
+    const workspace = await openWorkspace()
+    const editor = await workspace.openCreateEditor()
+
+    await expectFailureCode(
+      editor.submit({
+        ...editor.initialValues,
+        name: "Created channel",
+        type: AXON_HUB_CHANNEL_TYPE.OPENAI,
+        baseURL: "https://gateway.example.invalid",
+        key: { kind: "replace", value: "replacement-secret" },
+        supportedModels: ["model-a"],
+        defaultTestModel: "model-a",
+        status: AXON_HUB_CHANNEL_STATUS.ENABLED,
+      }),
+      MANAGED_RESOURCE_FAILURE_CODES.MutationStateUncertain,
+    )
+    expect(mocks.createChannel).toHaveBeenCalledOnce()
+    expect(mocks.updateStatus).toHaveBeenCalledOnce()
+
+    const detail = buildDetailChannel()
+    mocks.getChannel.mockResolvedValue(detail)
+    mocks.updateChannel.mockRejectedValue(
+      new mocks.RequestError("unavailable", "dispatched"),
+    )
+    const updateWorkspace = await openWorkspace()
+    const updateEditor = await updateWorkspace.openEditEditor(refFor(detail))
+    const changedValues = {
+      ...updateEditor.initialValues,
+      name: "Uncertain rename",
+    }
+
+    await expectFailureCode(
+      updateEditor.submit(changedValues),
+      MANAGED_RESOURCE_FAILURE_CODES.MutationStateUncertain,
+    )
+    await expectFailureCode(
+      updateEditor.submit(changedValues),
+      MANAGED_RESOURCE_FAILURE_CODES.ValidationFailed,
+    )
+    expect(mocks.updateChannel).toHaveBeenCalledOnce()
+  })
+
+  it("registers AxonHub separately from legacy SiteTypeCapabilities", () => {
+    const registration = getManagedResourceRegistration(
+      SITE_TYPES.AXON_HUB,
+      MANAGED_RESOURCE_KINDS.Channel,
+    )
+    const capabilities = getSiteTypeCapabilities(SITE_TYPES.AXON_HUB)
+
+    expect(registration).toBe(axonHubManagedResourceRegistration)
+    expect(registration).toMatchObject({
+      siteType: SITE_TYPES.AXON_HUB,
+      kind: MANAGED_RESOURCE_KINDS.Channel,
+    })
+    expect(capabilities.managedSites).not.toHaveProperty("nativeResources")
+    expect(capabilities.managedSites).not.toHaveProperty("resourceRegistration")
+  })
+
+  it("does not treat registration presence as native rollout mode", () => {
+    expect(
+      getManagedResourceRegistration(
+        SITE_TYPES.AXON_HUB,
+        MANAGED_RESOURCE_KINDS.Channel,
+      ),
+    ).not.toBeNull()
+    expect(
+      getAccountSiteDefinition(SITE_TYPES.AXON_HUB)?.managedResource?.mode,
+    ).toBe(MANAGED_RESOURCE_MODES.LegacyChannel)
+  })
+
+  it("has a registration for every definition currently marked native-resource", () => {
+    const nativeDefinitions = getAccountSiteDefinitions().filter(
+      (definition) =>
+        definition.managedResource?.mode ===
+        MANAGED_RESOURCE_MODES.NativeResource,
+    )
+
+    expect(
+      nativeDefinitions.every((definition) => {
+        const policy = definition.managedResource
+        if (!policy || !isManagedSiteType(definition.siteType)) return false
+        return Boolean(
+          getManagedResourceRegistration(
+            definition.siteType,
+            policy.primaryKind,
+          ),
+        )
+      }),
+    ).toBe(true)
+  })
+})

--- a/tests/services/apiAdapters/managedResources/axonHub.test.ts
+++ b/tests/services/apiAdapters/managedResources/axonHub.test.ts
@@ -286,7 +286,7 @@ describe("AxonHub native managed-resource Adapter", () => {
       ],
       [
         "upstream-rejected",
-        "dispatched",
+        "not-dispatched",
         MANAGED_RESOURCE_FAILURE_CODES.UpstreamRejected,
       ],
       ["not-found", "dispatched", MANAGED_RESOURCE_FAILURE_CODES.NotFound],
@@ -540,6 +540,7 @@ describe("AxonHub native managed-resource Adapter", () => {
         buildListChannel({ id: "archived", status: "archived" }),
         buildListChannel({ id: "disabled", status: "disabled" }),
         buildListChannel({ id: "auto", status: "auto-disabled" }),
+        buildListChannel({ id: "future", status: "future-status" }),
       ],
     })
     const workspace = await openWorkspace()
@@ -549,6 +550,7 @@ describe("AxonHub native managed-resource Adapter", () => {
       "archived",
       "disabled",
       "auto-disabled",
+      "unknown",
     ])
   })
 
@@ -693,6 +695,23 @@ describe("AxonHub native managed-resource Adapter", () => {
     }
 
     expect(editor.validate(validBase)).toEqual({ valid: true })
+    expect(
+      editor.validate({
+        ...validBase,
+        name: "",
+        type: "",
+        baseURL: "not-a-url",
+        key: { kind: "clear" },
+      }),
+    ).toEqual({
+      valid: false,
+      issues: expect.arrayContaining([
+        { fieldId: "name", code: "required" },
+        { fieldId: "type", code: "required" },
+        { fieldId: "baseURL", code: "invalid_value" },
+        { fieldId: "key", code: "required" },
+      ]),
+    })
     expect(editor.validate({ ...validBase, orderingWeight: 1.5 })).toEqual({
       valid: false,
       issues: expect.arrayContaining([
@@ -761,6 +780,35 @@ describe("AxonHub native managed-resource Adapter", () => {
     ).toEqual({ valid: true })
   })
 
+  it("keeps baseURL optional for native creation", async () => {
+    const created = buildDetailChannel({
+      id: "created-without-base-url",
+      baseURL: null,
+      status: AXON_HUB_CHANNEL_STATUS.DISABLED,
+    })
+    mocks.createChannel.mockResolvedValue(created)
+    const workspace = await openWorkspace()
+    const editor = await workspace.openCreateEditor()
+    const values: EditableResourceProjection = {
+      ...editor.initialValues,
+      name: "Created channel",
+      baseURL: "   ",
+      key: { kind: "replace", value: "replacement-secret" },
+      supportedModels: ["model-a"],
+      defaultTestModel: "model-a",
+    }
+
+    expect(
+      editor.fields.find((field) => field.fieldId === "baseURL"),
+    ).not.toMatchObject({ required: true })
+    expect(editor.validate(values)).toEqual({ valid: true })
+
+    await editor.submit(values)
+
+    expect(mocks.createChannel).toHaveBeenCalledOnce()
+    expect(mocks.createChannel.mock.calls[0]?.[1]).not.toHaveProperty("baseURL")
+  })
+
   it("maps create plus failed status follow-up to mutation_state_uncertain without replay", async () => {
     const created = buildDetailChannel({
       id: "created-id",
@@ -812,6 +860,54 @@ describe("AxonHub native managed-resource Adapter", () => {
     expect(mocks.updateChannel).toHaveBeenCalledOnce()
   })
 
+  it("treats a generic dispatched GraphQL rejection as possibly applied", async () => {
+    const detail = buildDetailChannel()
+    mocks.getChannel.mockResolvedValue(detail)
+    mocks.updateChannel.mockRejectedValue(
+      new mocks.RequestError("upstream-rejected", "dispatched"),
+    )
+    const workspace = await openWorkspace()
+    const editor = await workspace.openEditEditor(refFor(detail))
+
+    await expectFailureCode(
+      editor.submit({ ...editor.initialValues, name: "Uncertain rename" }),
+      MANAGED_RESOURCE_FAILURE_CODES.MutationStateUncertain,
+    )
+    await expectFailureCode(
+      editor.submit({ ...editor.initialValues, name: "Uncertain rename" }),
+      MANAGED_RESOURCE_FAILURE_CODES.ValidationFailed,
+    )
+    expect(mocks.updateChannel).toHaveBeenCalledOnce()
+  })
+
+  it("normalizes native delete outcomes without unsafe replay", async () => {
+    const workspace = await openWorkspace()
+    const ref = refFor()
+
+    mocks.deleteChannel.mockResolvedValueOnce(true)
+    await expect(workspace.delete(ref)).resolves.toBeUndefined()
+
+    mocks.deleteChannel.mockResolvedValueOnce(false)
+    await expectFailureCode(
+      workspace.delete(ref),
+      MANAGED_RESOURCE_FAILURE_CODES.UpstreamRejected,
+    )
+
+    mocks.deleteChannel.mockRejectedValueOnce(
+      new mocks.RequestError("not-found", "dispatched"),
+    )
+    await expect(workspace.delete(ref)).resolves.toBeUndefined()
+
+    mocks.deleteChannel.mockRejectedValueOnce(
+      new mocks.RequestError("unavailable", "dispatched"),
+    )
+    await expectFailureCode(
+      workspace.delete(ref),
+      MANAGED_RESOURCE_FAILURE_CODES.MutationStateUncertain,
+    )
+    expect(mocks.deleteChannel).toHaveBeenCalledTimes(4)
+  })
+
   it("registers AxonHub separately from legacy SiteTypeCapabilities", () => {
     const registration = getManagedResourceRegistration(
       SITE_TYPES.AXON_HUB,
@@ -826,6 +922,12 @@ describe("AxonHub native managed-resource Adapter", () => {
     })
     expect(capabilities.managedSites).not.toHaveProperty("nativeResources")
     expect(capabilities.managedSites).not.toHaveProperty("resourceRegistration")
+    expect(
+      getManagedResourceRegistration(
+        SITE_TYPES.NEW_API,
+        MANAGED_RESOURCE_KINDS.Channel,
+      ),
+    ).toBeNull()
   })
 
   it("does not treat registration presence as native rollout mode", () => {

--- a/tests/services/apiAdapters/managedResources/axonHub.test.ts
+++ b/tests/services/apiAdapters/managedResources/axonHub.test.ts
@@ -9,10 +9,7 @@ import {
   MANAGED_RESOURCE_KINDS,
   MANAGED_RESOURCE_MODES,
 } from "~/services/accountSiteDefinitions/contracts"
-import {
-  getAccountSiteDefinition,
-  getAccountSiteDefinitions,
-} from "~/services/accountSiteDefinitions/registry"
+import * as accountSiteDefinitionRegistry from "~/services/accountSiteDefinitions/registry"
 import {
   MANAGED_RESOURCE_FAILURE_CODES,
   ManagedResourceError,
@@ -237,6 +234,15 @@ describe("AxonHub native managed-resource Adapter", () => {
       MANAGED_RESOURCE_FAILURE_CODES.InvalidConfiguration,
     )
 
+    mocks.resolveRuntimeConfig.mockReturnValueOnce({
+      siteType: SITE_TYPES.AXON_HUB,
+      config: { ...config, baseUrl: "https://api.example.invalid/?unsafe=1" },
+    })
+    await expectFailureCode(
+      openWorkspace(),
+      MANAGED_RESOURCE_FAILURE_CODES.InvalidConfiguration,
+    )
+
     mocks.signIn.mockRejectedValueOnce(
       new mocks.RequestError("authentication", "not-dispatched"),
     )
@@ -374,6 +380,21 @@ describe("AxonHub native managed-resource Adapter", () => {
     ])
   })
 
+  it("falls back to no list fields when the site definition is unavailable", async () => {
+    const definitionSpy = vi
+      .spyOn(accountSiteDefinitionRegistry, "getAccountSiteDefinition")
+      .mockReturnValueOnce(undefined)
+
+    try {
+      const workspace = await openWorkspace()
+      const page = await workspace.list()
+
+      expect(page.items[0]?.fields).toEqual([])
+    } finally {
+      definitionSpy.mockRestore()
+    }
+  })
+
   it("searches across all AxonHub pages when supportsSearch is true", async () => {
     mocks.listPage.mockImplementation(async (_config, input) => {
       if (!input.cursor) {
@@ -437,6 +458,32 @@ describe("AxonHub native managed-resource Adapter", () => {
       MANAGED_RESOURCE_FAILURE_CODES.Unexpected,
     )
     expect(mocks.listPage).toHaveBeenCalledOnce()
+    expect(mocks.getChannel).not.toHaveBeenCalled()
+  })
+
+  it("forwards the abort signal to resource-wide search and rejects invalid refs", async () => {
+    const controller = new AbortController()
+    const workspace = await openWorkspace()
+
+    await workspace.list({ search: "example" }, { signal: controller.signal })
+
+    expect(mocks.listPage).toHaveBeenCalledWith(
+      config,
+      { limit: 100 },
+      { signal: controller.signal },
+    )
+    const operations = await openAxonHubNativeResourceOperations()
+    let invalidRefFailure: unknown
+    try {
+      operations.get({ ...refFor(), resourceId: "" })
+    } catch (error) {
+      invalidRefFailure = error
+    }
+    expect(invalidRefFailure).toBeInstanceOf(AxonHubNativeError)
+    expect((invalidRefFailure as AxonHubNativeError).failure).toEqual({
+      code: "unexpected",
+      dispatch: "before",
+    })
     expect(mocks.getChannel).not.toHaveBeenCalled()
   })
 
@@ -712,6 +759,21 @@ describe("AxonHub native managed-resource Adapter", () => {
         { fieldId: "key", code: "required" },
       ]),
     })
+    expect(
+      editor.validate({
+        ...validBase,
+        supportedModels: undefined as never,
+        key: { kind: "replace", value: 42 } as never,
+        status: AXON_HUB_CHANNEL_STATUS.ARCHIVED,
+      }),
+    ).toEqual({
+      valid: false,
+      issues: expect.arrayContaining([
+        { fieldId: "supportedModels", code: "required" },
+        { fieldId: "key", code: "required" },
+        { fieldId: "status", code: "unsupported_option" },
+      ]),
+    })
     expect(editor.validate({ ...validBase, orderingWeight: 1.5 })).toEqual({
       valid: false,
       issues: expect.arrayContaining([
@@ -778,6 +840,22 @@ describe("AxonHub native managed-resource Adapter", () => {
         manualModels: [],
       }),
     ).toEqual({ valid: true })
+
+    const futureStatusDetail = buildDetailChannel({ status: "future-status" })
+    mocks.getChannel.mockResolvedValueOnce(futureStatusDetail)
+    const futureStatusEditor = await workspace.openEditEditor(
+      refFor(futureStatusDetail),
+    )
+    const statusField = futureStatusEditor.fields.find(
+      (field) => field.fieldId === "status",
+    )
+    expect(statusField).toMatchObject({
+      type: "select",
+      options: expect.arrayContaining([{ value: "future-status" }]),
+    })
+    expect(
+      futureStatusEditor.validate(futureStatusEditor.initialValues),
+    ).toEqual({ valid: true })
   })
 
   it("keeps baseURL optional for native creation", async () => {
@@ -807,6 +885,65 @@ describe("AxonHub native managed-resource Adapter", () => {
 
     expect(mocks.createChannel).toHaveBeenCalledOnce()
     expect(mocks.createChannel.mock.calls[0]?.[1]).not.toHaveProperty("baseURL")
+  })
+
+  it("maps create rejection and applies the requested enabled status", async () => {
+    const workspace = await openWorkspace()
+    const editor = await workspace.openCreateEditor()
+    const values: EditableResourceProjection = {
+      ...editor.initialValues,
+      name: "Created channel",
+      key: { kind: "replace", value: "replacement-secret" },
+      supportedModels: ["model-a"],
+      defaultTestModel: "model-a",
+      status: AXON_HUB_CHANNEL_STATUS.ENABLED,
+    }
+
+    mocks.createChannel.mockRejectedValueOnce(
+      new mocks.RequestError("upstream-rejected", "not-dispatched"),
+    )
+    await expectFailureCode(
+      editor.submit(values),
+      MANAGED_RESOURCE_FAILURE_CODES.UpstreamRejected,
+    )
+
+    const created = buildDetailChannel({
+      id: "created-enabled-id",
+      status: AXON_HUB_CHANNEL_STATUS.DISABLED,
+    })
+    mocks.createChannel.mockResolvedValueOnce(created)
+    const result = await editor.submit(values)
+
+    expect(result).toMatchObject({
+      status: "enabled",
+      ref: { resourceId: "created-enabled-id" },
+    })
+    expect(mocks.updateStatus).toHaveBeenCalledWith(
+      config,
+      created.id,
+      AXON_HUB_CHANNEL_STATUS.ENABLED,
+      undefined,
+    )
+  })
+
+  it("submits changed default-model and auto-sync settings", async () => {
+    const detail = buildDetailChannel()
+    mocks.getChannel.mockResolvedValue(detail)
+    const workspace = await openWorkspace()
+    const editor = await workspace.openEditEditor(refFor(detail))
+
+    await editor.submit({
+      ...editor.initialValues,
+      supportedModels: ["model-a", "model-b"],
+      defaultTestModel: "model-b",
+      autoSyncSupportedModels: false,
+    })
+
+    expect(mocks.updateChannel.mock.calls.at(-1)?.[2]).toMatchObject({
+      supportedModels: ["model-a", "model-b"],
+      defaultTestModel: "model-b",
+      autoSyncSupportedModels: false,
+    })
   })
 
   it("maps create plus failed status follow-up to mutation_state_uncertain without replay", async () => {
@@ -938,16 +1075,20 @@ describe("AxonHub native managed-resource Adapter", () => {
       ),
     ).not.toBeNull()
     expect(
-      getAccountSiteDefinition(SITE_TYPES.AXON_HUB)?.managedResource?.mode,
+      accountSiteDefinitionRegistry.getAccountSiteDefinition(
+        SITE_TYPES.AXON_HUB,
+      )?.managedResource?.mode,
     ).toBe(MANAGED_RESOURCE_MODES.LegacyChannel)
   })
 
   it("has a registration for every definition currently marked native-resource", () => {
-    const nativeDefinitions = getAccountSiteDefinitions().filter(
-      (definition) =>
-        definition.managedResource?.mode ===
-        MANAGED_RESOURCE_MODES.NativeResource,
-    )
+    const nativeDefinitions = accountSiteDefinitionRegistry
+      .getAccountSiteDefinitions()
+      .filter(
+        (definition) =>
+          definition.managedResource?.mode ===
+          MANAGED_RESOURCE_MODES.NativeResource,
+      )
 
     expect(
       nativeDefinitions.every((definition) => {

--- a/tests/services/apiAdapters/managedResources/factory.test.ts
+++ b/tests/services/apiAdapters/managedResources/factory.test.ts
@@ -1,0 +1,787 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { SITE_TYPES } from "~/constants/siteType"
+import { MANAGED_RESOURCE_KINDS } from "~/services/accountSiteDefinitions/contracts"
+import {
+  MANAGED_RESOURCE_FAILURE_CODES,
+  MANAGED_RESOURCE_FIELD_ISSUE_CODES,
+  ManagedResourceError,
+  type EditableResourceProjection,
+  type ManagedResourceRef,
+  type ManagedResourceRegistration,
+  type ManagedResourceWorkspace,
+  type ResourceEditor,
+  type ResourceFailure,
+} from "~/services/apiAdapters/contracts/managedResourceNative"
+import {
+  defineNativeResourceKind,
+  type NativeResourceKindDefinition,
+  type NativeResourceMutationResult,
+} from "~/services/apiAdapters/managedResources/factory"
+
+type TestConfig = { scope: string }
+type TestLocator = { tenant: string; route: string }
+type TestListItem = {
+  locator: TestLocator
+  name: string
+  enabled: boolean
+}
+type TestDetail = {
+  id: TestLocator
+  name: string
+  secret: string
+  settings: { visible: string; hidden: string }
+}
+type TestCreateCommand = { name: string }
+type TestUpdateCommand = { name: string; visible: string }
+type TestFailure = "aborted" | "denied" | "not-found" | "unavailable"
+
+const encodeLocator = (locator: TestLocator) =>
+  `${encodeURIComponent(locator.tenant)}/${encodeURIComponent(locator.route)}`
+
+function createDeferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+  return { promise, resolve, reject }
+}
+
+type TestDefinition = NativeResourceKindDefinition<
+  TestConfig,
+  TestLocator,
+  TestListItem,
+  TestDetail,
+  TestCreateCommand,
+  TestUpdateCommand,
+  TestFailure
+>
+
+const TEST_LOCATOR: TestLocator = {
+  tenant: "tenant/example",
+  route: "opaque:id/alpha",
+}
+
+const TEST_DETAIL: TestDetail = {
+  id: TEST_LOCATOR,
+  name: "Example channel",
+  secret: "native-only-secret",
+  settings: { visible: "shown", hidden: "preserve-me" },
+}
+
+const OTHER_LOCATOR: TestLocator = {
+  tenant: "other-tenant",
+  route: "other-route",
+}
+
+const OTHER_DETAIL: TestDetail = {
+  ...TEST_DETAIL,
+  id: OTHER_LOCATOR,
+  name: "Other channel",
+}
+
+const toRef = (
+  resourceId = encodeLocator(TEST_LOCATOR),
+): ManagedResourceRef => ({
+  siteType: SITE_TYPES.AXON_HUB,
+  kind: MANAGED_RESOURCE_KINDS.Channel,
+  scopeKey: "scope-a",
+  resourceId,
+})
+
+const mapTestFailure = (error: unknown): ResourceFailure => {
+  switch (error) {
+    case "aborted":
+      return { code: MANAGED_RESOURCE_FAILURE_CODES.Aborted }
+    case "denied":
+      return { code: MANAGED_RESOURCE_FAILURE_CODES.PermissionDenied }
+    case "not-found":
+      return { code: MANAGED_RESOURCE_FAILURE_CODES.NotFound }
+    case "unavailable":
+      return { code: MANAGED_RESOURCE_FAILURE_CODES.Unavailable }
+    default:
+      return { code: MANAGED_RESOURCE_FAILURE_CODES.Unexpected }
+  }
+}
+
+const createHarness = (overrides: Partial<TestDefinition> = {}) => {
+  const definition: TestDefinition = {
+    siteType: SITE_TYPES.AXON_HUB,
+    kind: MANAGED_RESOURCE_KINDS.Channel,
+    supportsSearch: true,
+    openConfig: vi.fn<TestDefinition["openConfig"]>(async () => ({
+      scope: "scope-a",
+    })),
+    scopeKey: vi.fn<TestDefinition["scopeKey"]>((config) => config.scope),
+    encodeLocator: vi.fn<TestDefinition["encodeLocator"]>(encodeLocator),
+    decodeLocator: vi.fn<TestDefinition["decodeLocator"]>((resourceId) => {
+      const [tenant, route] = resourceId.split("/")
+      if (!tenant || !route) throw "unavailable"
+      return {
+        tenant: decodeURIComponent(tenant),
+        route: decodeURIComponent(route),
+      }
+    }),
+    locatorFromListItem: vi.fn<TestDefinition["locatorFromListItem"]>(
+      (item) => item.locator,
+    ),
+    locatorFromDetail: vi.fn<TestDefinition["locatorFromDetail"]>(
+      (detail) => detail.id,
+    ),
+    list: vi.fn<TestDefinition["list"]>(async () => ({
+      items: [
+        {
+          locator: TEST_LOCATOR,
+          name: TEST_DETAIL.name,
+          enabled: true,
+        },
+      ],
+    })),
+    get: vi.fn<TestDefinition["get"]>(async () => TEST_DETAIL),
+    toListFacts: vi.fn<TestDefinition["toListFacts"]>((item, ref) => ({
+      ref,
+      displayName: item.name,
+      status: item.enabled ? "enabled" : "disabled",
+      fields: [{ fieldId: "enabled", kind: "boolean", value: item.enabled }],
+      actions: { canUpdate: true, canDelete: true },
+    })),
+    toDetailFacts: vi.fn<TestDefinition["toDetailFacts"]>((detail, ref) => ({
+      ref,
+      displayName: detail.name,
+      status: "enabled",
+      fields: [
+        { fieldId: "visible", kind: "text", value: detail.settings.visible },
+        { fieldId: "secret", kind: "secret", state: "available" },
+      ],
+      actions: { canUpdate: true, canDelete: true },
+    })),
+    createEditor: vi.fn<TestDefinition["createEditor"]>(async () => ({
+      fields: [{ fieldId: "name", type: "text", required: true }],
+      initialValues: { name: "" },
+      validate: (values) =>
+        typeof values.name === "string" && values.name.length > 0
+          ? { valid: true }
+          : {
+              valid: false,
+              issues: [
+                {
+                  fieldId: "name",
+                  code: MANAGED_RESOURCE_FIELD_ISSUE_CODES.Required,
+                },
+              ],
+            },
+      buildCommand: (values) => ({ name: String(values.name) }),
+    })),
+    editEditor: vi.fn<TestDefinition["editEditor"]>((_config, detail) => ({
+      fields: [
+        { fieldId: "name", type: "text", required: true },
+        { fieldId: "visible", type: "text" },
+      ],
+      initialValues: {
+        name: detail.name,
+        visible: detail.settings.visible,
+      },
+      validate: (values) =>
+        typeof values.name === "string" && values.name.length > 0
+          ? { valid: true }
+          : {
+              valid: false,
+              issues: [
+                {
+                  fieldId: "name",
+                  code: MANAGED_RESOURCE_FIELD_ISSUE_CODES.Required,
+                },
+              ],
+            },
+      buildCommand: (values) => ({
+        name: String(values.name),
+        visible: String(values.visible),
+      }),
+    })),
+    create: vi.fn<TestDefinition["create"]>(async (_config, command) => ({
+      certainty: "applied",
+      value: { ...TEST_DETAIL, name: command.name },
+    })),
+    update: vi.fn<TestDefinition["update"]>(
+      async (_config, detail, command) => ({
+        certainty: "applied",
+        value: {
+          ...detail,
+          name: command.name,
+          settings: { ...detail.settings, visible: command.visible },
+        },
+      }),
+    ),
+    delete: vi.fn<TestDefinition["delete"]>(async () => ({
+      certainty: "applied",
+      value: undefined,
+    })),
+    mapFailure: vi.fn<TestDefinition["mapFailure"]>(mapTestFailure),
+    ...overrides,
+  }
+
+  return {
+    definition,
+    registration: defineNativeResourceKind(definition),
+  }
+}
+
+const captureManagedError = async (promise: Promise<unknown>) => {
+  try {
+    await promise
+  } catch (error) {
+    expect(error).toBeInstanceOf(ManagedResourceError)
+    const managedError = error as ManagedResourceError
+    expect(Object.values(MANAGED_RESOURCE_FAILURE_CODES)).toContain(
+      managedError.failure.code,
+    )
+    return managedError
+  }
+  throw new Error("Expected a controlled managed-resource failure")
+}
+
+describe("defineNativeResourceKind", () => {
+  it("opens a ready workspace without exposing native config or detail types", async () => {
+    const { registration } = createHarness()
+    const publicRegistration: ManagedResourceRegistration = registration
+    const workspace: ManagedResourceWorkspace = await publicRegistration.open()
+    const editor: ResourceEditor = await workspace.openEditEditor(toRef())
+
+    expect(workspace.supportsSearch).toBe(true)
+    expect(workspace).not.toHaveProperty("config")
+    expect(editor.initialValues).toEqual({
+      name: TEST_DETAIL.name,
+      visible: TEST_DETAIL.settings.visible,
+    })
+    expect(editor).not.toHaveProperty("detail")
+    expect(editor).not.toHaveProperty("secret")
+  })
+
+  it("supports an opaque nonnumeric resource id and cursor page without a total", async () => {
+    const nextCursor = "cursor:opaque/next"
+    const { registration } = createHarness({
+      list: vi.fn(async () => ({
+        items: [
+          { locator: TEST_LOCATOR, name: TEST_DETAIL.name, enabled: true },
+        ],
+        nextCursor,
+      })),
+    })
+
+    const page = await (await registration.open()).list({ cursor: "start" })
+
+    expect(page).toEqual({
+      items: [
+        expect.objectContaining({
+          ref: toRef(),
+          displayName: TEST_DETAIL.name,
+        }),
+      ],
+      nextCursor,
+    })
+    expect(page).not.toHaveProperty("total")
+    expect(page.items[0].ref.resourceId).toContain("opaque%3Aid%2Falpha")
+  })
+
+  it("rejects empty or over-512-character resource ids before native access", async () => {
+    const { definition, registration } = createHarness()
+    const workspace = await registration.open()
+
+    for (const resourceId of ["", "x".repeat(513), 42 as unknown as string]) {
+      const error = await captureManagedError(workspace.get(toRef(resourceId)))
+      expect(error.failure.code).toBe(
+        MANAGED_RESOURCE_FAILURE_CODES.ValidationFailed,
+      )
+    }
+    expect(definition.decodeLocator).not.toHaveBeenCalled()
+    expect(definition.get).not.toHaveBeenCalled()
+  })
+
+  it("rejects malformed runtime refs before native access", async () => {
+    const { definition, registration } = createHarness()
+    const workspace = await registration.open()
+    const malformedRefs = [null, undefined, {}, { ...toRef(), resourceId: 42 }]
+    const operations = [
+      (ref: ManagedResourceRef) => workspace.get(ref),
+      (ref: ManagedResourceRef) => workspace.openEditEditor(ref),
+      (ref: ManagedResourceRef) => workspace.delete(ref),
+    ]
+
+    for (const malformedRef of malformedRefs) {
+      for (const operation of operations) {
+        const error = await captureManagedError(
+          operation(malformedRef as ManagedResourceRef),
+        )
+        expect(error.failure.code).toBe(
+          MANAGED_RESOURCE_FAILURE_CODES.ValidationFailed,
+        )
+      }
+    }
+    expect(definition.decodeLocator).not.toHaveBeenCalled()
+    expect(definition.get).not.toHaveBeenCalled()
+    expect(definition.delete).not.toHaveBeenCalled()
+  })
+
+  it("rejects refs with the wrong site type resource kind or scope", async () => {
+    const { definition, registration } = createHarness()
+    const workspace = await registration.open()
+    const invalidRefs = [
+      { ...toRef(), siteType: SITE_TYPES.NEW_API },
+      { ...toRef(), kind: "not-channel" },
+      { ...toRef(), scopeKey: "scope-b" },
+    ] as ManagedResourceRef[]
+
+    for (const ref of invalidRefs) {
+      const error = await captureManagedError(workspace.get(ref))
+      expect(error.failure.code).toBe(
+        MANAGED_RESOURCE_FAILURE_CODES.ValidationFailed,
+      )
+    }
+    expect(definition.decodeLocator).not.toHaveBeenCalled()
+    expect(definition.get).not.toHaveBeenCalled()
+  })
+
+  it("rejects get details whose native identity differs from the requested ref", async () => {
+    const { definition, registration } = createHarness({
+      get: vi.fn(async () => OTHER_DETAIL),
+    })
+
+    const error = await captureManagedError(
+      (await registration.open()).get(toRef()),
+    )
+
+    expect(error.failure.code).toBe(MANAGED_RESOURCE_FAILURE_CODES.Unexpected)
+    expect(definition.toDetailFacts).not.toHaveBeenCalled()
+  })
+
+  it("rejects edit editors whose loaded detail has a different native identity", async () => {
+    const { definition, registration } = createHarness({
+      get: vi.fn(async () => OTHER_DETAIL),
+    })
+
+    const error = await captureManagedError(
+      (await registration.open()).openEditEditor(toRef()),
+    )
+
+    expect(error.failure.code).toBe(MANAGED_RESOURCE_FAILURE_CODES.Unexpected)
+    expect(definition.editEditor).not.toHaveBeenCalled()
+  })
+
+  it("snapshots caller refs before asynchronous reads and editor creation", async () => {
+    const readDeferred = createDeferred<TestDetail>()
+    const readHarness = createHarness({
+      get: vi.fn(() => readDeferred.promise),
+    })
+    const readWorkspace = await readHarness.registration.open()
+    const readRef = toRef()
+    const pendingFacts = readWorkspace.get(readRef)
+    Object.assign(readRef, {
+      siteType: SITE_TYPES.NEW_API,
+      scopeKey: "mutated-scope",
+      resourceId: encodeLocator(OTHER_LOCATOR),
+    })
+    readDeferred.resolve(TEST_DETAIL)
+
+    await expect(pendingFacts).resolves.toMatchObject({ ref: toRef() })
+
+    const editorDeferred = createDeferred<TestDetail>()
+    const editorHarness = createHarness({
+      get: vi.fn(() => editorDeferred.promise),
+    })
+    const editorWorkspace = await editorHarness.registration.open()
+    const editorRef = toRef()
+    const pendingEditor = editorWorkspace.openEditEditor(editorRef)
+    Object.assign(editorRef, {
+      kind: "mutated-kind",
+      scopeKey: "mutated-scope",
+      resourceId: encodeLocator(OTHER_LOCATOR),
+    })
+    editorDeferred.resolve(TEST_DETAIL)
+    const editor = await pendingEditor
+
+    await expect(
+      editor.submit({ name: "Renamed", visible: "updated" }),
+    ).resolves.toMatchObject({ ref: toRef() })
+  })
+
+  it("keeps hidden native detail in the edit-editor closure", async () => {
+    const { definition, registration } = createHarness()
+    const editor = await (await registration.open()).openEditEditor(toRef())
+
+    const validationError = await captureManagedError(
+      editor.submit({ name: "", visible: "unchanged" }),
+    )
+    expect(validationError.failure).toEqual({
+      code: MANAGED_RESOURCE_FAILURE_CODES.ValidationFailed,
+      fieldIssues: [
+        {
+          fieldId: "name",
+          code: MANAGED_RESOURCE_FIELD_ISSUE_CODES.Required,
+        },
+      ],
+    })
+    expect(definition.update).not.toHaveBeenCalled()
+    await editor.submit({ name: "Renamed", visible: "updated" })
+
+    expect(editor.initialValues).not.toHaveProperty("secret")
+    expect(editor.initialValues).not.toHaveProperty("settings")
+    expect(definition.update).toHaveBeenCalledWith(
+      { scope: "scope-a" },
+      TEST_DETAIL,
+      { name: "Renamed", visible: "updated" },
+      undefined,
+    )
+    await captureManagedError(
+      editor.submit({ name: "Do not replay", visible: "updated" }),
+    )
+    expect(definition.update).toHaveBeenCalledTimes(1)
+  })
+
+  it("preserves a hidden nested native field across an allowed edit", async () => {
+    const { definition, registration } = createHarness()
+    const editor = await (await registration.open()).openEditEditor(toRef())
+
+    const facts = await editor.submit({ name: "Renamed", visible: "updated" })
+
+    const sourceDetail = vi.mocked(definition.update).mock.calls[0][1]
+    expect(sourceDetail.settings.hidden).toBe("preserve-me")
+    expect(facts.fields).toContainEqual({
+      fieldId: "visible",
+      kind: "text",
+      value: "updated",
+    })
+  })
+
+  it("rejects retargeted applied updates and prevents replay", async () => {
+    const update = vi.fn(
+      async () => ({ certainty: "applied", value: OTHER_DETAIL }) as const,
+    )
+    const { registration } = createHarness({ update })
+    const editor = await (await registration.open()).openEditEditor(toRef())
+
+    const error = await captureManagedError(
+      editor.submit({ name: "Retargeted", visible: "updated" }),
+    )
+    expect(error.failure.code).toBe(MANAGED_RESOURCE_FAILURE_CODES.Unexpected)
+    await captureManagedError(
+      editor.submit({ name: "Do not replay", visible: "updated" }),
+    )
+    expect(update).toHaveBeenCalledTimes(1)
+  })
+
+  it("coalesces concurrent editor submits into one Adapter mutation", async () => {
+    const deferred =
+      createDeferred<NativeResourceMutationResult<TestDetail, TestFailure>>()
+    const create = vi.fn(() => deferred.promise)
+    const { registration } = createHarness({ create })
+    const editor = await (await registration.open()).openCreateEditor()
+    const values: EditableResourceProjection = { name: "Created" }
+
+    const first = editor.submit(values)
+    const second = editor.submit(values)
+
+    expect(first).toBe(second)
+    expect(create).toHaveBeenCalledTimes(1)
+    deferred.resolve({
+      certainty: "applied",
+      value: { ...TEST_DETAIL, name: "Created" },
+    })
+    await expect(first).resolves.toMatchObject({
+      displayName: "Created",
+      ref: toRef(),
+    })
+  })
+
+  it("maps possible and partial mutation outcomes to mutation_state_uncertain", async () => {
+    const create = vi.fn(
+      async () => ({ certainty: "possibly-applied" }) as const,
+    )
+    const update = vi.fn(
+      async () => ({ certainty: "partially-applied" }) as const,
+    )
+    const { registration } = createHarness({ create, update })
+    const workspace = await registration.open()
+    const createEditor = await workspace.openCreateEditor()
+    const editEditor = await workspace.openEditEditor(toRef())
+
+    for (const [editor, values] of [
+      [createEditor, { name: "Created" }],
+      [editEditor, { name: "Renamed", visible: "updated" }],
+    ] as const) {
+      const error = await captureManagedError(editor.submit(values))
+      expect(error.failure.code).toBe(
+        MANAGED_RESOURCE_FAILURE_CODES.MutationStateUncertain,
+      )
+      await captureManagedError(editor.submit(values))
+    }
+    expect(create).toHaveBeenCalledTimes(1)
+    expect(update).toHaveBeenCalledTimes(1)
+
+    const thrownCreate = vi.fn(async () => {
+      throw "post-dispatch-uncertain"
+    })
+    const thrownHarness = createHarness({
+      create: thrownCreate,
+      mapFailure: vi.fn((error) =>
+        error === "post-dispatch-uncertain"
+          ? { code: MANAGED_RESOURCE_FAILURE_CODES.MutationStateUncertain }
+          : mapTestFailure(error),
+      ),
+    })
+    const thrownEditor = await (
+      await thrownHarness.registration.open()
+    ).openCreateEditor()
+    expect(
+      (
+        await captureManagedError(
+          thrownEditor.submit({ name: "Uncertain create" }),
+        )
+      ).failure.code,
+    ).toBe(MANAGED_RESOURCE_FAILURE_CODES.MutationStateUncertain)
+    await captureManagedError(
+      thrownEditor.submit({ name: "Do not replay uncertain create" }),
+    )
+    expect(thrownCreate).toHaveBeenCalledTimes(1)
+  })
+
+  it("treats deletion of an already-missing resource as success", async () => {
+    const deleteResource = vi.fn(
+      async () =>
+        ({
+          certainty: "not-applied",
+          failure: "not-found",
+        }) as const,
+    )
+    const { registration } = createHarness({ delete: deleteResource })
+
+    await expect((await registration.open()).delete(toRef())).resolves.toBe(
+      undefined,
+    )
+    expect(deleteResource).toHaveBeenCalledTimes(1)
+
+    const thrownNotFound = createHarness({
+      delete: vi.fn(async () => {
+        throw "not-found"
+      }),
+    })
+    await expect(
+      (await thrownNotFound.registration.open()).delete(toRef()),
+    ).resolves.toBe(undefined)
+  })
+
+  it("maps abort before dispatch to aborted and keeps the editor reusable", async () => {
+    const create = vi
+      .fn()
+      .mockResolvedValueOnce({ certainty: "not-applied", failure: "aborted" })
+      .mockResolvedValueOnce({ certainty: "applied", value: TEST_DETAIL })
+    const { registration } = createHarness({ create })
+    const editor = await (await registration.open()).openCreateEditor()
+
+    const firstError = await captureManagedError(
+      editor.submit({ name: "First" }),
+    )
+    expect(firstError.failure.code).toBe(MANAGED_RESOURCE_FAILURE_CODES.Aborted)
+    await expect(editor.submit({ name: "Second" })).resolves.toMatchObject({
+      displayName: TEST_DETAIL.name,
+    })
+    expect(create).toHaveBeenCalledTimes(2)
+  })
+
+  it("maps abort after dispatch to mutation_state_uncertain and closes the editor", async () => {
+    const create = vi.fn(
+      async () => ({ certainty: "possibly-applied" }) as const,
+    )
+    const { registration } = createHarness({ create })
+    const editor = await (await registration.open()).openCreateEditor()
+
+    const firstError = await captureManagedError(
+      editor.submit({ name: "Possibly created" }),
+    )
+    expect(firstError.failure.code).toBe(
+      MANAGED_RESOURCE_FAILURE_CODES.MutationStateUncertain,
+    )
+    const secondError = await captureManagedError(
+      editor.submit({ name: "Do not replay" }),
+    )
+    expect(secondError.failure.code).toBe(
+      MANAGED_RESOURCE_FAILURE_CODES.ValidationFailed,
+    )
+    expect(create).toHaveBeenCalledTimes(1)
+  })
+
+  it("maps every Adapter read and mutation failure to a controlled public code", async () => {
+    const openFailure = createHarness({
+      openConfig: vi.fn(async () => {
+        throw "denied"
+      }),
+    })
+    expect(
+      (await captureManagedError(openFailure.registration.open())).failure.code,
+    ).toBe(MANAGED_RESOURCE_FAILURE_CODES.PermissionDenied)
+
+    const throwingOperations: (keyof TestDefinition)[] = [
+      "list",
+      "get",
+      "createEditor",
+      "editEditor",
+      "create",
+      "update",
+      "delete",
+    ]
+    for (const operation of throwingOperations) {
+      const { registration } = createHarness({
+        [operation]: vi.fn(() => {
+          throw "denied"
+        }),
+      })
+      const workspace = await registration.open()
+      let action: Promise<unknown>
+      switch (operation) {
+        case "list":
+          action = workspace.list()
+          break
+        case "get":
+          action = workspace.get(toRef())
+          break
+        case "createEditor":
+          action = workspace.openCreateEditor()
+          break
+        case "editEditor":
+          action = workspace.openEditEditor(toRef())
+          break
+        case "create":
+          action = workspace
+            .openCreateEditor()
+            .then((editor) => editor.submit({ name: "Created" }))
+          break
+        case "update":
+          action = workspace
+            .openEditEditor(toRef())
+            .then((editor) =>
+              editor.submit({ name: "Renamed", visible: "updated" }),
+            )
+          break
+        default:
+          action = workspace.delete(toRef())
+      }
+      expect((await captureManagedError(action)).failure.code).toBe(
+        MANAGED_RESOURCE_FAILURE_CODES.PermissionDenied,
+      )
+    }
+
+    const missingUpdate = vi.fn(
+      async () =>
+        ({
+          certainty: "not-applied",
+          failure: "not-found",
+        }) as const,
+    )
+    const missingUpdateHarness = createHarness({ update: missingUpdate })
+    const missingUpdateEditor = await (
+      await missingUpdateHarness.registration.open()
+    ).openEditEditor(toRef())
+    expect(
+      (
+        await captureManagedError(
+          missingUpdateEditor.submit({
+            name: "Missing",
+            visible: "unchanged",
+          }),
+        )
+      ).failure.code,
+    ).toBe(MANAGED_RESOURCE_FAILURE_CODES.NotFound)
+    await captureManagedError(
+      missingUpdateEditor.submit({
+        name: "Do not replay",
+        visible: "unchanged",
+      }),
+    )
+    expect(missingUpdate).toHaveBeenCalledTimes(1)
+
+    const duplicateFacts = [
+      { fieldId: "duplicate", kind: "text", value: "one" },
+      { fieldId: "duplicate", kind: "text", value: "two" },
+    ] as const
+    const duplicateList = createHarness({
+      toListFacts: vi.fn<TestDefinition["toListFacts"]>((item, ref) => ({
+        ref,
+        displayName: item.name,
+        status: "enabled",
+        fields: duplicateFacts,
+        actions: { canUpdate: true, canDelete: true },
+      })),
+    })
+    expect(
+      (
+        await captureManagedError(
+          (await duplicateList.registration.open()).list(),
+        )
+      ).failure.code,
+    ).toBe(MANAGED_RESOURCE_FAILURE_CODES.Unexpected)
+
+    const duplicateDetail = createHarness({
+      toDetailFacts: vi.fn<TestDefinition["toDetailFacts"]>((detail, ref) => ({
+        ref,
+        displayName: detail.name,
+        status: "enabled",
+        fields: duplicateFacts,
+        actions: { canUpdate: true, canDelete: true },
+      })),
+    })
+    expect(
+      (
+        await captureManagedError(
+          (await duplicateDetail.registration.open()).get(toRef()),
+        )
+      ).failure.code,
+    ).toBe(MANAGED_RESOURCE_FAILURE_CODES.Unexpected)
+
+    const retargetRef = (ref: ManagedResourceRef): ManagedResourceRef => ({
+      ...ref,
+      resourceId: "retargeted-resource",
+    })
+    const mismatchedListRef = createHarness({
+      toListFacts: vi.fn<TestDefinition["toListFacts"]>((item, ref) => ({
+        ref: retargetRef(ref),
+        displayName: item.name,
+        status: "enabled",
+        fields: [],
+        actions: { canUpdate: true, canDelete: true },
+      })),
+    })
+    expect(
+      (
+        await captureManagedError(
+          (await mismatchedListRef.registration.open()).list(),
+        )
+      ).failure.code,
+    ).toBe(MANAGED_RESOURCE_FAILURE_CODES.Unexpected)
+
+    const mismatchedDetailRef = createHarness({
+      toDetailFacts: vi.fn<TestDefinition["toDetailFacts"]>((detail, ref) => ({
+        ref: retargetRef(ref),
+        displayName: detail.name,
+        status: "enabled",
+        fields: [],
+        actions: { canUpdate: true, canDelete: true },
+      })),
+    })
+    const mismatchedDetailWorkspace =
+      await mismatchedDetailRef.registration.open()
+    expect(
+      (await captureManagedError(mismatchedDetailWorkspace.get(toRef())))
+        .failure.code,
+    ).toBe(MANAGED_RESOURCE_FAILURE_CODES.Unexpected)
+    expect(
+      (
+        await captureManagedError(
+          mismatchedDetailWorkspace
+            .openCreateEditor()
+            .then((editor) => editor.submit({ name: "Created" })),
+        )
+      ).failure.code,
+    ).toBe(MANAGED_RESOURCE_FAILURE_CODES.Unexpected)
+  })
+})

--- a/tests/services/apiAdapters/managedResources/factory.test.ts
+++ b/tests/services/apiAdapters/managedResources/factory.test.ts
@@ -343,6 +343,21 @@ describe("defineNativeResourceKind", () => {
     expect(definition.get).not.toHaveBeenCalled()
   })
 
+  it("maps failures safely when a native failure mapper throws", async () => {
+    const { registration } = createHarness({
+      openConfig: vi.fn(async () => {
+        throw new Error("native details")
+      }),
+      mapFailure: vi.fn(() => {
+        throw new Error("mapper details")
+      }),
+    })
+
+    const error = await captureManagedError(registration.open())
+
+    expect(error.failure.code).toBe(MANAGED_RESOURCE_FAILURE_CODES.Unexpected)
+  })
+
   it("rejects get details whose native identity differs from the requested ref", async () => {
     const { definition, registration } = createHarness({
       get: vi.fn(async () => OTHER_DETAIL),

--- a/tests/services/apiAdapters/managedSites/axonHub.test.ts
+++ b/tests/services/apiAdapters/managedSites/axonHub.test.ts
@@ -20,6 +20,7 @@ const axonHubProvider = vi.hoisted(() => ({
 
 const axonHubApi = vi.hoisted(() => ({
   axonHubChannelToManagedSite: vi.fn(),
+  getAxonHubChannel: vi.fn(),
   createAxonHubChannel: vi.fn(),
   updateAxonHubChannel: vi.fn(),
   updateAxonHubChannelStatus: vi.fn(),
@@ -340,11 +341,7 @@ describe("AxonHub managed-site channel capability", () => {
       remark: "native remark",
     })
     const updated = { ...native, name: "Axon Updated" }
-    axonHubProvider.listChannels.mockResolvedValue({
-      items: [buildAxonHubChannelRow(native)],
-      total: 1,
-      type_counts: { anthropic_gcp: 1 },
-    })
+    axonHubApi.getAxonHubChannel.mockResolvedValue(native)
     axonHubApi.updateAxonHubChannel.mockResolvedValue(updated)
     axonHubApi.axonHubChannelToManagedSite.mockReturnValue(
       buildAxonHubChannelRow(updated),
@@ -359,6 +356,7 @@ describe("AxonHub managed-site channel capability", () => {
       scopeKey: "https://axonhub.example.invalid",
       resourceId: native.id,
     }
+    const listCallsBefore = axonHubProvider.listChannels.mock.calls.length
 
     const detail = await resources.items.getDetail(config, ref)
     const draft = resources.drafts.prepareEditDraft(detail)
@@ -368,6 +366,8 @@ describe("AxonHub managed-site channel capability", () => {
     })
 
     expect(detail.native).toBe(native)
+    expect(axonHubApi.getAxonHubChannel).toHaveBeenCalledWith(config, native.id)
+    expect(axonHubProvider.listChannels).toHaveBeenCalledTimes(listCallsBefore)
     expect(draft).toEqual({
       name: "Axon Native",
       type: "anthropic_gcp",
@@ -427,11 +427,7 @@ describe("AxonHub managed-site channel capability", () => {
     const native = buildAxonHubChannel({
       settings: null,
     })
-    axonHubProvider.listChannels.mockResolvedValue({
-      items: [buildAxonHubChannelRow(native)],
-      total: 1,
-      type_counts: { openai: 1 },
-    })
+    axonHubApi.getAxonHubChannel.mockResolvedValue(native)
     axonHubApi.updateAxonHubChannel.mockResolvedValue(native)
     axonHubApi.axonHubChannelToManagedSite.mockReturnValue(
       buildAxonHubChannelRow(native),
@@ -468,11 +464,7 @@ describe("AxonHub managed-site channel capability", () => {
         apiKeys: ["sk-primary", "sk-secondary"],
       },
     })
-    axonHubProvider.listChannels.mockResolvedValue({
-      items: [buildAxonHubChannelRow(native)],
-      total: 1,
-      type_counts: { openai: 1 },
-    })
+    axonHubApi.getAxonHubChannel.mockResolvedValue(native)
     axonHubApi.updateAxonHubChannel.mockResolvedValue({
       ...native,
       name: "Renamed Axon",
@@ -514,11 +506,7 @@ describe("AxonHub managed-site channel capability", () => {
       manualModels: ["native-manual"],
       defaultTestModel: "native-manual",
     })
-    axonHubProvider.listChannels.mockResolvedValue({
-      items: [buildAxonHubChannelRow(native)],
-      total: 1,
-      type_counts: { openai: 1 },
-    })
+    axonHubApi.getAxonHubChannel.mockResolvedValue(native)
     axonHubApi.updateAxonHubChannel.mockResolvedValue(native)
     axonHubApi.axonHubChannelToManagedSite.mockReturnValue(
       buildAxonHubChannelRow(native),
@@ -557,11 +545,7 @@ describe("AxonHub managed-site channel capability", () => {
       defaultTestModel: null,
       orderingWeight: null,
     })
-    axonHubProvider.listChannels.mockResolvedValue({
-      items: [buildAxonHubChannelRow(native)],
-      total: 1,
-      type_counts: { openai: 1 },
-    })
+    axonHubApi.getAxonHubChannel.mockResolvedValue(native)
     axonHubApi.updateAxonHubChannel.mockResolvedValue(native)
     axonHubApi.axonHubChannelToManagedSite.mockReturnValue(
       buildAxonHubChannelRow(native),
@@ -697,11 +681,7 @@ describe("AxonHub managed-site channel capability", () => {
       manualModels: [],
       defaultTestModel: null,
     })
-    axonHubProvider.listChannels.mockResolvedValue({
-      items: [buildAxonHubChannelRow(native)],
-      total: 1,
-      type_counts: { openai: 1 },
-    })
+    axonHubApi.getAxonHubChannel.mockResolvedValue(native)
     axonHubApi.updateAxonHubChannel.mockResolvedValue({
       ...native,
       name: "Renamed Axon",
@@ -747,11 +727,7 @@ describe("AxonHub managed-site channel capability", () => {
     const native = buildAxonHubChannel({
       status: AXON_HUB_CHANNEL_STATUS.ARCHIVED,
     })
-    axonHubProvider.listChannels.mockResolvedValue({
-      items: [buildAxonHubChannelRow(native)],
-      total: 1,
-      type_counts: { openai: 1 },
-    })
+    axonHubApi.getAxonHubChannel.mockResolvedValue(native)
     axonHubApi.updateAxonHubChannel.mockResolvedValue(native)
     axonHubApi.axonHubChannelToManagedSite.mockReturnValue(
       buildAxonHubChannelRow(native),
@@ -780,11 +756,7 @@ describe("AxonHub managed-site channel capability", () => {
     const native = buildAxonHubChannel({
       status: AXON_HUB_CHANNEL_STATUS.ENABLED,
     })
-    axonHubProvider.listChannels.mockResolvedValue({
-      items: [buildAxonHubChannelRow(native)],
-      total: 1,
-      type_counts: { openai: 1 },
-    })
+    axonHubApi.getAxonHubChannel.mockResolvedValue(native)
     axonHubApi.updateAxonHubChannel.mockResolvedValue(native)
     axonHubApi.axonHubChannelToManagedSite.mockReturnValue(
       buildAxonHubChannelRow({
@@ -842,11 +814,7 @@ describe("AxonHub managed-site channel capability", () => {
         apiKeys: ["sk-********"],
       },
     })
-    axonHubProvider.listChannels.mockResolvedValue({
-      items: [buildAxonHubChannelRow(native)],
-      total: 1,
-      type_counts: { openai: 1 },
-    })
+    axonHubApi.getAxonHubChannel.mockResolvedValue(native)
     axonHubApi.updateAxonHubChannel.mockResolvedValue(native)
     axonHubApi.axonHubChannelToManagedSite.mockReturnValue(
       buildAxonHubChannelRow(native),

--- a/tests/services/apiService/axonHub/index.test.ts
+++ b/tests/services/apiService/axonHub/index.test.ts
@@ -5,13 +5,16 @@ import { AXON_HUB_CHANNEL_STATUS } from "~/constants/axonHub"
 import {
   __resetCachesForTesting,
   axonHubChannelToManagedSite,
+  AxonHubRequestError,
   createAxonHubChannel,
   createChannel as createChannelAdapter,
   deleteAxonHubChannel,
   deleteChannel as deleteChannelAdapter,
   fetchSiteUserGroups,
+  getAxonHubChannel,
   graphqlRequest,
   listAllChannels,
+  listAxonHubChannelPage,
   listChannels,
   resolveAxonHubGraphqlId,
   searchChannel as searchChannelAdapter,
@@ -23,6 +26,7 @@ import {
 } from "~/services/apiService/axonHub"
 import type { ApiServiceRequest } from "~/services/apiTransport/type"
 import { AuthTypeEnum } from "~/types"
+import type { AxonHubChannel, AxonHubCreateChannelInput } from "~/types/axonHub"
 import { CHANNEL_STATUS } from "~/types/managedSite"
 import { server } from "~~/tests/msw/server"
 
@@ -35,6 +39,120 @@ const config = {
 const AUTH_URL = "https://axonhub.example.com/admin/auth/signin"
 const GRAPHQL_URL = "https://axonhub.example.com/admin/graphql"
 
+const nativeNullBaseUrlChannel: AxonHubChannel = {
+  id: "gid://axonhub/Channel/native-null-base-url",
+  type: "openai",
+  baseURL: null,
+  name: "Native page channel",
+  status: AXON_HUB_CHANNEL_STATUS.ENABLED,
+  tags: ["table-tag"],
+  credentials: null,
+  supportedModels: ["model-alpha"],
+  manualModels: [],
+  defaultTestModel: "model-alpha",
+  settings: null,
+}
+
+const buildPinnedChannelSettings = () => ({
+  extraModelPrefix: null,
+  modelMappings: [{ from: "model-alpha", to: "model-upstream" }],
+  autoTrimedModelPrefixes: [],
+  hideOriginalModels: null,
+  hideMappedModels: null,
+  lowercaseModelId: null,
+  proxy: {
+    type: "URL",
+    url: null,
+    username: null,
+    password: null,
+  },
+  transformOptions: {
+    forceArrayInstructions: false,
+    forceArrayInputs: false,
+    replaceDeveloperRoleWithSystem: false,
+    reasoningEffortMapping: null,
+  },
+  headerOverrideOperations: [
+    {
+      op: "set",
+      path: null,
+      from: null,
+      to: null,
+      value: '{"enabled":true}',
+      condition: null,
+      match: null,
+      index: null,
+      splat: null,
+    },
+  ],
+  bodyOverrideOperations: [],
+  passThroughUserAgent: null,
+  passThroughBody: null,
+  rateLimit: {
+    rpm: null,
+    tpm: null,
+    maxConcurrent: null,
+    queueSize: null,
+    queueTimeoutMs: null,
+  },
+  retryableStatusCodes: [429],
+  retryableErrorPatterns: [{ pattern: "temporary", regex: false }],
+  providerQuota: {
+    opencodeGo: {
+      workspaceId: null,
+      authCookie: null,
+    },
+  },
+})
+
+const buildPinnedChannelCredentials = (
+  overrides: Record<string, unknown> = {},
+) => ({
+  apiKey: null,
+  apiKeys: null,
+  gcp: null,
+  oauth: null,
+  ...overrides,
+})
+
+const buildNativeChannelDetail = (
+  id: string,
+  overrides: Record<string, unknown> = {},
+) => ({
+  __typename: "Channel",
+  id,
+  createdAt: "2026-07-17T00:00:00Z",
+  updatedAt: "2026-07-17T00:00:00Z",
+  type: "openai",
+  baseURL: null,
+  name: "Native detail channel",
+  status: AXON_HUB_CHANNEL_STATUS.ENABLED,
+  policies: null,
+  credentials: null,
+  supportedModels: ["model-alpha"],
+  autoSyncSupportedModels: false,
+  autoSyncModelPattern: null,
+  manualModels: [],
+  tags: ["table-tag"],
+  defaultTestModel: "model-alpha",
+  settings: null,
+  orderingWeight: 0,
+  errorMessage: null,
+  remark: null,
+  endpoints: null,
+  disabledAPIKeys: null,
+  ...overrides,
+})
+
+const omitOutputField = (
+  value: Record<string, unknown>,
+  field: string,
+): Record<string, unknown> => {
+  const copy = { ...value }
+  delete copy[field]
+  return copy
+}
+
 const buildRequest = (): ApiServiceRequest => ({
   baseUrl: config.baseUrl,
   auth: {
@@ -46,7 +164,10 @@ const buildRequest = (): ApiServiceRequest => ({
 
 type AxonHubGraphqlRoute = {
   matches: (query: string) => boolean
-  respond: () => Response
+  respond: (request: {
+    query: string
+    variables?: Record<string, unknown>
+  }) => Response
 }
 
 function matchesGraphqlOperation(operationName: string) {
@@ -60,12 +181,15 @@ function useAxonHubGraphqlRoutes(params: {
   server.use(
     http.post(AUTH_URL, () => HttpResponse.json({ token: params.token })),
     http.post(GRAPHQL_URL, async ({ request }) => {
-      const body = (await request.json()) as { query?: string }
+      const body = (await request.json()) as {
+        query?: string
+        variables?: Record<string, unknown>
+      }
       const query = body.query ?? ""
       const route = params.routes.find((candidate) => candidate.matches(query))
 
       if (route) {
-        return route.respond()
+        return route.respond({ query, variables: body.variables })
       }
 
       return HttpResponse.json(
@@ -85,6 +209,974 @@ describe("AxonHub API service", () => {
   afterEach(() => {
     vi.unstubAllGlobals()
     vi.useRealTimers()
+  })
+
+  it("returns one native AxonHub channel page with its upstream cursor", async () => {
+    let capturedQuery = ""
+    let capturedVariables: Record<string, unknown> | undefined
+
+    useAxonHubGraphqlRoutes({
+      token: "page-token",
+      routes: [
+        {
+          matches: matchesGraphqlOperation("query ListAxonHubChannelPage"),
+          respond: ({ query, variables }) => {
+            capturedQuery = query
+            capturedVariables = variables
+            return HttpResponse.json({
+              data: {
+                queryChannels: {
+                  edges: [
+                    {
+                      node: nativeNullBaseUrlChannel,
+                      cursor: "edge-cursor",
+                    },
+                  ],
+                  pageInfo: {
+                    hasNextPage: true,
+                    endCursor: "upstream-next-cursor",
+                  },
+                  totalCount: 7,
+                },
+              },
+            })
+          },
+        },
+      ],
+    })
+
+    const page = await listAxonHubChannelPage(config, {
+      cursor: "upstream-current-cursor",
+      limit: 25,
+    })
+
+    expect(page).toEqual({
+      items: [
+        expect.objectContaining({
+          id: "gid://axonhub/Channel/native-null-base-url",
+          name: "Native page channel",
+          baseURL: null,
+          tags: ["table-tag"],
+        }),
+      ],
+      total: 7,
+      nextCursor: "upstream-next-cursor",
+    })
+    expect(page.items[0]).not.toHaveProperty("credentials")
+    expect(page.items[0]).not.toHaveProperty("settings")
+
+    expect(capturedQuery).toContain("queryChannels(input: $input)")
+    expect(capturedQuery).toContain("tags")
+    for (const detailOnlySelection of [
+      "settings",
+      "modelMappings",
+      "credentials",
+      "apiKey",
+      "apiKeys",
+      "oauth",
+      "accessToken",
+      "refreshToken",
+      "proxy",
+      "password",
+      "providerQuota",
+      "authCookie",
+      "headerOverrideOperations",
+      "bodyOverrideOperations",
+      "disabledAPIKeys",
+    ]) {
+      expect(capturedQuery).not.toContain(detailOnlySelection)
+    }
+    expect(capturedVariables).toEqual({
+      input: { first: 25, after: "upstream-current-cursor" },
+    })
+  })
+
+  it("loads native AxonHub detail by opaque GraphQL id", async () => {
+    const opaqueId = "gid://axonhub/Channel/native-detail"
+    let capturedQuery = ""
+    let capturedVariables: Record<string, unknown> | undefined
+
+    useAxonHubGraphqlRoutes({
+      token: "detail-token",
+      routes: [
+        {
+          matches: matchesGraphqlOperation("query GetAxonHubChannel"),
+          respond: ({ query, variables }) => {
+            capturedQuery = query
+            capturedVariables = variables
+            return HttpResponse.json({
+              data: {
+                node: buildNativeChannelDetail(opaqueId),
+              },
+            })
+          },
+        },
+      ],
+    })
+
+    await expect(getAxonHubChannel(config, opaqueId)).resolves.toMatchObject({
+      id: opaqueId,
+      name: "Native detail channel",
+      baseURL: null,
+      credentials: null,
+    })
+    expect(capturedQuery).toContain("__typename")
+    expect(capturedVariables).toEqual({ id: opaqueId })
+  })
+
+  it("accepts a complete pinned authoritative channel output", async () => {
+    const id = "complete-pinned-output"
+    const completeChannel = buildNativeChannelDetail(id, {
+      policies: { stream: null },
+      credentials: {
+        apiKey: null,
+        apiKeys: [],
+        gcp: {
+          region: "example-region",
+          projectID: "example-project",
+          jsonData: "{}",
+        },
+        oauth: {
+          accessToken: null,
+          refreshToken: null,
+          clientID: null,
+          expiresAt: null,
+          tokenType: null,
+          scopes: [],
+        },
+      },
+      settings: buildPinnedChannelSettings(),
+      endpoints: [
+        {
+          apiFormat: "openai",
+          path: null,
+          baseURL: null,
+          transport: null,
+        },
+      ],
+      disabledAPIKeys: [
+        {
+          key: "placeholder-key",
+          disabledAt: "2026-07-17T00:00:00Z",
+          errorCode: 401,
+          reason: null,
+        },
+      ],
+    })
+
+    useAxonHubGraphqlRoutes({
+      token: "complete-output-token",
+      routes: [
+        {
+          matches: matchesGraphqlOperation("query GetAxonHubChannel"),
+          respond: () => HttpResponse.json({ data: { node: completeChannel } }),
+        },
+      ],
+    })
+
+    await expect(getAxonHubChannel(config, id)).resolves.toMatchObject({
+      id,
+      settings: {
+        headerOverrideOperations: [
+          expect.objectContaining({ value: '{"enabled":true}' }),
+        ],
+        bodyOverrideOperations: [],
+      },
+    })
+  })
+
+  it("selects every pinned beta5 settings field required for replacement preservation", async () => {
+    let detailQuery = ""
+
+    useAxonHubGraphqlRoutes({
+      token: "settings-selection-token",
+      routes: [
+        {
+          matches: matchesGraphqlOperation("query GetAxonHubChannel"),
+          respond: ({ query }) => {
+            detailQuery = query
+            return HttpResponse.json({
+              data: {
+                node: buildNativeChannelDetail("opaque-settings-id", {
+                  baseURL: "https://settings.example.invalid/v1",
+                  name: "Settings channel",
+                  supportedModels: [],
+                }),
+              },
+            })
+          },
+        },
+      ],
+    })
+
+    await getAxonHubChannel(config, "opaque-settings-id")
+
+    expect(detailQuery).toMatch(/settings\s*\{[^}]*extraModelPrefix/s)
+    expect(detailQuery).toMatch(/modelMappings\s*\{\s*from\s+to\s*\}/s)
+    expect(detailQuery).toContain("autoTrimedModelPrefixes")
+    expect(detailQuery).toContain("hideOriginalModels")
+    expect(detailQuery).toContain("hideMappedModels")
+    expect(detailQuery).toContain("lowercaseModelId")
+    expect(detailQuery).toMatch(
+      /proxy\s*\{\s*type\s+url\s+username\s+password\s*\}/s,
+    )
+    expect(detailQuery).toMatch(
+      /transformOptions\s*\{[^}]*forceArrayInstructions[^}]*forceArrayInputs[^}]*replaceDeveloperRoleWithSystem[^}]*reasoningEffortMapping\s*\{\s*from\s+to\s*\}/s,
+    )
+    for (const selection of [
+      "headerOverrideOperations",
+      "bodyOverrideOperations",
+    ]) {
+      expect(detailQuery).toMatch(
+        new RegExp(
+          `${selection}\\s*\\{[^}]*op[^}]*path[^}]*from[^}]*to[^}]*value[^}]*condition[^}]*match\\s*\\{\\s*path\\s+eq\\s*\\}[^}]*index[^}]*splat`,
+          "s",
+        ),
+      )
+    }
+    expect(detailQuery).toContain("passThroughUserAgent")
+    expect(detailQuery).toContain("passThroughBody")
+    expect(detailQuery).toMatch(
+      /rateLimit\s*\{\s*rpm\s+tpm\s+maxConcurrent\s+queueSize\s+queueTimeoutMs\s*\}/s,
+    )
+    expect(detailQuery).toContain("retryableStatusCodes")
+    expect(detailQuery).toMatch(
+      /retryableErrorPatterns\s*\{\s*pattern\s+regex\s*\}/s,
+    )
+    expect(detailQuery).toMatch(
+      /providerQuota\s*\{\s*opencodeGo\s*\{\s*workspaceId\s+authCookie\s*\}\s*\}/s,
+    )
+  })
+
+  it("rejects malformed native detail nodes as controlled protocol failures", async () => {
+    const malformedNodes = [
+      "not-an-object",
+      { __typename: "User", id: "wrong-type" },
+      { __typename: "Channel", name: "missing-id" },
+    ]
+    let responseIndex = 0
+
+    useAxonHubGraphqlRoutes({
+      token: "malformed-detail-token",
+      routes: [
+        {
+          matches: matchesGraphqlOperation("query GetAxonHubChannel"),
+          respond: () =>
+            HttpResponse.json({
+              data: { node: malformedNodes[responseIndex++] },
+            }),
+        },
+      ],
+    })
+
+    for (const [index] of malformedNodes.entries()) {
+      await expect(
+        getAxonHubChannel(config, `malformed-detail-${index}`),
+      ).rejects.toMatchObject({
+        kind: "protocol",
+        dispatch: "not-dispatched",
+        message: "protocol",
+      })
+    }
+  })
+
+  it("rejects a native detail response retargeted to another channel", async () => {
+    useAxonHubGraphqlRoutes({
+      token: "retargeted-detail-token",
+      routes: [
+        {
+          matches: matchesGraphqlOperation("query GetAxonHubChannel"),
+          respond: () =>
+            HttpResponse.json({
+              data: {
+                node: buildNativeChannelDetail("different-channel-id"),
+              },
+            }),
+        },
+      ],
+    })
+
+    await expect(
+      getAxonHubChannel(config, "requested-channel-id"),
+    ).rejects.toMatchObject({
+      kind: "protocol",
+      dispatch: "not-dispatched",
+      message: "protocol",
+    })
+  })
+
+  it("rejects malformed authoritative nested channel fields", async () => {
+    const malformedDetails = [
+      { credentials: { apiKeys: ["valid-key", 42] } },
+      { credentials: { oauth: { scopes: ["scope", false] } } },
+      { settings: { modelMappings: [null] } },
+      { settings: { proxy: { type: "http", url: 42 } } },
+      { settings: { rateLimit: { rpm: "fast" } } },
+      { settings: { rateLimit: { queueTimeoutMs: 1.5 } } },
+      {
+        settings: {
+          providerQuota: { opencodeGo: { workspaceId: 42 } },
+        },
+      },
+      { endpoints: [{ apiFormat: "openai", path: 42 }] },
+    ]
+    let responseIndex = 0
+
+    useAxonHubGraphqlRoutes({
+      token: "malformed-nested-detail-token",
+      routes: [
+        {
+          matches: matchesGraphqlOperation("query GetAxonHubChannel"),
+          respond: () => {
+            const index = responseIndex++
+            return HttpResponse.json({
+              data: {
+                node: buildNativeChannelDetail(
+                  `malformed-nested-${index}`,
+                  malformedDetails[index],
+                ),
+              },
+            })
+          },
+        },
+      ],
+    })
+
+    for (const [index] of malformedDetails.entries()) {
+      await expect(
+        getAxonHubChannel(config, `malformed-nested-${index}`),
+      ).rejects.toMatchObject({
+        kind: "protocol",
+        dispatch: "not-dispatched",
+        message: "protocol",
+      })
+    }
+  })
+
+  it("rejects incomplete pinned authoritative output fields", async () => {
+    const completeSettings = buildPinnedChannelSettings()
+    const invalidDetails = [
+      omitOutputField(
+        buildNativeChannelDetail("missing-created-at"),
+        "createdAt",
+      ),
+      buildNativeChannelDetail("null-updated-at", { updatedAt: null }),
+      omitOutputField(
+        buildNativeChannelDetail("missing-supported-models"),
+        "supportedModels",
+      ),
+      buildNativeChannelDetail("null-supported-models", {
+        supportedModels: null,
+      }),
+      buildNativeChannelDetail("null-supported-model-entry", {
+        supportedModels: ["model-alpha", null],
+      }),
+      omitOutputField(
+        buildNativeChannelDetail("missing-auto-sync"),
+        "autoSyncSupportedModels",
+      ),
+      buildNativeChannelDetail("null-auto-sync", {
+        autoSyncSupportedModels: null,
+      }),
+      buildNativeChannelDetail("null-default-model", {
+        defaultTestModel: null,
+      }),
+      omitOutputField(
+        buildNativeChannelDetail("missing-ordering-weight"),
+        "orderingWeight",
+      ),
+      buildNativeChannelDetail("fractional-ordering-weight", {
+        orderingWeight: 1.5,
+      }),
+      buildNativeChannelDetail("missing-header-overrides", {
+        settings: omitOutputField(completeSettings, "headerOverrideOperations"),
+      }),
+      buildNativeChannelDetail("null-body-overrides", {
+        settings: { ...completeSettings, bodyOverrideOperations: null },
+      }),
+      buildNativeChannelDetail("missing-transform-boolean", {
+        settings: {
+          ...completeSettings,
+          transformOptions: omitOutputField(
+            completeSettings.transformOptions,
+            "forceArrayInputs",
+          ),
+        },
+      }),
+      buildNativeChannelDetail("missing-retry-regex", {
+        settings: {
+          ...completeSettings,
+          retryableErrorPatterns: [{ pattern: "temporary" }],
+        },
+      }),
+    ]
+    let responseIndex = 0
+
+    useAxonHubGraphqlRoutes({
+      token: "incomplete-output-token",
+      routes: [
+        {
+          matches: matchesGraphqlOperation("query GetAxonHubChannel"),
+          respond: () =>
+            HttpResponse.json({
+              data: { node: invalidDetails[responseIndex++] },
+            }),
+        },
+      ],
+    })
+
+    for (const detail of invalidDetails) {
+      await expect(
+        getAxonHubChannel(config, detail.id as string),
+      ).rejects.toMatchObject({
+        kind: "protocol",
+        dispatch: "not-dispatched",
+        message: "protocol",
+      })
+    }
+  })
+
+  it("rejects malformed native pages instead of silently truncating them", async () => {
+    const malformedConnections = [
+      {
+        edges: [{ node: "not-a-channel" }],
+        pageInfo: { hasNextPage: false, endCursor: null },
+        totalCount: 1,
+      },
+      {
+        edges: [],
+        pageInfo: { hasNextPage: true, endCursor: "" },
+        totalCount: 0,
+      },
+      {
+        edges: [],
+        pageInfo: "not-page-info",
+        totalCount: 0,
+      },
+      {
+        edges: [],
+        pageInfo: { hasNextPage: false, endCursor: null },
+        totalCount: "1",
+      },
+      {
+        edges: [],
+        pageInfo: { hasNextPage: false, endCursor: null },
+        totalCount: -1,
+      },
+      {
+        edges: [
+          {
+            node: {
+              ...nativeNullBaseUrlChannel,
+              tags: ["valid-tag", 42],
+            },
+            cursor: "malformed-tags-cursor",
+          },
+        ],
+        pageInfo: { hasNextPage: false, endCursor: null },
+        totalCount: 1,
+      },
+    ]
+    let responseIndex = 0
+
+    useAxonHubGraphqlRoutes({
+      token: "malformed-page-token",
+      routes: [
+        {
+          matches: matchesGraphqlOperation("query ListAxonHubChannelPage"),
+          respond: () =>
+            HttpResponse.json({
+              data: { queryChannels: malformedConnections[responseIndex++] },
+            }),
+        },
+      ],
+    })
+
+    for (const [index] of malformedConnections.entries()) {
+      await expect(
+        listAxonHubChannelPage(config, { limit: 10, cursor: `${index}` }),
+      ).rejects.toMatchObject({
+        kind: "protocol",
+        dispatch: "not-dispatched",
+        message: "protocol",
+      })
+    }
+  })
+
+  it("sends verified update and clear fields unchanged", async () => {
+    let capturedVariables: Record<string, unknown> | undefined
+    const input = {
+      status: AXON_HUB_CHANNEL_STATUS.DISABLED,
+      supportedModels: ["model-alpha"],
+      appendSupportedModels: ["model-beta"],
+      manualModels: ["manual-alpha"],
+      appendManualModels: ["manual-beta"],
+      tags: ["primary"],
+      appendTags: ["secondary"],
+      endpoints: [{ apiFormat: "openai/chat_completions", path: "/v1/chat" }],
+      appendEndpoints: [
+        { apiFormat: "openai/responses", path: "/v1/responses" },
+      ],
+      settings: {
+        extraModelPrefix: "replacement-prefix",
+        modelMappings: [{ from: "model-alpha", to: "model-upstream" }],
+        autoTrimedModelPrefixes: ["provider"],
+        hideOriginalModels: true,
+        hideMappedModels: false,
+        lowercaseModelId: true,
+        proxy: {
+          type: "URL",
+          url: "https://proxy.example.invalid",
+          username: "proxy-user",
+          password: "proxy-password",
+        },
+        transformOptions: {
+          forceArrayInstructions: true,
+          forceArrayInputs: false,
+          replaceDeveloperRoleWithSystem: true,
+          reasoningEffortMapping: [{ from: "high", to: "maximum" }],
+        },
+        headerOverrideOperations: [
+          {
+            op: "array_insert",
+            path: "X-Test",
+            from: "X-Source",
+            to: "X-Target",
+            value: "header-value",
+            condition: "enabled",
+            match: { path: "kind", eq: "example" },
+            index: 1,
+            splat: false,
+          },
+        ],
+        bodyOverrideOperations: [
+          {
+            op: "array_remove",
+            path: "items",
+            from: "source",
+            to: "target",
+            value: "body-value",
+            condition: "enabled",
+            match: { path: "kind", eq: "example" },
+            index: 2,
+            splat: true,
+          },
+        ],
+        passThroughUserAgent: null,
+        passThroughBody: true,
+        rateLimit: {
+          rpm: 10,
+          tpm: 20,
+          maxConcurrent: 3,
+          queueSize: 4,
+          queueTimeoutMs: 500,
+        },
+        retryableStatusCodes: [408, 429],
+        retryableErrorPatterns: [{ pattern: "temporary", regex: false }],
+        providerQuota: {
+          opencodeGo: {
+            workspaceId: "workspace-example",
+            authCookie: "cookie-example",
+          },
+        },
+      },
+      clearBaseURL: true,
+      clearManualModels: true,
+      clearAutoSyncModelPattern: true,
+      clearTags: true,
+      clearPolicies: true,
+      clearSettings: true,
+      clearErrorMessage: true,
+      clearRemark: true,
+      clearEndpoints: true,
+    }
+
+    useAxonHubGraphqlRoutes({
+      token: "update-fields-token",
+      routes: [
+        {
+          matches: matchesGraphqlOperation("mutation UpdateChannel"),
+          respond: ({ variables }) => {
+            capturedVariables = variables
+            return HttpResponse.json({
+              data: {
+                updateChannel: buildNativeChannelDetail("opaque-update-id", {
+                  baseURL: "https://updated.example.invalid/v1",
+                  name: "Updated channel",
+                  status: AXON_HUB_CHANNEL_STATUS.DISABLED,
+                  supportedModels: ["model-alpha", "model-beta"],
+                }),
+              },
+            })
+          },
+        },
+      ],
+    })
+
+    await updateAxonHubChannel(config, "opaque-update-id", input)
+
+    expect(capturedVariables).toEqual({ id: "opaque-update-id", input })
+  })
+
+  it("rejects malformed mutation roots with dispatched protocol failures", async () => {
+    useAxonHubGraphqlRoutes({
+      token: "malformed-mutation-token",
+      routes: [
+        {
+          matches: matchesGraphqlOperation("mutation CreateChannel"),
+          respond: () => HttpResponse.json({ data: { createChannel: true } }),
+        },
+        {
+          matches: matchesGraphqlOperation("mutation UpdateChannel"),
+          respond: () =>
+            HttpResponse.json({
+              data: {
+                updateChannel: buildNativeChannelDetail("malformed-update", {
+                  settings: { modelMappings: [null] },
+                }),
+              },
+            }),
+        },
+        {
+          matches: matchesGraphqlOperation("mutation UpdateChannelStatus"),
+          respond: () =>
+            HttpResponse.json({
+              data: { updateChannelStatus: { id: "missing-status" } },
+            }),
+        },
+        {
+          matches: matchesGraphqlOperation("mutation DeleteChannel"),
+          respond: () => HttpResponse.json({ data: { deleteChannel: "yes" } }),
+        },
+      ],
+    })
+
+    const expectedFailure = {
+      kind: "protocol",
+      dispatch: "dispatched",
+      message: "protocol",
+    }
+    await expect(
+      createAxonHubChannel(config, {
+        type: "openai",
+        name: "Malformed create",
+        credentials: { apiKeys: ["placeholder-key"] },
+        supportedModels: ["model-alpha"],
+        defaultTestModel: "model-alpha",
+      }),
+    ).rejects.toMatchObject(expectedFailure)
+    await expect(
+      updateAxonHubChannel(config, "malformed-update", {
+        name: "Malformed update",
+      }),
+    ).rejects.toMatchObject(expectedFailure)
+    await expect(
+      updateAxonHubChannelStatus(
+        config,
+        "malformed-status",
+        AXON_HUB_CHANNEL_STATUS.ENABLED,
+      ),
+    ).rejects.toMatchObject(expectedFailure)
+    await expect(
+      deleteAxonHubChannel(config, "malformed-delete"),
+    ).rejects.toMatchObject(expectedFailure)
+  })
+
+  it("correlates authoritative mutation channel identities and status", async () => {
+    const capturedQueries: string[] = []
+    let statusResponse = 0
+
+    useAxonHubGraphqlRoutes({
+      token: "mutation-correlation-token",
+      routes: [
+        {
+          matches: matchesGraphqlOperation("mutation CreateChannel"),
+          respond: ({ query }) => {
+            capturedQueries.push(query)
+            return HttpResponse.json({
+              data: {
+                createChannel: buildNativeChannelDetail("created-id", {
+                  __typename: "User",
+                }),
+              },
+            })
+          },
+        },
+        {
+          matches: matchesGraphqlOperation("mutation UpdateChannel("),
+          respond: ({ query }) => {
+            capturedQueries.push(query)
+            return HttpResponse.json({
+              data: {
+                updateChannel: buildNativeChannelDetail("retargeted-id"),
+              },
+            })
+          },
+        },
+        {
+          matches: matchesGraphqlOperation("mutation UpdateChannelStatus"),
+          respond: ({ query, variables }) => {
+            capturedQueries.push(query)
+            statusResponse += 1
+            return HttpResponse.json({
+              data: {
+                updateChannelStatus: {
+                  __typename: "Channel",
+                  id:
+                    statusResponse === 1
+                      ? "retargeted-status-id"
+                      : variables?.id,
+                  status:
+                    statusResponse === 2
+                      ? AXON_HUB_CHANNEL_STATUS.DISABLED
+                      : variables?.status,
+                },
+              },
+            })
+          },
+        },
+      ],
+    })
+
+    const expectedFailure = {
+      kind: "protocol",
+      dispatch: "dispatched",
+      message: "protocol",
+    }
+    await expect(
+      createAxonHubChannel(config, {
+        type: "openai",
+        name: "Wrong typename",
+        credentials: { apiKeys: ["placeholder-key"] },
+        supportedModels: ["model-alpha"],
+        defaultTestModel: "model-alpha",
+      }),
+    ).rejects.toMatchObject(expectedFailure)
+    await expect(
+      updateAxonHubChannel(config, "requested-update-id", {
+        name: "Retargeted update",
+      }),
+    ).rejects.toMatchObject(expectedFailure)
+    await expect(
+      updateAxonHubChannelStatus(
+        config,
+        "status-id",
+        AXON_HUB_CHANNEL_STATUS.ENABLED,
+      ),
+    ).rejects.toMatchObject(expectedFailure)
+    await expect(
+      updateAxonHubChannelStatus(
+        config,
+        "status-id",
+        AXON_HUB_CHANNEL_STATUS.ENABLED,
+      ),
+    ).rejects.toMatchObject(expectedFailure)
+    await expect(
+      updateAxonHubChannelStatus(
+        config,
+        "status-id",
+        AXON_HUB_CHANNEL_STATUS.ENABLED,
+      ),
+    ).resolves.toEqual({
+      id: "status-id",
+      status: AXON_HUB_CHANNEL_STATUS.ENABLED,
+    })
+
+    expect(capturedQueries).toHaveLength(5)
+    for (const query of capturedQueries) {
+      expect(query).toContain("__typename")
+    }
+  })
+
+  it("omits or passes null create baseURL according to the native protocol", async () => {
+    const capturedInputs: unknown[] = []
+    const omittedBaseUrlInput: AxonHubCreateChannelInput = {
+      type: "openai",
+      name: "No base URL",
+      credentials: { apiKeys: ["placeholder-key"] },
+      supportedModels: ["model-alpha"],
+      defaultTestModel: "model-alpha",
+    }
+    const nullBaseUrlInput: AxonHubCreateChannelInput = {
+      ...omittedBaseUrlInput,
+      name: "Null base URL",
+      baseURL: null,
+    }
+
+    useAxonHubGraphqlRoutes({
+      token: "nullable-create-token",
+      routes: [
+        {
+          matches: matchesGraphqlOperation("mutation CreateChannel"),
+          respond: ({ variables }) => {
+            capturedInputs.push(variables?.input)
+            return HttpResponse.json({
+              data: {
+                createChannel: buildNativeChannelDetail(
+                  `nullable-create-${capturedInputs.length}`,
+                  {
+                    name: "Created channel",
+                  },
+                ),
+              },
+            })
+          },
+        },
+      ],
+    })
+
+    await createAxonHubChannel(config, omittedBaseUrlInput)
+    await createAxonHubChannel(config, nullBaseUrlInput)
+
+    expect(capturedInputs).toEqual([omittedBaseUrlInput, nullBaseUrlInput])
+  })
+
+  it("normalizes a null native baseURL only in the legacy projection", () => {
+    const projected = axonHubChannelToManagedSite(nativeNullBaseUrlChannel)
+
+    expect(projected.base_url).toBe("")
+    expect(projected._axonHubData.baseURL).toBeNull()
+  })
+
+  it("classifies abort before mutation dispatch as not-dispatched", async () => {
+    const controller = new AbortController()
+    controller.abort()
+    const fetchSpy = vi.spyOn(globalThis, "fetch")
+
+    await expect(
+      updateAxonHubChannel(
+        config,
+        "opaque-pre-abort",
+        { name: "Ignored" },
+        {
+          signal: controller.signal,
+        },
+      ),
+    ).rejects.toMatchObject({
+      name: "AxonHubRequestError",
+      kind: "aborted",
+      dispatch: "not-dispatched",
+      message: "aborted",
+    })
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it("classifies abort after mutation dispatch as dispatched", async () => {
+    const controller = new AbortController()
+    let mutationSignal: AbortSignal | undefined
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((url: string, init?: RequestInit) => {
+        if (url.endsWith("/admin/auth/signin")) {
+          return Promise.resolve(
+            new Response(JSON.stringify({ token: "mutation-abort-token" }), {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            }),
+          )
+        }
+
+        mutationSignal = init?.signal ?? undefined
+        return new Promise((_resolve, reject) => {
+          mutationSignal?.addEventListener("abort", () => {
+            reject(
+              mutationSignal?.reason ??
+                new DOMException("The operation was aborted", "AbortError"),
+            )
+          })
+        })
+      }),
+    )
+
+    const request = updateAxonHubChannel(
+      config,
+      "opaque-inflight-abort",
+      { name: "Interrupted" },
+      { signal: controller.signal },
+    )
+    const expectation = expect(request).rejects.toMatchObject({
+      name: "AxonHubRequestError",
+      kind: "aborted",
+      dispatch: "dispatched",
+      message: "aborted",
+    })
+
+    await vi.waitFor(() => expect(mutationSignal).toBe(controller.signal))
+    controller.abort()
+    await expectation
+  })
+
+  it("classifies an abort while consuming a mutation body as dispatched", async () => {
+    const abortError = new Error("body consumption cancelled")
+    abortError.name = "AbortError"
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((url: string) => {
+        if (url.endsWith("/admin/auth/signin")) {
+          return Promise.resolve(
+            new Response(JSON.stringify({ token: "body-abort-token" }), {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            }),
+          )
+        }
+
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: vi.fn().mockRejectedValue(abortError),
+        } as unknown as Response)
+      }),
+    )
+
+    await expect(
+      updateAxonHubChannel(config, "body-abort", { name: "Interrupted" }),
+    ).rejects.toMatchObject({
+      kind: "aborted",
+      dispatch: "dispatched",
+      message: "aborted",
+    })
+  })
+
+  it("retains controlled status and dispatch phase in AxonHub protocol failures", async () => {
+    let authHits = 0
+    let graphQlHits = 0
+
+    server.use(
+      http.post(AUTH_URL, () => {
+        authHits += 1
+        return HttpResponse.json({ token: `permission-token-${authHits}` })
+      }),
+      http.post(GRAPHQL_URL, () => {
+        graphQlHits += 1
+        return HttpResponse.json(
+          {
+            errors: [
+              {
+                message:
+                  graphQlHits === 1 ? "expired token" : "permission denied",
+              },
+            ],
+          },
+          { status: graphQlHits === 1 ? 401 : 403 },
+        )
+      }),
+    )
+
+    const failure = await updateAxonHubChannel(config, "opaque-permission-id", {
+      name: "Rejected",
+    }).catch((error: unknown) => error)
+
+    expect(failure).toBeInstanceOf(AxonHubRequestError)
+    expect(failure).toMatchObject({
+      kind: "permission",
+      dispatch: "dispatched",
+      message: "permission",
+    })
+    expect(authHits).toBe(2)
+    expect(graphQlHits).toBe(2)
   })
 
   it("signs in against the normalized admin endpoint and returns the token", async () => {
@@ -108,7 +1200,26 @@ describe("AxonHub API service", () => {
     })
   })
 
-  it("uses the upstream message when AxonHub rejects admin credentials", async () => {
+  it("classifies an abort while consuming a sign-in body as not-dispatched", async () => {
+    const abortError = new Error("sign-in body cancelled")
+    abortError.name = "AbortError"
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: vi.fn().mockRejectedValue(abortError),
+      } as unknown as Response),
+    )
+
+    await expect(signIn(config)).rejects.toMatchObject({
+      kind: "aborted",
+      dispatch: "not-dispatched",
+      message: "aborted",
+    })
+  })
+
+  it("classifies rejected admin credentials without exposing response body", async () => {
     server.use(
       http.post(AUTH_URL, () =>
         HttpResponse.json(
@@ -122,20 +1233,59 @@ describe("AxonHub API service", () => {
 
     await expect(
       signIn({ ...config, email: "invalid@example.com" }),
-    ).rejects.toThrow("Invalid email or password")
+    ).rejects.toMatchObject({
+      kind: "authentication",
+      dispatch: "not-dispatched",
+      message: "authentication",
+    })
   })
 
-  it("includes the HTTP status when AxonHub sign-in fails without a response message", async () => {
+  it("classifies other sign-in rejections without exposing response body", async () => {
     server.use(
       http.post(AUTH_URL, () => HttpResponse.json({}, { status: 403 })),
     )
 
     await expect(
       signIn({ ...config, email: "cors@example.com" }),
-    ).rejects.toThrow("AxonHub sign-in failed (HTTP 403)")
+    ).rejects.toMatchObject({
+      kind: "authentication",
+      dispatch: "not-dispatched",
+      message: "authentication",
+    })
   })
 
-  it("redacts bearer tokens from GraphQL error messages", async () => {
+  it("classifies an unavailable AxonHub sign-in endpoint separately from credential rejection", async () => {
+    server.use(
+      http.post(AUTH_URL, () =>
+        HttpResponse.json(
+          { message: "internal details must stay private" },
+          { status: 503 },
+        ),
+      ),
+    )
+
+    await expect(
+      signIn({ ...config, email: "unavailable@example.com" }),
+    ).rejects.toMatchObject({
+      kind: "unavailable",
+      dispatch: "not-dispatched",
+      message: "unavailable",
+    })
+  })
+
+  it("classifies a malformed successful sign-in response as a protocol failure", async () => {
+    server.use(http.post(AUTH_URL, () => HttpResponse.json(null)))
+
+    await expect(
+      signIn({ ...config, email: "malformed@example.com" }),
+    ).rejects.toMatchObject({
+      kind: "protocol",
+      dispatch: "not-dispatched",
+      message: "protocol",
+    })
+  })
+
+  it("does not expose GraphQL response messages", async () => {
     server.use(
       http.post(AUTH_URL, () =>
         HttpResponse.json({ token: "graphql-redaction-token" }),
@@ -154,7 +1304,335 @@ describe("AxonHub API service", () => {
         undefined,
         { retryAuth: false },
       ),
-    ).rejects.toThrow("Bearer [redacted] is expired")
+    ).rejects.toMatchObject({
+      kind: "upstream-rejected",
+      dispatch: "not-dispatched",
+      message: "upstream-rejected",
+    })
+  })
+
+  it("classifies HTTP 500 GraphQL errors as unavailable by dispatch phase", async () => {
+    let authHits = 0
+    let graphQlHits = 0
+
+    server.use(
+      http.post(AUTH_URL, () => {
+        authHits += 1
+        return HttpResponse.json({ token: "server-error-token" })
+      }),
+      http.post(GRAPHQL_URL, () => {
+        graphQlHits += 1
+        return HttpResponse.json(
+          { errors: [{ message: "operation failed" }] },
+          { status: 500 },
+        )
+      }),
+    )
+
+    await expect(
+      graphqlRequest(
+        { ...config, email: "server-error@example.com" },
+        "query ServerErrorRead",
+      ),
+    ).rejects.toMatchObject({
+      kind: "unavailable",
+      dispatch: "not-dispatched",
+      message: "unavailable",
+    })
+    await expect(
+      graphqlRequest(
+        { ...config, email: "server-error@example.com" },
+        "mutation ServerErrorWrite { updateThing }",
+      ),
+    ).rejects.toMatchObject({
+      kind: "unavailable",
+      dispatch: "dispatched",
+      message: "unavailable",
+    })
+
+    expect(authHits).toBe(1)
+    expect(graphQlHits).toBe(2)
+  })
+
+  it("does not refresh or replay a forbidden mutation", async () => {
+    let authHits = 0
+    let graphQlHits = 0
+
+    server.use(
+      http.post(AUTH_URL, () => {
+        authHits += 1
+        return HttpResponse.json({ token: `forbidden-token-${authHits}` })
+      }),
+      http.post(GRAPHQL_URL, () => {
+        graphQlHits += 1
+        return HttpResponse.json(
+          {
+            errors: [
+              {
+                message: "request rejected",
+                extensions: { code: "FORBIDDEN" },
+              },
+            ],
+          },
+          { status: 403 },
+        )
+      }),
+    )
+
+    await expect(
+      graphqlRequest(
+        { ...config, email: "forbidden-mutation@example.com" },
+        "mutation ForbiddenWrite { updateThing }",
+      ),
+    ).rejects.toMatchObject({
+      kind: "permission",
+      dispatch: "dispatched",
+      message: "permission",
+    })
+    expect(authHits).toBe(1)
+    expect(graphQlHits).toBe(1)
+  })
+
+  it("marks a mutation not dispatched when refresh sign-in fails before replay", async () => {
+    let authHits = 0
+    let graphQlHits = 0
+
+    server.use(
+      http.post(AUTH_URL, () => {
+        authHits += 1
+        if (authHits === 1) {
+          return HttpResponse.json({ token: "initial-mutation-token" })
+        }
+        return HttpResponse.json({ message: "unavailable" }, { status: 503 })
+      }),
+      http.post(GRAPHQL_URL, () => {
+        graphQlHits += 1
+        return HttpResponse.json(
+          {
+            errors: [
+              {
+                message: "request rejected",
+                extensions: { code: "UNAUTHENTICATED" },
+              },
+            ],
+          },
+          { status: 401 },
+        )
+      }),
+    )
+
+    await expect(
+      graphqlRequest(
+        { ...config, email: "refresh-failure@example.com" },
+        "mutation RefreshFailure { updateThing }",
+      ),
+    ).rejects.toMatchObject({
+      kind: "unavailable",
+      dispatch: "not-dispatched",
+      message: "unavailable",
+    })
+    expect(authHits).toBe(2)
+    expect(graphQlHits).toBe(1)
+  })
+
+  it("marks a mutation not dispatched when aborted before auth replay", async () => {
+    const controller = new AbortController()
+    let authHits = 0
+    let graphQlHits = 0
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((url: string) => {
+        if (url.endsWith("/admin/auth/signin")) {
+          authHits += 1
+          return Promise.resolve(
+            new Response(JSON.stringify({ token: "initial-abort-token" }), {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            }),
+          )
+        }
+
+        graphQlHits += 1
+        controller.abort()
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              errors: [
+                {
+                  message: "request rejected",
+                  extensions: { code: "UNAUTHENTICATED" },
+                },
+              ],
+            }),
+            {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            },
+          ),
+        )
+      }),
+    )
+
+    await expect(
+      graphqlRequest(
+        { ...config, email: "pre-replay-abort@example.com" },
+        "mutation PreReplayAbort { updateThing }",
+        undefined,
+        { signal: controller.signal },
+      ),
+    ).rejects.toMatchObject({
+      kind: "aborted",
+      dispatch: "not-dispatched",
+      message: "aborted",
+    })
+    expect(authHits).toBe(1)
+    expect(graphQlHits).toBe(1)
+  })
+
+  it("refreshes only for an explicit UNAUTHENTICATED GraphQL code", async () => {
+    let authHits = 0
+    let graphQlHits = 0
+
+    server.use(
+      http.post(AUTH_URL, () => {
+        authHits += 1
+        return HttpResponse.json({ token: `coded-auth-token-${authHits}` })
+      }),
+      http.post(GRAPHQL_URL, () => {
+        graphQlHits += 1
+        return HttpResponse.json({
+          errors: [
+            {
+              message: "request rejected",
+              extensions: { code: "UNAUTHENTICATED" },
+            },
+          ],
+        })
+      }),
+    )
+
+    await expect(
+      graphqlRequest(
+        { ...config, email: "coded-auth@example.com" },
+        "query CodedAuthentication",
+      ),
+    ).rejects.toMatchObject({
+      kind: "authentication",
+      dispatch: "not-dispatched",
+      message: "authentication",
+    })
+    expect(authHits).toBe(2)
+    expect(graphQlHits).toBe(2)
+  })
+
+  it("classifies an explicit FORBIDDEN GraphQL code without refreshing", async () => {
+    let authHits = 0
+    let graphQlHits = 0
+
+    server.use(
+      http.post(AUTH_URL, () => {
+        authHits += 1
+        return HttpResponse.json({
+          token: `coded-permission-token-${authHits}`,
+        })
+      }),
+      http.post(GRAPHQL_URL, () => {
+        graphQlHits += 1
+        return HttpResponse.json({
+          errors: [
+            {
+              message: "request rejected",
+              extensions: { code: "FORBIDDEN" },
+            },
+          ],
+        })
+      }),
+    )
+
+    await expect(
+      graphqlRequest(
+        { ...config, email: "coded-permission@example.com" },
+        "query CodedPermission",
+      ),
+    ).rejects.toMatchObject({
+      kind: "permission",
+      dispatch: "not-dispatched",
+      message: "permission",
+    })
+    expect(authHits).toBe(1)
+    expect(graphQlHits).toBe(1)
+  })
+
+  it("rejects malformed GraphQL extension codes as protocol failures", async () => {
+    server.use(
+      http.post(AUTH_URL, () =>
+        HttpResponse.json({ token: "malformed-extension-token" }),
+      ),
+      http.post(GRAPHQL_URL, () =>
+        HttpResponse.json({
+          errors: [
+            {
+              message: "request rejected",
+              extensions: { code: 403 },
+            },
+          ],
+        }),
+      ),
+    )
+
+    await expect(
+      graphqlRequest(
+        { ...config, email: "malformed-extension@example.com" },
+        "query MalformedExtension",
+      ),
+    ).rejects.toMatchObject({
+      kind: "protocol",
+      dispatch: "not-dispatched",
+      message: "protocol",
+    })
+  })
+
+  it("classifies malformed successful GraphQL payloads as protocol failures", async () => {
+    server.use(
+      http.post(AUTH_URL, () =>
+        HttpResponse.json({ token: "malformed-graphql-token" }),
+      ),
+      http.post(GRAPHQL_URL, () => HttpResponse.json(null)),
+    )
+
+    await expect(
+      graphqlRequest(
+        { ...config, email: "malformed-graphql@example.com" },
+        "query MalformedPayload",
+      ),
+    ).rejects.toMatchObject({
+      kind: "protocol",
+      dispatch: "not-dispatched",
+      message: "protocol",
+    })
+  })
+
+  it("rejects malformed GraphQL error envelopes as protocol failures", async () => {
+    server.use(
+      http.post(AUTH_URL, () =>
+        HttpResponse.json({ token: "malformed-errors-token" }),
+      ),
+      http.post(GRAPHQL_URL, () =>
+        HttpResponse.json({ errors: "not-an-error-array" }),
+      ),
+    )
+
+    await expect(
+      graphqlRequest(
+        { ...config, email: "malformed-errors@example.com" },
+        "query MalformedErrors",
+      ),
+    ).rejects.toMatchObject({
+      kind: "protocol",
+      dispatch: "not-dispatched",
+      message: "protocol",
+    })
   })
 
   it("does not retry for generic token validation errors", async () => {
@@ -179,7 +1657,10 @@ describe("AxonHub API service", () => {
         { ...config, email: "generic-token@example.com" },
         "query { viewer { id } }",
       ),
-    ).rejects.toThrow("Token field is required")
+    ).rejects.toMatchObject({
+      kind: "upstream-rejected",
+      dispatch: "not-dispatched",
+    })
 
     expect(authHits).toBe(1)
     expect(graphQlHits).toBe(1)
@@ -228,7 +1709,9 @@ describe("AxonHub API service", () => {
       { retryAuth: false, signal: controller.signal },
     )
     const expectation = expect(request).rejects.toMatchObject({
-      message: abortReason.message,
+      kind: "aborted",
+      dispatch: "not-dispatched",
+      message: "aborted",
     })
 
     await vi.waitFor(() => expect(graphqlSignal).toBe(controller.signal))
@@ -281,6 +1764,65 @@ describe("AxonHub API service", () => {
     ])
   })
 
+  it("refreshes once when a non-JSON GraphQL response is unauthorized", async () => {
+    let authHits = 0
+    let graphQlHits = 0
+
+    server.use(
+      http.post(AUTH_URL, () => {
+        authHits += 1
+        return HttpResponse.json({ token: `non-json-token-${authHits}` })
+      }),
+      http.post(GRAPHQL_URL, () => {
+        graphQlHits += 1
+        if (graphQlHits === 1) {
+          return HttpResponse.text("unauthorized HTML", { status: 401 })
+        }
+        return HttpResponse.json({ data: { ping: "pong" } })
+      }),
+    )
+
+    await expect(
+      graphqlRequest(
+        { ...config, email: "non-json-unauthorized@example.com" },
+        "query NonJsonUnauthorized",
+      ),
+    ).resolves.toEqual({ ping: "pong" })
+    expect(authHits).toBe(2)
+    expect(graphQlHits).toBe(2)
+  })
+
+  it("classifies a message-only authentication error without refreshing", async () => {
+    let authHits = 0
+    let graphQlHits = 0
+
+    server.use(
+      http.post(AUTH_URL, () => {
+        authHits += 1
+        return HttpResponse.json({ token: `revoked-token-${authHits}` })
+      }),
+      http.post(GRAPHQL_URL, () => {
+        graphQlHits += 1
+        return HttpResponse.json({
+          errors: [{ message: "revoked token" }],
+        })
+      }),
+    )
+
+    await expect(
+      graphqlRequest(
+        { ...config, email: "revoked-token@example.com" },
+        "query RevokedToken",
+      ),
+    ).rejects.toMatchObject({
+      kind: "authentication",
+      dispatch: "not-dispatched",
+      message: "authentication",
+    })
+    expect(authHits).toBe(1)
+    expect(graphQlHits).toBe(1)
+  })
+
   it("surfaces the refreshed-token failure instead of masking it as a generic auth error", async () => {
     let authHits = 0
     let graphQlHits = 0
@@ -314,7 +1856,11 @@ describe("AxonHub API service", () => {
         { ...config, email: "retry-failure@example.com" },
         "query Ping",
       ),
-    ).rejects.toThrow("invalid token format")
+    ).rejects.toMatchObject({
+      kind: "authentication",
+      dispatch: "not-dispatched",
+      message: "authentication",
+    })
 
     expect(authHits).toBe(2)
   })
@@ -393,7 +1939,11 @@ describe("AxonHub API service", () => {
     )
     const abortReason = new Error("caller cancelled")
     abortReason.name = "AbortError"
-    const expectation = expect(timedRequest).rejects.toBe(abortReason)
+    const expectation = expect(timedRequest).rejects.toMatchObject({
+      kind: "aborted",
+      dispatch: "not-dispatched",
+      message: "aborted",
+    })
 
     controller.abort(abortReason)
 
@@ -450,7 +2000,11 @@ describe("AxonHub API service", () => {
         undefined,
         { signal: controller.signal },
       ),
-    ).rejects.toBe(abortReason)
+    ).rejects.toMatchObject({
+      kind: "aborted",
+      dispatch: "not-dispatched",
+      message: "aborted",
+    })
 
     resolveAuth?.(
       new Response(JSON.stringify({ token: "shared-token" }), {
@@ -506,8 +2060,10 @@ describe("AxonHub API service", () => {
         { signal: signalWithoutReason },
       ),
     ).rejects.toMatchObject({
-      message: "The operation was aborted",
-      name: "AbortError",
+      name: "AxonHubRequestError",
+      kind: "aborted",
+      dispatch: "not-dispatched",
+      message: "aborted",
     })
     expect(signalWithoutReason.addEventListener).not.toHaveBeenCalled()
 
@@ -737,16 +2293,58 @@ describe("AxonHub API service", () => {
     expect(resolveAxonHubGraphqlId(numeric.id)).toBe(String(opaque.id))
   })
 
-  it("lists paginated channels and trims API key entries", async () => {
-    let page = 0
+  it("hydrates legacy paginated channels without retaining details in the list cache", async () => {
+    const firstId = "gid://axonhub/Channel/one"
+    const secondId = "gid://axonhub/Channel/two"
+    let listPageHits = 0
+    const detailIds: unknown[] = []
+    const listQueries: string[] = []
 
     server.use(
       http.post(AUTH_URL, () => HttpResponse.json({ token: "list-token" })),
       http.post(GRAPHQL_URL, async ({ request }) => {
         const body = (await request.json()) as {
+          query?: string
           variables?: { input?: { after?: string | null } }
         }
-        page += 1
+        if (body.query?.includes("query GetAxonHubChannel")) {
+          const id = (body.variables as { id?: unknown } | undefined)?.id
+          detailIds.push(id)
+          const isFirst = id === firstId
+          return HttpResponse.json({
+            data: {
+              node: buildNativeChannelDetail(id as string, {
+                type: isFirst ? "openai" : "anthropic",
+                baseURL: isFirst
+                  ? "https://one.example.com"
+                  : "https://two.example.com",
+                name: isFirst ? "one" : "two",
+                status: isFirst
+                  ? AXON_HUB_CHANNEL_STATUS.ENABLED
+                  : AXON_HUB_CHANNEL_STATUS.DISABLED,
+                credentials: isFirst
+                  ? buildPinnedChannelCredentials({
+                      apiKeys: ["  sk-one  ", ""],
+                    })
+                  : buildPinnedChannelCredentials({ apiKey: "sk-two" }),
+                supportedModels: isFirst ? ["gpt-4.1"] : [],
+                manualModels: isFirst ? [] : ["claude-sonnet-4-5"],
+                settings: isFirst
+                  ? {
+                      ...buildPinnedChannelSettings(),
+                      modelMappings: [
+                        { from: "gpt-4.1", to: "gpt-4.1-upstream" },
+                      ],
+                      lowercaseModelId: true,
+                    }
+                  : null,
+              }),
+            },
+          })
+        }
+
+        listPageHits += 1
+        listQueries.push(body.query ?? "")
 
         if (!body.variables?.input?.after) {
           return HttpResponse.json({
@@ -755,7 +2353,7 @@ describe("AxonHub API service", () => {
                 edges: [
                   {
                     node: {
-                      id: "1",
+                      id: firstId,
                       type: "openai",
                       baseURL: "https://one.example.com",
                       name: "one",
@@ -779,7 +2377,7 @@ describe("AxonHub API service", () => {
               edges: [
                 {
                   node: {
-                    id: "2",
+                    id: secondId,
                     type: "anthropic",
                     baseURL: "https://two.example.com",
                     name: "two",
@@ -798,25 +2396,36 @@ describe("AxonHub API service", () => {
       }),
     )
 
-    const result = await listChannels({
+    const listConfig = {
       ...config,
       email: "list@example.com",
-    })
+    }
+    const result = await listChannels(listConfig)
+    await listChannels(listConfig)
 
-    expect(page).toBe(2)
+    expect(listPageHits).toBe(2)
+    expect(detailIds).toEqual([firstId, secondId, firstId, secondId])
+    for (const query of listQueries) {
+      expect(query).not.toContain("credentials")
+      expect(query).not.toContain("settings")
+    }
     expect(result.total).toBe(2)
     expect(result.items).toHaveLength(2)
     expect(result.items[0]).toEqual(
       expect.objectContaining({
-        id: 1,
+        id: expect.any(Number),
         key: "sk-one",
         type: "openai",
         status: CHANNEL_STATUS.Enable,
+        model_mapping: JSON.stringify({
+          "gpt-4.1": "gpt-4.1-upstream",
+        }),
+        setting: expect.stringContaining('"lowercaseModelId":true'),
       }),
     )
     expect(result.items[1]).toEqual(
       expect.objectContaining({
-        id: 2,
+        id: expect.any(Number),
         key: "sk-two",
         type: "anthropic",
         status: CHANNEL_STATUS.ManuallyDisabled,
@@ -861,8 +2470,35 @@ describe("AxonHub API service", () => {
         authHits += 1
         return HttpResponse.json({ token: "search-token" })
       }),
-      http.post(GRAPHQL_URL, () => {
+      http.post(GRAPHQL_URL, async ({ request }) => {
         graphQlHits += 1
+        const body = (await request.json()) as {
+          query?: string
+          variables?: { id?: unknown }
+        }
+        if (body.query?.includes("query GetAxonHubChannel")) {
+          const isAlpha = body.variables?.id === "1"
+          return HttpResponse.json({
+            data: {
+              node: buildNativeChannelDetail(body.variables?.id as string, {
+                type: isAlpha ? "openai" : "anthropic",
+                baseURL: isAlpha
+                  ? "https://alpha.example.com"
+                  : "https://beta.example.com",
+                name: isAlpha ? "alpha" : "beta",
+                status: isAlpha
+                  ? AXON_HUB_CHANNEL_STATUS.ENABLED
+                  : AXON_HUB_CHANNEL_STATUS.DISABLED,
+                credentials: buildPinnedChannelCredentials({
+                  apiKey: isAlpha ? "sk-alpha" : "sk-beta",
+                }),
+                supportedModels: isAlpha ? ["gpt-4.1"] : [],
+                manualModels: isAlpha ? [] : ["claude-sonnet-4-5"],
+              }),
+            },
+          })
+        }
+
         return HttpResponse.json({
           data: {
             queryChannels: {
@@ -914,6 +2550,13 @@ describe("AxonHub API service", () => {
     })
 
     await expect(
+      searchChannels(searchConfig, "sk-beta"),
+    ).resolves.toMatchObject({
+      total: 1,
+      items: [expect.objectContaining({ name: "beta", key: "sk-beta" })],
+    })
+
+    await expect(
       searchChannelAdapter(buildRequest(), "alpha"),
     ).resolves.toMatchObject({
       total: 1,
@@ -921,7 +2564,7 @@ describe("AxonHub API service", () => {
     })
 
     expect(authHits).toBe(2)
-    expect(graphQlHits).toBe(2)
+    expect(graphQlHits).toBe(8)
   })
 
   it("creates channels through the adapter wrapper and returns safe create errors", async () => {
@@ -935,20 +2578,22 @@ describe("AxonHub API service", () => {
         if (body.query?.includes("mutation CreateChannel")) {
           return HttpResponse.json({
             data: {
-              createChannel: {
-                id: "13",
-                type: "openai",
+              createChannel: buildNativeChannelDetail("13", {
                 baseURL: "https://created.example.com/v1",
                 name: "Created Channel",
                 status: AXON_HUB_CHANNEL_STATUS.ENABLED,
-                credentials: { apiKeys: ["sk-created"] },
+                credentials: buildPinnedChannelCredentials({
+                  apiKeys: ["sk-created"],
+                }),
                 supportedModels: ["gpt-4.1"],
                 manualModels: ["gpt-4.1"],
                 defaultTestModel: "gpt-4.1",
-                settings: { modelMappings: [] },
+                settings: {
+                  ...buildPinnedChannelSettings(),
+                  modelMappings: [],
+                },
                 orderingWeight: 5,
-                remark: null,
-              },
+              }),
             },
           })
         }
@@ -958,6 +2603,7 @@ describe("AxonHub API service", () => {
           return HttpResponse.json({
             data: {
               updateChannelStatus: {
+                __typename: "Channel",
                 id: "13",
                 status: AXON_HUB_CHANNEL_STATUS.ENABLED,
               },
@@ -1031,7 +2677,7 @@ describe("AxonHub API service", () => {
     ).resolves.toEqual({
       success: false,
       data: null,
-      message: "create exploded",
+      message: "unavailable",
     })
   })
 
@@ -1059,20 +2705,22 @@ describe("AxonHub API service", () => {
         if (body.query?.includes("mutation CreateChannel")) {
           return HttpResponse.json({
             data: {
-              createChannel: {
-                id: "13",
-                type: "openai",
+              createChannel: buildNativeChannelDetail("13", {
                 baseURL: "https://created.example.com/v1",
                 name: "Created Channel",
                 status: AXON_HUB_CHANNEL_STATUS.ENABLED,
-                credentials: { apiKeys: ["sk-created"] },
+                credentials: buildPinnedChannelCredentials({
+                  apiKeys: ["sk-created"],
+                }),
                 supportedModels: ["gpt-4.1"],
                 manualModels: ["gpt-4.1"],
                 defaultTestModel: "gpt-4.1",
-                settings: { modelMappings: [] },
+                settings: {
+                  ...buildPinnedChannelSettings(),
+                  modelMappings: [],
+                },
                 orderingWeight: 5,
-                remark: null,
-              },
+              }),
             },
           })
         }
@@ -1134,20 +2782,22 @@ describe("AxonHub API service", () => {
           respond: () =>
             HttpResponse.json({
               data: {
-                createChannel: {
-                  id: "13",
-                  type: "openai",
+                createChannel: buildNativeChannelDetail("13", {
                   baseURL: "https://created.example.com/v1",
                   name: "Created Channel",
                   status: AXON_HUB_CHANNEL_STATUS.DISABLED,
-                  credentials: { apiKeys: ["sk-created"] },
+                  credentials: buildPinnedChannelCredentials({
+                    apiKeys: ["sk-created"],
+                  }),
                   supportedModels: ["gpt-4.1"],
                   manualModels: ["gpt-4.1"],
                   defaultTestModel: "gpt-4.1",
-                  settings: { modelMappings: [] },
+                  settings: {
+                    ...buildPinnedChannelSettings(),
+                    modelMappings: [],
+                  },
                   orderingWeight: 5,
-                  remark: null,
-                },
+                }),
               },
             }),
         },
@@ -1183,7 +2833,7 @@ describe("AxonHub API service", () => {
       }),
     ).resolves.toMatchObject({
       success: false,
-      message: "status exploded",
+      message: "unavailable",
     })
 
     await listChannels(config)
@@ -1243,24 +2893,44 @@ describe("AxonHub API service", () => {
           },
         },
         {
+          matches: matchesGraphqlOperation("query GetAxonHubChannel"),
+          respond: () =>
+            HttpResponse.json({
+              data: {
+                node: buildNativeChannelDetail(graphqlId, {
+                  baseURL: "https://updated.example.com/v1",
+                  name: "Updated Channel",
+                  status: AXON_HUB_CHANNEL_STATUS.DISABLED,
+                  credentials: buildPinnedChannelCredentials({
+                    apiKey: "sk-updated",
+                  }),
+                  supportedModels: ["gpt-4.1"],
+                  settings: buildPinnedChannelSettings(),
+                }),
+              },
+            }),
+        },
+        {
           matches: matchesGraphqlOperation("mutation UpdateChannel("),
           respond: () =>
             HttpResponse.json({
               data: {
-                updateChannel: {
-                  id: graphqlId,
-                  type: "openai",
+                updateChannel: buildNativeChannelDetail(graphqlId, {
                   baseURL: "https://updated.example.com/v1",
                   name: "Updated Channel",
                   status: AXON_HUB_CHANNEL_STATUS.DISABLED,
-                  credentials: { apiKeys: ["sk-updated"] },
+                  credentials: buildPinnedChannelCredentials({
+                    apiKeys: ["sk-updated"],
+                  }),
                   supportedModels: ["gpt-4.1"],
                   manualModels: ["gpt-4.1"],
                   defaultTestModel: "gpt-4.1",
-                  settings: { modelMappings: [] },
+                  settings: {
+                    ...buildPinnedChannelSettings(),
+                    modelMappings: [],
+                  },
                   orderingWeight: 5,
-                  remark: null,
-                },
+                }),
               },
             }),
         },
@@ -1295,7 +2965,7 @@ describe("AxonHub API service", () => {
       }),
     ).resolves.toMatchObject({
       success: false,
-      message: "status exploded",
+      message: "unavailable",
     })
 
     await listChannels(config)
@@ -1357,21 +3027,18 @@ describe("AxonHub API service", () => {
         if (body.query?.includes("mutation UpdateChannel(")) {
           return HttpResponse.json({
             data: {
-              updateChannel: {
-                id: graphqlId,
-                type: "openai",
+              updateChannel: buildNativeChannelDetail(graphqlId, {
                 baseURL: "https://adapter.example.com/v1",
                 name: "Adapter Channel",
                 status: AXON_HUB_CHANNEL_STATUS.ENABLED,
-                credentials: { apiKey: "sk-adapter" },
+                credentials: buildPinnedChannelCredentials({
+                  apiKey: "sk-adapter",
+                }),
                 supportedModels: ["gpt-4.1"],
-                manualModels: [],
-                defaultTestModel: null,
-                settings: {},
+                defaultTestModel: "gpt-4.1",
+                settings: buildPinnedChannelSettings(),
                 orderingWeight: 0,
-                remark: null,
-                errorMessage: null,
-              },
+              }),
             },
           })
         }
@@ -1381,6 +3048,7 @@ describe("AxonHub API service", () => {
           return HttpResponse.json({
             data: {
               updateChannelStatus: {
+                __typename: "Channel",
                 id: graphqlId,
                 status: AXON_HUB_CHANNEL_STATUS.DISABLED,
               },
@@ -1508,13 +3176,13 @@ describe("AxonHub API service", () => {
     ).resolves.toEqual({
       success: false,
       data: null,
-      message: "update exploded",
+      message: "unavailable",
     })
 
     await expect(deleteChannelAdapter(buildRequest(), rowId)).resolves.toEqual({
       success: false,
       data: null,
-      message: "delete exploded",
+      message: "unavailable",
     })
 
     await expect(fetchSiteUserGroups()).resolves.toEqual([])
@@ -1523,8 +3191,25 @@ describe("AxonHub API service", () => {
   it("lists channels through the adapter wrapper", async () => {
     server.use(
       http.post(AUTH_URL, () => HttpResponse.json({ token: "adapter-list" })),
-      http.post(GRAPHQL_URL, () =>
-        HttpResponse.json({
+      http.post(GRAPHQL_URL, async ({ request }) => {
+        const body = (await request.json()) as { query?: string }
+        if (body.query?.includes("query GetAxonHubChannel")) {
+          return HttpResponse.json({
+            data: {
+              node: buildNativeChannelDetail("1", {
+                baseURL: "https://alpha.example.com",
+                name: "alpha",
+                status: AXON_HUB_CHANNEL_STATUS.ENABLED,
+                credentials: buildPinnedChannelCredentials({
+                  apiKey: "sk-alpha",
+                }),
+                supportedModels: ["gpt-4.1"],
+              }),
+            },
+          })
+        }
+
+        return HttpResponse.json({
           data: {
             queryChannels: {
               edges: [
@@ -1545,8 +3230,8 @@ describe("AxonHub API service", () => {
               totalCount: 1,
             },
           },
-        }),
-      ),
+        })
+      }),
     )
 
     await expect(listAllChannels(buildRequest())).resolves.toMatchObject({
@@ -1611,6 +3296,22 @@ describe("AxonHub API service", () => {
                 pageInfo: { hasNextPage: false, endCursor: null },
                 totalCount: 1,
               },
+            },
+          })
+        }
+
+        if (body.query?.includes("query GetAxonHubChannel")) {
+          return HttpResponse.json({
+            data: {
+              node: buildNativeChannelDetail(graphqlId, {
+                baseURL: "https://alpha.example.com",
+                name: "alpha",
+                status: AXON_HUB_CHANNEL_STATUS.ENABLED,
+                credentials: buildPinnedChannelCredentials({
+                  apiKey: "sk-alpha",
+                }),
+                supportedModels: ["gpt-4.1"],
+              }),
             },
           })
         }
@@ -1735,6 +3436,7 @@ describe("AxonHub API service", () => {
   it("reuses cached channel lists for repeated searches and invalidates after mutations", async () => {
     let authHits = 0
     let listHits = 0
+    let detailHits = 0
     let createHits = 0
     let updateHits = 0
     let statusHits = 0
@@ -1748,6 +3450,7 @@ describe("AxonHub API service", () => {
       http.post(GRAPHQL_URL, async ({ request }) => {
         const body = (await request.json()) as {
           query?: string
+          variables?: { id?: unknown }
         }
 
         if (body.query?.includes("query QueryChannels")) {
@@ -1788,24 +3491,46 @@ describe("AxonHub API service", () => {
           })
         }
 
+        if (body.query?.includes("query GetAxonHubChannel")) {
+          detailHits += 1
+          const isAlpha = body.variables?.id === "1"
+          return HttpResponse.json({
+            data: {
+              node: buildNativeChannelDetail(body.variables?.id as string, {
+                baseURL: isAlpha
+                  ? "https://alpha.example.com"
+                  : "https://beta.example.com",
+                name: isAlpha ? "alpha" : "beta",
+                status: AXON_HUB_CHANNEL_STATUS.ENABLED,
+                credentials: buildPinnedChannelCredentials({
+                  apiKey: isAlpha ? "sk-alpha" : "sk-beta",
+                }),
+                supportedModels: [isAlpha ? "gpt-4.1" : "gpt-4o"],
+              }),
+            },
+          })
+        }
+
         if (body.query?.includes("mutation CreateChannel")) {
           createHits += 1
           return HttpResponse.json({
             data: {
-              createChannel: {
-                id: "3",
-                type: "openai",
+              createChannel: buildNativeChannelDetail("3", {
                 baseURL: "https://created.example.com",
                 name: "created",
                 status: AXON_HUB_CHANNEL_STATUS.ENABLED,
-                credentials: { apiKeys: ["sk-created"] },
+                credentials: buildPinnedChannelCredentials({
+                  apiKeys: ["sk-created"],
+                }),
                 supportedModels: ["gpt-4.1"],
                 manualModels: ["gpt-4.1"],
                 defaultTestModel: "gpt-4.1",
-                settings: { modelMappings: [] },
+                settings: {
+                  ...buildPinnedChannelSettings(),
+                  modelMappings: [],
+                },
                 orderingWeight: 0,
-                remark: null,
-              },
+              }),
             },
           })
         }
@@ -1814,21 +3539,22 @@ describe("AxonHub API service", () => {
           updateHits += 1
           return HttpResponse.json({
             data: {
-              updateChannel: {
-                id: "1",
-                type: "openai",
+              updateChannel: buildNativeChannelDetail("1", {
                 baseURL: "https://alpha.example.com",
                 name: "updated",
                 status: AXON_HUB_CHANNEL_STATUS.ENABLED,
-                credentials: { apiKeys: ["sk-alpha"] },
+                credentials: buildPinnedChannelCredentials({
+                  apiKeys: ["sk-alpha"],
+                }),
                 supportedModels: ["gpt-4.1"],
                 manualModels: ["gpt-4.1"],
                 defaultTestModel: "gpt-4.1",
-                settings: { modelMappings: [] },
+                settings: {
+                  ...buildPinnedChannelSettings(),
+                  modelMappings: [],
+                },
                 orderingWeight: 0,
-                errorMessage: null,
-                remark: null,
-              },
+              }),
             },
           })
         }
@@ -1838,6 +3564,7 @@ describe("AxonHub API service", () => {
           return HttpResponse.json({
             data: {
               updateChannelStatus: {
+                __typename: "Channel",
                 id: "1",
                 status: AXON_HUB_CHANNEL_STATUS.DISABLED,
               },
@@ -1900,6 +3627,7 @@ describe("AxonHub API service", () => {
     await deleteAxonHubChannel(cacheConfig, "1")
     await searchChannels(cacheConfig, "alpha")
     expect(listHits).toBe(5)
+    expect(detailHits).toBe(12)
 
     expect(authHits).toBe(1)
     expect(createHits).toBe(1)

--- a/tests/services/apiService/axonHub/index.test.ts
+++ b/tests/services/apiService/axonHub/index.test.ts
@@ -2165,6 +2165,121 @@ describe("AxonHub API service", () => {
     expect(result._axonHubData.id).toBe("channel_opaque_id")
   })
 
+  it("sanitizes legacy managed-site rows to the compatibility allowlist", () => {
+    const result = axonHubChannelToManagedSite(
+      buildNativeChannelDetail("sensitive-detail", {
+        credentials: {
+          apiKey: "legacy-primary-key",
+          apiKeys: ["primary-key", "secondary-key"],
+          gcp: {
+            region: "example-region",
+            projectID: "example-project",
+            jsonData: "gcp-json-sentinel",
+          },
+          oauth: {
+            accessToken: "oauth-access-sentinel",
+            refreshToken: "oauth-refresh-sentinel",
+          },
+        },
+        settings: {
+          extraModelPrefix: "prefix-",
+          modelMappings: [
+            {
+              from: "model-alpha",
+              to: "model-upstream",
+              leaked: "mapping-extra-sentinel",
+            },
+          ],
+          transformOptions: {
+            forceArrayInstructions: true,
+            forceArrayInputs: false,
+            replaceDeveloperRoleWithSystem: true,
+            reasoningEffortMapping: [
+              {
+                from: "high",
+                to: "medium",
+                leaked: "reasoning-extra-sentinel",
+              },
+            ],
+            leaked: "transform-extra-sentinel",
+          },
+          proxy: { password: "proxy-password-sentinel" },
+          headerOverrideOperations: [{ value: "header-override-sentinel" }],
+          bodyOverrideOperations: [{ value: "body-override-sentinel" }],
+          rateLimit: {
+            rpm: 10,
+            tpm: 20,
+            maxConcurrent: 2,
+            queueSize: 3,
+            queueTimeoutMs: 4,
+            leaked: "rate-limit-extra-sentinel",
+          },
+          retryableStatusCodes: [429],
+          retryableErrorPatterns: [
+            {
+              pattern: "temporary",
+              regex: false,
+              leaked: "retry-extra-sentinel",
+            },
+          ],
+          providerQuota: {
+            opencodeGo: { authCookie: "provider-cookie-sentinel" },
+          },
+        },
+        disabledAPIKeys: [
+          {
+            key: "disabled-key-sentinel",
+            disabledAt: "2026-07-17T00:00:00Z",
+            errorCode: 401,
+          },
+        ],
+      }) as AxonHubChannel,
+    )
+
+    expect(result.key).toBe("primary-key")
+    expect(result._axonHubData.credentials).toEqual({
+      apiKeys: ["primary-key"],
+    })
+    expect(result._axonHubData.settings).toMatchObject({
+      modelMappings: [{ from: "model-alpha", to: "model-upstream" }],
+      transformOptions: {
+        forceArrayInstructions: true,
+        forceArrayInputs: false,
+        replaceDeveloperRoleWithSystem: true,
+        reasoningEffortMapping: [{ from: "high", to: "medium" }],
+      },
+      rateLimit: {
+        rpm: 10,
+        tpm: 20,
+        maxConcurrent: 2,
+        queueSize: 3,
+        queueTimeoutMs: 4,
+      },
+      retryableErrorPatterns: [{ pattern: "temporary", regex: false }],
+    })
+
+    const serialized = JSON.stringify(result)
+    for (const sentinel of [
+      "legacy-primary-key",
+      "secondary-key",
+      "gcp-json-sentinel",
+      "oauth-access-sentinel",
+      "oauth-refresh-sentinel",
+      "proxy-password-sentinel",
+      "header-override-sentinel",
+      "body-override-sentinel",
+      "provider-cookie-sentinel",
+      "disabled-key-sentinel",
+      "mapping-extra-sentinel",
+      "reasoning-extra-sentinel",
+      "transform-extra-sentinel",
+      "rate-limit-extra-sentinel",
+      "retry-extra-sentinel",
+    ]) {
+      expect(serialized).not.toContain(sentinel)
+    }
+  })
+
   it("falls back to zero when AxonHub timestamps are malformed", () => {
     const result = axonHubChannelToManagedSite({
       id: "bad-date-id",
@@ -2298,6 +2413,7 @@ describe("AxonHub API service", () => {
     const secondId = "gid://axonhub/Channel/two"
     let listPageHits = 0
     const detailIds: unknown[] = []
+    const detailQueries: string[] = []
     const listQueries: string[] = []
 
     server.use(
@@ -2308,6 +2424,7 @@ describe("AxonHub API service", () => {
           variables?: { input?: { after?: string | null } }
         }
         if (body.query?.includes("query GetAxonHubChannel")) {
+          detailQueries.push(body.query)
           const id = (body.variables as { id?: unknown } | undefined)?.id
           detailIds.push(id)
           const isFirst = id === firstId
@@ -2409,6 +2526,25 @@ describe("AxonHub API service", () => {
       expect(query).not.toContain("credentials")
       expect(query).not.toContain("settings")
     }
+    for (const query of detailQueries) {
+      for (const sensitiveSelection of [
+        "jsonData",
+        "oauth",
+        "accessToken",
+        "refreshToken",
+        "proxy",
+        "password",
+        "providerQuota",
+        "authCookie",
+        "headerOverrideOperations",
+        "bodyOverrideOperations",
+        "disabledAPIKeys",
+      ]) {
+        expect(query).not.toContain(sensitiveSelection)
+      }
+    }
+    expect(JSON.stringify(result.items)).not.toContain("proxy-password")
+    expect(JSON.stringify(result.items)).not.toContain("cookie-example")
     expect(result.total).toBe(2)
     expect(result.items).toHaveLength(2)
     expect(result.items[0]).toEqual(
@@ -2435,6 +2571,194 @@ describe("AxonHub API service", () => {
       openai: 1,
       anthropic: 1,
     })
+  })
+
+  it("bounds legacy detail hydration while preserving list order", async () => {
+    const ids = Array.from({ length: 8 }, (_, index) => `bounded-${index}`)
+    let active = 0
+    let maxActive = 0
+    let started = 0
+    let releaseDetails: (() => void) | undefined
+    const detailGate = new Promise<void>((resolve) => {
+      releaseDetails = resolve
+    })
+
+    server.use(
+      http.post(AUTH_URL, () => HttpResponse.json({ token: "bounded-token" })),
+      http.post(GRAPHQL_URL, async ({ request }) => {
+        const body = (await request.json()) as {
+          query?: string
+          variables?: { id?: string }
+        }
+        if (body.query?.includes("query GetAxonHubChannel")) {
+          const id = body.variables?.id ?? "missing"
+          started += 1
+          active += 1
+          maxActive = Math.max(maxActive, active)
+          await detailGate
+          active -= 1
+          return HttpResponse.json({
+            data: {
+              node: buildNativeChannelDetail(id, { name: id }),
+            },
+          })
+        }
+
+        return HttpResponse.json({
+          data: {
+            queryChannels: {
+              edges: ids.map((id) => ({
+                node: {
+                  id,
+                  type: "openai",
+                  baseURL: null,
+                  name: id,
+                  status: AXON_HUB_CHANNEL_STATUS.ENABLED,
+                  tags: [],
+                  supportedModels: [],
+                },
+              })),
+              pageInfo: { hasNextPage: false, endCursor: null },
+              totalCount: ids.length,
+            },
+          },
+        })
+      }),
+    )
+
+    const pending = listChannels({ ...config, email: "bounded@example.com" })
+    await vi.waitFor(() => expect(started).toBeGreaterThanOrEqual(4))
+    const startedBeforeRelease = started
+    releaseDetails?.()
+    const result = await pending
+
+    expect(startedBeforeRelease).toBe(4)
+    expect(maxActive).toBe(4)
+    expect(result.items.map((item) => item.name)).toEqual(ids)
+  })
+
+  it("stops scheduling legacy detail hydration after the first failure", async () => {
+    const ids = Array.from({ length: 8 }, (_, index) => `failure-${index}`)
+    let started = 0
+    let releaseDetails: (() => void) | undefined
+    const detailGate = new Promise<void>((resolve) => {
+      releaseDetails = resolve
+    })
+
+    server.use(
+      http.post(AUTH_URL, () => HttpResponse.json({ token: "failure-token" })),
+      http.post(GRAPHQL_URL, async ({ request }) => {
+        const body = (await request.json()) as {
+          query?: string
+          variables?: { id?: string }
+        }
+        if (body.query?.includes("query GetAxonHubChannel")) {
+          const id = body.variables?.id ?? "missing"
+          started += 1
+          if (id === ids[0]) {
+            return HttpResponse.json(
+              { errors: [{ message: "detail failed" }] },
+              { status: 400 },
+            )
+          }
+          await detailGate
+          return HttpResponse.json({
+            data: { node: buildNativeChannelDetail(id, { name: id }) },
+          })
+        }
+
+        return HttpResponse.json({
+          data: {
+            queryChannels: {
+              edges: ids.map((id) => ({
+                node: {
+                  id,
+                  type: "openai",
+                  baseURL: null,
+                  name: id,
+                  status: AXON_HUB_CHANNEL_STATUS.ENABLED,
+                  tags: [],
+                  supportedModels: [],
+                },
+              })),
+              pageInfo: { hasNextPage: false, endCursor: null },
+              totalCount: ids.length,
+            },
+          },
+        })
+      }),
+    )
+
+    const outcome = listChannels({
+      ...config,
+      email: "failure@example.com",
+    }).catch((error) => error)
+    await vi.waitFor(() => expect(started).toBeGreaterThanOrEqual(4))
+    releaseDetails?.()
+    const error = await outcome
+
+    expect(error).toMatchObject({ kind: "upstream-rejected" })
+    expect(started).toBe(4)
+  })
+
+  it("stops scheduling legacy detail hydration after cancellation", async () => {
+    const ids = Array.from({ length: 8 }, (_, index) => `abort-${index}`)
+    const controller = new AbortController()
+    let started = 0
+    let releaseDetails: (() => void) | undefined
+    const detailGate = new Promise<void>((resolve) => {
+      releaseDetails = resolve
+    })
+
+    server.use(
+      http.post(AUTH_URL, () => HttpResponse.json({ token: "abort-token" })),
+      http.post(GRAPHQL_URL, async ({ request }) => {
+        const body = (await request.json()) as {
+          query?: string
+          variables?: { id?: string }
+        }
+        if (body.query?.includes("query GetAxonHubChannel")) {
+          const id = body.variables?.id ?? "missing"
+          started += 1
+          await detailGate
+          return HttpResponse.json({
+            data: { node: buildNativeChannelDetail(id, { name: id }) },
+          })
+        }
+
+        return HttpResponse.json({
+          data: {
+            queryChannels: {
+              edges: ids.map((id) => ({
+                node: {
+                  id,
+                  type: "openai",
+                  baseURL: null,
+                  name: id,
+                  status: AXON_HUB_CHANNEL_STATUS.ENABLED,
+                  tags: [],
+                  supportedModels: [],
+                },
+              })),
+              pageInfo: { hasNextPage: false, endCursor: null },
+              totalCount: ids.length,
+            },
+          },
+        })
+      }),
+    )
+
+    const outcome = listChannels(
+      { ...config, email: "abort-hydration@example.com" },
+      { signal: controller.signal },
+    ).catch((error) => error)
+    await vi.waitFor(() => expect(started).toBe(4))
+    controller.abort()
+    releaseDetails?.()
+    const error = await outcome
+
+    expect(error).toMatchObject({ kind: "aborted" })
+    expect(started).toBe(4)
   })
 
   it("fails fast when AxonHub pagination repeats a cursor", async () => {

--- a/tests/services/apiService/axonHub/index.test.ts
+++ b/tests/services/apiService/axonHub/index.test.ts
@@ -326,6 +326,7 @@ describe("AxonHub API service", () => {
 
   it("accepts a complete pinned authoritative channel output", async () => {
     const id = "complete-pinned-output"
+    const settings = buildPinnedChannelSettings()
     const completeChannel = buildNativeChannelDetail(id, {
       policies: { stream: null },
       credentials: {
@@ -345,7 +346,19 @@ describe("AxonHub API service", () => {
           scopes: [],
         },
       },
-      settings: buildPinnedChannelSettings(),
+      settings: {
+        ...settings,
+        headerOverrideOperations: [
+          {
+            ...settings.headerOverrideOperations[0],
+            match: { path: "$.model", eq: "model-alpha" },
+          },
+        ],
+        transformOptions: {
+          ...settings.transformOptions,
+          reasoningEffortMapping: [{ from: "high", to: "medium" }],
+        },
+      },
       endpoints: [
         {
           apiFormat: "openai",
@@ -378,9 +391,15 @@ describe("AxonHub API service", () => {
       id,
       settings: {
         headerOverrideOperations: [
-          expect.objectContaining({ value: '{"enabled":true}' }),
+          expect.objectContaining({
+            value: '{"enabled":true}',
+            match: { path: "$.model", eq: "model-alpha" },
+          }),
         ],
         bodyOverrideOperations: [],
+        transformOptions: expect.objectContaining({
+          reasoningEffortMapping: [{ from: "high", to: "medium" }],
+        }),
       },
     })
   })
@@ -637,7 +656,8 @@ describe("AxonHub API service", () => {
   })
 
   it("rejects malformed native pages instead of silently truncating them", async () => {
-    const malformedConnections = [
+    const malformedConnections: unknown[] = [
+      null,
       {
         edges: [{ node: "not-a-channel" }],
         pageInfo: { hasNextPage: false, endCursor: null },
@@ -676,6 +696,16 @@ describe("AxonHub API service", () => {
         pageInfo: { hasNextPage: false, endCursor: null },
         totalCount: 1,
       },
+      {
+        edges: ["not-an-edge"],
+        pageInfo: { hasNextPage: false, endCursor: null },
+        totalCount: 1,
+      },
+      {
+        edges: [{ node: nativeNullBaseUrlChannel, cursor: 42 }],
+        pageInfo: { hasNextPage: false, endCursor: null },
+        totalCount: 1,
+      },
     ]
     let responseIndex = 0
 
@@ -701,6 +731,78 @@ describe("AxonHub API service", () => {
         message: "protocol",
       })
     }
+  })
+
+  it("distinguishes missing and absent native detail results", async () => {
+    const responses = [{}, { node: null }]
+    let responseIndex = 0
+
+    useAxonHubGraphqlRoutes({
+      token: "missing-detail-token",
+      routes: [
+        {
+          matches: matchesGraphqlOperation("query GetAxonHubChannel"),
+          respond: () =>
+            HttpResponse.json({ data: responses[responseIndex++] }),
+        },
+      ],
+    })
+
+    await expect(
+      getAxonHubChannel(config, "missing-detail-field"),
+    ).rejects.toMatchObject({
+      kind: "protocol",
+      dispatch: "not-dispatched",
+    })
+    await expect(
+      getAxonHubChannel(config, "absent-detail-node"),
+    ).rejects.toMatchObject({
+      kind: "not-found",
+      dispatch: "not-dispatched",
+    })
+  })
+
+  it("accepts optional summary numbers and an omitted total count", async () => {
+    useAxonHubGraphqlRoutes({
+      token: "optional-summary-token",
+      routes: [
+        {
+          matches: matchesGraphqlOperation("query ListAxonHubChannelPage"),
+          respond: () =>
+            HttpResponse.json({
+              data: {
+                queryChannels: {
+                  edges: [
+                    {
+                      node: {
+                        ...nativeNullBaseUrlChannel,
+                        id: "summary-null-ordering",
+                        orderingWeight: null,
+                      },
+                    },
+                    {
+                      node: {
+                        ...nativeNullBaseUrlChannel,
+                        id: "summary-finite-ordering",
+                        orderingWeight: 1.5,
+                      },
+                    },
+                  ],
+                  pageInfo: { hasNextPage: false, endCursor: null },
+                },
+              },
+            }),
+        },
+      ],
+    })
+
+    const page = await listAxonHubChannelPage(config, { limit: 10 })
+
+    expect(page.items.map((item) => item.id)).toEqual([
+      "summary-null-ordering",
+      "summary-finite-ordering",
+    ])
+    expect(page).not.toHaveProperty("total")
   })
 
   it("sends verified update and clear fields unchanged", async () => {
@@ -1308,6 +1410,101 @@ describe("AxonHub API service", () => {
       kind: "upstream-rejected",
       dispatch: "not-dispatched",
       message: "upstream-rejected",
+    })
+  })
+
+  it("classifies GraphQL not-found and message-only permission failures", async () => {
+    const responses = [
+      HttpResponse.json({ errors: [{ message: "missing" }] }, { status: 404 }),
+      HttpResponse.json({ errors: [{ message: "permission denied" }] }),
+    ]
+    let responseIndex = 0
+
+    server.use(
+      http.post(AUTH_URL, () =>
+        HttpResponse.json({ token: "classification-token" }),
+      ),
+      http.post(GRAPHQL_URL, () => responses[responseIndex++]),
+    )
+
+    await expect(
+      graphqlRequest(
+        { ...config, email: "not-found-classification@example.com" },
+        "query MissingChannel",
+        undefined,
+        { retryAuth: false },
+      ),
+    ).rejects.toMatchObject({
+      kind: "not-found",
+      dispatch: "not-dispatched",
+    })
+    await expect(
+      graphqlRequest(
+        { ...config, email: "permission-classification@example.com" },
+        "query ForbiddenChannel",
+        undefined,
+        { retryAuth: false },
+      ),
+    ).rejects.toMatchObject({
+      kind: "permission",
+      dispatch: "not-dispatched",
+    })
+  })
+
+  it("classifies non-JSON GraphQL rejection and success responses safely", async () => {
+    const responses = [
+      HttpResponse.text("bad request", { status: 400 }),
+      HttpResponse.text("not JSON", { status: 200 }),
+    ]
+    let responseIndex = 0
+
+    server.use(
+      http.post(AUTH_URL, () =>
+        HttpResponse.json({ token: "non-json-classification-token" }),
+      ),
+      http.post(GRAPHQL_URL, () => responses[responseIndex++]),
+    )
+
+    await expect(
+      graphqlRequest(
+        { ...config, email: "non-json-rejection@example.com" },
+        "query RejectedNonJson",
+        undefined,
+        { retryAuth: false },
+      ),
+    ).rejects.toMatchObject({
+      kind: "upstream-rejected",
+      dispatch: "not-dispatched",
+    })
+    await expect(
+      graphqlRequest(
+        { ...config, email: "non-json-success@example.com" },
+        "query SuccessfulNonJson",
+        undefined,
+        { retryAuth: false },
+      ),
+    ).rejects.toMatchObject({
+      kind: "protocol",
+      dispatch: "not-dispatched",
+    })
+  })
+
+  it("rejects a GraphQL envelope whose data is explicitly null", async () => {
+    server.use(
+      http.post(AUTH_URL, () =>
+        HttpResponse.json({ token: "null-data-token" }),
+      ),
+      http.post(GRAPHQL_URL, () => HttpResponse.json({ data: null })),
+    )
+
+    await expect(
+      graphqlRequest(
+        { ...config, email: "null-data@example.com" },
+        "query NullData",
+      ),
+    ).rejects.toMatchObject({
+      kind: "protocol",
+      dispatch: "not-dispatched",
     })
   })
 
@@ -2571,6 +2768,53 @@ describe("AxonHub API service", () => {
       openai: 1,
       anthropic: 1,
     })
+  })
+
+  it("rejects missing, absent, malformed, and retargeted legacy details", async () => {
+    const requestedId = "legacy-detail-id"
+    const detailResponses = [
+      {},
+      { node: null },
+      { node: { __typename: "Channel", id: requestedId } },
+      {
+        node: buildNativeChannelDetail("different-legacy-detail-id"),
+      },
+    ]
+    let detailIndex = 0
+
+    server.use(
+      http.post(AUTH_URL, () =>
+        HttpResponse.json({ token: "invalid-legacy-detail-token" }),
+      ),
+      http.post(GRAPHQL_URL, async ({ request }) => {
+        const body = (await request.json()) as { query?: string }
+        if (body.query?.includes("query GetAxonHubChannel")) {
+          return HttpResponse.json({ data: detailResponses[detailIndex++] })
+        }
+
+        return HttpResponse.json({
+          data: {
+            queryChannels: {
+              edges: [{ node: nativeNullBaseUrlChannel }],
+              pageInfo: { hasNextPage: false, endCursor: null },
+              totalCount: 1,
+            },
+          },
+        })
+      }),
+    )
+
+    for (const [index] of detailResponses.entries()) {
+      await expect(
+        listChannels({
+          ...config,
+          email: `invalid-legacy-detail-${index}@example.com`,
+        }),
+      ).rejects.toMatchObject({
+        kind: index === 1 ? "not-found" : "protocol",
+        dispatch: "not-dispatched",
+      })
+    }
   })
 
   it("bounds legacy detail hydration while preserving list order", async () => {


### PR DESCRIPTION
## Summary

- define the resource-native Managed Site contracts, product policy, factory, and exact site/kind registry
- expose strict AxonHub native channel protocol operations and register the first native resource adapter
- preserve the current production `legacy-channel` route while the migration and UI cutover land in follow-up PRs

## Why

The existing Managed Site flow normalizes every backend through New API-shaped `ManagedSiteChannel` and `ChannelFormData` contracts. This substrate keeps backend-native detail, secret handling, partial updates, and mutation certainty behind an adapter while exposing safe display facts and editor projections to product code.

## Scope boundary

- no production UI routing change
- no locale, analytics, migration, or E2E source changes
- all six current Managed Site definitions remain explicitly `legacy-channel`
- AxonHub's legacy path remains available until the later static cutover and retirement cleanup

## Validation

- `pnpm exec vitest run tests/services/accountSiteDefinitions/registry.test.ts tests/services/apiAdapters/managedResources/factory.test.ts tests/services/apiAdapters/managedResources/axonHub.test.ts tests/services/apiAdapters/managedSites/axonHub.test.ts tests/services/apiService/axonHub/index.test.ts` — 148 passed
- `pnpm run validate:push` — passed (`compile` and `knip`)
- pre-push validation — passed
- AxonHub real-site managed-channel flow — build and CRUD/search passed; token channel status skipped by design for non-New API sites

## Follow-ups

1. add AxonHub canonical migration capabilities
2. add the shared resource-native UI and switch only AxonHub to `native-resource`
3. retire the duplicate AxonHub legacy resource/provider projections after the native path is established

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled native managed-resource support for AxonHub, including list/search, native-backed details, and end-to-end create/edit/delete with a constrained editable field set.
  * Added a managed-resource policy definition to configure how each supported site surfaces its resource UI.
* **Bug Fixes**
  * Hardened AxonHub GraphQL interactions with safer validation, clearer failure handling, and improved behavior when optional/null fields (like endpoint values) are missing.
  * Improved defensive handling and deep-copying of managed-resource configuration (including uniqueness checks).
* **Documentation**
  * Added managed-resource architecture specs and step-by-step migration/cutover plans for AxonHub.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->