### PR TITLE
refactor(axonhub): route migration through native capabilities

### DIFF
--- a/src/services/apiAdapters/managedResources/axonHub.ts
+++ b/src/services/apiAdapters/managedResources/axonHub.ts
@@ -147,6 +147,10 @@ const REGULAR_AXON_HUB_CHANNEL_TYPE_SET = new Set<string>(
   REGULAR_AXON_HUB_CHANNEL_TYPES,
 )
 
+/** Returns whether AxonHub represents this channel with regular API-key credentials. */
+export const isRegularAxonHubChannelType = (type: string): boolean =>
+  REGULAR_AXON_HUB_CHANNEL_TYPE_SET.has(type)
+
 // Resource-wide search is client-side, so cap both upstream work and retained
 // input at conservative levels well above normal managed-site inventories.
 const AXON_HUB_SEARCH_PAGE_LIMIT = 100

--- a/src/services/apiAdapters/managedResources/axonHubChannelType.ts
+++ b/src/services/apiAdapters/managedResources/axonHubChannelType.ts
@@ -1,0 +1,56 @@
+import {
+  AXON_HUB_CHANNEL_TYPE,
+  isAxonHubChannelType,
+  type AxonHubChannelType,
+} from "~/constants/axonHub"
+import { ChannelType } from "~/constants/managedSite"
+
+const AXON_HUB_TO_CHANNEL_TYPE = {
+  [AXON_HUB_CHANNEL_TYPE.OPENAI]: ChannelType.OpenAI,
+  [AXON_HUB_CHANNEL_TYPE.OPENAI_RESPONSES]: ChannelType.OpenAI,
+  [AXON_HUB_CHANNEL_TYPE.ANTHROPIC]: ChannelType.Anthropic,
+  [AXON_HUB_CHANNEL_TYPE.ANTHROPIC_AWS]: ChannelType.Anthropic,
+  [AXON_HUB_CHANNEL_TYPE.ANTHROPIC_GCP]: ChannelType.Anthropic,
+  [AXON_HUB_CHANNEL_TYPE.CLAUDECODE]: ChannelType.Anthropic,
+  [AXON_HUB_CHANNEL_TYPE.GEMINI_OPENAI]: ChannelType.Gemini,
+  [AXON_HUB_CHANNEL_TYPE.GEMINI]: ChannelType.Gemini,
+  [AXON_HUB_CHANNEL_TYPE.GEMINI_VERTEX]: ChannelType.Gemini,
+  [AXON_HUB_CHANNEL_TYPE.DEEPSEEK]: ChannelType.DeepSeek,
+  [AXON_HUB_CHANNEL_TYPE.DEEPSEEK_ANTHROPIC]: ChannelType.DeepSeek,
+  [AXON_HUB_CHANNEL_TYPE.OPENROUTER]: ChannelType.OpenRouter,
+  [AXON_HUB_CHANNEL_TYPE.XAI]: ChannelType.Xai,
+  [AXON_HUB_CHANNEL_TYPE.SILICONFLOW]: ChannelType.SiliconFlow,
+  [AXON_HUB_CHANNEL_TYPE.VOLCENGINE]: ChannelType.VolcEngine,
+  [AXON_HUB_CHANNEL_TYPE.OLLAMA]: ChannelType.Ollama,
+  [AXON_HUB_CHANNEL_TYPE.GITHUB_COPILOT]: ChannelType.OpenAI,
+  [AXON_HUB_CHANNEL_TYPE.NANOGPT]: ChannelType.OpenAI,
+} satisfies Readonly<Record<AxonHubChannelType, ChannelType>>
+
+const CHANNEL_TYPE_TO_AXON_HUB: Readonly<
+  Partial<Record<ChannelType, AxonHubChannelType>>
+> = {
+  [ChannelType.OpenAI]: AXON_HUB_CHANNEL_TYPE.OPENAI,
+  [ChannelType.Anthropic]: AXON_HUB_CHANNEL_TYPE.ANTHROPIC,
+  [ChannelType.OpenRouter]: AXON_HUB_CHANNEL_TYPE.OPENROUTER,
+  [ChannelType.Gemini]: AXON_HUB_CHANNEL_TYPE.GEMINI,
+  [ChannelType.VertexAi]: AXON_HUB_CHANNEL_TYPE.GEMINI,
+  [ChannelType.SiliconFlow]: AXON_HUB_CHANNEL_TYPE.SILICONFLOW,
+  [ChannelType.DeepSeek]: AXON_HUB_CHANNEL_TYPE.DEEPSEEK,
+  [ChannelType.VolcEngine]: AXON_HUB_CHANNEL_TYPE.VOLCENGINE,
+  [ChannelType.Xai]: AXON_HUB_CHANNEL_TYPE.XAI,
+  [ChannelType.Ollama]: AXON_HUB_CHANNEL_TYPE.OLLAMA,
+}
+
+/** Maps an AxonHub-native channel type into the shared migration type. */
+export function mapAxonHubChannelTypeToChannelType(type: string): ChannelType {
+  return isAxonHubChannelType(type)
+    ? AXON_HUB_TO_CHANNEL_TYPE[type]
+    : ChannelType.OpenAI
+}
+
+/** Maps a shared migration type into the closest AxonHub-native type. */
+export function mapChannelTypeToAxonHubChannelType(
+  type: ChannelType,
+): AxonHubChannelType {
+  return CHANNEL_TYPE_TO_AXON_HUB[type] ?? AXON_HUB_CHANNEL_TYPE.OPENAI
+}

--- a/src/services/apiAdapters/managedResources/axonHubMigration.ts
+++ b/src/services/apiAdapters/managedResources/axonHubMigration.ts
@@ -1,0 +1,291 @@
+import {
+  AXON_HUB_CHANNEL_STATUS,
+  AXON_HUB_CHANNEL_TYPE,
+} from "~/constants/axonHub"
+import { ChannelType, DEFAULT_CHANNEL_FIELDS } from "~/constants/managedSite"
+import { SITE_TYPES } from "~/constants/siteType"
+import { hasUsableApiTokenKey } from "~/services/accountTokens/apiTokenKey"
+import {
+  AxonHubNativeError,
+  isRegularAxonHubChannelType,
+  openAxonHubNativeResourceOperations,
+  type AxonHubNativeFailure,
+} from "~/services/apiAdapters/managedResources/axonHub"
+import type { AxonHubChannel, AxonHubCreateChannelInput } from "~/types/axonHub"
+import { MANAGED_SITE_CHANNEL_MIGRATION_BLOCKED_REASON_CODES } from "~/types/managedSiteMigration"
+import {
+  MANAGED_SITE_MIGRATION_EXECUTION_FAILURE_CODES,
+  type ManagedSiteMigrationCapability,
+  type ManagedSiteMigrationConfirmedFailureCode,
+  type ManagedSiteMigrationSource,
+} from "~/types/managedSiteMigrationCapability"
+import { normalizeList } from "~/utils/core/string"
+
+const blockers = MANAGED_SITE_CHANNEL_MIGRATION_BLOCKED_REASON_CODES
+const failures = MANAGED_SITE_MIGRATION_EXECUTION_FAILURE_CODES
+
+const AXON_HUB_TO_CHANNEL_TYPE: Readonly<Partial<Record<string, ChannelType>>> =
+  {
+    [AXON_HUB_CHANNEL_TYPE.OPENAI]: ChannelType.OpenAI,
+    [AXON_HUB_CHANNEL_TYPE.OPENAI_RESPONSES]: ChannelType.OpenAI,
+    [AXON_HUB_CHANNEL_TYPE.ANTHROPIC]: ChannelType.Anthropic,
+    [AXON_HUB_CHANNEL_TYPE.ANTHROPIC_AWS]: ChannelType.Anthropic,
+    [AXON_HUB_CHANNEL_TYPE.ANTHROPIC_GCP]: ChannelType.Anthropic,
+    [AXON_HUB_CHANNEL_TYPE.CLAUDECODE]: ChannelType.Anthropic,
+    [AXON_HUB_CHANNEL_TYPE.GEMINI_OPENAI]: ChannelType.Gemini,
+    [AXON_HUB_CHANNEL_TYPE.GEMINI]: ChannelType.Gemini,
+    [AXON_HUB_CHANNEL_TYPE.GEMINI_VERTEX]: ChannelType.Gemini,
+    [AXON_HUB_CHANNEL_TYPE.DEEPSEEK]: ChannelType.DeepSeek,
+    [AXON_HUB_CHANNEL_TYPE.DEEPSEEK_ANTHROPIC]: ChannelType.DeepSeek,
+    [AXON_HUB_CHANNEL_TYPE.OPENROUTER]: ChannelType.OpenRouter,
+    [AXON_HUB_CHANNEL_TYPE.XAI]: ChannelType.Xai,
+    [AXON_HUB_CHANNEL_TYPE.SILICONFLOW]: ChannelType.SiliconFlow,
+    [AXON_HUB_CHANNEL_TYPE.VOLCENGINE]: ChannelType.VolcEngine,
+    [AXON_HUB_CHANNEL_TYPE.OLLAMA]: ChannelType.Ollama,
+    [AXON_HUB_CHANNEL_TYPE.GITHUB_COPILOT]: ChannelType.OpenAI,
+    [AXON_HUB_CHANNEL_TYPE.NANOGPT]: ChannelType.OpenAI,
+  }
+
+const CHANNEL_TYPE_TO_AXON_HUB: Readonly<Partial<Record<ChannelType, string>>> =
+  {
+    [ChannelType.OpenAI]: AXON_HUB_CHANNEL_TYPE.OPENAI,
+    [ChannelType.Anthropic]: AXON_HUB_CHANNEL_TYPE.ANTHROPIC,
+    [ChannelType.OpenRouter]: AXON_HUB_CHANNEL_TYPE.OPENROUTER,
+    [ChannelType.Gemini]: AXON_HUB_CHANNEL_TYPE.GEMINI,
+    [ChannelType.VertexAi]: AXON_HUB_CHANNEL_TYPE.GEMINI,
+    [ChannelType.SiliconFlow]: AXON_HUB_CHANNEL_TYPE.SILICONFLOW,
+    [ChannelType.DeepSeek]: AXON_HUB_CHANNEL_TYPE.DEEPSEEK,
+    [ChannelType.VolcEngine]: AXON_HUB_CHANNEL_TYPE.VOLCENGINE,
+    [ChannelType.Xai]: AXON_HUB_CHANNEL_TYPE.XAI,
+    [ChannelType.Ollama]: AXON_HUB_CHANNEL_TYPE.OLLAMA,
+  }
+
+const toAxonHubChannelType = (type: ChannelType): string =>
+  CHANNEL_TYPE_TO_AXON_HUB[type] ?? AXON_HUB_CHANNEL_TYPE.OPENAI
+
+const getCredentialCandidates = (channel: AxonHubChannel): string[] =>
+  [
+    ...(channel.credentials?.apiKeys ?? []),
+    ...(channel.credentials?.apiKey ? [channel.credentials.apiKey] : []),
+  ]
+    .map((key) => key.trim())
+    .filter(Boolean)
+
+const inspectCredential = (channel: AxonHubChannel) => {
+  if (channel.credentials === null) {
+    return { state: "permission-hidden" as const }
+  }
+  if (!isRegularAxonHubChannelType(String(channel.type))) {
+    return { state: "unavailable" as const }
+  }
+  const candidates = getCredentialCandidates(channel)
+  const credential = candidates.find(hasUsableApiTokenKey)
+  if (credential) return { state: "available" as const, credential }
+  return candidates.length > 0
+    ? { state: "masked" as const }
+    : { state: "unavailable" as const }
+}
+
+const credentialBlocker = (
+  state: "permission-hidden" | "masked" | "unavailable",
+) =>
+  state === "permission-hidden"
+    ? blockers.SOURCE_KEY_RESOLUTION_FAILED
+    : blockers.SOURCE_KEY_MISSING
+
+const hasAdvancedSettings = (channel: AxonHubChannel): boolean =>
+  Boolean(
+    (channel.settings && Object.keys(channel.settings).length > 0) ||
+      (channel.policies && Object.keys(channel.policies).length > 0) ||
+      channel.endpoints?.length ||
+      channel.tags?.length ||
+      channel.autoSyncSupportedModels ||
+      channel.autoSyncModelPattern ||
+      channel.remark,
+  )
+
+const toCanonicalSource = (
+  channel: AxonHubChannel,
+): ManagedSiteMigrationSource => ({
+  sourceSiteType: SITE_TYPES.AXON_HUB,
+  resourceType:
+    AXON_HUB_TO_CHANNEL_TYPE[String(channel.type)] ?? ChannelType.OpenAI,
+  baseUrl: channel.baseURL?.trim() ?? "",
+  models: normalizeList([
+    ...(channel.supportedModels ?? []),
+    ...(channel.manualModels ?? []),
+  ]),
+  groups: [],
+  priority: DEFAULT_CHANNEL_FIELDS.priority,
+  weight: channel.orderingWeight ?? DEFAULT_CHANNEL_FIELDS.weight,
+  status:
+    channel.status === AXON_HUB_CHANNEL_STATUS.ENABLED
+      ? "enabled"
+      : channel.status === AXON_HUB_CHANNEL_STATUS.DISABLED
+        ? "disabled"
+        : "other",
+  lossSignals: {
+    hasModelMapping: Boolean(channel.settings?.modelMappings?.length),
+    hasStatusCodeMapping: false,
+    hasAdvancedSettings: hasAdvancedSettings(channel),
+    hasMultiKeyState: getCredentialCandidates(channel).length > 1,
+  },
+})
+
+const toConfirmedFailureCode = (
+  failure: AxonHubNativeFailure,
+): ManagedSiteMigrationConfirmedFailureCode => {
+  switch (failure.code) {
+    case "upstream_rejected":
+      return failures.TargetRejected
+    case "configuration_required":
+    case "invalid_configuration":
+    case "authentication_failed":
+    case "permission_denied":
+    case "not_found":
+    case "unavailable":
+      return failures.TargetUnavailable
+    default:
+      return failures.Unexpected
+  }
+}
+
+const normalizeAxonHubNativeAbort = (error: unknown): unknown => {
+  if (
+    !(error instanceof AxonHubNativeError) ||
+    error.failure.code !== "aborted"
+  ) {
+    return error
+  }
+
+  const abortError = new Error("AxonHub native operation was aborted.", {
+    cause: error,
+  })
+  abortError.name = "AbortError"
+  return abortError
+}
+
+const withNormalizedAxonHubAbort = async <T>(
+  operation: () => Promise<T>,
+): Promise<T> => {
+  try {
+    return await operation()
+  } catch (error) {
+    throw normalizeAxonHubNativeAbort(error)
+  }
+}
+
+/**
+ * AxonHub beta5 regular channels use apiKeys and a separate status mutation.
+ * Source: https://github.com/looplj/axonhub/blob/d061ac7df6aef0c5ec6cdfa9dc5002546a1c5a57/frontend/src/features/channels/data/schema.ts
+ */
+export const axonHubManagedSiteMigrationCapability: ManagedSiteMigrationCapability =
+  {
+    source: {
+      prepare: async (selection, options) => {
+        const detail = await withNormalizedAxonHubAbort(async () => {
+          const operations = await openAxonHubNativeResourceOperations(options)
+          return await operations.get(selection.ref, options)
+        })
+        const credential = inspectCredential(detail)
+        if (credential.state !== "available") {
+          return {
+            status: "blocked",
+            reasonCode: credentialBlocker(credential.state),
+          }
+        }
+        return { status: "ready", source: toCanonicalSource(detail) }
+      },
+      resolveCredential: async (selection, options) => {
+        const detail = await withNormalizedAxonHubAbort(async () => {
+          const operations = await openAxonHubNativeResourceOperations(options)
+          return await operations.get(selection.ref, options)
+        })
+        const credential = inspectCredential(detail)
+        if (credential.state !== "available") {
+          return {
+            status: "blocked",
+            reasonCode: credentialBlocker(credential.state),
+          }
+        }
+        return { status: "ready", credential: credential.credential }
+      },
+    },
+    target: {
+      prepare: async (source) => {
+        const type = toAxonHubChannelType(source.resourceType)
+        const groups = [...DEFAULT_CHANNEL_FIELDS.groups]
+        const priority = DEFAULT_CHANNEL_FIELDS.priority
+        return {
+          projection: {
+            name: "",
+            type,
+            baseUrl: source.baseUrl,
+            models: [...source.models],
+            groups,
+            priority,
+            weight: source.weight,
+            status: source.status === "enabled" ? 1 : 2,
+          },
+          adjustments: {
+            remappedType: String(type) !== String(source.resourceType),
+            normalizedBaseUrl: false,
+            forcedDefaultGroup:
+              groups.length !== source.groups.length ||
+              groups.some((group, index) => group !== source.groups[index]),
+            ignoredPriority: priority !== source.priority,
+            ignoredWeight: false,
+            simplifiedStatus: source.status === "other",
+          },
+        }
+      },
+      create: async (command, options) => {
+        const baseURL = command.projection.baseUrl.trim()
+        const input: AxonHubCreateChannelInput = {
+          type:
+            typeof command.projection.type === "string"
+              ? command.projection.type
+              : toAxonHubChannelType(command.source.resourceType),
+          name: command.projection.name.trim(),
+          ...(baseURL ? { baseURL } : {}),
+          credentials: { apiKeys: [command.credential.trim()] },
+          supportedModels: [...command.projection.models],
+          manualModels: [...command.projection.models],
+          defaultTestModel: command.projection.models[0] ?? "",
+          settings: {},
+          orderingWeight: command.projection.weight,
+        }
+        let operations: Awaited<
+          ReturnType<typeof openAxonHubNativeResourceOperations>
+        >
+        try {
+          operations = await withNormalizedAxonHubAbort(() =>
+            openAxonHubNativeResourceOperations(options),
+          )
+        } catch (error) {
+          if (!(error instanceof AxonHubNativeError)) {
+            throw error
+          }
+          return {
+            status: "failed",
+            failureCode: toConfirmedFailureCode(error.failure),
+          }
+        }
+        const result = await operations.create(
+          input,
+          command.projection.status === 1
+            ? AXON_HUB_CHANNEL_STATUS.ENABLED
+            : AXON_HUB_CHANNEL_STATUS.DISABLED,
+          options,
+        )
+        if (result.certainty === "applied") return { status: "created" }
+        if (result.certainty === "not-applied") {
+          return {
+            status: "failed",
+            failureCode: toConfirmedFailureCode(result.failure),
+          }
+        }
+        return { status: "uncertain" }
+      },
+    },
+  }

--- a/src/services/apiAdapters/managedResources/axonHubMigration.ts
+++ b/src/services/apiAdapters/managedResources/axonHubMigration.ts
@@ -1,8 +1,5 @@
-import {
-  AXON_HUB_CHANNEL_STATUS,
-  AXON_HUB_CHANNEL_TYPE,
-} from "~/constants/axonHub"
-import { ChannelType, DEFAULT_CHANNEL_FIELDS } from "~/constants/managedSite"
+import { AXON_HUB_CHANNEL_STATUS } from "~/constants/axonHub"
+import { DEFAULT_CHANNEL_FIELDS } from "~/constants/managedSite"
 import { SITE_TYPES } from "~/constants/siteType"
 import { hasUsableApiTokenKey } from "~/services/accountTokens/apiTokenKey"
 import {
@@ -11,6 +8,10 @@ import {
   openAxonHubNativeResourceOperations,
   type AxonHubNativeFailure,
 } from "~/services/apiAdapters/managedResources/axonHub"
+import {
+  mapAxonHubChannelTypeToChannelType,
+  mapChannelTypeToAxonHubChannelType,
+} from "~/services/apiAdapters/managedResources/axonHubChannelType"
 import type { AxonHubChannel, AxonHubCreateChannelInput } from "~/types/axonHub"
 import { MANAGED_SITE_CHANNEL_MIGRATION_BLOCKED_REASON_CODES } from "~/types/managedSiteMigration"
 import {
@@ -23,45 +24,6 @@ import { normalizeList } from "~/utils/core/string"
 
 const blockers = MANAGED_SITE_CHANNEL_MIGRATION_BLOCKED_REASON_CODES
 const failures = MANAGED_SITE_MIGRATION_EXECUTION_FAILURE_CODES
-
-const AXON_HUB_TO_CHANNEL_TYPE: Readonly<Partial<Record<string, ChannelType>>> =
-  {
-    [AXON_HUB_CHANNEL_TYPE.OPENAI]: ChannelType.OpenAI,
-    [AXON_HUB_CHANNEL_TYPE.OPENAI_RESPONSES]: ChannelType.OpenAI,
-    [AXON_HUB_CHANNEL_TYPE.ANTHROPIC]: ChannelType.Anthropic,
-    [AXON_HUB_CHANNEL_TYPE.ANTHROPIC_AWS]: ChannelType.Anthropic,
-    [AXON_HUB_CHANNEL_TYPE.ANTHROPIC_GCP]: ChannelType.Anthropic,
-    [AXON_HUB_CHANNEL_TYPE.CLAUDECODE]: ChannelType.Anthropic,
-    [AXON_HUB_CHANNEL_TYPE.GEMINI_OPENAI]: ChannelType.Gemini,
-    [AXON_HUB_CHANNEL_TYPE.GEMINI]: ChannelType.Gemini,
-    [AXON_HUB_CHANNEL_TYPE.GEMINI_VERTEX]: ChannelType.Gemini,
-    [AXON_HUB_CHANNEL_TYPE.DEEPSEEK]: ChannelType.DeepSeek,
-    [AXON_HUB_CHANNEL_TYPE.DEEPSEEK_ANTHROPIC]: ChannelType.DeepSeek,
-    [AXON_HUB_CHANNEL_TYPE.OPENROUTER]: ChannelType.OpenRouter,
-    [AXON_HUB_CHANNEL_TYPE.XAI]: ChannelType.Xai,
-    [AXON_HUB_CHANNEL_TYPE.SILICONFLOW]: ChannelType.SiliconFlow,
-    [AXON_HUB_CHANNEL_TYPE.VOLCENGINE]: ChannelType.VolcEngine,
-    [AXON_HUB_CHANNEL_TYPE.OLLAMA]: ChannelType.Ollama,
-    [AXON_HUB_CHANNEL_TYPE.GITHUB_COPILOT]: ChannelType.OpenAI,
-    [AXON_HUB_CHANNEL_TYPE.NANOGPT]: ChannelType.OpenAI,
-  }
-
-const CHANNEL_TYPE_TO_AXON_HUB: Readonly<Partial<Record<ChannelType, string>>> =
-  {
-    [ChannelType.OpenAI]: AXON_HUB_CHANNEL_TYPE.OPENAI,
-    [ChannelType.Anthropic]: AXON_HUB_CHANNEL_TYPE.ANTHROPIC,
-    [ChannelType.OpenRouter]: AXON_HUB_CHANNEL_TYPE.OPENROUTER,
-    [ChannelType.Gemini]: AXON_HUB_CHANNEL_TYPE.GEMINI,
-    [ChannelType.VertexAi]: AXON_HUB_CHANNEL_TYPE.GEMINI,
-    [ChannelType.SiliconFlow]: AXON_HUB_CHANNEL_TYPE.SILICONFLOW,
-    [ChannelType.DeepSeek]: AXON_HUB_CHANNEL_TYPE.DEEPSEEK,
-    [ChannelType.VolcEngine]: AXON_HUB_CHANNEL_TYPE.VOLCENGINE,
-    [ChannelType.Xai]: AXON_HUB_CHANNEL_TYPE.XAI,
-    [ChannelType.Ollama]: AXON_HUB_CHANNEL_TYPE.OLLAMA,
-  }
-
-const toAxonHubChannelType = (type: ChannelType): string =>
-  CHANNEL_TYPE_TO_AXON_HUB[type] ?? AXON_HUB_CHANNEL_TYPE.OPENAI
 
 const getCredentialCandidates = (channel: AxonHubChannel): string[] =>
   [
@@ -108,8 +70,7 @@ const toCanonicalSource = (
   channel: AxonHubChannel,
 ): ManagedSiteMigrationSource => ({
   sourceSiteType: SITE_TYPES.AXON_HUB,
-  resourceType:
-    AXON_HUB_TO_CHANNEL_TYPE[String(channel.type)] ?? ChannelType.OpenAI,
+  resourceType: mapAxonHubChannelTypeToChannelType(String(channel.type)),
   baseUrl: channel.baseURL?.trim() ?? "",
   models: normalizeList([
     ...(channel.supportedModels ?? []),
@@ -213,7 +174,11 @@ export const axonHubManagedSiteMigrationCapability: ManagedSiteMigrationCapabili
     },
     target: {
       prepare: async (source) => {
-        const type = toAxonHubChannelType(source.resourceType)
+        const models = normalizeList(source.models)
+        if (models.length === 0) {
+          throw new Error("AxonHub migration requires at least one model.")
+        }
+        const type = mapChannelTypeToAxonHubChannelType(source.resourceType)
         const groups = [...DEFAULT_CHANNEL_FIELDS.groups]
         const priority = DEFAULT_CHANNEL_FIELDS.priority
         return {
@@ -221,7 +186,7 @@ export const axonHubManagedSiteMigrationCapability: ManagedSiteMigrationCapabili
             name: "",
             type,
             baseUrl: source.baseUrl,
-            models: [...source.models],
+            models,
             groups,
             priority,
             weight: source.weight,
@@ -245,7 +210,7 @@ export const axonHubManagedSiteMigrationCapability: ManagedSiteMigrationCapabili
           type:
             typeof command.projection.type === "string"
               ? command.projection.type
-              : toAxonHubChannelType(command.source.resourceType),
+              : mapChannelTypeToAxonHubChannelType(command.source.resourceType),
           name: command.projection.name.trim(),
           ...(baseURL ? { baseURL } : {}),
           credentials: { apiKeys: [command.credential.trim()] },
@@ -280,6 +245,14 @@ export const axonHubManagedSiteMigrationCapability: ManagedSiteMigrationCapabili
         )
         if (result.certainty === "applied") return { status: "created" }
         if (result.certainty === "not-applied") {
+          if (
+            result.failure.code === "aborted" &&
+            result.failure.dispatch === "before"
+          ) {
+            throw normalizeAxonHubNativeAbort(
+              new AxonHubNativeError(result.failure),
+            )
+          }
           return {
             status: "failed",
             failureCode: toConfirmedFailureCode(result.failure),

--- a/src/services/managedSites/channelMigration.ts
+++ b/src/services/managedSites/channelMigration.ts
@@ -1,19 +1,28 @@
-import { AXON_HUB_CHANNEL_TYPE } from "~/constants/axonHub"
-import { CLAUDE_CODE_HUB_PROVIDER_TYPE } from "~/constants/claudeCodeHub"
-import { ChannelType, DEFAULT_CHANNEL_FIELDS } from "~/constants/managedSite"
 import { SITE_TYPES, type ManagedSiteType } from "~/constants/siteType"
+import {
+  MANAGED_RESOURCE_FAILURE_CODES,
+  ManagedResourceError,
+  type ResourceOperationOptions,
+} from "~/services/apiAdapters/contracts/managedResourceNative"
 import type { ManagedUpstreamResourcesCapability } from "~/services/apiAdapters/contracts/managedUpstreamResources"
+import {
+  executeManagedSiteMigrationCore,
+  prepareManagedSiteMigrationPreviewCore,
+} from "~/services/managedSites/channelMigrationCanonicalOrchestrator"
+import { resolveManagedSiteMigrationCapability } from "~/services/managedSites/channelMigrationCapabilityRegistry"
+import {
+  toCanonicalMigrationSelectionFromLegacyRow,
+  toCanonicalMigrationSourceFromLegacyChannel,
+  toCanonicalTargetPreparationFromLegacyDraft,
+  toLegacyChannelFormDataProjection,
+  toLegacyMigrationWarningCodes,
+} from "~/services/managedSites/channelMigrationLegacyFacade"
 import {
   getManagedSiteServiceForType,
   type ManagedSiteService,
 } from "~/services/managedSites/managedSiteService"
 import { MANAGED_UPSTREAM_RESOURCE_FEATURES } from "~/services/managedSites/managedUpstreamResourceMigration"
 import { resolveManagedUpstreamResourceFeatureCapabilities } from "~/services/managedSites/managedUpstreamResourceService"
-import {
-  buildOctopusBaseUrl,
-  mapChannelTypeToOctopusOutboundType,
-  mapOctopusOutboundTypeToChannelType,
-} from "~/services/managedSites/providers/octopus"
 import {
   resolveManagedSiteRuntimeConfigForType,
   type ManagedSiteRuntimeConfigValue,
@@ -23,18 +32,23 @@ import type { UserPreferences } from "~/services/preferences/userPreferences"
 import type { ChannelFormData, ManagedSiteChannel } from "~/types/managedSite"
 import {
   MANAGED_SITE_CHANNEL_MIGRATION_BLOCKED_REASON_CODES,
-  MANAGED_SITE_CHANNEL_MIGRATION_GENERAL_WARNING_CODES,
-  MANAGED_SITE_CHANNEL_MIGRATION_ITEM_WARNING_CODES,
   type ManagedSiteChannelMigrationBlockedReasonCode,
   type ManagedSiteChannelMigrationExecutionItem,
   type ManagedSiteChannelMigrationExecutionResult,
-  type ManagedSiteChannelMigrationItemWarningCode,
   type ManagedSiteChannelMigrationPreview,
   type ManagedSiteChannelMigrationPreviewItem,
 } from "~/types/managedSiteMigration"
+import {
+  MANAGED_SITE_MIGRATION_EXECUTION_FAILURE_CODES,
+  type ManagedSiteMigrationCanonicalExecutionResult,
+  type ManagedSiteMigrationCanonicalPreview,
+  type ManagedSiteMigrationCanonicalPreviewItem,
+  type ManagedSiteMigrationSelection,
+  type ManagedSiteMigrationSource,
+  type ManagedSiteMigrationTargetPreparation,
+} from "~/types/managedSiteMigrationCapability"
 import { createManagedUpstreamResourceRef } from "~/types/managedUpstreamResource"
 import { getErrorMessage } from "~/utils/core/error"
-import { normalizeList } from "~/utils/core/string"
 
 interface PrepareManagedSiteChannelMigrationPreviewParams {
   preferences: UserPreferences
@@ -63,25 +77,8 @@ type ChannelMigrationResourceCapabilities = ManagedUpstreamResourcesCapability<
   ChannelFormData
 >
 
-const parseDelimitedValues = (value: string | null | undefined) =>
-  normalizeList(value?.split(",") ?? [])
-
-const areStringArraysEqual = (left: string[], right: string[]): boolean =>
-  left.length === right.length &&
-  left.every((item, index) => item === right[index])
-
-const hasMeaningfulValue = (value: string | null | undefined) =>
-  Boolean(value?.trim())
-
-const hasMultiKeyState = (channel: ManagedSiteChannel) =>
-  Boolean(
-    channel.channel_info?.is_multi_key ||
-      (channel.channel_info?.multi_key_size ?? 0) > 0 ||
-      channel.channel_info?.multi_key_status_list?.length ||
-      channel.channel_info?.multi_key_mode,
-  )
-
-const PREVIEW_BUILD_CONCURRENCY = 5
+const migrationBlockers = MANAGED_SITE_CHANNEL_MIGRATION_BLOCKED_REASON_CODES
+const migrationFailures = MANAGED_SITE_MIGRATION_EXECUTION_FAILURE_CODES
 
 const normalizeResourceScopeKey = (baseUrl: string): string => {
   const trimmed = baseUrl.trim()
@@ -106,386 +103,6 @@ const resolveChannelMigrationResourceCapabilities = (
   }
 
   return resolution.capabilities as ChannelMigrationResourceCapabilities
-}
-
-const AXON_HUB_TO_SHARED_CHANNEL_TYPE: Partial<Record<string, ChannelType>> = {
-  [AXON_HUB_CHANNEL_TYPE.OPENAI]: ChannelType.OpenAI,
-  [AXON_HUB_CHANNEL_TYPE.OPENAI_RESPONSES]: ChannelType.OpenAI,
-  [AXON_HUB_CHANNEL_TYPE.ANTHROPIC]: ChannelType.Anthropic,
-  [AXON_HUB_CHANNEL_TYPE.ANTHROPIC_AWS]: ChannelType.Anthropic,
-  [AXON_HUB_CHANNEL_TYPE.ANTHROPIC_GCP]: ChannelType.Anthropic,
-  [AXON_HUB_CHANNEL_TYPE.CLAUDECODE]: ChannelType.Anthropic,
-  [AXON_HUB_CHANNEL_TYPE.GEMINI_OPENAI]: ChannelType.Gemini,
-  [AXON_HUB_CHANNEL_TYPE.GEMINI]: ChannelType.Gemini,
-  [AXON_HUB_CHANNEL_TYPE.GEMINI_VERTEX]: ChannelType.Gemini,
-  [AXON_HUB_CHANNEL_TYPE.DEEPSEEK]: ChannelType.DeepSeek,
-  [AXON_HUB_CHANNEL_TYPE.DEEPSEEK_ANTHROPIC]: ChannelType.DeepSeek,
-  [AXON_HUB_CHANNEL_TYPE.OPENROUTER]: ChannelType.OpenRouter,
-  [AXON_HUB_CHANNEL_TYPE.XAI]: ChannelType.Xai,
-  [AXON_HUB_CHANNEL_TYPE.SILICONFLOW]: ChannelType.SiliconFlow,
-  [AXON_HUB_CHANNEL_TYPE.VOLCENGINE]: ChannelType.VolcEngine,
-  [AXON_HUB_CHANNEL_TYPE.OLLAMA]: ChannelType.Ollama,
-  [AXON_HUB_CHANNEL_TYPE.GITHUB_COPILOT]: ChannelType.OpenAI,
-  [AXON_HUB_CHANNEL_TYPE.NANOGPT]: ChannelType.OpenAI,
-}
-
-const SHARED_TO_AXON_HUB_CHANNEL_TYPE: Partial<Record<ChannelType, string>> = {
-  [ChannelType.Unknown]: AXON_HUB_CHANNEL_TYPE.OPENAI,
-  [ChannelType.OpenAI]: AXON_HUB_CHANNEL_TYPE.OPENAI,
-  [ChannelType.Azure]: AXON_HUB_CHANNEL_TYPE.OPENAI,
-  [ChannelType.OpenAIMax]: AXON_HUB_CHANNEL_TYPE.OPENAI,
-  [ChannelType.OhMyGPT]: AXON_HUB_CHANNEL_TYPE.OPENAI,
-  [ChannelType.Custom]: AXON_HUB_CHANNEL_TYPE.OPENAI,
-  [ChannelType.AILS]: AXON_HUB_CHANNEL_TYPE.OPENAI,
-  [ChannelType.AIProxy]: AXON_HUB_CHANNEL_TYPE.OPENAI,
-  [ChannelType.API2GPT]: AXON_HUB_CHANNEL_TYPE.OPENAI,
-  [ChannelType.AIGC2D]: AXON_HUB_CHANNEL_TYPE.OPENAI,
-  [ChannelType.Anthropic]: AXON_HUB_CHANNEL_TYPE.ANTHROPIC,
-  [ChannelType.OpenRouter]: AXON_HUB_CHANNEL_TYPE.OPENROUTER,
-  [ChannelType.Gemini]: AXON_HUB_CHANNEL_TYPE.GEMINI,
-  [ChannelType.VertexAi]: AXON_HUB_CHANNEL_TYPE.GEMINI,
-  [ChannelType.SiliconFlow]: AXON_HUB_CHANNEL_TYPE.SILICONFLOW,
-  [ChannelType.DeepSeek]: AXON_HUB_CHANNEL_TYPE.DEEPSEEK,
-  [ChannelType.VolcEngine]: AXON_HUB_CHANNEL_TYPE.VOLCENGINE,
-  [ChannelType.Xai]: AXON_HUB_CHANNEL_TYPE.XAI,
-  [ChannelType.Ollama]: AXON_HUB_CHANNEL_TYPE.OLLAMA,
-}
-
-const CLAUDE_CODE_HUB_TO_SHARED_CHANNEL_TYPE: Partial<
-  Record<string, ChannelType>
-> = {
-  [CLAUDE_CODE_HUB_PROVIDER_TYPE.OPENAI_COMPATIBLE]: ChannelType.OpenAI,
-  [CLAUDE_CODE_HUB_PROVIDER_TYPE.CODEX]: ChannelType.OpenAI,
-  [CLAUDE_CODE_HUB_PROVIDER_TYPE.CLAUDE]: ChannelType.Anthropic,
-  [CLAUDE_CODE_HUB_PROVIDER_TYPE.GEMINI]: ChannelType.Gemini,
-}
-
-const SHARED_TO_CLAUDE_CODE_HUB_PROVIDER_TYPE: Partial<
-  Record<ChannelType, string>
-> = {
-  [ChannelType.Unknown]: CLAUDE_CODE_HUB_PROVIDER_TYPE.OPENAI_COMPATIBLE,
-  [ChannelType.OpenAI]: CLAUDE_CODE_HUB_PROVIDER_TYPE.OPENAI_COMPATIBLE,
-  [ChannelType.Azure]: CLAUDE_CODE_HUB_PROVIDER_TYPE.OPENAI_COMPATIBLE,
-  [ChannelType.OpenAIMax]: CLAUDE_CODE_HUB_PROVIDER_TYPE.OPENAI_COMPATIBLE,
-  [ChannelType.OhMyGPT]: CLAUDE_CODE_HUB_PROVIDER_TYPE.OPENAI_COMPATIBLE,
-  [ChannelType.Custom]: CLAUDE_CODE_HUB_PROVIDER_TYPE.OPENAI_COMPATIBLE,
-  [ChannelType.AILS]: CLAUDE_CODE_HUB_PROVIDER_TYPE.OPENAI_COMPATIBLE,
-  [ChannelType.AIProxy]: CLAUDE_CODE_HUB_PROVIDER_TYPE.OPENAI_COMPATIBLE,
-  [ChannelType.API2GPT]: CLAUDE_CODE_HUB_PROVIDER_TYPE.OPENAI_COMPATIBLE,
-  [ChannelType.AIGC2D]: CLAUDE_CODE_HUB_PROVIDER_TYPE.OPENAI_COMPATIBLE,
-  [ChannelType.Anthropic]: CLAUDE_CODE_HUB_PROVIDER_TYPE.CLAUDE,
-  [ChannelType.OpenRouter]: CLAUDE_CODE_HUB_PROVIDER_TYPE.OPENAI_COMPATIBLE,
-  [ChannelType.Gemini]: CLAUDE_CODE_HUB_PROVIDER_TYPE.GEMINI,
-  [ChannelType.VertexAi]: CLAUDE_CODE_HUB_PROVIDER_TYPE.GEMINI,
-  [ChannelType.SiliconFlow]: CLAUDE_CODE_HUB_PROVIDER_TYPE.OPENAI_COMPATIBLE,
-  [ChannelType.DeepSeek]: CLAUDE_CODE_HUB_PROVIDER_TYPE.OPENAI_COMPATIBLE,
-  [ChannelType.VolcEngine]: CLAUDE_CODE_HUB_PROVIDER_TYPE.OPENAI_COMPATIBLE,
-  [ChannelType.Xai]: CLAUDE_CODE_HUB_PROVIDER_TYPE.OPENAI_COMPATIBLE,
-  [ChannelType.Ollama]: CLAUDE_CODE_HUB_PROVIDER_TYPE.OPENAI_COMPATIBLE,
-}
-
-const getSafeClaudeCodeHubWeight = (weight?: number) => {
-  const numericWeight = Number(weight ?? 1)
-  if (!Number.isFinite(numericWeight)) {
-    return 1
-  }
-
-  return Math.max(1, Math.trunc(numericWeight))
-}
-
-const mapWithConcurrency = async <TItem, TResult>(
-  items: TItem[],
-  concurrency: number,
-  mapper: (item: TItem, index: number) => Promise<TResult>,
-): Promise<TResult[]> => {
-  if (items.length === 0) {
-    return []
-  }
-
-  const results = new Array<TResult>(items.length)
-  let nextIndex = 0
-
-  const workers = Array.from(
-    { length: Math.min(concurrency, items.length) },
-    async () => {
-      while (true) {
-        const index = nextIndex
-        nextIndex += 1
-
-        if (index >= items.length) {
-          return
-        }
-
-        results[index] = await mapper(items[index], index)
-      }
-    },
-  )
-
-  await Promise.all(workers)
-
-  return results
-}
-
-const getSharedChannelType = (
-  sourceSiteType: ManagedSiteType,
-  channel: ManagedSiteChannel,
-): ChannelType => {
-  const numericChannelType =
-    typeof channel.type === "number"
-      ? channel.type
-      : sourceSiteType === SITE_TYPES.AXON_HUB
-        ? AXON_HUB_TO_SHARED_CHANNEL_TYPE[channel.type] ?? ChannelType.OpenAI
-        : sourceSiteType === SITE_TYPES.CLAUDE_CODE_HUB
-          ? CLAUDE_CODE_HUB_TO_SHARED_CHANNEL_TYPE[channel.type] ??
-            ChannelType.OpenAI
-          : ChannelType.OpenAI
-
-  if (sourceSiteType === SITE_TYPES.OCTOPUS) {
-    return mapOctopusOutboundTypeToChannelType(numericChannelType)
-  }
-
-  return numericChannelType as ChannelType
-}
-
-const getTargetChannelType = (
-  sourceSiteType: ManagedSiteType,
-  targetSiteType: ManagedSiteType,
-  channel: ManagedSiteChannel,
-) => {
-  const sharedType = getSharedChannelType(sourceSiteType, channel)
-
-  if (targetSiteType === SITE_TYPES.OCTOPUS) {
-    return mapChannelTypeToOctopusOutboundType(sharedType)
-  }
-
-  if (targetSiteType === SITE_TYPES.AXON_HUB) {
-    // AxonHub rejects New API numeric channel types. Unknown or unsupported
-    // shared types fall back to OpenAI-compatible with a preview remap warning.
-    return (
-      SHARED_TO_AXON_HUB_CHANNEL_TYPE[sharedType] ??
-      AXON_HUB_CHANNEL_TYPE.OPENAI
-    )
-  }
-
-  if (targetSiteType === SITE_TYPES.CLAUDE_CODE_HUB) {
-    // Claude Code Hub uses string provider types. Source types that cannot be
-    // represented exactly fall back to OpenAI-compatible and receive a preview
-    // remap warning before the create payload is built.
-    return (
-      SHARED_TO_CLAUDE_CODE_HUB_PROVIDER_TYPE[sharedType] ??
-      CLAUDE_CODE_HUB_PROVIDER_TYPE.OPENAI_COMPATIBLE
-    )
-  }
-
-  return sharedType
-}
-
-const collectItemWarningCodes = (params: {
-  sourceSiteType: ManagedSiteType
-  targetSiteType: ManagedSiteType
-  channel: ManagedSiteChannel
-}): ManagedSiteChannelMigrationItemWarningCode[] => {
-  const { sourceSiteType, targetSiteType, channel } = params
-  const warnings = new Set<ManagedSiteChannelMigrationItemWarningCode>()
-
-  if (hasMeaningfulValue(channel.model_mapping)) {
-    warnings.add(
-      MANAGED_SITE_CHANNEL_MIGRATION_ITEM_WARNING_CODES.DROPS_MODEL_MAPPING,
-    )
-  }
-
-  if (hasMeaningfulValue(channel.status_code_mapping)) {
-    warnings.add(
-      MANAGED_SITE_CHANNEL_MIGRATION_ITEM_WARNING_CODES.DROPS_STATUS_CODE_MAPPING,
-    )
-  }
-
-  if (
-    hasMeaningfulValue(channel.setting) ||
-    hasMeaningfulValue(channel.settings)
-  ) {
-    warnings.add(
-      MANAGED_SITE_CHANNEL_MIGRATION_ITEM_WARNING_CODES.DROPS_ADVANCED_SETTINGS,
-    )
-  }
-
-  if (hasMultiKeyState(channel)) {
-    warnings.add(
-      MANAGED_SITE_CHANNEL_MIGRATION_ITEM_WARNING_CODES.DROPS_MULTI_KEY_STATE,
-    )
-  }
-
-  if (sourceSiteType !== targetSiteType) {
-    if (
-      sourceSiteType === SITE_TYPES.OCTOPUS ||
-      targetSiteType === SITE_TYPES.OCTOPUS ||
-      targetSiteType === SITE_TYPES.AXON_HUB ||
-      targetSiteType === SITE_TYPES.CLAUDE_CODE_HUB ||
-      ((sourceSiteType === SITE_TYPES.AXON_HUB ||
-        sourceSiteType === SITE_TYPES.CLAUDE_CODE_HUB) &&
-        typeof channel.type === "string")
-    ) {
-      warnings.add(
-        MANAGED_SITE_CHANNEL_MIGRATION_ITEM_WARNING_CODES.TARGET_REMAPS_CHANNEL_TYPE,
-      )
-    }
-  }
-
-  if (targetSiteType === SITE_TYPES.OCTOPUS) {
-    const normalizedBaseUrl = buildOctopusBaseUrl(channel.base_url ?? "")
-    if ((channel.base_url ?? "").trim() !== normalizedBaseUrl) {
-      warnings.add(
-        MANAGED_SITE_CHANNEL_MIGRATION_ITEM_WARNING_CODES.TARGET_NORMALIZES_BASE_URL,
-      )
-    }
-
-    const groups = parseDelimitedValues(channel.group)
-    if (groups.length !== 1 || groups[0] !== DEFAULT_CHANNEL_FIELDS.groups[0]) {
-      warnings.add(
-        MANAGED_SITE_CHANNEL_MIGRATION_ITEM_WARNING_CODES.TARGET_FORCES_DEFAULT_GROUP,
-      )
-    }
-
-    if ((channel.priority ?? DEFAULT_CHANNEL_FIELDS.priority) !== 0) {
-      warnings.add(
-        MANAGED_SITE_CHANNEL_MIGRATION_ITEM_WARNING_CODES.TARGET_IGNORES_PRIORITY,
-      )
-    }
-
-    if ((channel.weight ?? DEFAULT_CHANNEL_FIELDS.weight) !== 0) {
-      warnings.add(
-        MANAGED_SITE_CHANNEL_MIGRATION_ITEM_WARNING_CODES.TARGET_IGNORES_WEIGHT,
-      )
-    }
-
-    if (![1, 2].includes(channel.status ?? DEFAULT_CHANNEL_FIELDS.status)) {
-      warnings.add(
-        MANAGED_SITE_CHANNEL_MIGRATION_ITEM_WARNING_CODES.TARGET_SIMPLIFIES_STATUS,
-      )
-    }
-  }
-
-  if (targetSiteType === SITE_TYPES.AXON_HUB) {
-    const sourceGroups = parseDelimitedValues(channel.group)
-    const emittedGroups = [...DEFAULT_CHANNEL_FIELDS.groups]
-    if (!areStringArraysEqual(sourceGroups, emittedGroups)) {
-      warnings.add(
-        MANAGED_SITE_CHANNEL_MIGRATION_ITEM_WARNING_CODES.TARGET_FORCES_DEFAULT_GROUP,
-      )
-    }
-
-    if ((channel.priority ?? DEFAULT_CHANNEL_FIELDS.priority) !== 0) {
-      warnings.add(
-        MANAGED_SITE_CHANNEL_MIGRATION_ITEM_WARNING_CODES.TARGET_IGNORES_PRIORITY,
-      )
-    }
-
-    if (![1, 2].includes(channel.status ?? DEFAULT_CHANNEL_FIELDS.status)) {
-      warnings.add(
-        MANAGED_SITE_CHANNEL_MIGRATION_ITEM_WARNING_CODES.TARGET_SIMPLIFIES_STATUS,
-      )
-    }
-  }
-
-  if (targetSiteType === SITE_TYPES.CLAUDE_CODE_HUB) {
-    const sourceGroups = parseDelimitedValues(channel.group)
-    const emittedGroups =
-      sourceGroups.length > 0
-        ? [sourceGroups[0]]
-        : [DEFAULT_CHANNEL_FIELDS.groups[0]]
-    if (!areStringArraysEqual(sourceGroups, emittedGroups)) {
-      warnings.add(
-        MANAGED_SITE_CHANNEL_MIGRATION_ITEM_WARNING_CODES.TARGET_FORCES_DEFAULT_GROUP,
-      )
-    }
-
-    const sourceWeight = channel.weight ?? DEFAULT_CHANNEL_FIELDS.weight
-    if (getSafeClaudeCodeHubWeight(sourceWeight) !== sourceWeight) {
-      warnings.add(
-        MANAGED_SITE_CHANNEL_MIGRATION_ITEM_WARNING_CODES.TARGET_IGNORES_WEIGHT,
-      )
-    }
-
-    if (![1, 2].includes(channel.status ?? DEFAULT_CHANNEL_FIELDS.status)) {
-      warnings.add(
-        MANAGED_SITE_CHANNEL_MIGRATION_ITEM_WARNING_CODES.TARGET_SIMPLIFIES_STATUS,
-      )
-    }
-  }
-
-  return Array.from(warnings)
-}
-
-const buildDraftFromSourceChannel = (params: {
-  sourceSiteType: ManagedSiteType
-  targetSiteType: ManagedSiteType
-  channel: ManagedSiteChannel
-  key: string
-}): ChannelFormData => {
-  const { sourceSiteType, targetSiteType, channel, key } = params
-  const groups = parseDelimitedValues(channel.group)
-  const models = parseDelimitedValues(channel.models)
-  const sourceStatus = channel.status ?? DEFAULT_CHANNEL_FIELDS.status
-  const targetStatus =
-    targetSiteType === SITE_TYPES.OCTOPUS ||
-    targetSiteType === SITE_TYPES.AXON_HUB ||
-    targetSiteType === SITE_TYPES.CLAUDE_CODE_HUB
-      ? sourceStatus === 1
-        ? 1
-        : 2
-      : sourceStatus
-
-  return {
-    name: channel.name?.trim() || `Channel #${channel.id}`,
-    type: getTargetChannelType(sourceSiteType, targetSiteType, channel),
-    key: key.trim(),
-    base_url:
-      targetSiteType === SITE_TYPES.OCTOPUS
-        ? buildOctopusBaseUrl(channel.base_url ?? "")
-        : (channel.base_url ?? "").trim(),
-    models,
-    groups:
-      targetSiteType === SITE_TYPES.OCTOPUS ||
-      targetSiteType === SITE_TYPES.AXON_HUB
-        ? [...DEFAULT_CHANNEL_FIELDS.groups]
-        : targetSiteType === SITE_TYPES.CLAUDE_CODE_HUB
-          ? [groups[0] ?? DEFAULT_CHANNEL_FIELDS.groups[0]]
-          : groups.length > 0
-            ? groups
-            : [...DEFAULT_CHANNEL_FIELDS.groups],
-    priority:
-      targetSiteType === SITE_TYPES.OCTOPUS ||
-      targetSiteType === SITE_TYPES.AXON_HUB
-        ? DEFAULT_CHANNEL_FIELDS.priority
-        : channel.priority ?? DEFAULT_CHANNEL_FIELDS.priority,
-    weight:
-      targetSiteType === SITE_TYPES.OCTOPUS
-        ? DEFAULT_CHANNEL_FIELDS.weight
-        : targetSiteType === SITE_TYPES.CLAUDE_CODE_HUB
-          ? getSafeClaudeCodeHubWeight(channel.weight)
-          : channel.weight ?? DEFAULT_CHANNEL_FIELDS.weight,
-    status: targetStatus,
-  }
-}
-
-const prepareTargetDraftFromSourceChannel = async (params: {
-  sourceSiteType: ManagedSiteType
-  targetSiteType: ManagedSiteType
-  channel: ManagedSiteChannel
-  key: string
-}): Promise<ChannelFormData> => {
-  const draft = buildDraftFromSourceChannel(params)
-  const resources = resolveChannelMigrationResourceCapabilities(
-    params.targetSiteType,
-  )
-
-  if (!resources) {
-    return draft
-  }
-
-  // The resource path owns any native target conversion before create; the UI
-  // still shows the resulting data with channel terminology.
-  return await resources.drafts.prepareImportDraft({ source: draft })
 }
 
 const buildManagedUpstreamResourceRefForChannel = (params: {
@@ -682,129 +299,6 @@ const resolveSourceChannelKey = async (params: {
   }
 }
 
-const buildBlockedPreviewItem = (params: {
-  channel: ManagedSiteChannel
-  sourceSiteType: ManagedSiteType
-  targetSiteType: ManagedSiteType
-  blockingReasonCode?: ManagedSiteChannelMigrationBlockedReasonCode
-  blockingMessage?: string
-}): ManagedSiteChannelMigrationPreviewItem => ({
-  channelId: params.channel.id,
-  channelName: params.channel.name,
-  sourceChannel: params.channel,
-  draft: null,
-  status: "blocked",
-  warningCodes: collectItemWarningCodes({
-    sourceSiteType: params.sourceSiteType,
-    targetSiteType: params.targetSiteType,
-    channel: params.channel,
-  }),
-  blockingReasonCode: params.blockingReasonCode,
-  blockingMessage: params.blockingMessage,
-})
-
-/**
- * Resolves the final preview row, including any source-key hydration required
- * before a target channel can be created safely.
- */
-async function buildPreviewItem(
-  params: PrepareManagedSiteChannelMigrationPreviewParams & {
-    channel: ManagedSiteChannel
-  },
-): Promise<ManagedSiteChannelMigrationPreviewItem> {
-  const { channel, sourceSiteType, targetSiteType } = params
-
-  const keyResolution = await resolveSourceChannelKey({
-    preferences: params.preferences,
-    sourceSiteType,
-    channel,
-    resolveNewApiSourceKey: params.resolveNewApiSourceKey,
-  })
-
-  if (!keyResolution.key) {
-    return buildBlockedPreviewItem({
-      channel,
-      sourceSiteType,
-      targetSiteType,
-      blockingReasonCode: keyResolution.blockingReasonCode,
-      blockingMessage: keyResolution.blockingMessage,
-    })
-  }
-
-  let draft: ChannelFormData
-  try {
-    draft = await prepareTargetDraftFromSourceChannel({
-      sourceSiteType,
-      targetSiteType,
-      channel,
-      key: keyResolution.key,
-    })
-  } catch (error) {
-    return buildBlockedPreviewItem({
-      channel,
-      sourceSiteType,
-      targetSiteType,
-      blockingReasonCode:
-        MANAGED_SITE_CHANNEL_MIGRATION_BLOCKED_REASON_CODES.TARGET_DRAFT_PREPARATION_FAILED,
-      blockingMessage: getErrorMessage(error),
-    })
-  }
-
-  return {
-    channelId: channel.id,
-    channelName: channel.name,
-    sourceChannel: channel,
-    draft,
-    status: "ready",
-    warningCodes: collectItemWarningCodes({
-      sourceSiteType,
-      targetSiteType,
-      channel,
-    }),
-  }
-}
-
-const buildExecutionFailureItem = (
-  item: ManagedSiteChannelMigrationPreviewItem,
-  params: {
-    skipped: boolean
-    fallbackError?: string
-  },
-): ManagedSiteChannelMigrationExecutionItem => ({
-  channelId: item.channelId,
-  channelName: item.channelName,
-  success: false,
-  skipped: params.skipped,
-  blockingReasonCode: item.blockingReasonCode,
-  error: item.blockingMessage || params.fallbackError,
-})
-
-/**
- * Converts a target-config failure into per-channel execution results so the UI
- * can still show which rows were blocked versus which ready rows failed.
- */
-const buildCreateFailureResults = (
-  preview: ManagedSiteChannelMigrationPreview,
-  message: string,
-): ManagedSiteChannelMigrationExecutionResult => {
-  const items: ManagedSiteChannelMigrationExecutionItem[] = preview.items.map(
-    (item) =>
-      buildExecutionFailureItem(item, {
-        skipped: item.status !== "ready",
-        fallbackError: message,
-      }),
-  )
-
-  return {
-    totalSelected: preview.totalCount,
-    attemptedCount: 0,
-    createdCount: 0,
-    failedCount: preview.readyCount,
-    skippedCount: preview.blockedCount,
-    items,
-  }
-}
-
 const createTargetChannelForMigration = async (params: {
   targetSiteType: ManagedSiteType
   targetService: ManagedSiteService
@@ -826,6 +320,140 @@ const createTargetChannelForMigration = async (params: {
   return await targetResources.items.create(params.targetConfig, params.draft)
 }
 
+const buildLegacyTargetPreparationFromCanonicalSource = async (params: {
+  selection: ManagedSiteMigrationSelection
+  source: ManagedSiteMigrationSource
+  targetSiteType: ManagedSiteType
+  legacyStatus?: ChannelFormData["status"]
+  onPreparedPreviewDraft?: (draft: Omit<ChannelFormData, "key">) => void
+}): Promise<ManagedSiteMigrationTargetPreparation> => {
+  const resources = resolveChannelMigrationResourceCapabilities(
+    params.targetSiteType,
+  )
+  return await toCanonicalTargetPreparationFromLegacyDraft({
+    source: params.source,
+    targetSiteType: params.targetSiteType,
+    displayName: params.selection.displayName,
+    selectionId: params.selection.selectionId,
+    legacyStatus: params.legacyStatus,
+    preparePreviewDraft: async (draft) => {
+      const preparedDraft = resources
+        ? await resources.drafts.prepareImportDraft({
+            source: draft as ChannelFormData,
+          })
+        : draft
+      const { key: _credential, ...secretFreeDraft } = preparedDraft as
+        | ChannelFormData
+        | (Omit<ChannelFormData, "key"> & { key?: string })
+      params.onPreparedPreviewDraft?.(secretFreeDraft)
+      return secretFreeDraft
+    },
+  })
+}
+
+/** Builds a secret-free migration preview from canonical resource selections. */
+export async function prepareManagedSiteMigrationPreview(params: {
+  sourceSiteType: ManagedSiteType
+  targetSiteType: ManagedSiteType
+  selections: readonly ManagedSiteMigrationSelection[]
+  options?: ResourceOperationOptions
+}): Promise<ManagedSiteMigrationCanonicalPreview> {
+  const sourceCapability = resolveManagedSiteMigrationCapability(
+    params.sourceSiteType,
+  )?.source
+  const targetCapability = resolveManagedSiteMigrationCapability(
+    params.targetSiteType,
+  )?.target
+  return await prepareManagedSiteMigrationPreviewCore({
+    sourceSiteType: params.sourceSiteType,
+    targetSiteType: params.targetSiteType,
+    selections: params.selections,
+    signal: params.options?.signal,
+    sourceFailureReasonCode: migrationBlockers.SOURCE_KEY_RESOLUTION_FAILED,
+    targetFailureReasonCode: migrationBlockers.TARGET_DRAFT_PREPARATION_FAILED,
+    getReadyWarningCodes: (source, target) =>
+      toLegacyMigrationWarningCodes({
+        lossSignals: source.lossSignals,
+        adjustments: target.adjustments,
+      }),
+    prepareSource: (selection) =>
+      sourceCapability
+        ? sourceCapability.prepare(selection, params.options)
+        : Promise.resolve({
+            status: "blocked",
+            reasonCode: migrationBlockers.SOURCE_KEY_RESOLUTION_FAILED,
+          }),
+    prepareTarget: (selection, source) =>
+      targetCapability
+        ? targetCapability.prepare(source, params.options)
+        : buildLegacyTargetPreparationFromCanonicalSource({
+            selection,
+            source,
+            targetSiteType: params.targetSiteType,
+          }),
+  })
+}
+
+const isUncertainMigrationError = (error: unknown) =>
+  error instanceof ManagedResourceError &&
+  error.failure.code === MANAGED_RESOURCE_FAILURE_CODES.MutationStateUncertain
+
+/** Executes canonical migration rows without retaining credentials or commands. */
+export async function executeManagedSiteMigration(params: {
+  preview: ManagedSiteMigrationCanonicalPreview
+  options?: ResourceOperationOptions
+}): Promise<ManagedSiteMigrationCanonicalExecutionResult> {
+  const { preview } = params
+  const sourceCapability = resolveManagedSiteMigrationCapability(
+    preview.sourceSiteType,
+  )?.source
+  const targetCapability = resolveManagedSiteMigrationCapability(
+    preview.targetSiteType,
+  )?.target
+  const legacyTargetService = targetCapability
+    ? null
+    : getManagedSiteServiceForType(preview.targetSiteType)
+  const legacyTargetConfig = legacyTargetService
+    ? await legacyTargetService.getConfig()
+    : null
+
+  return await executeManagedSiteMigrationCore({
+    preview,
+    targetAvailable: Boolean(targetCapability || legacyTargetConfig),
+    signal: params.options?.signal,
+    sourceFailureReasonCode: migrationBlockers.SOURCE_KEY_RESOLUTION_FAILED,
+    isMutationStateUncertain: isUncertainMigrationError,
+    resolveCredential: (selection) =>
+      sourceCapability
+        ? sourceCapability.resolveCredential(selection, params.options)
+        : Promise.resolve({
+            status: "blocked",
+            reasonCode: migrationBlockers.SOURCE_KEY_RESOLUTION_FAILED,
+          }),
+    create: async (command) => {
+      if (targetCapability) {
+        return await targetCapability.create(command, params.options)
+      }
+      const response = await createTargetChannelForMigration({
+        targetSiteType: preview.targetSiteType,
+        targetService: legacyTargetService!,
+        targetConfig: legacyTargetConfig!,
+        draft: toLegacyChannelFormDataProjection({
+          source: command.source,
+          target: command.projection,
+          credential: command.credential,
+        }),
+      })
+      return response.success
+        ? { status: "created" }
+        : {
+            status: "failed",
+            failureCode: migrationFailures.TargetRejected,
+          }
+    },
+  })
+}
+
 /**
  * Builds a create-only migration preview for the selected source channels and
  * target managed-site type, including per-row warnings and blockers.
@@ -833,31 +461,131 @@ const createTargetChannelForMigration = async (params: {
 export async function prepareManagedSiteChannelMigrationPreview(
   params: PrepareManagedSiteChannelMigrationPreviewParams,
 ): Promise<ManagedSiteChannelMigrationPreview> {
-  const items = await mapWithConcurrency(
-    params.channels,
-    PREVIEW_BUILD_CONCURRENCY,
-    (channel) =>
-      buildPreviewItem({
-        ...params,
-        channel,
-      }),
+  const sourceScopeKey = normalizeResourceScopeKey(
+    resolveManagedSiteRuntimeConfigForType(
+      params.preferences,
+      params.sourceSiteType,
+    )?.config.baseUrl ?? "",
   )
-
-  const readyCount = items.filter((item) => item.status === "ready").length
-  const blockedCount = items.length - readyCount
-
-  return {
+  const selections = params.channels.map((channel) =>
+    toCanonicalMigrationSelectionFromLegacyRow({
+      sourceSiteType: params.sourceSiteType,
+      channel,
+      scopeKey: sourceScopeKey,
+    }),
+  )
+  const channelsBySelectionId = new Map(
+    selections.map((selection, index) => [
+      selection.selectionId,
+      params.channels[index],
+    ]),
+  )
+  const credentials = new Map<string, string>()
+  const blockingMessages = new Map<string, string>()
+  const preparedDrafts = new Map<string, Omit<ChannelFormData, "key">>()
+  const getChannel = (selection: ManagedSiteMigrationSelection) =>
+    channelsBySelectionId.get(selection.selectionId)!
+  const getWarnings = (selection: ManagedSiteMigrationSelection) =>
+    toLegacyMigrationWarningCodes({
+      sourceSiteType: params.sourceSiteType,
+      targetSiteType: params.targetSiteType,
+      channel: getChannel(selection),
+    })
+  const canonicalPreview = await prepareManagedSiteMigrationPreviewCore({
     sourceSiteType: params.sourceSiteType,
     targetSiteType: params.targetSiteType,
-    generalWarningCodes: [
-      MANAGED_SITE_CHANNEL_MIGRATION_GENERAL_WARNING_CODES.CREATE_ONLY,
-      MANAGED_SITE_CHANNEL_MIGRATION_GENERAL_WARNING_CODES.NO_DEDUPE_OR_SYNC,
-      MANAGED_SITE_CHANNEL_MIGRATION_GENERAL_WARNING_CODES.NO_ROLLBACK,
-    ],
+    selections,
+    sourceFailureReasonCode: migrationBlockers.SOURCE_KEY_RESOLUTION_FAILED,
+    targetFailureReasonCode: migrationBlockers.TARGET_DRAFT_PREPARATION_FAILED,
+    getReadyWarningCodes: (source, target) =>
+      toLegacyMigrationWarningCodes({
+        lossSignals: source.lossSignals,
+        adjustments: target.adjustments,
+      }),
+    getBlockedWarningCodes: getWarnings,
+    prepareSource: async (selection) => {
+      const channel = getChannel(selection)
+      const resolution = await resolveSourceChannelKey({
+        preferences: params.preferences,
+        sourceSiteType: params.sourceSiteType,
+        channel,
+        resolveNewApiSourceKey: params.resolveNewApiSourceKey,
+      })
+      if (!resolution.key) {
+        if (resolution.blockingMessage) {
+          blockingMessages.set(
+            selection.selectionId,
+            resolution.blockingMessage,
+          )
+        }
+        return {
+          status: "blocked",
+          reasonCode:
+            resolution.blockingReasonCode ??
+            migrationBlockers.SOURCE_KEY_MISSING,
+        }
+      }
+      credentials.set(selection.selectionId, resolution.key)
+      return {
+        status: "ready",
+        source: toCanonicalMigrationSourceFromLegacyChannel({
+          sourceSiteType: params.sourceSiteType,
+          channel,
+        }),
+      }
+    },
+    prepareTarget: async (selection, source) => {
+      try {
+        return await buildLegacyTargetPreparationFromCanonicalSource({
+          selection,
+          source,
+          targetSiteType: params.targetSiteType,
+          legacyStatus: getChannel(selection).status,
+          onPreparedPreviewDraft: (draft) =>
+            preparedDrafts.set(selection.selectionId, draft),
+        })
+      } catch (error) {
+        blockingMessages.set(selection.selectionId, getErrorMessage(error))
+        throw error
+      }
+    },
+  })
+  const items: ManagedSiteChannelMigrationPreviewItem[] =
+    canonicalPreview.items.map((item) => {
+      const channel = getChannel(item.selection)
+      if (item.status === "blocked") {
+        return {
+          channelId: channel.id,
+          channelName: channel.name,
+          sourceChannel: channel,
+          draft: null,
+          status: "blocked",
+          warningCodes: [...item.warningCodes],
+          blockingReasonCode: item.blockingReasonCode,
+          blockingMessage: blockingMessages.get(item.selection.selectionId),
+        }
+      }
+      return {
+        channelId: channel.id,
+        channelName: channel.name,
+        sourceChannel: channel,
+        draft: {
+          ...preparedDrafts.get(item.selection.selectionId)!,
+          key: credentials.get(item.selection.selectionId)!,
+        },
+        status: "ready",
+        warningCodes: [...item.warningCodes],
+        canonicalPreparation: {
+          selection: item.selection,
+          source: item.source,
+          target: item.target,
+        },
+      }
+    })
+  return {
+    ...canonicalPreview,
+    generalWarningCodes: [...canonicalPreview.generalWarningCodes],
     items,
-    totalCount: items.length,
-    readyCount,
-    blockedCount,
   }
 }
 
@@ -869,82 +597,172 @@ export async function executeManagedSiteChannelMigration(
   params: ExecuteManagedSiteChannelMigrationParams,
 ): Promise<ManagedSiteChannelMigrationExecutionResult> {
   const { preview } = params
+  const canonicalItems = await Promise.all(
+    preview.items.map(
+      async (item): Promise<ManagedSiteMigrationCanonicalPreviewItem> => {
+        const selection =
+          item.canonicalPreparation?.selection ??
+          toCanonicalMigrationSelectionFromLegacyRow({
+            sourceSiteType: preview.sourceSiteType,
+            channel: item.sourceChannel,
+          })
+        if (item.status !== "ready" || !item.draft) {
+          return {
+            selection,
+            status: "blocked",
+            warningCodes: item.warningCodes,
+            blockingReasonCode:
+              item.blockingReasonCode ?? migrationBlockers.SOURCE_KEY_MISSING,
+          }
+        }
+        const source =
+          item.canonicalPreparation?.source ??
+          toCanonicalMigrationSourceFromLegacyChannel({
+            sourceSiteType: preview.sourceSiteType,
+            channel: item.sourceChannel,
+          })
+        return {
+          selection,
+          status: "ready",
+          warningCodes: item.warningCodes,
+          source,
+          target:
+            item.canonicalPreparation?.target ??
+            (await toCanonicalTargetPreparationFromLegacyDraft({
+              source,
+              draft: item.draft,
+            })),
+        }
+      },
+    ),
+  )
+  const canonicalPreview: ManagedSiteMigrationCanonicalPreview = {
+    sourceSiteType: preview.sourceSiteType,
+    targetSiteType: preview.targetSiteType,
+    generalWarningCodes: preview.generalWarningCodes,
+    items: canonicalItems,
+    totalCount: preview.totalCount,
+    readyCount: preview.readyCount,
+    blockedCount: preview.blockedCount,
+  }
+  const legacyItemsBySelectionId = new Map(
+    canonicalItems.map((item, index) => [
+      item.selection.selectionId,
+      preview.items[index],
+    ]),
+  )
+  const readyItemsBySource = new Map(
+    canonicalItems.flatMap((item) =>
+      item.status === "ready"
+        ? [
+            [
+              item.source,
+              {
+                canonical: item,
+                legacy: legacyItemsBySelectionId.get(
+                  item.selection.selectionId,
+                )!,
+              },
+            ] as const,
+          ]
+        : [],
+    ),
+  )
   const targetService: ManagedSiteService = getManagedSiteServiceForType(
     preview.targetSiteType,
   )
   const targetConfig = await targetService.getConfig()
-
+  const errors = new Map<string, string>()
   if (!targetConfig) {
-    return buildCreateFailureResults(
-      preview,
-      "Target managed-site configuration is missing.",
-    )
-  }
-
-  const items: ManagedSiteChannelMigrationExecutionItem[] = []
-  let attemptedCount = 0
-  let createdCount = 0
-  let failedCount = 0
-  let skippedCount = 0
-
-  for (const item of preview.items) {
-    if (item.status !== "ready" || !item.draft) {
-      skippedCount += 1
-      items.push(
-        buildExecutionFailureItem(item, {
-          skipped: true,
-        }),
+    canonicalItems
+      .filter((item) => item.status === "ready")
+      .forEach((item) =>
+        errors.set(
+          item.selection.selectionId,
+          "Target managed-site configuration is missing.",
+        ),
       )
-      continue
-    }
-
-    attemptedCount += 1
-
-    try {
-      const response = await createTargetChannelForMigration({
-        targetSiteType: preview.targetSiteType,
-        targetService,
-        targetConfig,
-        draft: item.draft,
-      })
-
-      if (!response.success) {
-        failedCount += 1
-        items.push({
-          channelId: item.channelId,
-          channelName: item.channelName,
-          success: false,
-          skipped: false,
-          error: response.message || "Unknown error",
-        })
-        continue
-      }
-
-      createdCount += 1
-      items.push({
-        channelId: item.channelId,
-        channelName: item.channelName,
-        success: true,
-        skipped: false,
-      })
-    } catch (error) {
-      failedCount += 1
-      items.push({
-        channelId: item.channelId,
-        channelName: item.channelName,
-        success: false,
-        skipped: false,
-        error: getErrorMessage(error),
-      })
-    }
   }
-
+  const canonicalResult = await executeManagedSiteMigrationCore({
+    preview: canonicalPreview,
+    targetAvailable: Boolean(targetConfig),
+    sourceFailureReasonCode: migrationBlockers.SOURCE_KEY_RESOLUTION_FAILED,
+    isMutationStateUncertain: isUncertainMigrationError,
+    resolveCredential: async (selection) => ({
+      status: "ready",
+      credential:
+        legacyItemsBySelectionId.get(selection.selectionId)?.draft?.key ?? "",
+    }),
+    create: async (command) => {
+      const targetItem = readyItemsBySource.get(command.source)!
+      try {
+        const executionDraft = toLegacyChannelFormDataProjection({
+          source: command.source,
+          target: targetItem.canonical.target,
+          credential: command.credential,
+        })
+        const response = await createTargetChannelForMigration({
+          targetSiteType: preview.targetSiteType,
+          targetService,
+          targetConfig: targetConfig!,
+          draft: {
+            ...executionDraft,
+            ...targetItem.legacy.draft!,
+            key: executionDraft.key,
+          },
+        })
+        if (!response.success) {
+          errors.set(
+            targetItem.canonical.selection.selectionId,
+            response.message || "Unknown error",
+          )
+          return {
+            status: "failed",
+            failureCode: migrationFailures.TargetRejected,
+          }
+        }
+        return { status: "created" }
+      } catch (error) {
+        errors.set(
+          targetItem.canonical.selection.selectionId,
+          getErrorMessage(error),
+        )
+        throw error
+      }
+    },
+  })
+  const items: ManagedSiteChannelMigrationExecutionItem[] =
+    canonicalResult.items.map((result) => {
+      const legacyItem = legacyItemsBySelectionId.get(result.selectionId)!
+      if (result.status === "created") {
+        return {
+          channelId: legacyItem.channelId,
+          channelName: legacyItem.channelName,
+          success: true,
+          skipped: false,
+        }
+      }
+      return {
+        channelId: legacyItem.channelId,
+        channelName: legacyItem.channelName,
+        success: false,
+        skipped: result.status === "skipped",
+        blockingReasonCode:
+          result.status === "skipped"
+            ? result.blockingReasonCode
+            : legacyItem.blockingReasonCode,
+        error:
+          result.status === "skipped"
+            ? legacyItem.blockingMessage
+            : errors.get(result.selectionId) ?? "Unknown error",
+      }
+    })
   return {
     totalSelected: preview.totalCount,
-    attemptedCount,
-    createdCount,
-    failedCount,
-    skippedCount,
+    attemptedCount: canonicalResult.attemptedCount,
+    createdCount: items.filter((item) => item.success).length,
+    failedCount: items.filter((item) => !item.success && !item.skipped).length,
+    skippedCount: items.filter((item) => item.skipped).length,
     items,
   }
 }

--- a/src/services/managedSites/channelMigration.ts
+++ b/src/services/managedSites/channelMigration.ts
@@ -67,11 +67,17 @@ interface ExecuteManagedSiteChannelMigrationParams {
   preview: ManagedSiteChannelMigrationPreview
 }
 
-interface SourceKeyResolutionResult {
-  key: string | null
-  blockingReasonCode?: ManagedSiteChannelMigrationBlockedReasonCode
-  blockingMessage?: string
-}
+type SourceKeyResolutionResult =
+  | {
+      key: string
+      blockingReasonCode?: never
+      blockingMessage?: never
+    }
+  | {
+      key: null
+      blockingReasonCode: ManagedSiteChannelMigrationBlockedReasonCode
+      blockingMessage?: string
+    }
 
 type ChannelMigrationResourceCapabilities = ManagedUpstreamResourcesCapability<
   ManagedSiteRuntimeConfigValue,
@@ -576,7 +582,7 @@ export async function prepareManagedSiteChannelMigrationPreview(
         channel,
         resolveNewApiSourceKey: params.resolveNewApiSourceKey,
       })
-      if (!resolution.key) {
+      if (resolution.key === null) {
         if (resolution.blockingMessage) {
           blockingMessages.set(
             selection.selectionId,
@@ -585,9 +591,7 @@ export async function prepareManagedSiteChannelMigrationPreview(
         }
         return {
           status: "blocked",
-          reasonCode:
-            resolution.blockingReasonCode ??
-            migrationBlockers.SOURCE_KEY_MISSING,
+          reasonCode: resolution.blockingReasonCode,
         }
       }
       credentials.set(selection.selectionId, resolution.key)
@@ -778,9 +782,8 @@ export async function executeManagedSiteChannelMigration(
         ? sourceCapability.resolveCredential(selection)
         : Promise.resolve({
             status: "ready",
-            credential:
-              legacyItemsBySelectionId.get(selection.selectionId)?.draft?.key ??
-              "",
+            credential: legacyItemsBySelectionId.get(selection.selectionId)!
+              .draft!.key,
           }),
     create: async (command) => {
       const targetItem = readyItemsBySource.get(command.source)!

--- a/src/services/managedSites/channelMigration.ts
+++ b/src/services/managedSites/channelMigration.ts
@@ -87,6 +87,8 @@ type ChannelMigrationResourceCapabilities = ManagedUpstreamResourcesCapability<
 
 const migrationBlockers = MANAGED_SITE_CHANNEL_MIGRATION_BLOCKED_REASON_CODES
 const migrationFailures = MANAGED_SITE_MIGRATION_EXECUTION_FAILURE_CODES
+const migrationUncertaintyWarning =
+  "Target creation may have succeeded. Verify the target before retrying."
 
 const getMigrationBlockingFallback = (
   reasonCode: ManagedSiteChannelMigrationBlockedReasonCode,
@@ -96,6 +98,9 @@ const getMigrationBlockingFallback = (
   }
   if (reasonCode === migrationBlockers.SOURCE_KEY_RESOLUTION_FAILED) {
     return "The source credential could not be resolved. Verify source access and try again."
+  }
+  if (reasonCode === migrationBlockers.TARGET_DRAFT_PREPARATION_FAILED) {
+    return "The target channel could not be prepared. Review channel models and target configuration, then retry."
   }
   return "This channel cannot be migrated right now. Verify source access and try again."
 }
@@ -645,7 +650,9 @@ export async function prepareManagedSiteChannelMigrationPreview(
           status: "blocked",
           warningCodes: [...item.warningCodes],
           blockingReasonCode: item.blockingReasonCode,
-          blockingMessage: blockingMessages.get(item.selection.selectionId),
+          blockingMessage:
+            blockingMessages.get(item.selection.selectionId)?.trim() ||
+            getMigrationBlockingFallback(item.blockingReasonCode),
         }
       }
       return {
@@ -795,11 +802,6 @@ export async function executeManagedSiteChannelMigration(
               targetItem.canonical.selection.selectionId,
               "Target channel creation failed.",
             )
-          } else if (result.status === "uncertain") {
-            errors.set(
-              targetItem.canonical.selection.selectionId,
-              "Target creation may have succeeded. Verify the target before retrying.",
-            )
           }
           return result
         }
@@ -862,7 +864,9 @@ export async function executeManagedSiteChannelMigration(
           result.status === "skipped"
             ? legacyItem.blockingMessage?.trim() ||
               getMigrationBlockingFallback(result.blockingReasonCode)
-            : errors.get(result.selectionId) ?? "Unknown error",
+            : result.status === "uncertain"
+              ? migrationUncertaintyWarning
+              : errors.get(result.selectionId)?.trim() || "Unknown error",
       }
     })
   return {

--- a/src/services/managedSites/channelMigration.ts
+++ b/src/services/managedSites/channelMigration.ts
@@ -1,7 +1,9 @@
 import { SITE_TYPES, type ManagedSiteType } from "~/constants/siteType"
+import { MANAGED_RESOURCE_KINDS } from "~/services/accountSiteDefinitions/contracts"
 import {
   MANAGED_RESOURCE_FAILURE_CODES,
   ManagedResourceError,
+  type ManagedResourceRef,
   type ResourceOperationOptions,
 } from "~/services/apiAdapters/contracts/managedResourceNative"
 import type { ManagedUpstreamResourcesCapability } from "~/services/apiAdapters/contracts/managedUpstreamResources"
@@ -11,7 +13,7 @@ import {
 } from "~/services/managedSites/channelMigrationCanonicalOrchestrator"
 import { resolveManagedSiteMigrationCapability } from "~/services/managedSites/channelMigrationCapabilityRegistry"
 import {
-  toCanonicalMigrationSelectionFromLegacyRow,
+  toCanonicalMigrationSelectionFromLegacyAxonRow,
   toCanonicalMigrationSourceFromLegacyChannel,
   toCanonicalTargetPreparationFromLegacyDraft,
   toLegacyChannelFormDataProjection,
@@ -80,6 +82,18 @@ type ChannelMigrationResourceCapabilities = ManagedUpstreamResourcesCapability<
 const migrationBlockers = MANAGED_SITE_CHANNEL_MIGRATION_BLOCKED_REASON_CODES
 const migrationFailures = MANAGED_SITE_MIGRATION_EXECUTION_FAILURE_CODES
 
+const getMigrationBlockingFallback = (
+  reasonCode: ManagedSiteChannelMigrationBlockedReasonCode,
+): string => {
+  if (reasonCode === migrationBlockers.SOURCE_KEY_MISSING) {
+    return "The source credential is unavailable. Verify source access and try again."
+  }
+  if (reasonCode === migrationBlockers.SOURCE_KEY_RESOLUTION_FAILED) {
+    return "The source credential could not be resolved. Verify source access and try again."
+  }
+  return "This channel cannot be migrated right now. Verify source access and try again."
+}
+
 const normalizeResourceScopeKey = (baseUrl: string): string => {
   const trimmed = baseUrl.trim()
 
@@ -87,6 +101,31 @@ const normalizeResourceScopeKey = (baseUrl: string): string => {
     return new URL(trimmed).origin
   } catch {
     return trimmed.replace(/\/+$/, "")
+  }
+}
+
+type LegacyChannelWithNativeResourceRef = ManagedSiteChannel & {
+  resourceRef?: ManagedResourceRef
+}
+
+const toCanonicalMigrationSelectionFromLegacyChannel = (params: {
+  sourceSiteType: ManagedSiteType
+  channel: LegacyChannelWithNativeResourceRef
+  scopeKey?: string
+}): ManagedSiteMigrationSelection => {
+  if (params.sourceSiteType === SITE_TYPES.AXON_HUB) {
+    return toCanonicalMigrationSelectionFromLegacyAxonRow(params)
+  }
+
+  return {
+    selectionId: String(params.channel.id),
+    displayName: params.channel.name,
+    ref: params.channel.resourceRef ?? {
+      siteType: params.sourceSiteType,
+      kind: MANAGED_RESOURCE_KINDS.Channel,
+      scopeKey: params.scopeKey ?? "",
+      resourceId: String(params.channel.id),
+    },
   }
 }
 
@@ -351,6 +390,21 @@ const buildLegacyTargetPreparationFromCanonicalSource = async (params: {
   })
 }
 
+const withSelectionDisplayName = (
+  selection: ManagedSiteMigrationSelection,
+  target: ManagedSiteMigrationTargetPreparation,
+): ManagedSiteMigrationTargetPreparation =>
+  target.projection.name.trim()
+    ? target
+    : {
+        ...target,
+        projection: {
+          ...target.projection,
+          name:
+            selection.displayName.trim() || `Channel #${selection.selectionId}`,
+        },
+      }
+
 /** Builds a secret-free migration preview from canonical resource selections. */
 export async function prepareManagedSiteMigrationPreview(params: {
   sourceSiteType: ManagedSiteType
@@ -385,7 +439,9 @@ export async function prepareManagedSiteMigrationPreview(params: {
           }),
     prepareTarget: (selection, source) =>
       targetCapability
-        ? targetCapability.prepare(source, params.options)
+        ? targetCapability
+            .prepare(source, params.options)
+            .then((target) => withSelectionDisplayName(selection, target))
         : buildLegacyTargetPreparationFromCanonicalSource({
             selection,
             source,
@@ -461,6 +517,12 @@ export async function executeManagedSiteMigration(params: {
 export async function prepareManagedSiteChannelMigrationPreview(
   params: PrepareManagedSiteChannelMigrationPreviewParams,
 ): Promise<ManagedSiteChannelMigrationPreview> {
+  const sourceCapability = resolveManagedSiteMigrationCapability(
+    params.sourceSiteType,
+  )?.source
+  const targetCapability = resolveManagedSiteMigrationCapability(
+    params.targetSiteType,
+  )?.target
   const sourceScopeKey = normalizeResourceScopeKey(
     resolveManagedSiteRuntimeConfigForType(
       params.preferences,
@@ -468,7 +530,7 @@ export async function prepareManagedSiteChannelMigrationPreview(
     )?.config.baseUrl ?? "",
   )
   const selections = params.channels.map((channel) =>
-    toCanonicalMigrationSelectionFromLegacyRow({
+    toCanonicalMigrationSelectionFromLegacyChannel({
       sourceSiteType: params.sourceSiteType,
       channel,
       scopeKey: sourceScopeKey,
@@ -504,6 +566,9 @@ export async function prepareManagedSiteChannelMigrationPreview(
       }),
     getBlockedWarningCodes: getWarnings,
     prepareSource: async (selection) => {
+      if (sourceCapability) {
+        return await sourceCapability.prepare(selection)
+      }
       const channel = getChannel(selection)
       const resolution = await resolveSourceChannelKey({
         preferences: params.preferences,
@@ -536,11 +601,25 @@ export async function prepareManagedSiteChannelMigrationPreview(
     },
     prepareTarget: async (selection, source) => {
       try {
+        if (targetCapability) {
+          const target = await targetCapability.prepare(source)
+          const preparedTarget = withSelectionDisplayName(selection, target)
+          const { key: _credential, ...draft } =
+            toLegacyChannelFormDataProjection({
+              source,
+              target: preparedTarget,
+              credential: "",
+            })
+          preparedDrafts.set(selection.selectionId, draft)
+          return preparedTarget
+        }
         return await buildLegacyTargetPreparationFromCanonicalSource({
           selection,
           source,
           targetSiteType: params.targetSiteType,
-          legacyStatus: getChannel(selection).status,
+          legacyStatus: sourceCapability
+            ? undefined
+            : getChannel(selection).status,
           onPreparedPreviewDraft: (draft) =>
             preparedDrafts.set(selection.selectionId, draft),
         })
@@ -571,7 +650,7 @@ export async function prepareManagedSiteChannelMigrationPreview(
         sourceChannel: channel,
         draft: {
           ...preparedDrafts.get(item.selection.selectionId)!,
-          key: credentials.get(item.selection.selectionId)!,
+          key: credentials.get(item.selection.selectionId) ?? "",
         },
         status: "ready",
         warningCodes: [...item.warningCodes],
@@ -597,12 +676,18 @@ export async function executeManagedSiteChannelMigration(
   params: ExecuteManagedSiteChannelMigrationParams,
 ): Promise<ManagedSiteChannelMigrationExecutionResult> {
   const { preview } = params
+  const sourceCapability = resolveManagedSiteMigrationCapability(
+    preview.sourceSiteType,
+  )?.source
+  const targetCapability = resolveManagedSiteMigrationCapability(
+    preview.targetSiteType,
+  )?.target
   const canonicalItems = await Promise.all(
     preview.items.map(
       async (item): Promise<ManagedSiteMigrationCanonicalPreviewItem> => {
         const selection =
           item.canonicalPreparation?.selection ??
-          toCanonicalMigrationSelectionFromLegacyRow({
+          toCanonicalMigrationSelectionFromLegacyChannel({
             sourceSiteType: preview.sourceSiteType,
             channel: item.sourceChannel,
           })
@@ -668,12 +753,12 @@ export async function executeManagedSiteChannelMigration(
         : [],
     ),
   )
-  const targetService: ManagedSiteService = getManagedSiteServiceForType(
-    preview.targetSiteType,
-  )
-  const targetConfig = await targetService.getConfig()
+  const targetService: ManagedSiteService | null = targetCapability
+    ? null
+    : getManagedSiteServiceForType(preview.targetSiteType)
+  const targetConfig = targetService ? await targetService.getConfig() : null
   const errors = new Map<string, string>()
-  if (!targetConfig) {
+  if (!targetCapability && !targetConfig) {
     canonicalItems
       .filter((item) => item.status === "ready")
       .forEach((item) =>
@@ -685,17 +770,36 @@ export async function executeManagedSiteChannelMigration(
   }
   const canonicalResult = await executeManagedSiteMigrationCore({
     preview: canonicalPreview,
-    targetAvailable: Boolean(targetConfig),
+    targetAvailable: Boolean(targetCapability || targetConfig),
     sourceFailureReasonCode: migrationBlockers.SOURCE_KEY_RESOLUTION_FAILED,
     isMutationStateUncertain: isUncertainMigrationError,
-    resolveCredential: async (selection) => ({
-      status: "ready",
-      credential:
-        legacyItemsBySelectionId.get(selection.selectionId)?.draft?.key ?? "",
-    }),
+    resolveCredential: (selection) =>
+      sourceCapability
+        ? sourceCapability.resolveCredential(selection)
+        : Promise.resolve({
+            status: "ready",
+            credential:
+              legacyItemsBySelectionId.get(selection.selectionId)?.draft?.key ??
+              "",
+          }),
     create: async (command) => {
       const targetItem = readyItemsBySource.get(command.source)!
       try {
+        if (targetCapability) {
+          const result = await targetCapability.create(command)
+          if (result.status === "failed") {
+            errors.set(
+              targetItem.canonical.selection.selectionId,
+              "Target channel creation failed.",
+            )
+          } else if (result.status === "uncertain") {
+            errors.set(
+              targetItem.canonical.selection.selectionId,
+              "Target creation may have succeeded. Verify the target before retrying.",
+            )
+          }
+          return result
+        }
         const executionDraft = toLegacyChannelFormDataProjection({
           source: command.source,
           target: targetItem.canonical.target,
@@ -703,7 +807,7 @@ export async function executeManagedSiteChannelMigration(
         })
         const response = await createTargetChannelForMigration({
           targetSiteType: preview.targetSiteType,
-          targetService,
+          targetService: targetService!,
           targetConfig: targetConfig!,
           draft: {
             ...executionDraft,
@@ -753,7 +857,8 @@ export async function executeManagedSiteChannelMigration(
             : legacyItem.blockingReasonCode,
         error:
           result.status === "skipped"
-            ? legacyItem.blockingMessage
+            ? legacyItem.blockingMessage?.trim() ||
+              getMigrationBlockingFallback(result.blockingReasonCode)
             : errors.get(result.selectionId) ?? "Unknown error",
       }
     })

--- a/src/services/managedSites/channelMigration.ts
+++ b/src/services/managedSites/channelMigration.ts
@@ -89,21 +89,18 @@ const migrationBlockers = MANAGED_SITE_CHANNEL_MIGRATION_BLOCKED_REASON_CODES
 const migrationFailures = MANAGED_SITE_MIGRATION_EXECUTION_FAILURE_CODES
 const migrationUncertaintyWarning =
   "Target creation may have succeeded. Verify the target before retrying."
+const migrationBlockingFallbacks = {
+  [migrationBlockers.SOURCE_KEY_MISSING]:
+    "The source credential is unavailable. Verify source access and try again.",
+  [migrationBlockers.SOURCE_KEY_RESOLUTION_FAILED]:
+    "The source credential could not be resolved. Verify source access and try again.",
+  [migrationBlockers.TARGET_DRAFT_PREPARATION_FAILED]:
+    "The target channel could not be prepared. Review channel models and target configuration, then retry.",
+} satisfies Record<ManagedSiteChannelMigrationBlockedReasonCode, string>
 
 const getMigrationBlockingFallback = (
   reasonCode: ManagedSiteChannelMigrationBlockedReasonCode,
-): string => {
-  if (reasonCode === migrationBlockers.SOURCE_KEY_MISSING) {
-    return "The source credential is unavailable. Verify source access and try again."
-  }
-  if (reasonCode === migrationBlockers.SOURCE_KEY_RESOLUTION_FAILED) {
-    return "The source credential could not be resolved. Verify source access and try again."
-  }
-  if (reasonCode === migrationBlockers.TARGET_DRAFT_PREPARATION_FAILED) {
-    return "The target channel could not be prepared. Review channel models and target configuration, then retry."
-  }
-  return "This channel cannot be migrated right now. Verify source access and try again."
-}
+): string => migrationBlockingFallbacks[reasonCode]
 
 const normalizeResourceScopeKey = (baseUrl: string): string => {
   const trimmed = baseUrl.trim()

--- a/src/services/managedSites/channelMigrationCanonicalOrchestrator.ts
+++ b/src/services/managedSites/channelMigrationCanonicalOrchestrator.ts
@@ -6,6 +6,7 @@ import {
 } from "~/types/managedSiteMigration"
 import {
   MANAGED_SITE_MIGRATION_EXECUTION_FAILURE_CODES,
+  ManagedSiteMigrationExecutionAbortedError,
   type ManagedSiteMigrationCanonicalExecutionResult,
   type ManagedSiteMigrationCanonicalPreview,
   type ManagedSiteMigrationCanonicalPreviewItem,
@@ -44,11 +45,17 @@ const mapWithConcurrency = async <TItem, TResult>(
 ): Promise<TResult[]> => {
   const results = new Array<TResult>(items.length)
   let nextIndex = 0
+  let stopped = false
   await Promise.all(
     Array.from({ length: Math.min(concurrency, items.length) }, async () => {
-      while (nextIndex < items.length) {
+      while (!stopped && nextIndex < items.length) {
         const index = nextIndex++
-        results[index] = await mapper(items[index])
+        try {
+          results[index] = await mapper(items[index])
+        } catch (error) {
+          stopped = true
+          throw error
+        }
       }
     }),
   )
@@ -161,7 +168,6 @@ type ExecuteManagedSiteMigrationCoreParams = {
 export async function executeManagedSiteMigrationCore(
   params: ExecuteManagedSiteMigrationCoreParams,
 ): Promise<ManagedSiteMigrationCanonicalExecutionResult> {
-  throwIfCancelled(params.signal)
   type ExecutionItem =
     ManagedSiteMigrationCanonicalExecutionResult["items"][number]
   type ExecutionOutcome =
@@ -189,9 +195,41 @@ export async function executeManagedSiteMigrationCore(
       ...outcome,
     })
   let attemptedCount = 0
+  const count = (status: ExecutionItem["status"]) =>
+    items.filter((item) => item.status === status).length
+  const buildResultSnapshot =
+    (): ManagedSiteMigrationCanonicalExecutionResult => ({
+      totalSelected: params.preview.totalCount,
+      attemptedCount,
+      createdCount: count("created"),
+      failedCount: count("failed"),
+      skippedCount: count("skipped"),
+      uncertainCount: count("uncertain"),
+      items: [...items],
+    })
+  const throwIfExecutionCancelled = (
+    remainingStartIndex: number,
+    error?: unknown,
+  ): void => {
+    const cancelled =
+      params.signal?.aborted || (error !== undefined && isAbortError(error))
+    if (!cancelled) return
 
-  for (const item of params.preview.items) {
-    throwIfCancelled(params.signal)
+    const cause = params.signal?.aborted ? params.signal.reason ?? error : error
+    throw new ManagedSiteMigrationExecutionAbortedError(
+      {
+        partialResult: buildResultSnapshot(),
+        remainingSelections: params.preview.items
+          .slice(remainingStartIndex)
+          .map((item) => item.selection),
+      },
+      cause === undefined ? undefined : { cause },
+    )
+  }
+
+  for (let index = 0; index < params.preview.items.length; index += 1) {
+    throwIfExecutionCancelled(index)
+    const item = params.preview.items[index]
     if (item.status === "blocked") {
       append(item, {
         status: "skipped",
@@ -209,11 +247,10 @@ export async function executeManagedSiteMigrationCore(
 
     let credentialResolution: ManagedSiteMigrationCredentialResolution
     try {
-      throwIfCancelled(params.signal)
       credentialResolution = await params.resolveCredential(item.selection)
-      throwIfCancelled(params.signal)
+      throwIfExecutionCancelled(index)
     } catch (error) {
-      throwIfCancelled(params.signal, error)
+      throwIfExecutionCancelled(index, error)
       credentialResolution = {
         status: "blocked",
         reasonCode: params.sourceFailureReasonCode,
@@ -227,54 +264,48 @@ export async function executeManagedSiteMigrationCore(
       continue
     }
 
+    throwIfExecutionCancelled(index)
     attemptedCount += 1
+    let createResult: ManagedSiteMigrationCreateResult
     try {
-      throwIfCancelled(params.signal)
-      const createResult = await params.create({
+      createResult = await params.create({
         source: item.source,
         targetSiteType: params.preview.targetSiteType,
         projection: item.target.projection,
         credential: credentialResolution.credential,
       })
-      throwIfCancelled(params.signal)
-      if (createResult.status === "created") {
-        append(item, { status: "created" })
-      } else if (createResult.status === "failed") {
-        append(item, {
-          status: "failed",
-          failureCode: createResult.failureCode,
-        })
-      } else {
-        append(item, {
-          status: "uncertain",
-          failureCode: migrationFailures.MutationStateUncertain,
-        })
-      }
     } catch (error) {
-      throwIfCancelled(params.signal, error)
       const uncertain = params.isMutationStateUncertain?.(error) ?? false
       if (uncertain) {
         append(item, {
           status: "uncertain",
           failureCode: migrationFailures.MutationStateUncertain,
         })
-      } else {
-        append(item, {
-          status: "failed",
-          failureCode: migrationFailures.Unexpected,
-        })
+        throwIfExecutionCancelled(index + 1, error)
+        continue
       }
+      throwIfExecutionCancelled(index, error)
+      append(item, {
+        status: "failed",
+        failureCode: migrationFailures.Unexpected,
+      })
+      continue
     }
+
+    if (createResult.status === "created") {
+      append(item, { status: "created" })
+    } else if (createResult.status === "failed") {
+      append(item, {
+        status: "failed",
+        failureCode: createResult.failureCode,
+      })
+    } else {
+      append(item, {
+        status: "uncertain",
+        failureCode: migrationFailures.MutationStateUncertain,
+      })
+    }
+    throwIfExecutionCancelled(index + 1)
   }
-  const count = (status: ExecutionItem["status"]) =>
-    items.filter((item) => item.status === status).length
-  return {
-    totalSelected: params.preview.totalCount,
-    attemptedCount,
-    createdCount: count("created"),
-    failedCount: count("failed"),
-    skippedCount: count("skipped"),
-    uncertainCount: count("uncertain"),
-    items,
-  }
+  return buildResultSnapshot()
 }

--- a/src/services/managedSites/channelMigrationCanonicalOrchestrator.ts
+++ b/src/services/managedSites/channelMigrationCanonicalOrchestrator.ts
@@ -1,0 +1,280 @@
+import type { ManagedSiteType } from "~/constants/siteType"
+import {
+  MANAGED_SITE_CHANNEL_MIGRATION_GENERAL_WARNING_CODES,
+  type ManagedSiteChannelMigrationBlockedReasonCode,
+  type ManagedSiteChannelMigrationItemWarningCode,
+} from "~/types/managedSiteMigration"
+import {
+  MANAGED_SITE_MIGRATION_EXECUTION_FAILURE_CODES,
+  type ManagedSiteMigrationCanonicalExecutionResult,
+  type ManagedSiteMigrationCanonicalPreview,
+  type ManagedSiteMigrationCanonicalPreviewItem,
+  type ManagedSiteMigrationConfirmedFailureCode,
+  type ManagedSiteMigrationCreateResult,
+  type ManagedSiteMigrationCredentialResolution,
+  type ManagedSiteMigrationExecutionCommand,
+  type ManagedSiteMigrationSelection,
+  type ManagedSiteMigrationSource,
+  type ManagedSiteMigrationSourcePreparation,
+  type ManagedSiteMigrationTargetPreparation,
+} from "~/types/managedSiteMigrationCapability"
+
+const PREVIEW_BUILD_CONCURRENCY = 5
+const migrationFailures = MANAGED_SITE_MIGRATION_EXECUTION_FAILURE_CODES
+
+const isAbortError = (error: unknown): boolean =>
+  typeof error === "object" &&
+  error !== null &&
+  (("name" in error && error.name === "AbortError") ||
+    ("code" in error && error.code === "ABORT_ERR"))
+
+const throwIfCancelled = (signal?: AbortSignal, error?: unknown): void => {
+  if (signal?.aborted) {
+    throw signal.reason ?? error
+  }
+  if (error !== undefined && isAbortError(error)) {
+    throw error
+  }
+}
+
+const mapWithConcurrency = async <TItem, TResult>(
+  items: readonly TItem[],
+  concurrency: number,
+  mapper: (item: TItem) => Promise<TResult>,
+): Promise<TResult[]> => {
+  const results = new Array<TResult>(items.length)
+  let nextIndex = 0
+  await Promise.all(
+    Array.from({ length: Math.min(concurrency, items.length) }, async () => {
+      while (nextIndex < items.length) {
+        const index = nextIndex++
+        results[index] = await mapper(items[index])
+      }
+    }),
+  )
+  return results
+}
+
+type PrepareManagedSiteMigrationPreviewCoreParams = {
+  sourceSiteType: ManagedSiteType
+  targetSiteType: ManagedSiteType
+  selections: readonly ManagedSiteMigrationSelection[]
+  sourceFailureReasonCode: ManagedSiteChannelMigrationBlockedReasonCode
+  targetFailureReasonCode: ManagedSiteChannelMigrationBlockedReasonCode
+  signal?: AbortSignal
+  prepareSource: (
+    selection: ManagedSiteMigrationSelection,
+  ) => Promise<ManagedSiteMigrationSourcePreparation>
+  prepareTarget: (
+    selection: ManagedSiteMigrationSelection,
+    source: ManagedSiteMigrationSource,
+  ) => Promise<ManagedSiteMigrationTargetPreparation>
+  getReadyWarningCodes: (
+    source: ManagedSiteMigrationSource,
+    target: ManagedSiteMigrationTargetPreparation,
+  ) => readonly ManagedSiteChannelMigrationItemWarningCode[]
+  getBlockedWarningCodes?: (
+    selection: ManagedSiteMigrationSelection,
+  ) => readonly ManagedSiteChannelMigrationItemWarningCode[]
+}
+
+/** Coordinates bounded, secret-free canonical preview preparation. */
+export async function prepareManagedSiteMigrationPreviewCore(
+  params: PrepareManagedSiteMigrationPreviewCoreParams,
+): Promise<ManagedSiteMigrationCanonicalPreview> {
+  throwIfCancelled(params.signal)
+  const blockedItem = (
+    selection: ManagedSiteMigrationSelection,
+    blockingReasonCode: ManagedSiteChannelMigrationBlockedReasonCode,
+  ): ManagedSiteMigrationCanonicalPreviewItem => ({
+    selection,
+    status: "blocked",
+    warningCodes: params.getBlockedWarningCodes?.(selection) ?? [],
+    blockingReasonCode,
+  })
+  const items = await mapWithConcurrency(
+    params.selections,
+    PREVIEW_BUILD_CONCURRENCY,
+    async (selection): Promise<ManagedSiteMigrationCanonicalPreviewItem> => {
+      throwIfCancelled(params.signal)
+      let sourcePreparation: ManagedSiteMigrationSourcePreparation
+      try {
+        sourcePreparation = await params.prepareSource(selection)
+        throwIfCancelled(params.signal)
+      } catch (error) {
+        throwIfCancelled(params.signal, error)
+        return blockedItem(selection, params.sourceFailureReasonCode)
+      }
+      if (sourcePreparation.status === "blocked") {
+        return blockedItem(selection, sourcePreparation.reasonCode)
+      }
+
+      try {
+        throwIfCancelled(params.signal)
+        const source = sourcePreparation.source
+        const target = await params.prepareTarget(selection, source)
+        throwIfCancelled(params.signal)
+        return {
+          selection,
+          status: "ready",
+          source,
+          target,
+          warningCodes: params.getReadyWarningCodes(source, target),
+        }
+      } catch (error) {
+        throwIfCancelled(params.signal, error)
+        return blockedItem(selection, params.targetFailureReasonCode)
+      }
+    },
+  )
+  const readyCount = items.filter((item) => item.status === "ready").length
+  return {
+    sourceSiteType: params.sourceSiteType,
+    targetSiteType: params.targetSiteType,
+    generalWarningCodes: [
+      MANAGED_SITE_CHANNEL_MIGRATION_GENERAL_WARNING_CODES.CREATE_ONLY,
+      MANAGED_SITE_CHANNEL_MIGRATION_GENERAL_WARNING_CODES.NO_DEDUPE_OR_SYNC,
+      MANAGED_SITE_CHANNEL_MIGRATION_GENERAL_WARNING_CODES.NO_ROLLBACK,
+    ],
+    items,
+    totalCount: items.length,
+    readyCount,
+    blockedCount: items.length - readyCount,
+  }
+}
+
+type ExecuteManagedSiteMigrationCoreParams = {
+  preview: ManagedSiteMigrationCanonicalPreview
+  targetAvailable: boolean
+  sourceFailureReasonCode: ManagedSiteChannelMigrationBlockedReasonCode
+  signal?: AbortSignal
+  resolveCredential: (
+    selection: ManagedSiteMigrationSelection,
+  ) => Promise<ManagedSiteMigrationCredentialResolution>
+  create: (
+    command: ManagedSiteMigrationExecutionCommand,
+  ) => Promise<ManagedSiteMigrationCreateResult>
+  isMutationStateUncertain?: (error: unknown) => boolean
+}
+
+/** Executes canonical commands while keeping credentials local to each create. */
+export async function executeManagedSiteMigrationCore(
+  params: ExecuteManagedSiteMigrationCoreParams,
+): Promise<ManagedSiteMigrationCanonicalExecutionResult> {
+  throwIfCancelled(params.signal)
+  type ExecutionItem =
+    ManagedSiteMigrationCanonicalExecutionResult["items"][number]
+  type ExecutionOutcome =
+    | { status: "created" }
+    | {
+        status: "failed"
+        failureCode: ManagedSiteMigrationConfirmedFailureCode
+      }
+    | {
+        status: "skipped"
+        blockingReasonCode: ManagedSiteChannelMigrationBlockedReasonCode
+      }
+    | {
+        status: "uncertain"
+        failureCode: typeof migrationFailures.MutationStateUncertain
+      }
+  const items: ExecutionItem[] = []
+  const append = (
+    item: ManagedSiteMigrationCanonicalPreviewItem,
+    outcome: ExecutionOutcome,
+  ) =>
+    items.push({
+      selectionId: item.selection.selectionId,
+      displayName: item.selection.displayName,
+      ...outcome,
+    })
+  let attemptedCount = 0
+
+  for (const item of params.preview.items) {
+    throwIfCancelled(params.signal)
+    if (item.status === "blocked") {
+      append(item, {
+        status: "skipped",
+        blockingReasonCode: item.blockingReasonCode,
+      })
+      continue
+    }
+    if (!params.targetAvailable) {
+      append(item, {
+        status: "failed",
+        failureCode: migrationFailures.TargetUnavailable,
+      })
+      continue
+    }
+
+    let credentialResolution: ManagedSiteMigrationCredentialResolution
+    try {
+      throwIfCancelled(params.signal)
+      credentialResolution = await params.resolveCredential(item.selection)
+      throwIfCancelled(params.signal)
+    } catch (error) {
+      throwIfCancelled(params.signal, error)
+      credentialResolution = {
+        status: "blocked",
+        reasonCode: params.sourceFailureReasonCode,
+      }
+    }
+    if (credentialResolution.status === "blocked") {
+      append(item, {
+        status: "skipped",
+        blockingReasonCode: credentialResolution.reasonCode,
+      })
+      continue
+    }
+
+    attemptedCount += 1
+    try {
+      throwIfCancelled(params.signal)
+      const createResult = await params.create({
+        source: item.source,
+        targetSiteType: params.preview.targetSiteType,
+        projection: item.target.projection,
+        credential: credentialResolution.credential,
+      })
+      throwIfCancelled(params.signal)
+      if (createResult.status === "created") {
+        append(item, { status: "created" })
+      } else if (createResult.status === "failed") {
+        append(item, {
+          status: "failed",
+          failureCode: createResult.failureCode,
+        })
+      } else {
+        append(item, {
+          status: "uncertain",
+          failureCode: migrationFailures.MutationStateUncertain,
+        })
+      }
+    } catch (error) {
+      throwIfCancelled(params.signal, error)
+      const uncertain = params.isMutationStateUncertain?.(error) ?? false
+      if (uncertain) {
+        append(item, {
+          status: "uncertain",
+          failureCode: migrationFailures.MutationStateUncertain,
+        })
+      } else {
+        append(item, {
+          status: "failed",
+          failureCode: migrationFailures.Unexpected,
+        })
+      }
+    }
+  }
+  const count = (status: ExecutionItem["status"]) =>
+    items.filter((item) => item.status === status).length
+  return {
+    totalSelected: params.preview.totalCount,
+    attemptedCount,
+    createdCount: count("created"),
+    failedCount: count("failed"),
+    skippedCount: count("skipped"),
+    uncertainCount: count("uncertain"),
+    items,
+  }
+}

--- a/src/services/managedSites/channelMigrationCapabilityRegistry.ts
+++ b/src/services/managedSites/channelMigrationCapabilityRegistry.ts
@@ -1,0 +1,17 @@
+import type { ManagedSiteType } from "~/constants/siteType"
+import type { ManagedSiteMigrationCapability } from "~/types/managedSiteMigrationCapability"
+
+const registrations: readonly {
+  siteType: ManagedSiteType
+  capability: ManagedSiteMigrationCapability
+}[] = []
+
+/** Returns the canonical migration capability registered for a managed site. */
+export function resolveManagedSiteMigrationCapability(
+  siteType: ManagedSiteType,
+): ManagedSiteMigrationCapability | null {
+  return (
+    registrations.find((entry) => entry.siteType === siteType)?.capability ??
+    null
+  )
+}

--- a/src/services/managedSites/channelMigrationCapabilityRegistry.ts
+++ b/src/services/managedSites/channelMigrationCapabilityRegistry.ts
@@ -1,10 +1,16 @@
-import type { ManagedSiteType } from "~/constants/siteType"
+import { SITE_TYPES, type ManagedSiteType } from "~/constants/siteType"
+import { axonHubManagedSiteMigrationCapability } from "~/services/apiAdapters/managedResources/axonHubMigration"
 import type { ManagedSiteMigrationCapability } from "~/types/managedSiteMigrationCapability"
 
 const registrations: readonly {
   siteType: ManagedSiteType
   capability: ManagedSiteMigrationCapability
-}[] = []
+}[] = [
+  {
+    siteType: SITE_TYPES.AXON_HUB,
+    capability: axonHubManagedSiteMigrationCapability,
+  },
+]
 
 /** Returns the canonical migration capability registered for a managed site. */
 export function resolveManagedSiteMigrationCapability(

--- a/src/services/managedSites/channelMigrationLegacyFacade.ts
+++ b/src/services/managedSites/channelMigrationLegacyFacade.ts
@@ -1,9 +1,12 @@
-import { AXON_HUB_CHANNEL_TYPE } from "~/constants/axonHub"
 import { CLAUDE_CODE_HUB_PROVIDER_TYPE } from "~/constants/claudeCodeHub"
 import { ChannelType, DEFAULT_CHANNEL_FIELDS } from "~/constants/managedSite"
 import { SITE_TYPES, type ManagedSiteType } from "~/constants/siteType"
 import { MANAGED_RESOURCE_KINDS } from "~/services/accountSiteDefinitions/contracts"
 import type { ManagedResourceRef } from "~/services/apiAdapters/contracts/managedResourceNative"
+import {
+  mapAxonHubChannelTypeToChannelType,
+  mapChannelTypeToAxonHubChannelType,
+} from "~/services/apiAdapters/managedResources/axonHubChannelType"
 import {
   buildOctopusBaseUrl,
   mapChannelTypeToOctopusOutboundType,
@@ -27,8 +30,13 @@ import { normalizeList } from "~/utils/core/string"
 const parseDelimitedValues = (value: string | null | undefined) =>
   normalizeList(value?.split(",") ?? [])
 
-const hasMeaningfulValue = (value: string | null | undefined) =>
-  Boolean(value?.trim())
+const hasMeaningfulValue = (value: unknown) => {
+  if (value == null) return false
+  if (typeof value === "string") return Boolean(value.trim())
+  if (Array.isArray(value)) return value.length > 0
+  if (typeof value === "object") return Object.keys(value).length > 0
+  return true
+}
 
 const hasMultiKeyState = (channel: ManagedSiteChannel) =>
   Boolean(
@@ -47,27 +55,6 @@ const areStringArraysEqual = (
 
 type LegacyMigrationPreviewDraft = Omit<ChannelFormData, "key">
 
-const AXON_HUB_TO_SHARED_CHANNEL_TYPE: Partial<Record<string, ChannelType>> = {
-  [AXON_HUB_CHANNEL_TYPE.OPENAI]: ChannelType.OpenAI,
-  [AXON_HUB_CHANNEL_TYPE.OPENAI_RESPONSES]: ChannelType.OpenAI,
-  [AXON_HUB_CHANNEL_TYPE.ANTHROPIC]: ChannelType.Anthropic,
-  [AXON_HUB_CHANNEL_TYPE.ANTHROPIC_AWS]: ChannelType.Anthropic,
-  [AXON_HUB_CHANNEL_TYPE.ANTHROPIC_GCP]: ChannelType.Anthropic,
-  [AXON_HUB_CHANNEL_TYPE.CLAUDECODE]: ChannelType.Anthropic,
-  [AXON_HUB_CHANNEL_TYPE.GEMINI_OPENAI]: ChannelType.Gemini,
-  [AXON_HUB_CHANNEL_TYPE.GEMINI]: ChannelType.Gemini,
-  [AXON_HUB_CHANNEL_TYPE.GEMINI_VERTEX]: ChannelType.Gemini,
-  [AXON_HUB_CHANNEL_TYPE.DEEPSEEK]: ChannelType.DeepSeek,
-  [AXON_HUB_CHANNEL_TYPE.DEEPSEEK_ANTHROPIC]: ChannelType.DeepSeek,
-  [AXON_HUB_CHANNEL_TYPE.OPENROUTER]: ChannelType.OpenRouter,
-  [AXON_HUB_CHANNEL_TYPE.XAI]: ChannelType.Xai,
-  [AXON_HUB_CHANNEL_TYPE.SILICONFLOW]: ChannelType.SiliconFlow,
-  [AXON_HUB_CHANNEL_TYPE.VOLCENGINE]: ChannelType.VolcEngine,
-  [AXON_HUB_CHANNEL_TYPE.OLLAMA]: ChannelType.Ollama,
-  [AXON_HUB_CHANNEL_TYPE.GITHUB_COPILOT]: ChannelType.OpenAI,
-  [AXON_HUB_CHANNEL_TYPE.NANOGPT]: ChannelType.OpenAI,
-}
-
 const CLAUDE_CODE_HUB_TO_SHARED_CHANNEL_TYPE: Partial<
   Record<string, ChannelType>
 > = {
@@ -85,7 +72,7 @@ const getSharedChannelType = (
     typeof channel.type === "number"
       ? channel.type
       : sourceSiteType === SITE_TYPES.AXON_HUB
-        ? AXON_HUB_TO_SHARED_CHANNEL_TYPE[channel.type] ?? ChannelType.OpenAI
+        ? mapAxonHubChannelTypeToChannelType(channel.type)
         : sourceSiteType === SITE_TYPES.CLAUDE_CODE_HUB
           ? CLAUDE_CODE_HUB_TO_SHARED_CHANNEL_TYPE[channel.type] ??
             ChannelType.OpenAI
@@ -93,19 +80,6 @@ const getSharedChannelType = (
   return sourceSiteType === SITE_TYPES.OCTOPUS
     ? mapOctopusOutboundTypeToChannelType(channelType)
     : (channelType as ChannelType)
-}
-
-const SHARED_TO_AXON_HUB_CHANNEL_TYPE: Partial<Record<ChannelType, string>> = {
-  [ChannelType.OpenAI]: AXON_HUB_CHANNEL_TYPE.OPENAI,
-  [ChannelType.Anthropic]: AXON_HUB_CHANNEL_TYPE.ANTHROPIC,
-  [ChannelType.OpenRouter]: AXON_HUB_CHANNEL_TYPE.OPENROUTER,
-  [ChannelType.Gemini]: AXON_HUB_CHANNEL_TYPE.GEMINI,
-  [ChannelType.VertexAi]: AXON_HUB_CHANNEL_TYPE.GEMINI,
-  [ChannelType.SiliconFlow]: AXON_HUB_CHANNEL_TYPE.SILICONFLOW,
-  [ChannelType.DeepSeek]: AXON_HUB_CHANNEL_TYPE.DEEPSEEK,
-  [ChannelType.VolcEngine]: AXON_HUB_CHANNEL_TYPE.VOLCENGINE,
-  [ChannelType.Xai]: AXON_HUB_CHANNEL_TYPE.XAI,
-  [ChannelType.Ollama]: AXON_HUB_CHANNEL_TYPE.OLLAMA,
 }
 
 const SHARED_TO_CLAUDE_CODE_HUB_PROVIDER_TYPE: Partial<
@@ -124,10 +98,7 @@ const getLegacyTargetType = (
     return mapChannelTypeToOctopusOutboundType(resourceType)
   }
   if (targetSiteType === SITE_TYPES.AXON_HUB) {
-    return (
-      SHARED_TO_AXON_HUB_CHANNEL_TYPE[resourceType] ??
-      AXON_HUB_CHANNEL_TYPE.OPENAI
-    )
+    return mapChannelTypeToAxonHubChannelType(resourceType)
   }
   if (targetSiteType === SITE_TYPES.CLAUDE_CODE_HUB) {
     return (
@@ -191,7 +162,10 @@ const getLegacyMigrationLossSignals = (
   hasModelMapping: hasMeaningfulValue(channel.model_mapping),
   hasStatusCodeMapping: hasMeaningfulValue(channel.status_code_mapping),
   hasAdvancedSettings:
-    hasMeaningfulValue(channel.setting) || hasMeaningfulValue(channel.settings),
+    hasMeaningfulValue(channel.setting) ||
+    hasMeaningfulValue(channel.settings) ||
+    hasMeaningfulValue(channel.param_override) ||
+    hasMeaningfulValue(channel.header_override),
   hasMultiKeyState: hasMultiKeyState(channel),
 })
 

--- a/src/services/managedSites/channelMigrationLegacyFacade.ts
+++ b/src/services/managedSites/channelMigrationLegacyFacade.ts
@@ -1,0 +1,466 @@
+import { AXON_HUB_CHANNEL_TYPE } from "~/constants/axonHub"
+import { CLAUDE_CODE_HUB_PROVIDER_TYPE } from "~/constants/claudeCodeHub"
+import { ChannelType, DEFAULT_CHANNEL_FIELDS } from "~/constants/managedSite"
+import { SITE_TYPES, type ManagedSiteType } from "~/constants/siteType"
+import { MANAGED_RESOURCE_KINDS } from "~/services/accountSiteDefinitions/contracts"
+import type { ManagedResourceRef } from "~/services/apiAdapters/contracts/managedResourceNative"
+import {
+  buildOctopusBaseUrl,
+  mapChannelTypeToOctopusOutboundType,
+  mapOctopusOutboundTypeToChannelType,
+} from "~/services/managedSites/providers/octopus"
+import type { ChannelFormData, ManagedSiteChannel } from "~/types/managedSite"
+import {
+  MANAGED_SITE_CHANNEL_MIGRATION_ITEM_WARNING_CODES,
+  type ManagedSiteChannelMigrationItemWarningCode,
+} from "~/types/managedSiteMigration"
+import type {
+  ManagedSiteMigrationLossSignals,
+  ManagedSiteMigrationPreviewProjection,
+  ManagedSiteMigrationSelection,
+  ManagedSiteMigrationSource,
+  ManagedSiteMigrationTargetAdjustments,
+  ManagedSiteMigrationTargetPreparation,
+} from "~/types/managedSiteMigrationCapability"
+import { normalizeList } from "~/utils/core/string"
+
+const parseDelimitedValues = (value: string | null | undefined) =>
+  normalizeList(value?.split(",") ?? [])
+
+const hasMeaningfulValue = (value: string | null | undefined) =>
+  Boolean(value?.trim())
+
+const hasMultiKeyState = (channel: ManagedSiteChannel) =>
+  Boolean(
+    channel.channel_info?.is_multi_key ||
+      (channel.channel_info?.multi_key_size ?? 0) > 0 ||
+      channel.channel_info?.multi_key_status_list?.length ||
+      channel.channel_info?.multi_key_mode,
+  )
+
+const areStringArraysEqual = (
+  left: readonly string[],
+  right: readonly string[],
+): boolean =>
+  left.length === right.length &&
+  left.every((item, index) => item === right[index])
+
+type LegacyMigrationPreviewDraft = Omit<ChannelFormData, "key">
+
+const AXON_HUB_TO_SHARED_CHANNEL_TYPE: Partial<Record<string, ChannelType>> = {
+  [AXON_HUB_CHANNEL_TYPE.OPENAI]: ChannelType.OpenAI,
+  [AXON_HUB_CHANNEL_TYPE.OPENAI_RESPONSES]: ChannelType.OpenAI,
+  [AXON_HUB_CHANNEL_TYPE.ANTHROPIC]: ChannelType.Anthropic,
+  [AXON_HUB_CHANNEL_TYPE.ANTHROPIC_AWS]: ChannelType.Anthropic,
+  [AXON_HUB_CHANNEL_TYPE.ANTHROPIC_GCP]: ChannelType.Anthropic,
+  [AXON_HUB_CHANNEL_TYPE.CLAUDECODE]: ChannelType.Anthropic,
+  [AXON_HUB_CHANNEL_TYPE.GEMINI_OPENAI]: ChannelType.Gemini,
+  [AXON_HUB_CHANNEL_TYPE.GEMINI]: ChannelType.Gemini,
+  [AXON_HUB_CHANNEL_TYPE.GEMINI_VERTEX]: ChannelType.Gemini,
+  [AXON_HUB_CHANNEL_TYPE.DEEPSEEK]: ChannelType.DeepSeek,
+  [AXON_HUB_CHANNEL_TYPE.DEEPSEEK_ANTHROPIC]: ChannelType.DeepSeek,
+  [AXON_HUB_CHANNEL_TYPE.OPENROUTER]: ChannelType.OpenRouter,
+  [AXON_HUB_CHANNEL_TYPE.XAI]: ChannelType.Xai,
+  [AXON_HUB_CHANNEL_TYPE.SILICONFLOW]: ChannelType.SiliconFlow,
+  [AXON_HUB_CHANNEL_TYPE.VOLCENGINE]: ChannelType.VolcEngine,
+  [AXON_HUB_CHANNEL_TYPE.OLLAMA]: ChannelType.Ollama,
+  [AXON_HUB_CHANNEL_TYPE.GITHUB_COPILOT]: ChannelType.OpenAI,
+  [AXON_HUB_CHANNEL_TYPE.NANOGPT]: ChannelType.OpenAI,
+}
+
+const CLAUDE_CODE_HUB_TO_SHARED_CHANNEL_TYPE: Partial<
+  Record<string, ChannelType>
+> = {
+  [CLAUDE_CODE_HUB_PROVIDER_TYPE.OPENAI_COMPATIBLE]: ChannelType.OpenAI,
+  [CLAUDE_CODE_HUB_PROVIDER_TYPE.CODEX]: ChannelType.OpenAI,
+  [CLAUDE_CODE_HUB_PROVIDER_TYPE.CLAUDE]: ChannelType.Anthropic,
+  [CLAUDE_CODE_HUB_PROVIDER_TYPE.GEMINI]: ChannelType.Gemini,
+}
+
+const getSharedChannelType = (
+  sourceSiteType: ManagedSiteType,
+  channel: ManagedSiteChannel,
+): ChannelType => {
+  const channelType =
+    typeof channel.type === "number"
+      ? channel.type
+      : sourceSiteType === SITE_TYPES.AXON_HUB
+        ? AXON_HUB_TO_SHARED_CHANNEL_TYPE[channel.type] ?? ChannelType.OpenAI
+        : sourceSiteType === SITE_TYPES.CLAUDE_CODE_HUB
+          ? CLAUDE_CODE_HUB_TO_SHARED_CHANNEL_TYPE[channel.type] ??
+            ChannelType.OpenAI
+          : ChannelType.OpenAI
+  return sourceSiteType === SITE_TYPES.OCTOPUS
+    ? mapOctopusOutboundTypeToChannelType(channelType)
+    : (channelType as ChannelType)
+}
+
+const SHARED_TO_AXON_HUB_CHANNEL_TYPE: Partial<Record<ChannelType, string>> = {
+  [ChannelType.OpenAI]: AXON_HUB_CHANNEL_TYPE.OPENAI,
+  [ChannelType.Anthropic]: AXON_HUB_CHANNEL_TYPE.ANTHROPIC,
+  [ChannelType.OpenRouter]: AXON_HUB_CHANNEL_TYPE.OPENROUTER,
+  [ChannelType.Gemini]: AXON_HUB_CHANNEL_TYPE.GEMINI,
+  [ChannelType.SiliconFlow]: AXON_HUB_CHANNEL_TYPE.SILICONFLOW,
+  [ChannelType.DeepSeek]: AXON_HUB_CHANNEL_TYPE.DEEPSEEK,
+  [ChannelType.VolcEngine]: AXON_HUB_CHANNEL_TYPE.VOLCENGINE,
+  [ChannelType.Xai]: AXON_HUB_CHANNEL_TYPE.XAI,
+  [ChannelType.Ollama]: AXON_HUB_CHANNEL_TYPE.OLLAMA,
+}
+
+const SHARED_TO_CLAUDE_CODE_HUB_PROVIDER_TYPE: Partial<
+  Record<ChannelType, string>
+> = {
+  [ChannelType.Anthropic]: CLAUDE_CODE_HUB_PROVIDER_TYPE.CLAUDE,
+  [ChannelType.Gemini]: CLAUDE_CODE_HUB_PROVIDER_TYPE.GEMINI,
+}
+
+const getLegacyTargetType = (
+  targetSiteType: ManagedSiteType,
+  resourceType: ChannelType,
+) => {
+  if (targetSiteType === SITE_TYPES.OCTOPUS) {
+    return mapChannelTypeToOctopusOutboundType(resourceType)
+  }
+  if (targetSiteType === SITE_TYPES.AXON_HUB) {
+    return (
+      SHARED_TO_AXON_HUB_CHANNEL_TYPE[resourceType] ??
+      AXON_HUB_CHANNEL_TYPE.OPENAI
+    )
+  }
+  if (targetSiteType === SITE_TYPES.CLAUDE_CODE_HUB) {
+    return (
+      SHARED_TO_CLAUDE_CODE_HUB_PROVIDER_TYPE[resourceType] ??
+      CLAUDE_CODE_HUB_PROVIDER_TYPE.OPENAI_COMPATIBLE
+    )
+  }
+  return resourceType
+}
+
+const getSafeClaudeCodeHubWeight = (weight: number) =>
+  Number.isFinite(weight) ? Math.max(1, Math.trunc(weight)) : 1
+
+const toLegacyMigrationPreviewDraft = (params: {
+  source: ManagedSiteMigrationSource
+  targetSiteType: ManagedSiteType
+  displayName: string
+  selectionId: string
+  legacyStatus?: ChannelFormData["status"]
+}): LegacyMigrationPreviewDraft => ({
+  name: params.displayName.trim() || `Channel #${params.selectionId}`,
+  type: getLegacyTargetType(params.targetSiteType, params.source.resourceType),
+  base_url:
+    params.targetSiteType === SITE_TYPES.OCTOPUS
+      ? buildOctopusBaseUrl(params.source.baseUrl)
+      : params.source.baseUrl,
+  models: [...params.source.models],
+  groups:
+    params.targetSiteType === SITE_TYPES.OCTOPUS ||
+    params.targetSiteType === SITE_TYPES.AXON_HUB
+      ? [...DEFAULT_CHANNEL_FIELDS.groups]
+      : params.targetSiteType === SITE_TYPES.CLAUDE_CODE_HUB
+        ? [params.source.groups[0] ?? DEFAULT_CHANNEL_FIELDS.groups[0]]
+        : params.source.groups.length > 0
+          ? [...params.source.groups]
+          : [...DEFAULT_CHANNEL_FIELDS.groups],
+  priority:
+    params.targetSiteType === SITE_TYPES.OCTOPUS ||
+    params.targetSiteType === SITE_TYPES.AXON_HUB
+      ? DEFAULT_CHANNEL_FIELDS.priority
+      : params.source.priority,
+  weight:
+    params.targetSiteType === SITE_TYPES.OCTOPUS
+      ? DEFAULT_CHANNEL_FIELDS.weight
+      : params.targetSiteType === SITE_TYPES.CLAUDE_CODE_HUB
+        ? getSafeClaudeCodeHubWeight(params.source.weight)
+        : params.source.weight,
+  status:
+    params.targetSiteType === SITE_TYPES.OCTOPUS ||
+    params.targetSiteType === SITE_TYPES.AXON_HUB ||
+    params.targetSiteType === SITE_TYPES.CLAUDE_CODE_HUB
+      ? params.source.status === "enabled"
+        ? 1
+        : 2
+      : params.legacyStatus ?? (params.source.status === "enabled" ? 1 : 2),
+})
+
+const getLegacyMigrationLossSignals = (
+  channel: ManagedSiteChannel,
+): ManagedSiteMigrationLossSignals => ({
+  hasModelMapping: hasMeaningfulValue(channel.model_mapping),
+  hasStatusCodeMapping: hasMeaningfulValue(channel.status_code_mapping),
+  hasAdvancedSettings:
+    hasMeaningfulValue(channel.setting) || hasMeaningfulValue(channel.settings),
+  hasMultiKeyState: hasMultiKeyState(channel),
+})
+
+/** Extracts the controlled legacy fields that cannot migrate losslessly. */
+export function collectLegacyMigrationLossSignals(
+  channel: ManagedSiteChannel,
+): ManagedSiteMigrationLossSignals {
+  return getLegacyMigrationLossSignals(channel)
+}
+
+/** Projects a legacy channel into the secret-free canonical source model. */
+export function toCanonicalMigrationSourceFromLegacyChannel(params: {
+  sourceSiteType: ManagedSiteType
+  channel: ManagedSiteChannel
+}): ManagedSiteMigrationSource {
+  const { channel } = params
+
+  return {
+    sourceSiteType: params.sourceSiteType,
+    resourceType: getSharedChannelType(params.sourceSiteType, channel),
+    baseUrl: (channel.base_url ?? "").trim(),
+    models: parseDelimitedValues(channel.models),
+    groups: parseDelimitedValues(channel.group),
+    priority: channel.priority ?? DEFAULT_CHANNEL_FIELDS.priority,
+    weight: channel.weight ?? DEFAULT_CHANNEL_FIELDS.weight,
+    status:
+      channel.status == null || channel.status === 1
+        ? "enabled"
+        : channel.status === 2
+          ? "disabled"
+          : "other",
+    lossSignals: getLegacyMigrationLossSignals(channel),
+  }
+}
+
+type LegacyChannelWithResourceIdentity = ManagedSiteChannel & {
+  resourceRef?: ManagedResourceRef
+  _axonHubData?: { id?: string | null }
+}
+
+type LegacyMigrationResourceRefParams = {
+  sourceSiteType: ManagedSiteType
+  channel: LegacyChannelWithResourceIdentity
+  scopeKey?: string
+  resourceRef?: ManagedResourceRef
+}
+
+const resolveMigrationResourceRefFromLegacyRow = (
+  params: LegacyMigrationResourceRefParams,
+): ManagedResourceRef => {
+  const existingResourceRef = params.resourceRef ?? params.channel.resourceRef
+  if (existingResourceRef) {
+    return existingResourceRef
+  }
+
+  return {
+    siteType: params.sourceSiteType,
+    kind: MANAGED_RESOURCE_KINDS.Channel,
+    scopeKey: params.scopeKey ?? "",
+    resourceId:
+      params.channel._axonHubData?.id?.trim() || String(params.channel.id),
+  }
+}
+
+/** Preserves the AxonHub facade contract while sharing generic ref resolution. */
+export function resolveAxonHubMigrationResourceRefFromLegacyRow(
+  params: LegacyMigrationResourceRefParams,
+): ManagedResourceRef {
+  return resolveMigrationResourceRefFromLegacyRow(params)
+}
+
+/** Separates legacy numeric row identity from native resource identity. */
+export function toCanonicalMigrationSelectionFromLegacyRow(params: {
+  sourceSiteType: ManagedSiteType
+  channel: LegacyChannelWithResourceIdentity
+  scopeKey?: string
+  resourceRef?: ManagedResourceRef
+}): ManagedSiteMigrationSelection {
+  return {
+    selectionId: String(params.channel.id),
+    displayName: params.channel.name,
+    ref: resolveMigrationResourceRefFromLegacyRow(params),
+  }
+}
+
+/** Preserves the AxonHub facade contract while sharing generic row conversion. */
+export function toCanonicalMigrationSelectionFromLegacyAxonRow(
+  params: LegacyMigrationResourceRefParams,
+): ManagedSiteMigrationSelection {
+  return toCanonicalMigrationSelectionFromLegacyRow(params)
+}
+
+const getTargetAdjustments = (
+  source: ManagedSiteMigrationSource,
+  draft: ChannelFormData | LegacyMigrationPreviewDraft,
+): ManagedSiteMigrationTargetAdjustments => ({
+  remappedType: String(draft.type) !== String(source.resourceType),
+  normalizedBaseUrl: draft.base_url !== source.baseUrl,
+  forcedDefaultGroup: !areStringArraysEqual(draft.groups, source.groups),
+  ignoredPriority: draft.priority !== source.priority,
+  ignoredWeight: draft.weight !== source.weight,
+  simplifiedStatus:
+    source.status === "other"
+      ? draft.status === 1 || draft.status === 2
+      : draft.status !== (source.status === "enabled" ? 1 : 2),
+})
+
+/** Removes credentials while retaining the target preview projection and adjustments. */
+export async function toCanonicalTargetPreparationFromLegacyDraft(
+  params:
+    | {
+        source: ManagedSiteMigrationSource
+        draft: ChannelFormData | LegacyMigrationPreviewDraft
+      }
+    | {
+        source: ManagedSiteMigrationSource
+        targetSiteType: ManagedSiteType
+        displayName: string
+        selectionId: string
+        legacyStatus?: ChannelFormData["status"]
+        preparePreviewDraft?: (
+          draft: LegacyMigrationPreviewDraft,
+        ) => Promise<LegacyMigrationPreviewDraft>
+      },
+): Promise<ManagedSiteMigrationTargetPreparation> {
+  const { source } = params
+  const draft =
+    "draft" in params
+      ? params.draft
+      : await (params.preparePreviewDraft?.(
+          toLegacyMigrationPreviewDraft(params),
+        ) ?? Promise.resolve(toLegacyMigrationPreviewDraft(params)))
+  const projection: ManagedSiteMigrationPreviewProjection = {
+    name: draft.name,
+    type: draft.type,
+    baseUrl: draft.base_url,
+    models: [...draft.models],
+    groups: [...draft.groups],
+    priority: draft.priority,
+    weight: draft.weight,
+    status: draft.status === 1 ? 1 : 2,
+  }
+  const adjustments = getTargetAdjustments(source, draft)
+  if (
+    "targetSiteType" in params &&
+    source.sourceSiteType !== params.targetSiteType &&
+    (source.sourceSiteType === SITE_TYPES.OCTOPUS ||
+      source.sourceSiteType === SITE_TYPES.AXON_HUB ||
+      source.sourceSiteType === SITE_TYPES.CLAUDE_CODE_HUB)
+  ) {
+    adjustments.remappedType = true
+  }
+  return { projection, adjustments }
+}
+
+/** Builds an execution-only legacy target draft from canonical data and a credential. */
+export function toLegacyChannelFormDataProjection(params: {
+  source: ManagedSiteMigrationSource
+  target:
+    | ManagedSiteMigrationTargetPreparation
+    | ManagedSiteMigrationPreviewProjection
+  credential: string
+}): ChannelFormData {
+  const projection =
+    "projection" in params.target ? params.target.projection : params.target
+  return {
+    name: projection.name,
+    type: projection.type,
+    key: params.credential,
+    base_url: projection.baseUrl,
+    models: [...projection.models],
+    groups: [...projection.groups],
+    priority: projection.priority,
+    weight: projection.weight,
+    status: projection.status,
+  }
+}
+
+/** Maps canonical loss and adjustment facts to stable legacy warning order. */
+export function toLegacyMigrationWarningCodes(
+  params:
+    | {
+        lossSignals: ManagedSiteMigrationLossSignals
+        adjustments: ManagedSiteMigrationTargetAdjustments
+      }
+    | {
+        sourceSiteType: ManagedSiteType
+        targetSiteType: ManagedSiteType
+        channel: ManagedSiteChannel
+      },
+): ManagedSiteChannelMigrationItemWarningCode[] {
+  const warnings: ManagedSiteChannelMigrationItemWarningCode[] = []
+  let lossSignals: ManagedSiteMigrationLossSignals
+  let adjustments: ManagedSiteMigrationTargetAdjustments
+  if ("channel" in params) {
+    const source = toCanonicalMigrationSourceFromLegacyChannel(params)
+    lossSignals = source.lossSignals
+    adjustments = getTargetAdjustments(
+      source,
+      toLegacyMigrationPreviewDraft({
+        source,
+        targetSiteType: params.targetSiteType,
+        displayName: params.channel.name,
+        selectionId: String(params.channel.id),
+        legacyStatus: params.channel.status,
+      }),
+    )
+    adjustments.remappedType =
+      params.sourceSiteType !== params.targetSiteType &&
+      (params.sourceSiteType === SITE_TYPES.OCTOPUS ||
+        params.targetSiteType === SITE_TYPES.OCTOPUS ||
+        params.targetSiteType === SITE_TYPES.AXON_HUB ||
+        params.targetSiteType === SITE_TYPES.CLAUDE_CODE_HUB ||
+        ((params.sourceSiteType === SITE_TYPES.AXON_HUB ||
+          params.sourceSiteType === SITE_TYPES.CLAUDE_CODE_HUB) &&
+          typeof params.channel.type === "string"))
+  } else {
+    lossSignals = params.lossSignals
+    adjustments = params.adjustments
+  }
+
+  if (lossSignals.hasModelMapping) {
+    warnings.push(
+      MANAGED_SITE_CHANNEL_MIGRATION_ITEM_WARNING_CODES.DROPS_MODEL_MAPPING,
+    )
+  }
+  if (lossSignals.hasStatusCodeMapping) {
+    warnings.push(
+      MANAGED_SITE_CHANNEL_MIGRATION_ITEM_WARNING_CODES.DROPS_STATUS_CODE_MAPPING,
+    )
+  }
+  if (lossSignals.hasAdvancedSettings) {
+    warnings.push(
+      MANAGED_SITE_CHANNEL_MIGRATION_ITEM_WARNING_CODES.DROPS_ADVANCED_SETTINGS,
+    )
+  }
+  if (lossSignals.hasMultiKeyState) {
+    warnings.push(
+      MANAGED_SITE_CHANNEL_MIGRATION_ITEM_WARNING_CODES.DROPS_MULTI_KEY_STATE,
+    )
+  }
+  if (adjustments.remappedType) {
+    warnings.push(
+      MANAGED_SITE_CHANNEL_MIGRATION_ITEM_WARNING_CODES.TARGET_REMAPS_CHANNEL_TYPE,
+    )
+  }
+  if (adjustments.normalizedBaseUrl) {
+    warnings.push(
+      MANAGED_SITE_CHANNEL_MIGRATION_ITEM_WARNING_CODES.TARGET_NORMALIZES_BASE_URL,
+    )
+  }
+  if (adjustments.forcedDefaultGroup) {
+    warnings.push(
+      MANAGED_SITE_CHANNEL_MIGRATION_ITEM_WARNING_CODES.TARGET_FORCES_DEFAULT_GROUP,
+    )
+  }
+  if (adjustments.ignoredPriority) {
+    warnings.push(
+      MANAGED_SITE_CHANNEL_MIGRATION_ITEM_WARNING_CODES.TARGET_IGNORES_PRIORITY,
+    )
+  }
+  if (adjustments.ignoredWeight) {
+    warnings.push(
+      MANAGED_SITE_CHANNEL_MIGRATION_ITEM_WARNING_CODES.TARGET_IGNORES_WEIGHT,
+    )
+  }
+  if (adjustments.simplifiedStatus) {
+    warnings.push(
+      MANAGED_SITE_CHANNEL_MIGRATION_ITEM_WARNING_CODES.TARGET_SIMPLIFIES_STATUS,
+    )
+  }
+
+  return warnings
+}

--- a/src/services/managedSites/channelMigrationLegacyFacade.ts
+++ b/src/services/managedSites/channelMigrationLegacyFacade.ts
@@ -100,6 +100,7 @@ const SHARED_TO_AXON_HUB_CHANNEL_TYPE: Partial<Record<ChannelType, string>> = {
   [ChannelType.Anthropic]: AXON_HUB_CHANNEL_TYPE.ANTHROPIC,
   [ChannelType.OpenRouter]: AXON_HUB_CHANNEL_TYPE.OPENROUTER,
   [ChannelType.Gemini]: AXON_HUB_CHANNEL_TYPE.GEMINI,
+  [ChannelType.VertexAi]: AXON_HUB_CHANNEL_TYPE.GEMINI,
   [ChannelType.SiliconFlow]: AXON_HUB_CHANNEL_TYPE.SILICONFLOW,
   [ChannelType.DeepSeek]: AXON_HUB_CHANNEL_TYPE.DEEPSEEK,
   [ChannelType.VolcEngine]: AXON_HUB_CHANNEL_TYPE.VOLCENGINE,
@@ -112,6 +113,7 @@ const SHARED_TO_CLAUDE_CODE_HUB_PROVIDER_TYPE: Partial<
 > = {
   [ChannelType.Anthropic]: CLAUDE_CODE_HUB_PROVIDER_TYPE.CLAUDE,
   [ChannelType.Gemini]: CLAUDE_CODE_HUB_PROVIDER_TYPE.GEMINI,
+  [ChannelType.VertexAi]: CLAUDE_CODE_HUB_PROVIDER_TYPE.GEMINI,
 }
 
 const getLegacyTargetType = (
@@ -262,7 +264,7 @@ export function resolveAxonHubMigrationResourceRefFromLegacyRow(
 }
 
 /** Separates legacy numeric row identity from native resource identity. */
-export function toCanonicalMigrationSelectionFromLegacyRow(params: {
+function toCanonicalMigrationSelectionFromLegacyRow(params: {
   sourceSiteType: ManagedSiteType
   channel: LegacyChannelWithResourceIdentity
   scopeKey?: string

--- a/src/services/managedSites/managedUpstreamResourceMigration.ts
+++ b/src/services/managedSites/managedUpstreamResourceMigration.ts
@@ -142,10 +142,6 @@ const defaultManagedUpstreamResourceMigrationGates =
         feature: MANAGED_UPSTREAM_RESOURCE_FEATURES.ChannelMigration,
       },
       {
-        siteType: SITE_TYPES.AXON_HUB,
-        feature: MANAGED_UPSTREAM_RESOURCE_FEATURES.ChannelMigration,
-      },
-      {
         siteType: SITE_TYPES.CLAUDE_CODE_HUB,
         feature: MANAGED_UPSTREAM_RESOURCE_FEATURES.ChannelMigration,
       },

--- a/src/types/managedSiteMigration.ts
+++ b/src/types/managedSiteMigration.ts
@@ -1,6 +1,11 @@
 import type { ManagedSiteType } from "~/constants/siteType"
 
 import type { ChannelFormData, ManagedSiteChannel } from "./managedSite"
+import type {
+  ManagedSiteMigrationSelection,
+  ManagedSiteMigrationSource,
+  ManagedSiteMigrationTargetPreparation,
+} from "./managedSiteMigrationCapability"
 
 export const MANAGED_SITE_CHANNEL_MIGRATION_GENERAL_WARNING_CODES = {
   CREATE_ONLY: "create-only",
@@ -36,6 +41,12 @@ export const MANAGED_SITE_CHANNEL_MIGRATION_BLOCKED_REASON_CODES = {
 export type ManagedSiteChannelMigrationBlockedReasonCode =
   (typeof MANAGED_SITE_CHANNEL_MIGRATION_BLOCKED_REASON_CODES)[keyof typeof MANAGED_SITE_CHANNEL_MIGRATION_BLOCKED_REASON_CODES]
 
+export type ManagedSiteMigrationCanonicalPreparation = {
+  selection: ManagedSiteMigrationSelection
+  source: ManagedSiteMigrationSource
+  target: ManagedSiteMigrationTargetPreparation
+}
+
 export interface ManagedSiteChannelMigrationPreviewItem {
   channelId: number
   channelName: string
@@ -45,6 +56,7 @@ export interface ManagedSiteChannelMigrationPreviewItem {
   warningCodes: ManagedSiteChannelMigrationItemWarningCode[]
   blockingReasonCode?: ManagedSiteChannelMigrationBlockedReasonCode
   blockingMessage?: string
+  canonicalPreparation?: ManagedSiteMigrationCanonicalPreparation
 }
 
 export interface ManagedSiteChannelMigrationPreview {

--- a/src/types/managedSiteMigrationCapability.ts
+++ b/src/types/managedSiteMigrationCapability.ts
@@ -176,6 +176,34 @@ export type ManagedSiteMigrationCanonicalExecutionResult = {
   items: readonly ManagedSiteMigrationCanonicalExecutionItem[]
 }
 
+/**
+ * Secret-free progress captured when canonical execution is cancelled.
+ *
+ * Invariants:
+ * - `partialResult.items.length + remainingSelections.length === partialResult.totalSelected`
+ * - The created, failed, skipped, and uncertain counts sum to `partialResult.items.length`.
+ *
+ * Credentials and execution commands must never be retained here.
+ */
+export type ManagedSiteMigrationExecutionAbortDetails = {
+  partialResult: ManagedSiteMigrationCanonicalExecutionResult
+  remainingSelections: readonly ManagedSiteMigrationSelection[]
+}
+
+/** Reports cancellation without discarding confirmed, secret-free progress. */
+export class ManagedSiteMigrationExecutionAbortedError extends Error {
+  readonly details: ManagedSiteMigrationExecutionAbortDetails
+
+  constructor(
+    details: ManagedSiteMigrationExecutionAbortDetails,
+    options?: ErrorOptions,
+  ) {
+    super("Managed-site migration execution was cancelled.", options)
+    this.name = "ManagedSiteMigrationExecutionAbortedError"
+    this.details = details
+  }
+}
+
 export type ManagedSiteMigrationCapability = {
   source?: {
     prepare(

--- a/src/types/managedSiteMigrationCapability.ts
+++ b/src/types/managedSiteMigrationCapability.ts
@@ -1,0 +1,200 @@
+import type { ChannelType } from "~/constants/managedSite"
+import type { ManagedSiteType } from "~/constants/siteType"
+import type {
+  ManagedResourceRef,
+  ResourceOperationOptions,
+} from "~/services/apiAdapters/contracts/managedResourceNative"
+
+import type {
+  ManagedSiteChannelMigrationBlockedReasonCode,
+  ManagedSiteChannelMigrationGeneralWarningCode,
+  ManagedSiteChannelMigrationItemWarningCode,
+} from "./managedSiteMigration"
+
+export type ManagedSiteMigrationSelection = {
+  selectionId: string
+  displayName: string
+  ref: ManagedResourceRef
+}
+
+export type ManagedSiteMigrationStatus = "enabled" | "disabled" | "other"
+
+export type ManagedSiteMigrationLossSignals = {
+  hasModelMapping: boolean
+  hasStatusCodeMapping: boolean
+  hasAdvancedSettings: boolean
+  hasMultiKeyState: boolean
+}
+
+export type ManagedSiteMigrationSource = {
+  sourceSiteType: ManagedSiteType
+  resourceType: ChannelType
+  baseUrl: string
+  models: string[]
+  groups: string[]
+  priority: number
+  weight: number
+  status: ManagedSiteMigrationStatus
+  lossSignals: ManagedSiteMigrationLossSignals
+}
+
+export type ManagedSiteMigrationPreviewProjection = {
+  name: string
+  type: ChannelType | string
+  baseUrl: string
+  models: string[]
+  groups: string[]
+  priority: number
+  weight: number
+  status: 1 | 2
+}
+
+export type ManagedSiteMigrationTargetAdjustments = {
+  remappedType: boolean
+  normalizedBaseUrl: boolean
+  forcedDefaultGroup: boolean
+  ignoredPriority: boolean
+  ignoredWeight: boolean
+  simplifiedStatus: boolean
+}
+
+/** Execution-only ephemeral command; it must never enter previews, results, persistence, React state, analytics, logs, or caches. */
+export type ManagedSiteMigrationExecutionCommand = {
+  source: ManagedSiteMigrationSource
+  targetSiteType: ManagedSiteType
+  projection: ManagedSiteMigrationPreviewProjection
+  credential: string
+}
+
+export type ManagedSiteMigrationTargetPreparation = {
+  projection: ManagedSiteMigrationPreviewProjection
+  adjustments: ManagedSiteMigrationTargetAdjustments
+}
+
+export type ManagedSiteMigrationSourcePreparation =
+  | { status: "ready"; source: ManagedSiteMigrationSource }
+  | {
+      status: "blocked"
+      reasonCode: ManagedSiteChannelMigrationBlockedReasonCode
+    }
+
+/** Execution-only ephemeral credential; it must never enter previews, results, persistence, React state, analytics, logs, or caches. */
+export type ManagedSiteMigrationCredentialResolution =
+  | { status: "ready"; credential: string }
+  | {
+      status: "blocked"
+      reasonCode: ManagedSiteChannelMigrationBlockedReasonCode
+    }
+
+export const MANAGED_SITE_MIGRATION_EXECUTION_FAILURE_CODES = {
+  SourceUnavailable: "source_unavailable",
+  TargetUnavailable: "target_unavailable",
+  TargetRejected: "target_rejected",
+  MutationStateUncertain: "mutation_state_uncertain",
+  Unexpected: "unexpected",
+} as const
+
+export type ManagedSiteMigrationExecutionFailureCode =
+  (typeof MANAGED_SITE_MIGRATION_EXECUTION_FAILURE_CODES)[keyof typeof MANAGED_SITE_MIGRATION_EXECUTION_FAILURE_CODES]
+
+export type ManagedSiteMigrationConfirmedFailureCode = Exclude<
+  ManagedSiteMigrationExecutionFailureCode,
+  typeof MANAGED_SITE_MIGRATION_EXECUTION_FAILURE_CODES.MutationStateUncertain
+>
+
+export type ManagedSiteMigrationCreateResult =
+  | { status: "created" }
+  | {
+      status: "failed"
+      failureCode: ManagedSiteMigrationConfirmedFailureCode
+    }
+  | { status: "uncertain" }
+
+type ManagedSiteMigrationCanonicalPreviewItemBase = {
+  selection: ManagedSiteMigrationSelection
+  warningCodes: readonly ManagedSiteChannelMigrationItemWarningCode[]
+}
+
+export type ManagedSiteMigrationCanonicalPreviewItem =
+  | (ManagedSiteMigrationCanonicalPreviewItemBase & {
+      status: "ready"
+      source: ManagedSiteMigrationSource
+      target: ManagedSiteMigrationTargetPreparation
+      blockingReasonCode?: never
+    })
+  | (ManagedSiteMigrationCanonicalPreviewItemBase & {
+      status: "blocked"
+      blockingReasonCode: ManagedSiteChannelMigrationBlockedReasonCode
+      source?: ManagedSiteMigrationSource
+      target?: never
+    })
+
+export type ManagedSiteMigrationCanonicalPreview = {
+  sourceSiteType: ManagedSiteType
+  targetSiteType: ManagedSiteType
+  generalWarningCodes: readonly ManagedSiteChannelMigrationGeneralWarningCode[]
+  items: readonly ManagedSiteMigrationCanonicalPreviewItem[]
+  totalCount: number
+  readyCount: number
+  blockedCount: number
+}
+
+type ManagedSiteMigrationCanonicalExecutionItemBase = {
+  selectionId: string
+  displayName: string
+}
+
+type ManagedSiteMigrationCanonicalExecutionItem =
+  | (ManagedSiteMigrationCanonicalExecutionItemBase & {
+      status: "created"
+      failureCode?: never
+      blockingReasonCode?: never
+    })
+  | (ManagedSiteMigrationCanonicalExecutionItemBase & {
+      status: "failed"
+      failureCode: ManagedSiteMigrationConfirmedFailureCode
+      blockingReasonCode?: never
+    })
+  | (ManagedSiteMigrationCanonicalExecutionItemBase & {
+      status: "skipped"
+      failureCode?: never
+      blockingReasonCode: ManagedSiteChannelMigrationBlockedReasonCode
+    })
+  | (ManagedSiteMigrationCanonicalExecutionItemBase & {
+      status: "uncertain"
+      failureCode: typeof MANAGED_SITE_MIGRATION_EXECUTION_FAILURE_CODES.MutationStateUncertain
+      blockingReasonCode?: never
+    })
+
+export type ManagedSiteMigrationCanonicalExecutionResult = {
+  totalSelected: number
+  attemptedCount: number
+  createdCount: number
+  failedCount: number
+  skippedCount: number
+  uncertainCount: number
+  items: readonly ManagedSiteMigrationCanonicalExecutionItem[]
+}
+
+export type ManagedSiteMigrationCapability = {
+  source?: {
+    prepare(
+      selection: ManagedSiteMigrationSelection,
+      options?: ResourceOperationOptions,
+    ): Promise<ManagedSiteMigrationSourcePreparation>
+    resolveCredential(
+      selection: ManagedSiteMigrationSelection,
+      options?: ResourceOperationOptions,
+    ): Promise<ManagedSiteMigrationCredentialResolution>
+  }
+  target?: {
+    prepare(
+      source: ManagedSiteMigrationSource,
+      options?: ResourceOperationOptions,
+    ): Promise<ManagedSiteMigrationTargetPreparation>
+    create(
+      command: ManagedSiteMigrationExecutionCommand,
+      options?: ResourceOperationOptions,
+    ): Promise<ManagedSiteMigrationCreateResult>
+  }
+}

--- a/tests/services/apiAdapters/managedResources/axonHub.test.ts
+++ b/tests/services/apiAdapters/managedResources/axonHub.test.ts
@@ -1191,6 +1191,40 @@ describe("AxonHub native managed-resource Adapter", () => {
     expect(JSON.stringify(result)).not.toContain("credentials")
   })
 
+  it("maps a plain disabled native detail without advanced migration loss", async () => {
+    mocks.getChannel.mockResolvedValue(
+      buildDetailChannel({
+        status: AXON_HUB_CHANNEL_STATUS.DISABLED,
+        settings: null,
+        policies: null,
+        endpoints: [],
+        tags: [],
+        autoSyncSupportedModels: false,
+        autoSyncModelPattern: null,
+        remark: null,
+      }),
+    )
+
+    const result = await axonHubManagedSiteMigrationCapability.source!.prepare({
+      selectionId: "plain-disabled",
+      displayName: "Plain disabled source",
+      ref: refFor(),
+    })
+
+    expect(result).toMatchObject({
+      status: "ready",
+      source: {
+        status: "disabled",
+        lossSignals: {
+          hasModelMapping: false,
+          hasStatusCodeMapping: false,
+          hasAdvancedSettings: false,
+          hasMultiKeyState: false,
+        },
+      },
+    })
+  })
+
   it("reloads native detail and returns a usable regular key only during execution", async () => {
     mocks.getChannel
       .mockResolvedValueOnce(
@@ -1581,5 +1615,22 @@ describe("AxonHub native managed-resource Adapter", () => {
       }),
     ).resolves.toEqual({ status: "uncertain" })
     expect(mocks.createChannel).toHaveBeenCalledTimes(3)
+  })
+
+  it("maps an unclassified confirmed native failure to unexpected", async () => {
+    mocks.createChannel.mockRejectedValue(
+      new mocks.RequestError("protocol", "not-dispatched"),
+    )
+
+    await expect(
+      axonHubManagedSiteMigrationCapability.target!.create(
+        await buildMigrationCreateCommand(),
+      ),
+    ).resolves.toEqual({
+      status: "failed",
+      failureCode: MANAGED_SITE_MIGRATION_EXECUTION_FAILURE_CODES.Unexpected,
+    })
+    expect(mocks.createChannel).toHaveBeenCalledOnce()
+    expect(mocks.updateStatus).not.toHaveBeenCalled()
   })
 })

--- a/tests/services/apiAdapters/managedResources/axonHub.test.ts
+++ b/tests/services/apiAdapters/managedResources/axonHub.test.ts
@@ -4,6 +4,7 @@ import {
   AXON_HUB_CHANNEL_STATUS,
   AXON_HUB_CHANNEL_TYPE,
 } from "~/constants/axonHub"
+import { ChannelType } from "~/constants/managedSite"
 import { isManagedSiteType, SITE_TYPES } from "~/constants/siteType"
 import {
   MANAGED_RESOURCE_KINDS,
@@ -24,9 +25,16 @@ import {
   type AxonHubNativeFailure,
   type AxonHubNativeResourceOperations,
 } from "~/services/apiAdapters/managedResources/axonHub"
+import * as axonHubNativeResources from "~/services/apiAdapters/managedResources/axonHub"
+import { axonHubManagedSiteMigrationCapability } from "~/services/apiAdapters/managedResources/axonHubMigration"
 import { getManagedResourceRegistration } from "~/services/apiAdapters/managedResources/registry"
 import { getSiteTypeCapabilities } from "~/services/apiAdapters/registry"
 import type { AxonHubChannel } from "~/types/axonHub"
+import { MANAGED_SITE_CHANNEL_MIGRATION_BLOCKED_REASON_CODES } from "~/types/managedSiteMigration"
+import {
+  MANAGED_SITE_MIGRATION_EXECUTION_FAILURE_CODES,
+  type ManagedSiteMigrationSource,
+} from "~/types/managedSiteMigrationCapability"
 
 const mocks = vi.hoisted(() => {
   class RequestError extends Error {
@@ -159,6 +167,26 @@ const refFor = (channel = buildDetailChannel()): ManagedResourceRef => ({
   resourceId: channel.id,
 })
 
+const buildMigrationSource = (
+  overrides: Partial<ManagedSiteMigrationSource> = {},
+): ManagedSiteMigrationSource => ({
+  sourceSiteType: SITE_TYPES.NEW_API,
+  resourceType: ChannelType.OpenAI,
+  baseUrl: "https://source.example.invalid",
+  models: ["model-one"],
+  groups: ["default"],
+  priority: 0,
+  weight: 0,
+  status: "disabled",
+  lossSignals: {
+    hasModelMapping: false,
+    hasStatusCodeMapping: false,
+    hasAdvancedSettings: false,
+    hasMultiKeyState: false,
+  },
+  ...overrides,
+})
+
 const expectFailureCode = async (promise: Promise<unknown>, code: string) => {
   const error = await promise.catch((failure) => failure)
   expect(error).toBeInstanceOf(ManagedResourceError)
@@ -166,6 +194,17 @@ const expectFailureCode = async (promise: Promise<unknown>, code: string) => {
 }
 
 const openWorkspace = () => axonHubManagedResourceRegistration.open()
+
+const buildMigrationCreateCommand = async (source = buildMigrationSource()) => {
+  const preparation =
+    await axonHubManagedSiteMigrationCapability.target!.prepare(source)
+  return {
+    source,
+    targetSiteType: SITE_TYPES.AXON_HUB,
+    projection: { ...preparation.projection, name: "Migration target" },
+    credential: "sk-migration-placeholder",
+  }
+}
 
 describe("AxonHub native managed-resource Adapter", () => {
   beforeEach(() => {
@@ -1102,5 +1141,445 @@ describe("AxonHub native managed-resource Adapter", () => {
         )
       }),
     ).toBe(true)
+  })
+
+  it("maps native Axon detail to a secret-free canonical migration source", async () => {
+    mocks.getChannel.mockResolvedValue(
+      buildDetailChannel({
+        type: AXON_HUB_CHANNEL_TYPE.ANTHROPIC,
+        status: AXON_HUB_CHANNEL_STATUS.ARCHIVED,
+        baseURL: " https://native.example.invalid/v1 ",
+        credentials: {
+          apiKeys: ["sk-preview-placeholder", "sk-second-placeholder"],
+        },
+        supportedModels: ["supported-model", "shared-model"],
+        manualModels: ["manual-model", "shared-model"],
+        orderingWeight: 11,
+        settings: {
+          modelMappings: [{ from: "alias-model", to: "supported-model" }],
+          proxy: { type: "http", url: "https://proxy.example.invalid" },
+        },
+      }),
+    )
+
+    const result = await axonHubManagedSiteMigrationCapability.source!.prepare({
+      selectionId: "legacy-401",
+      displayName: "Native source",
+      ref: refFor(),
+    })
+
+    expect(result).toEqual({
+      status: "ready",
+      source: {
+        sourceSiteType: SITE_TYPES.AXON_HUB,
+        resourceType: ChannelType.Anthropic,
+        baseUrl: "https://native.example.invalid/v1",
+        models: ["supported-model", "shared-model", "manual-model"],
+        groups: [],
+        priority: 0,
+        weight: 11,
+        status: "other",
+        lossSignals: {
+          hasModelMapping: true,
+          hasStatusCodeMapping: false,
+          hasAdvancedSettings: true,
+          hasMultiKeyState: true,
+        },
+      },
+    })
+    expect(JSON.stringify(result)).not.toContain("sk-preview-placeholder")
+    expect(JSON.stringify(result)).not.toContain("credentials")
+  })
+
+  it("reloads native detail and returns a usable regular key only during execution", async () => {
+    mocks.getChannel
+      .mockResolvedValueOnce(
+        buildDetailChannel({
+          credentials: { apiKeys: ["sk-preview-placeholder"] },
+        }),
+      )
+      .mockResolvedValueOnce(
+        buildDetailChannel({
+          credentials: { apiKeys: ["sk-execution-placeholder"] },
+        }),
+      )
+    const selection = {
+      selectionId: "native-credential",
+      displayName: "Native credential",
+      ref: refFor(),
+    }
+
+    const preview =
+      await axonHubManagedSiteMigrationCapability.source!.prepare(selection)
+    const resolution =
+      await axonHubManagedSiteMigrationCapability.source!.resolveCredential(
+        selection,
+      )
+
+    expect(preview.status).toBe("ready")
+    expect(resolution).toEqual({
+      status: "ready",
+      credential: "sk-execution-placeholder",
+    })
+    expect(mocks.getChannel).toHaveBeenCalledTimes(2)
+  })
+
+  it.each([
+    {
+      label: "permission-hidden",
+      credentials: null,
+      reasonCode:
+        MANAGED_SITE_CHANNEL_MIGRATION_BLOCKED_REASON_CODES.SOURCE_KEY_RESOLUTION_FAILED,
+    },
+    {
+      label: "masked",
+      credentials: { apiKeys: ["sk-********"] },
+      reasonCode:
+        MANAGED_SITE_CHANNEL_MIGRATION_BLOCKED_REASON_CODES.SOURCE_KEY_MISSING,
+    },
+    {
+      label: "unavailable",
+      credentials: { apiKeys: [] },
+      reasonCode:
+        MANAGED_SITE_CHANNEL_MIGRATION_BLOCKED_REASON_CODES.SOURCE_KEY_MISSING,
+    },
+  ])(
+    "maps $label native credentials to a controlled blocker",
+    async ({ credentials, reasonCode }) => {
+      mocks.getChannel.mockResolvedValue(buildDetailChannel({ credentials }))
+      const selection = {
+        selectionId: "blocked-native",
+        displayName: "Blocked native",
+        ref: refFor(),
+      }
+
+      await expect(
+        axonHubManagedSiteMigrationCapability.source!.prepare(selection),
+      ).resolves.toEqual({ status: "blocked", reasonCode })
+      await expect(
+        axonHubManagedSiteMigrationCapability.source!.resolveCredential(
+          selection,
+        ),
+      ).resolves.toEqual({ status: "blocked", reasonCode })
+    },
+  )
+
+  it("projects canonical targets and creates one direct native Axon input with signal propagation", async () => {
+    const controller = new AbortController()
+    const source = {
+      sourceSiteType: SITE_TYPES.NEW_API,
+      resourceType: ChannelType.Gemini,
+      baseUrl: "https://source.example.invalid/v1",
+      models: ["model-one", "model-two"],
+      groups: ["paid"],
+      priority: 8,
+      weight: 13,
+      status: "enabled" as const,
+      lossSignals: {
+        hasModelMapping: false,
+        hasStatusCodeMapping: false,
+        hasAdvancedSettings: false,
+        hasMultiKeyState: false,
+      },
+    }
+    const preparation =
+      await axonHubManagedSiteMigrationCapability.target!.prepare(source, {
+        signal: controller.signal,
+      })
+
+    expect(preparation).toEqual({
+      projection: {
+        name: "",
+        type: AXON_HUB_CHANNEL_TYPE.GEMINI,
+        baseUrl: "https://source.example.invalid/v1",
+        models: ["model-one", "model-two"],
+        groups: ["default"],
+        priority: 0,
+        weight: 13,
+        status: 1,
+      },
+      adjustments: {
+        remappedType: true,
+        normalizedBaseUrl: false,
+        forcedDefaultGroup: true,
+        ignoredPriority: true,
+        ignoredWeight: false,
+        simplifiedStatus: false,
+      },
+    })
+
+    const result = await axonHubManagedSiteMigrationCapability.target!.create(
+      {
+        source,
+        targetSiteType: SITE_TYPES.AXON_HUB,
+        projection: { ...preparation.projection, name: "Native target" },
+        credential: "sk-create-placeholder",
+      },
+      { signal: controller.signal },
+    )
+
+    expect(result).toEqual({ status: "created" })
+    expect(mocks.createChannel).toHaveBeenCalledOnce()
+    expect(mocks.createChannel).toHaveBeenCalledWith(
+      config,
+      {
+        type: AXON_HUB_CHANNEL_TYPE.GEMINI,
+        name: "Native target",
+        baseURL: "https://source.example.invalid/v1",
+        credentials: { apiKeys: ["sk-create-placeholder"] },
+        supportedModels: ["model-one", "model-two"],
+        manualModels: ["model-one", "model-two"],
+        defaultTestModel: "model-one",
+        settings: {},
+        orderingWeight: 13,
+      },
+      { signal: controller.signal },
+    )
+    expect(mocks.updateStatus).toHaveBeenCalledWith(
+      config,
+      "opaque-channel-1",
+      AXON_HUB_CHANNEL_STATUS.ENABLED,
+      { signal: controller.signal },
+    )
+  })
+
+  it("maps canonical Vertex AI targets to AxonHub Gemini during prepare and create", async () => {
+    const source = buildMigrationSource({
+      resourceType: ChannelType.VertexAi,
+      baseUrl: "https://vertex.example.invalid",
+    })
+    const command = await buildMigrationCreateCommand(source)
+
+    expect(command.projection.type).toBe(AXON_HUB_CHANNEL_TYPE.GEMINI)
+
+    await expect(
+      axonHubManagedSiteMigrationCapability.target!.create(command),
+    ).resolves.toEqual({ status: "created" })
+    expect(mocks.createChannel).toHaveBeenCalledWith(
+      config,
+      expect.objectContaining({ type: AXON_HUB_CHANNEL_TYPE.GEMINI }),
+      undefined,
+    )
+  })
+
+  it("omits an empty optional baseURL from native migration creation", async () => {
+    const command = await buildMigrationCreateCommand(
+      buildMigrationSource({ baseUrl: "   " }),
+    )
+
+    await expect(
+      axonHubManagedSiteMigrationCapability.target!.create(command),
+    ).resolves.toEqual({ status: "created" })
+
+    expect(mocks.createChannel).toHaveBeenCalledOnce()
+    expect(mocks.createChannel.mock.calls[0][1]).not.toHaveProperty("baseURL")
+  })
+
+  it.each([
+    {
+      code: "configuration_required",
+      arrange: () => mocks.resolveRuntimeConfig.mockReturnValue(null),
+    },
+    {
+      code: "authentication_failed",
+      arrange: () =>
+        mocks.signIn.mockRejectedValue(
+          new mocks.RequestError("authentication", "not-dispatched"),
+        ),
+    },
+    {
+      code: "unavailable",
+      arrange: () =>
+        mocks.signIn.mockRejectedValue(
+          new mocks.RequestError("unavailable", "not-dispatched"),
+        ),
+    },
+  ])(
+    "maps controlled native open failure $code to target unavailable",
+    async ({ arrange }) => {
+      arrange()
+      const command = await buildMigrationCreateCommand()
+
+      await expect(
+        axonHubManagedSiteMigrationCapability.target!.create(command),
+      ).resolves.toEqual({
+        status: "failed",
+        failureCode:
+          MANAGED_SITE_MIGRATION_EXECUTION_FAILURE_CODES.TargetUnavailable,
+      })
+      expect(mocks.createChannel).not.toHaveBeenCalled()
+    },
+  )
+
+  it("normalizes a controlled native abort while opening the target", async () => {
+    mocks.signIn.mockRejectedValue(
+      new mocks.RequestError("aborted", "not-dispatched"),
+    )
+    const command = await buildMigrationCreateCommand()
+
+    const error = await axonHubManagedSiteMigrationCapability
+      .target!.create(command)
+      .catch((failure) => failure)
+
+    expect(error).toMatchObject({ name: "AbortError" })
+    expect(error.cause).toBeInstanceOf(AxonHubNativeError)
+    expect((error.cause as AxonHubNativeError).failure).toEqual({
+      code: "aborted",
+      dispatch: "before",
+    })
+    expect(mocks.createChannel).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    { method: "prepare" as const, stage: "open" as const },
+    { method: "prepare" as const, stage: "get" as const },
+    { method: "resolveCredential" as const, stage: "open" as const },
+    { method: "resolveCredential" as const, stage: "get" as const },
+  ])(
+    "normalizes native aborts from source $method $stage boundaries",
+    async ({ method, stage }) => {
+      const nativeAbort = new mocks.RequestError("aborted", "not-dispatched")
+      if (stage === "open") mocks.signIn.mockRejectedValue(nativeAbort)
+      else mocks.getChannel.mockRejectedValue(nativeAbort)
+      const selection = {
+        selectionId: `${method}-${stage}-abort`,
+        displayName: "Aborted source",
+        ref: refFor(),
+      }
+
+      const error = await axonHubManagedSiteMigrationCapability
+        .source![method](selection)
+        .catch((failure) => failure)
+
+      expect(error).toMatchObject({ name: "AbortError" })
+      expect(error.cause).toBeInstanceOf(AxonHubNativeError)
+      expect((error.cause as AxonHubNativeError).failure).toEqual({
+        code: "aborted",
+        dispatch: "before",
+      })
+    },
+  )
+
+  it("rethrows non-native target open errors without normalization", async () => {
+    const nonNativeError = new Error("Non-native open failure")
+    const openSpy = vi
+      .spyOn(axonHubNativeResources, "openAxonHubNativeResourceOperations")
+      .mockRejectedValueOnce(nonNativeError)
+
+    try {
+      await expect(
+        axonHubManagedSiteMigrationCapability.target!.create(
+          await buildMigrationCreateCommand(),
+        ),
+      ).rejects.toBe(nonNativeError)
+    } finally {
+      openSpy.mockRestore()
+    }
+  })
+
+  it.each([
+    AXON_HUB_CHANNEL_TYPE.ANTHROPIC_AWS,
+    AXON_HUB_CHANNEL_TYPE.ANTHROPIC_GCP,
+    "future-structured-type",
+  ])(
+    "blocks non-regular native type %s even when apiKeys look usable",
+    async (type) => {
+      mocks.getChannel.mockResolvedValue(
+        buildDetailChannel({
+          type,
+          credentials: { apiKeys: ["sk-apparently-usable-placeholder"] },
+        }),
+      )
+      const selection = {
+        selectionId: `non-regular-${type}`,
+        displayName: "Non-regular native",
+        ref: refFor(),
+      }
+      const expected = {
+        status: "blocked",
+        reasonCode:
+          MANAGED_SITE_CHANNEL_MIGRATION_BLOCKED_REASON_CODES.SOURCE_KEY_MISSING,
+      }
+
+      await expect(
+        axonHubManagedSiteMigrationCapability.source!.prepare(selection),
+      ).resolves.toEqual(expected)
+      await expect(
+        axonHubManagedSiteMigrationCapability.source!.resolveCredential(
+          selection,
+        ),
+      ).resolves.toEqual(expected)
+    },
+  )
+
+  it("maps confirmed native rejection and uncertain mutation states without replay", async () => {
+    const preparation =
+      await axonHubManagedSiteMigrationCapability.target!.prepare({
+        sourceSiteType: SITE_TYPES.NEW_API,
+        resourceType: ChannelType.OpenAI,
+        baseUrl: "https://source.example.invalid",
+        models: ["model-one"],
+        groups: ["default"],
+        priority: 0,
+        weight: 0,
+        status: "disabled",
+        lossSignals: {
+          hasModelMapping: false,
+          hasStatusCodeMapping: false,
+          hasAdvancedSettings: false,
+          hasMultiKeyState: false,
+        },
+      })
+    const command = {
+      source: {
+        sourceSiteType: SITE_TYPES.NEW_API,
+        resourceType: ChannelType.OpenAI,
+        baseUrl: "https://source.example.invalid",
+        models: ["model-one"],
+        groups: ["default"],
+        priority: 0,
+        weight: 0,
+        status: "disabled" as const,
+        lossSignals: {
+          hasModelMapping: false,
+          hasStatusCodeMapping: false,
+          hasAdvancedSettings: false,
+          hasMultiKeyState: false,
+        },
+      },
+      targetSiteType: SITE_TYPES.AXON_HUB,
+      projection: { ...preparation.projection, name: "Outcome target" },
+      credential: "sk-outcome-placeholder",
+    }
+
+    mocks.createChannel.mockRejectedValueOnce(
+      new mocks.RequestError("upstream-rejected", "not-dispatched"),
+    )
+    await expect(
+      axonHubManagedSiteMigrationCapability.target!.create(command),
+    ).resolves.toEqual({
+      status: "failed",
+      failureCode:
+        MANAGED_SITE_MIGRATION_EXECUTION_FAILURE_CODES.TargetRejected,
+    })
+
+    mocks.createChannel.mockRejectedValueOnce(
+      new mocks.RequestError("unavailable", "dispatched"),
+    )
+    await expect(
+      axonHubManagedSiteMigrationCapability.target!.create(command),
+    ).resolves.toEqual({ status: "uncertain" })
+
+    mocks.createChannel.mockResolvedValueOnce(
+      buildDetailChannel({ status: AXON_HUB_CHANNEL_STATUS.DISABLED }),
+    )
+    mocks.updateStatus.mockRejectedValueOnce(new Error("status lost"))
+    await expect(
+      axonHubManagedSiteMigrationCapability.target!.create({
+        ...command,
+        projection: { ...command.projection, status: 1 },
+      }),
+    ).resolves.toEqual({ status: "uncertain" })
+    expect(mocks.createChannel).toHaveBeenCalledTimes(3)
   })
 })

--- a/tests/services/apiAdapters/managedResources/axonHub.test.ts
+++ b/tests/services/apiAdapters/managedResources/axonHub.test.ts
@@ -1377,6 +1377,25 @@ describe("AxonHub native managed-resource Adapter", () => {
     )
   })
 
+  it("rejects target preparation when canonical models normalize to empty", async () => {
+    await expect(
+      axonHubManagedSiteMigrationCapability.target!.prepare(
+        buildMigrationSource({ models: ["", "   "] }),
+      ),
+    ).rejects.toThrow("at least one model")
+  })
+
+  it("normalizes non-empty canonical models during target preparation", async () => {
+    const preparation =
+      await axonHubManagedSiteMigrationCapability.target!.prepare(
+        buildMigrationSource({
+          models: [" model-one ", "model-one", "", "model-two"],
+        }),
+      )
+
+    expect(preparation.projection.models).toEqual(["model-one", "model-two"])
+  })
+
   it("maps canonical Vertex AI targets to AxonHub Gemini during prepare and create", async () => {
     const source = buildMigrationSource({
       resourceType: ChannelType.VertexAi,
@@ -1462,6 +1481,25 @@ describe("AxonHub native managed-resource Adapter", () => {
       dispatch: "before",
     })
     expect(mocks.createChannel).not.toHaveBeenCalled()
+  })
+
+  it("propagates a pre-dispatch native create abort without replay or status mutation", async () => {
+    mocks.createChannel.mockRejectedValue(
+      new mocks.RequestError("aborted", "not-dispatched"),
+    )
+
+    const error = await axonHubManagedSiteMigrationCapability
+      .target!.create(await buildMigrationCreateCommand())
+      .catch((failure) => failure)
+
+    expect(error).toMatchObject({ name: "AbortError" })
+    expect(error.cause).toBeInstanceOf(AxonHubNativeError)
+    expect((error.cause as AxonHubNativeError).failure).toEqual({
+      code: "aborted",
+      dispatch: "before",
+    })
+    expect(mocks.createChannel).toHaveBeenCalledOnce()
+    expect(mocks.updateStatus).not.toHaveBeenCalled()
   })
 
   it.each([

--- a/tests/services/apiAdapters/managedResources/axonHubChannelType.test.ts
+++ b/tests/services/apiAdapters/managedResources/axonHubChannelType.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest"
+
+import { AXON_HUB_CHANNEL_TYPE } from "~/constants/axonHub"
+import { ChannelType } from "~/constants/managedSite"
+import {
+  mapAxonHubChannelTypeToChannelType,
+  mapChannelTypeToAxonHubChannelType,
+} from "~/services/apiAdapters/managedResources/axonHubChannelType"
+
+describe("axonHubChannelType", () => {
+  it.each([
+    [AXON_HUB_CHANNEL_TYPE.OPENAI, ChannelType.OpenAI],
+    [AXON_HUB_CHANNEL_TYPE.OPENAI_RESPONSES, ChannelType.OpenAI],
+    [AXON_HUB_CHANNEL_TYPE.ANTHROPIC, ChannelType.Anthropic],
+    [AXON_HUB_CHANNEL_TYPE.ANTHROPIC_AWS, ChannelType.Anthropic],
+    [AXON_HUB_CHANNEL_TYPE.ANTHROPIC_GCP, ChannelType.Anthropic],
+    [AXON_HUB_CHANNEL_TYPE.CLAUDECODE, ChannelType.Anthropic],
+    [AXON_HUB_CHANNEL_TYPE.GEMINI_OPENAI, ChannelType.Gemini],
+    [AXON_HUB_CHANNEL_TYPE.GEMINI, ChannelType.Gemini],
+    [AXON_HUB_CHANNEL_TYPE.GEMINI_VERTEX, ChannelType.Gemini],
+    [AXON_HUB_CHANNEL_TYPE.DEEPSEEK, ChannelType.DeepSeek],
+    [AXON_HUB_CHANNEL_TYPE.DEEPSEEK_ANTHROPIC, ChannelType.DeepSeek],
+    [AXON_HUB_CHANNEL_TYPE.OPENROUTER, ChannelType.OpenRouter],
+    [AXON_HUB_CHANNEL_TYPE.XAI, ChannelType.Xai],
+    [AXON_HUB_CHANNEL_TYPE.SILICONFLOW, ChannelType.SiliconFlow],
+    [AXON_HUB_CHANNEL_TYPE.VOLCENGINE, ChannelType.VolcEngine],
+    [AXON_HUB_CHANNEL_TYPE.OLLAMA, ChannelType.Ollama],
+    [AXON_HUB_CHANNEL_TYPE.GITHUB_COPILOT, ChannelType.OpenAI],
+    [AXON_HUB_CHANNEL_TYPE.NANOGPT, ChannelType.OpenAI],
+  ] as const)("maps AxonHub %s to shared type %s", (source, expected) => {
+    expect(mapAxonHubChannelTypeToChannelType(source)).toBe(expected)
+  })
+
+  it.each([
+    [ChannelType.OpenAI, AXON_HUB_CHANNEL_TYPE.OPENAI],
+    [ChannelType.Anthropic, AXON_HUB_CHANNEL_TYPE.ANTHROPIC],
+    [ChannelType.OpenRouter, AXON_HUB_CHANNEL_TYPE.OPENROUTER],
+    [ChannelType.Gemini, AXON_HUB_CHANNEL_TYPE.GEMINI],
+    [ChannelType.VertexAi, AXON_HUB_CHANNEL_TYPE.GEMINI],
+    [ChannelType.SiliconFlow, AXON_HUB_CHANNEL_TYPE.SILICONFLOW],
+    [ChannelType.DeepSeek, AXON_HUB_CHANNEL_TYPE.DEEPSEEK],
+    [ChannelType.VolcEngine, AXON_HUB_CHANNEL_TYPE.VOLCENGINE],
+    [ChannelType.Xai, AXON_HUB_CHANNEL_TYPE.XAI],
+    [ChannelType.Ollama, AXON_HUB_CHANNEL_TYPE.OLLAMA],
+  ] as const)("maps shared type %s to AxonHub %s", (source, expected) => {
+    expect(mapChannelTypeToAxonHubChannelType(source)).toBe(expected)
+  })
+
+  it("uses OpenAI compatibility for unknown or unsupported types", () => {
+    expect(mapAxonHubChannelTypeToChannelType("future-provider")).toBe(
+      ChannelType.OpenAI,
+    )
+    expect(mapChannelTypeToAxonHubChannelType(ChannelType.Midjourney)).toBe(
+      AXON_HUB_CHANNEL_TYPE.OPENAI,
+    )
+  })
+})

--- a/tests/services/managedSites/channelMigration.test.ts
+++ b/tests/services/managedSites/channelMigration.test.ts
@@ -4,6 +4,15 @@ import { AXON_HUB_CHANNEL_TYPE } from "~/constants/axonHub"
 import { CLAUDE_CODE_HUB_PROVIDER_TYPE } from "~/constants/claudeCodeHub"
 import { ChannelType } from "~/constants/managedSite"
 import { SITE_TYPES } from "~/constants/siteType"
+import {
+  executeManagedSiteMigrationCore,
+  prepareManagedSiteMigrationPreviewCore,
+} from "~/services/managedSites/channelMigrationCanonicalOrchestrator"
+import {
+  collectLegacyMigrationLossSignals,
+  resolveAxonHubMigrationResourceRefFromLegacyRow,
+  toCanonicalMigrationSelectionFromLegacyAxonRow,
+} from "~/services/managedSites/channelMigrationLegacyFacade"
 import { MANAGED_UPSTREAM_RESOURCE_FEATURES } from "~/services/managedSites/managedUpstreamResourceMigration"
 import {
   DEFAULT_PREFERENCES,
@@ -14,6 +23,13 @@ import {
   MANAGED_SITE_CHANNEL_MIGRATION_BLOCKED_REASON_CODES,
   MANAGED_SITE_CHANNEL_MIGRATION_ITEM_WARNING_CODES,
 } from "~/types/managedSiteMigration"
+import {
+  MANAGED_SITE_MIGRATION_EXECUTION_FAILURE_CODES,
+  type ManagedSiteMigrationCanonicalPreview,
+  type ManagedSiteMigrationSelection,
+  type ManagedSiteMigrationSource,
+  type ManagedSiteMigrationTargetPreparation,
+} from "~/types/managedSiteMigrationCapability"
 import { OctopusOutboundType } from "~/types/octopus"
 
 const mockGetManagedSiteServiceForType = vi.fn()
@@ -30,6 +46,7 @@ const mockClaudeCodeHubBuildChannelPayload = vi.fn()
 const mockClaudeCodeHubCreateChannel = vi.fn()
 const mockClaudeCodeHubGetConfig = vi.fn()
 const mockResolveManagedUpstreamResourceFeatureCapabilities = vi.fn()
+const mockResolveManagedSiteMigrationCapability = vi.fn()
 
 vi.mock("~/services/managedSites/managedSiteService", () => ({
   getManagedSiteServiceForType: mockGetManagedSiteServiceForType,
@@ -38,6 +55,11 @@ vi.mock("~/services/managedSites/managedSiteService", () => ({
 vi.mock("~/services/managedSites/managedUpstreamResourceService", () => ({
   resolveManagedUpstreamResourceFeatureCapabilities:
     mockResolveManagedUpstreamResourceFeatureCapabilities,
+}))
+
+vi.mock("~/services/managedSites/channelMigrationCapabilityRegistry", () => ({
+  resolveManagedSiteMigrationCapability:
+    mockResolveManagedSiteMigrationCapability,
 }))
 
 const buildManagedSiteChannel = (
@@ -96,9 +118,79 @@ const buildPreferences = (
     ...overrides,
   }) satisfies UserPreferences
 
+const buildMigrationSelection = (
+  selectionId: string,
+): ManagedSiteMigrationSelection => ({
+  selectionId,
+  displayName: `Selection ${selectionId}`,
+  ref: {
+    siteType: SITE_TYPES.NEW_API,
+    kind: "channel",
+    scopeKey: "https://source.example.invalid",
+    resourceId: `resource-${selectionId}`,
+  },
+})
+
+const buildMigrationSource = (): ManagedSiteMigrationSource => ({
+  sourceSiteType: SITE_TYPES.NEW_API,
+  resourceType: ChannelType.OpenAI,
+  baseUrl: "https://source.example.invalid",
+  models: ["model-example"],
+  groups: ["default"],
+  priority: 0,
+  weight: 0,
+  status: "enabled",
+  lossSignals: {
+    hasModelMapping: false,
+    hasStatusCodeMapping: false,
+    hasAdvancedSettings: false,
+    hasMultiKeyState: false,
+  },
+})
+
+const buildMigrationTarget = (): ManagedSiteMigrationTargetPreparation => ({
+  projection: {
+    name: "Example",
+    type: ChannelType.OpenAI,
+    baseUrl: "https://target.example.invalid",
+    models: ["model-example"],
+    groups: ["default"],
+    priority: 0,
+    weight: 0,
+    status: 1,
+  },
+  adjustments: {
+    remappedType: false,
+    normalizedBaseUrl: false,
+    forcedDefaultGroup: false,
+    ignoredPriority: false,
+    ignoredWeight: false,
+    simplifiedStatus: false,
+  },
+})
+
+const buildCanonicalPreview = (
+  selections: readonly ManagedSiteMigrationSelection[],
+): ManagedSiteMigrationCanonicalPreview => ({
+  sourceSiteType: SITE_TYPES.NEW_API,
+  targetSiteType: SITE_TYPES.DONE_HUB,
+  generalWarningCodes: [],
+  items: selections.map((selection) => ({
+    selection,
+    status: "ready",
+    source: buildMigrationSource(),
+    target: buildMigrationTarget(),
+    warningCodes: [],
+  })),
+  totalCount: selections.length,
+  readyCount: selections.length,
+  blockedCount: 0,
+})
+
 describe("channelMigration", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockResolveManagedSiteMigrationCapability.mockReturnValue(null)
     mockDoneHubGetConfig.mockResolvedValue({
       baseUrl: "https://donehub.example.com",
       adminToken: "donehub-token",
@@ -109,6 +201,7 @@ describe("channelMigration", () => {
       channel: {
         name: draft.name,
         key: draft.key,
+        status: draft.status,
       },
     }))
     mockDoneHubCreateChannel.mockResolvedValue({
@@ -239,6 +332,628 @@ describe("channelMigration", () => {
         }),
       }
     })
+  })
+
+  it("preserves the legacy non-Axon preview row contract", async () => {
+    const { prepareManagedSiteChannelMigrationPreview } = await import(
+      "~/services/managedSites/channelMigration"
+    )
+    const channels = [
+      buildManagedSiteChannel({
+        id: 701,
+        name: "First",
+        key: "first-key",
+        base_url: "https://source.example.invalid",
+        model_mapping: '{"legacy":"current"}',
+      }),
+      buildManagedSiteChannel({
+        id: 702,
+        name: "Second",
+        key: "sk-********",
+        base_url: "https://source.example.invalid",
+        status_code_mapping: '{"429":"503"}',
+      }),
+    ]
+
+    const preview = await prepareManagedSiteChannelMigrationPreview({
+      preferences: buildPreferences(),
+      sourceSiteType: SITE_TYPES.NEW_API,
+      targetSiteType: SITE_TYPES.DONE_HUB,
+      channels,
+      resolveNewApiSourceKey: vi.fn().mockResolvedValue(""),
+    })
+
+    expect(preview).toMatchObject({
+      totalCount: 2,
+      readyCount: 1,
+      blockedCount: 1,
+    })
+    expect(
+      preview.items.map(
+        ({ channelId, channelName, status, warningCodes, draft }) => ({
+          channelId,
+          channelName,
+          status,
+          warningCodes,
+          draft,
+        }),
+      ),
+    ).toEqual([
+      {
+        channelId: 701,
+        channelName: "First",
+        status: "ready",
+        warningCodes: [
+          MANAGED_SITE_CHANNEL_MIGRATION_ITEM_WARNING_CODES.DROPS_MODEL_MAPPING,
+        ],
+        draft: {
+          name: "First",
+          type: ChannelType.OpenAI,
+          key: "first-key",
+          base_url: "https://source.example.invalid",
+          models: ["gpt-4o", "gpt-4o-mini"],
+          groups: ["default"],
+          priority: 0,
+          weight: 0,
+          status: 1,
+        },
+      },
+      {
+        channelId: 702,
+        channelName: "Second",
+        status: "blocked",
+        warningCodes: [
+          MANAGED_SITE_CHANNEL_MIGRATION_ITEM_WARNING_CODES.DROPS_STATUS_CODE_MAPPING,
+        ],
+        draft: null,
+      },
+    ])
+  })
+
+  it("preserves AutoDisabled status through generic legacy target creation", async () => {
+    const {
+      executeManagedSiteChannelMigration,
+      prepareManagedSiteChannelMigrationPreview,
+    } = await import("~/services/managedSites/channelMigration")
+    const preview = await prepareManagedSiteChannelMigrationPreview({
+      preferences: buildPreferences(),
+      sourceSiteType: SITE_TYPES.NEW_API,
+      targetSiteType: SITE_TYPES.DONE_HUB,
+      channels: [
+        buildManagedSiteChannel({
+          id: 703,
+          name: "Auto-disabled",
+          key: "execution-key",
+          base_url: "https://source.example.invalid",
+          status: 3,
+        }),
+      ],
+    })
+
+    expect(preview.items[0].draft?.status).toBe(3)
+
+    const result = await executeManagedSiteChannelMigration({ preview })
+
+    expect(result.createdCount).toBe(1)
+    expect(mockDoneHubCreateChannel).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({
+        channel: expect.objectContaining({
+          key: "execution-key",
+          status: 3,
+        }),
+      }),
+    )
+  })
+
+  it("exposes canonical migration entry points using native resource selections", async () => {
+    const { executeManagedSiteMigration, prepareManagedSiteMigrationPreview } =
+      await import("~/services/managedSites/channelMigration")
+    const selection = {
+      selectionId: "legacy-row-7",
+      displayName: "Example",
+      ref: {
+        siteType: SITE_TYPES.NEW_API,
+        kind: "channel" as const,
+        scopeKey: "https://source.example.invalid",
+        resourceId: "native-channel-7",
+      },
+    }
+
+    const preview = await prepareManagedSiteMigrationPreview({
+      sourceSiteType: SITE_TYPES.NEW_API,
+      targetSiteType: SITE_TYPES.DONE_HUB,
+      selections: [selection],
+    })
+
+    expect(preview).toMatchObject({
+      sourceSiteType: SITE_TYPES.NEW_API,
+      targetSiteType: SITE_TYPES.DONE_HUB,
+      totalCount: 1,
+      readyCount: 0,
+      blockedCount: 1,
+      items: [
+        {
+          selection,
+          status: "blocked",
+          blockingReasonCode:
+            MANAGED_SITE_CHANNEL_MIGRATION_BLOCKED_REASON_CODES.SOURCE_KEY_RESOLUTION_FAILED,
+        },
+      ],
+    })
+    expect(preview.items[0]).not.toHaveProperty("draft")
+
+    const result = await executeManagedSiteMigration({ preview })
+
+    expect(result).toEqual({
+      totalSelected: 1,
+      attemptedCount: 0,
+      createdCount: 0,
+      failedCount: 0,
+      skippedCount: 1,
+      uncertainCount: 0,
+      items: [
+        {
+          selectionId: "legacy-row-7",
+          displayName: "Example",
+          status: "skipped",
+          blockingReasonCode:
+            MANAGED_SITE_CHANNEL_MIGRATION_BLOCKED_REASON_CODES.SOURCE_KEY_RESOLUTION_FAILED,
+        },
+      ],
+    })
+  })
+
+  it("keeps legacy channel credentials out of the canonical source model", async () => {
+    const { toCanonicalMigrationSourceFromLegacyChannel } = await import(
+      "~/services/managedSites/channelMigrationLegacyFacade"
+    )
+
+    const source = toCanonicalMigrationSourceFromLegacyChannel({
+      sourceSiteType: SITE_TYPES.NEW_API,
+      channel: buildManagedSiteChannel({ id: 7, name: "Example" }),
+    })
+
+    expect(source).toMatchObject({ sourceSiteType: SITE_TYPES.NEW_API })
+    expect(source).not.toHaveProperty("credential")
+    expect(source).not.toHaveProperty("key")
+  })
+
+  it("collects controlled legacy migration loss facts without exposing credentials", () => {
+    const lossSignals = collectLegacyMigrationLossSignals(
+      buildManagedSiteChannel({
+        key: "must-remain-private",
+        model_mapping: '{"legacy-model":"example-model"}',
+        status_code_mapping: '{"429":"503"}',
+        setting: '{"retry":true}',
+        channel_info: {
+          is_multi_key: true,
+          multi_key_size: 2,
+          multi_key_status_list: [1, 2],
+          multi_key_polling_index: 0,
+          multi_key_mode: "round-robin",
+        },
+      }),
+    )
+
+    expect(lossSignals).toEqual({
+      hasModelMapping: true,
+      hasStatusCodeMapping: true,
+      hasAdvancedSettings: true,
+      hasMultiKeyState: true,
+    })
+    expect(lossSignals).not.toHaveProperty("key")
+    expect(lossSignals).not.toHaveProperty("credential")
+  })
+
+  it("resolves AxonHub migration refs from explicit, existing, and native fallback identities", () => {
+    const providedRef = {
+      siteType: SITE_TYPES.AXON_HUB,
+      kind: "channel" as const,
+      scopeKey: "https://provided.example.invalid",
+      resourceId: "provided-resource",
+    }
+    const existingRef = {
+      siteType: SITE_TYPES.AXON_HUB,
+      kind: "channel" as const,
+      scopeKey: "https://existing.example.invalid",
+      resourceId: "existing-resource",
+    }
+    const channelWithExistingRef = {
+      ...buildManagedSiteChannel({ id: 81 }),
+      resourceRef: existingRef,
+      _axonHubData: { id: "native-resource" },
+    }
+
+    expect(
+      resolveAxonHubMigrationResourceRefFromLegacyRow({
+        sourceSiteType: SITE_TYPES.AXON_HUB,
+        channel: channelWithExistingRef,
+        resourceRef: providedRef,
+      }),
+    ).toBe(providedRef)
+    expect(
+      resolveAxonHubMigrationResourceRefFromLegacyRow({
+        sourceSiteType: SITE_TYPES.AXON_HUB,
+        channel: channelWithExistingRef,
+      }),
+    ).toBe(existingRef)
+    expect(
+      resolveAxonHubMigrationResourceRefFromLegacyRow({
+        sourceSiteType: SITE_TYPES.AXON_HUB,
+        channel: {
+          ...buildManagedSiteChannel({ id: 82 }),
+          _axonHubData: { id: "  native-fallback  " },
+        },
+        scopeKey: "https://axon.example.invalid",
+      }),
+    ).toEqual({
+      siteType: SITE_TYPES.AXON_HUB,
+      kind: "channel",
+      scopeKey: "https://axon.example.invalid",
+      resourceId: "native-fallback",
+    })
+  })
+
+  it("keeps legacy row and native AxonHub resource identities separate", () => {
+    const selection = toCanonicalMigrationSelectionFromLegacyAxonRow({
+      sourceSiteType: SITE_TYPES.AXON_HUB,
+      channel: {
+        ...buildManagedSiteChannel({ id: 83, name: "Example Axon channel" }),
+        _axonHubData: { id: "native-83" },
+      },
+      scopeKey: "https://axon.example.invalid",
+    })
+
+    expect(selection).toEqual({
+      selectionId: "83",
+      displayName: "Example Axon channel",
+      ref: {
+        siteType: SITE_TYPES.AXON_HUB,
+        kind: "channel",
+        scopeKey: "https://axon.example.invalid",
+        resourceId: "native-83",
+      },
+    })
+  })
+
+  it.each(["source", "target"] as const)(
+    "rethrows canonical preview cancellation from %s preparation",
+    async (stage) => {
+      const selection = buildMigrationSelection("abort-preview")
+      const abortError = Object.assign(new Error("Preview cancelled"), {
+        name: "AbortError",
+      })
+
+      const previewPromise = prepareManagedSiteMigrationPreviewCore({
+        sourceSiteType: SITE_TYPES.NEW_API,
+        targetSiteType: SITE_TYPES.DONE_HUB,
+        selections: [selection],
+        signal: new AbortController().signal,
+        sourceFailureReasonCode:
+          MANAGED_SITE_CHANNEL_MIGRATION_BLOCKED_REASON_CODES.SOURCE_KEY_RESOLUTION_FAILED,
+        targetFailureReasonCode:
+          MANAGED_SITE_CHANNEL_MIGRATION_BLOCKED_REASON_CODES.TARGET_DRAFT_PREPARATION_FAILED,
+        prepareSource: async () => {
+          if (stage === "source") throw abortError
+          return { status: "ready", source: buildMigrationSource() }
+        },
+        prepareTarget: async () => {
+          throw abortError
+        },
+        getReadyWarningCodes: () => [],
+      })
+
+      await expect(previewPromise).rejects.toBe(abortError)
+    },
+  )
+
+  it.each(["credential", "create"] as const)(
+    "rethrows canonical execution cancellation from %s and stops later rows",
+    async (stage) => {
+      const selections = [
+        buildMigrationSelection("first"),
+        buildMigrationSelection("second"),
+      ]
+      const abortError = Object.assign(new Error("Execution cancelled"), {
+        code: "ABORT_ERR",
+      })
+      const resolvedSelections: string[] = []
+      let createCount = 0
+
+      const executionPromise = executeManagedSiteMigrationCore({
+        preview: buildCanonicalPreview(selections),
+        targetAvailable: true,
+        signal: new AbortController().signal,
+        sourceFailureReasonCode:
+          MANAGED_SITE_CHANNEL_MIGRATION_BLOCKED_REASON_CODES.SOURCE_KEY_RESOLUTION_FAILED,
+        resolveCredential: async (selection) => {
+          resolvedSelections.push(selection.selectionId)
+          if (stage === "credential") throw abortError
+          return { status: "ready", credential: "execution-key" }
+        },
+        create: async () => {
+          createCount += 1
+          throw abortError
+        },
+      })
+
+      await expect(executionPromise).rejects.toBe(abortError)
+      expect(resolvedSelections).toEqual(["first"])
+      expect(createCount).toBe(stage === "create" ? 1 : 0)
+    },
+  )
+
+  it("accounts for every canonical execution outcome and continues after non-abort failures", async () => {
+    const selections = [
+      "created",
+      "failed",
+      "uncertain",
+      "thrown",
+      "blocked",
+      "after",
+    ].map(buildMigrationSelection)
+    const preview = buildCanonicalPreview(selections)
+    const items = preview.items.map((item) =>
+      item.selection.selectionId === "blocked"
+        ? {
+            selection: item.selection,
+            status: "blocked" as const,
+            warningCodes: [],
+            blockingReasonCode:
+              MANAGED_SITE_CHANNEL_MIGRATION_BLOCKED_REASON_CODES.SOURCE_KEY_MISSING,
+          }
+        : item,
+    )
+    const selectionIdBySource = new Map(
+      items.flatMap((item) =>
+        item.status === "ready"
+          ? [[item.source, item.selection.selectionId] as const]
+          : [],
+      ),
+    )
+    const resolvedSelections: string[] = []
+    const createCounts = new Map<string, number>()
+
+    const result = await executeManagedSiteMigrationCore({
+      preview: {
+        ...preview,
+        items,
+        readyCount: 5,
+        blockedCount: 1,
+      },
+      targetAvailable: true,
+      sourceFailureReasonCode:
+        MANAGED_SITE_CHANNEL_MIGRATION_BLOCKED_REASON_CODES.SOURCE_KEY_RESOLUTION_FAILED,
+      resolveCredential: async (selection) => {
+        resolvedSelections.push(selection.selectionId)
+        return { status: "ready", credential: "execution-key" }
+      },
+      create: async (command) => {
+        const selectionId = selectionIdBySource.get(command.source)!
+        createCounts.set(selectionId, (createCounts.get(selectionId) ?? 0) + 1)
+        if (selectionId === "failed") {
+          return {
+            status: "failed",
+            failureCode:
+              MANAGED_SITE_MIGRATION_EXECUTION_FAILURE_CODES.TargetRejected,
+          }
+        }
+        if (selectionId === "uncertain") return { status: "uncertain" }
+        if (selectionId === "thrown") throw new Error("Create failed")
+        return { status: "created" }
+      },
+    })
+
+    expect(result).toEqual({
+      totalSelected: 6,
+      attemptedCount: 5,
+      createdCount: 2,
+      failedCount: 2,
+      skippedCount: 1,
+      uncertainCount: 1,
+      items: [
+        {
+          selectionId: "created",
+          displayName: "Selection created",
+          status: "created",
+        },
+        {
+          selectionId: "failed",
+          displayName: "Selection failed",
+          status: "failed",
+          failureCode:
+            MANAGED_SITE_MIGRATION_EXECUTION_FAILURE_CODES.TargetRejected,
+        },
+        {
+          selectionId: "uncertain",
+          displayName: "Selection uncertain",
+          status: "uncertain",
+          failureCode:
+            MANAGED_SITE_MIGRATION_EXECUTION_FAILURE_CODES.MutationStateUncertain,
+        },
+        {
+          selectionId: "thrown",
+          displayName: "Selection thrown",
+          status: "failed",
+          failureCode:
+            MANAGED_SITE_MIGRATION_EXECUTION_FAILURE_CODES.Unexpected,
+        },
+        {
+          selectionId: "blocked",
+          displayName: "Selection blocked",
+          status: "skipped",
+          blockingReasonCode:
+            MANAGED_SITE_CHANNEL_MIGRATION_BLOCKED_REASON_CODES.SOURCE_KEY_MISSING,
+        },
+        {
+          selectionId: "after",
+          displayName: "Selection after",
+          status: "created",
+        },
+      ],
+    })
+    expect(resolvedSelections).toEqual([
+      "created",
+      "failed",
+      "uncertain",
+      "thrown",
+      "after",
+    ])
+    expect(createCounts).toEqual(
+      new Map([
+        ["created", 1],
+        ["failed", 1],
+        ["uncertain", 1],
+        ["thrown", 1],
+        ["after", 1],
+      ]),
+    )
+  })
+
+  it("skips blocked credential rows without attempting creation and continues in order", async () => {
+    const selections = [
+      buildMigrationSelection("blocked-credential"),
+      buildMigrationSelection("created-after-blocker"),
+    ]
+    const preview = buildCanonicalPreview(selections)
+    const resolveCredential = vi.fn(async (selection) =>
+      selection.selectionId === "blocked-credential"
+        ? {
+            status: "blocked" as const,
+            reasonCode:
+              MANAGED_SITE_CHANNEL_MIGRATION_BLOCKED_REASON_CODES.SOURCE_KEY_MISSING,
+          }
+        : { status: "ready" as const, credential: "execution-key" },
+    )
+    const create = vi.fn(async () => ({ status: "created" as const }))
+
+    const result = await executeManagedSiteMigrationCore({
+      preview,
+      targetAvailable: true,
+      sourceFailureReasonCode:
+        MANAGED_SITE_CHANNEL_MIGRATION_BLOCKED_REASON_CODES.SOURCE_KEY_RESOLUTION_FAILED,
+      resolveCredential,
+      create,
+    })
+
+    expect(result).toEqual({
+      totalSelected: 2,
+      attemptedCount: 1,
+      createdCount: 1,
+      failedCount: 0,
+      skippedCount: 1,
+      uncertainCount: 0,
+      items: [
+        {
+          selectionId: "blocked-credential",
+          displayName: "Selection blocked-credential",
+          status: "skipped",
+          blockingReasonCode:
+            MANAGED_SITE_CHANNEL_MIGRATION_BLOCKED_REASON_CODES.SOURCE_KEY_MISSING,
+        },
+        {
+          selectionId: "created-after-blocker",
+          displayName: "Selection created-after-blocker",
+          status: "created",
+        },
+      ],
+    })
+    expect(resolveCredential).toHaveBeenNthCalledWith(1, selections[0])
+    expect(resolveCredential).toHaveBeenNthCalledWith(2, selections[1])
+    expect(create).toHaveBeenCalledOnce()
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: preview.items[1].source,
+        projection:
+          preview.items[1].status === "ready"
+            ? preview.items[1].target.projection
+            : undefined,
+        credential: "execution-key",
+      }),
+    )
+  })
+
+  it("fails ready canonical rows without resolving credentials when the target is unavailable", async () => {
+    const selection = buildMigrationSelection("target-unavailable")
+    const resolveCredential = vi.fn()
+    const create = vi.fn()
+
+    const result = await executeManagedSiteMigrationCore({
+      preview: buildCanonicalPreview([selection]),
+      targetAvailable: false,
+      sourceFailureReasonCode:
+        MANAGED_SITE_CHANNEL_MIGRATION_BLOCKED_REASON_CODES.SOURCE_KEY_RESOLUTION_FAILED,
+      resolveCredential,
+      create,
+    })
+
+    expect(result).toMatchObject({
+      totalSelected: 1,
+      attemptedCount: 0,
+      createdCount: 0,
+      failedCount: 1,
+      skippedCount: 0,
+      uncertainCount: 0,
+      items: [
+        {
+          selectionId: "target-unavailable",
+          status: "failed",
+          failureCode:
+            MANAGED_SITE_MIGRATION_EXECUTION_FAILURE_CODES.TargetUnavailable,
+        },
+      ],
+    })
+    expect(resolveCredential).not.toHaveBeenCalled()
+    expect(create).not.toHaveBeenCalled()
+  })
+
+  it("propagates the public operation signal through canonical capabilities", async () => {
+    const { executeManagedSiteMigration, prepareManagedSiteMigrationPreview } =
+      await import("~/services/managedSites/channelMigration")
+    const selection = buildMigrationSelection("public-signal")
+    const source = buildMigrationSource()
+    const target = buildMigrationTarget()
+    const prepareSource = vi.fn(async () => ({
+      status: "ready" as const,
+      source,
+    }))
+    const resolveCredential = vi.fn(async () => ({
+      status: "ready" as const,
+      credential: "execution-key",
+    }))
+    const prepareTarget = vi.fn(async () => target)
+    const create = vi.fn(async () => ({ status: "created" as const }))
+    mockResolveManagedSiteMigrationCapability.mockImplementation(
+      (siteType: string) => {
+        if (siteType === SITE_TYPES.NEW_API) {
+          return { source: { prepare: prepareSource, resolveCredential } }
+        }
+        if (siteType === SITE_TYPES.DONE_HUB) {
+          return { target: { prepare: prepareTarget, create } }
+        }
+        return null
+      },
+    )
+    const controller = new AbortController()
+    const options = { signal: controller.signal }
+
+    const preview = await prepareManagedSiteMigrationPreview({
+      sourceSiteType: SITE_TYPES.NEW_API,
+      targetSiteType: SITE_TYPES.DONE_HUB,
+      selections: [selection],
+      options,
+    })
+    const result = await executeManagedSiteMigration({ preview, options })
+
+    expect(result.createdCount).toBe(1)
+    expect(prepareSource).toHaveBeenCalledWith(selection, options)
+    expect(prepareTarget).toHaveBeenCalledWith(source, options)
+    expect(resolveCredential).toHaveBeenCalledWith(selection, options)
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({ source, projection: target.projection }),
+      options,
+    )
   })
 
   it("blocks New API preview items when a masked source key still requires verification", async () => {
@@ -841,15 +1556,78 @@ describe("channelMigration", () => {
       source: expect.objectContaining({
         name: "Alpha",
         type: AXON_HUB_CHANNEL_TYPE.OPENAI,
-        key: "source-key",
         weight: 2,
       }),
     })
+    expect(prepareImportDraft.mock.calls[0][0].source).not.toHaveProperty("key")
     expect(preview.readyCount).toBe(1)
     expect(preview.items[0].draft).toMatchObject({
       type: AXON_HUB_CHANNEL_TYPE.OPENAI_RESPONSES,
+      key: "source-key",
       weight: 6,
     })
+  })
+
+  it("derives ready warnings from the actual prepared target projection", async () => {
+    const { prepareManagedSiteChannelMigrationPreview } = await import(
+      "~/services/managedSites/channelMigration"
+    )
+    const prepareImportDraft = vi.fn(async ({ source }) => ({
+      ...(source as Record<string, unknown>),
+      base_url: "https://normalized.example.invalid",
+    }))
+    mockResolveManagedUpstreamResourceFeatureCapabilities.mockImplementation(
+      (siteType: string, feature: string) =>
+        siteType === SITE_TYPES.DONE_HUB &&
+        feature === MANAGED_UPSTREAM_RESOURCE_FEATURES.ChannelMigration
+          ? {
+              supported: true,
+              siteType,
+              feature,
+              capabilities: {
+                items: {
+                  list: vi.fn(),
+                  search: vi.fn(),
+                  getDetail: vi.fn(),
+                  create: vi.fn(),
+                  update: vi.fn(),
+                  delete: vi.fn(),
+                },
+                drafts: {
+                  prepareImportDraft,
+                  prepareEditDraft: vi.fn(),
+                  describeFields: vi.fn(),
+                  validateDraft: vi.fn(),
+                },
+              },
+            }
+          : {
+              supported: false,
+              siteType,
+              feature,
+              reason: "feature-slice-disabled",
+            },
+    )
+
+    const preview = await prepareManagedSiteChannelMigrationPreview({
+      preferences: buildPreferences(),
+      sourceSiteType: SITE_TYPES.NEW_API,
+      targetSiteType: SITE_TYPES.DONE_HUB,
+      channels: [
+        buildManagedSiteChannel({
+          id: 22_62,
+          key: "source-key",
+          base_url: "https://source.example.invalid",
+        }),
+      ],
+    })
+
+    expect(
+      preview.items[0].canonicalPreparation?.target.adjustments,
+    ).toMatchObject({ normalizedBaseUrl: true })
+    expect(preview.items[0].warningCodes).toContain(
+      MANAGED_SITE_CHANNEL_MIGRATION_ITEM_WARNING_CODES.TARGET_NORMALIZES_BASE_URL,
+    )
   })
 
   it("blocks only the row whose resource target draft preparation fails", async () => {

--- a/tests/services/managedSites/channelMigration.test.ts
+++ b/tests/services/managedSites/channelMigration.test.ts
@@ -772,6 +772,69 @@ describe("channelMigration", () => {
     expect(lossSignals).not.toHaveProperty("credential")
   })
 
+  it.each([
+    ["param_override", { temperature: 0.2 }],
+    ["header_override", { "x-provider": "example" }],
+    ["param_override", 1],
+  ] as const)(
+    "classifies a meaningful %s as advanced-setting loss",
+    (field, value) => {
+      const lossSignals = collectLegacyMigrationLossSignals(
+        buildManagedSiteChannel({ [field]: value }),
+      )
+
+      expect(lossSignals.hasAdvancedSettings).toBe(true)
+    },
+  )
+
+  it.each([
+    ["null", "param_override", null],
+    ["undefined", "param_override", undefined],
+    ["blank string", "param_override", "  "],
+    ["empty array", "param_override", []],
+    ["empty object", "param_override", {}],
+    ["null", "header_override", null],
+    ["undefined", "header_override", undefined],
+    ["blank string", "header_override", "  "],
+    ["empty array", "header_override", []],
+    ["empty object", "header_override", {}],
+  ] as const)("ignores %s for %s", (_kind, field, value) => {
+    const lossSignals = collectLegacyMigrationLossSignals(
+      buildManagedSiteChannel({ [field]: value }),
+    )
+
+    expect(lossSignals.hasAdvancedSettings).toBe(false)
+  })
+
+  it.each([
+    ["param_override", { temperature: 0.2 }],
+    ["header_override", { "x-provider": "example" }],
+  ] as const)(
+    "warns when legacy migration drops a meaningful %s",
+    async (field, value) => {
+      const { prepareManagedSiteChannelMigrationPreview } = await import(
+        "~/services/managedSites/channelMigration"
+      )
+
+      const preview = await prepareManagedSiteChannelMigrationPreview({
+        preferences: buildPreferences(),
+        sourceSiteType: SITE_TYPES.NEW_API,
+        targetSiteType: SITE_TYPES.DONE_HUB,
+        channels: [
+          buildManagedSiteChannel({
+            id: field === "param_override" ? 706 : 707,
+            key: "source-key",
+            [field]: value,
+          }),
+        ],
+      })
+
+      expect(preview.items[0].warningCodes).toContain(
+        MANAGED_SITE_CHANNEL_MIGRATION_ITEM_WARNING_CODES.DROPS_ADVANCED_SETTINGS,
+      )
+    },
+  )
+
   it("resolves AxonHub migration refs from explicit, existing, and native fallback identities", () => {
     const providedRef = {
       siteType: SITE_TYPES.AXON_HUB,
@@ -1479,7 +1542,7 @@ describe("channelMigration", () => {
       ],
       resolveNewApiSourceKey: vi
         .fn()
-        .mockRejectedValue(new Error("Verification required")),
+        .mockRejectedValue(new Error("  Verification required  ")),
     })
 
     expect(preview.readyCount).toBe(0)
@@ -3425,33 +3488,47 @@ describe("channelMigration", () => {
     ])
   })
 
-  it("uses neutral fallback guidance for a blocked target-preparation row", async () => {
-    const { executeManagedSiteChannelMigration } = await import(
-      "~/services/managedSites/channelMigration"
+  it("uses target-specific fallback guidance when target preparation returns blank detail", async () => {
+    const {
+      executeManagedSiteChannelMigration,
+      prepareManagedSiteChannelMigrationPreview,
+    } = await import("~/services/managedSites/channelMigration")
+    const create = vi.fn()
+    mockResolveManagedSiteMigrationCapability.mockImplementation((siteType) =>
+      siteType === SITE_TYPES.AXON_HUB
+        ? {
+            target: {
+              prepare: vi.fn(async () => {
+                throw new Error("   ")
+              }),
+              create,
+            },
+          }
+        : null,
     )
 
-    const result = await executeManagedSiteChannelMigration({
-      preview: {
-        sourceSiteType: SITE_TYPES.NEW_API,
-        targetSiteType: SITE_TYPES.DONE_HUB,
-        generalWarningCodes: [],
-        totalCount: 1,
-        readyCount: 0,
-        blockedCount: 1,
-        items: [
-          {
-            channelId: 43,
-            channelName: "Blocked target preparation",
-            sourceChannel: buildManagedSiteChannel({ id: 43 }),
-            draft: null,
-            status: "blocked",
-            warningCodes: [],
-            blockingReasonCode:
-              MANAGED_SITE_CHANNEL_MIGRATION_BLOCKED_REASON_CODES.TARGET_DRAFT_PREPARATION_FAILED,
-          },
-        ],
-      },
+    const preview = await prepareManagedSiteChannelMigrationPreview({
+      preferences: buildPreferences(),
+      sourceSiteType: SITE_TYPES.NEW_API,
+      targetSiteType: SITE_TYPES.AXON_HUB,
+      channels: [
+        buildManagedSiteChannel({
+          id: 43,
+          key: "source-key",
+          name: "Blocked target preparation",
+        }),
+      ],
     })
+    const result = await executeManagedSiteChannelMigration({ preview })
+
+    expect(preview.items[0]).toMatchObject({
+      status: "blocked",
+      blockingReasonCode:
+        MANAGED_SITE_CHANNEL_MIGRATION_BLOCKED_REASON_CODES.TARGET_DRAFT_PREPARATION_FAILED,
+      blockingMessage:
+        "The target channel could not be prepared. Review channel models and target configuration, then retry.",
+    })
+    expect(create).not.toHaveBeenCalled()
 
     expect(result.items).toEqual([
       {
@@ -3462,7 +3539,7 @@ describe("channelMigration", () => {
         blockingReasonCode:
           MANAGED_SITE_CHANNEL_MIGRATION_BLOCKED_REASON_CODES.TARGET_DRAFT_PREPARATION_FAILED,
         error:
-          "This channel cannot be migrated right now. Verify source access and try again.",
+          "The target channel could not be prepared. Review channel models and target configuration, then retry.",
       },
     ])
   })
@@ -3530,7 +3607,7 @@ describe("channelMigration", () => {
       "~/services/managedSites/channelMigration"
     )
 
-    mockDoneHubCreateChannel.mockRejectedValue(new Error("Create exploded"))
+    mockDoneHubCreateChannel.mockRejectedValue(new Error("  Create exploded  "))
 
     const result = await executeManagedSiteChannelMigration({
       preview: {
@@ -3743,6 +3820,41 @@ describe("channelMigration", () => {
       status: "blocked",
       blockingReasonCode:
         MANAGED_SITE_CHANNEL_MIGRATION_BLOCKED_REASON_CODES.SOURCE_KEY_RESOLUTION_FAILED,
+    })
+  })
+
+  it("adds local guidance to native blocked preview rows without text", async () => {
+    const { prepareManagedSiteChannelMigrationPreview } = await import(
+      "~/services/managedSites/channelMigration"
+    )
+    mockResolveManagedSiteMigrationCapability.mockImplementation((siteType) =>
+      siteType === SITE_TYPES.AXON_HUB
+        ? {
+            source: {
+              prepare: vi.fn(async () => ({
+                status: "blocked" as const,
+                reasonCode:
+                  MANAGED_SITE_CHANNEL_MIGRATION_BLOCKED_REASON_CODES.SOURCE_KEY_MISSING,
+              })),
+              resolveCredential: vi.fn(),
+            },
+          }
+        : null,
+    )
+
+    const preview = await prepareManagedSiteChannelMigrationPreview({
+      preferences: buildPreferences(),
+      sourceSiteType: SITE_TYPES.AXON_HUB,
+      targetSiteType: SITE_TYPES.DONE_HUB,
+      channels: [buildManagedSiteChannel({ id: 304_1 })],
+    })
+
+    expect(preview.items[0]).toMatchObject({
+      status: "blocked",
+      blockingReasonCode:
+        MANAGED_SITE_CHANNEL_MIGRATION_BLOCKED_REASON_CODES.SOURCE_KEY_MISSING,
+      blockingMessage:
+        "The source credential is unavailable. Verify source access and try again.",
     })
   })
 
@@ -4021,6 +4133,55 @@ describe("channelMigration", () => {
       items: [
         {
           channelId: 311,
+          success: false,
+          skipped: false,
+          error:
+            "Target creation may have succeeded. Verify the target before retrying.",
+        },
+      ],
+    })
+  })
+
+  it("reports thrown target uncertainty with verify-before-retry guidance", async () => {
+    const {
+      executeManagedSiteChannelMigration,
+      prepareManagedSiteChannelMigrationPreview,
+    } = await import("~/services/managedSites/channelMigration")
+    const create = vi.fn(async () => {
+      throw new ManagedResourceError({
+        code: MANAGED_RESOURCE_FAILURE_CODES.MutationStateUncertain,
+      })
+    })
+    mockResolveManagedSiteMigrationCapability.mockImplementation((siteType) =>
+      siteType === SITE_TYPES.AXON_HUB
+        ? {
+            target: {
+              prepare: vi.fn(async (source) =>
+                buildAxonTargetPreparation(source),
+              ),
+              create,
+            },
+          }
+        : null,
+    )
+    const preview = await prepareManagedSiteChannelMigrationPreview({
+      preferences: buildPreferences(),
+      sourceSiteType: SITE_TYPES.NEW_API,
+      targetSiteType: SITE_TYPES.AXON_HUB,
+      channels: [buildManagedSiteChannel({ id: 311_1, key: "source-key" })],
+    })
+
+    const result = await executeManagedSiteChannelMigration({ preview })
+
+    expect(create).toHaveBeenCalledOnce()
+    expect(result).toMatchObject({
+      attemptedCount: 1,
+      createdCount: 0,
+      failedCount: 1,
+      skippedCount: 0,
+      items: [
+        {
+          channelId: 311_1,
           success: false,
           skipped: false,
           error:

--- a/tests/services/managedSites/channelMigration.test.ts
+++ b/tests/services/managedSites/channelMigration.test.ts
@@ -4,6 +4,8 @@ import { AXON_HUB_CHANNEL_TYPE } from "~/constants/axonHub"
 import { CLAUDE_CODE_HUB_PROVIDER_TYPE } from "~/constants/claudeCodeHub"
 import { ChannelType } from "~/constants/managedSite"
 import { SITE_TYPES } from "~/constants/siteType"
+import * as axonHubNativeResources from "~/services/apiAdapters/managedResources/axonHub"
+import { axonHubManagedSiteMigrationCapability } from "~/services/apiAdapters/managedResources/axonHubMigration"
 import {
   executeManagedSiteMigrationCore,
   prepareManagedSiteMigrationPreviewCore,
@@ -12,6 +14,8 @@ import {
   collectLegacyMigrationLossSignals,
   resolveAxonHubMigrationResourceRefFromLegacyRow,
   toCanonicalMigrationSelectionFromLegacyAxonRow,
+  toCanonicalMigrationSourceFromLegacyChannel,
+  toCanonicalTargetPreparationFromLegacyDraft,
 } from "~/services/managedSites/channelMigrationLegacyFacade"
 import { MANAGED_UPSTREAM_RESOURCE_FEATURES } from "~/services/managedSites/managedUpstreamResourceMigration"
 import {
@@ -21,11 +25,14 @@ import {
 import type { ManagedSiteChannel } from "~/types/managedSite"
 import {
   MANAGED_SITE_CHANNEL_MIGRATION_BLOCKED_REASON_CODES,
+  MANAGED_SITE_CHANNEL_MIGRATION_GENERAL_WARNING_CODES,
   MANAGED_SITE_CHANNEL_MIGRATION_ITEM_WARNING_CODES,
 } from "~/types/managedSiteMigration"
 import {
   MANAGED_SITE_MIGRATION_EXECUTION_FAILURE_CODES,
+  ManagedSiteMigrationExecutionAbortedError,
   type ManagedSiteMigrationCanonicalPreview,
+  type ManagedSiteMigrationExecutionAbortDetails,
   type ManagedSiteMigrationSelection,
   type ManagedSiteMigrationSource,
   type ManagedSiteMigrationTargetPreparation,
@@ -185,6 +192,78 @@ const buildCanonicalPreview = (
   totalCount: selections.length,
   readyCount: selections.length,
   blockedCount: 0,
+})
+
+const captureMigrationExecutionAbort = async (
+  execution: Promise<unknown>,
+): Promise<ManagedSiteMigrationExecutionAbortedError> => {
+  try {
+    await execution
+  } catch (error) {
+    expect(error).toBeInstanceOf(ManagedSiteMigrationExecutionAbortedError)
+    return error as ManagedSiteMigrationExecutionAbortedError
+  }
+  throw new Error("Expected migration execution to abort")
+}
+
+const expectMigrationAbortInvariants = (
+  error: ManagedSiteMigrationExecutionAbortedError,
+) => {
+  const details: ManagedSiteMigrationExecutionAbortDetails = error.details
+  const { partialResult, remainingSelections } = details
+  expect(partialResult.items.length + remainingSelections.length).toBe(
+    partialResult.totalSelected,
+  )
+  expect(
+    partialResult.createdCount +
+      partialResult.failedCount +
+      partialResult.skippedCount +
+      partialResult.uncertainCount,
+  ).toBe(partialResult.items.length)
+  const serializedDetails = JSON.stringify(details)
+  expect(serializedDetails).not.toContain("execution-key")
+  expect(serializedDetails).not.toContain('"credential"')
+  expect(serializedDetails).not.toContain('"projection"')
+}
+
+const buildAxonMigrationSource = (
+  overrides: Partial<ManagedSiteMigrationSource> = {},
+): ManagedSiteMigrationSource => ({
+  ...buildMigrationSource(),
+  sourceSiteType: SITE_TYPES.AXON_HUB,
+  resourceType: ChannelType.Anthropic,
+  baseUrl: "https://native-source.example.invalid",
+  models: ["model-native"],
+  groups: [],
+  priority: 0,
+  weight: 7,
+  ...overrides,
+})
+
+const buildAxonTargetPreparation = (
+  source: ManagedSiteMigrationSource,
+): ManagedSiteMigrationTargetPreparation => ({
+  projection: {
+    name: "",
+    type:
+      source.resourceType === ChannelType.Anthropic
+        ? AXON_HUB_CHANNEL_TYPE.ANTHROPIC
+        : AXON_HUB_CHANNEL_TYPE.OPENAI,
+    baseUrl: source.baseUrl,
+    models: [...source.models],
+    groups: ["default"],
+    priority: 0,
+    weight: source.weight,
+    status: source.status === "enabled" ? 1 : 2,
+  },
+  adjustments: {
+    remappedType: true,
+    normalizedBaseUrl: false,
+    forcedDefaultGroup: source.groups.join(",") !== "default",
+    ignoredPriority: source.priority !== 0,
+    ignoredWeight: false,
+    simplifiedStatus: source.status === "other",
+  },
 })
 
 describe("channelMigration", () => {
@@ -408,6 +487,57 @@ describe("channelMigration", () => {
         draft: null,
       },
     ])
+  })
+
+  it("preserves native ref precedence and fallback identity for non-Axon legacy rows", async () => {
+    const { prepareManagedSiteChannelMigrationPreview } = await import(
+      "~/services/managedSites/channelMigration"
+    )
+    const existingRef = {
+      siteType: SITE_TYPES.DONE_HUB,
+      kind: "channel" as const,
+      scopeKey: "https://native-scope.example.invalid",
+      resourceId: "native-resource",
+    }
+    const prepare = vi.fn(async () => ({
+      status: "blocked" as const,
+      reasonCode:
+        MANAGED_SITE_CHANNEL_MIGRATION_BLOCKED_REASON_CODES.SOURCE_KEY_MISSING,
+    }))
+    mockResolveManagedSiteMigrationCapability.mockImplementation((siteType) =>
+      siteType === SITE_TYPES.DONE_HUB
+        ? { source: { prepare, resolveCredential: vi.fn() } }
+        : null,
+    )
+
+    await prepareManagedSiteChannelMigrationPreview({
+      preferences: buildPreferences(),
+      sourceSiteType: SITE_TYPES.DONE_HUB,
+      targetSiteType: SITE_TYPES.VELOERA,
+      channels: [
+        {
+          ...buildManagedSiteChannel({ id: 704, name: "Native ref" }),
+          resourceRef: existingRef,
+        } as ManagedSiteChannel & { resourceRef: typeof existingRef },
+        buildManagedSiteChannel({ id: 705, name: "Fallback ref" }),
+      ],
+    })
+
+    expect(prepare).toHaveBeenNthCalledWith(1, {
+      selectionId: "704",
+      displayName: "Native ref",
+      ref: existingRef,
+    })
+    expect(prepare).toHaveBeenNthCalledWith(2, {
+      selectionId: "705",
+      displayName: "Fallback ref",
+      ref: {
+        siteType: SITE_TYPES.DONE_HUB,
+        kind: "channel",
+        scopeKey: "https://donehub.example.com",
+        resourceId: "705",
+      },
+    })
   })
 
   it("preserves AutoDisabled status through generic legacy target creation", async () => {
@@ -648,41 +778,294 @@ describe("channelMigration", () => {
     },
   )
 
-  it.each(["credential", "create"] as const)(
-    "rethrows canonical execution cancellation from %s and stops later rows",
-    async (stage) => {
-      const selections = [
-        buildMigrationSelection("first"),
-        buildMigrationSelection("second"),
-      ]
-      const abortError = Object.assign(new Error("Execution cancelled"), {
-        code: "ABORT_ERR",
-      })
-      const resolvedSelections: string[] = []
-      let createCount = 0
+  it("stops preview workers from claiming later rows after one mapper aborts", async () => {
+    const selections = Array.from({ length: 12 }, (_, index) =>
+      buildMigrationSelection(`preview-${index}`),
+    )
+    const abortError = Object.assign(new Error("Preview cancelled"), {
+      name: "AbortError",
+    })
+    const startedSelections: string[] = []
+    let releaseInitialBatch!: () => void
+    const initialBatchStarted = new Promise<void>((resolve) => {
+      releaseInitialBatch = resolve
+    })
+    let releaseInFlight!: () => void
+    const inFlightCanFinish = new Promise<void>((resolve) => {
+      releaseInFlight = resolve
+    })
+    let finishedInitialCount = 0
+    let resolveInitialFinished!: () => void
+    const initialInFlightFinished = new Promise<void>((resolve) => {
+      resolveInitialFinished = resolve
+    })
 
-      const executionPromise = executeManagedSiteMigrationCore({
+    const previewPromise = prepareManagedSiteMigrationPreviewCore({
+      sourceSiteType: SITE_TYPES.NEW_API,
+      targetSiteType: SITE_TYPES.DONE_HUB,
+      selections,
+      sourceFailureReasonCode:
+        MANAGED_SITE_CHANNEL_MIGRATION_BLOCKED_REASON_CODES.SOURCE_KEY_RESOLUTION_FAILED,
+      targetFailureReasonCode:
+        MANAGED_SITE_CHANNEL_MIGRATION_BLOCKED_REASON_CODES.TARGET_DRAFT_PREPARATION_FAILED,
+      prepareSource: async (selection) => {
+        startedSelections.push(selection.selectionId)
+        if (startedSelections.length === 5) releaseInitialBatch()
+        await initialBatchStarted
+        if (selection.selectionId === "preview-0") throw abortError
+        await inFlightCanFinish
+        if (Number(selection.selectionId.split("-")[1]) < 5) {
+          finishedInitialCount += 1
+          if (finishedInitialCount === 4) resolveInitialFinished()
+        }
+        return {
+          status: "blocked",
+          reasonCode:
+            MANAGED_SITE_CHANNEL_MIGRATION_BLOCKED_REASON_CODES.SOURCE_KEY_MISSING,
+        }
+      },
+      prepareTarget: async () => buildMigrationTarget(),
+      getReadyWarningCodes: () => [],
+    })
+
+    await expect(previewPromise).rejects.toBe(abortError)
+    expect(startedSelections).toHaveLength(5)
+
+    releaseInFlight()
+    await initialInFlightFinished
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(startedSelections).toHaveLength(5)
+  })
+
+  it("reports all selections remaining when execution is aborted before the first row", async () => {
+    const selections = [
+      buildMigrationSelection("first"),
+      buildMigrationSelection("second"),
+    ]
+    const controller = new AbortController()
+    const cause = new Error("Cancelled before execution")
+    controller.abort(cause)
+    const resolveCredential = vi.fn()
+    const create = vi.fn()
+
+    const error = await captureMigrationExecutionAbort(
+      executeManagedSiteMigrationCore({
         preview: buildCanonicalPreview(selections),
         targetAvailable: true,
-        signal: new AbortController().signal,
+        signal: controller.signal,
         sourceFailureReasonCode:
           MANAGED_SITE_CHANNEL_MIGRATION_BLOCKED_REASON_CODES.SOURCE_KEY_RESOLUTION_FAILED,
-        resolveCredential: async (selection) => {
-          resolvedSelections.push(selection.selectionId)
-          if (stage === "credential") throw abortError
-          return { status: "ready", credential: "execution-key" }
-        },
-        create: async () => {
-          createCount += 1
-          throw abortError
-        },
-      })
+        resolveCredential,
+        create,
+      }),
+    )
 
-      await expect(executionPromise).rejects.toBe(abortError)
-      expect(resolvedSelections).toEqual(["first"])
-      expect(createCount).toBe(stage === "create" ? 1 : 0)
-    },
-  )
+    expect(error.cause).toBe(cause)
+    expect(error.details).toEqual({
+      partialResult: {
+        totalSelected: 2,
+        attemptedCount: 0,
+        createdCount: 0,
+        failedCount: 0,
+        skippedCount: 0,
+        uncertainCount: 0,
+        items: [],
+      },
+      remainingSelections: selections,
+    })
+    expect(resolveCredential).not.toHaveBeenCalled()
+    expect(create).not.toHaveBeenCalled()
+    expectMigrationAbortInvariants(error)
+  })
+
+  it("retains a created result when cancellation arrives with the create response", async () => {
+    const selections = [
+      buildMigrationSelection("created"),
+      buildMigrationSelection("remaining"),
+    ]
+    const controller = new AbortController()
+    const resolveCredential = vi.fn(async () => ({
+      status: "ready" as const,
+      credential: "execution-key",
+    }))
+    const create = vi.fn(async () => {
+      controller.abort(new Error("Cancelled after create"))
+      return { status: "created" as const }
+    })
+
+    const error = await captureMigrationExecutionAbort(
+      executeManagedSiteMigrationCore({
+        preview: buildCanonicalPreview(selections),
+        targetAvailable: true,
+        signal: controller.signal,
+        sourceFailureReasonCode:
+          MANAGED_SITE_CHANNEL_MIGRATION_BLOCKED_REASON_CODES.SOURCE_KEY_RESOLUTION_FAILED,
+        resolveCredential,
+        create,
+      }),
+    )
+
+    expect(error.details.partialResult).toEqual({
+      totalSelected: 2,
+      attemptedCount: 1,
+      createdCount: 1,
+      failedCount: 0,
+      skippedCount: 0,
+      uncertainCount: 0,
+      items: [
+        {
+          selectionId: "created",
+          displayName: "Selection created",
+          status: "created",
+        },
+      ],
+    })
+    expect(error.details.remainingSelections).toEqual([selections[1]])
+    expect(resolveCredential).toHaveBeenCalledOnce()
+    expect(create).toHaveBeenCalledOnce()
+    expectMigrationAbortInvariants(error)
+  })
+
+  it("retains an uncertain result when cancellation arrives with the create response", async () => {
+    const selections = [
+      buildMigrationSelection("uncertain"),
+      buildMigrationSelection("remaining"),
+    ]
+    const controller = new AbortController()
+    const resolveCredential = vi.fn(async () => ({
+      status: "ready" as const,
+      credential: "execution-key",
+    }))
+    const create = vi.fn(async () => {
+      controller.abort(new Error("Cancelled after uncertain create"))
+      return { status: "uncertain" as const }
+    })
+
+    const error = await captureMigrationExecutionAbort(
+      executeManagedSiteMigrationCore({
+        preview: buildCanonicalPreview(selections),
+        targetAvailable: true,
+        signal: controller.signal,
+        sourceFailureReasonCode:
+          MANAGED_SITE_CHANNEL_MIGRATION_BLOCKED_REASON_CODES.SOURCE_KEY_RESOLUTION_FAILED,
+        resolveCredential,
+        create,
+      }),
+    )
+
+    expect(error.details.partialResult).toMatchObject({
+      totalSelected: 2,
+      attemptedCount: 1,
+      createdCount: 0,
+      failedCount: 0,
+      skippedCount: 0,
+      uncertainCount: 1,
+      items: [
+        {
+          selectionId: "uncertain",
+          status: "uncertain",
+          failureCode:
+            MANAGED_SITE_MIGRATION_EXECUTION_FAILURE_CODES.MutationStateUncertain,
+        },
+      ],
+    })
+    expect(error.details.remainingSelections).toEqual([selections[1]])
+    expect(resolveCredential).toHaveBeenCalledOnce()
+    expect(create).toHaveBeenCalledOnce()
+    expectMigrationAbortInvariants(error)
+  })
+
+  it("classifies uncertain create errors before honoring cancellation", async () => {
+    const selections = [
+      buildMigrationSelection("uncertain-error"),
+      buildMigrationSelection("remaining"),
+    ]
+    const controller = new AbortController()
+    const mutationError = new Error("Mutation state is uncertain")
+    const create = vi.fn(async () => {
+      controller.abort(new Error("Cancelled during uncertain create"))
+      throw mutationError
+    })
+
+    const error = await captureMigrationExecutionAbort(
+      executeManagedSiteMigrationCore({
+        preview: buildCanonicalPreview(selections),
+        targetAvailable: true,
+        signal: controller.signal,
+        sourceFailureReasonCode:
+          MANAGED_SITE_CHANNEL_MIGRATION_BLOCKED_REASON_CODES.SOURCE_KEY_RESOLUTION_FAILED,
+        resolveCredential: async () => ({
+          status: "ready",
+          credential: "execution-key",
+        }),
+        create,
+        isMutationStateUncertain: (error) => error === mutationError,
+      }),
+    )
+
+    expect(error.details.partialResult).toMatchObject({
+      attemptedCount: 1,
+      uncertainCount: 1,
+      items: [
+        {
+          selectionId: "uncertain-error",
+          status: "uncertain",
+          failureCode:
+            MANAGED_SITE_MIGRATION_EXECUTION_FAILURE_CODES.MutationStateUncertain,
+        },
+      ],
+    })
+    expect(error.details.remainingSelections).toEqual([selections[1]])
+    expect(create).toHaveBeenCalledOnce()
+    expectMigrationAbortInvariants(error)
+  })
+
+  it("retains earlier outcomes when cancellation occurs during a later credential resolution", async () => {
+    const selections = [
+      buildMigrationSelection("created"),
+      buildMigrationSelection("credential-aborted"),
+      buildMigrationSelection("remaining"),
+    ]
+    const controller = new AbortController()
+    const cause = new Error("Credential resolution cancelled")
+    const resolveCredential = vi.fn(async (selection) => {
+      if (selection.selectionId === "credential-aborted") {
+        controller.abort(cause)
+        throw cause
+      }
+      return { status: "ready" as const, credential: "execution-key" }
+    })
+    const create = vi.fn(async () => ({ status: "created" as const }))
+
+    const error = await captureMigrationExecutionAbort(
+      executeManagedSiteMigrationCore({
+        preview: buildCanonicalPreview(selections),
+        targetAvailable: true,
+        signal: controller.signal,
+        sourceFailureReasonCode:
+          MANAGED_SITE_CHANNEL_MIGRATION_BLOCKED_REASON_CODES.SOURCE_KEY_RESOLUTION_FAILED,
+        resolveCredential,
+        create,
+      }),
+    )
+
+    expect(error.cause).toBe(cause)
+    expect(error.details.partialResult).toMatchObject({
+      totalSelected: 3,
+      attemptedCount: 1,
+      createdCount: 1,
+      failedCount: 0,
+      skippedCount: 0,
+      uncertainCount: 0,
+      items: [{ selectionId: "created", status: "created" }],
+    })
+    expect(error.details.remainingSelections).toEqual(selections.slice(1))
+    expect(resolveCredential).toHaveBeenCalledTimes(2)
+    expect(create).toHaveBeenCalledOnce()
+    expectMigrationAbortInvariants(error)
+  })
 
   it("accounts for every canonical execution outcome and continues after non-abort failures", async () => {
     const selections = [
@@ -1490,6 +1873,26 @@ describe("channelMigration", () => {
     )
   })
 
+  it("projects legacy Vertex AI channels to AxonHub Gemini compatibility", async () => {
+    const channel = buildManagedSiteChannel({
+      id: 22_601,
+      type: ChannelType.VertexAi,
+    })
+    const source = toCanonicalMigrationSourceFromLegacyChannel({
+      sourceSiteType: SITE_TYPES.NEW_API,
+      channel,
+    })
+
+    const target = await toCanonicalTargetPreparationFromLegacyDraft({
+      source,
+      targetSiteType: SITE_TYPES.AXON_HUB,
+      displayName: channel.name,
+      selectionId: String(channel.id),
+    })
+
+    expect(target.projection.type).toBe(AXON_HUB_CHANNEL_TYPE.GEMINI)
+  })
+
   it("lets feature-gated target resources prepare the migration preview draft", async () => {
     const { prepareManagedSiteChannelMigrationPreview } = await import(
       "~/services/managedSites/channelMigration"
@@ -1854,6 +2257,35 @@ describe("channelMigration", () => {
         MANAGED_SITE_CHANNEL_MIGRATION_ITEM_WARNING_CODES.TARGET_FORCES_DEFAULT_GROUP,
         MANAGED_SITE_CHANNEL_MIGRATION_ITEM_WARNING_CODES.TARGET_SIMPLIFIES_STATUS,
       ]),
+    )
+  })
+
+  it("maps legacy Vertex AI channels to Claude Code Hub Gemini providers", async () => {
+    const { prepareManagedSiteChannelMigrationPreview } = await import(
+      "~/services/managedSites/channelMigration"
+    )
+
+    const preview = await prepareManagedSiteChannelMigrationPreview({
+      preferences: buildPreferences({
+        claudeCodeHub: {
+          baseUrl: "https://cch.example.com",
+          adminToken: "cch-token",
+        },
+      }),
+      sourceSiteType: SITE_TYPES.NEW_API,
+      targetSiteType: SITE_TYPES.CLAUDE_CODE_HUB,
+      channels: [
+        buildManagedSiteChannel({
+          id: 22_711,
+          type: ChannelType.VertexAi,
+          key: "source-key",
+        }),
+      ],
+    })
+
+    expect(preview.readyCount).toBe(1)
+    expect(preview.items[0].draft?.type).toBe(
+      CLAUDE_CODE_HUB_PROVIDER_TYPE.GEMINI,
     )
   })
 
@@ -2980,6 +3412,664 @@ describe("channelMigration", () => {
         skipped: false,
         error: "Create exploded",
       },
+    ])
+  })
+
+  it("prepares an Axon target through the named capability and keeps the displayed legacy draft equivalent", async () => {
+    const { prepareManagedSiteChannelMigrationPreview } = await import(
+      "~/services/managedSites/channelMigration"
+    )
+    const prepare = vi.fn(async (source: ManagedSiteMigrationSource) =>
+      buildAxonTargetPreparation(source),
+    )
+    mockResolveManagedSiteMigrationCapability.mockImplementation((siteType) =>
+      siteType === SITE_TYPES.AXON_HUB ? { target: { prepare } } : null,
+    )
+
+    const preview = await prepareManagedSiteChannelMigrationPreview({
+      preferences: buildPreferences(),
+      sourceSiteType: SITE_TYPES.NEW_API,
+      targetSiteType: SITE_TYPES.AXON_HUB,
+      channels: [
+        buildManagedSiteChannel({
+          id: 301,
+          name: "Native target",
+          type: ChannelType.Anthropic,
+          key: "source-key",
+          base_url: "https://source.example.invalid",
+          models: "model-a,model-b",
+          weight: 7,
+        }),
+      ],
+    })
+
+    expect(prepare).toHaveBeenCalledOnce()
+    expect(preview.items[0]).toMatchObject({
+      channelId: 301,
+      status: "ready",
+      draft: {
+        name: "Native target",
+        type: AXON_HUB_CHANNEL_TYPE.ANTHROPIC,
+        base_url: "https://source.example.invalid",
+        models: ["model-a", "model-b"],
+        groups: ["default"],
+        priority: 0,
+        weight: 7,
+        status: 1,
+      },
+    })
+    expect(
+      mockResolveManagedUpstreamResourceFeatureCapabilities,
+    ).not.toHaveBeenCalledWith(
+      SITE_TYPES.AXON_HUB,
+      MANAGED_UPSTREAM_RESOURCE_FEATURES.ChannelMigration,
+    )
+  })
+
+  it("resolves an Axon credential only at execution and creates exactly once without legacy payload builders", async () => {
+    const {
+      executeManagedSiteChannelMigration,
+      prepareManagedSiteChannelMigrationPreview,
+    } = await import("~/services/managedSites/channelMigration")
+    const source = buildAxonMigrationSource()
+    const sourcePrepare = vi.fn(async () => ({
+      status: "ready" as const,
+      source,
+    }))
+    const resolveCredential = vi.fn(async () => ({
+      status: "ready" as const,
+      credential: "execution-only-key",
+    }))
+    const targetPrepare = vi.fn(async () => buildAxonTargetPreparation(source))
+    const create = vi.fn(async () => ({ status: "created" as const }))
+    mockResolveManagedSiteMigrationCapability.mockImplementation((siteType) =>
+      siteType === SITE_TYPES.AXON_HUB
+        ? {
+            source: { prepare: sourcePrepare, resolveCredential },
+            target: { prepare: targetPrepare, create },
+          }
+        : null,
+    )
+    const channel = {
+      ...buildManagedSiteChannel({ id: 302, name: "Native round trip" }),
+      _axonHubData: { id: "native-302" },
+    } as ManagedSiteChannel
+
+    const preview = await prepareManagedSiteChannelMigrationPreview({
+      preferences: buildPreferences(),
+      sourceSiteType: SITE_TYPES.AXON_HUB,
+      targetSiteType: SITE_TYPES.AXON_HUB,
+      channels: [channel],
+    })
+    expect(resolveCredential).not.toHaveBeenCalled()
+
+    const result = await executeManagedSiteChannelMigration({ preview })
+
+    expect(resolveCredential).toHaveBeenCalledOnce()
+    expect(create).toHaveBeenCalledOnce()
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({ credential: "execution-only-key" }),
+    )
+    expect(mockAxonHubBuildChannelPayload).not.toHaveBeenCalled()
+    expect(mockAxonHubCreateChannel).not.toHaveBeenCalled()
+    expect(result.createdCount).toBe(1)
+  })
+
+  it("prepares an Axon source from its native string ref without old secret hydration", async () => {
+    const { prepareManagedSiteChannelMigrationPreview } = await import(
+      "~/services/managedSites/channelMigration"
+    )
+    const prepare = vi.fn(async () => ({
+      status: "ready" as const,
+      source: buildAxonMigrationSource(),
+    }))
+    const resolveCredential = vi.fn()
+    mockResolveManagedSiteMigrationCapability.mockImplementation((siteType) =>
+      siteType === SITE_TYPES.AXON_HUB
+        ? { source: { prepare, resolveCredential } }
+        : null,
+    )
+
+    const preview = await prepareManagedSiteChannelMigrationPreview({
+      preferences: buildPreferences(),
+      sourceSiteType: SITE_TYPES.AXON_HUB,
+      targetSiteType: SITE_TYPES.DONE_HUB,
+      channels: [
+        {
+          ...buildManagedSiteChannel({ id: 303, key: "sk-********" }),
+          _axonHubData: { id: "native-string-303" },
+        } as ManagedSiteChannel,
+      ],
+    })
+
+    expect(prepare).toHaveBeenCalledWith(
+      expect.objectContaining({
+        selectionId: "303",
+        ref: expect.objectContaining({ resourceId: "native-string-303" }),
+      }),
+    )
+    expect(resolveCredential).not.toHaveBeenCalled()
+    expect(preview.readyCount).toBe(1)
+  })
+
+  it("maps permission-hidden Axon credentials to the existing blocked row", async () => {
+    const { prepareManagedSiteChannelMigrationPreview } = await import(
+      "~/services/managedSites/channelMigration"
+    )
+    const prepare = vi.fn(async () => ({
+      status: "blocked" as const,
+      reasonCode:
+        MANAGED_SITE_CHANNEL_MIGRATION_BLOCKED_REASON_CODES.SOURCE_KEY_RESOLUTION_FAILED,
+    }))
+    mockResolveManagedSiteMigrationCapability.mockImplementation((siteType) =>
+      siteType === SITE_TYPES.AXON_HUB
+        ? { source: { prepare, resolveCredential: vi.fn() } }
+        : null,
+    )
+
+    const preview = await prepareManagedSiteChannelMigrationPreview({
+      preferences: buildPreferences(),
+      sourceSiteType: SITE_TYPES.AXON_HUB,
+      targetSiteType: SITE_TYPES.DONE_HUB,
+      channels: [buildManagedSiteChannel({ id: 304 })],
+    })
+
+    expect(preview.items[0]).toMatchObject({
+      status: "blocked",
+      blockingReasonCode:
+        MANAGED_SITE_CHANNEL_MIGRATION_BLOCKED_REASON_CODES.SOURCE_KEY_RESOLUTION_FAILED,
+    })
+  })
+
+  it("preserves Axon source projection when targeting a legacy site", async () => {
+    const { prepareManagedSiteChannelMigrationPreview } = await import(
+      "~/services/managedSites/channelMigration"
+    )
+    const source = buildAxonMigrationSource({
+      resourceType: ChannelType.OpenRouter,
+      baseUrl: "https://native.example.invalid",
+      models: ["model-one", "model-two"],
+      weight: 9,
+      status: "disabled",
+    })
+    mockResolveManagedSiteMigrationCapability.mockImplementation((siteType) =>
+      siteType === SITE_TYPES.AXON_HUB
+        ? {
+            source: {
+              prepare: vi.fn(async () => ({
+                status: "ready" as const,
+                source,
+              })),
+              resolveCredential: vi.fn(),
+            },
+          }
+        : null,
+    )
+
+    const preview = await prepareManagedSiteChannelMigrationPreview({
+      preferences: buildPreferences(),
+      sourceSiteType: SITE_TYPES.AXON_HUB,
+      targetSiteType: SITE_TYPES.DONE_HUB,
+      channels: [
+        buildManagedSiteChannel({ id: 305, name: "Projected native" }),
+      ],
+    })
+
+    expect(preview.items[0].draft).toMatchObject({
+      name: "Projected native",
+      type: ChannelType.OpenRouter,
+      base_url: "https://native.example.invalid",
+      models: ["model-one", "model-two"],
+      weight: 9,
+      status: 2,
+    })
+    expect(preview.items[0].canonicalPreparation?.source).toEqual(source)
+  })
+
+  it("executes an Axon native selection into a legacy target with one just-in-time credential resolution and one create", async () => {
+    const {
+      executeManagedSiteChannelMigration,
+      prepareManagedSiteChannelMigrationPreview,
+    } = await import("~/services/managedSites/channelMigration")
+    const source = buildAxonMigrationSource()
+    const resolveCredential = vi.fn(async () => ({
+      status: "ready" as const,
+      credential: "jit-native-key",
+    }))
+    mockResolveManagedSiteMigrationCapability.mockImplementation((siteType) =>
+      siteType === SITE_TYPES.AXON_HUB
+        ? {
+            source: {
+              prepare: vi.fn(async () => ({
+                status: "ready" as const,
+                source,
+              })),
+              resolveCredential,
+            },
+          }
+        : null,
+    )
+    const preview = await prepareManagedSiteChannelMigrationPreview({
+      preferences: buildPreferences(),
+      sourceSiteType: SITE_TYPES.AXON_HUB,
+      targetSiteType: SITE_TYPES.DONE_HUB,
+      channels: [buildManagedSiteChannel({ id: 306 })],
+    })
+
+    expect(resolveCredential).not.toHaveBeenCalled()
+    const result = await executeManagedSiteChannelMigration({ preview })
+
+    expect(resolveCredential).toHaveBeenCalledOnce()
+    expect(mockDoneHubCreateChannel).toHaveBeenCalledOnce()
+    expect(mockDoneHubBuildChannelPayload).toHaveBeenCalledWith(
+      expect.objectContaining({ key: "jit-native-key" }),
+    )
+    expect(result.createdCount).toBe(1)
+  })
+
+  it.each([
+    {
+      reasonCode:
+        MANAGED_SITE_CHANNEL_MIGRATION_BLOCKED_REASON_CODES.SOURCE_KEY_MISSING,
+      expectedError:
+        "The source credential is unavailable. Verify source access and try again.",
+    },
+    {
+      reasonCode:
+        MANAGED_SITE_CHANNEL_MIGRATION_BLOCKED_REASON_CODES.SOURCE_KEY_RESOLUTION_FAILED,
+      expectedError:
+        "The source credential could not be resolved. Verify source access and try again.",
+    },
+  ])(
+    "explains a just-in-time $reasonCode blocker without creating the ready preview row",
+    async ({ reasonCode, expectedError }) => {
+      const {
+        executeManagedSiteChannelMigration,
+        prepareManagedSiteChannelMigrationPreview,
+      } = await import("~/services/managedSites/channelMigration")
+      const source = buildAxonMigrationSource()
+      const resolveCredential = vi.fn(async () => ({
+        status: "blocked" as const,
+        reasonCode,
+      }))
+      mockResolveManagedSiteMigrationCapability.mockImplementation(
+        (siteType) =>
+          siteType === SITE_TYPES.AXON_HUB
+            ? {
+                source: {
+                  prepare: vi.fn(async () => ({
+                    status: "ready" as const,
+                    source,
+                  })),
+                  resolveCredential,
+                },
+              }
+            : null,
+      )
+      const preview = await prepareManagedSiteChannelMigrationPreview({
+        preferences: buildPreferences(),
+        sourceSiteType: SITE_TYPES.AXON_HUB,
+        targetSiteType: SITE_TYPES.DONE_HUB,
+        channels: [buildManagedSiteChannel({ id: 306_1 })],
+      })
+
+      expect(preview.items[0].status).toBe("ready")
+      const result = await executeManagedSiteChannelMigration({ preview })
+
+      expect(resolveCredential).toHaveBeenCalledOnce()
+      expect(mockDoneHubBuildChannelPayload).not.toHaveBeenCalled()
+      expect(mockDoneHubCreateChannel).not.toHaveBeenCalled()
+      expect(result).toMatchObject({
+        totalSelected: 1,
+        attemptedCount: 0,
+        createdCount: 0,
+        failedCount: 0,
+        skippedCount: 1,
+        items: [
+          {
+            channelId: 306_1,
+            success: false,
+            skipped: true,
+            blockingReasonCode: reasonCode,
+            error: expectedError,
+          },
+        ],
+      })
+    },
+  )
+
+  it("blocks only the row whose named target preparation fails", async () => {
+    const { prepareManagedSiteChannelMigrationPreview } = await import(
+      "~/services/managedSites/channelMigration"
+    )
+    const prepare = vi.fn(async (source: ManagedSiteMigrationSource) => {
+      if (source.baseUrl.includes("blocked")) throw new Error("blocked target")
+      return buildAxonTargetPreparation(source)
+    })
+    mockResolveManagedSiteMigrationCapability.mockImplementation((siteType) =>
+      siteType === SITE_TYPES.AXON_HUB ? { target: { prepare } } : null,
+    )
+
+    const preview = await prepareManagedSiteChannelMigrationPreview({
+      preferences: buildPreferences(),
+      sourceSiteType: SITE_TYPES.NEW_API,
+      targetSiteType: SITE_TYPES.AXON_HUB,
+      channels: [
+        buildManagedSiteChannel({
+          id: 307,
+          base_url: "https://blocked.example.invalid",
+        }),
+        buildManagedSiteChannel({
+          id: 308,
+          base_url: "https://ready.example.invalid",
+        }),
+      ],
+    })
+
+    expect(preview.items.map((item) => item.status)).toEqual([
+      "blocked",
+      "ready",
+    ])
+    expect(preview.items[0].blockingReasonCode).toBe(
+      MANAGED_SITE_CHANNEL_MIGRATION_BLOCKED_REASON_CODES.TARGET_DRAFT_PREPARATION_FAILED,
+    )
+  })
+
+  it("continues after one named target create failure", async () => {
+    const {
+      executeManagedSiteChannelMigration,
+      prepareManagedSiteChannelMigrationPreview,
+    } = await import("~/services/managedSites/channelMigration")
+    const create = vi
+      .fn()
+      .mockResolvedValueOnce({
+        status: "failed",
+        failureCode:
+          MANAGED_SITE_MIGRATION_EXECUTION_FAILURE_CODES.TargetRejected,
+      })
+      .mockResolvedValueOnce({ status: "created" })
+    mockResolveManagedSiteMigrationCapability.mockImplementation((siteType) =>
+      siteType === SITE_TYPES.AXON_HUB
+        ? {
+            target: {
+              prepare: vi.fn(async (source) =>
+                buildAxonTargetPreparation(source),
+              ),
+              create,
+            },
+          }
+        : null,
+    )
+    const preview = await prepareManagedSiteChannelMigrationPreview({
+      preferences: buildPreferences(),
+      sourceSiteType: SITE_TYPES.NEW_API,
+      targetSiteType: SITE_TYPES.AXON_HUB,
+      channels: [
+        buildManagedSiteChannel({ id: 309, key: "key-one" }),
+        buildManagedSiteChannel({ id: 310, key: "key-two" }),
+      ],
+    })
+
+    const result = await executeManagedSiteChannelMigration({ preview })
+
+    expect(create).toHaveBeenCalledTimes(2)
+    expect(result).toMatchObject({
+      attemptedCount: 2,
+      createdCount: 1,
+      failedCount: 1,
+    })
+    expect(result.items.map((item) => item.success)).toEqual([false, true])
+  })
+
+  it("preserves string selection identity and order across native preparation", async () => {
+    const { prepareManagedSiteChannelMigrationPreview } = await import(
+      "~/services/managedSites/channelMigration"
+    )
+    const prepare = vi.fn(async (selection: ManagedSiteMigrationSelection) => ({
+      status: "ready" as const,
+      source: buildAxonMigrationSource({ baseUrl: selection.ref.resourceId }),
+    }))
+    mockResolveManagedSiteMigrationCapability.mockImplementation((siteType) =>
+      siteType === SITE_TYPES.AXON_HUB
+        ? { source: { prepare, resolveCredential: vi.fn() } }
+        : null,
+    )
+    const channels = ["native-z", "native-a", "native-m"].map(
+      (resourceId, index) =>
+        ({
+          ...buildManagedSiteChannel({ id: 311 + index, name: resourceId }),
+          _axonHubData: { id: resourceId },
+        }) as ManagedSiteChannel,
+    )
+
+    const preview = await prepareManagedSiteChannelMigrationPreview({
+      preferences: buildPreferences(),
+      sourceSiteType: SITE_TYPES.AXON_HUB,
+      targetSiteType: SITE_TYPES.DONE_HUB,
+      channels,
+    })
+
+    expect(
+      prepare.mock.calls.map(([selection]) => selection.ref.resourceId),
+    ).toEqual(["native-z", "native-a", "native-m"])
+    expect(preview.items.map((item) => item.channelId)).toEqual([311, 312, 313])
+    expect(
+      preview.items.map(
+        (item) => item.canonicalPreparation?.selection.ref.resourceId,
+      ),
+    ).toEqual(["native-z", "native-a", "native-m"])
+  })
+
+  it("maps uncertain target creation to an explicit non-replayable result", async () => {
+    const { executeManagedSiteMigration, prepareManagedSiteMigrationPreview } =
+      await import("~/services/managedSites/channelMigration")
+    const source = buildAxonMigrationSource()
+    const create = vi.fn(async () => ({ status: "uncertain" as const }))
+    mockResolveManagedSiteMigrationCapability.mockImplementation((siteType) =>
+      siteType === SITE_TYPES.AXON_HUB
+        ? {
+            source: {
+              prepare: vi.fn(async () => ({
+                status: "ready" as const,
+                source,
+              })),
+              resolveCredential: vi.fn(async () => ({
+                status: "ready" as const,
+                credential: "ephemeral-key",
+              })),
+            },
+            target: {
+              prepare: vi.fn(async () => buildAxonTargetPreparation(source)),
+              create,
+            },
+          }
+        : null,
+    )
+    const preview = await prepareManagedSiteMigrationPreview({
+      sourceSiteType: SITE_TYPES.AXON_HUB,
+      targetSiteType: SITE_TYPES.AXON_HUB,
+      selections: [
+        {
+          ...buildMigrationSelection("native-selection"),
+          ref: {
+            ...buildMigrationSelection("native-selection").ref,
+            siteType: SITE_TYPES.AXON_HUB,
+            resourceId: "native-selection",
+          },
+        },
+      ],
+    })
+    expect(preview.items[0]).toMatchObject({
+      status: "ready",
+      target: { projection: { name: "Selection native-selection" } },
+    })
+
+    const result = await executeManagedSiteMigration({ preview })
+
+    expect(create).toHaveBeenCalledOnce()
+    expect(result).toMatchObject({
+      attemptedCount: 1,
+      createdCount: 0,
+      failedCount: 0,
+      uncertainCount: 1,
+      items: [
+        {
+          status: "uncertain",
+          failureCode:
+            MANAGED_SITE_MIGRATION_EXECUTION_FAILURE_CODES.MutationStateUncertain,
+        },
+      ],
+    })
+  })
+
+  it("stops canonical Axon creation after an actual native abort and retains secret-free progress", async () => {
+    const { executeManagedSiteMigration } = await import(
+      "~/services/managedSites/channelMigration"
+    )
+    const selections = [
+      buildMigrationSelection("native-aborted"),
+      buildMigrationSelection("must-not-create"),
+    ]
+    const preview = {
+      ...buildCanonicalPreview(selections),
+      targetSiteType: SITE_TYPES.AXON_HUB,
+    }
+    const resolveCredential = vi.fn(async () => ({
+      status: "ready" as const,
+      credential: "execution-key",
+    }))
+    mockResolveManagedSiteMigrationCapability.mockImplementation((siteType) =>
+      siteType === SITE_TYPES.NEW_API
+        ? {
+            source: {
+              prepare: vi.fn(),
+              resolveCredential,
+            },
+          }
+        : siteType === SITE_TYPES.AXON_HUB
+          ? { target: axonHubManagedSiteMigrationCapability.target }
+          : null,
+    )
+    const nativeAbort = new axonHubNativeResources.AxonHubNativeError({
+      code: "aborted",
+      dispatch: "before",
+    })
+    const openSpy = vi
+      .spyOn(axonHubNativeResources, "openAxonHubNativeResourceOperations")
+      .mockRejectedValue(nativeAbort)
+
+    try {
+      const error = await captureMigrationExecutionAbort(
+        executeManagedSiteMigration({ preview }),
+      )
+
+      expect(error.cause).toMatchObject({ name: "AbortError" })
+      expect((error.cause as Error).cause).toBe(nativeAbort)
+      expect(error.details.partialResult).toEqual({
+        totalSelected: 2,
+        attemptedCount: 1,
+        createdCount: 0,
+        failedCount: 0,
+        skippedCount: 0,
+        uncertainCount: 0,
+        items: [],
+      })
+      expect(error.details.remainingSelections).toEqual(selections)
+      expect(resolveCredential).toHaveBeenCalledOnce()
+      expect(openSpy).toHaveBeenCalledOnce()
+      expectMigrationAbortInvariants(error)
+    } finally {
+      openSpy.mockRestore()
+    }
+  })
+
+  it("keeps canonical preview and result objects free of credentials and commands", async () => {
+    const { executeManagedSiteMigration, prepareManagedSiteMigrationPreview } =
+      await import("~/services/managedSites/channelMigration")
+    const source = buildAxonMigrationSource()
+    const secret = "execution-secret-placeholder"
+    mockResolveManagedSiteMigrationCapability.mockImplementation((siteType) =>
+      siteType === SITE_TYPES.AXON_HUB
+        ? {
+            source: {
+              prepare: vi.fn(async () => ({
+                status: "ready" as const,
+                source,
+              })),
+              resolveCredential: vi.fn(async () => ({
+                status: "ready" as const,
+                credential: secret,
+              })),
+            },
+            target: {
+              prepare: vi.fn(async () => buildAxonTargetPreparation(source)),
+              create: vi.fn(async () => ({ status: "created" as const })),
+            },
+          }
+        : null,
+    )
+    const selection = {
+      ...buildMigrationSelection("safe"),
+      ref: {
+        ...buildMigrationSelection("safe").ref,
+        siteType: SITE_TYPES.AXON_HUB,
+      },
+    }
+
+    const preview = await prepareManagedSiteMigrationPreview({
+      sourceSiteType: SITE_TYPES.AXON_HUB,
+      targetSiteType: SITE_TYPES.AXON_HUB,
+      selections: [selection],
+    })
+    const result = await executeManagedSiteMigration({ preview })
+
+    expect(JSON.stringify(preview)).not.toContain(secret)
+    expect(JSON.stringify(preview)).not.toContain("credential")
+    expect(JSON.stringify(result)).not.toContain(secret)
+    expect(JSON.stringify(result)).not.toContain("command")
+  })
+
+  it("returns the existing create-only no-dedupe and no-rollback general warnings", async () => {
+    const { prepareManagedSiteMigrationPreview } = await import(
+      "~/services/managedSites/channelMigration"
+    )
+    const source = buildAxonMigrationSource()
+    mockResolveManagedSiteMigrationCapability.mockImplementation((siteType) =>
+      siteType === SITE_TYPES.AXON_HUB
+        ? {
+            source: {
+              prepare: vi.fn(async () => ({
+                status: "ready" as const,
+                source,
+              })),
+              resolveCredential: vi.fn(),
+            },
+            target: {
+              prepare: vi.fn(async () => buildAxonTargetPreparation(source)),
+              create: vi.fn(),
+            },
+          }
+        : null,
+    )
+
+    const preview = await prepareManagedSiteMigrationPreview({
+      sourceSiteType: SITE_TYPES.AXON_HUB,
+      targetSiteType: SITE_TYPES.AXON_HUB,
+      selections: [
+        {
+          ...buildMigrationSelection("warnings"),
+          ref: {
+            ...buildMigrationSelection("warnings").ref,
+            siteType: SITE_TYPES.AXON_HUB,
+          },
+        },
+      ],
+    })
+
+    expect(preview.generalWarningCodes).toEqual([
+      MANAGED_SITE_CHANNEL_MIGRATION_GENERAL_WARNING_CODES.CREATE_ONLY,
+      MANAGED_SITE_CHANNEL_MIGRATION_GENERAL_WARNING_CODES.NO_DEDUPE_OR_SYNC,
+      MANAGED_SITE_CHANNEL_MIGRATION_GENERAL_WARNING_CODES.NO_ROLLBACK,
     ])
   })
 })

--- a/tests/services/managedSites/channelMigration.test.ts
+++ b/tests/services/managedSites/channelMigration.test.ts
@@ -4,6 +4,10 @@ import { AXON_HUB_CHANNEL_TYPE } from "~/constants/axonHub"
 import { CLAUDE_CODE_HUB_PROVIDER_TYPE } from "~/constants/claudeCodeHub"
 import { ChannelType } from "~/constants/managedSite"
 import { SITE_TYPES } from "~/constants/siteType"
+import {
+  MANAGED_RESOURCE_FAILURE_CODES,
+  ManagedResourceError,
+} from "~/services/apiAdapters/contracts/managedResourceNative"
 import * as axonHubNativeResources from "~/services/apiAdapters/managedResources/axonHub"
 import { axonHubManagedSiteMigrationCapability } from "~/services/apiAdapters/managedResources/axonHubMigration"
 import {
@@ -138,7 +142,9 @@ const buildMigrationSelection = (
   },
 })
 
-const buildMigrationSource = (): ManagedSiteMigrationSource => ({
+const buildMigrationSource = (
+  overrides: Partial<ManagedSiteMigrationSource> = {},
+): ManagedSiteMigrationSource => ({
   sourceSiteType: SITE_TYPES.NEW_API,
   resourceType: ChannelType.OpenAI,
   baseUrl: "https://source.example.invalid",
@@ -153,6 +159,7 @@ const buildMigrationSource = (): ManagedSiteMigrationSource => ({
     hasAdvancedSettings: false,
     hasMultiKeyState: false,
   },
+  ...overrides,
 })
 
 const buildMigrationTarget = (): ManagedSiteMigrationTargetPreparation => ({
@@ -634,6 +641,80 @@ describe("channelMigration", () => {
     })
   })
 
+  it("bridges canonical sources into legacy target creation outcomes", async () => {
+    const { executeManagedSiteMigration, prepareManagedSiteMigrationPreview } =
+      await import("~/services/managedSites/channelMigration")
+    const selections = ["created", "rejected"].map(buildMigrationSelection)
+    const prepare = vi.fn(async (selection: ManagedSiteMigrationSelection) => ({
+      status: "ready" as const,
+      source: buildMigrationSource({ baseUrl: selection.ref.resourceId }),
+    }))
+    const resolveCredential = vi.fn(
+      async (selection: ManagedSiteMigrationSelection) => ({
+        status: "ready" as const,
+        credential: `credential-${selection.selectionId}`,
+      }),
+    )
+    mockResolveManagedSiteMigrationCapability.mockImplementation((siteType) =>
+      siteType === SITE_TYPES.NEW_API
+        ? { source: { prepare, resolveCredential } }
+        : null,
+    )
+    mockDoneHubCreateChannel
+      .mockResolvedValueOnce({ success: true, message: "ok" })
+      .mockResolvedValueOnce({ success: false, message: "rejected" })
+
+    const preview = await prepareManagedSiteMigrationPreview({
+      sourceSiteType: SITE_TYPES.NEW_API,
+      targetSiteType: SITE_TYPES.DONE_HUB,
+      selections,
+    })
+    const result = await executeManagedSiteMigration({ preview })
+
+    expect(preview.items.map((item) => item.status)).toEqual(["ready", "ready"])
+    expect(result).toMatchObject({
+      attemptedCount: 2,
+      createdCount: 1,
+      failedCount: 1,
+      items: [
+        { selectionId: "created", status: "created" },
+        {
+          selectionId: "rejected",
+          status: "failed",
+          failureCode:
+            MANAGED_SITE_MIGRATION_EXECUTION_FAILURE_CODES.TargetRejected,
+        },
+      ],
+    })
+  })
+
+  it("fails closed when a ready canonical preview loses its source capability", async () => {
+    const { executeManagedSiteMigration } = await import(
+      "~/services/managedSites/channelMigration"
+    )
+
+    const result = await executeManagedSiteMigration({
+      preview: buildCanonicalPreview([
+        buildMigrationSelection("missing-source-capability"),
+      ]),
+    })
+
+    expect(result).toMatchObject({
+      attemptedCount: 0,
+      createdCount: 0,
+      skippedCount: 1,
+      items: [
+        {
+          selectionId: "missing-source-capability",
+          status: "skipped",
+          blockingReasonCode:
+            MANAGED_SITE_CHANNEL_MIGRATION_BLOCKED_REASON_CODES.SOURCE_KEY_RESOLUTION_FAILED,
+        },
+      ],
+    })
+    expect(mockDoneHubCreateChannel).not.toHaveBeenCalled()
+  })
+
   it("keeps legacy channel credentials out of the canonical source model", async () => {
     const { toCanonicalMigrationSourceFromLegacyChannel } = await import(
       "~/services/managedSites/channelMigrationLegacyFacade"
@@ -647,6 +728,21 @@ describe("channelMigration", () => {
     expect(source).toMatchObject({ sourceSiteType: SITE_TYPES.NEW_API })
     expect(source).not.toHaveProperty("credential")
     expect(source).not.toHaveProperty("key")
+  })
+
+  it("normalizes unknown Claude Code Hub providers and disabled legacy status", () => {
+    const source = toCanonicalMigrationSourceFromLegacyChannel({
+      sourceSiteType: SITE_TYPES.CLAUDE_CODE_HUB,
+      channel: buildManagedSiteChannel({
+        type: "future-provider",
+        status: 2,
+      }),
+    })
+
+    expect(source).toMatchObject({
+      resourceType: ChannelType.OpenAI,
+      status: "disabled",
+    })
   })
 
   it("collects controlled legacy migration loss facts without exposing credentials", () => {
@@ -745,6 +841,33 @@ describe("channelMigration", () => {
         resourceId: "native-83",
       },
     })
+  })
+
+  it("rejects a pre-aborted preview before adapter work starts", async () => {
+    const selection = buildMigrationSelection("pre-aborted-preview")
+    const cancellation = new Error("Preview cancelled before start")
+    const controller = new AbortController()
+    controller.abort(cancellation)
+    const prepareSource = vi.fn()
+    const prepareTarget = vi.fn()
+
+    await expect(
+      prepareManagedSiteMigrationPreviewCore({
+        sourceSiteType: SITE_TYPES.NEW_API,
+        targetSiteType: SITE_TYPES.DONE_HUB,
+        selections: [selection],
+        signal: controller.signal,
+        sourceFailureReasonCode:
+          MANAGED_SITE_CHANNEL_MIGRATION_BLOCKED_REASON_CODES.SOURCE_KEY_RESOLUTION_FAILED,
+        targetFailureReasonCode:
+          MANAGED_SITE_CHANNEL_MIGRATION_BLOCKED_REASON_CODES.TARGET_DRAFT_PREPARATION_FAILED,
+        prepareSource,
+        prepareTarget,
+        getReadyWarningCodes: () => [],
+      }),
+    ).rejects.toBe(cancellation)
+    expect(prepareSource).not.toHaveBeenCalled()
+    expect(prepareTarget).not.toHaveBeenCalled()
   })
 
   it.each(["source", "target"] as const)(
@@ -3302,6 +3425,48 @@ describe("channelMigration", () => {
     ])
   })
 
+  it("uses neutral fallback guidance for a blocked target-preparation row", async () => {
+    const { executeManagedSiteChannelMigration } = await import(
+      "~/services/managedSites/channelMigration"
+    )
+
+    const result = await executeManagedSiteChannelMigration({
+      preview: {
+        sourceSiteType: SITE_TYPES.NEW_API,
+        targetSiteType: SITE_TYPES.DONE_HUB,
+        generalWarningCodes: [],
+        totalCount: 1,
+        readyCount: 0,
+        blockedCount: 1,
+        items: [
+          {
+            channelId: 43,
+            channelName: "Blocked target preparation",
+            sourceChannel: buildManagedSiteChannel({ id: 43 }),
+            draft: null,
+            status: "blocked",
+            warningCodes: [],
+            blockingReasonCode:
+              MANAGED_SITE_CHANNEL_MIGRATION_BLOCKED_REASON_CODES.TARGET_DRAFT_PREPARATION_FAILED,
+          },
+        ],
+      },
+    })
+
+    expect(result.items).toEqual([
+      {
+        channelId: 43,
+        channelName: "Blocked target preparation",
+        success: false,
+        skipped: true,
+        blockingReasonCode:
+          MANAGED_SITE_CHANNEL_MIGRATION_BLOCKED_REASON_CODES.TARGET_DRAFT_PREPARATION_FAILED,
+        error:
+          "This channel cannot be migrated right now. Verify source access and try again.",
+      },
+    ])
+  })
+
   it("uses a local fallback message when target creation fails without an error message", async () => {
     const { executeManagedSiteChannelMigration } = await import(
       "~/services/managedSites/channelMigration"
@@ -3821,6 +3986,50 @@ describe("channelMigration", () => {
     expect(result.items.map((item) => item.success)).toEqual([false, true])
   })
 
+  it("reports named-target uncertainty with verify-before-retry guidance", async () => {
+    const {
+      executeManagedSiteChannelMigration,
+      prepareManagedSiteChannelMigrationPreview,
+    } = await import("~/services/managedSites/channelMigration")
+    const create = vi.fn(async () => ({ status: "uncertain" as const }))
+    mockResolveManagedSiteMigrationCapability.mockImplementation((siteType) =>
+      siteType === SITE_TYPES.AXON_HUB
+        ? {
+            target: {
+              prepare: vi.fn(async (source) =>
+                buildAxonTargetPreparation(source),
+              ),
+              create,
+            },
+          }
+        : null,
+    )
+    const preview = await prepareManagedSiteChannelMigrationPreview({
+      preferences: buildPreferences(),
+      sourceSiteType: SITE_TYPES.NEW_API,
+      targetSiteType: SITE_TYPES.AXON_HUB,
+      channels: [buildManagedSiteChannel({ id: 311, key: "source-key" })],
+    })
+
+    const result = await executeManagedSiteChannelMigration({ preview })
+
+    expect(result).toMatchObject({
+      attemptedCount: 1,
+      createdCount: 0,
+      failedCount: 1,
+      skippedCount: 0,
+      items: [
+        {
+          channelId: 311,
+          success: false,
+          skipped: false,
+          error:
+            "Target creation may have succeeded. Verify the target before retrying.",
+        },
+      ],
+    })
+  })
+
   it("preserves string selection identity and order across native preparation", async () => {
     const { prepareManagedSiteChannelMigrationPreview } = await import(
       "~/services/managedSites/channelMigration"
@@ -3914,6 +4123,57 @@ describe("channelMigration", () => {
       uncertainCount: 1,
       items: [
         {
+          status: "uncertain",
+          failureCode:
+            MANAGED_SITE_MIGRATION_EXECUTION_FAILURE_CODES.MutationStateUncertain,
+        },
+      ],
+    })
+  })
+
+  it("classifies managed-resource mutation errors as uncertain", async () => {
+    const { executeManagedSiteMigration } = await import(
+      "~/services/managedSites/channelMigration"
+    )
+    const mutationError = new ManagedResourceError({
+      code: MANAGED_RESOURCE_FAILURE_CODES.MutationStateUncertain,
+    })
+    const create = vi.fn(async () => {
+      throw mutationError
+    })
+    mockResolveManagedSiteMigrationCapability.mockImplementation((siteType) => {
+      if (siteType === SITE_TYPES.NEW_API) {
+        return {
+          source: {
+            prepare: vi.fn(),
+            resolveCredential: vi.fn(async () => ({
+              status: "ready" as const,
+              credential: "ephemeral-key",
+            })),
+          },
+        }
+      }
+      if (siteType === SITE_TYPES.DONE_HUB) {
+        return { target: { prepare: vi.fn(), create } }
+      }
+      return null
+    })
+
+    const result = await executeManagedSiteMigration({
+      preview: buildCanonicalPreview([
+        buildMigrationSelection("uncertain-mutation-error"),
+      ]),
+    })
+
+    expect(create).toHaveBeenCalledOnce()
+    expect(result).toMatchObject({
+      attemptedCount: 1,
+      createdCount: 0,
+      failedCount: 0,
+      uncertainCount: 1,
+      items: [
+        {
+          selectionId: "uncertain-mutation-error",
           status: "uncertain",
           failureCode:
             MANAGED_SITE_MIGRATION_EXECUTION_FAILURE_CODES.MutationStateUncertain,

--- a/tests/services/managedSites/channelMigrationCapabilityRegistry.test.ts
+++ b/tests/services/managedSites/channelMigrationCapabilityRegistry.test.ts
@@ -1,0 +1,34 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { SITE_TYPES } from "~/constants/siteType"
+import { resolveManagedSiteMigrationCapability } from "~/services/managedSites/channelMigrationCapabilityRegistry"
+
+const { resolveManagedUpstreamResourceFeatureCapabilitiesMock } = vi.hoisted(
+  () => ({
+    resolveManagedUpstreamResourceFeatureCapabilitiesMock: vi.fn(),
+  }),
+)
+
+vi.mock("~/services/managedSites/managedUpstreamResourceService", () => ({
+  resolveManagedUpstreamResourceFeatureCapabilities: (...args: unknown[]) =>
+    resolveManagedUpstreamResourceFeatureCapabilitiesMock(...args),
+}))
+
+describe("managed site migration capability registry", () => {
+  beforeEach(() => {
+    resolveManagedUpstreamResourceFeatureCapabilitiesMock.mockReset()
+  })
+
+  it("returns null when New API has no migration capability registration", () => {
+    expect(resolveManagedSiteMigrationCapability(SITE_TYPES.NEW_API)).toBeNull()
+  })
+
+  it("returns null for AxonHub without falling back to the legacy feature gate", () => {
+    expect(
+      resolveManagedSiteMigrationCapability(SITE_TYPES.AXON_HUB),
+    ).toBeNull()
+    expect(
+      resolveManagedUpstreamResourceFeatureCapabilitiesMock,
+    ).not.toHaveBeenCalled()
+  })
+})

--- a/tests/services/managedSites/channelMigrationCapabilityRegistry.test.ts
+++ b/tests/services/managedSites/channelMigrationCapabilityRegistry.test.ts
@@ -23,10 +23,19 @@ describe("managed site migration capability registry", () => {
     expect(resolveManagedSiteMigrationCapability(SITE_TYPES.NEW_API)).toBeNull()
   })
 
-  it("returns null for AxonHub without falling back to the legacy feature gate", () => {
+  it("resolves AxonHub without falling back to the legacy feature gate", () => {
     expect(
       resolveManagedSiteMigrationCapability(SITE_TYPES.AXON_HUB),
-    ).toBeNull()
+    ).toMatchObject({
+      source: {
+        prepare: expect.any(Function),
+        resolveCredential: expect.any(Function),
+      },
+      target: {
+        prepare: expect.any(Function),
+        create: expect.any(Function),
+      },
+    })
     expect(
       resolveManagedUpstreamResourceFeatureCapabilitiesMock,
     ).not.toHaveBeenCalled()

--- a/tests/services/managedSites/managedUpstreamResourceService.test.ts
+++ b/tests/services/managedSites/managedUpstreamResourceService.test.ts
@@ -380,7 +380,7 @@ describe("managed upstream resource service", () => {
     )
   })
 
-  it("enables channel migration resource slices for migrated managed sites by default", () => {
+  it("keeps AxonHub migration off the old feature gate without changing other site slices", () => {
     const resources = buildResourcesCapability()
     getSiteTypeCapabilitiesMock.mockImplementation((siteType) => ({
       siteType,
@@ -391,30 +391,40 @@ describe("managed upstream resource service", () => {
         resources,
       },
     }))
-    const migratedSiteTypes = [
+    const legacyMigratedSiteTypes = [
       SITE_TYPES.NEW_API,
       SITE_TYPES.VELOERA,
       SITE_TYPES.DONE_HUB,
       SITE_TYPES.OCTOPUS,
-      SITE_TYPES.AXON_HUB,
       SITE_TYPES.CLAUDE_CODE_HUB,
     ]
 
     expect(
-      migratedSiteTypes.map((siteType) =>
+      legacyMigratedSiteTypes.map((siteType) =>
         resolveManagedUpstreamResourceFeatureCapabilities(
           siteType,
           MANAGED_UPSTREAM_RESOURCE_FEATURES.ChannelMigration,
         ),
       ),
     ).toEqual(
-      migratedSiteTypes.map((siteType) => ({
+      legacyMigratedSiteTypes.map((siteType) => ({
         supported: true,
         siteType,
         feature: MANAGED_UPSTREAM_RESOURCE_FEATURES.ChannelMigration,
         capabilities: resources,
       })),
     )
+    expect(
+      resolveManagedUpstreamResourceFeatureCapabilities(
+        SITE_TYPES.AXON_HUB,
+        MANAGED_UPSTREAM_RESOURCE_FEATURES.ChannelMigration,
+      ),
+    ).toEqual({
+      supported: false,
+      siteType: SITE_TYPES.AXON_HUB,
+      feature: MANAGED_UPSTREAM_RESOURCE_FEATURES.ChannelMigration,
+      reason: "feature-slice-disabled",
+    })
   })
 
   it("enables channel filter resource config slices for channel-shaped migrated sites by default", () => {


### PR DESCRIPTION
## Summary

- define secret-free canonical migration contracts and an explicit feature-owned capability registry
- preserve existing managed-site migration behavior behind a compatibility facade and canonical orchestrator
- route AxonHub source and target migration through native operations with just-in-time credentials, controlled uncertainty, and cancellation progress

## Validation

- task-scoped `pnpm run validate:staged` for each logical commit
- related migration surface: 11 test files, 247 tests passed
- `pnpm run validate:push`
- actual pre-push hook: compile and Knip passed

## Release readiness

- Telemetry: reuse existing migration analytics; action IDs and aggregate payloads are unchanged
- E2E: no new scenario; focused orchestration, adapter, and unchanged dialog behavior are covered by Vitest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added managed-site channel migration support for AxonHub, including preview, credential resolution, and target creation with loss-signal and status mapping.
  * Introduced a unified canonical migration workflow with standardized blocked/ready/uncertain handling and per-item readiness summaries.
  * Added AxonHub↔shared channel type compatibility mapping.

* **Bug Fixes**
  * Improved consistency of cancellation/abort and “target unavailable” behaviors across native open/create flows.
  * Refined migration feature gating so AxonHub no longer relies on the legacy migration path.

* **Tests**
  * Expanded coverage for canonical orchestration, legacy compatibility, cancellation, credential masking/blocking, and failure classification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->