### PR TITLE
refactor(checkin): move page concurrency limits to resource layers

### DIFF
--- a/docs/superpowers/plans/2026-07-17-temp-page-concurrency.md
+++ b/docs/superpowers/plans/2026-07-17-temp-page-concurrency.md
@@ -1,0 +1,949 @@
+# Temporary Page Concurrency Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove scheduler-level account batching and limit active temporary-page operations to three globally and one per origin.
+
+**Architecture:** Add a feature-owned `p-queue` scheduler beside the background temp-window pool. Each self-contained page handler enters its per-origin queue before the global queue, while API-only check-in and post-checkin refresh work dispatch without scheduler batch barriers and remain protected by the existing API transport limiter.
+
+**Tech Stack:** TypeScript, WXT, Manifest V3 background service worker, `p-queue` 9.x, Vitest, pnpm.
+
+---
+
+## File Map
+
+- Create `src/entrypoints/background/tempPageTaskScheduler.ts`: own the global
+  page-operation queue, per-origin queues, concurrency constant, and idle queue
+  cleanup.
+- Create `tests/entrypoints/background/tempPageTaskScheduler.test.ts`: prove
+  global admission, continuous refill, same-origin serialization, failure
+  release, and non-blocking behavior across origins.
+- Modify `src/entrypoints/background/tempWindowPool.ts`: route the five
+  self-contained temporary-page handlers through the shared scheduler without
+  changing manual `OpenTempWindow`/`CloseTempWindow` semantics.
+- Modify
+  `tests/entrypoints/background/tempWindowPoolWindowFallback.test.ts`: prove the
+  real temp-window handler boundary is globally limited and update existing
+  same-origin overlap expectations to the new serialized contract.
+- Modify `src/services/checkin/autoCheckin/scheduler.ts`: remove both fixed
+  account batches and the 250 ms batch delay while preserving error isolation
+  and post-checkin refresh.
+- Modify `tests/services/autoCheckin/scheduler.test.ts`: replace batch-shape
+  assertions with orchestration and best-effort behavior assertions.
+- Modify `package.json` and `pnpm-lock.yaml`: add the direct `p-queue`
+  dependency.
+
+### Task 1: Build the page-task scheduler with TDD
+
+**Files:**
+
+- Create: `tests/entrypoints/background/tempPageTaskScheduler.test.ts`
+- Create: `src/entrypoints/background/tempPageTaskScheduler.ts`
+- Modify: `package.json`
+- Modify: `pnpm-lock.yaml`
+
+- [ ] **Step 1: Confirm the worktree and index are safe**
+
+Run:
+
+```powershell
+git status --porcelain
+```
+
+Expected: no output. If there is output, preserve unrelated state and stop if it
+overlaps any task-scoped file.
+
+- [ ] **Step 2: Add the queue dependency**
+
+Run:
+
+```powershell
+pnpm add p-queue@9.3.1
+```
+
+Expected: `package.json` gains a direct `p-queue` dependency and
+`pnpm-lock.yaml` records `p-queue` plus its transitive dependencies. Do not
+modify WXT or manifest configuration.
+
+- [ ] **Step 3: Write the failing scheduler tests**
+
+Create `tests/entrypoints/background/tempPageTaskScheduler.test.ts` with a
+local deferred helper and these behaviors:
+
+```ts
+import { describe, expect, it, vi } from "vitest"
+
+import { createTempPageTaskScheduler } from "~/entrypoints/background/tempPageTaskScheduler"
+
+const createDeferred = <T = void>() => {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+
+  return { promise, resolve, reject }
+}
+
+describe("tempPageTaskScheduler", () => {
+  it("runs at most three page tasks and refills the first available slot", async () => {
+    const scheduler = createTempPageTaskScheduler(3)
+    const gates = Array.from({ length: 4 }, () => createDeferred())
+    const started: number[] = []
+
+    const tasks = gates.map((gate, index) =>
+      scheduler.run(`https://site-${index}.example.invalid`, async () => {
+        started.push(index)
+        await gate.promise
+        return index
+      }),
+    )
+
+    await vi.waitFor(() => expect(started).toEqual([0, 1, 2]))
+
+    gates[1].resolve()
+    await vi.waitFor(() => expect(started).toEqual([0, 1, 2, 3]))
+
+    gates[0].resolve()
+    gates[2].resolve()
+    gates[3].resolve()
+    await expect(Promise.all(tasks)).resolves.toEqual([0, 1, 2, 3])
+  })
+
+  it("serializes tasks for one origin without occupying another global slot", async () => {
+    const scheduler = createTempPageTaskScheduler(3)
+    const firstOriginGate = createDeferred()
+    const secondOriginGate = createDeferred()
+    const otherOriginGate = createDeferred()
+    const started: string[] = []
+
+    const first = scheduler.run("https://same.example.invalid", async () => {
+      started.push("same-1")
+      await firstOriginGate.promise
+    })
+    const second = scheduler.run("https://same.example.invalid", async () => {
+      started.push("same-2")
+      await secondOriginGate.promise
+    })
+    const other = scheduler.run("https://other.example.invalid", async () => {
+      started.push("other")
+      await otherOriginGate.promise
+    })
+
+    await vi.waitFor(() => expect(started).toEqual(["same-1", "other"]))
+
+    firstOriginGate.resolve()
+    await vi.waitFor(() =>
+      expect(started).toEqual(["same-1", "other", "same-2"]),
+    )
+
+    secondOriginGate.resolve()
+    otherOriginGate.resolve()
+    await Promise.all([first, second, other])
+  })
+
+  it("releases global and origin capacity when a task rejects", async () => {
+    const scheduler = createTempPageTaskScheduler(1)
+    const started: string[] = []
+
+    const failed = scheduler.run("https://example.invalid", async () => {
+      started.push("failed")
+      throw new Error("page failed")
+    })
+    const recovered = scheduler.run("https://example.invalid", async () => {
+      started.push("recovered")
+      return "ok"
+    })
+
+    await expect(failed).rejects.toThrow("page failed")
+    await expect(recovered).resolves.toBe("ok")
+    expect(started).toEqual(["failed", "recovered"])
+  })
+})
+```
+
+- [ ] **Step 4: Run the test and verify RED**
+
+Run:
+
+```powershell
+pnpm vitest run tests/entrypoints/background/tempPageTaskScheduler.test.ts
+```
+
+Expected: FAIL because
+`~/entrypoints/background/tempPageTaskScheduler` does not exist.
+
+- [ ] **Step 5: Implement the minimal scheduler**
+
+Create `src/entrypoints/background/tempPageTaskScheduler.ts`:
+
+```ts
+import PQueue from "p-queue"
+
+export const TEMP_PAGE_TASK_CONCURRENCY = 3
+
+export interface TempPageTaskScheduler {
+  run<T>(originKey: string, task: () => Promise<T>): Promise<T>
+}
+
+function enqueue<T>(queue: PQueue, task: () => Promise<T>): Promise<T> {
+  return queue.add(task, { throwOnTimeout: true })
+}
+
+/**
+ * Creates a scheduler that limits active page work globally and serializes
+ * work that may reuse the same origin-scoped tab.
+ */
+export function createTempPageTaskScheduler(
+  concurrency = TEMP_PAGE_TASK_CONCURRENCY,
+): TempPageTaskScheduler {
+  const globalQueue = new PQueue({ concurrency })
+  const originQueues = new Map<string, PQueue>()
+
+  return {
+    async run<T>(originKey: string, task: () => Promise<T>): Promise<T> {
+      const originQueue =
+        originQueues.get(originKey) ?? new PQueue({ concurrency: 1 })
+      originQueues.set(originKey, originQueue)
+
+      try {
+        return await enqueue(originQueue, () => enqueue(globalQueue, task))
+      } finally {
+        if (
+          originQueue.pending === 0 &&
+          originQueue.size === 0 &&
+          originQueues.get(originKey) === originQueue
+        ) {
+          originQueues.delete(originKey)
+        }
+      }
+    },
+  }
+}
+
+export const tempPageTaskScheduler = createTempPageTaskScheduler()
+```
+
+The per-origin queue must be entered before the global queue. Reversing the
+order allows several same-origin tasks to consume all global slots while they
+wait for one tab.
+
+- [ ] **Step 6: Run the scheduler tests and verify GREEN**
+
+Run:
+
+```powershell
+pnpm vitest run tests/entrypoints/background/tempPageTaskScheduler.test.ts
+```
+
+Expected: all three tests PASS with no unhandled rejection warnings.
+
+- [ ] **Step 7: Validate and commit the scheduler slice**
+
+Run:
+
+```powershell
+git add -- package.json pnpm-lock.yaml src/entrypoints/background/tempPageTaskScheduler.ts tests/entrypoints/background/tempPageTaskScheduler.test.ts
+pnpm run validate:staged
+git diff --cached --check
+git commit -m "feat(temp-window): add page task scheduler"
+```
+
+Expected: staged validation passes and the commit contains only the dependency,
+scheduler, and focused scheduler test.
+
+### Task 2: Route temporary-page handlers through the scheduler
+
+**Files:**
+
+- Modify: `src/entrypoints/background/tempWindowPool.ts`
+- Modify:
+  `tests/entrypoints/background/tempWindowPoolWindowFallback.test.ts`
+
+- [ ] **Step 1: Replace same-origin overlap expectations with the desired serialized contract**
+
+In
+`tests/entrypoints/background/tempWindowPoolWindowFallback.test.ts`, replace
+`"defers same-origin cleanup while a reused temp tab is still busy"` with a
+test that keeps the first content fetch pending, starts a second same-origin
+fetch, and verifies the second does not enter content work until the first
+finishes:
+
+```ts
+it("serializes complete operations that reuse a same-origin temp tab", async () => {
+  tempContextMode = "tab"
+  createTabMock.mockResolvedValueOnce({ id: 608 })
+
+  const firstFetch = createDeferred<any>()
+  const secondFetch = createDeferred<any>()
+  let fetchAttempt = 0
+  sendMessageMock.mockImplementation(
+    async (_tabId: number, message: { action: string }) => {
+      if (
+        message.action === RuntimeActionIds.ContentCheckCapGuard ||
+        message.action === RuntimeActionIds.ContentCheckCloudflareGuard
+      ) {
+        return { success: true, passed: true }
+      }
+      if (message.action === RuntimeActionIds.ContentShowShieldBypassUi) {
+        return undefined
+      }
+      if (message.action === RuntimeActionIds.ContentPerformTempWindowFetch) {
+        fetchAttempt += 1
+        return fetchAttempt === 1 ? firstFetch.promise : secondFetch.promise
+      }
+      throw new Error(`Unexpected action: ${message.action}`)
+    },
+  )
+
+  const { handleTempWindowFetch } = await import(
+    "~/entrypoints/background/tempWindowPool"
+  )
+  const response = {
+    success: true,
+    data: { success: true, message: "", data: "ok" },
+  }
+
+  const first = handleTempWindowFetch(
+    {
+      originUrl: "https://example.invalid/one",
+      fetchUrl: "https://example.invalid/api/one",
+      fetchOptions: { method: "GET" },
+      requestId: "same-origin-1",
+    },
+    vi.fn(),
+  )
+  await vi.advanceTimersByTimeAsync(500)
+
+  const second = handleTempWindowFetch(
+    {
+      originUrl: "https://example.invalid/two",
+      fetchUrl: "https://example.invalid/api/two",
+      fetchOptions: { method: "GET" },
+      requestId: "same-origin-2",
+    },
+    vi.fn(),
+  )
+  await vi.advanceTimersByTimeAsync(500)
+  expect(fetchAttempt).toBe(1)
+
+  firstFetch.resolve(response)
+  await first
+  await vi.advanceTimersByTimeAsync(500)
+  expect(fetchAttempt).toBe(2)
+
+  secondFetch.resolve(response)
+  await second
+  expect(createTabMock).toHaveBeenCalledTimes(1)
+})
+```
+
+Replace the existing force-close overlap test with this serialized equivalent.
+It proves the queued request is not attached to the active tab and creates a
+fresh context after the first operation settles:
+
+```ts
+it("recreates a context for queued same-origin work after force close", async () => {
+  tempContextMode = "tab"
+  createTabMock
+    .mockResolvedValueOnce({ id: 650 })
+    .mockResolvedValueOnce({ id: 651 })
+
+  const firstFetch = createDeferred<any>()
+  let fetchAttempt = 0
+  sendMessageMock.mockImplementation(
+    async (_tabId: number, message: { action: string }) => {
+      if (
+        message.action === RuntimeActionIds.ContentCheckCapGuard ||
+        message.action === RuntimeActionIds.ContentCheckCloudflareGuard
+      ) {
+        return { success: true, passed: true }
+      }
+      if (message.action === RuntimeActionIds.ContentShowShieldBypassUi) {
+        return undefined
+      }
+      if (message.action === RuntimeActionIds.ContentPerformTempWindowFetch) {
+        fetchAttempt += 1
+        if (fetchAttempt === 1) return firstFetch.promise
+        return {
+          success: true,
+          data: { success: true, message: "", data: "recovered" },
+        }
+      }
+      throw new Error(`Unexpected action: ${message.action}`)
+    },
+  )
+
+  const { handleCloseTempWindow, handleTempWindowFetch } = await import(
+    "~/entrypoints/background/tempWindowPool"
+  )
+  const firstResponse = vi.fn()
+  const first = handleTempWindowFetch(
+    {
+      originUrl: "https://example.invalid/one",
+      fetchUrl: "https://example.invalid/api/one",
+      fetchOptions: { method: "GET" },
+      requestId: "force-close-1",
+    },
+    firstResponse,
+  )
+  await vi.advanceTimersByTimeAsync(500)
+
+  const secondResponse = vi.fn()
+  const second = handleTempWindowFetch(
+    {
+      originUrl: "https://example.invalid/two",
+      fetchUrl: "https://example.invalid/api/two",
+      fetchOptions: { method: "GET" },
+      requestId: "force-close-2",
+    },
+    secondResponse,
+  )
+  await vi.advanceTimersByTimeAsync(500)
+  expect(fetchAttempt).toBe(1)
+
+  const closeResponse = vi.fn()
+  await handleCloseTempWindow(
+    { requestId: "force-close-1" },
+    closeResponse,
+  )
+  await vi.advanceTimersByTimeAsync(2000)
+  expect(closeResponse).toHaveBeenCalledWith({ success: true })
+  expect(removeTabMock).toHaveBeenCalledWith(650)
+
+  firstFetch.reject(new Error("active temp tab was force-closed"))
+  await first
+  await vi.advanceTimersByTimeAsync(500)
+  await second
+
+  expect(createTabMock).toHaveBeenCalledTimes(2)
+  expect(fetchAttempt).toBe(2)
+  expect(firstResponse).toHaveBeenCalledWith({
+    success: false,
+    error: "active temp tab was force-closed",
+    code: undefined,
+  })
+  expect(secondResponse).toHaveBeenCalledWith({
+    success: true,
+    data: { success: true, message: "", data: "recovered" },
+  })
+})
+```
+
+- [ ] **Step 2: Add a failing real-handler global concurrency test**
+
+Add a test using four different reserved example origins. Make each
+`ContentPerformTempWindowFetch` call return a separate deferred response:
+
+```ts
+it("limits active temp-page handlers to three and continuously refills capacity", async () => {
+  tempContextMode = "tab"
+  createTabMock.mockImplementation(async () => ({
+    id: 700 + createTabMock.mock.calls.length,
+  }))
+
+  const fetches = Array.from({ length: 4 }, () => createDeferred<any>())
+  let fetchAttempt = 0
+  sendMessageMock.mockImplementation(
+    async (_tabId: number, message: { action: string }) => {
+      if (
+        message.action === RuntimeActionIds.ContentCheckCapGuard ||
+        message.action === RuntimeActionIds.ContentCheckCloudflareGuard
+      ) {
+        return { success: true, passed: true }
+      }
+      if (message.action === RuntimeActionIds.ContentShowShieldBypassUi) {
+        return undefined
+      }
+      if (message.action === RuntimeActionIds.ContentPerformTempWindowFetch) {
+        const current = fetchAttempt
+        fetchAttempt += 1
+        return fetches[current].promise
+      }
+      throw new Error(`Unexpected action: ${message.action}`)
+    },
+  )
+
+  const { handleTempWindowFetch } = await import(
+    "~/entrypoints/background/tempWindowPool"
+  )
+  const requests = fetches.map((_fetch, index) =>
+    handleTempWindowFetch(
+      {
+        originUrl: `https://site-${index}.example.invalid`,
+        fetchUrl: `https://site-${index}.example.invalid/api/account`,
+        fetchOptions: { method: "GET" },
+        requestId: `global-page-${index}`,
+      },
+      vi.fn(),
+    ),
+  )
+
+  await vi.advanceTimersByTimeAsync(1000)
+  expect(fetchAttempt).toBe(3)
+
+  const response = {
+    success: true,
+    data: { success: true, message: "", data: "ok" },
+  }
+  fetches[0].resolve(response)
+  await vi.advanceTimersByTimeAsync(1000)
+  expect(fetchAttempt).toBe(4)
+
+  fetches.slice(1).forEach((fetch) => fetch.resolve(response))
+  await Promise.all(requests)
+})
+```
+
+- [ ] **Step 3: Run the two targeted tests and verify RED**
+
+Run:
+
+```powershell
+pnpm vitest run tests/entrypoints/background/tempPageTaskScheduler.test.ts tests/entrypoints/background/tempWindowPoolWindowFallback.test.ts
+```
+
+Expected:
+
+- the scheduler unit tests remain green;
+- the new real-handler test FAILS because all four different-origin handlers
+  currently enter page work;
+- the rewritten same-origin test FAILS because the current origin lock covers
+  acquisition only and both operations can use one tab concurrently.
+
+- [ ] **Step 4: Add one shared handler wrapper and route all five operations**
+
+Import the scheduler in `src/entrypoints/background/tempWindowPool.ts`:
+
+```ts
+import { tempPageTaskScheduler } from "./tempPageTaskScheduler"
+```
+
+Add a small helper near the temp-window logging/policy helpers:
+
+```ts
+async function runTempPageHandler(
+  url: string,
+  options: { incognito?: boolean },
+  task: () => Promise<void>,
+): Promise<void> {
+  const originKey = buildTempContextOriginKey(normalizeOrigin(url), options)
+  await tempPageTaskScheduler.run(originKey, task)
+}
+```
+
+Mechanically rename only the five existing function declarations, leaving each
+current function body unchanged:
+
+```ts
+handleTempWindowGetRenderedTitle -> executeTempWindowGetRenderedTitle
+handleAutoDetectSite -> executeAutoDetectSite
+handleTempWindowFetch -> executeTempWindowFetch
+handleTempWindowCheckinPageAction -> executeTempWindowCheckinPageAction
+handleTempWindowTurnstileFetch -> executeTempWindowTurnstileFetch
+```
+
+Remove `export` from those five renamed declarations. Then add these queued
+public wrappers after their corresponding implementations:
+
+```ts
+export async function handleTempWindowGetRenderedTitle(
+  request: TempWindowRenderedTitleParams,
+  sendResponse: (response?: any) => void,
+) {
+  await runTempPageHandler(request.originUrl, {}, () =>
+    executeTempWindowGetRenderedTitle(request, sendResponse),
+  )
+}
+
+export async function handleAutoDetectSite(
+  request: any,
+  sendResponse: (response?: any) => void,
+) {
+  await runTempPageHandler(
+    request.url,
+    { incognito: Boolean(request.useIncognito) },
+    () => executeAutoDetectSite(request, sendResponse),
+  )
+}
+
+export async function handleTempWindowFetch(
+  request: TempWindowFetchParams,
+  sendResponse: (response?: any) => void,
+) {
+  await runTempPageHandler(
+    request.originUrl,
+    { incognito: Boolean(request.useIncognito) },
+    () => executeTempWindowFetch(request, sendResponse),
+  )
+}
+
+export async function handleTempWindowCheckinPageAction(
+  request: TempWindowCheckinPageActionParams,
+  sendResponse: (response?: TempWindowCheckinPageAction) => void,
+) {
+  await runTempPageHandler(
+    request.pageUrl || request.originUrl,
+    {},
+    () => executeTempWindowCheckinPageAction(request, sendResponse),
+  )
+}
+
+export async function handleTempWindowTurnstileFetch(
+  request: TempWindowTurnstileFetchParams,
+  sendResponse: (response?: any) => void,
+) {
+  await runTempPageHandler(
+    request.pageUrl || request.originUrl,
+    { incognito: Boolean(request.useIncognito) },
+    () => executeTempWindowTurnstileFetch(request, sendResponse),
+  )
+}
+```
+
+Do not route `handleOpenTempWindow` or `handleCloseTempWindow` through this
+helper. Do not move `acquireTempContext`, `releaseTempContext`, or their existing
+cleanup timers.
+
+- [ ] **Step 5: Run the temp-page tests and verify GREEN**
+
+Run:
+
+```powershell
+pnpm vitest run tests/entrypoints/background/tempPageTaskScheduler.test.ts tests/entrypoints/background/tempWindowPoolWindowFallback.test.ts tests/entrypoints/background/tempWindowPoolNativeCheckin.test.ts tests/entrypoints/background/tempWindowPoolProtectionGuards.test.ts tests/entrypoints/background/tempWindowPoolSuspendCleanup.test.ts
+```
+
+Expected: all tests PASS. The global test starts the fourth different-origin
+task when any one slot completes, and the same-origin test never overlaps
+content fetches.
+
+- [ ] **Step 6: Run related validation and commit the integration slice**
+
+Run:
+
+```powershell
+pnpm vitest related --run src/entrypoints/background/tempWindowPool.ts src/entrypoints/background/tempPageTaskScheduler.ts
+git add -- src/entrypoints/background/tempWindowPool.ts tests/entrypoints/background/tempWindowPoolWindowFallback.test.ts
+pnpm run validate:staged
+git diff --cached --check
+git commit -m "refactor(temp-window): bound active page tasks"
+```
+
+Expected: related tests and staged validation pass. The commit does not include
+scheduler changes.
+
+### Task 3: Remove both scheduler batch barriers
+
+**Files:**
+
+- Modify: `tests/services/autoCheckin/scheduler.test.ts`
+- Modify: `src/services/checkin/autoCheckin/scheduler.ts`
+
+- [ ] **Step 1: Rewrite the daily-run test to require immediate account dispatch**
+
+Replace `"limits concurrent account check-ins during daily runs"` with a test
+that holds all five provider promises open and proves all five have started
+without advancing a 250 ms batch timer:
+
+```ts
+it("dispatches every eligible account without a scheduler batch barrier", async () => {
+  const accounts = Array.from({ length: 5 }, (_, index) => ({
+    id: `account-${index + 1}`,
+    disabled: false,
+    site_name: `Site ${index + 1}`,
+    site_type: SITE_TYPES.VELOERA,
+    account_info: { username: `user-${index + 1}` },
+    checkIn: { enableDetection: true, autoCheckInEnabled: true },
+  }))
+  mockedAccountStorage.getAllAccounts.mockResolvedValue(accounts)
+
+  const completions = accounts.map(() => createDeferred<{ status: "success" }>())
+  const provider = {
+    canCheckIn: vi.fn(() => true),
+    checkIn: vi.fn(
+      (_account: unknown, _context: unknown) =>
+        completions[provider.checkIn.mock.calls.length - 1].promise,
+    ),
+  }
+  mockedProviders.resolveAutoCheckinProvider.mockReturnValue(provider as any)
+
+  const runPromise = autoCheckinScheduler.runCheckins({
+    runType: AUTO_CHECKIN_RUN_TYPE.DAILY,
+  })
+
+  await vi.waitFor(() => expect(provider.checkIn).toHaveBeenCalledTimes(5))
+  completions.forEach((completion) => completion.resolve({ status: "success" }))
+  await runPromise
+
+  expect(storedStatus.summary).toMatchObject({
+    executed: 5,
+    successCount: 5,
+    failedCount: 0,
+  })
+})
+```
+
+Add this typed deferred helper near the scheduler test's existing shared test
+helpers, then keep the full preferences setup from the current daily-run test
+so the test reaches the real scheduler seam:
+
+```ts
+const createDeferred = <T>() => {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+
+  return { promise, resolve, reject }
+}
+```
+
+- [ ] **Step 2: Rewrite the unexpected-rejection test without batch timing**
+
+Rename `"continues later check-in batches when one account task rejects
+unexpectedly"` to `"isolates an unexpected account rejection without aborting
+the run"`. Keep the `runAccountCheckin` spy that rejects account 2, remove fake
+timer advancement, await the run directly, and preserve these assertions:
+
+```ts
+expect(runAccountCheckinSpy).toHaveBeenCalledTimes(4)
+expect(storedStatus.lastRunResult).toBe("partial")
+expect(storedStatus.summary).toMatchObject({
+  executed: 4,
+  successCount: 3,
+  failedCount: 1,
+})
+expect(storedStatus.perAccount["account-2"]).toMatchObject({
+  status: "failed",
+  rawMessage: "Error: unexpected task failure",
+})
+```
+
+- [ ] **Step 3: Make post-checkin refresh prove best-effort concurrent dispatch**
+
+Update the private-helper refresh test to use four unique account IDs and four
+deferred refresh results. Start the refresh and assert all four calls occur
+before resolving any result:
+
+```ts
+const refreshes = Array.from({ length: 4 }, () => createDeferred<any>())
+mockedAccountStorage.refreshAccount.mockImplementation(
+  (_accountId: string) =>
+    refreshes[mockedAccountStorage.refreshAccount.mock.calls.length - 1].promise,
+)
+
+const refreshPromise = (autoCheckinScheduler as any)
+  .refreshAccountsAfterSuccessfulCheckins({
+    accountIds: ["a", "a", " ", "b", "c", "d"],
+    force: false,
+    tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+  })
+
+await vi.waitFor(() =>
+  expect(mockedAccountStorage.refreshAccount).toHaveBeenCalledTimes(4),
+)
+
+refreshes[0].resolve({ refreshed: true })
+refreshes[1].resolve(null)
+refreshes[2].reject(new Error("refresh failed"))
+refreshes[3].resolve({ refreshed: false })
+await expect(refreshPromise).resolves.toBeUndefined()
+```
+
+Retain assertions that the source and `force: false` are passed to every
+refresh. Delete the test that directly calls `processInBatches`, because that
+private helper will no longer exist.
+
+- [ ] **Step 4: Run the scheduler test and verify RED**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/autoCheckin/scheduler.test.ts
+```
+
+Expected: the new immediate-dispatch tests FAIL because the fourth account is
+still held behind the first fixed batch and its timer.
+
+- [ ] **Step 5: Replace batching with concurrency-neutral orchestration**
+
+In `src/services/checkin/autoCheckin/scheduler.ts`, delete:
+
+```ts
+private static readonly CHECKIN_EXECUTION_BATCH_SIZE = 3
+private static readonly CHECKIN_EXECUTION_BATCH_DELAY_MS = 250
+```
+
+Delete `processInBatches`, `delay`, and `runAccountCheckinsInBatches`. Add a
+concurrency-neutral account runner that preserves the existing result shape:
+
+```ts
+private async runAccountCheckins(params: {
+  accounts: SiteAccount[]
+  accountDisplayNameById: Map<string, string>
+  tempWindowRequestSource: TempWindowRequestSource
+}): Promise<
+  Array<{
+    result: CheckinAccountResult
+    successful: boolean
+  }>
+> {
+  return await Promise.all(
+    params.accounts.map(async (account) => {
+      const accountName =
+        params.accountDisplayNameById.get(account.id) ?? account.id
+
+      try {
+        return await this.runAccountCheckin(
+          account,
+          accountName,
+          params.tempWindowRequestSource,
+        )
+      } catch (error) {
+        return {
+          result: {
+            accountId: account.id,
+            accountName,
+            status: CHECKIN_RESULT_STATUS.FAILED,
+            rawMessage: getErrorMessage(error),
+            timestamp: Date.now(),
+          },
+          successful: false,
+        }
+      }
+    }),
+  )
+}
+```
+
+Rename the call site from `runAccountCheckinsInBatches` to
+`runAccountCheckins` and change its comment to state that API and page resources
+are limited by their owning lower layers.
+
+Replace the refresh `processInBatches` call with a best-effort `Promise.all`
+that normalizes each account independently:
+
+```ts
+const results = await Promise.all(
+  uniqueAccountIds.map(async (accountId): Promise<PostCheckinRefreshOutcome> => {
+    try {
+      const result = params.tempWindowRequestSource
+        ? await accountStorage.refreshAccount(accountId, force, {
+            tempWindowRequestSource: params.tempWindowRequestSource,
+          })
+        : await accountStorage.refreshAccount(accountId, force)
+
+      if (result?.refreshed === true) return "refreshed"
+      if (result == null) return "failed"
+      return "unchanged"
+    } catch {
+      return "failed"
+    }
+  }),
+)
+```
+
+Keep deduplication, empty-input return, result counts, logging, forced refresh,
+source propagation, and the outer best-effort catch unchanged.
+
+- [ ] **Step 6: Run scheduler tests and verify GREEN**
+
+Run:
+
+```powershell
+pnpm vitest run tests/services/autoCheckin/scheduler.test.ts
+```
+
+Expected: the entire scheduler suite PASSes without advancing an inter-batch
+timer, and the post-checkin refresh tests still prove source propagation,
+deduplication, default force behavior, empty input, and failure isolation.
+
+- [ ] **Step 7: Run related validation and commit the scheduler slice**
+
+Run:
+
+```powershell
+pnpm vitest related --run src/services/checkin/autoCheckin/scheduler.ts
+git add -- src/services/checkin/autoCheckin/scheduler.ts tests/services/autoCheckin/scheduler.test.ts
+pnpm run validate:staged
+git diff --cached --check
+git commit -m "refactor(checkin): move limits to resource layers"
+```
+
+Expected: related tests and staged validation pass. No batching constants or
+batch helper references remain.
+
+### Task 4: Final integration and cross-browser verification
+
+**Files:**
+
+- Inspect all task-scoped files from Tasks 1–3.
+- Modify only task-scoped files if validation exposes a real integration issue.
+
+- [ ] **Step 1: Verify obsolete batching and accidental bypasses are absent**
+
+Run:
+
+```powershell
+rg -n "CHECKIN_EXECUTION_BATCH|processInBatches|runAccountCheckinsInBatches" src tests
+rg -n "tempPageTaskScheduler|runTempPageHandler" src/entrypoints/background tests/entrypoints/background
+```
+
+Expected:
+
+- the first command returns no matches;
+- the second shows the scheduler module plus all five self-contained page
+  handlers and their focused tests;
+- manual open/close handlers do not call `runTempPageHandler`.
+
+- [ ] **Step 2: Run focused regression suites**
+
+Run:
+
+```powershell
+pnpm vitest run tests/entrypoints/background/tempPageTaskScheduler.test.ts tests/entrypoints/background/tempWindowPoolWindowFallback.test.ts tests/entrypoints/background/tempWindowPoolNativeCheckin.test.ts tests/entrypoints/background/tempWindowPoolProtectionGuards.test.ts tests/entrypoints/background/tempWindowPoolSuspendCleanup.test.ts tests/services/autoCheckin/scheduler.test.ts tests/utils/tempWindowFetch.background.test.ts tests/utils/tempWindowFetch.fallback.test.ts
+```
+
+Expected: all focused suites PASS with no unhandled promise rejection or fake
+timer leak.
+
+- [ ] **Step 3: Run repository push validation**
+
+Run:
+
+```powershell
+pnpm run validate:push
+```
+
+Expected: TypeScript compilation and `knip` both PASS. In particular, the new
+factory and singleton exports are both considered used.
+
+- [ ] **Step 4: Build every supported browser target**
+
+Run:
+
+```powershell
+pnpm run build:all
+```
+
+Expected: Chromium, Firefox, and Safari WXT builds PASS, proving `p-queue` is
+bundled correctly for each target and does not introduce a Node runtime import.
+
+- [ ] **Step 5: Inspect final repository state and task diff**
+
+Run:
+
+```powershell
+git status --porcelain
+git log -4 --oneline
+git diff HEAD~3..HEAD --check
+git diff HEAD~3..HEAD --stat
+```
+
+Expected: worktree and index are clean; the three implementation commits are
+present after the design/plan commits; diff check reports no whitespace errors;
+only the dependency, page scheduler, temp-window integration, scheduler, and
+focused tests changed.

--- a/docs/superpowers/specs/2026-07-17-temp-page-concurrency-design.md
+++ b/docs/superpowers/specs/2026-07-17-temp-page-concurrency-design.md
@@ -1,0 +1,158 @@
+# Temporary Page Concurrency Design
+
+Date: 2026-07-17
+
+## Purpose
+
+Prevent automatic check-in and account refresh work from opening or operating
+too many temporary browser pages at once without throttling ordinary API work
+at the scheduler layer.
+
+The current scheduler processes account check-ins in fixed batches of three
+with a 250 ms delay between batches. Post-checkin account refresh uses the same
+batch size. Each batch waits for its slowest item before the next batch starts,
+so completed slots cannot be refilled continuously. The limit also applies to
+API-only work even though the original resource failure involved providers that
+opened many browser pages concurrently.
+
+## Decision
+
+Remove both account-level batching policies from the auto-checkin scheduler and
+move resource admission to the layers that own the constrained resource:
+
+- API requests continue through the existing per-origin API transport limiter.
+- Self-contained temporary-page operations enter one background `p-queue` with
+  global concurrency `3`.
+- Temporary-page operations for the same origin execute serially because the
+  pool may reuse one tab for that origin.
+- The scheduler remains responsible only for account orchestration, error
+  isolation, result aggregation, retry state, post-checkin refresh, persistence,
+  and completion notification.
+
+The concurrency value is fixed. This slice does not inspect device performance,
+add system permissions, expose a setting, or implement adaptive scaling.
+
+## Scheduler Behavior
+
+Delete the scheduler-owned check-in batch size, inter-batch delay, generic batch
+processor, and batch-specific account runner.
+
+Eligible account check-ins start without an account-level batch barrier. Each
+account keeps its current independent error-to-result conversion so one
+unexpected rejection does not abort the run.
+
+Successful check-ins still trigger the existing best-effort forced account
+refresh before the completion notification. These refreshes also start without
+an account-level batch barrier. Refresh failures remain isolated and do not
+change check-in completion semantics.
+
+This preserves the business behavior introduced to update balances, quotas,
+health, and check-in status while removing duplicate resource policy from the
+scheduler.
+
+## Resource Boundaries
+
+### API requests
+
+The existing API transport limiter remains authoritative for API traffic. It
+limits each site origin independently, including API calls made during account
+refresh. No new cross-origin global network limit is added.
+
+If cross-origin API traffic later proves harmful, the appropriate extension
+point is the API transport layer rather than the auto-checkin scheduler.
+
+### Temporary-page operations
+
+One feature-owned queue in the background temp-window pool limits active,
+self-contained page operations to three. The queue covers the entire operation:
+
+1. wait for global and origin admission;
+2. acquire or reuse a temporary context;
+3. navigate, inspect, trigger, or fetch through the page;
+4. execute cleanup in the existing `finally` path;
+5. release the queue slot whether the operation succeeds or fails.
+
+The shared queue covers every pool path that calls `acquireTempContext`:
+
+- rendered-title reads;
+- site auto-detection page reads;
+- generic temp-window fetch;
+- native check-in page action;
+- Turnstile-assisted fetch.
+
+Queueing belongs inside these handlers/helpers rather than only at runtime
+message routing because background-local fallback code calls them directly.
+Queueing only context creation or acquisition is insufficient because it would
+release the slot before navigation and page work finish.
+
+### Same-origin serialization
+
+The existing origin lock protects pool bookkeeping only. It does not cover the
+full operation after acquisition, and concurrent requests can reuse the same
+tab. Add a separate per-origin operation queue with concurrency one.
+
+Origin admission must precede global admission so several same-origin tasks do
+not occupy all three global slots while waiting for one shared tab.
+
+Idle per-origin queues are removed after they drain so origins do not accumulate
+for the lifetime of the service worker.
+
+## Scope Boundary
+
+The limit applies to active page operations, not the exact number of physical
+tabs or windows still present in the browser. Existing delayed context cleanup
+may retain an idle context briefly after its operation releases a queue slot.
+
+`OpenTempWindow` and `CloseTempWindow` are excluded. They form a manual,
+cross-message lifecycle, so queueing only the open handler would limit creation
+momentarily rather than hold capacity until close. Strict physical-page limits
+or manual-page permits would require a separate lifecycle design.
+
+The queue is process-local like the existing temporary-context maps. MV3 service
+worker restart behavior is unchanged; no queue state is persisted and no
+keepalive mechanism is added.
+
+## Failure and Compatibility Behavior
+
+- A page-operation rejection releases both origin and global capacity.
+- Waiting tasks start as soon as capacity becomes available; there is no fixed
+  delay between tasks.
+- Invalid or policy-blocked requests return before consuming page capacity where
+  practical.
+- Existing force-close, delayed cleanup, suspend cleanup, Firefox behavior,
+  window/tab fallback, and response contracts remain unchanged.
+- API-only providers do not wait for temporary-page capacity.
+- The queue must bundle in Chromium, Firefox, and Safari WXT builds.
+
+## Testing
+
+Use TDD at the resource boundaries:
+
+- start four different-origin page tasks and prove only three enter page work;
+- complete one of the first three while the others remain pending and prove the
+  fourth starts immediately;
+- prove a rejected page task releases capacity;
+- prove two same-origin operations do not overlap while another origin can use
+  a free global slot;
+- prove each temp-page handler participates in the shared queue;
+- update scheduler tests to prove all eligible check-ins can be dispatched
+  without a batch delay while unexpected per-account failures remain isolated;
+- preserve post-checkin refresh, deduplication, and best-effort failure tests
+  without asserting fixed account batches.
+
+Focused Vitest tests are the primary coverage layer. No new Playwright scenario
+is planned because the contract is deterministic queue admission and scheduler
+orchestration, which browser-level E2E would test less precisely.
+
+Run related Vitest suites, dependency/build checks, `pnpm run validate:staged`,
+and `pnpm run validate:push` before handoff because the change adds a dependency
+and modifies background runtime behavior.
+
+## Release Readiness
+
+- Telemetry: reuse existing check-in and temporary-window result events; no new
+  event is needed for an internal scheduling change.
+- Settings search/deep links: not applicable; no setting is added.
+- Permissions: none; device CPU and memory APIs are not used.
+- Maintainability: centralize page admission in one feature-owned module and
+  remove scheduler batching rather than introducing another concurrency helper.

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "lucide-react": "^0.564.0",
     "marked": "16.4.0",
     "otpauth": "^9.5.0",
+    "p-queue": "9.3.1",
     "postcss": "^8.5.6",
     "posthog-js": "^1.392.0",
     "radix-ui": "^1.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,6 +116,9 @@ importers:
       otpauth:
         specifier: ^9.5.0
         version: 9.5.0
+      p-queue:
+        specifier: 9.3.1
+        version: 9.3.1
       postcss:
         specifier: ^8.5.6
         version: 8.5.6
@@ -5075,9 +5078,6 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
-  eventemitter3@5.0.1:
-    resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
-
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
@@ -7047,9 +7047,17 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
+  p-queue@9.3.1:
+    resolution: {integrity: sha512-POWdiIPmsUPGwb4FeQ4OBg46aqmcInSWe45CKDsGHiOBiVQM9chqfQTuqhuTzcg2Vz9faTI65at0KkVyVEiCHw==}
+    engines: {node: '>=20'}
+
   p-timeout@3.2.0:
     resolution: {integrity: sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==}
     engines: {node: '>=8'}
+
+  p-timeout@7.0.1:
+    resolution: {integrity: sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==}
+    engines: {node: '>=20'}
 
   package-json@10.0.1:
     resolution: {integrity: sha512-ua1L4OgXSBdsu1FPb7F3tYH0F48a6kxvod4pLUlGY9COeJAJQNX/sNH2IiEmsxw7lqYiAwrdHMjz1FctOsyDQg==}
@@ -14238,8 +14246,6 @@ snapshots:
 
   etag@1.8.1: {}
 
-  eventemitter3@5.0.1: {}
-
   eventemitter3@5.0.4: {}
 
   eventsource-parser@3.0.6: {}
@@ -15586,7 +15592,7 @@ snapshots:
     dependencies:
       cli-truncate: 5.1.1
       colorette: 2.0.20
-      eventemitter3: 5.0.1
+      eventemitter3: 5.0.4
       log-update: 6.1.0
       rfdc: 1.4.1
       wrap-ansi: 9.0.2
@@ -16630,9 +16636,16 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
+  p-queue@9.3.1:
+    dependencies:
+      eventemitter3: 5.0.4
+      p-timeout: 7.0.1
+
   p-timeout@3.2.0:
     dependencies:
       p-finally: 1.0.0
+
+  p-timeout@7.0.1: {}
 
   package-json@10.0.1:
     dependencies:

--- a/src/entrypoints/background/tempPageTaskScheduler.ts
+++ b/src/entrypoints/background/tempPageTaskScheduler.ts
@@ -1,0 +1,47 @@
+import PQueue from "p-queue"
+
+export const TEMP_PAGE_TASK_CONCURRENCY = 3
+
+export interface TempPageTaskScheduler {
+  run<T>(originKey: string, task: () => Promise<T>): Promise<T>
+}
+
+/** Adds a task to a queue while preserving task rejection semantics. */
+function enqueue<T>(queue: PQueue, task: () => Promise<T>): Promise<T> {
+  return queue.add(task)
+}
+
+/**
+ * Limits temporary-page work globally while serializing same-origin tasks that
+ * share a reusable tab.
+ */
+export function createTempPageTaskScheduler(
+  concurrency = TEMP_PAGE_TASK_CONCURRENCY,
+): TempPageTaskScheduler {
+  const globalQueue = new PQueue({ concurrency })
+  const originQueues = new Map<string, PQueue>()
+
+  return {
+    async run<T>(originKey: string, task: () => Promise<T>): Promise<T> {
+      let originQueue = originQueues.get(originKey)
+      if (!originQueue) {
+        originQueue = new PQueue({ concurrency: 1 })
+        originQueues.set(originKey, originQueue)
+      }
+
+      try {
+        return await enqueue(originQueue, () => enqueue(globalQueue, task))
+      } finally {
+        if (
+          originQueue.pending === 0 &&
+          originQueue.size === 0 &&
+          originQueues.get(originKey) === originQueue
+        ) {
+          originQueues.delete(originKey)
+        }
+      }
+    },
+  }
+}
+
+export const tempPageTaskScheduler = createTempPageTaskScheduler()

--- a/src/entrypoints/background/tempWindowPool.ts
+++ b/src/entrypoints/background/tempWindowPool.ts
@@ -95,6 +95,8 @@ import { sanitizeUrlForLog } from "~/utils/core/sanitizeUrlForLog"
 import { appendQueryParam } from "~/utils/core/url"
 import { t } from "~/utils/i18n/core"
 
+import { tempPageTaskScheduler } from "./tempPageTaskScheduler"
+
 /**
  * Unified logger scoped to background temp-window lifecycle and fetch helpers.
  */
@@ -380,7 +382,7 @@ async function navigateTempContextToPage(
 /**
  * 在临时上下文中渲染页面并读取真实的 document.title。
  */
-export async function handleTempWindowGetRenderedTitle(
+async function executeTempWindowGetRenderedTitle(
   request: TempWindowRenderedTitleParams,
   sendResponse: (response?: any) => void,
 ) {
@@ -434,6 +436,16 @@ export async function handleTempWindowGetRenderedTitle(
   }
 }
 
+/** Queues rendered-title work through the shared temp-page scheduler. */
+export async function handleTempWindowGetRenderedTitle(
+  request: TempWindowRenderedTitleParams,
+  sendResponse: (response?: any) => void,
+) {
+  await runTempPageHandler(request.originUrl, {}, () =>
+    executeTempWindowGetRenderedTitle(request, sendResponse),
+  )
+}
+
 /**
  * Log temporary window events through the unified logger.
  */
@@ -443,6 +455,16 @@ function logTempWindow(event: string, details?: Record<string, unknown>) {
   } catch {
     // ignore logging errors
   }
+}
+
+/** Runs one complete temp-page handler operation under its origin key. */
+async function runTempPageHandler(
+  url: string,
+  options: { incognito?: boolean },
+  task: () => Promise<void>,
+): Promise<void> {
+  const originKey = buildTempContextOriginKey(normalizeOrigin(url), options)
+  await tempPageTaskScheduler.run(originKey, task)
 }
 
 type TempContextSharedFields = {
@@ -1193,7 +1215,7 @@ export async function handleCloseTempWindow(
 /**
  * 自动检测站点类型与用户信息，通过临时上下文访问目标站点。
  */
-export async function handleAutoDetectSite(
+async function executeAutoDetectSite(
   request: any,
   sendResponse: (response?: any) => void,
 ) {
@@ -1253,10 +1275,22 @@ export async function handleAutoDetectSite(
   }
 }
 
+/** Queues site auto-detection through the shared temp-page scheduler. */
+export async function handleAutoDetectSite(
+  request: any,
+  sendResponse: (response?: any) => void,
+) {
+  await runTempPageHandler(
+    request.url,
+    { incognito: Boolean(request.useIncognito) },
+    () => executeAutoDetectSite(request, sendResponse),
+  )
+}
+
 /**
  * 在临时上下文中执行跨域 fetch 请求，用于绕过需要真实浏览器环境的接口访问。
  */
-export async function handleTempWindowFetch(
+async function executeTempWindowFetch(
   request: TempWindowFetchParams,
   sendResponse: (response?: any) => void,
 ) {
@@ -1414,6 +1448,18 @@ export async function handleTempWindowFetch(
   }
 }
 
+/** Queues a temp-page fetch through the shared temp-page scheduler. */
+export async function handleTempWindowFetch(
+  request: TempWindowFetchParams,
+  sendResponse: (response?: any) => void,
+) {
+  await runTempPageHandler(
+    request.originUrl,
+    { incognito: Boolean(request.useIncognito) },
+    () => executeTempWindowFetch(request, sendResponse),
+  )
+}
+
 /**
  * Resolves the logged-in account identity from a temporary page tab.
  */
@@ -1464,7 +1510,7 @@ async function resolveTempPageAccountIdentity(params: {
 /**
  * Opens a temporary page context and triggers the native check-in page action after identity verification.
  */
-export async function handleTempWindowCheckinPageAction(
+async function executeTempWindowCheckinPageAction(
   request: TempWindowCheckinPageActionParams,
   sendResponse: (response?: TempWindowCheckinPageAction) => void,
 ) {
@@ -1608,6 +1654,16 @@ export async function handleTempWindowCheckinPageAction(
   }
 }
 
+/** Queues a native check-in page action through the shared scheduler. */
+export async function handleTempWindowCheckinPageAction(
+  request: TempWindowCheckinPageActionParams,
+  sendResponse: (response?: TempWindowCheckinPageAction) => void,
+) {
+  await runTempPageHandler(request.pageUrl || request.originUrl, {}, () =>
+    executeTempWindowCheckinPageAction(request, sendResponse),
+  )
+}
+
 /**
  * Executes a Turnstile-assisted temp-context fetch.
  *
@@ -1615,7 +1671,7 @@ export async function handleTempWindowCheckinPageAction(
  * waits for protection guards to clear, waits for a Turnstile token in the
  * content script, then replays the target request in the same tab.
  */
-export async function handleTempWindowTurnstileFetch(
+async function executeTempWindowTurnstileFetch(
   request: TempWindowTurnstileFetchParams,
   sendResponse: (response?: any) => void,
 ) {
@@ -1853,6 +1909,18 @@ export async function handleTempWindowTurnstileFetch(
   }
 }
 
+/** Queues a Turnstile-assisted fetch through the shared scheduler. */
+export async function handleTempWindowTurnstileFetch(
+  request: TempWindowTurnstileFetchParams,
+  sendResponse: (response?: any) => void,
+) {
+  await runTempPageHandler(
+    request.pageUrl || request.originUrl,
+    { incognito: Boolean(request.useIncognito) },
+    () => executeTempWindowTurnstileFetch(request, sendResponse),
+  )
+}
+
 /**
  * 通过临时浏览上下文中的标签页获取站点用户信息
  * @param url 页面地址（含 origin），用于确定要获取或创建的临时上下文
@@ -2063,104 +2131,119 @@ async function releaseTempContext(
   requestId: string,
   options: { forceClose?: boolean; reason?: string } = {},
 ) {
+  if (options.forceClose) {
+    await executeTempContextRelease(requestId, options)
+    return
+  }
+
   logTempWindow("releaseTempContextScheduled", {
     requestId,
-    forceClose: Boolean(options.forceClose),
+    forceClose: false,
     reason: options.reason ?? null,
   })
   // 延迟释放，提高并发时的复用率
-  setTimeout(async () => {
-    const context = tempRequestContextMap.get(requestId)
-    tempRequestContextMap.delete(requestId)
+  setTimeout(() => {
+    void executeTempContextRelease(requestId, options).catch((error) => {
+      logger.error("Delayed temp context release failed", error)
+    })
+  }, 2000)
+}
 
-    if (!context) {
-      logTempWindow("releaseTempContextNoContext", {
+/** Executes the shared release operation after its timing policy is chosen. */
+async function executeTempContextRelease(
+  requestId: string,
+  options: { forceClose?: boolean; reason?: string },
+): Promise<void> {
+  const context = tempRequestContextMap.get(requestId)
+  tempRequestContextMap.delete(requestId)
+
+  if (!context) {
+    logTempWindow("releaseTempContextNoContext", {
+      requestId,
+      forceClose: Boolean(options.forceClose),
+      reason: options.reason ?? null,
+    })
+    return
+  }
+
+  await withOriginLock(context.origin, async () => {
+    context.activeRequestIds.delete(requestId)
+
+    if (!isTrackedContext(context)) {
+      logTempWindow("releaseTempContextAlreadyDestroyed", {
         requestId,
-        forceClose: Boolean(options.forceClose),
+        origin: context.origin,
+        contextId: context.id,
+        tabId: context.tabId,
+        type: context.type,
         reason: options.reason ?? null,
       })
       return
     }
 
-    await withOriginLock(context.origin, async () => {
-      context.activeRequestIds.delete(requestId)
-
-      if (!isTrackedContext(context)) {
-        logTempWindow("releaseTempContextAlreadyDestroyed", {
-          requestId,
-          origin: context.origin,
-          contextId: context.id,
-          tabId: context.tabId,
-          type: context.type,
-          reason: options.reason ?? null,
+    if (options.forceClose) {
+      logTempWindow("releaseTempContextForceClose", {
+        requestId,
+        origin: context.origin,
+        contextId: context.id,
+        tabId: context.tabId,
+        type: context.type,
+        reason: options.reason ?? null,
+      })
+      destroyingOrigins.add(context.origin)
+      try {
+        await destroyContext(context, {
+          reason: options.reason ?? "forceClose",
         })
-        return
+      } finally {
+        destroyingOrigins.delete(context.origin)
       }
+      return
+    }
 
-      if (options.forceClose) {
-        logTempWindow("releaseTempContextForceClose", {
-          requestId,
-          origin: context.origin,
-          contextId: context.id,
-          tabId: context.tabId,
-          type: context.type,
-          reason: options.reason ?? null,
-        })
-        destroyingOrigins.add(context.origin)
-        try {
-          await destroyContext(context, {
-            reason: options.reason ?? "forceClose",
-          })
-        } finally {
-          destroyingOrigins.delete(context.origin)
-        }
-        return
+    if (hasActiveRequests(context)) {
+      logTempWindow("releaseTempContextStillInUse", {
+        requestId,
+        origin: context.origin,
+        contextId: context.id,
+        tabId: context.tabId,
+        type: context.type,
+        reason: options.reason ?? null,
+        activeRequestCount: context.activeRequestIds.size,
+      })
+      return
+    }
+
+    context.lastUsed = Date.now()
+
+    const pool = tempContextsByOrigin.get(context.origin)
+    if (pool && pool.every(isContextIdle)) {
+      logTempWindow("releaseTempContextDestroyOriginPool", {
+        requestId,
+        origin: context.origin,
+        poolSize: pool.length,
+      })
+      // Mark this origin as destroying while we tear down the pool. Any
+      // concurrent acquire attempts for this origin will be rejected by
+      // acquireTempContext until destruction finishes.
+      destroyingOrigins.add(context.origin)
+      try {
+        await destroyOriginPool(context.origin, pool, "originPoolIdle")
+      } finally {
+        destroyingOrigins.delete(context.origin)
       }
-
-      if (hasActiveRequests(context)) {
-        logTempWindow("releaseTempContextStillInUse", {
-          requestId,
-          origin: context.origin,
-          contextId: context.id,
-          tabId: context.tabId,
-          type: context.type,
-          reason: options.reason ?? null,
-          activeRequestCount: context.activeRequestIds.size,
-        })
-        return
-      }
-
-      context.lastUsed = Date.now()
-
-      const pool = tempContextsByOrigin.get(context.origin)
-      if (pool && pool.every(isContextIdle)) {
-        logTempWindow("releaseTempContextDestroyOriginPool", {
-          requestId,
-          origin: context.origin,
-          poolSize: pool.length,
-        })
-        // Mark this origin as destroying while we tear down the pool. Any
-        // concurrent acquire attempts for this origin will be rejected by
-        // acquireTempContext until destruction finishes.
-        destroyingOrigins.add(context.origin)
-        try {
-          await destroyOriginPool(context.origin, pool, "originPoolIdle")
-        } finally {
-          destroyingOrigins.delete(context.origin)
-        }
-      } else {
-        logTempWindow("releaseTempContextScheduleIdleCleanup", {
-          requestId,
-          origin: context.origin,
-          contextId: context.id,
-          tabId: context.tabId,
-          type: context.type,
-          idleTimeoutMs: TEMP_CONTEXT_IDLE_TIMEOUT,
-        })
-        scheduleContextCleanup(context)
-      }
-    })
-  }, 2000)
+    } else {
+      logTempWindow("releaseTempContextScheduleIdleCleanup", {
+        requestId,
+        origin: context.origin,
+        contextId: context.id,
+        tabId: context.tabId,
+        type: context.type,
+        idleTimeoutMs: TEMP_CONTEXT_IDLE_TIMEOUT,
+      })
+      scheduleContextCleanup(context)
+    }
+  })
 }
 
 /**

--- a/src/services/checkin/autoCheckin/scheduler.ts
+++ b/src/services/checkin/autoCheckin/scheduler.ts
@@ -166,16 +166,13 @@ type PostCheckinRefreshOutcome = "refreshed" | "unchanged" | "failed"
  * - A separate *retry* alarm retries only the accounts that failed in today's normal run.
  */
 class AutoCheckinScheduler {
-  private static readonly CHECKIN_EXECUTION_BATCH_SIZE = 3
-  private static readonly CHECKIN_EXECUTION_BATCH_DELAY_MS = 250
-
   /**
    * Post-checkin account refresh to ensure balances/quotas reflect the effect of a successful check-in.
    *
    * Notes:
    * - This MUST NOT invoke provider `checkIn` again; it uses the existing account refresh pipeline.
    * - Best-effort: failures are swallowed so check-in completion semantics are unchanged.
-   * - Uses a small concurrency limit to avoid spiking network load when many accounts were checked in.
+   * - API/page resources are limited by their owning lower layers.
    */
   private async refreshAccountsAfterSuccessfulCheckins(params: {
     accountIds: string[]
@@ -195,24 +192,24 @@ class AutoCheckinScheduler {
       let failedCount = 0
 
       const force = params.force ?? true
-      const results = await this.processInBatches<
-        string,
-        PostCheckinRefreshOutcome
-      >({
-        items: uniqueAccountIds,
-        batchSize: AutoCheckinScheduler.CHECKIN_EXECUTION_BATCH_SIZE,
-        processItem: async (accountId) => {
-          const result = params.tempWindowRequestSource
-            ? await accountStorage.refreshAccount(accountId, force, {
-                tempWindowRequestSource: params.tempWindowRequestSource,
-              })
-            : await accountStorage.refreshAccount(accountId, force)
-          if (result?.refreshed === true) return "refreshed"
-          if (result == null) return "failed"
-          return "unchanged"
-        },
-        onItemError: () => "failed",
-      })
+      const results = await Promise.all(
+        uniqueAccountIds.map(
+          async (accountId): Promise<PostCheckinRefreshOutcome> => {
+            try {
+              const result = params.tempWindowRequestSource
+                ? await accountStorage.refreshAccount(accountId, force, {
+                    tempWindowRequestSource: params.tempWindowRequestSource,
+                  })
+                : await accountStorage.refreshAccount(accountId, force)
+              if (result?.refreshed === true) return "refreshed"
+              if (result == null) return "failed"
+              return "unchanged"
+            } catch {
+              return "failed"
+            }
+          },
+        ),
+      )
 
       for (const result of results) {
         if (result === "refreshed") {
@@ -1031,49 +1028,7 @@ class AutoCheckinScheduler {
     }
   }
 
-  private async processInBatches<TItem, TResult>(params: {
-    items: TItem[]
-    batchSize: number
-    processItem: (item: TItem) => Promise<TResult>
-    onItemError?: (error: unknown, item: TItem) => TResult | Promise<TResult>
-    delayBetweenBatchesMs?: number
-  }): Promise<TResult[]> {
-    const outcomes: TResult[] = []
-    const batchSize = Math.max(1, Math.floor(params.batchSize))
-    const delayBetweenBatchesMs = Math.max(0, params.delayBetweenBatchesMs ?? 0)
-
-    for (let index = 0; index < params.items.length; index += batchSize) {
-      const batch = params.items.slice(index, index + batchSize)
-      const batchOutcomes = await Promise.all(
-        batch.map(async (item) => {
-          try {
-            return await params.processItem(item)
-          } catch (error) {
-            if (!params.onItemError) {
-              throw error
-            }
-            return params.onItemError(error, item)
-          }
-        }),
-      )
-      outcomes.push(...batchOutcomes)
-
-      const hasMoreBatches = index + batchSize < params.items.length
-      if (hasMoreBatches && delayBetweenBatchesMs > 0) {
-        await this.delay(delayBetweenBatchesMs)
-      }
-    }
-
-    return outcomes
-  }
-
-  private async delay(ms: number): Promise<void> {
-    await new Promise<void>((resolve) => {
-      setTimeout(resolve, ms)
-    })
-  }
-
-  private async runAccountCheckinsInBatches(params: {
+  private async runAccountCheckins(params: {
     accounts: SiteAccount[]
     accountDisplayNameById: Map<string, string>
     tempWindowRequestSource: TempWindowRequestSource
@@ -1083,29 +1038,30 @@ class AutoCheckinScheduler {
       successful: boolean
     }>
   > {
-    return this.processInBatches({
-      items: params.accounts,
-      batchSize: AutoCheckinScheduler.CHECKIN_EXECUTION_BATCH_SIZE,
-      delayBetweenBatchesMs:
-        AutoCheckinScheduler.CHECKIN_EXECUTION_BATCH_DELAY_MS,
-      onItemError: (error, account) => ({
-        result: {
-          accountId: account.id,
-          accountName:
-            params.accountDisplayNameById.get(account.id) ?? account.id,
-          status: CHECKIN_RESULT_STATUS.FAILED,
-          rawMessage: getErrorMessage(error),
-          timestamp: Date.now(),
-        },
-        successful: false,
+    return Promise.all(
+      params.accounts.map(async (account) => {
+        const accountName =
+          params.accountDisplayNameById.get(account.id) ?? account.id
+        try {
+          return await this.runAccountCheckin(
+            account,
+            accountName,
+            params.tempWindowRequestSource,
+          )
+        } catch (error) {
+          return {
+            result: {
+              accountId: account.id,
+              accountName,
+              status: CHECKIN_RESULT_STATUS.FAILED,
+              rawMessage: getErrorMessage(error),
+              timestamp: Date.now(),
+            },
+            successful: false,
+          }
+        }
       }),
-      processItem: (account) =>
-        this.runAccountCheckin(
-          account,
-          params.accountDisplayNameById.get(account.id) ?? account.id,
-          params.tempWindowRequestSource,
-        ),
-    })
+    )
   }
 
   /**
@@ -2150,11 +2106,11 @@ class AutoCheckinScheduler {
         return
       }
 
-      // Execute check-ins in small batches because some providers open pages.
+      // API/page resources are limited by their owning lower layers.
       let successCount = 0
       let failedCount = 0
 
-      const checkinOutcomes = await this.runAccountCheckinsInBatches({
+      const checkinOutcomes = await this.runAccountCheckins({
         accounts: runnableAccounts,
         accountDisplayNameById,
         tempWindowRequestSource,

--- a/tests/entrypoints/background/tempPageTaskScheduler.test.ts
+++ b/tests/entrypoints/background/tempPageTaskScheduler.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  createTempPageTaskScheduler,
+  TEMP_PAGE_TASK_CONCURRENCY,
+  type TempPageTaskScheduler,
+} from "~/entrypoints/background/tempPageTaskScheduler"
+
+interface Deferred<T> {
+  promise: Promise<T>
+  reject: (reason?: unknown) => void
+  resolve: (value: T | PromiseLike<T>) => void
+}
+
+function createDeferred<T>(): Deferred<T> {
+  let resolve!: Deferred<T>["resolve"]
+  let reject!: Deferred<T>["reject"]
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve
+    reject = promiseReject
+  })
+
+  return { promise, reject, resolve }
+}
+
+describe("createTempPageTaskScheduler", () => {
+  it("limits global concurrency to three and refills a slot as soon as any task finishes", async () => {
+    const scheduler: TempPageTaskScheduler = createTempPageTaskScheduler()
+    const controls = Array.from({ length: 4 }, () => createDeferred<void>())
+    const started: number[] = []
+    let active = 0
+    let maxActive = 0
+
+    expect(TEMP_PAGE_TASK_CONCURRENCY).toBe(3)
+
+    const tasks = controls.map((control, index) =>
+      scheduler.run(`https://site-${index + 1}.example.invalid`, async () => {
+        started.push(index + 1)
+        active += 1
+        maxActive = Math.max(maxActive, active)
+        await control.promise
+        active -= 1
+      }),
+    )
+
+    await vi.waitFor(() => {
+      expect(started).toEqual([1, 2, 3])
+    })
+    expect(maxActive).toBe(3)
+
+    controls[1].resolve()
+
+    await vi.waitFor(() => {
+      expect(started).toEqual([1, 2, 3, 4])
+    })
+    expect(maxActive).toBe(3)
+
+    controls[0].resolve()
+    controls[2].resolve()
+    controls[3].resolve()
+    await expect(Promise.all(tasks)).resolves.toEqual([
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+    ])
+  })
+
+  it("serializes same-origin tasks without consuming a global slot while they wait", async () => {
+    const scheduler = createTempPageTaskScheduler(2)
+    const firstControl = createDeferred<void>()
+    const otherControl = createDeferred<void>()
+    const firstTask = vi.fn(async () => firstControl.promise)
+    const queuedSameOriginTask = vi.fn(async () => undefined)
+    const otherOriginTask = vi.fn(async () => otherControl.promise)
+
+    const first = scheduler.run("https://site-1.example.invalid", firstTask)
+    const queuedSameOrigin = scheduler.run(
+      "https://site-1.example.invalid",
+      queuedSameOriginTask,
+    )
+    const otherOrigin = scheduler.run(
+      "https://site-2.example.invalid",
+      otherOriginTask,
+    )
+
+    await vi.waitFor(() => {
+      expect(firstTask).toHaveBeenCalledOnce()
+      expect(otherOriginTask).toHaveBeenCalledOnce()
+    })
+    expect(queuedSameOriginTask).not.toHaveBeenCalled()
+
+    firstControl.resolve()
+    await expect(first).resolves.toBeUndefined()
+    await expect(queuedSameOrigin).resolves.toBeUndefined()
+
+    otherControl.resolve()
+    await expect(otherOrigin).resolves.toBeUndefined()
+  })
+
+  it("releases global and origin capacity after rejection so queued same-origin work can run", async () => {
+    const scheduler = createTempPageTaskScheduler(1)
+    const failureControl = createDeferred<void>()
+    const succeedingTask = vi.fn(async () => "succeeded")
+
+    const failing = scheduler.run(
+      "https://site-1.example.invalid",
+      async () => failureControl.promise,
+    )
+    const failureAssertion = expect(failing).rejects.toThrow("task failed")
+    const succeeding = scheduler.run(
+      "https://site-1.example.invalid",
+      succeedingTask,
+    )
+
+    failureControl.reject(new Error("task failed"))
+
+    await failureAssertion
+    await expect(succeeding).resolves.toBe("succeeded")
+    expect(succeedingTask).toHaveBeenCalledOnce()
+  })
+})

--- a/tests/entrypoints/background/tempWindowPoolWindowFallback.test.ts
+++ b/tests/entrypoints/background/tempWindowPoolWindowFallback.test.ts
@@ -2862,6 +2862,64 @@ describe("tempWindowPool window fallback", () => {
     expect(fetchCalls.at(-1)?.[0]).toBe(709)
   })
 
+  it("ignores a delayed release after stale-context replacement", async () => {
+    tempContextMode = "tab"
+    createTabMock
+      .mockResolvedValueOnce({ id: 710 })
+      .mockResolvedValueOnce({ id: 711 })
+
+    const { handleTempWindowFetch } = await import(
+      "~/entrypoints/background/tempWindowPool"
+    )
+
+    const firstResponse = vi.fn()
+    const firstRequest = handleTempWindowFetch(
+      {
+        originUrl: "https://example.com",
+        fetchUrl: "https://example.com/api/delayed-release",
+        fetchOptions: { method: "GET" },
+        requestId: "req-delayed-release-1",
+      },
+      firstResponse,
+    )
+    await vi.advanceTimersByTimeAsync(500)
+    await firstRequest
+
+    const staleTabCheck = createDeferred<{ status: string }>()
+    tabsGetMock.mockImplementationOnce(() => staleTabCheck.promise)
+
+    const secondResponse = vi.fn()
+    const secondRequest = handleTempWindowFetch(
+      {
+        originUrl: "https://example.com",
+        fetchUrl: "https://example.com/api/stale-replacement",
+        fetchOptions: { method: "GET" },
+        requestId: "req-delayed-release-2",
+      },
+      secondResponse,
+    )
+
+    await vi.advanceTimersByTimeAsync(0)
+    expect(createTabMock).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(2000)
+    staleTabCheck.reject(new Error("tab disappeared during reuse"))
+    await vi.advanceTimersByTimeAsync(500)
+    await secondRequest
+
+    expect(createTabMock).toHaveBeenCalledTimes(2)
+    expect(sendMessageMock.mock.calls.at(-1)?.[0]).toBe(711)
+    expect(secondResponse).toHaveBeenCalledWith({
+      success: true,
+      data: {
+        success: true,
+        message: "",
+        data: "ok",
+      },
+    })
+    expect(removeTabMock).not.toHaveBeenCalledWith(710)
+  })
+
   it("omits abort signals from content temp fetch messages", async () => {
     tempContextMode = "tab"
     createTabMock.mockResolvedValueOnce({ id: 605 })

--- a/tests/entrypoints/background/tempWindowPoolWindowFallback.test.ts
+++ b/tests/entrypoints/background/tempWindowPoolWindowFallback.test.ts
@@ -2425,19 +2425,21 @@ describe("tempWindowPool window fallback", () => {
     })
   })
 
-  it("defers same-origin cleanup while a reused temp tab is still busy", async () => {
+  it("serializes complete operations that reuse a same-origin temp tab", async () => {
     tempContextMode = "tab"
     createTabMock.mockResolvedValueOnce({ id: 608 })
 
-    const secondFetchDeferred = createDeferred<{
-      success: boolean
-      data: {
+    const fetchDeferreds = Array.from({ length: 2 }, () =>
+      createDeferred<{
         success: boolean
-        message: string
-        data: string
-      }
-    }>()
-    let fetchAttempt = 0
+        data: {
+          success: boolean
+          message: string
+          data: string
+        }
+      }>(),
+    )
+    let fetchAttempts = 0
     sendMessageMock.mockImplementation(
       async (_tabId: number, message: { action: string }) => {
         switch (message.action) {
@@ -2459,19 +2461,7 @@ describe("tempWindowPool window fallback", () => {
               },
             }
           case RuntimeActionIds.ContentPerformTempWindowFetch:
-            fetchAttempt += 1
-            if (fetchAttempt === 1) {
-              return {
-                success: true,
-                data: {
-                  success: true,
-                  message: "",
-                  data: "first-result",
-                },
-              }
-            }
-
-            return secondFetchDeferred.promise
+            return fetchDeferreds[fetchAttempts++].promise
           default:
             throw new Error(`Unexpected action: ${message.action}`)
         }
@@ -2485,39 +2475,44 @@ describe("tempWindowPool window fallback", () => {
     const firstResponse = vi.fn()
     const firstRequest = handleTempWindowFetch(
       {
-        originUrl: "https://example.com/one",
-        fetchUrl: "https://example.com/api/one",
+        originUrl: "https://example.invalid/one",
+        fetchUrl: "https://example.invalid/api/one",
         fetchOptions: { method: "GET" },
         requestId: "req-overlap-1",
       },
       firstResponse,
     )
     await vi.advanceTimersByTimeAsync(500)
-    await firstRequest
 
     const secondResponse = vi.fn()
     const secondRequest = handleTempWindowFetch(
       {
-        originUrl: "https://example.com/two",
-        fetchUrl: "https://example.com/api/two",
+        originUrl: "https://example.invalid/two",
+        fetchUrl: "https://example.invalid/api/two",
         fetchOptions: { method: "GET" },
         requestId: "req-overlap-2",
       },
       secondResponse,
     )
-    await vi.advanceTimersByTimeAsync(1000)
+    await vi.advanceTimersByTimeAsync(500)
 
-    expect(createTabMock).toHaveBeenCalledTimes(1)
-    expect(fetchAttempt).toBe(2)
+    expect(fetchAttempts).toBe(1)
     expect(secondResponse).not.toHaveBeenCalled()
 
-    await vi.advanceTimersByTimeAsync(1500)
-    expect(removeTabOrWindowMock).not.toHaveBeenCalled()
+    fetchDeferreds[0].resolve({
+      success: true,
+      data: {
+        success: true,
+        message: "",
+        data: "first-result",
+      },
+    })
+    await firstRequest
+    await vi.advanceTimersByTimeAsync(500)
 
-    await vi.advanceTimersByTimeAsync(5000)
-    expect(removeTabOrWindowMock).not.toHaveBeenCalled()
+    expect(fetchAttempts).toBe(2)
 
-    secondFetchDeferred.resolve({
+    fetchDeferreds[1].resolve({
       success: true,
       data: {
         success: true,
@@ -2527,34 +2522,16 @@ describe("tempWindowPool window fallback", () => {
     })
     await secondRequest
 
-    await vi.advanceTimersByTimeAsync(2500)
-    expect(removeTabMock).toHaveBeenCalledTimes(1)
-    expect(removeTabMock).toHaveBeenCalledWith(608)
-    expect(secondResponse).toHaveBeenCalledWith({
-      success: true,
-      data: {
-        success: true,
-        message: "",
-        data: "second-result",
-      },
-    })
+    expect(createTabMock).toHaveBeenCalledTimes(1)
   })
 
-  it("force-closing one shared temp tab clears the other request mapping and requires a fresh context next time", async () => {
+  it("recreates a context for queued same-origin work after force close", async () => {
     tempContextMode = "tab"
     createTabMock
       .mockResolvedValueOnce({ id: 650 })
       .mockResolvedValueOnce({ id: 651 })
 
     const firstFetchDeferred = createDeferred<{
-      success: boolean
-      data: {
-        success: boolean
-        message: string
-        data: string
-      }
-    }>()
-    const secondFetchDeferred = createDeferred<{
       success: boolean
       data: {
         success: boolean
@@ -2577,22 +2554,14 @@ describe("tempWindowPool window fallback", () => {
               return firstFetchDeferred.promise
             }
 
-            if (fetchAttempt === 2) {
-              return secondFetchDeferred.promise
-            }
-
-            if (fetchAttempt === 3) {
-              return {
+            return {
+              success: true,
+              data: {
                 success: true,
-                data: {
-                  success: true,
-                  message: "",
-                  data: `result-${fetchAttempt}`,
-                },
-              }
+                message: "",
+                data: "recovered-result",
+              },
             }
-
-            return secondFetchDeferred.promise
           default:
             throw new Error(`Unexpected action: ${message.action}`)
         }
@@ -2606,8 +2575,8 @@ describe("tempWindowPool window fallback", () => {
     const firstResponse = vi.fn()
     const firstRequest = handleTempWindowFetch(
       {
-        originUrl: "https://example.com/force-close-one",
-        fetchUrl: "https://example.com/api/force-close-one",
+        originUrl: "https://example.invalid/force-close-one",
+        fetchUrl: "https://example.invalid/api/force-close-one",
         fetchOptions: { method: "GET" },
         requestId: "req-force-close-1",
       },
@@ -2618,8 +2587,8 @@ describe("tempWindowPool window fallback", () => {
     const secondResponse = vi.fn()
     const secondRequest = handleTempWindowFetch(
       {
-        originUrl: "https://example.com/force-close-two",
-        fetchUrl: "https://example.com/api/force-close-two",
+        originUrl: "https://example.invalid/force-close-two",
+        fetchUrl: "https://example.invalid/api/force-close-two",
         fetchOptions: { method: "GET" },
         requestId: "req-force-close-2",
       },
@@ -2628,6 +2597,7 @@ describe("tempWindowPool window fallback", () => {
     await vi.advanceTimersByTimeAsync(500)
 
     expect(createTabMock).toHaveBeenCalledTimes(1)
+    expect(fetchAttempt).toBe(1)
     expect(secondResponse).not.toHaveBeenCalled()
 
     const closeResponse = vi.fn()
@@ -2638,65 +2608,211 @@ describe("tempWindowPool window fallback", () => {
 
     expect(closeResponse).toHaveBeenCalledWith({ success: true })
 
-    await vi.advanceTimersByTimeAsync(2000)
     expect(removeTabMock).toHaveBeenCalledTimes(1)
     expect(removeTabMock).toHaveBeenCalledWith(650)
 
-    const otherCloseResponse = vi.fn()
-    await handleCloseTempWindow(
-      { requestId: "req-force-close-2" },
-      otherCloseResponse,
-    )
-
-    expect(otherCloseResponse).toHaveBeenCalledWith({
-      success: false,
-      error: "messages:background.windowNotFound",
-    })
-
-    firstFetchDeferred.reject(new Error("shared temp tab was force-closed"))
-    secondFetchDeferred.reject(new Error("shared temp tab was force-closed"))
-    await Promise.all([firstRequest, secondRequest])
+    firstFetchDeferred.reject(new Error("active temp tab was force-closed"))
+    await firstRequest
+    await vi.advanceTimersByTimeAsync(500)
+    await secondRequest
 
     expect(firstResponse).toHaveBeenCalledWith({
       success: false,
-      error: "shared temp tab was force-closed",
+      error: "active temp tab was force-closed",
       code: undefined,
     })
     expect(secondResponse).toHaveBeenCalledWith({
-      success: false,
-      error: "shared temp tab was force-closed",
-      code: undefined,
-    })
-
-    await vi.advanceTimersByTimeAsync(2000)
-    expect(removeTabMock).toHaveBeenCalledTimes(1)
-
-    const thirdResponse = vi.fn()
-    const thirdRequest = handleTempWindowFetch(
-      {
-        originUrl: "https://example.com/force-close-three",
-        fetchUrl: "https://example.com/api/force-close-three",
-        fetchOptions: { method: "GET" },
-        requestId: "req-force-close-3",
-      },
-      thirdResponse,
-    )
-    await vi.advanceTimersByTimeAsync(500)
-    await thirdRequest
-
-    expect(createTabMock).toHaveBeenCalledTimes(2)
-    expect(createTabMock).toHaveBeenLastCalledWith("about:blank", false)
-    expect(tabsUpdateMock).toHaveBeenCalledWith(651, {
-      url: "https://example.com/force-close-three",
-    })
-    expect(thirdResponse).toHaveBeenCalledWith({
       success: true,
       data: {
         success: true,
         message: "",
-        data: "result-3",
+        data: "recovered-result",
       },
     })
+    expect(createTabMock).toHaveBeenCalledTimes(2)
+    expect(fetchAttempt).toBe(2)
+  })
+
+  it("recreates a fresh context before refilling queued same-origin work after a natural handler error", async () => {
+    tempContextMode = "tab"
+    createTabMock
+      .mockResolvedValueOnce({ id: 660 })
+      .mockResolvedValueOnce({ id: 661 })
+
+    const fetchDeferreds = Array.from({ length: 2 }, () =>
+      createDeferred<{
+        success: boolean
+        data: {
+          success: boolean
+          message: string
+          data: string
+        }
+      }>(),
+    )
+    let fetchAttempts = 0
+    sendMessageMock.mockImplementation(
+      async (_tabId: number, message: { action: string }) => {
+        switch (message.action) {
+          case RuntimeActionIds.ContentShowShieldBypassUi:
+            return undefined
+          case RuntimeActionIds.ContentCheckCapGuard:
+          case RuntimeActionIds.ContentCheckCloudflareGuard:
+            return { success: true, passed: true }
+          case RuntimeActionIds.ContentPerformTempWindowFetch:
+            return fetchDeferreds[fetchAttempts++].promise
+          default:
+            throw new Error(`Unexpected action: ${message.action}`)
+        }
+      },
+    )
+
+    const { handleTempWindowFetch } = await import(
+      "~/entrypoints/background/tempWindowPool"
+    )
+
+    const firstResponse = vi.fn()
+    const firstRequest = handleTempWindowFetch(
+      {
+        originUrl: "https://example.invalid/natural-error-one",
+        fetchUrl: "https://example.invalid/api/natural-error-one",
+        fetchOptions: { method: "GET" },
+        requestId: "req-natural-error-1",
+      },
+      firstResponse,
+    )
+    await vi.advanceTimersByTimeAsync(500)
+
+    const secondResponse = vi.fn()
+    const secondRequest = handleTempWindowFetch(
+      {
+        originUrl: "https://example.invalid/natural-error-two",
+        fetchUrl: "https://example.invalid/api/natural-error-two",
+        fetchOptions: { method: "GET" },
+        requestId: "req-natural-error-2",
+      },
+      secondResponse,
+    )
+    await vi.advanceTimersByTimeAsync(500)
+
+    expect(fetchAttempts).toBe(1)
+
+    fetchDeferreds[0].reject(new Error("natural temp fetch failed"))
+    await firstRequest
+    await vi.advanceTimersByTimeAsync(500)
+
+    const fetchTabIds = sendMessageMock.mock.calls
+      .filter(
+        ([, message]) =>
+          message.action === RuntimeActionIds.ContentPerformTempWindowFetch,
+      )
+      .map(([tabId]) => tabId)
+    expect(fetchTabIds).toEqual([660, 661])
+    expect(createTabMock).toHaveBeenCalledTimes(2)
+    expect(removeTabMock).toHaveBeenCalledTimes(1)
+    expect(removeTabMock).toHaveBeenCalledWith(660)
+
+    await vi.advanceTimersByTimeAsync(2000)
+
+    expect(removeTabMock).toHaveBeenCalledTimes(1)
+    expect(removeTabMock).not.toHaveBeenCalledWith(661)
+    expect(secondResponse).not.toHaveBeenCalled()
+
+    fetchDeferreds[1].resolve({
+      success: true,
+      data: {
+        success: true,
+        message: "",
+        data: "recovered-after-natural-error",
+      },
+    })
+    await secondRequest
+
+    expect(firstResponse).toHaveBeenCalledWith({
+      success: false,
+      error: "natural temp fetch failed",
+      code: undefined,
+    })
+    expect(secondResponse).toHaveBeenCalledWith({
+      success: true,
+      data: {
+        success: true,
+        message: "",
+        data: "recovered-after-natural-error",
+      },
+    })
+  })
+
+  it("limits active temp-page handlers to three and continuously refills capacity", async () => {
+    tempContextMode = "tab"
+    createTabMock.mockImplementation(async () => ({
+      id: 700 + createTabMock.mock.calls.length,
+    }))
+
+    const fetchDeferreds = Array.from({ length: 4 }, () =>
+      createDeferred<{
+        success: boolean
+        data: {
+          success: boolean
+          message: string
+          data: string
+        }
+      }>(),
+    )
+    let fetchAttempts = 0
+    sendMessageMock.mockImplementation(
+      async (_tabId: number, message: { action: string }) => {
+        switch (message.action) {
+          case RuntimeActionIds.ContentShowShieldBypassUi:
+            return undefined
+          case RuntimeActionIds.ContentCheckCapGuard:
+          case RuntimeActionIds.ContentCheckCloudflareGuard:
+            return { success: true, passed: true }
+          case RuntimeActionIds.ContentPerformTempWindowFetch:
+            return fetchDeferreds[fetchAttempts++].promise
+          default:
+            throw new Error(`Unexpected action: ${message.action}`)
+        }
+      },
+    )
+
+    const { handleTempWindowFetch } = await import(
+      "~/entrypoints/background/tempWindowPool"
+    )
+
+    const requests = Array.from({ length: 4 }, (_, index) => {
+      const siteNumber = index + 1
+      return handleTempWindowFetch(
+        {
+          originUrl: `https://site-${siteNumber}.example.invalid`,
+          fetchUrl: `https://site-${siteNumber}.example.invalid/api/data`,
+          fetchOptions: { method: "GET" },
+          requestId: `req-global-limit-${siteNumber}`,
+        },
+        vi.fn(),
+      )
+    })
+
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(fetchAttempts).toBe(3)
+
+    fetchDeferreds[0].resolve({
+      success: true,
+      data: { success: true, message: "", data: "result-1" },
+    })
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(fetchAttempts).toBe(4)
+
+    fetchDeferreds.slice(1).forEach((deferred, index) => {
+      deferred.resolve({
+        success: true,
+        data: {
+          success: true,
+          message: "",
+          data: `result-${index + 2}`,
+        },
+      })
+    })
+    await Promise.all(requests)
   })
 
   it("drops a stale pooled context and creates a fresh tab for the next same-origin fetch", async () => {

--- a/tests/services/autoCheckin/scheduler.test.ts
+++ b/tests/services/autoCheckin/scheduler.test.ts
@@ -173,6 +173,17 @@ const mockedProductAnalytics = {
     trackProductAnalyticsEvent as unknown as ReturnType<typeof vi.fn>,
 }
 
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+
+  return { promise, resolve, reject }
+}
+
 let storedStatus: any = null
 let alarmStore: Record<string, any> = {}
 
@@ -1089,11 +1100,12 @@ describe("autoCheckinScheduler daily+retry behavior", () => {
     vi.useRealTimers()
   })
 
-  it("limits concurrent account check-ins during daily runs", async () => {
+  it("dispatches every eligible account without a scheduler batch barrier", async () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date(2024, 0, 1, 9, 0, 0))
 
     mockedUserPreferences.getPreferences.mockResolvedValue({
+      ...(DEFAULT_PREFERENCES as any),
       autoCheckin: {
         ...(DEFAULT_PREFERENCES as any).autoCheckin,
         globalEnabled: true,
@@ -1116,22 +1128,16 @@ describe("autoCheckinScheduler daily+retry behavior", () => {
     }))
     mockedAccountStorage.getAllAccounts.mockResolvedValue(accounts)
 
-    const resolvers: Array<() => void> = []
-    let inFlight = 0
-    let maxInFlight = 0
+    const deferredCheckins: Array<
+      ReturnType<typeof createDeferred<{ status: "success" }>>
+    > = []
     const provider = {
       canCheckIn: vi.fn(() => true),
-      checkIn: vi.fn(
-        () =>
-          new Promise<{ status: "success" }>((resolve) => {
-            inFlight += 1
-            maxInFlight = Math.max(maxInFlight, inFlight)
-            resolvers.push(() => {
-              inFlight -= 1
-              resolve({ status: "success" })
-            })
-          }),
-      ),
+      checkIn: vi.fn(() => {
+        const deferred = createDeferred<{ status: "success" }>()
+        deferredCheckins.push(deferred)
+        return deferred.promise
+      }),
     }
     mockedProviders.resolveAutoCheckinProvider.mockReturnValue(provider)
 
@@ -1139,35 +1145,26 @@ describe("autoCheckinScheduler daily+retry behavior", () => {
       runType: AUTO_CHECKIN_RUN_TYPE.DAILY,
     })
 
-    await vi.waitFor(() => {
-      expect(provider.checkIn).toHaveBeenCalledTimes(3)
-    })
-    expect(maxInFlight).toBeLessThanOrEqual(3)
+    try {
+      await vi.waitFor(() => {
+        expect(provider.checkIn).toHaveBeenCalledTimes(5)
+      })
+      deferredCheckins.forEach((deferred) => {
+        deferred.resolve({ status: "success" })
+      })
+      await runPromise
 
-    resolvers.splice(0).forEach((resolve) => resolve())
-    await vi.advanceTimersByTimeAsync(0)
-    expect(provider.checkIn).toHaveBeenCalledTimes(3)
-
-    await vi.advanceTimersByTimeAsync(250)
-    expect(provider.checkIn).toHaveBeenCalledTimes(5)
-    expect(maxInFlight).toBeLessThanOrEqual(3)
-
-    resolvers.splice(0).forEach((resolve) => resolve())
-    await runPromise
-
-    expect(storedStatus.summary).toMatchObject({
-      executed: 5,
-      successCount: 5,
-      failedCount: 0,
-    })
-
-    vi.useRealTimers()
+      expect(storedStatus.summary).toMatchObject({
+        executed: 5,
+        successCount: 5,
+        failedCount: 0,
+      })
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
-  it("continues later check-in batches when one account task rejects unexpectedly", async () => {
-    vi.useFakeTimers()
-    vi.setSystemTime(new Date(2024, 0, 1, 9, 0, 0))
-
+  it("isolates an unexpected account rejection without aborting the run", async () => {
     mockedUserPreferences.getPreferences.mockResolvedValue({
       autoCheckin: {
         ...(DEFAULT_PREFERENCES as any).autoCheckin,
@@ -1216,11 +1213,9 @@ describe("autoCheckinScheduler daily+retry behavior", () => {
         }
       })
 
-    const runPromise = autoCheckinScheduler.runCheckins({
+    await autoCheckinScheduler.runCheckins({
       runType: AUTO_CHECKIN_RUN_TYPE.DAILY,
     })
-    await vi.advanceTimersByTimeAsync(250)
-    await runPromise
 
     expect(runAccountCheckinSpy).toHaveBeenCalledTimes(4)
     expect(storedStatus.lastRunResult).toBe("partial")
@@ -1235,7 +1230,6 @@ describe("autoCheckinScheduler daily+retry behavior", () => {
     })
 
     runAccountCheckinSpy.mockRestore()
-    vi.useRealTimers()
   })
 
   it("does not create a retry queue when daily failures already reached the max-attempts boundary", async () => {
@@ -5356,21 +5350,31 @@ describe("autoCheckinScheduler private helpers", () => {
     vi.clearAllMocks()
   })
 
-  it("preserves a temp window source through post-checkin refresh batches", async () => {
-    mockedAccountStorage.refreshAccount
-      .mockResolvedValueOnce({ refreshed: true })
-      .mockResolvedValueOnce(null)
-      .mockRejectedValueOnce(new Error("refresh failed"))
+  it("dispatches post-checkin refreshes concurrently with best-effort isolation", async () => {
+    type ObservableRefreshResult = Pick<
+      NonNullable<Awaited<ReturnType<typeof accountStorage.refreshAccount>>>,
+      "refreshed"
+    > | null
+    const deferredRefreshes = Array.from({ length: 4 }, () =>
+      createDeferred<ObservableRefreshResult>(),
+    )
+    let refreshIndex = 0
+    mockedAccountStorage.refreshAccount.mockImplementation(
+      () => deferredRefreshes[refreshIndex++].promise,
+    )
 
-    await expect(
-      (autoCheckinScheduler as any).refreshAccountsAfterSuccessfulCheckins({
-        accountIds: ["a", "a", " ", "b", "c"],
-        force: false,
-        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
-      }),
-    ).resolves.toBeUndefined()
+    const refreshPromise = (
+      autoCheckinScheduler as any
+    ).refreshAccountsAfterSuccessfulCheckins({
+      accountIds: ["a", "a", " ", "b", "c", "d"],
+      force: false,
+      tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+    })
 
-    expect(mockedAccountStorage.refreshAccount).toHaveBeenCalledTimes(3)
+    await vi.waitFor(() => {
+      expect(mockedAccountStorage.refreshAccount).toHaveBeenCalledTimes(4)
+    })
+
     expect(mockedAccountStorage.refreshAccount).toHaveBeenNthCalledWith(
       1,
       "a",
@@ -5395,6 +5399,21 @@ describe("autoCheckinScheduler private helpers", () => {
         tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
       },
     )
+    expect(mockedAccountStorage.refreshAccount).toHaveBeenNthCalledWith(
+      4,
+      "d",
+      false,
+      {
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+      },
+    )
+
+    deferredRefreshes[0].resolve({ refreshed: true })
+    deferredRefreshes[1].resolve(null)
+    deferredRefreshes[2].reject(new Error("refresh failed"))
+    deferredRefreshes[3].resolve({ refreshed: false })
+
+    await expect(refreshPromise).resolves.toBeUndefined()
   })
 
   it("defaults post-checkin refreshes to force=true when no force flag is provided", async () => {
@@ -5422,18 +5441,6 @@ describe("autoCheckinScheduler private helpers", () => {
     ).resolves.toBeUndefined()
 
     expect(mockedAccountStorage.refreshAccount).not.toHaveBeenCalled()
-  })
-
-  it("propagates batch item failures when no item fallback is provided", async () => {
-    await expect(
-      (autoCheckinScheduler as any).processInBatches({
-        items: ["account-1"],
-        batchSize: 3,
-        processItem: async () => {
-          throw new Error("batch item failed")
-        },
-      }),
-    ).rejects.toThrow("batch item failed")
   })
 
   it("parses time strings and rejects invalid hour or minute values", () => {
@@ -5781,7 +5788,7 @@ describe("autoCheckinScheduler private helpers", () => {
     expect(throwingProvider.checkIn).toHaveBeenCalledTimes(1)
   })
 
-  it("retains one normalized source across account batches", async () => {
+  it("retains one normalized source across account dispatch", async () => {
     const accounts = [
       { id: "source-a", site_name: "Source A" },
       { id: "source-b", site_name: "Source B" },
@@ -5791,7 +5798,7 @@ describe("autoCheckinScheduler private helpers", () => {
     }
     mockedProviders.resolveAutoCheckinProvider.mockReturnValue(provider as any)
 
-    await (autoCheckinScheduler as any).runAccountCheckinsInBatches({
+    await (autoCheckinScheduler as any).runAccountCheckins({
       accounts,
       accountDisplayNameById: new Map([
         ["source-a", "Source A"],

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -68,7 +68,8 @@ export default defineConfig({
       browser_specific_settings: {
         gecko: {
           id: "{bc73541a-133d-4b50-b261-36ea20df0d24}",
-          strict_min_version: "58.0",
+          // Firefox 104 covers the current Vite baseline and p-queue 9 runtime APIs.
+          strict_min_version: "104.0",
         },
         gecko_android: {
           strict_min_version: "120.0",


### PR DESCRIPTION
## Summary

- move temporary-page resource admission into one background scheduler with global concurrency 3 and per-origin serialization
- route rendered-title, auto-detect, generic fetch, native check-in, and Turnstile page operations through the shared scheduler
- remove account-level check-in and refresh batches while preserving per-item failure isolation, summaries, and telemetry
- raise the Firefox desktop minimum version from 58 to 104 for the `p-queue` 9 runtime

## Why

The previous fixed batches applied the page-resource limit to API-only work and waited for each batch's slowest account before refilling capacity. This change places admission at the constrained resource boundary so temporary-page slots refill continuously while ordinary API work continues through the existing transport limiter.

## Validation

- [x] focused Vitest regression suites: 8 files, 272 tests passed
- [x] `pnpm run validate:push`
- [x] `pnpm run build:all` (Chromium, Firefox, Safari)
- [ ] `pnpm test:ci` — the local parallel coverage run produced temp-window test timeouts and cascading mock-count failures; the affected NativeCheckin and OpenClose files passed when rerun independently

## Compatibility

- Firefox desktop now requires version 104 or newer
- Firefox Android remains at version 120
- no new permissions, settings, telemetry events, or migration steps


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added background scheduling for temporary-page operations, globally limiting active work and serializing requests per origin.
- **Bug Fixes**
  - Auto-check-in now dispatches account refreshes and check-ins without batching delays, using best-effort concurrent outcomes.
  - Improved temp-window fallback sequencing, force-close behavior, and cleanup after failures/stale replacements.
- **Compatibility**
  - Updated minimum supported Firefox version.
- **Tests**
  - Added/expanded Vitest coverage for the new scheduler and temp-window pooling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->