### PR TITLE
feat(kilocode): improve V7 provider exports

### DIFF
--- a/docs/docs/api-credential-profiles.md
+++ b/docs/docs/api-credential-profiles.md
@@ -154,6 +154,8 @@
 
 导出到 Kilo Code 7.x 时，当前凭据会成为一个名称易读的 `provider`，其中包含从接口发现并规范化的全部模型 ID，以及为该 `provider` 手动输入并保留的模型 ID。被包含在导出中并不保证每个模型都适用于所有工作流；导出前只需选择默认 `model`。旧版 Roo Code / Kilo Code 5.x 格式仍是每个配置一个模型，并将复制内容合并到 `providerProfiles.apiConfigs`。
 
+当前 `provider` 可选择 OpenAI Compatible、OpenAI Responses 或 Anthropic Messages 协议，默认使用 OpenAI Compatible。协议只改变导出的 AI SDK provider 包；模型列表仍沿用 All API Hub 现有的加载结果，选择 Anthropic Messages 也不会跳过或减少模型。
+
 Kilo Code 7.x 的文件导入、`{ provider, model }` 手动合并方式、文件大小恢复操作和 API 密钥编辑框显示限制，请参阅[支持的导出工具与集成目标](./supported-export-tools.md)。
 
 如果你主要是“管理一堆上游接口配置，然后分发到多个下游工具”，`API 凭据库` 会比完整账号管理更直接。

--- a/docs/docs/api-credential-profiles.md
+++ b/docs/docs/api-credential-profiles.md
@@ -152,6 +152,10 @@
 - Claude Code Router
 - 当前自建托管站点
 
+导出到 Kilo Code 7.x 时，当前凭据会成为一个名称易读的 `provider`，其中包含从接口发现并规范化的全部模型 ID，以及为该 `provider` 手动输入并保留的模型 ID。被包含在导出中并不保证每个模型都适用于所有工作流；导出前只需选择默认 `model`。旧版 Roo Code / Kilo Code 5.x 格式仍是每个配置一个模型，并将复制内容合并到 `providerProfiles.apiConfigs`。
+
+Kilo Code 7.x 的文件导入、`{ provider, model }` 手动合并方式、文件大小恢复操作和 API 密钥编辑框显示限制，请参阅[支持的导出工具与集成目标](./supported-export-tools.md)。
+
 如果你主要是“管理一堆上游接口配置，然后分发到多个下游工具”，`API 凭据库` 会比完整账号管理更直接。
 
 ## 使用建议

--- a/docs/docs/key-management.md
+++ b/docs/docs/key-management.md
@@ -52,6 +52,8 @@
 
 选择 Kilo Code 7.x 时，每个账号密钥会导出为一个名称易读的 `provider`，其中包含从对应接口发现并规范化的全部模型 ID，以及为该 `provider` 手动输入并保留的模型 ID。被包含在导出中并不保证每个模型都适用于所有工作流。请分别选择默认 `model` 和默认 `provider`；这不会减少其他 `provider` 中导出的模型。
 
+每个 `provider` 还可以选择 OpenAI Compatible、OpenAI Responses 或 Anthropic Messages 协议，默认使用 OpenAI Compatible。协议只决定 Kilo Code 使用的 AI SDK provider 包，不会重新请求、清空或裁剪 All API Hub 已加载的模型列表。
+
 旧版 Roo Code / Kilo Code 5.x 格式则是每个配置选择一个模型，复制内容需合并到 `providerProfiles.apiConfigs`。下载文件、手动合并、文件大小限制和导入后的 API 密钥显示说明，请参阅[支持的导出工具与集成目标](./supported-export-tools.md)。
 
 ## 管理联动

--- a/docs/docs/key-management.md
+++ b/docs/docs/key-management.md
@@ -48,6 +48,12 @@
 - Claude Code Router
 - 你配置的自建托管站点
 
+#### 导出到 Kilo Code / Roo Code
+
+选择 Kilo Code 7.x 时，每个账号密钥会导出为一个名称易读的 `provider`，其中包含从对应接口发现并规范化的全部模型 ID，以及为该 `provider` 手动输入并保留的模型 ID。被包含在导出中并不保证每个模型都适用于所有工作流。请分别选择默认 `model` 和默认 `provider`；这不会减少其他 `provider` 中导出的模型。
+
+旧版 Roo Code / Kilo Code 5.x 格式则是每个配置选择一个模型，复制内容需合并到 `providerProfiles.apiConfigs`。下载文件、手动合并、文件大小限制和导入后的 API 密钥显示说明，请参阅[支持的导出工具与集成目标](./supported-export-tools.md)。
+
 ## 管理联动
 
 如果你觉得某个 Token 非常常用，或者想给它加上更详细的备注和标签，可以点击 **`保存到 API 凭据库`**。这会将该 `URL + Key` 组合复制到 [API 凭据库](./api-credential-profiles.md) 中。

--- a/docs/docs/supported-export-tools.md
+++ b/docs/docs/supported-export-tools.md
@@ -13,6 +13,27 @@
 | CLIProxyAPI | 将 Gemini CLI、Antigravity、ChatGPT Codex、Claude Code、Qwen Code、iFlow 封装为兼容 OpenAI / Gemini / Claude / Codex 的 API 服务。 | [文档](https://help.router-for.me/) / [GitHub](https://github.com/router-for-me/CLIProxyAPI) |
 | Claude Code Router | 以 Claude Code 作为编码基础设施，让你在持续获得 Anthropic 更新的同时，自行决定如何与模型交互。 | [官网](https://musistudio.github.io/claude-code-router/) / [GitHub](https://github.com/musistudio/claude-code-router) |
 
+## Kilo Code / Roo Code 导出
+
+### Kilo Code 7.x
+
+选择 Kilo Code 7.x 后，每个账号密钥或 API 凭据会导出为一个名称易读的 `provider`。每个 `provider` 都包含从对应接口发现并规范化的全部模型 ID，以及为该 `provider` 手动输入并保留的模型 ID。无论模型 ID 来自接口还是手动输入，被包含在导出中都不代表 All API Hub 验证了该模型适用于所有工作流。请先选择默认 `model`；导出多个 `provider` 时，还需选择默认 `provider`。
+
+你可以按需要选择两种使用方式：
+
+- **下载设置文件**：点击“下载 Kilo 7.x 设置”，再到 Kilo Code 的设置 → About Kilo Code → Import 中选择下载的 `kilo-settings.json`，确认内容后保存。下载文件是可直接走当前 Kilo Code 导入流程的设置文件。
+- **复制配置**：点击“复制 provider 配置”会得到顶层 `{ provider, model }` 片段。请把这两个字段合并到现有设置 JSON 的同名顶层字段；这个片段本身不是完整的导入文件。
+
+Kilo Code 当前的设置导入大小上限为 1 MiB。文件超出限制时，单个 API 凭据导出需改用复制配置并手动合并；账号密钥批量导出可减少选中的 `provider`，或改用复制配置并手动合并。
+
+::: tip 导入后 API 密钥字段可能为空
+导入包含内联 API 密钥的设置后，Kilo Code 的 `provider` 编辑页可能仍将 API 密钥字段显示为空。这是 Kilo Code 当前的界面限制，不表示导出失败：导入的内联密钥与编辑器认证状态分开存储，运行时仍可使用该密钥。
+:::
+
+### 旧版 Roo Code / Kilo Code 5.x
+
+旧版格式每个配置只导出一个模型。点击“复制旧版 apiConfigs”后，请把复制内容合并到设置中的 `providerProfiles.apiConfigs`；如需完整设置文件，则下载 `kilo-code-settings.json`，再使用对应版本的设置导入功能。
+
 ## 自建后台 / 管理面板
 
 如果你自己也搭了 AI 中转或聚合后台，All API Hub 还可以把当前站点直接导入到你选中的后台目标里。

--- a/docs/docs/supported-export-tools.md
+++ b/docs/docs/supported-export-tools.md
@@ -19,6 +19,14 @@
 
 选择 Kilo Code 7.x 后，每个账号密钥或 API 凭据会导出为一个名称易读的 `provider`。每个 `provider` 都包含从对应接口发现并规范化的全部模型 ID，以及为该 `provider` 手动输入并保留的模型 ID。无论模型 ID 来自接口还是手动输入，被包含在导出中都不代表 All API Hub 验证了该模型适用于所有工作流。请先选择默认 `model`；导出多个 `provider` 时，还需选择默认 `provider`。
 
+每个 `provider` 可选择以下 API 协议：
+
+- **OpenAI Compatible**（默认）：导出 `@ai-sdk/openai-compatible`。
+- **OpenAI Responses**：导出 `@ai-sdk/openai`。
+- **Anthropic Messages**：导出 `@ai-sdk/anthropic`。
+
+协议选择只改变 Kilo Code 的 AI SDK provider 包。All API Hub 仍沿用现有模型发现流程并导出完整加载结果，不会因为选择 Anthropic Messages 而跳过模型发现，也不会额外改写模型 ID 或补充未经验证的模型元数据。
+
 你可以按需要选择两种使用方式：
 
 - **下载设置文件**：点击“下载 Kilo 7.x 设置”，再到 Kilo Code 的设置 → About Kilo Code → Import 中选择下载的 `kilo-settings.json`，确认内容后保存。下载文件是可直接走当前 Kilo Code 导入流程的设置文件。

--- a/docs/superpowers/plans/2026-07-17-kilo-code-provider-catalog-export.md
+++ b/docs/superpowers/plans/2026-07-17-kilo-code-provider-catalog-export.md
@@ -1292,6 +1292,52 @@ git commit -m "test(kilocode): cover provider catalog downloads"
 
 Skip this commit only if the files are already clean because their changes were committed with the owning implementation slice.
 
+## Task 9: Add Per-provider V7 Protocol Selection
+
+**Files:**
+
+- Modify: `src/services/integrations/kiloCodeV7Catalog.ts`
+- Modify: `src/services/integrations/kiloCodeExport.ts`
+- Modify: `src/components/useKiloCodeAccountModelDiscovery.ts`
+- Modify: `src/components/KiloCodeExportDialog.tsx`
+- Modify: `src/features/ApiCredentialProfiles/components/useKiloCodeProfileModelDiscovery.ts`
+- Modify: `src/features/ApiCredentialProfiles/components/KiloCodeProfileExportDialog.tsx`
+- Modify: the focused service, hook, and dialog tests plus all app locales.
+
+- [ ] **Step 1: Add failing protocol contract tests**
+
+Cover the three runtime protocol values, their AI SDK `npm` mappings, the
+OpenAI-compatible default, and stable provider IDs when only protocol changes.
+
+- [ ] **Step 2: Normalize protocol at the V7 catalog boundary**
+
+Carry a provider protocol through the prepared catalog and serialize:
+
+- `openai-compatible` -> `@ai-sdk/openai-compatible`
+- `openai-responses` -> `@ai-sdk/openai`
+- `anthropic-messages` -> `@ai-sdk/anthropic`
+
+Reject unknown prepared values. Keep the Legacy schema unchanged.
+
+- [ ] **Step 3: Add target-local dialog controls**
+
+Add one protocol selector per account provider and one selector for a profile
+provider. Default to OpenAI Compatible, preserve the choice while switching
+targets, and reset it for a fresh dialog context. Include account protocol state
+in the async export action signature.
+
+- [ ] **Step 4: Preserve model discovery capabilities**
+
+Changing protocol must not refetch, clear, disable, or filter the existing model
+inventory. Keep the current model-discovery path for all three choices,
+including Anthropic Messages.
+
+- [ ] **Step 5: Synchronize copy, docs, and validation**
+
+Add the protocol labels and choices to all app locales, update the Chinese
+source docs, run focused related tests, `pnpm run i18n:extract:ci`,
+`pnpm run validate:staged`, and the compile/knip push gate.
+
 ## Implementation Review Gates
 
 After each implementation task:

--- a/docs/superpowers/plans/2026-07-17-kilo-code-provider-catalog-export.md
+++ b/docs/superpowers/plans/2026-07-17-kilo-code-provider-catalog-export.md
@@ -1,0 +1,1308 @@
+# Kilo Code Provider Catalog Export Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Export human-readable Kilo Code 7.x providers with complete per-key model catalogs and one explicit global default while preserving the legacy single-model format.
+
+**Architecture:** Introduce a pure V7 catalog-preparation boundary that owns provider display names, stable IDs, model normalization, and analytics counts. Feed its prepared output into a schema-only V7 builder and a discriminated output policy; both dialogs consume the same prepared facts, while target-local UI state keeps legacy model choices separate from V7 catalogs/defaults. Reuse existing model inventories and browser download flows, adding a bounded-result default-model control instead of rendering every model at once.
+
+**Tech Stack:** TypeScript, React, Vitest, Testing Library, i18next, Playwright, WXT, pnpm.
+
+**Design:** `docs/superpowers/specs/2026-07-17-kilo-code-provider-catalog-export-design.md`
+
+---
+
+## File and Responsibility Map
+
+- Create `src/services/integrations/kiloCodeV7Catalog.ts`: V7 input contracts, provider display-name disambiguation, current-compatible provider IDs, code-point model ordering, and prepared catalog output.
+- Modify `src/services/integrations/kiloCodeExport.ts`: isolate legacy selection input and make the V7 schema builder consume a prepared catalog plus explicit default selection.
+- Modify `src/services/integrations/kiloCodeExportPolicy.ts`: discriminated V7/legacy inputs, `{ provider, model }` V7 copy fragment, normalized counts, pretty JSON, and 1 MiB file-size metadata.
+- Create `src/components/KiloCodeDefaultModelSelect.tsx`: feature-local searchable/custom default-model control with at most 100 rendered results.
+- Create `src/components/kiloCodeExportTestIds.ts`: stable selectors shared by component and Playwright coverage.
+- Modify `src/features/ApiCredentialProfiles/components/KiloCodeProfileExportDialog.tsx`: full V7 catalog, custom/retry/remove flow, V7/legacy state isolation, and size-aware download.
+- Modify `src/components/KiloCodeExportDialog.tsx`: per-provider V7 catalogs, global default provider/model, legacy single-model preservation, retry/remove flow, and normalized telemetry.
+- Modify `src/components/KiloCodeExportGuidance.tsx`: copy/import guidance for the top-level V7 fragment and oversized-file recovery.
+- Modify `src/locales/{en,es-419,ja,vi,zh-CN,zh-TW}/ui.json`: target-specific labels, recovery actions, bounded search, and size errors.
+- Modify `docs/docs/{key-management,api-credential-profiles,supported-export-tools}.md`: Chinese source documentation.
+- Modify related Vitest files under `tests/services`, `tests/components`, and `tests/features/ApiCredentialProfiles/components`.
+- Modify `e2e/apiCredentialProfilesOptionsActions.spec.ts`: representative V7 catalog/name/default download contract and retained legacy regression.
+
+## Task 1: Prepare V7 Provider Catalogs at One Pure Boundary
+
+**Files:**
+
+- Create: `src/services/integrations/kiloCodeV7Catalog.ts`
+- Create: `tests/services/kiloCodeV7Catalog.test.ts`
+- Modify: `src/services/integrations/kiloCodeExport.ts`
+
+- [ ] **Step 1: Write failing catalog tests**
+
+Create `tests/services/kiloCodeV7Catalog.test.ts` with reserved example data:
+
+```ts
+import { describe, expect, it } from "vitest"
+
+import {
+  prepareKiloCodeV7Catalog,
+  type KiloCodeV7ProviderSelection,
+} from "~/services/integrations/kiloCodeV7Catalog"
+
+const baseSelection: KiloCodeV7ProviderSelection = {
+  selectionId: "account-a:7",
+  accountId: "account-a",
+  siteName: "Example",
+  baseUrl: "https://api.example.invalid",
+  tokenId: 7,
+  tokenName: "Default",
+  tokenKey: "example-key",
+  providerName: "Example - Default",
+  discoveredModelIds: ["model-b", " model-a ", "model-b", ""],
+}
+
+describe("prepareKiloCodeV7Catalog", () => {
+  it("prepares a readable provider with a normalized multi-model catalog", () => {
+    const result = prepareKiloCodeV7Catalog([baseSelection])
+
+    expect(result.providers).toEqual([
+      expect.objectContaining({
+        selectionId: "account-a:7",
+        providerName: "Example - Default",
+        providerId: expect.stringMatching(/^example-default-[a-f0-9]{8}$/),
+        baseURL: "https://api.example.invalid/v1",
+        tokenKey: "example-key",
+        modelIds: ["model-a", "model-b"],
+      }),
+    ])
+    expect(result.providerCount).toBe(1)
+    expect(result.modelCount).toBe(2)
+  })
+
+  it("unions a manual model with discovered models until it is cleared", () => {
+    const result = prepareKiloCodeV7Catalog([
+      { ...baseSelection, manualModelId: " custom/model " },
+    ])
+
+    expect(result.providers[0]?.modelIds).toEqual([
+      "custom/model",
+      "model-a",
+      "model-b",
+    ])
+  })
+
+  it("uses code-point order instead of locale-sensitive ordering", () => {
+    const result = prepareKiloCodeV7Catalog([
+      {
+        ...baseSelection,
+        discoveredModelIds: ["ä-model", "Z-model", "a-model", "A-model"],
+      },
+    ])
+
+    expect(result.providers[0]?.modelIds).toEqual([
+      "A-model",
+      "Z-model",
+      "a-model",
+      "ä-model",
+    ])
+  })
+
+  it("disambiguates duplicate display names without merging credentials", () => {
+    const result = prepareKiloCodeV7Catalog([
+      baseSelection,
+      {
+        ...baseSelection,
+        selectionId: "account-b:8",
+        accountId: "account-b",
+        baseUrl: "https://second.example.invalid",
+        tokenId: 8,
+      },
+    ])
+
+    expect(result.providers.map((provider) => provider.providerName)).toEqual([
+      "Example - Default (api.example.invalid)",
+      "Example - Default (second.example.invalid)",
+    ])
+    expect(new Set(result.providers.map((provider) => provider.providerId))).toHaveLength(2)
+  })
+
+  it("keeps the current provider ID stable across secret and catalog changes", () => {
+    const first = prepareKiloCodeV7Catalog([baseSelection])
+    const second = prepareKiloCodeV7Catalog([
+      {
+        ...baseSelection,
+        tokenKey: "rotated-example-key",
+        discoveredModelIds: ["different-model"],
+      },
+    ])
+
+    expect(second.providers[0]?.providerId).toBe(first.providers[0]?.providerId)
+  })
+
+  it("rejects duplicate opaque selection IDs", () => {
+    expect(() =>
+      prepareKiloCodeV7Catalog([
+        baseSelection,
+        { ...baseSelection, accountId: "account-b" },
+      ]),
+    ).toThrow("Kilo Code selection IDs must be unique")
+  })
+})
+```
+
+- [ ] **Step 2: Run the catalog test and verify RED**
+
+Run:
+
+```powershell
+pnpm vitest related tests/services/kiloCodeV7Catalog.test.ts --run
+```
+
+Expected: FAIL because `kiloCodeV7Catalog.ts` does not exist.
+
+- [ ] **Step 3: Add the target-specific catalog contracts and preparation function**
+
+Create `src/services/integrations/kiloCodeV7Catalog.ts` with these public shapes:
+
+```ts
+import { coerceBaseUrlToPathSuffix } from "~/utils/core/url"
+
+export interface KiloCodeRuntimeKeyExportInput {
+  accountId: string
+  siteName: string
+  baseUrl: string
+  tokenId: number
+  tokenName: string
+  tokenKey: string
+}
+
+export interface KiloCodeLegacySelection
+  extends KiloCodeRuntimeKeyExportInput {
+  legacyModelId?: string
+}
+
+export interface KiloCodeV7ProviderSelection
+  extends KiloCodeRuntimeKeyExportInput {
+  selectionId: string
+  providerName?: string
+  discoveredModelIds: string[]
+  manualModelId?: string
+}
+
+export interface KiloCodeDefaultModelSelection {
+  selectionId: string
+  modelId: string
+}
+
+export interface PreparedKiloCodeV7Provider {
+  selectionId: string
+  providerId: string
+  providerName: string
+  baseURL: string
+  tokenKey: string
+  modelIds: string[]
+}
+
+export interface PreparedKiloCodeV7Catalog {
+  providers: PreparedKiloCodeV7Provider[]
+  providerCount: number
+  modelCount: number
+}
+```
+
+Implement deterministic normalization without `localeCompare`:
+
+```ts
+function compareCodePoints(left: string, right: string) {
+  if (left === right) return 0
+  return left < right ? -1 : 1
+}
+
+function normalizeModelIds(selection: KiloCodeV7ProviderSelection) {
+  return Array.from(
+    new Set(
+      [...selection.discoveredModelIds, selection.manualModelId]
+        .filter((value): value is string => typeof value === "string")
+        .map((value) => value.trim())
+        .filter(Boolean),
+    ),
+  ).sort(compareCodePoints)
+}
+```
+
+Move the current slug/hash/provider-ID logic from `kiloCodeExport.ts` into this file byte-for-byte. Reuse the existing domain/ordinal profile-name disambiguation rules, extending them to prefer `providerName?.trim()` before the current `<site> - <token>` fallback. Validate unique selection IDs, non-blank keys, HTTP/HTTPS URLs, non-empty model catalogs, settings-safe unique provider IDs, and return normalized counts.
+
+- [ ] **Step 4: Replace the shared tuple with an explicit legacy selection**
+
+In `src/services/integrations/kiloCodeExport.ts`, remove `KiloCodeExportTuple` and import/re-export the target-specific contracts. Change the legacy builder signature and field access:
+
+```ts
+import type { KiloCodeLegacySelection } from "~/services/integrations/kiloCodeV7Catalog"
+
+interface BuildKiloCodeApiConfigsOptions {
+  selections: KiloCodeLegacySelection[]
+  generateId?: (profileName: string) => string
+}
+
+const normalizedModelId = tuple.legacyModelId?.trim()
+apiConfigs[name] = {
+  id: idFactory(name),
+  apiProvider: "openai",
+  openAiBaseUrl: coerceBaseUrlToPathSuffix(tuple.baseUrl, "/v1"),
+  openAiApiKey: tuple.tokenKey,
+  ...(normalizedModelId ? { openAiModelId: normalizedModelId } : {}),
+}
+```
+
+This preserves the existing low-level omission behavior for blank models. Both
+dialogs continue to require a legacy model before enabling user export.
+
+- [ ] **Step 5: Run catalog and legacy tests and verify GREEN**
+
+Run:
+
+```powershell
+pnpm vitest related tests/services/kiloCodeV7Catalog.test.ts tests/services/kiloCodeExport.test.ts --run
+```
+
+Expected: PASS; existing legacy assertions remain unchanged after fixture field renames.
+
+- [ ] **Step 6: Commit the preparation boundary**
+
+```powershell
+git add -- src/services/integrations/kiloCodeV7Catalog.ts src/services/integrations/kiloCodeExport.ts tests/services/kiloCodeV7Catalog.test.ts tests/services/kiloCodeExport.test.ts
+git commit -m "refactor(kilocode): prepare provider catalogs"
+```
+
+## Task 2: Build Named Multi-model V7 Settings
+
+**Files:**
+
+- Modify: `src/services/integrations/kiloCodeExport.ts`
+- Modify: `tests/services/kiloCodeExport.test.ts`
+
+- [ ] **Step 1: Replace the one-model V7 test with failing prepared-catalog tests**
+
+Add tests that use `prepareKiloCodeV7Catalog` and assert the exact output:
+
+```ts
+it("builds named multi-model providers with an explicit global default", () => {
+  const catalog = prepareKiloCodeV7Catalog([
+    {
+      selectionId: "account-a:7",
+      accountId: "account-a",
+      siteName: "Example",
+      baseUrl: "https://api.example.invalid",
+      tokenId: 7,
+      tokenName: "Default",
+      tokenKey: "example-key",
+      providerName: "Example - Default",
+      discoveredModelIds: ["model-b", "model-a"],
+    },
+  ])
+
+  const result = buildKiloCodeV7SettingsFile({
+    catalog,
+    defaultModel: { selectionId: "account-a:7", modelId: "model-b" },
+    now: () => new Date("2026-07-17T00:00:00.000Z"),
+  })
+  const providerId = catalog.providers[0]!.providerId
+
+  expect(result).toEqual({
+    _meta: {
+      version: 1,
+      exportedAt: "2026-07-17T00:00:00.000Z",
+    },
+    provider: {
+      [providerId]: {
+        name: "Example - Default",
+        npm: "@ai-sdk/openai-compatible",
+        models: {
+          "model-a": { name: "model-a" },
+          "model-b": { name: "model-b" },
+        },
+        options: {
+          apiKey: "example-key",
+          baseURL: "https://api.example.invalid/v1",
+        },
+      },
+    },
+    model: `${providerId}/model-b`,
+  })
+})
+
+it.each([
+  [undefined, "Kilo Code default model is required"],
+  [
+    { selectionId: "missing", modelId: "model-a" },
+    "Kilo Code default provider must be exported",
+  ],
+  [
+    { selectionId: "account-a:7", modelId: "missing" },
+    "Kilo Code default model must exist in its provider catalog",
+  ],
+])("rejects invalid default selections", (defaultModel, message) => {
+  expect(() =>
+    buildKiloCodeV7SettingsFile({ catalog, defaultModel: defaultModel as never }),
+  ).toThrow(message)
+})
+```
+
+- [ ] **Step 2: Run the builder test and verify RED**
+
+Run:
+
+```powershell
+pnpm vitest related tests/services/kiloCodeExport.test.ts --run
+```
+
+Expected: FAIL because the builder still accepts raw one-model selections and omits `name`.
+
+- [ ] **Step 3: Make the V7 builder schema-only**
+
+Update the provider and builder contracts:
+
+```ts
+interface KiloCodeV7Provider {
+  name: string
+  npm: "@ai-sdk/openai-compatible"
+  models: Record<string, { name: string }>
+  options: {
+    apiKey: string
+    baseURL: string
+  }
+}
+
+export function buildKiloCodeV7SettingsFile(options: {
+  catalog: PreparedKiloCodeV7Catalog
+  defaultModel: KiloCodeDefaultModelSelection
+  now?: () => Date
+}): KiloCodeV7SettingsFile {
+  if (!options.catalog.providers.length) {
+    throw new Error("Select at least one runtime key")
+  }
+
+  const defaultProvider = options.catalog.providers.find(
+    (provider) => provider.selectionId === options.defaultModel?.selectionId,
+  )
+  if (!options.defaultModel) throw new Error("Kilo Code default model is required")
+  if (!defaultProvider) throw new Error("Kilo Code default provider must be exported")
+  if (!defaultProvider.modelIds.includes(options.defaultModel.modelId)) {
+    throw new Error("Kilo Code default model must exist in its provider catalog")
+  }
+
+  return {
+    _meta: {
+      version: 1,
+      exportedAt: (options.now ?? (() => new Date()))().toISOString(),
+    },
+    provider: Object.fromEntries(
+      options.catalog.providers.map((provider) => [
+        provider.providerId,
+        {
+          name: provider.providerName,
+          npm: "@ai-sdk/openai-compatible" as const,
+          models: Object.fromEntries(
+            provider.modelIds.map((modelId) => [modelId, { name: modelId }]),
+          ),
+          options: { apiKey: provider.tokenKey, baseURL: provider.baseURL },
+        },
+      ]),
+    ),
+    model: `${defaultProvider.providerId}/${options.defaultModel.modelId}`,
+  }
+}
+```
+
+Expand the upstream source comment to mention provider `name`, multi-model `models`, and top-level default `model`.
+
+- [ ] **Step 4: Run focused tests and compile**
+
+Run:
+
+```powershell
+pnpm vitest related tests/services/kiloCodeExport.test.ts tests/services/kiloCodeV7Catalog.test.ts --run
+pnpm compile
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the V7 schema change**
+
+```powershell
+git add -- src/services/integrations/kiloCodeExport.ts tests/services/kiloCodeExport.test.ts
+git commit -m "feat(kilocode): export named model catalogs"
+```
+
+## Task 3: Discriminate Output Policy and Enforce the File-size Contract
+
+**Files:**
+
+- Modify: `src/services/integrations/kiloCodeExportPolicy.ts`
+- Modify: `tests/services/kiloCodeExportPolicy.test.ts`
+
+- [ ] **Step 1: Write failing V7 copy/count/size tests**
+
+Replace the shared options fixture with target-specific inputs and add:
+
+```ts
+it("copies the complete V7 top-level fragment and reports normalized counts", () => {
+  const output = buildKiloCodeExportOutput({
+    target: KILO_CODE_EXPORT_TARGETS.KiloV7,
+    selections: [v7Selection],
+    defaultModel: { selectionId: v7Selection.selectionId, modelId: "model-b" },
+    now,
+  })
+
+  expect(output.copyPayload).toEqual({
+    provider: output.downloadPayload.provider,
+    model: output.downloadPayload.model,
+  })
+  expect(output.itemCount).toBe(1)
+  expect(output.modelCount).toBe(2)
+  expect(output.downloadJson).toBe(JSON.stringify(output.downloadPayload, null, 2))
+  expect(output.downloadByteLength).toBe(
+    new TextEncoder().encode(output.downloadJson).byteLength,
+  )
+  expect(output.isDownloadTooLarge).toBe(false)
+})
+
+it("accepts exactly 1 MiB and rejects 1 MiB plus one byte", () => {
+  expect(isKiloCodeSettingsFileTooLarge(1_048_576)).toBe(false)
+  expect(isKiloCodeSettingsFileTooLarge(1_048_577)).toBe(true)
+})
+
+it("keeps the legacy copy payload and model count unchanged", () => {
+  const output = buildKiloCodeExportOutput({
+    target: KILO_CODE_EXPORT_TARGETS.Legacy,
+    selections: [legacySelection],
+    currentLegacyProfileName: "Example - Default",
+  })
+
+  expect(output.copyPayload).toEqual(
+    output.downloadPayload.providerProfiles.apiConfigs,
+  )
+  expect(output.modelCount).toBe(1)
+})
+```
+
+- [ ] **Step 2: Run policy tests and verify RED**
+
+Run:
+
+```powershell
+pnpm vitest related tests/services/kiloCodeExportPolicy.test.ts --run
+```
+
+Expected: FAIL on missing discriminated inputs, V7 copy envelope, counts, and size metadata.
+
+- [ ] **Step 3: Add discriminated policy inputs and output metadata**
+
+Implement:
+
+```ts
+export const KILO_CODE_SETTINGS_MAX_IMPORT_BYTES = 1_048_576
+
+export function isKiloCodeSettingsFileTooLarge(byteLength: number) {
+  return byteLength > KILO_CODE_SETTINGS_MAX_IMPORT_BYTES
+}
+
+interface BuildKiloCodeV7ExportOutputOptions {
+  target: typeof KILO_CODE_EXPORT_TARGETS.KiloV7
+  selections: KiloCodeV7ProviderSelection[]
+  defaultModel: KiloCodeDefaultModelSelection
+  now?: () => Date
+}
+
+interface BuildKiloCodeLegacyExportOutputOptions {
+  target: typeof KILO_CODE_EXPORT_TARGETS.Legacy
+  selections: KiloCodeLegacySelection[]
+  currentLegacyProfileName: string
+}
+
+type BuildKiloCodeExportOutputOptions =
+  | BuildKiloCodeV7ExportOutputOptions
+  | BuildKiloCodeLegacyExportOutputOptions
+
+interface KiloCodeExportOutputBase {
+  filename: KiloCodeExportFilename
+  downloadJson: string
+  downloadByteLength: number
+  isDownloadTooLarge: boolean
+  itemCount: number
+  modelCount: number
+}
+
+interface KiloCodeV7ExportOutput extends KiloCodeExportOutputBase {
+  target: typeof KILO_CODE_EXPORT_TARGETS.KiloV7
+  copyPayload: Pick<KiloCodeV7SettingsFile, "provider" | "model">
+  downloadPayload: KiloCodeV7SettingsFile
+}
+
+interface KiloCodeLegacyExportOutput extends KiloCodeExportOutputBase {
+  target: typeof KILO_CODE_EXPORT_TARGETS.Legacy
+  copyPayload: KiloCodeSettingsFile["providerProfiles"]["apiConfigs"]
+  downloadPayload: KiloCodeSettingsFile
+}
+
+export type KiloCodeExportOutput =
+  | KiloCodeV7ExportOutput
+  | KiloCodeLegacyExportOutput
+
+export function buildKiloCodeExportOutput(
+  options: BuildKiloCodeV7ExportOutputOptions,
+): KiloCodeV7ExportOutput
+export function buildKiloCodeExportOutput(
+  options: BuildKiloCodeLegacyExportOutputOptions,
+): KiloCodeLegacyExportOutput
+```
+
+For V7, call `prepareKiloCodeV7Catalog`, build the payload, and use `{ provider, model }` for copy. For legacy, retain API-config copy behavior. Serialize exactly once with `JSON.stringify(payload, null, 2)` and compute bytes with `new TextEncoder().encode(downloadJson).byteLength`. Add a concise source comment beside the 1 MiB constant pointing to Kilo's pinned `settings-io.ts` `MAX_IMPORT_SIZE`.
+
+- [ ] **Step 4: Run policy, builder, and privacy-adjacent tests**
+
+Run:
+
+```powershell
+pnpm vitest related tests/services/kiloCodeExportPolicy.test.ts tests/services/kiloCodeExport.test.ts tests/services/productAnalytics/actions.test.ts tests/services/productAnalytics/privacy.test.ts --run
+```
+
+Expected: PASS; no new identifiers enter analytics.
+
+- [ ] **Step 5: Commit the output policy**
+
+```powershell
+git add -- src/services/integrations/kiloCodeExportPolicy.ts tests/services/kiloCodeExportPolicy.test.ts
+git commit -m "feat(kilocode): describe catalog export output"
+```
+
+## Task 4: Add the Bounded Default-model Control and Selection Helpers
+
+**Files:**
+
+- Create: `src/components/KiloCodeDefaultModelSelect.tsx`
+- Create: `src/components/kiloCodeExportTestIds.ts`
+- Create: `src/services/integrations/kiloCodeV7Selection.ts`
+- Create: `tests/components/KiloCodeDefaultModelSelect.test.tsx`
+- Create: `tests/services/kiloCodeV7Selection.test.ts`
+
+- [ ] **Step 1: Write failing default-selection reconciliation tests**
+
+Create `tests/services/kiloCodeV7Selection.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest"
+
+import {
+  reconcileKiloCodeV7DefaultSelection,
+} from "~/services/integrations/kiloCodeV7Selection"
+
+const catalog: PreparedKiloCodeV7Catalog = {
+  providers: [
+    {
+      selectionId: "provider-a",
+      providerId: "provider-a-12345678",
+      providerName: "Provider A",
+      baseURL: "https://api.example.invalid/v1",
+      tokenKey: "example-key",
+      modelIds: ["model-a", "model-b"],
+    },
+  ],
+  providerCount: 1,
+  modelCount: 2,
+}
+
+const catalogWithCustom: PreparedKiloCodeV7Catalog = {
+  ...catalog,
+  providers: [
+    {
+      ...catalog.providers[0]!,
+      modelIds: ["custom/model", "model-a", "model-b"],
+    },
+  ],
+  modelCount: 3,
+}
+
+it("selects the first provider and model when the current default is invalid", () => {
+  expect(
+    reconcileKiloCodeV7DefaultSelection(catalog, {
+      selectionId: "removed",
+      modelId: "removed/model",
+    }),
+  ).toEqual({ selectionId: "provider-a", modelId: "model-a" })
+})
+
+it("preserves a valid custom default", () => {
+  expect(
+    reconcileKiloCodeV7DefaultSelection(catalogWithCustom, {
+      selectionId: "provider-a",
+      modelId: "custom/model",
+    }),
+  ).toEqual({ selectionId: "provider-a", modelId: "custom/model" })
+})
+
+it("repairs the default after a manual model is removed and re-prepared", () => {
+  expect(
+    reconcileKiloCodeV7DefaultSelection(catalog, {
+      selectionId: "provider-a",
+      modelId: "custom/model",
+    }),
+  ).toEqual({ selectionId: "provider-a", modelId: "model-a" })
+})
+```
+
+- [ ] **Step 2: Write failing bounded-render component tests**
+
+Create `tests/components/KiloCodeDefaultModelSelect.test.tsx`:
+
+```tsx
+it("renders at most 100 rows and searches the complete 5,000-model catalog", async () => {
+  const user = userEvent.setup()
+  const models = Array.from({ length: 5_000 }, (_, index) =>
+    `example-model-${index.toString().padStart(4, "0")}`,
+  )
+
+  render(
+    <KiloCodeDefaultModelSelect
+      value="example-model-4999"
+      modelIds={models}
+      onChange={vi.fn()}
+      allowCustomValue
+    />,
+  )
+
+  await user.click(screen.getByRole("combobox"))
+  expect(screen.getAllByTestId(KILO_CODE_EXPORT_TEST_IDS.modelOption)).toHaveLength(100)
+
+  await user.type(
+    screen.getByTestId(KILO_CODE_EXPORT_TEST_IDS.defaultModelSearch),
+    "4999",
+  )
+  expect(screen.getByRole("option", { name: "example-model-4999" })).toBeVisible()
+})
+```
+
+Also cover a selected custom value, the “first 100 of N” hint, and exact model IDs containing `/`.
+
+- [ ] **Step 3: Run both tests and verify RED**
+
+Run:
+
+```powershell
+pnpm vitest related tests/services/kiloCodeV7Selection.test.ts tests/components/KiloCodeDefaultModelSelect.test.tsx --run
+```
+
+Expected: FAIL because the helper, component, and test IDs do not exist.
+
+- [ ] **Step 4: Implement pure default reconciliation**
+
+Create `src/services/integrations/kiloCodeV7Selection.ts`:
+
+```ts
+export function reconcileKiloCodeV7DefaultSelection(
+  catalog: PreparedKiloCodeV7Catalog,
+  current?: KiloCodeDefaultModelSelection,
+): KiloCodeDefaultModelSelection | undefined {
+  const currentProvider = catalog.providers.find(
+    (provider) => provider.selectionId === current?.selectionId,
+  )
+  if (currentProvider?.modelIds.includes(current!.modelId)) return current
+
+  const provider = currentProvider ?? catalog.providers[0]
+  const modelId = provider?.modelIds[0]
+  return provider && modelId
+    ? { selectionId: provider.selectionId, modelId }
+    : undefined
+}
+```
+
+Manual-model state remains dialog-owned. Remove actions clear that state, rebuild
+the catalog through `prepareKiloCodeV7Catalog`, and pass the previous default to
+this same reconciliation function.
+
+- [ ] **Step 5: Implement the bounded feature-local model selector**
+
+Add stable IDs:
+
+```ts
+export const KILO_CODE_EXPORT_TEST_IDS = {
+  defaultProvider: "kilo-code-default-provider",
+  defaultModel: "kilo-code-default-model",
+  defaultModelSearch: "kilo-code-default-model-search",
+  modelOption: "kilo-code-model-option",
+  removeManualModel: "kilo-code-remove-manual-model",
+} as const
+```
+
+Build `KiloCodeDefaultModelSelect` from existing `Popover`, `Command`, `CommandInput`, `CommandList`, and `CommandItem` primitives. Keep the full catalog in memory, filter by code-point-stable input matching, and render at most:
+
+```ts
+const MAX_RENDERED_KILO_CODE_MODELS = 100
+
+const matchingModels = modelIds.filter((modelId) =>
+  modelId.toLocaleLowerCase().includes(search.trim().toLocaleLowerCase()),
+)
+const renderedModels = matchingModels.slice(0, MAX_RENDERED_KILO_CODE_MODELS)
+```
+
+Ensure the selected value replaces the last bounded result when it falls outside
+the first 100, so the DOM never exceeds 100 model option rows. Offer the trimmed
+custom search value when absent, expose `role="combobox"`, preserve keyboard
+navigation through Command primitives, and show translated bounded-result copy.
+Import this feature-local component directly from both dialogs; do not add it to
+the shared UI barrel.
+
+- [ ] **Step 6: Run focused tests and verify GREEN**
+
+Run:
+
+```powershell
+pnpm vitest related tests/services/kiloCodeV7Selection.test.ts tests/components/KiloCodeDefaultModelSelect.test.tsx --run
+```
+
+Expected: PASS with no more than 100 option rows for 5,000 inputs.
+
+- [ ] **Step 7: Commit the selection UI foundation**
+
+```powershell
+git add -- src/components/KiloCodeDefaultModelSelect.tsx src/components/kiloCodeExportTestIds.ts src/services/integrations/kiloCodeV7Selection.ts tests/components/KiloCodeDefaultModelSelect.test.tsx tests/services/kiloCodeV7Selection.test.ts
+git commit -m "feat(kilocode): select bounded default models"
+```
+
+## Task 5: Upgrade the Single-profile Export Dialog
+
+**Files:**
+
+- Modify: `src/features/ApiCredentialProfiles/components/KiloCodeProfileExportDialog.tsx`
+- Modify: `tests/features/ApiCredentialProfiles/components/KiloCodeProfileExportDialog.test.tsx`
+
+- [ ] **Step 1: Add failing V7 catalog and readable-name tests**
+
+Extend the component test's policy mock to inspect target-specific inputs. Assert that V7 sends the full discovered catalog and profile display name:
+
+```tsx
+expect(mockBuildKiloCodeExportOutput).toHaveBeenCalledWith({
+  target: KILO_CODE_EXPORT_TARGETS.KiloV7,
+  selections: [
+    expect.objectContaining({
+      selectionId: `profile:${profile.id}`,
+      providerName: profile.name,
+      discoveredModelIds: ["model-a", "model-b"],
+      manualModelId: undefined,
+    }),
+  ],
+  defaultModel: {
+    selectionId: `profile:${profile.id}`,
+    modelId: "model-a",
+  },
+})
+```
+
+Add tests for:
+
+- target label is Default model for V7 and Model ID for legacy;
+- entering a custom V7 default unions it into `manualModelId`;
+- retry after discovery failure preserves the manual model;
+- Remove manual model clears it and repairs the default;
+- switching targets preserves separate V7 and legacy choices without refetching;
+- V7 copy serializes `{ provider, model }`;
+- V7 telemetry uses `output.modelCount`;
+- an oversized download is blocked and single-profile recovery mentions copy/manual merge.
+
+- [ ] **Step 2: Run the profile component test and verify RED**
+
+Run:
+
+```powershell
+pnpm vitest related tests/features/ApiCredentialProfiles/components/KiloCodeProfileExportDialog.test.tsx --run
+```
+
+Expected: FAIL because the dialog still sends one shared tuple/model and lacks retry/remove/size behavior.
+
+- [ ] **Step 3: Separate target-local state and extract a retryable loader**
+
+Replace `modelId`/`modelOptions` with:
+
+```ts
+const selectionId = `profile:${profile.id}`
+const [legacyModelId, setLegacyModelId] = useState("")
+const [v7DefaultModelId, setV7DefaultModelId] = useState("")
+const [v7ManualModelId, setV7ManualModelId] = useState("")
+const [modelIds, setModelIds] = useState<string[]>([])
+const [modelStatus, setModelStatus] = useState<ModelLoadStatus>(
+  KILO_CODE_INVENTORY_STATUSES.Idle,
+)
+```
+
+Use one `loadModels` callback for initial load and retry. On success, update `modelIds`, default both target-local choices only when absent, and never clear `v7ManualModelId`. On failure, set Error while preserving prior models/manual state.
+
+- [ ] **Step 4: Build target-specific policy inputs**
+
+Construct separate inputs:
+
+```ts
+const runtimeKey = {
+  accountId: profile.id,
+  siteName: profile.name,
+  baseUrl: profile.baseUrl,
+  tokenId: 0,
+  tokenName: t("common:labels.apiKey"),
+  tokenKey: profile.apiKey,
+}
+
+const v7Selection: KiloCodeV7ProviderSelection = {
+  ...runtimeKey,
+  selectionId,
+  providerName: profile.name,
+  discoveredModelIds: modelIds,
+  ...(v7ManualModelId.trim()
+    ? { manualModelId: v7ManualModelId.trim() }
+    : {}),
+}
+
+const legacySelection: KiloCodeLegacySelection = {
+  ...runtimeKey,
+  legacyModelId,
+}
+```
+
+Build the output only inside action handlers using the selected target. Use `output.downloadJson` for the Blob, `output.modelCount` for completion analytics, and block when `output.isDownloadTooLarge`.
+
+- [ ] **Step 5: Render target-specific default/recovery controls**
+
+For V7, render `KiloCodeDefaultModelSelect` with the discovered catalog and custom values. For Error/empty state render Retry plus a manual model input. Whenever `v7ManualModelId` is non-blank, render the value and an explicit Remove action; clearing it reconciles the default against discovered models.
+
+For legacy, retain the existing `SearchableSelect` bound to `legacyModelId`. Do not share state between controls.
+
+- [ ] **Step 6: Run related profile tests and compile**
+
+Run:
+
+```powershell
+pnpm vitest related tests/features/ApiCredentialProfiles/components/KiloCodeProfileExportDialog.test.tsx tests/services/kiloCodeExportPolicy.test.ts --run
+pnpm compile
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit the single-profile flow**
+
+```powershell
+git add -- src/features/ApiCredentialProfiles/components/KiloCodeProfileExportDialog.tsx tests/features/ApiCredentialProfiles/components/KiloCodeProfileExportDialog.test.tsx
+git commit -m "feat(kilocode): export profile model catalogs"
+```
+
+## Task 6: Upgrade the Multi-account Export Dialog
+
+**Files:**
+
+- Modify: `src/components/KiloCodeExportDialog.tsx`
+- Modify: `tests/components/KiloCodeExportDialog.test.tsx`
+
+- [ ] **Step 1: Add failing global-default and catalog tests**
+
+Add behavior-level component tests for:
+
+```tsx
+expect(screen.getByRole("combobox", { name: "Default provider" })).toHaveValue(
+  "site-a:7",
+)
+expect(screen.getByRole("combobox", { name: "Default model" })).toHaveValue(
+  "model-a",
+)
+
+expect(mockBuildKiloCodeExportOutput).toHaveBeenCalledWith(
+  expect.objectContaining({
+    target: KILO_CODE_EXPORT_TARGETS.KiloV7,
+    selections: expect.arrayContaining([
+      expect.objectContaining({
+        selectionId: "site-a:7",
+        providerName: "Example - Default",
+        discoveredModelIds: ["model-a", "model-b"],
+      }),
+    ]),
+    defaultModel: { selectionId: "site-a:7", modelId: "model-a" },
+  }),
+)
+```
+
+Also cover:
+
+- selecting a different default provider scopes the model control to that provider;
+- duplicate provider names show disambiguated labels from prepared catalog facts;
+- removing the current provider/model repairs the default deterministically;
+- discovery error/empty exposes Retry and manual recovery per provider;
+- retry success unions the manual model until Remove is clicked;
+- a non-default provider's manual model can be removed;
+- switching to legacy restores per-token single-model controls and does not refetch;
+- V7 completion analytics uses prepared/output provider/model counts while `selectedCount` remains selected sites;
+- oversized multi-account download advises fewer providers or manual copy/merge.
+
+- [ ] **Step 2: Run the multi-account test and verify RED**
+
+Run:
+
+```powershell
+pnpm vitest related tests/components/KiloCodeExportDialog.test.tsx --run
+```
+
+Expected: FAIL because the dialog still binds one model ID to every target and has no global default controls.
+
+- [ ] **Step 3: Rename legacy state and add V7-local state**
+
+Replace shared state with:
+
+```ts
+const [legacyModelIdByToken, setLegacyModelIdByToken] = useState<
+  Record<string, string>
+>({})
+const [v7ManualModelIdByToken, setV7ManualModelIdByToken] = useState<
+  Record<string, string>
+>({})
+const [v7DefaultModel, setV7DefaultModel] = useState<
+  KiloCodeDefaultModelSelection | undefined
+>()
+```
+
+Reset all three only when the dialog closes. Model loads default `legacyModelIdByToken` when absent but do not write V7 manual/default state directly.
+
+- [ ] **Step 4: Build unresolved V7/legacy inputs once**
+
+Map selected sites/tokens into target-specific input arrays. V7 input uses:
+
+```ts
+{
+  ...runtimeKey,
+  selectionId: tokenSelectionKey,
+  providerName: `${getSiteDisplayName(site)} - ${getTokenLabel(token, tokenFallback)}`,
+  discoveredModelIds: modelInventories[tokenSelectionKey]?.modelIds ?? [],
+  manualModelId: v7ManualModelIdByToken[tokenSelectionKey],
+}
+```
+
+Legacy uses `legacyModelIdByToken[tokenSelectionKey]`. Prepare the unresolved V7 catalog with masked/current token values only for UI facts; continue resolving real secrets immediately before copy/download and rebuild the same prepared catalog with resolved keys. Never log either payload.
+
+- [ ] **Step 5: Reconcile and render the global default controls**
+
+Use an effect driven by the prepared V7 catalog:
+
+```ts
+useEffect(() => {
+  setV7DefaultModel((current) =>
+    reconcileKiloCodeV7DefaultSelection(preparedV7Catalog, current),
+  )
+}, [preparedV7Catalog])
+```
+
+Render a Default provider `SearchableSelect` from prepared providers and a `KiloCodeDefaultModelSelect` scoped to the selected provider. Updating the provider immediately reconciles to its first model. Use opaque selection IDs, never delimiter-parsed provider/model values.
+
+- [ ] **Step 6: Render target-specific provider model controls**
+
+When V7 is selected, provider rows show status/count, Retry on Error/empty, manual recovery input, and a visible Remove manual model action whenever a manual value exists. When legacy is selected, retain the current per-token model select bound to `legacyModelIdByToken`.
+
+Compute `canExport` separately:
+
+```ts
+const canExportV7 =
+  preparedV7Catalog.providers.length > 0 &&
+  preparedV7Catalog.providers.every((provider) => provider.modelIds.length > 0) &&
+  Boolean(v7DefaultModel)
+
+const canExportLegacy =
+  legacySelections.length > 0 &&
+  legacySelections.every((selection) => selection.legacyModelId?.trim())
+```
+
+- [ ] **Step 7: Route copy/download and analytics through the discriminated policy**
+
+For V7 pass resolved selections and `v7DefaultModel`; for legacy pass resolved legacy selections and current profile name. Use `output.downloadJson`, block oversized downloads, copy `output.copyPayload`, and complete analytics with:
+
+```ts
+{
+  selectedCount: selectedSiteIds.length,
+  itemCount: output.itemCount,
+  modelCount: output.modelCount,
+  kiloCodeExportTarget: getKiloCodeExportAnalyticsTarget(exportTarget),
+}
+```
+
+- [ ] **Step 8: Run related tests and compile**
+
+Run:
+
+```powershell
+pnpm vitest related tests/components/KiloCodeExportDialog.test.tsx tests/services/kiloCodeV7Selection.test.ts tests/services/kiloCodeExportPolicy.test.ts --run
+pnpm compile
+```
+
+Expected: PASS; switching targets performs no additional model loads or secret resolution.
+
+- [ ] **Step 9: Commit the multi-account flow**
+
+```powershell
+git add -- src/components/KiloCodeExportDialog.tsx tests/components/KiloCodeExportDialog.test.tsx
+git commit -m "feat(kilocode): export account model catalogs"
+```
+
+## Task 7: Synchronize Guidance, Locales, and User Documentation
+
+**Files:**
+
+- Modify: `src/components/KiloCodeExportGuidance.tsx`
+- Modify: `tests/test-utils/kiloCodeExportGuidance.ts`
+- Modify: `tests/components/KiloCodeExportDialog.test.tsx`
+- Modify: `tests/features/ApiCredentialProfiles/components/KiloCodeProfileExportDialog.test.tsx`
+- Modify: `src/locales/{en,es-419,ja,vi,zh-CN,zh-TW}/ui.json`
+- Modify: `docs/docs/key-management.md`
+- Modify: `docs/docs/api-credential-profiles.md`
+- Modify: `docs/docs/supported-export-tools.md`
+
+- [ ] **Step 1: Add failing copy/guidance assertions**
+
+Update guidance helpers and component assertions to require:
+
+- V7 copy contains both top-level `provider` and `model`;
+- imported providers show readable names;
+- the default provider/model is selected separately from the exported catalog;
+- legacy still copies `providerProfiles.apiConfigs`;
+- oversized single-profile guidance says copy/manual merge;
+- oversized multi-account guidance offers fewer providers or copy/manual merge.
+
+Run:
+
+```powershell
+pnpm vitest related tests/components/KiloCodeExportDialog.test.tsx tests/features/ApiCredentialProfiles/components/KiloCodeProfileExportDialog.test.tsx --run
+```
+
+Expected: FAIL on missing translation keys/copy.
+
+- [ ] **Step 2: Add synchronized app-locale keys**
+
+Add the same shape to every `ui.json` locale under `dialog.kiloCode`, including:
+
+```json
+{
+  "labels": {
+    "defaultProvider": "Default provider",
+    "defaultModel": "Default model",
+    "legacyModelId": "Model ID"
+  },
+  "actions": {
+    "retryModels": "Retry model discovery",
+    "removeManualModel": "Remove manual model"
+  },
+  "messages": {
+    "modelSearchLimited": "Showing the first {{visible}} of {{count}} models. Keep typing to narrow the list.",
+    "v7ProviderModelsRequired": "Enter a model ID, retry discovery, or deselect this provider.",
+    "settingsFileTooLargeSingle": "This file is too large for Kilo Code import. Copy the configuration and merge it manually.",
+    "settingsFileTooLargeMultiple": "This file is too large for Kilo Code import. Select fewer providers, or copy the configuration and merge it manually."
+  }
+}
+```
+
+Translate naturally in Chinese, Traditional Chinese, Japanese, Spanish, Vietnamese, and English. Do not use `defaultValue` to hide missing locale entries.
+
+Use these exact localized values for the new keys (merge them into the existing
+`dialog.kiloCode` shape rather than creating a parallel object):
+
+```jsonc
+// zh-CN
+{
+  "defaultProvider": "默认供应商",
+  "defaultModel": "默认模型",
+  "legacyModelId": "模型 ID",
+  "retryModels": "重试获取模型",
+  "removeManualModel": "移除手动模型",
+  "modelSearchLimited": "仅显示前 {{visible}} 个（共 {{count}} 个）模型，请继续输入以缩小范围。",
+  "v7ProviderModelsRequired": "请输入模型 ID、重试获取模型，或取消选择此供应商。",
+  "settingsFileTooLargeSingle": "此文件超过 Kilo Code 的导入大小限制。请复制配置并手动合并。",
+  "settingsFileTooLargeMultiple": "此文件超过 Kilo Code 的导入大小限制。请选择更少的供应商，或复制配置并手动合并。"
+}
+
+// zh-TW
+{
+  "defaultProvider": "預設供應商",
+  "defaultModel": "預設模型",
+  "legacyModelId": "模型 ID",
+  "retryModels": "重試取得模型",
+  "removeManualModel": "移除手動模型",
+  "modelSearchLimited": "僅顯示前 {{visible}} 個（共 {{count}} 個）模型，請繼續輸入以縮小範圍。",
+  "v7ProviderModelsRequired": "請輸入模型 ID、重試取得模型，或取消選取此供應商。",
+  "settingsFileTooLargeSingle": "此檔案超過 Kilo Code 的匯入大小限制。請複製設定並手動合併。",
+  "settingsFileTooLargeMultiple": "此檔案超過 Kilo Code 的匯入大小限制。請選取較少的供應商，或複製設定並手動合併。"
+}
+
+// ja
+{
+  "defaultProvider": "既定のプロバイダー",
+  "defaultModel": "既定のモデル",
+  "legacyModelId": "モデル ID",
+  "retryModels": "モデル検出を再試行",
+  "removeManualModel": "手動モデルを削除",
+  "modelSearchLimited": "{{count}} 件中、最初の {{visible}} 件を表示しています。入力を続けて絞り込んでください。",
+  "v7ProviderModelsRequired": "モデル ID を入力するか、モデル検出を再試行するか、このプロバイダーの選択を解除してください。",
+  "settingsFileTooLargeSingle": "このファイルは Kilo Code のインポート上限を超えています。設定をコピーして手動で統合してください。",
+  "settingsFileTooLargeMultiple": "このファイルは Kilo Code のインポート上限を超えています。プロバイダーを減らすか、設定をコピーして手動で統合してください。"
+}
+
+// es-419
+{
+  "defaultProvider": "Proveedor predeterminado",
+  "defaultModel": "Modelo predeterminado",
+  "legacyModelId": "ID del modelo",
+  "retryModels": "Reintentar detección de modelos",
+  "removeManualModel": "Quitar modelo manual",
+  "modelSearchLimited": "Se muestran los primeros {{visible}} de {{count}} modelos. Sigue escribiendo para reducir la lista.",
+  "v7ProviderModelsRequired": "Ingresa un ID de modelo, reintenta la detección o deselecciona este proveedor.",
+  "settingsFileTooLargeSingle": "Este archivo supera el límite de importación de Kilo Code. Copia la configuración y combínala manualmente.",
+  "settingsFileTooLargeMultiple": "Este archivo supera el límite de importación de Kilo Code. Selecciona menos proveedores o copia la configuración y combínala manualmente."
+}
+
+// vi
+{
+  "defaultProvider": "Nhà cung cấp mặc định",
+  "defaultModel": "Mô hình mặc định",
+  "legacyModelId": "ID mô hình",
+  "retryModels": "Thử tìm mô hình lại",
+  "removeManualModel": "Xóa mô hình nhập thủ công",
+  "modelSearchLimited": "Chỉ hiển thị {{visible}} mô hình đầu tiên trong tổng số {{count}}. Hãy tiếp tục nhập để thu hẹp danh sách.",
+  "v7ProviderModelsRequired": "Hãy nhập ID mô hình, thử tìm mô hình lại hoặc bỏ chọn nhà cung cấp này.",
+  "settingsFileTooLargeSingle": "Tệp này vượt quá giới hạn nhập của Kilo Code. Hãy sao chép cấu hình và hợp nhất thủ công.",
+  "settingsFileTooLargeMultiple": "Tệp này vượt quá giới hạn nhập của Kilo Code. Hãy chọn ít nhà cung cấp hơn hoặc sao chép cấu hình và hợp nhất thủ công."
+}
+```
+
+- [ ] **Step 3: Update target guidance and Chinese source docs**
+
+Explain that Kilo 7.x:
+
+- imports readable provider names;
+- includes the full model catalog reported for each key;
+- uses one explicit default provider/model;
+- copies a mergeable `{ provider, model }` top-level fragment;
+- may still show an empty API-key editor field because Kilo stores imported inline keys separately from editor auth state, while runtime use remains valid.
+
+Keep legacy wording explicitly single-model and do not manually edit generated `docs/docs/en/**` or `docs/docs/ja/**` pages.
+
+- [ ] **Step 4: Run locale extraction and related tests**
+
+Run:
+
+```powershell
+pnpm run i18n:extract:ci
+pnpm vitest related tests/components/KiloCodeExportDialog.test.tsx tests/features/ApiCredentialProfiles/components/KiloCodeProfileExportDialog.test.tsx --run
+```
+
+Expected: PASS with no locale shape drift or extracted updates.
+
+- [ ] **Step 5: Commit localized guidance**
+
+```powershell
+git add -- src/components/KiloCodeExportGuidance.tsx tests/test-utils/kiloCodeExportGuidance.ts tests/components/KiloCodeExportDialog.test.tsx tests/features/ApiCredentialProfiles/components/KiloCodeProfileExportDialog.test.tsx src/locales/en/ui.json src/locales/es-419/ui.json src/locales/ja/ui.json src/locales/vi/ui.json src/locales/zh-CN/ui.json src/locales/zh-TW/ui.json docs/docs/key-management.md docs/docs/api-credential-profiles.md docs/docs/supported-export-tools.md
+git commit -m "docs(kilocode): explain provider catalog exports"
+```
+
+## Task 8: Update Browser Coverage and Run the Release Gates
+
+**Files:**
+
+- Modify: `e2e/apiCredentialProfilesOptionsActions.spec.ts`
+
+- [ ] **Step 1: Make the existing V7 download E2E fail on the richer contract**
+
+Update the existing `downloads Kilo Code settings for an API credential profile` scenario so the mocked `/models` response contains at least two IDs. Assert:
+
+```ts
+expect(Object.values(v7Settings.provider)[0]).toMatchObject({
+  name: "Example Profile",
+  models: {
+    "example-model-a": { name: "example-model-a" },
+    "example-model-b": { name: "example-model-b" },
+  },
+})
+expect(v7Settings.model).toMatch(/\/example-model-a$/)
+```
+
+Retain the existing legacy filename and single `openAiModelId` assertion in the same scenario.
+
+- [ ] **Step 2: Run the focused E2E and verify RED**
+
+Run:
+
+```powershell
+pnpm playwright test e2e/apiCredentialProfilesOptionsActions.spec.ts --grep "downloads Kilo Code settings"
+```
+
+Expected: FAIL because the current payload omits provider `name` and the second model.
+
+- [ ] **Step 3: Use the feature-local stable selectors from Task 4**
+
+Import `KILO_CODE_EXPORT_TEST_IDS.defaultModel` when Playwright must select the
+default. Do not add another selector, and do not locate workflow-critical
+controls by translated copy, CSS class, or position. Keep visible text
+assertions only for outcomes.
+
+- [ ] **Step 4: Run the E2E and verify GREEN**
+
+Run the Step 2 command.
+
+Expected: PASS for V7 multi-model/name/default and legacy single-model download.
+
+- [ ] **Step 5: Run the focused unit/component suite**
+
+Run:
+
+```powershell
+pnpm vitest related tests/services/kiloCodeV7Catalog.test.ts tests/services/kiloCodeExport.test.ts tests/services/kiloCodeExportPolicy.test.ts tests/services/kiloCodeV7Selection.test.ts tests/components/KiloCodeDefaultModelSelect.test.tsx tests/components/KiloCodeExportDialog.test.tsx tests/features/ApiCredentialProfiles/components/KiloCodeProfileExportDialog.test.tsx --run
+```
+
+Expected: PASS with zero failed files/tests.
+
+- [ ] **Step 6: Run extraction, commit-equivalent, and push-equivalent validation**
+
+Run:
+
+```powershell
+pnpm run i18n:extract:ci
+pnpm run validate:staged
+pnpm run validate:push
+```
+
+Before `validate:staged`, stage only the task-scoped files that remain after the prior commits. Expected: all commands PASS; `validate:push` covers compile and `knip` for the new exports/files.
+
+- [ ] **Step 7: Inspect final scope and runtime-verification status**
+
+Run:
+
+```powershell
+git status --short
+git diff origin/main...HEAD --stat
+git diff origin/main...HEAD --check
+rg -n "\[DEBUG-|console\.log|TODO|FIXME" src/services/integrations src/components/KiloCodeExportDialog.tsx src/components/KiloCodeDefaultModelSelect.tsx src/features/ApiCredentialProfiles/components/KiloCodeProfileExportDialog.tsx
+```
+
+Expected: only task commits/files, no debug instrumentation, no whitespace errors, and no unrelated changes.
+
+If a real Kilo Code environment is available, import the generated file and verify readable provider name, multiple switchable models, and the selected default. If unavailable, report the manual runtime check as residual risk rather than claiming end-to-end verification.
+
+- [ ] **Step 8: Commit the E2E slice if it was not included earlier**
+
+```powershell
+git add -- e2e/apiCredentialProfilesOptionsActions.spec.ts
+git commit -m "test(kilocode): cover provider catalog downloads"
+```
+
+Skip this commit only if the files are already clean because their changes were committed with the owning implementation slice.
+
+## Implementation Review Gates
+
+After each implementation task:
+
+1. Review spec compliance against `docs/superpowers/specs/2026-07-17-kilo-code-provider-catalog-export-design.md`.
+2. Review code quality, especially duplicate normalization, target-state leakage, oversized component growth, and accidental legacy behavior changes.
+3. Do not proceed while material findings remain unresolved.
+
+Before final handoff, explicitly report:
+
+- telemetry decision: reuse existing actions; normalized V7 model counts;
+- E2E decision: update the existing single-profile browser download scenario;
+- maintainability decision: shared V7 preparation/selection boundaries, no duplicate dialog normalization;
+- runtime verification: completed in real Kilo Code or listed as an unverified manual step.

--- a/docs/superpowers/specs/2026-07-17-kilo-code-provider-catalog-export-design.md
+++ b/docs/superpowers/specs/2026-07-17-kilo-code-provider-catalog-export-design.md
@@ -1,0 +1,474 @@
+# Kilo Code Provider Catalog Export Design
+
+## Context
+
+All API Hub's Kilo Code 7.x exporter currently preserves the legacy Kilo Code
+5.x interaction model: each selected account runtime key becomes one provider,
+and each provider contains only the single model selected for that key.
+
+That behavior was appropriate for the legacy `providerProfiles` contract,
+where each profile has one `openAiModelId`. Kilo Code 7.x has a different
+contract:
+
+- a provider has a stable machine ID and a separate user-facing `name`;
+- a provider's `models` field is a model-ID map and can contain multiple models;
+- the top-level `model` field selects one global default `provider/model`.
+
+The current exporter uses the stable provider ID, including its identity hash,
+as the visible provider label because it omits the provider `name`. It also
+underuses model inventories that the dialogs already fetch. This change aligns
+the exported payload and UI with the Kilo Code 7.x model without changing the
+legacy format.
+
+## Goals
+
+- Keep one exported provider per selected account runtime key so each provider
+  owns exactly one `baseURL + apiKey` credential pair.
+- Add a concise, human-readable provider `name` while retaining the current
+  stable, collision-resistant provider ID.
+- Export every normalized model ID successfully discovered for each Kilo Code
+  7.x provider.
+- Let the user choose one explicit global default provider/model.
+- Preserve a manual model-ID recovery path when discovery fails or returns no
+  models.
+- Keep the Kilo Code 5.x / Roo Code legacy output and its per-profile single
+  model behavior unchanged.
+- Reuse the model inventories already loaded by the dialogs without additional
+  requests when switching export targets.
+
+## Non-goals
+
+- Combining multiple API keys into one provider.
+- Filtering or ranking models by inferred chat, image, embedding, reasoning,
+  context-window, or pricing capabilities.
+- Adding per-model metadata that All API Hub cannot verify reliably.
+- Adding a per-provider model multi-select or an exhaustive model-management
+  interface to the export dialog.
+- Writing credentials to Kilo Code's `auth.json` or changing Kilo Code's import
+  behavior.
+- Changing the legacy `providerProfiles` schema or its filenames.
+- Refactoring unrelated account runtime key, token provisioning, or model
+  discovery services.
+
+## Verified Kilo Code Contract
+
+The design remains pinned to the Kilo Code source used by the original 7.x
+export and was rechecked against current upstream behavior:
+
+- `ProviderConfig` supports a provider `name` and a `models` record:
+  <https://github.com/Kilo-Org/kilocode/blob/3cb82a0907f888749435c1d208e56d8365747df2/packages/opencode/src/config/provider.ts>
+- The OpenAI-compatible provider documentation configures multiple models and
+  separately selects a default `provider/model`:
+  <https://github.com/Kilo-Org/kilocode/blob/3cb82a0907f888749435c1d208e56d8365747df2/packages/kilo-docs/pages/ai-providers/openai-compatible.md>
+- The custom-provider editor displays the provider name, loads every entry in
+  `models`, and supports adding multiple models:
+  <https://github.com/Kilo-Org/kilocode/blob/3cb82a0907f888749435c1d208e56d8365747df2/packages/kilo-vscode/webview-ui/src/components/settings/CustomProviderDialog.tsx>
+- Settings import preserves the complete top-level `provider` value rather than
+  reducing providers to one model:
+  <https://github.com/Kilo-Org/kilocode/blob/3cb82a0907f888749435c1d208e56d8365747df2/packages/kilo-vscode/webview-ui/src/components/settings/settings-io.ts>
+
+The existing protocol-source comment near the exporter must be expanded to
+record the provider-name, model-map, and top-level-default contracts.
+
+## User Experience
+
+### Provider names
+
+The Kilo Code provider ID remains an implementation identity, not display copy.
+The exported provider object gains a `name`:
+
+- account runtime key: `<site display name> - <key display name>`;
+- API credential profile: the profile's display name;
+- blank account/key names use the existing URL and `Token <id>` fallbacks;
+- duplicate names are disambiguated deterministically with the existing domain
+  and ordinal rules.
+
+Provider names may contain Unicode and spaces. Provider IDs retain the current
+settings-safe slug plus stable digest so repeated exports keep the same IDs and
+secret rotation does not change identity.
+
+The provider-ID algorithm remains byte-for-byte compatible with the current
+exporter: the readable slug and digest continue to use the current site/key
+inputs. Identical identity/display inputs and secret rotation therefore keep the
+same ID. Renaming the site or key, or changing locale-derived legacy inputs, may
+still change the ID; making IDs rename- or locale-stable is a separate migration
+decision and is not part of this change. The new `providerName` display field
+does not independently participate in ID generation.
+
+### Kilo Code 7.x model workflow
+
+For Kilo Code 7.x, every selected provider exports its complete successfully
+loaded model inventory. Model IDs are normalized by trimming blanks, removing
+duplicates, and sorting deterministically. All API Hub does not claim that every
+listed model supports every Kilo Code workflow; it exports the upstream model
+catalog as reported for that credential.
+
+The multi-account dialog exposes two explicit controls:
+
+1. **Default provider**, containing the selected provider display names.
+2. **Default model**, scoped to the selected default provider and containing its
+   discovered model IDs.
+
+The model control keeps the existing custom-value behavior in both dialogs,
+including when discovery succeeds. A custom default model that was not returned
+by discovery is added to that provider's exported catalog. Separating provider
+and model selection avoids ambiguous free-form values while keeping large
+cross-provider catalogs searchable.
+
+For example:
+
+```text
+Default provider: Example - Default Key
+Default model: example-model
+```
+
+The provider control value uses a stable internal provider-selection identity;
+the model control value is the selected model ID. Together they supply Kilo
+Code's top-level `model` field without exposing generated provider IDs in the
+dialog.
+
+The two controls consume a shared prepared-catalog result rather than rebuilding
+names or model normalization in either dialog. Provider values are opaque stable
+selection IDs mapped back to prepared providers; model IDs are never combined
+with provider IDs through a delimiter because valid model IDs may contain `/`.
+
+The default provider initializes to the first provider in the existing
+deterministic order. Its default model initializes to that provider's first
+normalized model. Once the user changes either control, asynchronous inventory
+updates preserve each selection while it remains valid. Removing the selected
+provider selects the next deterministic provider. Removing a selected discovered
+model selects the next model for that provider; a user-entered custom model
+remains valid until the user clears it or removes the provider.
+
+Provider rows no longer require a normal single-model choice for Kilo Code 7.x.
+They show discovery status and model count. If a provider's model discovery
+fails or returns an empty list, that row exposes the existing custom-value model
+input as a manual recovery field plus a retry action. The entered model becomes
+that provider's catalog entry and is eligible for the global default selector.
+If a later retry succeeds, the manual model remains explicitly included alongside
+the discovered catalog. While `manualModelId` exists, the provider row continues
+to show that value with an explicit **Remove manual model** action even after
+discovery succeeds. The same action is available in the single-profile dialog
+and for non-default providers. Removing a manual model deletes it from the
+prepared catalog; if it was the global default, the dialog selects the first
+deterministic discovered model for that provider or marks the default invalid
+when none remains.
+
+The default-model popover searches the full catalog for the selected provider
+but renders at most the first 100 deterministic matches. When more matches exist,
+it tells the user to continue typing to narrow the list. An exact selected or
+custom value always remains renderable. This feature-local bounded-result control
+uses the existing command/popover primitives and avoids sending thousands of
+unfiltered rows through the non-virtualized shared `SearchableSelect`.
+
+Export is disabled until every selected provider has at least one model and a
+valid global default exists. Error copy identifies the affected provider and the
+next action: enter a model ID, retry discovery, or deselect the provider.
+
+### Single-profile dialog
+
+The API credential profile dialog has one provider, so its existing model
+selector becomes the **Default model** selector. The generated provider still
+contains the full discovered model inventory, with a custom entered default
+included if it was not returned by discovery. The dialog exposes the same retry
+and **Remove manual model** actions and preserves a manual model across a
+successful retry until that explicit removal.
+
+### Legacy target
+
+When the target is Roo Code / Kilo Code 5.x, the dialogs retain the existing
+per-key single-model selectors and validation. Switching between targets reuses
+the same loaded inventories but keeps legacy model selections, V7 manual models,
+and the V7 global default in separate target-local state. Switching targets
+preserves those values without refetching models or resolving secrets again.
+
+## Export Contract
+
+The Kilo Code 7.x payload becomes:
+
+```json
+{
+  "_meta": {
+    "version": 1,
+    "exportedAt": "2026-07-17T00:00:00.000Z"
+  },
+  "provider": {
+    "example-default-2f8a7c1d": {
+      "name": "Example - Default",
+      "npm": "@ai-sdk/openai-compatible",
+      "models": {
+        "example-model": { "name": "example-model" },
+        "example-model-mini": { "name": "example-model-mini" }
+      },
+      "options": {
+        "apiKey": "example-key",
+        "baseURL": "https://example.invalid/v1"
+      }
+    }
+  },
+  "model": "example-default-2f8a7c1d/example-model"
+}
+```
+
+Each provider has one credential pair and one or more models. Only the top-level
+`model` is a default; it does not limit the provider's model catalog.
+
+For Kilo Code 7.x, **Copy configuration** changes from copying only the
+`provider` value to copying a mergeable top-level fragment containing both
+`provider` and `model`. This preserves the user's explicit global default. The
+button label, help copy, tests, and documentation must describe pasting both
+top-level fields. Legacy copy behavior remains `providerProfiles.apiConfigs`.
+
+## Data and Ownership Boundaries
+
+### Dialog-owned selection input
+
+Runtime-key identity, display facts, URL, and resolved secret live in a shared
+base. Target-specific inputs do not overload the legacy single model:
+
+```ts
+interface KiloCodeRuntimeKeyExportInput {
+  accountId: string
+  siteName: string
+  baseUrl: string
+  tokenId: number
+  tokenName: string
+  tokenKey: string
+}
+
+interface KiloCodeLegacySelection extends KiloCodeRuntimeKeyExportInput {
+  legacyModelId: string
+}
+
+interface KiloCodeV7ProviderSelection extends KiloCodeRuntimeKeyExportInput {
+  selectionId: string
+  providerName?: string
+  discoveredModelIds: string[]
+  manualModelId?: string
+}
+
+interface KiloCodeDefaultModelSelection {
+  selectionId: string
+  modelId: string
+}
+```
+
+- `providerName` is the caller-selected display fact. The preparation boundary
+  applies a deterministic fallback and disambiguation when it is blank or
+  duplicated.
+- `legacyModelId` is isolated to the legacy target.
+- `discoveredModelIds` is the V7 inventory loaded for that credential.
+- `manualModelId` is explicit V7 state and is unioned with discovered models
+  until the user clears it.
+- `selectionId` is an opaque, stable dialog identity. It is not exported and
+  does not contain secrets.
+- `KiloCodeDefaultModelSelection` identifies the one top-level default without
+  coupling callers to generated provider IDs.
+
+### Shared V7 preparation boundary
+
+A pure `prepareKiloCodeV7Catalog` boundary owns everything the UI and builder
+must agree on:
+
+- provider-name fallback and collision disambiguation;
+- stable provider-ID generation;
+- normalized, deduplicated, deterministically sorted model IDs;
+- opaque selection-ID lookup;
+- provider/default option facts used by the dialogs;
+- provider and model counts used by analytics.
+
+It returns prepared providers containing the final display name, generated ID,
+selection ID, normalized model list, and credential options. Both dialogs use
+this result for selector labels and validation. The V7 schema builder consumes
+the same prepared result, so normalization and naming cannot drift or be
+duplicated across UI consumers.
+
+Provider order remains the existing deterministic selection order. Model order
+uses code-point lexical ordering after trimming and deduplication rather than
+locale-sensitive `localeCompare`, so output is stable across runtime locale and
+ICU versions. Tests include mixed-case and Unicode model IDs, model IDs containing
+`/`, identical model IDs across providers, and duplicate provider display names.
+
+### Pure V7 builder
+
+The V7 builder owns:
+
+- validation of the prepared catalog and non-empty provider models;
+- resolution of the requested default selection to the generated provider ID;
+- validation that the default model exists in that provider's model map;
+- schema construction.
+
+The dialogs own model fetching, loading/error/retry UI, target-local selections,
+and translation. The output policy accepts a discriminated target input so
+legacy selections cannot leak into V7 catalogs. It dispatches target-specific
+inputs and describes filenames/copy payloads.
+
+### Legacy isolation
+
+The legacy builder continues to consume only `KiloCodeLegacySelection`. It never
+receives V7 provider names, catalogs, manual models, or global-default inputs.
+Legacy unit tests must prove byte-for-byte-equivalent object shapes for
+representative fixtures.
+
+## Validation and Failure Paths
+
+The V7 builder rejects:
+
+- no selected providers;
+- blank runtime keys;
+- invalid HTTP/HTTPS base URLs;
+- providers with no normalized models;
+- blank or duplicate final provider IDs;
+- missing default selection;
+- a default selection that does not match an exported provider/model.
+
+The UI covers:
+
+- model discovery loading, empty, and failure states per provider;
+- manual recovery model IDs;
+- removal of the current global default;
+- duplicate provider display names;
+- payload generation errors with local translated fallback copy;
+- Kilo Code's 1 MiB settings-import limit.
+
+Before download, the actual pretty-printed Kilo Code 7.x JSON string is measured
+as UTF-8. Exactly `1_048_576` bytes is accepted; larger files are blocked to
+match Kilo Code's pinned `MAX_IMPORT_SIZE`. The shared limit constant records
+the upstream source.
+
+For multi-account exports, recovery copy suggests selecting fewer providers or
+copying the fragment and merging it manually. For a single-profile export,
+where reducing providers is impossible, recovery copy points only to copying
+and manually merging the fragment. Copy remains available with an explicit
+warning because clipboard fragments are not constrained by Kilo Code's file
+picker, but help text must not imply that an oversized fragment can be imported
+as a file.
+
+## Telemetry
+
+Reuse the existing Kilo copy/download actions and controlled target enum.
+
+- `selected_count`: number of selected sites in the multi-account dialog and
+  `1` in the single-profile dialog, preserving current semantics;
+- `item_count`: number of exported providers/runtime keys;
+- `model_count`: total number of model entries exported for Kilo Code 7.x and
+  the existing selected-model count for legacy;
+- result/error category: existing controlled values only.
+
+Counts come from the prepared/output descriptor after normalization rather than
+from raw inventory arrays, so blanks and duplicates are not over-counted.
+
+Do not record provider names or IDs, model IDs, URLs, hosts, API keys, inventory
+errors, or backend messages. No new passive impression event is needed.
+
+## Localization and Documentation
+
+Target-specific copy must distinguish:
+
+- Kilo Code 7.x **Default model** and exported model catalog;
+- legacy per-profile **Model ID**;
+- model discovery failure recovery;
+- oversized file recovery;
+- provider display-name behavior where user guidance mentions imported names.
+
+Update all app locales together and run `pnpm run i18n:extract:ci`. Update the
+Chinese source documentation for supported export tools and Kilo export flows;
+generated English and Japanese docs stay under the translation workflow.
+
+Settings search and deep links do not change because all controls remain
+transient export-dialog state.
+
+## Testing
+
+### Unit tests
+
+Cover the pure builder and output policy:
+
+- explicit provider names and deterministic duplicate-name disambiguation;
+- unchanged stable provider IDs when secrets or model catalogs change;
+- changing only explicit `providerName` changes display copy without changing
+  the current ID;
+- changing `siteName` updates the readable slug while retaining the digest;
+- changing `tokenName` updates the ID under the current algorithm because it
+  participates in both the slug and digest;
+- multiple normalized models per provider;
+- blank and duplicate model removal;
+- manual recovery model inclusion;
+- retry failure -> manual model -> retry success unions discovered and manual
+  values until the manual value is cleared;
+- explicit global-default resolution across multiple providers;
+- missing/unknown default failures;
+- empty-provider-model failure;
+- unchanged legacy output;
+- V7 copy includes both `provider` and `model` while legacy copy remains
+  unchanged;
+- exactly 1 MiB is accepted and 1 MiB plus one byte is blocked.
+
+### Component tests
+
+Cover both dialogs:
+
+- multi-account Kilo Code 7.x renders global Default provider and Default model
+  controls;
+- V7 exports all loaded model IDs and the selected default;
+- single-profile V7 exports its full catalog;
+- discovery failure exposes manual recovery;
+- successful and failed discovery both preserve custom default-model entry;
+- retry success retains an explicit manual model until the user clears it;
+- the visible Remove manual model action removes the entry for default and
+  non-default providers and repairs or invalidates the global default;
+- removing the selected default chooses the next deterministic option;
+- legacy retains per-key single-model controls;
+- switching targets does not refetch inventories or secrets;
+- analytics counts exported models without exposing identifiers;
+- duplicate display names produce disambiguated selector labels;
+- model IDs containing `/` round-trip through opaque provider selection values;
+- a 5,000-model catalog renders at most 100 model rows, search finds an exact
+  item outside the initial 100, and the selected/custom item remains visible;
+- oversized multi-account and single-profile downloads show their respective
+  actionable recovery messages.
+
+Use roles, accessible names, and stable feature-local test IDs where a workflow
+control needs disambiguation. Do not assert incidental DOM structure or exact
+class names.
+
+### Browser-level test
+
+Update the existing Kilo Code download scenario rather than adding a parallel
+workflow. Verify that the downloaded file contains:
+
+- a human-readable provider `name` separate from its stable ID;
+- at least two models under one provider;
+- a top-level default that references an exported provider/model;
+- no change to the representative legacy download assertion.
+
+Lower-level tests cover inventory permutations and failure matrices. The E2E
+test remains one representative single-profile browser download path. It does
+not cover the multi-provider default selectors; component tests own that
+contract.
+
+### Runtime verification
+
+Import a generated file through a real Kilo Code 7.x About Kilo Code -> Import
+flow. Confirm that:
+
+- the imported provider displays the human-readable name;
+- Kilo's model picker lists multiple exported models;
+- switching between two exported models works with the same provider key;
+- the chosen top-level default is initially selected;
+- the existing inline-key/editor-display limitation remains only a known Kilo
+  UX issue and does not prevent runtime use.
+
+If the environment is unavailable, report this as a remaining manual check and
+do not claim end-to-end runtime verification.
+
+## Maintainability Decision
+
+Reuse the current stable provider-ID algorithm, base-URL normalization, unique
+profile naming rules, model inventories, target selector, output policy,
+analytics actions, and legacy builders. Extend the pure V7 contract and extract
+small target-specific UI helpers/hooks where needed to keep model catalog and
+default-selection orchestration out of the already-large multi-account dialog.
+
+Do not add a parallel exporter, duplicate model normalization in both dialogs,
+or broaden the change into general model-management architecture.

--- a/docs/superpowers/specs/2026-07-17-kilo-code-provider-catalog-export-design.md
+++ b/docs/superpowers/specs/2026-07-17-kilo-code-provider-catalog-export-design.md
@@ -35,6 +35,11 @@ legacy format.
   model behavior unchanged.
 - Reuse the model inventories already loaded by the dialogs without additional
   requests when switching export targets.
+- Let each Kilo Code 7.x provider choose its AI SDK protocol package: OpenAI
+  Compatible (default), OpenAI Responses, or Anthropic Messages.
+- Keep the existing model discovery path for every protocol,
+  including Anthropic, so protocol selection never removes models from the
+  exported catalog.
 
 ## Non-goals
 
@@ -49,6 +54,8 @@ legacy format.
 - Changing the legacy `providerProfiles` schema or its filenames.
 - Refactoring unrelated account runtime key, token provisioning, or model
   discovery services.
+- Adding protocol-specific discovery fallbacks, `/models` requests, headers, or
+  model metadata that the existing adapters do not already provide.
 
 ## Verified Kilo Code Contract
 
@@ -183,6 +190,36 @@ and the V7 global default in separate target-local state. Switching targets
 preserves those values without refetching models or resolving secrets again.
 
 ## Export Contract
+
+### Protocol selection
+
+Each V7 provider carries a normalized protocol choice in the dialog-owned
+selection input. The default is `openai-compatible` for backward-compatible
+exports. The choice maps to Kilo Code's provider package as follows:
+
+| UI choice | Runtime value | Exported `npm` |
+| --- | --- | --- |
+| OpenAI Compatible | `openai-compatible` | `@ai-sdk/openai-compatible` |
+| OpenAI Responses | `openai-responses` | `@ai-sdk/openai` |
+| Anthropic Messages | `anthropic-messages` | `@ai-sdk/anthropic` |
+
+The account dialog stores this value per selected runtime-key provider. The
+profile dialog stores one value for its single provider. Switching between V7
+and Legacy preserves the V7 choice but does not add a protocol control to the
+Legacy flow. Closing and reopening a dialog starts a fresh V7 context with the
+default protocol, matching the existing transient export state.
+
+Changing the protocol does not refetch models, clear manual models, resolve
+secrets, or change provider IDs. It is included in the async export action
+signature so a copy/download that began under one protocol cannot complete with
+another protocol's payload. The builder validates the normalized value and
+serializes only the mapped `npm` field; all other provider fields remain
+unchanged.
+
+Model discovery remains independent of this choice. In particular, selecting
+Anthropic Messages keeps the repository's existing loaded inventory instead of
+adopting Kilo Code's UI-level rule that skips its generic OpenAI-compatible
+`/models` discovery helper for Anthropic providers.
 
 The Kilo Code 7.x payload becomes:
 

--- a/e2e/apiCredentialProfilesOptionsActions.spec.ts
+++ b/e2e/apiCredentialProfilesOptionsActions.spec.ts
@@ -359,7 +359,11 @@ test("downloads Kilo Code settings for an API credential profile", async ({
     KILO_CODE_EXPORT_TEST_IDS.defaultModelSearch,
   )
   await defaultModelSearch.fill(slashBearingModel)
-  await defaultModelSearch.press("ArrowDown")
+  const slashBearingModelOption = page.getByRole("option", {
+    name: slashBearingModel,
+    exact: true,
+  })
+  await expect(slashBearingModelOption).toHaveAttribute("aria-selected", "true")
   await defaultModelSearch.press("Enter")
   await expect(defaultModel).toContainText(slashBearingModel)
 

--- a/e2e/apiCredentialProfilesOptionsActions.spec.ts
+++ b/e2e/apiCredentialProfilesOptionsActions.spec.ts
@@ -363,8 +363,8 @@ test("downloads Kilo Code settings for an API credential profile", async ({
     name: slashBearingModel,
     exact: true,
   })
-  await expect(slashBearingModelOption).toHaveAttribute("aria-selected", "true")
-  await defaultModelSearch.press("Enter")
+  await expect(slashBearingModelOption).toBeVisible()
+  await slashBearingModelOption.click({ force: true })
   await expect(defaultModel).toContainText(slashBearingModel)
 
   const v7DownloadPromise = page.waitForEvent("download")

--- a/e2e/apiCredentialProfilesOptionsActions.spec.ts
+++ b/e2e/apiCredentialProfilesOptionsActions.spec.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises"
 import type { BrowserContext, Page } from "@playwright/test"
 
+import { KILO_CODE_EXPORT_TEST_IDS } from "~/components/kiloCodeExportTestIds"
 import { OPTIONS_PAGE_PATH } from "~/constants/extensionPages"
 import { MENU_ITEM_IDS } from "~/constants/optionsMenuIds"
 import { API_CREDENTIAL_PROFILES_TEST_IDS } from "~/features/ApiCredentialProfiles/testIds"
@@ -313,19 +314,31 @@ test("downloads Kilo Code settings for an API credential profile", async ({
   extensionId,
   page,
 }) => {
+  const profileName = "Example Profile"
+  const profileBaseUrl = "https://kilo-export.example.invalid"
+  const modelIds = [
+    "example-model-a",
+    "example-model-b",
+    "vendor/example-model-c",
+  ] as const
   const serviceWorker = await getServiceWorker(context)
   await seedApiCredentialProfiles(serviceWorker, [
     createStoredApiCredentialProfile({
       id: "profile-kilo-export",
-      name: "Kilo Export Profile",
-      baseUrl: "https://kilo-export.example.com",
+      name: profileName,
+      baseUrl: profileBaseUrl,
       apiKey: "sk-kilo-export-profile",
     }),
   ])
 
-  await installOpenAiCompatibleModelsRoute(context, {
-    baseUrl: "https://kilo-export.example.com",
-    modelId: "gpt-kilo-export",
+  await context.route(`${profileBaseUrl}/v1/models`, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        data: modelIds.map((id) => ({ id })),
+      }),
+    })
   })
 
   await openProfilesPage(page, extensionId)
@@ -338,7 +351,17 @@ test("downloads Kilo Code settings for an API credential profile", async ({
     .click()
 
   await expect(page.getByText("Export Kilo Code JSON")).toBeVisible()
-  await expect(page.getByText("gpt-kilo-export")).toBeVisible()
+  const slashBearingModel = modelIds[2]
+  const defaultModel = page.getByTestId(KILO_CODE_EXPORT_TEST_IDS.defaultModel)
+  await expect(defaultModel).toBeEnabled()
+  await defaultModel.click()
+  const defaultModelSearch = page.getByTestId(
+    KILO_CODE_EXPORT_TEST_IDS.defaultModelSearch,
+  )
+  await defaultModelSearch.fill(slashBearingModel)
+  await defaultModelSearch.press("ArrowDown")
+  await defaultModelSearch.press("Enter")
+  await expect(defaultModel).toContainText(slashBearingModel)
 
   const v7DownloadPromise = page.waitForEvent("download")
   await page.getByRole("button", { name: "Download Kilo 7.x settings" }).click()
@@ -357,8 +380,9 @@ test("downloads Kilo Code settings for an API credential profile", async ({
     provider?: Record<
       string,
       {
+        name?: string
         npm?: string
-        models?: Record<string, unknown>
+        models?: Record<string, { name?: string }>
         options?: { apiKey?: string; baseURL?: string }
       }
     >
@@ -366,17 +390,28 @@ test("downloads Kilo Code settings for an API credential profile", async ({
   }
 
   expect(v7Settings._meta?.version).toBe(1)
-  expect(Object.keys(v7Settings.provider ?? {})).toHaveLength(1)
-  const [providerId, provider] = Object.entries(v7Settings.provider ?? {})[0]
+  const providerEntries = Object.entries(v7Settings.provider ?? {})
+  expect(providerEntries).toHaveLength(1)
+  const [providerId, provider] = providerEntries[0]
+  expect(provider.name).toBe(profileName)
+  expect(providerId).not.toBe(profileName)
   expect(provider).toMatchObject({
     npm: "@ai-sdk/openai-compatible",
+    models: {
+      [modelIds[0]]: { name: modelIds[0] },
+      [modelIds[1]]: { name: modelIds[1] },
+      [modelIds[2]]: { name: modelIds[2] },
+    },
     options: {
       apiKey: "sk-kilo-export-profile",
-      baseURL: "https://kilo-export.example.com/v1",
+      baseURL: `${profileBaseUrl}/v1`,
     },
   })
-  expect(Object.keys(provider.models ?? {})).toContain("gpt-kilo-export")
-  expect(v7Settings.model).toBe(`${providerId}/gpt-kilo-export`)
+
+  expect(v7Settings.model).toBe(`${providerId}/${slashBearingModel}`)
+  expect(
+    v7Settings.provider?.[providerId]?.models?.[slashBearingModel],
+  ).toEqual({ name: slashBearingModel })
 
   await page.getByRole("button", { name: "Cancel" }).click()
   await expect(page.getByText("Export Kilo Code JSON")).toHaveCount(0)
@@ -427,20 +462,20 @@ test("downloads Kilo Code settings for an API credential profile", async ({
     }
   }
 
-  const profileName = "Kilo Export Profile - API Key"
+  const legacyProfileName = `${profileName} - API Key`
   expect(legacySettings.providerProfiles?.currentApiConfigName).toBe(
-    profileName,
+    legacyProfileName,
   )
   expect(
-    legacySettings.providerProfiles?.apiConfigs?.[profileName],
+    legacySettings.providerProfiles?.apiConfigs?.[legacyProfileName],
   ).toMatchObject({
     apiProvider: "openai",
-    openAiBaseUrl: "https://kilo-export.example.com/v1",
+    openAiBaseUrl: `${profileBaseUrl}/v1`,
     openAiApiKey: "sk-kilo-export-profile",
-    openAiModelId: "gpt-kilo-export",
+    openAiModelId: modelIds[0],
   })
   expect(
-    legacySettings.providerProfiles?.apiConfigs?.[profileName]?.id,
+    legacySettings.providerProfiles?.apiConfigs?.[legacyProfileName]?.id,
   ).toEqual(expect.any(String))
 })
 

--- a/src/components/KiloCodeDefaultModelSelect.tsx
+++ b/src/components/KiloCodeDefaultModelSelect.tsx
@@ -1,0 +1,264 @@
+import { CheckIcon, ChevronsUpDownIcon } from "lucide-react"
+import * as React from "react"
+import { useTranslation } from "react-i18next"
+
+import { Button } from "~/components/ui/button"
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "~/components/ui/command"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "~/components/ui/popover"
+import { cn } from "~/lib/utils"
+
+import { KILO_CODE_EXPORT_TEST_IDS } from "./kiloCodeExportTestIds"
+
+const MAX_RENDERED_KILO_CODE_MODELS = 100
+
+export interface KiloCodeDefaultModelSelectProps
+  extends Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "onChange"> {
+  value: string
+  modelIds: string[]
+  onChange: (value: string) => void
+  allowCustomValue?: boolean
+  placeholder?: string
+  searchPlaceholder?: string
+  portalContainer?: HTMLElement
+}
+
+interface BoundedModelResults {
+  customValue?: string
+  matchingCount: number
+  renderedModelIds: string[]
+  visibleMatchingCount: number
+}
+
+/** Filter the full catalog, then fit catalog, selected, and custom rows safely. */
+function getBoundedModelResults({
+  allowCustomValue,
+  modelIds,
+  search,
+  value,
+}: Pick<
+  KiloCodeDefaultModelSelectProps,
+  "allowCustomValue" | "modelIds" | "value"
+> & { search: string }): BoundedModelResults {
+  const normalizedSearch = search.trim()
+  const normalizedQuery = normalizedSearch.toLocaleLowerCase()
+  const isSearchActive = normalizedSearch.length > 0
+  const matchingModelIds = modelIds.filter((modelId) =>
+    modelId.toLocaleLowerCase().includes(normalizedQuery),
+  )
+  const customValue =
+    allowCustomValue &&
+    normalizedSearch.length > 0 &&
+    !modelIds.includes(normalizedSearch)
+      ? normalizedSearch
+      : undefined
+  const isSelectedInCatalog = modelIds.includes(value)
+  const selectedMatchesSearch =
+    !isSearchActive || value.toLocaleLowerCase().includes(normalizedQuery)
+  const canRenderSelected =
+    value.length > 0 &&
+    selectedMatchesSearch &&
+    (isSelectedInCatalog || Boolean(allowCustomValue)) &&
+    customValue !== value
+  const hasExternalSelectedRow = canRenderSelected && !isSelectedInCatalog
+  const catalogBudget =
+    MAX_RENDERED_KILO_CODE_MODELS -
+    (customValue ? 1 : 0) -
+    (hasExternalSelectedRow ? 1 : 0)
+  const renderedModelIds = matchingModelIds.slice(0, catalogBudget)
+
+  if (canRenderSelected && !renderedModelIds.includes(value)) {
+    if (hasExternalSelectedRow || renderedModelIds.length < catalogBudget) {
+      renderedModelIds.push(value)
+    } else if (catalogBudget > 0) {
+      renderedModelIds[catalogBudget - 1] = value
+    }
+  }
+
+  const matchingModelIdSet = new Set(matchingModelIds)
+
+  return {
+    customValue,
+    matchingCount: matchingModelIds.length,
+    renderedModelIds,
+    visibleMatchingCount: renderedModelIds.filter((modelId) =>
+      matchingModelIdSet.has(modelId),
+    ).length,
+  }
+}
+
+/**
+ * Select a Kilo Code default model without mounting an unbounded upstream
+ * catalog in the DOM.
+ */
+export const KiloCodeDefaultModelSelect = React.forwardRef<
+  HTMLButtonElement,
+  KiloCodeDefaultModelSelectProps
+>(function KiloCodeDefaultModelSelect(
+  {
+    value,
+    modelIds,
+    onChange,
+    allowCustomValue = false,
+    placeholder,
+    searchPlaceholder,
+    portalContainer,
+    className,
+    disabled,
+    ...buttonProps
+  },
+  ref,
+) {
+  const { t } = useTranslation("ui")
+  const [open, setOpen] = React.useState(false)
+  const [search, setSearch] = React.useState("")
+  const { customValue, matchingCount, renderedModelIds, visibleMatchingCount } =
+    React.useMemo(
+      () =>
+        getBoundedModelResults({
+          allowCustomValue,
+          modelIds,
+          search,
+          value,
+        }),
+      [allowCustomValue, modelIds, search, value],
+    )
+  const isLimited = matchingCount > visibleMatchingCount
+  const limitedMessageValues = {
+    visible: visibleMatchingCount,
+    count: matchingCount,
+  }
+  const resolvedSearchPlaceholder =
+    searchPlaceholder ?? t("searchableSelect.searchPlaceholder")
+  const emptyMessage =
+    modelIds.length === 0
+      ? allowCustomValue
+        ? t("searchableSelect.noOptionsAllowCustom")
+        : t("searchableSelect.noOptions")
+      : t("searchableSelect.empty")
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    setOpen(nextOpen)
+    if (!nextOpen) setSearch("")
+  }
+
+  const handleSelect = (modelId: string) => {
+    onChange(modelId)
+    handleOpenChange(false)
+  }
+
+  return (
+    <Popover open={open} onOpenChange={handleOpenChange}>
+      <PopoverTrigger asChild>
+        <Button
+          {...buttonProps}
+          ref={ref}
+          type="button"
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          aria-haspopup="listbox"
+          aria-label={
+            buttonProps["aria-label"] ??
+            (buttonProps["aria-labelledby"] ? undefined : value || placeholder)
+          }
+          data-testid={KILO_CODE_EXPORT_TEST_IDS.defaultModel}
+          data-placeholder={value ? undefined : ""}
+          disabled={disabled}
+          className={cn(
+            "dark:border-dark-bg-tertiary dark:bg-dark-bg-secondary dark:text-dark-text-primary dark:hover:bg-dark-bg-secondary/80 flex w-full items-center justify-between gap-2 rounded-md border border-gray-300 bg-white px-3 text-sm whitespace-nowrap text-gray-900 shadow-xs transition-colors outline-none hover:bg-gray-50 focus-visible:border-transparent focus-visible:ring-2 focus-visible:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-60 aria-invalid:border-red-500 aria-invalid:focus-visible:ring-red-500/40 data-placeholder:text-gray-400 dark:aria-invalid:border-red-400 dark:aria-invalid:focus-visible:ring-red-400/40 dark:data-placeholder:text-gray-500",
+            !value && "text-muted-foreground",
+            className,
+          )}
+          rightIcon={
+            <ChevronsUpDownIcon className="size-4 shrink-0 opacity-50" />
+          }
+        >
+          <span className="min-w-0 flex-1 truncate text-left">
+            {value || placeholder}
+          </span>
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        container={portalContainer}
+        className="flex max-h-(--radix-popover-content-available-height) w-(--radix-popper-anchor-width) flex-col overflow-hidden p-0"
+        collisionPadding={8}
+      >
+        <Command
+          shouldFilter={false}
+          label={resolvedSearchPlaceholder}
+          className="min-h-0 flex-1 [&_[data-slot='command-input-wrapper']]:shrink-0"
+        >
+          <CommandInput
+            aria-label={resolvedSearchPlaceholder}
+            placeholder={resolvedSearchPlaceholder}
+            value={search}
+            onValueChange={setSearch}
+            data-testid={KILO_CODE_EXPORT_TEST_IDS.defaultModelSearch}
+          />
+          {isLimited ? (
+            <div
+              role="status"
+              className="text-muted-foreground shrink-0 border-b px-3 py-2 text-xs"
+            >
+              {t(
+                "dialog.kiloCode.messages.modelSearchLimited",
+                limitedMessageValues,
+              )}
+            </div>
+          ) : null}
+          <CommandList className="min-h-0 flex-1">
+            {!renderedModelIds.length && !customValue ? (
+              <CommandEmpty>{emptyMessage}</CommandEmpty>
+            ) : null}
+            <CommandGroup>
+              {customValue ? (
+                <CommandItem
+                  value={customValue}
+                  data-testid={KILO_CODE_EXPORT_TEST_IDS.modelOption}
+                  onSelect={() => handleSelect(customValue)}
+                >
+                  <CheckIcon
+                    className={cn(
+                      "size-4",
+                      value === customValue ? "opacity-100" : "opacity-0",
+                    )}
+                  />
+                  <span className="min-w-0 flex-1 truncate">
+                    {t("searchableSelect.useValue", { value: customValue })}
+                  </span>
+                </CommandItem>
+              ) : null}
+              {renderedModelIds.map((modelId) => (
+                <CommandItem
+                  key={modelId}
+                  value={modelId}
+                  data-testid={KILO_CODE_EXPORT_TEST_IDS.modelOption}
+                  onSelect={() => handleSelect(modelId)}
+                >
+                  <CheckIcon
+                    className={cn(
+                      "size-4",
+                      value === modelId ? "opacity-100" : "opacity-0",
+                    )}
+                  />
+                  <span className="min-w-0 flex-1 truncate">{modelId}</span>
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  )
+})

--- a/src/components/KiloCodeExportDialog.tsx
+++ b/src/components/KiloCodeExportDialog.tsx
@@ -37,6 +37,7 @@ import {
   KILO_CODE_EXPORT_FILENAMES,
   KILO_CODE_EXPORT_TARGET_OPTIONS,
   KILO_CODE_EXPORT_TARGETS,
+  KILO_CODE_PROVIDER_PROTOCOLS,
   type KiloCodeExportTarget,
 } from "~/services/integrations/kiloCodeExport"
 import { getKiloCodeExportAnalyticsTarget } from "~/services/integrations/kiloCodeExportAnalytics"
@@ -79,6 +80,21 @@ const KILO_CODE_INVENTORY_STATUSES = {
   Loaded: "loaded",
   Error: "error",
 } as const
+
+const KILO_CODE_PROTOCOL_OPTIONS = [
+  {
+    value: KILO_CODE_PROVIDER_PROTOCOLS.OpenAICompatible,
+    label: "ui:dialog.kiloCode.protocols.openAICompatible",
+  },
+  {
+    value: KILO_CODE_PROVIDER_PROTOCOLS.OpenAIResponses,
+    label: "ui:dialog.kiloCode.protocols.openAIResponses",
+  },
+  {
+    value: KILO_CODE_PROVIDER_PROTOCOLS.AnthropicMessages,
+    label: "ui:dialog.kiloCode.protocols.anthropicMessages",
+  },
+] as const
 
 /**
  * Builds the stable toast id used while Kilo Code export creates a missing token.
@@ -204,6 +220,7 @@ export function KiloCodeExportDialog({
   const pendingRetrySelectionIdRef = useRef<string | undefined>(undefined)
   const pendingRemoveSelectionIdRef = useRef<string | undefined>(undefined)
   const retryButtonRefs = useRef(new Map<string, HTMLButtonElement>())
+  const protocolSelectorRefs = useRef(new Map<string, HTMLButtonElement>())
   const modelSelectorRefs = useRef(new Map<string, HTMLButtonElement>())
   const actionGenerationRef = useRef(0)
   const actionContextRef = useRef({
@@ -226,6 +243,7 @@ export function KiloCodeExportDialog({
     pendingRetrySelectionIdRef.current = undefined
     pendingRemoveSelectionIdRef.current = undefined
     retryButtonRefs.current.clear()
+    protocolSelectorRefs.current.clear()
     modelSelectorRefs.current.clear()
     initialSelectionAppliedRef.current = false
   }, [isOpen])
@@ -558,6 +576,7 @@ export function KiloCodeExportDialog({
     selectV7DefaultModel,
     selectV7DefaultProvider,
     selectV7ManualModel,
+    selectV7Protocol,
     v7DefaultModel,
     v7Selections,
   } = useKiloCodeAccountModelDiscovery({
@@ -634,6 +653,7 @@ export function KiloCodeExportDialog({
                 tokenId: selection.tokenId,
                 tokenName: selection.tokenName,
                 providerName: selection.providerName ?? "",
+                protocol: selection.protocol,
                 discoveredModelIds: selection.discoveredModelIds,
                 manualModelId: selection.manualModelId ?? "",
               })),
@@ -751,15 +771,24 @@ export function KiloCodeExportDialog({
       retryButtonRefs.current.get(selectionId)?.focus()
       return
     }
+    if (isKiloV7Export) {
+      protocolSelectorRefs.current.get(selectionId)?.focus()
+      return
+    }
     modelSelectorRefs.current.get(selectionId)?.focus()
-  }, [getModelInventory, modelStatusSignature])
+  }, [getModelInventory, isKiloV7Export, modelStatusSignature])
 
   useEffect(() => {
     const selectionId = pendingRemoveSelectionIdRef.current
     if (!selectionId || v7SelectionById.get(selectionId)?.manualModelId?.trim())
       return
     pendingRemoveSelectionIdRef.current = undefined
-    modelSelectorRefs.current.get(selectionId)?.focus()
+    const recoverySelector = modelSelectorRefs.current.get(selectionId)
+    if (recoverySelector) {
+      recoverySelector.focus()
+      return
+    }
+    protocolSelectorRefs.current.get(selectionId)?.focus()
   }, [v7SelectionById])
 
   const buildCurrentExportOutput = useCallback(() => {
@@ -1099,8 +1128,16 @@ export function KiloCodeExportDialog({
 
             {selectedTokenIds.length > 0 && (
               <FormField
-                label={t("ui:dialog.kiloCode.labels.modelId")}
-                description={t("ui:dialog.kiloCode.descriptions.modelId")}
+                label={
+                  isKiloV7Export
+                    ? undefined
+                    : t("ui:dialog.kiloCode.labels.legacyModelId")
+                }
+                description={
+                  isKiloV7Export
+                    ? undefined
+                    : t("ui:dialog.kiloCode.descriptions.modelId")
+                }
               >
                 <div className="space-y-2">
                   {inventory.tokens
@@ -1129,6 +1166,8 @@ export function KiloCodeExportDialog({
                         isModelInventoryError ||
                         (isModelInventoryLoaded &&
                           modelInventory.modelIds.length === 0)
+                      const showV7ManualRecovery =
+                        showRetry && modelInventory.modelIds.length === 0
                       const modelOptions = modelInventory.modelIds.map(
                         (id) => ({
                           value: id,
@@ -1208,46 +1247,120 @@ export function KiloCodeExportDialog({
                                   {t("ui:dialog.kiloCode.actions.retryModels")}
                                 </Button>
                               )}
-                              <div className="w-full min-w-0 sm:w-[280px]">
-                                <SearchableSelect
-                                  ref={(element) => {
-                                    if (element) {
-                                      modelSelectorRefs.current.set(
-                                        selectionId,
-                                        element,
-                                      )
-                                    } else {
-                                      modelSelectorRefs.current.delete(
-                                        selectionId,
-                                      )
+                              {isKiloV7Export && (
+                                <FormField
+                                  className="w-full min-w-0 sm:w-[220px]"
+                                  label={t(
+                                    "ui:dialog.kiloCode.labels.providerProtocol",
+                                  )}
+                                >
+                                  <Select
+                                    value={
+                                      v7SelectionById.get(selectionId)
+                                        ?.protocol ??
+                                      KILO_CODE_PROVIDER_PROTOCOLS.OpenAICompatible
                                     }
-                                  }}
-                                  aria-label={`${selection.providerName} ${t(
-                                    isKiloV7Export
-                                      ? "ui:dialog.kiloCode.labels.modelId"
-                                      : "ui:dialog.kiloCode.labels.legacyModelId",
-                                  )}`}
-                                  value={selectedModelId}
-                                  onChange={(value) => {
-                                    if (isKiloV7Export) {
-                                      selectV7ManualModel(selectionId, value)
-                                    } else {
-                                      selectLegacyModel(selectionId, value)
-                                    }
-                                    setIsDownloadTooLarge(false)
-                                  }}
-                                  placeholder={
-                                    isModelInventoryLoading ||
-                                    isModelInventoryIdle
-                                      ? t("common:status.loading")
-                                      : t(
-                                          "ui:dialog.kiloCode.placeholders.modelId",
+                                    onValueChange={(value) => {
+                                      const option =
+                                        KILO_CODE_PROTOCOL_OPTIONS.find(
+                                          (candidate) =>
+                                            candidate.value === value,
                                         )
+                                      if (!option) return
+                                      selectV7Protocol(
+                                        selectionId,
+                                        option.value,
+                                      )
+                                      setIsDownloadTooLarge(false)
+                                    }}
+                                  >
+                                    <SelectTrigger
+                                      ref={(element) => {
+                                        if (element) {
+                                          protocolSelectorRefs.current.set(
+                                            selectionId,
+                                            element,
+                                          )
+                                        } else {
+                                          protocolSelectorRefs.current.delete(
+                                            selectionId,
+                                          )
+                                        }
+                                      }}
+                                      aria-label={`${selection.providerName} ${t(
+                                        "ui:dialog.kiloCode.labels.providerProtocol",
+                                      )}`}
+                                    >
+                                      <SelectValue
+                                        placeholder={t(
+                                          "ui:dialog.kiloCode.labels.providerProtocol",
+                                        )}
+                                      />
+                                    </SelectTrigger>
+                                    <SelectContent>
+                                      {KILO_CODE_PROTOCOL_OPTIONS.map(
+                                        (option) => (
+                                          <SelectItem
+                                            key={option.value}
+                                            value={option.value}
+                                          >
+                                            {t(option.label)}
+                                          </SelectItem>
+                                        ),
+                                      )}
+                                    </SelectContent>
+                                  </Select>
+                                </FormField>
+                              )}
+                              {(!isKiloV7Export || showV7ManualRecovery) && (
+                                <FormField
+                                  className="w-full min-w-0 sm:w-[280px]"
+                                  label={
+                                    isKiloV7Export
+                                      ? t("ui:dialog.kiloCode.labels.modelId")
+                                      : undefined
                                   }
-                                  options={modelOptions}
-                                  allowCustomValue
-                                />
-                              </div>
+                                >
+                                  <SearchableSelect
+                                    ref={(element) => {
+                                      if (element) {
+                                        modelSelectorRefs.current.set(
+                                          selectionId,
+                                          element,
+                                        )
+                                      } else {
+                                        modelSelectorRefs.current.delete(
+                                          selectionId,
+                                        )
+                                      }
+                                    }}
+                                    aria-label={`${selection.providerName} ${t(
+                                      isKiloV7Export
+                                        ? "ui:dialog.kiloCode.labels.modelId"
+                                        : "ui:dialog.kiloCode.labels.legacyModelId",
+                                    )}`}
+                                    value={selectedModelId}
+                                    onChange={(value) => {
+                                      if (isKiloV7Export) {
+                                        selectV7ManualModel(selectionId, value)
+                                      } else {
+                                        selectLegacyModel(selectionId, value)
+                                      }
+                                      setIsDownloadTooLarge(false)
+                                    }}
+                                    placeholder={
+                                      isModelInventoryLoading ||
+                                      isModelInventoryIdle
+                                        ? t("common:status.loading")
+                                        : t(
+                                            "ui:dialog.kiloCode.placeholders.modelId",
+                                          )
+                                    }
+                                    options={modelOptions}
+                                    allowCustomValue
+                                  />
+                                </FormField>
+                              )}
                             </div>
                           </div>
 
@@ -1259,7 +1372,7 @@ export function KiloCodeExportDialog({
                             </div>
                           )}
 
-                          {showRetry && isKiloV7Export && (
+                          {showV7ManualRecovery && isKiloV7Export && (
                             <div className="dark:text-dark-text-tertiary text-sm text-gray-500">
                               {t(
                                 "ui:dialog.kiloCode.messages.v7ProviderModelsRequired",

--- a/src/components/KiloCodeExportDialog.tsx
+++ b/src/components/KiloCodeExportDialog.tsx
@@ -32,21 +32,14 @@ import {
   requireDisplayAccountKeyManagement,
 } from "~/services/accounts/utils/apiServiceRequest"
 import { resolveExportTokenForSecret } from "~/services/accounts/utils/exportTokenSecret"
-import { fetchOpenAICompatibleModelIds } from "~/services/aiApi/openaiCompatible"
 import {
   buildKiloCodeApiConfigs,
   KILO_CODE_EXPORT_FILENAMES,
   KILO_CODE_EXPORT_TARGET_OPTIONS,
   KILO_CODE_EXPORT_TARGETS,
   type KiloCodeExportTarget,
-  type KiloCodeExportTuple,
 } from "~/services/integrations/kiloCodeExport"
 import { getKiloCodeExportAnalyticsTarget } from "~/services/integrations/kiloCodeExportAnalytics"
-import {
-  buildKiloCodeExportOutput,
-  type BuildKiloCodeExportOutputOptions,
-  type KiloCodeExportOutput,
-} from "~/services/integrations/kiloCodeExportPolicy"
 import { startProductAnalyticsAction } from "~/services/productAnalytics/actions"
 import {
   PRODUCT_ANALYTICS_ACTION_IDS,
@@ -58,10 +51,19 @@ import {
 } from "~/services/productAnalytics/contracts"
 import type { ApiToken, DisplaySiteData, SiteAccount } from "~/types"
 import { getErrorMessage } from "~/utils/core/error"
-import { stripTrailingOpenAIV1 } from "~/utils/core/url"
 
+import {
+  resolveKiloCodeAccountExportOutput,
+  type KiloCodeAccountExportSelection,
+} from "./kiloCodeAccountExport"
+import { KiloCodeDefaultModelSelect } from "./KiloCodeDefaultModelSelect"
 import { KiloCodeExportGuidance } from "./KiloCodeExportGuidance"
+import { KILO_CODE_EXPORT_TEST_IDS } from "./kiloCodeExportTestIds"
 import { pickNewestKiloCodeToken } from "./kiloCodeTokenSelection"
+import {
+  KILO_CODE_ACCOUNT_MODEL_STATUSES,
+  useKiloCodeAccountModelDiscovery,
+} from "./useKiloCodeAccountModelDiscovery"
 
 const kiloCodeAccountExportAnalyticsContext = {
   entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Options,
@@ -110,15 +112,6 @@ interface TokenInventoryState {
 type DefaultTokenCreateContext = {
   siteId: string
   allowedGroups: string[]
-}
-
-type ModelLoadStatus =
-  (typeof KILO_CODE_INVENTORY_STATUSES)[keyof typeof KILO_CODE_INVENTORY_STATUSES]
-
-interface ModelInventoryState {
-  status: ModelLoadStatus
-  modelIds: string[]
-  errorMessage?: string
 }
 
 /**
@@ -184,23 +177,12 @@ export function KiloCodeExportDialog({
   const [defaultTokenCreateContext, setDefaultTokenCreateContext] =
     useState<DefaultTokenCreateContext | null>(null)
 
-  const [modelInventories, setModelInventories] = useState<
-    Record<string, ModelInventoryState>
-  >({})
-  const [selectedModelIdByToken, setSelectedModelIdByToken] = useState<
-    Record<string, string>
-  >({})
-
-  /**
-   * Prevents duplicate model fetches when selection effects fire in quick succession.
-   */
-  const modelLoadsInFlightRef = useRef<Set<string>>(new Set())
+  const [isDownloadTooLarge, setIsDownloadTooLarge] = useState(false)
   const initialSelectionAppliedRef = useRef(false)
-  const isDialogActiveRef = useRef(false)
-
-  useEffect(() => {
-    isDialogActiveRef.current = isOpen
-  }, [isOpen])
+  const pendingRetrySelectionIdRef = useRef<string | undefined>(undefined)
+  const pendingRemoveSelectionIdRef = useRef<string | undefined>(undefined)
+  const retryButtonRefs = useRef(new Map<string, HTMLButtonElement>())
+  const modelSelectorRefs = useRef(new Map<string, HTMLButtonElement>())
 
   useEffect(() => {
     if (isOpen) return
@@ -211,9 +193,11 @@ export function KiloCodeExportDialog({
     setTokenInventories({})
     setIsCreatingToken({})
     setDefaultTokenCreateContext(null)
-    setModelInventories({})
-    setSelectedModelIdByToken({})
-    modelLoadsInFlightRef.current.clear()
+    setIsDownloadTooLarge(false)
+    pendingRetrySelectionIdRef.current = undefined
+    pendingRemoveSelectionIdRef.current = undefined
+    retryButtonRefs.current.clear()
+    modelSelectorRefs.current.clear()
     initialSelectionAppliedRef.current = false
   }, [isOpen])
 
@@ -258,18 +242,6 @@ export function KiloCodeExportDialog({
       )
     },
     [tokenInventories],
-  )
-
-  const getModelInventory = useCallback(
-    (tokenSelectionKey: string): ModelInventoryState => {
-      return (
-        modelInventories[tokenSelectionKey] ?? {
-          status: KILO_CODE_INVENTORY_STATUSES.Idle,
-          modelIds: [],
-        }
-      )
-    },
-    [modelInventories],
   )
 
   const loadTokensForSite = useCallback(
@@ -349,74 +321,6 @@ export function KiloCodeExportDialog({
       }
     },
     [displayById, t],
-  )
-
-  const loadModelsForToken = useCallback(
-    async (siteId: string, token: ApiToken) => {
-      const site = displayById.get(siteId)
-      if (!site) return
-
-      const tokenSelectionKey = getTokenSelectionKey(siteId, token.id)
-      if (modelLoadsInFlightRef.current.has(tokenSelectionKey)) return
-
-      const existingStatus = modelInventories[tokenSelectionKey]?.status
-      if (existingStatus === KILO_CODE_INVENTORY_STATUSES.Loaded) return
-
-      modelLoadsInFlightRef.current.add(tokenSelectionKey)
-
-      setModelInventories((prev) => ({
-        ...prev,
-        [tokenSelectionKey]: {
-          status: KILO_CODE_INVENTORY_STATUSES.Loading,
-          modelIds: prev[tokenSelectionKey]?.modelIds ?? [],
-          errorMessage: undefined,
-        },
-      }))
-
-      try {
-        const resolvedToken = await resolveExportTokenForSecret(site, token)
-        const modelIds = await fetchOpenAICompatibleModelIds({
-          baseUrl: stripTrailingOpenAIV1(site.baseUrl),
-          apiKey: resolvedToken.key,
-        })
-
-        const normalized = modelIds
-          .map((item) => (typeof item === "string" ? item.trim() : ""))
-          .filter(Boolean)
-
-        if (!isDialogActiveRef.current) return
-
-        setModelInventories((prev) => ({
-          ...prev,
-          [tokenSelectionKey]: {
-            status: KILO_CODE_INVENTORY_STATUSES.Loaded,
-            modelIds: normalized,
-            errorMessage: undefined,
-          },
-        }))
-
-        // UX: default to the first upstream model for this API key unless the user already chose something.
-        setSelectedModelIdByToken((prev) => {
-          if (prev[tokenSelectionKey] !== undefined) return prev
-          if (!normalized.length) return prev
-          return { ...prev, [tokenSelectionKey]: normalized[0] }
-        })
-      } catch {
-        if (!isDialogActiveRef.current) return
-
-        setModelInventories((prev) => ({
-          ...prev,
-          [tokenSelectionKey]: {
-            status: KILO_CODE_INVENTORY_STATUSES.Error,
-            modelIds: prev[tokenSelectionKey]?.modelIds ?? [],
-            errorMessage: t("ui:dialog.kiloCode.messages.loadModelsFailed"),
-          },
-        }))
-      } finally {
-        modelLoadsInFlightRef.current.delete(tokenSelectionKey)
-      }
-    },
-    [displayById, modelInventories, t],
   )
 
   const createDefaultTokenForSite = async (siteId: string) => {
@@ -559,135 +463,114 @@ export function KiloCodeExportDialog({
     }
   }, [isOpen, loadTokensForSite, selectedSiteIds, tokenInventories])
 
-  useEffect(() => {
-    if (!isOpen) return
-    if (selectedSiteIds.length === 0) return
+  const accountExportSelections = useMemo<
+    KiloCodeAccountExportSelection[]
+  >(() => {
+    const selections: KiloCodeAccountExportSelection[] = []
 
     for (const siteId of selectedSiteIds) {
-      const inventory = tokenInventories[siteId]
-      if (
-        !inventory ||
-        inventory.status !== KILO_CODE_INVENTORY_STATUSES.Loaded
-      )
-        continue
-
       const tokenIds = selectedTokenIdsBySite[siteId] ?? []
-      for (const tokenId of tokenIds) {
+      if (tokenIds.length === 0) continue
+
+      const site = displayById.get(siteId)
+      if (!site) continue
+
+      const inventory = getTokenInventory(siteId)
+      const uniqueTokenIds = Array.from(new Set(tokenIds))
+      for (const tokenId of uniqueTokenIds) {
         const token = inventory.tokens.find(
           (candidate) => `${candidate.id}` === tokenId,
         )
         if (!token) continue
 
-        const tokenSelectionKey = getTokenSelectionKey(siteId, token.id)
-        const modelStatus =
-          modelInventories[tokenSelectionKey]?.status ??
-          KILO_CODE_INVENTORY_STATUSES.Idle
-        if (modelStatus === KILO_CODE_INVENTORY_STATUSES.Idle) {
-          void loadModelsForToken(siteId, token)
-        }
+        const selectionId = getTokenSelectionKey(siteId, token.id)
+        const tokenName = getTokenLabel(token, t("common:labels.token"))
+        const siteName = getSiteDisplayName(site)
+
+        selections.push({
+          selectionId,
+          site,
+          token,
+          providerName: `${siteName} - ${tokenName}`,
+          runtimeKey: {
+            accountId: siteId,
+            siteName,
+            baseUrl: site.baseUrl,
+            tokenId: token.id,
+            tokenName,
+            tokenKey: token.key,
+          },
+        })
       }
     }
+
+    return selections
   }, [
+    displayById,
+    getTokenInventory,
+    selectedSiteIds,
+    selectedTokenIdsBySite,
+    t,
+  ])
+
+  const {
+    getModelInventory,
+    invalidSelection,
+    legacySelections,
+    loadModels,
+    preparedCatalog,
+    removeV7ManualModel,
+    selectLegacyModel,
+    selectV7DefaultModel,
+    selectV7DefaultProvider,
+    selectV7ManualModel,
+    v7DefaultModel,
+    v7Selections,
+  } = useKiloCodeAccountModelDiscovery({
     isOpen,
-    loadModelsForToken,
-    modelInventories,
-    selectedSiteIds,
-    selectedTokenIdsBySite,
-    tokenInventories,
-  ])
+    selections: accountExportSelections,
+  })
 
-  const exportSelections: KiloCodeExportTuple[] = useMemo(() => {
-    if (!displayData.length) return []
+  const v7SelectionById = useMemo(
+    () =>
+      new Map(
+        v7Selections.map((selection) => [selection.selectionId, selection]),
+      ),
+    [v7Selections],
+  )
+  const legacySelectionById = useMemo(
+    () =>
+      new Map(
+        legacySelections.map((selection) => [selection.selectionId, selection]),
+      ),
+    [legacySelections],
+  )
+  const secretSourcesBySelectionId = useMemo(
+    () =>
+      new Map(
+        accountExportSelections.map((selection) => [
+          selection.selectionId,
+          { site: selection.site, token: selection.token },
+        ]),
+      ),
+    [accountExportSelections],
+  )
+  const exportSelectionSignature = useMemo(
+    () =>
+      accountExportSelections
+        .map((selection) => selection.selectionId)
+        .sort()
+        .join("\u0000"),
+    [accountExportSelections],
+  )
 
-    const selections: KiloCodeExportTuple[] = []
-
-    for (const siteId of selectedSiteIds) {
-      const tokenIds = selectedTokenIdsBySite[siteId] ?? []
-      if (tokenIds.length === 0) continue
-
-      const site = displayById.get(siteId)
-      if (!site) continue
-
-      const inventory = getTokenInventory(siteId)
-      const uniqueTokenIds = Array.from(new Set(tokenIds))
-      for (const tokenId of uniqueTokenIds) {
-        const token = inventory.tokens.find(
-          (candidate) => `${candidate.id}` === tokenId,
-        )
-        if (!token) continue
-
-        const tokenSelectionKey = getTokenSelectionKey(siteId, token.id)
-
-        selections.push({
-          accountId: siteId,
-          siteName: site.name || site.baseUrl,
-          baseUrl: site.baseUrl,
-          tokenId: token.id,
-          tokenName: token.name,
-          tokenKey: token.key,
-          modelId: selectedModelIdByToken[tokenSelectionKey],
-        })
-      }
-    }
-
-    return selections
-  }, [
-    displayData.length,
-    displayById,
-    getTokenInventory,
-    selectedSiteIds,
-    selectedModelIdByToken,
-    selectedTokenIdsBySite,
-  ])
-
-  const { profileNames } = useMemo(() => {
-    return buildKiloCodeApiConfigs({
-      selections: exportSelections,
-    })
-  }, [exportSelections])
-
-  const buildResolvedExportSelections = useCallback(async () => {
-    const selections: KiloCodeExportTuple[] = []
-
-    for (const siteId of selectedSiteIds) {
-      const tokenIds = selectedTokenIdsBySite[siteId] ?? []
-      if (tokenIds.length === 0) continue
-
-      const site = displayById.get(siteId)
-      if (!site) continue
-
-      const inventory = getTokenInventory(siteId)
-      const uniqueTokenIds = Array.from(new Set(tokenIds))
-
-      for (const tokenId of uniqueTokenIds) {
-        const token = inventory.tokens.find(
-          (candidate) => `${candidate.id}` === tokenId,
-        )
-        if (!token) continue
-
-        const resolvedToken = await resolveExportTokenForSecret(site, token)
-        const tokenSelectionKey = getTokenSelectionKey(siteId, token.id)
-
-        selections.push({
-          accountId: siteId,
-          siteName: site.name || site.baseUrl,
-          baseUrl: site.baseUrl,
-          tokenId: token.id,
-          tokenName: token.name,
-          tokenKey: resolvedToken.key,
-          modelId: selectedModelIdByToken[tokenSelectionKey],
-        })
-      }
-    }
-
-    return selections
-  }, [
-    displayById,
-    getTokenInventory,
-    selectedModelIdByToken,
-    selectedSiteIds,
-    selectedTokenIdsBySite,
-  ])
+  useEffect(() => {
+    setIsDownloadTooLarge(false)
+  }, [exportSelectionSignature])
+  const { profileNames } = useMemo(
+    () => buildKiloCodeApiConfigs({ selections: legacySelections }),
+    [legacySelections],
+  )
 
   useEffect(() => {
     if (profileNames.length === 0) {
@@ -699,33 +582,133 @@ export function KiloCodeExportDialog({
     }
   }, [currentApiConfigName, profileNames])
 
-  const missingModelIdCount = useMemo(() => {
-    return exportSelections.filter((tuple) => !tuple.modelId?.trim()).length
-  }, [exportSelections])
-
-  const hasExportableProfiles = profileNames.length > 0
-  const canExport = hasExportableProfiles && missingModelIdCount === 0
   const effectiveCurrentApiConfigName =
     currentApiConfigName || profileNames[0] || ""
+  const isKiloV7Export = exportTarget === KILO_CODE_EXPORT_TARGETS.KiloV7
+  const missingModelIdCount = isKiloV7Export
+    ? v7Selections.filter(
+        (selection) =>
+          !selection.discoveredModelIds.length &&
+          !selection.manualModelId?.trim(),
+      ).length
+    : legacySelections.filter((selection) => !selection.legacyModelId?.trim())
+        .length
+  const hasExportableProfiles =
+    accountExportSelections.length > 0 &&
+    v7Selections.length === accountExportSelections.length &&
+    legacySelections.length === accountExportSelections.length
+  const canExportV7 = Boolean(
+    hasExportableProfiles &&
+      !invalidSelection &&
+      preparedCatalog?.providers.length === v7Selections.length &&
+      v7DefaultModel,
+  )
+  const canExportLegacy = Boolean(
+    hasExportableProfiles &&
+      !invalidSelection &&
+      effectiveCurrentApiConfigName &&
+      legacySelections.every((selection) => selection.legacyModelId?.trim()),
+  )
+  const canExport = isKiloV7Export ? canExportV7 : canExportLegacy
   const legacyFilename = KILO_CODE_EXPORT_FILENAMES.Legacy
   const selectionSummary = t("ui:dialog.kiloCode.descriptions.selectedSites", {
     sites: selectedSiteIds.length,
-    keys: exportSelections.length,
+    keys: accountExportSelections.length,
   })
   const exportInsights = {
-    itemCount: exportSelections.length,
-    modelCount: exportSelections.filter((tuple) => tuple.modelId?.trim())
-      .length,
+    itemCount: accountExportSelections.length,
+    modelCount: isKiloV7Export
+      ? preparedCatalog?.modelCount ?? 0
+      : legacySelections.filter((selection) => selection.legacyModelId?.trim())
+          .length,
     selectedCount: selectedSiteIds.length,
     kiloCodeExportTarget: getKiloCodeExportAnalyticsTarget(exportTarget),
   }
-  const isKiloV7Export = exportTarget === KILO_CODE_EXPORT_TARGETS.KiloV7
+  const defaultProviderOptions =
+    preparedCatalog?.providers.map((provider) => ({
+      value: provider.selectionId,
+      label: provider.providerName,
+    })) ?? []
+  const selectedDefaultProvider = preparedCatalog?.providers.find(
+    (provider) => provider.selectionId === v7DefaultModel?.selectionId,
+  )
   const copyActionLabel = isKiloV7Export
     ? t("ui:dialog.kiloCode.actions.copyKiloV7Provider")
     : t("ui:dialog.kiloCode.actions.copyLegacyApiConfigs")
   const downloadActionLabel = isKiloV7Export
     ? t("ui:dialog.kiloCode.actions.downloadKiloV7Settings")
     : t("ui:dialog.kiloCode.actions.downloadLegacySettings")
+  const modelStatusSignature = accountExportSelections
+    .map(
+      (selection) =>
+        `${selection.selectionId}:${getModelInventory(selection.selectionId).status}`,
+    )
+    .join("|")
+
+  useEffect(() => {
+    const selectionId = pendingRetrySelectionIdRef.current
+    if (!selectionId) return
+    const status = getModelInventory(selectionId).status
+    if (status === KILO_CODE_ACCOUNT_MODEL_STATUSES.Loading) return
+
+    pendingRetrySelectionIdRef.current = undefined
+    if (status === KILO_CODE_ACCOUNT_MODEL_STATUSES.Error) {
+      retryButtonRefs.current.get(selectionId)?.focus()
+      return
+    }
+    modelSelectorRefs.current.get(selectionId)?.focus()
+  }, [getModelInventory, modelStatusSignature])
+
+  useEffect(() => {
+    const selectionId = pendingRemoveSelectionIdRef.current
+    if (!selectionId || v7SelectionById.get(selectionId)?.manualModelId?.trim())
+      return
+    pendingRemoveSelectionIdRef.current = undefined
+    modelSelectorRefs.current.get(selectionId)?.focus()
+  }, [v7SelectionById])
+
+  const buildCurrentExportOutput = useCallback(() => {
+    if (isKiloV7Export) {
+      if (!v7DefaultModel) {
+        throw new Error("A valid V7 default model is required")
+      }
+      return resolveKiloCodeAccountExportOutput({
+        target: KILO_CODE_EXPORT_TARGETS.KiloV7,
+        selections: v7Selections,
+        secretSourcesBySelectionId,
+        defaultModel: v7DefaultModel,
+        resolveToken: resolveExportTokenForSecret,
+      })
+    }
+
+    return resolveKiloCodeAccountExportOutput({
+      target: KILO_CODE_EXPORT_TARGETS.Legacy,
+      selections: legacySelections,
+      secretSourcesBySelectionId,
+      currentLegacyProfileName: effectiveCurrentApiConfigName,
+      resolveToken: resolveExportTokenForSecret,
+    })
+  }, [
+    effectiveCurrentApiConfigName,
+    isKiloV7Export,
+    legacySelections,
+    secretSourcesBySelectionId,
+    v7DefaultModel,
+    v7Selections,
+  ])
+
+  const handleRetryModels = (selectionId: string) => {
+    pendingRetrySelectionIdRef.current = selectionId
+    setIsDownloadTooLarge(false)
+    void loadModels(selectionId)
+  }
+
+  const handleRemoveManualModel = (selectionId: string) => {
+    pendingRemoveSelectionIdRef.current = selectionId
+    removeV7ManualModel(selectionId)
+    setIsDownloadTooLarge(false)
+  }
+
   const handleCopyApiConfigs = async () => {
     if (!canExport) return
 
@@ -734,25 +717,24 @@ export function KiloCodeExportDialog({
       actionId: PRODUCT_ANALYTICS_ACTION_IDS.CopyKiloCodeAccountExportConfig,
     })
 
+    let actionInsights = exportInsights
     try {
       if (typeof navigator === "undefined") {
         throw new Error(t("ui:dialog.kiloCode.messages.copyFailed"))
       }
 
-      const resolvedSelections = await buildResolvedExportSelections()
-      const outputOptions: BuildKiloCodeExportOutputOptions = {
-        target: exportTarget,
-        selections: resolvedSelections,
-        currentLegacyProfileName: effectiveCurrentApiConfigName,
+      const output = await buildCurrentExportOutput()
+      actionInsights = {
+        ...exportInsights,
+        itemCount: output.itemCount,
+        modelCount: output.modelCount,
       }
-      const output: KiloCodeExportOutput =
-        buildKiloCodeExportOutput(outputOptions)
       await navigator.clipboard.writeText(
         JSON.stringify(output.copyPayload, null, 2),
       )
       toast.success(t("ui:dialog.kiloCode.messages.copiedExportConfig"))
       tracker.complete(PRODUCT_ANALYTICS_RESULTS.Success, {
-        insights: exportInsights,
+        insights: actionInsights,
       })
     } catch (error) {
       toast.error(
@@ -760,7 +742,7 @@ export function KiloCodeExportDialog({
       )
       tracker.complete(PRODUCT_ANALYTICS_RESULTS.Failure, {
         errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
-        insights: exportInsights,
+        insights: actionInsights,
       })
     }
   }
@@ -775,16 +757,27 @@ export function KiloCodeExportDialog({
 
     let url: string | null = null
     let link: HTMLAnchorElement | null = null
+    let actionInsights = exportInsights
+    setIsDownloadTooLarge(false)
 
     try {
-      const resolvedSelections = await buildResolvedExportSelections()
-      const output = buildKiloCodeExportOutput({
-        target: exportTarget,
-        selections: resolvedSelections,
-        currentLegacyProfileName: effectiveCurrentApiConfigName,
-      })
+      const output = await buildCurrentExportOutput()
+      actionInsights = {
+        ...exportInsights,
+        itemCount: output.itemCount,
+        modelCount: output.modelCount,
+      }
 
-      const blob = new Blob([JSON.stringify(output.downloadPayload, null, 2)], {
+      if (output.isDownloadTooLarge) {
+        setIsDownloadTooLarge(true)
+        tracker.complete(PRODUCT_ANALYTICS_RESULTS.Failure, {
+          errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Validation,
+          insights: actionInsights,
+        })
+        return
+      }
+
+      const blob = new Blob([output.downloadJson], {
         type: "application/json",
       })
       url = URL.createObjectURL(blob)
@@ -796,7 +789,7 @@ export function KiloCodeExportDialog({
 
       toast.success(t("ui:dialog.kiloCode.messages.downloadedSettings"))
       tracker.complete(PRODUCT_ANALYTICS_RESULTS.Success, {
-        insights: exportInsights,
+        insights: actionInsights,
       })
     } catch (error) {
       toast.error(
@@ -804,7 +797,7 @@ export function KiloCodeExportDialog({
       )
       tracker.complete(PRODUCT_ANALYTICS_RESULTS.Failure, {
         errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
-        insights: exportInsights,
+        insights: actionInsights,
       })
     } finally {
       if (link && document.body.contains(link)) {
@@ -985,38 +978,41 @@ export function KiloCodeExportDialog({
                   {inventory.tokens
                     .filter((token) => selectedTokenIds.includes(`${token.id}`))
                     .map((token) => {
-                      const tokenSelectionKey = getTokenSelectionKey(
-                        siteId,
-                        token.id,
+                      const selectionId = getTokenSelectionKey(siteId, token.id)
+                      const selection = accountExportSelections.find(
+                        (candidate) => candidate.selectionId === selectionId,
                       )
-                      const modelInventory =
-                        getModelInventory(tokenSelectionKey)
-                      const selectedModelId =
-                        selectedModelIdByToken[tokenSelectionKey] ?? ""
+                      if (!selection) return null
+
+                      const modelInventory = getModelInventory(selectionId)
                       const isModelInventoryIdle =
                         modelInventory.status ===
-                        KILO_CODE_INVENTORY_STATUSES.Idle
+                        KILO_CODE_ACCOUNT_MODEL_STATUSES.Idle
                       const isModelInventoryLoading =
                         modelInventory.status ===
-                        KILO_CODE_INVENTORY_STATUSES.Loading
+                        KILO_CODE_ACCOUNT_MODEL_STATUSES.Loading
                       const isModelInventoryLoaded =
                         modelInventory.status ===
-                        KILO_CODE_INVENTORY_STATUSES.Loaded
+                        KILO_CODE_ACCOUNT_MODEL_STATUSES.Loaded
                       const isModelInventoryError =
                         modelInventory.status ===
-                        KILO_CODE_INVENTORY_STATUSES.Error
-
-                      const modelOptions = Array.from(
-                        new Set(
-                          modelInventory.modelIds
-                            .map((id) =>
-                              typeof id === "string" ? id.trim() : "",
-                            )
-                            .filter(Boolean),
-                        ),
+                        KILO_CODE_ACCOUNT_MODEL_STATUSES.Error
+                      const showRetry =
+                        isModelInventoryError ||
+                        (isModelInventoryLoaded &&
+                          modelInventory.modelIds.length === 0)
+                      const modelOptions = modelInventory.modelIds.map(
+                        (id) => ({
+                          value: id,
+                          label: id,
+                        }),
                       )
-                        .sort((a, b) => a.localeCompare(b))
-                        .map((id) => ({ value: id, label: id }))
+                      const manualModelId =
+                        v7SelectionById.get(selectionId)?.manualModelId ?? ""
+                      const selectedModelId = isKiloV7Export
+                        ? manualModelId
+                        : legacySelectionById.get(selectionId)?.legacyModelId ??
+                          ""
 
                       const statusBadge = isModelInventoryError ? (
                         <Badge variant="danger" size="sm">
@@ -1037,7 +1033,12 @@ export function KiloCodeExportDialog({
                       )
 
                       return (
-                        <div key={tokenSelectionKey} className="space-y-1">
+                        <div
+                          key={selectionId}
+                          role="group"
+                          aria-label={selection.providerName}
+                          className="space-y-2"
+                        >
                           <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
                             <div className="flex min-w-0 flex-1 items-center gap-2">
                               <div
@@ -1050,28 +1051,62 @@ export function KiloCodeExportDialog({
                                 {getTokenLabel(token, t("common:labels.token"))}
                               </div>
                               {statusBadge}
+                              {isModelInventoryLoaded && (
+                                <Badge variant="secondary" size="sm">
+                                  {modelInventory.modelIds.length}
+                                </Badge>
+                              )}
                             </div>
-                            <div className="flex shrink-0 items-center gap-2">
-                              {isModelInventoryError && (
+                            <div className="flex w-full min-w-0 flex-col items-stretch gap-2 sm:w-auto sm:shrink-0 sm:flex-row sm:items-center">
+                              {showRetry && (
                                 <Button
+                                  ref={(element) => {
+                                    if (element) {
+                                      retryButtonRefs.current.set(
+                                        selectionId,
+                                        element,
+                                      )
+                                    } else {
+                                      retryButtonRefs.current.delete(
+                                        selectionId,
+                                      )
+                                    }
+                                  }}
                                   size="sm"
                                   type="button"
                                   variant="secondary"
-                                  onClick={() =>
-                                    loadModelsForToken(siteId, token)
-                                  }
+                                  onClick={() => handleRetryModels(selectionId)}
                                 >
-                                  {t("common:actions.retry")}
+                                  {t("ui:dialog.kiloCode.actions.retryModels")}
                                 </Button>
                               )}
-                              <div className="w-full min-w-[220px] sm:w-[280px]">
+                              <div className="w-full min-w-0 sm:w-[280px]">
                                 <SearchableSelect
+                                  ref={(element) => {
+                                    if (element) {
+                                      modelSelectorRefs.current.set(
+                                        selectionId,
+                                        element,
+                                      )
+                                    } else {
+                                      modelSelectorRefs.current.delete(
+                                        selectionId,
+                                      )
+                                    }
+                                  }}
+                                  aria-label={`${selection.providerName} ${t(
+                                    isKiloV7Export
+                                      ? "ui:dialog.kiloCode.labels.modelId"
+                                      : "ui:dialog.kiloCode.labels.legacyModelId",
+                                  )}`}
                                   value={selectedModelId}
                                   onChange={(value) => {
-                                    setSelectedModelIdByToken((prev) => ({
-                                      ...prev,
-                                      [tokenSelectionKey]: value,
-                                    }))
+                                    if (isKiloV7Export) {
+                                      selectV7ManualModel(selectionId, value)
+                                    } else {
+                                      selectLegacyModel(selectionId, value)
+                                    }
+                                    setIsDownloadTooLarge(false)
                                   }}
                                   placeholder={
                                     isModelInventoryLoading ||
@@ -1090,21 +1125,42 @@ export function KiloCodeExportDialog({
 
                           {isModelInventoryError && (
                             <div className="text-sm text-red-700 dark:text-red-300">
-                              {modelInventory.errorMessage ||
-                                t(
-                                  "ui:dialog.kiloCode.messages.loadModelsFailed",
-                                )}
+                              {t(
+                                "ui:dialog.kiloCode.messages.loadModelsFailed",
+                              )}
                             </div>
                           )}
 
-                          {isModelInventoryLoaded &&
-                            modelInventory.modelIds.length === 0 && (
-                              <div className="dark:text-dark-text-tertiary text-sm text-gray-500">
+                          {showRetry && isKiloV7Export && (
+                            <div className="dark:text-dark-text-tertiary text-sm text-gray-500">
+                              {t(
+                                "ui:dialog.kiloCode.messages.v7ProviderModelsRequired",
+                              )}
+                            </div>
+                          )}
+
+                          {isKiloV7Export && manualModelId.trim() && (
+                            <div className="dark:border-dark-bg-tertiary flex min-w-0 items-center justify-between gap-3 rounded-md border border-gray-200 px-3 py-2 text-sm">
+                              <span className="min-w-0 flex-1 break-all">
+                                {manualModelId}
+                              </span>
+                              <Button
+                                type="button"
+                                variant="ghost"
+                                size="sm"
+                                data-testid={
+                                  KILO_CODE_EXPORT_TEST_IDS.removeManualModel
+                                }
+                                onClick={() =>
+                                  handleRemoveManualModel(selectionId)
+                                }
+                              >
                                 {t(
-                                  "ui:dialog.kiloCode.messages.noModelsDescription",
+                                  "ui:dialog.kiloCode.actions.removeManualModel",
                                 )}
-                              </div>
-                            )}
+                              </Button>
+                            </div>
+                          )}
                         </div>
                       )
                     })}
@@ -1172,6 +1228,7 @@ export function KiloCodeExportDialog({
           description={selectionSummary}
         >
           <CompactMultiSelect
+            aria-label={t("ui:dialog.kiloCode.labels.selectedSites")}
             options={siteOptions}
             selected={selectedSiteIds}
             onChange={setSelectedSiteIds}
@@ -1197,7 +1254,10 @@ export function KiloCodeExportDialog({
               const target = KILO_CODE_EXPORT_TARGET_OPTIONS.find(
                 (candidate) => candidate === value,
               )
-              if (target) setExportTarget(target)
+              if (target) {
+                setExportTarget(target)
+                setIsDownloadTooLarge(false)
+              }
             }}
           >
             <SelectTrigger id="kilo-code-account-export-target">
@@ -1213,6 +1273,43 @@ export function KiloCodeExportDialog({
             </SelectContent>
           </Select>
         </FormField>
+
+        {isKiloV7Export && (
+          <div className="grid gap-3 sm:grid-cols-2">
+            <FormField
+              label={t("ui:dialog.kiloCode.labels.defaultProvider")}
+              htmlFor="kilo-code-account-default-provider"
+            >
+              <SearchableSelect
+                id="kilo-code-account-default-provider"
+                aria-label={t("ui:dialog.kiloCode.labels.defaultProvider")}
+                data-testid={KILO_CODE_EXPORT_TEST_IDS.defaultProvider}
+                value={v7DefaultModel?.selectionId ?? ""}
+                options={defaultProviderOptions}
+                onChange={(selectionId) => {
+                  selectV7DefaultProvider(selectionId)
+                  setIsDownloadTooLarge(false)
+                }}
+                placeholder={t("ui:dialog.kiloCode.labels.defaultProvider")}
+                disabled={!preparedCatalog}
+              />
+            </FormField>
+
+            <FormField label={t("ui:dialog.kiloCode.labels.defaultModel")}>
+              <KiloCodeDefaultModelSelect
+                aria-label={t("ui:dialog.kiloCode.labels.defaultModel")}
+                value={v7DefaultModel?.modelId ?? ""}
+                modelIds={selectedDefaultProvider?.modelIds ?? []}
+                onChange={(modelId) => {
+                  selectV7DefaultModel(modelId)
+                  setIsDownloadTooLarge(false)
+                }}
+                placeholder={t("ui:dialog.kiloCode.placeholders.modelId")}
+                disabled={!selectedDefaultProvider}
+              />
+            </FormField>
+          </div>
+        )}
 
         {!isKiloV7Export && (
           <FormField
@@ -1245,6 +1342,23 @@ export function KiloCodeExportDialog({
               </SelectContent>
             </Select>
           </FormField>
+        )}
+
+        {invalidSelection && hasExportableProfiles && (
+          <Alert
+            variant="destructive"
+            title={t("ui:dialog.kiloCode.messages.invalidProfile")}
+          />
+        )}
+
+        {isDownloadTooLarge && (
+          <Alert
+            variant="warning"
+            title={t("ui:dialog.kiloCode.warning.title")}
+            description={t(
+              "ui:dialog.kiloCode.messages.settingsFileTooLargeMultiple",
+            )}
+          />
         )}
 
         {hasExportableProfiles && missingModelIdCount > 0 && (

--- a/src/components/KiloCodeExportDialog.tsx
+++ b/src/components/KiloCodeExportDialog.tsx
@@ -680,12 +680,6 @@ export function KiloCodeExportDialog({
     ],
   )
 
-  actionContextRef.current = {
-    isOpen,
-    exportTarget,
-    exportActionSignature,
-  }
-
   const isCurrentExportAction = useCallback(
     (generation: number, signature: typeof actionContextRef.current) =>
       generation === actionGenerationRef.current &&
@@ -695,6 +689,14 @@ export function KiloCodeExportDialog({
         signature.exportActionSignature,
     [],
   )
+
+  useEffect(() => {
+    actionContextRef.current = {
+      isOpen,
+      exportTarget,
+      exportActionSignature,
+    }
+  }, [isOpen, exportTarget, exportActionSignature])
 
   useEffect(() => {
     setIsDownloadTooLarge(false)

--- a/src/components/KiloCodeExportDialog.tsx
+++ b/src/components/KiloCodeExportDialog.tsx
@@ -33,7 +33,7 @@ import {
 } from "~/services/accounts/utils/apiServiceRequest"
 import { resolveExportTokenForSecret } from "~/services/accounts/utils/exportTokenSecret"
 import {
-  buildKiloCodeApiConfigs,
+  getKiloCodeApiConfigProfileNames,
   KILO_CODE_EXPORT_FILENAMES,
   KILO_CODE_EXPORT_TARGET_OPTIONS,
   KILO_CODE_EXPORT_TARGETS,
@@ -55,6 +55,7 @@ import { getErrorMessage } from "~/utils/core/error"
 import {
   resolveKiloCodeAccountExportOutput,
   type KiloCodeAccountExportSelection,
+  type KiloCodeAccountSecretSource,
 } from "./kiloCodeAccountExport"
 import { KiloCodeDefaultModelSelect } from "./KiloCodeDefaultModelSelect"
 import { KiloCodeExportGuidance } from "./KiloCodeExportGuidance"
@@ -143,6 +144,27 @@ function getTokenSelectionKey(siteId: string, tokenId: number) {
   return `${siteId}:${tokenId}`
 }
 
+/** Compare resolver inputs by identity without serializing credential fields. */
+function haveMatchingSecretSourceIdentities(
+  previous: ReadonlyMap<string, KiloCodeAccountSecretSource>,
+  current: ReadonlyMap<string, KiloCodeAccountSecretSource>,
+) {
+  if (previous.size !== current.size) return false
+
+  for (const [selectionId, previousSource] of previous) {
+    const currentSource = current.get(selectionId)
+    if (
+      !currentSource ||
+      currentSource.site !== previousSource.site ||
+      currentSource.token !== previousSource.token
+    ) {
+      return false
+    }
+  }
+
+  return true
+}
+
 /**
  * Modal for exporting selected accounts/tokens into Kilo Code / Roo Code settings JSON.
  *
@@ -183,9 +205,16 @@ export function KiloCodeExportDialog({
   const pendingRemoveSelectionIdRef = useRef<string | undefined>(undefined)
   const retryButtonRefs = useRef(new Map<string, HTMLButtonElement>())
   const modelSelectorRefs = useRef(new Map<string, HTMLButtonElement>())
+  const actionGenerationRef = useRef(0)
+  const actionContextRef = useRef({
+    isOpen,
+    exportTarget,
+    exportActionSignature: "",
+  })
 
   useEffect(() => {
     if (isOpen) return
+    actionGenerationRef.current += 1
     setSelectedSiteIds([])
     setSelectedTokenIdsBySite({})
     setCurrentApiConfigName("")
@@ -200,6 +229,11 @@ export function KiloCodeExportDialog({
     modelSelectorRefs.current.clear()
     initialSelectionAppliedRef.current = false
   }, [isOpen])
+
+  const invalidateAndClose = useCallback(() => {
+    actionGenerationRef.current += 1
+    onClose()
+  }, [onClose])
 
   useEffect(() => {
     if (!isOpen) return
@@ -555,20 +589,21 @@ export function KiloCodeExportDialog({
       ),
     [accountExportSelections],
   )
-  const exportSelectionSignature = useMemo(
-    () =>
-      accountExportSelections
-        .map((selection) => selection.selectionId)
-        .sort()
-        .join("\u0000"),
-    [accountExportSelections],
+  const previousSecretSourcesBySelectionIdRef = useRef(
+    secretSourcesBySelectionId,
   )
 
   useEffect(() => {
-    setIsDownloadTooLarge(false)
-  }, [exportSelectionSignature])
-  const { profileNames } = useMemo(
-    () => buildKiloCodeApiConfigs({ selections: legacySelections }),
+    const previous = previousSecretSourcesBySelectionIdRef.current
+    previousSecretSourcesBySelectionIdRef.current = secretSourcesBySelectionId
+    if (
+      !haveMatchingSecretSourceIdentities(previous, secretSourcesBySelectionId)
+    ) {
+      actionGenerationRef.current += 1
+    }
+  }, [secretSourcesBySelectionId])
+  const profileNames = useMemo(
+    () => getKiloCodeApiConfigProfileNames({ selections: legacySelections }),
     [legacySelections],
   )
 
@@ -585,6 +620,66 @@ export function KiloCodeExportDialog({
   const effectiveCurrentApiConfigName =
     currentApiConfigName || profileNames[0] || ""
   const isKiloV7Export = exportTarget === KILO_CODE_EXPORT_TARGETS.KiloV7
+  const exportActionSignature = useMemo(
+    () =>
+      JSON.stringify(
+        isKiloV7Export
+          ? {
+              defaultModel: v7DefaultModel,
+              selections: v7Selections.map((selection) => ({
+                selectionId: selection.selectionId,
+                accountId: selection.accountId,
+                siteName: selection.siteName,
+                baseUrl: selection.baseUrl,
+                tokenId: selection.tokenId,
+                tokenName: selection.tokenName,
+                providerName: selection.providerName ?? "",
+                discoveredModelIds: selection.discoveredModelIds,
+                manualModelId: selection.manualModelId ?? "",
+              })),
+            }
+          : {
+              currentLegacyProfileName: effectiveCurrentApiConfigName,
+              selections: legacySelections.map((selection) => ({
+                selectionId: selection.selectionId,
+                accountId: selection.accountId,
+                siteName: selection.siteName,
+                baseUrl: selection.baseUrl,
+                tokenId: selection.tokenId,
+                tokenName: selection.tokenName,
+                legacyModelId: selection.legacyModelId ?? "",
+              })),
+            },
+      ),
+    [
+      effectiveCurrentApiConfigName,
+      isKiloV7Export,
+      legacySelections,
+      v7DefaultModel,
+      v7Selections,
+    ],
+  )
+
+  actionContextRef.current = {
+    isOpen,
+    exportTarget,
+    exportActionSignature,
+  }
+
+  const isCurrentExportAction = useCallback(
+    (generation: number, signature: typeof actionContextRef.current) =>
+      generation === actionGenerationRef.current &&
+      actionContextRef.current.isOpen &&
+      actionContextRef.current.exportTarget === signature.exportTarget &&
+      actionContextRef.current.exportActionSignature ===
+        signature.exportActionSignature,
+    [],
+  )
+
+  useEffect(() => {
+    setIsDownloadTooLarge(false)
+    actionGenerationRef.current += 1
+  }, [exportActionSignature])
   const missingModelIdCount = isKiloV7Export
     ? v7Selections.filter(
         (selection) =>
@@ -712,6 +807,9 @@ export function KiloCodeExportDialog({
   const handleCopyApiConfigs = async () => {
     if (!canExport) return
 
+    const generation = ++actionGenerationRef.current
+    const signature = actionContextRef.current
+
     const tracker = startProductAnalyticsAction({
       ...kiloCodeAccountExportAnalyticsContext,
       actionId: PRODUCT_ANALYTICS_ACTION_IDS.CopyKiloCodeAccountExportConfig,
@@ -724,6 +822,9 @@ export function KiloCodeExportDialog({
       }
 
       const output = await buildCurrentExportOutput()
+      if (!isCurrentExportAction(generation, signature)) {
+        return
+      }
       actionInsights = {
         ...exportInsights,
         itemCount: output.itemCount,
@@ -732,11 +833,17 @@ export function KiloCodeExportDialog({
       await navigator.clipboard.writeText(
         JSON.stringify(output.copyPayload, null, 2),
       )
+      if (!isCurrentExportAction(generation, signature)) {
+        return
+      }
       toast.success(t("ui:dialog.kiloCode.messages.copiedExportConfig"))
       tracker.complete(PRODUCT_ANALYTICS_RESULTS.Success, {
         insights: actionInsights,
       })
     } catch (error) {
+      if (!isCurrentExportAction(generation, signature)) {
+        return
+      }
       toast.error(
         getErrorMessage(error, t("ui:dialog.kiloCode.messages.copyFailed")),
       )
@@ -750,6 +857,9 @@ export function KiloCodeExportDialog({
   const handleDownloadSettings = async () => {
     if (!canExport) return
 
+    const generation = ++actionGenerationRef.current
+    const signature = actionContextRef.current
+
     const tracker = startProductAnalyticsAction({
       ...kiloCodeAccountExportAnalyticsContext,
       actionId: PRODUCT_ANALYTICS_ACTION_IDS.ExportKiloCodeAccountSettingsFile,
@@ -762,6 +872,9 @@ export function KiloCodeExportDialog({
 
     try {
       const output = await buildCurrentExportOutput()
+      if (!isCurrentExportAction(generation, signature)) {
+        return
+      }
       actionInsights = {
         ...exportInsights,
         itemCount: output.itemCount,
@@ -769,6 +882,9 @@ export function KiloCodeExportDialog({
       }
 
       if (output.isDownloadTooLarge) {
+        if (!isCurrentExportAction(generation, signature)) {
+          return
+        }
         setIsDownloadTooLarge(true)
         tracker.complete(PRODUCT_ANALYTICS_RESULTS.Failure, {
           errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Validation,
@@ -780,18 +896,30 @@ export function KiloCodeExportDialog({
       const blob = new Blob([output.downloadJson], {
         type: "application/json",
       })
+      if (!isCurrentExportAction(generation, signature)) {
+        return
+      }
       url = URL.createObjectURL(blob)
       link = document.createElement("a")
       link.href = url
       link.download = output.filename
       document.body.appendChild(link)
+      if (!isCurrentExportAction(generation, signature)) {
+        return
+      }
       link.click()
 
+      if (!isCurrentExportAction(generation, signature)) {
+        return
+      }
       toast.success(t("ui:dialog.kiloCode.messages.downloadedSettings"))
       tracker.complete(PRODUCT_ANALYTICS_RESULTS.Success, {
         insights: actionInsights,
       })
     } catch (error) {
+      if (!isCurrentExportAction(generation, signature)) {
+        return
+      }
       toast.error(
         getErrorMessage(error, t("ui:dialog.kiloCode.messages.downloadFailed")),
       )
@@ -1177,7 +1305,7 @@ export function KiloCodeExportDialog({
     <>
       <Modal
         isOpen={isOpen}
-        onClose={onClose}
+        onClose={invalidateAndClose}
         size="lg"
         header={
           <div className="pr-8">
@@ -1196,7 +1324,7 @@ export function KiloCodeExportDialog({
                 {selectionSummary}
               </div>
             )}
-            <Button variant="ghost" type="button" onClick={onClose}>
+            <Button variant="ghost" type="button" onClick={invalidateAndClose}>
               {t("common:actions.cancel")}
             </Button>
             <Button
@@ -1305,6 +1433,7 @@ export function KiloCodeExportDialog({
                   setIsDownloadTooLarge(false)
                 }}
                 placeholder={t("ui:dialog.kiloCode.placeholders.modelId")}
+                allowCustomValue
                 disabled={!selectedDefaultProvider}
               />
             </FormField>

--- a/src/components/KiloCodeExportGuidance.tsx
+++ b/src/components/KiloCodeExportGuidance.tsx
@@ -15,20 +15,47 @@ export function KiloCodeExportGuidance({
   target,
 }: KiloCodeExportGuidanceProps) {
   const { t } = useTranslation("ui")
-  const firstInstructions =
+  const instructions =
     target === KILO_CODE_EXPORT_TARGETS.KiloV7
-      ? t("dialog.kiloCode.help.kiloV7DownloadInstructions")
-      : t("dialog.kiloCode.help.legacyDownloadInstructions")
-  const secondInstructions =
-    target === KILO_CODE_EXPORT_TARGETS.KiloV7
-      ? t("dialog.kiloCode.help.kiloV7CopyInstructions")
-      : t("dialog.kiloCode.help.legacyCopyInstructions")
+      ? [
+          {
+            id: "catalog",
+            text: t("dialog.kiloCode.help.kiloV7CatalogInstructions"),
+          },
+          {
+            id: "download",
+            text: t("dialog.kiloCode.help.kiloV7DownloadInstructions"),
+          },
+          {
+            id: "copy",
+            text: t("dialog.kiloCode.help.kiloV7CopyInstructions"),
+          },
+          {
+            id: "api-key-editor",
+            text: t("dialog.kiloCode.help.kiloV7ApiKeyEditorNote"),
+          },
+        ]
+      : [
+          {
+            id: "single-model",
+            text: t("dialog.kiloCode.help.legacySingleModelInstructions"),
+          },
+          {
+            id: "download",
+            text: t("dialog.kiloCode.help.legacyDownloadInstructions"),
+          },
+          {
+            id: "copy",
+            text: t("dialog.kiloCode.help.legacyCopyInstructions"),
+          },
+        ]
 
   return (
     <Alert variant="info" title={t("dialog.kiloCode.help.usageTitle")}>
       <div className="space-y-2 text-sm">
-        <p>{firstInstructions}</p>
-        <p>{secondInstructions}</p>
+        {instructions.map(({ id, text }) => (
+          <p key={id}>{text}</p>
+        ))}
       </div>
     </Alert>
   )

--- a/src/components/kiloCodeAccountExport.ts
+++ b/src/components/kiloCodeAccountExport.ts
@@ -1,0 +1,104 @@
+import type {
+  KiloCodeDefaultModelSelection,
+  KiloCodeLegacySelection,
+  KiloCodeRuntimeKeyExportInput,
+  KiloCodeV7ProviderSelection,
+} from "~/services/integrations/kiloCodeExport"
+import { KILO_CODE_EXPORT_TARGETS } from "~/services/integrations/kiloCodeExport"
+import {
+  buildKiloCodeExportOutput,
+  type KiloCodeExportOutput,
+} from "~/services/integrations/kiloCodeExportPolicy"
+import type { ApiToken, DisplaySiteData } from "~/types"
+
+export interface KiloCodeAccountExportSelection {
+  selectionId: string
+  site: DisplaySiteData
+  token: ApiToken
+  providerName: string
+  runtimeKey: KiloCodeRuntimeKeyExportInput
+}
+
+export interface KiloCodeAccountLegacySelection
+  extends KiloCodeLegacySelection {
+  selectionId: string
+}
+
+export interface KiloCodeAccountSecretSource {
+  site: DisplaySiteData
+  token: ApiToken
+}
+
+interface ResolveKiloCodeAccountExportOutputBaseOptions {
+  secretSourcesBySelectionId: ReadonlyMap<string, KiloCodeAccountSecretSource>
+  resolveToken: (site: DisplaySiteData, token: ApiToken) => Promise<ApiToken>
+}
+
+interface ResolveKiloCodeAccountV7ExportOutputOptions
+  extends ResolveKiloCodeAccountExportOutputBaseOptions {
+  target: typeof KILO_CODE_EXPORT_TARGETS.KiloV7
+  selections: KiloCodeV7ProviderSelection[]
+  defaultModel: KiloCodeDefaultModelSelection
+}
+
+interface ResolveKiloCodeAccountLegacyExportOutputOptions
+  extends ResolveKiloCodeAccountExportOutputBaseOptions {
+  target: typeof KILO_CODE_EXPORT_TARGETS.Legacy
+  selections: KiloCodeAccountLegacySelection[]
+  currentLegacyProfileName: string
+}
+
+type ResolveKiloCodeAccountExportOutputOptions =
+  | ResolveKiloCodeAccountV7ExportOutputOptions
+  | ResolveKiloCodeAccountLegacyExportOutputOptions
+
+/** Replace only the transient token secret in already-canonical selections. */
+async function resolveCanonicalSelectionSecrets<
+  TSelection extends { selectionId: string; tokenKey: string },
+>(
+  selections: TSelection[],
+  secretSourcesBySelectionId: ReadonlyMap<string, KiloCodeAccountSecretSource>,
+  resolveToken: (site: DisplaySiteData, token: ApiToken) => Promise<ApiToken>,
+): Promise<TSelection[]> {
+  return Promise.all(
+    selections.map(async (selection) => {
+      const source = secretSourcesBySelectionId.get(selection.selectionId)
+      if (!source) {
+        throw new Error("Kilo Code export selection source is unavailable")
+      }
+      const resolvedToken = await resolveToken(source.site, source.token)
+      return { ...selection, tokenKey: resolvedToken.key }
+    }),
+  )
+}
+
+/** Resolve secrets only for an export action, then build a canonical policy output. */
+export async function resolveKiloCodeAccountExportOutput(
+  options: ResolveKiloCodeAccountExportOutputOptions,
+): Promise<KiloCodeExportOutput> {
+  if (options.target === KILO_CODE_EXPORT_TARGETS.KiloV7) {
+    const selections = await resolveCanonicalSelectionSecrets(
+      options.selections,
+      options.secretSourcesBySelectionId,
+      options.resolveToken,
+    )
+
+    return buildKiloCodeExportOutput({
+      target: KILO_CODE_EXPORT_TARGETS.KiloV7,
+      selections,
+      defaultModel: options.defaultModel,
+    })
+  }
+
+  const selections = await resolveCanonicalSelectionSecrets(
+    options.selections,
+    options.secretSourcesBySelectionId,
+    options.resolveToken,
+  )
+
+  return buildKiloCodeExportOutput({
+    target: KILO_CODE_EXPORT_TARGETS.Legacy,
+    selections,
+    currentLegacyProfileName: options.currentLegacyProfileName,
+  })
+}

--- a/src/components/kiloCodeExportTestIds.ts
+++ b/src/components/kiloCodeExportTestIds.ts
@@ -1,0 +1,8 @@
+/** Stable selectors for Kilo Code export controls and browser-level workflows. */
+export const KILO_CODE_EXPORT_TEST_IDS = {
+  defaultProvider: "kilo-code-default-provider",
+  defaultModel: "kilo-code-default-model",
+  defaultModelSearch: "kilo-code-default-model-search",
+  modelOption: "kilo-code-model-option",
+  removeManualModel: "kilo-code-remove-manual-model",
+} as const

--- a/src/components/useKiloCodeAccountModelDiscovery.ts
+++ b/src/components/useKiloCodeAccountModelDiscovery.ts
@@ -1,0 +1,488 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+
+import { resolveExportTokenForSecret } from "~/services/accounts/utils/exportTokenSecret"
+import { fetchOpenAICompatibleModelIds } from "~/services/aiApi/openaiCompatible"
+import type {
+  KiloCodeDefaultModelSelection,
+  KiloCodeV7ProviderSelection,
+  PreparedKiloCodeV7Catalog,
+} from "~/services/integrations/kiloCodeExport"
+import { prepareKiloCodeV7Catalog } from "~/services/integrations/kiloCodeV7Catalog"
+import { reconcileKiloCodeV7DefaultSelection } from "~/services/integrations/kiloCodeV7Selection"
+import {
+  coerceBaseUrlToPathSuffix,
+  stripTrailingOpenAIV1,
+} from "~/utils/core/url"
+
+import type {
+  KiloCodeAccountExportSelection,
+  KiloCodeAccountLegacySelection,
+} from "./kiloCodeAccountExport"
+
+export const KILO_CODE_ACCOUNT_MODEL_STATUSES = {
+  Idle: "idle",
+  Loading: "loading",
+  Loaded: "loaded",
+  Error: "error",
+} as const
+
+export type KiloCodeAccountModelStatus =
+  (typeof KILO_CODE_ACCOUNT_MODEL_STATUSES)[keyof typeof KILO_CODE_ACCOUNT_MODEL_STATUSES]
+
+export interface KiloCodeAccountModelInventory {
+  status: KiloCodeAccountModelStatus
+  modelIds: string[]
+  sourceFingerprint?: string
+}
+
+interface PreparedAccountCatalog {
+  catalog?: PreparedKiloCodeV7Catalog
+  invalidSelection: boolean
+}
+
+/** Normalize upstream IDs once at the async inventory boundary. */
+function normalizeDiscoveredModelIds(modelIds: unknown[] | null | undefined) {
+  return Array.from(
+    new Set(
+      (modelIds ?? [])
+        .map((item) => (typeof item === "string" ? item.trim() : ""))
+        .filter(Boolean),
+    ),
+  ).sort((left, right) => (left === right ? 0 : left < right ? -1 : 1))
+}
+
+/** Validate persisted runtime facts before invoking the throwing catalog API. */
+function hasInvalidRuntimeKey(selection: KiloCodeAccountExportSelection) {
+  if (
+    typeof selection.runtimeKey.tokenKey !== "string" ||
+    !selection.runtimeKey.tokenKey.trim() ||
+    typeof selection.runtimeKey.baseUrl !== "string"
+  ) {
+    return true
+  }
+
+  try {
+    const url = new URL(
+      coerceBaseUrlToPathSuffix(selection.runtimeKey.baseUrl, "/v1"),
+    )
+    return url.protocol !== "http:" && url.protocol !== "https:"
+  } catch {
+    return true
+  }
+}
+
+/** Hash the primitive inputs that can change model discovery results. */
+function getModelDiscoverySourceFingerprint(
+  selection: KiloCodeAccountExportSelection,
+) {
+  const serialized = JSON.stringify([
+    selection.runtimeKey.baseUrl,
+    selection.site.id,
+    selection.site.siteType,
+    selection.site.baseUrl,
+    selection.site.authType,
+    selection.site.userId,
+    selection.site.token,
+    selection.site.cookieAuthSessionCookie ?? null,
+    selection.token.id,
+    selection.token.key,
+  ])
+  let hash = 0x811c9dc5
+  for (const character of serialized) {
+    hash ^= character.charCodeAt(0)
+    hash = Math.imul(hash, 16777619)
+  }
+  return (hash >>> 0).toString(16).padStart(8, "0")
+}
+
+/** Convert incomplete or invalid selections into controlled dialog state. */
+function prepareAccountCatalog(
+  selections: KiloCodeAccountExportSelection[],
+  v7Selections: KiloCodeV7ProviderSelection[],
+): PreparedAccountCatalog {
+  if (selections.some(hasInvalidRuntimeKey)) {
+    return { invalidSelection: true }
+  }
+  if (
+    !v7Selections.length ||
+    v7Selections.some(
+      (selection) =>
+        !selection.discoveredModelIds.length &&
+        !selection.manualModelId?.trim(),
+    )
+  ) {
+    return { invalidSelection: false }
+  }
+
+  try {
+    const catalog = prepareKiloCodeV7Catalog(v7Selections)
+    return {
+      catalog,
+      invalidSelection: catalog.providers.length !== selections.length,
+    }
+  } catch {
+    return { invalidSelection: true }
+  }
+}
+
+const EMPTY_MODEL_INVENTORY: KiloCodeAccountModelInventory = {
+  status: KILO_CODE_ACCOUNT_MODEL_STATUSES.Idle,
+  modelIds: [],
+}
+
+/** Own per-token model inventory plus isolated legacy and V7 model state. */
+export function useKiloCodeAccountModelDiscovery({
+  isOpen,
+  selections,
+}: {
+  isOpen: boolean
+  selections: KiloCodeAccountExportSelection[]
+}) {
+  const [modelInventories, setModelInventories] = useState<
+    Record<string, KiloCodeAccountModelInventory>
+  >({})
+  const [legacyModelIdByToken, setLegacyModelIdByToken] = useState<
+    Record<string, string>
+  >({})
+  const [v7ManualModelIdByToken, setV7ManualModelIdByToken] = useState<
+    Record<string, string>
+  >({})
+  const [v7DefaultModel, setV7DefaultModel] = useState<
+    KiloCodeDefaultModelSelection | undefined
+  >()
+  const requestIdsRef = useRef(new Map<string, number>())
+  const activeSelectionIdsRef = useRef(new Set<string>())
+  const activeSourceFingerprintsRef = useRef(new Map<string, string>())
+  const isOpenRef = useRef(isOpen)
+  const isMountedRef = useRef(false)
+
+  const selectionById = useMemo(
+    () =>
+      new Map(
+        selections.map((selection) => [selection.selectionId, selection]),
+      ),
+    [selections],
+  )
+  const sourceFingerprintById = useMemo(
+    () =>
+      new Map(
+        selections.map((selection) => [
+          selection.selectionId,
+          getModelDiscoverySourceFingerprint(selection),
+        ]),
+      ),
+    [selections],
+  )
+
+  useEffect(() => {
+    const requestIds = requestIdsRef.current
+    const activeSelectionIds = activeSelectionIdsRef.current
+    const activeSourceFingerprints = activeSourceFingerprintsRef.current
+    isMountedRef.current = true
+    return () => {
+      isMountedRef.current = false
+      isOpenRef.current = false
+      for (const selectionId of requestIds.keys()) {
+        requestIds.set(selectionId, (requestIds.get(selectionId) ?? 0) + 1)
+      }
+      activeSelectionIds.clear()
+      activeSourceFingerprints.clear()
+    }
+  }, [])
+
+  useEffect(() => {
+    isOpenRef.current = isOpen
+  }, [isOpen])
+
+  useEffect(() => {
+    const nextIds = new Set(
+      selections.map((selection) => selection.selectionId),
+    )
+    for (const selectionId of new Set([
+      ...activeSelectionIdsRef.current,
+      ...nextIds,
+    ])) {
+      const previousFingerprint =
+        activeSourceFingerprintsRef.current.get(selectionId)
+      const nextFingerprint = sourceFingerprintById.get(selectionId)
+      if (
+        previousFingerprint !== undefined &&
+        previousFingerprint !== nextFingerprint
+      ) {
+        requestIdsRef.current.set(
+          selectionId,
+          (requestIdsRef.current.get(selectionId) ?? 0) + 1,
+        )
+      }
+    }
+    activeSelectionIdsRef.current.clear()
+    for (const selectionId of nextIds) {
+      activeSelectionIdsRef.current.add(selectionId)
+    }
+    activeSourceFingerprintsRef.current.clear()
+    for (const [selectionId, sourceFingerprint] of sourceFingerprintById) {
+      activeSourceFingerprintsRef.current.set(selectionId, sourceFingerprint)
+    }
+
+    const prune = <T>(values: Record<string, T>) => {
+      const entries = Object.entries(values).filter(([selectionId]) =>
+        nextIds.has(selectionId),
+      )
+      return entries.length === Object.keys(values).length
+        ? values
+        : Object.fromEntries(entries)
+    }
+    setModelInventories((current) => {
+      let changed = Object.keys(current).length !== nextIds.size
+      const next: Record<string, KiloCodeAccountModelInventory> = {}
+      for (const selectionId of nextIds) {
+        const sourceFingerprint = sourceFingerprintById.get(selectionId)
+        const inventory = current[selectionId]
+        if (inventory && inventory.sourceFingerprint === sourceFingerprint) {
+          next[selectionId] = inventory
+          continue
+        }
+        changed = true
+        next[selectionId] = {
+          status: KILO_CODE_ACCOUNT_MODEL_STATUSES.Idle,
+          modelIds: [],
+          sourceFingerprint,
+        }
+      }
+      return changed ? next : current
+    })
+    setLegacyModelIdByToken(prune)
+    setV7ManualModelIdByToken(prune)
+  }, [selections, sourceFingerprintById])
+
+  useEffect(() => {
+    if (isOpen) return
+
+    for (const selectionId of activeSelectionIdsRef.current) {
+      requestIdsRef.current.set(
+        selectionId,
+        (requestIdsRef.current.get(selectionId) ?? 0) + 1,
+      )
+    }
+    setModelInventories({})
+    setLegacyModelIdByToken({})
+    setV7ManualModelIdByToken({})
+    setV7DefaultModel(undefined)
+  }, [isOpen])
+
+  const loadModels = useCallback(
+    async (selectionId: string) => {
+      const selection = selectionById.get(selectionId)
+      if (
+        !selection ||
+        hasInvalidRuntimeKey(selection) ||
+        !isOpenRef.current ||
+        !isMountedRef.current
+      )
+        return
+
+      const sourceFingerprint = getModelDiscoverySourceFingerprint(selection)
+      const requestId = (requestIdsRef.current.get(selectionId) ?? 0) + 1
+      requestIdsRef.current.set(selectionId, requestId)
+      setModelInventories((current) => ({
+        ...current,
+        [selectionId]: {
+          status: KILO_CODE_ACCOUNT_MODEL_STATUSES.Loading,
+          modelIds: current[selectionId]?.modelIds ?? [],
+          sourceFingerprint,
+        },
+      }))
+
+      try {
+        const resolvedToken = await resolveExportTokenForSecret(
+          selection.site,
+          selection.token,
+        )
+        const upstreamModelIds = await fetchOpenAICompatibleModelIds({
+          baseUrl: stripTrailingOpenAIV1(selection.runtimeKey.baseUrl),
+          apiKey: resolvedToken.key,
+        })
+        const modelIds = normalizeDiscoveredModelIds(upstreamModelIds)
+        if (
+          !isMountedRef.current ||
+          !isOpenRef.current ||
+          !activeSelectionIdsRef.current.has(selectionId) ||
+          activeSourceFingerprintsRef.current.get(selectionId) !==
+            sourceFingerprint ||
+          requestIdsRef.current.get(selectionId) !== requestId
+        ) {
+          return
+        }
+
+        setModelInventories((current) => ({
+          ...current,
+          [selectionId]: {
+            status: KILO_CODE_ACCOUNT_MODEL_STATUSES.Loaded,
+            modelIds,
+            sourceFingerprint,
+          },
+        }))
+        setLegacyModelIdByToken((current) =>
+          current[selectionId]?.trim() || !modelIds[0]
+            ? current
+            : { ...current, [selectionId]: modelIds[0] },
+        )
+      } catch {
+        if (
+          !isMountedRef.current ||
+          !isOpenRef.current ||
+          !activeSelectionIdsRef.current.has(selectionId) ||
+          activeSourceFingerprintsRef.current.get(selectionId) !==
+            sourceFingerprint ||
+          requestIdsRef.current.get(selectionId) !== requestId
+        ) {
+          return
+        }
+        setModelInventories((current) => ({
+          ...current,
+          [selectionId]: {
+            status: KILO_CODE_ACCOUNT_MODEL_STATUSES.Error,
+            modelIds: current[selectionId]?.modelIds ?? [],
+            sourceFingerprint,
+          },
+        }))
+      }
+    },
+    [selectionById],
+  )
+
+  useEffect(() => {
+    if (!isOpen) return
+    for (const selection of selections) {
+      if (hasInvalidRuntimeKey(selection)) continue
+      const inventory = modelInventories[selection.selectionId]
+      const sourceFingerprint = sourceFingerprintById.get(selection.selectionId)
+      if (
+        !inventory ||
+        inventory.sourceFingerprint !== sourceFingerprint ||
+        inventory.status === KILO_CODE_ACCOUNT_MODEL_STATUSES.Idle
+      ) {
+        void loadModels(selection.selectionId)
+      }
+    }
+  }, [isOpen, loadModels, modelInventories, selections, sourceFingerprintById])
+
+  const discoveredModelIdsByToken = useMemo(
+    () =>
+      Object.fromEntries(
+        Object.entries(modelInventories).map(([selectionId, inventory]) => [
+          selectionId,
+          inventory.modelIds,
+        ]),
+      ),
+    [modelInventories],
+  )
+  const v7Selections = useMemo<KiloCodeV7ProviderSelection[]>(
+    () =>
+      selections.map((selection) => ({
+        ...selection.runtimeKey,
+        selectionId: selection.selectionId,
+        providerName: selection.providerName,
+        discoveredModelIds:
+          discoveredModelIdsByToken[selection.selectionId] ?? [],
+        manualModelId:
+          v7ManualModelIdByToken[selection.selectionId]?.trim() || undefined,
+      })),
+    [discoveredModelIdsByToken, selections, v7ManualModelIdByToken],
+  )
+  const legacySelections = useMemo<KiloCodeAccountLegacySelection[]>(
+    () =>
+      selections.map((selection) => ({
+        ...selection.runtimeKey,
+        selectionId: selection.selectionId,
+        legacyModelId:
+          legacyModelIdByToken[selection.selectionId]?.trim() || undefined,
+      })),
+    [legacyModelIdByToken, selections],
+  )
+  const preparedV7 = useMemo(
+    () => prepareAccountCatalog(selections, v7Selections),
+    [selections, v7Selections],
+  )
+  const validV7Default = useMemo(
+    () =>
+      preparedV7.catalog
+        ? reconcileKiloCodeV7DefaultSelection(
+            preparedV7.catalog,
+            v7DefaultModel,
+          )
+        : undefined,
+    [preparedV7.catalog, v7DefaultModel],
+  )
+
+  useEffect(() => {
+    setV7DefaultModel((current) =>
+      preparedV7.catalog
+        ? reconcileKiloCodeV7DefaultSelection(preparedV7.catalog, current)
+        : undefined,
+    )
+  }, [preparedV7.catalog])
+
+  const selectV7DefaultProvider = useCallback(
+    (selectionId: string) => {
+      const provider = preparedV7.catalog?.providers.find(
+        (candidate) => candidate.selectionId === selectionId,
+      )
+      setV7DefaultModel(
+        provider?.modelIds[0]
+          ? { selectionId, modelId: provider.modelIds[0] }
+          : undefined,
+      )
+    },
+    [preparedV7.catalog],
+  )
+
+  const selectV7DefaultModel = useCallback((modelId: string) => {
+    setV7DefaultModel((current) =>
+      current ? { ...current, modelId } : undefined,
+    )
+  }, [])
+
+  const selectLegacyModel = useCallback(
+    (selectionId: string, modelId: string) => {
+      setLegacyModelIdByToken((current) => ({
+        ...current,
+        [selectionId]: modelId,
+      }))
+    },
+    [],
+  )
+
+  const selectV7ManualModel = useCallback(
+    (selectionId: string, modelId: string) => {
+      setV7ManualModelIdByToken((current) => ({
+        ...current,
+        [selectionId]: modelId.trim(),
+      }))
+    },
+    [],
+  )
+
+  const removeV7ManualModel = useCallback((selectionId: string) => {
+    setV7ManualModelIdByToken((current) => {
+      const { [selectionId]: _removed, ...remaining } = current
+      return remaining
+    })
+  }, [])
+
+  return {
+    getModelInventory: (selectionId: string) =>
+      modelInventories[selectionId] ?? EMPTY_MODEL_INVENTORY,
+    invalidSelection: preparedV7.invalidSelection,
+    legacySelections,
+    loadModels,
+    preparedCatalog: preparedV7.catalog,
+    removeV7ManualModel,
+    selectLegacyModel,
+    selectV7DefaultModel,
+    selectV7DefaultProvider,
+    selectV7ManualModel,
+    v7DefaultModel: validV7Default,
+    v7Selections,
+  }
+}

--- a/src/components/useKiloCodeAccountModelDiscovery.ts
+++ b/src/components/useKiloCodeAccountModelDiscovery.ts
@@ -2,6 +2,10 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 
 import { resolveExportTokenForSecret } from "~/services/accounts/utils/exportTokenSecret"
 import { fetchOpenAICompatibleModelIds } from "~/services/aiApi/openaiCompatible"
+import {
+  KILO_CODE_PROVIDER_PROTOCOLS,
+  type KiloCodeProviderProtocol,
+} from "~/services/integrations/kiloCodeExport"
 import type {
   KiloCodeDefaultModelSelection,
   KiloCodeV7ProviderSelection,
@@ -139,6 +143,9 @@ export function useKiloCodeAccountModelDiscovery({
   const [v7ManualModelIdByToken, setV7ManualModelIdByToken] = useState<
     Record<string, string>
   >({})
+  const [v7ProtocolBySelectionId, setV7ProtocolBySelectionId] = useState<
+    Record<string, KiloCodeProviderProtocol>
+  >({})
   const [v7DefaultModel, setV7DefaultModel] = useState<
     KiloCodeDefaultModelSelection | undefined
   >()
@@ -245,6 +252,19 @@ export function useKiloCodeAccountModelDiscovery({
     })
     setLegacyModelIdByToken(prune)
     setV7ManualModelIdByToken(prune)
+    setV7ProtocolBySelectionId((current) => {
+      const next: Record<string, KiloCodeProviderProtocol> = {}
+      for (const selectionId of nextIds) {
+        next[selectionId] =
+          current[selectionId] ?? KILO_CODE_PROVIDER_PROTOCOLS.OpenAICompatible
+      }
+      return Object.keys(current).length === nextIds.size &&
+        Object.keys(next).every(
+          (selectionId) => next[selectionId] === current[selectionId],
+        )
+        ? current
+        : next
+    })
   }, [selections, sourceFingerprintById])
 
   useEffect(() => {
@@ -259,6 +279,7 @@ export function useKiloCodeAccountModelDiscovery({
     setModelInventories({})
     setLegacyModelIdByToken({})
     setV7ManualModelIdByToken({})
+    setV7ProtocolBySelectionId({})
     setV7DefaultModel(undefined)
   }, [isOpen])
 
@@ -375,12 +396,20 @@ export function useKiloCodeAccountModelDiscovery({
         ...selection.runtimeKey,
         selectionId: selection.selectionId,
         providerName: selection.providerName,
+        protocol:
+          v7ProtocolBySelectionId[selection.selectionId] ??
+          KILO_CODE_PROVIDER_PROTOCOLS.OpenAICompatible,
         discoveredModelIds:
           discoveredModelIdsByToken[selection.selectionId] ?? [],
         manualModelId:
           v7ManualModelIdByToken[selection.selectionId]?.trim() || undefined,
       })),
-    [discoveredModelIdsByToken, selections, v7ManualModelIdByToken],
+    [
+      discoveredModelIdsByToken,
+      selections,
+      v7ManualModelIdByToken,
+      v7ProtocolBySelectionId,
+    ],
   )
   const legacySelections = useMemo<KiloCodeAccountLegacySelection[]>(
     () =>
@@ -479,6 +508,16 @@ export function useKiloCodeAccountModelDiscovery({
     [v7Selections],
   )
 
+  const selectV7Protocol = useCallback(
+    (selectionId: string, protocol: KiloCodeProviderProtocol) => {
+      setV7ProtocolBySelectionId((current) => ({
+        ...current,
+        [selectionId]: protocol,
+      }))
+    },
+    [],
+  )
+
   const removeV7ManualModel = useCallback((selectionId: string) => {
     setV7ManualModelIdByToken((current) => {
       const { [selectionId]: _removed, ...remaining } = current
@@ -498,6 +537,7 @@ export function useKiloCodeAccountModelDiscovery({
     selectV7DefaultModel,
     selectV7DefaultProvider,
     selectV7ManualModel,
+    selectV7Protocol,
     v7DefaultModel: validV7Default,
     v7Selections,
   }

--- a/src/components/useKiloCodeAccountModelDiscovery.ts
+++ b/src/components/useKiloCodeAccountModelDiscovery.ts
@@ -7,7 +7,10 @@ import type {
   KiloCodeV7ProviderSelection,
   PreparedKiloCodeV7Catalog,
 } from "~/services/integrations/kiloCodeExport"
-import { prepareKiloCodeV7Catalog } from "~/services/integrations/kiloCodeV7Catalog"
+import {
+  normalizeKiloCodeModelIds,
+  prepareKiloCodeV7Catalog,
+} from "~/services/integrations/kiloCodeV7Catalog"
 import { reconcileKiloCodeV7DefaultSelection } from "~/services/integrations/kiloCodeV7Selection"
 import {
   coerceBaseUrlToPathSuffix,
@@ -38,17 +41,6 @@ export interface KiloCodeAccountModelInventory {
 interface PreparedAccountCatalog {
   catalog?: PreparedKiloCodeV7Catalog
   invalidSelection: boolean
-}
-
-/** Normalize upstream IDs once at the async inventory boundary. */
-function normalizeDiscoveredModelIds(modelIds: unknown[] | null | undefined) {
-  return Array.from(
-    new Set(
-      (modelIds ?? [])
-        .map((item) => (typeof item === "string" ? item.trim() : ""))
-        .filter(Boolean),
-    ),
-  ).sort((left, right) => (left === right ? 0 : left < right ? -1 : 1))
 }
 
 /** Validate persisted runtime facts before invoking the throwing catalog API. */
@@ -302,7 +294,7 @@ export function useKiloCodeAccountModelDiscovery({
           baseUrl: stripTrailingOpenAIV1(selection.runtimeKey.baseUrl),
           apiKey: resolvedToken.key,
         })
-        const modelIds = normalizeDiscoveredModelIds(upstreamModelIds)
+        const modelIds = normalizeKiloCodeModelIds(upstreamModelIds ?? [])
         if (
           !isMountedRef.current ||
           !isOpenRef.current ||
@@ -437,11 +429,28 @@ export function useKiloCodeAccountModelDiscovery({
     [preparedV7.catalog],
   )
 
-  const selectV7DefaultModel = useCallback((modelId: string) => {
-    setV7DefaultModel((current) =>
-      current ? { ...current, modelId } : undefined,
-    )
-  }, [])
+  const selectV7DefaultModel = useCallback(
+    (modelId: string) => {
+      const normalized = modelId.trim()
+      setV7DefaultModel((current) =>
+        current ? { ...current, modelId: normalized } : undefined,
+      )
+      if (!normalized) return
+      setV7ManualModelIdByToken((current) => {
+        const selection = v7Selections.find(
+          (candidate) => candidate.selectionId === v7DefaultModel?.selectionId,
+        )
+        if (!selection || selection.discoveredModelIds.includes(normalized)) {
+          return current
+        }
+        return {
+          ...current,
+          [selection.selectionId]: normalized,
+        }
+      })
+    },
+    [v7DefaultModel, v7Selections],
+  )
 
   const selectLegacyModel = useCallback(
     (selectionId: string, modelId: string) => {
@@ -455,12 +464,19 @@ export function useKiloCodeAccountModelDiscovery({
 
   const selectV7ManualModel = useCallback(
     (selectionId: string, modelId: string) => {
-      setV7ManualModelIdByToken((current) => ({
-        ...current,
-        [selectionId]: modelId.trim(),
-      }))
+      const normalized = modelId.trim()
+      const selection = v7Selections.find(
+        (candidate) => candidate.selectionId === selectionId,
+      )
+      setV7ManualModelIdByToken((current) => {
+        if (!normalized || selection?.discoveredModelIds.includes(normalized)) {
+          const { [selectionId]: _removed, ...remaining } = current
+          return remaining
+        }
+        return { ...current, [selectionId]: normalized }
+      })
     },
-    [],
+    [v7Selections],
   )
 
   const removeV7ManualModel = useCallback((selectionId: string) => {

--- a/src/features/ApiCredentialProfiles/components/KiloCodeProfileExportDialog.tsx
+++ b/src/features/ApiCredentialProfiles/components/KiloCodeProfileExportDialog.tsx
@@ -20,7 +20,7 @@ import {
 } from "~/components/ui"
 import { ProductAnalyticsScope } from "~/contexts/ProductAnalyticsScopeContext"
 import {
-  buildKiloCodeApiConfigs,
+  getKiloCodeApiConfigProfileNames,
   KILO_CODE_EXPORT_TARGET_OPTIONS,
   KILO_CODE_EXPORT_TARGETS,
   type KiloCodeExportTarget,
@@ -124,7 +124,7 @@ export function KiloCodeProfileExportDialog({
     [legacyModelId, runtimeKey],
   )
   const currentLegacyProfileName = useMemo(() => {
-    const { profileNames } = buildKiloCodeApiConfigs({
+    const profileNames = getKiloCodeApiConfigProfileNames({
       selections: [legacySelection],
     })
     return profileNames[0] ?? ""

--- a/src/features/ApiCredentialProfiles/components/KiloCodeProfileExportDialog.tsx
+++ b/src/features/ApiCredentialProfiles/components/KiloCodeProfileExportDialog.tsx
@@ -1,9 +1,11 @@
-import { useEffect, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import toast from "react-hot-toast"
 import { useTranslation } from "react-i18next"
 
 import { KiloCodeIcon } from "~/components/icons/KiloCodeIcon"
+import { KiloCodeDefaultModelSelect } from "~/components/KiloCodeDefaultModelSelect"
 import { KiloCodeExportGuidance } from "~/components/KiloCodeExportGuidance"
+import { KILO_CODE_EXPORT_TEST_IDS } from "~/components/kiloCodeExportTestIds"
 import {
   Alert,
   Button,
@@ -17,13 +19,13 @@ import {
   SelectValue,
 } from "~/components/ui"
 import { ProductAnalyticsScope } from "~/contexts/ProductAnalyticsScopeContext"
-import { fetchOpenAICompatibleModelIds } from "~/services/aiApi/openaiCompatible"
 import {
   buildKiloCodeApiConfigs,
   KILO_CODE_EXPORT_TARGET_OPTIONS,
   KILO_CODE_EXPORT_TARGETS,
   type KiloCodeExportTarget,
-  type KiloCodeExportTuple,
+  type KiloCodeLegacySelection,
+  type KiloCodeRuntimeKeyExportInput,
 } from "~/services/integrations/kiloCodeExport"
 import { getKiloCodeExportAnalyticsTarget } from "~/services/integrations/kiloCodeExportAnalytics"
 import { buildKiloCodeExportOutput } from "~/services/integrations/kiloCodeExportPolicy"
@@ -38,11 +40,13 @@ import {
 } from "~/services/productAnalytics/contracts"
 import type { ApiCredentialProfile } from "~/types/apiCredentialProfiles"
 import { createLogger } from "~/utils/core/logger"
-import { stripTrailingOpenAIV1 } from "~/utils/core/url"
 
-/**
- * Unified logger scoped to the Kilo Code export dialog for API credential profiles.
- */
+import {
+  KILO_CODE_MODEL_STATUSES,
+  useKiloCodeProfileModelDiscovery,
+} from "./useKiloCodeProfileModelDiscovery"
+
+/** Unified logger scoped to the Kilo Code export dialog for API credential profiles. */
 const logger = createLogger("KiloCodeProfileExportDialog")
 const exportDialogSurface =
   PRODUCT_ANALYTICS_SURFACE_IDS.OptionsApiCredentialProfilesExportDialog
@@ -58,96 +62,167 @@ interface KiloCodeProfileExportDialogProps {
   profile: ApiCredentialProfile
 }
 
-/**
- * Modal dialog for exporting a single API credential profile as Kilo Code / Roo Code settings JSON.
- */
+/** Modal dialog for exporting a single API credential profile as Kilo Code settings JSON. */
 export function KiloCodeProfileExportDialog({
   isOpen,
   onClose,
   profile,
 }: KiloCodeProfileExportDialogProps) {
   const { t } = useTranslation(["ui", "common"])
-  const [modelId, setModelId] = useState("")
-  const [modelOptions, setModelOptions] = useState<
-    { value: string; label: string }[]
-  >([])
-  const [isLoadingModels, setIsLoadingModels] = useState(false)
-  const [exportTarget, setExportTarget] = useState<KiloCodeExportTarget>(
-    KILO_CODE_EXPORT_TARGETS.KiloV7,
-  )
-
-  useEffect(() => {
-    if (!isOpen) return
-
-    setModelId("")
-    setModelOptions([])
-    setIsLoadingModels(true)
-    setExportTarget(KILO_CODE_EXPORT_TARGETS.KiloV7)
-
-    let isMounted = true
-    void (async () => {
-      try {
-        const upstreamBaseUrl = stripTrailingOpenAIV1(profile.baseUrl)
-        const modelIds = await fetchOpenAICompatibleModelIds({
-          baseUrl: upstreamBaseUrl,
-          apiKey: profile.apiKey,
-        })
-        const normalized = (modelIds || [])
-          .map((item) => (typeof item === "string" ? item.trim() : ""))
-          .filter(Boolean)
-          .sort((a, b) => a.localeCompare(b))
-
-        if (!isMounted) return
-        setModelOptions(normalized.map((id) => ({ value: id, label: id })))
-        if (normalized.length > 0) {
-          setModelId(normalized[0]!)
-        }
-      } catch (error) {
-        logger.warn("Failed to fetch upstream model list", error)
-        if (!isMounted) return
-        setModelOptions([])
-      } finally {
-        if (isMounted) {
-          setIsLoadingModels(false)
-        }
-      }
-    })()
-
-    return () => {
-      isMounted = false
-    }
-  }, [isOpen, profile.apiKey, profile.baseUrl])
-
-  const { exportTuple, currentApiConfigName } = useMemo(() => {
-    const selectedModelId = modelId.trim() || undefined
-    const exportTuple: KiloCodeExportTuple = {
+  const selectionId = `profile:${profile.id}`
+  const runtimeKey = useMemo<KiloCodeRuntimeKeyExportInput>(
+    () => ({
       accountId: profile.id,
       siteName: profile.name,
       baseUrl: profile.baseUrl,
       tokenId: 0,
       tokenName: t("common:labels.apiKey"),
       tokenKey: profile.apiKey,
-      modelId: selectedModelId,
-    }
+    }),
+    [profile.apiKey, profile.baseUrl, profile.id, profile.name, t],
+  )
+  const {
+    invalidProfile,
+    legacyModelId,
+    loadModels,
+    modelIds,
+    modelStatus,
+    preparedV7ModelIds,
+    removeManualModel,
+    selectLegacyModel,
+    selectV7Model,
+    v7DefaultModelId,
+    v7ManualModelId,
+    v7Selection,
+    validV7Default,
+  } = useKiloCodeProfileModelDiscovery({
+    isOpen,
+    profileName: profile.name,
+    runtimeKey,
+    selectionId,
+  })
+  const [exportTarget, setExportTarget] = useState<KiloCodeExportTarget>(
+    KILO_CODE_EXPORT_TARGETS.KiloV7,
+  )
+  const [isDownloadTooLarge, setIsDownloadTooLarge] = useState(false)
+  const pendingRetryFocusRef = useRef(false)
+  const pendingRemoveFocusRef = useRef(false)
+  const retryButtonRef = useRef<HTMLButtonElement>(null)
+  const v7ModelSelectorRef = useRef<HTMLButtonElement>(null)
+  const legacyModelSelectorRef = useRef<HTMLButtonElement>(null)
 
+  useEffect(() => {
+    pendingRetryFocusRef.current = false
+    pendingRemoveFocusRef.current = false
+    if (!isOpen) return
+    setExportTarget(KILO_CODE_EXPORT_TARGETS.KiloV7)
+    setIsDownloadTooLarge(false)
+  }, [isOpen, runtimeKey])
+
+  const legacySelection = useMemo<KiloCodeLegacySelection>(
+    () => ({ ...runtimeKey, legacyModelId: legacyModelId.trim() || undefined }),
+    [legacyModelId, runtimeKey],
+  )
+  const currentLegacyProfileName = useMemo(() => {
     const { profileNames } = buildKiloCodeApiConfigs({
-      selections: [exportTuple],
+      selections: [legacySelection],
     })
+    return profileNames[0] ?? ""
+  }, [legacySelection])
+  const legacyModelOptions = useMemo(
+    () => modelIds.map((id) => ({ value: id, label: id })),
+    [modelIds],
+  )
 
-    return {
-      exportTuple,
-      currentApiConfigName: profileNames[0] ?? "",
-    }
-  }, [modelId, profile.apiKey, profile.baseUrl, profile.id, profile.name, t])
-
-  const canExport = Boolean(currentApiConfigName && modelId.trim())
   const isKiloV7Target = exportTarget === KILO_CODE_EXPORT_TARGETS.KiloV7
-  const exportInsights = {
+  const isLoadingModels = modelStatus === KILO_CODE_MODEL_STATUSES.Loading
+  const showModelRecovery =
+    !invalidProfile &&
+    (modelStatus === KILO_CODE_MODEL_STATUSES.Error ||
+      (modelStatus === KILO_CODE_MODEL_STATUSES.Loaded &&
+        modelIds.length === 0))
+  const canExport =
+    !invalidProfile &&
+    (isKiloV7Target
+      ? Boolean(validV7Default)
+      : Boolean(currentLegacyProfileName && legacyModelId.trim()))
+  const fallbackExportInsights = {
     itemCount: 1,
-    modelCount: modelId.trim() ? 1 : 0,
+    modelCount: isKiloV7Target ? preparedV7ModelIds.length : 1,
     selectedCount: 1,
     kiloCodeExportTarget: getKiloCodeExportAnalyticsTarget(exportTarget),
   }
+
+  useEffect(() => {
+    if (
+      !pendingRetryFocusRef.current ||
+      modelStatus === KILO_CODE_MODEL_STATUSES.Loading
+    ) {
+      return
+    }
+
+    pendingRetryFocusRef.current = false
+    if (modelStatus === KILO_CODE_MODEL_STATUSES.Error) {
+      retryButtonRef.current?.focus()
+      return
+    }
+    const activeModelSelector = isKiloV7Target
+      ? v7ModelSelectorRef.current
+      : legacyModelSelectorRef.current
+    activeModelSelector?.focus()
+  }, [isKiloV7Target, modelStatus])
+
+  useEffect(() => {
+    if (!pendingRemoveFocusRef.current || v7ManualModelId.trim()) return
+    pendingRemoveFocusRef.current = false
+    v7ModelSelectorRef.current?.focus()
+  }, [v7ManualModelId])
+
+  const handleRetryModels = () => {
+    pendingRetryFocusRef.current = true
+    setIsDownloadTooLarge(false)
+    void loadModels()
+  }
+
+  const handleV7ModelChange = (value: string) => {
+    selectV7Model(value)
+    setIsDownloadTooLarge(false)
+  }
+
+  const handleRemoveManualModel = () => {
+    pendingRemoveFocusRef.current = true
+    removeManualModel()
+    setIsDownloadTooLarge(false)
+  }
+
+  const buildCurrentExportOutput = useCallback(() => {
+    if (invalidProfile) {
+      throw new Error("The profile is invalid")
+    }
+    if (isKiloV7Target) {
+      if (!validV7Default) {
+        throw new Error("A valid V7 default model is required")
+      }
+      return buildKiloCodeExportOutput({
+        target: KILO_CODE_EXPORT_TARGETS.KiloV7,
+        selections: [v7Selection],
+        defaultModel: validV7Default,
+      })
+    }
+
+    return buildKiloCodeExportOutput({
+      target: KILO_CODE_EXPORT_TARGETS.Legacy,
+      selections: [legacySelection],
+      currentLegacyProfileName,
+    })
+  }, [
+    currentLegacyProfileName,
+    invalidProfile,
+    isKiloV7Target,
+    legacySelection,
+    v7Selection,
+    validV7Default,
+  ])
 
   const handleCopyApiConfigs = async () => {
     if (!canExport) {
@@ -160,25 +235,27 @@ export function KiloCodeProfileExportDialog({
       ...exportDialogAnalyticsContext,
       actionId: PRODUCT_ANALYTICS_ACTION_IDS.CopyApiCredentialExportConfig,
     })
+    let actionInsights = fallbackExportInsights
 
     try {
-      const output = buildKiloCodeExportOutput({
-        target: exportTarget,
-        selections: [exportTuple],
-        currentLegacyProfileName: currentApiConfigName,
-      })
+      const output = buildCurrentExportOutput()
+      actionInsights = {
+        ...fallbackExportInsights,
+        itemCount: output.itemCount,
+        modelCount: output.modelCount,
+      }
       await navigator.clipboard.writeText(
         JSON.stringify(output.copyPayload, null, 2),
       )
       toast.success(t("ui:dialog.kiloCode.messages.copiedExportConfig"))
       tracker.complete(PRODUCT_ANALYTICS_RESULTS.Success, {
-        insights: { ...exportInsights, itemCount: output.itemCount },
+        insights: actionInsights,
       })
     } catch {
       toast.error(t("ui:dialog.kiloCode.messages.copyFailed"))
       tracker.complete(PRODUCT_ANALYTICS_RESULTS.Failure, {
         errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
-        insights: exportInsights,
+        insights: actionInsights,
       })
     }
   }
@@ -193,18 +270,29 @@ export function KiloCodeProfileExportDialog({
       ...exportDialogAnalyticsContext,
       actionId: PRODUCT_ANALYTICS_ACTION_IDS.ExportApiCredentialSettingsFile,
     })
-
+    let actionInsights = fallbackExportInsights
     let url: string | null = null
     let link: HTMLAnchorElement | null = null
+    setIsDownloadTooLarge(false)
 
     try {
-      const output = buildKiloCodeExportOutput({
-        target: exportTarget,
-        selections: [exportTuple],
-        currentLegacyProfileName: currentApiConfigName,
-      })
+      const output = buildCurrentExportOutput()
+      actionInsights = {
+        ...fallbackExportInsights,
+        itemCount: output.itemCount,
+        modelCount: output.modelCount,
+      }
 
-      const blob = new Blob([JSON.stringify(output.downloadPayload, null, 2)], {
+      if (output.isDownloadTooLarge) {
+        setIsDownloadTooLarge(true)
+        tracker.complete(PRODUCT_ANALYTICS_RESULTS.Failure, {
+          errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Validation,
+          insights: actionInsights,
+        })
+        return
+      }
+
+      const blob = new Blob([output.downloadJson], {
         type: "application/json",
       })
       url = URL.createObjectURL(blob)
@@ -216,22 +304,20 @@ export function KiloCodeProfileExportDialog({
 
       toast.success(t("ui:dialog.kiloCode.messages.downloadedSettings"))
       tracker.complete(PRODUCT_ANALYTICS_RESULTS.Success, {
-        insights: { ...exportInsights, itemCount: output.itemCount },
+        insights: actionInsights,
       })
     } catch (error) {
       logger.error("Failed to download Kilo Code settings file", error)
       toast.error(t("ui:dialog.kiloCode.messages.downloadFailed"))
       tracker.complete(PRODUCT_ANALYTICS_RESULTS.Failure, {
         errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
-        insights: exportInsights,
+        insights: actionInsights,
       })
     } finally {
       if (link && document.body.contains(link)) {
         document.body.removeChild(link)
       }
-      if (url) {
-        URL.revokeObjectURL(url)
-      }
+      if (url) URL.revokeObjectURL(url)
     }
   }
 
@@ -289,13 +375,47 @@ export function KiloCodeProfileExportDialog({
       }
     >
       <div className="space-y-4">
-        {!isLoadingModels && modelOptions.length === 0 && (
+        {invalidProfile ? (
           <Alert
-            variant="info"
-            title={t("ui:dialog.kiloCode.messages.noModelsTitle")}
-            description={t("ui:dialog.kiloCode.messages.noModelsDescription")}
+            variant="destructive"
+            title={t("ui:dialog.kiloCode.messages.invalidProfile")}
           />
-        )}
+        ) : null}
+
+        {showModelRecovery ? (
+          <Alert
+            variant={
+              modelStatus === KILO_CODE_MODEL_STATUSES.Error
+                ? "destructive"
+                : "info"
+            }
+            title={
+              modelStatus === KILO_CODE_MODEL_STATUSES.Error
+                ? t("ui:dialog.kiloCode.messages.loadModelsFailed")
+                : t("ui:dialog.kiloCode.messages.noModelsTitle")
+            }
+            description={t("ui:dialog.kiloCode.messages.noModelsDescription")}
+          >
+            <Button
+              ref={retryButtonRef}
+              type="button"
+              variant="outline"
+              onClick={handleRetryModels}
+            >
+              {t("ui:dialog.kiloCode.actions.retryModels")}
+            </Button>
+          </Alert>
+        ) : null}
+
+        {isDownloadTooLarge ? (
+          <Alert
+            variant="warning"
+            title={t("ui:dialog.kiloCode.warning.title")}
+            description={t(
+              "ui:dialog.kiloCode.messages.settingsFileTooLargeSingle",
+            )}
+          />
+        ) : null}
 
         <FormField
           label={t("ui:dialog.kiloCode.labels.exportTarget")}
@@ -307,7 +427,10 @@ export function KiloCodeProfileExportDialog({
               const target = KILO_CODE_EXPORT_TARGET_OPTIONS.find(
                 (candidate) => candidate === value,
               )
-              if (target) setExportTarget(target)
+              if (target) {
+                setExportTarget(target)
+                setIsDownloadTooLarge(false)
+              }
             }}
           >
             <SelectTrigger id="kilo-code-export-target">
@@ -324,23 +447,65 @@ export function KiloCodeProfileExportDialog({
           </Select>
         </FormField>
 
-        <FormField
-          label={t("ui:dialog.kiloCode.labels.modelId")}
-          description={t("ui:dialog.kiloCode.descriptions.modelId")}
-        >
-          <SearchableSelect
-            value={modelId}
-            onChange={setModelId}
-            placeholder={
-              isLoadingModels
-                ? t("common:status.loading")
-                : t("ui:dialog.kiloCode.placeholders.modelId")
-            }
-            options={modelOptions}
-            allowCustomValue
-            disabled={isLoadingModels}
-          />
-        </FormField>
+        {isKiloV7Target ? (
+          <FormField
+            label={t("ui:dialog.kiloCode.labels.defaultModel")}
+            description={t("ui:dialog.kiloCode.descriptions.modelId")}
+          >
+            <KiloCodeDefaultModelSelect
+              ref={v7ModelSelectorRef}
+              aria-label={t("ui:dialog.kiloCode.labels.defaultModel")}
+              value={validV7Default?.modelId ?? v7DefaultModelId}
+              modelIds={preparedV7ModelIds}
+              onChange={handleV7ModelChange}
+              placeholder={
+                isLoadingModels
+                  ? t("common:status.loading")
+                  : t("ui:dialog.kiloCode.placeholders.modelId")
+              }
+              allowCustomValue
+              disabled={isLoadingModels}
+            />
+          </FormField>
+        ) : (
+          <FormField
+            label={t("ui:dialog.kiloCode.labels.legacyModelId")}
+            description={t("ui:dialog.kiloCode.descriptions.modelId")}
+          >
+            <SearchableSelect
+              ref={legacyModelSelectorRef}
+              aria-label={t("ui:dialog.kiloCode.labels.legacyModelId")}
+              value={legacyModelId}
+              onChange={(value) => {
+                selectLegacyModel(value)
+                setIsDownloadTooLarge(false)
+              }}
+              placeholder={
+                isLoadingModels
+                  ? t("common:status.loading")
+                  : t("ui:dialog.kiloCode.placeholders.modelId")
+              }
+              options={legacyModelOptions}
+              allowCustomValue
+              disabled={isLoadingModels}
+            />
+          </FormField>
+        )}
+
+        {isKiloV7Target && v7ManualModelId.trim() ? (
+          <div className="dark:border-dark-bg-tertiary flex items-center justify-between gap-3 rounded-md border border-gray-200 px-3 py-2 text-sm">
+            <span className="min-w-0 flex-1 truncate">{v7ManualModelId}</span>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              data-testid={KILO_CODE_EXPORT_TEST_IDS.removeManualModel}
+              onClick={handleRemoveManualModel}
+            >
+              {t("ui:dialog.kiloCode.actions.removeManualModel")}
+            </Button>
+          </div>
+        ) : null}
 
         <KiloCodeExportGuidance target={exportTarget} />
 

--- a/src/features/ApiCredentialProfiles/components/KiloCodeProfileExportDialog.tsx
+++ b/src/features/ApiCredentialProfiles/components/KiloCodeProfileExportDialog.tsx
@@ -1,3 +1,4 @@
+import type { TFunction } from "i18next"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import toast from "react-hot-toast"
 import { useTranslation } from "react-i18next"
@@ -23,8 +24,10 @@ import {
   getKiloCodeApiConfigProfileNames,
   KILO_CODE_EXPORT_TARGET_OPTIONS,
   KILO_CODE_EXPORT_TARGETS,
+  KILO_CODE_PROVIDER_PROTOCOLS,
   type KiloCodeExportTarget,
   type KiloCodeLegacySelection,
+  type KiloCodeProviderProtocol,
   type KiloCodeRuntimeKeyExportInput,
 } from "~/services/integrations/kiloCodeExport"
 import { getKiloCodeExportAnalyticsTarget } from "~/services/integrations/kiloCodeExportAnalytics"
@@ -48,6 +51,28 @@ import {
 
 /** Unified logger scoped to the Kilo Code export dialog for API credential profiles. */
 const logger = createLogger("KiloCodeProfileExportDialog")
+const KILO_CODE_PROVIDER_PROTOCOL_OPTIONS: ReadonlyArray<{
+  value: KiloCodeProviderProtocol
+}> = [
+  { value: KILO_CODE_PROVIDER_PROTOCOLS.OpenAICompatible },
+  { value: KILO_CODE_PROVIDER_PROTOCOLS.OpenAIResponses },
+  { value: KILO_CODE_PROVIDER_PROTOCOLS.AnthropicMessages },
+]
+
+/** Translate a normalized Kilo Code provider protocol with extractable keys. */
+function translateProviderProtocol(
+  t: TFunction,
+  protocol: KiloCodeProviderProtocol,
+) {
+  switch (protocol) {
+    case KILO_CODE_PROVIDER_PROTOCOLS.OpenAIResponses:
+      return t("ui:dialog.kiloCode.protocols.openAIResponses")
+    case KILO_CODE_PROVIDER_PROTOCOLS.AnthropicMessages:
+      return t("ui:dialog.kiloCode.protocols.anthropicMessages")
+    default:
+      return t("ui:dialog.kiloCode.protocols.openAICompatible")
+  }
+}
 const exportDialogSurface =
   PRODUCT_ANALYTICS_SURFACE_IDS.OptionsApiCredentialProfilesExportDialog
 const exportDialogAnalyticsContext = {
@@ -90,9 +115,11 @@ export function KiloCodeProfileExportDialog({
     preparedV7ModelIds,
     removeManualModel,
     selectLegacyModel,
+    selectV7Protocol,
     selectV7Model,
     v7DefaultModelId,
     v7ManualModelId,
+    v7Protocol,
     v7Selection,
     validV7Default,
   } = useKiloCodeProfileModelDiscovery({
@@ -448,25 +475,54 @@ export function KiloCodeProfileExportDialog({
         </FormField>
 
         {isKiloV7Target ? (
-          <FormField
-            label={t("ui:dialog.kiloCode.labels.defaultModel")}
-            description={t("ui:dialog.kiloCode.descriptions.modelId")}
-          >
-            <KiloCodeDefaultModelSelect
-              ref={v7ModelSelectorRef}
-              aria-label={t("ui:dialog.kiloCode.labels.defaultModel")}
-              value={validV7Default?.modelId ?? v7DefaultModelId}
-              modelIds={preparedV7ModelIds}
-              onChange={handleV7ModelChange}
-              placeholder={
-                isLoadingModels
-                  ? t("common:status.loading")
-                  : t("ui:dialog.kiloCode.placeholders.modelId")
-              }
-              allowCustomValue
-              disabled={isLoadingModels}
-            />
-          </FormField>
+          <>
+            <FormField
+              label={t("ui:dialog.kiloCode.labels.providerProtocol")}
+              htmlFor="kilo-code-provider-protocol"
+            >
+              <Select
+                value={v7Protocol}
+                onValueChange={(value) => {
+                  const option = KILO_CODE_PROVIDER_PROTOCOL_OPTIONS.find(
+                    (candidate) => candidate.value === value,
+                  )
+                  if (!option) return
+                  selectV7Protocol(option.value)
+                  setIsDownloadTooLarge(false)
+                }}
+              >
+                <SelectTrigger id="kilo-code-provider-protocol">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {KILO_CODE_PROVIDER_PROTOCOL_OPTIONS.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {translateProviderProtocol(t, option.value)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </FormField>
+            <FormField
+              label={t("ui:dialog.kiloCode.labels.defaultModel")}
+              description={t("ui:dialog.kiloCode.descriptions.modelId")}
+            >
+              <KiloCodeDefaultModelSelect
+                ref={v7ModelSelectorRef}
+                aria-label={t("ui:dialog.kiloCode.labels.defaultModel")}
+                value={validV7Default?.modelId ?? v7DefaultModelId}
+                modelIds={preparedV7ModelIds}
+                onChange={handleV7ModelChange}
+                placeholder={
+                  isLoadingModels
+                    ? t("common:status.loading")
+                    : t("ui:dialog.kiloCode.placeholders.modelId")
+                }
+                allowCustomValue
+                disabled={isLoadingModels}
+              />
+            </FormField>
+          </>
         ) : (
           <FormField
             label={t("ui:dialog.kiloCode.labels.legacyModelId")}

--- a/src/features/ApiCredentialProfiles/components/useKiloCodeProfileModelDiscovery.ts
+++ b/src/features/ApiCredentialProfiles/components/useKiloCodeProfileModelDiscovery.ts
@@ -7,7 +7,10 @@ import type {
   KiloCodeV7ProviderSelection,
   PreparedKiloCodeV7Catalog,
 } from "~/services/integrations/kiloCodeExport"
-import { prepareKiloCodeV7Catalog } from "~/services/integrations/kiloCodeV7Catalog"
+import {
+  normalizeKiloCodeModelIds,
+  prepareKiloCodeV7Catalog,
+} from "~/services/integrations/kiloCodeV7Catalog"
 import { reconcileKiloCodeV7DefaultSelection } from "~/services/integrations/kiloCodeV7Selection"
 import { createLogger } from "~/utils/core/logger"
 import {
@@ -40,16 +43,6 @@ interface UseKiloCodeProfileModelDiscoveryOptions {
 }
 
 /** Normalize upstream model IDs once at the discovery boundary. */
-function normalizeDiscoveredModelIds(modelIds: unknown[] | null | undefined) {
-  return Array.from(
-    new Set(
-      (modelIds ?? [])
-        .map((item) => (typeof item === "string" ? item.trim() : ""))
-        .filter(Boolean),
-    ),
-  ).sort((left, right) => (left === right ? 0 : left < right ? -1 : 1))
-}
-
 /** Validate persisted profile facts before invoking the throwing catalog API. */
 function hasInvalidRuntimeProfile(runtimeKey: KiloCodeRuntimeKeyExportInput) {
   if (!runtimeKey.tokenKey.trim()) return true
@@ -124,7 +117,7 @@ export function useKiloCodeProfileModelDiscovery({
         baseUrl: stripTrailingOpenAIV1(runtimeKey.baseUrl),
         apiKey: runtimeKey.tokenKey,
       })
-      const normalized = normalizeDiscoveredModelIds(upstreamModelIds)
+      const normalized = normalizeKiloCodeModelIds(upstreamModelIds ?? [])
       if (requestId !== requestIdRef.current) return
 
       setModelIds(normalized)

--- a/src/features/ApiCredentialProfiles/components/useKiloCodeProfileModelDiscovery.ts
+++ b/src/features/ApiCredentialProfiles/components/useKiloCodeProfileModelDiscovery.ts
@@ -3,10 +3,12 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { fetchOpenAICompatibleModelIds } from "~/services/aiApi/openaiCompatible"
 import type {
   KiloCodeDefaultModelSelection,
+  KiloCodeProviderProtocol,
   KiloCodeRuntimeKeyExportInput,
   KiloCodeV7ProviderSelection,
   PreparedKiloCodeV7Catalog,
 } from "~/services/integrations/kiloCodeExport"
+import { KILO_CODE_PROVIDER_PROTOCOLS } from "~/services/integrations/kiloCodeExport"
 import {
   normalizeKiloCodeModelIds,
   prepareKiloCodeV7Catalog,
@@ -89,19 +91,30 @@ export function useKiloCodeProfileModelDiscovery({
   const [legacyModelId, setLegacyModelId] = useState("")
   const [v7DefaultModelId, setV7DefaultModelId] = useState("")
   const [v7ManualModelId, setV7ManualModelId] = useState("")
+  const [v7Protocol, setV7Protocol] = useState<KiloCodeProviderProtocol>(
+    KILO_CODE_PROVIDER_PROTOCOLS.OpenAICompatible,
+  )
   const [modelIds, setModelIds] = useState<string[]>([])
   const [modelStatus, setModelStatus] = useState<KiloCodeModelStatus>(
     KILO_CODE_MODEL_STATUSES.Idle,
   )
   const requestIdRef = useRef(0)
   const v7ManualModelIdRef = useRef("")
+  const v7ProtocolRef = useRef<KiloCodeProviderProtocol>(
+    KILO_CODE_PROVIDER_PROTOCOLS.OpenAICompatible,
+  )
   const invalidRuntimeProfile = hasInvalidRuntimeProfile(runtimeKey)
 
   const buildV7Selection = useCallback(
-    (discoveredModelIds: string[], manualModelId?: string) => ({
+    (
+      discoveredModelIds: string[],
+      manualModelId: string | undefined,
+      protocol: KiloCodeProviderProtocol,
+    ) => ({
       ...runtimeKey,
       selectionId,
       providerName: profileName,
+      protocol,
       discoveredModelIds,
       manualModelId: manualModelId?.trim() || undefined,
     }),
@@ -126,7 +139,11 @@ export function useKiloCodeProfileModelDiscovery({
       )
       setV7DefaultModelId((current) => {
         const prepared = prepareSingleProfileCatalog(
-          buildV7Selection(normalized, v7ManualModelIdRef.current),
+          buildV7Selection(
+            normalized,
+            v7ManualModelIdRef.current,
+            v7ProtocolRef.current,
+          ),
         )
         if (!prepared.catalog) return ""
         return (
@@ -154,6 +171,8 @@ export function useKiloCodeProfileModelDiscovery({
     setV7DefaultModelId("")
     setV7ManualModelId("")
     v7ManualModelIdRef.current = ""
+    setV7Protocol(KILO_CODE_PROVIDER_PROTOCOLS.OpenAICompatible)
+    v7ProtocolRef.current = KILO_CODE_PROVIDER_PROTOCOLS.OpenAICompatible
     setModelIds([])
     setModelStatus(KILO_CODE_MODEL_STATUSES.Idle)
     if (invalidRuntimeProfile) {
@@ -170,8 +189,8 @@ export function useKiloCodeProfileModelDiscovery({
   }, [invalidRuntimeProfile, isOpen, loadModels])
 
   const v7Selection = useMemo<KiloCodeV7ProviderSelection>(
-    () => buildV7Selection(modelIds, v7ManualModelId),
-    [buildV7Selection, modelIds, v7ManualModelId],
+    () => buildV7Selection(modelIds, v7ManualModelId, v7Protocol),
+    [buildV7Selection, modelIds, v7ManualModelId, v7Protocol],
   )
   const preparedV7 = useMemo(
     () => prepareSingleProfileCatalog(v7Selection),
@@ -202,11 +221,17 @@ export function useKiloCodeProfileModelDiscovery({
   const selectLegacyModel = useCallback((value: string) => {
     setLegacyModelId(value)
   }, [])
+  const selectV7Protocol = useCallback((protocol: KiloCodeProviderProtocol) => {
+    v7ProtocolRef.current = protocol
+    setV7Protocol(protocol)
+  }, [])
   const removeManualModel = useCallback(() => {
     v7ManualModelIdRef.current = ""
     setV7ManualModelId("")
     setV7DefaultModelId((current) => {
-      const prepared = prepareSingleProfileCatalog(buildV7Selection(modelIds))
+      const prepared = prepareSingleProfileCatalog(
+        buildV7Selection(modelIds, undefined, v7ProtocolRef.current),
+      )
       if (!prepared.catalog) return ""
       return (
         reconcileKiloCodeV7DefaultSelection(prepared.catalog, {
@@ -226,9 +251,11 @@ export function useKiloCodeProfileModelDiscovery({
     preparedV7ModelIds: preparedV7.catalog?.providers[0]?.modelIds ?? modelIds,
     removeManualModel,
     selectLegacyModel,
+    selectV7Protocol,
     selectV7Model,
     v7DefaultModelId,
     v7ManualModelId,
+    v7Protocol,
     v7Selection,
     validV7Default,
   }

--- a/src/features/ApiCredentialProfiles/components/useKiloCodeProfileModelDiscovery.ts
+++ b/src/features/ApiCredentialProfiles/components/useKiloCodeProfileModelDiscovery.ts
@@ -44,7 +44,6 @@ interface UseKiloCodeProfileModelDiscoveryOptions {
   selectionId: string
 }
 
-/** Normalize upstream model IDs once at the discovery boundary. */
 /** Validate persisted profile facts before invoking the throwing catalog API. */
 function hasInvalidRuntimeProfile(runtimeKey: KiloCodeRuntimeKeyExportInput) {
   if (!runtimeKey.tokenKey.trim()) return true

--- a/src/features/ApiCredentialProfiles/components/useKiloCodeProfileModelDiscovery.ts
+++ b/src/features/ApiCredentialProfiles/components/useKiloCodeProfileModelDiscovery.ts
@@ -1,0 +1,242 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+
+import { fetchOpenAICompatibleModelIds } from "~/services/aiApi/openaiCompatible"
+import type {
+  KiloCodeDefaultModelSelection,
+  KiloCodeRuntimeKeyExportInput,
+  KiloCodeV7ProviderSelection,
+  PreparedKiloCodeV7Catalog,
+} from "~/services/integrations/kiloCodeExport"
+import { prepareKiloCodeV7Catalog } from "~/services/integrations/kiloCodeV7Catalog"
+import { reconcileKiloCodeV7DefaultSelection } from "~/services/integrations/kiloCodeV7Selection"
+import { createLogger } from "~/utils/core/logger"
+import {
+  coerceBaseUrlToPathSuffix,
+  stripTrailingOpenAIV1,
+} from "~/utils/core/url"
+
+const logger = createLogger("KiloCodeProfileModelDiscovery")
+
+export const KILO_CODE_MODEL_STATUSES = {
+  Idle: "idle",
+  Loading: "loading",
+  Loaded: "loaded",
+  Error: "error",
+} as const
+
+type KiloCodeModelStatus =
+  (typeof KILO_CODE_MODEL_STATUSES)[keyof typeof KILO_CODE_MODEL_STATUSES]
+
+interface PreparedSingleProfileCatalog {
+  catalog?: PreparedKiloCodeV7Catalog
+  invalidProfile: boolean
+}
+
+interface UseKiloCodeProfileModelDiscoveryOptions {
+  isOpen: boolean
+  profileName: string
+  runtimeKey: KiloCodeRuntimeKeyExportInput
+  selectionId: string
+}
+
+/** Normalize upstream model IDs once at the discovery boundary. */
+function normalizeDiscoveredModelIds(modelIds: unknown[] | null | undefined) {
+  return Array.from(
+    new Set(
+      (modelIds ?? [])
+        .map((item) => (typeof item === "string" ? item.trim() : ""))
+        .filter(Boolean),
+    ),
+  ).sort((left, right) => (left === right ? 0 : left < right ? -1 : 1))
+}
+
+/** Validate persisted profile facts before invoking the throwing catalog API. */
+function hasInvalidRuntimeProfile(runtimeKey: KiloCodeRuntimeKeyExportInput) {
+  if (!runtimeKey.tokenKey.trim()) return true
+
+  try {
+    const url = new URL(coerceBaseUrlToPathSuffix(runtimeKey.baseUrl, "/v1"))
+    return url.protocol !== "http:" && url.protocol !== "https:"
+  } catch {
+    return true
+  }
+}
+
+/** Convert catalog validation failures into controlled single-profile state. */
+function prepareSingleProfileCatalog(
+  selection: KiloCodeV7ProviderSelection,
+): PreparedSingleProfileCatalog {
+  if (hasInvalidRuntimeProfile(selection)) {
+    return { invalidProfile: true }
+  }
+  if (
+    !selection.discoveredModelIds.length &&
+    !selection.manualModelId?.trim()
+  ) {
+    return { invalidProfile: false }
+  }
+
+  try {
+    return {
+      catalog: prepareKiloCodeV7Catalog([selection]),
+      invalidProfile: false,
+    }
+  } catch {
+    return { invalidProfile: true }
+  }
+}
+
+/** Own model discovery and target-local model state for one profile export. */
+export function useKiloCodeProfileModelDiscovery({
+  isOpen,
+  profileName,
+  runtimeKey,
+  selectionId,
+}: UseKiloCodeProfileModelDiscoveryOptions) {
+  const [legacyModelId, setLegacyModelId] = useState("")
+  const [v7DefaultModelId, setV7DefaultModelId] = useState("")
+  const [v7ManualModelId, setV7ManualModelId] = useState("")
+  const [modelIds, setModelIds] = useState<string[]>([])
+  const [modelStatus, setModelStatus] = useState<KiloCodeModelStatus>(
+    KILO_CODE_MODEL_STATUSES.Idle,
+  )
+  const requestIdRef = useRef(0)
+  const v7ManualModelIdRef = useRef("")
+  const invalidRuntimeProfile = hasInvalidRuntimeProfile(runtimeKey)
+
+  const buildV7Selection = useCallback(
+    (discoveredModelIds: string[], manualModelId?: string) => ({
+      ...runtimeKey,
+      selectionId,
+      providerName: profileName,
+      discoveredModelIds,
+      manualModelId: manualModelId?.trim() || undefined,
+    }),
+    [profileName, runtimeKey, selectionId],
+  )
+
+  const loadModels = useCallback(async () => {
+    const requestId = ++requestIdRef.current
+    setModelStatus(KILO_CODE_MODEL_STATUSES.Loading)
+
+    try {
+      const upstreamModelIds = await fetchOpenAICompatibleModelIds({
+        baseUrl: stripTrailingOpenAIV1(runtimeKey.baseUrl),
+        apiKey: runtimeKey.tokenKey,
+      })
+      const normalized = normalizeDiscoveredModelIds(upstreamModelIds)
+      if (requestId !== requestIdRef.current) return
+
+      setModelIds(normalized)
+      setLegacyModelId((current) =>
+        current.trim() ? current : normalized[0] ?? "",
+      )
+      setV7DefaultModelId((current) => {
+        const prepared = prepareSingleProfileCatalog(
+          buildV7Selection(normalized, v7ManualModelIdRef.current),
+        )
+        if (!prepared.catalog) return ""
+        return (
+          reconcileKiloCodeV7DefaultSelection(prepared.catalog, {
+            selectionId,
+            modelId: current,
+          })?.modelId ?? ""
+        )
+      })
+      setModelStatus(KILO_CODE_MODEL_STATUSES.Loaded)
+    } catch (error) {
+      logger.warn("Failed to fetch upstream model list", error)
+      if (requestId !== requestIdRef.current) return
+      setModelStatus(KILO_CODE_MODEL_STATUSES.Error)
+    }
+  }, [buildV7Selection, runtimeKey.baseUrl, runtimeKey.tokenKey, selectionId])
+
+  useEffect(() => {
+    if (!isOpen) {
+      requestIdRef.current += 1
+      return
+    }
+
+    setLegacyModelId("")
+    setV7DefaultModelId("")
+    setV7ManualModelId("")
+    v7ManualModelIdRef.current = ""
+    setModelIds([])
+    setModelStatus(KILO_CODE_MODEL_STATUSES.Idle)
+    if (invalidRuntimeProfile) {
+      setModelStatus(KILO_CODE_MODEL_STATUSES.Loaded)
+      return () => {
+        requestIdRef.current += 1
+      }
+    }
+    void loadModels()
+
+    return () => {
+      requestIdRef.current += 1
+    }
+  }, [invalidRuntimeProfile, isOpen, loadModels])
+
+  const v7Selection = useMemo<KiloCodeV7ProviderSelection>(
+    () => buildV7Selection(modelIds, v7ManualModelId),
+    [buildV7Selection, modelIds, v7ManualModelId],
+  )
+  const preparedV7 = useMemo(
+    () => prepareSingleProfileCatalog(v7Selection),
+    [v7Selection],
+  )
+  const validV7Default = useMemo<KiloCodeDefaultModelSelection | undefined>(
+    () =>
+      preparedV7.catalog
+        ? reconcileKiloCodeV7DefaultSelection(preparedV7.catalog, {
+            selectionId,
+            modelId: v7DefaultModelId,
+          })
+        : undefined,
+    [preparedV7.catalog, selectionId, v7DefaultModelId],
+  )
+
+  const selectV7Model = useCallback(
+    (value: string) => {
+      const normalized = value.trim()
+      setV7DefaultModelId(normalized)
+      if (normalized && !modelIds.includes(normalized)) {
+        v7ManualModelIdRef.current = normalized
+        setV7ManualModelId(normalized)
+      }
+    },
+    [modelIds],
+  )
+  const selectLegacyModel = useCallback((value: string) => {
+    setLegacyModelId(value)
+  }, [])
+  const removeManualModel = useCallback(() => {
+    v7ManualModelIdRef.current = ""
+    setV7ManualModelId("")
+    setV7DefaultModelId((current) => {
+      const prepared = prepareSingleProfileCatalog(buildV7Selection(modelIds))
+      if (!prepared.catalog) return ""
+      return (
+        reconcileKiloCodeV7DefaultSelection(prepared.catalog, {
+          selectionId,
+          modelId: current,
+        })?.modelId ?? ""
+      )
+    })
+  }, [buildV7Selection, modelIds, selectionId])
+
+  return {
+    invalidProfile: preparedV7.invalidProfile,
+    legacyModelId,
+    loadModels,
+    modelIds,
+    modelStatus,
+    preparedV7ModelIds: preparedV7.catalog?.providers[0]?.modelIds ?? modelIds,
+    removeManualModel,
+    selectLegacyModel,
+    selectV7Model,
+    v7DefaultModelId,
+    v7ManualModelId,
+    v7Selection,
+    validV7Default,
+  }
+}

--- a/src/locales/en/ui.json
+++ b/src/locales/en/ui.json
@@ -327,6 +327,7 @@
         "exportTarget": "Export target",
         "legacyModelId": "Model ID",
         "modelId": "Model ID",
+        "providerProtocol": "API protocol",
         "selectedSites": "Selected sites",
         "selectedTokens": "Selected tokens"
       },
@@ -362,6 +363,11 @@
         "modelId": "Search or enter model ID",
         "selectSites": "Select sites",
         "selectTokens": "Select tokens"
+      },
+      "protocols": {
+        "anthropicMessages": "Anthropic Messages",
+        "openAICompatible": "OpenAI Compatible",
+        "openAIResponses": "OpenAI Responses"
       },
       "targets": {
         "kiloV7": "Kilo Code 7.x",

--- a/src/locales/en/ui.json
+++ b/src/locales/en/ui.json
@@ -336,6 +336,7 @@
         "modelIdRequiredDescription_one": "Select or enter a model ID for all selected API keys to enable export (missing: {{count}}).",
         "modelIdRequiredDescription_other": "Select or enter a model ID for all selected API keys to enable export (missing: {{count}}).",
         "modelIdRequiredTitle": "Model ID required",
+        "modelSearchLimited": "Showing the first {{visible}} of {{count}} models. Keep typing to narrow the list.",
         "noModelsDescription": "No upstream models were returned for this API key. Kilo Code typically requires a model ID — please enter one manually.",
         "noModelsTitle": "No models",
         "nothingToExportDescription": "Select at least one exportable token/site to enable copy/download.",

--- a/src/locales/en/ui.json
+++ b/src/locales/en/ui.json
@@ -320,6 +320,7 @@
       "labels": {
         "currentApiConfigName": "Current profile",
         "defaultModel": "Default model",
+        "defaultProvider": "Default provider",
         "exportTarget": "Export target",
         "legacyModelId": "Model ID",
         "modelId": "Model ID",
@@ -348,8 +349,10 @@
         "nothingToExportTitle": "Nothing to export",
         "noTokensDescription": "This site will be skipped until a token is created.",
         "noTokensTitle": "No tokens available",
+        "settingsFileTooLargeMultiple": "This file is too large for Kilo Code import. Select fewer providers, or copy the configuration and merge it manually.",
         "settingsFileTooLargeSingle": "This file is too large for Kilo Code import. Copy the configuration and merge it manually.",
-        "tokenCreated": "Token created"
+        "tokenCreated": "Token created",
+        "v7ProviderModelsRequired": "Enter a model ID, retry discovery, or deselect this provider."
       },
       "placeholders": {
         "currentApiConfigName": "Select current profile",

--- a/src/locales/en/ui.json
+++ b/src/locales/en/ui.json
@@ -309,13 +309,16 @@
         "selectedSites": "Selected sites: {{sites}}, selected keys: {{keys}}."
       },
       "help": {
-        "kiloV7CopyInstructions": "To maintain the configuration manually, click \"Copy provider config\" and merge the copied content into the top-level provider field in the settings JSON.",
-        "kiloV7DownloadInstructions": "Click \"Download Kilo 7.x settings\". Then, in Kilo Code, click the gear to open Settings, go to About Kilo Code → Import, select the downloaded kilo-settings.json, review the content to import, and save.",
+        "kiloV7ApiKeyEditorNote": "After import, Kilo Code may show the provider API key field as empty. This is a known editor limitation: imported inline keys are stored separately from the editor authentication state and remain available at runtime.",
+        "kiloV7CatalogInstructions": "Each selected API key becomes a provider with a readable name. It includes every normalized model ID discovered from that API plus any model ID entered manually for the provider; inclusion does not guarantee that every model works in every workflow. Choose the default model and, when exporting multiple providers, the default provider.",
+        "kiloV7CopyInstructions": "Click \"Copy provider config\" to copy a mergeable top-level fragment containing both provider and model. Merge both fields into your settings JSON; the copied fragment is not a complete import file.",
+        "kiloV7DownloadInstructions": "Click \"Download Kilo 7.x settings\", then import the downloaded kilo-settings.json from Kilo Code Settings → About Kilo Code → Import. Review the imported settings and save.",
         "legacyCopyInstructions": "Click \"Copy legacy apiConfigs\" and paste the content into providerProfiles.apiConfigs in the Roo Code or Kilo Code 5.x settings.",
         "legacyDownloadInstructions": "To get a complete settings file, click \"Download legacy settings\" to download kilo-code-settings.json, then import it using the settings import feature in the corresponding version.",
+        "legacySingleModelInstructions": "Legacy Roo Code and Kilo Code 5.x exports support one model per profile. Select the model to use before copying or downloading.",
         "perSiteDescription": "Select sites to load tokens automatically. The first token is preselected, and you can select multiple tokens per site.",
         "perSiteTitle": "Per-site export",
-        "usageTitle": "How to use"
+        "usageTitle": "Use the export"
       },
       "labels": {
         "currentApiConfigName": "Current profile",

--- a/src/locales/en/ui.json
+++ b/src/locales/en/ui.json
@@ -298,7 +298,9 @@
         "copyLegacyApiConfigs": "Copy legacy apiConfigs",
         "createDefaultToken": "Create default token",
         "downloadKiloV7Settings": "Download Kilo 7.x settings",
-        "downloadLegacySettings": "Download legacy settings"
+        "downloadLegacySettings": "Download legacy settings",
+        "removeManualModel": "Remove manual model",
+        "retryModels": "Retry model discovery"
       },
       "description": "Generate Kilo Code / Roo Code provider profiles from your selected sites and tokens.",
       "descriptions": {
@@ -317,7 +319,9 @@
       },
       "labels": {
         "currentApiConfigName": "Current profile",
+        "defaultModel": "Default model",
         "exportTarget": "Export target",
+        "legacyModelId": "Model ID",
         "modelId": "Model ID",
         "selectedSites": "Selected sites",
         "selectedTokens": "Selected tokens"
@@ -330,6 +334,7 @@
         "createTokenFailed": "Failed to create token.",
         "downloadedSettings": "Settings file downloaded",
         "downloadFailed": "Failed to download settings file",
+        "invalidProfile": "This profile has an invalid base URL or missing API key. Update the profile before exporting.",
         "loadingTokens": "Loading token list…",
         "loadModelsFailed": "Failed to load upstream models for this API key.",
         "loadTokensFailed": "Failed to load tokens for this site.",
@@ -343,6 +348,7 @@
         "nothingToExportTitle": "Nothing to export",
         "noTokensDescription": "This site will be skipped until a token is created.",
         "noTokensTitle": "No tokens available",
+        "settingsFileTooLargeSingle": "This file is too large for Kilo Code import. Copy the configuration and merge it manually.",
         "tokenCreated": "Token created"
       },
       "placeholders": {

--- a/src/locales/es-419/ui.json
+++ b/src/locales/es-419/ui.json
@@ -336,6 +336,7 @@
         "exportTarget": "Destino de exportación",
         "legacyModelId": "ID del modelo",
         "modelId": "Model ID",
+        "providerProtocol": "Protocolo de API",
         "selectedSites": "Sitios seleccionados",
         "selectedTokens": "Tokens seleccionados"
       },
@@ -372,6 +373,11 @@
         "modelId": "Buscar o ingresar Model ID",
         "selectSites": "Seleccionar sitios",
         "selectTokens": "Seleccionar tokens"
+      },
+      "protocols": {
+        "anthropicMessages": "Anthropic Messages",
+        "openAICompatible": "OpenAI Compatible",
+        "openAIResponses": "OpenAI Responses"
       },
       "targets": {
         "kiloV7": "Kilo Code 7.x",

--- a/src/locales/es-419/ui.json
+++ b/src/locales/es-419/ui.json
@@ -307,7 +307,9 @@
         "copyLegacyApiConfigs": "Copiar apiConfigs heredado",
         "createDefaultToken": "Crear token predeterminado",
         "downloadKiloV7Settings": "Descargar ajustes de Kilo 7.x",
-        "downloadLegacySettings": "Descargar ajustes heredados"
+        "downloadLegacySettings": "Descargar ajustes heredados",
+        "removeManualModel": "Quitar modelo manual",
+        "retryModels": "Reintentar detección de modelos"
       },
       "description": "Genera perfiles de proveedor de Kilo Code / Roo Code desde tus sitios y tokens seleccionados.",
       "descriptions": {
@@ -326,7 +328,9 @@
       },
       "labels": {
         "currentApiConfigName": "Perfil actual",
+        "defaultModel": "Modelo predeterminado",
         "exportTarget": "Destino de exportación",
+        "legacyModelId": "ID del modelo",
         "modelId": "Model ID",
         "selectedSites": "Sitios seleccionados",
         "selectedTokens": "Tokens seleccionados"
@@ -339,6 +343,7 @@
         "createTokenFailed": "No se pudo crear el token.",
         "downloadedSettings": "Archivo de ajustes descargado",
         "downloadFailed": "No se pudo descargar el archivo de ajustes",
+        "invalidProfile": "Este perfil tiene una URL base no válida o no tiene clave de API. Actualiza el perfil antes de exportar.",
         "loadingTokens": "Cargando lista de tokens…",
         "loadModelsFailed": "No se pudieron cargar los modelos upstream para esta API key.",
         "loadTokensFailed": "No se pudieron cargar los tokens de este sitio.",
@@ -353,6 +358,7 @@
         "nothingToExportTitle": "Nada para exportar",
         "noTokensDescription": "Este sitio se omitirá hasta que se cree un token.",
         "noTokensTitle": "No hay tokens disponibles",
+        "settingsFileTooLargeSingle": "Este archivo supera el límite de importación de Kilo Code. Copia la configuración y combínala manualmente.",
         "tokenCreated": "Token creado"
       },
       "placeholders": {

--- a/src/locales/es-419/ui.json
+++ b/src/locales/es-419/ui.json
@@ -329,6 +329,7 @@
       "labels": {
         "currentApiConfigName": "Perfil actual",
         "defaultModel": "Modelo predeterminado",
+        "defaultProvider": "Proveedor predeterminado",
         "exportTarget": "Destino de exportación",
         "legacyModelId": "ID del modelo",
         "modelId": "Model ID",
@@ -358,8 +359,10 @@
         "nothingToExportTitle": "Nada para exportar",
         "noTokensDescription": "Este sitio se omitirá hasta que se cree un token.",
         "noTokensTitle": "No hay tokens disponibles",
+        "settingsFileTooLargeMultiple": "Este archivo supera el límite de importación de Kilo Code. Selecciona menos proveedores o copia la configuración y combínala manualmente.",
         "settingsFileTooLargeSingle": "Este archivo supera el límite de importación de Kilo Code. Copia la configuración y combínala manualmente.",
-        "tokenCreated": "Token creado"
+        "tokenCreated": "Token creado",
+        "v7ProviderModelsRequired": "Ingresa un ID de modelo, reintenta la detección o deselecciona este proveedor."
       },
       "placeholders": {
         "currentApiConfigName": "Seleccionar perfil actual",

--- a/src/locales/es-419/ui.json
+++ b/src/locales/es-419/ui.json
@@ -346,6 +346,7 @@
         "modelIdRequiredDescription_many": "Selecciona o ingresa un Model ID para todas las API keys seleccionadas para habilitar la exportación (faltan: {{count}}).",
         "modelIdRequiredDescription_other": "Selecciona o ingresa un Model ID para todas las API keys seleccionadas para habilitar la exportación (faltan: {{count}}).",
         "modelIdRequiredTitle": "Model ID obligatorio",
+        "modelSearchLimited": "Se muestran los primeros {{visible}} de {{count}} modelos. Sigue escribiendo para reducir la lista.",
         "noModelsDescription": "No se devolvieron modelos upstream para esta API key. Kilo Code normalmente requiere un Model ID; ingrésalo manualmente.",
         "noModelsTitle": "Sin modelos",
         "nothingToExportDescription": "Selecciona al menos un token/sitio exportable para habilitar copiar/descargar.",

--- a/src/locales/es-419/ui.json
+++ b/src/locales/es-419/ui.json
@@ -318,13 +318,16 @@
         "selectedSites": "Sitios seleccionados: {{sites}}, claves seleccionadas: {{keys}}."
       },
       "help": {
-        "kiloV7CopyInstructions": "Si necesitas mantener la configuración manualmente, haz clic en “Copiar configuración del proveedor” y combina el contenido copiado con el campo provider de nivel superior del JSON de ajustes.",
-        "kiloV7DownloadInstructions": "Haz clic en “Descargar ajustes de Kilo 7.x”. Luego, en Kilo Code, haz clic en el engranaje para abrir Ajustes, ve a About Kilo Code → Import, selecciona el archivo kilo-settings.json descargado, revisa el contenido que se importará y guarda los cambios.",
+        "kiloV7ApiKeyEditorNote": "Después de importar, Kilo Code puede mostrar vacío el campo de API key del provider. Es una limitación conocida del editor: las claves integradas importadas se guardan por separado del estado de autenticación del editor y siguen disponibles durante la ejecución.",
+        "kiloV7CatalogInstructions": "Cada API key seleccionada se convierte en un provider con un nombre legible. Incluye todos los ID de modelo normalizados detectados mediante esa API y cualquier ID ingresado manualmente para el provider; incluirlos no garantiza que cada modelo funcione en todos los flujos. Elige el model predeterminado y, si exportas varios providers, también el provider predeterminado.",
+        "kiloV7CopyInstructions": "Haz clic en “Copiar configuración del proveedor” para copiar un fragmento combinable de nivel superior que contiene provider y model. Combina ambos campos con tu JSON de ajustes; el fragmento copiado no es un archivo de importación completo.",
+        "kiloV7DownloadInstructions": "Haz clic en “Descargar ajustes de Kilo 7.x” y, en Kilo Code, importa el archivo kilo-settings.json descargado desde Ajustes → About Kilo Code → Import. Revisa los ajustes importados y guárdalos.",
         "legacyCopyInstructions": "Haz clic en “Copiar apiConfigs heredado” y pega el contenido en providerProfiles.apiConfigs de los ajustes de Roo Code o Kilo Code 5.x.",
         "legacyDownloadInstructions": "Si necesitas un archivo de ajustes completo, haz clic en “Descargar ajustes heredados” para obtener kilo-code-settings.json e impórtalo mediante la función de importación de ajustes de la versión correspondiente.",
+        "legacySingleModelInstructions": "Las exportaciones para Roo Code y Kilo Code 5.x heredados admiten un modelo por perfil. Selecciona el modelo que se usará antes de copiar o descargar.",
         "perSiteDescription": "Selecciona sitios para cargar tokens automáticamente. El primer token queda preseleccionado y puedes seleccionar varios tokens por sitio.",
         "perSiteTitle": "Exportación por sitio",
-        "usageTitle": "Cómo usarlo"
+        "usageTitle": "Usar la exportación"
       },
       "labels": {
         "currentApiConfigName": "Perfil actual",

--- a/src/locales/ja/ui.json
+++ b/src/locales/ja/ui.json
@@ -321,6 +321,7 @@
         "exportTarget": "エクスポート先",
         "legacyModelId": "モデル ID",
         "modelId": "モデル ID",
+        "providerProtocol": "API プロトコル",
         "selectedSites": "選択したサイト",
         "selectedTokens": "選択したトークン"
       },
@@ -355,6 +356,11 @@
         "modelId": "モデル ID を検索または入力",
         "selectSites": "サイトを選択",
         "selectTokens": "トークンを選択"
+      },
+      "protocols": {
+        "anthropicMessages": "Anthropic Messages",
+        "openAICompatible": "OpenAI Compatible",
+        "openAIResponses": "OpenAI Responses"
       },
       "targets": {
         "kiloV7": "Kilo Code 7.x",

--- a/src/locales/ja/ui.json
+++ b/src/locales/ja/ui.json
@@ -314,6 +314,7 @@
       "labels": {
         "currentApiConfigName": "現在のプロファイル",
         "defaultModel": "既定のモデル",
+        "defaultProvider": "既定のプロバイダー",
         "exportTarget": "エクスポート先",
         "legacyModelId": "モデル ID",
         "modelId": "モデル ID",
@@ -341,8 +342,10 @@
         "nothingToExportTitle": "エクスポート対象がありません",
         "noTokensDescription": "トークンが作成されるまで、このサイトはスキップされます。",
         "noTokensTitle": "利用可能なトークンがありません",
+        "settingsFileTooLargeMultiple": "このファイルは Kilo Code のインポート上限を超えています。プロバイダーを減らすか、設定をコピーして手動で統合してください。",
         "settingsFileTooLargeSingle": "このファイルは Kilo Code のインポート上限を超えています。設定をコピーして手動で統合してください。",
-        "tokenCreated": "トークンを作成しました"
+        "tokenCreated": "トークンを作成しました",
+        "v7ProviderModelsRequired": "モデル ID を入力するか、モデル検出を再試行するか、このプロバイダーの選択を解除してください。"
       },
       "placeholders": {
         "currentApiConfigName": "現在のプロファイルを選択",

--- a/src/locales/ja/ui.json
+++ b/src/locales/ja/ui.json
@@ -329,6 +329,7 @@
         "loadTokensFailed": "このサイトのトークン読み込みに失敗しました。",
         "modelIdRequiredDescription_other": "エクスポートを有効にするには、選択したすべての API キーにモデル ID を選択または入力してください（不足: {{count}}）。",
         "modelIdRequiredTitle": "モデル ID が必要です",
+        "modelSearchLimited": "{{count}} 件中、最初の {{visible}} 件を表示しています。入力を続けて絞り込んでください。",
         "noModelsDescription": "この API キーでは上流モデルが返されませんでした。Kilo Code では通常モデル ID が必要なため、手動入力してください。",
         "noModelsTitle": "モデルがありません",
         "nothingToExportDescription": "コピー / ダウンロードを有効にするには、エクスポート可能なトークンまたはサイトを少なくとも 1 つ選択してください。",

--- a/src/locales/ja/ui.json
+++ b/src/locales/ja/ui.json
@@ -303,13 +303,16 @@
         "selectedSites": "選択したサイト: {{sites}}、選択したキー: {{keys}}。"
       },
       "help": {
-        "kiloV7CopyInstructions": "設定を手動で管理する場合は、「プロバイダー設定をコピー」をクリックし、コピーした内容を設定 JSON のトップレベルにある provider フィールドへマージします。",
-        "kiloV7DownloadInstructions": "「Kilo 7.x 設定をダウンロード」をクリックします。次に Kilo Code で歯車アイコンをクリックして設定を開き、About Kilo Code → Import に移動します。ダウンロードした kilo-settings.json を選択し、インポート内容を確認してから保存します。",
+        "kiloV7ApiKeyEditorNote": "インポート後、Kilo Code の provider 編集画面で API キーフィールドが空に見える場合があります。これは既知の制限です。インポートされたインラインキーと編集画面の認証状態は別に保存されるため、実行時にはそのキーを引き続き使用できます。",
+        "kiloV7CatalogInstructions": "選択した API キーごとに、読みやすい名前の provider を出力します。API から検出して正規化したすべてのモデル ID と、その provider に手動で入力したモデル ID が含まれます。含まれていても、すべてのモデルがあらゆるワークフローで動作するとは限りません。既定の model を選択し、複数の provider をエクスポートする場合は既定の provider も選択してください。",
+        "kiloV7CopyInstructions": "「プロバイダー設定をコピー」をクリックすると、provider と model を含む、マージ可能なトップレベルの断片をコピーできます。両方のフィールドを設定 JSON にマージしてください。コピーした断片だけでは完全なインポートファイルになりません。",
+        "kiloV7DownloadInstructions": "「Kilo 7.x 設定をダウンロード」をクリックし、Kilo Code の設定 → About Kilo Code → Import から、ダウンロードした kilo-settings.json をインポートします。インポート内容を確認して保存してください。",
         "legacyCopyInstructions": "「旧形式の apiConfigs をコピー」をクリックし、内容を Roo Code または Kilo Code 5.x の設定にある providerProfiles.apiConfigs へ貼り付けます。",
         "legacyDownloadInstructions": "完全な設定ファイルが必要な場合は、「旧形式の設定をダウンロード」をクリックして kilo-code-settings.json を取得し、該当バージョンの設定インポート機能からインポートします。",
+        "legacySingleModelInstructions": "旧形式の Roo Code と Kilo Code 5.x へのエクスポートでは、プロファイルごとに 1 つのモデルを使用します。コピーまたはダウンロードする前に使用するモデルを選択してください。",
         "perSiteDescription": "サイトを選択してトークンを自動読み込みします。最初のトークンが事前選択され、サイトごとに複数トークンを選択できます。",
         "perSiteTitle": "サイト別エクスポート",
-        "usageTitle": "使用方法"
+        "usageTitle": "エクスポートの使用方法"
       },
       "labels": {
         "currentApiConfigName": "現在のプロファイル",

--- a/src/locales/ja/ui.json
+++ b/src/locales/ja/ui.json
@@ -292,7 +292,9 @@
         "copyLegacyApiConfigs": "旧形式の apiConfigs をコピー",
         "createDefaultToken": "既定トークンを作成",
         "downloadKiloV7Settings": "Kilo 7.x 設定をダウンロード",
-        "downloadLegacySettings": "旧形式の設定をダウンロード"
+        "downloadLegacySettings": "旧形式の設定をダウンロード",
+        "removeManualModel": "手動モデルを削除",
+        "retryModels": "モデル検出を再試行"
       },
       "description": "選択したサイトとトークンから Kilo Code / Roo Code のプロバイダープロファイルを生成します。",
       "descriptions": {
@@ -311,7 +313,9 @@
       },
       "labels": {
         "currentApiConfigName": "現在のプロファイル",
+        "defaultModel": "既定のモデル",
         "exportTarget": "エクスポート先",
+        "legacyModelId": "モデル ID",
         "modelId": "モデル ID",
         "selectedSites": "選択したサイト",
         "selectedTokens": "選択したトークン"
@@ -324,6 +328,7 @@
         "createTokenFailed": "トークンの作成に失敗しました。",
         "downloadedSettings": "設定ファイルをダウンロードしました",
         "downloadFailed": "設定ファイルのダウンロードに失敗しました",
+        "invalidProfile": "このプロファイルのベース URL が無効か、API キーがありません。エクスポートする前にプロファイルを更新してください。",
         "loadingTokens": "トークン一覧を読み込み中…",
         "loadModelsFailed": "この API キーの上流モデル読み込みに失敗しました。",
         "loadTokensFailed": "このサイトのトークン読み込みに失敗しました。",
@@ -336,6 +341,7 @@
         "nothingToExportTitle": "エクスポート対象がありません",
         "noTokensDescription": "トークンが作成されるまで、このサイトはスキップされます。",
         "noTokensTitle": "利用可能なトークンがありません",
+        "settingsFileTooLargeSingle": "このファイルは Kilo Code のインポート上限を超えています。設定をコピーして手動で統合してください。",
         "tokenCreated": "トークンを作成しました"
       },
       "placeholders": {

--- a/src/locales/vi/ui.json
+++ b/src/locales/vi/ui.json
@@ -321,6 +321,7 @@
         "exportTarget": "Đích xuất",
         "legacyModelId": "ID mô hình",
         "modelId": "ID mô hình",
+        "providerProtocol": "Giao thức API",
         "selectedSites": "Các trang web đã chọn",
         "selectedTokens": "Các API Key đã chọn"
       },
@@ -355,6 +356,11 @@
         "modelId": "Tìm kiếm hoặc nhập ID mô hình",
         "selectSites": "Vui lòng chọn trang web",
         "selectTokens": "Vui lòng chọn API Key"
+      },
+      "protocols": {
+        "anthropicMessages": "Anthropic Messages",
+        "openAICompatible": "OpenAI Compatible",
+        "openAIResponses": "OpenAI Responses"
       },
       "targets": {
         "kiloV7": "Kilo Code 7.x",

--- a/src/locales/vi/ui.json
+++ b/src/locales/vi/ui.json
@@ -329,6 +329,7 @@
         "loadTokensFailed": "Tải API Key thất bại.",
         "modelIdRequiredDescription_other": "Vui lòng chọn hoặc nhập model ID cho tất cả API Key đã chọn trước khi xuất (còn thiếu {{count}}).",
         "modelIdRequiredTitle": "Yêu cầu ID mô hình",
+        "modelSearchLimited": "Chỉ hiển thị {{visible}} mô hình đầu tiên trong tổng số {{count}}. Hãy tiếp tục nhập để thu hẹp danh sách.",
         "noModelsDescription": "API Key này không trả về mô hình khả dụng. Kilo Code thực tế sử dụng thường yêu cầu ID mô hình, vui lòng nhập thủ công.",
         "noModelsTitle": "Không có mô hình",
         "nothingToExportDescription": "Vui lòng chọn ít nhất một trang web/API Key có thể xuất trước khi sao chép/tải xuống.",

--- a/src/locales/vi/ui.json
+++ b/src/locales/vi/ui.json
@@ -303,13 +303,16 @@
         "selectedSites": "Trang web đã chọn: {{sites}}, API Key đã chọn: {{keys}}."
       },
       "help": {
-        "kiloV7CopyInstructions": "Nếu cần tự duy trì cấu hình, hãy nhấp vào “Sao chép cấu hình nhà cung cấp” và hợp nhất nội dung đã sao chép vào trường provider ở cấp cao nhất của JSON cài đặt.",
-        "kiloV7DownloadInstructions": "Nhấp vào “Tải cài đặt Kilo 7.x”. Sau đó, trong Kilo Code, nhấp vào biểu tượng bánh răng để mở Cài đặt, vào About Kilo Code → Import, chọn tệp kilo-settings.json đã tải xuống, xem lại nội dung sẽ nhập rồi lưu.",
+        "kiloV7ApiKeyEditorNote": "Sau khi nhập, Kilo Code có thể hiển thị trống trường API key của provider. Đây là hạn chế đã biết của trình chỉnh sửa: khóa nội tuyến đã nhập được lưu riêng với trạng thái xác thực của trình chỉnh sửa và vẫn dùng được khi chạy.",
+        "kiloV7CatalogInstructions": "Mỗi API key đã chọn trở thành một provider có tên dễ đọc. Provider bao gồm tất cả ID mô hình đã chuẩn hóa được phát hiện từ API và mọi ID được nhập thủ công cho provider đó; việc có trong bản xuất không đảm bảo mọi mô hình hoạt động với mọi quy trình. Chọn model mặc định; khi xuất nhiều provider, hãy chọn cả provider mặc định.",
+        "kiloV7CopyInstructions": "Nhấp vào “Sao chép cấu hình nhà cung cấp” để sao chép một đoạn cấp cao nhất có thể hợp nhất, gồm cả provider và model. Hãy hợp nhất cả hai trường vào JSON cài đặt; đoạn đã sao chép không phải là tệp nhập hoàn chỉnh.",
+        "kiloV7DownloadInstructions": "Nhấp vào “Tải cài đặt Kilo 7.x”, rồi nhập tệp kilo-settings.json đã tải xuống trong Kilo Code tại Cài đặt → About Kilo Code → Import. Xem lại cài đặt đã nhập rồi lưu.",
         "legacyCopyInstructions": "Nhấp vào “Sao chép apiConfigs kiểu cũ”, rồi dán nội dung vào providerProfiles.apiConfigs trong cài đặt của Roo Code hoặc Kilo Code 5.x.",
         "legacyDownloadInstructions": "Nếu cần tệp cài đặt đầy đủ, hãy nhấp vào “Tải cài đặt kiểu cũ” để lấy kilo-code-settings.json rồi nhập tệp bằng tính năng nhập cài đặt của phiên bản tương ứng.",
+        "legacySingleModelInstructions": "Bản xuất cho Roo Code và Kilo Code 5.x kiểu cũ hỗ trợ một mô hình cho mỗi hồ sơ. Chọn mô hình cần dùng trước khi sao chép hoặc tải xuống.",
         "perSiteDescription": "Sau khi chọn trang web để xuất, các API Key sẽ tự động được tải, và API Key đầu tiên được chọn mặc định (hỗ trợ chọn nhiều cho mỗi trang web).",
         "perSiteTitle": "Xuất theo trang web",
-        "usageTitle": "Cách sử dụng"
+        "usageTitle": "Sử dụng bản xuất"
       },
       "labels": {
         "currentApiConfigName": "Cấu hình hiện tại",

--- a/src/locales/vi/ui.json
+++ b/src/locales/vi/ui.json
@@ -314,6 +314,7 @@
       "labels": {
         "currentApiConfigName": "Cấu hình hiện tại",
         "defaultModel": "Mô hình mặc định",
+        "defaultProvider": "Nhà cung cấp mặc định",
         "exportTarget": "Đích xuất",
         "legacyModelId": "ID mô hình",
         "modelId": "ID mô hình",
@@ -341,8 +342,10 @@
         "nothingToExportTitle": "Không có nội dung để xuất",
         "noTokensDescription": "Trang web này sẽ bị bỏ qua cho đến khi tạo API Key.",
         "noTokensTitle": "Chưa có API Key",
+        "settingsFileTooLargeMultiple": "Tệp này vượt quá giới hạn nhập của Kilo Code. Hãy chọn ít nhà cung cấp hơn hoặc sao chép cấu hình và hợp nhất thủ công.",
         "settingsFileTooLargeSingle": "Tệp này vượt quá giới hạn nhập của Kilo Code. Hãy sao chép cấu hình và hợp nhất thủ công.",
-        "tokenCreated": "Tạo API Key thành công"
+        "tokenCreated": "Tạo API Key thành công",
+        "v7ProviderModelsRequired": "Hãy nhập ID mô hình, thử tìm mô hình lại hoặc bỏ chọn nhà cung cấp này."
       },
       "placeholders": {
         "currentApiConfigName": "Vui lòng chọn cấu hình hiện tại",

--- a/src/locales/vi/ui.json
+++ b/src/locales/vi/ui.json
@@ -292,7 +292,9 @@
         "copyLegacyApiConfigs": "Sao chép apiConfigs kiểu cũ",
         "createDefaultToken": "Tạo API Key mặc định",
         "downloadKiloV7Settings": "Tải cài đặt Kilo 7.x",
-        "downloadLegacySettings": "Tải cài đặt kiểu cũ"
+        "downloadLegacySettings": "Tải cài đặt kiểu cũ",
+        "removeManualModel": "Xóa mô hình nhập thủ công",
+        "retryModels": "Thử tìm mô hình lại"
       },
       "description": "Tạo cấu hình providerProfiles cho Kilo Code / Roo Code dựa trên các trang web và API Key đã chọn.",
       "descriptions": {
@@ -311,7 +313,9 @@
       },
       "labels": {
         "currentApiConfigName": "Cấu hình hiện tại",
+        "defaultModel": "Mô hình mặc định",
         "exportTarget": "Đích xuất",
+        "legacyModelId": "ID mô hình",
         "modelId": "ID mô hình",
         "selectedSites": "Các trang web đã chọn",
         "selectedTokens": "Các API Key đã chọn"
@@ -324,6 +328,7 @@
         "createTokenFailed": "Tạo API Key thất bại.",
         "downloadedSettings": "Đã tải xuống tệp cài đặt",
         "downloadFailed": "Tải tệp cài đặt thất bại",
+        "invalidProfile": "Hồ sơ này có URL cơ sở không hợp lệ hoặc thiếu khóa API. Hãy cập nhật hồ sơ trước khi xuất.",
         "loadingTokens": "Đang tải danh sách API Key...",
         "loadModelsFailed": "Tải danh sách mô hình của API Key này thất bại.",
         "loadTokensFailed": "Tải API Key thất bại.",
@@ -336,6 +341,7 @@
         "nothingToExportTitle": "Không có nội dung để xuất",
         "noTokensDescription": "Trang web này sẽ bị bỏ qua cho đến khi tạo API Key.",
         "noTokensTitle": "Chưa có API Key",
+        "settingsFileTooLargeSingle": "Tệp này vượt quá giới hạn nhập của Kilo Code. Hãy sao chép cấu hình và hợp nhất thủ công.",
         "tokenCreated": "Tạo API Key thành công"
       },
       "placeholders": {

--- a/src/locales/zh-CN/ui.json
+++ b/src/locales/zh-CN/ui.json
@@ -300,13 +300,16 @@
         "selectedSites": "已选站点：{{sites}}，已选密钥：{{keys}}。"
       },
       "help": {
-        "kiloV7CopyInstructions": "如需手动维护配置，可点击“复制 provider 配置”，将复制的内容合并到设置 JSON 顶层的 provider 字段。",
-        "kiloV7DownloadInstructions": "点击“下载 Kilo 7.x 设置”。然后在 Kilo Code 中点击齿轮打开设置，进入 About Kilo Code → Import，选择下载的 kilo-settings.json，确认导入内容后保存。",
+        "kiloV7ApiKeyEditorNote": "导入后，Kilo Code 的 provider 编辑页可能会将 API 密钥字段显示为空。这是已知的编辑器限制：导入的内联密钥与编辑器认证状态分开存储，运行时仍可使用该密钥。",
+        "kiloV7CatalogInstructions": "每个选中的 API 密钥都会导出为一个名称易读的 provider，其中包含从接口发现并规范化的全部模型 ID，以及为该 provider 手动输入并保留的模型 ID。被包含在导出中并不保证每个模型都适用于所有工作流。请先选择默认 model；导出多个 provider 时，还需选择默认 provider。",
+        "kiloV7CopyInstructions": "点击“复制 provider 配置”可复制同时包含 provider 和 model 的顶层可合并片段。请将这两个字段合并到设置 JSON 中；复制的片段不是完整的导入文件。",
+        "kiloV7DownloadInstructions": "点击“下载 Kilo 7.x 设置”，然后在 Kilo Code 的设置 → About Kilo Code → Import 中导入下载的 kilo-settings.json，确认导入内容后保存。",
         "legacyCopyInstructions": "点击“复制旧版 apiConfigs”，将内容粘贴到 Roo Code 或 Kilo Code 5.x 设置的 providerProfiles.apiConfigs 中。",
         "legacyDownloadInstructions": "如需完整设置文件，可点击“下载旧版设置”获取 kilo-code-settings.json，并通过对应版本的设置导入功能导入。",
+        "legacySingleModelInstructions": "旧版 Roo Code 和 Kilo Code 5.x 导出每个配置只支持一个模型。复制或下载前，请先选择要使用的模型。",
         "perSiteDescription": "选择要导出的站点后将自动加载密钥，并默认选择第一个密钥（每个站点支持多选）。",
         "perSiteTitle": "按站点导出",
-        "usageTitle": "使用方法"
+        "usageTitle": "使用导出内容"
       },
       "labels": {
         "currentApiConfigName": "当前配置",

--- a/src/locales/zh-CN/ui.json
+++ b/src/locales/zh-CN/ui.json
@@ -311,6 +311,7 @@
       "labels": {
         "currentApiConfigName": "当前配置",
         "defaultModel": "默认模型",
+        "defaultProvider": "默认供应商",
         "exportTarget": "导出目标",
         "legacyModelId": "模型 ID",
         "modelId": "模型 ID",
@@ -338,8 +339,10 @@
         "nothingToExportTitle": "无可导出的内容",
         "noTokensDescription": "该站点将被跳过，直到创建密钥。",
         "noTokensTitle": "暂无密钥",
+        "settingsFileTooLargeMultiple": "此文件超过 Kilo Code 的导入大小限制。请选择更少的供应商，或复制配置并手动合并。",
         "settingsFileTooLargeSingle": "此文件超过 Kilo Code 的导入大小限制。请复制配置并手动合并。",
-        "tokenCreated": "密钥创建成功"
+        "tokenCreated": "密钥创建成功",
+        "v7ProviderModelsRequired": "请输入模型 ID、重试获取模型，或取消选择此供应商。"
       },
       "placeholders": {
         "currentApiConfigName": "请选择当前配置",

--- a/src/locales/zh-CN/ui.json
+++ b/src/locales/zh-CN/ui.json
@@ -289,7 +289,9 @@
         "copyLegacyApiConfigs": "复制旧版 apiConfigs",
         "createDefaultToken": "创建默认密钥",
         "downloadKiloV7Settings": "下载 Kilo 7.x 设置",
-        "downloadLegacySettings": "下载旧版设置"
+        "downloadLegacySettings": "下载旧版设置",
+        "removeManualModel": "移除手动模型",
+        "retryModels": "重试获取模型"
       },
       "description": "根据选中的站点和密钥生成 Kilo Code / Roo Code 的 providerProfiles 配置。",
       "descriptions": {
@@ -308,7 +310,9 @@
       },
       "labels": {
         "currentApiConfigName": "当前配置",
+        "defaultModel": "默认模型",
         "exportTarget": "导出目标",
+        "legacyModelId": "模型 ID",
         "modelId": "模型 ID",
         "selectedSites": "已选择的站点",
         "selectedTokens": "已选择的密钥"
@@ -321,6 +325,7 @@
         "createTokenFailed": "创建密钥失败。",
         "downloadedSettings": "已下载设置文件",
         "downloadFailed": "设置文件下载失败",
+        "invalidProfile": "此配置的基础 URL 无效或缺少 API 密钥。请先更新配置再导出。",
         "loadingTokens": "正在加载密钥列表…",
         "loadModelsFailed": "加载该密钥的模型列表失败。",
         "loadTokensFailed": "加载密钥失败。",
@@ -333,6 +338,7 @@
         "nothingToExportTitle": "无可导出的内容",
         "noTokensDescription": "该站点将被跳过，直到创建密钥。",
         "noTokensTitle": "暂无密钥",
+        "settingsFileTooLargeSingle": "此文件超过 Kilo Code 的导入大小限制。请复制配置并手动合并。",
         "tokenCreated": "密钥创建成功"
       },
       "placeholders": {

--- a/src/locales/zh-CN/ui.json
+++ b/src/locales/zh-CN/ui.json
@@ -326,6 +326,7 @@
         "loadTokensFailed": "加载密钥失败。",
         "modelIdRequiredDescription": "请为所有已选择的密钥选择或输入模型 ID 后再导出（还缺 {{count}} 个）。",
         "modelIdRequiredTitle": "需要模型 ID",
+        "modelSearchLimited": "仅显示前 {{visible}} 个（共 {{count}} 个）模型，请继续输入以缩小范围。",
         "noModelsDescription": "该密钥未返回可用模型。Kilo Code 实际使用通常需要模型 ID，请手动输入。",
         "noModelsTitle": "无模型",
         "nothingToExportDescription": "请至少选择一个可导出的站点/密钥后再进行复制/下载。",

--- a/src/locales/zh-CN/ui.json
+++ b/src/locales/zh-CN/ui.json
@@ -318,6 +318,7 @@
         "exportTarget": "导出目标",
         "legacyModelId": "模型 ID",
         "modelId": "模型 ID",
+        "providerProtocol": "API 协议",
         "selectedSites": "已选择的站点",
         "selectedTokens": "已选择的密钥"
       },
@@ -352,6 +353,11 @@
         "modelId": "搜索或输入模型 ID",
         "selectSites": "请选择站点",
         "selectTokens": "请选择密钥"
+      },
+      "protocols": {
+        "anthropicMessages": "Anthropic Messages",
+        "openAICompatible": "OpenAI Compatible",
+        "openAIResponses": "OpenAI Responses"
       },
       "targets": {
         "kiloV7": "Kilo Code 7.x",

--- a/src/locales/zh-TW/ui.json
+++ b/src/locales/zh-TW/ui.json
@@ -321,6 +321,7 @@
         "exportTarget": "匯出目標",
         "legacyModelId": "模型 ID",
         "modelId": "模型 ID",
+        "providerProtocol": "API 通訊協定",
         "selectedSites": "已選擇的站點",
         "selectedTokens": "已選擇的金鑰"
       },
@@ -355,6 +356,11 @@
         "modelId": "搜尋或輸入模型 ID",
         "selectSites": "請選擇站點",
         "selectTokens": "請選擇金鑰"
+      },
+      "protocols": {
+        "anthropicMessages": "Anthropic Messages",
+        "openAICompatible": "OpenAI Compatible",
+        "openAIResponses": "OpenAI Responses"
       },
       "targets": {
         "kiloV7": "Kilo Code 7.x",

--- a/src/locales/zh-TW/ui.json
+++ b/src/locales/zh-TW/ui.json
@@ -314,6 +314,7 @@
       "labels": {
         "currentApiConfigName": "當前配置",
         "defaultModel": "預設模型",
+        "defaultProvider": "預設供應商",
         "exportTarget": "匯出目標",
         "legacyModelId": "模型 ID",
         "modelId": "模型 ID",
@@ -341,8 +342,10 @@
         "nothingToExportTitle": "無可匯出的內容",
         "noTokensDescription": "該站點將被跳過，直到建立金鑰。",
         "noTokensTitle": "暫無金鑰",
+        "settingsFileTooLargeMultiple": "此檔案超過 Kilo Code 的匯入大小限制。請選取較少的供應商，或複製設定並手動合併。",
         "settingsFileTooLargeSingle": "此檔案超過 Kilo Code 的匯入大小限制。請複製設定並手動合併。",
-        "tokenCreated": "金鑰建立成功"
+        "tokenCreated": "金鑰建立成功",
+        "v7ProviderModelsRequired": "請輸入模型 ID、重試取得模型，或取消選取此供應商。"
       },
       "placeholders": {
         "currentApiConfigName": "請選擇當前配置",

--- a/src/locales/zh-TW/ui.json
+++ b/src/locales/zh-TW/ui.json
@@ -303,13 +303,16 @@
         "selectedSites": "已選站點：{{sites}}，已選金鑰：{{keys}}。"
       },
       "help": {
-        "kiloV7CopyInstructions": "如需手動維護設定，可點擊「複製 provider 設定」，將複製的內容合併到設定 JSON 頂層的 provider 欄位。",
-        "kiloV7DownloadInstructions": "點擊「下載 Kilo 7.x 設定」。然後在 Kilo Code 中點擊齒輪開啟設定，進入 About Kilo Code → Import，選擇下載的 kilo-settings.json，確認匯入內容後儲存。",
+        "kiloV7ApiKeyEditorNote": "匯入後，Kilo Code 的 provider 編輯頁可能會將 API 金鑰欄位顯示為空白。這是已知的編輯器限制：匯入的內嵌金鑰與編輯器驗證狀態分開儲存，執行時仍可使用該金鑰。",
+        "kiloV7CatalogInstructions": "每個選取的 API 金鑰都會匯出為一個名稱易讀的 provider，其中包含從介面發現並正規化的全部模型 ID，以及為該 provider 手動輸入並保留的模型 ID。被包含在匯出內容中並不保證每個模型都適用於所有工作流程。請先選取預設 model；匯出多個 provider 時，還需選取預設 provider。",
+        "kiloV7CopyInstructions": "點擊「複製 provider 設定」可複製同時包含 provider 和 model 的頂層可合併片段。請將這兩個欄位合併到設定 JSON 中；複製的片段不是完整的匯入檔案。",
+        "kiloV7DownloadInstructions": "點擊「下載 Kilo 7.x 設定」，然後在 Kilo Code 的設定 → About Kilo Code → Import 中匯入下載的 kilo-settings.json，確認匯入內容後儲存。",
         "legacyCopyInstructions": "點擊「複製舊版 apiConfigs」，將內容貼到 Roo Code 或 Kilo Code 5.x 設定的 providerProfiles.apiConfigs 中。",
         "legacyDownloadInstructions": "如需完整設定檔，可點擊「下載舊版設定」取得 kilo-code-settings.json，並透過對應版本的設定匯入功能匯入。",
+        "legacySingleModelInstructions": "舊版 Roo Code 和 Kilo Code 5.x 匯出每個設定只支援一個模型。複製或下載前，請先選取要使用的模型。",
         "perSiteDescription": "選擇要匯出的站點後將自動載入金鑰，並預設選擇第一個金鑰（每個站點支援多選）。",
         "perSiteTitle": "按站點匯出",
-        "usageTitle": "使用方法"
+        "usageTitle": "使用匯出內容"
       },
       "labels": {
         "currentApiConfigName": "當前配置",

--- a/src/locales/zh-TW/ui.json
+++ b/src/locales/zh-TW/ui.json
@@ -292,7 +292,9 @@
         "copyLegacyApiConfigs": "複製舊版 apiConfigs",
         "createDefaultToken": "建立預設金鑰",
         "downloadKiloV7Settings": "下載 Kilo 7.x 設定",
-        "downloadLegacySettings": "下載舊版設定"
+        "downloadLegacySettings": "下載舊版設定",
+        "removeManualModel": "移除手動模型",
+        "retryModels": "重試取得模型"
       },
       "description": "根據選中的站點和金鑰生成 Kilo Code / Roo Code 的 providerProfiles 配置。",
       "descriptions": {
@@ -311,7 +313,9 @@
       },
       "labels": {
         "currentApiConfigName": "當前配置",
+        "defaultModel": "預設模型",
         "exportTarget": "匯出目標",
+        "legacyModelId": "模型 ID",
         "modelId": "模型 ID",
         "selectedSites": "已選擇的站點",
         "selectedTokens": "已選擇的金鑰"
@@ -324,6 +328,7 @@
         "createTokenFailed": "建立金鑰失敗。",
         "downloadedSettings": "已下載設定檔案",
         "downloadFailed": "設定檔案下載失敗",
+        "invalidProfile": "此設定檔的基礎 URL 無效或缺少 API 金鑰。請先更新設定檔再匯出。",
         "loadingTokens": "正在載入金鑰列表…",
         "loadModelsFailed": "載入該金鑰的模型列表失敗。",
         "loadTokensFailed": "載入金鑰失敗。",
@@ -336,6 +341,7 @@
         "nothingToExportTitle": "無可匯出的內容",
         "noTokensDescription": "該站點將被跳過，直到建立金鑰。",
         "noTokensTitle": "暫無金鑰",
+        "settingsFileTooLargeSingle": "此檔案超過 Kilo Code 的匯入大小限制。請複製設定並手動合併。",
         "tokenCreated": "金鑰建立成功"
       },
       "placeholders": {

--- a/src/locales/zh-TW/ui.json
+++ b/src/locales/zh-TW/ui.json
@@ -329,6 +329,7 @@
         "loadTokensFailed": "載入金鑰失敗。",
         "modelIdRequiredDescription_other": "請為所有已選擇的金鑰選擇或輸入模型 ID 後再匯出（還缺 {{count}} 個）。",
         "modelIdRequiredTitle": "需要模型 ID",
+        "modelSearchLimited": "僅顯示前 {{visible}} 個（共 {{count}} 個）模型，請繼續輸入以縮小範圍。",
         "noModelsDescription": "該金鑰未返回可用模型。Kilo Code 實際使用通常需要模型 ID，請手動輸入。",
         "noModelsTitle": "無模型",
         "nothingToExportDescription": "請至少選擇一個可匯出的站點/金鑰後再進行複製/下載。",

--- a/src/services/integrations/kiloCodeExport.ts
+++ b/src/services/integrations/kiloCodeExport.ts
@@ -186,7 +186,7 @@ function validatePreparedKiloCodeV7Catalog(catalog: PreparedKiloCodeV7Catalog) {
 /**
  * Build the Kilo Code 7.x settings format.
  *
- * Contract source: https://github.com/Kilo-Org/kilocode/blob/938919ab72e3977d1512e0363417270e3337c7b1/packages/kilo-vscode/webview-ui/src/components/settings/CustomProviderDialog.tsx
+ * Contract source: https://github.com/Kilo-Org/kilocode/blob/3cb82a0907f888749435c1d208e56d8365747df2/packages/kilo-vscode/webview-ui/src/components/settings/CustomProviderDialog.tsx
  * Custom providers require a display `name`, select one of Kilo's supported AI
  * SDK packages, expose a multi-model `models` map, and select the top-level
  * default `model` with a provider/model identifier.
@@ -313,7 +313,9 @@ export function buildKiloCodeApiConfigs(
     }
   }
 
-  const profileNames = getKiloCodeApiConfigProfileNames({ selections })
+  const profileNames = names
+    .map(({ name }) => name)
+    .sort((left, right) => left.localeCompare(right))
   return { apiConfigs, profileNames }
 }
 

--- a/src/services/integrations/kiloCodeExport.ts
+++ b/src/services/integrations/kiloCodeExport.ts
@@ -1,5 +1,21 @@
+import { buildUniqueKiloCodeProviderNames } from "~/services/integrations/kiloCodeV7Catalog"
+import type {
+  KiloCodeDefaultModelSelection,
+  KiloCodeLegacySelection,
+  KiloCodeRuntimeKeyExportInput,
+  PreparedKiloCodeV7Catalog,
+} from "~/services/integrations/kiloCodeV7Catalog"
 import { safeRandomUUID } from "~/utils/core/identifier"
 import { coerceBaseUrlToPathSuffix } from "~/utils/core/url"
+
+export type {
+  KiloCodeDefaultModelSelection,
+  KiloCodeLegacySelection,
+  KiloCodeRuntimeKeyExportInput,
+  KiloCodeV7ProviderSelection,
+  PreparedKiloCodeV7Catalog,
+  PreparedKiloCodeV7Provider,
+} from "~/services/integrations/kiloCodeV7Catalog"
 
 export const KILO_CODE_EXPORT_TARGETS = {
   KiloV7: "kilo-v7",
@@ -48,6 +64,7 @@ export interface KiloCodeSettingsFile {
 }
 
 interface KiloCodeV7Provider {
+  name: string
   npm: "@ai-sdk/openai-compatible"
   models: Record<string, { name: string }>
   options: {
@@ -65,129 +82,71 @@ export interface KiloCodeV7SettingsFile {
   model: string
 }
 
-export interface KiloCodeExportTuple {
-  accountId: string
-  siteName: string
-  baseUrl: string
-  tokenId: number
-  tokenName: string
-  tokenKey: string
+interface BuildPreparedKiloCodeV7SettingsOptions {
+  catalog: PreparedKiloCodeV7Catalog
+  defaultModel: KiloCodeDefaultModelSelection
+  now?: () => Date
+}
+
+/**
+ * Compatibility input for the current dialogs and legacy builder.
+ * @deprecated Remove after Tasks 5 and 6 migrate both dialogs to the
+ * target-specific V7 and legacy contracts.
+ */
+export interface KiloCodeExportTuple extends KiloCodeRuntimeKeyExportInput {
   /**
    * Upstream model id to export for this API key.
    */
   modelId?: string
 }
 
-interface NormalizedKiloCodeV7Selection {
-  tuple: KiloCodeExportTuple
-  baseURL: string
-  modelId: string
-}
-
-/** Convert a provider label to Kilo Code's settings-safe identifier format. */
-function slugifyProviderName(value: string) {
-  return (
-    value
-      .normalize("NFKD")
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, "-")
-      .replace(/^-+|-+$/g, "") || "provider"
-  )
-}
-
-/** Produce a deterministic FNV-1a digest for a provider identity. */
-function hashProviderIdentity(value: string) {
-  let hash = 0x811c9dc5
-  for (const character of value) {
-    hash ^= character.charCodeAt(0)
-    hash = Math.imul(hash, 16777619)
-  }
-  return (hash >>> 0).toString(16).padStart(8, "0")
-}
-
-/** Combine a readable label with a stable identity digest. */
-function defaultKiloCodeV7ProviderId(selection: NormalizedKiloCodeV7Selection) {
-  const { tuple, baseURL } = selection
-  const identity = [
-    tuple.accountId,
-    baseURL,
-    `${tuple.tokenId}`,
-    tuple.tokenName.trim(),
-  ].join("\u0000")
-  const name = slugifyProviderName(
-    `${tuple.siteName.trim()}-${tuple.tokenName.trim()}`,
-  )
-  return `${name}-${hashProviderIdentity(identity)}`
-}
-
-/** Validate and normalize one selection before settings construction. */
-function normalizeKiloCodeV7Selection(
-  tuple: KiloCodeExportTuple,
-): NormalizedKiloCodeV7Selection {
-  if (!tuple.tokenKey.trim()) throw new Error("Runtime key cannot be blank")
-
-  const modelId = tuple.modelId?.trim()
-  if (!modelId) throw new Error("Model ID cannot be blank")
-
-  const baseURL = coerceBaseUrlToPathSuffix(tuple.baseUrl, "/v1")
-  let parsedUrl: URL
-  try {
-    parsedUrl = new URL(baseURL)
-  } catch {
-    throw new Error("Base URL must be a valid HTTP or HTTPS URL")
-  }
-  if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
-    throw new Error("Base URL must be a valid HTTP or HTTPS URL")
-  }
-
-  return { tuple, baseURL, modelId }
-}
-
 /**
  * Build the Kilo Code 7.x settings format.
  *
  * Contract source: https://github.com/Kilo-Org/kilocode/tree/3cb82a0907f888749435c1d208e56d8365747df2
- * Custom providers use the AI SDK OpenAI-compatible package and select models
- * with a provider/model identifier.
+ * Custom providers require a display `name`, use the AI SDK OpenAI-compatible
+ * package, expose a multi-model `models` map, and select the top-level default
+ * `model` with a provider/model identifier.
  */
-export function buildKiloCodeV7SettingsFile(options: {
-  selections: KiloCodeExportTuple[]
-  now?: () => Date
-  generateProviderId?: (selection: KiloCodeExportTuple) => string
-}): KiloCodeV7SettingsFile {
-  if (!options.selections.length) {
+function buildPreparedKiloCodeV7SettingsFile(
+  options: BuildPreparedKiloCodeV7SettingsOptions,
+): KiloCodeV7SettingsFile {
+  if (!options.catalog.providers.length) {
     throw new Error("Select at least one runtime key")
   }
-
-  const selections = options.selections.map(normalizeKiloCodeV7Selection)
-  const providerIds = selections.map((selection) =>
-    options.generateProviderId
-      ? options.generateProviderId(selection.tuple)
-      : defaultKiloCodeV7ProviderId(selection),
-  )
-  if (new Set(providerIds).size !== providerIds.length) {
-    throw new Error("Kilo Code provider IDs must be unique")
+  if (!options.defaultModel) {
+    throw new Error("Kilo Code default model is required")
   }
-  if (providerIds.some((id) => !/^[a-z0-9][a-z0-9-]*$/.test(id))) {
-    throw new Error("Kilo Code provider IDs must be settings-safe")
+
+  const defaultProvider = options.catalog.providers.find(
+    (provider) => provider.selectionId === options.defaultModel.selectionId,
+  )
+  if (!defaultProvider) {
+    throw new Error("Kilo Code default provider must be exported")
+  }
+  if (!defaultProvider.modelIds.includes(options.defaultModel.modelId)) {
+    throw new Error(
+      "Kilo Code default model must exist in its provider catalog",
+    )
   }
 
   const provider: Record<string, KiloCodeV7Provider> = {}
-  selections.forEach((selection, index) => {
-    provider[providerIds[index]] = {
+  for (const preparedProvider of options.catalog.providers) {
+    provider[preparedProvider.providerId] = {
+      name: preparedProvider.providerName,
       npm: "@ai-sdk/openai-compatible",
-      models: {
-        [selection.modelId]: { name: selection.modelId },
-      },
+      models: Object.fromEntries(
+        preparedProvider.modelIds.map((modelId) => [
+          modelId,
+          { name: modelId },
+        ]),
+      ),
       options: {
-        apiKey: selection.tuple.tokenKey,
-        baseURL: selection.baseURL,
+        apiKey: preparedProvider.tokenKey,
+        baseURL: preparedProvider.baseURL,
       },
     }
-  })
-
-  const firstSelection = selections[0]
-  const firstProviderId = providerIds[0]
+  }
 
   return {
     _meta: {
@@ -195,12 +154,19 @@ export function buildKiloCodeV7SettingsFile(options: {
       exportedAt: (options.now ?? (() => new Date()))().toISOString(),
     },
     provider,
-    model: `${firstProviderId}/${firstSelection.modelId}`,
+    model: `${defaultProvider.providerId}/${options.defaultModel.modelId}`,
   }
 }
 
+/** Build a Kilo Code V7 settings file from a prepared provider catalog. */
+export function buildKiloCodeV7SettingsFile(
+  options: BuildPreparedKiloCodeV7SettingsOptions,
+): KiloCodeV7SettingsFile {
+  return buildPreparedKiloCodeV7SettingsFile(options)
+}
+
 interface BuildKiloCodeApiConfigsOptions {
-  selections: KiloCodeExportTuple[]
+  selections: KiloCodeLegacySelection[]
   generateId?: (profileName: string) => string
 }
 
@@ -216,92 +182,25 @@ interface BuildKiloCodeApiConfigsResult {
  * exporter we name profiles per API key so multiple keys can be exported from
  * the same site without collisions.
  */
-function getBaseProfileName(tuple: KiloCodeExportTuple) {
+function getBaseProfileName(tuple: KiloCodeLegacySelection) {
   const siteName = tuple.siteName.trim() || tuple.baseUrl.trim()
   const tokenLabel = tuple.tokenName.trim() || `Token ${tuple.tokenId}`
   return `${siteName} - ${tokenLabel}`
 }
 
-/**
- * Extract a stable domain label for disambiguation.
- */
-function getDomainLabel(baseUrl: string) {
-  try {
-    return new URL(baseUrl).host
-  } catch {
-    return baseUrl.trim()
-  }
-}
-
-/**
- * Build stable, collision-resistant profile names.
- *
- * Rules:
- * - Start with a human-readable `${site} - ${token}` base.
- * - If duplicates exist, append the domain.
- * - If duplicates still exist, append deterministic numbering.
- */
-function buildUniqueProfileNames(selections: KiloCodeExportTuple[]) {
-  const baseNames = selections.map((tuple) => ({
-    tuple,
-    baseName: getBaseProfileName(tuple),
-    domain: getDomainLabel(tuple.baseUrl),
-  }))
-
-  const byBaseName = new Map<string, typeof baseNames>()
-  for (const item of baseNames) {
-    const existing = byBaseName.get(item.baseName)
-    if (existing) {
-      existing.push(item)
-    } else {
-      byBaseName.set(item.baseName, [item])
-    }
+/** Read the target-specific legacy model or the temporary shared-tuple field. */
+function getLegacyModelId(selection: KiloCodeLegacySelection) {
+  if (selection.legacyModelId !== undefined) {
+    return selection.legacyModelId.trim() || undefined
   }
 
-  const withDomainNames = baseNames.map((item) => {
-    const group = byBaseName.get(item.baseName) ?? []
-    if (group.length <= 1) {
-      return { ...item, name: item.baseName }
-    }
-    return { ...item, name: `${item.baseName} (${item.domain})` }
-  })
-
-  const byName = new Map<string, typeof withDomainNames>()
-  for (const item of withDomainNames) {
-    const existing = byName.get(item.name)
-    if (existing) {
-      existing.push(item)
-    } else {
-      byName.set(item.name, [item])
-    }
+  // Remove with KiloCodeExportTuple after Tasks 5 and 6 migrate both dialogs.
+  const compatibilitySelection = selection as KiloCodeLegacySelection & {
+    modelId?: unknown
   }
-
-  const stableSortKey = (tuple: KiloCodeExportTuple) => {
-    return [
-      tuple.siteName.trim(),
-      tuple.baseUrl.trim(),
-      tuple.tokenName.trim(),
-      `${tuple.tokenId}`,
-      tuple.accountId,
-    ].join("\u0000")
-  }
-
-  const finalNames = withDomainNames.map((item) => {
-    const group = byName.get(item.name) ?? []
-    if (group.length <= 1) {
-      return { tuple: item.tuple, name: item.name }
-    }
-
-    const sorted = [...group].sort((a, b) =>
-      stableSortKey(a.tuple).localeCompare(stableSortKey(b.tuple)),
-    )
-    const index = sorted.findIndex(
-      (candidate) => candidate.tuple === item.tuple,
-    )
-    return { tuple: item.tuple, name: `${item.name} #${index + 1}` }
-  })
-
-  return finalNames
+  return typeof compatibilitySelection.modelId === "string"
+    ? compatibilitySelection.modelId.trim()
+    : undefined
 }
 
 /**
@@ -318,16 +217,16 @@ export function buildKiloCodeApiConfigs(
   if (!selections.length) return { apiConfigs: {}, profileNames: [] }
 
   const idFactory = generateId ?? (() => safeRandomUUID("kilocode-api-config"))
-  const names = buildUniqueProfileNames(selections)
+  const names = buildUniqueKiloCodeProviderNames(selections, getBaseProfileName)
 
   const apiConfigs: Record<string, KiloCodeApiConfig> = {}
-  for (const { tuple, name } of names) {
-    const normalizedModelId = tuple.modelId?.trim()
+  for (const { selection, name } of names) {
+    const normalizedModelId = getLegacyModelId(selection)
     apiConfigs[name] = {
       id: idFactory(name),
       apiProvider: "openai",
-      openAiBaseUrl: coerceBaseUrlToPathSuffix(tuple.baseUrl, "/v1"),
-      openAiApiKey: tuple.tokenKey,
+      openAiBaseUrl: coerceBaseUrlToPathSuffix(selection.baseUrl, "/v1"),
+      openAiApiKey: selection.tokenKey,
       ...(normalizedModelId ? { openAiModelId: normalizedModelId } : {}),
     }
   }

--- a/src/services/integrations/kiloCodeExport.ts
+++ b/src/services/integrations/kiloCodeExport.ts
@@ -1,4 +1,7 @@
-import { buildUniqueKiloCodeProviderNames } from "~/services/integrations/kiloCodeV7Catalog"
+import {
+  buildUniqueKiloCodeProviderNames,
+  normalizeKiloCodeModelIds,
+} from "~/services/integrations/kiloCodeV7Catalog"
 import type {
   KiloCodeDefaultModelSelection,
   KiloCodeLegacySelection,
@@ -86,6 +89,92 @@ interface BuildPreparedKiloCodeV7SettingsOptions {
   now?: () => Date
 }
 
+/** Reject malformed prepared catalogs at the public schema boundary. */
+function validatePreparedKiloCodeV7Catalog(catalog: PreparedKiloCodeV7Catalog) {
+  if (!catalog.providers.length) {
+    throw new Error("Select at least one runtime key")
+  }
+  if (catalog.providerCount !== catalog.providers.length) {
+    throw new Error("Kilo Code catalog provider count is inconsistent")
+  }
+
+  const providerIds = new Set<string>()
+  const providerNames = new Set<string>()
+  const selectionIds = new Set<string>()
+  let modelCount = 0
+  for (const provider of catalog.providers) {
+    if (!provider.selectionId.trim()) {
+      throw new Error("Kilo Code provider selection ID cannot be blank")
+    }
+    if (selectionIds.has(provider.selectionId)) {
+      throw new Error("Kilo Code provider selection IDs must be unique")
+    }
+    selectionIds.add(provider.selectionId)
+    if (!provider.providerId.trim()) {
+      throw new Error("Kilo Code provider ID cannot be blank")
+    }
+    if (!/^[a-z0-9][a-z0-9-]*$/.test(provider.providerId)) {
+      throw new Error("Kilo Code provider IDs must be settings-safe")
+    }
+    if (providerIds.has(provider.providerId)) {
+      throw new Error("Kilo Code provider IDs must be unique")
+    }
+    providerIds.add(provider.providerId)
+    if (!provider.providerName.trim()) {
+      throw new Error("Kilo Code provider name cannot be blank")
+    }
+    const providerName = provider.providerName.trim()
+    if (providerNames.has(providerName)) {
+      throw new Error("Kilo Code provider names must be unique")
+    }
+    providerNames.add(providerName)
+    if (!provider.tokenKey.trim()) {
+      throw new Error("Kilo Code provider token key cannot be blank")
+    }
+    let parsedBaseURL: URL
+    try {
+      parsedBaseURL = new URL(provider.baseURL)
+    } catch {
+      throw new Error(
+        "Kilo Code provider base URL must be a valid HTTP or HTTPS URL",
+      )
+    }
+    if (
+      parsedBaseURL.protocol !== "http:" &&
+      parsedBaseURL.protocol !== "https:"
+    ) {
+      throw new Error(
+        "Kilo Code provider base URL must be a valid HTTP or HTTPS URL",
+      )
+    }
+    if (!provider.modelIds.length) {
+      throw new Error("Kilo Code provider model catalog cannot be empty")
+    }
+    const modelIds = new Set<string>()
+    for (const modelId of provider.modelIds) {
+      if (!modelId.trim() || modelId !== modelId.trim()) {
+        throw new Error("Kilo Code provider model IDs must be normalized")
+      }
+      if (modelIds.has(modelId)) {
+        throw new Error("Kilo Code provider model IDs must be unique")
+      }
+      modelIds.add(modelId)
+    }
+    const normalizedModelIds = normalizeKiloCodeModelIds(provider.modelIds)
+    if (
+      provider.modelIds.some(
+        (modelId, index) => modelId !== normalizedModelIds[index],
+      )
+    ) {
+      throw new Error("Kilo Code provider model IDs must use canonical order")
+    }
+    modelCount += provider.modelIds.length
+  }
+  if (catalog.modelCount !== modelCount) {
+    throw new Error("Kilo Code catalog model count is inconsistent")
+  }
+}
+
 /**
  * Build the Kilo Code 7.x settings format.
  *
@@ -97,9 +186,7 @@ interface BuildPreparedKiloCodeV7SettingsOptions {
 function buildPreparedKiloCodeV7SettingsFile(
   options: BuildPreparedKiloCodeV7SettingsOptions,
 ): KiloCodeV7SettingsFile {
-  if (!options.catalog.providers.length) {
-    throw new Error("Select at least one runtime key")
-  }
+  validatePreparedKiloCodeV7Catalog(options.catalog)
   if (!options.defaultModel) {
     throw new Error("Kilo Code default model is required")
   }
@@ -179,6 +266,17 @@ function getLegacyModelId(selection: KiloCodeLegacySelection) {
   return selection.legacyModelId?.trim() || undefined
 }
 
+/** Derive deterministic legacy profile names without materializing API keys. */
+export function getKiloCodeApiConfigProfileNames(
+  options: Pick<BuildKiloCodeApiConfigsOptions, "selections">,
+) {
+  const names = buildUniqueKiloCodeProviderNames(
+    options.selections,
+    getBaseProfileName,
+  ).map(({ name }) => name)
+  return names.sort((left, right) => left.localeCompare(right))
+}
+
 /**
  * Build `providerProfiles.apiConfigs` entries for Kilo Code / Roo Code settings.
  *
@@ -207,9 +305,7 @@ export function buildKiloCodeApiConfigs(
     }
   }
 
-  const profileNames = Object.keys(apiConfigs).sort((a, b) =>
-    a.localeCompare(b),
-  )
+  const profileNames = getKiloCodeApiConfigProfileNames({ selections })
   return { apiConfigs, profileNames }
 }
 

--- a/src/services/integrations/kiloCodeExport.ts
+++ b/src/services/integrations/kiloCodeExport.ts
@@ -2,7 +2,6 @@ import { buildUniqueKiloCodeProviderNames } from "~/services/integrations/kiloCo
 import type {
   KiloCodeDefaultModelSelection,
   KiloCodeLegacySelection,
-  KiloCodeRuntimeKeyExportInput,
   PreparedKiloCodeV7Catalog,
 } from "~/services/integrations/kiloCodeV7Catalog"
 import { safeRandomUUID } from "~/utils/core/identifier"
@@ -14,7 +13,6 @@ export type {
   KiloCodeRuntimeKeyExportInput,
   KiloCodeV7ProviderSelection,
   PreparedKiloCodeV7Catalog,
-  PreparedKiloCodeV7Provider,
 } from "~/services/integrations/kiloCodeV7Catalog"
 
 export const KILO_CODE_EXPORT_TARGETS = {
@@ -86,18 +84,6 @@ interface BuildPreparedKiloCodeV7SettingsOptions {
   catalog: PreparedKiloCodeV7Catalog
   defaultModel: KiloCodeDefaultModelSelection
   now?: () => Date
-}
-
-/**
- * Compatibility input for the current dialogs and legacy builder.
- * @deprecated Remove after Tasks 5 and 6 migrate both dialogs to the
- * target-specific V7 and legacy contracts.
- */
-export interface KiloCodeExportTuple extends KiloCodeRuntimeKeyExportInput {
-  /**
-   * Upstream model id to export for this API key.
-   */
-  modelId?: string
 }
 
 /**
@@ -188,19 +174,9 @@ function getBaseProfileName(tuple: KiloCodeLegacySelection) {
   return `${siteName} - ${tokenLabel}`
 }
 
-/** Read the target-specific legacy model or the temporary shared-tuple field. */
+/** Read the target-specific legacy model. */
 function getLegacyModelId(selection: KiloCodeLegacySelection) {
-  if (selection.legacyModelId !== undefined) {
-    return selection.legacyModelId.trim() || undefined
-  }
-
-  // Remove with KiloCodeExportTuple after Tasks 5 and 6 migrate both dialogs.
-  const compatibilitySelection = selection as KiloCodeLegacySelection & {
-    modelId?: unknown
-  }
-  return typeof compatibilitySelection.modelId === "string"
-    ? compatibilitySelection.modelId.trim()
-    : undefined
+  return selection.legacyModelId?.trim() || undefined
 }
 
 /**

--- a/src/services/integrations/kiloCodeExport.ts
+++ b/src/services/integrations/kiloCodeExport.ts
@@ -1,10 +1,12 @@
 import {
   buildUniqueKiloCodeProviderNames,
+  KILO_CODE_PROVIDER_PROTOCOL_NPM,
   normalizeKiloCodeModelIds,
 } from "~/services/integrations/kiloCodeV7Catalog"
 import type {
   KiloCodeDefaultModelSelection,
   KiloCodeLegacySelection,
+  KiloCodeProviderNpm,
   PreparedKiloCodeV7Catalog,
 } from "~/services/integrations/kiloCodeV7Catalog"
 import { safeRandomUUID } from "~/utils/core/identifier"
@@ -13,10 +15,13 @@ import { coerceBaseUrlToPathSuffix } from "~/utils/core/url"
 export type {
   KiloCodeDefaultModelSelection,
   KiloCodeLegacySelection,
+  KiloCodeProviderProtocol,
   KiloCodeRuntimeKeyExportInput,
   KiloCodeV7ProviderSelection,
   PreparedKiloCodeV7Catalog,
 } from "~/services/integrations/kiloCodeV7Catalog"
+
+export { KILO_CODE_PROVIDER_PROTOCOLS } from "~/services/integrations/kiloCodeV7Catalog"
 
 export const KILO_CODE_EXPORT_TARGETS = {
   KiloV7: "kilo-v7",
@@ -66,7 +71,7 @@ export interface KiloCodeSettingsFile {
 
 interface KiloCodeV7Provider {
   name: string
-  npm: "@ai-sdk/openai-compatible"
+  npm: KiloCodeProviderNpm
   models: Record<string, { name: string }>
   options: {
     apiKey: string
@@ -128,6 +133,9 @@ function validatePreparedKiloCodeV7Catalog(catalog: PreparedKiloCodeV7Catalog) {
       throw new Error("Kilo Code provider names must be unique")
     }
     providerNames.add(providerName)
+    if (!Object.hasOwn(KILO_CODE_PROVIDER_PROTOCOL_NPM, provider.protocol)) {
+      throw new Error("Kilo Code provider protocol is unsupported")
+    }
     if (!provider.tokenKey.trim()) {
       throw new Error("Kilo Code provider token key cannot be blank")
     }
@@ -178,10 +186,10 @@ function validatePreparedKiloCodeV7Catalog(catalog: PreparedKiloCodeV7Catalog) {
 /**
  * Build the Kilo Code 7.x settings format.
  *
- * Contract source: https://github.com/Kilo-Org/kilocode/tree/3cb82a0907f888749435c1d208e56d8365747df2
- * Custom providers require a display `name`, use the AI SDK OpenAI-compatible
- * package, expose a multi-model `models` map, and select the top-level default
- * `model` with a provider/model identifier.
+ * Contract source: https://github.com/Kilo-Org/kilocode/blob/938919ab72e3977d1512e0363417270e3337c7b1/packages/kilo-vscode/webview-ui/src/components/settings/CustomProviderDialog.tsx
+ * Custom providers require a display `name`, select one of Kilo's supported AI
+ * SDK packages, expose a multi-model `models` map, and select the top-level
+ * default `model` with a provider/model identifier.
  */
 function buildPreparedKiloCodeV7SettingsFile(
   options: BuildPreparedKiloCodeV7SettingsOptions,
@@ -207,7 +215,7 @@ function buildPreparedKiloCodeV7SettingsFile(
   for (const preparedProvider of options.catalog.providers) {
     provider[preparedProvider.providerId] = {
       name: preparedProvider.providerName,
-      npm: "@ai-sdk/openai-compatible",
+      npm: KILO_CODE_PROVIDER_PROTOCOL_NPM[preparedProvider.protocol],
       models: Object.fromEntries(
         preparedProvider.modelIds.map((modelId) => [
           modelId,

--- a/src/services/integrations/kiloCodeExportPolicy.ts
+++ b/src/services/integrations/kiloCodeExportPolicy.ts
@@ -6,8 +6,6 @@ import {
   KILO_CODE_EXPORT_TARGETS,
   type KiloCodeDefaultModelSelection,
   type KiloCodeExportFilename,
-  type KiloCodeExportTarget,
-  type KiloCodeExportTuple,
   type KiloCodeLegacySelection,
   type KiloCodeSettingsFile,
   type KiloCodeV7ProviderSelection,
@@ -16,7 +14,7 @@ import {
 import { prepareKiloCodeV7Catalog } from "~/services/integrations/kiloCodeV7Catalog"
 
 // Kilo MAX_IMPORT_SIZE source: https://github.com/Kilo-Org/kilocode/blob/3cb82a0907f888749435c1d208e56d8365747df2/packages/kilo-vscode/webview-ui/src/components/settings/settings-io.ts
-export const KILO_CODE_SETTINGS_MAX_IMPORT_BYTES = 1_048_576
+const KILO_CODE_SETTINGS_MAX_IMPORT_BYTES = 1_048_576
 
 /** Report whether a serialized settings file exceeds Kilo's import limit. */
 export function isKiloCodeSettingsFileTooLarge(byteLength: number) {
@@ -36,21 +34,9 @@ interface BuildKiloCodeLegacyExportOutputOptions {
   currentLegacyProfileName: string
 }
 
-/**
- * Compatibility input for the two dialogs that still share a tuple and target.
- * @deprecated Remove after Tasks 5 and 6 migrate both dialogs to discriminated inputs.
- */
-interface DeprecatedBuildKiloCodeExportOutputOptions {
-  target: KiloCodeExportTarget
-  selections: KiloCodeExportTuple[]
-  currentLegacyProfileName: string
-  now?: () => Date
-}
-
-export type BuildKiloCodeExportOutputOptions =
+type BuildKiloCodeExportOutputOptions =
   | BuildKiloCodeV7ExportOutputOptions
   | BuildKiloCodeLegacyExportOutputOptions
-  | DeprecatedBuildKiloCodeExportOutputOptions
 
 interface KiloCodeExportOutputBase {
   filename: KiloCodeExportFilename
@@ -96,63 +82,22 @@ function buildDownloadMetadata(
   }
 }
 
-/** Convert the pre-Task-5/6 dialog tuple to the canonical V7 policy input. */
-function prepareDeprecatedDialogV7Input(
-  options: DeprecatedBuildKiloCodeExportOutputOptions,
-): {
-  selections: KiloCodeV7ProviderSelection[]
-  defaultModel: KiloCodeDefaultModelSelection
-} {
-  const modelIds = options.selections.map((selection) => {
-    const modelId = selection.modelId?.trim()
-    if (!modelId) throw new Error("Model ID cannot be blank")
-    return modelId
-  })
-  const selections = options.selections.map((selection, index) => ({
-    ...selection,
-    selectionId: `legacy-v7-selection-${index}`,
-    discoveredModelIds: [modelIds[index]!],
-  }))
-
-  return {
-    selections,
-    defaultModel: {
-      selectionId: "legacy-v7-selection-0",
-      modelId: modelIds[0] ?? "",
-    },
-  }
-}
-
 export function buildKiloCodeExportOutput(
   options: BuildKiloCodeV7ExportOutputOptions,
 ): KiloCodeV7ExportOutput
 export function buildKiloCodeExportOutput(
   options: BuildKiloCodeLegacyExportOutputOptions,
 ): KiloCodeLegacyExportOutput
-/**
- * Build output for the temporary dialog tuple or a discriminated option union.
- * @deprecated Remove this overload after Tasks 5 and 6 migrate both dialogs.
- */
-export function buildKiloCodeExportOutput(
-  options: BuildKiloCodeExportOutputOptions,
-): KiloCodeExportOutput
 /** Build the target-specific copy and download payloads for Kilo Code export. */
 export function buildKiloCodeExportOutput(
   options: BuildKiloCodeExportOutputOptions,
 ): KiloCodeExportOutput {
   if (options.target === KILO_CODE_EXPORT_TARGETS.KiloV7) {
-    const canonicalInput =
-      "defaultModel" in options
-        ? options
-        : {
-            ...prepareDeprecatedDialogV7Input(options),
-            now: options.now,
-          }
-    const catalog = prepareKiloCodeV7Catalog(canonicalInput.selections)
+    const catalog = prepareKiloCodeV7Catalog(options.selections)
     const downloadPayload = buildKiloCodeV7SettingsFile({
       catalog,
-      defaultModel: canonicalInput.defaultModel,
-      now: canonicalInput.now,
+      defaultModel: options.defaultModel,
+      now: options.now,
     })
 
     return {
@@ -195,5 +140,5 @@ export function buildKiloCodeExportOutput(
     }
   }
 
-  return assertNeverTarget(options.target)
+  return assertNeverTarget((options as unknown as { target: never }).target)
 }

--- a/src/services/integrations/kiloCodeExportPolicy.ts
+++ b/src/services/integrations/kiloCodeExportPolicy.ts
@@ -4,47 +4,168 @@ import {
   buildKiloCodeV7SettingsFile,
   KILO_CODE_EXPORT_FILENAMES,
   KILO_CODE_EXPORT_TARGETS,
+  type KiloCodeDefaultModelSelection,
   type KiloCodeExportFilename,
   type KiloCodeExportTarget,
   type KiloCodeExportTuple,
+  type KiloCodeLegacySelection,
   type KiloCodeSettingsFile,
+  type KiloCodeV7ProviderSelection,
   type KiloCodeV7SettingsFile,
 } from "~/services/integrations/kiloCodeExport"
+import { prepareKiloCodeV7Catalog } from "~/services/integrations/kiloCodeV7Catalog"
 
-export interface BuildKiloCodeExportOutputOptions {
+// Kilo MAX_IMPORT_SIZE source: https://github.com/Kilo-Org/kilocode/blob/3cb82a0907f888749435c1d208e56d8365747df2/packages/kilo-vscode/webview-ui/src/components/settings/settings-io.ts
+export const KILO_CODE_SETTINGS_MAX_IMPORT_BYTES = 1_048_576
+
+/** Report whether a serialized settings file exceeds Kilo's import limit. */
+export function isKiloCodeSettingsFileTooLarge(byteLength: number) {
+  return byteLength > KILO_CODE_SETTINGS_MAX_IMPORT_BYTES
+}
+
+interface BuildKiloCodeV7ExportOutputOptions {
+  target: typeof KILO_CODE_EXPORT_TARGETS.KiloV7
+  selections: KiloCodeV7ProviderSelection[]
+  defaultModel: KiloCodeDefaultModelSelection
+  now?: () => Date
+}
+
+interface BuildKiloCodeLegacyExportOutputOptions {
+  target: typeof KILO_CODE_EXPORT_TARGETS.Legacy
+  selections: KiloCodeLegacySelection[]
+  currentLegacyProfileName: string
+}
+
+/**
+ * Compatibility input for the two dialogs that still share a tuple and target.
+ * @deprecated Remove after Tasks 5 and 6 migrate both dialogs to discriminated inputs.
+ */
+interface DeprecatedBuildKiloCodeExportOutputOptions {
   target: KiloCodeExportTarget
   selections: KiloCodeExportTuple[]
   currentLegacyProfileName: string
   now?: () => Date
 }
 
-export interface KiloCodeExportOutput {
+export type BuildKiloCodeExportOutputOptions =
+  | BuildKiloCodeV7ExportOutputOptions
+  | BuildKiloCodeLegacyExportOutputOptions
+  | DeprecatedBuildKiloCodeExportOutputOptions
+
+interface KiloCodeExportOutputBase {
   filename: KiloCodeExportFilename
-  copyPayload: Record<string, unknown>
-  downloadPayload: KiloCodeV7SettingsFile | KiloCodeSettingsFile
+  downloadJson: string
+  downloadByteLength: number
+  isDownloadTooLarge: boolean
   itemCount: number
+  modelCount: number
 }
+
+interface KiloCodeV7ExportOutput extends KiloCodeExportOutputBase {
+  target: typeof KILO_CODE_EXPORT_TARGETS.KiloV7
+  copyPayload: Pick<KiloCodeV7SettingsFile, "provider" | "model">
+  downloadPayload: KiloCodeV7SettingsFile
+}
+
+interface KiloCodeLegacyExportOutput extends KiloCodeExportOutputBase {
+  target: typeof KILO_CODE_EXPORT_TARGETS.Legacy
+  copyPayload: KiloCodeSettingsFile["providerProfiles"]["apiConfigs"]
+  downloadPayload: KiloCodeSettingsFile
+}
+
+export type KiloCodeExportOutput =
+  | KiloCodeV7ExportOutput
+  | KiloCodeLegacyExportOutput
 
 /** Fail at runtime while making unhandled export targets a compile-time error. */
 function assertNeverTarget(target: never): never {
   throw new Error(`Unsupported Kilo Code export target: ${String(target)}`)
 }
 
+/** Describe the serialized settings file without re-serializing its payload. */
+function buildDownloadMetadata(
+  downloadPayload: KiloCodeV7SettingsFile | KiloCodeSettingsFile,
+) {
+  const downloadJson = JSON.stringify(downloadPayload, null, 2)
+  const downloadByteLength = new TextEncoder().encode(downloadJson).byteLength
+
+  return {
+    downloadJson,
+    downloadByteLength,
+    isDownloadTooLarge: isKiloCodeSettingsFileTooLarge(downloadByteLength),
+  }
+}
+
+/** Convert the pre-Task-5/6 dialog tuple to the canonical V7 policy input. */
+function prepareDeprecatedDialogV7Input(
+  options: DeprecatedBuildKiloCodeExportOutputOptions,
+): {
+  selections: KiloCodeV7ProviderSelection[]
+  defaultModel: KiloCodeDefaultModelSelection
+} {
+  const modelIds = options.selections.map((selection) => {
+    const modelId = selection.modelId?.trim()
+    if (!modelId) throw new Error("Model ID cannot be blank")
+    return modelId
+  })
+  const selections = options.selections.map((selection, index) => ({
+    ...selection,
+    selectionId: `legacy-v7-selection-${index}`,
+    discoveredModelIds: [modelIds[index]!],
+  }))
+
+  return {
+    selections,
+    defaultModel: {
+      selectionId: "legacy-v7-selection-0",
+      modelId: modelIds[0] ?? "",
+    },
+  }
+}
+
+export function buildKiloCodeExportOutput(
+  options: BuildKiloCodeV7ExportOutputOptions,
+): KiloCodeV7ExportOutput
+export function buildKiloCodeExportOutput(
+  options: BuildKiloCodeLegacyExportOutputOptions,
+): KiloCodeLegacyExportOutput
+/**
+ * Build output for the temporary dialog tuple or a discriminated option union.
+ * @deprecated Remove this overload after Tasks 5 and 6 migrate both dialogs.
+ */
+export function buildKiloCodeExportOutput(
+  options: BuildKiloCodeExportOutputOptions,
+): KiloCodeExportOutput
 /** Build the target-specific copy and download payloads for Kilo Code export. */
 export function buildKiloCodeExportOutput(
   options: BuildKiloCodeExportOutputOptions,
 ): KiloCodeExportOutput {
   if (options.target === KILO_CODE_EXPORT_TARGETS.KiloV7) {
+    const canonicalInput =
+      "defaultModel" in options
+        ? options
+        : {
+            ...prepareDeprecatedDialogV7Input(options),
+            now: options.now,
+          }
+    const catalog = prepareKiloCodeV7Catalog(canonicalInput.selections)
     const downloadPayload = buildKiloCodeV7SettingsFile({
-      selections: options.selections,
-      now: options.now,
+      catalog,
+      defaultModel: canonicalInput.defaultModel,
+      now: canonicalInput.now,
     })
 
     return {
+      target: KILO_CODE_EXPORT_TARGETS.KiloV7,
       filename: KILO_CODE_EXPORT_FILENAMES.KiloV7,
-      copyPayload: downloadPayload.provider,
+      copyPayload: {
+        provider: downloadPayload.provider,
+        model: downloadPayload.model,
+      },
       downloadPayload,
-      itemCount: Object.keys(downloadPayload.provider).length,
+      ...buildDownloadMetadata(downloadPayload),
+      itemCount: catalog.providerCount,
+      modelCount: catalog.modelCount,
     }
   }
 
@@ -62,10 +183,15 @@ export function buildKiloCodeExportOutput(
     })
 
     return {
+      target: KILO_CODE_EXPORT_TARGETS.Legacy,
       filename: KILO_CODE_EXPORT_FILENAMES.Legacy,
-      copyPayload: apiConfigs,
+      copyPayload: downloadPayload.providerProfiles.apiConfigs,
       downloadPayload,
+      ...buildDownloadMetadata(downloadPayload),
       itemCount: Object.keys(apiConfigs).length,
+      modelCount: Object.values(apiConfigs).filter(
+        (apiConfig) => apiConfig.openAiModelId,
+      ).length,
     }
   }
 

--- a/src/services/integrations/kiloCodeV7Catalog.ts
+++ b/src/services/integrations/kiloCodeV7Catalog.ts
@@ -1,0 +1,253 @@
+import { coerceBaseUrlToPathSuffix } from "~/utils/core/url"
+
+export interface KiloCodeRuntimeKeyExportInput {
+  accountId: string
+  siteName: string
+  baseUrl: string
+  tokenId: number
+  tokenName: string
+  tokenKey: string
+}
+
+export interface KiloCodeLegacySelection extends KiloCodeRuntimeKeyExportInput {
+  legacyModelId?: string
+}
+
+export interface KiloCodeV7ProviderSelection
+  extends KiloCodeRuntimeKeyExportInput {
+  selectionId: string
+  providerName?: string
+  discoveredModelIds: string[]
+  manualModelId?: string
+}
+
+export interface KiloCodeDefaultModelSelection {
+  selectionId: string
+  modelId: string
+}
+
+export interface PreparedKiloCodeV7Provider {
+  selectionId: string
+  providerId: string
+  providerName: string
+  baseURL: string
+  tokenKey: string
+  modelIds: string[]
+}
+
+export interface PreparedKiloCodeV7Catalog {
+  providers: PreparedKiloCodeV7Provider[]
+  providerCount: number
+  modelCount: number
+}
+
+interface NormalizedKiloCodeV7Selection {
+  tuple: KiloCodeV7ProviderSelection
+  baseURL: string
+  modelIds: string[]
+}
+
+/** Convert a provider label to Kilo Code's settings-safe identifier format. */
+function slugifyProviderName(value: string) {
+  return (
+    value
+      .normalize("NFKD")
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "") || "provider"
+  )
+}
+
+/** Produce a deterministic FNV-1a digest for a provider identity. */
+function hashProviderIdentity(value: string) {
+  let hash = 0x811c9dc5
+  for (const character of value) {
+    hash ^= character.charCodeAt(0)
+    hash = Math.imul(hash, 16777619)
+  }
+  return (hash >>> 0).toString(16).padStart(8, "0")
+}
+
+/** Combine a readable label with a stable identity digest. */
+function defaultKiloCodeV7ProviderId(selection: NormalizedKiloCodeV7Selection) {
+  const { tuple, baseURL } = selection
+  const identity = [
+    tuple.accountId,
+    baseURL,
+    `${tuple.tokenId}`,
+    tuple.tokenName.trim(),
+  ].join("\u0000")
+  const name = slugifyProviderName(
+    `${tuple.siteName.trim()}-${tuple.tokenName.trim()}`,
+  )
+  return `${name}-${hashProviderIdentity(identity)}`
+}
+
+/** Compare model IDs using deterministic Unicode code-point order. */
+function compareCodePoints(left: string, right: string) {
+  if (left === right) return 0
+  return left < right ? -1 : 1
+}
+
+/** Trim, deduplicate, and sort discovered and manually entered model IDs. */
+function normalizeModelIds(selection: KiloCodeV7ProviderSelection) {
+  return Array.from(
+    new Set(
+      [...selection.discoveredModelIds, selection.manualModelId]
+        .filter((value): value is string => typeof value === "string")
+        .map((value) => value.trim())
+        .filter(Boolean),
+    ),
+  ).sort(compareCodePoints)
+}
+
+/** Resolve a caller-provided provider name or the legacy site/token fallback. */
+function getBaseProviderName(selection: KiloCodeV7ProviderSelection) {
+  const preferredName = selection.providerName?.trim()
+  if (preferredName) return preferredName
+
+  const siteName = selection.siteName.trim() || selection.baseUrl.trim()
+  const tokenLabel = selection.tokenName.trim() || `Token ${selection.tokenId}`
+  return `${siteName} - ${tokenLabel}`
+}
+
+/** Extract a stable host label for duplicate-name disambiguation. */
+function getDomainLabel(baseUrl: string) {
+  try {
+    return new URL(baseUrl).host
+  } catch {
+    return baseUrl.trim()
+  }
+}
+
+/** Disambiguate duplicate provider display names by host and stable ordinal. */
+export function buildUniqueKiloCodeProviderNames<
+  TSelection extends KiloCodeRuntimeKeyExportInput,
+>(selections: TSelection[], getBaseName: (selection: TSelection) => string) {
+  const baseNames = selections.map((selection) => ({
+    selection,
+    baseName: getBaseName(selection),
+    domain: getDomainLabel(selection.baseUrl),
+  }))
+
+  const byBaseName = new Map<string, typeof baseNames>()
+  for (const item of baseNames) {
+    const existing = byBaseName.get(item.baseName)
+    if (existing) {
+      existing.push(item)
+    } else {
+      byBaseName.set(item.baseName, [item])
+    }
+  }
+
+  const withDomainNames = baseNames.map((item) => {
+    const group = byBaseName.get(item.baseName) ?? []
+    if (group.length <= 1) {
+      return { ...item, name: item.baseName }
+    }
+    return { ...item, name: `${item.baseName} (${item.domain})` }
+  })
+
+  const byName = new Map<string, typeof withDomainNames>()
+  for (const item of withDomainNames) {
+    const existing = byName.get(item.name)
+    if (existing) {
+      existing.push(item)
+    } else {
+      byName.set(item.name, [item])
+    }
+  }
+
+  const stableSortKey = (selection: TSelection) => {
+    return [
+      selection.siteName.trim(),
+      selection.baseUrl.trim(),
+      selection.tokenName.trim(),
+      `${selection.tokenId}`,
+      selection.accountId,
+    ].join("\u0000")
+  }
+
+  return withDomainNames.map((item) => {
+    const group = byName.get(item.name) ?? []
+    if (group.length <= 1) {
+      return { selection: item.selection, name: item.name }
+    }
+
+    const sorted = [...group].sort((left, right) =>
+      stableSortKey(left.selection).localeCompare(
+        stableSortKey(right.selection),
+      ),
+    )
+    const index = sorted.findIndex(
+      (candidate) => candidate.selection === item.selection,
+    )
+    return { selection: item.selection, name: `${item.name} #${index + 1}` }
+  })
+}
+
+/** Validate and normalize one V7 provider selection. */
+function normalizeSelection(
+  selection: KiloCodeV7ProviderSelection,
+): NormalizedKiloCodeV7Selection {
+  if (!selection.tokenKey.trim()) throw new Error("Runtime key cannot be blank")
+
+  const modelIds = normalizeModelIds(selection)
+  if (!modelIds.length) {
+    throw new Error("Select at least one model for each provider")
+  }
+
+  const baseURL = coerceBaseUrlToPathSuffix(selection.baseUrl, "/v1")
+  let parsedUrl: URL
+  try {
+    parsedUrl = new URL(baseURL)
+  } catch {
+    throw new Error("Base URL must be a valid HTTP or HTTPS URL")
+  }
+  if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
+    throw new Error("Base URL must be a valid HTTP or HTTPS URL")
+  }
+
+  return { tuple: selection, baseURL, modelIds }
+}
+
+/** Prepare normalized provider facts shared by Kilo Code V7 UI and export. */
+export function prepareKiloCodeV7Catalog(
+  selections: KiloCodeV7ProviderSelection[],
+): PreparedKiloCodeV7Catalog {
+  const selectionIds = selections.map((selection) => selection.selectionId)
+  if (new Set(selectionIds).size !== selectionIds.length) {
+    throw new Error("Kilo Code selection IDs must be unique")
+  }
+
+  const normalizedSelections = selections.map(normalizeSelection)
+  const providerIds = normalizedSelections.map(defaultKiloCodeV7ProviderId)
+  if (new Set(providerIds).size !== providerIds.length) {
+    throw new Error("Kilo Code provider IDs must be unique")
+  }
+  if (providerIds.some((id) => !/^[a-z0-9][a-z0-9-]*$/.test(id))) {
+    throw new Error("Kilo Code provider IDs must be settings-safe")
+  }
+
+  const providerNames = buildUniqueKiloCodeProviderNames(
+    selections,
+    getBaseProviderName,
+  )
+  const providers = normalizedSelections.map((normalized, index) => ({
+    selectionId: normalized.tuple.selectionId,
+    providerId: providerIds[index],
+    providerName: providerNames[index].name,
+    baseURL: normalized.baseURL,
+    tokenKey: normalized.tuple.tokenKey,
+    modelIds: normalized.modelIds,
+  }))
+
+  return {
+    providers,
+    providerCount: providers.length,
+    modelCount: providers.reduce(
+      (count, provider) => count + provider.modelIds.length,
+      0,
+    ),
+  }
+}

--- a/src/services/integrations/kiloCodeV7Catalog.ts
+++ b/src/services/integrations/kiloCodeV7Catalog.ts
@@ -84,21 +84,45 @@ function defaultKiloCodeV7ProviderId(selection: NormalizedKiloCodeV7Selection) {
 }
 
 /** Compare model IDs using deterministic Unicode code-point order. */
-function compareCodePoints(left: string, right: string) {
+function compareKiloCodeModelIds(left: string, right: string) {
   if (left === right) return 0
-  return left < right ? -1 : 1
+  const leftCodePoints = Array.from(
+    left,
+    (character) => character.codePointAt(0)!,
+  )
+  const rightCodePoints = Array.from(
+    right,
+    (character) => character.codePointAt(0)!,
+  )
+  const length = Math.min(leftCodePoints.length, rightCodePoints.length)
+  for (let index = 0; index < length; index += 1) {
+    const leftCodePoint = leftCodePoints[index]!
+    const rightCodePoint = rightCodePoints[index]!
+    if (leftCodePoint !== rightCodePoint) {
+      return leftCodePoint < rightCodePoint ? -1 : 1
+    }
+  }
+  return leftCodePoints.length < rightCodePoints.length ? -1 : 1
 }
 
 /** Trim, deduplicate, and sort discovered and manually entered model IDs. */
-function normalizeModelIds(selection: KiloCodeV7ProviderSelection) {
+export function normalizeKiloCodeModelIds(modelIds: readonly unknown[]) {
   return Array.from(
     new Set(
-      [...selection.discoveredModelIds, selection.manualModelId]
+      modelIds
         .filter((value): value is string => typeof value === "string")
         .map((value) => value.trim())
         .filter(Boolean),
     ),
-  ).sort(compareCodePoints)
+  ).sort(compareKiloCodeModelIds)
+}
+
+/** Normalize the complete discovered and manual catalog for one provider. */
+function normalizeModelIds(selection: KiloCodeV7ProviderSelection) {
+  return normalizeKiloCodeModelIds([
+    ...selection.discoveredModelIds,
+    selection.manualModelId,
+  ])
 }
 
 /** Resolve a caller-provided provider name or the legacy site/token fallback. */

--- a/src/services/integrations/kiloCodeV7Catalog.ts
+++ b/src/services/integrations/kiloCodeV7Catalog.ts
@@ -1,5 +1,23 @@
 import { coerceBaseUrlToPathSuffix } from "~/utils/core/url"
 
+export const KILO_CODE_PROVIDER_PROTOCOLS = {
+  OpenAICompatible: "openai-compatible",
+  OpenAIResponses: "openai-responses",
+  AnthropicMessages: "anthropic-messages",
+} as const
+
+export type KiloCodeProviderProtocol =
+  (typeof KILO_CODE_PROVIDER_PROTOCOLS)[keyof typeof KILO_CODE_PROVIDER_PROTOCOLS]
+
+export const KILO_CODE_PROVIDER_PROTOCOL_NPM = {
+  [KILO_CODE_PROVIDER_PROTOCOLS.OpenAICompatible]: "@ai-sdk/openai-compatible",
+  [KILO_CODE_PROVIDER_PROTOCOLS.OpenAIResponses]: "@ai-sdk/openai",
+  [KILO_CODE_PROVIDER_PROTOCOLS.AnthropicMessages]: "@ai-sdk/anthropic",
+} as const satisfies Record<KiloCodeProviderProtocol, string>
+
+export type KiloCodeProviderNpm =
+  (typeof KILO_CODE_PROVIDER_PROTOCOL_NPM)[KiloCodeProviderProtocol]
+
 export interface KiloCodeRuntimeKeyExportInput {
   accountId: string
   siteName: string
@@ -17,6 +35,7 @@ export interface KiloCodeV7ProviderSelection
   extends KiloCodeRuntimeKeyExportInput {
   selectionId: string
   providerName?: string
+  protocol?: KiloCodeProviderProtocol
   discoveredModelIds: string[]
   manualModelId?: string
 }
@@ -32,6 +51,7 @@ export interface PreparedKiloCodeV7Provider {
   providerName: string
   baseURL: string
   tokenKey: string
+  protocol: KiloCodeProviderProtocol
   modelIds: string[]
 }
 
@@ -44,6 +64,7 @@ export interface PreparedKiloCodeV7Catalog {
 interface NormalizedKiloCodeV7Selection {
   tuple: KiloCodeV7ProviderSelection
   baseURL: string
+  protocol: KiloCodeProviderProtocol
   modelIds: string[]
 }
 
@@ -232,7 +253,13 @@ function normalizeSelection(
     throw new Error("Base URL must be a valid HTTP or HTTPS URL")
   }
 
-  return { tuple: selection, baseURL, modelIds }
+  const protocol =
+    selection.protocol ?? KILO_CODE_PROVIDER_PROTOCOLS.OpenAICompatible
+  if (!Object.hasOwn(KILO_CODE_PROVIDER_PROTOCOL_NPM, protocol)) {
+    throw new Error("Kilo Code provider protocol is unsupported")
+  }
+
+  return { tuple: selection, baseURL, protocol, modelIds }
 }
 
 /** Prepare normalized provider facts shared by Kilo Code V7 UI and export. */
@@ -263,6 +290,7 @@ export function prepareKiloCodeV7Catalog(
     providerName: providerNames[index].name,
     baseURL: normalized.baseURL,
     tokenKey: normalized.tuple.tokenKey,
+    protocol: normalized.protocol,
     modelIds: normalized.modelIds,
   }))
 

--- a/src/services/integrations/kiloCodeV7Selection.ts
+++ b/src/services/integrations/kiloCodeV7Selection.ts
@@ -1,0 +1,25 @@
+import type {
+  KiloCodeDefaultModelSelection,
+  PreparedKiloCodeV7Catalog,
+} from "~/services/integrations/kiloCodeV7Catalog"
+
+/** Keep a valid default selection or repair it against the prepared catalog. */
+export function reconcileKiloCodeV7DefaultSelection(
+  catalog: PreparedKiloCodeV7Catalog,
+  current?: KiloCodeDefaultModelSelection,
+): KiloCodeDefaultModelSelection | undefined {
+  const currentProvider = catalog.providers.find(
+    (provider) => provider.selectionId === current?.selectionId,
+  )
+
+  if (current && currentProvider?.modelIds.includes(current.modelId)) {
+    return current
+  }
+
+  const provider = currentProvider ?? catalog.providers[0]
+  const modelId = provider?.modelIds[0]
+
+  return provider && modelId
+    ? { selectionId: provider.selectionId, modelId }
+    : undefined
+}

--- a/tests/components/KiloCodeDefaultModelSelect.test.tsx
+++ b/tests/components/KiloCodeDefaultModelSelect.test.tsx
@@ -1,0 +1,447 @@
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import { KiloCodeDefaultModelSelect } from "~/components/KiloCodeDefaultModelSelect"
+import { KILO_CODE_EXPORT_TEST_IDS } from "~/components/kiloCodeExportTestIds"
+import { testI18n } from "~~/tests/test-utils/i18n"
+import { render, screen } from "~~/tests/test-utils/render"
+
+const LIMITED_MESSAGE_KEY = "dialog.kiloCode.messages.modelSearchLimited"
+
+function addLimitedMessageResource() {
+  testI18n.addResource(
+    "en",
+    "ui",
+    LIMITED_MESSAGE_KEY,
+    "Showing the first {{visible}} of {{count}} models.",
+  )
+}
+
+describe("KiloCodeDefaultModelSelect", () => {
+  it("renders at most 100 rows, keeps the selected row visible, and searches all 5,000 models", async () => {
+    const user = userEvent.setup()
+    const models = Array.from(
+      { length: 5_000 },
+      (_, index) => `example-model-${index.toString().padStart(4, "0")}`,
+    )
+
+    render(
+      <KiloCodeDefaultModelSelect
+        aria-label="Default model"
+        value="example-model-4999"
+        modelIds={models}
+        onChange={vi.fn()}
+        allowCustomValue
+      />,
+      { withThemeProvider: false, withUserPreferencesProvider: false },
+    )
+
+    await user.click(
+      await screen.findByRole("combobox", { name: "Default model" }),
+    )
+
+    const initialRows = screen.getAllByTestId(
+      KILO_CODE_EXPORT_TEST_IDS.modelOption,
+    )
+    expect(initialRows).toHaveLength(100)
+    expect(
+      screen.getByRole("option", { name: "example-model-4999" }),
+    ).toBeVisible()
+
+    await user.type(
+      screen.getByTestId(KILO_CODE_EXPORT_TEST_IDS.defaultModelSearch),
+      "4998",
+    )
+
+    expect(
+      screen.getByRole("option", { name: "example-model-4998" }),
+    ).toBeVisible()
+    expect(
+      screen.queryByRole("option", { name: "example-model-4999" }),
+    ).not.toBeInTheDocument()
+  })
+
+  it("does not inject a selected model that does not match an active search", async () => {
+    const user = userEvent.setup()
+    const models = Array.from(
+      { length: 150 },
+      (_, index) => `example-model-${index.toString().padStart(3, "0")}`,
+    )
+
+    render(
+      <KiloCodeDefaultModelSelect
+        value="example-model-149"
+        modelIds={models}
+        onChange={vi.fn()}
+      />,
+      { withThemeProvider: false, withUserPreferencesProvider: false },
+    )
+
+    await user.click(await screen.findByRole("combobox"))
+    await user.type(
+      screen.getByTestId(KILO_CODE_EXPORT_TEST_IDS.defaultModelSearch),
+      "000",
+    )
+
+    expect(
+      screen.queryByRole("option", { name: "example-model-149" }),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.getByRole("option", { name: "example-model-000" }),
+    ).toBeVisible()
+  })
+
+  it("offers a trimmed custom value without exceeding the 100-row budget", async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    const models = Array.from(
+      { length: 150 },
+      (_, index) => `model-${index.toString().padStart(3, "0")}`,
+    )
+
+    render(
+      <KiloCodeDefaultModelSelect
+        value=""
+        modelIds={models}
+        onChange={onChange}
+        allowCustomValue
+        placeholder="Choose a model"
+      />,
+      { withThemeProvider: false, withUserPreferencesProvider: false },
+    )
+
+    await user.click(
+      await screen.findByRole("combobox", { name: "Choose a model" }),
+    )
+    const search = screen.getByTestId(
+      KILO_CODE_EXPORT_TEST_IDS.defaultModelSearch,
+    )
+    await user.type(search, " model ")
+
+    expect(
+      screen.getAllByTestId(KILO_CODE_EXPORT_TEST_IDS.modelOption),
+    ).toHaveLength(100)
+
+    await user.click(
+      screen.getByRole("option", {
+        name: "ui:searchableSelect.useValue",
+      }),
+    )
+    expect(onChange).toHaveBeenCalledWith("model")
+  })
+
+  it("shows a selected custom value when it is outside the catalog", async () => {
+    const user = userEvent.setup()
+
+    render(
+      <KiloCodeDefaultModelSelect
+        value="custom/model"
+        modelIds={["catalog-model"]}
+        onChange={vi.fn()}
+        allowCustomValue
+      />,
+      { withThemeProvider: false, withUserPreferencesProvider: false },
+    )
+
+    const trigger = await screen.findByRole("combobox", {
+      name: "custom/model",
+    })
+    expect(trigger).toHaveTextContent("custom/model")
+
+    await user.click(trigger)
+    expect(screen.getByRole("option", { name: "custom/model" })).toBeVisible()
+  })
+
+  it("shows translated bounded-result counts", async () => {
+    const user = userEvent.setup()
+    addLimitedMessageResource()
+
+    render(
+      <KiloCodeDefaultModelSelect
+        value="model-000"
+        modelIds={Array.from(
+          { length: 101 },
+          (_, index) => `model-${index.toString().padStart(3, "0")}`,
+        )}
+        onChange={vi.fn()}
+      />,
+      { withThemeProvider: false, withUserPreferencesProvider: false },
+    )
+
+    await user.click(await screen.findByRole("combobox"))
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Showing the first 100 of 101 models.",
+    )
+  })
+
+  it("counts only catalog matches left after an external selection is injected", async () => {
+    const user = userEvent.setup()
+    addLimitedMessageResource()
+
+    render(
+      <KiloCodeDefaultModelSelect
+        value="external-selected-model"
+        modelIds={Array.from(
+          { length: 100 },
+          (_, index) => `catalog-model-${index.toString().padStart(3, "0")}`,
+        )}
+        onChange={vi.fn()}
+        allowCustomValue
+      />,
+      { withThemeProvider: false, withUserPreferencesProvider: false },
+    )
+
+    await user.click(await screen.findByRole("combobox"))
+
+    expect(screen.getAllByRole("option")).toHaveLength(100)
+    expect(
+      screen.getAllByRole("option", { name: /^catalog-model-/ }),
+    ).toHaveLength(99)
+    expect(
+      screen.getByRole("option", { name: "external-selected-model" }),
+    ).toBeVisible()
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Showing the first 99 of 100 models.",
+    )
+  })
+
+  it("reserves rows for distinct selected and custom values", async () => {
+    const user = userEvent.setup()
+    addLimitedMessageResource()
+
+    render(
+      <KiloCodeDefaultModelSelect
+        value="model-selected"
+        modelIds={Array.from(
+          { length: 100 },
+          (_, index) => `model-${index.toString().padStart(3, "0")}`,
+        )}
+        onChange={vi.fn()}
+        allowCustomValue
+      />,
+      { withThemeProvider: false, withUserPreferencesProvider: false },
+    )
+
+    await user.click(await screen.findByRole("combobox"))
+    await user.type(
+      screen.getByTestId(KILO_CODE_EXPORT_TEST_IDS.defaultModelSearch),
+      "model",
+    )
+
+    expect(screen.getAllByRole("option")).toHaveLength(100)
+    expect(screen.getAllByRole("option", { name: /^model-\d+$/ })).toHaveLength(
+      98,
+    )
+    expect(
+      screen.getAllByRole("option", { name: "model-selected" }),
+    ).toHaveLength(1)
+    expect(
+      screen.getAllByRole("option", {
+        name: "ui:searchableSelect.useValue",
+      }),
+    ).toHaveLength(1)
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Showing the first 98 of 100 models.",
+    )
+  })
+
+  it("uses one row when the custom search equals the external selection", async () => {
+    const user = userEvent.setup()
+
+    render(
+      <KiloCodeDefaultModelSelect
+        value="model"
+        modelIds={Array.from(
+          { length: 100 },
+          (_, index) => `model-${index.toString().padStart(3, "0")}`,
+        )}
+        onChange={vi.fn()}
+        allowCustomValue
+      />,
+      { withThemeProvider: false, withUserPreferencesProvider: false },
+    )
+
+    await user.click(await screen.findByRole("combobox"))
+    await user.type(
+      screen.getByTestId(KILO_CODE_EXPORT_TEST_IDS.defaultModelSearch),
+      "model",
+    )
+
+    expect(screen.getAllByRole("option")).toHaveLength(100)
+    expect(
+      screen.getAllByRole("option", {
+        name: "ui:searchableSelect.useValue",
+      }),
+    ).toHaveLength(1)
+  })
+
+  it("keeps search and wrapped status outside the remaining scrollable height", async () => {
+    const user = userEvent.setup()
+    addLimitedMessageResource()
+
+    render(
+      <KiloCodeDefaultModelSelect
+        value="model-000"
+        modelIds={Array.from(
+          { length: 101 },
+          (_, index) => `model-${index.toString().padStart(3, "0")}`,
+        )}
+        onChange={vi.fn()}
+      />,
+      { withThemeProvider: false, withUserPreferencesProvider: false },
+    )
+
+    await user.click(await screen.findByRole("combobox"))
+
+    const popoverContent = document.querySelector(
+      '[data-slot="popover-content"]',
+    )
+    const command = document.querySelector('[data-slot="command"]')
+    const status = screen.getByRole("status")
+    const list = screen.getByRole("listbox")
+
+    expect(popoverContent).toHaveClass("flex", "flex-col", "overflow-hidden")
+    expect(command).toHaveClass(
+      "min-h-0",
+      "flex-1",
+      "[&_[data-slot='command-input-wrapper']]:shrink-0",
+    )
+    expect(status).toHaveClass("shrink-0")
+    expect(list).toHaveClass("min-h-0", "flex-1", "overflow-y-auto")
+    expect(list).not.toHaveClass(
+      "max-h-[calc(var(--radix-popover-content-available-height)-2.25rem)]",
+    )
+  })
+
+  it("selects the next model with ArrowDown and Enter", async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+
+    render(
+      <KiloCodeDefaultModelSelect
+        value=""
+        modelIds={["model-a", "model-b"]}
+        onChange={onChange}
+      />,
+      { withThemeProvider: false, withUserPreferencesProvider: false },
+    )
+
+    await user.click(await screen.findByRole("combobox"))
+    await user.keyboard("{ArrowDown}{Enter}")
+
+    expect(onChange).toHaveBeenCalledWith("model-b")
+  })
+
+  it("returns focus when Escape closes the popover", async () => {
+    const user = userEvent.setup()
+
+    render(
+      <KiloCodeDefaultModelSelect
+        aria-label="Default model"
+        value=""
+        modelIds={["model-a"]}
+        onChange={vi.fn()}
+        searchPlaceholder="Search models"
+      />,
+      { withThemeProvider: false, withUserPreferencesProvider: false },
+    )
+
+    const trigger = await screen.findByRole("combobox", {
+      name: "Default model",
+    })
+    await user.click(trigger)
+    expect(
+      screen.getByRole("combobox", { name: "Search models" }),
+    ).toHaveFocus()
+
+    await user.keyboard("{Escape}")
+
+    expect(trigger).toHaveFocus()
+    expect(trigger).toHaveAttribute("aria-expanded", "false")
+  })
+
+  it("does not open when disabled", async () => {
+    const user = userEvent.setup()
+
+    render(
+      <KiloCodeDefaultModelSelect
+        aria-label="Default model"
+        value=""
+        modelIds={["model-a"]}
+        onChange={vi.fn()}
+        disabled
+      />,
+      { withThemeProvider: false, withUserPreferencesProvider: false },
+    )
+
+    const trigger = await screen.findByRole("combobox", {
+      name: "Default model",
+    })
+    expect(trigger).toBeDisabled()
+
+    await user.click(trigger)
+
+    expect(trigger).toHaveAttribute("aria-expanded", "false")
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+  })
+
+  it("supports exact slash IDs and returns focus after keyboard selection", async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+
+    render(
+      <KiloCodeDefaultModelSelect
+        aria-label="Default model"
+        value=""
+        modelIds={["vendor/model", "vendor/model-plus"]}
+        onChange={onChange}
+        searchPlaceholder="Search models"
+      />,
+      { withThemeProvider: false, withUserPreferencesProvider: false },
+    )
+
+    const trigger = await screen.findByRole("combobox", {
+      name: "Default model",
+    })
+    expect(trigger).toHaveAttribute("aria-expanded", "false")
+
+    await user.click(trigger)
+    const search = screen.getByRole("combobox", { name: "Search models" })
+    expect(trigger).toHaveAttribute("aria-expanded", "true")
+    expect(search).toHaveFocus()
+
+    await user.type(search, "vendor/model")
+    await user.keyboard("{Enter}")
+
+    expect(onChange).toHaveBeenCalledWith("vendor/model")
+    expect(trigger).toHaveAttribute("aria-expanded", "false")
+    expect(trigger).toHaveFocus()
+  })
+
+  it("resets search when the popover closes", async () => {
+    const user = userEvent.setup()
+
+    render(
+      <KiloCodeDefaultModelSelect
+        value="model-a"
+        modelIds={["model-a", "model-b"]}
+        onChange={vi.fn()}
+      />,
+      { withThemeProvider: false, withUserPreferencesProvider: false },
+    )
+
+    const trigger = await screen.findByRole("combobox")
+    await user.click(trigger)
+    await user.type(
+      screen.getByTestId(KILO_CODE_EXPORT_TEST_IDS.defaultModelSearch),
+      "model-b",
+    )
+    await user.keyboard("{Escape}")
+    await user.click(trigger)
+
+    expect(
+      screen.getByTestId(KILO_CODE_EXPORT_TEST_IDS.defaultModelSearch),
+    ).toHaveValue("")
+  })
+})

--- a/tests/components/KiloCodeDefaultModelSelect.test.tsx
+++ b/tests/components/KiloCodeDefaultModelSelect.test.tsx
@@ -18,6 +18,26 @@ function addLimitedMessageResource() {
 }
 
 describe("KiloCodeDefaultModelSelect", () => {
+  it("shows the standard empty state when no models or custom values are available", async () => {
+    const user = userEvent.setup()
+
+    render(
+      <KiloCodeDefaultModelSelect
+        value=""
+        modelIds={[]}
+        onChange={vi.fn()}
+        placeholder="Choose a model"
+      />,
+      { withThemeProvider: false, withUserPreferencesProvider: false },
+    )
+
+    await user.click(
+      await screen.findByRole("combobox", { name: "Choose a model" }),
+    )
+
+    expect(screen.getByText("ui:searchableSelect.noOptions")).toBeVisible()
+  })
+
   it("renders at most 100 rows, keeps the selected row visible, and searches all 5,000 models", async () => {
     const user = userEvent.setup()
     const models = Array.from(

--- a/tests/components/KiloCodeExportDialog.test.tsx
+++ b/tests/components/KiloCodeExportDialog.test.tsx
@@ -5,6 +5,7 @@ import {
   buildKiloCodeCreateTokenToastId,
   KiloCodeExportDialog,
 } from "~/components/KiloCodeExportDialog"
+import { KILO_CODE_EXPORT_TEST_IDS } from "~/components/kiloCodeExportTestIds"
 import { pickNewestKiloCodeToken } from "~/components/kiloCodeTokenSelection"
 import { SITE_TYPES } from "~/constants/siteType"
 import { DEFAULT_AUTO_PROVISION_TOKEN_NAME } from "~/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken"
@@ -27,7 +28,13 @@ import {
   type SiteAccount,
 } from "~/types"
 import { expectKiloCodeUsageGuidance } from "~~/tests/test-utils/kiloCodeExportGuidance"
-import { render, screen, waitFor, within } from "~~/tests/test-utils/render"
+import {
+  act,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "~~/tests/test-utils/render"
 
 const mockUseAccountData = vi.fn()
 const {
@@ -204,6 +211,46 @@ const expectKiloAccountExportActionStarted = (
   })
 }
 
+async function chooseKiloCodeExportTarget(
+  user: ReturnType<typeof userEvent.setup>,
+  target: "kiloV7" | "legacy",
+) {
+  await user.click(
+    screen.getByRole("combobox", {
+      name: "ui:dialog.kiloCode.labels.exportTarget",
+    }),
+  )
+  await user.click(
+    await screen.findByRole("option", {
+      name: `ui:dialog.kiloCode.targets.${target}`,
+    }),
+  )
+}
+
+async function chooseProviderModel(
+  user: ReturnType<typeof userEvent.setup>,
+  providerName: string,
+  labelKey: "modelId" | "legacyModelId",
+  modelId: string,
+) {
+  const provider = screen.getByRole("group", { name: providerName })
+  await user.click(
+    within(provider).getByRole("combobox", {
+      name: `${providerName} ui:dialog.kiloCode.labels.${labelKey}`,
+    }),
+  )
+  const search = screen
+    .getAllByPlaceholderText("ui:searchableSelect.searchPlaceholder")
+    .find((input) => input.getAttribute("aria-expanded") === "true")
+  if (!search) throw new Error("Expected the open provider model search")
+  await user.clear(search)
+  await user.type(search, modelId)
+  await user.click(
+    screen.queryByRole("option", { name: modelId }) ??
+      screen.getByRole("option", { name: "ui:searchableSelect.useValue" }),
+  )
+}
+
 describe("KiloCodeExportDialog", () => {
   beforeEach(() => {
     toastSuccessMock.mockReset()
@@ -218,15 +265,33 @@ describe("KiloCodeExportDialog", () => {
     mockFetchOpenAICompatibleModelIds.mockResolvedValue(["gpt-4o-mini"])
     mockBuildKiloCodeExportOutput.mockReset()
     mockBuildKiloCodeExportOutput.mockImplementation(
-      ({ target, selections }: any) => ({
-        filename:
-          target === KILO_CODE_EXPORT_TARGETS.KiloV7
-            ? "kilo-settings.json"
-            : "kilo-code-settings.json",
-        copyPayload: { target, selections },
-        downloadPayload: { target, selections },
-        itemCount: selections.length,
-      }),
+      ({ target, selections }: any) => {
+        const downloadPayload = { target, selections }
+        return {
+          filename:
+            target === KILO_CODE_EXPORT_TARGETS.KiloV7
+              ? "kilo-settings.json"
+              : "kilo-code-settings.json",
+          copyPayload: downloadPayload,
+          downloadPayload,
+          downloadJson: JSON.stringify(downloadPayload, null, 2),
+          isDownloadTooLarge: false,
+          itemCount: selections.length,
+          modelCount:
+            target === KILO_CODE_EXPORT_TARGETS.KiloV7
+              ? selections.reduce(
+                  (
+                    count: number,
+                    selection: { discoveredModelIds: string[] },
+                  ) => count + selection.discoveredModelIds.length,
+                  0,
+                )
+              : selections.filter(
+                  (selection: { legacyModelId?: string }) =>
+                    selection.legacyModelId,
+                ).length,
+        }
+      },
     )
     mockFetchAccountTokens.mockReset()
     mockgetSiteTypeCapabilities.mockReset()
@@ -553,15 +618,13 @@ describe("KiloCodeExportDialog", () => {
     )
     expect(errorText).toBeInTheDocument()
 
-    const tokenSection = errorText.closest(".space-y-1")
-    expect(tokenSection).toBeInstanceOf(HTMLElement)
-    if (!(tokenSection instanceof HTMLElement)) {
-      throw new Error("Expected token retry section to be an HTMLElement")
-    }
+    const tokenSection = screen.getByRole("group", {
+      name: "Site B - Default",
+    })
 
     await user.click(
       within(tokenSection).getByRole("button", {
-        name: "common:actions.retry",
+        name: "ui:dialog.kiloCode.actions.retryModels",
       }),
     )
 
@@ -576,6 +639,54 @@ describe("KiloCodeExportDialog", () => {
         }),
       ).not.toBeDisabled()
     })
+  })
+
+  it("stacks model recovery controls without a mobile minimum-width overflow", async () => {
+    mockUseAccountData.mockReturnValue({
+      enabledAccounts: [],
+      enabledDisplayData: [
+        createDisplayAccount({
+          id: "b",
+          name: "Site B",
+          baseUrl: "https://b.example.invalid",
+        }),
+      ],
+    })
+    mockFetchAccountTokens.mockResolvedValueOnce([
+      { id: 1, name: "Default", key: "masked-key" },
+    ])
+    mockFetchOpenAICompatibleModelIds.mockRejectedValueOnce(
+      new Error("offline"),
+    )
+
+    render(
+      <KiloCodeExportDialog
+        isOpen={true}
+        onClose={() => {}}
+        initialSelectedSiteIds={["b"]}
+      />,
+    )
+
+    const provider = await screen.findByRole("group", {
+      name: "Site B - Default",
+    })
+    const retry = within(provider).getByRole("button", {
+      name: "ui:dialog.kiloCode.actions.retryModels",
+    })
+    const recoveryControls = retry.parentElement
+    expect(recoveryControls).toHaveClass(
+      "min-w-0",
+      "w-full",
+      "flex-col",
+      "sm:w-auto",
+      "sm:flex-row",
+    )
+
+    const modelSelector = within(provider).getByRole("combobox", {
+      name: "Site B - Default ui:dialog.kiloCode.labels.modelId",
+    }).parentElement
+    expect(modelSelector).toHaveClass("min-w-0", "w-full", "sm:w-[280px]")
+    expect(modelSelector).not.toHaveClass("min-w-[220px]")
   })
 
   it("preselects sites/tokens when initial selections are provided", async () => {
@@ -1168,6 +1279,739 @@ describe("KiloCodeExportDialog", () => {
     expect(mockEnsureAccountApiToken).not.toHaveBeenCalled()
   })
 
+  it("scopes the V7 default model to an opaque selected provider and passes the canonical catalog to policy", async () => {
+    const user = userEvent.setup()
+    vi.spyOn(navigator.clipboard, "writeText").mockResolvedValue(undefined)
+
+    mockUseAccountData.mockReturnValue({
+      enabledAccounts: [],
+      enabledDisplayData: [
+        createDisplayAccount({
+          id: "account-a",
+          name: "Duplicate",
+          baseUrl: "https://a.example.invalid",
+        }),
+        createDisplayAccount({
+          id: "account-b",
+          name: "Duplicate",
+          baseUrl: "https://b.example.invalid",
+        }),
+      ],
+    })
+    mockFetchAccountTokens.mockImplementation(
+      async (request: { accountId: string }) => [
+        {
+          id: request.accountId === "account-a" ? 1 : 2,
+          name: "Shared",
+          key: `masked-${request.accountId}`,
+        },
+      ],
+    )
+    mockFetchOpenAICompatibleModelIds.mockImplementation(
+      async ({ apiKey }: { apiKey: string }) =>
+        apiKey.includes("account-a")
+          ? ["z-model", "a-model", "a-model"]
+          : ["vendor/model", "b-model"],
+    )
+
+    render(
+      <KiloCodeExportDialog
+        isOpen={true}
+        onClose={() => {}}
+        initialSelectedSiteIds={["account-a", "account-b"]}
+      />,
+    )
+
+    const providerSelect = await screen.findByTestId(
+      KILO_CODE_EXPORT_TEST_IDS.defaultProvider,
+    )
+    expect(providerSelect).toHaveAccessibleName(
+      "ui:dialog.kiloCode.labels.defaultProvider",
+    )
+    await waitFor(() => {
+      expect(providerSelect).toHaveTextContent(
+        "Duplicate - Shared (a.example.invalid)",
+      )
+    })
+    expect(
+      screen.getByTestId(KILO_CODE_EXPORT_TEST_IDS.defaultModel),
+    ).toHaveTextContent("a-model")
+
+    await user.click(providerSelect)
+    await user.click(
+      await screen.findByRole("option", {
+        name: "Duplicate - Shared (b.example.invalid)",
+      }),
+    )
+    expect(
+      screen.getByTestId(KILO_CODE_EXPORT_TEST_IDS.defaultModel),
+    ).toHaveTextContent("b-model")
+
+    await user.click(screen.getByTestId(KILO_CODE_EXPORT_TEST_IDS.defaultModel))
+    await user.click(await screen.findByText("vendor/model"))
+    await user.click(
+      screen.getByRole("button", {
+        name: "ui:dialog.kiloCode.actions.copyKiloV7Provider",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(mockBuildKiloCodeExportOutput).toHaveBeenCalledWith({
+        target: KILO_CODE_EXPORT_TARGETS.KiloV7,
+        selections: [
+          expect.objectContaining({
+            selectionId: "account-a:1",
+            providerName: "Duplicate - Shared",
+            discoveredModelIds: ["a-model", "z-model"],
+          }),
+          expect.objectContaining({
+            selectionId: "account-b:2",
+            providerName: "Duplicate - Shared",
+            discoveredModelIds: ["b-model", "vendor/model"],
+          }),
+        ],
+        defaultModel: {
+          selectionId: "account-b:2",
+          modelId: "vendor/model",
+        },
+      })
+    })
+  })
+
+  it("unions a manual provider model across retry and repairs focus/default after Remove", async () => {
+    const user = userEvent.setup()
+    vi.spyOn(navigator.clipboard, "writeText").mockResolvedValue(undefined)
+    mockUseAccountData.mockReturnValue({
+      enabledAccounts: [],
+      enabledDisplayData: [
+        createDisplayAccount({
+          id: "b",
+          name: "Site B",
+          baseUrl: "https://b.example.invalid",
+        }),
+      ],
+    })
+    mockFetchAccountTokens.mockResolvedValueOnce([
+      { id: 1, name: "Default", key: "masked-key" },
+    ])
+    mockFetchOpenAICompatibleModelIds
+      .mockRejectedValueOnce(new Error("offline"))
+      .mockResolvedValueOnce(["z-model", "a-model", "a-model"])
+
+    render(
+      <KiloCodeExportDialog
+        isOpen={true}
+        onClose={() => {}}
+        initialSelectedSiteIds={["b"]}
+      />,
+    )
+
+    const providerName = "Site B - Default"
+    const provider = await screen.findByRole("group", { name: providerName })
+    const retry = within(provider).getByRole("button", {
+      name: "ui:dialog.kiloCode.actions.retryModels",
+    })
+    await chooseProviderModel(user, providerName, "modelId", "manual/model")
+
+    expect(
+      screen.getByTestId(KILO_CODE_EXPORT_TEST_IDS.defaultModel),
+    ).toHaveTextContent("manual/model")
+    await user.click(retry)
+    await waitFor(() => {
+      expect(mockFetchOpenAICompatibleModelIds).toHaveBeenCalledTimes(2)
+    })
+    await waitFor(() => {
+      expect(
+        within(provider).getByRole("combobox", {
+          name: `${providerName} ui:dialog.kiloCode.labels.modelId`,
+        }),
+      ).toHaveFocus()
+    })
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "ui:dialog.kiloCode.actions.copyKiloV7Provider",
+      }),
+    )
+    expect(mockBuildKiloCodeExportOutput).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        selections: [
+          expect.objectContaining({
+            discoveredModelIds: ["a-model", "z-model"],
+            manualModelId: "manual/model",
+          }),
+        ],
+        defaultModel: { selectionId: "b:1", modelId: "manual/model" },
+      }),
+    )
+
+    await user.click(
+      within(provider).getByTestId(KILO_CODE_EXPORT_TEST_IDS.removeManualModel),
+    )
+    await waitFor(() => {
+      expect(
+        within(provider).getByRole("combobox", {
+          name: `${providerName} ui:dialog.kiloCode.labels.modelId`,
+        }),
+      ).toHaveFocus()
+    })
+    expect(
+      screen.getByTestId(KILO_CODE_EXPORT_TEST_IDS.defaultModel),
+    ).toHaveTextContent("a-model")
+  })
+
+  it("returns focus to Retry and preserves manual recovery after retry failure", async () => {
+    const user = userEvent.setup()
+    mockUseAccountData.mockReturnValue({
+      enabledAccounts: [],
+      enabledDisplayData: [
+        createDisplayAccount({
+          id: "b",
+          name: "Site B",
+          baseUrl: "https://b.example.invalid",
+        }),
+      ],
+    })
+    mockFetchAccountTokens.mockResolvedValueOnce([
+      { id: 1, name: "Default", key: "masked-key" },
+    ])
+    mockFetchOpenAICompatibleModelIds
+      .mockRejectedValueOnce(new Error("offline"))
+      .mockRejectedValueOnce(new Error("still offline"))
+
+    render(
+      <KiloCodeExportDialog
+        isOpen={true}
+        onClose={() => {}}
+        initialSelectedSiteIds={["b"]}
+      />,
+    )
+
+    const providerName = "Site B - Default"
+    const provider = await screen.findByRole("group", { name: providerName })
+    await chooseProviderModel(user, providerName, "modelId", "manual/model")
+    await user.click(
+      within(provider).getByRole("button", {
+        name: "ui:dialog.kiloCode.actions.retryModels",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(
+        within(provider).getByRole("button", {
+          name: "ui:dialog.kiloCode.actions.retryModels",
+        }),
+      ).toHaveFocus()
+    })
+    expect(within(provider).getAllByText("manual/model")).not.toHaveLength(0)
+    expect(
+      screen.getByRole("button", {
+        name: "ui:dialog.kiloCode.actions.copyKiloV7Provider",
+      }),
+    ).toBeEnabled()
+  })
+
+  it("removes a non-default provider manual model without changing the default provider", async () => {
+    const user = userEvent.setup()
+    vi.spyOn(navigator.clipboard, "writeText").mockResolvedValue(undefined)
+    mockUseAccountData.mockReturnValue({
+      enabledAccounts: [],
+      enabledDisplayData: [
+        createDisplayAccount({
+          id: "a",
+          name: "Site A",
+          baseUrl: "https://a.example.invalid",
+        }),
+        createDisplayAccount({
+          id: "b",
+          name: "Site B",
+          baseUrl: "https://b.example.invalid",
+        }),
+      ],
+    })
+    mockFetchAccountTokens.mockImplementation(
+      async (request: { accountId: string }) => [
+        {
+          id: 1,
+          name: "Default",
+          key: `masked-${request.accountId}`,
+        },
+      ],
+    )
+    let providerBAttempts = 0
+    mockFetchOpenAICompatibleModelIds.mockImplementation(
+      async ({ apiKey }: { apiKey: string }) => {
+        if (apiKey === "masked-a") return ["a-model"]
+        providerBAttempts += 1
+        if (providerBAttempts === 1) throw new Error("provider b offline")
+        return ["b-z-model", "b-a-model"]
+      },
+    )
+
+    render(
+      <KiloCodeExportDialog
+        isOpen={true}
+        onClose={() => {}}
+        initialSelectedSiteIds={["a", "b"]}
+      />,
+    )
+
+    const providerBName = "Site B - Default"
+    const providerB = await screen.findByRole("group", {
+      name: providerBName,
+    })
+    await chooseProviderModel(
+      user,
+      providerBName,
+      "modelId",
+      "manual/provider-b",
+    )
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(KILO_CODE_EXPORT_TEST_IDS.defaultProvider),
+      ).toHaveTextContent("Site A - Default")
+    })
+
+    await user.click(
+      within(providerB).getByRole("button", {
+        name: "ui:dialog.kiloCode.actions.retryModels",
+      }),
+    )
+    await waitFor(() => expect(providerBAttempts).toBe(2))
+    await user.click(
+      screen.getByRole("button", {
+        name: "ui:dialog.kiloCode.actions.copyKiloV7Provider",
+      }),
+    )
+    expect(mockBuildKiloCodeExportOutput).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        selections: expect.arrayContaining([
+          expect.objectContaining({
+            selectionId: "b:1",
+            discoveredModelIds: ["b-a-model", "b-z-model"],
+            manualModelId: "manual/provider-b",
+          }),
+        ]),
+        defaultModel: { selectionId: "a:1", modelId: "a-model" },
+      }),
+    )
+
+    await user.click(
+      within(providerB).getByTestId(
+        KILO_CODE_EXPORT_TEST_IDS.removeManualModel,
+      ),
+    )
+    await waitFor(() => {
+      expect(
+        within(providerB).getByRole("combobox", {
+          name: `${providerBName} ui:dialog.kiloCode.labels.modelId`,
+        }),
+      ).toHaveFocus()
+    })
+    expect(
+      screen.getByTestId(KILO_CODE_EXPORT_TEST_IDS.defaultProvider),
+    ).toHaveTextContent("Site A - Default")
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "ui:dialog.kiloCode.actions.copyKiloV7Provider",
+      }),
+    )
+    expect(mockBuildKiloCodeExportOutput).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        selections: expect.arrayContaining([
+          expect.objectContaining({
+            selectionId: "b:1",
+            discoveredModelIds: ["b-a-model", "b-z-model"],
+            manualModelId: undefined,
+          }),
+        ]),
+        defaultModel: { selectionId: "a:1", modelId: "a-model" },
+      }),
+    )
+  })
+
+  it("does not resurrect a deselected site when its model request resolves late", async () => {
+    const user = userEvent.setup()
+    vi.spyOn(navigator.clipboard, "writeText").mockResolvedValue(undefined)
+    let resolveProviderB: ((modelIds: string[]) => void) | undefined
+    const providerBModels = new Promise<string[]>((resolve) => {
+      resolveProviderB = resolve
+    })
+    mockUseAccountData.mockReturnValue({
+      enabledAccounts: [],
+      enabledDisplayData: [
+        createDisplayAccount({
+          id: "a",
+          name: "Site A",
+          baseUrl: "https://a.example.invalid",
+        }),
+        createDisplayAccount({
+          id: "b",
+          name: "Site B",
+          baseUrl: "https://b.example.invalid",
+        }),
+      ],
+    })
+    mockFetchAccountTokens.mockImplementation(
+      async (request: { accountId: string }) => [
+        {
+          id: 1,
+          name: "Default",
+          key: `masked-${request.accountId}`,
+        },
+      ],
+    )
+    mockFetchOpenAICompatibleModelIds.mockImplementation(
+      async ({ apiKey }: { apiKey: string }) =>
+        apiKey === "masked-a" ? ["a-model"] : providerBModels,
+    )
+
+    render(
+      <KiloCodeExportDialog
+        isOpen={true}
+        onClose={() => {}}
+        initialSelectedSiteIds={["a", "b"]}
+      />,
+    )
+    await waitFor(() => {
+      expect(mockFetchOpenAICompatibleModelIds).toHaveBeenCalledTimes(2)
+    })
+
+    const sitePicker = screen.getByRole("combobox", {
+      name: "ui:dialog.kiloCode.labels.selectedSites",
+    })
+    await user.click(sitePicker)
+    await user.click(await screen.findByRole("option", { name: "Site B" }))
+    await user.keyboard("{Escape}")
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(KILO_CODE_EXPORT_TEST_IDS.defaultProvider),
+      ).toHaveTextContent("Site A - Default")
+    })
+    expect(
+      screen.queryByRole("group", { name: "Site B - Default" }),
+    ).not.toBeInTheDocument()
+
+    await act(async () => {
+      resolveProviderB?.(["stale-b-model"])
+      await providerBModels
+    })
+    expect(screen.queryByText("stale-b-model")).not.toBeInTheDocument()
+    expect(
+      screen.getByRole("button", {
+        name: "ui:dialog.kiloCode.actions.copyKiloV7Provider",
+      }),
+    ).toBeEnabled()
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "ui:dialog.kiloCode.actions.copyKiloV7Provider",
+      }),
+    )
+    expect(mockBuildKiloCodeExportOutput).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        selections: [expect.objectContaining({ selectionId: "a:1" })],
+        defaultModel: { selectionId: "a:1", modelId: "a-model" },
+      }),
+    )
+  })
+
+  it("preserves separate V7 manual and legacy model choices without target-switch loads or secret resolution", async () => {
+    const user = userEvent.setup()
+    mockUseAccountData.mockReturnValue({
+      enabledAccounts: [],
+      enabledDisplayData: [
+        createDisplayAccount({
+          id: "b",
+          name: "Site B",
+          baseUrl: "https://b.example.invalid",
+        }),
+      ],
+    })
+    mockFetchAccountTokens.mockResolvedValueOnce([
+      { id: 1, name: "Default", key: "masked-key" },
+    ])
+    mockFetchOpenAICompatibleModelIds.mockResolvedValueOnce(["model-a"])
+
+    render(
+      <KiloCodeExportDialog
+        isOpen={true}
+        onClose={() => {}}
+        initialSelectedSiteIds={["b"]}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(KILO_CODE_EXPORT_TEST_IDS.defaultModel),
+      ).toHaveTextContent("model-a")
+    })
+    await chooseProviderModel(user, "Site B - Default", "modelId", "manual/v7")
+    await user.click(screen.getByTestId(KILO_CODE_EXPORT_TEST_IDS.defaultModel))
+    await user.click(await screen.findByRole("option", { name: "manual/v7" }))
+
+    const modelLoadCount = mockFetchOpenAICompatibleModelIds.mock.calls.length
+    mockResolveApiTokenKey.mockClear()
+    await chooseKiloCodeExportTarget(user, "legacy")
+    await chooseProviderModel(
+      user,
+      "Site B - Default",
+      "legacyModelId",
+      "legacy/custom",
+    )
+    await chooseKiloCodeExportTarget(user, "kiloV7")
+
+    expect(
+      screen.getByTestId(KILO_CODE_EXPORT_TEST_IDS.defaultModel),
+    ).toHaveTextContent("manual/v7")
+    await chooseKiloCodeExportTarget(user, "legacy")
+    expect(
+      within(screen.getByRole("group", { name: "Site B - Default" })).getByRole(
+        "combobox",
+        {
+          name: "Site B - Default ui:dialog.kiloCode.labels.legacyModelId",
+        },
+      ),
+    ).toHaveTextContent("legacy/custom")
+    expect(mockFetchOpenAICompatibleModelIds).toHaveBeenCalledTimes(
+      modelLoadCount,
+    )
+    expect(mockResolveApiTokenKey).not.toHaveBeenCalled()
+  })
+
+  it("blocks oversized downloads without creating a URL while keeping copy available", async () => {
+    const user = userEvent.setup()
+    const createObjectUrl = vi.spyOn(URL, "createObjectURL")
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, "click")
+    mockUseAccountData.mockReturnValue({
+      enabledAccounts: [],
+      enabledDisplayData: [
+        createDisplayAccount({
+          id: "b",
+          name: "Site B",
+          baseUrl: "https://b.example.invalid",
+        }),
+      ],
+    })
+    mockFetchAccountTokens.mockResolvedValueOnce([
+      { id: 1, name: "Default", key: "masked-key" },
+    ])
+    mockBuildKiloCodeExportOutput.mockReturnValueOnce({
+      filename: "kilo-settings.json",
+      copyPayload: { provider: {}, model: "example/model" },
+      downloadPayload: { provider: {}, model: "example/model" },
+      downloadJson: "exact oversized JSON",
+      isDownloadTooLarge: true,
+      itemCount: 1,
+      modelCount: 3,
+    })
+
+    render(
+      <KiloCodeExportDialog
+        isOpen={true}
+        onClose={() => {}}
+        initialSelectedSiteIds={["b"]}
+      />,
+    )
+    const download = await screen.findByRole("button", {
+      name: "ui:dialog.kiloCode.actions.downloadKiloV7Settings",
+    })
+    await waitFor(() => expect(download).toBeEnabled())
+    await user.click(download)
+
+    expect(
+      await screen.findByText(
+        "ui:dialog.kiloCode.messages.settingsFileTooLargeMultiple",
+      ),
+    ).toBeVisible()
+    expect(createObjectUrl).not.toHaveBeenCalled()
+    expect(clickSpy).not.toHaveBeenCalled()
+    expect(
+      screen.getByRole("button", {
+        name: "ui:dialog.kiloCode.actions.copyKiloV7Provider",
+      }),
+    ).toBeEnabled()
+    expect(completeProductAnalyticsActionMock).toHaveBeenCalledWith(
+      PRODUCT_ANALYTICS_RESULTS.Failure,
+      {
+        errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Validation,
+        insights: expect.objectContaining({ itemCount: 1, modelCount: 3 }),
+      },
+    )
+
+    const sitePicker = screen.getByRole("combobox", {
+      name: "ui:dialog.kiloCode.labels.selectedSites",
+    })
+    await user.click(sitePicker)
+    await user.click(await screen.findByRole("option", { name: "Site B" }))
+    await waitFor(() => {
+      expect(
+        screen.queryByText(
+          "ui:dialog.kiloCode.messages.settingsFileTooLargeMultiple",
+        ),
+      ).not.toBeInTheDocument()
+    })
+  })
+
+  it("contains invalid site facts as disabled UI state without calling policy", async () => {
+    mockUseAccountData.mockReturnValue({
+      enabledAccounts: [],
+      enabledDisplayData: [
+        createDisplayAccount({ id: "bad", name: "Bad", baseUrl: "not a url" }),
+      ],
+    })
+    mockFetchAccountTokens.mockResolvedValueOnce([
+      { id: 1, name: "Default", key: "masked-key" },
+    ])
+
+    render(
+      <KiloCodeExportDialog
+        isOpen={true}
+        onClose={() => {}}
+        initialSelectedSiteIds={["bad"]}
+      />,
+    )
+
+    expect(
+      await screen.findByText("ui:dialog.kiloCode.messages.invalidProfile"),
+    ).toBeVisible()
+    expect(
+      screen.getByRole("button", {
+        name: "ui:dialog.kiloCode.actions.copyKiloV7Provider",
+      }),
+    ).toBeDisabled()
+    expect(mockBuildKiloCodeExportOutput).not.toHaveBeenCalled()
+  })
+
+  it("contains non-string token keys and invalid URL siblings without loading secrets or models", async () => {
+    mockUseAccountData.mockReturnValue({
+      enabledAccounts: [],
+      enabledDisplayData: [
+        createDisplayAccount({
+          id: "malformed-key",
+          name: "Malformed key",
+          baseUrl: "https://valid.example.invalid",
+        }),
+        createDisplayAccount({
+          id: "invalid-url",
+          name: "Invalid URL",
+          baseUrl: "not a url",
+        }),
+      ],
+    })
+    mockFetchAccountTokens.mockImplementation(
+      async (request: { accountId: string }) => [
+        {
+          id: 1,
+          name: "Default",
+          key:
+            request.accountId === "malformed-key"
+              ? (null as unknown as string)
+              : "valid-key",
+        },
+      ],
+    )
+    mockResolveApiTokenKey.mockClear()
+    mockFetchOpenAICompatibleModelIds.mockClear()
+
+    render(
+      <KiloCodeExportDialog
+        isOpen={true}
+        onClose={() => {}}
+        initialSelectedSiteIds={["malformed-key", "invalid-url"]}
+      />,
+    )
+
+    expect(
+      await screen.findByText("ui:dialog.kiloCode.messages.invalidProfile"),
+    ).toBeVisible()
+    expect(
+      screen.getByRole("button", {
+        name: "ui:dialog.kiloCode.actions.copyKiloV7Provider",
+      }),
+    ).toBeDisabled()
+    expect(mockResolveApiTokenKey).not.toHaveBeenCalled()
+    expect(mockFetchOpenAICompatibleModelIds).not.toHaveBeenCalled()
+    expect(mockBuildKiloCodeExportOutput).not.toHaveBeenCalled()
+  })
+
+  it("ignores a stale model result after close and reopen for the same token", async () => {
+    let resolveStale: ((modelIds: string[]) => void) | undefined
+    let resolveCurrent: ((modelIds: string[]) => void) | undefined
+    const staleModels = new Promise<string[]>((resolve) => {
+      resolveStale = resolve
+    })
+    const currentModels = new Promise<string[]>((resolve) => {
+      resolveCurrent = resolve
+    })
+    mockUseAccountData.mockReturnValue({
+      enabledAccounts: [],
+      enabledDisplayData: [
+        createDisplayAccount({
+          id: "b",
+          name: "Site B",
+          baseUrl: "https://b.example.invalid",
+        }),
+      ],
+    })
+    mockFetchAccountTokens.mockResolvedValue([
+      { id: 1, name: "Default", key: "masked-key" },
+    ])
+    mockFetchOpenAICompatibleModelIds
+      .mockReturnValueOnce(staleModels)
+      .mockReturnValueOnce(currentModels)
+
+    const { rerender } = render(
+      <KiloCodeExportDialog
+        isOpen={true}
+        onClose={() => {}}
+        initialSelectedSiteIds={["b"]}
+      />,
+    )
+    await waitFor(() => {
+      expect(mockFetchOpenAICompatibleModelIds).toHaveBeenCalledTimes(1)
+    })
+
+    rerender(
+      <KiloCodeExportDialog
+        isOpen={false}
+        onClose={() => {}}
+        initialSelectedSiteIds={["b"]}
+      />,
+    )
+    rerender(
+      <KiloCodeExportDialog
+        isOpen={true}
+        onClose={() => {}}
+        initialSelectedSiteIds={["b"]}
+      />,
+    )
+    await waitFor(() => {
+      expect(mockFetchOpenAICompatibleModelIds).toHaveBeenCalledTimes(2)
+    })
+
+    await act(async () => {
+      resolveStale?.(["stale-model"])
+      await staleModels
+    })
+    expect(screen.queryByText("stale-model")).not.toBeInTheDocument()
+    expect(
+      screen.getByTestId(KILO_CODE_EXPORT_TEST_IDS.defaultProvider),
+    ).toBeDisabled()
+
+    await act(async () => {
+      resolveCurrent?.(["current-model"])
+      await currentModels
+    })
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(KILO_CODE_EXPORT_TEST_IDS.defaultModel),
+      ).toHaveTextContent("current-model")
+    })
+  })
+
   it("copies export configs with resolved full keys instead of masked inventory values", async () => {
     const user = userEvent.setup()
     const writeText = vi
@@ -1203,6 +2047,7 @@ describe("KiloCodeExportDialog", () => {
     })
     await waitFor(() => expect(copyButton).toBeEnabled())
 
+    mockResolveApiTokenKey.mockClear()
     await user.click(copyButton)
 
     await waitFor(() => {
@@ -1212,6 +2057,8 @@ describe("KiloCodeExportDialog", () => {
     const copiedPayload = String(writeText.mock.calls[0]?.[0] ?? "")
     expect(copiedPayload).toContain("sk-full-secret")
     expect(copiedPayload).not.toContain("sk-abcd************wxyz")
+    expect(screen.queryByText("sk-full-secret")).not.toBeInTheDocument()
+    expect(mockResolveApiTokenKey).toHaveBeenCalledTimes(1)
     expectKiloAccountExportActionStarted(
       PRODUCT_ANALYTICS_ACTION_IDS.CopyKiloCodeAccountExportConfig,
     )
@@ -1331,7 +2178,10 @@ describe("KiloCodeExportDialog", () => {
       filename: "kilo-settings.json",
       copyPayload: { format: "v7-copy" },
       downloadPayload: { format: "v7-download" },
+      downloadJson: JSON.stringify({ format: "v7-download" }, null, 2),
+      isDownloadTooLarge: false,
       itemCount: 1,
+      modelCount: 1,
     })
 
     render(
@@ -1380,8 +2230,17 @@ describe("KiloCodeExportDialog", () => {
 
     expect(mockBuildKiloCodeExportOutput).toHaveBeenCalledWith({
       target: KILO_CODE_EXPORT_TARGETS.KiloV7,
-      selections: [expect.objectContaining({ tokenKey: "sk-full-secret" })],
-      currentLegacyProfileName: expect.any(String),
+      selections: [
+        expect.objectContaining({
+          tokenKey: "sk-full-secret",
+          selectionId: "b:1",
+          discoveredModelIds: ["gpt-4o-mini"],
+        }),
+      ],
+      defaultModel: {
+        selectionId: "b:1",
+        modelId: "gpt-4o-mini",
+      },
     })
     expect(payload).toBe(JSON.stringify({ format: "v7-download" }, null, 2))
     expect(clickSpy).toHaveBeenCalledTimes(1)

--- a/tests/components/KiloCodeExportDialog.test.tsx
+++ b/tests/components/KiloCodeExportDialog.test.tsx
@@ -254,6 +254,40 @@ async function chooseProviderModel(
   )
 }
 
+async function chooseProviderProtocol(
+  user: ReturnType<typeof userEvent.setup>,
+  providerName: string,
+  protocolKey: "openAICompatible" | "openAIResponses" | "anthropicMessages",
+) {
+  const provider = screen.getByRole("group", { name: providerName })
+  await user.click(
+    within(provider).getByRole("combobox", {
+      name: `${providerName} ui:dialog.kiloCode.labels.providerProtocol`,
+    }),
+  )
+  await user.click(
+    await screen.findByRole("option", {
+      name: `ui:dialog.kiloCode.protocols.${protocolKey}`,
+    }),
+  )
+}
+
+async function chooseDefaultModel(
+  user: ReturnType<typeof userEvent.setup>,
+  modelId: string,
+) {
+  await user.click(screen.getByTestId(KILO_CODE_EXPORT_TEST_IDS.defaultModel))
+  const search = screen.getByTestId(
+    KILO_CODE_EXPORT_TEST_IDS.defaultModelSearch,
+  )
+  await user.clear(search)
+  await user.type(search, modelId)
+  await user.click(
+    screen.queryByRole("option", { name: modelId }) ??
+      screen.getByRole("option", { name: "ui:searchableSelect.useValue" }),
+  )
+}
+
 describe("KiloCodeExportDialog", () => {
   beforeEach(() => {
     toastSuccessMock.mockReset()
@@ -690,6 +724,50 @@ describe("KiloCodeExportDialog", () => {
     }).parentElement
     expect(modelSelector).toHaveClass("min-w-0", "w-full", "sm:w-[280px]")
     expect(modelSelector).not.toHaveClass("min-w-[220px]")
+  })
+
+  it("uses the global default selector after V7 model discovery succeeds", async () => {
+    mockUseAccountData.mockReturnValue({
+      enabledAccounts: [],
+      enabledDisplayData: [
+        createDisplayAccount({
+          id: "b",
+          name: "Site B",
+          baseUrl: "https://b.example.invalid",
+        }),
+      ],
+    })
+    mockFetchAccountTokens.mockResolvedValueOnce([
+      { id: 1, name: "Default", key: "masked-key" },
+    ])
+    mockFetchOpenAICompatibleModelIds.mockResolvedValueOnce([
+      "model-a",
+      "model-b",
+    ])
+
+    render(
+      <KiloCodeExportDialog
+        isOpen={true}
+        onClose={() => {}}
+        initialSelectedSiteIds={["b"]}
+      />,
+    )
+
+    const provider = await screen.findByRole("group", {
+      name: "Site B - Default",
+    })
+    await waitFor(() => {
+      expect(within(provider).getByText("common:status.success")).toBeVisible()
+    })
+
+    expect(
+      within(provider).queryByRole("combobox", {
+        name: "Site B - Default ui:dialog.kiloCode.labels.modelId",
+      }),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.getByTestId(KILO_CODE_EXPORT_TEST_IDS.defaultModel),
+    ).toHaveTextContent("model-a")
   })
 
   it("preselects sites/tokens when initial selections are provided", async () => {
@@ -1413,7 +1491,6 @@ describe("KiloCodeExportDialog", () => {
     await waitFor(() => {
       expect(within(provider).getByText("common:status.success")).toBeVisible()
     })
-    await chooseProviderModel(user, "Site A - Default", "modelId", "model-a")
     await user.click(
       screen.getByRole("button", {
         name: "ui:dialog.kiloCode.actions.copyKiloV7Provider",
@@ -1953,7 +2030,7 @@ describe("KiloCodeExportDialog", () => {
     await waitFor(() => {
       expect(
         within(provider).getByRole("combobox", {
-          name: `${providerName} ui:dialog.kiloCode.labels.modelId`,
+          name: `${providerName} ui:dialog.kiloCode.labels.providerProtocol`,
         }),
       ).toHaveFocus()
     })
@@ -1981,7 +2058,7 @@ describe("KiloCodeExportDialog", () => {
     await waitFor(() => {
       expect(
         within(provider).getByRole("combobox", {
-          name: `${providerName} ui:dialog.kiloCode.labels.modelId`,
+          name: `${providerName} ui:dialog.kiloCode.labels.providerProtocol`,
         }),
       ).toHaveFocus()
     })
@@ -2039,6 +2116,17 @@ describe("KiloCodeExportDialog", () => {
         name: "ui:dialog.kiloCode.actions.copyKiloV7Provider",
       }),
     ).toBeEnabled()
+
+    await user.click(
+      within(provider).getByTestId(KILO_CODE_EXPORT_TEST_IDS.removeManualModel),
+    )
+    await waitFor(() => {
+      expect(
+        within(provider).getByRole("combobox", {
+          name: `${providerName} ui:dialog.kiloCode.labels.modelId`,
+        }),
+      ).toHaveFocus()
+    })
   })
 
   it("removes a non-default provider manual model without changing the default provider", async () => {
@@ -2090,6 +2178,9 @@ describe("KiloCodeExportDialog", () => {
     const providerB = await screen.findByRole("group", {
       name: providerBName,
     })
+    await within(providerB).findByRole("button", {
+      name: "ui:dialog.kiloCode.actions.retryModels",
+    })
     await chooseProviderModel(
       user,
       providerBName,
@@ -2134,7 +2225,7 @@ describe("KiloCodeExportDialog", () => {
     await waitFor(() => {
       expect(
         within(providerB).getByRole("combobox", {
-          name: `${providerBName} ui:dialog.kiloCode.labels.modelId`,
+          name: `${providerBName} ui:dialog.kiloCode.labels.providerProtocol`,
         }),
       ).toHaveFocus()
     })
@@ -2278,9 +2369,7 @@ describe("KiloCodeExportDialog", () => {
         screen.getByTestId(KILO_CODE_EXPORT_TEST_IDS.defaultModel),
       ).toHaveTextContent("model-a")
     })
-    await chooseProviderModel(user, "Site B - Default", "modelId", "manual/v7")
-    await user.click(screen.getByTestId(KILO_CODE_EXPORT_TEST_IDS.defaultModel))
-    await user.click(await screen.findByRole("option", { name: "manual/v7" }))
+    await chooseDefaultModel(user, "manual/v7")
 
     const modelLoadCount = mockFetchOpenAICompatibleModelIds.mock.calls.length
     mockResolveApiTokenKey.mockClear()
@@ -2796,6 +2885,283 @@ describe("KiloCodeExportDialog", () => {
     clickSpy.mockRestore()
     revokeObjectUrl.mockRestore()
     createObjectUrl.mockRestore()
+  })
+
+  it("lets each V7 account provider choose a protocol without refetching models", async () => {
+    const user = userEvent.setup()
+
+    mockUseAccountData.mockReturnValue({
+      enabledAccounts: [],
+      enabledDisplayData: [
+        createDisplayAccount({
+          id: "b",
+          name: "Site B",
+          baseUrl: "https://b.test",
+        }),
+      ],
+    })
+    mockFetchAccountTokens.mockResolvedValueOnce([
+      { id: 1, name: "Default", key: "sk-test" },
+    ])
+    mockBuildKiloCodeExportOutput.mockReturnValueOnce({
+      filename: "kilo-settings.json",
+      copyPayload: { format: "v7-copy" },
+      downloadPayload: { format: "v7-download" },
+      downloadJson: JSON.stringify({ format: "v7-download" }, null, 2),
+      isDownloadTooLarge: false,
+      itemCount: 1,
+      modelCount: 1,
+    })
+
+    render(
+      <KiloCodeExportDialog
+        isOpen={true}
+        onClose={() => {}}
+        initialSelectedSiteIds={["b"]}
+      />,
+    )
+
+    const copyButton = await screen.findByRole("button", {
+      name: "ui:dialog.kiloCode.actions.copyKiloV7Provider",
+    })
+    await waitFor(() => expect(copyButton).toBeEnabled())
+
+    const provider = screen.getByRole("group", {
+      name: "Site B - Default",
+    })
+    const protocol = within(provider).getByRole("combobox", {
+      name: "Site B - Default ui:dialog.kiloCode.labels.providerProtocol",
+    })
+    expect(protocol).toHaveTextContent(
+      "ui:dialog.kiloCode.protocols.openAICompatible",
+    )
+
+    const modelFetchCount = mockFetchOpenAICompatibleModelIds.mock.calls.length
+    await user.click(protocol)
+    await user.click(
+      await screen.findByRole("option", {
+        name: "ui:dialog.kiloCode.protocols.anthropicMessages",
+      }),
+    )
+
+    expect(mockFetchOpenAICompatibleModelIds).toHaveBeenCalledTimes(
+      modelFetchCount,
+    )
+    expect(protocol).toHaveTextContent(
+      "ui:dialog.kiloCode.protocols.anthropicMessages",
+    )
+
+    await user.click(copyButton)
+    await waitFor(() =>
+      expect(mockBuildKiloCodeExportOutput).toHaveBeenCalled(),
+    )
+    expect(mockBuildKiloCodeExportOutput).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        selections: [
+          expect.objectContaining({ protocol: "anthropic-messages" }),
+        ],
+      }),
+    )
+  })
+
+  it("keeps protocol changes isolated across V7 account providers", async () => {
+    const user = userEvent.setup()
+
+    mockUseAccountData.mockReturnValue({
+      enabledAccounts: [],
+      enabledDisplayData: [
+        createDisplayAccount({
+          id: "account-a",
+          name: "Site A",
+          baseUrl: "https://a.example.invalid",
+        }),
+      ],
+    })
+    mockFetchAccountTokens.mockResolvedValueOnce([
+      { id: 1, name: "First", key: "sk-first" },
+      { id: 2, name: "Second", key: "sk-second" },
+    ])
+
+    render(
+      <KiloCodeExportDialog
+        isOpen={true}
+        onClose={() => {}}
+        initialSelectedSiteIds={["account-a"]}
+        initialSelectedTokenIdsBySite={{ "account-a": ["1", "2"] }}
+      />,
+    )
+
+    const firstProviderName = "Site A - First"
+    const secondProviderName = "Site A - Second"
+    await waitFor(() => {
+      expect(mockFetchOpenAICompatibleModelIds).toHaveBeenCalledTimes(2)
+    })
+
+    await chooseProviderProtocol(user, firstProviderName, "anthropicMessages")
+
+    expect(
+      within(screen.getByRole("group", { name: firstProviderName })).getByRole(
+        "combobox",
+        {
+          name: `${firstProviderName} ui:dialog.kiloCode.labels.providerProtocol`,
+        },
+      ),
+    ).toHaveTextContent("ui:dialog.kiloCode.protocols.anthropicMessages")
+    expect(
+      within(screen.getByRole("group", { name: secondProviderName })).getByRole(
+        "combobox",
+        {
+          name: `${secondProviderName} ui:dialog.kiloCode.labels.providerProtocol`,
+        },
+      ),
+    ).toHaveTextContent("ui:dialog.kiloCode.protocols.openAICompatible")
+
+    await chooseProviderProtocol(user, secondProviderName, "openAIResponses")
+    await user.click(
+      screen.getByRole("button", {
+        name: "ui:dialog.kiloCode.actions.copyKiloV7Provider",
+      }),
+    )
+
+    await waitFor(() =>
+      expect(mockBuildKiloCodeExportOutput).toHaveBeenCalled(),
+    )
+    expect(mockBuildKiloCodeExportOutput).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        selections: expect.arrayContaining([
+          expect.objectContaining({
+            selectionId: "account-a:1",
+            protocol: "anthropic-messages",
+          }),
+          expect.objectContaining({
+            selectionId: "account-a:2",
+            protocol: "openai-responses",
+          }),
+        ]),
+      }),
+    )
+  })
+
+  it("preserves V7 protocols across target changes and resets them after reopening", async () => {
+    const user = userEvent.setup()
+
+    mockUseAccountData.mockReturnValue({
+      enabledAccounts: [],
+      enabledDisplayData: [
+        createDisplayAccount({
+          id: "account-a",
+          name: "Site A",
+          baseUrl: "https://a.example.invalid",
+        }),
+      ],
+    })
+    const token = { id: 1, name: "Default", key: "sk-test" }
+    mockFetchAccountTokens.mockResolvedValueOnce([token])
+
+    const { rerender } = render(
+      <KiloCodeExportDialog
+        isOpen={true}
+        onClose={() => {}}
+        initialSelectedSiteIds={["account-a"]}
+      />,
+    )
+
+    const providerName = "Site A - Default"
+    const protocolName = `${providerName} ui:dialog.kiloCode.labels.providerProtocol`
+    const protocol = await within(
+      await screen.findByRole("group", { name: providerName }),
+    ).findByRole("combobox", { name: protocolName })
+    await chooseProviderProtocol(user, providerName, "anthropicMessages")
+    expect(protocol).toHaveTextContent(
+      "ui:dialog.kiloCode.protocols.anthropicMessages",
+    )
+
+    await chooseKiloCodeExportTarget(user, "legacy")
+    expect(
+      screen.queryByRole("combobox", { name: protocolName }),
+    ).not.toBeInTheDocument()
+    await chooseKiloCodeExportTarget(user, "kiloV7")
+    expect(
+      screen.getByRole("combobox", { name: protocolName }),
+    ).toHaveTextContent("ui:dialog.kiloCode.protocols.anthropicMessages")
+
+    rerender(
+      <KiloCodeExportDialog
+        isOpen={false}
+        onClose={() => {}}
+        initialSelectedSiteIds={["account-a"]}
+      />,
+    )
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("combobox", { name: protocolName }),
+      ).not.toBeInTheDocument()
+    })
+
+    mockFetchAccountTokens.mockResolvedValueOnce([token])
+    rerender(
+      <KiloCodeExportDialog
+        isOpen={true}
+        onClose={() => {}}
+        initialSelectedSiteIds={["account-a"]}
+      />,
+    )
+
+    expect(
+      await screen.findByRole("combobox", { name: protocolName }),
+    ).toHaveTextContent("ui:dialog.kiloCode.protocols.openAICompatible")
+  })
+
+  it("drops a delayed account export when its provider protocol changes", async () => {
+    const user = userEvent.setup()
+    const writeText = vi
+      .spyOn(navigator.clipboard, "writeText")
+      .mockResolvedValue(undefined)
+    let resolveSecret: (value: string) => void = () => {}
+    const delayedSecret = new Promise<string>((resolve) => {
+      resolveSecret = resolve
+    })
+
+    mockUseAccountData.mockReturnValue({
+      enabledAccounts: [],
+      enabledDisplayData: [
+        createDisplayAccount({
+          id: "account-a",
+          name: "Site A",
+          baseUrl: "https://a.example.invalid",
+        }),
+      ],
+    })
+    mockFetchAccountTokens.mockResolvedValueOnce([
+      { id: 1, name: "Default", key: "sk-masked********" },
+    ])
+
+    render(
+      <KiloCodeExportDialog
+        isOpen={true}
+        onClose={() => {}}
+        initialSelectedSiteIds={["account-a"]}
+      />,
+    )
+
+    const copyButton = await screen.findByRole("button", {
+      name: "ui:dialog.kiloCode.actions.copyKiloV7Provider",
+    })
+    await waitFor(() => expect(copyButton).toBeEnabled())
+    mockResolveApiTokenKey.mockClear()
+    mockResolveApiTokenKey.mockReturnValueOnce(delayedSecret)
+
+    await user.click(copyButton)
+    await waitFor(() => expect(mockResolveApiTokenKey).toHaveBeenCalledTimes(1))
+    await chooseProviderProtocol(user, "Site A - Default", "anthropicMessages")
+
+    resolveSecret("sk-full-secret")
+    await delayedSecret
+    await act(async () => {})
+
+    expect(writeText).not.toHaveBeenCalled()
+    expect(toastSuccessMock).not.toHaveBeenCalled()
+    expect(completeProductAnalyticsActionMock).not.toHaveBeenCalled()
   })
 
   it("switches to legacy policy output without refetching or resolving another secret", async () => {

--- a/tests/components/KiloCodeExportDialog.test.tsx
+++ b/tests/components/KiloCodeExportDialog.test.tsx
@@ -1,4 +1,5 @@
 import userEvent from "@testing-library/user-event"
+import { Suspense, type ComponentProps } from "react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import {
@@ -41,18 +42,35 @@ import {
 
 const mockUseAccountData = vi.fn()
 const {
+  modalRenderControl,
   toastSuccessMock,
   toastErrorMock,
   addTokenDialogPropsMock,
   completeProductAnalyticsActionMock,
   startProductAnalyticsActionMock,
 } = vi.hoisted(() => ({
+  modalRenderControl: {
+    pending: null as Promise<void> | null,
+  },
   toastSuccessMock: vi.fn(),
   toastErrorMock: vi.fn(),
   addTokenDialogPropsMock: vi.fn(),
   completeProductAnalyticsActionMock: vi.fn(),
   startProductAnalyticsActionMock: vi.fn(),
 }))
+
+vi.mock("~/components/ui", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("~/components/ui")>()
+
+  return {
+    ...actual,
+    Modal: (props: ComponentProps<typeof actual.Modal>) => {
+      if (modalRenderControl.pending) throw modalRenderControl.pending
+      const ActualModal = actual.Modal
+      return <ActualModal {...props} />
+    },
+  }
+})
 
 vi.mock("react-hot-toast", () => ({
   default: {
@@ -290,6 +308,7 @@ async function chooseDefaultModel(
 
 describe("KiloCodeExportDialog", () => {
   beforeEach(() => {
+    modalRenderControl.pending = null
     toastSuccessMock.mockReset()
     toastErrorMock.mockReset()
     addTokenDialogPropsMock.mockReset()
@@ -911,13 +930,16 @@ describe("KiloCodeExportDialog", () => {
       />,
     )
 
-    await waitFor(() => {
-      expect(
-        screen.getByRole("button", {
-          name: "ui:dialog.kiloCode.actions.copyKiloV7Provider",
-        }),
-      ).toBeEnabled()
-    })
+    await waitFor(
+      () => {
+        expect(
+          screen.getByRole("button", {
+            name: "ui:dialog.kiloCode.actions.copyKiloV7Provider",
+          }),
+        ).toBeEnabled()
+      },
+      { timeout: 5_000 },
+    )
 
     currentAccountData = {
       enabledAccounts: [],
@@ -1583,6 +1605,76 @@ describe("KiloCodeExportDialog", () => {
     expect(writeText).not.toHaveBeenCalled()
     expect(toastSuccessMock).not.toHaveBeenCalled()
     expect(completeProductAnalyticsActionMock).not.toHaveBeenCalled()
+  })
+
+  it("keeps a delayed export action current when a closing render is discarded", async () => {
+    const user = userEvent.setup()
+    const writeText = vi
+      .spyOn(navigator.clipboard, "writeText")
+      .mockResolvedValue(undefined)
+    let resolveSecret: (value: string) => void = () => {}
+    const delayedSecret = new Promise<string>((resolve) => {
+      resolveSecret = resolve
+    })
+    let releaseDiscardedRender: () => void = () => {}
+    const discardedRender = new Promise<void>((resolve) => {
+      releaseDiscardedRender = resolve
+    })
+    mockUseAccountData.mockReturnValue({
+      enabledAccounts: [],
+      enabledDisplayData: [
+        createDisplayAccount({
+          id: "account-a",
+          name: "Site A",
+          baseUrl: "https://a.example.invalid",
+        }),
+      ],
+    })
+    mockFetchAccountTokens.mockResolvedValueOnce([
+      { id: 1, name: "Default", key: "sk-masked********" },
+    ])
+    mockFetchOpenAICompatibleModelIds.mockResolvedValueOnce(["model-a"])
+
+    const { rerender } = render(
+      <Suspense fallback={<div>discarded-render</div>}>
+        <KiloCodeExportDialog
+          isOpen={true}
+          onClose={() => {}}
+          initialSelectedSiteIds={["account-a"]}
+        />
+      </Suspense>,
+    )
+    const copyButton = await screen.findByRole("button", {
+      name: "ui:dialog.kiloCode.actions.copyKiloV7Provider",
+    })
+    await waitFor(() => expect(copyButton).toBeEnabled())
+    mockResolveApiTokenKey.mockClear()
+    mockResolveApiTokenKey.mockReturnValueOnce(delayedSecret)
+
+    await user.click(copyButton)
+    await waitFor(() => expect(mockResolveApiTokenKey).toHaveBeenCalledTimes(1))
+    modalRenderControl.pending = discardedRender
+    rerender(
+      <Suspense fallback={<div>discarded-render</div>}>
+        <KiloCodeExportDialog
+          isOpen={false}
+          onClose={() => {}}
+          initialSelectedSiteIds={["account-a"]}
+        />
+      </Suspense>,
+    )
+    resolveSecret("sk-full-secret")
+    await delayedSecret
+    await act(async () => {})
+
+    expect(writeText).toHaveBeenCalledTimes(1)
+    expect(toastSuccessMock).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      modalRenderControl.pending = null
+      releaseDiscardedRender()
+      await discardedRender
+    })
   })
 
   it("drops a delayed export action when runtime facts change for the same selection ID", async () => {

--- a/tests/components/KiloCodeExportDialog.test.tsx
+++ b/tests/components/KiloCodeExportDialog.test.tsx
@@ -27,7 +27,10 @@ import {
   type DisplaySiteData,
   type SiteAccount,
 } from "~/types"
-import { expectKiloCodeUsageGuidance } from "~~/tests/test-utils/kiloCodeExportGuidance"
+import {
+  expectKiloCodeSettingsSizeGuidance,
+  expectKiloCodeUsageGuidance,
+} from "~~/tests/test-utils/kiloCodeExportGuidance"
 import {
   act,
   render,
@@ -670,7 +673,7 @@ describe("KiloCodeExportDialog", () => {
     const provider = await screen.findByRole("group", {
       name: "Site B - Default",
     })
-    const retry = within(provider).getByRole("button", {
+    const retry = await within(provider).findByRole("button", {
       name: "ui:dialog.kiloCode.actions.retryModels",
     })
     const recoveryControls = retry.parentElement
@@ -1378,6 +1381,533 @@ describe("KiloCodeExportDialog", () => {
     })
   })
 
+  it("keeps discovered provider choices out of manual state while retaining a global custom default", async () => {
+    const user = userEvent.setup()
+    vi.spyOn(navigator.clipboard, "writeText").mockResolvedValue(undefined)
+    mockUseAccountData.mockReturnValue({
+      enabledAccounts: [],
+      enabledDisplayData: [
+        createDisplayAccount({
+          id: "account-a",
+          name: "Site A",
+          baseUrl: "https://a.example.invalid",
+        }),
+      ],
+    })
+    mockFetchAccountTokens.mockResolvedValueOnce([
+      { id: 1, name: "Default", key: "sk-masked********" },
+    ])
+    mockFetchOpenAICompatibleModelIds.mockResolvedValueOnce(["model-a"])
+
+    render(
+      <KiloCodeExportDialog
+        isOpen={true}
+        onClose={() => {}}
+        initialSelectedSiteIds={["account-a"]}
+      />,
+    )
+
+    const provider = await screen.findByRole("group", {
+      name: "Site A - Default",
+    })
+    await waitFor(() => {
+      expect(within(provider).getByText("common:status.success")).toBeVisible()
+    })
+    await chooseProviderModel(user, "Site A - Default", "modelId", "model-a")
+    await user.click(
+      screen.getByRole("button", {
+        name: "ui:dialog.kiloCode.actions.copyKiloV7Provider",
+      }),
+    )
+    expect(mockBuildKiloCodeExportOutput).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        selections: [expect.objectContaining({ manualModelId: undefined })],
+        defaultModel: { selectionId: "account-a:1", modelId: "model-a" },
+      }),
+    )
+
+    await user.click(screen.getByTestId(KILO_CODE_EXPORT_TEST_IDS.defaultModel))
+    const search = screen.getByTestId(
+      KILO_CODE_EXPORT_TEST_IDS.defaultModelSearch,
+    )
+    await user.type(search, "custom/model")
+    await user.click(
+      screen.getByRole("option", {
+        name: "ui:searchableSelect.useValue",
+      }),
+    )
+    await user.click(
+      screen.getByRole("button", {
+        name: "ui:dialog.kiloCode.actions.copyKiloV7Provider",
+      }),
+    )
+
+    expect(mockBuildKiloCodeExportOutput).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        selections: [
+          expect.objectContaining({ manualModelId: "custom/model" }),
+        ],
+        defaultModel: { selectionId: "account-a:1", modelId: "custom/model" },
+      }),
+    )
+  })
+
+  it("drops a delayed export action after the dialog closes", async () => {
+    const user = userEvent.setup()
+    const writeText = vi
+      .spyOn(navigator.clipboard, "writeText")
+      .mockResolvedValue(undefined)
+    let resolveSecret: (value: string) => void = () => {}
+    const delayedSecret = new Promise<string>((resolve) => {
+      resolveSecret = resolve
+    })
+    mockUseAccountData.mockReturnValue({
+      enabledAccounts: [],
+      enabledDisplayData: [
+        createDisplayAccount({
+          id: "account-a",
+          name: "Site A",
+          baseUrl: "https://a.example.invalid",
+        }),
+      ],
+    })
+    mockFetchAccountTokens.mockResolvedValueOnce([
+      { id: 1, name: "Default", key: "sk-masked********" },
+    ])
+    mockFetchOpenAICompatibleModelIds.mockResolvedValueOnce(["model-a"])
+
+    const { rerender } = render(
+      <KiloCodeExportDialog
+        isOpen={true}
+        onClose={() => {}}
+        initialSelectedSiteIds={["account-a"]}
+      />,
+    )
+    const copyButton = await screen.findByRole("button", {
+      name: "ui:dialog.kiloCode.actions.copyKiloV7Provider",
+    })
+    await waitFor(() => expect(copyButton).toBeEnabled())
+    mockResolveApiTokenKey.mockClear()
+    mockResolveApiTokenKey.mockReturnValueOnce(delayedSecret)
+
+    await user.click(copyButton)
+    await waitFor(() => expect(mockResolveApiTokenKey).toHaveBeenCalledTimes(1))
+    rerender(
+      <KiloCodeExportDialog
+        isOpen={false}
+        onClose={() => {}}
+        initialSelectedSiteIds={["account-a"]}
+      />,
+    )
+    resolveSecret("sk-full-secret")
+    await delayedSecret
+    await act(async () => {})
+
+    expect(writeText).not.toHaveBeenCalled()
+    expect(toastSuccessMock).not.toHaveBeenCalled()
+    expect(completeProductAnalyticsActionMock).not.toHaveBeenCalled()
+  })
+
+  it("drops a delayed export action when runtime facts change for the same selection ID", async () => {
+    const user = userEvent.setup()
+    const writeText = vi
+      .spyOn(navigator.clipboard, "writeText")
+      .mockResolvedValue(undefined)
+    let resolveSecret: (value: string) => void = () => {}
+    const delayedSecret = new Promise<string>((resolve) => {
+      resolveSecret = resolve
+    })
+    let currentDisplayData = [
+      createDisplayAccount({
+        id: "account-a",
+        name: "Site A",
+        baseUrl: "https://old.example.invalid",
+      }),
+    ]
+    mockUseAccountData.mockImplementation(() => ({
+      enabledAccounts: [],
+      enabledDisplayData: currentDisplayData,
+    }))
+    mockFetchAccountTokens.mockResolvedValueOnce([
+      { id: 1, name: "Default", key: "sk-masked********" },
+    ])
+    mockFetchOpenAICompatibleModelIds.mockResolvedValue(["model-a"])
+
+    const { rerender } = render(
+      <KiloCodeExportDialog
+        isOpen={true}
+        onClose={() => {}}
+        initialSelectedSiteIds={["account-a"]}
+      />,
+    )
+    const copyButton = await screen.findByRole("button", {
+      name: "ui:dialog.kiloCode.actions.copyKiloV7Provider",
+    })
+    await waitFor(() => expect(copyButton).toBeEnabled())
+    mockResolveApiTokenKey.mockClear()
+    mockResolveApiTokenKey.mockReturnValueOnce(delayedSecret)
+
+    await user.click(copyButton)
+    await waitFor(() => expect(mockResolveApiTokenKey).toHaveBeenCalledTimes(1))
+    currentDisplayData = [
+      createDisplayAccount({
+        id: "account-a",
+        name: "Site A",
+        baseUrl: "https://new.example.invalid",
+      }),
+    ]
+    rerender(
+      <KiloCodeExportDialog
+        isOpen={true}
+        onClose={() => {}}
+        initialSelectedSiteIds={["account-a"]}
+      />,
+    )
+    await waitFor(() => {
+      expect(mockFetchOpenAICompatibleModelIds).toHaveBeenCalledWith(
+        expect.objectContaining({
+          baseUrl: "https://new.example.invalid",
+        }),
+      )
+    })
+    resolveSecret("sk-full-secret")
+    await delayedSecret
+    await act(async () => {})
+
+    expect(writeText).not.toHaveBeenCalled()
+    expect(toastSuccessMock).not.toHaveBeenCalled()
+    expect(completeProductAnalyticsActionMock).not.toHaveBeenCalled()
+  })
+
+  it("drops a delayed export action when the selected token source changes", async () => {
+    const user = userEvent.setup()
+    const writeText = vi
+      .spyOn(navigator.clipboard, "writeText")
+      .mockResolvedValue(undefined)
+    let resolveSecret: (value: string) => void = () => {}
+    const delayedSecret = new Promise<string>((resolve) => {
+      resolveSecret = resolve
+    })
+    mockUseAccountData.mockReturnValue({
+      enabledAccounts: [],
+      enabledDisplayData: [
+        createDisplayAccount({
+          id: "account-a",
+          name: "Site A",
+          baseUrl: "https://a.example.invalid",
+        }),
+      ],
+    })
+    mockFetchAccountTokens
+      .mockResolvedValueOnce([
+        { id: 1, name: "Default", key: "sk-old********" },
+      ])
+      .mockResolvedValueOnce([
+        { id: 1, name: "Default", key: "sk-old********" },
+      ])
+    mockFetchOpenAICompatibleModelIds.mockResolvedValue(["model-a"])
+
+    render(
+      <KiloCodeExportDialog
+        isOpen={true}
+        onClose={() => {}}
+        initialSelectedSiteIds={["account-a"]}
+      />,
+    )
+    const copyButton = await screen.findByRole("button", {
+      name: "ui:dialog.kiloCode.actions.copyKiloV7Provider",
+    })
+    await waitFor(() => expect(copyButton).toBeEnabled())
+    mockResolveApiTokenKey.mockClear()
+    mockResolveApiTokenKey.mockReturnValueOnce(delayedSecret)
+
+    await user.click(copyButton)
+    await waitFor(() => expect(mockResolveApiTokenKey).toHaveBeenCalledTimes(1))
+    await user.click(
+      screen.getByRole("button", { name: "common:actions.refresh" }),
+    )
+    await waitFor(() => expect(mockFetchAccountTokens).toHaveBeenCalledTimes(2))
+
+    resolveSecret("sk-old-full-secret")
+    await delayedSecret
+    await act(async () => {})
+
+    expect(writeText).not.toHaveBeenCalled()
+    expect(toastSuccessMock).not.toHaveBeenCalled()
+    expect(completeProductAnalyticsActionMock).not.toHaveBeenCalled()
+  })
+
+  it("drops a delayed export action when the account authentication source is replaced", async () => {
+    const user = userEvent.setup()
+    const writeText = vi
+      .spyOn(navigator.clipboard, "writeText")
+      .mockResolvedValue(undefined)
+    let resolveSecret: (value: string) => void = () => {}
+    const delayedSecret = new Promise<string>((resolve) => {
+      resolveSecret = resolve
+    })
+    let currentDisplayData = [
+      createDisplayAccount({
+        id: "account-a",
+        name: "Site A",
+        baseUrl: "https://a.example.invalid",
+        token: "old-account-token",
+      }),
+    ]
+    mockUseAccountData.mockImplementation(() => ({
+      enabledAccounts: [],
+      enabledDisplayData: currentDisplayData,
+    }))
+    mockFetchAccountTokens.mockResolvedValueOnce([
+      { id: 1, name: "Default", key: "sk-masked********" },
+    ])
+    mockFetchOpenAICompatibleModelIds.mockResolvedValue(["model-a"])
+
+    const { rerender } = render(
+      <KiloCodeExportDialog
+        isOpen={true}
+        onClose={() => {}}
+        initialSelectedSiteIds={["account-a"]}
+      />,
+    )
+    const copyButton = await screen.findByRole("button", {
+      name: "ui:dialog.kiloCode.actions.copyKiloV7Provider",
+    })
+    await waitFor(() => expect(copyButton).toBeEnabled())
+    mockResolveApiTokenKey.mockClear()
+    mockResolveApiTokenKey.mockReturnValueOnce(delayedSecret)
+
+    await user.click(copyButton)
+    await waitFor(() => expect(mockResolveApiTokenKey).toHaveBeenCalledTimes(1))
+    currentDisplayData = [
+      createDisplayAccount({
+        id: "account-a",
+        name: "Site A",
+        baseUrl: "https://a.example.invalid",
+        token: "old-account-token",
+      }),
+    ]
+    rerender(
+      <KiloCodeExportDialog
+        isOpen={true}
+        onClose={() => {}}
+        initialSelectedSiteIds={["account-a"]}
+      />,
+    )
+
+    resolveSecret("sk-full-secret")
+    await delayedSecret
+    await act(async () => {})
+
+    expect(writeText).not.toHaveBeenCalled()
+    expect(toastSuccessMock).not.toHaveBeenCalled()
+    expect(completeProductAnalyticsActionMock).not.toHaveBeenCalled()
+  })
+
+  it("drops a delayed export action when retry discovers a newer model catalog", async () => {
+    const user = userEvent.setup()
+    const writeText = vi
+      .spyOn(navigator.clipboard, "writeText")
+      .mockResolvedValue(undefined)
+    let resolveSecret: (value: string) => void = () => {}
+    const delayedSecret = new Promise<string>((resolve) => {
+      resolveSecret = resolve
+    })
+    mockUseAccountData.mockReturnValue({
+      enabledAccounts: [],
+      enabledDisplayData: [
+        createDisplayAccount({
+          id: "account-a",
+          name: "Site A",
+          baseUrl: "https://a.example.invalid",
+        }),
+      ],
+    })
+    mockFetchAccountTokens.mockResolvedValueOnce([
+      { id: 1, name: "Default", key: "sk-masked********" },
+    ])
+    mockFetchOpenAICompatibleModelIds
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce(["discovered/model"])
+
+    render(
+      <KiloCodeExportDialog
+        isOpen={true}
+        onClose={() => {}}
+        initialSelectedSiteIds={["account-a"]}
+      />,
+    )
+
+    const providerName = "Site A - Default"
+    const provider = await screen.findByRole("group", { name: providerName })
+    const retry = await within(provider).findByRole("button", {
+      name: "ui:dialog.kiloCode.actions.retryModels",
+    })
+    await chooseProviderModel(user, providerName, "modelId", "manual/model")
+    await chooseKiloCodeExportTarget(user, "legacy")
+    await chooseProviderModel(
+      user,
+      providerName,
+      "legacyModelId",
+      "legacy/manual",
+    )
+    await chooseKiloCodeExportTarget(user, "kiloV7")
+    const copyButton = screen.getByRole("button", {
+      name: "ui:dialog.kiloCode.actions.copyKiloV7Provider",
+    })
+    await waitFor(() => expect(copyButton).toBeEnabled())
+    mockResolveApiTokenKey.mockClear()
+    mockResolveApiTokenKey.mockReturnValueOnce(delayedSecret)
+
+    await user.click(copyButton)
+    await waitFor(() => expect(mockResolveApiTokenKey).toHaveBeenCalledTimes(1))
+    await user.click(retry)
+    await waitFor(() => {
+      expect(mockFetchOpenAICompatibleModelIds).toHaveBeenCalledTimes(2)
+    })
+    await within(provider).findByText("common:status.success")
+
+    resolveSecret("sk-full-secret")
+    await delayedSecret
+    await act(async () => {})
+
+    expect(writeText).not.toHaveBeenCalled()
+    expect(toastSuccessMock).not.toHaveBeenCalled()
+    expect(completeProductAnalyticsActionMock).not.toHaveBeenCalled()
+  })
+
+  it("drops a delayed legacy export action when the effective profile changes", async () => {
+    const user = userEvent.setup()
+    const writeText = vi
+      .spyOn(navigator.clipboard, "writeText")
+      .mockResolvedValue(undefined)
+    let resolveSecret: (value: string) => void = () => {}
+    const delayedSecret = new Promise<string>((resolve) => {
+      resolveSecret = resolve
+    })
+    mockUseAccountData.mockReturnValue({
+      enabledAccounts: [],
+      enabledDisplayData: [
+        createDisplayAccount({
+          id: "account-a",
+          name: "Site A",
+          baseUrl: "https://a.example.invalid",
+        }),
+      ],
+    })
+    mockFetchAccountTokens.mockResolvedValueOnce([
+      { id: 1, name: "First", key: "sk-first********" },
+      { id: 2, name: "Second", key: "sk-second********" },
+    ])
+    mockFetchOpenAICompatibleModelIds.mockResolvedValue(["model-a"])
+
+    render(
+      <KiloCodeExportDialog
+        isOpen={true}
+        onClose={() => {}}
+        initialSelectedSiteIds={["account-a"]}
+        initialSelectedTokenIdsBySite={{ "account-a": ["1", "2"] }}
+      />,
+    )
+
+    await screen.findByRole("combobox", {
+      name: "ui:dialog.kiloCode.labels.exportTarget",
+    })
+    await waitFor(() => {
+      expect(mockFetchOpenAICompatibleModelIds).toHaveBeenCalledTimes(2)
+    })
+    await chooseKiloCodeExportTarget(user, "legacy")
+    const copyButton = await screen.findByRole("button", {
+      name: "ui:dialog.kiloCode.actions.copyLegacyApiConfigs",
+    })
+    await waitFor(() => expect(copyButton).toBeEnabled())
+    mockResolveApiTokenKey.mockClear()
+    mockResolveApiTokenKey.mockReturnValue(delayedSecret)
+
+    await user.click(copyButton)
+    await waitFor(() => expect(mockResolveApiTokenKey).toHaveBeenCalledTimes(2))
+    const currentProfileSelect = screen
+      .getAllByRole("combobox")
+      .find((element) => element.textContent === "Site A - First")
+    expect(currentProfileSelect).toBeDefined()
+    await user.click(currentProfileSelect!)
+    await user.click(
+      await screen.findByRole("option", { name: "Site A - Second" }),
+    )
+
+    resolveSecret("sk-full-secret")
+    await delayedSecret
+    await act(async () => {})
+
+    expect(writeText).not.toHaveBeenCalled()
+    expect(toastSuccessMock).not.toHaveBeenCalled()
+    expect(completeProductAnalyticsActionMock).not.toHaveBeenCalled()
+  })
+
+  it("drops a delayed oversized download after the export target changes", async () => {
+    const user = userEvent.setup()
+    const createObjectUrl = vi.spyOn(URL, "createObjectURL")
+    let resolveSecret: (value: string) => void = () => {}
+    const delayedSecret = new Promise<string>((resolve) => {
+      resolveSecret = resolve
+    })
+    mockUseAccountData.mockReturnValue({
+      enabledAccounts: [],
+      enabledDisplayData: [
+        createDisplayAccount({
+          id: "account-a",
+          name: "Site A",
+          baseUrl: "https://a.example.invalid",
+        }),
+      ],
+    })
+    mockFetchAccountTokens.mockResolvedValueOnce([
+      { id: 1, name: "Default", key: "sk-masked********" },
+    ])
+    mockFetchOpenAICompatibleModelIds.mockResolvedValueOnce(["model-a"])
+    mockBuildKiloCodeExportOutput.mockReturnValueOnce({
+      filename: "kilo-settings.json",
+      copyPayload: {},
+      downloadPayload: {},
+      downloadJson: "{}",
+      isDownloadTooLarge: true,
+      itemCount: 1,
+      modelCount: 1,
+    })
+
+    render(
+      <KiloCodeExportDialog
+        isOpen={true}
+        onClose={() => {}}
+        initialSelectedSiteIds={["account-a"]}
+      />,
+    )
+    const downloadButton = await screen.findByRole("button", {
+      name: "ui:dialog.kiloCode.actions.downloadKiloV7Settings",
+    })
+    await waitFor(() => expect(downloadButton).toBeEnabled())
+    mockResolveApiTokenKey.mockClear()
+    mockResolveApiTokenKey.mockReturnValueOnce(delayedSecret)
+
+    await user.click(downloadButton)
+    await waitFor(() => expect(mockResolveApiTokenKey).toHaveBeenCalledTimes(1))
+    await chooseKiloCodeExportTarget(user, "legacy")
+    resolveSecret("sk-full-secret")
+    await delayedSecret
+    await act(async () => {})
+
+    expect(createObjectUrl).not.toHaveBeenCalled()
+    expect(
+      screen.queryByText(
+        "ui:dialog.kiloCode.messages.settingsFileTooLargeMultiple",
+      ),
+    ).not.toBeInTheDocument()
+    expect(toastSuccessMock).not.toHaveBeenCalled()
+    expect(toastErrorMock).not.toHaveBeenCalled()
+    expect(completeProductAnalyticsActionMock).not.toHaveBeenCalled()
+    createObjectUrl.mockRestore()
+  })
+
   it("unions a manual provider model across retry and repairs focus/default after Remove", async () => {
     const user = userEvent.setup()
     vi.spyOn(navigator.clipboard, "writeText").mockResolvedValue(undefined)
@@ -1408,7 +1938,7 @@ describe("KiloCodeExportDialog", () => {
 
     const providerName = "Site B - Default"
     const provider = await screen.findByRole("group", { name: providerName })
-    const retry = within(provider).getByRole("button", {
+    const retry = await within(provider).findByRole("button", {
       name: "ui:dialog.kiloCode.actions.retryModels",
     })
     await chooseProviderModel(user, providerName, "modelId", "manual/model")
@@ -1821,11 +2351,10 @@ describe("KiloCodeExportDialog", () => {
     await waitFor(() => expect(download).toBeEnabled())
     await user.click(download)
 
-    expect(
-      await screen.findByText(
-        "ui:dialog.kiloCode.messages.settingsFileTooLargeMultiple",
-      ),
-    ).toBeVisible()
+    await screen.findByText(
+      "ui:dialog.kiloCode.messages.settingsFileTooLargeMultiple",
+    )
+    expectKiloCodeSettingsSizeGuidance("multiple")
     expect(createObjectUrl).not.toHaveBeenCalled()
     expect(clickSpy).not.toHaveBeenCalled()
     expect(

--- a/tests/components/kiloCodeAccountExport.test.ts
+++ b/tests/components/kiloCodeAccountExport.test.ts
@@ -107,4 +107,34 @@ describe("resolveKiloCodeAccountExportOutput", () => {
       currentLegacyProfileName: "Prepared site - Prepared token",
     })
   })
+
+  it("rejects an export when its transient secret source is unavailable", async () => {
+    const selection: KiloCodeV7ProviderSelection = {
+      accountId: "account-a",
+      siteName: "Example",
+      baseUrl: "https://api.example.invalid",
+      tokenId: 7,
+      tokenName: "Default",
+      tokenKey: "masked-key",
+      selectionId: "missing-source",
+      providerName: "Example - Default",
+      discoveredModelIds: ["example-model"],
+    }
+    const resolveToken = vi.fn()
+
+    await expect(
+      resolveKiloCodeAccountExportOutput({
+        target: KILO_CODE_EXPORT_TARGETS.KiloV7,
+        selections: [selection],
+        secretSourcesBySelectionId: new Map(),
+        defaultModel: {
+          selectionId: selection.selectionId,
+          modelId: "example-model",
+        },
+        resolveToken,
+      }),
+    ).rejects.toThrow("Kilo Code export selection source is unavailable")
+    expect(resolveToken).not.toHaveBeenCalled()
+    expect(buildKiloCodeExportOutputMock).not.toHaveBeenCalled()
+  })
 })

--- a/tests/components/kiloCodeAccountExport.test.ts
+++ b/tests/components/kiloCodeAccountExport.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+  resolveKiloCodeAccountExportOutput,
+  type KiloCodeAccountLegacySelection,
+} from "~/components/kiloCodeAccountExport"
+import {
+  KILO_CODE_EXPORT_TARGETS,
+  type KiloCodeV7ProviderSelection,
+} from "~/services/integrations/kiloCodeExport"
+import type { ApiToken, DisplaySiteData } from "~/types"
+
+const buildKiloCodeExportOutputMock = vi.hoisted(() => vi.fn())
+
+vi.mock("~/services/integrations/kiloCodeExportPolicy", () => ({
+  buildKiloCodeExportOutput: (...args: unknown[]) =>
+    buildKiloCodeExportOutputMock(...args),
+}))
+
+const site = { id: "account-a" } as DisplaySiteData
+const token = { id: 7, key: "masked-key" } as ApiToken
+
+describe("resolveKiloCodeAccountExportOutput", () => {
+  beforeEach(() => {
+    buildKiloCodeExportOutputMock.mockReset()
+    buildKiloCodeExportOutputMock.mockReturnValue({ target: "test-output" })
+  })
+
+  it("preserves canonical V7 selection facts verbatim while replacing only tokenKey", async () => {
+    const discoveredModelIds = ["z-model", " model/already-canonical "]
+    const selection: KiloCodeV7ProviderSelection = {
+      accountId: "account-a",
+      siteName: "Prepared site",
+      baseUrl: "https://api.example.invalid",
+      tokenId: 7,
+      tokenName: "Prepared token",
+      tokenKey: "masked-key",
+      selectionId: "opaque-selection-id",
+      providerName: "Prepared provider (disambiguated)",
+      discoveredModelIds,
+      manualModelId: " manual/already-canonical ",
+    }
+    const resolveToken = vi.fn().mockResolvedValue({
+      ...token,
+      key: "resolved-secret",
+    })
+
+    await resolveKiloCodeAccountExportOutput({
+      target: KILO_CODE_EXPORT_TARGETS.KiloV7,
+      selections: [selection],
+      secretSourcesBySelectionId: new Map([
+        [selection.selectionId, { site, token }],
+      ]),
+      defaultModel: {
+        selectionId: selection.selectionId,
+        modelId: "model/already-canonical",
+      },
+      resolveToken,
+    })
+
+    expect(resolveToken).toHaveBeenCalledTimes(1)
+    expect(resolveToken).toHaveBeenCalledWith(site, token)
+    expect(buildKiloCodeExportOutputMock).toHaveBeenCalledWith({
+      target: KILO_CODE_EXPORT_TARGETS.KiloV7,
+      selections: [{ ...selection, tokenKey: "resolved-secret" }],
+      defaultModel: {
+        selectionId: selection.selectionId,
+        modelId: "model/already-canonical",
+      },
+    })
+    const resolvedSelection = buildKiloCodeExportOutputMock.mock.calls[0]?.[0]
+      ?.selections[0] as KiloCodeV7ProviderSelection
+    expect(resolvedSelection.discoveredModelIds).toBe(discoveredModelIds)
+    expect(resolvedSelection.manualModelId).toBe(selection.manualModelId)
+  })
+
+  it("preserves canonical legacy facts while resolving each selection exactly once", async () => {
+    const selection: KiloCodeAccountLegacySelection = {
+      accountId: "account-a",
+      siteName: "Prepared site",
+      baseUrl: "https://api.example.invalid",
+      tokenId: 7,
+      tokenName: "Prepared token",
+      tokenKey: "masked-key",
+      selectionId: "opaque-selection-id",
+      legacyModelId: " legacy/already-canonical ",
+    }
+    const resolveToken = vi.fn().mockResolvedValue({
+      ...token,
+      key: "resolved-secret",
+    })
+
+    await resolveKiloCodeAccountExportOutput({
+      target: KILO_CODE_EXPORT_TARGETS.Legacy,
+      selections: [selection],
+      secretSourcesBySelectionId: new Map([
+        [selection.selectionId, { site, token }],
+      ]),
+      currentLegacyProfileName: "Prepared site - Prepared token",
+      resolveToken,
+    })
+
+    expect(resolveToken).toHaveBeenCalledTimes(1)
+    expect(buildKiloCodeExportOutputMock).toHaveBeenCalledWith({
+      target: KILO_CODE_EXPORT_TARGETS.Legacy,
+      selections: [{ ...selection, tokenKey: "resolved-secret" }],
+      currentLegacyProfileName: "Prepared site - Prepared token",
+    })
+  })
+})

--- a/tests/components/useKiloCodeAccountModelDiscovery.test.tsx
+++ b/tests/components/useKiloCodeAccountModelDiscovery.test.tsx
@@ -1,0 +1,167 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import type { KiloCodeAccountExportSelection } from "~/components/kiloCodeAccountExport"
+import { useKiloCodeAccountModelDiscovery } from "~/components/useKiloCodeAccountModelDiscovery"
+import { SITE_TYPES } from "~/constants/siteType"
+import { AuthTypeEnum, type ApiToken, type DisplaySiteData } from "~/types"
+import { act, renderHook, waitFor } from "~~/tests/test-utils/render"
+
+const resolveExportTokenForSecretMock = vi.fn()
+const fetchOpenAICompatibleModelIdsMock = vi.fn()
+
+vi.mock("~/services/accounts/utils/exportTokenSecret", () => ({
+  resolveExportTokenForSecret: (...args: unknown[]) =>
+    resolveExportTokenForSecretMock(...args),
+}))
+
+vi.mock("~/services/aiApi/openaiCompatible", () => ({
+  fetchOpenAICompatibleModelIds: (...args: unknown[]) =>
+    fetchOpenAICompatibleModelIdsMock(...args),
+}))
+
+function createSelection({
+  baseUrl,
+  tokenKey,
+  accountAccessToken,
+}: {
+  baseUrl: string
+  tokenKey: string
+  accountAccessToken: string
+}): KiloCodeAccountExportSelection {
+  const site = {
+    id: "account-a",
+    name: "Example",
+    siteType: SITE_TYPES.UNKNOWN,
+    baseUrl,
+    authType: AuthTypeEnum.AccessToken,
+    userId: "user-a",
+    token: accountAccessToken,
+  } as DisplaySiteData
+  const token = {
+    id: 7,
+    name: "Default",
+    key: tokenKey,
+  } as ApiToken
+
+  return {
+    selectionId: "account-a:7",
+    site,
+    token,
+    providerName: "Example - Default",
+    runtimeKey: {
+      accountId: site.id,
+      siteName: site.name,
+      baseUrl,
+      tokenId: token.id,
+      tokenName: token.name,
+      tokenKey,
+    },
+  }
+}
+
+describe("useKiloCodeAccountModelDiscovery", () => {
+  beforeEach(() => {
+    resolveExportTokenForSecretMock.mockReset()
+    resolveExportTokenForSecretMock.mockImplementation(
+      async (_site: DisplaySiteData, token: ApiToken) => token,
+    )
+    fetchOpenAICompatibleModelIdsMock.mockReset()
+  })
+
+  it("reloads the same selection ID when primitive runtime source facts change and ignores the old result", async () => {
+    let resolveOld: ((modelIds: string[]) => void) | undefined
+    let resolveNew: ((modelIds: string[]) => void) | undefined
+    const oldModels = new Promise<string[]>((resolve) => {
+      resolveOld = resolve
+    })
+    const newModels = new Promise<string[]>((resolve) => {
+      resolveNew = resolve
+    })
+    fetchOpenAICompatibleModelIdsMock
+      .mockReturnValueOnce(oldModels)
+      .mockReturnValueOnce(newModels)
+    const oldSelection = createSelection({
+      baseUrl: "https://old.example.invalid",
+      tokenKey: "old-runtime-key",
+      accountAccessToken: "old-account-token",
+    })
+    const newSelection = createSelection({
+      baseUrl: "https://new.example.invalid",
+      tokenKey: "new-runtime-key",
+      accountAccessToken: "new-account-token",
+    })
+
+    const { result, rerender } = renderHook(
+      ({ selections }) =>
+        useKiloCodeAccountModelDiscovery({
+          isOpen: true,
+          selections,
+        }),
+      { initialProps: { selections: [oldSelection] } },
+    )
+    await waitFor(() => {
+      expect(fetchOpenAICompatibleModelIdsMock).toHaveBeenCalledTimes(1)
+    })
+
+    rerender({ selections: [newSelection] })
+    await waitFor(() => {
+      expect(fetchOpenAICompatibleModelIdsMock).toHaveBeenCalledTimes(2)
+    })
+    expect(fetchOpenAICompatibleModelIdsMock).toHaveBeenLastCalledWith({
+      baseUrl: "https://new.example.invalid",
+      apiKey: "new-runtime-key",
+    })
+
+    await act(async () => {
+      resolveOld?.(["old-model"])
+      await oldModels
+    })
+    expect(result.current.v7Selections[0]?.discoveredModelIds).toEqual([])
+
+    await act(async () => {
+      resolveNew?.(["new-model"])
+      await newModels
+    })
+    await waitFor(() => {
+      expect(result.current.v7Selections[0]).toMatchObject({
+        baseUrl: "https://new.example.invalid",
+        tokenKey: "new-runtime-key",
+        discoveredModelIds: ["new-model"],
+      })
+    })
+  })
+
+  it("invalidates a pending generation on unmount without post-unmount errors", async () => {
+    let resolveModels: ((modelIds: string[]) => void) | undefined
+    const models = new Promise<string[]>((resolve) => {
+      resolveModels = resolve
+    })
+    fetchOpenAICompatibleModelIdsMock.mockReturnValueOnce(models)
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {})
+    const selection = createSelection({
+      baseUrl: "https://api.example.invalid",
+      tokenKey: "runtime-key",
+      accountAccessToken: "account-token",
+    })
+
+    const selections = [selection]
+    const { unmount } = renderHook(() =>
+      useKiloCodeAccountModelDiscovery({
+        isOpen: true,
+        selections,
+      }),
+    )
+    await waitFor(() => {
+      expect(fetchOpenAICompatibleModelIdsMock).toHaveBeenCalledTimes(1)
+    })
+
+    unmount()
+    await act(async () => {
+      resolveModels?.(["late-model"])
+      await models
+    })
+
+    expect(consoleError).not.toHaveBeenCalled()
+    consoleError.mockRestore()
+  })
+})

--- a/tests/components/useKiloCodeAccountModelDiscovery.test.tsx
+++ b/tests/components/useKiloCodeAccountModelDiscovery.test.tsx
@@ -164,4 +164,48 @@ describe("useKiloCodeAccountModelDiscovery", () => {
     expect(consoleError).not.toHaveBeenCalled()
     consoleError.mockRestore()
   })
+
+  it("stores only custom provider and global-default models as manual catalog entries", async () => {
+    fetchOpenAICompatibleModelIdsMock.mockResolvedValueOnce([
+      "model-b",
+      "model-a",
+    ])
+    const selection = createSelection({
+      baseUrl: "https://api.example.invalid",
+      tokenKey: "runtime-key",
+      accountAccessToken: "account-token",
+    })
+
+    const { result } = renderHook(() =>
+      useKiloCodeAccountModelDiscovery({
+        isOpen: true,
+        selections: [selection],
+      }),
+    )
+    await waitFor(() => {
+      expect(result.current.preparedCatalog?.providers[0]?.modelIds).toEqual([
+        "model-a",
+        "model-b",
+      ])
+    })
+
+    act(() => {
+      result.current.selectV7ManualModel(selection.selectionId, "model-b")
+    })
+    expect(result.current.v7Selections[0]?.manualModelId).toBeUndefined()
+
+    act(() => {
+      result.current.selectV7ManualModel(selection.selectionId, "custom/row")
+    })
+    expect(result.current.v7Selections[0]?.manualModelId).toBe("custom/row")
+
+    act(() => {
+      result.current.selectV7DefaultModel("custom/default")
+    })
+    expect(result.current.v7DefaultModel).toEqual({
+      selectionId: selection.selectionId,
+      modelId: "custom/default",
+    })
+    expect(result.current.v7Selections[0]?.manualModelId).toBe("custom/default")
+  })
 })

--- a/tests/components/useKiloCodeAccountModelDiscovery.test.tsx
+++ b/tests/components/useKiloCodeAccountModelDiscovery.test.tsx
@@ -208,4 +208,44 @@ describe("useKiloCodeAccountModelDiscovery", () => {
     })
     expect(result.current.v7Selections[0]?.manualModelId).toBe("custom/default")
   })
+
+  it("keeps the discovered catalog when changing the V7 provider protocol", async () => {
+    fetchOpenAICompatibleModelIdsMock.mockResolvedValueOnce([
+      "model-b",
+      "model-a",
+    ])
+    const selection = createSelection({
+      baseUrl: "https://api.example.invalid",
+      tokenKey: "runtime-key",
+      accountAccessToken: "account-token",
+    })
+
+    const { result } = renderHook(() =>
+      useKiloCodeAccountModelDiscovery({
+        isOpen: true,
+        selections: [selection],
+      }),
+    )
+
+    await waitFor(() => {
+      expect(result.current.v7Selections[0]?.discoveredModelIds).toEqual([
+        "model-a",
+        "model-b",
+      ])
+    })
+    expect(result.current.v7Selections[0]?.protocol).toBe("openai-compatible")
+
+    act(() => {
+      result.current.selectV7Protocol(
+        selection.selectionId,
+        "anthropic-messages",
+      )
+    })
+
+    expect(result.current.v7Selections[0]).toMatchObject({
+      protocol: "anthropic-messages",
+      discoveredModelIds: ["model-a", "model-b"],
+    })
+    expect(fetchOpenAICompatibleModelIdsMock).toHaveBeenCalledTimes(1)
+  })
 })

--- a/tests/features/ApiCredentialProfiles/components/KiloCodeProfileExportDialog.test.tsx
+++ b/tests/features/ApiCredentialProfiles/components/KiloCodeProfileExportDialog.test.tsx
@@ -14,7 +14,10 @@ import {
   PRODUCT_ANALYTICS_SURFACE_IDS,
 } from "~/services/productAnalytics/contracts"
 import { API_TYPES } from "~/services/verification/aiApiVerification"
-import { expectKiloCodeUsageGuidance } from "~~/tests/test-utils/kiloCodeExportGuidance"
+import {
+  expectKiloCodeSettingsSizeGuidance,
+  expectKiloCodeUsageGuidance,
+} from "~~/tests/test-utils/kiloCodeExportGuidance"
 import { act, render, screen, waitFor } from "~~/tests/test-utils/render"
 
 const mockFetchOpenAICompatibleModelIds = vi.fn()
@@ -207,6 +210,7 @@ describe("KiloCodeProfileExportDialog", () => {
       name: "ui:dialog.kiloCode.actions.copyKiloV7Provider",
     })
     await waitFor(() => expect(copyButton).toBeEnabled())
+    expectKiloCodeUsageGuidance(KILO_CODE_EXPORT_TARGETS.KiloV7)
     expect(
       screen.getByRole("combobox", {
         name: "ui:dialog.kiloCode.labels.defaultModel",
@@ -764,11 +768,7 @@ describe("KiloCodeProfileExportDialog", () => {
 
     expect(createObjectURLSpy).not.toHaveBeenCalled()
     expect(clickSpy).not.toHaveBeenCalled()
-    expect(
-      screen.getByText(
-        "ui:dialog.kiloCode.messages.settingsFileTooLargeSingle",
-      ),
-    ).toBeVisible()
+    expectKiloCodeSettingsSizeGuidance("single")
     expect(
       screen.getByRole("button", {
         name: "ui:dialog.kiloCode.actions.copyKiloV7Provider",

--- a/tests/features/ApiCredentialProfiles/components/KiloCodeProfileExportDialog.test.tsx
+++ b/tests/features/ApiCredentialProfiles/components/KiloCodeProfileExportDialog.test.tsx
@@ -87,6 +87,22 @@ async function chooseExportTarget(
   )
 }
 
+async function chooseV7ProviderProtocol(
+  user: ReturnType<typeof userEvent.setup>,
+  protocol: "openAICompatible" | "openAIResponses" | "anthropicMessages",
+) {
+  await user.click(
+    screen.getByRole("combobox", {
+      name: "ui:dialog.kiloCode.labels.providerProtocol",
+    }),
+  )
+  await user.click(
+    await screen.findByRole("option", {
+      name: `ui:dialog.kiloCode.protocols.${protocol}`,
+    }),
+  )
+}
+
 async function chooseV7Model(
   user: ReturnType<typeof userEvent.setup>,
   modelId: string,
@@ -235,6 +251,7 @@ describe("KiloCodeProfileExportDialog", () => {
           tokenKey: "sk-secret",
           selectionId: "profile:profile-1",
           providerName: "Reusable Key",
+          protocol: "openai-compatible",
           discoveredModelIds: ["a-model", "z-model"],
           manualModelId: undefined,
         },
@@ -269,6 +286,44 @@ describe("KiloCodeProfileExportDialog", () => {
         },
       },
     )
+  })
+
+  it("selects the V7 provider protocol without reloading the adapter model catalog", async () => {
+    const user = userEvent.setup()
+    vi.spyOn(navigator.clipboard, "writeText").mockResolvedValue(undefined)
+    mockFetchOpenAICompatibleModelIds.mockResolvedValueOnce(["model-a"])
+
+    renderDialog()
+
+    const protocolSelect = await screen.findByRole("combobox", {
+      name: "ui:dialog.kiloCode.labels.providerProtocol",
+    })
+    expect(protocolSelect).toHaveTextContent(
+      "ui:dialog.kiloCode.protocols.openAICompatible",
+    )
+    await screen.findByText("model-a")
+
+    await chooseV7ProviderProtocol(user, "openAIResponses")
+    await user.click(
+      screen.getByRole("button", {
+        name: "ui:dialog.kiloCode.actions.copyKiloV7Provider",
+      }),
+    )
+
+    expect(mockFetchOpenAICompatibleModelIds).toHaveBeenCalledTimes(1)
+    expect(mockBuildKiloCodeExportOutput).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        target: KILO_CODE_EXPORT_TARGETS.KiloV7,
+        selections: [expect.objectContaining({ protocol: "openai-responses" })],
+      }),
+    )
+
+    await chooseExportTarget(user, "legacy")
+    expect(
+      screen.queryByRole("combobox", {
+        name: "ui:dialog.kiloCode.labels.providerProtocol",
+      }),
+    ).not.toBeInTheDocument()
   })
 
   it("uses target-specific model labels", async () => {

--- a/tests/features/ApiCredentialProfiles/components/KiloCodeProfileExportDialog.test.tsx
+++ b/tests/features/ApiCredentialProfiles/components/KiloCodeProfileExportDialog.test.tsx
@@ -1,6 +1,7 @@
 import userEvent from "@testing-library/user-event"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
+import { KILO_CODE_EXPORT_TEST_IDS } from "~/components/kiloCodeExportTestIds"
 import { KiloCodeProfileExportDialog } from "~/features/ApiCredentialProfiles/components/KiloCodeProfileExportDialog"
 import { KILO_CODE_EXPORT_TARGETS } from "~/services/integrations/kiloCodeExport"
 import {
@@ -14,7 +15,7 @@ import {
 } from "~/services/productAnalytics/contracts"
 import { API_TYPES } from "~/services/verification/aiApiVerification"
 import { expectKiloCodeUsageGuidance } from "~~/tests/test-utils/kiloCodeExportGuidance"
-import { render, screen, waitFor } from "~~/tests/test-utils/render"
+import { act, render, screen, waitFor } from "~~/tests/test-utils/render"
 
 const mockFetchOpenAICompatibleModelIds = vi.fn()
 const mockBuildKiloCodeExportOutput = vi.fn()
@@ -45,18 +46,6 @@ vi.mock("~/services/productAnalytics/actions", () => ({
     startProductAnalyticsActionMock(...args),
 }))
 
-const expectApiCredentialProfileActionStarted = (
-  actionId: (typeof PRODUCT_ANALYTICS_ACTION_IDS)[keyof typeof PRODUCT_ANALYTICS_ACTION_IDS],
-) => {
-  expect(startProductAnalyticsActionMock).toHaveBeenCalledWith({
-    featureId: PRODUCT_ANALYTICS_FEATURE_IDS.ApiCredentialProfiles,
-    actionId,
-    surfaceId:
-      PRODUCT_ANALYTICS_SURFACE_IDS.OptionsApiCredentialProfilesExportDialog,
-    entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Options,
-  })
-}
-
 const PROFILE = {
   id: "profile-1",
   name: "Reusable Key",
@@ -68,6 +57,85 @@ const PROFILE = {
   createdAt: 1,
   updatedAt: 2,
 } as any
+
+function renderDialog(profile = PROFILE) {
+  return render(
+    <KiloCodeProfileExportDialog
+      isOpen={true}
+      onClose={() => {}}
+      profile={profile}
+    />,
+  )
+}
+
+async function chooseExportTarget(
+  user: ReturnType<typeof userEvent.setup>,
+  target: "kiloV7" | "legacy",
+) {
+  await user.click(
+    screen.getByRole("combobox", {
+      name: "ui:dialog.kiloCode.labels.exportTarget",
+    }),
+  )
+  await user.click(
+    await screen.findByRole("option", {
+      name: `ui:dialog.kiloCode.targets.${target}`,
+    }),
+  )
+}
+
+async function chooseV7Model(
+  user: ReturnType<typeof userEvent.setup>,
+  modelId: string,
+) {
+  await user.click(
+    screen.getByRole("combobox", {
+      name: "ui:dialog.kiloCode.labels.defaultModel",
+    }),
+  )
+  const search = screen.getByTestId(
+    KILO_CODE_EXPORT_TEST_IDS.defaultModelSearch,
+  )
+  await user.clear(search)
+  await user.type(search, modelId)
+  const exactOption = screen.queryByRole("option", { name: modelId })
+  await user.click(
+    exactOption ??
+      screen.getByRole("option", { name: "ui:searchableSelect.useValue" }),
+  )
+}
+
+async function chooseLegacyModel(
+  user: ReturnType<typeof userEvent.setup>,
+  modelId: string,
+) {
+  await user.click(
+    screen.getByRole("combobox", {
+      name: "ui:dialog.kiloCode.labels.legacyModelId",
+    }),
+  )
+  const search = screen.getByPlaceholderText(
+    "ui:searchableSelect.searchPlaceholder",
+  )
+  await user.clear(search)
+  await user.type(search, modelId)
+  await user.click(
+    screen.queryByRole("option", { name: modelId }) ??
+      screen.getByRole("option", { name: "ui:searchableSelect.useValue" }),
+  )
+}
+
+const expectApiCredentialProfileActionStarted = (
+  actionId: (typeof PRODUCT_ANALYTICS_ACTION_IDS)[keyof typeof PRODUCT_ANALYTICS_ACTION_IDS],
+) => {
+  expect(startProductAnalyticsActionMock).toHaveBeenCalledWith({
+    featureId: PRODUCT_ANALYTICS_FEATURE_IDS.ApiCredentialProfiles,
+    actionId,
+    surfaceId:
+      PRODUCT_ANALYTICS_SURFACE_IDS.OptionsApiCredentialProfilesExportDialog,
+    entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Options,
+  })
+}
 
 describe("KiloCodeProfileExportDialog", () => {
   beforeEach(() => {
@@ -81,163 +149,116 @@ describe("KiloCodeProfileExportDialog", () => {
       complete: completeProductAnalyticsActionMock,
     })
 
-    mockBuildKiloCodeExportOutput.mockImplementation(
-      ({ target, selections }: any) =>
-        target === KILO_CODE_EXPORT_TARGETS.KiloV7
-          ? {
-              filename: "kilo-settings.json",
-              copyPayload: { v7: selections[0]?.modelId },
-              downloadPayload: { format: "v7", model: selections[0]?.modelId },
-              itemCount: 1,
-            }
-          : {
-              filename: "kilo-code-settings.json",
-              copyPayload: { legacy: selections[0]?.modelId },
-              downloadPayload: {
-                format: "legacy",
-                model: selections[0]?.modelId,
-              },
-              itemCount: 1,
-            },
-    )
+    mockBuildKiloCodeExportOutput.mockImplementation((options: any) => {
+      if (options.target === KILO_CODE_EXPORT_TARGETS.KiloV7) {
+        const downloadPayload = {
+          format: "v7",
+          model: options.defaultModel?.modelId,
+        }
+        return {
+          target: KILO_CODE_EXPORT_TARGETS.KiloV7,
+          filename: "kilo-settings.json",
+          copyPayload: {
+            provider: { "reusable-key": { models: {} } },
+            model: options.defaultModel?.modelId,
+          },
+          downloadPayload,
+          downloadJson: JSON.stringify(downloadPayload, null, 2),
+          downloadByteLength: 42,
+          isDownloadTooLarge: false,
+          itemCount: 1,
+          modelCount: 7,
+        }
+      }
+
+      const downloadPayload = {
+        format: "legacy",
+        model: options.selections[0]?.legacyModelId,
+      }
+      return {
+        target: KILO_CODE_EXPORT_TARGETS.Legacy,
+        filename: "kilo-code-settings.json",
+        copyPayload: { legacy: options.selections[0]?.legacyModelId },
+        downloadPayload,
+        downloadJson: JSON.stringify(downloadPayload, null, 2),
+        downloadByteLength: 43,
+        isDownloadTooLarge: false,
+        itemCount: 1,
+        modelCount: 3,
+      }
+    })
   })
 
-  it("loads and normalizes model ids, auto-selects the first option, and copies api configs", async () => {
+  it("passes the full normalized V7 catalog, readable name, and default to the policy", async () => {
     const user = userEvent.setup()
     const writeText = vi
       .spyOn(navigator.clipboard, "writeText")
       .mockResolvedValue(undefined)
-
     mockFetchOpenAICompatibleModelIds.mockResolvedValueOnce([
       " z-model ",
+      "a-model",
       "",
       "a-model",
     ])
 
-    render(
-      <KiloCodeProfileExportDialog
-        isOpen={true}
-        onClose={() => {}}
-        profile={PROFILE}
-      />,
-    )
-
-    await waitFor(() => {
-      expect(mockFetchOpenAICompatibleModelIds).toHaveBeenCalledWith({
-        baseUrl: "https://profile.example.com",
-        apiKey: "sk-secret",
-      })
-    })
-
-    const copyButton = await screen.findByRole("button", {
-      name: "ui:dialog.kiloCode.actions.copyKiloV7Provider",
-    })
-    expect(copyButton).toBeEnabled()
-
-    await user.click(copyButton)
-
-    expectApiCredentialProfileActionStarted(
-      PRODUCT_ANALYTICS_ACTION_IDS.CopyApiCredentialExportConfig,
-    )
-    await waitFor(() => {
-      expect(writeText).toHaveBeenCalledTimes(1)
-    })
-    expect(mockBuildKiloCodeExportOutput).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        target: KILO_CODE_EXPORT_TARGETS.KiloV7,
-        selections: [
-          expect.objectContaining({
-            accountId: "profile-1",
-            modelId: "a-model",
-          }),
-        ],
-      }),
-    )
-    expect(writeText).toHaveBeenCalledWith(
-      JSON.stringify({ v7: "a-model" }, null, 2),
-    )
-    expect(toastSuccessMock).toHaveBeenCalledWith(
-      "ui:dialog.kiloCode.messages.copiedExportConfig",
-    )
-    await waitFor(() => {
-      expect(completeProductAnalyticsActionMock).toHaveBeenCalledWith(
-        PRODUCT_ANALYTICS_RESULTS.Success,
-        {
-          insights: {
-            itemCount: 1,
-            modelCount: 1,
-            selectedCount: 1,
-            kiloCodeExportTarget:
-              PRODUCT_ANALYTICS_KILO_CODE_EXPORT_TARGETS.KiloV7,
-          },
-        },
-      )
-    })
-  })
-
-  it("shows the no-model notice and keeps export actions disabled when the upstream list is empty", async () => {
-    mockFetchOpenAICompatibleModelIds.mockResolvedValueOnce([" ", ""])
-
-    render(
-      <KiloCodeProfileExportDialog
-        isOpen={true}
-        onClose={() => {}}
-        profile={PROFILE}
-      />,
-    )
-
-    expect(
-      await screen.findByText("ui:dialog.kiloCode.messages.noModelsTitle"),
-    ).toBeInTheDocument()
-    expect(
-      screen.getByRole("button", {
-        name: "ui:dialog.kiloCode.actions.copyKiloV7Provider",
-      }),
-    ).toBeDisabled()
-    expect(
-      screen.getByRole("button", {
-        name: "ui:dialog.kiloCode.actions.downloadKiloV7Settings",
-      }),
-    ).toBeDisabled()
-  })
-
-  it("shows a copy-failed toast when clipboard export fails", async () => {
-    const user = userEvent.setup()
-    vi.spyOn(navigator.clipboard, "writeText").mockRejectedValueOnce(
-      new Error("clipboard blocked"),
-    )
-    mockFetchOpenAICompatibleModelIds.mockResolvedValueOnce(["gpt-4o-mini"])
-
-    render(
-      <KiloCodeProfileExportDialog
-        isOpen={true}
-        onClose={() => {}}
-        profile={PROFILE}
-      />,
-    )
+    renderDialog()
 
     const copyButton = await screen.findByRole("button", {
       name: "ui:dialog.kiloCode.actions.copyKiloV7Provider",
     })
     await waitFor(() => expect(copyButton).toBeEnabled())
+    expect(
+      screen.getByRole("combobox", {
+        name: "ui:dialog.kiloCode.labels.defaultModel",
+      }),
+    ).toHaveTextContent("a-model")
 
     await user.click(copyButton)
 
+    expect(mockFetchOpenAICompatibleModelIds).toHaveBeenCalledWith({
+      baseUrl: "https://profile.example.com",
+      apiKey: "sk-secret",
+    })
+    expect(mockBuildKiloCodeExportOutput).toHaveBeenLastCalledWith({
+      target: KILO_CODE_EXPORT_TARGETS.KiloV7,
+      selections: [
+        {
+          accountId: "profile-1",
+          siteName: "Reusable Key",
+          baseUrl: "https://profile.example.com/v1",
+          tokenId: 0,
+          tokenName: "common:labels.apiKey",
+          tokenKey: "sk-secret",
+          selectionId: "profile:profile-1",
+          providerName: "Reusable Key",
+          discoveredModelIds: ["a-model", "z-model"],
+          manualModelId: undefined,
+        },
+      ],
+      defaultModel: {
+        selectionId: "profile:profile-1",
+        modelId: "a-model",
+      },
+    })
+    expect(writeText).toHaveBeenCalledWith(
+      JSON.stringify(
+        {
+          provider: { "reusable-key": { models: {} } },
+          model: "a-model",
+        },
+        null,
+        2,
+      ),
+    )
     expectApiCredentialProfileActionStarted(
       PRODUCT_ANALYTICS_ACTION_IDS.CopyApiCredentialExportConfig,
     )
-    await waitFor(() => {
-      expect(toastErrorMock).toHaveBeenCalledWith(
-        "ui:dialog.kiloCode.messages.copyFailed",
-      )
-    })
     expect(completeProductAnalyticsActionMock).toHaveBeenCalledWith(
-      PRODUCT_ANALYTICS_RESULTS.Failure,
+      PRODUCT_ANALYTICS_RESULTS.Success,
       {
-        errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
         insights: {
           itemCount: 1,
-          modelCount: 1,
+          modelCount: 7,
           selectedCount: 1,
           kiloCodeExportTarget:
             PRODUCT_ANALYTICS_KILO_CODE_EXPORT_TARGETS.KiloV7,
@@ -246,92 +267,318 @@ describe("KiloCodeProfileExportDialog", () => {
     )
   })
 
-  it("downloads a settings file and revokes the temporary object url", async () => {
+  it("uses target-specific model labels", async () => {
     const user = userEvent.setup()
-    const createObjectURLSpy = vi
-      .spyOn(URL, "createObjectURL")
-      .mockReturnValue("blob:test")
-    const revokeObjectURLSpy = vi
-      .spyOn(URL, "revokeObjectURL")
-      .mockImplementation(() => {})
-    const clickSpy = vi
-      .spyOn(HTMLAnchorElement.prototype, "click")
-      .mockImplementation(() => {})
+    mockFetchOpenAICompatibleModelIds.mockResolvedValueOnce(["model-a"])
+    renderDialog()
 
-    mockFetchOpenAICompatibleModelIds.mockResolvedValueOnce(["gpt-4o-mini"])
-
-    render(
-      <KiloCodeProfileExportDialog
-        isOpen={true}
-        onClose={() => {}}
-        profile={PROFILE}
-      />,
-    )
-
-    const downloadButton = await screen.findByRole("button", {
-      name: "ui:dialog.kiloCode.actions.downloadKiloV7Settings",
-    })
-    await waitFor(() => expect(downloadButton).toBeEnabled())
-
-    const targetSelect = await screen.findByRole("combobox", {
-      name: "ui:dialog.kiloCode.labels.exportTarget",
-    })
-    expect(targetSelect).toHaveTextContent("ui:dialog.kiloCode.targets.kiloV7")
-    expectKiloCodeUsageGuidance(KILO_CODE_EXPORT_TARGETS.KiloV7)
     expect(
-      screen.queryByText("ui:dialog.kiloCode.help.kiloV7Description"),
-    ).not.toBeInTheDocument()
+      await screen.findByRole("combobox", {
+        name: "ui:dialog.kiloCode.labels.defaultModel",
+      }),
+    ).toBeVisible()
 
-    await user.click(downloadButton)
+    await chooseExportTarget(user, "legacy")
 
-    expectApiCredentialProfileActionStarted(
-      PRODUCT_ANALYTICS_ACTION_IDS.ExportApiCredentialSettingsFile,
-    )
-    await waitFor(() => {
-      expect(mockBuildKiloCodeExportOutput).toHaveBeenCalledWith(
-        expect.objectContaining({ target: KILO_CODE_EXPORT_TARGETS.KiloV7 }),
-      )
-    })
-    const link = document.querySelector('a[download="kilo-settings.json"]')
-    expect(link).not.toBeInTheDocument()
-    expect(createObjectURLSpy.mock.calls[0]?.[0]).toBeInstanceOf(Blob)
-    const blobPayload = await new Promise<string>((resolve, reject) => {
-      const reader = new FileReader()
-      reader.onload = () => resolve(String(reader.result ?? ""))
-      reader.onerror = () => reject(reader.error)
-      reader.readAsText(createObjectURLSpy.mock.calls[0]![0] as Blob)
-    })
-    expect(blobPayload).toBe(
-      JSON.stringify({ format: "v7", model: "gpt-4o-mini" }, null, 2),
-    )
-    expect(createObjectURLSpy).toHaveBeenCalledTimes(1)
-    expect(clickSpy).toHaveBeenCalledTimes(1)
-    expect(revokeObjectURLSpy).toHaveBeenCalledWith("blob:test")
-    expect(toastSuccessMock).toHaveBeenCalledWith(
-      "ui:dialog.kiloCode.messages.downloadedSettings",
-    )
-    await waitFor(() => {
-      expect(completeProductAnalyticsActionMock).toHaveBeenCalledWith(
-        PRODUCT_ANALYTICS_RESULTS.Success,
-        {
-          insights: {
-            itemCount: 1,
-            modelCount: 1,
-            selectedCount: 1,
-            kiloCodeExportTarget:
-              PRODUCT_ANALYTICS_KILO_CODE_EXPORT_TARGETS.KiloV7,
-          },
-        },
-      )
-    })
+    expect(
+      screen.getByRole("combobox", {
+        name: "ui:dialog.kiloCode.labels.legacyModelId",
+      }),
+    ).toBeVisible()
   })
 
-  it("switches to legacy output for copy and download without refetching models", async () => {
+  it("unions a custom V7 default into the manual model field", async () => {
+    const user = userEvent.setup()
+    vi.spyOn(navigator.clipboard, "writeText").mockResolvedValue(undefined)
+    mockFetchOpenAICompatibleModelIds.mockResolvedValueOnce(["model-a"])
+    renderDialog()
+
+    await screen.findByText("model-a")
+    await chooseV7Model(user, "custom/model")
+    expect(screen.getAllByText("custom/model")).not.toHaveLength(0)
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "ui:dialog.kiloCode.actions.copyKiloV7Provider",
+      }),
+    )
+
+    expect(mockBuildKiloCodeExportOutput).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        selections: [
+          expect.objectContaining({
+            discoveredModelIds: ["model-a"],
+            manualModelId: "custom/model",
+          }),
+        ],
+        defaultModel: {
+          selectionId: "profile:profile-1",
+          modelId: "custom/model",
+        },
+      }),
+    )
+  })
+
+  it("keeps the manual catalog entry when a discovered default is selected", async () => {
+    const user = userEvent.setup()
+    vi.spyOn(navigator.clipboard, "writeText").mockResolvedValue(undefined)
+    mockFetchOpenAICompatibleModelIds.mockResolvedValueOnce([
+      "model-a",
+      "model-b",
+    ])
+    renderDialog()
+
+    await screen.findByText("model-a")
+    await chooseV7Model(user, "manual/model")
+    await chooseV7Model(user, "model-b")
+    await user.click(
+      screen.getByRole("button", {
+        name: "ui:dialog.kiloCode.actions.copyKiloV7Provider",
+      }),
+    )
+
+    expect(screen.getAllByText("manual/model")).not.toHaveLength(0)
+    expect(mockBuildKiloCodeExportOutput).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        selections: [
+          expect.objectContaining({ manualModelId: "manual/model" }),
+        ],
+        defaultModel: expect.objectContaining({ modelId: "model-b" }),
+      }),
+    )
+  })
+
+  it("preserves a manual model when retry fails", async () => {
+    const user = userEvent.setup()
+    vi.spyOn(navigator.clipboard, "writeText").mockResolvedValue(undefined)
+    mockFetchOpenAICompatibleModelIds
+      .mockRejectedValueOnce(new Error("offline"))
+      .mockRejectedValueOnce(new Error("still offline"))
+    renderDialog()
+
+    const retry = await screen.findByRole("button", {
+      name: "ui:dialog.kiloCode.actions.retryModels",
+    })
+    await chooseV7Model(user, "manual/model")
+    await user.click(retry)
+    await screen.findByRole("button", {
+      name: "ui:dialog.kiloCode.actions.retryModels",
+    })
+
+    expect(
+      screen.getByRole("combobox", {
+        name: "ui:dialog.kiloCode.labels.defaultModel",
+      }),
+    ).toHaveTextContent("manual/model")
+    expect(screen.getAllByText("manual/model")).not.toHaveLength(0)
+  })
+
+  it("preserves a custom Legacy model when retry discovers other models", async () => {
+    const user = userEvent.setup()
+    vi.spyOn(navigator.clipboard, "writeText").mockResolvedValue(undefined)
+    mockFetchOpenAICompatibleModelIds
+      .mockRejectedValueOnce(new Error("offline"))
+      .mockResolvedValueOnce(["discovered-model"])
+    renderDialog()
+
+    const retry = await screen.findByRole("button", {
+      name: "ui:dialog.kiloCode.actions.retryModels",
+    })
+    await chooseExportTarget(user, "legacy")
+    await chooseLegacyModel(user, "legacy/custom")
+    await user.click(retry)
+
+    const legacyModel = screen.getByRole("combobox", {
+      name: "ui:dialog.kiloCode.labels.legacyModelId",
+    })
+    await waitFor(() => expect(legacyModel).toBeEnabled())
+    expect(legacyModel).toHaveTextContent("legacy/custom")
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "ui:dialog.kiloCode.actions.copyLegacyApiConfigs",
+      }),
+    )
+    expect(mockBuildKiloCodeExportOutput).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        target: KILO_CODE_EXPORT_TARGETS.Legacy,
+        selections: [
+          expect.objectContaining({ legacyModelId: "legacy/custom" }),
+        ],
+      }),
+    )
+  })
+
+  it("focuses the active model selector after a successful retry", async () => {
+    const user = userEvent.setup()
+    mockFetchOpenAICompatibleModelIds
+      .mockRejectedValueOnce(new Error("offline"))
+      .mockResolvedValueOnce(["model-a"])
+    renderDialog()
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "ui:dialog.kiloCode.actions.retryModels",
+      }),
+    )
+
+    const defaultModel = screen.getByRole("combobox", {
+      name: "ui:dialog.kiloCode.labels.defaultModel",
+    })
+    await waitFor(() => expect(defaultModel).toHaveFocus())
+  })
+
+  it("focuses the remounted Retry action after a failed retry", async () => {
+    const user = userEvent.setup()
+    mockFetchOpenAICompatibleModelIds
+      .mockRejectedValueOnce(new Error("offline"))
+      .mockRejectedValueOnce(new Error("still offline"))
+    renderDialog()
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "ui:dialog.kiloCode.actions.retryModels",
+      }),
+    )
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", {
+          name: "ui:dialog.kiloCode.actions.retryModels",
+        }),
+      ).toHaveFocus(),
+    )
+  })
+
+  it("returns focus to the V7 selector after removing a manual model", async () => {
+    const user = userEvent.setup()
+    mockFetchOpenAICompatibleModelIds.mockResolvedValueOnce(["model-a"])
+    renderDialog()
+
+    await screen.findByText("model-a")
+    await chooseV7Model(user, "manual/model")
+    await user.click(
+      screen.getByTestId(KILO_CODE_EXPORT_TEST_IDS.removeManualModel),
+    )
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("combobox", {
+          name: "ui:dialog.kiloCode.labels.defaultModel",
+        }),
+      ).toHaveFocus(),
+    )
+  })
+
+  it("unions a manual model after successful retry until Remove repairs the default", async () => {
+    const user = userEvent.setup()
+    vi.spyOn(navigator.clipboard, "writeText").mockResolvedValue(undefined)
+    mockFetchOpenAICompatibleModelIds
+      .mockRejectedValueOnce(new Error("offline"))
+      .mockResolvedValueOnce(["model-b", "model-a"])
+    renderDialog()
+
+    await screen.findByRole("button", {
+      name: "ui:dialog.kiloCode.actions.retryModels",
+    })
+    await chooseV7Model(user, "manual/model")
+    await user.click(
+      screen.getByRole("button", {
+        name: "ui:dialog.kiloCode.actions.retryModels",
+      }),
+    )
+    await waitFor(() =>
+      expect(mockFetchOpenAICompatibleModelIds).toHaveBeenCalledTimes(2),
+    )
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "ui:dialog.kiloCode.actions.copyKiloV7Provider",
+      }),
+    )
+    expect(mockBuildKiloCodeExportOutput).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        selections: [
+          expect.objectContaining({
+            discoveredModelIds: ["model-a", "model-b"],
+            manualModelId: "manual/model",
+          }),
+        ],
+        defaultModel: expect.objectContaining({ modelId: "manual/model" }),
+      }),
+    )
+
+    await user.click(
+      screen.getByTestId(KILO_CODE_EXPORT_TEST_IDS.removeManualModel),
+    )
+    expect(screen.queryByText("manual/model")).not.toBeInTheDocument()
+    expect(
+      screen.getByRole("combobox", {
+        name: "ui:dialog.kiloCode.labels.defaultModel",
+      }),
+    ).toHaveTextContent("model-a")
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "ui:dialog.kiloCode.actions.copyKiloV7Provider",
+      }),
+    )
+    expect(mockBuildKiloCodeExportOutput).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        selections: [
+          expect.not.objectContaining({ manualModelId: expect.anything() }),
+        ],
+        defaultModel: expect.objectContaining({ modelId: "model-a" }),
+      }),
+    )
+  })
+
+  it("preserves separate V7 and legacy choices while switching without refetching", async () => {
+    const user = userEvent.setup()
+    mockFetchOpenAICompatibleModelIds.mockResolvedValueOnce([
+      "model-a",
+      "model-b",
+    ])
+    renderDialog()
+
+    await screen.findByText("model-a")
+    await chooseV7Model(user, "manual/v7")
+    await chooseExportTarget(user, "legacy")
+    expect(screen.queryByText("manual/v7")).not.toBeInTheDocument()
+    expect(
+      screen.queryByTestId(KILO_CODE_EXPORT_TEST_IDS.removeManualModel),
+    ).not.toBeInTheDocument()
+    await chooseLegacyModel(user, "legacy/custom")
+    await chooseExportTarget(user, "kiloV7")
+
+    expect(
+      screen.getByRole("combobox", {
+        name: "ui:dialog.kiloCode.labels.defaultModel",
+      }),
+    ).toHaveTextContent("manual/v7")
+    expect(screen.getAllByText("manual/v7")).not.toHaveLength(0)
+    expect(
+      screen.getByTestId(KILO_CODE_EXPORT_TEST_IDS.removeManualModel),
+    ).toBeVisible()
+
+    await chooseExportTarget(user, "legacy")
+    expect(
+      screen.getByRole("combobox", {
+        name: "ui:dialog.kiloCode.labels.legacyModelId",
+      }),
+    ).toHaveTextContent("legacy/custom")
+    expect(mockFetchOpenAICompatibleModelIds).toHaveBeenCalledTimes(1)
+    expectKiloCodeUsageGuidance(KILO_CODE_EXPORT_TARGETS.Legacy)
+  })
+
+  it("copies and downloads canonical Legacy output with output-derived analytics", async () => {
     const user = userEvent.setup()
     const writeText = vi
       .spyOn(navigator.clipboard, "writeText")
       .mockResolvedValue(undefined)
-    vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:legacy")
+    const createObjectURLSpy = vi
+      .spyOn(URL, "createObjectURL")
+      .mockReturnValue("blob:legacy")
     vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {})
     let downloadedFilename = ""
     vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(function (
@@ -339,62 +586,402 @@ describe("KiloCodeProfileExportDialog", () => {
     ) {
       downloadedFilename = this.download
     })
-    mockFetchOpenAICompatibleModelIds.mockResolvedValueOnce(["gpt-4o-mini"])
+    mockFetchOpenAICompatibleModelIds.mockResolvedValueOnce(["model-a"])
+    renderDialog()
 
-    const { rerender } = render(
-      <KiloCodeProfileExportDialog
-        isOpen={true}
-        onClose={() => {}}
-        profile={PROFILE}
-      />,
-    )
-
-    const targetSelect = await screen.findByRole("combobox", {
-      name: "ui:dialog.kiloCode.labels.exportTarget",
-    })
-    await user.click(targetSelect)
-    expect(screen.queryByRole("combobox")).not.toBeInTheDocument()
-    await user.click(
-      await screen.findByRole("option", {
-        name: "ui:dialog.kiloCode.targets.legacy",
-      }),
-    )
-
+    await screen.findByText("model-a")
+    await chooseExportTarget(user, "legacy")
+    await chooseLegacyModel(user, "legacy/custom")
     await user.click(
       screen.getByRole("button", {
         name: "ui:dialog.kiloCode.actions.copyLegacyApiConfigs",
       }),
     )
-    expect(writeText).toHaveBeenCalledWith(
-      JSON.stringify({ legacy: "gpt-4o-mini" }, null, 2),
-    )
-    expect(toastSuccessMock).toHaveBeenCalledWith(
-      "ui:dialog.kiloCode.messages.copiedExportConfig",
-    )
-
     await user.click(
       screen.getByRole("button", {
         name: "ui:dialog.kiloCode.actions.downloadLegacySettings",
       }),
     )
 
-    expect(mockBuildKiloCodeExportOutput).toHaveBeenLastCalledWith(
-      expect.objectContaining({ target: KILO_CODE_EXPORT_TARGETS.Legacy }),
+    const expectedPolicyInput = {
+      target: KILO_CODE_EXPORT_TARGETS.Legacy,
+      selections: [
+        {
+          accountId: "profile-1",
+          siteName: "Reusable Key",
+          baseUrl: "https://profile.example.com/v1",
+          tokenId: 0,
+          tokenName: "common:labels.apiKey",
+          tokenKey: "sk-secret",
+          legacyModelId: "legacy/custom",
+        },
+      ],
+      currentLegacyProfileName: "Reusable Key - common:labels.apiKey",
+    }
+    expect(mockBuildKiloCodeExportOutput).toHaveBeenCalledTimes(2)
+    expect(mockBuildKiloCodeExportOutput).toHaveBeenNthCalledWith(
+      1,
+      expectedPolicyInput,
+    )
+    expect(mockBuildKiloCodeExportOutput).toHaveBeenNthCalledWith(
+      2,
+      expectedPolicyInput,
+    )
+    expect(writeText).toHaveBeenCalledWith(
+      JSON.stringify({ legacy: "legacy/custom" }, null, 2),
+    )
+    const blobPayload = await new Promise<string>((resolve, reject) => {
+      const reader = new FileReader()
+      reader.onload = () => resolve(String(reader.result ?? ""))
+      reader.onerror = () => reject(reader.error)
+      reader.readAsText(createObjectURLSpy.mock.calls[0]![0] as Blob)
+    })
+    expect(blobPayload).toBe(
+      JSON.stringify({ format: "legacy", model: "legacy/custom" }, null, 2),
     )
     expect(downloadedFilename).toBe("kilo-code-settings.json")
     expect(mockFetchOpenAICompatibleModelIds).toHaveBeenCalledTimes(1)
-    expectKiloCodeUsageGuidance(KILO_CODE_EXPORT_TARGETS.Legacy)
-    expect(
-      screen.queryByText("ui:dialog.kiloCode.help.legacyDescription"),
-    ).not.toBeInTheDocument()
+    expect(completeProductAnalyticsActionMock).toHaveBeenCalledTimes(2)
     expect(completeProductAnalyticsActionMock).toHaveBeenLastCalledWith(
       PRODUCT_ANALYTICS_RESULTS.Success,
       {
-        insights: expect.objectContaining({
+        insights: {
+          itemCount: 1,
+          modelCount: 3,
+          selectedCount: 1,
           kiloCodeExportTarget:
             PRODUCT_ANALYTICS_KILO_CODE_EXPORT_TARGETS.Legacy,
-        }),
+        },
       },
+    )
+  })
+
+  it("passes all 5,000 discovered models to V7 copy and download policy inputs", async () => {
+    const user = userEvent.setup()
+    vi.spyOn(navigator.clipboard, "writeText").mockResolvedValue(undefined)
+    vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:catalog")
+    vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {})
+    vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {})
+    const discoveredModelIds = Array.from(
+      { length: 5_000 },
+      (_, index) => `model-${index.toString().padStart(4, "0")}`,
+    )
+    mockFetchOpenAICompatibleModelIds.mockResolvedValueOnce(discoveredModelIds)
+    renderDialog()
+
+    const copyButton = await screen.findByRole("button", {
+      name: "ui:dialog.kiloCode.actions.copyKiloV7Provider",
+    })
+    await waitFor(() => expect(copyButton).toBeEnabled())
+    await user.click(copyButton)
+    await user.click(
+      screen.getByRole("button", {
+        name: "ui:dialog.kiloCode.actions.downloadKiloV7Settings",
+      }),
+    )
+
+    expect(mockBuildKiloCodeExportOutput).toHaveBeenCalledTimes(2)
+    for (const [input] of mockBuildKiloCodeExportOutput.mock.calls) {
+      expect(input.selections[0].discoveredModelIds).toHaveLength(5_000)
+      expect(input.selections[0].discoveredModelIds).toContain("model-4999")
+    }
+  })
+
+  it("uses policy downloadJson exactly and revokes the object URL", async () => {
+    const user = userEvent.setup()
+    const createObjectURLSpy = vi
+      .spyOn(URL, "createObjectURL")
+      .mockReturnValue("blob:test")
+    const revokeObjectURLSpy = vi
+      .spyOn(URL, "revokeObjectURL")
+      .mockImplementation(() => {})
+    vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {})
+    mockFetchOpenAICompatibleModelIds.mockResolvedValueOnce(["model-a"])
+    mockBuildKiloCodeExportOutput.mockImplementationOnce(() => ({
+      target: KILO_CODE_EXPORT_TARGETS.KiloV7,
+      filename: "kilo-settings.json",
+      copyPayload: { provider: {}, model: "model-a" },
+      downloadPayload: { this: "must not be serialized" },
+      downloadJson: '{"exact":"policy-json"}',
+      downloadByteLength: 23,
+      isDownloadTooLarge: false,
+      itemCount: 2,
+      modelCount: 11,
+    }))
+    renderDialog()
+
+    const downloadButton = await screen.findByRole("button", {
+      name: "ui:dialog.kiloCode.actions.downloadKiloV7Settings",
+    })
+    await waitFor(() => expect(downloadButton).toBeEnabled())
+    await user.click(downloadButton)
+
+    const blobPayload = await new Promise<string>((resolve, reject) => {
+      const reader = new FileReader()
+      reader.onload = () => resolve(String(reader.result ?? ""))
+      reader.onerror = () => reject(reader.error)
+      reader.readAsText(createObjectURLSpy.mock.calls[0]![0] as Blob)
+    })
+    expect(blobPayload).toBe('{"exact":"policy-json"}')
+    expect(revokeObjectURLSpy).toHaveBeenCalledWith("blob:test")
+    expect(completeProductAnalyticsActionMock).toHaveBeenCalledWith(
+      PRODUCT_ANALYTICS_RESULTS.Success,
+      {
+        insights: {
+          itemCount: 2,
+          modelCount: 11,
+          selectedCount: 1,
+          kiloCodeExportTarget:
+            PRODUCT_ANALYTICS_KILO_CODE_EXPORT_TARGETS.KiloV7,
+        },
+      },
+    )
+  })
+
+  it("blocks oversized downloads and keeps copy recovery available", async () => {
+    const user = userEvent.setup()
+    const createObjectURLSpy = vi.spyOn(URL, "createObjectURL")
+    const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, "click")
+    mockFetchOpenAICompatibleModelIds.mockResolvedValueOnce(["model-a"])
+    mockBuildKiloCodeExportOutput.mockImplementationOnce(() => ({
+      target: KILO_CODE_EXPORT_TARGETS.KiloV7,
+      filename: "kilo-settings.json",
+      copyPayload: { provider: {}, model: "model-a" },
+      downloadPayload: {},
+      downloadJson: "oversized",
+      downloadByteLength: 1_048_577,
+      isDownloadTooLarge: true,
+      itemCount: 1,
+      modelCount: 5000,
+    }))
+    renderDialog()
+
+    const downloadButton = await screen.findByRole("button", {
+      name: "ui:dialog.kiloCode.actions.downloadKiloV7Settings",
+    })
+    await waitFor(() => expect(downloadButton).toBeEnabled())
+    await user.click(downloadButton)
+
+    expect(createObjectURLSpy).not.toHaveBeenCalled()
+    expect(clickSpy).not.toHaveBeenCalled()
+    expect(
+      screen.getByText(
+        "ui:dialog.kiloCode.messages.settingsFileTooLargeSingle",
+      ),
+    ).toBeVisible()
+    expect(
+      screen.getByRole("button", {
+        name: "ui:dialog.kiloCode.actions.copyKiloV7Provider",
+      }),
+    ).toBeEnabled()
+    expect(completeProductAnalyticsActionMock).toHaveBeenCalledWith(
+      PRODUCT_ANALYTICS_RESULTS.Failure,
+      {
+        errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Validation,
+        insights: {
+          itemCount: 1,
+          modelCount: 5000,
+          selectedCount: 1,
+          kiloCodeExportTarget:
+            PRODUCT_ANALYTICS_KILO_CODE_EXPORT_TARGETS.KiloV7,
+        },
+      },
+    )
+  })
+
+  it.each([
+    {
+      label: "malformed URL",
+      profile: { ...PROFILE, baseUrl: "not-a-valid-url" },
+    },
+    {
+      label: "blank API key",
+      profile: { ...PROFILE, apiKey: "" },
+    },
+  ])(
+    "contains an invalid profile instead of crashing for $label",
+    async ({ profile }) => {
+      const user = userEvent.setup()
+
+      renderDialog(profile)
+
+      expect(await screen.findByRole("dialog")).toBeVisible()
+      expect(
+        await screen.findByText("ui:dialog.kiloCode.messages.invalidProfile"),
+      ).toBeVisible()
+      expect(
+        screen.getByRole("button", {
+          name: "ui:dialog.kiloCode.actions.copyKiloV7Provider",
+        }),
+      ).toBeDisabled()
+      expect(
+        screen.getByRole("button", {
+          name: "ui:dialog.kiloCode.actions.downloadKiloV7Settings",
+        }),
+      ).toBeDisabled()
+      await chooseExportTarget(user, "legacy")
+      expect(
+        screen.getByText("ui:dialog.kiloCode.messages.invalidProfile"),
+      ).toBeVisible()
+      expect(
+        screen.getByRole("button", {
+          name: "ui:dialog.kiloCode.actions.copyLegacyApiConfigs",
+        }),
+      ).toBeDisabled()
+      expect(
+        screen.getByRole("button", {
+          name: "ui:dialog.kiloCode.actions.downloadLegacySettings",
+        }),
+      ).toBeDisabled()
+      expect(mockBuildKiloCodeExportOutput).not.toHaveBeenCalled()
+      expect(mockFetchOpenAICompatibleModelIds).not.toHaveBeenCalled()
+    },
+  )
+
+  it.each([
+    { label: "empty", fails: false },
+    { label: "error", fails: true },
+  ])(
+    "offers retry and manual recovery for $label discovery",
+    async ({ fails }) => {
+      const user = userEvent.setup()
+      if (fails) {
+        mockFetchOpenAICompatibleModelIds.mockRejectedValueOnce(
+          new Error("offline"),
+        )
+      } else {
+        mockFetchOpenAICompatibleModelIds.mockResolvedValueOnce([" ", ""])
+      }
+      renderDialog()
+
+      expect(
+        await screen.findByRole("button", {
+          name: "ui:dialog.kiloCode.actions.retryModels",
+        }),
+      ).toBeVisible()
+      const defaultModel = screen.getByRole("combobox", {
+        name: "ui:dialog.kiloCode.labels.defaultModel",
+      })
+      expect(defaultModel).toBeEnabled()
+
+      await chooseV7Model(user, "manual/recovery")
+      expect(
+        screen.getByRole("button", {
+          name: "ui:dialog.kiloCode.actions.copyKiloV7Provider",
+        }),
+      ).toBeEnabled()
+    },
+  )
+
+  it("ignores a stale model response after profile credentials change", async () => {
+    let resolveStale: (models: string[]) => void = () => {}
+    const stale = new Promise<string[]>((resolve) => {
+      resolveStale = resolve
+    })
+    mockFetchOpenAICompatibleModelIds
+      .mockReturnValueOnce(stale)
+      .mockResolvedValueOnce(["new-model"])
+    const { rerender } = renderDialog()
+    await waitFor(() =>
+      expect(mockFetchOpenAICompatibleModelIds).toHaveBeenCalledTimes(1),
+    )
+
+    const nextProfile = {
+      ...PROFILE,
+      id: "profile-2",
+      name: "New Profile",
+      baseUrl: "https://new-profile.example.com/v1",
+      apiKey: "sk-new",
+    }
+    rerender(
+      <KiloCodeProfileExportDialog
+        isOpen={true}
+        onClose={() => {}}
+        profile={nextProfile}
+      />,
+    )
+
+    await waitFor(() =>
+      expect(mockFetchOpenAICompatibleModelIds).toHaveBeenCalledTimes(2),
+    )
+    expect(await screen.findByText("new-model")).toBeVisible()
+    resolveStale(["stale-model"])
+    await waitFor(() =>
+      expect(screen.queryByText("stale-model")).not.toBeInTheDocument(),
+    )
+    expect(
+      screen.getByRole("combobox", {
+        name: "ui:dialog.kiloCode.labels.defaultModel",
+      }),
+    ).toHaveTextContent("new-model")
+  })
+
+  it("does not move focus during initial or changed-profile discovery", async () => {
+    let resolveInitial: (models: string[]) => void = () => {}
+    let resolveChanged: (models: string[]) => void = () => {}
+    const initialRequest = new Promise<string[]>((resolve) => {
+      resolveInitial = resolve
+    })
+    const changedRequest = new Promise<string[]>((resolve) => {
+      resolveChanged = resolve
+    })
+    mockFetchOpenAICompatibleModelIds
+      .mockReturnValueOnce(initialRequest)
+      .mockReturnValueOnce(changedRequest)
+    const { rerender } = renderDialog()
+    await waitFor(() =>
+      expect(mockFetchOpenAICompatibleModelIds).toHaveBeenCalledTimes(1),
+    )
+    const exportTarget = screen.getByRole("combobox", {
+      name: "ui:dialog.kiloCode.labels.exportTarget",
+    })
+    exportTarget.focus()
+
+    await act(async () => {
+      resolveInitial(["initial-model"])
+      await initialRequest
+    })
+    expect(exportTarget).toHaveFocus()
+
+    rerender(
+      <KiloCodeProfileExportDialog
+        isOpen={true}
+        onClose={() => {}}
+        profile={{
+          ...PROFILE,
+          id: "profile-2",
+          baseUrl: "https://changed.example.com/v1",
+          apiKey: "sk-changed",
+        }}
+      />,
+    )
+    await waitFor(() =>
+      expect(mockFetchOpenAICompatibleModelIds).toHaveBeenCalledTimes(2),
+    )
+    expect(exportTarget).toHaveFocus()
+
+    await act(async () => {
+      resolveChanged(["changed-model"])
+      await changedRequest
+    })
+    expect(exportTarget).toHaveFocus()
+  })
+
+  it("ignores an in-flight response from before close after reopening", async () => {
+    let resolveStale: (models: string[]) => void = () => {}
+    let resolveCurrent: (models: string[]) => void = () => {}
+    const staleRequest = new Promise<string[]>((resolve) => {
+      resolveStale = resolve
+    })
+    const currentRequest = new Promise<string[]>((resolve) => {
+      resolveCurrent = resolve
+    })
+    mockFetchOpenAICompatibleModelIds
+      .mockReturnValueOnce(staleRequest)
+      .mockReturnValueOnce(currentRequest)
+    const { rerender } = renderDialog()
+    await waitFor(() =>
+      expect(mockFetchOpenAICompatibleModelIds).toHaveBeenCalledTimes(1),
     )
 
     rerender(
@@ -404,7 +991,6 @@ describe("KiloCodeProfileExportDialog", () => {
         profile={PROFILE}
       />,
     )
-    mockFetchOpenAICompatibleModelIds.mockResolvedValueOnce(["gpt-4o-mini"])
     rerender(
       <KiloCodeProfileExportDialog
         isOpen={true}
@@ -412,31 +998,112 @@ describe("KiloCodeProfileExportDialog", () => {
         profile={PROFILE}
       />,
     )
-    await waitFor(() => {
-      expect(mockFetchOpenAICompatibleModelIds).toHaveBeenCalledTimes(2)
+    await waitFor(() =>
+      expect(mockFetchOpenAICompatibleModelIds).toHaveBeenCalledTimes(2),
+    )
+
+    await act(async () => {
+      resolveStale(["stale-model"])
+      await staleRequest
     })
+    expect(screen.queryByText("stale-model")).not.toBeInTheDocument()
+    expect(
+      screen.getByRole("button", {
+        name: "ui:dialog.kiloCode.actions.copyKiloV7Provider",
+      }),
+    ).toBeDisabled()
+    expect(
+      screen.getByRole("combobox", {
+        name: "ui:dialog.kiloCode.labels.defaultModel",
+      }),
+    ).toHaveTextContent("common:status.loading")
+
+    await act(async () => {
+      resolveCurrent(["current-model"])
+      await currentRequest
+    })
+    expect(await screen.findByText("current-model")).toBeVisible()
+  })
+
+  it("resets target-local state before loading changed profile credentials", async () => {
+    const user = userEvent.setup()
+    let resolveNextProfile: (models: string[]) => void = () => {}
+    const nextProfileRequest = new Promise<string[]>((resolve) => {
+      resolveNextProfile = resolve
+    })
+    mockFetchOpenAICompatibleModelIds
+      .mockResolvedValueOnce(["model-a"])
+      .mockReturnValueOnce(nextProfileRequest)
+    const { rerender } = renderDialog()
+
+    await screen.findByText("model-a")
+    await chooseV7Model(user, "manual/v7")
+    await chooseExportTarget(user, "legacy")
+    await chooseLegacyModel(user, "legacy/custom")
+
+    const nextProfile = {
+      ...PROFILE,
+      id: "profile-2",
+      name: "Next Profile",
+      baseUrl: "https://next-profile.example.com/v1",
+      apiKey: "sk-next",
+    }
+    rerender(
+      <KiloCodeProfileExportDialog
+        isOpen={true}
+        onClose={() => {}}
+        profile={nextProfile}
+      />,
+    )
+    await waitFor(() =>
+      expect(mockFetchOpenAICompatibleModelIds).toHaveBeenCalledTimes(2),
+    )
+
     expect(
       screen.getByRole("combobox", {
         name: "ui:dialog.kiloCode.labels.exportTarget",
       }),
     ).toHaveTextContent("ui:dialog.kiloCode.targets.kiloV7")
-    await waitFor(() => {
-      expect(
-        screen.getByRole("button", {
-          name: "ui:dialog.kiloCode.actions.downloadKiloV7Settings",
-        }),
-      ).toBeEnabled()
+    expect(screen.queryByText("manual/v7")).not.toBeInTheDocument()
+    expect(screen.queryByText("legacy/custom")).not.toBeInTheDocument()
+    expect(
+      screen.getByRole("button", {
+        name: "ui:dialog.kiloCode.actions.copyKiloV7Provider",
+      }),
+    ).toBeDisabled()
+
+    await act(async () => {
+      resolveNextProfile(["next-model"])
+      await nextProfileRequest
     })
+    expect(await screen.findByText("next-model")).toBeVisible()
+
+    await chooseExportTarget(user, "legacy")
+    const legacyModel = screen.getByRole("combobox", {
+      name: "ui:dialog.kiloCode.labels.legacyModelId",
+    })
+    expect(legacyModel).toHaveTextContent("next-model")
+    expect(legacyModel).not.toHaveTextContent("legacy/custom")
   })
 
-  it("shows a download-failed toast when building the settings file throws", async () => {
+  it("resets target-local values and refetches when the dialog reopens", async () => {
     const user = userEvent.setup()
-    mockFetchOpenAICompatibleModelIds.mockResolvedValueOnce(["gpt-4o-mini"])
-    mockBuildKiloCodeExportOutput.mockImplementationOnce(() => {
-      throw new Error("disk blocked")
-    })
+    mockFetchOpenAICompatibleModelIds
+      .mockResolvedValueOnce(["model-a"])
+      .mockResolvedValueOnce(["model-b"])
+    const { rerender } = renderDialog()
 
-    render(
+    await screen.findByText("model-a")
+    await chooseV7Model(user, "manual/model")
+    await chooseExportTarget(user, "legacy")
+    rerender(
+      <KiloCodeProfileExportDialog
+        isOpen={false}
+        onClose={() => {}}
+        profile={PROFILE}
+      />,
+    )
+    rerender(
       <KiloCodeProfileExportDialog
         isOpen={true}
         onClose={() => {}}
@@ -444,33 +1111,72 @@ describe("KiloCodeProfileExportDialog", () => {
       />,
     )
 
+    await waitFor(() =>
+      expect(mockFetchOpenAICompatibleModelIds).toHaveBeenCalledTimes(2),
+    )
+    expect(
+      screen.getByRole("combobox", {
+        name: "ui:dialog.kiloCode.labels.exportTarget",
+      }),
+    ).toHaveTextContent("ui:dialog.kiloCode.targets.kiloV7")
+    expect(
+      screen.getByRole("combobox", {
+        name: "ui:dialog.kiloCode.labels.defaultModel",
+      }),
+    ).toHaveTextContent("model-b")
+    expect(screen.queryByText("manual/model")).not.toBeInTheDocument()
+  })
+
+  it("keeps copy failure semantics when clipboard export fails", async () => {
+    const user = userEvent.setup()
+    vi.spyOn(navigator.clipboard, "writeText").mockRejectedValueOnce(
+      new Error("clipboard blocked"),
+    )
+    mockFetchOpenAICompatibleModelIds.mockResolvedValueOnce(["model-a"])
+    renderDialog()
+
+    const copyButton = await screen.findByRole("button", {
+      name: "ui:dialog.kiloCode.actions.copyKiloV7Provider",
+    })
+    await waitFor(() => expect(copyButton).toBeEnabled())
+    await user.click(copyButton)
+
+    expect(toastErrorMock).toHaveBeenCalledWith(
+      "ui:dialog.kiloCode.messages.copyFailed",
+    )
+    expect(completeProductAnalyticsActionMock).toHaveBeenCalledWith(
+      PRODUCT_ANALYTICS_RESULTS.Failure,
+      expect.objectContaining({
+        errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
+      }),
+    )
+  })
+
+  it("keeps build failure semantics for settings downloads", async () => {
+    const user = userEvent.setup()
+    mockFetchOpenAICompatibleModelIds.mockResolvedValueOnce(["model-a"])
+    mockBuildKiloCodeExportOutput.mockImplementationOnce(() => {
+      throw new Error("build failed")
+    })
+    renderDialog()
+
     const downloadButton = await screen.findByRole("button", {
       name: "ui:dialog.kiloCode.actions.downloadKiloV7Settings",
     })
     await waitFor(() => expect(downloadButton).toBeEnabled())
-
     await user.click(downloadButton)
 
     expectApiCredentialProfileActionStarted(
       PRODUCT_ANALYTICS_ACTION_IDS.ExportApiCredentialSettingsFile,
     )
-    await waitFor(() => {
-      expect(toastErrorMock).toHaveBeenCalledWith(
-        "ui:dialog.kiloCode.messages.downloadFailed",
-      )
-    })
+    expect(toastErrorMock).toHaveBeenCalledWith(
+      "ui:dialog.kiloCode.messages.downloadFailed",
+    )
     expect(completeProductAnalyticsActionMock).toHaveBeenCalledWith(
       PRODUCT_ANALYTICS_RESULTS.Failure,
-      {
+      expect.objectContaining({
         errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
-        insights: {
-          itemCount: 1,
-          modelCount: 1,
-          selectedCount: 1,
-          kiloCodeExportTarget:
-            PRODUCT_ANALYTICS_KILO_CODE_EXPORT_TARGETS.KiloV7,
-        },
-      },
+      }),
     )
   })
 })

--- a/tests/services/kiloCodeExport.test.ts
+++ b/tests/services/kiloCodeExport.test.ts
@@ -206,6 +206,44 @@ describe("buildKiloCodeV7SettingsFile", () => {
       "Kilo Code provider protocol is unsupported",
     ],
     [
+      "blank selection IDs",
+      {
+        providers: [{ ...preparedCatalog.providers[0]!, selectionId: "   " }],
+        providerCount: 1,
+        modelCount: 2,
+      },
+      "Kilo Code provider selection ID cannot be blank",
+    ],
+    [
+      "blank provider IDs",
+      {
+        providers: [{ ...preparedCatalog.providers[0]!, providerId: "   " }],
+        providerCount: 1,
+        modelCount: 2,
+      },
+      "Kilo Code provider ID cannot be blank",
+    ],
+    [
+      "settings-unsafe provider IDs",
+      {
+        providers: [
+          { ...preparedCatalog.providers[0]!, providerId: "Unsafe ID" },
+        ],
+        providerCount: 1,
+        modelCount: 2,
+      },
+      "Kilo Code provider IDs must be settings-safe",
+    ],
+    [
+      "blank provider names",
+      {
+        providers: [{ ...preparedCatalog.providers[0]!, providerName: "   " }],
+        providerCount: 1,
+        modelCount: 2,
+      },
+      "Kilo Code provider name cannot be blank",
+    ],
+    [
       "empty models",
       {
         providers: [{ ...preparedCatalog.providers[0]!, modelIds: [] }],
@@ -231,6 +269,34 @@ describe("buildKiloCodeV7SettingsFile", () => {
         modelCount: 2,
       },
       "Kilo Code provider base URL must be a valid HTTP or HTTPS URL",
+    ],
+    [
+      "non-HTTP base URL",
+      {
+        providers: [
+          {
+            ...preparedCatalog.providers[0]!,
+            baseURL: "ftp://api.example.invalid/v1",
+          },
+        ],
+        providerCount: 1,
+        modelCount: 2,
+      },
+      "Kilo Code provider base URL must be a valid HTTP or HTTPS URL",
+    ],
+    [
+      "non-normalized model IDs",
+      {
+        providers: [
+          {
+            ...preparedCatalog.providers[0]!,
+            modelIds: ["model-a", " model-b"],
+          },
+        ],
+        providerCount: 1,
+        modelCount: 2,
+      },
+      "Kilo Code provider model IDs must be normalized",
     ],
     [
       "count mismatch",
@@ -400,6 +466,36 @@ describe("buildKiloCodeApiConfigs", () => {
       "Example - Default (a.test)",
       "Example - Default (b.test)",
     ])
+  })
+
+  it("returns profile names in locale order independently of config insertion order", () => {
+    const { apiConfigs, profileNames } = buildKiloCodeApiConfigs({
+      selections: [
+        {
+          accountId: "z",
+          siteName: "Zulu",
+          baseUrl: "https://z.example.invalid",
+          tokenId: 1,
+          tokenName: "Default",
+          tokenKey: "example-z-key",
+        },
+        {
+          accountId: "a",
+          siteName: "Alpha",
+          baseUrl: "https://a.example.invalid",
+          tokenId: 2,
+          tokenName: "Default",
+          tokenKey: "example-a-key",
+        },
+      ],
+      generateId: (name) => `id-${name}`,
+    })
+
+    expect(Object.keys(apiConfigs)).toEqual([
+      "Zulu - Default",
+      "Alpha - Default",
+    ])
+    expect(profileNames).toEqual(["Alpha - Default", "Zulu - Default"])
   })
 
   it("falls back to deterministic numbering when duplicates still collide after domain disambiguation", () => {

--- a/tests/services/kiloCodeExport.test.ts
+++ b/tests/services/kiloCodeExport.test.ts
@@ -5,36 +5,52 @@ import {
   buildKiloCodeV7SettingsFile,
   KILO_CODE_EXPORT_FILENAMES,
   KILO_CODE_EXPORT_TARGETS,
+  type KiloCodeDefaultModelSelection,
+  type KiloCodeExportTuple,
+  type KiloCodeLegacySelection,
 } from "~/services/integrations/kiloCodeExport"
+import { prepareKiloCodeV7Catalog } from "~/services/integrations/kiloCodeV7Catalog"
 
-const v7Selection = {
-  accountId: "account-a",
-  siteName: "Example",
-  baseUrl: "https://api.example.invalid",
-  tokenId: 7,
-  tokenName: "Default",
-  tokenKey: "example-key",
-  modelId: "example-model",
+const preparedCatalog = prepareKiloCodeV7Catalog([
+  {
+    selectionId: "account-a:7",
+    accountId: "account-a",
+    siteName: "Example",
+    baseUrl: "https://api.example.invalid",
+    tokenId: 7,
+    tokenName: "Default",
+    tokenKey: "example-key",
+    providerName: "Example - Default",
+    discoveredModelIds: ["model-b", "model-a"],
+  },
+])
+
+const defaultModel: KiloCodeDefaultModelSelection = {
+  selectionId: "account-a:7",
+  modelId: "model-b",
 }
 
 describe("buildKiloCodeV7SettingsFile", () => {
-  it("builds a Kilo Code 7.x provider and selects its model", () => {
+  it("builds named multi-model providers and selects the explicit default", () => {
     const result = buildKiloCodeV7SettingsFile({
-      selections: [v7Selection],
-      now: () => new Date("2026-07-13T00:00:00.000Z"),
+      catalog: preparedCatalog,
+      defaultModel,
+      now: () => new Date("2026-07-17T00:00:00.000Z"),
     })
-    const providerId = Object.keys(result.provider)[0]
+    const providerId = preparedCatalog.providers[0]!.providerId
 
     expect(result).toEqual({
       _meta: {
         version: 1,
-        exportedAt: "2026-07-13T00:00:00.000Z",
+        exportedAt: "2026-07-17T00:00:00.000Z",
       },
       provider: {
         [providerId]: {
+          name: "Example - Default",
           npm: "@ai-sdk/openai-compatible",
           models: {
-            "example-model": { name: "example-model" },
+            "model-a": { name: "model-a" },
+            "model-b": { name: "model-b" },
           },
           options: {
             apiKey: "example-key",
@@ -42,8 +58,47 @@ describe("buildKiloCodeV7SettingsFile", () => {
           },
         },
       },
-      model: `${providerId}/example-model`,
+      model: `${providerId}/model-b`,
     })
+  })
+
+  it("selects a slash-containing model from a non-first provider", () => {
+    const catalog = prepareKiloCodeV7Catalog([
+      {
+        selectionId: "account-a:7",
+        accountId: "account-a",
+        siteName: "First Example",
+        baseUrl: "https://first.example.invalid",
+        tokenId: 7,
+        tokenName: "Default",
+        tokenKey: "first-example-key",
+        discoveredModelIds: ["model-a"],
+      },
+      {
+        selectionId: "account-b:8",
+        accountId: "account-b",
+        siteName: "Second Example",
+        baseUrl: "https://second.example.invalid",
+        tokenId: 8,
+        tokenName: "Default",
+        tokenKey: "second-example-key",
+        discoveredModelIds: ["other-model", "vendor/model-b"],
+      },
+    ])
+    const selectedProvider = catalog.providers[1]!
+
+    const result = buildKiloCodeV7SettingsFile({
+      catalog,
+      defaultModel: {
+        selectionId: selectedProvider.selectionId,
+        modelId: "vendor/model-b",
+      },
+    })
+
+    expect(result.provider[selectedProvider.providerId]?.models).toMatchObject({
+      "vendor/model-b": { name: "vendor/model-b" },
+    })
+    expect(result.model).toBe(`${selectedProvider.providerId}/vendor/model-b`)
   })
 
   it("exposes the supported export targets", () => {
@@ -57,98 +112,40 @@ describe("buildKiloCodeV7SettingsFile", () => {
     })
   })
 
-  it("keeps the provider ID stable when only the secret changes", () => {
-    const first = buildKiloCodeV7SettingsFile({ selections: [v7Selection] })
-    const second = buildKiloCodeV7SettingsFile({
-      selections: [{ ...v7Selection, tokenKey: "rotated-example-key" }],
-    })
-
-    expect(Object.keys(first.provider)[0]).toBe(Object.keys(second.provider)[0])
-  })
-
-  it("hashes non-BMP provider identities by Unicode character", () => {
-    const result = buildKiloCodeV7SettingsFile({
-      selections: [{ ...v7Selection, accountId: "account-😀" }],
-    })
-
-    expect(Object.keys(result.provider)).toEqual(["example-default-f58ad972"])
-  })
-
-  it("falls back to a settings-safe provider label for non-Latin names", () => {
-    const result = buildKiloCodeV7SettingsFile({
-      selections: [
-        {
-          ...v7Selection,
-          siteName: "示例",
-          tokenName: "默认",
-        },
-      ],
-    })
-
-    expect(Object.keys(result.provider)[0]).toMatch(/^provider-[a-f0-9]{8}$/)
-  })
-
-  it("creates unique, settings-safe provider IDs", () => {
-    const result = buildKiloCodeV7SettingsFile({
-      selections: [
-        v7Selection,
-        {
-          ...v7Selection,
-          accountId: "account-b",
-          siteName: "Second Example",
-          tokenId: 8,
-        },
-      ],
-    })
-    const providerIds = Object.keys(result.provider)
-
-    expect(new Set(providerIds)).toHaveLength(2)
-    expect(providerIds).toEqual(
-      expect.arrayContaining([
-        expect.stringMatching(/^[a-z0-9][a-z0-9-]*$/),
-        expect.stringMatching(/^[a-z0-9][a-z0-9-]*$/),
-      ]),
-    )
-  })
-
-  it("rejects an empty selection", () => {
-    expect(() => buildKiloCodeV7SettingsFile({ selections: [] })).toThrow(
-      "Select at least one runtime key",
-    )
-  })
-
-  it.each([
-    ["blank token key", { tokenKey: "  " }],
-    ["blank model ID", { modelId: "  " }],
-    ["invalid base URL", { baseUrl: "not-a-url" }],
-    ["non-HTTP base URL", { baseUrl: "ftp://api.example.invalid" }],
-  ])("rejects %s", (_name, overrides) => {
+  it("rejects an empty prepared catalog", () => {
     expect(() =>
       buildKiloCodeV7SettingsFile({
-        selections: [{ ...v7Selection, ...overrides }],
+        catalog: { providers: [], providerCount: 0, modelCount: 0 },
+        defaultModel,
       }),
-    ).toThrow()
+    ).toThrow("Select at least one runtime key")
   })
 
-  it("rejects duplicate generated provider IDs", () => {
+  it("requires an explicit default model", () => {
     expect(() =>
       buildKiloCodeV7SettingsFile({
-        selections: [
-          v7Selection,
-          { ...v7Selection, accountId: "account-b", tokenId: 8 },
-        ],
-        generateProviderId: () => "duplicate-provider",
+        catalog: preparedCatalog,
+        defaultModel: undefined as unknown as KiloCodeDefaultModelSelection,
       }),
-    ).toThrow("Kilo Code provider IDs must be unique")
+    ).toThrow("Kilo Code default model is required")
   })
 
-  it("rejects generated provider IDs that are not settings-safe", () => {
+  it("requires the default provider to be present in the catalog", () => {
     expect(() =>
       buildKiloCodeV7SettingsFile({
-        selections: [v7Selection],
-        generateProviderId: () => "Unsafe Provider",
+        catalog: preparedCatalog,
+        defaultModel: { selectionId: "missing-selection", modelId: "model-b" },
       }),
-    ).toThrow("Kilo Code provider IDs must be settings-safe")
+    ).toThrow("Kilo Code default provider must be exported")
+  })
+
+  it("requires the default model to be present in its provider catalog", () => {
+    expect(() =>
+      buildKiloCodeV7SettingsFile({
+        catalog: preparedCatalog,
+        defaultModel: { selectionId: "account-a:7", modelId: "missing-model" },
+      }),
+    ).toThrow("Kilo Code default model must exist in its provider catalog")
   })
 })
 
@@ -262,12 +259,33 @@ describe("buildKiloCodeApiConfigs", () => {
           tokenId: 1,
           tokenName: "Default",
           tokenKey: "sk-test",
-          modelId: "gpt-4o-mini",
+          legacyModelId: "gpt-4o-mini",
         },
       ],
       generateId: (name) => `id-${name}`,
     })
 
     expect(apiConfigs["Example - Default"].openAiModelId).toBe("gpt-4o-mini")
+  })
+
+  it("preserves explicit legacy model omission during tuple compatibility", () => {
+    const compatibilitySelection: KiloCodeExportTuple &
+      KiloCodeLegacySelection = {
+      accountId: "a",
+      siteName: "Example",
+      baseUrl: "https://api.example.invalid",
+      tokenId: 1,
+      tokenName: "Default",
+      tokenKey: "example-key",
+      legacyModelId: "  ",
+      modelId: "compatibility-model",
+    }
+
+    const { apiConfigs } = buildKiloCodeApiConfigs({
+      selections: [compatibilitySelection],
+      generateId: (name) => `id-${name}`,
+    })
+
+    expect(apiConfigs["Example - Default"]).not.toHaveProperty("openAiModelId")
   })
 })

--- a/tests/services/kiloCodeExport.test.ts
+++ b/tests/services/kiloCodeExport.test.ts
@@ -6,8 +6,6 @@ import {
   KILO_CODE_EXPORT_FILENAMES,
   KILO_CODE_EXPORT_TARGETS,
   type KiloCodeDefaultModelSelection,
-  type KiloCodeExportTuple,
-  type KiloCodeLegacySelection,
 } from "~/services/integrations/kiloCodeExport"
 import { prepareKiloCodeV7Catalog } from "~/services/integrations/kiloCodeV7Catalog"
 
@@ -266,26 +264,5 @@ describe("buildKiloCodeApiConfigs", () => {
     })
 
     expect(apiConfigs["Example - Default"].openAiModelId).toBe("gpt-4o-mini")
-  })
-
-  it("preserves explicit legacy model omission during tuple compatibility", () => {
-    const compatibilitySelection: KiloCodeExportTuple &
-      KiloCodeLegacySelection = {
-      accountId: "a",
-      siteName: "Example",
-      baseUrl: "https://api.example.invalid",
-      tokenId: 1,
-      tokenName: "Default",
-      tokenKey: "example-key",
-      legacyModelId: "  ",
-      modelId: "compatibility-model",
-    }
-
-    const { apiConfigs } = buildKiloCodeApiConfigs({
-      selections: [compatibilitySelection],
-      generateId: (name) => `id-${name}`,
-    })
-
-    expect(apiConfigs["Example - Default"]).not.toHaveProperty("openAiModelId")
   })
 })

--- a/tests/services/kiloCodeExport.test.ts
+++ b/tests/services/kiloCodeExport.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest"
 import {
   buildKiloCodeApiConfigs,
   buildKiloCodeV7SettingsFile,
+  getKiloCodeApiConfigProfileNames,
   KILO_CODE_EXPORT_FILENAMES,
   KILO_CODE_EXPORT_TARGETS,
   type KiloCodeDefaultModelSelection,
@@ -145,9 +146,164 @@ describe("buildKiloCodeV7SettingsFile", () => {
       }),
     ).toThrow("Kilo Code default model must exist in its provider catalog")
   })
+
+  it.each([
+    [
+      "duplicate provider IDs",
+      {
+        providers: [
+          {
+            ...preparedCatalog.providers[0]!,
+            providerId: preparedCatalog.providers[0]!.providerId,
+          },
+          {
+            ...preparedCatalog.providers[0]!,
+            selectionId: "second",
+            providerId: preparedCatalog.providers[0]!.providerId,
+          },
+        ],
+        providerCount: 2,
+        modelCount: 2,
+      },
+      "Kilo Code provider IDs must be unique",
+    ],
+    [
+      "empty models",
+      {
+        providers: [{ ...preparedCatalog.providers[0]!, modelIds: [] }],
+        providerCount: 1,
+        modelCount: 0,
+      },
+      "Kilo Code provider model catalog cannot be empty",
+    ],
+    [
+      "blank token key",
+      {
+        providers: [{ ...preparedCatalog.providers[0]!, tokenKey: " " }],
+        providerCount: 1,
+        modelCount: 2,
+      },
+      "Kilo Code provider token key cannot be blank",
+    ],
+    [
+      "invalid base URL",
+      {
+        providers: [{ ...preparedCatalog.providers[0]!, baseURL: "not-a-url" }],
+        providerCount: 1,
+        modelCount: 2,
+      },
+      "Kilo Code provider base URL must be a valid HTTP or HTTPS URL",
+    ],
+    [
+      "count mismatch",
+      { providers: preparedCatalog.providers, providerCount: 2, modelCount: 2 },
+      "Kilo Code catalog provider count is inconsistent",
+    ],
+    [
+      "model count mismatch",
+      { providers: preparedCatalog.providers, providerCount: 1, modelCount: 3 },
+      "Kilo Code catalog model count is inconsistent",
+    ],
+    [
+      "duplicate selection IDs",
+      {
+        providers: [
+          preparedCatalog.providers[0]!,
+          {
+            ...preparedCatalog.providers[0]!,
+            providerId: "second-provider-id",
+          },
+        ],
+        providerCount: 2,
+        modelCount: 4,
+      },
+      "Kilo Code provider selection IDs must be unique",
+    ],
+  ] as const)(
+    "rejects forged prepared catalogs with %s",
+    (_label, catalog, message) => {
+      expect(() =>
+        buildKiloCodeV7SettingsFile({
+          catalog: catalog as typeof preparedCatalog,
+          defaultModel,
+        }),
+      ).toThrow(message)
+    },
+  )
+
+  it("rejects forged duplicate model IDs instead of silently overwriting the map", () => {
+    expect(() =>
+      buildKiloCodeV7SettingsFile({
+        catalog: {
+          ...preparedCatalog,
+          providers: [
+            {
+              ...preparedCatalog.providers[0]!,
+              modelIds: ["model-a", "model-a"],
+            },
+          ],
+          modelCount: 2,
+        },
+        defaultModel,
+      }),
+    ).toThrow("Kilo Code provider model IDs must be unique")
+  })
+
+  it("rejects forged model catalogs that do not use canonical code-point order", () => {
+    expect(() =>
+      buildKiloCodeV7SettingsFile({
+        catalog: {
+          ...preparedCatalog,
+          providers: [
+            {
+              ...preparedCatalog.providers[0]!,
+              modelIds: ["model-b", "model-a"],
+            },
+          ],
+        },
+        defaultModel,
+      }),
+    ).toThrow("Kilo Code provider model IDs must use canonical order")
+  })
+
+  it("rejects forged catalogs with duplicate provider display names", () => {
+    expect(() =>
+      buildKiloCodeV7SettingsFile({
+        catalog: {
+          providers: [
+            preparedCatalog.providers[0]!,
+            {
+              ...preparedCatalog.providers[0]!,
+              selectionId: "account-b:8",
+              providerId: "second-provider-id",
+            },
+          ],
+          providerCount: 2,
+          modelCount: 4,
+        },
+        defaultModel,
+      }),
+    ).toThrow("Kilo Code provider names must be unique")
+  })
 })
 
 describe("buildKiloCodeApiConfigs", () => {
+  it("derives legacy profile names without constructing secret-bearing configs", () => {
+    expect(
+      getKiloCodeApiConfigProfileNames({
+        selections: [
+          {
+            accountId: "a",
+            siteName: "Example",
+            baseUrl: "https://x.test",
+            tokenId: 1,
+            tokenName: "Default",
+            tokenKey: "secret",
+          },
+        ],
+      }),
+    ).toEqual(["Example - Default"])
+  })
   it("normalizes openAiBaseUrl to end with /v1 without duplicating segments", () => {
     const { apiConfigs } = buildKiloCodeApiConfigs({
       selections: [

--- a/tests/services/kiloCodeExport.test.ts
+++ b/tests/services/kiloCodeExport.test.ts
@@ -6,6 +6,7 @@ import {
   getKiloCodeApiConfigProfileNames,
   KILO_CODE_EXPORT_FILENAMES,
   KILO_CODE_EXPORT_TARGETS,
+  KILO_CODE_PROVIDER_PROTOCOLS,
   type KiloCodeDefaultModelSelection,
 } from "~/services/integrations/kiloCodeExport"
 import { prepareKiloCodeV7Catalog } from "~/services/integrations/kiloCodeV7Catalog"
@@ -60,6 +61,29 @@ describe("buildKiloCodeV7SettingsFile", () => {
       model: `${providerId}/model-b`,
     })
   })
+
+  it.each([
+    [
+      KILO_CODE_PROVIDER_PROTOCOLS.OpenAICompatible,
+      "@ai-sdk/openai-compatible",
+    ],
+    [KILO_CODE_PROVIDER_PROTOCOLS.OpenAIResponses, "@ai-sdk/openai"],
+    [KILO_CODE_PROVIDER_PROTOCOLS.AnthropicMessages, "@ai-sdk/anthropic"],
+  ] as const)(
+    "maps %s to the corresponding AI SDK package",
+    (protocol, npm) => {
+      const catalog = {
+        ...preparedCatalog,
+        providers: [{ ...preparedCatalog.providers[0]!, protocol }],
+      }
+      const result = buildKiloCodeV7SettingsFile({
+        catalog,
+        defaultModel,
+      })
+
+      expect(Object.values(result.provider)[0]?.npm).toBe(npm)
+    },
+  )
 
   it("selects a slash-containing model from a non-first provider", () => {
     const catalog = prepareKiloCodeV7Catalog([
@@ -166,6 +190,20 @@ describe("buildKiloCodeV7SettingsFile", () => {
         modelCount: 2,
       },
       "Kilo Code provider IDs must be unique",
+    ],
+    [
+      "invalid provider protocols",
+      {
+        providers: [
+          {
+            ...preparedCatalog.providers[0]!,
+            protocol: "unknown-protocol",
+          },
+        ],
+        providerCount: 1,
+        modelCount: 2,
+      },
+      "Kilo Code provider protocol is unsupported",
     ],
     [
       "empty models",

--- a/tests/services/kiloCodeExportPolicy.test.ts
+++ b/tests/services/kiloCodeExportPolicy.test.ts
@@ -3,14 +3,12 @@ import { describe, expect, it } from "vitest"
 import {
   KILO_CODE_EXPORT_TARGETS,
   type KiloCodeExportTarget,
-  type KiloCodeExportTuple,
   type KiloCodeLegacySelection,
   type KiloCodeV7ProviderSelection,
 } from "~/services/integrations/kiloCodeExport"
 import {
   buildKiloCodeExportOutput,
   isKiloCodeSettingsFileTooLarge,
-  type BuildKiloCodeExportOutputOptions,
 } from "~/services/integrations/kiloCodeExportPolicy"
 
 const v7DefaultModelId = "模型-b 🚀"
@@ -103,68 +101,6 @@ describe("buildKiloCodeExportOutput", () => {
     expect(isKiloCodeSettingsFileTooLarge(1_048_577)).toBe(true)
   })
 
-  it("keeps the temporary V7 dialog tuple at the policy edge until Tasks 5 and 6", () => {
-    const target: KiloCodeExportTarget = KILO_CODE_EXPORT_TARGETS.KiloV7
-    const selection: KiloCodeExportTuple = {
-      accountId: "account-example",
-      siteName: "Example",
-      baseUrl: "https://api.example.invalid",
-      tokenId: 7,
-      tokenName: "Default",
-      tokenKey: "example-key",
-      modelId: "example-model",
-    }
-    const options: BuildKiloCodeExportOutputOptions = {
-      target,
-      selections: [selection],
-      currentLegacyProfileName: "Example - Default",
-    }
-
-    const output = buildKiloCodeExportOutput(options)
-
-    expect(output.target).toBe(KILO_CODE_EXPORT_TARGETS.KiloV7)
-    if (output.target !== KILO_CODE_EXPORT_TARGETS.KiloV7) {
-      throw new Error("Expected a Kilo Code V7 output")
-    }
-    expect(output.copyPayload).toEqual({
-      provider: output.downloadPayload.provider,
-      model: output.downloadPayload.model,
-    })
-  })
-
-  it("keeps the temporary legacy dialog tuple at the policy edge until Tasks 5 and 6", () => {
-    const target: KiloCodeExportTarget = KILO_CODE_EXPORT_TARGETS.Legacy
-    const selection: KiloCodeExportTuple = {
-      accountId: "account-example",
-      siteName: "Example",
-      baseUrl: "https://api.example.invalid",
-      tokenId: 7,
-      tokenName: "Default",
-      tokenKey: "example-key",
-      modelId: "compatibility-model",
-    }
-    const options: BuildKiloCodeExportOutputOptions = {
-      target,
-      selections: [selection],
-      currentLegacyProfileName: "Example - Default",
-    }
-
-    const output = buildKiloCodeExportOutput(options)
-
-    expect(output.target).toBe(KILO_CODE_EXPORT_TARGETS.Legacy)
-    if (output.target !== KILO_CODE_EXPORT_TARGETS.Legacy) {
-      throw new Error("Expected a legacy Kilo Code output")
-    }
-    expect(output.copyPayload).toEqual(
-      output.downloadPayload.providerProfiles.apiConfigs,
-    )
-    expect(output.copyPayload).toMatchObject({
-      "Example - Default": {
-        openAiModelId: "compatibility-model",
-      },
-    })
-  })
-
   it.each(["", "   "])(
     "rejects an invalid legacy current profile name: %j",
     (currentLegacyProfileName) => {
@@ -179,8 +115,15 @@ describe("buildKiloCodeExportOutput", () => {
   )
 
   it("rejects an unsupported runtime export target", () => {
+    const buildWithRuntimeTarget =
+      buildKiloCodeExportOutput as unknown as (options: {
+        target: KiloCodeExportTarget
+        selections: KiloCodeLegacySelection[]
+        currentLegacyProfileName: string
+      }) => unknown
+
     expect(() =>
-      buildKiloCodeExportOutput({
+      buildWithRuntimeTarget({
         target: "unsupported" as KiloCodeExportTarget,
         selections: [legacySelection],
         currentLegacyProfileName: "Example - Default",

--- a/tests/services/kiloCodeExportPolicy.test.ts
+++ b/tests/services/kiloCodeExportPolicy.test.ts
@@ -4,50 +4,165 @@ import {
   KILO_CODE_EXPORT_TARGETS,
   type KiloCodeExportTarget,
   type KiloCodeExportTuple,
+  type KiloCodeLegacySelection,
+  type KiloCodeV7ProviderSelection,
 } from "~/services/integrations/kiloCodeExport"
-import { buildKiloCodeExportOutput } from "~/services/integrations/kiloCodeExportPolicy"
+import {
+  buildKiloCodeExportOutput,
+  isKiloCodeSettingsFileTooLarge,
+  type BuildKiloCodeExportOutputOptions,
+} from "~/services/integrations/kiloCodeExportPolicy"
 
-const selection: KiloCodeExportTuple = {
+const v7DefaultModelId = "模型-b 🚀"
+
+const v7Selection: KiloCodeV7ProviderSelection = {
+  accountId: "account-example",
+  siteName: "示例站 🚀",
+  baseUrl: "https://api.example.invalid",
+  tokenId: 7,
+  tokenName: "Default",
+  tokenKey: "example-key",
+  selectionId: "account-example:7",
+  discoveredModelIds: [v7DefaultModelId, "model-a"],
+}
+
+const legacySelection: KiloCodeLegacySelection = {
   accountId: "account-example",
   siteName: "Example",
   baseUrl: "https://api.example.invalid",
   tokenId: 7,
   tokenName: "Default",
   tokenKey: "example-key",
-  modelId: "example-model",
+  legacyModelId: "example-model",
 }
 
 describe("buildKiloCodeExportOutput", () => {
-  it("builds the Kilo Code 7.x download and provider copy payloads", () => {
+  it("copies the complete V7 top-level fragment and reports normalized counts", () => {
     const output = buildKiloCodeExportOutput({
       target: KILO_CODE_EXPORT_TARGETS.KiloV7,
-      selections: [selection],
-      currentLegacyProfileName: "Example - Default",
+      selections: [v7Selection],
+      defaultModel: {
+        selectionId: v7Selection.selectionId,
+        modelId: v7DefaultModelId,
+      },
       now: () => new Date("2026-07-13T00:00:00.000Z"),
     })
 
+    expect(output.target).toBe(KILO_CODE_EXPORT_TARGETS.KiloV7)
     expect(output.filename).toBe("kilo-settings.json")
-    expect(output.downloadPayload).toMatchObject({
-      provider: output.copyPayload,
+    expect(output.copyPayload).toEqual({
+      provider: output.downloadPayload.provider,
+      model: output.downloadPayload.model,
     })
     expect(output.itemCount).toBe(1)
+    expect(output.modelCount).toBe(2)
+    expect(output.downloadJson).toBe(
+      JSON.stringify(output.downloadPayload, null, 2),
+    )
+    expect(output.downloadByteLength).toBe(
+      new TextEncoder().encode(output.downloadJson).byteLength,
+    )
+    expect(output.downloadByteLength).toBeGreaterThan(
+      output.downloadJson.length,
+    )
+    expect(output.isDownloadTooLarge).toBe(false)
   })
 
-  it("builds the legacy settings download around the API configs copy payload", () => {
+  it("keeps the legacy copy payload and model count unchanged", () => {
     const output = buildKiloCodeExportOutput({
       target: KILO_CODE_EXPORT_TARGETS.Legacy,
-      selections: [selection],
+      selections: [legacySelection],
       currentLegacyProfileName: "Example - Default",
     })
 
+    expect(output.target).toBe(KILO_CODE_EXPORT_TARGETS.Legacy)
     expect(output.filename).toBe("kilo-code-settings.json")
     expect(output.downloadPayload).toEqual({
       providerProfiles: {
         currentApiConfigName: "Example - Default",
-        apiConfigs: output.copyPayload,
+        apiConfigs: output.downloadPayload.providerProfiles.apiConfigs,
+      },
+    })
+    expect(output.copyPayload).toEqual(
+      output.downloadPayload.providerProfiles.apiConfigs,
+    )
+    expect(output.copyPayload).toMatchObject({
+      "Example - Default": {
+        openAiModelId: "example-model",
       },
     })
     expect(output.itemCount).toBe(1)
+    expect(output.modelCount).toBe(1)
+    expect(output.downloadJson).toBe(
+      JSON.stringify(output.downloadPayload, null, 2),
+    )
+  })
+
+  it("accepts exactly 1 MiB and rejects 1 MiB plus one byte", () => {
+    expect(isKiloCodeSettingsFileTooLarge(1_048_576)).toBe(false)
+    expect(isKiloCodeSettingsFileTooLarge(1_048_577)).toBe(true)
+  })
+
+  it("keeps the temporary V7 dialog tuple at the policy edge until Tasks 5 and 6", () => {
+    const target: KiloCodeExportTarget = KILO_CODE_EXPORT_TARGETS.KiloV7
+    const selection: KiloCodeExportTuple = {
+      accountId: "account-example",
+      siteName: "Example",
+      baseUrl: "https://api.example.invalid",
+      tokenId: 7,
+      tokenName: "Default",
+      tokenKey: "example-key",
+      modelId: "example-model",
+    }
+    const options: BuildKiloCodeExportOutputOptions = {
+      target,
+      selections: [selection],
+      currentLegacyProfileName: "Example - Default",
+    }
+
+    const output = buildKiloCodeExportOutput(options)
+
+    expect(output.target).toBe(KILO_CODE_EXPORT_TARGETS.KiloV7)
+    if (output.target !== KILO_CODE_EXPORT_TARGETS.KiloV7) {
+      throw new Error("Expected a Kilo Code V7 output")
+    }
+    expect(output.copyPayload).toEqual({
+      provider: output.downloadPayload.provider,
+      model: output.downloadPayload.model,
+    })
+  })
+
+  it("keeps the temporary legacy dialog tuple at the policy edge until Tasks 5 and 6", () => {
+    const target: KiloCodeExportTarget = KILO_CODE_EXPORT_TARGETS.Legacy
+    const selection: KiloCodeExportTuple = {
+      accountId: "account-example",
+      siteName: "Example",
+      baseUrl: "https://api.example.invalid",
+      tokenId: 7,
+      tokenName: "Default",
+      tokenKey: "example-key",
+      modelId: "compatibility-model",
+    }
+    const options: BuildKiloCodeExportOutputOptions = {
+      target,
+      selections: [selection],
+      currentLegacyProfileName: "Example - Default",
+    }
+
+    const output = buildKiloCodeExportOutput(options)
+
+    expect(output.target).toBe(KILO_CODE_EXPORT_TARGETS.Legacy)
+    if (output.target !== KILO_CODE_EXPORT_TARGETS.Legacy) {
+      throw new Error("Expected a legacy Kilo Code output")
+    }
+    expect(output.copyPayload).toEqual(
+      output.downloadPayload.providerProfiles.apiConfigs,
+    )
+    expect(output.copyPayload).toMatchObject({
+      "Example - Default": {
+        openAiModelId: "compatibility-model",
+      },
+    })
   })
 
   it.each(["", "   "])(
@@ -56,7 +171,7 @@ describe("buildKiloCodeExportOutput", () => {
       expect(() =>
         buildKiloCodeExportOutput({
           target: KILO_CODE_EXPORT_TARGETS.Legacy,
-          selections: [selection],
+          selections: [legacySelection],
           currentLegacyProfileName,
         }),
       ).toThrow("Legacy current profile name cannot be blank")
@@ -67,7 +182,7 @@ describe("buildKiloCodeExportOutput", () => {
     expect(() =>
       buildKiloCodeExportOutput({
         target: "unsupported" as KiloCodeExportTarget,
-        selections: [selection],
+        selections: [legacySelection],
         currentLegacyProfileName: "Example - Default",
       }),
     ).toThrow("Unsupported Kilo Code export target: unsupported")

--- a/tests/services/kiloCodeV7Catalog.test.ts
+++ b/tests/services/kiloCodeV7Catalog.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 
 import {
+  normalizeKiloCodeModelIds,
   prepareKiloCodeV7Catalog,
   type KiloCodeV7ProviderSelection,
 } from "~/services/integrations/kiloCodeV7Catalog"
@@ -61,6 +62,16 @@ describe("prepareKiloCodeV7Catalog", () => {
       "a-model",
       "ä-model",
     ])
+  })
+
+  it("orders astral model IDs by Unicode code point", () => {
+    expect(
+      normalizeKiloCodeModelIds([
+        "\u{1f600}-model",
+        "z-model",
+        "\u{10000}-model",
+      ]),
+    ).toEqual(["z-model", "\u{10000}-model", "\u{1f600}-model"])
   })
 
   it("disambiguates duplicate display names without merging credentials", () => {

--- a/tests/services/kiloCodeV7Catalog.test.ts
+++ b/tests/services/kiloCodeV7Catalog.test.ts
@@ -75,6 +75,26 @@ describe("prepareKiloCodeV7Catalog", () => {
     ).toEqual(["z-model", "\u{10000}-model", "\u{1f600}-model"])
   })
 
+  it("orders a model ID before a longer ID with the same prefix", () => {
+    expect(normalizeKiloCodeModelIds(["model-a", "model"])).toEqual([
+      "model",
+      "model-a",
+    ])
+  })
+
+  it("uses a settings-safe fallback when the provider label cannot be slugified", () => {
+    const result = prepareKiloCodeV7Catalog([
+      {
+        ...baseSelection,
+        siteName: "示例",
+        tokenName: "默认",
+        providerName: undefined,
+      },
+    ])
+
+    expect(result.providers[0]?.providerId).toMatch(/^provider-[a-f0-9]{8}$/)
+  })
+
   it("disambiguates duplicate display names without merging credentials", () => {
     const result = prepareKiloCodeV7Catalog([
       baseSelection,
@@ -220,9 +240,19 @@ describe("prepareKiloCodeV7Catalog", () => {
       { discoveredModelIds: ["", "  "] },
       "Select at least one model for each provider",
     ],
+    [
+      "unsupported protocols",
+      { protocol: "unsupported-protocol" },
+      "Kilo Code provider protocol is unsupported",
+    ],
   ])("rejects %s", (_name, overrides, message) => {
     expect(() =>
-      prepareKiloCodeV7Catalog([{ ...baseSelection, ...overrides }]),
+      prepareKiloCodeV7Catalog([
+        {
+          ...baseSelection,
+          ...(overrides as Partial<KiloCodeV7ProviderSelection>),
+        },
+      ]),
     ).toThrow(message)
   })
 

--- a/tests/services/kiloCodeV7Catalog.test.ts
+++ b/tests/services/kiloCodeV7Catalog.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 
 import {
+  KILO_CODE_PROVIDER_PROTOCOLS,
   normalizeKiloCodeModelIds,
   prepareKiloCodeV7Catalog,
   type KiloCodeV7ProviderSelection,
@@ -107,6 +108,41 @@ describe("prepareKiloCodeV7Catalog", () => {
         ...baseSelection,
         tokenKey: "rotated-example-key",
         discoveredModelIds: ["different-model"],
+      },
+    ])
+
+    expect(second.providers[0]?.providerId).toBe(first.providers[0]?.providerId)
+  })
+
+  it("defaults missing protocols to OpenAI Compatible", () => {
+    const result = prepareKiloCodeV7Catalog([baseSelection])
+
+    expect(result.providers[0]?.protocol).toBe(
+      KILO_CODE_PROVIDER_PROTOCOLS.OpenAICompatible,
+    )
+  })
+
+  it.each([
+    KILO_CODE_PROVIDER_PROTOCOLS.OpenAICompatible,
+    KILO_CODE_PROVIDER_PROTOCOLS.OpenAIResponses,
+    KILO_CODE_PROVIDER_PROTOCOLS.AnthropicMessages,
+  ])("preserves the selected %s protocol", (protocol) => {
+    const result = prepareKiloCodeV7Catalog([{ ...baseSelection, protocol }])
+
+    expect(result.providers[0]?.protocol).toBe(protocol)
+  })
+
+  it("keeps the provider ID stable when only its protocol changes", () => {
+    const first = prepareKiloCodeV7Catalog([
+      {
+        ...baseSelection,
+        protocol: KILO_CODE_PROVIDER_PROTOCOLS.OpenAICompatible,
+      },
+    ])
+    const second = prepareKiloCodeV7Catalog([
+      {
+        ...baseSelection,
+        protocol: KILO_CODE_PROVIDER_PROTOCOLS.AnthropicMessages,
       },
     ])
 

--- a/tests/services/kiloCodeV7Catalog.test.ts
+++ b/tests/services/kiloCodeV7Catalog.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  prepareKiloCodeV7Catalog,
+  type KiloCodeV7ProviderSelection,
+} from "~/services/integrations/kiloCodeV7Catalog"
+
+const baseSelection: KiloCodeV7ProviderSelection = {
+  selectionId: "account-a:7",
+  accountId: "account-a",
+  siteName: "Example",
+  baseUrl: "https://api.example.invalid",
+  tokenId: 7,
+  tokenName: "Default",
+  tokenKey: "example-key",
+  providerName: "Example - Default",
+  discoveredModelIds: ["model-b", " model-a ", "model-b", ""],
+}
+
+describe("prepareKiloCodeV7Catalog", () => {
+  it("prepares a readable provider with a normalized multi-model catalog", () => {
+    const result = prepareKiloCodeV7Catalog([baseSelection])
+
+    expect(result.providers).toEqual([
+      expect.objectContaining({
+        selectionId: "account-a:7",
+        providerName: "Example - Default",
+        providerId: "example-default-f92fc95e",
+        baseURL: "https://api.example.invalid/v1",
+        tokenKey: "example-key",
+        modelIds: ["model-a", "model-b"],
+      }),
+    ])
+    expect(result.providerCount).toBe(1)
+    expect(result.modelCount).toBe(2)
+  })
+
+  it("unions a manual model with discovered models until it is cleared", () => {
+    const result = prepareKiloCodeV7Catalog([
+      { ...baseSelection, manualModelId: " custom/model " },
+    ])
+
+    expect(result.providers[0]?.modelIds).toEqual([
+      "custom/model",
+      "model-a",
+      "model-b",
+    ])
+  })
+
+  it("uses code-point order instead of locale-sensitive ordering", () => {
+    const result = prepareKiloCodeV7Catalog([
+      {
+        ...baseSelection,
+        discoveredModelIds: ["ä-model", "Z-model", "a-model", "A-model"],
+      },
+    ])
+
+    expect(result.providers[0]?.modelIds).toEqual([
+      "A-model",
+      "Z-model",
+      "a-model",
+      "ä-model",
+    ])
+  })
+
+  it("disambiguates duplicate display names without merging credentials", () => {
+    const result = prepareKiloCodeV7Catalog([
+      baseSelection,
+      {
+        ...baseSelection,
+        selectionId: "account-b:8",
+        accountId: "account-b",
+        baseUrl: "https://second.example.invalid",
+        tokenId: 8,
+        tokenKey: "second-example-key",
+      },
+    ])
+
+    expect(result.providers.map((provider) => provider.providerName)).toEqual([
+      "Example - Default (api.example.invalid)",
+      "Example - Default (second.example.invalid)",
+    ])
+    expect(
+      new Set(result.providers.map((provider) => provider.providerId)),
+    ).toHaveLength(2)
+    expect(result.providers.map((provider) => provider.tokenKey)).toEqual([
+      "example-key",
+      "second-example-key",
+    ])
+  })
+
+  it("keeps the current provider ID stable across secret and catalog changes", () => {
+    const first = prepareKiloCodeV7Catalog([baseSelection])
+    const second = prepareKiloCodeV7Catalog([
+      {
+        ...baseSelection,
+        tokenKey: "rotated-example-key",
+        discoveredModelIds: ["different-model"],
+      },
+    ])
+
+    expect(second.providers[0]?.providerId).toBe(first.providers[0]?.providerId)
+  })
+
+  it("keeps the provider ID stable when only its display name changes", () => {
+    const first = prepareKiloCodeV7Catalog([baseSelection])
+    const second = prepareKiloCodeV7Catalog([
+      { ...baseSelection, providerName: "Renamed Provider" },
+    ])
+
+    expect(second.providers[0]?.providerId).toBe(first.providers[0]?.providerId)
+  })
+
+  it("uses stable ordinals when duplicate display names share a host", () => {
+    const result = prepareKiloCodeV7Catalog([
+      { ...baseSelection, baseUrl: "https://api.example.invalid/z" },
+      {
+        ...baseSelection,
+        selectionId: "account-b:8",
+        accountId: "account-b",
+        baseUrl: "https://api.example.invalid/a",
+        tokenId: 8,
+      },
+    ])
+
+    expect(result.providers.map((provider) => provider.providerName)).toEqual([
+      "Example - Default (api.example.invalid) #2",
+      "Example - Default (api.example.invalid) #1",
+    ])
+  })
+
+  it("preserves provider input order", () => {
+    const result = prepareKiloCodeV7Catalog([
+      {
+        ...baseSelection,
+        selectionId: "account-b:8",
+        accountId: "account-b",
+        providerName: "Second Input",
+        tokenId: 8,
+      },
+      { ...baseSelection, providerName: "First Input" },
+    ])
+
+    expect(result.providers.map((provider) => provider.selectionId)).toEqual([
+      "account-b:8",
+      "account-a:7",
+    ])
+  })
+
+  it("rejects duplicate opaque selection IDs", () => {
+    expect(() =>
+      prepareKiloCodeV7Catalog([
+        baseSelection,
+        { ...baseSelection, accountId: "account-b" },
+      ]),
+    ).toThrow("Kilo Code selection IDs must be unique")
+  })
+
+  it.each([
+    ["blank runtime keys", { tokenKey: "  " }, "Runtime key cannot be blank"],
+    [
+      "invalid base URLs",
+      { baseUrl: "not-a-url" },
+      "Base URL must be a valid HTTP or HTTPS URL",
+    ],
+    [
+      "non-HTTP base URLs",
+      { baseUrl: "ftp://api.example.invalid" },
+      "Base URL must be a valid HTTP or HTTPS URL",
+    ],
+    [
+      "empty model catalogs",
+      { discoveredModelIds: ["", "  "] },
+      "Select at least one model for each provider",
+    ],
+  ])("rejects %s", (_name, overrides, message) => {
+    expect(() =>
+      prepareKiloCodeV7Catalog([{ ...baseSelection, ...overrides }]),
+    ).toThrow(message)
+  })
+
+  it("rejects duplicate generated provider IDs", () => {
+    expect(() =>
+      prepareKiloCodeV7Catalog([
+        baseSelection,
+        {
+          ...baseSelection,
+          selectionId: "alternate-selection",
+        },
+      ]),
+    ).toThrow("Kilo Code provider IDs must be unique")
+  })
+})

--- a/tests/services/kiloCodeV7Selection.test.ts
+++ b/tests/services/kiloCodeV7Selection.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest"
+
+import type { PreparedKiloCodeV7Catalog } from "~/services/integrations/kiloCodeV7Catalog"
+import { reconcileKiloCodeV7DefaultSelection } from "~/services/integrations/kiloCodeV7Selection"
+
+const catalog: PreparedKiloCodeV7Catalog = {
+  providers: [
+    {
+      selectionId: "provider-a",
+      providerId: "provider-a-12345678",
+      providerName: "Provider A",
+      baseURL: "https://api.example.invalid/v1",
+      tokenKey: "example-key",
+      modelIds: ["model-a", "model-b"],
+    },
+    {
+      selectionId: "provider-b",
+      providerId: "provider-b-12345678",
+      providerName: "Provider B",
+      baseURL: "https://other.example.invalid/v1",
+      tokenKey: "other-example-key",
+      modelIds: ["model-c"],
+    },
+  ],
+  providerCount: 2,
+  modelCount: 3,
+}
+
+describe("reconcileKiloCodeV7DefaultSelection", () => {
+  it("selects the first provider and model when the current provider was removed", () => {
+    expect(
+      reconcileKiloCodeV7DefaultSelection(catalog, {
+        selectionId: "removed-provider",
+        modelId: "removed/model",
+      }),
+    ).toEqual({ selectionId: "provider-a", modelId: "model-a" })
+  })
+
+  it("preserves an existing provider and repairs its removed model", () => {
+    expect(
+      reconcileKiloCodeV7DefaultSelection(catalog, {
+        selectionId: "provider-b",
+        modelId: "removed/model",
+      }),
+    ).toEqual({ selectionId: "provider-b", modelId: "model-c" })
+  })
+
+  it("preserves a valid prepared custom model", () => {
+    const catalogWithCustom: PreparedKiloCodeV7Catalog = {
+      ...catalog,
+      providers: [
+        {
+          ...catalog.providers[0]!,
+          modelIds: ["custom/model", "model-a", "model-b"],
+        },
+        catalog.providers[1]!,
+      ],
+      modelCount: 4,
+    }
+    const current = {
+      selectionId: "provider-a",
+      modelId: "custom/model",
+    }
+
+    expect(
+      reconcileKiloCodeV7DefaultSelection(catalogWithCustom, current),
+    ).toBe(current)
+  })
+
+  it("repairs the default after a manual model is removed", () => {
+    expect(
+      reconcileKiloCodeV7DefaultSelection(catalog, {
+        selectionId: "provider-a",
+        modelId: "custom/model",
+      }),
+    ).toEqual({ selectionId: "provider-a", modelId: "model-a" })
+  })
+
+  it("returns undefined when the catalog is empty", () => {
+    expect(
+      reconcileKiloCodeV7DefaultSelection({
+        providers: [],
+        providerCount: 0,
+        modelCount: 0,
+      }),
+    ).toBeUndefined()
+  })
+
+  it("returns undefined when the selected fallback provider has no models", () => {
+    const catalogWithoutModels: PreparedKiloCodeV7Catalog = {
+      providers: [{ ...catalog.providers[0]!, modelIds: [] }],
+      providerCount: 1,
+      modelCount: 0,
+    }
+
+    expect(
+      reconcileKiloCodeV7DefaultSelection(catalogWithoutModels, {
+        selectionId: "provider-a",
+        modelId: "removed/model",
+      }),
+    ).toBeUndefined()
+  })
+})

--- a/tests/services/kiloCodeV7Selection.test.ts
+++ b/tests/services/kiloCodeV7Selection.test.ts
@@ -11,6 +11,7 @@ const catalog: PreparedKiloCodeV7Catalog = {
       providerName: "Provider A",
       baseURL: "https://api.example.invalid/v1",
       tokenKey: "example-key",
+      protocol: "openai-compatible",
       modelIds: ["model-a", "model-b"],
     },
     {
@@ -19,6 +20,7 @@ const catalog: PreparedKiloCodeV7Catalog = {
       providerName: "Provider B",
       baseURL: "https://other.example.invalid/v1",
       tokenKey: "other-example-key",
+      protocol: "openai-compatible",
       modelIds: ["model-c"],
     },
   ],

--- a/tests/test-utils/kiloCodeExportGuidance.ts
+++ b/tests/test-utils/kiloCodeExportGuidance.ts
@@ -10,14 +10,22 @@ import { screen, within } from "./render"
 
 const GUIDANCE_KEYS_BY_TARGET = {
   [KILO_CODE_EXPORT_TARGETS.KiloV7]: [
+    "ui:dialog.kiloCode.help.kiloV7CatalogInstructions",
     "ui:dialog.kiloCode.help.kiloV7DownloadInstructions",
     "ui:dialog.kiloCode.help.kiloV7CopyInstructions",
+    "ui:dialog.kiloCode.help.kiloV7ApiKeyEditorNote",
   ],
   [KILO_CODE_EXPORT_TARGETS.Legacy]: [
+    "ui:dialog.kiloCode.help.legacySingleModelInstructions",
     "ui:dialog.kiloCode.help.legacyDownloadInstructions",
     "ui:dialog.kiloCode.help.legacyCopyInstructions",
   ],
 } as const satisfies Record<KiloCodeExportTarget, readonly string[]>
+
+const SETTINGS_SIZE_GUIDANCE_KEYS = {
+  single: "ui:dialog.kiloCode.messages.settingsFileTooLargeSingle",
+  multiple: "ui:dialog.kiloCode.messages.settingsFileTooLargeMultiple",
+} as const
 
 /** Assert the visible Kilo export guidance and hide guidance for other targets. */
 export function expectKiloCodeUsageGuidance(target: KiloCodeExportTarget) {
@@ -62,4 +70,16 @@ export function expectKiloCodeUsageGuidance(target: KiloCodeExportTarget) {
   expect(
     screen.queryByText("ui:dialog.kiloCode.help.legacyTitle"),
   ).not.toBeInTheDocument()
+}
+
+/** Assert that oversized-export recovery matches the dialog's selection scope. */
+export function expectKiloCodeSettingsSizeGuidance(
+  scope: keyof typeof SETTINGS_SIZE_GUIDANCE_KEYS,
+) {
+  const expectedKey = SETTINGS_SIZE_GUIDANCE_KEYS[scope]
+  const oppositeKey =
+    SETTINGS_SIZE_GUIDANCE_KEYS[scope === "single" ? "multiple" : "single"]
+
+  expect(screen.getByText(expectedKey)).toBeVisible()
+  expect(screen.queryByText(oppositeKey)).not.toBeInTheDocument()
 }


### PR DESCRIPTION
## Summary

- export named, multi-model provider catalogs for Kilo Code 7.x with an explicit global default
- support per-provider protocol selection across account and API credential profile exports while preserving the legacy Kilo Code 5.x / Roo Code contract
- add bounded model selection, recovery handling, synchronized locales and documentation, and browser-level download coverage

Related to #1169

## Validation

- focused Kilo Code Vitest suites: 10 files, 157 tests passed
- `pnpm run i18n:extract:ci`
- `pnpm run validate:push`
- `pnpm playwright test e2e/apiCredentialProfilesOptionsActions.spec.ts --grep "downloads Kilo Code settings"`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Kilo Code 7.x exports now generate a provider catalog (one provider per selected runtime key) with multiple models per provider and an explicit default provider/model.
  * Added protocol selection (OpenAI Compatible, OpenAI Responses, Anthropic Messages) and improved model recovery for both Kilo 7.x and legacy export flows.
* **Bug Fixes**
  * Prevented stale async discovery and export/copy/download actions after dialog close or state changes.
  * Enforced a strict 1 MiB export size limit and improved “too large” recovery behavior.
* **Documentation**
  * Expanded export tool guidance for Kilo Code 7.x vs older Roo/Kilo formats, including merge/download differences and editor notes.
* **UI Copy/Localization**
  * Updated Kilo Code dialog labels, validation/help text, and added protocol display strings across locales.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->