### PR TITLE
fix(site-announcements): preserve read state beyond content cache

### DIFF
--- a/docs/superpowers/plans/2026-07-18-site-announcement-account-lifecycle.md
+++ b/docs/superpowers/plans/2026-07-18-site-announcement-account-lifecycle.md
@@ -1,0 +1,540 @@
+# Site Announcement Account Lifecycle Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Retain announcement state while any account still references a site, prune orphaned sites after authoritative account changes, and route manual checks through live site keys instead of stale cached account ids.
+
+**Architecture:** Treat changes to `ACCOUNT_STORAGE_KEYS.ACCOUNTS` as the repository-wide account event because imports, WebDAV, tag migration, and ordinary mutations all write that key. Derive retained site keys from event snapshots, serialize reconciliation with announcement checks, and reuse one fail-closed all-account snapshot for pre-poll cleanup and enabled-account selection.
+
+**Tech Stack:** TypeScript, WXT storage events, existing site-announcement providers/storage, React, Vitest, Testing Library.
+
+---
+
+## Preconditions
+
+Complete `2026-07-18-site-announcement-identity-ledger.md` first. This plan expects schema-v2 `identityLedger`, `mutateStore` no-op support, and the 100/1,000/10,000 limits to exist.
+
+## File Map
+
+- Create `src/services/siteAnnouncements/accountLifecycle.ts`: account snapshot validation and retained-site-key derivation.
+- Create `tests/services/siteAnnouncements/accountLifecycle.test.ts`: common/Sub2API/disabled account key semantics.
+- Create `src/services/siteAnnouncements/operationQueue.ts`: feature-local serialized operation primitive.
+- Create `tests/services/siteAnnouncements/operationQueue.test.ts`: ordering and rejection recovery.
+- Modify `src/services/siteAnnouncements/storage.ts`: prune orphaned content and ledger state without no-op writes.
+- Modify `tests/services/siteAnnouncements/storage.test.ts`: common and Sub2API pruning behavior.
+- Modify `src/services/siteAnnouncements/scheduler.ts`: account listener, latest pending snapshot, startup/poll repair, and live manual routing.
+- Modify `tests/services/siteAnnouncements/scheduler.test.ts`: event, queue, failure, and live representative behavior.
+- Modify `src/services/siteAnnouncements/messaging.ts`: prefer `siteKeys` while retaining `accountIds` compatibility.
+- Modify `src/features/SiteAnnouncements/SiteAnnouncements.tsx`: send visible site keys.
+- Modify `tests/entrypoints/options/SiteAnnouncementsPage.test.tsx`: assert the new request contract.
+
+### Task 1: Retained Site-Key Derivation
+
+**Files:**
+
+- Create: `src/services/siteAnnouncements/accountLifecycle.ts`
+- Create: `tests/services/siteAnnouncements/accountLifecycle.test.ts`
+
+- [ ] **Step 1: Write failing common/Sub2API lifecycle tests**
+
+```ts
+import { describe, expect, it } from "vitest"
+
+import {
+  deriveRetainedSiteKeys,
+  readAccountsFromStorageChangeValue,
+} from "~/services/siteAnnouncements/accountLifecycle"
+
+describe("site announcement account lifecycle", () => {
+  it("dedupes common sites and retains disabled accounts", () => {
+    const keys = deriveRetainedSiteKeys([
+      createAccount({ id: "common-1", disabled: true }),
+      createAccount({ id: "common-2" }),
+    ])
+    expect([...keys]).toEqual(["notice:new-api:https://example.invalid"])
+  })
+
+  it("keeps Sub2API identities account scoped", () => {
+    const keys = deriveRetainedSiteKeys([
+      createAccount({ id: "sub-1", site_type: "sub2api" }),
+      createAccount({ id: "sub-2", site_type: "sub2api" }),
+    ])
+    expect([...keys].sort()).toEqual([
+      "sub2api:sub-1:https://example.invalid",
+      "sub2api:sub-2:https://example.invalid",
+    ])
+  })
+
+  it("distinguishes intentional removal from malformed event data", () => {
+    expect(readAccountsFromStorageChangeValue(undefined)).toEqual([])
+    expect(() => readAccountsFromStorageChangeValue({ accounts: "broken" })).toThrow(
+      "Malformed account storage change",
+    )
+  })
+})
+```
+
+Use the scheduler test's existing account factory shape but reserved `example.invalid` domains.
+
+- [ ] **Step 2: Run the focused test and verify the missing-module failure**
+
+Run: `pnpm exec vitest run tests/services/siteAnnouncements/accountLifecycle.test.ts`
+
+Expected: FAIL because `accountLifecycle.ts` does not exist.
+
+- [ ] **Step 3: Implement strict event parsing and key derivation**
+
+```ts
+import { normalizeAccountStorageConfigForRead } from "~/services/accounts/accountDefaults"
+import { getSiteAnnouncementProvider } from "~/services/siteAnnouncements/providers"
+import type { AccountStorageConfig, SiteAccount } from "~/types"
+import { isPlainObject } from "~/utils/core/object"
+
+export function readAccountsFromStorageChangeValue(value: unknown): SiteAccount[] {
+  if (value === undefined) return []
+  if (!isPlainObject(value) || !Array.isArray(value.accounts)) {
+    throw new Error("Malformed account storage change")
+  }
+  return normalizeAccountStorageConfigForRead(value as AccountStorageConfig).accounts
+}
+
+export function deriveRetainedSiteKeys(accounts: readonly SiteAccount[]) {
+  const keys = new Set<string>()
+  for (const account of accounts) {
+    const provider = getSiteAnnouncementProvider(account.site_type)
+    keys.add(
+      provider.createSiteKey({
+        accountId: account.id,
+        siteType: account.site_type,
+        baseUrl: account.site_url,
+      }),
+    )
+  }
+  return keys
+}
+
+export function haveEqualSiteKeys(left: ReadonlySet<string>, right: ReadonlySet<string>) {
+  return left.size === right.size && [...left].every((key) => right.has(key))
+}
+```
+
+Disabled state is deliberately ignored by key derivation.
+
+- [ ] **Step 4: Run focused tests and compile**
+
+Run:
+
+```bash
+pnpm exec vitest run tests/services/siteAnnouncements/accountLifecycle.test.ts
+pnpm compile
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the pure lifecycle boundary**
+
+```bash
+git add src/services/siteAnnouncements/accountLifecycle.ts tests/services/siteAnnouncements/accountLifecycle.test.ts
+pnpm run validate:staged
+git commit -m "feat(site-announcements): derive retained account site keys"
+```
+
+### Task 2: Orphaned State Pruning
+
+**Files:**
+
+- Modify: `src/services/siteAnnouncements/storage.ts`
+- Modify: `tests/services/siteAnnouncements/storage.test.ts`
+
+- [ ] **Step 1: Write failing lifecycle pruning tests**
+
+Seed two common-site records and two account-scoped Sub2API records. Assert:
+
+```ts
+await expect(
+  siteAnnouncementStorage.pruneOrphanedSites(
+    new Set(["notice:new-api:https://example.invalid"]),
+  ),
+).resolves.toBe(true)
+
+const store = await siteAnnouncementStorage.getStore()
+expect(Object.keys(store.sites)).toEqual([
+  "notice:new-api:https://example.invalid",
+])
+expect(Object.keys(store.identityLedger)).toEqual([
+  "notice:new-api:https://example.invalid",
+])
+```
+
+Call the same method again with the same set, spy on storage `set`, and assert it returns `false` without another write. Add a throwing-read case and assert no write.
+
+- [ ] **Step 2: Run the storage test and verify the missing-method failure**
+
+Run: `pnpm exec vitest run tests/services/siteAnnouncements/storage.test.ts`
+
+Expected: FAIL because `pruneOrphanedSites` does not exist.
+
+- [ ] **Step 3: Implement atomic content/ledger pruning**
+
+```ts
+async pruneOrphanedSites(retainedSiteKeys: ReadonlySet<string>): Promise<boolean> {
+  return await this.mutateStore((store) => {
+    let changed = false
+    const storedSiteKeys = new Set([
+      ...Object.keys(store.sites),
+      ...Object.keys(store.identityLedger),
+    ])
+
+    for (const siteKey of storedSiteKeys) {
+      if (retainedSiteKeys.has(siteKey)) continue
+      if (siteKey in store.sites) {
+        delete store.sites[siteKey]
+        changed = true
+      }
+      if (siteKey in store.identityLedger) {
+        delete store.identityLedger[siteKey]
+        changed = true
+      }
+    }
+
+    return { changed, result: changed }
+  })
+}
+```
+
+- [ ] **Step 4: Run storage tests and compile**
+
+Run:
+
+```bash
+pnpm exec vitest run tests/services/siteAnnouncements/storage.test.ts
+pnpm compile
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit lifecycle pruning**
+
+```bash
+git add src/services/siteAnnouncements/storage.ts tests/services/siteAnnouncements/storage.test.ts
+pnpm run validate:staged
+git commit -m "feat(site-announcements): prune orphaned account sites"
+```
+
+### Task 3: Serialized Event And Poll Reconciliation
+
+**Files:**
+
+- Create: `src/services/siteAnnouncements/operationQueue.ts`
+- Create: `tests/services/siteAnnouncements/operationQueue.test.ts`
+- Modify: `src/services/siteAnnouncements/scheduler.ts`
+- Modify: `tests/services/siteAnnouncements/scheduler.test.ts`
+
+- [ ] **Step 1: Write failing operation queue tests**
+
+```ts
+import { describe, expect, it, vi } from "vitest"
+
+import { SiteAnnouncementOperationQueue } from "~/services/siteAnnouncements/operationQueue"
+
+describe("SiteAnnouncementOperationQueue", () => {
+  it("runs operations in insertion order", async () => {
+    const queue = new SiteAnnouncementOperationQueue()
+    let release!: () => void
+    const released = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const calls: string[] = []
+    const first = queue.enqueue(async () => {
+      calls.push("first-start")
+      await released
+      calls.push("first-end")
+    })
+    const second = queue.enqueue(async () => calls.push("second"))
+    await Promise.resolve()
+    expect(calls).toEqual(["first-start"])
+    release()
+    await Promise.all([first, second])
+    expect(calls).toEqual(["first-start", "first-end", "second"])
+  })
+
+  it("continues after a rejected operation", async () => {
+    const queue = new SiteAnnouncementOperationQueue()
+    await expect(queue.enqueue(async () => { throw new Error("failed") })).rejects.toThrow("failed")
+    await expect(queue.enqueue(async () => "recovered")).resolves.toBe("recovered")
+  })
+})
+```
+
+- [ ] **Step 2: Run the queue test and verify the missing-module failure**
+
+Run: `pnpm exec vitest run tests/services/siteAnnouncements/operationQueue.test.ts`
+
+Expected: FAIL because `operationQueue.ts` does not exist.
+
+- [ ] **Step 3: Implement the feature-local queue**
+
+```ts
+export class SiteAnnouncementOperationQueue {
+  private tail: Promise<void> = Promise.resolve()
+
+  enqueue<T>(operation: () => Promise<T>): Promise<T> {
+    const result = this.tail.then(operation, operation)
+    this.tail = result.then(
+      () => undefined,
+      () => undefined,
+    )
+    return result
+  }
+}
+```
+
+- [ ] **Step 4: Write failing scheduler lifecycle tests**
+
+Extend the account storage mock with `getAllAccountsOrThrow`. Capture the callback registered through a mocked `onStorageChanged`. Add tests proving:
+
+- same retained keys between `oldValue` and `newValue` cause no prune;
+- deleting the last common account queues one prune;
+- deleting one of two common accounts keeps the shared site;
+- a pending newer snapshot replaces an older pending snapshot while a check runs;
+- startup and each poll call `getAllAccountsOrThrow` once and reuse that snapshot;
+- account read rejection returns `null`, performs no provider fetch, and performs no announcement write;
+- disabled accounts remain in retained keys but are filtered before provider fetch.
+
+Use this failure assertion:
+
+```ts
+getAllAccountsOrThrowMock.mockRejectedValueOnce(new Error("accounts unavailable"))
+const response = await resolveSiteAnnouncementsCheckNowMessage({})
+expect(response).toEqual({ success: true, data: null })
+expect(providerFetchMock).not.toHaveBeenCalled()
+expect(pruneOrphanedSitesSpy).not.toHaveBeenCalled()
+```
+
+- [ ] **Step 5: Register the account event before the first await**
+
+Import `ACCOUNT_STORAGE_KEYS`, `onStorageChanged`, and the lifecycle helpers. During `initialize()`, register once before schedule initialization:
+
+```ts
+this.cleanupAccountChanges = onStorageChanged((changes, areaName) => {
+  if (areaName !== "local") return
+  const change = changes[ACCOUNT_STORAGE_KEYS.ACCOUNTS]
+  if (!change) return
+  try {
+    const previous = readAccountsFromStorageChangeValue(change.oldValue)
+    const next = readAccountsFromStorageChangeValue(change.newValue)
+    if (haveEqualSiteKeys(deriveRetainedSiteKeys(previous), deriveRetainedSiteKeys(next))) return
+    this.requestAccountReconciliation(next)
+  } catch (error) {
+    logger.error("Failed to process account storage change", error)
+  }
+})
+```
+
+Do not use `setTimeout`.
+
+- [ ] **Step 6: Coalesce snapshots and serialize checks**
+
+Add queue state to the scheduler:
+
+```ts
+private operationQueue = new SiteAnnouncementOperationQueue()
+private pendingReconciliation: SiteAccount[] | null = null
+private reconciliationScheduled = false
+private checkQueuedOrRunning = false
+```
+
+`requestAccountReconciliation(accounts)` stores the newest array and drains it with:
+
+```ts
+private requestAccountReconciliation(accounts: SiteAccount[]) {
+  this.pendingReconciliation = accounts
+  if (this.reconciliationScheduled) return
+
+  this.reconciliationScheduled = true
+  void this.operationQueue
+    .enqueue(async () => {
+      while (this.pendingReconciliation !== null) {
+        const snapshot = this.pendingReconciliation
+        this.pendingReconciliation = null
+        await siteAnnouncementStorage.pruneOrphanedSites(
+          deriveRetainedSiteKeys(snapshot),
+        )
+      }
+    })
+    .catch((error) => {
+      logger.error("Failed to reconcile site announcement accounts", error)
+    })
+    .finally(() => {
+      this.reconciliationScheduled = false
+      if (this.pendingReconciliation !== null) {
+        this.requestAccountReconciliation(this.pendingReconciliation)
+      }
+    })
+}
+```
+
+Wrap manual/alarm checks in the same queue. Preserve the current overlapping-check contract with:
+
+```ts
+private async runCheck(params: SiteAnnouncementCheckParams) {
+  if (this.checkQueuedOrRunning) return null
+  this.checkQueuedOrRunning = true
+  try {
+    return await this.operationQueue.enqueue(() => this.runCheckInternal(params))
+  } finally {
+    this.checkQueuedOrRunning = false
+  }
+}
+```
+
+- [ ] **Step 7: Reuse one successful account snapshot per poll**
+
+At the start of the queued internal check:
+
+```ts
+const allAccounts = await accountStorage.getAllAccountsOrThrow()
+await siteAnnouncementStorage.pruneOrphanedSites(
+  deriveRetainedSiteKeys(allAccounts),
+)
+const enabledAccounts = allAccounts.filter((account) => account.disabled !== true)
+```
+
+Use `enabledAccounts` for dedupe/filter/fetch. Any read rejection exits the whole check before storage mutation or provider IO. Scheduler initialization performs the same reconciliation once as a repair point, then passes `enabledAccounts` into schedule calculation so initialization does not issue a second account read. Later settings/status schedule reconciliation obtains one new `getAllAccountsOrThrow()` snapshot and never calls the swallowing `getEnabledAccounts()` path.
+
+- [ ] **Step 8: Run queue/scheduler tests and compile**
+
+Run:
+
+```bash
+pnpm exec vitest run tests/services/siteAnnouncements/operationQueue.test.ts tests/services/siteAnnouncements/accountLifecycle.test.ts tests/services/siteAnnouncements/storage.test.ts tests/services/siteAnnouncements/scheduler.test.ts
+pnpm compile
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit event-driven reconciliation**
+
+```bash
+git add src/services/siteAnnouncements/operationQueue.ts src/services/siteAnnouncements/scheduler.ts tests/services/siteAnnouncements/operationQueue.test.ts tests/services/siteAnnouncements/scheduler.test.ts
+pnpm run validate:staged
+git commit -m "feat(site-announcements): reconcile account lifecycle events"
+```
+
+### Task 4: Live Site-Key Manual Checks
+
+**Files:**
+
+- Modify: `src/services/siteAnnouncements/messaging.ts`
+- Modify: `src/services/siteAnnouncements/scheduler.ts`
+- Modify: `src/features/SiteAnnouncements/SiteAnnouncements.tsx`
+- Modify: `tests/services/siteAnnouncements/scheduler.test.ts`
+- Modify: `tests/entrypoints/options/SiteAnnouncementsPage.test.tsx`
+
+- [ ] **Step 1: Write failing UI and scheduler routing tests**
+
+Update options tests to expect:
+
+```ts
+expect(sendSiteAnnouncementsMessage).toHaveBeenCalledWith(
+  SiteAnnouncementsMessageTypes.CheckNow,
+  { siteKeys: ["notice:new-api:https://example.invalid"] },
+)
+```
+
+Add a scheduler test with a cached common site whose old representative account is absent, plus another enabled account resolving to the same site key. Send that `siteKey` and assert the provider receives the live account. Add a Sub2API test proving only the exact account-specific key is selected.
+
+- [ ] **Step 2: Run the UI and scheduler tests and verify the contract failure**
+
+Run:
+
+```bash
+pnpm exec vitest run tests/services/siteAnnouncements/scheduler.test.ts tests/entrypoints/options/SiteAnnouncementsPage.test.tsx
+```
+
+Expected: FAIL because the request and UI still use cached `accountIds`.
+
+- [ ] **Step 3: Add the preferred request field with compatibility**
+
+```ts
+export interface SiteAnnouncementsCheckNowRequest {
+  siteKeys?: string[]
+  /** Compatibility for extension pages opened before a background update. */
+  accountIds?: string[]
+}
+```
+
+Change `runManualCheck` and `runCheck` to accept the request object. If `siteKeys` is present, create each enabled account's live provider site key and retain one representative per requested key. If only legacy `accountIds` is present, preserve the current enabled-id filter. If neither exists, check all enabled accounts.
+
+- [ ] **Step 4: Send site keys from the options page**
+
+Replace `manualCheckAccountIds` with:
+
+```ts
+const manualCheckSiteKeys = useMemo(
+  () => [...new Set(filteredRecords.map((record) => record.siteKey))],
+  [filteredRecords],
+)
+```
+
+Use its length for `canRunManualCheck` and send `{ siteKeys: manualCheckSiteKeys }`. Do not derive routing from `record.accountId`; it remains provenance for rendering and Sub2API single-record upstream read synchronization.
+
+- [ ] **Step 5: Run component, scheduler, and compile checks**
+
+Run:
+
+```bash
+pnpm exec vitest run tests/services/siteAnnouncements/scheduler.test.ts tests/entrypoints/options/SiteAnnouncementsPage.test.tsx
+pnpm compile
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit live manual routing**
+
+```bash
+git add src/services/siteAnnouncements/messaging.ts src/services/siteAnnouncements/scheduler.ts src/features/SiteAnnouncements/SiteAnnouncements.tsx tests/services/siteAnnouncements/scheduler.test.ts tests/entrypoints/options/SiteAnnouncementsPage.test.tsx
+pnpm run validate:staged
+git commit -m "fix(site-announcements): route manual checks by live site"
+```
+
+### Task 5: Lifecycle Slice Validation
+
+**Files:** Review all files changed by Tasks 1-4.
+
+- [ ] **Step 1: Run focused service and options tests**
+
+Run:
+
+```bash
+pnpm exec vitest run tests/services/siteAnnouncements tests/entrypoints/options/SiteAnnouncementsPage.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run the push-equivalent gate**
+
+Run: `pnpm run validate:push`
+
+Expected: PASS for compile and `knip` because new executable modules and shared runtime contracts were added.
+
+- [ ] **Step 3: Inspect scope**
+
+Run:
+
+```bash
+git diff --check HEAD~4..HEAD
+git status --short
+```
+
+Expected: only lifecycle files are committed; unrelated workspace files remain untouched.
+
+Each task commit already runs `validate:staged`; inspect the index/worktree after every gate because formatting hooks may update staged files.
+
+## Release Decisions
+
+- **Telemetry:** Reuse existing manual-check analytics. The request changes routing identity but does not add a new action or setting.
+- **E2E:** No Playwright test. The risk is account snapshot/event ordering and runtime payload mapping, covered by Vitest and Testing Library.
+- **Settings discoverability:** No settings are added, renamed, moved, or removed.
+- **Permissions:** No permission changes.
+- **Compatibility:** Keep `accountIds` only as a narrow mixed-version runtime shim; route all new UI work through `siteKeys`.

--- a/docs/superpowers/plans/2026-07-18-site-announcement-identity-ledger.md
+++ b/docs/superpowers/plans/2026-07-18-site-announcement-identity-ledger.md
@@ -1,0 +1,455 @@
+# Site Announcement Identity Ledger Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent cached site announcements from becoming new again after content eviction by persisting bounded seen/read identity state independently from complete content.
+
+**Architecture:** Upgrade the existing single-key announcement store to schema v2 with a SHA-256 keyed identity ledger. Keep 100 complete records per site, retain up to 1,000 identities per site and 10,000 globally, and make mutation reads fail closed so storage failures or unsupported schemas cannot overwrite valid bytes.
+
+**Tech Stack:** TypeScript, WXT, `@plasmohq/storage`, WebCrypto SHA-256, Vitest.
+
+---
+
+## File Map
+
+- Create `src/services/siteAnnouncements/identity.ts`: fingerprint digest and deterministic ledger pruning.
+- Create `tests/services/siteAnnouncements/identity.test.ts`: digest vectors and pruning contracts.
+- Modify `src/types/siteAnnouncements.ts`: schema-v2 marker/store types.
+- Modify `src/services/siteAnnouncements/constants.ts`: schema and retention limits.
+- Modify `src/services/siteAnnouncements/storage.ts`: migration, fail-closed writes, identity-aware upsert, and read projection.
+- Modify `src/services/siteAnnouncements/scheduler.ts`: preserve provider `readAt` and notification semantics.
+- Modify `tests/services/siteAnnouncements/storage.test.ts`: persistence regressions.
+- Modify `tests/services/siteAnnouncements/scheduler.test.ts`: provider and two-poll regressions.
+
+### Task 1: Identity Contract And Digest
+
+**Files:**
+
+- Create: `src/services/siteAnnouncements/identity.ts`
+- Create: `tests/services/siteAnnouncements/identity.test.ts`
+- Modify: `src/types/siteAnnouncements.ts`
+- Modify: `src/services/siteAnnouncements/constants.ts`
+
+- [ ] **Step 1: Write the failing digest tests**
+
+```ts
+import { describe, expect, it } from "vitest"
+
+import {
+  compareIdentityEntriesOldestFirst,
+  digestAnnouncementFingerprint,
+} from "~/services/siteAnnouncements/identity"
+
+describe("site announcement identities", () => {
+  it("uses lowercase SHA-256 over UTF-8 fingerprints", async () => {
+    await expect(digestAnnouncementFingerprint("abc")).resolves.toBe(
+      "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+    )
+  })
+
+  it("breaks equal timestamps by site key and digest", () => {
+    const entries = [
+      { siteKey: "site-b", digest: "a", marker: { firstSeenAt: 1, lastSeenAt: 5 } },
+      { siteKey: "site-a", digest: "b", marker: { firstSeenAt: 1, lastSeenAt: 5 } },
+      { siteKey: "site-a", digest: "a", marker: { firstSeenAt: 1, lastSeenAt: 5 } },
+    ]
+    expect(entries.sort(compareIdentityEntriesOldestFirst).map(({ siteKey, digest }) => `${siteKey}:${digest}`)).toEqual([
+      "site-a:a",
+      "site-a:b",
+      "site-b:a",
+    ])
+  })
+})
+```
+
+- [ ] **Step 2: Run the test and verify the missing-module failure**
+
+Run: `pnpm exec vitest run tests/services/siteAnnouncements/identity.test.ts`
+
+Expected: FAIL because `identity.ts` does not exist.
+
+- [ ] **Step 3: Add schema-v2 types and limits**
+
+```ts
+export interface SiteAnnouncementIdentityMarker {
+  firstSeenAt: number
+  lastSeenAt: number
+  readAt?: number
+}
+
+export interface SiteAnnouncementStoreState {
+  schemaVersion: 2
+  sites: Record<string, SiteAnnouncementSiteState>
+  identityLedger: Record<string, Record<string, SiteAnnouncementIdentityMarker>>
+}
+```
+
+Set `SITE_ANNOUNCEMENTS_STORE_SCHEMA_VERSION` to `2`, then set `recordsPerSite: 100`, `identitiesPerSite: 1_000`, and `identitiesTotal: 10_000` without changing `summaryLength`.
+
+- [ ] **Step 4: Implement the digest and comparator**
+
+```ts
+import type { SiteAnnouncementIdentityMarker } from "~/types/siteAnnouncements"
+
+export interface SiteAnnouncementIdentityEntry {
+  siteKey: string
+  digest: string
+  marker: SiteAnnouncementIdentityMarker
+}
+
+export async function digestAnnouncementFingerprint(fingerprint: string) {
+  const bytes = new TextEncoder().encode(fingerprint)
+  const digest = await crypto.subtle.digest("SHA-256", bytes)
+  return Array.from(new Uint8Array(digest), (byte) =>
+    byte.toString(16).padStart(2, "0"),
+  ).join("")
+}
+
+export function compareIdentityEntriesOldestFirst(
+  left: SiteAnnouncementIdentityEntry,
+  right: SiteAnnouncementIdentityEntry,
+) {
+  return (
+    left.marker.lastSeenAt - right.marker.lastSeenAt ||
+    left.siteKey.localeCompare(right.siteKey) ||
+    left.digest.localeCompare(right.digest)
+  )
+}
+```
+
+Let missing WebCrypto or digest rejection propagate.
+
+- [ ] **Step 5: Run the focused test**
+
+Run: `pnpm exec vitest run tests/services/siteAnnouncements/identity.test.ts`
+
+Expected: PASS. Do not commit until Task 2 restores repo compile after the schema change.
+
+### Task 2: Migration And Fail-Closed Mutations
+
+**Files:**
+
+- Modify: `src/services/siteAnnouncements/storage.ts`
+- Modify: `tests/services/siteAnnouncements/storage.test.ts`
+- Include all Task 1 files in the commit.
+
+- [ ] **Step 1: Write failing migration and no-overwrite tests**
+
+Add a schema-v1 fixture containing one unread and one read record. Assert `getStore()` returns schema 2, two marker entries, and preserves the read record's `readAt`. Add mutation tests with storage `get` rejection, schema `999`, and malformed root data; call `markAllRead()` and assert rejection plus no `storage.set` call.
+
+Use this mutation assertion for each invalid source:
+
+```ts
+const storageApi = (siteAnnouncementStorage as any).storage
+const setSpy = vi.spyOn(storageApi, "set")
+vi.spyOn(storageApi, "get").mockResolvedValueOnce({ schemaVersion: 999, sites: {} })
+
+await expect(siteAnnouncementStorage.markAllRead()).rejects.toThrow(
+  "Unsupported site announcement store schema",
+)
+expect(setSpy).not.toHaveBeenCalled()
+```
+
+- [ ] **Step 2: Run the storage tests and verify failure**
+
+Run: `pnpm exec vitest run tests/services/siteAnnouncements/storage.test.ts`
+
+Expected: FAIL because schema mismatches currently become empty stores and mutation reads swallow failures.
+
+- [ ] **Step 3: Make store sanitization asynchronous and migrate v1**
+
+Keep the existing record/site normalization, but force every sanitized record's `siteKey` to its outer map key. Implement this store-level control flow:
+
+```ts
+function createEmptyStore(): SiteAnnouncementStoreState {
+  return { schemaVersion: 2, sites: {}, identityLedger: {} }
+}
+
+async function sanitizeStore(value: unknown): Promise<SiteAnnouncementStoreState> {
+  if (value === undefined) return createEmptyStore()
+  if (!isPlainObject(value)) throw new Error("Malformed site announcement store")
+  if (value.schemaVersion !== 1 && value.schemaVersion !== 2) {
+    throw new Error("Unsupported site announcement store schema")
+  }
+
+  const sites = sanitizeSites(value.sites)
+  const identityLedger =
+    value.schemaVersion === 2 ? sanitizeIdentityLedger(value.identityLedger) : {}
+
+  for (const [siteKey, site] of Object.entries(sites)) {
+    const markers = (identityLedger[siteKey] ??= {})
+    for (const record of site.records) {
+      record.siteKey = siteKey
+      const digest = await digestAnnouncementFingerprint(record.fingerprint)
+      const current = markers[digest]
+      const nextMarker = {
+        firstSeenAt: current?.firstSeenAt ?? record.firstSeenAt,
+        lastSeenAt: Math.max(current?.lastSeenAt ?? 0, record.lastSeenAt),
+        readAt: current?.readAt ?? (record.read ? (record.readAt ?? record.lastSeenAt) : undefined),
+      }
+      markers[digest] = nextMarker
+      if (nextMarker.readAt !== undefined) {
+        record.read = true
+        record.readAt = nextMarker.readAt
+      }
+    }
+  }
+
+  return { schemaVersion: 2, sites, identityLedger }
+}
+```
+
+`sanitizeIdentityLedger` must accept only nested plain objects with finite `firstSeenAt`, `lastSeenAt`, and optional finite `readAt`. Tighten the existing record sanitizer to use `Number.isFinite` for `firstSeenAt`, `lastSeenAt`, and optional record timestamps so `NaN` and `Infinity` never enter sorting or pruning.
+
+- [ ] **Step 4: Separate display fallback from mutation reads**
+
+```ts
+private async getStoreOrThrow() {
+  const stored = await this.storage.get(STORAGE_KEYS.SITE_ANNOUNCEMENTS_STORE)
+  return await sanitizeStore(stored)
+}
+
+async getStore() {
+  try {
+    return await this.getStoreOrThrow()
+  } catch (error) {
+    logger.error("Failed to load site announcement store", error)
+    return createEmptyStore()
+  }
+}
+
+private async mutateStore<T>(
+  mutation: (
+    store: SiteAnnouncementStoreState,
+  ) =>
+    | { changed: boolean; result: T }
+    | Promise<{ changed: boolean; result: T }>,
+): Promise<T> {
+  return await this.withStorageWriteLock(async () => {
+    const store = await this.getStoreOrThrow()
+    const { changed, result } = await mutation(store)
+    if (changed && !(await this.setStore(store))) {
+      throw new Error("Failed to persist site announcement store")
+    }
+    return result
+  })
+}
+```
+
+Adapt every existing mutator to return `{ changed, result }`; unknown ids, empty id arrays, and already-read records use `changed: false`.
+
+- [ ] **Step 5: Run tests and compile**
+
+Run:
+
+```bash
+pnpm exec vitest run tests/services/siteAnnouncements/identity.test.ts tests/services/siteAnnouncements/storage.test.ts
+pnpm compile
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit the persisted contract**
+
+```bash
+git add src/types/siteAnnouncements.ts src/services/siteAnnouncements/constants.ts src/services/siteAnnouncements/identity.ts src/services/siteAnnouncements/storage.ts tests/services/siteAnnouncements/identity.test.ts tests/services/siteAnnouncements/storage.test.ts
+pnpm run validate:staged
+git commit -m "feat(site-announcements): add durable identity ledger"
+```
+
+### Task 3: Identity-Aware Upsert And Capacity
+
+**Files:**
+
+- Modify: `src/services/siteAnnouncements/identity.ts`
+- Modify: `src/services/siteAnnouncements/storage.ts`
+- Modify: `tests/services/siteAnnouncements/identity.test.ts`
+- Modify: `tests/services/siteAnnouncements/storage.test.ts`
+
+- [ ] **Step 1: Write the 101-item and pruning tests**
+
+Insert 101 unique fingerprints at one timestamp, repeat them in reverse order, and assert:
+
+```ts
+expect(firstCreated).toHaveLength(101)
+expect(await siteAnnouncementStorage.listRecords()).toHaveLength(100)
+expect(secondCreated).toHaveLength(0)
+expect(Object.keys((await siteAnnouncementStorage.getStore()).identityLedger[siteKey]!)).toHaveLength(101)
+```
+
+Test `pruneIdentityLedger` with explicit test limits `{ identitiesPerSite: 2, identitiesTotal: 3 }`, including equal timestamps. Assert the oldest deterministic entries disappear and pruning the result again produces an equal ledger.
+
+- [ ] **Step 2: Run tests and verify the old cache-boundary failure**
+
+Run: `pnpm exec vitest run tests/services/siteAnnouncements/identity.test.ts tests/services/siteAnnouncements/storage.test.ts`
+
+Expected: FAIL because complete records still establish all identity state.
+
+- [ ] **Step 3: Implement bounded deterministic pruning**
+
+In `identity.ts`, clone the ledger, prune each site oldest-first to `identitiesPerSite`, flatten the survivors, then prune globally oldest-first to `identitiesTotal`. Use `compareIdentityEntriesOldestFirst` for both passes and remove empty site maps.
+
+The function signature is:
+
+```ts
+export function pruneIdentityLedger(
+  ledger: SiteAnnouncementStoreState["identityLedger"],
+  limits: { identitiesPerSite: number; identitiesTotal: number },
+): SiteAnnouncementStoreState["identityLedger"]
+```
+
+- [ ] **Step 4: Establish identity before slicing content**
+
+Before acquiring the lock, compute each input digest:
+
+```ts
+const inputs = await Promise.all(
+  params.records.map(async (record) => ({
+    record,
+    digest: await digestAnnouncementFingerprint(record.fingerprint),
+  })),
+)
+```
+
+Inside `mutateStore`, treat either a marker or cached raw fingerprint as known. New identities create a marker and complete record; known evicted identities reconstruct content using marker `firstSeenAt`; cached identities refresh timestamps and read projection. Only a record with neither prior marker nor cached record and no provider `readAt` enters `createdRecords`.
+
+After all inputs, apply:
+
+```ts
+records.sort(
+  (left, right) =>
+    right.firstSeenAt - left.firstSeenAt ||
+    left.fingerprint.localeCompare(right.fingerprint),
+)
+site.records = records.slice(0, SITE_ANNOUNCEMENTS_LIMITS.recordsPerSite)
+store.identityLedger = pruneIdentityLedger(store.identityLedger, {
+  identitiesPerSite: SITE_ANNOUNCEMENTS_LIMITS.identitiesPerSite,
+  identitiesTotal: SITE_ANNOUNCEMENTS_LIMITS.identitiesTotal,
+})
+```
+
+- [ ] **Step 5: Run tests and compile**
+
+Run:
+
+```bash
+pnpm exec vitest run tests/services/siteAnnouncements/identity.test.ts tests/services/siteAnnouncements/storage.test.ts
+pnpm compile
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit retention behavior**
+
+```bash
+git add src/services/siteAnnouncements/identity.ts src/services/siteAnnouncements/storage.ts tests/services/siteAnnouncements/identity.test.ts tests/services/siteAnnouncements/storage.test.ts
+pnpm run validate:staged
+git commit -m "fix(site-announcements): retain identities beyond content cache"
+```
+
+### Task 4: Read Projection And Notification Regression
+
+**Files:**
+
+- Modify: `src/services/siteAnnouncements/scheduler.ts`
+- Modify: `src/services/siteAnnouncements/storage.ts`
+- Modify: `tests/services/siteAnnouncements/storage.test.ts`
+- Modify: `tests/services/siteAnnouncements/scheduler.test.ts`
+
+- [ ] **Step 1: Write failing provider-read and mark-all tests**
+
+Add a storage test inserting 101 items, marking the site read, and expecting `markAllRead(siteKey)` to return `101`. Repeat the same inputs and expect zero created records.
+
+Add a scheduler test returning one provider item with `readAt: 1234` and assert:
+
+```ts
+expect(response).toMatchObject({ success: true, data: { created: 0, notified: 0 } })
+expect(notifySiteAnnouncementsMock).not.toHaveBeenCalled()
+expect(await siteAnnouncementStorage.listRecords()).toEqual([
+  expect.objectContaining({ read: true, readAt: 1234 }),
+])
+```
+
+Add a scheduler test returning the same 101 items on two checks with `markAllRead` between them; expect the second result to contain `{ created: 0, notified: 0 }`.
+
+- [ ] **Step 2: Run focused tests and verify failure**
+
+Run: `pnpm exec vitest run tests/services/siteAnnouncements/storage.test.ts tests/services/siteAnnouncements/scheduler.test.ts`
+
+Expected: FAIL because scheduler drops provider `readAt` and mark-all visits only cached content.
+
+- [ ] **Step 3: Pass provider `readAt` through `createRecordInput`**
+
+Add `readAt: params.announcement.readAt` beside `createdAt` and `updatedAt` in the returned record input.
+
+- [ ] **Step 4: Make ledger read state authoritative**
+
+`markRead(recordId)` must use an async `mutateStore` callback, locate the cached record under the lock, compute its fingerprint digest, and update both record and marker with one timestamp. `markAllRead(siteKey?)` must visit every selected ledger marker, set missing `readAt`, count marker transitions, then update matching cached projections. Return `{ changed: changedCount > 0, result: changedCount }` from the mutation.
+
+Use this loop for the ledger source:
+
+```ts
+for (const selectedSiteKey of selectedSiteKeys) {
+  for (const marker of Object.values(store.identityLedger[selectedSiteKey] ?? {})) {
+    if (marker.readAt === undefined) {
+      marker.readAt = now
+      changedCount += 1
+    }
+  }
+}
+```
+
+- [ ] **Step 5: Run all affected tests and compile**
+
+Run:
+
+```bash
+pnpm exec vitest run tests/services/siteAnnouncements tests/services/apiAdapters/sub2api/siteAnnouncements.test.ts tests/services/apiService/newApiFamily/siteAnnouncements.test.ts
+pnpm compile
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit read-state behavior**
+
+```bash
+git add src/services/siteAnnouncements/scheduler.ts src/services/siteAnnouncements/storage.ts tests/services/siteAnnouncements/storage.test.ts tests/services/siteAnnouncements/scheduler.test.ts
+pnpm run validate:staged
+git commit -m "fix(site-announcements): preserve read state beyond cached content"
+```
+
+### Task 5: Core Slice Validation
+
+**Files:** Review all files changed by Tasks 1-4.
+
+- [ ] **Step 1: Run the focused service suite**
+
+Run: `pnpm exec vitest run tests/services/siteAnnouncements tests/services/apiAdapters/sub2api/siteAnnouncements.test.ts tests/services/apiService/newApiFamily/siteAnnouncements.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 2: Run the push-equivalent gate**
+
+Run: `pnpm run validate:push`
+
+Expected: PASS for compile and `knip` because persisted types and exports changed.
+
+- [ ] **Step 3: Inspect scope**
+
+Run:
+
+```bash
+git diff --check HEAD~3..HEAD
+git status --short
+```
+
+Expected: only task-scoped files are committed; unrelated workspace files remain untouched.
+
+Each task commit already runs `validate:staged`; inspect the index/worktree after every gate because formatting hooks may update staged files.
+
+## Release Decisions
+
+- **Telemetry:** Reuse existing check and mark-read analytics; identity persistence adds no new user action.
+- **E2E:** No Playwright test. Vitest directly covers persistence and scheduler notification behavior.
+- **Permissions:** Do not add `unlimitedStorage` or another optional permission.
+- **Next slice:** Run the account-lifecycle plan only after this core slice passes independently.

--- a/docs/superpowers/specs/2026-07-18-site-announcement-identity-ledger-design.md
+++ b/docs/superpowers/specs/2026-07-18-site-announcement-identity-ledger-design.md
@@ -1,0 +1,366 @@
+# Site Announcement Identity Ledger Design
+
+Date: 2026-07-18
+
+## Purpose
+
+Prevent a previously seen site announcement from becoming new again when the
+bounded content cache evicts it. Keep the immediate change within the existing
+`storage.local` architecture and do not add or request the `unlimitedStorage`
+permission.
+
+## Current Problem
+
+Site announcement content and identity state currently live in the same
+persisted record. Each site retains only ten records. When a provider returns
+more than the retention limit, an evicted record loses the only evidence that
+it was seen. A later poll recreates that announcement as unread and can notify
+the user again.
+
+Raising the content limit to 100 reduces the trigger frequency but does not fix
+the boundary: the same failure returns at record 101.
+
+## Goals
+
+- Retain up to 100 complete announcement records per site.
+- Persist compact identity state for every accepted provider item, including
+  items outside the content cache.
+- Preserve both seen and read state when complete content is evicted.
+- Migrate existing schema-v1 records without discarding content or state.
+- Never notify a provider-supplied read item as newly created.
+- Bound long-term identity growth by entry count and oldest-use eviction, not
+  by age.
+- Remove a site's content and identity state only after no stored account,
+  enabled or disabled, references its site key.
+- Keep correctness independent of `unlimitedStorage`.
+
+## Non-Goals
+
+- Do not add required or optional storage permissions, permission prompts, or
+  browser-specific permission branches.
+- Do not add storage-usage telemetry in this change.
+- Do not split announcement state across multiple storage keys yet.
+- Do not change Sub2API upstream mark-read behavior.
+- Do not redefine the existing announcement fingerprint contract.
+- Do not make account storage depend on the announcement feature.
+
+## Alternatives Considered
+
+### Raise The Record Limit Only
+
+Changing ten records to 100 covers known payload sizes but moves the bug to
+record 101. Content retention and identity retention remain incorrectly
+coupled.
+
+### Read-Only Ledger
+
+Keeping markers only for read records protects previously read cached content,
+but it still fails when one initial response contains more records than the
+content limit. The uncached item has neither a record nor a marker, so every
+later response looks new. A read-only ledger is therefore insufficient.
+
+### Seen Identity Ledger
+
+Keep complete content bounded while retaining a compact marker for every seen
+identity. Marker presence answers whether the item is new; optional `readAt`
+answers whether it is read. This is the selected approach.
+
+## Persisted Model
+
+Upgrade `SiteAnnouncementStoreState` to schema version 2:
+
+```ts
+interface SiteAnnouncementIdentityMarker {
+  firstSeenAt: number
+  lastSeenAt: number
+  readAt?: number
+}
+
+interface SiteAnnouncementStoreState {
+  schemaVersion: 2
+  sites: Record<string, SiteAnnouncementSiteState>
+  identityLedger: Record<
+    string,
+    Record<string, SiteAnnouncementIdentityMarker>
+  >
+}
+```
+
+The outer ledger key is the existing `siteKey`. The inner key is a fixed-size
+digest of the existing raw fingerprint. Complete records continue to retain
+their raw fingerprint and projected `read` / `readAt` fields for rendering.
+The ledger is the durable source for identity and read state.
+
+Use SHA-256 over the UTF-8 bytes of the existing fingerprint through WebCrypto,
+serialized as lowercase hexadecimal. This is asynchronous but fits the
+existing asynchronous storage flow, requires no dependency or permission, and
+avoids an underspecified custom hash. Add fixed test vectors so the persisted
+identity contract cannot drift between browsers or refactors.
+
+## Migration And Self-Healing
+
+`sanitizeStore` must accept schema versions 1 and 2 instead of resetting data
+whenever the version differs.
+
+For every sanitized schema-v1 record, whether read or unread:
+
+1. Compute its fingerprint digest.
+2. Create a marker with the record's `firstSeenAt` and `lastSeenAt`.
+3. Set marker `readAt` only when the record is read, using
+   `readAt ?? lastSeenAt ?? firstSeenAt`.
+4. Return schema version 2 and persist it during the next normal write.
+
+Schema-v2 sanitization ignores malformed markers without dropping valid site
+content. It also self-heals the two projections during a normal write:
+
+- a marker with `readAt` forces a matching cached record to read;
+- a cached record missing a marker recreates the marker from its timestamps;
+- a cached read record enriches a marker whose `readAt` is missing.
+
+A missing storage key is a legitimate empty schema-v2 store. An unknown or
+future schema, a malformed root object, or a digest failure must remain
+distinguishable from that empty state: mutation reads throw and perform no
+write. Best-effort UI reads may return an empty display projection, but that
+projection must never feed a mutation.
+
+## Polling And Read Flow
+
+### Poll Upsert
+
+Compute input fingerprint digests before entering the storage write lock. For
+every accepted provider item inside the update:
+
+`createRecordInput` must pass the provider's `readAt` through to storage; the
+current implementation drops that field.
+
+1. If its marker exists, refresh `lastSeenAt`. Marker presence means the item
+   is already known and it is never returned in `createdRecords`.
+2. If its complete record exists but its marker does not, recreate the marker
+   from that record and treat the item as already known.
+3. If neither exists, create a marker and a complete record. Return the record
+   in `createdRecords` only when the provider did not supply `readAt`.
+4. If provider `readAt` exists, set marker `readAt`, project the record as read,
+   and exclude it from notifications.
+5. If a known evicted item returns, reconstruct its complete record using the
+   marker's `firstSeenAt` and read projection.
+6. Sort complete records by `(firstSeenAt descending, fingerprint ascending)` and
+   retain the first 100 for the site. This stabilizes cache membership when a
+   single response gives many items the same first-seen timestamp.
+
+All accepted items receive markers before the content slice is applied. Thus a
+response containing 101 items produces 101 identities even though only 100
+complete records remain.
+
+### Mark One Read
+
+Mark the cached record and its identity marker with the same `readAt`. A record
+id can address only cached content, so a missing cached record remains a
+failure as today.
+
+### Mark All Read
+
+Mark every ledger identity in the requested site scope, not only the complete
+records still cached, and update matching cached projections. Return the number
+of marker entries that changed from unread to read. This makes “mark all” true
+for all identities the extension has seen, including the 101st uncached item.
+
+## Capacity Policy
+
+Complete content is limited to 100 records per site.
+
+There is no time-based identity expiry. Identity markers have two count bounds:
+
+- at most 1,000 markers per site, preventing one provider from consuming the
+  entire ledger;
+- at most 10,000 markers globally across retained sites.
+
+Normalize and self-heal records and markers first, then apply the per-site
+limit and global limit exactly once before persistence. Evict the oldest marker
+by the deterministic order `(lastSeenAt, siteKey, digest)`. Reject or normalize
+non-finite timestamps during sanitization. A subsequent normal write must
+remain within both limits even when cached records recreate missing markers.
+Skip persistence when reconciliation or pruning made no change.
+
+These are capacity boundaries, not an absolute promise of infinite dedupe.
+After an identity is evicted from both the ledger and content cache, a provider
+may make it appear new again. Active provider results refresh `lastSeenAt`, and
+site-level isolation prevents one large site from evicting every other site's
+state. The 10,000 global limit is a conservative unmeasured starting point, not
+evidence that worst-case content and markers fit the browser quota. Actual
+bytes and write duration must be measured before raising it.
+
+## Account Lifecycle
+
+Account enabled state controls fetching, not retention:
+
+- A common-provider site key is retained while any stored account, enabled or
+  disabled, resolves to the same normalized site type and origin.
+- A Sub2API site key is retained while its exact account still exists because
+  the account id is part of the key.
+- Disabling an account stops polling but does not remove announcement state.
+- Deleting the last account, changing its URL, changing its site type, importing
+  a replacement set, or intentionally clearing all accounts removes orphaned
+  site content and ledger entries.
+
+### Account Change Event
+
+Register a background `storage.onChanged` listener for
+`ACCOUNT_STORAGE_KEYS.ACCOUNTS`. This is the repository's exhaustive account
+change event: it covers ordinary account service mutations, imports, WebDAV,
+clear-all, and storage migrations without coupling those modules to site
+announcements.
+
+Use `oldValue` and `newValue` from the event and the existing account config
+normalizer to derive retained site-key sets. Reconcile only when those sets
+differ; balance refreshes, disabled-state changes, ordering, pinning, and other
+same-site account updates become no-ops. A missing `newValue` is an intentional
+account-store removal and therefore means an empty retained-key set.
+
+Do not defer the work through a plain `setTimeout`: an MV3 service worker may
+suspend before an untracked timer fires. Compare the key sets synchronously in
+the event callback. When they differ, request reconciliation immediately. If
+an announcement operation is already running, retain only the newest pending
+account snapshot and consume it before the operation queue becomes idle.
+
+The current scheduler's `isRunning` flag is not a queue; it drops overlapping
+checks. Add one explicit serialized operation queue shared by checks and
+lifecycle reconciliation so an older account snapshot cannot prune state
+created after a newer account change.
+
+### Startup And Poll Repair
+
+The event is the primary cleanup trigger. Add two repair points:
+
+- reconcile once when the site-announcement scheduler initializes;
+- before a poll, read all accounts once, reconcile from that successful
+  snapshot, then filter the same snapshot to enabled accounts for network
+  fetches.
+
+Do not perform cleanup from status or list getters. Read-only UI queries must
+not mutate storage.
+
+If the startup or poll account read fails, abort both that reconciliation and
+that poll without writing announcement state. This throwing read is a
+data-loss guard, not a recovery mechanism: the next account event, startup, or
+poll retries naturally. A stale orphan is harmless between retries; deleting
+valid history because a transient read looked empty is not. A persistent
+corruption may not recover naturally and must remain visible as an error while
+the original bytes stay untouched.
+
+### Live Manual Check Scope
+
+Stored common-site `accountId` is provenance, not a durable routing target.
+When the representative account is deleted or disabled, another enabled
+account may still represent the same common site.
+
+Change manual-check selection to optional `siteKeys`. Resolve each requested
+site key against the same live enabled-account snapshot and choose its current
+representative. This avoids silently skipping a shared site because the cached
+record points at a stale account id. Sub2API remains exact-account scoped
+through its account-specific site key.
+
+## Storage Failure Safety
+
+The current announcement `updateStore()` calls a read method that converts a
+storage error into an empty store. A transient read failure can therefore be
+followed by a successful write that replaces all announcement data.
+
+Add an internal throwing `getStoreOrThrow()` and require every mutation to use
+it under the existing announcement storage lock. It returns an empty store only
+when the storage key is absent; storage failures, unknown schemas, malformed
+roots, and digest failures reject. A failed read performs no `storage.set`.
+Public best-effort read methods may keep their current fallback behavior for
+display, but that fallback must never feed a mutation.
+
+A failed write continues to reject the runtime operation. The single-store
+schema preserves atomic content/ledger updates for this focused fix.
+
+## Testing
+
+Focused storage tests must cover:
+
+- every schema-v1 record migrates to an identity marker, preserving read state;
+- provider `readAt` creates a read marker and no notification candidate;
+- 11-item and 101-item responses produce no duplicates on the second poll;
+- mark-all covers ledger entries outside the 100-record content cache;
+- marker and cached-record self-healing works in both directions;
+- SHA-256 digest test vectors are stable;
+- per-site and global `limit + 1` eviction uses deterministic oldest order;
+- a normal write after pruning remains within both limits;
+- malformed ledger values and timestamps do not drop valid site content;
+- missing storage creates an empty store, while unknown schema, malformed root,
+  and digest failure perform no write;
+- announcement-store read failure performs no write;
+- no-op reconciliation and pruning perform no write.
+
+Lifecycle and scheduler tests must cover:
+
+- account change events prune only when retained site keys change;
+- disabled accounts retain state without being fetched;
+- deleting one shared common account retains the site;
+- deleting the last shared account prunes the site;
+- Sub2API deletion prunes only its exact account site key;
+- imports, URL/site-type changes, and clear-all reconcile correctly;
+- startup/poll account-read failure leaves announcement state untouched;
+- manual site-key checks resolve a live enabled representative;
+- two checks returning the same over-limit set, with mark-all between them,
+  produce no second notification.
+
+Use Vitest service tests. Playwright is not required because the risk is
+persistence, event handling, and scheduler behavior rather than browser layout
+or a cross-entrypoint interaction.
+
+## Delivery Boundaries
+
+Implement and validate the approved design as two independently reviewable
+slices:
+
+1. Core issue fix: schema-v2 identity ledger, content limit 100, migration,
+   deterministic pruning, provider `readAt`, mark-read behavior, stable content
+   ordering, and fail-closed announcement-store mutations.
+2. Account lifecycle: account-key change handling, retained-site-key
+   reconciliation, explicit operation queue, startup/poll repair, and live
+   `siteKeys` manual-check routing.
+
+The second slice is included because account deletion and shared-site routing
+were explicitly selected product semantics, but the core #1189 regression does
+not depend on it. Keeping the slices separate limits review and rollback risk.
+
+## Known Residual Risks
+
+- The existing fingerprint contract treats a changed fingerprint as a new
+  identity. If a provider edits fields included in the fingerprint, the item
+  may legitimately appear new even though its upstream concept is unchanged.
+- The finite identity limits intentionally provide bounded, not infinite,
+  deduplication.
+- Sub2API mark-all still does not synchronize every local ledger identity to
+  upstream; changing that provider contract remains out of scope.
+- The issue report does not identify the provider or include a raw payload, so
+  cache-eviction reproduction is confirmed but provider-specific fingerprint
+  drift cannot be ruled out.
+
+## Maintainability
+
+Reuse the existing site-key factory, fingerprint, account config normalizer,
+storage-change wrapper, and announcement storage lock. Add one feature-local
+operation queue because the current scheduler has no serialization primitive.
+Extract focused helpers for digesting, ledger normalization/pruning, and
+retained-site-key derivation. Do not add provider-specific retention logic or a
+parallel account event bus.
+
+## Future Capacity Work
+
+`unlimitedStorage` is explicitly deferred and is not part of the current
+implementation or permission surface. Before reconsidering capacity, measure
+feature bytes and total extension bytes with `storage.local.getBytesInUse()`
+where supported. Any future telemetry must use only byte buckets, site counts,
+record counts, marker counts, and quota-failure categories.
+
+If measured usage or single-object rewrite cost becomes material, evaluate
+per-site storage keys before adding permissions. Storage permission must remain
+a capacity enhancement rather than a correctness dependency.
+
+The current single-key design rewrites the whole announcement object when poll
+status or marker timestamps change. Accept that as the focused implementation
+tradeoff at the initial 10,000-marker cap, then use measured bytes and write
+duration to decide whether per-site sharding is warranted.

--- a/e2e/utils/commonUserFlows.ts
+++ b/e2e/utils/commonUserFlows.ts
@@ -379,6 +379,7 @@ export async function seedSiteAnnouncementsStore(
     {
       schemaVersion: SITE_ANNOUNCEMENTS_STORE_SCHEMA_VERSION,
       sites,
+      identityLedger: {},
     } satisfies SiteAnnouncementStoreState,
   )
 }

--- a/src/services/siteAnnouncements/constants.ts
+++ b/src/services/siteAnnouncements/constants.ts
@@ -1,8 +1,10 @@
 export const SITE_ANNOUNCEMENTS_ALARM_NAME = "siteAnnouncementsCheck" as const
 
-export const SITE_ANNOUNCEMENTS_STORE_SCHEMA_VERSION = 1 as const
+export const SITE_ANNOUNCEMENTS_STORE_SCHEMA_VERSION = 2 as const
 
 export const SITE_ANNOUNCEMENTS_LIMITS = {
-  recordsPerSite: 10,
+  recordsPerSite: 100,
+  identitiesPerSite: 1_000,
+  identitiesTotal: 10_000,
   summaryLength: 180,
 } as const

--- a/src/services/siteAnnouncements/identity.ts
+++ b/src/services/siteAnnouncements/identity.ts
@@ -1,0 +1,85 @@
+import type {
+  SiteAnnouncementIdentityMarker,
+  SiteAnnouncementStoreState,
+} from "~/types/siteAnnouncements"
+
+export interface SiteAnnouncementIdentityEntry {
+  siteKey: string
+  digest: string
+  marker: SiteAnnouncementIdentityMarker
+}
+
+/** Compares strings by UTF-16 code unit order without locale collation. */
+export function compareStringsOrdinal(left: string, right: string) {
+  if (left < right) return -1
+  if (left > right) return 1
+  return 0
+}
+
+/** Returns a stable lowercase hexadecimal SHA-256 digest of UTF-8 bytes. */
+export async function digestAnnouncementFingerprint(fingerprint: string) {
+  const bytes = new TextEncoder().encode(fingerprint)
+  const digest = await crypto.subtle.digest("SHA-256", bytes)
+  return Array.from(new Uint8Array(digest), (byte) =>
+    byte.toString(16).padStart(2, "0"),
+  ).join("")
+}
+
+/** Orders identities oldest first by (lastSeenAt, siteKey, digest). */
+export function compareIdentityEntriesOldestFirst(
+  left: SiteAnnouncementIdentityEntry,
+  right: SiteAnnouncementIdentityEntry,
+) {
+  return (
+    left.marker.lastSeenAt - right.marker.lastSeenAt ||
+    compareStringsOrdinal(left.siteKey, right.siteKey) ||
+    compareStringsOrdinal(left.digest, right.digest)
+  )
+}
+
+/** Prunes identity markers per site and globally, retaining the newest entries. */
+export function pruneIdentityLedger(
+  ledger: SiteAnnouncementStoreState["identityLedger"],
+  limits: { identitiesPerSite: number; identitiesTotal: number },
+): SiteAnnouncementStoreState["identityLedger"] {
+  const identitiesPerSite = Math.max(0, Math.trunc(limits.identitiesPerSite))
+  const identitiesTotal = Math.max(0, Math.trunc(limits.identitiesTotal))
+  const perSite: SiteAnnouncementStoreState["identityLedger"] = {}
+
+  for (const [siteKey, markers] of Object.entries(ledger)) {
+    const entries = Object.entries(markers)
+      .map(([digest, marker]) => ({
+        siteKey,
+        digest,
+        marker: { ...marker },
+      }))
+      .sort(compareIdentityEntriesOldestFirst)
+    const survivors = entries.slice(
+      Math.max(0, entries.length - identitiesPerSite),
+    )
+
+    if (survivors.length > 0) {
+      perSite[siteKey] = Object.fromEntries(
+        survivors.map(({ digest, marker }) => [digest, marker]),
+      )
+    }
+  }
+
+  const entries = Object.entries(perSite)
+    .flatMap(([siteKey, markers]) =>
+      Object.entries(markers).map(([digest, marker]) => ({
+        siteKey,
+        digest,
+        marker,
+      })),
+    )
+    .sort(compareIdentityEntriesOldestFirst)
+  const survivors = entries.slice(Math.max(0, entries.length - identitiesTotal))
+
+  const result: SiteAnnouncementStoreState["identityLedger"] = {}
+  for (const { siteKey, digest, marker } of survivors) {
+    const siteMarkers = (result[siteKey] ??= {})
+    siteMarkers[digest] = marker
+  }
+  return result
+}

--- a/src/services/siteAnnouncements/scheduler.ts
+++ b/src/services/siteAnnouncements/scheduler.ts
@@ -13,6 +13,7 @@ import type {
   SiteAnnouncementProvider,
   SiteAnnouncementProviderRequest,
   SiteAnnouncementRecord,
+  SiteAnnouncementRecordInput,
   SiteAnnouncementSiteState,
 } from "~/types/siteAnnouncements"
 import {
@@ -82,7 +83,7 @@ function createRecordInput(params: {
   request: SiteAnnouncementProviderRequest
   siteKey: string
   announcement: SiteAnnouncement
-}): Omit<SiteAnnouncementRecord, "id" | "firstSeenAt" | "lastSeenAt" | "read"> {
+}): SiteAnnouncementRecordInput {
   const title = normalizeAnnouncementText(params.announcement.title)
   const content = normalizeAnnouncementText(params.announcement.content)
   const fingerprint =
@@ -107,6 +108,7 @@ function createRecordInput(params: {
     content,
     createdAt: params.announcement.createdAt,
     updatedAt: params.announcement.updatedAt,
+    readAt: params.announcement.readAt,
     fingerprint,
   }
 }

--- a/src/services/siteAnnouncements/storage.ts
+++ b/src/services/siteAnnouncements/storage.ts
@@ -74,54 +74,28 @@ function compareRecordsNewestFirst(
   )
 }
 
-/** Compares identity ledgers without depending on object insertion order. */
-function areIdentityLedgersEqual(
-  left: SiteAnnouncementStoreState["identityLedger"],
-  right: SiteAnnouncementStoreState["identityLedger"],
+/** Serializes identity ledgers without depending on object insertion order. */
+function serializeIdentityLedger(
+  ledger: SiteAnnouncementStoreState["identityLedger"],
 ) {
-  const leftSiteKeys = Object.keys(left).sort(compareStringsOrdinal)
-  const rightSiteKeys = Object.keys(right).sort(compareStringsOrdinal)
-  if (leftSiteKeys.length !== rightSiteKeys.length) {
-    return false
-  }
-
-  for (let index = 0; index < leftSiteKeys.length; index += 1) {
-    const siteKey = leftSiteKeys[index]
-    if (siteKey !== rightSiteKeys[index]) {
-      return false
-    }
-
-    const leftMarkers = left[siteKey] ?? {}
-    const rightMarkers = right[siteKey] ?? {}
-    const leftDigests = Object.keys(leftMarkers).sort(compareStringsOrdinal)
-    const rightDigests = Object.keys(rightMarkers).sort(compareStringsOrdinal)
-    if (leftDigests.length !== rightDigests.length) {
-      return false
-    }
-
-    for (
-      let digestIndex = 0;
-      digestIndex < leftDigests.length;
-      digestIndex += 1
-    ) {
-      const digest = leftDigests[digestIndex]
-      if (digest !== rightDigests[digestIndex]) {
-        return false
-      }
-
-      const leftMarker = leftMarkers[digest]
-      const rightMarker = rightMarkers[digest]
-      if (
-        leftMarker.firstSeenAt !== rightMarker.firstSeenAt ||
-        leftMarker.lastSeenAt !== rightMarker.lastSeenAt ||
-        leftMarker.readAt !== rightMarker.readAt
-      ) {
-        return false
-      }
-    }
-  }
-
-  return true
+  return JSON.stringify(
+    Object.entries(ledger)
+      .flatMap(([siteKey, markers]) =>
+        Object.entries(markers).map(([digest, marker]) => [
+          siteKey,
+          digest,
+          marker.firstSeenAt,
+          marker.lastSeenAt,
+          marker.readAt,
+        ]),
+      )
+      .sort((left, right) =>
+        compareStringsOrdinal(
+          `${left[0]}\0${left[1]}`,
+          `${right[0]}\0${right[1]}`,
+        ),
+      ),
+  )
 }
 
 /**
@@ -412,10 +386,9 @@ class SiteAnnouncementStorage {
           identitiesPerSite: SITE_ANNOUNCEMENTS_LIMITS.identitiesPerSite,
           identitiesTotal: SITE_ANNOUNCEMENTS_LIMITS.identitiesTotal,
         })
-        const pruningChanged = !areIdentityLedgersEqual(
-          store.identityLedger,
-          prunedIdentityLedger,
-        )
+        const pruningChanged =
+          serializeIdentityLedger(store.identityLedger) !==
+          serializeIdentityLedger(prunedIdentityLedger)
         if (changed || pruningChanged) {
           store.identityLedger = prunedIdentityLedger
           if (!(await this.setStore(store))) {
@@ -512,18 +485,6 @@ class SiteAnnouncementStorage {
         const existing = records.find(
           (record) => record.fingerprint === input.fingerprint,
         )
-        const marker = markers[digest]
-
-        if (!marker && existing) {
-          markers[digest] = {
-            firstSeenAt: existing.firstSeenAt,
-            lastSeenAt: existing.lastSeenAt,
-            readAt: existing.read
-              ? existing.readAt ?? existing.lastSeenAt
-              : undefined,
-          }
-        }
-
         const knownMarker = markers[digest]
         if (knownMarker) {
           knownMarker.lastSeenAt = Math.max(knownMarker.lastSeenAt, now)
@@ -686,10 +647,7 @@ class SiteAnnouncementStorage {
         )
         for (const [digest, marker] of Object.entries(
           store.identityLedger[selectedSiteKey] ?? {},
-        )) {
-          if (marker.readAt === undefined) {
-            continue
-          }
+        ).filter(([, marker]) => marker.readAt !== undefined)) {
           const record = recordsByDigest.get(digest)
           if (record) {
             record.read = true

--- a/src/services/siteAnnouncements/storage.ts
+++ b/src/services/siteAnnouncements/storage.ts
@@ -8,8 +8,10 @@ import {
 import { STORAGE_KEYS, STORAGE_LOCKS } from "~/services/core/storageKeys"
 import { withExtensionStorageWriteLock } from "~/services/core/storageWriteLock"
 import type {
+  SiteAnnouncementIdentityMarker,
   SiteAnnouncementProviderId,
   SiteAnnouncementRecord,
+  SiteAnnouncementRecordInput,
   SiteAnnouncementSiteState,
   SiteAnnouncementStatus,
   SiteAnnouncementStoreState,
@@ -27,8 +29,100 @@ import {
   SITE_ANNOUNCEMENTS_LIMITS,
   SITE_ANNOUNCEMENTS_STORE_SCHEMA_VERSION,
 } from "./constants"
+import {
+  compareStringsOrdinal,
+  digestAnnouncementFingerprint,
+  pruneIdentityLedger,
+} from "./identity"
 
 const logger = createLogger("SiteAnnouncementStorage")
+const SHA256_HEX_DIGEST_PATTERN = /^[0-9a-f]{64}$/
+
+/** Serializes stable record fields used to choose a duplicate representative. */
+function serializeRecordInputForComparison(
+  record: SiteAnnouncementRecordInput,
+) {
+  return JSON.stringify(
+    Object.entries(record)
+      // Read state is merged independently so it cannot affect content choice.
+      .filter(([key]) => key !== "readAt")
+      .sort(([leftKey], [rightKey]) =>
+        compareStringsOrdinal(leftKey, rightKey),
+      ),
+  )
+}
+
+/** Orders duplicate record inputs without depending on provider response order. */
+function compareRecordInputs(
+  left: SiteAnnouncementRecordInput,
+  right: SiteAnnouncementRecordInput,
+) {
+  return compareStringsOrdinal(
+    serializeRecordInputForComparison(left),
+    serializeRecordInputForComparison(right),
+  )
+}
+
+/** Orders cached records newest first with deterministic cache membership. */
+function compareRecordsNewestFirst(
+  left: SiteAnnouncementRecord,
+  right: SiteAnnouncementRecord,
+) {
+  return (
+    right.firstSeenAt - left.firstSeenAt ||
+    compareStringsOrdinal(left.fingerprint, right.fingerprint)
+  )
+}
+
+/** Compares identity ledgers without depending on object insertion order. */
+function areIdentityLedgersEqual(
+  left: SiteAnnouncementStoreState["identityLedger"],
+  right: SiteAnnouncementStoreState["identityLedger"],
+) {
+  const leftSiteKeys = Object.keys(left).sort(compareStringsOrdinal)
+  const rightSiteKeys = Object.keys(right).sort(compareStringsOrdinal)
+  if (leftSiteKeys.length !== rightSiteKeys.length) {
+    return false
+  }
+
+  for (let index = 0; index < leftSiteKeys.length; index += 1) {
+    const siteKey = leftSiteKeys[index]
+    if (siteKey !== rightSiteKeys[index]) {
+      return false
+    }
+
+    const leftMarkers = left[siteKey] ?? {}
+    const rightMarkers = right[siteKey] ?? {}
+    const leftDigests = Object.keys(leftMarkers).sort(compareStringsOrdinal)
+    const rightDigests = Object.keys(rightMarkers).sort(compareStringsOrdinal)
+    if (leftDigests.length !== rightDigests.length) {
+      return false
+    }
+
+    for (
+      let digestIndex = 0;
+      digestIndex < leftDigests.length;
+      digestIndex += 1
+    ) {
+      const digest = leftDigests[digestIndex]
+      if (digest !== rightDigests[digestIndex]) {
+        return false
+      }
+
+      const leftMarker = leftMarkers[digest]
+      const rightMarker = rightMarkers[digest]
+      if (
+        leftMarker.firstSeenAt !== rightMarker.firstSeenAt ||
+        leftMarker.lastSeenAt !== rightMarker.lastSeenAt ||
+        leftMarker.readAt !== rightMarker.readAt
+      ) {
+        return false
+      }
+    }
+  }
+
+  return true
+}
 
 /**
  * Coerces unknown persisted provider ids to the supported announcement providers.
@@ -53,7 +147,13 @@ function createEmptyStore(): SiteAnnouncementStoreState {
   return {
     schemaVersion: SITE_ANNOUNCEMENTS_STORE_SCHEMA_VERSION,
     sites: {},
+    identityLedger: {},
   }
+}
+
+/** Checks persisted timestamps before they enter ordering and retention logic. */
+function isFiniteNumber(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value)
 }
 
 /**
@@ -98,26 +198,23 @@ function sanitizeRecord(value: unknown): SiteAnnouncementRecord | null {
     title: typeof value.title === "string" ? value.title : "",
     content,
     fingerprint,
-    firstSeenAt:
-      typeof value.firstSeenAt === "number" ? value.firstSeenAt : Date.now(),
-    lastSeenAt:
-      typeof value.lastSeenAt === "number"
-        ? value.lastSeenAt
-        : typeof value.firstSeenAt === "number"
-          ? value.firstSeenAt
-          : Date.now(),
-    createdAt:
-      typeof value.createdAt === "number" ? value.createdAt : undefined,
-    updatedAt:
-      typeof value.updatedAt === "number" ? value.updatedAt : undefined,
-    notifiedAt:
-      typeof value.notifiedAt === "number" ? value.notifiedAt : undefined,
+    firstSeenAt: isFiniteNumber(value.firstSeenAt)
+      ? value.firstSeenAt
+      : Date.now(),
+    lastSeenAt: isFiniteNumber(value.lastSeenAt)
+      ? value.lastSeenAt
+      : isFiniteNumber(value.firstSeenAt)
+        ? value.firstSeenAt
+        : Date.now(),
+    createdAt: isFiniteNumber(value.createdAt) ? value.createdAt : undefined,
+    updatedAt: isFiniteNumber(value.updatedAt) ? value.updatedAt : undefined,
+    notifiedAt: isFiniteNumber(value.notifiedAt) ? value.notifiedAt : undefined,
     notificationError:
       typeof value.notificationError === "string"
         ? value.notificationError
         : undefined,
     read: value.read === true,
-    readAt: typeof value.readAt === "number" ? value.readAt : undefined,
+    readAt: isFiniteNumber(value.readAt) ? value.readAt : undefined,
   }
 }
 
@@ -136,7 +233,6 @@ function sanitizeSiteState(
     ? value.records
         .map(sanitizeRecord)
         .filter((record): record is SiteAnnouncementRecord => Boolean(record))
-        .slice(0, SITE_ANNOUNCEMENTS_LIMITS.recordsPerSite)
     : []
 
   return {
@@ -147,10 +243,12 @@ function sanitizeSiteState(
     accountId: typeof value.accountId === "string" ? value.accountId : "",
     providerId: normalizeProviderId(value.providerId),
     status: sanitizeStatus(value.status),
-    lastCheckedAt:
-      typeof value.lastCheckedAt === "number" ? value.lastCheckedAt : undefined,
-    lastSuccessAt:
-      typeof value.lastSuccessAt === "number" ? value.lastSuccessAt : undefined,
+    lastCheckedAt: isFiniteNumber(value.lastCheckedAt)
+      ? value.lastCheckedAt
+      : undefined,
+    lastSuccessAt: isFiniteNumber(value.lastSuccessAt)
+      ? value.lastSuccessAt
+      : undefined,
     lastError:
       typeof value.lastError === "string" ? value.lastError : undefined,
     lastNotifiedFingerprint:
@@ -161,21 +259,11 @@ function sanitizeSiteState(
   }
 }
 
-/**
- * Validates the persisted store and drops data from incompatible schemas.
- */
-function sanitizeStore(value: unknown): SiteAnnouncementStoreState {
-  if (!isPlainObject(value)) {
-    return createEmptyStore()
-  }
-
-  if (value.schemaVersion !== SITE_ANNOUNCEMENTS_STORE_SCHEMA_VERSION) {
-    return createEmptyStore()
-  }
-
+/** Normalizes the persisted site map while retaining independently valid sites. */
+function sanitizeSites(value: unknown) {
   const sites: Record<string, SiteAnnouncementSiteState> = {}
-  if (isPlainObject(value.sites)) {
-    for (const [siteKey, siteValue] of Object.entries(value.sites)) {
+  if (isPlainObject(value)) {
+    for (const [siteKey, siteValue] of Object.entries(value)) {
       const siteState = sanitizeSiteState(siteKey, siteValue)
       if (siteState) {
         sites[siteKey] = siteState
@@ -183,25 +271,115 @@ function sanitizeStore(value: unknown): SiteAnnouncementStoreState {
     }
   }
 
+  return sites
+}
+
+/** Drops malformed identity markers while retaining independently valid entries. */
+function sanitizeIdentityLedger(
+  value: unknown,
+): SiteAnnouncementStoreState["identityLedger"] {
+  const identityLedger: SiteAnnouncementStoreState["identityLedger"] = {}
+  if (!isPlainObject(value)) {
+    return identityLedger
+  }
+
+  for (const [siteKey, markerValues] of Object.entries(value)) {
+    if (!siteKey || !isPlainObject(markerValues)) {
+      continue
+    }
+
+    const markers: Record<string, SiteAnnouncementIdentityMarker> = {}
+    for (const [digest, markerValue] of Object.entries(markerValues)) {
+      if (
+        !SHA256_HEX_DIGEST_PATTERN.test(digest) ||
+        !isPlainObject(markerValue) ||
+        !isFiniteNumber(markerValue.firstSeenAt) ||
+        !isFiniteNumber(markerValue.lastSeenAt) ||
+        (markerValue.readAt !== undefined &&
+          !isFiniteNumber(markerValue.readAt))
+      ) {
+        continue
+      }
+
+      markers[digest] = {
+        firstSeenAt: markerValue.firstSeenAt,
+        lastSeenAt: markerValue.lastSeenAt,
+        readAt: markerValue.readAt,
+      }
+    }
+    identityLedger[siteKey] = markers
+  }
+
+  return identityLedger
+}
+
+/** Migrates and self-heals persisted announcement state. */
+async function sanitizeStore(
+  value: unknown,
+): Promise<SiteAnnouncementStoreState> {
+  if (value === undefined) {
+    return createEmptyStore()
+  }
+  if (!isPlainObject(value)) {
+    throw new Error("Malformed site announcement store")
+  }
+  if (value.schemaVersion !== 1 && value.schemaVersion !== 2) {
+    throw new Error("Unsupported site announcement store schema")
+  }
+  if (!isPlainObject(value.sites)) {
+    throw new Error("Malformed site announcement store")
+  }
+
+  const sites = sanitizeSites(value.sites)
+  const identityLedger =
+    value.schemaVersion === 2
+      ? sanitizeIdentityLedger(value.identityLedger)
+      : {}
+
+  for (const [siteKey, site] of Object.entries(sites)) {
+    const markers = (identityLedger[siteKey] ??= {})
+    for (const record of site.records) {
+      record.siteKey = siteKey
+      const digest = await digestAnnouncementFingerprint(record.fingerprint)
+      const current = markers[digest]
+      const nextMarker: SiteAnnouncementIdentityMarker = {
+        firstSeenAt: current?.firstSeenAt ?? record.firstSeenAt,
+        lastSeenAt: Math.max(current?.lastSeenAt ?? 0, record.lastSeenAt),
+        readAt:
+          current?.readAt ??
+          (record.read ? record.readAt ?? record.lastSeenAt : undefined),
+      }
+      markers[digest] = nextMarker
+      if (nextMarker.readAt !== undefined) {
+        record.read = true
+        record.readAt = nextMarker.readAt
+      }
+    }
+    site.records.sort(compareRecordsNewestFirst)
+    site.records = site.records.slice(
+      0,
+      SITE_ANNOUNCEMENTS_LIMITS.recordsPerSite,
+    )
+  }
+
   return {
     schemaVersion: SITE_ANNOUNCEMENTS_STORE_SCHEMA_VERSION,
     sites,
+    identityLedger,
   }
 }
 
 class SiteAnnouncementStorage {
   private storage = new Storage({ area: "local" })
 
-  private async withStorageWriteLock<T>(work: () => Promise<T>): Promise<T> {
-    return withExtensionStorageWriteLock(STORAGE_LOCKS.SITE_ANNOUNCEMENTS, work)
+  private async getStoreOrThrow(): Promise<SiteAnnouncementStoreState> {
+    const stored = await this.storage.get(STORAGE_KEYS.SITE_ANNOUNCEMENTS_STORE)
+    return await sanitizeStore(stored)
   }
 
   async getStore(): Promise<SiteAnnouncementStoreState> {
     try {
-      const stored = await this.storage.get(
-        STORAGE_KEYS.SITE_ANNOUNCEMENTS_STORE,
-      )
-      return sanitizeStore(stored)
+      return await this.getStoreOrThrow()
     } catch (error) {
       logger.error("Failed to load site announcement store", error)
       return createEmptyStore()
@@ -218,19 +396,35 @@ class SiteAnnouncementStorage {
     }
   }
 
-  async updateStore(
-    updater: (
+  private async mutateStore<T>(
+    mutation: (
       store: SiteAnnouncementStoreState,
-    ) => SiteAnnouncementStoreState | void,
-  ): Promise<SiteAnnouncementStoreState> {
-    return this.withStorageWriteLock(async () => {
-      const current = await this.getStore()
-      const updated = updater(current) ?? current
-      if (!(await this.setStore(updated))) {
-        throw new Error("Failed to persist site announcement store")
-      }
-      return updated
-    })
+    ) =>
+      | { changed: boolean; result: T }
+      | Promise<{ changed: boolean; result: T }>,
+  ): Promise<T> {
+    return withExtensionStorageWriteLock(
+      STORAGE_LOCKS.SITE_ANNOUNCEMENTS,
+      async () => {
+        const store = await this.getStoreOrThrow()
+        const { changed, result } = await mutation(store)
+        const prunedIdentityLedger = pruneIdentityLedger(store.identityLedger, {
+          identitiesPerSite: SITE_ANNOUNCEMENTS_LIMITS.identitiesPerSite,
+          identitiesTotal: SITE_ANNOUNCEMENTS_LIMITS.identitiesTotal,
+        })
+        const pruningChanged = !areIdentityLedgersEqual(
+          store.identityLedger,
+          prunedIdentityLedger,
+        )
+        if (changed || pruningChanged) {
+          store.identityLedger = prunedIdentityLedger
+          if (!(await this.setStore(store))) {
+            throw new Error("Failed to persist site announcement store")
+          }
+        }
+        return result
+      },
+    )
   }
 
   async listRecords(): Promise<SiteAnnouncementRecord[]> {
@@ -248,17 +442,16 @@ class SiteAnnouncementStorage {
   }
 
   async upsertSiteStatus(
-    site: Omit<SiteAnnouncementSiteState, "records"> & {
-      records?: SiteAnnouncementRecord[]
-    },
+    site: Omit<SiteAnnouncementSiteState, "records">,
   ): Promise<void> {
-    await this.updateStore((store) => {
+    await this.mutateStore((store) => {
       const current = store.sites[site.siteKey]
       store.sites[site.siteKey] = {
         ...current,
         ...site,
-        records: site.records ?? current?.records ?? [],
+        records: current?.records ?? [],
       }
+      return { changed: true, result: undefined }
     })
   }
 
@@ -266,48 +459,132 @@ class SiteAnnouncementStorage {
     site: Omit<SiteAnnouncementSiteState, "records" | "status"> & {
       status: SiteAnnouncementStatus
     }
-    records: Array<
-      Omit<SiteAnnouncementRecord, "id" | "firstSeenAt" | "lastSeenAt" | "read">
-    >
+    records: SiteAnnouncementRecordInput[]
     now?: number
   }): Promise<SiteAnnouncementRecord[]> {
     const now = params.now ?? Date.now()
-    const createdRecords: SiteAnnouncementRecord[] = []
+    if (!isFiniteNumber(now)) {
+      throw new Error("Invalid site announcement timestamp")
+    }
 
-    await this.updateStore((store) => {
+    const inputCandidates = await Promise.all(
+      params.records.map(async (record) => ({
+        record,
+        digest: await digestAnnouncementFingerprint(record.fingerprint),
+      })),
+    )
+    const inputsByDigest = new Map<string, (typeof inputCandidates)[number]>()
+    for (const candidate of inputCandidates) {
+      const existing = inputsByDigest.get(candidate.digest)
+      if (!existing) {
+        inputsByDigest.set(candidate.digest, candidate)
+        continue
+      }
+
+      const representative =
+        compareRecordInputs(candidate.record, existing.record) < 0
+          ? candidate.record
+          : existing.record
+      const readAtValues = [
+        existing.record.readAt,
+        candidate.record.readAt,
+      ].filter(isFiniteNumber)
+      const readAt =
+        readAtValues.length > 0 ? Math.max(...readAtValues) : undefined
+      inputsByDigest.set(candidate.digest, {
+        digest: candidate.digest,
+        record: { ...representative, readAt },
+      })
+    }
+    const inputs = [...inputsByDigest.values()].sort((left, right) =>
+      compareStringsOrdinal(left.digest, right.digest),
+    )
+
+    return await this.mutateStore((store) => {
+      // Compare normalized state so repeated polls do not write unchanged data.
+      const previousStore = JSON.stringify(store)
+      const createdRecords: SiteAnnouncementRecord[] = []
       const current = store.sites[params.site.siteKey]
       const records = [...(current?.records ?? [])]
+      const markers = (store.identityLedger[params.site.siteKey] ??= {})
 
-      for (const input of params.records) {
+      for (const { record: input, digest } of inputs) {
         const existing = records.find(
           (record) => record.fingerprint === input.fingerprint,
         )
+        const marker = markers[digest]
 
-        if (existing) {
-          existing.lastSeenAt = now
+        if (!marker && existing) {
+          markers[digest] = {
+            firstSeenAt: existing.firstSeenAt,
+            lastSeenAt: existing.lastSeenAt,
+            readAt: existing.read
+              ? existing.readAt ?? existing.lastSeenAt
+              : undefined,
+          }
+        }
+
+        const knownMarker = markers[digest]
+        if (knownMarker) {
+          knownMarker.lastSeenAt = Math.max(knownMarker.lastSeenAt, now)
+          if (
+            knownMarker.readAt === undefined &&
+            isFiniteNumber(input.readAt)
+          ) {
+            knownMarker.readAt = input.readAt
+          }
+
+          if (existing) {
+            const id = existing.id
+            Object.assign(existing, input, {
+              id,
+              firstSeenAt: knownMarker.firstSeenAt,
+              lastSeenAt: knownMarker.lastSeenAt,
+              read: knownMarker.readAt !== undefined,
+              readAt: knownMarker.readAt,
+            })
+          } else {
+            const reconstructed: SiteAnnouncementRecord = {
+              ...input,
+              id: safeRandomUUID("site-announcement"),
+              firstSeenAt: knownMarker.firstSeenAt,
+              lastSeenAt: knownMarker.lastSeenAt,
+              read: knownMarker.readAt !== undefined,
+              readAt: knownMarker.readAt,
+            }
+            records.push(reconstructed)
+          }
           continue
         }
+
+        const readAt = isFiniteNumber(input.readAt) ? input.readAt : undefined
+        markers[digest] = { firstSeenAt: now, lastSeenAt: now, readAt }
 
         const record: SiteAnnouncementRecord = {
           ...input,
           id: safeRandomUUID("site-announcement"),
           firstSeenAt: now,
           lastSeenAt: now,
-          read: typeof input.readAt === "number",
+          read: readAt !== undefined,
+          readAt,
         }
-        records.unshift(record)
-        createdRecords.push(record)
+        records.push(record)
+        if (readAt === undefined) {
+          createdRecords.push(record)
+        }
       }
 
-      records.sort((a, b) => b.firstSeenAt - a.firstSeenAt)
+      records.sort(compareRecordsNewestFirst)
       store.sites[params.site.siteKey] = {
         ...current,
         ...params.site,
         records: records.slice(0, SITE_ANNOUNCEMENTS_LIMITS.recordsPerSite),
       }
+      return {
+        changed: JSON.stringify(store) !== previousStore,
+        result: createdRecords,
+      }
     })
-
-    return createdRecords
   }
 
   async updateNotificationState(
@@ -315,21 +592,25 @@ class SiteAnnouncementStorage {
     recordIds: string[],
     input: { notifiedAt?: number; notificationError?: string },
   ): Promise<void> {
-    if (recordIds.length === 0) {
-      return
-    }
+    await this.mutateStore((store) => {
+      if (recordIds.length === 0) {
+        return { changed: false, result: undefined }
+      }
 
-    await this.updateStore((store) => {
       const site = store.sites[siteKey]
       if (!site) {
-        return
+        return { changed: false, result: undefined }
       }
 
       const recordIdSet = new Set(recordIds)
+      let changed = false
       for (const record of site.records) {
         if (!recordIdSet.has(record.id)) {
           continue
         }
+        changed ||=
+          record.notifiedAt !== input.notifiedAt ||
+          record.notificationError !== input.notificationError
         record.notifiedAt = input.notifiedAt
         record.notificationError = input.notificationError
       }
@@ -338,50 +619,87 @@ class SiteAnnouncementStorage {
         recordIdSet.has(record.id),
       )
       if (notifiedRecord && input.notifiedAt) {
+        changed ||= site.lastNotifiedFingerprint !== notifiedRecord.fingerprint
         site.lastNotifiedFingerprint = notifiedRecord.fingerprint
       }
+      return { changed, result: undefined }
     })
   }
 
   async markRead(recordId: string): Promise<boolean> {
-    const now = Date.now()
-    let changed = false
-    await this.updateStore((store) => {
+    return await this.mutateStore(async (store) => {
       for (const site of Object.values(store.sites)) {
         const record = site.records.find((item) => item.id === recordId)
         if (record && !record.read) {
+          const now = Date.now()
+          const digest = await digestAnnouncementFingerprint(record.fingerprint)
+          const markers = (store.identityLedger[record.siteKey] ??= {})
+          const marker = (markers[digest] ??= {
+            firstSeenAt: record.firstSeenAt,
+            lastSeenAt: record.lastSeenAt,
+          })
+          marker.readAt = now
           record.read = true
           record.readAt = now
-          changed = true
-          break
+          return { changed: true, result: true }
         }
       }
+      return { changed: false, result: false }
     })
-    return changed
   }
 
   async markAllRead(siteKey?: string): Promise<number> {
-    const now = Date.now()
-    let changedCount = 0
-    await this.updateStore((store) => {
-      const sites = siteKey
-        ? store.sites[siteKey]
-          ? [store.sites[siteKey]]
-          : []
-        : Object.values(store.sites)
+    return await this.mutateStore(async (store) => {
+      const now = Date.now()
+      let changedCount = 0
+      const selectedSiteKeys = siteKey
+        ? [siteKey]
+        : Object.keys(store.identityLedger)
 
-      for (const site of sites) {
-        for (const record of site.records) {
-          if (!record.read) {
-            record.read = true
-            record.readAt = now
+      for (const selectedSiteKey of selectedSiteKeys) {
+        for (const marker of Object.values(
+          store.identityLedger[selectedSiteKey] ?? {},
+        )) {
+          if (marker.readAt === undefined) {
+            marker.readAt = now
             changedCount += 1
           }
         }
       }
-    })
 
-    return changedCount
+      for (const selectedSiteKey of selectedSiteKeys) {
+        const site = store.sites[selectedSiteKey]
+        if (!site) {
+          continue
+        }
+
+        const recordsByDigest = new Map(
+          await Promise.all(
+            site.records.map(
+              async (record) =>
+                [
+                  await digestAnnouncementFingerprint(record.fingerprint),
+                  record,
+                ] as const,
+            ),
+          ),
+        )
+        for (const [digest, marker] of Object.entries(
+          store.identityLedger[selectedSiteKey] ?? {},
+        )) {
+          if (marker.readAt === undefined) {
+            continue
+          }
+          const record = recordsByDigest.get(digest)
+          if (record) {
+            record.read = true
+            record.readAt = marker.readAt
+          }
+        }
+      }
+
+      return { changed: changedCount > 0, result: changedCount }
+    })
   }
 
   async recordFailure(params: {

--- a/src/services/siteAnnouncements/storage.ts
+++ b/src/services/siteAnnouncements/storage.ts
@@ -382,12 +382,15 @@ class SiteAnnouncementStorage {
       async () => {
         const store = await this.getStoreOrThrow()
         const { changed, result } = await mutation(store)
+        const previousIdentityLedger = serializeIdentityLedger(
+          store.identityLedger,
+        )
         const prunedIdentityLedger = pruneIdentityLedger(store.identityLedger, {
           identitiesPerSite: SITE_ANNOUNCEMENTS_LIMITS.identitiesPerSite,
           identitiesTotal: SITE_ANNOUNCEMENTS_LIMITS.identitiesTotal,
         })
         const pruningChanged =
-          serializeIdentityLedger(store.identityLedger) !==
+          previousIdentityLedger !==
           serializeIdentityLedger(prunedIdentityLedger)
         if (changed || pruningChanged) {
           store.identityLedger = prunedIdentityLedger
@@ -594,7 +597,7 @@ class SiteAnnouncementStorage {
         if (record && !record.read) {
           const now = Date.now()
           const digest = await digestAnnouncementFingerprint(record.fingerprint)
-          const markers = (store.identityLedger[record.siteKey] ??= {})
+          const markers = (store.identityLedger[site.siteKey] ??= {})
           const marker = (markers[digest] ??= {
             firstSeenAt: record.firstSeenAt,
             lastSeenAt: record.lastSeenAt,
@@ -613,6 +616,7 @@ class SiteAnnouncementStorage {
     return await this.mutateStore(async (store) => {
       const now = Date.now()
       let changedCount = 0
+      let recordSyncChanged = false
       const selectedSiteKeys = siteKey
         ? [siteKey]
         : Object.keys(store.identityLedger)
@@ -650,13 +654,18 @@ class SiteAnnouncementStorage {
         ).filter(([, marker]) => marker.readAt !== undefined)) {
           const record = recordsByDigest.get(digest)
           if (record) {
+            recordSyncChanged ||=
+              !record.read || record.readAt !== marker.readAt
             record.read = true
             record.readAt = marker.readAt
           }
         }
       }
 
-      return { changed: changedCount > 0, result: changedCount }
+      return {
+        changed: changedCount > 0 || recordSyncChanged,
+        result: changedCount,
+      }
     })
   }
 

--- a/src/types/siteAnnouncements.ts
+++ b/src/types/siteAnnouncements.ts
@@ -122,6 +122,11 @@ export interface SiteAnnouncementRecord {
   readAt?: number
 }
 
+export type SiteAnnouncementRecordInput = Omit<
+  SiteAnnouncementRecord,
+  "id" | "firstSeenAt" | "lastSeenAt" | "read"
+>
+
 export interface SiteAnnouncementSiteState {
   siteKey: string
   siteName: string
@@ -137,9 +142,16 @@ export interface SiteAnnouncementSiteState {
   records: SiteAnnouncementRecord[]
 }
 
+export interface SiteAnnouncementIdentityMarker {
+  firstSeenAt: number
+  lastSeenAt: number
+  readAt?: number
+}
+
 export interface SiteAnnouncementStoreState {
-  schemaVersion: 1
+  schemaVersion: 2
   sites: Record<string, SiteAnnouncementSiteState>
+  identityLedger: Record<string, Record<string, SiteAnnouncementIdentityMarker>>
 }
 
 export interface SiteAnnouncementCheckResult {

--- a/tests/services/siteAnnouncements/identity.test.ts
+++ b/tests/services/siteAnnouncements/identity.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  compareIdentityEntriesOldestFirst,
+  digestAnnouncementFingerprint,
+  pruneIdentityLedger,
+} from "~/services/siteAnnouncements/identity"
+import type { SiteAnnouncementIdentityEntry } from "~/services/siteAnnouncements/identity"
+import type { SiteAnnouncementStoreState } from "~/types/siteAnnouncements"
+
+describe("site announcement identities", () => {
+  it("uses lowercase SHA-256 over UTF-8 fingerprints", async () => {
+    await expect(digestAnnouncementFingerprint("abc")).resolves.toBe(
+      "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+    )
+  })
+
+  it("encodes non-ASCII fingerprints as UTF-8", async () => {
+    await expect(digestAnnouncementFingerprint("站点公告🚀")).resolves.toBe(
+      "1fb81783e25e03155054de64e19b0e0d7419fe72575c0881834e012d75cca52f",
+    )
+  })
+
+  it("breaks equal timestamps by site key and digest", () => {
+    const entries: SiteAnnouncementIdentityEntry[] = [
+      {
+        siteKey: "site-b",
+        digest: "a",
+        marker: { firstSeenAt: 1, lastSeenAt: 5 },
+      },
+      {
+        siteKey: "site-a",
+        digest: "b",
+        marker: { firstSeenAt: 1, lastSeenAt: 5 },
+      },
+      {
+        siteKey: "site-a",
+        digest: "a",
+        marker: { firstSeenAt: 1, lastSeenAt: 5 },
+      },
+    ]
+    expect(
+      entries
+        .sort(compareIdentityEntriesOldestFirst)
+        .map(({ siteKey, digest }) => `${siteKey}:${digest}`),
+    ).toEqual(["site-a:a", "site-a:b", "site-b:a"])
+  })
+
+  it("uses ordinal ordering for non-ASCII tie-break values", () => {
+    const entries: SiteAnnouncementIdentityEntry[] = [
+      {
+        siteKey: "site-ä",
+        digest: "a",
+        marker: { firstSeenAt: 1, lastSeenAt: 5 },
+      },
+      {
+        siteKey: "site-z",
+        digest: "a",
+        marker: { firstSeenAt: 1, lastSeenAt: 5 },
+      },
+    ]
+
+    expect(
+      entries
+        .sort(compareIdentityEntriesOldestFirst)
+        .map(({ siteKey }) => siteKey),
+    ).toEqual(["site-z", "site-ä"])
+  })
+
+  it("prunes per-site and global identities deterministically and idempotently", () => {
+    const ledger: SiteAnnouncementStoreState["identityLedger"] = {
+      "site-a": {
+        ["a".repeat(64)]: { firstSeenAt: 1, lastSeenAt: 10 },
+        ["b".repeat(64)]: { firstSeenAt: 1, lastSeenAt: 10 },
+        ["c".repeat(64)]: { firstSeenAt: 1, lastSeenAt: 10 },
+      },
+      "site-b": {
+        ["d".repeat(64)]: { firstSeenAt: 1, lastSeenAt: 10 },
+        ["e".repeat(64)]: { firstSeenAt: 1, lastSeenAt: 10 },
+      },
+      "site-c": {
+        ["f".repeat(64)]: { firstSeenAt: 1, lastSeenAt: 10 },
+      },
+    }
+
+    const pruned = pruneIdentityLedger(ledger, {
+      identitiesPerSite: 2,
+      identitiesTotal: 3,
+    })
+
+    expect(pruned).toEqual({
+      "site-b": {
+        ["d".repeat(64)]: { firstSeenAt: 1, lastSeenAt: 10 },
+        ["e".repeat(64)]: { firstSeenAt: 1, lastSeenAt: 10 },
+      },
+      "site-c": {
+        ["f".repeat(64)]: { firstSeenAt: 1, lastSeenAt: 10 },
+      },
+    })
+    expect(
+      pruneIdentityLedger(pruned, {
+        identitiesPerSite: 2,
+        identitiesTotal: 3,
+      }),
+    ).toEqual(pruned)
+    expect(ledger["site-a"]).toHaveProperty("a".repeat(64))
+  })
+})

--- a/tests/services/siteAnnouncements/scheduler.test.ts
+++ b/tests/services/siteAnnouncements/scheduler.test.ts
@@ -615,6 +615,104 @@ describe("siteAnnouncementScheduler", () => {
     }
   })
 
+  it("preserves provider read state without notifying", async () => {
+    providerFetchMock.mockResolvedValue({
+      providerId: SITE_ANNOUNCEMENT_PROVIDER_IDS.Common,
+      siteKey: "notice:new-api:https://example.com",
+      status: "success",
+      announcements: [
+        {
+          title: "Already read",
+          content: "Provider-owned read state",
+          readAt: 1234,
+        },
+      ],
+    })
+    getEnabledAccountsMock.mockResolvedValue([createAccount()])
+
+    const response = await resolveSiteAnnouncementsCheckNowMessage({})
+
+    expect(response).toMatchObject({
+      success: true,
+      data: { created: 0, notified: 0 },
+    })
+    expect(notifySiteAnnouncementsMock).not.toHaveBeenCalled()
+    expect(await siteAnnouncementStorage.listRecords()).toEqual([
+      expect.objectContaining({ read: true, readAt: 1234 }),
+    ])
+  })
+
+  it.each([
+    [undefined, 1234],
+    [1234, undefined],
+  ])(
+    "does not notify duplicate provider fingerprints in either read ordering (%s, %s)",
+    async (firstReadAt, secondReadAt) => {
+      providerFetchMock.mockResolvedValue({
+        providerId: SITE_ANNOUNCEMENT_PROVIDER_IDS.Common,
+        siteKey: "notice:new-api:https://example.com",
+        status: "success",
+        announcements: [
+          {
+            title: "B representative",
+            content: "B body",
+            fingerprint: "scheduler-duplicate-order",
+            readAt: firstReadAt,
+          },
+          {
+            title: "A representative",
+            content: "A body",
+            fingerprint: "scheduler-duplicate-order",
+            readAt: secondReadAt,
+          },
+        ],
+      })
+      getEnabledAccountsMock.mockResolvedValue([createAccount()])
+
+      const response = await resolveSiteAnnouncementsCheckNowMessage({})
+
+      expect(response).toMatchObject({
+        success: true,
+        data: { created: 0, notified: 0 },
+      })
+      expect(notifySiteAnnouncementsMock).not.toHaveBeenCalled()
+      expect(await siteAnnouncementStorage.listRecords()).toEqual([
+        expect.objectContaining({
+          title: "A representative",
+          content: "A body",
+          read: true,
+          readAt: 1234,
+        }),
+      ])
+    },
+  )
+
+  it("does not recreate evicted announcements after marking the site read", async () => {
+    const announcements = Array.from({ length: 101 }, (_, index) => ({
+      title: `Notice ${index}`,
+      content: `Body ${index}`,
+      fingerprint: `scheduler-mark-all-${index}`,
+    }))
+    providerFetchMock.mockResolvedValue({
+      providerId: SITE_ANNOUNCEMENT_PROVIDER_IDS.Common,
+      siteKey: "notice:new-api:https://example.com",
+      status: "success",
+      announcements,
+    })
+    getEnabledAccountsMock.mockResolvedValue([createAccount()])
+
+    await resolveSiteAnnouncementsCheckNowMessage({})
+    await siteAnnouncementStorage.markAllRead(
+      "notice:new-api:https://example.com",
+    )
+    const secondResponse = await resolveSiteAnnouncementsCheckNowMessage({})
+
+    expect(secondResponse).toMatchObject({
+      success: true,
+      data: { created: 0, notified: 0 },
+    })
+  })
+
   it("uses the stored-account API context for provider requests", async () => {
     providerFetchMock.mockResolvedValue({
       providerId: SITE_ANNOUNCEMENT_PROVIDER_IDS.Sub2Api,

--- a/tests/services/siteAnnouncements/storage.test.ts
+++ b/tests/services/siteAnnouncements/storage.test.ts
@@ -129,11 +129,52 @@ describe("siteAnnouncementStorage", () => {
   })
 
   it.each([
-    [undefined, 1234],
-    [1234, undefined],
+    {
+      firstTitle: "B representative",
+      firstContent: "B body",
+      firstReadAt: undefined,
+      secondTitle: "A representative",
+      secondContent: "A body",
+      secondReadAt: 1234,
+      expectedTitle: "A representative",
+      expectedContent: "A body",
+      expectedReadAt: 1234,
+    },
+    {
+      firstTitle: "B representative",
+      firstContent: "B body",
+      firstReadAt: 1234,
+      secondTitle: "A representative",
+      secondContent: "A body",
+      secondReadAt: undefined,
+      expectedTitle: "A representative",
+      expectedContent: "A body",
+      expectedReadAt: 1234,
+    },
+    {
+      firstTitle: "A representative",
+      firstContent: "A body",
+      firstReadAt: 1234,
+      secondTitle: "B representative",
+      secondContent: "B body",
+      secondReadAt: 5678,
+      expectedTitle: "A representative",
+      expectedContent: "A body",
+      expectedReadAt: 5678,
+    },
   ])(
-    "coalesces duplicate fingerprints independent of provider read ordering (%s, %s)",
-    async (firstReadAt, secondReadAt) => {
+    "coalesces duplicate fingerprints independent of provider read ordering",
+    async ({
+      firstTitle,
+      firstContent,
+      firstReadAt,
+      secondTitle,
+      secondContent,
+      secondReadAt,
+      expectedTitle,
+      expectedContent,
+      expectedReadAt,
+    }) => {
       const siteKey = "notice:new-api:https://example.invalid"
       const site = {
         siteKey,
@@ -159,14 +200,14 @@ describe("siteAnnouncementStorage", () => {
         records: [
           {
             ...baseRecord,
-            title: "B representative",
-            content: "B body",
+            title: firstTitle,
+            content: firstContent,
             readAt: firstReadAt ?? undefined,
           },
           {
             ...baseRecord,
-            title: "A representative",
-            content: "A body",
+            title: secondTitle,
+            content: secondContent,
             readAt: secondReadAt ?? undefined,
           },
         ],
@@ -176,10 +217,10 @@ describe("siteAnnouncementStorage", () => {
       expect(created).toEqual([])
       await expect(siteAnnouncementStorage.listRecords()).resolves.toEqual([
         expect.objectContaining({
-          title: "A representative",
-          content: "A body",
+          title: expectedTitle,
+          content: expectedContent,
           read: true,
-          readAt: 1234,
+          readAt: expectedReadAt,
         }),
       ])
     },
@@ -340,6 +381,67 @@ describe("siteAnnouncementStorage", () => {
         readAt: 1234,
       }),
     ])
+  })
+
+  it("imports provider read state onto a known unread identity marker", async () => {
+    const siteKey = "notice:new-api:https://example.invalid"
+    const site = {
+      siteKey,
+      siteName: "Example",
+      siteType: "new-api" as const,
+      baseUrl: "https://example.invalid",
+      accountId: "account-1",
+      providerId: SITE_ANNOUNCEMENT_PROVIDER_IDS.Common,
+      status: SITE_ANNOUNCEMENT_STATUS.Success,
+    }
+    const record = {
+      siteKey,
+      siteName: "Example",
+      siteType: "new-api" as const,
+      baseUrl: "https://example.invalid",
+      accountId: "account-1",
+      providerId: SITE_ANNOUNCEMENT_PROVIDER_IDS.Common,
+      title: "Notice",
+      content: "Body",
+      fingerprint: "provider-read-import",
+    }
+    const digest = await digestAnnouncementFingerprint(record.fingerprint)
+
+    await expect(
+      siteAnnouncementStorage.upsertDiscoveredRecords({
+        site,
+        records: [record],
+        now: 100,
+      }),
+    ).resolves.toHaveLength(1)
+    await expect(
+      siteAnnouncementStorage.upsertDiscoveredRecords({
+        site,
+        records: [{ ...record, readAt: 300 }],
+        now: 200,
+      }),
+    ).resolves.toHaveLength(0)
+
+    await expect(siteAnnouncementStorage.listRecords()).resolves.toEqual([
+      expect.objectContaining({
+        fingerprint: record.fingerprint,
+        read: true,
+        readAt: 300,
+        lastSeenAt: 200,
+      }),
+    ])
+    await expect(siteAnnouncementStorage.getStore()).resolves.toEqual(
+      expect.objectContaining({
+        identityLedger: expect.objectContaining({
+          [siteKey]: expect.objectContaining({
+            [digest]: expect.objectContaining({
+              readAt: 300,
+              lastSeenAt: 200,
+            }),
+          }),
+        }),
+      }),
+    )
   })
 
   it("keeps an older supplied timestamp from moving marker state backward", async () => {
@@ -756,6 +858,32 @@ describe("siteAnnouncementStorage", () => {
     expect(store.sites.valid).toMatchObject({
       lastCheckedAt: 200,
       lastSuccessAt: 150,
+    })
+  })
+
+  it("drops a malformed schema-v2 identity ledger root while retaining valid sites", async () => {
+    vi.spyOn(getSiteAnnouncementStorageBackend(), "get").mockResolvedValueOnce({
+      schemaVersion: 2,
+      sites: {
+        valid: {
+          siteName: "Valid",
+          siteType: "new-api",
+          baseUrl: "https://example.invalid",
+          accountId: "account-1",
+          providerId: SITE_ANNOUNCEMENT_PROVIDER_IDS.Common,
+          status: SITE_ANNOUNCEMENT_STATUS.Success,
+          records: [],
+        },
+      },
+      identityLedger: "malformed",
+    })
+
+    const store = await siteAnnouncementStorage.getStore()
+
+    expect(store.identityLedger).toEqual({ valid: {} })
+    expect(store.sites.valid).toMatchObject({
+      siteName: "Valid",
+      status: SITE_ANNOUNCEMENT_STATUS.Success,
     })
   })
 

--- a/tests/services/siteAnnouncements/storage.test.ts
+++ b/tests/services/siteAnnouncements/storage.test.ts
@@ -3,11 +3,47 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import { Storage } from "@plasmohq/storage"
 
 import { STORAGE_KEYS } from "~/services/core/storageKeys"
+import { digestAnnouncementFingerprint } from "~/services/siteAnnouncements/identity"
 import { siteAnnouncementStorage } from "~/services/siteAnnouncements/storage"
 import {
   SITE_ANNOUNCEMENT_PROVIDER_IDS,
   SITE_ANNOUNCEMENT_STATUS,
 } from "~/types/siteAnnouncements"
+import type { SiteAnnouncementStoreState } from "~/types/siteAnnouncements"
+
+function getSiteAnnouncementStorageBackend() {
+  return (siteAnnouncementStorage as unknown as { storage: Storage }).storage
+}
+
+function createOversizedIdentityLedger(
+  readAtOffset?: number,
+): SiteAnnouncementStoreState["identityLedger"] {
+  const identityLedger: SiteAnnouncementStoreState["identityLedger"] = {}
+  for (let siteIndex = 0; siteIndex < 11; siteIndex += 1) {
+    const siteKey = `site-${siteIndex}`
+    const markers: SiteAnnouncementStoreState["identityLedger"][string] = {}
+    const markerCount = siteIndex === 10 ? 1001 : 1000
+    for (let markerIndex = 0; markerIndex < markerCount; markerIndex += 1) {
+      const value = siteIndex * 1000 + markerIndex
+      markers[value.toString(16).padStart(64, "0")] = {
+        firstSeenAt: value,
+        lastSeenAt: value,
+        ...(readAtOffset === undefined ? {} : { readAt: value + readAtOffset }),
+      }
+    }
+    identityLedger[siteKey] = markers
+  }
+  return identityLedger
+}
+
+function countIdentityMarkers(
+  identityLedger: SiteAnnouncementStoreState["identityLedger"],
+) {
+  return Object.values(identityLedger).reduce(
+    (count, markers) => count + Object.keys(markers).length,
+    0,
+  )
+}
 
 describe("siteAnnouncementStorage", () => {
   beforeEach(async () => {
@@ -92,7 +128,64 @@ describe("siteAnnouncementStorage", () => {
     expect(records[0].lastSeenAt).toBe(2000)
   })
 
-  it("keeps only the latest ten records per site and marks read state", async () => {
+  it.each([
+    [undefined, 1234],
+    [1234, undefined],
+  ])(
+    "coalesces duplicate fingerprints independent of provider read ordering (%s, %s)",
+    async (firstReadAt, secondReadAt) => {
+      const siteKey = "notice:new-api:https://example.invalid"
+      const site = {
+        siteKey,
+        siteName: "Example",
+        siteType: "new-api" as const,
+        baseUrl: "https://example.invalid",
+        accountId: "account-1",
+        providerId: SITE_ANNOUNCEMENT_PROVIDER_IDS.Common,
+        status: SITE_ANNOUNCEMENT_STATUS.Success,
+      }
+      const baseRecord = {
+        siteKey: site.siteKey,
+        siteName: site.siteName,
+        siteType: site.siteType,
+        baseUrl: site.baseUrl,
+        accountId: site.accountId,
+        providerId: site.providerId,
+        fingerprint: "duplicate-order",
+      }
+
+      const created = await siteAnnouncementStorage.upsertDiscoveredRecords({
+        site,
+        records: [
+          {
+            ...baseRecord,
+            title: "B representative",
+            content: "B body",
+            readAt: firstReadAt ?? undefined,
+          },
+          {
+            ...baseRecord,
+            title: "A representative",
+            content: "A body",
+            readAt: secondReadAt ?? undefined,
+          },
+        ],
+        now: 100,
+      })
+
+      expect(created).toEqual([])
+      await expect(siteAnnouncementStorage.listRecords()).resolves.toEqual([
+        expect.objectContaining({
+          title: "A representative",
+          content: "A body",
+          read: true,
+          readAt: 1234,
+        }),
+      ])
+    },
+  )
+
+  it("retains identities beyond the content cache when polling in reverse order", async () => {
     vi.spyOn(Date, "now").mockReturnValue(3000)
 
     const created = await siteAnnouncementStorage.upsertDiscoveredRecords({
@@ -107,7 +200,7 @@ describe("siteAnnouncementStorage", () => {
         lastCheckedAt: 3000,
         lastSuccessAt: 3000,
       },
-      records: Array.from({ length: 11 }, (_, index) => ({
+      records: Array.from({ length: 101 }, (_, index) => ({
         siteKey: "notice:new-api:https://example.com",
         siteName: "Example",
         siteType: "new-api",
@@ -120,24 +213,101 @@ describe("siteAnnouncementStorage", () => {
       })),
     })
 
-    expect(created).toHaveLength(11)
+    expect(created).toHaveLength(101)
     const records = await siteAnnouncementStorage.listRecords()
-    expect(records).toHaveLength(10)
+    expect(records).toHaveLength(100)
+
+    const secondCreated = await siteAnnouncementStorage.upsertDiscoveredRecords(
+      {
+        site: {
+          siteKey: "notice:new-api:https://example.com",
+          siteName: "Example",
+          siteType: "new-api",
+          baseUrl: "https://example.com",
+          accountId: "account-1",
+          providerId: SITE_ANNOUNCEMENT_PROVIDER_IDS.Common,
+          status: SITE_ANNOUNCEMENT_STATUS.Success,
+          lastCheckedAt: 3000,
+          lastSuccessAt: 3000,
+        },
+        records: Array.from({ length: 101 }, (_, index) => {
+          const reversedIndex = 100 - index
+          return {
+            siteKey: "notice:new-api:https://example.com",
+            siteName: "Example",
+            siteType: "new-api" as const,
+            baseUrl: "https://example.com",
+            accountId: "account-1",
+            providerId: SITE_ANNOUNCEMENT_PROVIDER_IDS.Common,
+            title: `Notice ${reversedIndex}`,
+            content: `Hello ${reversedIndex}`,
+            fingerprint: `fingerprint-${reversedIndex}`,
+          }
+        }),
+      },
+    )
+
+    expect(secondCreated).toHaveLength(0)
+    const siteKey = "notice:new-api:https://example.com"
     expect(
-      records.some((record) => record.fingerprint === "fingerprint-0"),
-    ).toBe(false)
+      Object.keys(
+        (await siteAnnouncementStorage.getStore()).identityLedger[siteKey]!,
+      ),
+    ).toHaveLength(101)
 
     await expect(
       siteAnnouncementStorage.markRead(records[0]!.id),
     ).resolves.toBe(true)
-    await expect(siteAnnouncementStorage.markAllRead()).resolves.toBe(9)
+    await expect(siteAnnouncementStorage.markAllRead()).resolves.toBe(100)
 
     const afterRead = await siteAnnouncementStorage.listRecords()
     expect(afterRead.every((record) => record.read)).toBe(true)
   })
 
-  it("preserves the read invariant when imported records already include readAt", async () => {
-    const [created] = await siteAnnouncementStorage.upsertDiscoveredRecords({
+  it("marks every ledger identity read beyond the content cache", async () => {
+    const siteKey = "notice:new-api:https://example.invalid"
+    const site = {
+      siteKey,
+      siteName: "Example",
+      siteType: "new-api" as const,
+      baseUrl: "https://example.invalid",
+      accountId: "account-1",
+      providerId: SITE_ANNOUNCEMENT_PROVIDER_IDS.Common,
+      status: SITE_ANNOUNCEMENT_STATUS.Success,
+    }
+    const records = Array.from({ length: 101 }, (_, index) => ({
+      siteKey,
+      siteName: "Example",
+      siteType: "new-api" as const,
+      baseUrl: "https://example.invalid",
+      accountId: "account-1",
+      providerId: SITE_ANNOUNCEMENT_PROVIDER_IDS.Common,
+      title: `Notice ${index}`,
+      content: `Body ${index}`,
+      fingerprint: `mark-all-${index}`,
+    }))
+
+    await expect(
+      siteAnnouncementStorage.upsertDiscoveredRecords({
+        site,
+        records,
+        now: 100,
+      }),
+    ).resolves.toHaveLength(101)
+    await expect(siteAnnouncementStorage.markAllRead(siteKey)).resolves.toBe(
+      101,
+    )
+    await expect(
+      siteAnnouncementStorage.upsertDiscoveredRecords({
+        site,
+        records,
+        now: 200,
+      }),
+    ).resolves.toHaveLength(0)
+  })
+
+  it("preserves the read invariant without creating a notification candidate for read imports", async () => {
+    const created = await siteAnnouncementStorage.upsertDiscoveredRecords({
       site: {
         siteKey: "notice:new-api:https://example.com",
         siteName: "Example",
@@ -163,17 +333,199 @@ describe("siteAnnouncementStorage", () => {
       ],
     })
 
-    expect(created).toMatchObject({
-      read: true,
-      readAt: 1234,
+    expect(created).toHaveLength(0)
+    await expect(siteAnnouncementStorage.listRecords()).resolves.toEqual([
+      expect.objectContaining({
+        read: true,
+        readAt: 1234,
+      }),
+    ])
+  })
+
+  it("keeps an older supplied timestamp from moving marker state backward", async () => {
+    const site = {
+      siteKey: "notice:new-api:https://example.invalid",
+      siteName: "Example",
+      siteType: "new-api" as const,
+      baseUrl: "https://example.invalid",
+      accountId: "account-1",
+      providerId: SITE_ANNOUNCEMENT_PROVIDER_IDS.Common,
+      status: SITE_ANNOUNCEMENT_STATUS.Success,
+    }
+    const record = {
+      siteKey: site.siteKey,
+      siteName: site.siteName,
+      siteType: site.siteType,
+      baseUrl: site.baseUrl,
+      accountId: site.accountId,
+      providerId: site.providerId,
+      title: "Notice",
+      content: "Body",
+      fingerprint: "monotonic-last-seen",
+    }
+
+    await siteAnnouncementStorage.upsertDiscoveredRecords({
+      site,
+      records: [record],
+      now: 200,
     })
+    await siteAnnouncementStorage.upsertDiscoveredRecords({
+      site,
+      records: [record],
+      now: 100,
+    })
+
+    await expect(siteAnnouncementStorage.getStore()).resolves.toEqual(
+      expect.objectContaining({
+        identityLedger: expect.objectContaining({
+          [site.siteKey]: expect.objectContaining({
+            [await digestAnnouncementFingerprint(record.fingerprint)]:
+              expect.objectContaining({ lastSeenAt: 200 }),
+          }),
+        }),
+      }),
+    )
+    await expect(siteAnnouncementStorage.listRecords()).resolves.toEqual([
+      expect.objectContaining({ lastSeenAt: 200 }),
+    ])
+  })
+
+  it("rejects non-finite supplied timestamps", async () => {
+    await expect(
+      siteAnnouncementStorage.upsertDiscoveredRecords({
+        site: {
+          siteKey: "notice:new-api:https://example.invalid",
+          siteName: "Example",
+          siteType: "new-api",
+          baseUrl: "https://example.invalid",
+          accountId: "account-1",
+          providerId: SITE_ANNOUNCEMENT_PROVIDER_IDS.Common,
+          status: SITE_ANNOUNCEMENT_STATUS.Success,
+        },
+        records: [],
+        now: Number.NaN,
+      }),
+    ).rejects.toThrow("Invalid site announcement timestamp")
+  })
+
+  it("projects a durable marker firstSeenAt onto an existing cached record", async () => {
+    const storage = new Storage({ area: "local" })
+    const siteKey = "notice:new-api:https://example.invalid"
+    const fingerprint = "marker-projection"
+    const digest = await digestAnnouncementFingerprint(fingerprint)
+
+    await storage.set(STORAGE_KEYS.SITE_ANNOUNCEMENTS_STORE, {
+      schemaVersion: 2,
+      sites: {
+        [siteKey]: {
+          siteKey,
+          siteName: "Example",
+          siteType: "new-api",
+          baseUrl: "https://example.invalid",
+          accountId: "account-1",
+          providerId: SITE_ANNOUNCEMENT_PROVIDER_IDS.Common,
+          status: SITE_ANNOUNCEMENT_STATUS.Success,
+          records: [
+            {
+              id: "cached-record",
+              siteKey,
+              siteName: "Example",
+              siteType: "new-api",
+              baseUrl: "https://example.invalid",
+              accountId: "account-1",
+              providerId: SITE_ANNOUNCEMENT_PROVIDER_IDS.Common,
+              title: "Cached",
+              content: "Cached content",
+              fingerprint,
+              firstSeenAt: 200,
+              lastSeenAt: 250,
+              read: false,
+            },
+          ],
+        },
+      },
+      identityLedger: {
+        [siteKey]: {
+          [digest]: { firstSeenAt: 100, lastSeenAt: 250 },
+        },
+      },
+    })
+
+    await siteAnnouncementStorage.upsertDiscoveredRecords({
+      site: {
+        siteKey,
+        siteName: "Example",
+        siteType: "new-api",
+        baseUrl: "https://example.invalid",
+        accountId: "account-1",
+        providerId: SITE_ANNOUNCEMENT_PROVIDER_IDS.Common,
+        status: SITE_ANNOUNCEMENT_STATUS.Success,
+      },
+      records: [
+        {
+          siteKey,
+          siteName: "Example",
+          siteType: "new-api",
+          baseUrl: "https://example.invalid",
+          accountId: "account-1",
+          providerId: SITE_ANNOUNCEMENT_PROVIDER_IDS.Common,
+          title: "Updated",
+          content: "Updated content",
+          fingerprint,
+        },
+      ],
+      now: 300,
+    })
+
+    await expect(siteAnnouncementStorage.listRecords()).resolves.toEqual([
+      expect.objectContaining({
+        id: "cached-record",
+        firstSeenAt: 100,
+        lastSeenAt: 300,
+        title: "Updated",
+      }),
+    ])
+  })
+
+  it("does not persist an exact repeated upsert", async () => {
+    const site = {
+      siteKey: "notice:new-api:https://example.invalid",
+      siteName: "Example",
+      siteType: "new-api" as const,
+      baseUrl: "https://example.invalid",
+      accountId: "account-1",
+      providerId: SITE_ANNOUNCEMENT_PROVIDER_IDS.Common,
+      status: SITE_ANNOUNCEMENT_STATUS.Success,
+    }
+    const records = [
+      {
+        siteKey: site.siteKey,
+        siteName: site.siteName,
+        siteType: site.siteType,
+        baseUrl: site.baseUrl,
+        accountId: site.accountId,
+        providerId: site.providerId,
+        title: "Notice",
+        content: "Body",
+        fingerprint: "exact-repeat",
+      },
+    ]
+    const setSpy = vi.spyOn(getSiteAnnouncementStorageBackend(), "set")
+
+    vi.spyOn(Date, "now").mockReturnValue(100)
+    await siteAnnouncementStorage.upsertDiscoveredRecords({ site, records })
+    setSpy.mockClear()
+
+    await expect(
+      siteAnnouncementStorage.upsertDiscoveredRecords({ site, records }),
+    ).resolves.toHaveLength(0)
+    expect(setSpy).not.toHaveBeenCalled()
   })
 
   it("surfaces persistence failures instead of returning a successful in-memory update", async () => {
-    vi.spyOn(
-      (siteAnnouncementStorage as any).storage,
-      "set",
-    ).mockRejectedValueOnce(new Error("disk full"))
+    vi.spyOn(getSiteAnnouncementStorageBackend(), "set").mockRejectedValueOnce(
+      new Error("disk full"),
+    )
 
     await expect(
       siteAnnouncementStorage.upsertDiscoveredRecords({
@@ -278,8 +630,462 @@ describe("siteAnnouncementStorage", () => {
     ])
   })
 
+  it("migrates schema-v1 records into identity markers and preserves read timestamps", async () => {
+    const storage = new Storage({ area: "local" })
+    const siteKey = "notice:new-api:https://example.invalid"
+    await storage.set(STORAGE_KEYS.SITE_ANNOUNCEMENTS_STORE, {
+      schemaVersion: 1,
+      sites: {
+        [siteKey]: {
+          siteKey,
+          records: [
+            {
+              id: "unread-record",
+              siteKey: "wrong-site-key",
+              fingerprint: "unread-fingerprint",
+              firstSeenAt: 100,
+              lastSeenAt: 200,
+              read: false,
+            },
+            {
+              id: "read-record",
+              siteKey,
+              fingerprint: "read-fingerprint",
+              firstSeenAt: 300,
+              lastSeenAt: 400,
+              read: true,
+              readAt: 350,
+            },
+          ],
+        },
+      },
+    })
+
+    const store = await siteAnnouncementStorage.getStore()
+    const unreadDigest =
+      await digestAnnouncementFingerprint("unread-fingerprint")
+    const readDigest = await digestAnnouncementFingerprint("read-fingerprint")
+
+    expect(store.schemaVersion).toBe(2)
+    expect(store.sites[siteKey]?.records).toHaveLength(2)
+    expect(store.sites[siteKey]?.records[0]?.siteKey).toBe(siteKey)
+    expect(store.identityLedger[siteKey]).toEqual({
+      [unreadDigest]: {
+        firstSeenAt: 100,
+        lastSeenAt: 200,
+      },
+      [readDigest]: {
+        firstSeenAt: 300,
+        lastSeenAt: 400,
+        readAt: 350,
+      },
+    })
+    expect(
+      store.sites[siteKey]?.records.find(
+        (record) => record.id === "read-record",
+      ),
+    ).toMatchObject({
+      read: true,
+      readAt: 350,
+    })
+  })
+
+  it("creates identity markers before truncating an oversized schema-v1 cache", async () => {
+    const storage = new Storage({ area: "local" })
+    const siteKey = "notice:new-api:https://example.invalid"
+    const records = Array.from({ length: 101 }, (_, index) => {
+      const suffix = index.toString().padStart(3, "0")
+      return {
+        id: `record-${suffix}`,
+        siteKey,
+        fingerprint: `fingerprint-${suffix}`,
+        firstSeenAt: 1,
+        lastSeenAt: 1,
+        read: false,
+      }
+    })
+
+    await storage.set(STORAGE_KEYS.SITE_ANNOUNCEMENTS_STORE, {
+      schemaVersion: 1,
+      sites: {
+        [siteKey]: {
+          siteKey,
+          records,
+        },
+      },
+    })
+
+    const store = await siteAnnouncementStorage.getStore()
+    const evictedDigest = await digestAnnouncementFingerprint("fingerprint-100")
+
+    expect(store.sites[siteKey]?.records).toHaveLength(100)
+    expect(store.sites[siteKey]?.records).not.toContainEqual(
+      expect.objectContaining({ fingerprint: "fingerprint-100" }),
+    )
+    expect(Object.keys(store.identityLedger[siteKey] ?? {})).toHaveLength(101)
+    expect(store.identityLedger[siteKey]?.[evictedDigest]).toEqual({
+      firstSeenAt: 1,
+      lastSeenAt: 1,
+    })
+  })
+
+  it("normalizes non-finite site timestamps while preserving valid sibling data", async () => {
+    vi.spyOn(getSiteAnnouncementStorageBackend(), "get").mockResolvedValueOnce({
+      schemaVersion: 2,
+      sites: {
+        malformed: {
+          lastCheckedAt: Number.NaN,
+          lastSuccessAt: Number.POSITIVE_INFINITY,
+          records: [],
+        },
+        valid: {
+          lastCheckedAt: 200,
+          lastSuccessAt: 150,
+          records: [],
+        },
+      },
+      identityLedger: {},
+    })
+
+    const store = await siteAnnouncementStorage.getStore()
+
+    expect(store.sites.malformed).toMatchObject({
+      lastCheckedAt: undefined,
+      lastSuccessAt: undefined,
+    })
+    expect(store.sites.valid).toMatchObject({
+      lastCheckedAt: 200,
+      lastSuccessAt: 150,
+    })
+  })
+
+  it("self-heals schema-v2 ledger and cached record read state", async () => {
+    const storage = new Storage({ area: "local" })
+    const siteKey = "notice:new-api:https://example.invalid"
+    const forcedReadDigest = await digestAnnouncementFingerprint("forced-read")
+    const missingMarkerDigest =
+      await digestAnnouncementFingerprint("missing-marker")
+    const enrichedReadDigest =
+      await digestAnnouncementFingerprint("enriched-read")
+
+    await storage.set(STORAGE_KEYS.SITE_ANNOUNCEMENTS_STORE, {
+      schemaVersion: 2,
+      sites: {
+        [siteKey]: {
+          siteKey,
+          records: [
+            {
+              id: "forced-read-record",
+              siteKey,
+              fingerprint: "forced-read",
+              firstSeenAt: 10,
+              lastSeenAt: 20,
+              read: false,
+            },
+            {
+              id: "missing-marker-record",
+              siteKey,
+              fingerprint: "missing-marker",
+              firstSeenAt: 30,
+              lastSeenAt: 40,
+              read: false,
+            },
+            {
+              id: "enriched-read-record",
+              siteKey,
+              fingerprint: "enriched-read",
+              firstSeenAt: 50,
+              lastSeenAt: 60,
+              read: true,
+            },
+          ],
+        },
+      },
+      identityLedger: {
+        [siteKey]: {
+          [forcedReadDigest]: {
+            firstSeenAt: 5,
+            lastSeenAt: 15,
+            readAt: 12,
+          },
+          [enrichedReadDigest]: {
+            firstSeenAt: 45,
+            lastSeenAt: 55,
+          },
+          invalid: {
+            firstSeenAt: 1,
+            lastSeenAt: Number.POSITIVE_INFINITY,
+          },
+        },
+        malformed: null,
+      },
+    })
+
+    const store = await siteAnnouncementStorage.getStore()
+
+    expect(store.sites[siteKey]?.records).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "forced-read-record",
+          read: true,
+          readAt: 12,
+        }),
+        expect.objectContaining({
+          id: "missing-marker-record",
+          read: false,
+        }),
+        expect.objectContaining({
+          id: "enriched-read-record",
+          read: true,
+          readAt: 60,
+        }),
+      ]),
+    )
+    expect(store.identityLedger[siteKey]).toEqual({
+      [forcedReadDigest]: {
+        firstSeenAt: 5,
+        lastSeenAt: 20,
+        readAt: 12,
+      },
+      [missingMarkerDigest]: {
+        firstSeenAt: 30,
+        lastSeenAt: 40,
+      },
+      [enrichedReadDigest]: {
+        firstSeenAt: 45,
+        lastSeenAt: 60,
+        readAt: 60,
+      },
+    })
+  })
+
+  it("drops malformed identity keys while retaining valid sibling entries", async () => {
+    const storage = new Storage({ area: "local" })
+    const validDigest = await digestAnnouncementFingerprint("valid")
+    const siblingDigest = await digestAnnouncementFingerprint("sibling")
+    await storage.set(STORAGE_KEYS.SITE_ANNOUNCEMENTS_STORE, {
+      schemaVersion: 2,
+      sites: {
+        site: { records: [] },
+        sibling: { records: [] },
+      },
+      identityLedger: {
+        "": {
+          [validDigest]: { firstSeenAt: 1, lastSeenAt: 2 },
+        },
+        site: {
+          [validDigest]: { firstSeenAt: 3, lastSeenAt: 4 },
+          ["A".repeat(64)]: { firstSeenAt: 5, lastSeenAt: 6 },
+          short: { firstSeenAt: 7, lastSeenAt: 8 },
+        },
+        sibling: {
+          [siblingDigest]: { firstSeenAt: 9, lastSeenAt: 10 },
+        },
+      },
+    })
+
+    const store = await siteAnnouncementStorage.getStore()
+
+    expect(store.identityLedger).toEqual({
+      site: {
+        [validDigest]: { firstSeenAt: 3, lastSeenAt: 4 },
+      },
+      sibling: {
+        [siblingDigest]: { firstSeenAt: 9, lastSeenAt: 10 },
+      },
+    })
+  })
+
+  it("keeps non-finite record timestamps out of the sanitized store", async () => {
+    const storage = new Storage({ area: "local" })
+    vi.spyOn(Date, "now").mockReturnValue(500)
+    await storage.set(STORAGE_KEYS.SITE_ANNOUNCEMENTS_STORE, {
+      schemaVersion: 1,
+      sites: {
+        site: {
+          records: [
+            {
+              id: "record",
+              siteKey: "site",
+              fingerprint: "fingerprint",
+              firstSeenAt: Number.NaN,
+              lastSeenAt: Number.POSITIVE_INFINITY,
+              createdAt: Number.NaN,
+              updatedAt: Number.NEGATIVE_INFINITY,
+              notifiedAt: Number.POSITIVE_INFINITY,
+              readAt: Number.NaN,
+            },
+          ],
+        },
+      },
+    })
+
+    await expect(siteAnnouncementStorage.listRecords()).resolves.toEqual([
+      expect.objectContaining({
+        firstSeenAt: 500,
+        lastSeenAt: 500,
+        createdAt: undefined,
+        updatedAt: undefined,
+        notifiedAt: undefined,
+        readAt: undefined,
+      }),
+    ])
+  })
+
+  it.each([
+    {
+      name: "storage get rejection",
+      stored: new Error("read failed"),
+      rejects: true,
+      message: "read failed",
+    },
+    {
+      name: "unsupported schema",
+      stored: { schemaVersion: 999, sites: {} },
+      rejects: false,
+      message: "Unsupported site announcement store schema",
+    },
+    {
+      name: "malformed root data",
+      stored: "malformed",
+      rejects: false,
+      message: "Malformed site announcement store",
+    },
+    {
+      name: "missing sites container",
+      stored: { schemaVersion: 2, identityLedger: {} },
+      rejects: false,
+      message: "Malformed site announcement store",
+    },
+    {
+      name: "malformed sites container",
+      stored: { schemaVersion: 1, sites: "malformed" },
+      rejects: false,
+      message: "Malformed site announcement store",
+    },
+  ])("rejects mutations without writes after $name", async (scenario) => {
+    const storageApi = getSiteAnnouncementStorageBackend()
+    const setSpy = vi.spyOn(storageApi, "set")
+    const getSpy = vi.spyOn(storageApi, "get")
+    if (scenario.rejects) {
+      getSpy.mockRejectedValueOnce(scenario.stored)
+    } else {
+      getSpy.mockResolvedValueOnce(scenario.stored)
+    }
+
+    await expect(siteAnnouncementStorage.markAllRead()).rejects.toThrow(
+      scenario.message,
+    )
+    expect(setSpy).not.toHaveBeenCalled()
+  })
+
+  it("rejects empty notification updates without writes after an invalid source", async () => {
+    const storageApi = getSiteAnnouncementStorageBackend()
+    const setSpy = vi.spyOn(storageApi, "set")
+    vi.spyOn(storageApi, "get").mockResolvedValueOnce({
+      schemaVersion: 999,
+      sites: {},
+    })
+
+    await expect(
+      siteAnnouncementStorage.updateNotificationState("site", [], {
+        notifiedAt: 3,
+      }),
+    ).rejects.toThrow("Unsupported site announcement store schema")
+    expect(setSpy).not.toHaveBeenCalled()
+  })
+
+  it("rejects mutations without writes when identity digesting fails", async () => {
+    const storageApi = getSiteAnnouncementStorageBackend()
+    await storageApi.set(STORAGE_KEYS.SITE_ANNOUNCEMENTS_STORE, {
+      schemaVersion: 1,
+      sites: {
+        site: {
+          records: [
+            {
+              id: "record",
+              siteKey: "site",
+              fingerprint: "fingerprint",
+              firstSeenAt: 1,
+              lastSeenAt: 2,
+            },
+          ],
+        },
+      },
+    })
+    const setSpy = vi.spyOn(storageApi, "set")
+    vi.spyOn(crypto.subtle, "digest").mockRejectedValueOnce(
+      new Error("digest failed"),
+    )
+
+    await expect(siteAnnouncementStorage.markAllRead()).rejects.toThrow(
+      "digest failed",
+    )
+    expect(setSpy).not.toHaveBeenCalled()
+  })
+
+  it("returns an empty schema-v2 store when the storage key is missing", async () => {
+    await expect(siteAnnouncementStorage.getStore()).resolves.toEqual({
+      schemaVersion: 2,
+      sites: {},
+      identityLedger: {},
+    })
+  })
+
+  it("does not persist mutation no-ops", async () => {
+    const storageApi = getSiteAnnouncementStorageBackend()
+    const siteKey = "notice:new-api:https://example.invalid"
+    const digest = await digestAnnouncementFingerprint("already-read")
+    await storageApi.set(STORAGE_KEYS.SITE_ANNOUNCEMENTS_STORE, {
+      schemaVersion: 2,
+      sites: {
+        [siteKey]: {
+          siteKey,
+          records: [
+            {
+              id: "already-read-record",
+              siteKey,
+              fingerprint: "already-read",
+              firstSeenAt: 1,
+              lastSeenAt: 2,
+              read: true,
+              readAt: 2,
+            },
+          ],
+        },
+      },
+      identityLedger: {
+        [siteKey]: {
+          [digest]: { firstSeenAt: 1, lastSeenAt: 2, readAt: 2 },
+        },
+      },
+    })
+    const setSpy = vi.spyOn(storageApi, "set")
+
+    await expect(siteAnnouncementStorage.markRead("missing")).resolves.toBe(
+      false,
+    )
+    await expect(
+      siteAnnouncementStorage.markRead("already-read-record"),
+    ).resolves.toBe(false)
+    await expect(
+      siteAnnouncementStorage.markAllRead("missing-site"),
+    ).resolves.toBe(0)
+    await expect(siteAnnouncementStorage.markAllRead(siteKey)).resolves.toBe(0)
+    await siteAnnouncementStorage.updateNotificationState(siteKey, [], {
+      notifiedAt: 3,
+    })
+    await siteAnnouncementStorage.updateNotificationState(
+      siteKey,
+      ["missing"],
+      { notifiedAt: 3 },
+    )
+
+    expect(setSpy).not.toHaveBeenCalled()
+  })
+
   it("returns empty state when persisted storage cannot be read", async () => {
-    vi.spyOn((siteAnnouncementStorage as any).storage, "get").mockRejectedValue(
+    vi.spyOn(getSiteAnnouncementStorageBackend(), "get").mockRejectedValue(
       new Error("read failed"),
     )
 
@@ -437,6 +1243,117 @@ describe("siteAnnouncementStorage", () => {
         }),
       ]),
     )
+  })
+
+  it("bounds an oversized ledger when a status mutation changes the store", async () => {
+    const storage = new Storage({ area: "local" })
+    const identityLedger = createOversizedIdentityLedger()
+
+    await storage.set(STORAGE_KEYS.SITE_ANNOUNCEMENTS_STORE, {
+      schemaVersion: 2,
+      sites: {},
+      identityLedger,
+    })
+    await siteAnnouncementStorage.upsertSiteStatus({
+      siteKey: "site-0",
+      siteName: "Site 0",
+      siteType: "new-api",
+      baseUrl: "https://example.invalid",
+      accountId: "account-0",
+      providerId: SITE_ANNOUNCEMENT_PROVIDER_IDS.Common,
+      status: SITE_ANNOUNCEMENT_STATUS.Success,
+    })
+
+    const store = await siteAnnouncementStorage.getStore()
+    const total = countIdentityMarkers(store.identityLedger)
+    expect(total).toBe(10_000)
+    expect(Object.keys(store.identityLedger["site-0"] ?? {})).toHaveLength(0)
+    expect(Object.keys(store.identityLedger["site-1"] ?? {})).toHaveLength(1000)
+    expect(Object.keys(store.identityLedger["site-10"] ?? {})).toHaveLength(
+      1000,
+    )
+    expect(
+      store.identityLedger["site-10"]?.[
+        (10_000).toString(16).padStart(64, "0")
+      ],
+    ).toBeUndefined()
+    expect(
+      store.identityLedger["site-10"]?.[
+        (10_001).toString(16).padStart(64, "0")
+      ],
+    ).toBeDefined()
+  })
+
+  it("prunes an oversized all-read ledger during a no-op mark-all mutation", async () => {
+    const storage = new Storage({ area: "local" })
+    const identityLedger = createOversizedIdentityLedger(1)
+
+    await storage.set(STORAGE_KEYS.SITE_ANNOUNCEMENTS_STORE, {
+      schemaVersion: 2,
+      sites: {},
+      identityLedger,
+    })
+    const setSpy = vi.spyOn(getSiteAnnouncementStorageBackend(), "set")
+
+    await expect(siteAnnouncementStorage.markAllRead()).resolves.toBe(0)
+    expect(setSpy).toHaveBeenCalledTimes(1)
+    const firstPersistedStore = setSpy.mock.calls[0]?.[1] as
+      | SiteAnnouncementStoreState
+      | undefined
+    expect(firstPersistedStore).toBeDefined()
+    const firstPersistedTotal = countIdentityMarkers(
+      firstPersistedStore!.identityLedger,
+    )
+    expect(firstPersistedTotal).toBe(10_000)
+    expect(
+      Object.keys(firstPersistedStore!.identityLedger["site-10"] ?? {}),
+    ).toHaveLength(1000)
+
+    setSpy.mockClear()
+    await expect(siteAnnouncementStorage.markAllRead()).resolves.toBe(0)
+    expect(setSpy).not.toHaveBeenCalled()
+  })
+
+  it("preserves discovered records when updating status", async () => {
+    const siteKey = "notice:new-api:https://example.invalid"
+    await siteAnnouncementStorage.upsertDiscoveredRecords({
+      site: {
+        siteKey,
+        siteName: "Example",
+        siteType: "new-api",
+        baseUrl: "https://example.invalid",
+        accountId: "account-1",
+        providerId: SITE_ANNOUNCEMENT_PROVIDER_IDS.Common,
+        status: SITE_ANNOUNCEMENT_STATUS.Success,
+      },
+      records: [
+        {
+          siteKey,
+          siteName: "Example",
+          siteType: "new-api",
+          baseUrl: "https://example.invalid",
+          accountId: "account-1",
+          providerId: SITE_ANNOUNCEMENT_PROVIDER_IDS.Common,
+          title: "Notice",
+          content: "Body",
+          fingerprint: "status-preserves-record",
+        },
+      ],
+    })
+
+    await siteAnnouncementStorage.upsertSiteStatus({
+      siteKey,
+      siteName: "Example",
+      siteType: "new-api",
+      baseUrl: "https://example.invalid",
+      accountId: "account-1",
+      providerId: SITE_ANNOUNCEMENT_PROVIDER_IDS.Common,
+      status: SITE_ANNOUNCEMENT_STATUS.Error,
+    })
+
+    await expect(siteAnnouncementStorage.listRecords()).resolves.toEqual([
+      expect.objectContaining({ fingerprint: "status-preserves-record" }),
+    ])
   })
 
   it("swallows record-failure persistence errors after logging the warning path", async () => {


### PR DESCRIPTION
## Summary

Prevent previously read site announcements from becoming unread or triggering duplicate notifications after their full content leaves the bounded cache.

## What changed

- Add a schema-v2 durable identity ledger with schema-v1 migration.
- Preserve seen and read state independently from cached announcement content.
- Bound cached content and identity growth with deterministic pruning.
- Fail closed when persisted store structure is malformed.
- Preserve provider-supplied read state and mark-all state beyond cached records.
- Document the separately deferred account-lifecycle reconciliation slice.

Fixes #1189

## Validation

- `pnpm exec vitest run tests/services/siteAnnouncements tests/services/apiAdapters/sub2api/siteAnnouncements.test.ts tests/services/apiService/newApiFamily/siteAnnouncements.test.ts`
  - 8 files, 121 tests passed
- `pnpm run validate:push`
  - TypeScript compile passed
  - `knip` passed

## Release decisions

- Reuses existing analytics; no new telemetry payload.
- No Playwright expansion because the risk is isolated to persistence and scheduler behavior.
- No permission or settings changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a persistent identity ledger for site announcements to keep deduplication stable across polling, migrations, and cache rebuilds.
  * Increased retained announcement content to **100 per site** and introduced bounded identity retention (**1,000 per site / 10,000 total**).
  * Preserved provider-supplied and locally recorded **read state** end-to-end.
* **Bug Fixes**
  * Prevented duplicate notifications and ensured “all read” items aren’t recreated after truncation or recovery.
  * Improved handling of malformed or mismatched stored data to avoid unintended overwrites.
* **Documentation**
  * Published updated implementation plans/specs for the identity ledger and lifecycle.
* **Tests**
  * Expanded Vitest coverage for pruning/retention, schema migration, deduplication, and scheduler read-state behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->