### PR TITLE
fix(account-dialog): apply auth default to automatic URL prefill

### DIFF
--- a/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
+++ b/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
@@ -544,6 +544,17 @@ export function useAccountDialog({
     },
     [updateDraft],
   )
+  const applyAuthDefaultForUrl = useCallback(
+    (siteUrl: string) => {
+      if (hasExplicitAuthTypeRef.current) return
+
+      updateDraft((prev) => ({
+        ...prev,
+        authType: resolveDefaultAccountAuthType({ siteUrl }),
+      }))
+    },
+    [updateDraft],
+  )
   const setCookieAuthSessionCookie = useCallback(
     (value: string) => {
       updateDraft((prev) => ({ ...prev, cookieAuthSessionCookie: value }))
@@ -1161,7 +1172,15 @@ export function useAccountDialog({
 
     hasConsumedAutoFillCurrentSiteUrlRef.current = true
     setUrl(currentTabUrl)
-  }, [autoFillCurrentSiteUrlOnAccountAdd, currentTabUrl, isOpen, mode, url])
+    applyAuthDefaultForUrl(currentTabUrl)
+  }, [
+    applyAuthDefaultForUrl,
+    autoFillCurrentSiteUrlOnAccountAdd,
+    currentTabUrl,
+    isOpen,
+    mode,
+    url,
+  ])
 
   useEffect(() => {
     // 打开 popup 时立即检测一次
@@ -1223,13 +1242,8 @@ export function useAccountDialog({
         const urlObj = new URL(newUrl)
         const baseUrl = `${urlObj.protocol}//${urlObj.host}`
         setUrl(baseUrl)
-        if (shouldApplyAuthDefault && !hasExplicitAuthTypeRef.current) {
-          updateDraft((prev) => ({
-            ...prev,
-            authType: resolveDefaultAccountAuthType({
-              siteUrl: baseUrl,
-            }),
-          }))
+        if (shouldApplyAuthDefault) {
+          applyAuthDefaultForUrl(baseUrl)
         }
       } catch (error) {
         logger.warn("Failed to normalize URL input", { error, url: newUrl })

--- a/tests/features/AccountManagement/hooks/useAccountDialog.currentTabDetection.test.tsx
+++ b/tests/features/AccountManagement/hooks/useAccountDialog.currentTabDetection.test.tsx
@@ -685,7 +685,7 @@ describe("useAccountDialog current tab detection", () => {
     tabsQueryMock.mockResolvedValue([
       {
         id: 8,
-        url: "https://prefill.example.com/dashboard?x=1",
+        url: "https://anyrouter.top/console",
       },
     ])
 
@@ -701,11 +701,55 @@ describe("useAccountDialog current tab detection", () => {
     })
 
     await waitFor(() => {
-      expect(result.current.state.currentTabUrl).toBe(
-        "https://prefill.example.com",
-      )
-      expect(result.current.state.url).toBe("https://prefill.example.com")
+      expect(result.current.state.currentTabUrl).toBe("https://anyrouter.top")
+      expect(result.current.state.url).toBe("https://anyrouter.top")
+      expect(result.current.state.authType).toBe(AuthTypeEnum.Cookie)
     })
+  })
+
+  it("preserves an explicitly selected auth type during current-tab url prefill", async () => {
+    mockUserPreferencesContext.current = {
+      ...mockUserPreferencesContext.current,
+      autoFillCurrentSiteUrlOnAccountAdd: true,
+    }
+
+    const tabsQueryMock = globalThis.browser.tabs.query as ReturnType<
+      typeof vi.fn
+    >
+    let resolveTabs: ((value: any[]) => void) | null = null
+    tabsQueryMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveTabs = resolve
+        }),
+    )
+
+    const { result } = renderAccountDialogHook({
+      mode: DIALOG_MODES.ADD,
+      isOpen: true,
+      onClose: vi.fn(),
+      onSuccess: vi.fn(),
+    })
+
+    await waitFor(() => {
+      expect(result.current).toBeTruthy()
+    })
+
+    await act(async () => {
+      result.current.setters.setAuthType(AuthTypeEnum.AccessToken)
+      resolveTabs?.([
+        {
+          id: 13,
+          url: "https://anyrouter.top/console",
+        },
+      ])
+    })
+
+    await waitFor(() => {
+      expect(result.current.state.currentTabUrl).toBe("https://anyrouter.top")
+      expect(result.current.state.url).toBe("https://anyrouter.top")
+    })
+    expect(result.current.state.authType).toBe(AuthTypeEnum.AccessToken)
   })
 
   it("keeps the url field empty when the setting is disabled", async () => {


### PR DESCRIPTION
## Summary

- Apply URL-derived account authentication defaults when the current-site URL is filled automatically.
- Preserve an explicitly selected authentication method while sharing the same default-resolution seam with manual URL changes.

## Root cause

The opt-in automatic URL-prefill effect wrote the URL state directly, bypassing the authentication-default resolver used by manual URL updates.

## Validation

- `pnpm exec vitest run tests/features/AccountManagement/hooks/useAccountDialog.currentTabDetection.test.tsx tests/features/AccountManagement/hooks/useAccountDialog.authDefaults.test.tsx` (29 passed)
- `pnpm run validate:push`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Automatically selects the appropriate authentication type when an account URL is populated from the current browser tab.
  * Preserves an authentication type explicitly selected by the user during URL prefill.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->