### PR TITLE
feat(cc-switch): support Grok CLI and Hermes exports

### DIFF
--- a/docs/docs/supported-export-tools.md
+++ b/docs/docs/supported-export-tools.md
@@ -7,7 +7,7 @@
 | 产品 | 官方描述 | 官方链接 |
 |------|----------|----------|
 | Cherry Studio | AI 生产力工作室，提供智能对话、自主代理和 300+ 助手，统一接入前沿大模型。 | [官网](https://www.cherry-ai.com/) / [GitHub](https://github.com/CherryHQ/cherry-studio) |
-| CC Switch | 面向 Claude Code、Codex、OpenCode、openclaw 与 Gemini CLI 的跨平台桌面一体化助手。 | [GitHub](https://github.com/farion1231/cc-switch) |
+| CC Switch | 面向 Claude Code、Codex、Gemini CLI、Grok CLI、Hermes、OpenCode 与 OpenClaw 的跨平台桌面一体化助手。 | [GitHub](https://github.com/farion1231/cc-switch) |
 | Kilo Code | Kilo 是一体化的 Agentic Engineering 平台。 | [官网](https://kilocode.ai/) / [GitHub](https://github.com/Kilo-Org/kilocode) |
 | Roo Code | Roo Code 让一整支 AI 开发团队直接驻留在你的代码编辑器里。 | [官网](https://roocode.com/) / [GitHub](https://github.com/RooCodeInc/Roo-Code) |
 | CLIProxyAPI | 将 Gemini CLI、Antigravity、ChatGPT Codex、Claude Code、Qwen Code、iFlow 封装为兼容 OpenAI / Gemini / Claude / Codex 的 API 服务。 | [文档](https://help.router-for.me/) / [GitHub](https://github.com/router-for-me/CLIProxyAPI) |

--- a/src/components/CCSwitchExportDialog.tsx
+++ b/src/components/CCSwitchExportDialog.tsx
@@ -74,6 +74,10 @@ const getCCSwitchAppLabel = (t: TFunction, app: CCSwitchApp) => {
       return t("ui:dialog.ccswitch.appOptions.codex")
     case "gemini":
       return t("ui:dialog.ccswitch.appOptions.gemini")
+    case "grokbuild":
+      return t("ui:dialog.ccswitch.appOptions.grokbuild")
+    case "hermes":
+      return t("ui:dialog.ccswitch.appOptions.hermes")
     case "opencode":
       return t("ui:dialog.ccswitch.appOptions.opencode")
     case "openclaw":
@@ -83,6 +87,8 @@ const getCCSwitchAppLabel = (t: TFunction, app: CCSwitchApp) => {
 
 const getCCSwitchLimitationNotice = (t: TFunction, app: CCSwitchApp) => {
   switch (app) {
+    case "hermes":
+      return t("ui:dialog.ccswitch.notices.hermes")
     case "opencode":
       return t("ui:dialog.ccswitch.notices.opencode")
     case "openclaw":

--- a/src/locales/en/ui.json
+++ b/src/locales/en/ui.json
@@ -76,6 +76,8 @@
         "claude": "Claude",
         "codex": "Codex",
         "gemini": "Gemini",
+        "grokbuild": "Grok CLI",
+        "hermes": "Hermes",
         "openclaw": "OpenClaw",
         "opencode": "OpenCode"
       },
@@ -95,6 +97,7 @@
         "none": "No default model"
       },
       "notices": {
+        "hermes": "CC Switch imports Hermes using the Chat Completions protocol. During export, the provider name is converted to a valid identifier containing only lowercase letters, numbers, and hyphens. To use another format, such as Anthropic Messages or Codex Responses, adjust it in CC Switch after import.",
         "openclaw": "CC Switch currently does not support configuring OpenClaw AI service API formats through external import. Adjust it in CC Switch after import if needed.",
         "opencode": "CC Switch currently does not support configuring OpenCode AI service API formats through external import. Adjust it in CC Switch after import if needed."
       },

--- a/src/locales/es-419/ui.json
+++ b/src/locales/es-419/ui.json
@@ -81,6 +81,8 @@
         "claude": "Claude",
         "codex": "Codex",
         "gemini": "Gemini",
+        "grokbuild": "Grok CLI",
+        "hermes": "Hermes",
         "openclaw": "OpenClaw",
         "opencode": "OpenCode"
       },
@@ -100,6 +102,7 @@
         "none": "Sin modelo predeterminado"
       },
       "notices": {
+        "hermes": "CC Switch importa Hermes con el protocolo Chat Completions. Durante la exportación, el nombre del proveedor se convierte en un identificador válido que solo contiene letras minúsculas, números y guiones. Para usar otro formato, como Anthropic Messages o Codex Responses, ajústalo en CC Switch después de importar.",
         "openclaw": "CC Switch actualmente no admite configurar formatos de API del servicio de IA OpenClaw mediante importación externa. Ajústalo en CC Switch después de importar si es necesario.",
         "opencode": "CC Switch actualmente no admite configurar formatos de API del servicio de IA OpenCode mediante importación externa. Ajústalo en CC Switch después de importar si es necesario."
       },

--- a/src/locales/ja/ui.json
+++ b/src/locales/ja/ui.json
@@ -74,6 +74,8 @@
         "claude": "Claude",
         "codex": "Codex",
         "gemini": "Gemini",
+        "grokbuild": "Grok CLI",
+        "hermes": "Hermes",
         "openclaw": "OpenClaw",
         "opencode": "OpenCode"
       },
@@ -93,6 +95,7 @@
         "none": "既定モデルなし"
       },
       "notices": {
+        "hermes": "CC Switch は Hermes を Chat Completions プロトコルとしてインポートします。エクスポート時に、プロバイダー名は小文字、数字、ハイフンのみの有効な識別子に変換されます。Anthropic Messages や Codex Responses など別の形式を使用する場合は、インポート後に CC Switch 側で調整してください。",
         "openclaw": "CC Switch は現在、外部インポート経由で OpenClaw AI サービス API 形式を設定できません。必要に応じて、インポート後に CC Switch 側で調整してください。",
         "opencode": "CC Switch は現在、外部インポート経由で OpenCode AI サービス API 形式を設定できません。必要に応じて、インポート後に CC Switch 側で調整してください。"
       },

--- a/src/locales/vi/ui.json
+++ b/src/locales/vi/ui.json
@@ -74,6 +74,8 @@
         "claude": "Claude",
         "codex": "Codex",
         "gemini": "Gemini",
+        "grokbuild": "Grok CLI",
+        "hermes": "Hermes",
         "openclaw": "OpenClaw",
         "opencode": "OpenCode"
       },
@@ -93,6 +95,7 @@
         "none": "Không đặt mô hình mặc định"
       },
       "notices": {
+        "hermes": "CC Switch nhập Hermes bằng giao thức Chat Completions. Khi xuất, tên nhà cung cấp được chuyển thành mã định danh hợp lệ chỉ gồm chữ thường, chữ số và dấu gạch nối. Để sử dụng định dạng khác như Anthropic Messages hoặc Codex Responses, hãy điều chỉnh trong CC Switch sau khi nhập.",
         "openclaw": "CC Switch hiện không hỗ trợ định dạng API của dịch vụ OpenClaw AI thông qua nhập bên ngoài; nếu cần, vui lòng điều chỉnh thủ công trong CC Switch sau khi nhập.",
         "opencode": "CC Switch hiện không hỗ trợ định dạng API của dịch vụ OpenCode AI thông qua nhập bên ngoài; nếu cần, vui lòng điều chỉnh thủ công trong CC Switch sau khi nhập."
       },

--- a/src/locales/zh-CN/ui.json
+++ b/src/locales/zh-CN/ui.json
@@ -71,6 +71,8 @@
         "claude": "Claude",
         "codex": "Codex",
         "gemini": "Gemini",
+        "grokbuild": "Grok CLI",
+        "hermes": "Hermes",
         "openclaw": "OpenClaw",
         "opencode": "OpenCode"
       },
@@ -90,6 +92,7 @@
         "none": "不设置默认模型"
       },
       "notices": {
+        "hermes": "CC Switch 会将 Hermes 导入为 Chat Completions 协议。导出时，供应商名称会转换为只含小写字母、数字和连字符的合法标识；如需 Anthropic Messages、Codex Responses 等其他格式，请在导入后到 CC Switch 中调整。",
         "openclaw": "CC Switch 当前不支持通过外部导入的方式配置 OpenClaw AI 服务的 API 接口格式；如有需要，请在导入后到 CC Switch 中手动调整。",
         "opencode": "CC Switch 当前不支持通过外部导入的方式配置 OpenCode AI 服务的 API 接口格式；如有需要，请在导入后到 CC Switch 中手动调整。"
       },

--- a/src/locales/zh-TW/ui.json
+++ b/src/locales/zh-TW/ui.json
@@ -74,6 +74,8 @@
         "claude": "Claude",
         "codex": "Codex",
         "gemini": "Gemini",
+        "grokbuild": "Grok CLI",
+        "hermes": "Hermes",
         "openclaw": "OpenClaw",
         "opencode": "OpenCode"
       },
@@ -93,6 +95,7 @@
         "none": "不設定預設模型"
       },
       "notices": {
+        "hermes": "CC Switch 會將 Hermes 匯入為 Chat Completions 協定。匯出時，供應商名稱會轉換為只含小寫字母、數字和連字號的有效識別碼；如需 Anthropic Messages、Codex Responses 等其他格式，請在匯入後到 CC Switch 中調整。",
         "openclaw": "CC Switch 當前不支援透過外部匯入的方式配置 OpenClaw AI 服務的 API 介面格式；如有需要，請在匯入後到 CC Switch 中手動調整。",
         "opencode": "CC Switch 當前不支援透過外部匯入的方式配置 OpenCode AI 服務的 API 介面格式；如有需要，請在匯入後到 CC Switch 中手動調整。"
       },

--- a/src/services/integrations/ccSwitch.ts
+++ b/src/services/integrations/ccSwitch.ts
@@ -17,10 +17,18 @@ export const CCSWITCH_APPS = [
   "claude",
   "codex",
   "gemini",
+  "grokbuild",
+  "hermes",
   "opencode",
   "openclaw",
 ] as const
 export type CCSwitchApp = (typeof CCSWITCH_APPS)[number]
+
+// CC Switch's Hermes importer fixes api_mode to chat_completions and derives
+// the provider ID from name, while ProviderForm requires ^[a-z0-9]+(-[a-z0-9]+)*$.
+// Sources: src-tauri/src/deeplink/{provider.rs,mod.rs},
+// src/components/providers/forms/ProviderForm.tsx
+// https://github.com/farion1231/cc-switch
 
 /**
  * Minimal payload required by CC Switch deeplink import protocol.
@@ -74,6 +82,18 @@ function generateCCSwitchURL(payload: CCSwitchDeeplinkPayload) {
   return `ccswitch://v1/import?${params.toString()}`
 }
 
+const toHermesProviderSlug = (value: string) =>
+  value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "")
+
+const normalizeHermesProviderName = (name: string, endpoint: string) =>
+  toHermesProviderSlug(name) ||
+  toHermesProviderSlug(new URL(endpoint).hostname) ||
+  "provider"
+
 /**
  * Attempt to open the CC Switch desktop client via deeplink.
  * Validates inputs, normalizes URLs, and surfaces toast feedback.
@@ -121,9 +141,13 @@ export function openInCCSwitch(options: OpenInCCSwitchOptions) {
     return false
   }
 
+  const providerName = name?.trim() || account.name
   const deeplink = generateCCSwitchURL({
     app,
-    name: name?.trim() || account.name,
+    name:
+      app === "hermes"
+        ? normalizeHermesProviderName(providerName, normalizedEndpoint)
+        : providerName,
     homepage,
     endpoint: normalizedEndpoint,
     apiKey: token.key,

--- a/tests/components/CCSwitchExportDialog.test.tsx
+++ b/tests/components/CCSwitchExportDialog.test.tsx
@@ -250,6 +250,10 @@ describe("CCSwitchExportDialog", () => {
       appLabel: "ui:dialog.ccswitch.appOptions.openclaw",
       notice: "ui:dialog.ccswitch.notices.openclaw",
     },
+    {
+      appLabel: "ui:dialog.ccswitch.appOptions.hermes",
+      notice: "ui:dialog.ccswitch.notices.hermes",
+    },
   ])(
     "shows the protocol limitation notice for $appLabel",
     async ({ appLabel, notice }) => {
@@ -287,6 +291,51 @@ describe("CCSwitchExportDialog", () => {
         "aria-describedby",
         "ccswitch-app-limitation",
       )
+    },
+  )
+
+  it.each([
+    {
+      app: "grokbuild",
+      appLabel: "ui:dialog.ccswitch.appOptions.grokbuild",
+    },
+    {
+      app: "hermes",
+      appLabel: "ui:dialog.ccswitch.appOptions.hermes",
+    },
+  ] as const)(
+    "submits the selected $app CC Switch app",
+    async ({ app, appLabel }) => {
+      const user = userEvent.setup()
+      mockFetchOpenAICompatibleModelIds.mockResolvedValue([])
+
+      render(
+        <CCSwitchExportDialog
+          isOpen={true}
+          onClose={() => {}}
+          account={
+            { id: "acc", name: "Example", baseUrl: "https://x.test" } as any
+          }
+          token={{ id: "tok", key: "sk-test" } as any}
+        />,
+      )
+
+      const appSelect = await screen.findByLabelText(
+        "ui:dialog.ccswitch.fields.app",
+      )
+      await user.click(appSelect)
+      await user.click(await screen.findByRole("option", { name: appLabel }))
+      await user.click(
+        screen.getByRole("button", {
+          name: "ui:dialog.ccswitch.actions.export",
+        }),
+      )
+
+      await waitFor(() => {
+        expect(mockOpenInCCSwitch).toHaveBeenCalledWith(
+          expect.objectContaining({ app }),
+        )
+      })
     },
   )
 

--- a/tests/utils/ccSwitch.test.ts
+++ b/tests/utils/ccSwitch.test.ts
@@ -33,7 +33,7 @@ const mockToken: ApiToken = {
 
 describe("ccSwitch", () => {
   describe("openInCCSwitch", () => {
-    it.each(["opencode", "openclaw"] as const)(
+    it.each(["opencode", "openclaw", "grokbuild", "hermes"] as const)(
       "uses the selected app parameter for %s exports",
       (app) => {
         const openSpy = vi.spyOn(window, "open").mockImplementation(() => null)
@@ -100,6 +100,58 @@ describe("ccSwitch", () => {
       const deeplink = openSpy.mock.calls[0][0] as string
       const parsed = new URL(deeplink)
       expect(parsed.searchParams.get("endpoint")).toBe("https://x.test/v1")
+
+      openSpy.mockRestore()
+    })
+
+    it("normalizes the Hermes provider name to a lowercase ASCII slug", () => {
+      const openSpy = vi.spyOn(window, "open").mockImplementation(() => null)
+
+      openInCCSwitch({
+        account: mockAccount,
+        token: mockToken,
+        app: "hermes",
+        name: "  Acme 中文_API Gateway__  ",
+      })
+
+      const deeplink = openSpy.mock.calls[0][0] as string
+      const parsed = new URL(deeplink)
+      expect(parsed.searchParams.get("name")).toBe("acme-api-gateway")
+
+      openSpy.mockRestore()
+    })
+
+    it("uses the endpoint hostname when the Hermes name has no ASCII characters", () => {
+      const openSpy = vi.spyOn(window, "open").mockImplementation(() => null)
+
+      openInCCSwitch({
+        account: mockAccount,
+        token: mockToken,
+        app: "hermes",
+        name: "示例中转",
+        endpoint: "https://api.example.invalid/v1",
+      })
+
+      const deeplink = openSpy.mock.calls[0][0] as string
+      const parsed = new URL(deeplink)
+      expect(parsed.searchParams.get("name")).toBe("api-example-invalid")
+
+      openSpy.mockRestore()
+    })
+
+    it("preserves Unicode and underscores in provider names for non-Hermes apps", () => {
+      const openSpy = vi.spyOn(window, "open").mockImplementation(() => null)
+
+      openInCCSwitch({
+        account: mockAccount,
+        token: mockToken,
+        app: "grokbuild",
+        name: "示例_Provider",
+      })
+
+      const deeplink = openSpy.mock.calls[0][0] as string
+      const parsed = new URL(deeplink)
+      expect(parsed.searchParams.get("name")).toBe("示例_Provider")
 
       openSpy.mockRestore()
     })


### PR DESCRIPTION
## Summary

- add Grok CLI and Hermes as CC Switch export targets
- normalize Hermes provider identifiers to CC Switch's lowercase ASCII format, with endpoint hostname fallback, while preserving names for other apps
- document Hermes Chat Completions import behavior and synchronize the user-facing notices across supported locales

Close #1201

## Validation

- `pnpm exec vitest run tests/utils/ccSwitch.test.ts tests/components/CCSwitchExportDialog.test.tsx` (30 passed)
- `pnpm run validate:staged`
- `pnpm run validate:push`

## Notes

- reuses the existing CC Switch export telemetry action
- no E2E test was added because deeplink construction and dialog behavior are covered by focused Vitest tests, while the external desktop import is outside the extension E2E boundary


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CC Switch export support for Grok CLI and Hermes.
  * Added Hermes-specific import/export guidance and provider-name formatting.
  * Added localized labels and notices across supported languages.
* **Documentation**
  * Updated the supported tools list to include Grok CLI and Hermes.
* **Tests**
  * Added coverage for selecting and exporting with the new apps, including Hermes name normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->