### PR TITLE
perf(accounts): bound bulk invite-link copy latency

### DIFF
--- a/src/features/AccountManagement/components/AccountList/index.tsx
+++ b/src/features/AccountManagement/components/AccountList/index.tsx
@@ -42,6 +42,7 @@ import {
   getPrimaryInviteLinkFailureReason,
 } from "~/features/AccountManagement/inviteLinkCopyFeedback"
 import {
+  BULK_INVITE_LINK_COPY_POLICY,
   INVITE_LINK_COPY_RESULTS,
   runInviteLinkCopyWorkflow,
 } from "~/features/AccountManagement/inviteLinkCopyWorkflow"
@@ -871,6 +872,7 @@ export default function AccountList({ initialSearchQuery }: AccountListProps) {
         accounts: selectedAccounts,
         format: "labeled",
         signal: controller.signal,
+        ...BULK_INVITE_LINK_COPY_POLICY,
       })
       const insights = {
         itemCount: result.itemCount,

--- a/src/features/AccountManagement/inviteLinkCopyWorkflow.ts
+++ b/src/features/AccountManagement/inviteLinkCopyWorkflow.ts
@@ -3,6 +3,8 @@ import {
   fetchDisplayAccountInviteLink,
 } from "~/services/accounts/utils/apiServiceRequest"
 import {
+  INVITE_LINK_FAILURE_REASONS,
+  InviteLinkError,
   normalizeInviteLinkError,
   type InviteLinkFailureReasonCounts,
 } from "~/services/inviteLinks/errors"
@@ -17,6 +19,12 @@ export const INVITE_LINK_COPY_RESULTS = {
   Cancelled: "cancelled",
 } as const
 
+export const BULK_INVITE_LINK_COPY_POLICY = {
+  maxConcurrency: 4,
+  requestTimeoutMs: 8_000,
+  batchTimeoutMs: 20_000,
+} as const
+
 type InviteLinkCopyResult =
   (typeof INVITE_LINK_COPY_RESULTS)[keyof typeof INVITE_LINK_COPY_RESULTS]
 
@@ -24,6 +32,9 @@ interface RunInviteLinkCopyWorkflowOptions {
   accounts: DisplaySiteData[]
   format: "raw" | "labeled"
   signal?: AbortSignal
+  maxConcurrency?: number
+  requestTimeoutMs?: number
+  batchTimeoutMs?: number
 }
 
 interface InviteLinkFetchSuccess {
@@ -35,30 +46,170 @@ interface InviteLinkFetchFailure {
   reason: ReturnType<typeof normalizeInviteLinkError>["reason"]
 }
 
-/** Fetches invite links concurrently while preserving account order. */
+/** Fetches one invite link and settles even when an adapter ignores abort. */
+async function fetchInviteLink({
+  account,
+  signal,
+  batchSignal,
+  requestTimeoutMs,
+}: {
+  account: DisplaySiteData
+  signal?: AbortSignal
+  batchSignal?: AbortSignal
+  requestTimeoutMs?: number
+}): Promise<string> {
+  const hasRequestTimeout =
+    typeof requestTimeoutMs === "number" &&
+    Number.isFinite(requestTimeoutMs) &&
+    requestTimeoutMs > 0
+
+  const sourceSignals = [signal, batchSignal].filter(
+    (sourceSignal): sourceSignal is AbortSignal => sourceSignal !== undefined,
+  )
+
+  if (!hasRequestTimeout && sourceSignals.length === 0) {
+    return fetchDisplayAccountInviteLink(account, {
+      abortSignal: undefined,
+    })
+  }
+
+  const controller = new AbortController()
+  const signalCleanups: Array<() => void> = []
+  const cleanupSourceSignals = () => {
+    signalCleanups.forEach((cleanup) => cleanup())
+    signalCleanups.length = 0
+  }
+  for (const sourceSignal of sourceSignals) {
+    const relayAbort = () => {
+      if (!controller.signal.aborted) {
+        controller.abort(sourceSignal.reason)
+      }
+    }
+
+    if (sourceSignal.aborted) {
+      relayAbort()
+      break
+    }
+
+    sourceSignal.addEventListener("abort", relayAbort, { once: true })
+    signalCleanups.push(() => {
+      sourceSignal.removeEventListener("abort", relayAbort)
+    })
+  }
+
+  if (controller.signal.aborted) {
+    cleanupSourceSignals()
+    throw controller.signal.reason
+  }
+
+  const timeoutId = hasRequestTimeout
+    ? setTimeout(() => {
+        controller.abort(
+          new InviteLinkError(INVITE_LINK_FAILURE_REASONS.Timeout),
+        )
+      }, requestTimeoutMs)
+    : undefined
+  let rejectOnAbort: (() => void) | undefined
+  const abortPromise = new Promise<never>((_resolve, reject) => {
+    rejectOnAbort = () => reject(controller.signal.reason)
+    controller.signal.addEventListener("abort", rejectOnAbort, { once: true })
+  })
+
+  try {
+    return await Promise.race([
+      fetchDisplayAccountInviteLink(account, {
+        abortSignal: controller.signal,
+      }),
+      abortPromise,
+    ])
+  } finally {
+    if (timeoutId !== undefined) clearTimeout(timeoutId)
+    cleanupSourceSignals()
+    if (rejectOnAbort) {
+      controller.signal.removeEventListener("abort", rejectOnAbort)
+    }
+  }
+}
+
+/** Fetches invite links with optional concurrency limiting while preserving order. */
 async function fetchInviteLinks({
   accounts,
   signal,
+  maxConcurrency,
+  requestTimeoutMs,
+  batchTimeoutMs,
 }: {
   accounts: DisplaySiteData[]
   signal?: AbortSignal
+  maxConcurrency?: number
+  requestTimeoutMs?: number
+  batchTimeoutMs?: number
 }): Promise<Array<InviteLinkFetchSuccess | InviteLinkFetchFailure>> {
-  return Promise.all(
-    accounts.map(async (account) => {
+  const results = new Array<InviteLinkFetchSuccess | InviteLinkFetchFailure>(
+    accounts.length,
+  )
+  const requestedConcurrency =
+    typeof maxConcurrency === "number" &&
+    Number.isFinite(maxConcurrency) &&
+    maxConcurrency > 0
+      ? Math.floor(maxConcurrency)
+      : accounts.length
+  const workerCount = Math.min(accounts.length, requestedConcurrency)
+  const hasBatchTimeout =
+    typeof batchTimeoutMs === "number" &&
+    Number.isFinite(batchTimeoutMs) &&
+    batchTimeoutMs > 0
+  const batchController = hasBatchTimeout ? new AbortController() : undefined
+  const batchTimeoutId = batchController
+    ? setTimeout(() => {
+        batchController.abort(
+          new InviteLinkError(INVITE_LINK_FAILURE_REASONS.Timeout),
+        )
+      }, batchTimeoutMs)
+    : undefined
+  let nextAccountIndex = 0
+
+  const fetchNext = async () => {
+    while (nextAccountIndex < accounts.length) {
+      if (signal?.aborted || batchController?.signal.aborted) return
+
+      const accountIndex = nextAccountIndex
+      nextAccountIndex += 1
+      const account = accounts[accountIndex]
+
       try {
-        return {
+        results[accountIndex] = {
           account,
-          inviteLink: await fetchDisplayAccountInviteLink(account, {
-            abortSignal: signal,
+          inviteLink: await fetchInviteLink({
+            account,
+            signal,
+            batchSignal: batchController?.signal,
+            requestTimeoutMs,
           }),
         }
       } catch (error) {
-        return {
+        results[accountIndex] = {
           reason: normalizeInviteLinkError(error).reason,
         }
       }
-    }),
-  )
+    }
+  }
+
+  try {
+    await Promise.all(Array.from({ length: workerCount }, () => fetchNext()))
+  } finally {
+    if (batchTimeoutId !== undefined) clearTimeout(batchTimeoutId)
+  }
+
+  for (let accountIndex = 0; accountIndex < results.length; accountIndex += 1) {
+    if (!results[accountIndex]) {
+      results[accountIndex] = {
+        reason: INVITE_LINK_FAILURE_REASONS.Timeout,
+      }
+    }
+  }
+
+  return results
 }
 
 interface InviteLinkCopyWorkflowResult {
@@ -80,6 +231,9 @@ export async function runInviteLinkCopyWorkflow({
   accounts,
   format,
   signal,
+  maxConcurrency,
+  requestTimeoutMs,
+  batchTimeoutMs,
 }: RunInviteLinkCopyWorkflowOptions): Promise<InviteLinkCopyWorkflowResult> {
   const enabledAccounts = accounts.filter(
     (account) => account.disabled !== true,
@@ -115,6 +269,9 @@ export async function runInviteLinkCopyWorkflow({
   const fetchResults = await fetchInviteLinks({
     accounts: supportedAccounts,
     signal,
+    maxConcurrency,
+    requestTimeoutMs,
+    batchTimeoutMs,
   })
 
   if (signal?.aborted) {

--- a/src/features/AccountManagement/inviteLinkCopyWorkflow.ts
+++ b/src/features/AccountManagement/inviteLinkCopyWorkflow.ts
@@ -44,6 +44,9 @@ interface InviteLinkFetchFailure {
   reason: ReturnType<typeof normalizeInviteLinkError>["reason"]
 }
 
+const isPositiveFiniteTimeout = (value: unknown): value is number =>
+  typeof value === "number" && Number.isFinite(value) && value > 0
+
 /** Fetches one invite link and settles even when an adapter ignores abort. */
 async function fetchInviteLink({
   account,
@@ -56,10 +59,7 @@ async function fetchInviteLink({
   batchSignal?: AbortSignal
   requestTimeoutMs?: number
 }): Promise<string> {
-  const hasRequestTimeout =
-    typeof requestTimeoutMs === "number" &&
-    Number.isFinite(requestTimeoutMs) &&
-    requestTimeoutMs > 0
+  const hasRequestTimeout = isPositiveFiniteTimeout(requestTimeoutMs)
 
   const sourceSignals = [signal, batchSignal].filter(
     (sourceSignal): sourceSignal is AbortSignal => sourceSignal !== undefined,
@@ -131,10 +131,7 @@ async function fetchInviteLinks({
   requestTimeoutMs?: number
   batchTimeoutMs?: number
 }): Promise<Array<InviteLinkFetchSuccess | InviteLinkFetchFailure>> {
-  const hasBatchTimeout =
-    typeof batchTimeoutMs === "number" &&
-    Number.isFinite(batchTimeoutMs) &&
-    batchTimeoutMs > 0
+  const hasBatchTimeout = isPositiveFiniteTimeout(batchTimeoutMs)
   const batchController = hasBatchTimeout ? new AbortController() : undefined
   const batchTimeoutId = batchController
     ? setTimeout(() => {

--- a/src/features/AccountManagement/inviteLinkCopyWorkflow.ts
+++ b/src/features/AccountManagement/inviteLinkCopyWorkflow.ts
@@ -20,7 +20,6 @@ export const INVITE_LINK_COPY_RESULTS = {
 } as const
 
 export const BULK_INVITE_LINK_COPY_POLICY = {
-  maxConcurrency: 4,
   requestTimeoutMs: 8_000,
   batchTimeoutMs: 20_000,
 } as const
@@ -32,7 +31,6 @@ interface RunInviteLinkCopyWorkflowOptions {
   accounts: DisplaySiteData[]
   format: "raw" | "labeled"
   signal?: AbortSignal
-  maxConcurrency?: number
   requestTimeoutMs?: number
   batchTimeoutMs?: number
 }
@@ -79,27 +77,23 @@ async function fetchInviteLink({
     signalCleanups.forEach((cleanup) => cleanup())
     signalCleanups.length = 0
   }
+  let rejectOnAbort!: () => void
+  const abortPromise = new Promise<never>((_resolve, reject) => {
+    rejectOnAbort = () => reject(controller.signal.reason)
+    controller.signal.addEventListener("abort", rejectOnAbort, { once: true })
+  })
+
+  // The parent is checked before this batch starts and adapter calls are
+  // deferred below, so every source listener is attached before abort can race.
   for (const sourceSignal of sourceSignals) {
     const relayAbort = () => {
-      if (!controller.signal.aborted) {
-        controller.abort(sourceSignal.reason)
-      }
-    }
-
-    if (sourceSignal.aborted) {
-      relayAbort()
-      break
+      controller.abort(sourceSignal.reason)
     }
 
     sourceSignal.addEventListener("abort", relayAbort, { once: true })
     signalCleanups.push(() => {
       sourceSignal.removeEventListener("abort", relayAbort)
     })
-  }
-
-  if (controller.signal.aborted) {
-    cleanupSourceSignals()
-    throw controller.signal.reason
   }
 
   const timeoutId = hasRequestTimeout
@@ -109,52 +103,34 @@ async function fetchInviteLink({
         )
       }, requestTimeoutMs)
     : undefined
-  let rejectOnAbort: (() => void) | undefined
-  const abortPromise = new Promise<never>((_resolve, reject) => {
-    rejectOnAbort = () => reject(controller.signal.reason)
-    controller.signal.addEventListener("abort", rejectOnAbort, { once: true })
+  const fetchPromise = Promise.resolve().then(() => {
+    controller.signal.throwIfAborted()
+    return fetchDisplayAccountInviteLink(account, {
+      abortSignal: controller.signal,
+    })
   })
 
   try {
-    return await Promise.race([
-      fetchDisplayAccountInviteLink(account, {
-        abortSignal: controller.signal,
-      }),
-      abortPromise,
-    ])
+    return await Promise.race([fetchPromise, abortPromise])
   } finally {
     if (timeoutId !== undefined) clearTimeout(timeoutId)
     cleanupSourceSignals()
-    if (rejectOnAbort) {
-      controller.signal.removeEventListener("abort", rejectOnAbort)
-    }
+    controller.signal.removeEventListener("abort", rejectOnAbort)
   }
 }
 
-/** Fetches invite links with optional concurrency limiting while preserving order. */
+/** Fetches invite links concurrently while preserving account order. */
 async function fetchInviteLinks({
   accounts,
   signal,
-  maxConcurrency,
   requestTimeoutMs,
   batchTimeoutMs,
 }: {
   accounts: DisplaySiteData[]
   signal?: AbortSignal
-  maxConcurrency?: number
   requestTimeoutMs?: number
   batchTimeoutMs?: number
 }): Promise<Array<InviteLinkFetchSuccess | InviteLinkFetchFailure>> {
-  const results = new Array<InviteLinkFetchSuccess | InviteLinkFetchFailure>(
-    accounts.length,
-  )
-  const requestedConcurrency =
-    typeof maxConcurrency === "number" &&
-    Number.isFinite(maxConcurrency) &&
-    maxConcurrency > 0
-      ? Math.floor(maxConcurrency)
-      : accounts.length
-  const workerCount = Math.min(accounts.length, requestedConcurrency)
   const hasBatchTimeout =
     typeof batchTimeoutMs === "number" &&
     Number.isFinite(batchTimeoutMs) &&
@@ -167,49 +143,29 @@ async function fetchInviteLinks({
         )
       }, batchTimeoutMs)
     : undefined
-  let nextAccountIndex = 0
-
-  const fetchNext = async () => {
-    while (nextAccountIndex < accounts.length) {
-      if (signal?.aborted || batchController?.signal.aborted) return
-
-      const accountIndex = nextAccountIndex
-      nextAccountIndex += 1
-      const account = accounts[accountIndex]
-
-      try {
-        results[accountIndex] = {
-          account,
-          inviteLink: await fetchInviteLink({
-            account,
-            signal,
-            batchSignal: batchController?.signal,
-            requestTimeoutMs,
-          }),
-        }
-      } catch (error) {
-        results[accountIndex] = {
-          reason: normalizeInviteLinkError(error).reason,
-        }
-      }
-    }
-  }
-
   try {
-    await Promise.all(Array.from({ length: workerCount }, () => fetchNext()))
+    return await Promise.all(
+      accounts.map(async (account) => {
+        try {
+          return {
+            account,
+            inviteLink: await fetchInviteLink({
+              account,
+              signal,
+              batchSignal: batchController?.signal,
+              requestTimeoutMs,
+            }),
+          }
+        } catch (error) {
+          return {
+            reason: normalizeInviteLinkError(error).reason,
+          }
+        }
+      }),
+    )
   } finally {
     if (batchTimeoutId !== undefined) clearTimeout(batchTimeoutId)
   }
-
-  for (let accountIndex = 0; accountIndex < results.length; accountIndex += 1) {
-    if (!results[accountIndex]) {
-      results[accountIndex] = {
-        reason: INVITE_LINK_FAILURE_REASONS.Timeout,
-      }
-    }
-  }
-
-  return results
 }
 
 interface InviteLinkCopyWorkflowResult {
@@ -231,7 +187,6 @@ export async function runInviteLinkCopyWorkflow({
   accounts,
   format,
   signal,
-  maxConcurrency,
   requestTimeoutMs,
   batchTimeoutMs,
 }: RunInviteLinkCopyWorkflowOptions): Promise<InviteLinkCopyWorkflowResult> {
@@ -269,7 +224,6 @@ export async function runInviteLinkCopyWorkflow({
   const fetchResults = await fetchInviteLinks({
     accounts: supportedAccounts,
     signal,
-    maxConcurrency,
     requestTimeoutMs,
     batchTimeoutMs,
   })

--- a/src/services/apiService/aihubmix/index.ts
+++ b/src/services/apiService/aihubmix/index.ts
@@ -28,6 +28,7 @@ import type {
 } from "~/services/apiAdapters/contracts/accountBootstrap"
 import { API_ERROR_CODES, ApiError } from "~/services/apiTransport/errors"
 import { fetchApiData } from "~/services/apiTransport/request"
+import { withSiteApiRequestLimit } from "~/services/apiTransport/siteRequestLimiter"
 import type {
   ApiResponse,
   ApiServiceRequest,
@@ -661,10 +662,15 @@ export async function fetchAccountQuota(
 export async function fetchInviteLink(
   request: ApiServiceRequest,
 ): Promise<string> {
-  const userInfo = await fetchAIHubMixData<unknown>(
-    request,
-    AIHUBMIX_API_USER_SELF_ENDPOINT,
-    { cache: "no-store", signal: request.abortSignal },
+  const userInfo = await withSiteApiRequestLimit(
+    AIHUBMIX_API_ORIGIN,
+    async () =>
+      await fetchAIHubMixData<unknown>(
+        request,
+        AIHUBMIX_API_USER_SELF_ENDPOINT,
+        { cache: "no-store", signal: request.abortSignal },
+      ),
+    request.abortSignal,
   )
   if (!userInfo || typeof userInfo !== "object" || Array.isArray(userInfo)) {
     throw new InviteLinkError(INVITE_LINK_FAILURE_REASONS.InviteDataMissing)

--- a/src/services/apiTransport/request.ts
+++ b/src/services/apiTransport/request.ts
@@ -642,7 +642,11 @@ const _fetchApi = async <T>(
 
   const siteRequestLimitKey = resolveSiteRequestLimitKey(baseUrl)
 
-  return await withSiteApiRequestLimit(siteRequestLimitKey, executeRequest)
+  return await withSiteApiRequestLimit(
+    siteRequestLimitKey,
+    executeRequest,
+    fetchOptions.signal ?? undefined,
+  )
 }
 
 /**

--- a/src/services/apiTransport/siteRequestLimiter.ts
+++ b/src/services/apiTransport/siteRequestLimiter.ts
@@ -11,6 +11,8 @@ type QueueItem = {
   task: () => Promise<unknown>
   resolve: (value: unknown) => void
   reject: (reason?: unknown) => void
+  signal?: AbortSignal
+  abortListener?: () => void
 }
 
 type SiteLimiterState = {
@@ -29,6 +31,16 @@ const SITE_API_REQUEST_LIMITS = {
 } as const satisfies SiteRequestLimiterConfig
 
 const IDLE_STATE_TTL_MS = 5 * 60 * 1000
+
+const getAbortReason = (signal: AbortSignal): unknown =>
+  signal.reason ?? new DOMException("The operation was aborted", "AbortError")
+
+const detachAbortListener = (item: QueueItem): void => {
+  if (!item.signal || !item.abortListener) return
+
+  item.signal.removeEventListener("abort", item.abortListener)
+  item.abortListener = undefined
+}
 
 /**
  * Resolve a numeric limiter config field and reject NaN/Infinity early.
@@ -96,8 +108,14 @@ export function createSiteRequestLimiter(config: SiteRequestLimiterConfig) {
   const states = new Map<string, SiteLimiterState>()
 
   if (!enabled || requestsPerMinute <= 0) {
-    return async <T>(_key: string, task: () => Promise<T>): Promise<T> =>
-      await task()
+    return async <T>(
+      _key: string,
+      task: () => Promise<T>,
+      signal?: AbortSignal,
+    ): Promise<T> => {
+      if (signal?.aborted) throw getAbortReason(signal)
+      return await task()
+    }
   }
 
   const refillTokens = (state: SiteLimiterState) => {
@@ -172,10 +190,12 @@ export function createSiteRequestLimiter(config: SiteRequestLimiterConfig) {
         return
       }
 
-      state.tokens -= 1
-      const item = state.queue.shift()
-      if (!item) continue
+      // Abort dispatch is synchronous: queued handlers remove their item before
+      // this turn, and this turn detaches the handler before starting the task.
+      const item = state.queue.shift()!
+      detachAbortListener(item)
 
+      state.tokens -= 1
       state.activeCount += 1
       void Promise.resolve()
         .then(item.task)
@@ -190,17 +210,36 @@ export function createSiteRequestLimiter(config: SiteRequestLimiterConfig) {
     scheduleCleanup(key, state)
   }
 
-  return async <T>(key: string, task: () => Promise<T>): Promise<T> => {
+  return async <T>(
+    key: string,
+    task: () => Promise<T>,
+    signal?: AbortSignal,
+  ): Promise<T> => {
+    if (signal?.aborted) throw getAbortReason(signal)
     if (!key) return await task()
 
     const state = getState(key)
 
     return await new Promise<T>((resolve, reject) => {
-      state.queue.push({
+      const item: QueueItem = {
         task: async () => await task(),
         resolve: (value) => resolve(value as T),
         reject,
-      })
+        signal,
+      }
+
+      if (signal) {
+        item.abortListener = () => {
+          const queueIndex = state.queue.indexOf(item)
+          state.queue.splice(queueIndex, 1)
+          detachAbortListener(item)
+          reject(getAbortReason(signal))
+          schedule(key, state)
+        }
+        signal.addEventListener("abort", item.abortListener, { once: true })
+      }
+
+      state.queue.push(item)
       schedule(key, state)
     })
   }
@@ -217,6 +256,7 @@ const productionSiteRequestLimiter = createSiteRequestLimiter({
 export async function withSiteApiRequestLimit<T>(
   key: string,
   task: () => Promise<T>,
+  signal?: AbortSignal,
 ): Promise<T> {
-  return await productionSiteRequestLimiter(key, task)
+  return await productionSiteRequestLimiter(key, task, signal)
 }

--- a/tests/features/AccountManagement/components/AccountList.test.tsx
+++ b/tests/features/AccountManagement/components/AccountList.test.tsx
@@ -1869,11 +1869,11 @@ describe("AccountList", () => {
       )
       expect(workflowSpy).toHaveBeenCalledWith(
         expect.objectContaining({
-          maxConcurrency: 4,
           requestTimeoutMs: 8_000,
           batchTimeoutMs: 20_000,
         }),
       )
+      expect(workflowSpy.mock.calls[0][0]).not.toHaveProperty("maxConcurrency")
       expect(toastSuccessMock).toHaveBeenCalledWith(
         "account:bulk.copyInviteLinksSuccess",
       )

--- a/tests/features/AccountManagement/components/AccountList.test.tsx
+++ b/tests/features/AccountManagement/components/AccountList.test.tsx
@@ -1810,6 +1810,10 @@ describe("AccountList", () => {
 
   it("copies invite links for supported selected accounts", async () => {
     const user = userEvent.setup()
+    const workflowSpy = vi.spyOn(
+      inviteLinkCopyWorkflow,
+      "runInviteLinkCopyWorkflow",
+    )
     const inviteA = buildDisplaySiteData({
       id: "invite-a",
       name: "Invite A",
@@ -1862,6 +1866,13 @@ describe("AccountList", () => {
       expect(fetchDisplayAccountInviteLinkMock).toHaveBeenCalledWith(
         expect.objectContaining({ id: "invite-b" }),
         expect.objectContaining({ abortSignal: expect.any(AbortSignal) }),
+      )
+      expect(workflowSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          maxConcurrency: 4,
+          requestTimeoutMs: 8_000,
+          batchTimeoutMs: 20_000,
+        }),
       )
       expect(toastSuccessMock).toHaveBeenCalledWith(
         "account:bulk.copyInviteLinksSuccess",

--- a/tests/features/AccountManagement/inviteLinkCopyWorkflow.test.ts
+++ b/tests/features/AccountManagement/inviteLinkCopyWorkflow.test.ts
@@ -93,11 +93,20 @@ describe("runInviteLinkCopyWorkflow", () => {
     expect(clipboardWriteTextMock).not.toHaveBeenCalled()
   })
 
-  it("starts all supported account fetches without a client concurrency cap", async () => {
+  it("limits concurrent fetches while preserving queued work", async () => {
     const releases: Array<() => void> = []
+    let activeCount = 0
+    let maxActiveCount = 0
     fetchDisplayAccountInviteLinkMock.mockImplementation(
       async (account: { id: string }) => {
-        await new Promise<void>((resolve) => releases.push(resolve))
+        activeCount += 1
+        maxActiveCount = Math.max(maxActiveCount, activeCount)
+        await new Promise<void>((resolve) =>
+          releases.push(() => {
+            activeCount -= 1
+            resolve()
+          }),
+        )
         return `https://invite.example.invalid/${account.id}`
       },
     )
@@ -107,16 +116,53 @@ describe("runInviteLinkCopyWorkflow", () => {
         buildAccount(String(index)),
       ),
       format: "labeled",
+      maxConcurrency: 4,
     })
 
     await vi.waitFor(() => {
+      expect(fetchDisplayAccountInviteLinkMock).toHaveBeenCalledTimes(4)
+    })
+
+    releases.shift()?.()
+    await vi.waitFor(() => {
+      expect(fetchDisplayAccountInviteLinkMock).toHaveBeenCalledTimes(5)
+    })
+
+    releases.shift()?.()
+    await vi.waitFor(() => {
       expect(fetchDisplayAccountInviteLinkMock).toHaveBeenCalledTimes(6)
     })
-    while (releases.length > 0) {
-      releases.shift()?.()
-      await Promise.resolve()
-    }
+    releases.splice(0).forEach((release) => release())
+
     await copyPromise
+    expect(maxActiveCount).toBe(4)
+  })
+
+  it("preserves account order when concurrent fetches finish out of order", async () => {
+    const resolvers = new Map<string, (value: string) => void>()
+    fetchDisplayAccountInviteLinkMock.mockImplementation(
+      (account: { id: string }) =>
+        new Promise<string>((resolve) => {
+          resolvers.set(account.id, resolve)
+        }),
+    )
+
+    const copyPromise = runInviteLinkCopyWorkflow({
+      accounts: [buildAccount("first"), buildAccount("second")],
+      format: "raw",
+      maxConcurrency: 2,
+    })
+    await vi.waitFor(() => {
+      expect(fetchDisplayAccountInviteLinkMock).toHaveBeenCalledTimes(2)
+    })
+
+    resolvers.get("second")?.("https://invite.example.invalid/second")
+    resolvers.get("first")?.("https://invite.example.invalid/first")
+
+    await copyPromise
+    expect(clipboardWriteTextMock).toHaveBeenCalledWith(
+      "https://invite.example.invalid/first\nhttps://invite.example.invalid/second",
+    )
   })
 
   it("returns exact unsupported counts without touching the clipboard", async () => {
@@ -373,6 +419,158 @@ describe("runInviteLinkCopyWorkflow", () => {
       unsupportedCount: 0,
       skippedCount: 0,
     })
+  })
+
+  it("times out one slow request without delaying successful queued work", async () => {
+    vi.useFakeTimers()
+    let resolveSlowFetch: ((value: string) => void) | undefined
+    fetchDisplayAccountInviteLinkMock.mockImplementation(
+      (account: { id: string }) => {
+        if (account.id === "slow") {
+          return new Promise<string>((resolve) => {
+            resolveSlowFetch = resolve
+          })
+        }
+        return Promise.resolve(`https://invite.example.invalid/${account.id}`)
+      },
+    )
+
+    try {
+      const copyPromise = runInviteLinkCopyWorkflow({
+        accounts: [buildAccount("slow"), buildAccount("successful")],
+        format: "raw",
+        maxConcurrency: 1,
+        requestTimeoutMs: 1_000,
+      })
+
+      await vi.advanceTimersByTimeAsync(1_000)
+      const startedCountAfterTimeout =
+        fetchDisplayAccountInviteLinkMock.mock.calls.length
+      resolveSlowFetch?.("https://invite.example.invalid/late")
+
+      await expect(copyPromise).resolves.toEqual({
+        result: INVITE_LINK_COPY_RESULTS.PartialSuccess,
+        payload: "https://invite.example.invalid/successful",
+        selectedCount: 2,
+        itemCount: 2,
+        successCount: 1,
+        failureCount: 1,
+        failureReasonCounts: {
+          [INVITE_LINK_FAILURE_REASONS.Timeout]: 1,
+        },
+        unsupportedCount: 0,
+        skippedCount: 0,
+      })
+      expect(startedCountAfterTimeout).toBe(2)
+      expect(clipboardWriteTextMock).toHaveBeenCalledWith(
+        "https://invite.example.invalid/successful",
+      )
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it("stops active and queued work at the batch deadline while keeping successes", async () => {
+    vi.useFakeTimers()
+    const startedAccountIds: string[] = []
+    const requestSignals: Array<{ accountId: string; signal: AbortSignal }> = []
+    fetchDisplayAccountInviteLinkMock.mockImplementation(
+      (account: { id: string }, options: { abortSignal?: AbortSignal }) => {
+        startedAccountIds.push(account.id)
+        if (options.abortSignal) {
+          requestSignals.push({
+            accountId: account.id,
+            signal: options.abortSignal,
+          })
+        }
+        if (account.id === "successful") {
+          return Promise.resolve("https://invite.example.invalid/successful")
+        }
+        return new Promise<string>(() => {})
+      },
+    )
+
+    try {
+      const copyPromise = runInviteLinkCopyWorkflow({
+        accounts: [
+          buildAccount("successful"),
+          buildAccount("active-one"),
+          buildAccount("active-two"),
+          buildAccount("queued-one"),
+          buildAccount("queued-two"),
+        ],
+        format: "raw",
+        maxConcurrency: 2,
+        batchTimeoutMs: 2_000,
+      })
+      let settledResult: Awaited<typeof copyPromise> | undefined
+      void copyPromise.then((result) => {
+        settledResult = result
+      })
+
+      await vi.advanceTimersByTimeAsync(2_000)
+
+      expect(settledResult).toEqual({
+        result: INVITE_LINK_COPY_RESULTS.PartialSuccess,
+        payload: "https://invite.example.invalid/successful",
+        selectedCount: 5,
+        itemCount: 5,
+        successCount: 1,
+        failureCount: 4,
+        failureReasonCounts: {
+          [INVITE_LINK_FAILURE_REASONS.Timeout]: 4,
+        },
+        unsupportedCount: 0,
+        skippedCount: 0,
+      })
+      expect(startedAccountIds).toHaveLength(3)
+      expect(startedAccountIds).not.toContain("queued-one")
+      expect(startedAccountIds).not.toContain("queued-two")
+      expect(requestSignals).toHaveLength(3)
+      expect(
+        requestSignals
+          .filter(({ accountId }) => accountId.startsWith("active-"))
+          .every(({ signal }) => signal.aborted),
+      ).toBe(true)
+      expect(clipboardWriteTextMock).toHaveBeenCalledWith(
+        "https://invite.example.invalid/successful",
+      )
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it("prioritizes parent cancellation over request and batch timeouts", async () => {
+    const controller = new AbortController()
+    fetchDisplayAccountInviteLinkMock.mockImplementation(
+      () => new Promise<string>(() => {}),
+    )
+
+    const copyPromise = runInviteLinkCopyWorkflow({
+      accounts: [buildAccount("active"), buildAccount("queued")],
+      format: "raw",
+      signal: controller.signal,
+      maxConcurrency: 1,
+      requestTimeoutMs: 8_000,
+      batchTimeoutMs: 20_000,
+    })
+    await vi.waitFor(() => {
+      expect(fetchDisplayAccountInviteLinkMock).toHaveBeenCalledTimes(1)
+    })
+
+    controller.abort()
+
+    await expect(copyPromise).resolves.toEqual({
+      result: INVITE_LINK_COPY_RESULTS.Cancelled,
+      selectedCount: 2,
+      itemCount: 2,
+      successCount: 0,
+      failureCount: 0,
+      unsupportedCount: 0,
+      skippedCount: 0,
+    })
+    expect(fetchDisplayAccountInviteLinkMock).toHaveBeenCalledTimes(1)
+    expect(clipboardWriteTextMock).not.toHaveBeenCalled()
   })
 
   it("does not impose a feature-specific timeout on queued requests", async () => {

--- a/tests/features/AccountManagement/inviteLinkCopyWorkflow.test.ts
+++ b/tests/features/AccountManagement/inviteLinkCopyWorkflow.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import {
+  BULK_INVITE_LINK_COPY_POLICY,
   INVITE_LINK_COPY_RESULTS,
   runInviteLinkCopyWorkflow,
 } from "~/features/AccountManagement/inviteLinkCopyWorkflow"
@@ -93,20 +94,11 @@ describe("runInviteLinkCopyWorkflow", () => {
     expect(clipboardWriteTextMock).not.toHaveBeenCalled()
   })
 
-  it("limits concurrent fetches while preserving queued work", async () => {
+  it("starts every supported fetch without a global cap under the bulk policy", async () => {
     const releases: Array<() => void> = []
-    let activeCount = 0
-    let maxActiveCount = 0
     fetchDisplayAccountInviteLinkMock.mockImplementation(
       async (account: { id: string }) => {
-        activeCount += 1
-        maxActiveCount = Math.max(maxActiveCount, activeCount)
-        await new Promise<void>((resolve) =>
-          releases.push(() => {
-            activeCount -= 1
-            resolve()
-          }),
-        )
+        await new Promise<void>((resolve) => releases.push(resolve))
         return `https://invite.example.invalid/${account.id}`
       },
     )
@@ -116,26 +108,16 @@ describe("runInviteLinkCopyWorkflow", () => {
         buildAccount(String(index)),
       ),
       format: "labeled",
-      maxConcurrency: 4,
+      ...BULK_INVITE_LINK_COPY_POLICY,
     })
 
-    await vi.waitFor(() => {
-      expect(fetchDisplayAccountInviteLinkMock).toHaveBeenCalledTimes(4)
-    })
-
-    releases.shift()?.()
-    await vi.waitFor(() => {
-      expect(fetchDisplayAccountInviteLinkMock).toHaveBeenCalledTimes(5)
-    })
-
-    releases.shift()?.()
     await vi.waitFor(() => {
       expect(fetchDisplayAccountInviteLinkMock).toHaveBeenCalledTimes(6)
     })
+
     releases.splice(0).forEach((release) => release())
 
     await copyPromise
-    expect(maxActiveCount).toBe(4)
   })
 
   it("preserves account order when concurrent fetches finish out of order", async () => {
@@ -150,7 +132,6 @@ describe("runInviteLinkCopyWorkflow", () => {
     const copyPromise = runInviteLinkCopyWorkflow({
       accounts: [buildAccount("first"), buildAccount("second")],
       format: "raw",
-      maxConcurrency: 2,
     })
     await vi.waitFor(() => {
       expect(fetchDisplayAccountInviteLinkMock).toHaveBeenCalledTimes(2)
@@ -421,7 +402,7 @@ describe("runInviteLinkCopyWorkflow", () => {
     })
   })
 
-  it("times out one slow request without delaying successful queued work", async () => {
+  it("times out one slow request without delaying successful concurrent work", async () => {
     vi.useFakeTimers()
     let resolveSlowFetch: ((value: string) => void) | undefined
     fetchDisplayAccountInviteLinkMock.mockImplementation(
@@ -439,7 +420,6 @@ describe("runInviteLinkCopyWorkflow", () => {
       const copyPromise = runInviteLinkCopyWorkflow({
         accounts: [buildAccount("slow"), buildAccount("successful")],
         format: "raw",
-        maxConcurrency: 1,
         requestTimeoutMs: 1_000,
       })
 
@@ -470,7 +450,7 @@ describe("runInviteLinkCopyWorkflow", () => {
     }
   })
 
-  it("stops active and queued work at the batch deadline while keeping successes", async () => {
+  it("stops every unresolved request at the batch deadline while keeping successes", async () => {
     vi.useFakeTimers()
     const startedAccountIds: string[] = []
     const requestSignals: Array<{ accountId: string; signal: AbortSignal }> = []
@@ -496,21 +476,16 @@ describe("runInviteLinkCopyWorkflow", () => {
           buildAccount("successful"),
           buildAccount("active-one"),
           buildAccount("active-two"),
-          buildAccount("queued-one"),
-          buildAccount("queued-two"),
+          buildAccount("active-three"),
+          buildAccount("active-four"),
         ],
         format: "raw",
-        maxConcurrency: 2,
         batchTimeoutMs: 2_000,
-      })
-      let settledResult: Awaited<typeof copyPromise> | undefined
-      void copyPromise.then((result) => {
-        settledResult = result
       })
 
       await vi.advanceTimersByTimeAsync(2_000)
 
-      expect(settledResult).toEqual({
+      await expect(copyPromise).resolves.toEqual({
         result: INVITE_LINK_COPY_RESULTS.PartialSuccess,
         payload: "https://invite.example.invalid/successful",
         selectedCount: 5,
@@ -523,10 +498,8 @@ describe("runInviteLinkCopyWorkflow", () => {
         unsupportedCount: 0,
         skippedCount: 0,
       })
-      expect(startedAccountIds).toHaveLength(3)
-      expect(startedAccountIds).not.toContain("queued-one")
-      expect(startedAccountIds).not.toContain("queued-two")
-      expect(requestSignals).toHaveLength(3)
+      expect(startedAccountIds).toHaveLength(5)
+      expect(requestSignals).toHaveLength(5)
       expect(
         requestSignals
           .filter(({ accountId }) => accountId.startsWith("active-"))
@@ -547,15 +520,14 @@ describe("runInviteLinkCopyWorkflow", () => {
     )
 
     const copyPromise = runInviteLinkCopyWorkflow({
-      accounts: [buildAccount("active"), buildAccount("queued")],
+      accounts: [buildAccount("active-one"), buildAccount("active-two")],
       format: "raw",
       signal: controller.signal,
-      maxConcurrency: 1,
       requestTimeoutMs: 8_000,
       batchTimeoutMs: 20_000,
     })
     await vi.waitFor(() => {
-      expect(fetchDisplayAccountInviteLinkMock).toHaveBeenCalledTimes(1)
+      expect(fetchDisplayAccountInviteLinkMock).toHaveBeenCalledTimes(2)
     })
 
     controller.abort()
@@ -569,12 +541,13 @@ describe("runInviteLinkCopyWorkflow", () => {
       unsupportedCount: 0,
       skippedCount: 0,
     })
-    expect(fetchDisplayAccountInviteLinkMock).toHaveBeenCalledTimes(1)
+    expect(fetchDisplayAccountInviteLinkMock).toHaveBeenCalledTimes(2)
     expect(clipboardWriteTextMock).not.toHaveBeenCalled()
   })
 
-  it("does not impose a feature-specific timeout on queued requests", async () => {
+  it("keeps single-account requests alive beyond the bulk deadlines", async () => {
     vi.useFakeTimers()
+    const controller = new AbortController()
     let requestSignal: AbortSignal | undefined
     let resolveFetch: ((value: string) => void) | undefined
     fetchDisplayAccountInviteLinkMock.mockImplementation(
@@ -589,14 +562,17 @@ describe("runInviteLinkCopyWorkflow", () => {
       const copyPromise = runInviteLinkCopyWorkflow({
         accounts: [buildAccount("slow")],
         format: "raw",
+        signal: controller.signal,
       })
-      await vi.advanceTimersByTimeAsync(15_000)
+      await vi.advanceTimersByTimeAsync(25_000)
+
+      expect(requestSignal).toBeDefined()
+      expect(requestSignal?.aborted).toBe(false)
       resolveFetch?.("https://invite.example.invalid/slow")
 
       await expect(copyPromise).resolves.toMatchObject({
         result: INVITE_LINK_COPY_RESULTS.Success,
       })
-      expect(requestSignal).toBeUndefined()
     } finally {
       vi.useRealTimers()
     }

--- a/tests/features/AccountManagement/inviteLinkCopyWorkflow.test.ts
+++ b/tests/features/AccountManagement/inviteLinkCopyWorkflow.test.ts
@@ -5,6 +5,7 @@ import {
   INVITE_LINK_COPY_RESULTS,
   runInviteLinkCopyWorkflow,
 } from "~/features/AccountManagement/inviteLinkCopyWorkflow"
+import { createSiteRequestLimiter } from "~/services/apiTransport/siteRequestLimiter"
 import {
   INVITE_LINK_FAILURE_REASONS,
   InviteLinkError,
@@ -118,6 +119,68 @@ describe("runInviteLinkCopyWorkflow", () => {
     releases.splice(0).forEach((release) => release())
 
     await copyPromise
+  })
+
+  it("counts site-limiter queue time toward each request deadline", async () => {
+    vi.useFakeTimers()
+    const limiter = createSiteRequestLimiter({
+      maxConcurrentPerSite: 1,
+      requestsPerMinute: 60_000,
+      burst: 1,
+    })
+    const startedAccountIds: string[] = []
+    let releaseFirst: (() => void) | undefined
+    fetchDisplayAccountInviteLinkMock.mockImplementation(
+      (account: { id: string }, options: { abortSignal?: AbortSignal }) =>
+        limiter(
+          "https://shared.example.invalid",
+          async () => {
+            startedAccountIds.push(account.id)
+            if (account.id === "first") {
+              await new Promise<void>((resolve) => {
+                releaseFirst = resolve
+              })
+            }
+            return `https://invite.example.invalid/${account.id}`
+          },
+          options.abortSignal,
+        ),
+    )
+
+    try {
+      const copyPromise = runInviteLinkCopyWorkflow({
+        accounts: [buildAccount("first"), buildAccount("queued")],
+        format: "raw",
+        requestTimeoutMs: 1_000,
+      })
+
+      await vi.advanceTimersByTimeAsync(0)
+      expect(startedAccountIds).toEqual(["first"])
+
+      await vi.advanceTimersByTimeAsync(1_000)
+
+      await expect(copyPromise).resolves.toEqual({
+        result: INVITE_LINK_COPY_RESULTS.Failure,
+        selectedCount: 2,
+        itemCount: 2,
+        successCount: 0,
+        failureCount: 2,
+        failureReasonCounts: {
+          [INVITE_LINK_FAILURE_REASONS.Timeout]: 2,
+        },
+        unsupportedCount: 0,
+        skippedCount: 0,
+      })
+      expect(startedAccountIds).toEqual(["first"])
+
+      releaseFirst?.()
+      await vi.advanceTimersByTimeAsync(0)
+      expect(startedAccountIds).toEqual(["first"])
+    } finally {
+      releaseFirst?.()
+      vi.clearAllTimers()
+      vi.useRealTimers()
+    }
   })
 
   it("preserves account order when concurrent fetches finish out of order", async () => {

--- a/tests/services/apiService/aihubmix/index.test.ts
+++ b/tests/services/apiService/aihubmix/index.test.ts
@@ -41,6 +41,27 @@ import {
 } from "~/types"
 import { server } from "~~/tests/msw/server"
 
+const { mockWithSiteApiRequestLimit } = vi.hoisted(() => ({
+  mockWithSiteApiRequestLimit: vi.fn(
+    async (_key: string, task: () => Promise<unknown>, _signal?: AbortSignal) =>
+      await task(),
+  ),
+}))
+
+vi.mock(
+  "~/services/apiTransport/siteRequestLimiter",
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import("~/services/apiTransport/siteRequestLimiter")
+      >()
+    return {
+      ...actual,
+      withSiteApiRequestLimit: mockWithSiteApiRequestLimit,
+    }
+  },
+)
+
 const baseRequest = {
   baseUrl: "https://aihubmix.com",
   auth: {
@@ -69,6 +90,14 @@ const tokenRequest: CreateTokenRequest = {
 describe("apiService AIHubMix", () => {
   beforeEach(() => {
     server.resetHandlers()
+    mockWithSiteApiRequestLimit.mockClear()
+    mockWithSiteApiRequestLimit.mockImplementation(
+      async (
+        _key: string,
+        task: () => Promise<unknown>,
+        _signal?: AbortSignal,
+      ) => await task(),
+    )
   })
 
   it("uses the app default exchange rate because AIHubMix exposes no site rate field", () => {
@@ -195,6 +224,31 @@ describe("apiService AIHubMix", () => {
     await fetchInviteLink(baseRequest)
 
     expect(requestCache).toBe("no-store")
+  })
+
+  it("admits the raw invite-link request through the site limiter once", async () => {
+    const abortController = new AbortController()
+    server.use(
+      http.get("https://aihubmix.com/api/user/self", () =>
+        HttpResponse.json({
+          success: true,
+          data: { aff_code: "invite-code" },
+        }),
+      ),
+    )
+    const { fetchInviteLink } = await import("~/services/apiService/aihubmix")
+
+    await fetchInviteLink({
+      ...baseRequest,
+      abortSignal: abortController.signal,
+    })
+
+    expect(mockWithSiteApiRequestLimit).toHaveBeenCalledTimes(1)
+    expect(mockWithSiteApiRequestLimit).toHaveBeenCalledWith(
+      "https://aihubmix.com",
+      expect.any(Function),
+      abortController.signal,
+    )
   })
 
   it("forwards invite-link cancellation to the native request", async () => {

--- a/tests/services/apiTransport/request.test.ts
+++ b/tests/services/apiTransport/request.test.ts
@@ -3,6 +3,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { RuntimeActionIds } from "~/constants/runtimeActions"
 import {
+  ApiError,
+  API_ERROR_CODES as ApiErrorCodes,
+} from "~/services/apiTransport/errors"
+import { fetchApi, fetchApiData } from "~/services/apiTransport/request"
+import {
+  extractDataFromApiResponseBody,
+  isHttpUrl,
+} from "~/services/apiTransport/response"
+import {
   API_AUTH_TOKEN_MODES,
   API_TRANSPORT_FETCH_CONTEXT_KINDS,
 } from "~/services/apiTransport/type"
@@ -13,13 +22,6 @@ import {
   COOKIE_SESSION_OVERRIDE_HEADER_NAME,
 } from "~/utils/browser/cookieHelper"
 import { server } from "~~/tests/msw/server"
-
-let fetchApiData: typeof import("~/services/apiTransport/request").fetchApiData
-let fetchApi: typeof import("~/services/apiTransport/request").fetchApi
-let extractDataFromApiResponseBody: typeof import("~/services/apiTransport/response").extractDataFromApiResponseBody
-let isHttpUrl: typeof import("~/services/apiTransport/response").isHttpUrl
-let ApiError: typeof import("~/services/apiTransport/errors").ApiError
-let ApiErrorCodes: typeof import("~/services/apiTransport/errors").API_ERROR_CODES
 
 const { mockLogRequestRateLimiter, mockCreateMinIntervalLimiter } = vi.hoisted(
   () => {
@@ -32,7 +34,8 @@ const { mockLogRequestRateLimiter, mockCreateMinIntervalLimiter } = vi.hoisted(
 
 const { mockWithSiteApiRequestLimit } = vi.hoisted(() => {
   const mockWithSiteApiRequestLimit = vi.fn(
-    async (_key: string, task: () => Promise<unknown>) => await task(),
+    async (_key: string, task: () => Promise<unknown>, _signal?: AbortSignal) =>
+      await task(),
   )
 
   return { mockWithSiteApiRequestLimit }
@@ -156,27 +159,6 @@ async function expectTempWindowDisabledFallback(
 }
 
 describe("apiTransport request helpers", () => {
-  beforeEach(async () => {
-    // Ensure we always use the real implementations even if other tests mock these modules.
-    const request = await vi.importActual<
-      typeof import("~/services/apiTransport/request")
-    >("~/services/apiTransport/request")
-    fetchApiData = request.fetchApiData
-    fetchApi = request.fetchApi
-
-    const response = await vi.importActual<
-      typeof import("~/services/apiTransport/response")
-    >("~/services/apiTransport/response")
-    extractDataFromApiResponseBody = response.extractDataFromApiResponseBody
-    isHttpUrl = response.isHttpUrl
-
-    const errors = await vi.importActual<
-      typeof import("~/services/apiTransport/errors")
-    >("~/services/apiTransport/errors")
-    ApiError = errors.ApiError
-    ApiErrorCodes = errors.API_ERROR_CODES
-  })
-
   beforeEach(() => {
     vi.restoreAllMocks()
     server.resetHandlers()
@@ -184,7 +166,11 @@ describe("apiTransport request helpers", () => {
     mockHasCookieInterceptorPermissions.mockReset()
     mockGetPreferences.mockReset()
     mockWithSiteApiRequestLimit.mockImplementation(
-      async (_key: string, task: () => Promise<unknown>) => await task(),
+      async (
+        _key: string,
+        task: () => Promise<unknown>,
+        _signal?: AbortSignal,
+      ) => await task(),
     )
     mockHasCookieInterceptorPermissions.mockResolvedValue(true)
     mockGetPreferences.mockResolvedValue({
@@ -407,8 +393,67 @@ describe("apiTransport request helpers", () => {
     expect(mockWithSiteApiRequestLimit).toHaveBeenCalledWith(
       "https://example.com",
       expect.any(Function),
+      undefined,
     )
   })
+
+  it.each([
+    {
+      caseName: "request abort signal",
+      createSignals: () => {
+        const requestController = new AbortController()
+        return {
+          requestSignal: requestController.signal,
+          optionsSignal: undefined,
+          expectedSignal: requestController.signal,
+        }
+      },
+    },
+    {
+      caseName: "RequestInit signal override",
+      createSignals: () => {
+        const requestController = new AbortController()
+        const optionsController = new AbortController()
+        return {
+          requestSignal: requestController.signal,
+          optionsSignal: optionsController.signal,
+          expectedSignal: optionsController.signal,
+        }
+      },
+    },
+  ])(
+    "fetchApiData passes the effective $caseName to site limiter admission",
+    async ({ createSignals }) => {
+      const { requestSignal, optionsSignal, expectedSignal } = createSignals()
+      server.use(
+        http.get(/^https:\/\/example\.invalid\/base\//, () =>
+          HttpResponse.json({
+            success: true,
+            data: { ok: true },
+            message: "ok",
+          }),
+        ),
+      )
+
+      await fetchApiData(
+        {
+          baseUrl: "https://example.invalid/base/",
+          auth: { authType: AuthTypeEnum.AccessToken, accessToken: "token" },
+          abortSignal: requestSignal,
+        },
+        {
+          endpoint: "/api/user/self",
+          options: { signal: optionsSignal },
+        },
+      )
+
+      expect(mockWithSiteApiRequestLimit).toHaveBeenCalledWith(
+        "https://example.invalid",
+        expect.any(Function),
+        expectedSignal,
+      )
+    },
+  )
 
   it("fetchApiData uses the same site limiter key for different paths on the same origin", async () => {
     server.use(
@@ -1814,6 +1859,7 @@ describe("apiTransport request helpers", () => {
       expect(mockWithSiteApiRequestLimit).toHaveBeenCalledWith(
         "https://example.com",
         expect.any(Function),
+        undefined,
       )
 
       if (shouldRateLimit) {

--- a/tests/services/apiTransport/siteRequestLimiter.test.ts
+++ b/tests/services/apiTransport/siteRequestLimiter.test.ts
@@ -131,6 +131,130 @@ describe("createSiteRequestLimiter", () => {
     ])
   })
 
+  it("removes queued aborted work without running it or consuming a token", async () => {
+    const limiter = createSiteRequestLimiter({
+      maxConcurrentPerSite: 1,
+      requestsPerMinute: 60,
+      burst: 1,
+    })
+    const abortController = new AbortController()
+    const events: string[] = []
+    let releaseFirst: (() => void) | undefined
+
+    const first = limiter("site-a", async () => {
+      events.push("first:start")
+      await new Promise<void>((resolve) => {
+        releaseFirst = resolve
+      })
+      events.push("first:end")
+    })
+    const secondTask = vi.fn(async () => {
+      events.push("second:start")
+    })
+    const second = limiter("site-a", secondTask, abortController.signal)
+    let secondOutcome: unknown = "pending"
+    const captureSecondOutcome = second.then(
+      () => {
+        secondOutcome = "resolved"
+      },
+      (error) => {
+        secondOutcome = error
+      },
+    )
+    const third = limiter("site-a", async () => {
+      events.push("third:start")
+    })
+
+    await flushMicrotasks()
+    abortController.abort()
+    await flushMicrotasks()
+    releaseFirst?.()
+    await first
+
+    vi.advanceTimersByTime(999)
+    await flushMicrotasks()
+    expect(events).toEqual(["first:start", "first:end"])
+
+    vi.advanceTimersByTime(1)
+    await flushMicrotasks()
+
+    expect(secondOutcome).toBe(abortController.signal.reason)
+    expect(secondTask).not.toHaveBeenCalled()
+    expect(events).toEqual(["first:start", "first:end", "third:start"])
+    await third
+    await captureSecondOutcome
+  })
+
+  it("does not start work admitted with an already aborted signal", async () => {
+    const limiter = createSiteRequestLimiter({
+      maxConcurrentPerSite: 1,
+      requestsPerMinute: 60,
+      burst: 1,
+    })
+    const abortController = new AbortController()
+    const task = vi.fn(async () => "unexpected")
+    abortController.abort()
+
+    await expect(limiter("site-a", task, abortController.signal)).rejects.toBe(
+      abortController.signal.reason,
+    )
+    expect(task).not.toHaveBeenCalled()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it("does not start disabled limiter work with an already aborted signal", async () => {
+    const limiter = createSiteRequestLimiter({
+      enabled: false,
+      maxConcurrentPerSite: 1,
+      requestsPerMinute: 60,
+      burst: 1,
+    })
+    const abortController = new AbortController()
+    const task = vi.fn(async () => "unexpected")
+    abortController.abort()
+
+    await expect(limiter("site-a", task, abortController.signal)).rejects.toBe(
+      abortController.signal.reason,
+    )
+    expect(task).not.toHaveBeenCalled()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it("keeps an acquired task active and detaches its queue abort listener", async () => {
+    const limiter = createSiteRequestLimiter({
+      maxConcurrentPerSite: 1,
+      requestsPerMinute: 60,
+      burst: 1,
+    })
+    const abortController = new AbortController()
+    const removeEventListener = vi.spyOn(
+      abortController.signal,
+      "removeEventListener",
+    )
+    let releaseTask: (() => void) | undefined
+
+    const task = limiter(
+      "site-a",
+      async () => {
+        await new Promise<void>((resolve) => {
+          releaseTask = resolve
+        })
+        return "done"
+      },
+      abortController.signal,
+    )
+
+    await flushMicrotasks()
+    abortController.abort()
+    releaseTask?.()
+
+    await expect(task).resolves.toBe("done")
+    expect(removeEventListener).toHaveBeenCalledWith(
+      "abort",
+      expect.any(Function),
+    )
+  })
+
   it("does not block different site keys", async () => {
     const limiter = createSiteRequestLimiter({
       maxConcurrentPerSite: 1,


### PR DESCRIPTION
## Summary

Remove the arbitrary cross-site concurrency cap from bulk invite-link copying and rely on the existing per-origin request limiter instead.

## Changes

- Start all supported account lookups together while preserving account-order output.
- Keep the 8-second end-to-end per-account deadline (including site-limiter queue time) and 20-second batch deadline, partial results, parent cancellation, clipboard fallback, and existing telemetry.
- Make queued per-site limiter admission abort-aware so cancelled work does not execute or consume a rate-limit token.
- Route the AIHubMix invite-link request through the same per-origin limiter; other AIHubMix APIs remain unchanged.
- Stabilize the transport test module loading by replacing repeated dynamic real-module imports with static imports.

## Validation

- Focused invite-link workflow suite: 18 tests passed, including real queued-request timeout coverage.
- `pnpm run validate:staged`
- `pnpm run validate:push` (TypeScript compile + Knip)
- Pre-push validation passed again during `git push`.
- Current-head CI passed quality, unit, build, default E2E, and DNR-required E2E jobs.
- Codecov patch coverage: 100% (79/79 changed coverable lines).
- No Playwright test added: the changed risk is deterministic request scheduling/queue admission and is covered at unit and transport level.

Follow-up to #1159, #1160, and #1203.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced bulk invite-link copying with standardized request and batch timeout policy.
  * Preserved the original account order in copied results, even when individual links complete out of order.
  * Continues processing to support partial success when some invite-link fetches fail or time out.
* **Bug Fixes**
  * Improved cancellation and timeout handling to prevent incomplete or stale clipboard writes.
  * Improved invite-link fetching reliability by routing requests through the site request limiter with proper abort signaling, including cancellation for queued limiter items.
* **Tests**
  * Expanded coverage for bulk-policy, ordering, timeout, and abort precedence behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->