### PR TITLE
fix: start invite link timeout after limiter dispatch

### DIFF
--- a/src/features/AccountManagement/inviteLinkCopyWorkflow.ts
+++ b/src/features/AccountManagement/inviteLinkCopyWorkflow.ts
@@ -2,6 +2,7 @@ import {
   canFetchDisplayAccountInviteLink,
   fetchDisplayAccountInviteLink,
 } from "~/services/accounts/utils/apiServiceRequest"
+import { runAbortableTask } from "~/services/apiTransport/abortableTask"
 import {
   INVITE_LINK_FAILURE_REASONS,
   InviteLinkError,
@@ -59,64 +60,14 @@ async function fetchInviteLink({
   batchSignal?: AbortSignal
   requestTimeoutMs?: number
 }): Promise<string> {
-  const hasRequestTimeout = isPositiveFiniteTimeout(requestTimeoutMs)
-
-  const sourceSignals = [signal, batchSignal].filter(
-    (sourceSignal): sourceSignal is AbortSignal => sourceSignal !== undefined,
+  return await runAbortableTask(
+    async (abortSignal) =>
+      await fetchDisplayAccountInviteLink(account, {
+        abortSignal,
+        requestTimeoutMs,
+      }),
+    { signals: [signal, batchSignal] },
   )
-
-  if (!hasRequestTimeout && sourceSignals.length === 0) {
-    return fetchDisplayAccountInviteLink(account, {
-      abortSignal: undefined,
-    })
-  }
-
-  const controller = new AbortController()
-  const signalCleanups: Array<() => void> = []
-  const cleanupSourceSignals = () => {
-    signalCleanups.forEach((cleanup) => cleanup())
-    signalCleanups.length = 0
-  }
-  let rejectOnAbort!: () => void
-  const abortPromise = new Promise<never>((_resolve, reject) => {
-    rejectOnAbort = () => reject(controller.signal.reason)
-    controller.signal.addEventListener("abort", rejectOnAbort, { once: true })
-  })
-
-  // The parent is checked before this batch starts and adapter calls are
-  // deferred below, so every source listener is attached before abort can race.
-  for (const sourceSignal of sourceSignals) {
-    const relayAbort = () => {
-      controller.abort(sourceSignal.reason)
-    }
-
-    sourceSignal.addEventListener("abort", relayAbort, { once: true })
-    signalCleanups.push(() => {
-      sourceSignal.removeEventListener("abort", relayAbort)
-    })
-  }
-
-  const timeoutId = hasRequestTimeout
-    ? setTimeout(() => {
-        controller.abort(
-          new InviteLinkError(INVITE_LINK_FAILURE_REASONS.Timeout),
-        )
-      }, requestTimeoutMs)
-    : undefined
-  const fetchPromise = Promise.resolve().then(() => {
-    controller.signal.throwIfAborted()
-    return fetchDisplayAccountInviteLink(account, {
-      abortSignal: controller.signal,
-    })
-  })
-
-  try {
-    return await Promise.race([fetchPromise, abortPromise])
-  } finally {
-    if (timeoutId !== undefined) clearTimeout(timeoutId)
-    cleanupSourceSignals()
-    controller.signal.removeEventListener("abort", rejectOnAbort)
-  }
 }
 
 /** Fetches invite links concurrently while preserving account order. */

--- a/src/services/accounts/utils/apiServiceRequest.ts
+++ b/src/services/accounts/utils/apiServiceRequest.ts
@@ -349,13 +349,20 @@ export const createDisplayAccountApiContext = (
  */
 export async function fetchDisplayAccountInviteLink(
   account: DisplayAccountApiSnapshot,
-  options: { abortSignal?: AbortSignal } = {},
+  options: {
+    abortSignal?: AbortSignal
+    requestTimeoutMs?: number
+  } = {},
 ): Promise<string> {
   try {
     const { inviteLink, request } = createDisplayAccountApiContext(account)
-    const inviteLinkRequest = options.abortSignal
-      ? { ...request, abortSignal: options.abortSignal }
-      : request
+    const inviteLinkRequest = {
+      ...request,
+      ...(options.abortSignal ? { abortSignal: options.abortSignal } : {}),
+      ...(options.requestTimeoutMs !== undefined
+        ? { requestTimeoutMs: options.requestTimeoutMs }
+        : {}),
+    }
 
     return await requireDisplayAccountInviteLink(
       account,

--- a/src/services/accounts/utils/apiServiceRequest.ts
+++ b/src/services/accounts/utils/apiServiceRequest.ts
@@ -24,6 +24,10 @@ import type { SiteTypeCapabilities } from "~/services/apiAdapters/contracts/site
 import type { TokenProvisioningCapability } from "~/services/apiAdapters/contracts/tokenProvisioning"
 import { getSiteTypeCapabilities } from "~/services/apiAdapters/registry"
 import type { Sub2ApiAuthSessionRequest } from "~/services/apiService/sub2api/authSession"
+import {
+  createDeferredAbortDeadline,
+  runAbortableTask,
+} from "~/services/apiTransport/abortableTask"
 import type { ApiServiceRequest } from "~/services/apiTransport/type"
 import { normalizeInviteLinkError } from "~/services/inviteLinks/errors"
 import {
@@ -354,24 +358,39 @@ export async function fetchDisplayAccountInviteLink(
     requestTimeoutMs?: number
   } = {},
 ): Promise<string> {
+  const abortDeadline =
+    typeof options.requestTimeoutMs === "number" &&
+    Number.isFinite(options.requestTimeoutMs) &&
+    options.requestTimeoutMs > 0
+      ? createDeferredAbortDeadline(options.requestTimeoutMs)
+      : undefined
+
   try {
     const { inviteLink, request } = createDisplayAccountApiContext(account)
-    const inviteLinkRequest = {
-      ...request,
-      ...(options.abortSignal ? { abortSignal: options.abortSignal } : {}),
-      ...(options.requestTimeoutMs !== undefined
-        ? { requestTimeoutMs: options.requestTimeoutMs }
-        : {}),
-    }
+    return await runAbortableTask(
+      async (signal) => {
+        const inviteLinkRequest = {
+          ...request,
+          ...(signal ? { abortSignal: signal } : {}),
+          ...(options.requestTimeoutMs !== undefined
+            ? { requestTimeoutMs: options.requestTimeoutMs }
+            : {}),
+          ...(abortDeadline ? { abortDeadline } : {}),
+        }
 
-    return await requireDisplayAccountInviteLink(
-      account,
-      inviteLink,
-    ).fetchInviteLink({
-      request: inviteLinkRequest,
-    })
+        return await requireDisplayAccountInviteLink(
+          account,
+          inviteLink,
+        ).fetchInviteLink({
+          request: inviteLinkRequest,
+        })
+      },
+      { signals: [options.abortSignal, abortDeadline?.signal] },
+    )
   } catch (error) {
     throw normalizeInviteLinkError(error)
+  } finally {
+    abortDeadline?.dispose()
   }
 }
 

--- a/src/services/apiService/aihubmix/index.ts
+++ b/src/services/apiService/aihubmix/index.ts
@@ -26,12 +26,15 @@ import type {
   SiteStatusInfo,
   UserInfo,
 } from "~/services/apiAdapters/contracts/accountBootstrap"
-import { runAbortableTask } from "~/services/apiTransport/abortableTask"
+import {
+  composeAbortSignals,
+  startAbortableTask,
+} from "~/services/apiTransport/abortableTask"
 import { API_ERROR_CODES, ApiError } from "~/services/apiTransport/errors"
 import { fetchApiData } from "~/services/apiTransport/request"
 import {
   resolveSiteRequestLimitKey,
-  withSiteApiRequestLimit,
+  withSiteApiRequestLease,
 } from "~/services/apiTransport/siteRequestLimiter"
 import type {
   ApiResponse,
@@ -666,24 +669,39 @@ export async function fetchAccountQuota(
 export async function fetchInviteLink(
   request: ApiServiceRequest,
 ): Promise<string> {
-  const userInfo = await withSiteApiRequestLimit(
-    resolveSiteRequestLimitKey(AIHUBMIX_API_ORIGIN),
-    // Keep timeout setup inside this callback so limiter queue wait is excluded.
-    async () =>
-      await runAbortableTask(
-        async (signal) =>
-          await fetchAIHubMixData<unknown>(
-            request,
-            AIHUBMIX_API_USER_SELF_ENDPOINT,
-            { cache: "no-store", signal },
-          ),
-        {
-          signals: [request.abortSignal],
-          timeoutMs: request.requestTimeoutMs,
-        },
-      ),
+  const admissionAbort = composeAbortSignals([
     request.abortSignal,
-  )
+    request.abortDeadline?.signal,
+  ])
+  let userInfo: unknown
+
+  try {
+    userInfo = await withSiteApiRequestLease(
+      resolveSiteRequestLimitKey(AIHUBMIX_API_ORIGIN),
+      () => {
+        return startAbortableTask(
+          async (signal) => {
+            request.abortDeadline?.start()
+            return await fetchAIHubMixData<unknown>(
+              request,
+              AIHUBMIX_API_USER_SELF_ENDPOINT,
+              { cache: "no-store", signal },
+            )
+          },
+          {
+            signals: [request.abortSignal, request.abortDeadline?.signal],
+            timeoutMs: request.abortDeadline
+              ? undefined
+              : request.requestTimeoutMs,
+          },
+        )
+      },
+      admissionAbort.signal,
+    )
+  } finally {
+    admissionAbort.dispose()
+  }
+
   if (!userInfo || typeof userInfo !== "object" || Array.isArray(userInfo)) {
     throw new InviteLinkError(INVITE_LINK_FAILURE_REASONS.InviteDataMissing)
   }

--- a/src/services/apiService/aihubmix/index.ts
+++ b/src/services/apiService/aihubmix/index.ts
@@ -26,9 +26,13 @@ import type {
   SiteStatusInfo,
   UserInfo,
 } from "~/services/apiAdapters/contracts/accountBootstrap"
+import { runAbortableTask } from "~/services/apiTransport/abortableTask"
 import { API_ERROR_CODES, ApiError } from "~/services/apiTransport/errors"
 import { fetchApiData } from "~/services/apiTransport/request"
-import { withSiteApiRequestLimit } from "~/services/apiTransport/siteRequestLimiter"
+import {
+  resolveSiteRequestLimitKey,
+  withSiteApiRequestLimit,
+} from "~/services/apiTransport/siteRequestLimiter"
 import type {
   ApiResponse,
   ApiServiceRequest,
@@ -663,12 +667,19 @@ export async function fetchInviteLink(
   request: ApiServiceRequest,
 ): Promise<string> {
   const userInfo = await withSiteApiRequestLimit(
-    AIHUBMIX_API_ORIGIN,
+    resolveSiteRequestLimitKey(AIHUBMIX_API_ORIGIN),
     async () =>
-      await fetchAIHubMixData<unknown>(
-        request,
-        AIHUBMIX_API_USER_SELF_ENDPOINT,
-        { cache: "no-store", signal: request.abortSignal },
+      await runAbortableTask(
+        async (signal) =>
+          await fetchAIHubMixData<unknown>(
+            request,
+            AIHUBMIX_API_USER_SELF_ENDPOINT,
+            { cache: "no-store", signal },
+          ),
+        {
+          signals: [request.abortSignal],
+          timeoutMs: request.requestTimeoutMs,
+        },
       ),
     request.abortSignal,
   )

--- a/src/services/apiService/aihubmix/index.ts
+++ b/src/services/apiService/aihubmix/index.ts
@@ -679,6 +679,7 @@ export async function fetchInviteLink(
     userInfo = await withSiteApiRequestLease(
       resolveSiteRequestLimitKey(AIHUBMIX_API_ORIGIN),
       () => {
+        // Keep the deadline inside limiter dispatch so queue wait is not charged.
         return startAbortableTask(
           async (signal) => {
             request.abortDeadline?.start()

--- a/src/services/apiService/aihubmix/index.ts
+++ b/src/services/apiService/aihubmix/index.ts
@@ -668,6 +668,7 @@ export async function fetchInviteLink(
 ): Promise<string> {
   const userInfo = await withSiteApiRequestLimit(
     resolveSiteRequestLimitKey(AIHUBMIX_API_ORIGIN),
+    // Keep timeout setup inside this callback so limiter queue wait is excluded.
     async () =>
       await runAbortableTask(
         async (signal) =>

--- a/src/services/apiTransport/abortableTask.ts
+++ b/src/services/apiTransport/abortableTask.ts
@@ -30,6 +30,35 @@ const isPositiveFiniteTimeout = (value: unknown): value is number =>
 const createTimeoutError = (timeoutMs: number): DOMException =>
   new DOMException(`Request timed out after ${timeoutMs}ms`, "TimeoutError")
 
+const relayAbortsInto = (
+  controller: AbortController,
+  sourceSignals: readonly AbortSignal[],
+): (() => void) => {
+  const cleanups: Array<() => void> = []
+
+  for (const sourceSignal of sourceSignals) {
+    const relayAbort = () => {
+      if (!controller.signal.aborted) {
+        controller.abort(getAbortReason(sourceSignal))
+      }
+    }
+
+    if (sourceSignal.aborted) {
+      relayAbort()
+      break
+    }
+
+    sourceSignal.addEventListener("abort", relayAbort, { once: true })
+    cleanups.push(() => {
+      sourceSignal.removeEventListener("abort", relayAbort)
+    })
+  }
+
+  return () => {
+    cleanups.forEach((cleanup) => cleanup())
+  }
+}
+
 /**
  * Combines cancellation sources for queue admission without starting any
  * deferred deadline. Call dispose once admission has settled.
@@ -52,31 +81,11 @@ export function composeAbortSignals(
   }
 
   const controller = new AbortController()
-  const cleanups: Array<() => void> = []
-
-  for (const sourceSignal of sourceSignals) {
-    const relayAbort = () => {
-      if (!controller.signal.aborted) {
-        controller.abort(getAbortReason(sourceSignal))
-      }
-    }
-
-    if (sourceSignal.aborted) {
-      relayAbort()
-      break
-    }
-
-    sourceSignal.addEventListener("abort", relayAbort, { once: true })
-    cleanups.push(() => {
-      sourceSignal.removeEventListener("abort", relayAbort)
-    })
-  }
+  const dispose = relayAbortsInto(controller, sourceSignals)
 
   return {
     signal: controller.signal,
-    dispose: () => {
-      cleanups.forEach((cleanup) => cleanup())
-    },
+    dispose,
   }
 }
 
@@ -137,10 +146,7 @@ export function startAbortableTask<T>(
       const result = Promise.reject<T>(getAbortReason(signal))
       return {
         result,
-        completion: result.then(
-          () => undefined,
-          () => undefined,
-        ),
+        completion: result.then<void, void>(undefined, () => undefined),
       }
     }
   }
@@ -170,27 +176,9 @@ export function startAbortableTask<T>(
       ? new AbortController()
       : undefined
   const effectiveSignal = controller?.signal ?? sourceSignals[0]
-  const cleanups: Array<() => void> = []
-
-  if (controller) {
-    for (const sourceSignal of sourceSignals) {
-      const relayAbort = () => {
-        if (!controller.signal.aborted) {
-          controller.abort(getAbortReason(sourceSignal))
-        }
-      }
-
-      sourceSignal.addEventListener("abort", relayAbort, { once: true })
-      cleanups.push(() => {
-        sourceSignal.removeEventListener("abort", relayAbort)
-      })
-
-      if (sourceSignal.aborted) {
-        relayAbort()
-        break
-      }
-    }
-  }
+  const disposeRelays = controller
+    ? relayAbortsInto(controller, sourceSignals)
+    : () => {}
 
   const timeoutId =
     timeoutMs !== undefined
@@ -213,7 +201,7 @@ export function startAbortableTask<T>(
   const result = Promise.race([taskPromise, abortPromise]).finally(() => {
     if (timeoutId !== undefined) clearTimeout(timeoutId)
     effectiveSignal.removeEventListener("abort", rejectOnAbort)
-    cleanups.forEach((cleanup) => cleanup())
+    disposeRelays()
   })
 
   return {

--- a/src/services/apiTransport/abortableTask.ts
+++ b/src/services/apiTransport/abortableTask.ts
@@ -3,6 +3,24 @@ type AbortableTaskOptions = {
   timeoutMs?: number
 }
 
+type AbortableTaskExecution<T> = {
+  /** Settles when the caller should observe success, cancellation, or timeout. */
+  result: Promise<T>
+  /** Settles only after the original task promise has actually finished. */
+  completion: Promise<void>
+}
+
+export type DeferredAbortDeadline = {
+  signal: AbortSignal
+  start: () => void
+  dispose: () => void
+}
+
+type ComposedAbortSignal = {
+  signal?: AbortSignal
+  dispose: () => void
+}
+
 const getAbortReason = (signal: AbortSignal): unknown =>
   signal.reason ?? new DOMException("The operation was aborted", "AbortError")
 
@@ -13,13 +31,99 @@ const createTimeoutError = (timeoutMs: number): DOMException =>
   new DOMException(`Request timed out after ${timeoutMs}ms`, "TimeoutError")
 
 /**
+ * Combines cancellation sources for queue admission without starting any
+ * deferred deadline. Call dispose once admission has settled.
+ */
+export function composeAbortSignals(
+  signals: readonly (AbortSignal | undefined)[],
+): ComposedAbortSignal {
+  const sourceSignals = Array.from(
+    new Set(
+      signals.filter((signal): signal is AbortSignal => signal !== undefined),
+    ),
+  )
+
+  if (sourceSignals.length === 0) {
+    return { signal: undefined, dispose: () => {} }
+  }
+
+  if (sourceSignals.length === 1) {
+    return { signal: sourceSignals[0], dispose: () => {} }
+  }
+
+  const controller = new AbortController()
+  const cleanups: Array<() => void> = []
+
+  for (const sourceSignal of sourceSignals) {
+    const relayAbort = () => {
+      if (!controller.signal.aborted) {
+        controller.abort(getAbortReason(sourceSignal))
+      }
+    }
+
+    if (sourceSignal.aborted) {
+      relayAbort()
+      break
+    }
+
+    sourceSignal.addEventListener("abort", relayAbort, { once: true })
+    cleanups.push(() => {
+      sourceSignal.removeEventListener("abort", relayAbort)
+    })
+  }
+
+  return {
+    signal: controller.signal,
+    dispose: () => {
+      cleanups.forEach((cleanup) => cleanup())
+    },
+  }
+}
+
+/**
+ * Creates a timeout signal whose clock starts on the first dispatch.
+ */
+export function createDeferredAbortDeadline(
+  timeoutMs: number | undefined,
+): DeferredAbortDeadline {
+  const controller = new AbortController()
+  const resolvedTimeoutMs = isPositiveFiniteTimeout(timeoutMs)
+    ? timeoutMs
+    : undefined
+  let timeoutId: ReturnType<typeof setTimeout> | undefined
+  let started = false
+  let disposed = false
+
+  return {
+    signal: controller.signal,
+    start: () => {
+      if (started || disposed) return
+      started = true
+      if (resolvedTimeoutMs === undefined) return
+
+      timeoutId = setTimeout(() => {
+        timeoutId = undefined
+        controller.abort(createTimeoutError(resolvedTimeoutMs))
+      }, resolvedTimeoutMs)
+    },
+    dispose: () => {
+      disposed = true
+      if (timeoutId !== undefined) {
+        clearTimeout(timeoutId)
+        timeoutId = undefined
+      }
+    },
+  }
+}
+
+/**
  * Runs work with composed cancellation and an optional timeout that starts at
  * invocation time. The abort race also settles when the work ignores signals.
  */
-export async function runAbortableTask<T>(
+export function startAbortableTask<T>(
   task: (signal?: AbortSignal) => Promise<T>,
   options: AbortableTaskOptions = {},
-): Promise<T> {
+): AbortableTaskExecution<T> {
   const sourceSignals = Array.from(
     new Set(
       (options.signals ?? []).filter(
@@ -29,7 +133,16 @@ export async function runAbortableTask<T>(
   )
 
   for (const signal of sourceSignals) {
-    if (signal.aborted) throw getAbortReason(signal)
+    if (signal.aborted) {
+      const result = Promise.reject<T>(getAbortReason(signal))
+      return {
+        result,
+        completion: result.then(
+          () => undefined,
+          () => undefined,
+        ),
+      }
+    }
   }
 
   const timeoutMs = isPositiveFiniteTimeout(options.timeoutMs)
@@ -37,7 +150,19 @@ export async function runAbortableTask<T>(
     : undefined
 
   if (sourceSignals.length === 0 && timeoutMs === undefined) {
-    return await task(undefined)
+    let result: Promise<T>
+    try {
+      result = Promise.resolve(task(undefined))
+    } catch (error) {
+      result = Promise.reject(error)
+    }
+    return {
+      result,
+      completion: result.then(
+        () => undefined,
+        () => undefined,
+      ),
+    }
   }
 
   const controller =
@@ -85,11 +210,28 @@ export async function runAbortableTask<T>(
     return task(effectiveSignal)
   })
 
-  try {
-    return await Promise.race([taskPromise, abortPromise])
-  } finally {
+  const result = Promise.race([taskPromise, abortPromise]).finally(() => {
     if (timeoutId !== undefined) clearTimeout(timeoutId)
     effectiveSignal.removeEventListener("abort", rejectOnAbort)
     cleanups.forEach((cleanup) => cleanup())
+  })
+
+  return {
+    result,
+    completion: taskPromise.then(
+      () => undefined,
+      () => undefined,
+    ),
   }
+}
+
+/**
+ * Runs work with composed cancellation and an optional timeout that starts at
+ * invocation time. The abort race also settles when the work ignores signals.
+ */
+export async function runAbortableTask<T>(
+  task: (signal?: AbortSignal) => Promise<T>,
+  options: AbortableTaskOptions = {},
+): Promise<T> {
+  return await startAbortableTask(task, options).result
 }

--- a/src/services/apiTransport/abortableTask.ts
+++ b/src/services/apiTransport/abortableTask.ts
@@ -1,0 +1,95 @@
+type AbortableTaskOptions = {
+  signals?: readonly (AbortSignal | undefined)[]
+  timeoutMs?: number
+}
+
+const getAbortReason = (signal: AbortSignal): unknown =>
+  signal.reason ?? new DOMException("The operation was aborted", "AbortError")
+
+const isPositiveFiniteTimeout = (value: unknown): value is number =>
+  typeof value === "number" && Number.isFinite(value) && value > 0
+
+const createTimeoutError = (timeoutMs: number): DOMException =>
+  new DOMException(`Request timed out after ${timeoutMs}ms`, "TimeoutError")
+
+/**
+ * Runs work with composed cancellation and an optional timeout that starts at
+ * invocation time. The abort race also settles when the work ignores signals.
+ */
+export async function runAbortableTask<T>(
+  task: (signal?: AbortSignal) => Promise<T>,
+  options: AbortableTaskOptions = {},
+): Promise<T> {
+  const sourceSignals = Array.from(
+    new Set(
+      (options.signals ?? []).filter(
+        (signal): signal is AbortSignal => signal !== undefined,
+      ),
+    ),
+  )
+
+  for (const signal of sourceSignals) {
+    if (signal.aborted) throw getAbortReason(signal)
+  }
+
+  const timeoutMs = isPositiveFiniteTimeout(options.timeoutMs)
+    ? options.timeoutMs
+    : undefined
+
+  if (sourceSignals.length === 0 && timeoutMs === undefined) {
+    return await task(undefined)
+  }
+
+  const controller =
+    timeoutMs !== undefined || sourceSignals.length > 1
+      ? new AbortController()
+      : undefined
+  const effectiveSignal = controller?.signal ?? sourceSignals[0]
+  const cleanups: Array<() => void> = []
+
+  if (controller) {
+    for (const sourceSignal of sourceSignals) {
+      const relayAbort = () => {
+        if (!controller.signal.aborted) {
+          controller.abort(getAbortReason(sourceSignal))
+        }
+      }
+
+      sourceSignal.addEventListener("abort", relayAbort, { once: true })
+      cleanups.push(() => {
+        sourceSignal.removeEventListener("abort", relayAbort)
+      })
+
+      if (sourceSignal.aborted) {
+        relayAbort()
+        break
+      }
+    }
+  }
+
+  const timeoutId =
+    timeoutMs !== undefined
+      ? setTimeout(() => {
+          controller?.abort(createTimeoutError(timeoutMs))
+        }, timeoutMs)
+      : undefined
+
+  let rejectOnAbort!: () => void
+  const abortPromise = new Promise<never>((_resolve, reject) => {
+    rejectOnAbort = () => reject(getAbortReason(effectiveSignal))
+    effectiveSignal.addEventListener("abort", rejectOnAbort, { once: true })
+    if (effectiveSignal.aborted) rejectOnAbort()
+  })
+  const taskPromise = Promise.resolve().then(() => {
+    if (effectiveSignal.aborted) throw getAbortReason(effectiveSignal)
+    return task(effectiveSignal)
+  })
+
+  try {
+    return await Promise.race([taskPromise, abortPromise])
+  } finally {
+    if (timeoutId !== undefined) clearTimeout(timeoutId)
+    effectiveSignal.removeEventListener("abort", rejectOnAbort)
+    cleanups.forEach((cleanup) => cleanup())
+  }
+}

--- a/src/services/apiTransport/request.ts
+++ b/src/services/apiTransport/request.ts
@@ -1,4 +1,5 @@
 import { RuntimeActionIds } from "~/constants/runtimeActions"
+import { runAbortableTask } from "~/services/apiTransport/abortableTask"
 import { buildCompatUserIdHeaders } from "~/services/apiTransport/compatHeaders"
 import { REQUEST_CONFIG } from "~/services/apiTransport/constant"
 import {
@@ -8,7 +9,10 @@ import {
 } from "~/services/apiTransport/errors"
 import { createMinIntervalLimiter } from "~/services/apiTransport/minIntervalLimiter"
 import { extractDataFromApiResponseBody } from "~/services/apiTransport/response"
-import { withSiteApiRequestLimit } from "~/services/apiTransport/siteRequestLimiter"
+import {
+  resolveSiteRequestLimitKey,
+  withSiteApiRequestLimit,
+} from "~/services/apiTransport/siteRequestLimiter"
 import type {
   ApiAuthTokenMode,
   ApiResponse,
@@ -163,16 +167,6 @@ function isLogApiEndpoint(endpoint: string | undefined): boolean {
  */
 function resolveLogRateLimitKey(baseUrl: string): string {
   return normalizeUrlForOriginKey(baseUrl, { stripTrailingSlashes: true })
-}
-
-/**
- * Extract the canonical site origin used for process-local API request limiting.
- */
-function resolveSiteRequestLimitKey(baseUrl: string): string {
-  return normalizeUrlForOriginKey(baseUrl, {
-    lowerCase: true,
-    stripTrailingSlashes: true,
-  })
 }
 
 /**
@@ -597,44 +591,56 @@ const _fetchApi = async <T>(
     )
   }
 
-  const executeRequest = async () => {
-    const fallback = async () =>
-      await executeWithTempWindowFallback(context, async () => {
-        if (onlyData) {
-          return await apiRequestData<T>(
+  const executeRequest = async () =>
+    await runAbortableTask(
+      async (signal) => {
+        const dispatchedFetchOptions = { ...fetchOptions, signal }
+        const dispatchedContext = {
+          ...context,
+          fetchOptions: dispatchedFetchOptions,
+        }
+        const fallback = async () =>
+          await executeWithTempWindowFallback(dispatchedContext, async () => {
+            if (onlyData) {
+              return await apiRequestData<T>(
+                url,
+                dispatchedFetchOptions,
+                options.endpoint,
+                responseType,
+              )
+            }
+            const response = await apiRequest<T>(
+              url,
+              dispatchedFetchOptions,
+              options.endpoint,
+              responseType,
+            )
+
+            if (responseType === "json") {
+              return response as ApiResponse<T>
+            }
+
+            return response as T
+          })
+
+        return await executeWithCurrentTabContentPreference<T>(
+          {
+            request,
             url,
-            fetchOptions,
-            options.endpoint,
+            endpoint: options.endpoint,
+            fetchOptions: dispatchedFetchOptions,
+            onlyData,
             responseType,
-          )
-        }
-        const response = await apiRequest<T>(
-          url,
-          fetchOptions,
-          options.endpoint,
-          responseType,
+            options,
+          },
+          fallback,
         )
-
-        if (responseType === "json") {
-          return response as ApiResponse<T>
-        }
-
-        return response as T
-      })
-
-    return await executeWithCurrentTabContentPreference<T>(
-      {
-        request,
-        url,
-        endpoint: options.endpoint,
-        fetchOptions,
-        onlyData,
-        responseType,
-        options,
       },
-      fallback,
+      {
+        signals: [fetchOptions.signal ?? undefined],
+        timeoutMs: request.requestTimeoutMs,
+      },
     )
-  }
 
   if (request.bypassSiteRequestLimit) {
     return await executeRequest()

--- a/src/services/apiTransport/request.ts
+++ b/src/services/apiTransport/request.ts
@@ -1,5 +1,8 @@
 import { RuntimeActionIds } from "~/constants/runtimeActions"
-import { runAbortableTask } from "~/services/apiTransport/abortableTask"
+import {
+  composeAbortSignals,
+  startAbortableTask,
+} from "~/services/apiTransport/abortableTask"
 import { buildCompatUserIdHeaders } from "~/services/apiTransport/compatHeaders"
 import { REQUEST_CONFIG } from "~/services/apiTransport/constant"
 import {
@@ -11,7 +14,7 @@ import { createMinIntervalLimiter } from "~/services/apiTransport/minIntervalLim
 import { extractDataFromApiResponseBody } from "~/services/apiTransport/response"
 import {
   resolveSiteRequestLimitKey,
-  withSiteApiRequestLimit,
+  withSiteApiRequestLease,
 } from "~/services/apiTransport/siteRequestLimiter"
 import type {
   ApiAuthTokenMode,
@@ -591,9 +594,10 @@ const _fetchApi = async <T>(
     )
   }
 
-  const executeRequest = async () =>
-    await runAbortableTask(
+  const startRequest = () => {
+    return startAbortableTask(
       async (signal) => {
+        request.abortDeadline?.start()
         const dispatchedFetchOptions = { ...fetchOptions, signal }
         const dispatchedContext = {
           ...context,
@@ -637,22 +641,34 @@ const _fetchApi = async <T>(
         )
       },
       {
-        signals: [fetchOptions.signal ?? undefined],
-        timeoutMs: request.requestTimeoutMs,
+        signals: [
+          fetchOptions.signal ?? undefined,
+          request.abortDeadline?.signal,
+        ],
+        timeoutMs: request.abortDeadline ? undefined : request.requestTimeoutMs,
       },
     )
+  }
 
   if (request.bypassSiteRequestLimit) {
-    return await executeRequest()
+    return await startRequest().result
   }
 
   const siteRequestLimitKey = resolveSiteRequestLimitKey(baseUrl)
-
-  return await withSiteApiRequestLimit(
-    siteRequestLimitKey,
-    executeRequest,
+  const admissionAbort = composeAbortSignals([
     fetchOptions.signal ?? undefined,
-  )
+    request.abortDeadline?.signal,
+  ])
+
+  try {
+    return await withSiteApiRequestLease(
+      siteRequestLimitKey,
+      startRequest,
+      admissionAbort.signal,
+    )
+  } finally {
+    admissionAbort.dispose()
+  }
 }
 
 /**

--- a/src/services/apiTransport/siteRequestLimiter.ts
+++ b/src/services/apiTransport/siteRequestLimiter.ts
@@ -9,11 +9,18 @@ type SiteRequestLimiterConfig = {
 }
 
 type QueueItem = {
-  task: () => Promise<unknown>
+  task: () => SiteRequestLease<unknown>
   resolve: (value: unknown) => void
   reject: (reason?: unknown) => void
   signal?: AbortSignal
   abortListener?: () => void
+}
+
+type SiteRequestLease<T> = {
+  /** Caller-facing result, which may settle before the underlying work. */
+  result: Promise<T>
+  /** Underlying completion that owns the acquired concurrency slot. */
+  completion: Promise<unknown>
 }
 
 type SiteLimiterState = {
@@ -102,7 +109,7 @@ function resolveNonNegativeNumber(
  * Defaults are chosen to stay below New API's dashboard/web default of
  * 60 requests / 180 seconds while still allowing a small local burst.
  */
-export function createSiteRequestLimiter(config: SiteRequestLimiterConfig) {
+function createSiteRequestLeaseLimiterCore(config: SiteRequestLimiterConfig) {
   const enabled = config.enabled !== false
   const maxConcurrentPerSite = resolvePositiveInteger(
     config,
@@ -116,14 +123,22 @@ export function createSiteRequestLimiter(config: SiteRequestLimiterConfig) {
   const refillRatePerMs = requestsPerMinute / 60_000
   const states = new Map<string, SiteLimiterState>()
 
+  const runWithoutLimit = async <T>(
+    task: () => SiteRequestLease<T>,
+  ): Promise<T> => {
+    const lease = task()
+    void Promise.resolve(lease.completion).catch(() => undefined)
+    return await lease.result
+  }
+
   if (!enabled || requestsPerMinute <= 0) {
     return async <T>(
       _key: string,
-      task: () => Promise<T>,
+      task: () => SiteRequestLease<T>,
       signal?: AbortSignal,
     ): Promise<T> => {
       if (signal?.aborted) throw getAbortReason(signal)
-      return await task()
+      return await runWithoutLimit(task)
     }
   }
 
@@ -208,7 +223,13 @@ export function createSiteRequestLimiter(config: SiteRequestLimiterConfig) {
       state.activeCount += 1
       void Promise.resolve()
         .then(item.task)
-        .then(item.resolve, item.reject)
+        .then((lease) => {
+          void lease.result.then(item.resolve, item.reject)
+          return Promise.resolve(lease.completion).then(
+            () => undefined,
+            () => undefined,
+          )
+        }, item.reject)
         .finally(() => {
           state.activeCount -= 1
           schedule(key, state)
@@ -221,17 +242,17 @@ export function createSiteRequestLimiter(config: SiteRequestLimiterConfig) {
 
   return async <T>(
     key: string,
-    task: () => Promise<T>,
+    task: () => SiteRequestLease<T>,
     signal?: AbortSignal,
   ): Promise<T> => {
     if (signal?.aborted) throw getAbortReason(signal)
-    if (!key) return await task()
+    if (!key) return await runWithoutLimit(task)
 
     const state = getState(key)
 
     return await new Promise<T>((resolve, reject) => {
       const item: QueueItem = {
-        task: async () => await task(),
+        task: () => task() as SiteRequestLease<unknown>,
         resolve: (value) => resolve(value as T),
         reject,
         signal,
@@ -256,10 +277,55 @@ export function createSiteRequestLimiter(config: SiteRequestLimiterConfig) {
   }
 }
 
-const productionSiteRequestLimiter = createSiteRequestLimiter({
+/**
+ * Creates a limiter whose caller result and slot-owning completion may settle
+ * independently.
+ */
+export function createSiteRequestLeaseLimiter(
+  config: SiteRequestLimiterConfig,
+) {
+  return createSiteRequestLeaseLimiterCore(config)
+}
+
+const wrapLeaseLimiterForTasks =
+  (limiter: ReturnType<typeof createSiteRequestLeaseLimiterCore>) =>
+  async <T>(
+    key: string,
+    task: () => Promise<T>,
+    signal?: AbortSignal,
+  ): Promise<T> =>
+    await limiter(
+      key,
+      () => {
+        let result: Promise<T>
+        try {
+          result = Promise.resolve(task())
+        } catch (error) {
+          result = Promise.reject(error)
+        }
+        return {
+          result,
+          completion: result.then(
+            () => undefined,
+            () => undefined,
+          ),
+        }
+      },
+      signal,
+    )
+
+/** Creates a limiter that retains its slot until each task promise settles. */
+export function createSiteRequestLimiter(config: SiteRequestLimiterConfig) {
+  return wrapLeaseLimiterForTasks(createSiteRequestLeaseLimiterCore(config))
+}
+
+const productionSiteRequestLeaseLimiter = createSiteRequestLeaseLimiterCore({
   ...SITE_API_REQUEST_LIMITS,
   enabled: !isTestMode(),
 })
+const productionSiteRequestLimiter = wrapLeaseLimiterForTasks(
+  productionSiteRequestLeaseLimiter,
+)
 
 /**
  * Runs a site API request through the process-local per-site limiter.
@@ -270,4 +336,16 @@ export async function withSiteApiRequestLimit<T>(
   signal?: AbortSignal,
 ): Promise<T> {
   return await productionSiteRequestLimiter(key, task, signal)
+}
+
+/**
+ * Runs a request through the limiter while retaining its slot until the
+ * supplied underlying completion settles.
+ */
+export async function withSiteApiRequestLease<T>(
+  key: string,
+  task: () => SiteRequestLease<T>,
+  signal?: AbortSignal,
+): Promise<T> {
+  return await productionSiteRequestLeaseLimiter(key, task, signal)
 }

--- a/src/services/apiTransport/siteRequestLimiter.ts
+++ b/src/services/apiTransport/siteRequestLimiter.ts
@@ -104,12 +104,15 @@ function resolveNonNegativeNumber(
 }
 
 /**
- * Creates a per-site FIFO token-bucket limiter.
+ * Creates a per-site FIFO token-bucket limiter. Each lease retains its
+ * concurrency slot until completion, even if its caller result settles first.
  *
  * Defaults are chosen to stay below New API's dashboard/web default of
  * 60 requests / 180 seconds while still allowing a small local burst.
  */
-function createSiteRequestLeaseLimiterCore(config: SiteRequestLimiterConfig) {
+export function createSiteRequestLeaseLimiter(
+  config: SiteRequestLimiterConfig,
+) {
   const enabled = config.enabled !== false
   const maxConcurrentPerSite = resolvePositiveInteger(
     config,
@@ -277,18 +280,8 @@ function createSiteRequestLeaseLimiterCore(config: SiteRequestLimiterConfig) {
   }
 }
 
-/**
- * Creates a limiter whose caller result and slot-owning completion may settle
- * independently.
- */
-export function createSiteRequestLeaseLimiter(
-  config: SiteRequestLimiterConfig,
-) {
-  return createSiteRequestLeaseLimiterCore(config)
-}
-
 const wrapLeaseLimiterForTasks =
-  (limiter: ReturnType<typeof createSiteRequestLeaseLimiterCore>) =>
+  (limiter: ReturnType<typeof createSiteRequestLeaseLimiter>) =>
   async <T>(
     key: string,
     task: () => Promise<T>,
@@ -316,10 +309,10 @@ const wrapLeaseLimiterForTasks =
 
 /** Creates a limiter that retains its slot until each task promise settles. */
 export function createSiteRequestLimiter(config: SiteRequestLimiterConfig) {
-  return wrapLeaseLimiterForTasks(createSiteRequestLeaseLimiterCore(config))
+  return wrapLeaseLimiterForTasks(createSiteRequestLeaseLimiter(config))
 }
 
-const productionSiteRequestLeaseLimiter = createSiteRequestLeaseLimiterCore({
+const productionSiteRequestLeaseLimiter = createSiteRequestLeaseLimiter({
   ...SITE_API_REQUEST_LIMITS,
   enabled: !isTestMode(),
 })

--- a/src/services/apiTransport/siteRequestLimiter.ts
+++ b/src/services/apiTransport/siteRequestLimiter.ts
@@ -1,4 +1,5 @@
 import { isTestMode } from "~/utils/core/environment"
+import { normalizeUrlForOriginKey } from "~/utils/core/urlParsing"
 
 type SiteRequestLimiterConfig = {
   enabled?: boolean
@@ -31,6 +32,14 @@ const SITE_API_REQUEST_LIMITS = {
 } as const satisfies SiteRequestLimiterConfig
 
 const IDLE_STATE_TTL_MS = 5 * 60 * 1000
+
+/** Resolves the canonical site origin used by process-local request limiting. */
+export function resolveSiteRequestLimitKey(baseUrl: string): string {
+  return normalizeUrlForOriginKey(baseUrl, {
+    lowerCase: true,
+    stripTrailingSlashes: true,
+  })
+}
 
 const getAbortReason = (signal: AbortSignal): unknown =>
   signal.reason ?? new DOMException("The operation was aborted", "AbortError")
@@ -231,6 +240,8 @@ export function createSiteRequestLimiter(config: SiteRequestLimiterConfig) {
       if (signal) {
         item.abortListener = () => {
           const queueIndex = state.queue.indexOf(item)
+          if (queueIndex < 0) return
+
           state.queue.splice(queueIndex, 1)
           detachAbortListener(item)
           reject(getAbortReason(signal))

--- a/src/services/apiTransport/type.ts
+++ b/src/services/apiTransport/type.ts
@@ -1,3 +1,4 @@
+import type { DeferredAbortDeadline } from "~/services/apiTransport/abortableTask"
 import { AuthTypeEnum } from "~/types"
 import type {
   TempWindowFallbackAllowlist,
@@ -96,6 +97,8 @@ export interface ApiTransportRequest {
   abortSignal?: AbortSignal
   /** Maximum dispatched request duration; limiter queue time is excluded. */
   requestTimeoutMs?: number
+  /** Shared process-local deadline for one higher-level account operation. */
+  abortDeadline?: DeferredAbortDeadline
   cookieAuthSessionCookie?: string
   fetchContext?: ApiTransportFetchContext
   /** Originating extension surface for temporary-window presentation policy. */

--- a/src/services/apiTransport/type.ts
+++ b/src/services/apiTransport/type.ts
@@ -94,6 +94,8 @@ export interface ApiTransportRequest {
   data?: Record<string, any>
   accountId?: string
   abortSignal?: AbortSignal
+  /** Maximum dispatched request duration; limiter queue time is excluded. */
+  requestTimeoutMs?: number
   cookieAuthSessionCookie?: string
   fetchContext?: ApiTransportFetchContext
   /** Originating extension surface for temporary-window presentation policy. */

--- a/tests/features/AccountManagement/inviteLinkCopyWorkflow.test.ts
+++ b/tests/features/AccountManagement/inviteLinkCopyWorkflow.test.ts
@@ -5,6 +5,7 @@ import {
   INVITE_LINK_COPY_RESULTS,
   runInviteLinkCopyWorkflow,
 } from "~/features/AccountManagement/inviteLinkCopyWorkflow"
+import { runAbortableTask } from "~/services/apiTransport/abortableTask"
 import { createSiteRequestLimiter } from "~/services/apiTransport/siteRequestLimiter"
 import {
   INVITE_LINK_FAILURE_REASONS,
@@ -121,7 +122,7 @@ describe("runInviteLinkCopyWorkflow", () => {
     await copyPromise
   })
 
-  it("counts site-limiter queue time toward each request deadline", async () => {
+  it("forwards request deadlines without expiring site-limiter queue time", async () => {
     vi.useFakeTimers()
     const limiter = createSiteRequestLimiter({
       maxConcurrentPerSite: 1,
@@ -131,7 +132,13 @@ describe("runInviteLinkCopyWorkflow", () => {
     const startedAccountIds: string[] = []
     let releaseFirst: (() => void) | undefined
     fetchDisplayAccountInviteLinkMock.mockImplementation(
-      (account: { id: string }, options: { abortSignal?: AbortSignal }) =>
+      (
+        account: { id: string },
+        options: {
+          abortSignal?: AbortSignal
+          requestTimeoutMs?: number
+        },
+      ) =>
         limiter(
           "https://shared.example.invalid",
           async () => {
@@ -158,24 +165,34 @@ describe("runInviteLinkCopyWorkflow", () => {
       expect(startedAccountIds).toEqual(["first"])
 
       await vi.advanceTimersByTimeAsync(1_000)
-
-      await expect(copyPromise).resolves.toEqual({
-        result: INVITE_LINK_COPY_RESULTS.Failure,
-        selectedCount: 2,
-        itemCount: 2,
-        successCount: 0,
-        failureCount: 2,
-        failureReasonCounts: {
-          [INVITE_LINK_FAILURE_REASONS.Timeout]: 2,
-        },
-        unsupportedCount: 0,
-        skippedCount: 0,
-      })
       expect(startedAccountIds).toEqual(["first"])
+      expect(fetchDisplayAccountInviteLinkMock).toHaveBeenCalledTimes(2)
+      expect(fetchDisplayAccountInviteLinkMock).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({ id: "first" }),
+        expect.objectContaining({ requestTimeoutMs: 1_000 }),
+      )
+      expect(fetchDisplayAccountInviteLinkMock).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({ id: "queued" }),
+        expect.objectContaining({ requestTimeoutMs: 1_000 }),
+      )
 
       releaseFirst?.()
       await vi.advanceTimersByTimeAsync(0)
-      expect(startedAccountIds).toEqual(["first"])
+      expect(startedAccountIds).toEqual(["first", "queued"])
+
+      await expect(copyPromise).resolves.toEqual({
+        result: INVITE_LINK_COPY_RESULTS.Success,
+        payload:
+          "https://invite.example.invalid/first\nhttps://invite.example.invalid/queued",
+        selectedCount: 2,
+        itemCount: 2,
+        successCount: 2,
+        failureCount: 0,
+        unsupportedCount: 0,
+        skippedCount: 0,
+      })
     } finally {
       releaseFirst?.()
       vi.clearAllTimers()
@@ -469,14 +486,27 @@ describe("runInviteLinkCopyWorkflow", () => {
     vi.useFakeTimers()
     let resolveSlowFetch: ((value: string) => void) | undefined
     fetchDisplayAccountInviteLinkMock.mockImplementation(
-      (account: { id: string }) => {
-        if (account.id === "slow") {
-          return new Promise<string>((resolve) => {
-            resolveSlowFetch = resolve
-          })
-        }
-        return Promise.resolve(`https://invite.example.invalid/${account.id}`)
-      },
+      (
+        account: { id: string },
+        options: {
+          abortSignal?: AbortSignal
+          requestTimeoutMs?: number
+        },
+      ) =>
+        runAbortableTask(
+          async () => {
+            if (account.id === "slow") {
+              return await new Promise<string>((resolve) => {
+                resolveSlowFetch = resolve
+              })
+            }
+            return `https://invite.example.invalid/${account.id}`
+          },
+          {
+            signals: [options.abortSignal],
+            timeoutMs: options.requestTimeoutMs,
+          },
+        ),
     )
 
     try {

--- a/tests/services/accounts/apiServiceRequest.test.ts
+++ b/tests/services/accounts/apiServiceRequest.test.ts
@@ -1,4 +1,12 @@
-import { beforeEach, describe, expect, expectTypeOf, it, vi } from "vitest"
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  expectTypeOf,
+  it,
+  vi,
+} from "vitest"
 
 import { SITE_TYPES } from "~/constants/siteType"
 import {
@@ -178,6 +186,10 @@ describe("fetchDisplayAccountTokens", () => {
     mockGetAccountById.mockReset()
   })
 
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   it("types runtime key loading as account runtime keys only", () => {
     expectTypeOf(
       fetchDisplayAccountRuntimeKeys,
@@ -353,10 +365,75 @@ describe("fetchDisplayAccountTokens", () => {
     expect(fetchInviteLink).toHaveBeenCalledWith({
       request: expect.objectContaining({
         ...REQUEST,
-        abortSignal: controller.signal,
+        abortSignal: expect.any(AbortSignal),
+        abortDeadline: expect.objectContaining({
+          signal: expect.any(AbortSignal),
+          start: expect.any(Function),
+        }),
         requestTimeoutMs: 1_000,
       }),
     })
+  })
+
+  it("uses one invite-link deadline starting at the first provider dispatch", async () => {
+    vi.useFakeTimers()
+    const controller = new AbortController()
+    let dispatchRequest: (() => void) | undefined
+    let receivedSignal: AbortSignal | undefined
+    let requestError: unknown
+
+    fetchInviteLink.mockImplementationOnce(
+      async ({ request }: { request: Record<string, any> }) => {
+        await new Promise<void>((resolve) => {
+          dispatchRequest = () => {
+            dispatchRequest = undefined
+            resolve()
+          }
+        })
+        request.abortDeadline.start()
+        receivedSignal = request.abortSignal
+        await new Promise<void>((resolve) => setTimeout(resolve, 900))
+        request.abortDeadline.start()
+
+        return await new Promise<string>((_resolve, reject) => {
+          request.abortSignal.addEventListener(
+            "abort",
+            () => reject(request.abortSignal.reason),
+            { once: true },
+          )
+        })
+      },
+    )
+
+    const requestSettled = fetchDisplayAccountInviteLink(ACCOUNT as any, {
+      abortSignal: controller.signal,
+      requestTimeoutMs: 1_000,
+    }).then(
+      () => undefined,
+      (error) => {
+        requestError = error
+      },
+    )
+
+    try {
+      await vi.advanceTimersByTimeAsync(5_000)
+      expect(receivedSignal).toBeUndefined()
+
+      dispatchRequest?.()
+      await vi.advanceTimersByTimeAsync(999)
+      expect(receivedSignal?.aborted).toBe(false)
+
+      await vi.advanceTimersByTimeAsync(1)
+      await requestSettled
+      expect(receivedSignal?.aborted).toBe(true)
+      expect(requestError).toMatchObject({
+        reason: INVITE_LINK_FAILURE_REASONS.Timeout,
+      })
+    } finally {
+      dispatchRequest?.()
+      controller.abort()
+      await requestSettled
+    }
   })
 
   it("keeps cookie-auth sessions in request auth for display snapshots", () => {

--- a/tests/services/accounts/apiServiceRequest.test.ts
+++ b/tests/services/accounts/apiServiceRequest.test.ts
@@ -339,7 +339,7 @@ describe("fetchDisplayAccountTokens", () => {
     })
   })
 
-  it("forwards invite-link cancellation through the API request context", async () => {
+  it("forwards invite-link request controls through the API request context", async () => {
     const controller = new AbortController()
     fetchInviteLink.mockResolvedValueOnce(
       "https://example.com/register?aff=invite-code",
@@ -347,12 +347,14 @@ describe("fetchDisplayAccountTokens", () => {
 
     await fetchDisplayAccountInviteLink(ACCOUNT as any, {
       abortSignal: controller.signal,
+      requestTimeoutMs: 1_000,
     })
 
     expect(fetchInviteLink).toHaveBeenCalledWith({
       request: expect.objectContaining({
         ...REQUEST,
         abortSignal: controller.signal,
+        requestTimeoutMs: 1_000,
       }),
     })
   })

--- a/tests/services/apiService/aihubmix/index.test.ts
+++ b/tests/services/apiService/aihubmix/index.test.ts
@@ -41,14 +41,10 @@ import {
   AuthTypeEnum,
 } from "~/types"
 import { server } from "~~/tests/msw/server"
+import { runMockSiteRequestTask } from "~~/tests/test-utils/siteRequestLease"
 
 const { mockWithSiteApiRequestLimit } = vi.hoisted(() => ({
-  mockWithSiteApiRequestLimit: vi.fn(
-    async (_key: string, task: () => any, _signal?: AbortSignal) => {
-      const dispatched = task()
-      return await (dispatched?.result ?? dispatched)
-    },
-  ),
+  mockWithSiteApiRequestLimit: vi.fn(),
 }))
 
 vi.mock(
@@ -96,10 +92,8 @@ describe("apiService AIHubMix", () => {
     server.resetHandlers()
     mockWithSiteApiRequestLimit.mockClear()
     mockWithSiteApiRequestLimit.mockImplementation(
-      async (_key: string, task: () => any, _signal?: AbortSignal) => {
-        const dispatched = task()
-        return await (dispatched?.result ?? dispatched)
-      },
+      async (_key: string, task: () => any, _signal?: AbortSignal) =>
+        await runMockSiteRequestTask(task),
     )
   })
 

--- a/tests/services/apiService/aihubmix/index.test.ts
+++ b/tests/services/apiService/aihubmix/index.test.ts
@@ -251,6 +251,73 @@ describe("apiService AIHubMix", () => {
     )
   })
 
+  it("starts the native invite-link timeout after site-limiter dispatch", async () => {
+    vi.useFakeTimers()
+    const abortController = new AbortController()
+    let dispatchRequest: (() => void) | undefined
+    let receivedSignal: AbortSignal | null | undefined
+    let requestError: unknown
+    let requestSettled: Promise<void> | undefined
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation((_input, options) => {
+        receivedSignal = options?.signal
+
+        return new Promise<Response>((_resolve, reject) => {
+          options?.signal?.addEventListener(
+            "abort",
+            () => reject(options.signal?.reason),
+            { once: true },
+          )
+        })
+      })
+
+    mockWithSiteApiRequestLimit.mockImplementation(
+      async (_key: string, task: () => Promise<unknown>) =>
+        await new Promise<unknown>((resolve, reject) => {
+          dispatchRequest = () => {
+            dispatchRequest = undefined
+            void task().then(resolve, reject)
+          }
+        }),
+    )
+
+    try {
+      const { fetchInviteLink } = await import("~/services/apiService/aihubmix")
+      requestSettled = fetchInviteLink({
+        ...baseRequest,
+        abortSignal: abortController.signal,
+        requestTimeoutMs: 1_000,
+      }).then(
+        () => undefined,
+        (error) => {
+          requestError = error
+        },
+      )
+
+      await vi.advanceTimersByTimeAsync(1_000)
+      expect(fetchSpy).not.toHaveBeenCalled()
+
+      dispatchRequest?.()
+      await vi.advanceTimersByTimeAsync(0)
+      expect(fetchSpy).toHaveBeenCalledTimes(1)
+
+      await vi.advanceTimersByTimeAsync(999)
+      expect(receivedSignal?.aborted).toBe(false)
+
+      await vi.advanceTimersByTimeAsync(1)
+      expect(receivedSignal?.aborted).toBe(true)
+      await requestSettled
+      expect(requestError).toMatchObject({ name: "TimeoutError" })
+    } finally {
+      dispatchRequest?.()
+      abortController.abort()
+      await requestSettled
+      fetchSpy.mockRestore()
+      vi.useRealTimers()
+    }
+  })
+
   it("forwards invite-link cancellation to the native request", async () => {
     const abortController = new AbortController()
     let receivedSignal: AbortSignal | null | undefined
@@ -259,19 +326,11 @@ describe("apiService AIHubMix", () => {
       .mockImplementationOnce((_input, options) => {
         receivedSignal = options?.signal
 
-        return new Promise<Response>((resolve, reject) => {
+        return new Promise<Response>((_resolve, reject) => {
           options?.signal?.addEventListener(
             "abort",
             () => reject(new DOMException("Aborted", "AbortError")),
             { once: true },
-          )
-          queueMicrotask(() =>
-            resolve(
-              HttpResponse.json({
-                success: true,
-                data: { aff_code: "invite-code" },
-              }),
-            ),
           )
         })
       })
@@ -290,6 +349,9 @@ describe("apiService AIHubMix", () => {
         abortSignal: abortController.signal,
       })
 
+      await vi.waitFor(() => {
+        expect(fetchSpy).toHaveBeenCalledTimes(1)
+      })
       abortController.abort()
 
       await expect(inviteLinkPromise).rejects.toMatchObject({

--- a/tests/services/apiService/aihubmix/index.test.ts
+++ b/tests/services/apiService/aihubmix/index.test.ts
@@ -28,6 +28,7 @@ import {
   updateApiToken,
   validateAccountConnection,
 } from "~/services/apiService/aihubmix"
+import { createDeferredAbortDeadline } from "~/services/apiTransport/abortableTask"
 import { API_ERROR_CODES, ApiError } from "~/services/apiTransport/errors"
 import { INVITE_LINK_FAILURE_REASONS } from "~/services/inviteLinks/errors"
 import { MODEL_LIST_SOURCE_KINDS } from "~/services/modelList/pricingModel"
@@ -43,8 +44,10 @@ import { server } from "~~/tests/msw/server"
 
 const { mockWithSiteApiRequestLimit } = vi.hoisted(() => ({
   mockWithSiteApiRequestLimit: vi.fn(
-    async (_key: string, task: () => Promise<unknown>, _signal?: AbortSignal) =>
-      await task(),
+    async (_key: string, task: () => any, _signal?: AbortSignal) => {
+      const dispatched = task()
+      return await (dispatched?.result ?? dispatched)
+    },
   ),
 }))
 
@@ -58,6 +61,7 @@ vi.mock(
     return {
       ...actual,
       withSiteApiRequestLimit: mockWithSiteApiRequestLimit,
+      withSiteApiRequestLease: mockWithSiteApiRequestLimit,
     }
   },
 )
@@ -92,11 +96,10 @@ describe("apiService AIHubMix", () => {
     server.resetHandlers()
     mockWithSiteApiRequestLimit.mockClear()
     mockWithSiteApiRequestLimit.mockImplementation(
-      async (
-        _key: string,
-        task: () => Promise<unknown>,
-        _signal?: AbortSignal,
-      ) => await task(),
+      async (_key: string, task: () => any, _signal?: AbortSignal) => {
+        const dispatched = task()
+        return await (dispatched?.result ?? dispatched)
+      },
     )
   })
 
@@ -228,6 +231,7 @@ describe("apiService AIHubMix", () => {
 
   it("admits the raw invite-link request through the site limiter once", async () => {
     const abortController = new AbortController()
+    const startDeadline = vi.fn()
     server.use(
       http.get("https://aihubmix.com/api/user/self", () =>
         HttpResponse.json({
@@ -241,6 +245,11 @@ describe("apiService AIHubMix", () => {
     await fetchInviteLink({
       ...baseRequest,
       abortSignal: abortController.signal,
+      abortDeadline: {
+        signal: abortController.signal,
+        start: startDeadline,
+        dispose: vi.fn(),
+      },
     })
 
     expect(mockWithSiteApiRequestLimit).toHaveBeenCalledTimes(1)
@@ -249,12 +258,80 @@ describe("apiService AIHubMix", () => {
       expect.any(Function),
       abortController.signal,
     )
+    expect(startDeadline).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not start the native deadline for a pre-aborted dispatch", async () => {
+    const abortController = new AbortController()
+    const startDeadline = vi.fn()
+    abortController.abort(new DOMException("Cancelled", "AbortError"))
+    const { fetchInviteLink } = await import("~/services/apiService/aihubmix")
+
+    await expect(
+      fetchInviteLink({
+        ...baseRequest,
+        abortSignal: abortController.signal,
+        abortDeadline: {
+          signal: abortController.signal,
+          start: startDeadline,
+          dispose: vi.fn(),
+        },
+      }),
+    ).rejects.toBe(abortController.signal.reason)
+
+    expect(startDeadline).not.toHaveBeenCalled()
+  })
+
+  it("aborts the native invite-link request when only its shared deadline expires", async () => {
+    vi.useFakeTimers()
+    const abortDeadline = createDeferredAbortDeadline(1_000)
+    let receivedSignal: AbortSignal | null | undefined
+    let settleFetch: (() => void) | undefined
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation((_input, options) => {
+        receivedSignal = options?.signal
+        return new Promise<Response>((resolve, reject) => {
+          settleFetch = () => resolve(new Response("late response"))
+          receivedSignal?.addEventListener(
+            "abort",
+            () => reject(receivedSignal?.reason),
+            { once: true },
+          )
+        })
+      })
+
+    try {
+      const { fetchInviteLink } = await import("~/services/apiService/aihubmix")
+      const request = fetchInviteLink({ ...baseRequest, abortDeadline })
+      void request.catch(() => undefined)
+
+      await vi.advanceTimersByTimeAsync(0)
+      expect(fetchSpy).toHaveBeenCalledTimes(1)
+      expect(mockWithSiteApiRequestLimit).toHaveBeenCalledWith(
+        "https://aihubmix.com",
+        expect.any(Function),
+        abortDeadline.signal,
+      )
+
+      await vi.advanceTimersByTimeAsync(1_000)
+      expect(receivedSignal?.aborted).toBe(true)
+      await expect(request).rejects.toMatchObject({ name: "TimeoutError" })
+    } finally {
+      abortDeadline.dispose()
+      settleFetch?.()
+      fetchSpy.mockRestore()
+      vi.useRealTimers()
+    }
   })
 
   it("starts the native invite-link timeout after site-limiter dispatch", async () => {
     vi.useFakeTimers()
     const abortController = new AbortController()
     let dispatchRequest: (() => void) | undefined
+    let completeFetch: (() => void) | undefined
+    let underlyingCompletion: Promise<unknown> | undefined
+    let underlyingCompleted = false
     let receivedSignal: AbortSignal | null | undefined
     let requestError: unknown
     let requestSettled: Promise<void> | undefined
@@ -263,21 +340,32 @@ describe("apiService AIHubMix", () => {
       .mockImplementation((_input, options) => {
         receivedSignal = options?.signal
 
-        return new Promise<Response>((_resolve, reject) => {
-          options?.signal?.addEventListener(
-            "abort",
-            () => reject(options.signal?.reason),
-            { once: true },
-          )
+        return new Promise<Response>((resolve) => {
+          completeFetch = () =>
+            resolve(
+              new Response(
+                JSON.stringify({
+                  success: true,
+                  data: { aff_code: "late-code" },
+                  message: "ok",
+                }),
+                { headers: { "content-type": "application/json" } },
+              ),
+            )
         })
       })
 
     mockWithSiteApiRequestLimit.mockImplementation(
-      async (_key: string, task: () => Promise<unknown>) =>
+      async (_key: string, task: () => any) =>
         await new Promise<unknown>((resolve, reject) => {
           dispatchRequest = () => {
             dispatchRequest = undefined
-            void task().then(resolve, reject)
+            const dispatched = task()
+            underlyingCompletion = dispatched?.completion
+            void underlyingCompletion?.then(() => {
+              underlyingCompleted = true
+            })
+            void (dispatched?.result ?? dispatched).then(resolve, reject)
           }
         }),
     )
@@ -309,9 +397,16 @@ describe("apiService AIHubMix", () => {
       expect(receivedSignal?.aborted).toBe(true)
       await requestSettled
       expect(requestError).toMatchObject({ name: "TimeoutError" })
+      expect(underlyingCompleted).toBe(false)
+
+      completeFetch?.()
+      await underlyingCompletion
+      expect(underlyingCompleted).toBe(true)
     } finally {
       dispatchRequest?.()
       abortController.abort()
+      completeFetch?.()
+      await underlyingCompletion
       await requestSettled
       fetchSpy.mockRestore()
       vi.useRealTimers()

--- a/tests/services/apiService/sub2api/index.test.ts
+++ b/tests/services/apiService/sub2api/index.test.ts
@@ -45,6 +45,7 @@ import type {
   Sub2ApiAnnouncementListData,
   Sub2ApiEnvelope,
 } from "~/services/apiService/sub2api/type"
+import { createDeferredAbortDeadline } from "~/services/apiTransport/abortableTask"
 import { API_ERROR_CODES, ApiError } from "~/services/apiTransport/errors"
 import { fetchApi } from "~/services/apiTransport/request"
 import { INVITE_LINK_FAILURE_REASONS } from "~/services/inviteLinks/errors"
@@ -1395,6 +1396,11 @@ describe("apiService sub2api exported operations", () => {
   })
 
   it("checks the public flag before fetching and encoding the affiliate code", async () => {
+    const abortDeadline = {
+      signal: new AbortController().signal,
+      start: vi.fn(),
+      dispose: vi.fn(),
+    }
     vi.mocked(fetchApi)
       .mockResolvedValueOnce({
         code: 0,
@@ -1411,6 +1417,7 @@ describe("apiService sub2api exported operations", () => {
       fetchInviteLink({
         ...baseRequest,
         baseUrl: "https://sub2.example.invalid/console",
+        abortDeadline,
       } as any),
     ).resolves.toBe(
       "https://sub2.example.invalid/register?aff=code%2Fwith%20spaces%3F",
@@ -1418,6 +1425,7 @@ describe("apiService sub2api exported operations", () => {
 
     expect(vi.mocked(fetchApi)).toHaveBeenCalledTimes(2)
     const publicSettingsRequest = vi.mocked(fetchApi).mock.calls[0]?.[0]
+    expect(publicSettingsRequest?.abortDeadline).toBe(abortDeadline)
     expect(publicSettingsRequest?.baseUrl).toBe(
       "https://sub2.example.invalid/console",
     )
@@ -1433,9 +1441,84 @@ describe("apiService sub2api exported operations", () => {
         accessToken: "jwt-token",
       },
     })
+    expect(vi.mocked(fetchApi).mock.calls[1]?.[0]?.abortDeadline).toBe(
+      abortDeadline,
+    )
     expect((vi.mocked(fetchApi).mock.calls[1]?.[1] as any)?.endpoint).toBe(
       "/api/v1/user/aff",
     )
+  })
+
+  it("does not reset one invite-link deadline through an authenticated 401 retry", async () => {
+    vi.useFakeTimers()
+    const abortDeadline = createDeferredAbortDeadline(1_000)
+    let callCount = 0
+    vi.mocked(fetchApi).mockImplementation(async (request) => {
+      if (request.abortSignal?.aborted) {
+        throw request.abortSignal.reason
+      }
+
+      request.abortDeadline?.start()
+      callCount += 1
+
+      if (callCount === 1) {
+        await vi.advanceTimersByTimeAsync(900)
+        return {
+          code: 0,
+          message: "ok",
+          data: { affiliate_enabled: true },
+        } as any
+      }
+
+      if (callCount === 2) {
+        await vi.advanceTimersByTimeAsync(100)
+        throw new ApiError("Unauthorized", 401, "/api/v1/user/aff")
+      }
+
+      return {
+        code: 0,
+        message: "ok",
+        data: { aff_code: "unexpected-retry" },
+      } as any
+    })
+    vi.mocked(resyncSub2ApiAuthToken).mockResolvedValueOnce({
+      accessToken: "retry-jwt",
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB,
+    })
+
+    try {
+      await expect(
+        fetchInviteLink({
+          ...baseRequest,
+          baseUrl: "https://sub2.example.invalid",
+          abortSignal: abortDeadline.signal,
+          abortDeadline,
+        } as any),
+      ).rejects.toMatchObject({ name: "TimeoutError" })
+
+      expect(vi.mocked(fetchApi)).toHaveBeenCalledTimes(3)
+      for (const [request] of vi.mocked(fetchApi).mock.calls) {
+        expect(request.abortDeadline).toBe(abortDeadline)
+      }
+      expect(
+        vi
+          .mocked(fetchApi)
+          .mock.calls.map(
+            ([, options]) => (options as { endpoint: string }).endpoint,
+          ),
+      ).toEqual([
+        "/api/v1/settings/public",
+        "/api/v1/user/aff",
+        "/api/v1/user/aff",
+      ])
+      expect(vi.mocked(fetchApi).mock.calls[2]?.[0]?.auth.accessToken).toBe(
+        "retry-jwt",
+      )
+      expect(abortDeadline.signal.aborted).toBe(true)
+    } finally {
+      abortDeadline.dispose()
+      vi.useRealTimers()
+    }
   })
 
   it.each([

--- a/tests/services/apiTransport/abortableTask.test.ts
+++ b/tests/services/apiTransport/abortableTask.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { runAbortableTask } from "~/services/apiTransport/abortableTask"
+
+describe("runAbortableTask", () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("does not execute work when a source signal is already aborted", async () => {
+    const controller = new AbortController()
+    const reason = new DOMException("Cancelled", "AbortError")
+    const task = vi.fn(async () => "unexpected")
+    controller.abort(reason)
+
+    await expect(
+      runAbortableTask(task, { signals: [controller.signal] }),
+    ).rejects.toBe(reason)
+    expect(task).not.toHaveBeenCalled()
+  })
+
+  it("does not start deferred work when cancellation wins the dispatch race", async () => {
+    const controller = new AbortController()
+    const reason = new DOMException("Cancelled", "AbortError")
+    const task = vi.fn(async () => "unexpected")
+
+    const result = runAbortableTask(task, { signals: [controller.signal] })
+    controller.abort(reason)
+
+    await expect(result).rejects.toBe(reason)
+    expect(task).not.toHaveBeenCalled()
+  })
+
+  it("settles at the timeout when work ignores the composed signal", async () => {
+    vi.useFakeTimers()
+    let receivedSignal: AbortSignal | undefined
+    const task = vi.fn(
+      (signal?: AbortSignal) =>
+        new Promise<string>(() => {
+          receivedSignal = signal
+        }),
+    )
+
+    const result = runAbortableTask(task, { timeoutMs: 1_000 })
+    const rejection = expect(result).rejects.toMatchObject({
+      name: "TimeoutError",
+    })
+    await vi.advanceTimersByTimeAsync(1_000)
+
+    await rejection
+    expect(receivedSignal?.aborted).toBe(true)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+})

--- a/tests/services/apiTransport/abortableTask.test.ts
+++ b/tests/services/apiTransport/abortableTask.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
 
-import { runAbortableTask } from "~/services/apiTransport/abortableTask"
+import {
+  composeAbortSignals,
+  createDeferredAbortDeadline,
+  runAbortableTask,
+  startAbortableTask,
+} from "~/services/apiTransport/abortableTask"
 
 describe("runAbortableTask", () => {
   afterEach(() => {
@@ -106,6 +111,129 @@ describe("runAbortableTask", () => {
 
     await rejection
     expect(receivedSignal?.aborted).toBe(true)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it("reports timeout before signal-ignoring work actually completes", async () => {
+    vi.useFakeTimers()
+    let completeTask: ((value: string) => void) | undefined
+    const execution = startAbortableTask(
+      () =>
+        new Promise<string>((resolve) => {
+          completeTask = resolve
+        }),
+      { timeoutMs: 1_000 },
+    )
+    let completionSettled = false
+    void execution.completion.then(() => {
+      completionSettled = true
+    })
+    const rejection = expect(execution.result).rejects.toMatchObject({
+      name: "TimeoutError",
+    })
+
+    await vi.advanceTimersByTimeAsync(1_000)
+
+    await rejection
+    expect(completionSettled).toBe(false)
+
+    completeTask?.("late result")
+    await execution.completion
+    expect(completionSettled).toBe(true)
+  })
+
+  it("waits for completion and consumes a late task rejection after timeout", async () => {
+    vi.useFakeTimers()
+    const lateError = new Error("late failure")
+    let rejectTask: ((reason: unknown) => void) | undefined
+    const execution = startAbortableTask(
+      () =>
+        new Promise<never>((_resolve, reject) => {
+          rejectTask = reject
+        }),
+      { timeoutMs: 1_000 },
+    )
+    const timeoutRejection = expect(execution.result).rejects.toMatchObject({
+      name: "TimeoutError",
+    })
+    let completionSettled = false
+    void execution.completion.then(() => {
+      completionSettled = true
+    })
+
+    await vi.advanceTimersByTimeAsync(1_000)
+    await timeoutRejection
+    expect(completionSettled).toBe(false)
+
+    rejectTask?.(lateError)
+    await execution.completion
+    expect(completionSettled).toBe(true)
+  })
+
+  it("starts a deferred deadline once without resetting its timeout", async () => {
+    vi.useFakeTimers()
+    const deadline = createDeferredAbortDeadline(1_000)
+
+    await vi.advanceTimersByTimeAsync(5_000)
+    expect(deadline.signal.aborted).toBe(false)
+
+    deadline.start()
+    await vi.advanceTimersByTimeAsync(900)
+    deadline.start()
+    await vi.advanceTimersByTimeAsync(99)
+    expect(deadline.signal.aborted).toBe(false)
+
+    await vi.advanceTimersByTimeAsync(1)
+    expect(deadline.signal.reason).toMatchObject({ name: "TimeoutError" })
+    deadline.dispose()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it("composes queue cancellation without starting a deferred deadline", async () => {
+    vi.useFakeTimers()
+    const externalController = new AbortController()
+    const deadline = createDeferredAbortDeadline(1_000)
+    const removeExternalListener = vi.spyOn(
+      externalController.signal,
+      "removeEventListener",
+    )
+    const removeDeadlineListener = vi.spyOn(
+      deadline.signal,
+      "removeEventListener",
+    )
+    const composed = composeAbortSignals([
+      externalController.signal,
+      deadline.signal,
+    ])
+
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(composed.signal?.aborted).toBe(false)
+
+    deadline.start()
+    await vi.advanceTimersByTimeAsync(1_000)
+    expect(composed.signal?.reason).toMatchObject({ name: "TimeoutError" })
+
+    composed.dispose()
+    deadline.dispose()
+    expect(removeExternalListener).toHaveBeenCalledWith(
+      "abort",
+      expect.any(Function),
+    )
+    expect(removeDeadlineListener).toHaveBeenCalledWith(
+      "abort",
+      expect.any(Function),
+    )
+  })
+
+  it("disposes a deferred deadline before it aborts", async () => {
+    vi.useFakeTimers()
+    const deadline = createDeferredAbortDeadline(1_000)
+
+    deadline.start()
+    deadline.dispose()
+    await vi.advanceTimersByTimeAsync(1_000)
+
+    expect(deadline.signal.aborted).toBe(false)
     expect(vi.getTimerCount()).toBe(0)
   })
 })

--- a/tests/services/apiTransport/abortableTask.test.ts
+++ b/tests/services/apiTransport/abortableTask.test.ts
@@ -31,6 +31,54 @@ describe("runAbortableTask", () => {
     expect(task).not.toHaveBeenCalled()
   })
 
+  it.each([undefined, 0, -1])(
+    "uses the fast path without arming a timer for timeoutMs=%s",
+    async (timeoutMs) => {
+      vi.useFakeTimers()
+      const task = vi.fn(async (signal?: AbortSignal) => ({ signal }))
+
+      await expect(runAbortableTask(task, { timeoutMs })).resolves.toEqual({
+        signal: undefined,
+      })
+      expect(task).toHaveBeenCalledWith(undefined)
+      expect(vi.getTimerCount()).toBe(0)
+    },
+  )
+
+  it("passes successful results through and clears the timeout", async () => {
+    vi.useFakeTimers()
+    const task = vi.fn(async () => "done")
+
+    await expect(runAbortableTask(task, { timeoutMs: 1_000 })).resolves.toBe(
+      "done",
+    )
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it("rejects with the reason from the first of two source signals to abort", async () => {
+    const firstController = new AbortController()
+    const secondController = new AbortController()
+    const secondReason = new DOMException("Second cancelled", "AbortError")
+    let receivedSignal: AbortSignal | undefined
+    const task = vi.fn(
+      (signal?: AbortSignal) =>
+        new Promise<string>(() => {
+          receivedSignal = signal
+        }),
+    )
+
+    const result = runAbortableTask(task, {
+      signals: [firstController.signal, secondController.signal],
+    })
+    const rejection = expect(result).rejects.toBe(secondReason)
+    await Promise.resolve()
+    secondController.abort(secondReason)
+
+    await rejection
+    expect(receivedSignal?.reason).toBe(secondReason)
+    expect(firstController.signal.aborted).toBe(false)
+  })
+
   it("settles at the timeout when work ignores the composed signal", async () => {
     vi.useFakeTimers()
     let receivedSignal: AbortSignal | undefined

--- a/tests/services/apiTransport/abortableTask.test.ts
+++ b/tests/services/apiTransport/abortableTask.test.ts
@@ -31,7 +31,14 @@ describe("runAbortableTask", () => {
     expect(task).not.toHaveBeenCalled()
   })
 
-  it.each([undefined, 0, -1])(
+  it.each([
+    undefined,
+    0,
+    -1,
+    Number.NaN,
+    Number.POSITIVE_INFINITY,
+    Number.NEGATIVE_INFINITY,
+  ])(
     "uses the fast path without arming a timer for timeoutMs=%s",
     async (timeoutMs) => {
       vi.useFakeTimers()
@@ -59,6 +66,7 @@ describe("runAbortableTask", () => {
     const firstController = new AbortController()
     const secondController = new AbortController()
     const secondReason = new DOMException("Second cancelled", "AbortError")
+    const firstReason = new DOMException("First cancelled", "AbortError")
     let receivedSignal: AbortSignal | undefined
     const task = vi.fn(
       (signal?: AbortSignal) =>
@@ -73,10 +81,11 @@ describe("runAbortableTask", () => {
     const rejection = expect(result).rejects.toBe(secondReason)
     await Promise.resolve()
     secondController.abort(secondReason)
+    firstController.abort(firstReason)
 
     await rejection
     expect(receivedSignal?.reason).toBe(secondReason)
-    expect(firstController.signal.aborted).toBe(false)
+    expect(firstController.signal.reason).toBe(firstReason)
   })
 
   it("settles at the timeout when work ignores the composed signal", async () => {

--- a/tests/services/apiTransport/abortableTask.test.ts
+++ b/tests/services/apiTransport/abortableTask.test.ts
@@ -7,11 +7,11 @@ import {
   startAbortableTask,
 } from "~/services/apiTransport/abortableTask"
 
-describe("runAbortableTask", () => {
-  afterEach(() => {
-    vi.useRealTimers()
-  })
+afterEach(() => {
+  vi.useRealTimers()
+})
 
+describe("runAbortableTask", () => {
   it("does not execute work when a source signal is already aborted", async () => {
     const controller = new AbortController()
     const reason = new DOMException("Cancelled", "AbortError")
@@ -113,6 +113,33 @@ describe("runAbortableTask", () => {
     expect(receivedSignal?.aborted).toBe(true)
     expect(vi.getTimerCount()).toBe(0)
   })
+})
+
+describe("startAbortableTask", () => {
+  it("settles completion without starting work for a pre-aborted signal", async () => {
+    const controller = new AbortController()
+    const reason = new DOMException("Cancelled", "AbortError")
+    const task = vi.fn(async () => "unexpected")
+    controller.abort(reason)
+
+    const execution = startAbortableTask(task, {
+      signals: [controller.signal],
+    })
+
+    await expect(execution.result).rejects.toBe(reason)
+    await expect(execution.completion).resolves.toBeUndefined()
+    expect(task).not.toHaveBeenCalled()
+  })
+
+  it("settles completion after a synchronous fast-path failure", async () => {
+    const taskError = new Error("synchronous failure")
+    const execution = startAbortableTask(() => {
+      throw taskError
+    })
+
+    await expect(execution.result).rejects.toBe(taskError)
+    await expect(execution.completion).resolves.toBeUndefined()
+  })
 
   it("reports timeout before signal-ignoring work actually completes", async () => {
     vi.useFakeTimers()
@@ -169,6 +196,27 @@ describe("runAbortableTask", () => {
     await execution.completion
     expect(completionSettled).toBe(true)
   })
+})
+
+describe("createDeferredAbortDeadline", () => {
+  it.each([
+    undefined,
+    0,
+    -1,
+    Number.NaN,
+    Number.POSITIVE_INFINITY,
+    Number.NEGATIVE_INFINITY,
+  ])("does not arm a timer for timeoutMs=%s", async (timeoutMs) => {
+    vi.useFakeTimers()
+    const deadline = createDeferredAbortDeadline(timeoutMs)
+
+    deadline.start()
+    await vi.advanceTimersByTimeAsync(10_000)
+
+    expect(deadline.signal.aborted).toBe(false)
+    expect(vi.getTimerCount()).toBe(0)
+    deadline.dispose()
+  })
 
   it("starts a deferred deadline once without resetting its timeout", async () => {
     vi.useFakeTimers()
@@ -189,6 +237,20 @@ describe("runAbortableTask", () => {
     expect(vi.getTimerCount()).toBe(0)
   })
 
+  it("disposes a deferred deadline before it aborts", async () => {
+    vi.useFakeTimers()
+    const deadline = createDeferredAbortDeadline(1_000)
+
+    deadline.start()
+    deadline.dispose()
+    await vi.advanceTimersByTimeAsync(1_000)
+
+    expect(deadline.signal.aborted).toBe(false)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+})
+
+describe("composeAbortSignals", () => {
   it("composes queue cancellation without starting a deferred deadline", async () => {
     vi.useFakeTimers()
     const externalController = new AbortController()
@@ -225,15 +287,32 @@ describe("runAbortableTask", () => {
     )
   })
 
-  it("disposes a deferred deadline before it aborts", async () => {
-    vi.useFakeTimers()
-    const deadline = createDeferredAbortDeadline(1_000)
+  it("immediately relays the first pre-aborted source and cleans earlier listeners", () => {
+    const liveController = new AbortController()
+    const firstAbortedController = new AbortController()
+    const laterAbortedController = new AbortController()
+    const firstReason = new DOMException("First cancelled", "AbortError")
+    const laterReason = new DOMException("Later cancelled", "AbortError")
+    const removeLiveListener = vi.spyOn(
+      liveController.signal,
+      "removeEventListener",
+    )
+    firstAbortedController.abort(firstReason)
+    laterAbortedController.abort(laterReason)
 
-    deadline.start()
-    deadline.dispose()
-    await vi.advanceTimersByTimeAsync(1_000)
+    const composed = composeAbortSignals([
+      liveController.signal,
+      firstAbortedController.signal,
+      laterAbortedController.signal,
+    ])
 
-    expect(deadline.signal.aborted).toBe(false)
-    expect(vi.getTimerCount()).toBe(0)
+    expect(composed.signal?.aborted).toBe(true)
+    expect(composed.signal?.reason).toBe(firstReason)
+
+    composed.dispose()
+    expect(removeLiveListener).toHaveBeenCalledWith(
+      "abort",
+      expect.any(Function),
+    )
   })
 })

--- a/tests/services/apiTransport/request.test.ts
+++ b/tests/services/apiTransport/request.test.ts
@@ -2,6 +2,7 @@ import { http, HttpResponse } from "msw"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { RuntimeActionIds } from "~/constants/runtimeActions"
+import { createDeferredAbortDeadline } from "~/services/apiTransport/abortableTask"
 import {
   ApiError,
   API_ERROR_CODES as ApiErrorCodes,
@@ -34,8 +35,10 @@ const { mockLogRequestRateLimiter, mockCreateMinIntervalLimiter } = vi.hoisted(
 
 const { mockWithSiteApiRequestLimit } = vi.hoisted(() => {
   const mockWithSiteApiRequestLimit = vi.fn(
-    async (_key: string, task: () => Promise<unknown>, _signal?: AbortSignal) =>
-      await task(),
+    async (_key: string, task: () => any, _signal?: AbortSignal) => {
+      const dispatched = task()
+      return await (dispatched?.result ?? dispatched)
+    },
   )
 
   return { mockWithSiteApiRequestLimit }
@@ -108,6 +111,7 @@ vi.mock(
     return {
       ...actual,
       withSiteApiRequestLimit: mockWithSiteApiRequestLimit,
+      withSiteApiRequestLease: mockWithSiteApiRequestLimit,
     }
   },
 )
@@ -170,11 +174,10 @@ describe("apiTransport request helpers", () => {
     mockHasCookieInterceptorPermissions.mockReset()
     mockGetPreferences.mockReset()
     mockWithSiteApiRequestLimit.mockImplementation(
-      async (
-        _key: string,
-        task: () => Promise<unknown>,
-        _signal?: AbortSignal,
-      ) => await task(),
+      async (_key: string, task: () => any, _signal?: AbortSignal) => {
+        const dispatched = task()
+        return await (dispatched?.result ?? dispatched)
+      },
     )
     mockHasCookieInterceptorPermissions.mockResolvedValue(true)
     mockGetPreferences.mockResolvedValue({
@@ -463,30 +466,64 @@ describe("apiTransport request helpers", () => {
     vi.useFakeTimers()
     const abortController = new AbortController()
     let dispatchRequest: (() => void) | undefined
+    let completeFetch: (() => void) | undefined
+    let underlyingCompletion: Promise<unknown> | undefined
+    let underlyingCompleted = false
     let receivedSignal: AbortSignal | undefined
     let requestError: unknown
     let requestSettled: Promise<void> | undefined
+    let runDispatchedTask: (() => void) | undefined
+    let dispatchRequested = false
+    let resolveLimiter!: (value: unknown) => void
+    let forceRejectLimiter!: (reason?: unknown) => void
+    const limiterResult = new Promise<unknown>((resolve, reject) => {
+      resolveLimiter = resolve
+      forceRejectLimiter = reject
+    })
+    void limiterResult.catch(() => undefined)
+    const dispatchOrQueueRequest = () => {
+      dispatchRequested = true
+      runDispatchedTask?.()
+    }
+    dispatchRequest = dispatchOrQueueRequest
     const fetchSpy = vi
       .spyOn(globalThis, "fetch")
       .mockImplementation((_input, options) => {
         receivedSignal = options?.signal ?? undefined
 
-        return new Promise<Response>((_resolve, reject) => {
-          options?.signal?.addEventListener(
-            "abort",
-            () => reject(options.signal?.reason),
-            { once: true },
-          )
+        return new Promise<Response>((resolve) => {
+          completeFetch = () =>
+            resolve(
+              new Response(
+                JSON.stringify({
+                  success: true,
+                  data: { ok: true },
+                  message: "ok",
+                }),
+                { headers: { "content-type": "application/json" } },
+              ),
+            )
         })
       })
 
     mockWithSiteApiRequestLimit.mockImplementation(
-      async (_key: string, task: () => Promise<unknown>) =>
-        await new Promise<unknown>((resolve, reject) => {
-          dispatchRequest = () => {
-            void task().then(resolve, reject)
-          }
-        }),
+      async (_key: string, task: () => any) => {
+        runDispatchedTask = () => {
+          runDispatchedTask = undefined
+          dispatchRequest = undefined
+          const dispatched = task()
+          underlyingCompletion = dispatched?.completion
+          void underlyingCompletion?.then(() => {
+            underlyingCompleted = true
+          })
+          void (dispatched?.result ?? dispatched).then(
+            resolveLimiter,
+            forceRejectLimiter,
+          )
+        }
+        if (dispatchRequested) runDispatchedTask()
+        return await limiterResult
+      },
     )
 
     try {
@@ -520,12 +557,123 @@ describe("apiTransport request helpers", () => {
       expect(receivedSignal?.aborted).toBe(true)
       await requestSettled
       expect(requestError).toMatchObject({ name: "TimeoutError" })
+      expect(underlyingCompleted).toBe(false)
+
+      completeFetch?.()
+      await underlyingCompletion
+      expect(underlyingCompleted).toBe(true)
     } finally {
       abortController.abort()
-      await requestSettled
+      forceRejectLimiter(new DOMException("Test cleanup", "AbortError"))
+      await vi.advanceTimersByTimeAsync(0)
+      completeFetch?.()
+      await underlyingCompletion
       fetchSpy.mockRestore()
       vi.useRealTimers()
     }
+  })
+
+  it("starts a shared deadline when the limiter dispatches the request", async () => {
+    const abortController = new AbortController()
+    const start = vi.fn()
+    server.use(
+      http.get("https://example.invalid/base/api/user/self", () =>
+        HttpResponse.json({
+          success: true,
+          data: { ok: true },
+          message: "ok",
+        }),
+      ),
+    )
+
+    await fetchApiData(
+      {
+        baseUrl: "https://example.invalid/base/",
+        auth: { authType: AuthTypeEnum.AccessToken, accessToken: "token" },
+        abortSignal: abortController.signal,
+        abortDeadline: {
+          signal: abortController.signal,
+          start,
+          dispose: vi.fn(),
+        },
+      },
+      { endpoint: "/api/user/self" },
+    )
+
+    expect(start).toHaveBeenCalledTimes(1)
+  })
+
+  it("aborts a dispatched request when only its shared deadline expires", async () => {
+    vi.useFakeTimers()
+    const abortDeadline = createDeferredAbortDeadline(1_000)
+    let receivedSignal: AbortSignal | undefined
+    let settleFetch: (() => void) | undefined
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation((_input, options) => {
+        receivedSignal = options?.signal ?? undefined
+        return new Promise<Response>((resolve, reject) => {
+          settleFetch = () => resolve(new Response("late response"))
+          receivedSignal?.addEventListener(
+            "abort",
+            () => reject(receivedSignal?.reason),
+            { once: true },
+          )
+        })
+      })
+
+    try {
+      const request = fetchApiData(
+        {
+          baseUrl: "https://example.invalid/base/",
+          auth: { authType: AuthTypeEnum.AccessToken, accessToken: "token" },
+          abortDeadline,
+        },
+        { endpoint: "/api/user/self" },
+      )
+      void request.catch(() => undefined)
+
+      await vi.advanceTimersByTimeAsync(0)
+      expect(fetchSpy).toHaveBeenCalledTimes(1)
+      expect(mockWithSiteApiRequestLimit).toHaveBeenCalledWith(
+        "https://example.invalid",
+        expect.any(Function),
+        abortDeadline.signal,
+      )
+
+      await vi.advanceTimersByTimeAsync(1_000)
+      expect(receivedSignal?.aborted).toBe(true)
+      await expect(request).rejects.toMatchObject({ name: "TimeoutError" })
+    } finally {
+      abortDeadline.dispose()
+      settleFetch?.()
+      fetchSpy.mockRestore()
+      vi.useRealTimers()
+    }
+  })
+
+  it("does not start a shared deadline for a pre-aborted dispatch", async () => {
+    const abortController = new AbortController()
+    const start = vi.fn()
+    abortController.abort(new DOMException("Cancelled", "AbortError"))
+
+    await expect(
+      fetchApiData(
+        {
+          baseUrl: "https://example.invalid/base/",
+          auth: { authType: AuthTypeEnum.AccessToken, accessToken: "token" },
+          abortSignal: abortController.signal,
+          abortDeadline: {
+            signal: abortController.signal,
+            start,
+            dispose: vi.fn(),
+          },
+        },
+        { endpoint: "/api/user/self" },
+      ),
+    ).rejects.toBe(abortController.signal.reason)
+
+    expect(start).not.toHaveBeenCalled()
   })
 
   it("fetchApiData uses the same site limiter key for different paths on the same origin", async () => {

--- a/tests/services/apiTransport/request.test.ts
+++ b/tests/services/apiTransport/request.test.ts
@@ -23,6 +23,7 @@ import {
   COOKIE_SESSION_OVERRIDE_HEADER_NAME,
 } from "~/utils/browser/cookieHelper"
 import { server } from "~~/tests/msw/server"
+import { runMockSiteRequestTask } from "~~/tests/test-utils/siteRequestLease"
 
 const { mockLogRequestRateLimiter, mockCreateMinIntervalLimiter } = vi.hoisted(
   () => {
@@ -34,12 +35,7 @@ const { mockLogRequestRateLimiter, mockCreateMinIntervalLimiter } = vi.hoisted(
 )
 
 const { mockWithSiteApiRequestLimit } = vi.hoisted(() => {
-  const mockWithSiteApiRequestLimit = vi.fn(
-    async (_key: string, task: () => any, _signal?: AbortSignal) => {
-      const dispatched = task()
-      return await (dispatched?.result ?? dispatched)
-    },
-  )
+  const mockWithSiteApiRequestLimit = vi.fn()
 
   return { mockWithSiteApiRequestLimit }
 })
@@ -174,10 +170,8 @@ describe("apiTransport request helpers", () => {
     mockHasCookieInterceptorPermissions.mockReset()
     mockGetPreferences.mockReset()
     mockWithSiteApiRequestLimit.mockImplementation(
-      async (_key: string, task: () => any, _signal?: AbortSignal) => {
-        const dispatched = task()
-        return await (dispatched?.result ?? dispatched)
-      },
+      async (_key: string, task: () => any, _signal?: AbortSignal) =>
+        await runMockSiteRequestTask(task),
     )
     mockHasCookieInterceptorPermissions.mockResolvedValue(true)
     mockGetPreferences.mockResolvedValue({

--- a/tests/services/apiTransport/request.test.ts
+++ b/tests/services/apiTransport/request.test.ts
@@ -98,15 +98,19 @@ vi.mock("~/services/apiTransport/minIntervalLimiter", () => ({
   createMinIntervalLimiter: mockCreateMinIntervalLimiter,
 }))
 
-vi.mock("~/services/apiTransport/siteRequestLimiter", () => ({
-  SITE_API_REQUEST_LIMITS: {
-    maxConcurrentPerSite: 2,
-    requestsPerMinute: 18,
-    burst: 4,
+vi.mock(
+  "~/services/apiTransport/siteRequestLimiter",
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import("~/services/apiTransport/siteRequestLimiter")
+      >()
+    return {
+      ...actual,
+      withSiteApiRequestLimit: mockWithSiteApiRequestLimit,
+    }
   },
-  createSiteRequestLimiter: vi.fn(),
-  withSiteApiRequestLimit: mockWithSiteApiRequestLimit,
-}))
+)
 
 vi.mock("~/utils/browser/protectionBypass", () => ({
   isProtectionBypassFirefoxEnv: mockIsProtectionBypassFirefoxEnv,
@@ -454,6 +458,75 @@ describe("apiTransport request helpers", () => {
       )
     },
   )
+
+  it("starts a request timeout only after site-limiter dispatch", async () => {
+    vi.useFakeTimers()
+    const abortController = new AbortController()
+    let dispatchRequest: (() => void) | undefined
+    let receivedSignal: AbortSignal | undefined
+    let requestError: unknown
+    let requestSettled: Promise<void> | undefined
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation((_input, options) => {
+        receivedSignal = options?.signal ?? undefined
+
+        return new Promise<Response>((_resolve, reject) => {
+          options?.signal?.addEventListener(
+            "abort",
+            () => reject(options.signal?.reason),
+            { once: true },
+          )
+        })
+      })
+
+    mockWithSiteApiRequestLimit.mockImplementation(
+      async (_key: string, task: () => Promise<unknown>) =>
+        await new Promise<unknown>((resolve, reject) => {
+          dispatchRequest = () => {
+            void task().then(resolve, reject)
+          }
+        }),
+    )
+
+    try {
+      const request = fetchApiData(
+        {
+          baseUrl: "https://example.invalid/base/",
+          auth: { authType: AuthTypeEnum.AccessToken, accessToken: "token" },
+          abortSignal: abortController.signal,
+          requestTimeoutMs: 1_000,
+        },
+        { endpoint: "/api/user/self" },
+      )
+      requestSettled = request.then(
+        () => undefined,
+        (error) => {
+          requestError = error
+        },
+      )
+
+      await vi.advanceTimersByTimeAsync(1_000)
+      expect(fetchSpy).not.toHaveBeenCalled()
+
+      dispatchRequest?.()
+      await vi.advanceTimersByTimeAsync(0)
+      expect(fetchSpy).toHaveBeenCalledTimes(1)
+
+      await vi.advanceTimersByTimeAsync(999)
+      expect(receivedSignal?.aborted).toBe(false)
+
+      await vi.advanceTimersByTimeAsync(1)
+      expect(receivedSignal?.aborted).toBe(true)
+      await requestSettled
+      expect(requestError).toMatchObject({ name: "TimeoutError" })
+    } finally {
+      abortController.abort()
+      await requestSettled
+      fetchSpy.mockRestore()
+      vi.useRealTimers()
+    }
+  })
 
   it("fetchApiData uses the same site limiter key for different paths on the same origin", async () => {
     server.use(

--- a/tests/services/apiTransport/siteRequestLimiter.production.test.ts
+++ b/tests/services/apiTransport/siteRequestLimiter.production.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("~/utils/core/environment", () => ({
+  isTestMode: () => false,
+}))
+
+const flushMicrotasks = async () => {
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+describe("production site request limiter wrappers", () => {
+  afterEach(() => {
+    vi.clearAllTimers()
+    vi.useRealTimers()
+  })
+
+  it("shares concurrency state between legacy tasks and leases", async () => {
+    vi.useFakeTimers()
+    const { withSiteApiRequestLease, withSiteApiRequestLimit } = await import(
+      "~/services/apiTransport/siteRequestLimiter"
+    )
+    const releases: Array<() => void> = []
+    const startLegacyTask = () =>
+      withSiteApiRequestLimit("https://example.invalid", async () => {
+        await new Promise<void>((resolve) => {
+          releases.push(resolve)
+        })
+      })
+    const first = startLegacyTask()
+    const second = startLegacyTask()
+    const leaseFactory = vi.fn(() => ({
+      result: Promise.resolve("lease result"),
+      completion: Promise.resolve(),
+    }))
+
+    await flushMicrotasks()
+    const leased = withSiteApiRequestLease(
+      "https://example.invalid",
+      leaseFactory,
+    )
+    await flushMicrotasks()
+    expect(leaseFactory).not.toHaveBeenCalled()
+
+    releases[0]?.()
+    await first
+    await flushMicrotasks()
+    expect(leaseFactory).toHaveBeenCalledTimes(1)
+    await expect(leased).resolves.toBe("lease result")
+
+    releases[1]?.()
+    await second
+  })
+})

--- a/tests/services/apiTransport/siteRequestLimiter.test.ts
+++ b/tests/services/apiTransport/siteRequestLimiter.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
+import { createDeferredAbortDeadline } from "~/services/apiTransport/abortableTask"
 import {
+  createSiteRequestLeaseLimiter,
   createSiteRequestLimiter,
   withSiteApiRequestLimit,
 } from "~/services/apiTransport/siteRequestLimiter"
@@ -183,6 +185,45 @@ describe("createSiteRequestLimiter", () => {
     expect(events).toEqual(["first:start", "first:end", "third:start"])
     await third
     await captureSecondOutcome
+  })
+
+  it("removes a queued request when its started shared deadline expires", async () => {
+    const limiter = createSiteRequestLimiter({
+      maxConcurrentPerSite: 1,
+      requestsPerMinute: 600,
+      burst: 10,
+    })
+    const abortDeadline = createDeferredAbortDeadline(1_000)
+    let releaseFirst: (() => void) | undefined
+    const secondTask = vi.fn(async () => "unexpected")
+    const first = limiter("site-a", async () => {
+      abortDeadline.start()
+      await new Promise<void>((resolve) => {
+        releaseFirst = resolve
+      })
+    })
+    const second = limiter("site-a", secondTask, abortDeadline.signal)
+    const secondOutcome = second.then(
+      () => ({ status: "fulfilled" }) as const,
+      (reason) => ({ status: "rejected", reason }) as const,
+    )
+
+    try {
+      await flushMicrotasks()
+      await vi.advanceTimersByTimeAsync(1_000)
+
+      await expect(secondOutcome).resolves.toMatchObject({
+        status: "rejected",
+        reason: { name: "TimeoutError" },
+      })
+      releaseFirst?.()
+      await first
+      expect(secondTask).not.toHaveBeenCalled()
+    } finally {
+      abortDeadline.dispose()
+      releaseFirst?.()
+      await Promise.allSettled([first, second])
+    }
   })
 
   it("does not start work admitted with an already aborted signal", async () => {
@@ -441,6 +482,97 @@ describe("createSiteRequestLimiter", () => {
     await expect(second).resolves.toBe("ok")
     expect(events).toEqual(["first:start", "second:start"])
   })
+
+  it("holds a lease slot until completion after its result rejects", async () => {
+    const limiter = createSiteRequestLeaseLimiter({
+      maxConcurrentPerSite: 1,
+      requestsPerMinute: 600,
+      burst: 10,
+    })
+    const timeoutError = new DOMException("Timed out", "TimeoutError")
+    let rejectResult: ((reason: unknown) => void) | undefined
+    let completeWork: (() => void) | undefined
+    const events: string[] = []
+
+    const first = limiter("site-a", () => {
+      events.push("first:start")
+      return {
+        result: new Promise<never>((_resolve, reject) => {
+          rejectResult = reject
+        }),
+        completion: new Promise<void>((resolve) => {
+          completeWork = resolve
+        }),
+      }
+    })
+    const second = limiter("site-a", () => {
+      events.push("second:start")
+      return {
+        result: Promise.resolve("second"),
+        completion: Promise.resolve(),
+      }
+    })
+
+    await flushMicrotasks()
+    rejectResult?.(timeoutError)
+    await expect(first).rejects.toBe(timeoutError)
+    await flushMicrotasks()
+    expect(events).toEqual(["first:start"])
+
+    completeWork?.()
+    await flushMicrotasks()
+    await expect(second).resolves.toBe("second")
+    expect(events).toEqual(["first:start", "second:start"])
+  })
+
+  it("releases a lease slot when its factory throws synchronously", async () => {
+    const limiter = createSiteRequestLeaseLimiter({
+      maxConcurrentPerSite: 1,
+      requestsPerMinute: 600,
+      burst: 10,
+    })
+    const factoryError = new Error("factory failed")
+    const events: string[] = []
+
+    const first = limiter("site-a", () => {
+      events.push("first:start")
+      throw factoryError
+    })
+    const second = limiter("site-a", () => {
+      events.push("second:start")
+      return {
+        result: Promise.resolve("second"),
+        completion: Promise.resolve(),
+      }
+    })
+
+    await expect(first).rejects.toBe(factoryError)
+    await expect(second).resolves.toBe("second")
+    expect(events).toEqual(["first:start", "second:start"])
+  })
+
+  it.each([
+    ["disabled limiter", false, "site-a"],
+    ["empty key", true, ""],
+  ])(
+    "consumes rejecting completion for the %s fast path",
+    async (_label, enabled, key) => {
+      const limiter = createSiteRequestLeaseLimiter({
+        enabled,
+        maxConcurrentPerSite: 1,
+        requestsPerMinute: 600,
+        burst: 10,
+      })
+
+      await expect(
+        limiter(key, () => ({
+          result: Promise.resolve("result"),
+          completion: Promise.reject(new Error("late completion failure")),
+        })),
+      ).resolves.toBe("result")
+      await flushMicrotasks()
+    },
+  )
 
   it("runs immediately when disabled or when the key is empty", async () => {
     const disabledLimiter = createSiteRequestLimiter({

--- a/tests/services/apiTransport/siteRequestLimiter.test.ts
+++ b/tests/services/apiTransport/siteRequestLimiter.test.ts
@@ -255,6 +255,56 @@ describe("createSiteRequestLimiter", () => {
     )
   })
 
+  it("does not remove queued work when an acquired item's stale abort listener fires", async () => {
+    const limiter = createSiteRequestLimiter({
+      maxConcurrentPerSite: 1,
+      requestsPerMinute: 600,
+      burst: 10,
+    })
+    const firstController = new AbortController()
+    const secondController = new AbortController()
+    vi.spyOn(firstController.signal, "removeEventListener").mockImplementation(
+      () => {},
+    )
+    let releaseFirst: (() => void) | undefined
+    const firstTask = vi.fn(
+      async () =>
+        await new Promise<string>((resolve) => {
+          releaseFirst = () => resolve("first")
+        }),
+    )
+    const secondTask = vi.fn(async () => "second")
+
+    const first = limiter("site-a", firstTask, firstController.signal)
+    const firstOutcome = first.then(
+      (value) => ({ status: "fulfilled", value }) as const,
+      (reason) => ({ status: "rejected", reason }) as const,
+    )
+    const second = limiter("site-a", secondTask, secondController.signal)
+
+    try {
+      await flushMicrotasks()
+      expect(firstTask).toHaveBeenCalledTimes(1)
+      expect(secondTask).not.toHaveBeenCalled()
+
+      firstController.abort()
+      releaseFirst?.()
+      const settledFirst = await firstOutcome
+      await flushMicrotasks()
+
+      expect(settledFirst).toEqual({
+        status: "fulfilled",
+        value: "first",
+      })
+      expect(secondTask).toHaveBeenCalledTimes(1)
+      await expect(second).resolves.toBe("second")
+    } finally {
+      releaseFirst?.()
+      secondController.abort()
+      await Promise.allSettled([first, second])
+    }
+  })
+
   it("does not block different site keys", async () => {
     const limiter = createSiteRequestLimiter({
       maxConcurrentPerSite: 1,

--- a/tests/services/apiTransport/siteRequestLimiter.test.ts
+++ b/tests/services/apiTransport/siteRequestLimiter.test.ts
@@ -483,6 +483,29 @@ describe("createSiteRequestLimiter", () => {
     expect(events).toEqual(["first:start", "second:start"])
   })
 
+  it("releases the concurrency slot when a task throws synchronously", async () => {
+    const limiter = createSiteRequestLimiter({
+      maxConcurrentPerSite: 1,
+      requestsPerMinute: 600,
+      burst: 10,
+    })
+    const taskError = new Error("synchronous failure")
+    const events: string[] = []
+
+    const first = limiter("site-a", () => {
+      events.push("first:start")
+      throw taskError
+    })
+    const second = limiter("site-a", async () => {
+      events.push("second:start")
+      return "ok"
+    })
+
+    await expect(first).rejects.toBe(taskError)
+    await expect(second).resolves.toBe("ok")
+    expect(events).toEqual(["first:start", "second:start"])
+  })
+
   it("holds a lease slot until completion after its result rejects", async () => {
     const limiter = createSiteRequestLeaseLimiter({
       maxConcurrentPerSite: 1,
@@ -520,6 +543,43 @@ describe("createSiteRequestLimiter", () => {
     expect(events).toEqual(["first:start"])
 
     completeWork?.()
+    await flushMicrotasks()
+    await expect(second).resolves.toBe("second")
+    expect(events).toEqual(["first:start", "second:start"])
+  })
+
+  it("releases a lease slot when completion rejects after result settles", async () => {
+    const limiter = createSiteRequestLeaseLimiter({
+      maxConcurrentPerSite: 1,
+      requestsPerMinute: 600,
+      burst: 10,
+    })
+    const completionError = new Error("late completion failure")
+    let rejectCompletion: ((reason: unknown) => void) | undefined
+    const events: string[] = []
+
+    const first = limiter("site-a", () => {
+      events.push("first:start")
+      return {
+        result: Promise.resolve("first"),
+        completion: new Promise<void>((_resolve, reject) => {
+          rejectCompletion = reject
+        }),
+      }
+    })
+    const second = limiter("site-a", () => {
+      events.push("second:start")
+      return {
+        result: Promise.resolve("second"),
+        completion: Promise.resolve(),
+      }
+    })
+
+    await expect(first).resolves.toBe("first")
+    await flushMicrotasks()
+    expect(events).toEqual(["first:start"])
+
+    rejectCompletion?.(completionError)
     await flushMicrotasks()
     await expect(second).resolves.toBe("second")
     expect(events).toEqual(["first:start", "second:start"])

--- a/tests/test-utils/siteRequestLease.ts
+++ b/tests/test-utils/siteRequestLease.ts
@@ -1,0 +1,9 @@
+type SiteRequestDispatch<T> = Promise<T> | { result: Promise<T> }
+
+/** Runs the task shape accepted by mocked plain and lease site limiters. */
+export async function runMockSiteRequestTask<T>(
+  task: () => SiteRequestDispatch<T>,
+): Promise<T> {
+  const dispatched = task()
+  return await ("result" in dispatched ? dispatched.result : dispatched)
+}


### PR DESCRIPTION
## Summary

- Start each invite-link request timeout only after site-limiter dispatch, so queue wait is excluded from the 8-second request budget.
- Forward the timeout through the account adapter and apply the same behavior to AIHubMix's native fetch path.
- Share normalized limiter keys, preserve parent/batch cancellation, and harden stale queue-abort handling.

## Validation

- `pnpm vitest --run` affected suites: 6 files, 222 tests passed
- `pnpm compile`
- `pnpm run validate:staged`
- `pnpm run validate:push`

Related: #1159, #1160, #1203, #1210

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cancellation/timeout coordination for invite-link and API requests, including ensuring timeouts start after limiter dispatch and only the intended request aborts.
  * Prevented stale cancellation from interfering with other queued requests for the same site.

* **Improvements**
  * Added `requestTimeoutMs` support for invite-link fetching with shared abort-deadline reuse across retry flows.
  * Updated site throttling to use canonical keys and lease-based scheduling for consistent concurrency handling.

* **Tests**
  * Expanded coverage for abortable tasks, deferred deadlines, and site limiter/lease edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->