### PR TITLE
fix(new-api): support rc22 account auto-detection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,6 +202,7 @@ Treat telemetry and settings discoverability as related release-readiness checks
 
 - Add brief inline comments or short code-block comments when non-obvious intent, invariants, edge cases, or protocol/browser constraints need clarification; do not narrate obvious code.
 - For user-visible success/error feedback, do not rely solely on backend `message` fields; provide a local fallback when responses may be empty, unstable, or not suitable for direct display.
+- Treat private user-facing errors, local logs, and telemetry as different disclosure boundaries. Preserve useful upstream `code` and `message` by default in errors shown only to the affected user, and explicitly map only known opaque or unhelpful errors. Local logs may retain useful diagnostic context after redacting tokens, API keys, cookies, refresh/session secrets, credentials, and full authentication payloads. Telemetry and external reports must not include raw backend messages or secrets.
 
 ### Validation Strategy
 

--- a/docs/superpowers/plans/2026-07-27-new-api-rc22-auto-detect-compatibility.md
+++ b/docs/superpowers/plans/2026-07-27-new-api-rc22-auto-detect-compatibility.md
@@ -1,0 +1,934 @@
+# New API rc.22 Auto-Detect Compatibility Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restore New API rc.22 account auto-detection by adapting its AuthBundle dashboard session into the existing get-or-create PAT flow while preserving legacy New API-family behavior.
+
+**Architecture:** Add an exact-site content-session extractor that obtains and validates a short-lived dashboard Bearer from the same-origin refresh cookie. Propagate that credential through a discriminated, completion-only `transientAuth` contract, consume it only inside New API account completion, and persist only the management PAT returned by the existing bootstrap. Update real-site and deterministic browser E2E paths to recognize AuthBundle sessions and clean up sessions created by tests.
+
+**Tech Stack:** TypeScript, React account workflow, WXT Manifest V3 content/background messaging, Vitest/jsdom, Playwright Chromium, pnpm.
+
+---
+
+## File And Responsibility Map
+
+### New files
+
+- `src/services/accountSiteOnboarding/contentSession/newApiAuthBundle.ts`
+  - exact `SITE_TYPES.NEW_API` refresh/AuthBundle extraction
+  - strict response validation and controlled modern-auth errors
+- `tests/services/accountSiteOnboarding/contentSession/newApiAuthBundle.test.ts`
+  - extractor protocol and security-contract tests
+- `tests/utils/realSiteCompatibleApi.test.ts`
+  - compatible real-site login parser, fallback, and owned-session cleanup tests
+
+### Modified production files
+
+- `src/services/accountSiteOnboarding/contracts.ts`
+  - discriminated completion-only transient dashboard auth type
+- `src/services/accountSiteOnboarding/registry.ts`
+  - exact New API extractor ordering before generic legacy storage
+- `src/services/accountBrowserSession/types.ts`
+  - normalized transient-auth field on browser-session results
+- `src/services/accountBrowserSession/sessionReader.ts`
+  - whitelist and normalize transient runtime-message data
+- `src/services/siteDetection/autoDetectService.ts`
+  - propagate transient auth through detection only
+- `src/services/accounts/autoDetectCompletion/types.ts`
+  - expose transient auth on detected identity, not completion output
+- `src/services/apiAdapters/newApi/accountCompletion.ts`
+  - consume rc.22 Bearer through existing get-or-create PAT capability
+- `src/entrypoints/background/tempWindowPool.ts`
+  - preserve transient auth through background temp-context detection
+
+### Modified E2E files
+
+- `e2e/utils/realSite/compatibleApi.ts`
+  - opt-in AuthBundle login state machine and controlled cleanup closure
+- `e2e/utils/realSite/newApi.ts`
+  - enable AuthBundle mode only for the exact New API real-site wrapper
+- `e2e/utils/realSite/compatibleAccountSaveFlow.ts`
+  - propagate login-owned cleanup into the scenario
+- `e2e/utils/realSite/accountSaveFlow.ts`
+  - pass dynamic detectable-site cleanup through the account scenario
+- `e2e/scenarios/accountAutoDetect.ts`
+  - run dynamic session cleanup before environment cleanup and page close
+- `e2e/utils/commonUserFlows.ts`
+  - opt-in rc.22 mock routes with separate dashboard Bearer and management PAT
+- `e2e/accountOnboardingCommonFlows.spec.ts`
+  - deterministic legacy and rc.22 browser-level assertions
+
+### Modified tests
+
+- `tests/services/accountSiteOnboarding/registry.test.ts`
+- `tests/entrypoints/content/messageHandlers/handlers/storage.test.ts`
+- `tests/services/accountBrowserSession/sessionReader.test.ts`
+- `tests/services/autoDetectService.test.ts`
+- `tests/services/apiAdapters/newApi/accountCompletion.test.ts`
+- `tests/services/accountOperations.autoDetectAccount.test.ts`
+- `tests/utils/accountScenarios.test.ts`
+
+## Task 1: Extract And Validate The rc.22 AuthBundle
+
+**Files:**
+
+- Create: `src/services/accountSiteOnboarding/contentSession/newApiAuthBundle.ts`
+- Create: `tests/services/accountSiteOnboarding/contentSession/newApiAuthBundle.test.ts`
+- Modify: `src/services/accountSiteOnboarding/contracts.ts`
+- Modify: `src/services/accountSiteOnboarding/registry.ts`
+- Modify: `tests/services/accountSiteOnboarding/registry.test.ts`
+- Modify: `tests/entrypoints/content/messageHandlers/handlers/storage.test.ts`
+
+- [ ] **Step 1: Write failing extractor tests**
+
+Create tests using reserved example origins. Cover exact-site gating, successful
+AuthBundle parsing, same-origin endpoint construction, `credentials: "include"`,
+future-expiry enforcement, no storage writes, 404/405 legacy fallback, and
+controlled 401/409/429 failures.
+
+```ts
+const validBundle = {
+  success: true,
+  data: {
+    access_token: "dashboard-jwt",
+    token_type: "Bearer",
+    access_expires_at: Math.floor(Date.now() / 1000) + 900,
+    user: { id: 42, username: "example-user" },
+    session: { sid: "session-example", current: true },
+  },
+}
+
+it("extracts exact New API AuthBundle without persisting its bearer", async () => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue(
+      new Response(JSON.stringify(validBundle), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    ),
+  )
+
+  await expect(
+    newApiAuthBundleContentSessionExtractor.extract({
+      url: "https://ignored.example.invalid/path",
+      siteTypeHint: SITE_TYPES.NEW_API,
+    }),
+  ).resolves.toMatchObject({
+    userId: 42,
+    user: { id: 42, username: "example-user" },
+    siteTypeHint: SITE_TYPES.NEW_API,
+    transientAuth: {
+      kind: NEW_API_DASHBOARD_TRANSIENT_AUTH_KIND,
+      token: "dashboard-jwt",
+      sessionId: "session-example",
+    },
+  })
+
+  expect(fetch).toHaveBeenCalledWith(
+    `${location.origin}/api/user/auth/refresh`,
+    expect.objectContaining({ method: "POST", credentials: "include" }),
+  )
+  expect(localStorage.length).toBe(0)
+})
+
+it.each([404, 405])("returns null for legacy HTTP %s", async (status) => {
+  vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response("", { status })))
+  await expect(
+    newApiAuthBundleContentSessionExtractor.extract({
+      siteTypeHint: SITE_TYPES.NEW_API,
+    }),
+  ).resolves.toBeNull()
+})
+```
+
+- [ ] **Step 2: Run the new test and verify RED**
+
+Run:
+
+```powershell
+pnpm exec vitest tests/services/accountSiteOnboarding/contentSession/newApiAuthBundle.test.ts --run
+```
+
+Expected: FAIL because the extractor and transient-auth exports do not exist.
+
+- [ ] **Step 3: Add the transient-auth contract and extractor**
+
+Add to `contracts.ts`:
+
+```ts
+export const NEW_API_DASHBOARD_TRANSIENT_AUTH_KIND =
+  "new_api_dashboard_bearer" as const
+
+export type NewApiDashboardTransientAuth = {
+  kind: typeof NEW_API_DASHBOARD_TRANSIENT_AUTH_KIND
+  token: string
+  expiresAt: number
+  sessionId: string
+  origin: string
+}
+
+export type ContentSessionTransientAuth = NewApiDashboardTransientAuth
+```
+
+Add `transientAuth?: ContentSessionTransientAuth` to
+`ContentSessionExtractionResult`. Include a doc comment stating that this field
+is completion-only and must never be persisted as `account_info.access_token`.
+
+Implement the extractor with these fixed rules:
+
+```ts
+const NEW_API_AUTH_REFRESH_PATH = "/api/user/auth/refresh"
+
+export const newApiAuthBundleContentSessionExtractor: ContentSessionExtractor = {
+  id: "new-api-auth-bundle",
+  canExtract: ({ siteTypeHint }) => siteTypeHint === SITE_TYPES.NEW_API,
+  async extract() {
+    // New API rc.22: short dashboard Bearers stay in memory and refresh via
+    // an HttpOnly cookie. See the pinned upstream authentication contract.
+    const origin = location.origin
+    const response = await fetch(`${origin}${NEW_API_AUTH_REFRESH_PATH}`, {
+      method: "POST",
+      credentials: "include",
+      headers: { "Content-Type": "application/json" },
+    })
+
+    if (response.status === 404 || response.status === 405) return null
+    const body = await parseControlledJson(response)
+    if (!response.ok) throw createNewApiDashboardSessionError(response, body)
+
+    const bundle = parseNewApiAuthBundle(body, origin)
+    return bundle ?? null
+  },
+}
+```
+
+Use small private validators for unknown JSON. Accept only a Bearer token,
+future epoch-seconds expiry, object user with a resolvable identity, and a
+non-empty SID. Error messages may include controlled upstream `code` and
+`message` but never the response body, token, or SID.
+
+- [ ] **Step 4: Register the exact extractor before generic storage fallback**
+
+Update `getContentSessionExtractors()` to return:
+
+```ts
+return [
+  sub2ApiContentSessionExtractor,
+  sharedChatContentSessionExtractor,
+  voApiV2ContentSessionExtractor,
+  newApiAuthBundleContentSessionExtractor,
+  compatibleUserContentSessionExtractor,
+]
+```
+
+Update registry and storage-handler tests to assert that an AuthBundle result is
+returned unchanged and a legacy `null` result continues to the compatible-user
+extractor.
+
+- [ ] **Step 5: Run focused tests and verify GREEN**
+
+Run:
+
+```powershell
+pnpm exec vitest tests/services/accountSiteOnboarding/contentSession/newApiAuthBundle.test.ts tests/services/accountSiteOnboarding/registry.test.ts tests/entrypoints/content/messageHandlers/handlers/storage.test.ts --run
+```
+
+Expected: all selected tests PASS.
+
+- [ ] **Step 6: Commit Task 1**
+
+```powershell
+git add -- src/services/accountSiteOnboarding/contracts.ts src/services/accountSiteOnboarding/registry.ts src/services/accountSiteOnboarding/contentSession/newApiAuthBundle.ts tests/services/accountSiteOnboarding/contentSession/newApiAuthBundle.test.ts tests/services/accountSiteOnboarding/registry.test.ts tests/entrypoints/content/messageHandlers/handlers/storage.test.ts
+git commit -m "feat(new-api): extract rc22 dashboard session"
+```
+
+## Task 2: Propagate Transient Auth Without Persistence Leakage
+
+**Files:**
+
+- Modify: `src/services/accountBrowserSession/types.ts`
+- Modify: `src/services/accountBrowserSession/sessionReader.ts`
+- Modify: `src/services/siteDetection/autoDetectService.ts`
+- Modify: `src/services/accounts/autoDetectCompletion/types.ts`
+- Modify: `src/entrypoints/background/tempWindowPool.ts`
+- Modify: `tests/services/accountBrowserSession/sessionReader.test.ts`
+- Modify: `tests/services/autoDetectService.test.ts`
+
+- [ ] **Step 1: Write failing browser-session normalization tests**
+
+Add one valid and two invalid runtime-message cases:
+
+```ts
+it("normalizes exact New API transient auth from the content boundary", async () => {
+  mockSendTabMessageWithRetry.mockResolvedValueOnce({
+    success: true,
+    data: {
+      userId: 42,
+      user: { id: 42, username: "example-user" },
+      transientAuth: {
+        kind: NEW_API_DASHBOARD_TRANSIENT_AUTH_KIND,
+        token: " dashboard-jwt ",
+        expiresAt: 2_000_000_000,
+        sessionId: " session-example ",
+        origin: "https://panel.example.invalid",
+      },
+    },
+  })
+
+  const options = {
+    tabId: 7,
+    baseUrl: "https://panel.example.invalid",
+    siteType: SITE_TYPES.NEW_API,
+    source: ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB,
+  } as const
+
+  await expect(readAccountBrowserSessionFromTab(options)).resolves.toMatchObject({
+    transientAuth: {
+      kind: NEW_API_DASHBOARD_TRANSIENT_AUTH_KIND,
+      token: "dashboard-jwt",
+      sessionId: "session-example",
+      origin: "https://panel.example.invalid",
+    },
+  })
+})
+```
+
+Unknown `kind`, blank token, invalid origin, non-finite expiry, and blank SID
+must drop `transientAuth` while preserving the usable identity result.
+
+- [ ] **Step 2: Write failing auto-detect propagation tests**
+
+Extend current-tab and background response fixtures with valid transient auth.
+Assert `autoDetectSmart()` returns it inside `data`, while
+`autoDetectContext` contains only existing privacy-safe fields.
+
+- [ ] **Step 3: Run the focused tests and verify RED**
+
+Run:
+
+```powershell
+pnpm exec vitest tests/services/accountBrowserSession/sessionReader.test.ts tests/services/autoDetectService.test.ts --run
+```
+
+Expected: FAIL because browser-session and auto-detect types drop the new field.
+
+- [ ] **Step 4: Add strict normalization and detection propagation**
+
+Add `transientAuth?: ContentSessionTransientAuth` to `AccountBrowserSession`.
+In `sessionReader.ts`, whitelist the discriminant and fields:
+
+```ts
+function normalizeTransientAuth(
+  value: unknown,
+): AccountBrowserSession["transientAuth"] {
+  if (!value || typeof value !== "object") return undefined
+  const candidate = value as Record<string, unknown>
+  if (candidate.kind !== NEW_API_DASHBOARD_TRANSIENT_AUTH_KIND) return undefined
+
+  const token = normalizeOptionalString(candidate.token)
+  const sessionId = normalizeOptionalString(candidate.sessionId)
+  const origin = normalizeOptionalString(candidate.origin)
+  const expiresAt = candidate.expiresAt
+  if (!token || !sessionId || !origin) return undefined
+  if (typeof expiresAt !== "number" || !Number.isFinite(expiresAt)) return undefined
+
+  try {
+    if (new URL(origin).origin !== origin) return undefined
+  } catch {
+    return undefined
+  }
+
+  return {
+    kind: NEW_API_DASHBOARD_TRANSIENT_AUTH_KIND,
+    token,
+    expiresAt,
+    sessionId,
+    origin,
+  }
+}
+```
+
+Add the field to `UserDataResult`, `AutoDetectResult.data`, and
+`DetectedAccountIdentity`. Copy it only in current-tab/background data paths and
+`combineUserDataAndSiteType`. Do not add it to `AutoDetectCompletionData`.
+
+Add it to the explicit `getSiteDataFromTab()` response projection in
+`tempWindowPool.ts`; do not spread the whole content response.
+
+- [ ] **Step 5: Run focused tests and compile**
+
+Run:
+
+```powershell
+pnpm exec vitest tests/services/accountBrowserSession/sessionReader.test.ts tests/services/autoDetectService.test.ts --run
+pnpm compile
+```
+
+Expected: selected tests and TypeScript compilation PASS.
+
+- [ ] **Step 6: Commit Task 2**
+
+```powershell
+git add -- src/services/accountBrowserSession/types.ts src/services/accountBrowserSession/sessionReader.ts src/services/siteDetection/autoDetectService.ts src/services/accounts/autoDetectCompletion/types.ts src/entrypoints/background/tempWindowPool.ts tests/services/accountBrowserSession/sessionReader.test.ts tests/services/autoDetectService.test.ts
+git commit -m "feat(new-api): propagate transient dashboard auth"
+```
+
+## Task 3: Consume The Bearer Through Existing Get-Or-Create PAT Completion
+
+**Files:**
+
+- Modify: `src/services/apiAdapters/newApi/accountBootstrap.ts`
+- Modify: `src/services/apiAdapters/newApi/accountCompletion.ts`
+- Modify: `src/services/apiService/newApiFamily/default/accountBootstrap.ts`
+- Modify: `src/services/apiTransport/request.ts`
+- Modify: `src/utils/browser/tempWindowFetch.ts`
+- Modify: `tests/services/apiAdapters/newApi/accountBootstrap.test.ts`
+- Modify: `tests/services/apiAdapters/newApi/accountCompletion.test.ts`
+- Modify: `tests/services/accountOperations.autoDetectAccount.test.ts`
+- Modify: `tests/services/apiService/newApiFamily/accountBootstrap.test.ts`
+- Modify: `tests/services/apiTransport/request.test.ts`
+- Modify: `tests/utils/tempWindowFetch.fallback.test.ts`
+
+- [ ] **Step 1: Write a failing rc.22 completion test**
+
+Add a case where the user requested Cookie but exact New API detection contains
+transient auth:
+
+```ts
+it("uses rc22 dashboard bearer to get or create the persisted PAT", async () => {
+  mockGetOrCreateAccessToken.mockResolvedValueOnce({
+    username: "rc22-user",
+    access_token: "management-pat",
+  })
+  mockFetchSiteStatus.mockResolvedValueOnce({
+    system_name: "rc22 portal",
+    checkin_enabled: false,
+  })
+  mockExtractDefaultExchangeRate.mockReturnValueOnce(null)
+
+  const result = await newApiAccountCompletion.complete(
+    {
+      url: "https://panel.example.invalid",
+      requestedAuthType: AuthTypeEnum.Cookie,
+      detected: {
+        userId: "42",
+        siteType: SITE_TYPES.NEW_API,
+        transientAuth: {
+          kind: NEW_API_DASHBOARD_TRANSIENT_AUTH_KIND,
+          token: "dashboard-jwt",
+          expiresAt: 2_000_000_000,
+          sessionId: "session-example",
+          origin: "https://panel.example.invalid",
+        },
+      },
+      context: { fetchContext: currentTabFetchContext },
+    },
+    helpers,
+  )
+
+  expect(mockGetOrCreateAccessToken).toHaveBeenCalledWith({
+    baseUrl: "https://panel.example.invalid",
+    fetchContext: currentTabFetchContext,
+    auth: {
+      authType: AuthTypeEnum.AccessToken,
+      accessToken: "dashboard-jwt",
+    },
+  })
+  expect(result).toMatchObject({
+    accessToken: "management-pat",
+    authType: AuthTypeEnum.AccessToken,
+  })
+  expect(result).not.toHaveProperty("transientAuth")
+})
+```
+
+Add origin-mismatch and expired-token tests that reject before calling the
+bootstrap. Retain the existing legacy Cookie and AccessToken assertions.
+
+- [ ] **Step 2: Write a failing account-operations leakage regression test**
+
+Mock auto-detection with `transientAuth` and completion with `management-pat`.
+Assert the public result contains only `accessToken: "management-pat"` and no
+dashboard JWT or transient-auth field.
+
+- [ ] **Step 3: Run focused tests and verify RED**
+
+Run:
+
+```powershell
+pnpm exec vitest tests/services/apiAdapters/newApi/accountCompletion.test.ts tests/services/accountOperations.autoDetectAccount.test.ts --run
+```
+
+Expected: FAIL because completion still attempts cookie authentication.
+
+- [ ] **Step 4: Add the exact modern completion branch**
+
+Resolve valid transient auth before the legacy `fetchTokenInfo` function:
+
+```ts
+const modernDashboardAuth =
+  detected.siteType === SITE_TYPES.NEW_API &&
+  detected.transientAuth?.kind === NEW_API_DASHBOARD_TRANSIENT_AUTH_KIND &&
+  detected.transientAuth.origin === new URL(url).origin &&
+  detected.transientAuth.expiresAt > Math.floor(Date.now() / 1000)
+    ? detected.transientAuth
+    : undefined
+
+const effectiveAuthType = modernDashboardAuth
+  ? AuthTypeEnum.AccessToken
+  : requestedAuthType
+```
+
+For a detected transient-auth object with the exact kind but mismatched origin
+or expired timestamp, throw a controlled `TokenFetchFailed` completion error;
+do not fall back to cookies.
+
+When `modernDashboardAuth` is present, create the New API account bootstrap
+with an adapter-local token-creation policy:
+
+```ts
+const accountBootstrap = modernDashboardAuth
+  ? createNewApiAccountBootstrap(detected.siteType, {
+      accessTokenCreationPolicy: {
+        currentTabTransport: "disabled",
+        tempWindowFallback: { statusCodes: [], codes: [] },
+      },
+    })
+  : createNewApiAccountBootstrap(detected.siteType)
+```
+
+Thread this optional policy through the New API adapter factory and shared
+get-or-create implementation only when `/api/user/token` is actually needed.
+The default must remain `undefined` so legacy New API and other New API-family
+site types retain their current transport behavior.
+
+Call the existing bootstrap with no user ID:
+
+```ts
+if (modernDashboardAuth) {
+  return accountBootstrap.getOrCreateAccessToken(
+    createRequest({
+      authType: AuthTypeEnum.AccessToken,
+      accessToken: modernDashboardAuth.token,
+    }),
+  )
+}
+```
+
+Return `authType: effectiveAuthType` and apply the missing-token check to the
+effective AccessToken mode. Keep site-status probing public as it is today.
+
+Make explicit fallback allowlists authoritative in the generic temporary-window
+transport: an explicit empty allowlist must suppress the implicit Cookie 401
+fallback. Redact the exact request access token from current-tab fallback
+diagnostics before logging the error text. Add focused regressions for both
+transport contracts and for non-rc.22 New API-family callers retaining their
+default behavior.
+
+Add a concise source comment linking the pinned rc.22 authentication contract
+and explaining why the dashboard Bearer is completion-only and omits user ID.
+
+- [ ] **Step 5: Run focused tests and compile**
+
+Run:
+
+```powershell
+pnpm exec vitest tests/services/apiAdapters/newApi/accountBootstrap.test.ts tests/services/apiAdapters/newApi/accountCompletion.test.ts tests/services/accountOperations.autoDetectAccount.test.ts tests/services/apiService/newApiFamily/accountBootstrap.test.ts tests/services/apiTransport/request.test.ts tests/utils/tempWindowFetch.fallback.test.ts --run
+pnpm compile
+```
+
+Expected: selected tests and compilation PASS; legacy assertions remain green.
+
+- [ ] **Step 6: Commit Task 3**
+
+```powershell
+git add -- src/services/apiAdapters/newApi/accountBootstrap.ts src/services/apiAdapters/newApi/accountCompletion.ts src/services/apiService/newApiFamily/default/accountBootstrap.ts src/services/apiTransport/request.ts src/utils/browser/tempWindowFetch.ts tests/services/apiAdapters/newApi/accountBootstrap.test.ts tests/services/apiAdapters/newApi/accountCompletion.test.ts tests/services/accountOperations.autoDetectAccount.test.ts tests/services/apiService/newApiFamily/accountBootstrap.test.ts tests/services/apiTransport/request.test.ts tests/utils/tempWindowFetch.fallback.test.ts
+git commit -m "fix(new-api): exchange rc22 dashboard auth for PAT"
+```
+
+## Task 4: Fix Real-Site AuthBundle Login And Owned-Session Cleanup
+
+**Files:**
+
+- Create: `tests/utils/realSiteCompatibleApi.test.ts`
+- Modify: `e2e/utils/realSite/compatibleApi.ts`
+- Modify: `e2e/utils/realSite/newApi.ts`
+- Modify: `e2e/utils/realSite/compatibleAccountSaveFlow.ts`
+- Modify: `e2e/utils/realSite/accountSaveFlow.ts`
+- Modify: `e2e/scenarios/accountAutoDetect.ts`
+- Modify: `tests/utils/accountScenarios.test.ts`
+
+- [ ] **Step 1: Write failing real-site login state-machine tests**
+
+Mock a minimal Playwright `Page`/`APIRequestContext`. Define the response helper
+and shared-function mocks at module scope:
+
+```ts
+const mocks = vi.hoisted(() => ({
+  ensureRealSiteOriginPage: vi.fn(),
+  seedLocalStorageValues: vi.fn(),
+}))
+
+vi.mock("~~/e2e/utils/realSite/shared", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("~~/e2e/utils/realSite/shared")>()),
+  ensureRealSiteOriginPage: mocks.ensureRealSiteOriginPage,
+  seedLocalStorageValues: mocks.seedLocalStorageValues,
+}))
+
+function createApiResponse(body: unknown, status = 200) {
+  const text = JSON.stringify(body)
+  return {
+    ok: () => status >= 200 && status < 300,
+    status: () => status,
+    text: vi.fn().mockResolvedValue(text),
+  }
+}
+
+function createAuthBundleResponse() {
+  return {
+    success: true,
+    data: {
+      access_token: "dashboard-jwt",
+      token_type: "Bearer",
+      access_expires_at: 2_000_000_000,
+      user: { id: 42, username: "example-user" },
+      session: { sid: "session-example", current: true },
+    },
+  }
+}
+```
+
+Then cover:
+
+```ts
+it("accepts an rc22 AuthBundle without seeding localStorage or UI login", async () => {
+  const requestPost = vi
+    .fn()
+    .mockResolvedValueOnce(createApiResponse(createAuthBundleResponse()))
+  const page = {
+    request: { post: requestPost, get: vi.fn() },
+    waitForFunction: vi.fn().mockRejectedValue(new Error("storage missing")),
+  } as unknown as Page
+
+  const result = await loginToCompatibleApiRealSite(page, config, {
+    label: "Example API",
+    envPrefix: "EXAMPLE",
+    authBundle: true,
+  })
+
+  expect(result.user).toEqual({ id: 42, username: "example-user" })
+  expect(result.reusedSession).toBe(false)
+  expect(result.cleanupOwnedSession).toEqual(expect.any(Function))
+  expect(mocks.seedLocalStorageValues).not.toHaveBeenCalled()
+  expect(requestPost).toHaveBeenCalledTimes(1)
+})
+```
+
+Also assert:
+
+- legacy top-level users still seed localStorage
+- successful unrecognized 2xx never falls through to UI login
+- 409 `AUTH_SESSION_LIMIT` and 429 `AUTH_SESSION_ISSUANCE_LIMIT` surface
+  controlled code/message without dumping response JSON
+- an existing refresh AuthBundle is marked reused and has no cleanup closure
+- fresh-session cleanup sends Origin, Bearer, SID, and credentials via the
+  shared request context
+- cleanup does not log token or SID
+
+- [ ] **Step 2: Write failing dynamic-finalizer tests**
+
+Add cases to `accountScenarios.test.ts` proving:
+
+```ts
+expect(finalizerOrder).toEqual([
+  "detectable-site-cleanup",
+  "environment-cleanup",
+  "site-page-close",
+])
+```
+
+Run the same assertion on primary save failure. Add a case where primary and
+dynamic cleanup both fail and assert the existing `AggregateError` contains
+both failures.
+
+- [ ] **Step 3: Run tests and verify RED**
+
+Run:
+
+```powershell
+pnpm exec vitest tests/utils/realSiteCompatibleApi.test.ts tests/utils/accountScenarios.test.ts --run
+```
+
+Expected: FAIL because AuthBundle options, cleanup ownership, and dynamic
+finalizers are absent.
+
+- [ ] **Step 4: Implement the opt-in AuthBundle login state machine**
+
+Extend login options without changing other compatible wrappers:
+
+```ts
+type CompatibleApiLoginOptions = {
+  label: string
+  envPrefix: string
+  authBundle?: boolean
+}
+
+export interface CompatibleApiRealSiteLoginResult {
+  reusedSession: boolean
+  user: Record<string, unknown>
+  cleanupOwnedSession?: () => Promise<void>
+}
+```
+
+Use a private discriminated parser:
+
+```ts
+type CompatibleLoginPayload =
+  | { kind: "legacy-user"; user: Record<string, unknown> }
+  | {
+      kind: "auth-bundle"
+      user: Record<string, unknown>
+      token: string
+      sessionId: string
+    }
+```
+
+When `authBundle` is enabled, probe refresh before creating a session. A 200
+bundle means reuse; 401 allows login; 409/429/5xx are terminal. Parse API-login
+and 2FA responses through the same function. Never seed localStorage for an
+AuthBundle and never UI-login after any successful but malformed 2xx response.
+
+Create the logout closure only for a fresh API/UI AuthBundle session. Post to
+`/api/user/auth/logout` with:
+
+```ts
+{
+  failOnStatusCode: false,
+  headers: {
+    Origin: new URL(config.baseUrl).origin,
+    Authorization: `Bearer ${token}`,
+    "X-Auth-Session": sessionId,
+  },
+}
+```
+
+Do not interpolate the token, SID, or raw body into errors.
+
+Enable `authBundle: true` only in `loginToRealNewApiSite()`.
+
+- [ ] **Step 5: Propagate and order dynamic cleanup**
+
+Extend `AccountDetectionContext` with:
+
+```ts
+cleanupDetectableSite?: () => Promise<void>
+```
+
+Have compatible account-save wrappers return the login cleanup closure. In
+`runAccountAutoDetectScenario`, retain the returned detection context and run:
+
+```ts
+await runFinalizers([
+  async () => detectionContext?.cleanupDetectableSite?.(),
+  async () => env.cleanup?.(),
+  async () => sitePage.close(),
+])
+```
+
+This must execute after account persistence, so subsequent real-site usage
+checks prove the saved PAT is independent from the dashboard session.
+
+- [ ] **Step 6: Run focused tests and compile**
+
+Run:
+
+```powershell
+pnpm exec vitest tests/utils/realSiteCompatibleApi.test.ts tests/utils/accountScenarios.test.ts --run
+pnpm compile
+```
+
+Expected: selected tests and compilation PASS.
+
+- [ ] **Step 7: Commit Task 4**
+
+```powershell
+git add -- e2e/utils/realSite/compatibleApi.ts e2e/utils/realSite/newApi.ts e2e/utils/realSite/compatibleAccountSaveFlow.ts e2e/utils/realSite/accountSaveFlow.ts e2e/scenarios/accountAutoDetect.ts tests/utils/realSiteCompatibleApi.test.ts tests/utils/accountScenarios.test.ts
+git commit -m "test(real-site): support rc22 auth bundles"
+```
+
+## Task 5: Add Deterministic Browser-Level rc.22 Coverage
+
+**Files:**
+
+- Modify: `e2e/utils/commonUserFlows.ts`
+- Modify: `e2e/accountOnboardingCommonFlows.spec.ts`
+
+- [ ] **Step 1: Extend the mock-site contract for rc.22 mode**
+
+Add an option:
+
+```ts
+type StubNewApiSiteRoutesOptions = {
+  // existing fields stay unchanged
+  dashboardAuthMode?: "legacy" | "auth-bundle"
+}
+```
+
+In AuthBundle mode:
+
+- `POST /api/user/auth/refresh` returns dashboard Bearer, expiry, user, and SID
+- `GET /api/user/self` requires `Authorization: Bearer dashboard-jwt` and omits
+  `access_token`
+- `GET /api/user/token` requires the dashboard Bearer and returns
+  `management-pat`
+- other authenticated account endpoints require `management-pat`
+- `POST /api/user/auth/logout` marks the dashboard session revoked
+- after logout, PAT-authenticated account endpoints still succeed
+
+Keep legacy mode as the default so all existing E2E tests remain unchanged.
+
+- [ ] **Step 2: Add the browser-level rc.22 scenario**
+
+Use a separate reserved origin to avoid conflicting with the legacy route:
+
+```ts
+test("adds an rc22 account from AuthBundle and persists only its PAT", async ({
+  context,
+  extensionId,
+  page,
+}) => {
+  const baseUrl = "https://rc22.example.invalid"
+  await stubNewApiSiteRoutes(context, {
+    baseUrl,
+    dashboardAuthMode: "auth-bundle",
+    accessToken: "management-pat",
+  })
+
+  const serviceWorker = await getServiceWorker(context)
+  const fixture = await runAccountAutoDetectScenario({
+    extensionId,
+    extensionPage: page,
+    baseUrl,
+    siteType: SITE_TYPES.NEW_API,
+    getServiceWorker: async () => serviceWorker,
+    openSitePage: async () => {
+      const sitePage = await context.newPage()
+      await sitePage.goto(baseUrl)
+      expect(await sitePage.evaluate(() => localStorage.getItem("user"))).toBeNull()
+      return sitePage
+    },
+    prepareDetectableSite: async () => undefined,
+  })
+
+  const accounts = await readStoredAccounts(serviceWorker)
+  const saved = accounts.find((account) => account.id === fixture.accountId)
+  expect(saved?.account_info.access_token).toBe("management-pat")
+  expect(JSON.stringify(saved)).not.toContain("dashboard-jwt")
+})
+```
+
+If scenario-owned logout is covered only by the real-site wrapper, add a
+deterministic logout callback to `prepareDetectableSite` and assert a subsequent
+PAT-authenticated account read succeeds after cleanup.
+
+- [ ] **Step 3: Run legacy and rc.22 Chromium scenarios**
+
+Run the narrow project-supported Playwright invocation for the two named tests:
+
+```powershell
+pnpm exec playwright test e2e/accountOnboardingCommonFlows.spec.ts --project=chromium --grep "adds an account through|adds an rc22 account"
+```
+
+Expected: both legacy localStorage and rc.22 AuthBundle tests PASS.
+
+- [ ] **Step 4: Commit Task 5**
+
+```powershell
+git add -- e2e/utils/commonUserFlows.ts e2e/accountOnboardingCommonFlows.spec.ts
+git commit -m "test(new-api): cover rc22 account onboarding"
+```
+
+## Task 6: Integration Validation And Final Review
+
+**Files:**
+
+- Review: all files changed since `0e050f96e`
+
+- [ ] **Step 1: Run all focused related Vitest tests**
+
+```powershell
+pnpm exec vitest tests/services/accountSiteOnboarding/contentSession/newApiAuthBundle.test.ts tests/services/accountSiteOnboarding/registry.test.ts tests/entrypoints/content/messageHandlers/handlers/storage.test.ts tests/services/accountBrowserSession/sessionReader.test.ts tests/services/autoDetectService.test.ts tests/services/apiAdapters/newApi/accountCompletion.test.ts tests/services/accountOperations.autoDetectAccount.test.ts tests/utils/realSiteCompatibleApi.test.ts tests/utils/accountScenarios.test.ts --run
+```
+
+Expected: all selected tests PASS.
+
+- [ ] **Step 2: Run locale extraction consistency**
+
+Even if no locale copy changed, the content/background TypeScript imports can
+participate in extraction. Run:
+
+```powershell
+pnpm run i18n:extract:ci
+```
+
+Expected: PASS with no unexpected locale diff.
+
+- [ ] **Step 3: Run the commit and push-equivalent gates**
+
+Stage only task-scoped files, then run:
+
+```powershell
+pnpm run validate:staged
+pnpm run validate:push
+```
+
+Expected: lint/format, TypeScript compile, and Knip PASS.
+
+- [ ] **Step 4: Re-run deterministic browser coverage**
+
+```powershell
+pnpm exec playwright test e2e/accountOnboardingCommonFlows.spec.ts --project=chromium --grep "adds an account through|adds an rc22 account"
+```
+
+Expected: legacy and rc.22 tests PASS.
+
+- [ ] **Step 5: Inspect security and maintainability invariants**
+
+Run:
+
+```powershell
+rg -n "dashboard-jwt|session-example|transientAuth" src e2e tests
+git diff 0e050f96e..HEAD --check
+git diff 0e050f96e..HEAD --stat
+git status --short
+```
+
+Confirm:
+
+- placeholder secrets appear only in tests
+- production log calls never receive token, SID, AuthBundle, or transient auth
+- `AutoDetectCompletionData`, account drafts, and `SiteAccount` have no
+  transient-auth field
+- exact New API owns the new protocol branch
+- legacy Cookie/PAT branches and other family variants remain intact
+- no unrelated files or generated artifacts are present
+
+- [ ] **Step 6: Run the live New API E2E when credentials permit**
+
+Use the repository workflow or the equivalent local secret-backed command.
+Before retrying, revoke leaked active sessions from the test account. If the
+24-hour issuance limit is active, report it as an external validation blocker;
+revoking sessions does not reset that counter.
+
+- [ ] **Step 7: Commit any final validation-only cleanup**
+
+If validation required a task-scoped correction, stage only the files owned by
+this plan:
+
+```powershell
+git add -- src/services/accountSiteOnboarding/contracts.ts src/services/accountSiteOnboarding/registry.ts src/services/accountSiteOnboarding/contentSession/newApiAuthBundle.ts src/services/accountBrowserSession/types.ts src/services/accountBrowserSession/sessionReader.ts src/services/siteDetection/autoDetectService.ts src/services/accounts/autoDetectCompletion/types.ts src/services/apiAdapters/newApi/accountCompletion.ts src/entrypoints/background/tempWindowPool.ts e2e/utils/realSite/compatibleApi.ts e2e/utils/realSite/newApi.ts e2e/utils/realSite/compatibleAccountSaveFlow.ts e2e/utils/realSite/accountSaveFlow.ts e2e/scenarios/accountAutoDetect.ts e2e/utils/commonUserFlows.ts e2e/accountOnboardingCommonFlows.spec.ts tests/services/accountSiteOnboarding/contentSession/newApiAuthBundle.test.ts tests/services/accountSiteOnboarding/registry.test.ts tests/entrypoints/content/messageHandlers/handlers/storage.test.ts tests/services/accountBrowserSession/sessionReader.test.ts tests/services/autoDetectService.test.ts tests/services/apiAdapters/newApi/accountCompletion.test.ts tests/services/accountOperations.autoDetectAccount.test.ts tests/utils/realSiteCompatibleApi.test.ts tests/utils/accountScenarios.test.ts
+git commit -m "fix(new-api): finalize rc22 compatibility"
+```
+
+If no correction is needed, do not create an empty commit.

--- a/docs/superpowers/specs/2026-07-27-new-api-rc22-auto-detect-compatibility-design.md
+++ b/docs/superpowers/specs/2026-07-27-new-api-rc22-auto-detect-compatibility-design.md
@@ -1,0 +1,339 @@
+# New API rc.22 Auto-Detect Compatibility Design
+
+Date: 2026-07-27
+
+## Purpose
+
+Restore account auto-detection for upstream New API `v1.0.0-rc.22` while
+preserving legacy New API and New API-family behavior.
+
+The compatibility boundary is intentionally narrow: adapt the browser-login
+session used during account onboarding, then reuse the existing
+`getOrCreateAccessToken` completion contract. Existing saved PAT accounts and
+ordinary account runtime requests remain unchanged.
+
+## Upstream Contract Change
+
+New API rc.22 replaced the legacy dashboard session contract:
+
+- the browser no longer persists `localStorage.user`
+- the legacy Gin session cookie no longer authenticates `/api/user/self`
+- dashboard endpoints require a 15-minute Bearer access token
+- the refresh token is an HttpOnly cookie and rotates through
+  `POST /api/user/auth/refresh`
+- login and refresh return an AuthBundle containing the short-lived Bearer,
+  safe user DTO, and login-session metadata
+- the safe user DTO intentionally excludes the management PAT
+- `GET /api/user/token` generates and stores a new management PAT
+- existing PAT authentication remains supported
+
+Source:
+
+- <https://github.com/QuantumNous/new-api/blob/v1.0.0-rc.22/docs/authentication.md>
+- <https://github.com/QuantumNous/new-api/blob/v1.0.0-rc.22/controller/user.go>
+
+The failed real-site E2E run exposed both obsolete assumptions. Its helper did
+not recognize `data.user`, then retried through UI login and waited for
+`localStorage.user`. Repeated attempts accumulated login sessions until the
+upstream returned `AUTH_SESSION_LIMIT`.
+
+## Goals
+
+- Detect an authenticated rc.22 New API user from a same-origin page.
+- Keep the rc.22 dashboard Bearer in memory only.
+- Reuse the existing New API `getOrCreateAccessToken` behavior:
+  - reuse a PAT when the upstream exposes one
+  - otherwise generate a PAT through `/api/user/token`
+- Save only the resulting long-lived PAT as the account access token.
+- Normalize rc.22 auto-detected accounts to AccessToken authentication because
+  the new dashboard session cookie is not an account API credential.
+- Preserve legacy `localStorage.user`, cookie-auth, and PAT behavior.
+- Preserve other New API-family site types unless their upstream contract is
+  separately verified.
+- Make real-site E2E login recognize AuthBundle responses and clean up sessions
+  created by the test.
+
+## Non-Goals
+
+- Do not migrate or rewrite existing saved accounts.
+- Do not change runtime requests for existing PAT accounts.
+- Do not remove legacy cookie support globally.
+- Do not apply the rc.22 refresh protocol to Veloera, AnyRouter, WONG, or other
+  New API-family compatibility buckets.
+- Do not persist or refresh the rc.22 dashboard Bearer after onboarding.
+- Do not add a PAT-generation confirmation. Auto-detect already owns the
+  get-or-create PAT contract; rc.22 preserves that product behavior even
+  though hiding the existing PAT means the generation branch can replace it.
+- Do not redesign generic API transport authentication.
+
+## Approaches Considered
+
+### A. Persist The Dashboard Bearer
+
+This would make the smallest immediate change, but the token expires after 15
+minutes and upstream explicitly requires it to stay in browser memory. It
+would create accounts that fail shortly after onboarding and is rejected.
+
+### B. Detect Identity And Require Manual PAT Entry
+
+This avoids PAT replacement, but changes the established auto-detect contract
+from get-or-create to a partial form fill. It also leaves the real-site account
+save flow unable to complete without an additional credential. This is not the
+chosen product behavior.
+
+### C. Use Transient Dashboard Auth Then Reuse Get-Or-Create PAT
+
+This is the selected approach. It adapts only the changed browser-session
+boundary, structurally separates the short-lived Bearer from persisted account
+credentials, and reuses the existing completion capability.
+
+## Design
+
+### 1. Add An Exact New API AuthBundle Extractor
+
+Add a content-session extractor dedicated to `SITE_TYPES.NEW_API`.
+
+It constructs the refresh URL from `location.origin`, not from an arbitrary
+runtime-message URL, and calls:
+
+```http
+POST /api/user/auth/refresh
+credentials: include
+```
+
+Cold-start refresh omits `X-Auth-Session`, as allowed by the upstream contract.
+The extractor strictly validates:
+
+- `success !== false`
+- `data.token_type === "Bearer"`
+- a non-empty `data.access_token`
+- a future `data.access_expires_at`
+- a valid user identity
+- a non-empty current session SID
+
+It returns `null` for legacy unsupported responses such as 404/405 or a
+non-AuthBundle response so the existing compatible-user extractor can run.
+Confirmed modern authentication errors such as 401, 409, and 429 must remain
+actionable rather than falling through to another login attempt.
+
+The exact New API extractor runs before the generic compatible-user extractor.
+That avoids stale pre-upgrade `localStorage.user` selecting the obsolete cookie
+path after a deployment upgrades to rc.22.
+
+### 2. Introduce Completion-Only Transient Auth
+
+Add a discriminated onboarding-only type similar to:
+
+```ts
+type NewApiDashboardTransientAuth = {
+  kind: "new_api_dashboard_bearer"
+  token: string
+  expiresAt: number
+  sessionId: string
+  origin: string
+}
+```
+
+Propagate it only through:
+
+```text
+ContentSessionExtractionResult
+→ AccountBrowserSession
+→ auto-detect detected identity
+→ New API account completion
+```
+
+It must not appear in `AutoDetectCompletionData`, Account Dialog drafts,
+`SiteAccount`, browser storage, logs, analytics, snapshots, or error messages.
+The account-browser-session normalization boundary must whitelist the known
+discriminant and fields instead of spreading an untrusted message object.
+
+### 3. Consume The Bearer In New API Completion
+
+When the detected site type is exactly `SITE_TYPES.NEW_API` and the validated
+transient-auth kind is present, New API account completion builds a temporary
+service request with:
+
+```ts
+{
+  authType: AuthTypeEnum.AccessToken,
+  accessToken: transientAuth.token,
+}
+```
+
+It deliberately omits `userId`, so the rc.22 request sends
+`Authorization: Bearer ...` without the obsolete `New-Api-User` header.
+
+The existing account bootstrap then performs:
+
+```text
+GET /api/user/self
+→ reuse access_token when returned
+→ otherwise GET /api/user/token
+→ return the resulting management PAT
+```
+
+For rc.22, the safe self DTO excludes the management PAT, so the existing
+generation branch replaces the prior PAT. This is an accepted consequence of
+preserving the current auto-detect get-or-create contract.
+
+`GET /api/user/token` regenerates and overwrites the management PAT. The exact
+New API transient-auth branch therefore injects an adapter-local token-creation
+policy that disables current-tab transport and supplies an explicit empty
+temporary-window fallback allowlist. This keeps the side effect at-most-once.
+The policy defaults to absent, so legacy New API and other New API-family site
+types retain their existing transport and fallback behavior.
+
+The completion result contains only the management PAT and returns effective
+authentication type `AccessToken`, including when the user initially selected
+Cookie. The short-lived dashboard Bearer is discarded with the call stack.
+
+When transient auth is absent, the current branches remain byte-for-byte in
+behavior:
+
+- requested Cookie uses cookie-auth user info
+- requested AccessToken uses cookie-auth get-or-create PAT
+- other New API-family site types keep their existing shared implementation
+
+### 4. Preserve Transport And Runtime Behavior
+
+The generic API transport already supports Bearer authentication for
+`AuthTypeEnum.AccessToken`; no new auth mode is required.
+
+An explicit temporary-window fallback allowlist is authoritative. In
+particular, an explicit empty allowlist must suppress the default Cookie 401
+fallback rather than allowing an implicit replay. Current-tab transport
+diagnostics redact the exact request access token before logging any fallback
+error text.
+
+The rc.22 completion request must not include a user ID. The legacy compatible
+user-header fan-out remains available for old deployments and other site types.
+
+No saved-account request, persistence schema, migration, refresh capability,
+token CRUD operation, check-in provider, or model-list behavior changes.
+
+### 5. Repair Real-Site E2E Login State
+
+The compatible real-site login helper gains an opt-in AuthBundle mode used only
+by the New API wrapper.
+
+It distinguishes:
+
+- legacy top-level user response: preserve localStorage seeding
+- rc.22 AuthBundle: use nested user and do not fabricate localStorage
+- recoverable anonymous response: allow one UI fallback
+- terminal 409/429 or unrecognized successful response: surface a controlled
+  error and do not create another session
+
+UI login completion accepts either legacy storage or an AuthBundle refresh
+probe. A successful API login never falls through to UI login.
+
+The helper tracks ownership only for sessions it creates. The account-scenario
+finalizer calls `/api/user/auth/logout` with the captured Bearer, SID, Origin,
+and refresh cookie after the account has been saved. Reused pre-existing
+sessions are never logged out.
+
+The cleanup proves that the saved account uses the management PAT: later
+account operations must continue working after the dashboard session is
+revoked.
+
+## Error Handling
+
+- 404/405 or non-AuthBundle refresh response: legacy extractor/API fallback.
+- 401 from a recognized modern refresh endpoint: login required.
+- 409 `AUTH_SESSION_MISMATCH`: actionable session mismatch, no login retry.
+- 409 `AUTH_SESSION_LIMIT`: actionable session-limit guidance, no login retry.
+- 429 `AUTH_SESSION_ISSUANCE_LIMIT`: actionable issuance-limit guidance, no
+  login retry.
+- malformed or expired AuthBundle: invalid-response failure without logging
+  the body or token.
+- cleanup failure: preserve the primary E2E failure and report cleanup failure
+  through the existing finalizer aggregation.
+
+## Security And Privacy
+
+- Build the refresh endpoint from the actual page origin.
+- Use an isolated content-script fetch; do not inject into MAIN world or
+  intercept page requests.
+- Do not persist the Bearer, refresh cookie, SID, or AuthBundle.
+- Do not log or include them in telemetry and test diagnostics.
+- Strictly normalize runtime-message data at the browser-session boundary.
+- Verify the transient-auth origin matches the completion target origin.
+- Add an upstream-contract comment near the extractor and completion logic.
+
+## Telemetry Decision
+
+Telemetry decision: reuse existing.
+
+This preserves the existing account auto-detect action and success/failure
+contract. Existing privacy-safe strategy, site-type, fetch-context, and failure
+reason telemetry remains sufficient. No auth kind, token, SID, expiry, URL, or
+backend message is added.
+
+## Settings Search Decision
+
+Settings search decision: none. No settings UI, route, anchor, or search target
+changes.
+
+## E2E Decision
+
+E2E decision: update browser-level coverage.
+
+This regression depends on HttpOnly cookies, content-script same-origin fetch,
+runtime-message propagation, and the difference between dashboard Bearer and
+persisted PAT. Focused Vitest tests are necessary but not sufficient.
+
+Add or update one deterministic Chromium flow that proves:
+
+- rc.22 has no `localStorage.user`
+- refresh returns AuthBundle
+- `/api/user/self` requires the dashboard Bearer
+- `/api/user/token` returns a management PAT
+- the saved account contains the PAT, not the dashboard Bearer
+- saved-account operations still work after dashboard logout
+
+Keep the existing legacy browser flow to prove old compatibility.
+
+## Testing Strategy
+
+Use TDD in these slices:
+
+1. AuthBundle extractor parsing, exact-site gating, origin construction,
+   expiry validation, legacy fallback, and modern errors.
+2. Content extractor ordering and message-handler error propagation.
+3. Browser-session transient-auth normalization and rejection of malformed
+   message data.
+4. Current-tab and background auto-detect propagation without analytics or
+   completion-output leakage.
+5. New API completion consumes Bearer without a user header, returns only the
+   management PAT, and normalizes auth type to AccessToken.
+6. Existing New API Cookie and AccessToken completion tests remain unchanged.
+7. Real-site helper recognizes AuthBundle, avoids double login, surfaces
+   409/429, and cleans up only owned sessions.
+8. Deterministic browser E2E covers rc.22 and legacy flows.
+
+## Validation
+
+Run focused related Vitest tests first, then:
+
+```powershell
+pnpm run i18n:extract:ci
+pnpm run validate:staged
+pnpm run validate:push
+```
+
+Run the deterministic Chromium account-onboarding E2E locally. The live New
+API matrix requires repository secrets and an account below its active-session
+and issuance limits; report that boundary separately if it cannot be run.
+
+## Rollout
+
+1. Add transient-auth contracts and strict normalization.
+2. Add the exact New API AuthBundle extractor and typed modern errors.
+3. Propagate transient auth through current-tab and background detection.
+4. Consume it in New API completion using existing get-or-create PAT behavior.
+5. Repair real-site login parsing, terminal errors, and owned-session cleanup.
+6. Add deterministic browser-level rc.22 coverage while retaining legacy
+   coverage.
+7. Run focused tests, local gates, and final diff review.
+8. Run the live real-site New API job when credentials and session limits permit.

--- a/e2e/accountOnboardingCommonFlows.spec.ts
+++ b/e2e/accountOnboardingCommonFlows.spec.ts
@@ -26,6 +26,7 @@ import {
 import { verifyCcSwitchModelExportDeepLink } from "~~/e2e/scenarios/ccSwitchExport"
 import {
   createStoredAccount,
+  E2E_NEW_API_RC22_AUTH,
   forceExtensionLanguage,
   installExtensionPageGuards,
   seedStoredAccounts,
@@ -448,6 +449,85 @@ test("adds an account through the real add-account auto-detect flow", async ({
   expect(persistedAccounts).toContain('"username":"e2e-user"')
 })
 
+test("adds an rc22 account from AuthBundle and persists only its PAT", async ({
+  context,
+  extensionId,
+  page,
+}) => {
+  const baseUrl = "https://rc22.example.invalid"
+  const { dashboardToken, managementPat, sessionId } = E2E_NEW_API_RC22_AUTH
+
+  await stubNewApiSiteRoutes(context, {
+    baseUrl,
+    dashboardAuthMode: "auth-bundle",
+    accessToken: managementPat,
+  })
+
+  const serviceWorker = await getServiceWorker(context)
+  await seedUserPreferences(serviceWorker, {
+    tempWindowFallback: {
+      enabled: false,
+    },
+  })
+
+  const fixture = await runAccountAutoDetectScenario({
+    extensionId,
+    extensionPage: page,
+    baseUrl,
+    siteType: SITE_TYPES.NEW_API,
+    getServiceWorker: async () => serviceWorker,
+    openSitePage: async () => {
+      const sitePage = await context.newPage()
+      await sitePage.goto(baseUrl)
+      expect(
+        await sitePage.evaluate(() => localStorage.getItem("user")),
+      ).toBeNull()
+      await sitePage.bringToFront()
+      return sitePage
+    },
+    prepareDetectableSite: async (sitePage) => ({
+      cleanupDetectableSite: async () => {
+        const cleanupResult = await sitePage.evaluate(
+          async ({ dashboardToken, managementPat, sessionId }) => {
+            const logoutResponse = await fetch("/api/user/auth/logout", {
+              method: "POST",
+              credentials: "include",
+              headers: {
+                Authorization: `Bearer ${dashboardToken}`,
+                "X-Auth-Session": sessionId,
+              },
+            })
+            const revokedDashboardResponse = await fetch("/api/user/self", {
+              headers: { Authorization: `Bearer ${dashboardToken}` },
+            })
+            const patResponse = await fetch("/api/user/self", {
+              headers: { Authorization: `Bearer ${managementPat}` },
+            })
+
+            return {
+              logoutStatus: logoutResponse.status,
+              revokedDashboardStatus: revokedDashboardResponse.status,
+              patStatus: patResponse.status,
+            }
+          },
+          { dashboardToken, managementPat, sessionId },
+        )
+
+        expect(cleanupResult).toEqual({
+          logoutStatus: 200,
+          revokedDashboardStatus: 401,
+          patStatus: 200,
+        })
+      },
+    }),
+  })
+
+  const accounts = await readStoredAccounts(serviceWorker)
+  const saved = accounts.find((account) => account.id === fixture.accountId)
+  expect(saved?.account_info.access_token).toBe(managementPat)
+  expect(JSON.stringify(saved)).not.toContain(dashboardToken)
+})
+
 test("enables default-key provisioning, adds an account, saves the created key as a reusable API profile, and verifies it from the popup", async ({
   context,
   extensionId,
@@ -481,7 +561,6 @@ test("enables default-key provisioning, adds an account, saves the created key a
     getServiceWorker: async () => serviceWorker,
     openSitePage: async () => {
       const sitePage = await context.newPage()
-      installExtensionPageGuards(sitePage)
       await forceExtensionLanguage(sitePage, "en")
       await sitePage.addInitScript(() => {
         window.localStorage.setItem(

--- a/e2e/accountToApiProfileJourney.spec.ts
+++ b/e2e/accountToApiProfileJourney.spec.ts
@@ -117,6 +117,8 @@ test("adds an account, creates a reusable API profile from its key, and verifies
   extensionId,
   page,
 }) => {
+  test.slow()
+
   const serviceWorker = await getServiceWorker(context)
   await seedUserPreferences(serviceWorker, {
     tempWindowFallback: {
@@ -125,7 +127,6 @@ test("adds an account, creates a reusable API profile from its key, and verifies
   })
 
   const sitePage = await context.newPage()
-  installExtensionPageGuards(sitePage)
   await forceExtensionLanguage(sitePage, "en")
   await sitePage.addInitScript(() => {
     window.localStorage.setItem(

--- a/e2e/scenarios/accountAutoDetect.ts
+++ b/e2e/scenarios/accountAutoDetect.ts
@@ -14,6 +14,7 @@ type ServiceWorker = Awaited<ReturnType<typeof getServiceWorker>>
 
 type AccountDetectionContext = void | {
   prepareDetectedDialog?: (dialog: AccountAddDialog) => Promise<void>
+  cleanupDetectableSite?: () => Promise<void>
 }
 
 async function runFinalizers(finalizers: Array<() => Promise<void>>) {
@@ -81,9 +82,10 @@ export async function runAccountAutoDetectScenario(
   const sitePage = await env.openSitePage()
   let fixture: AccountFixture | undefined
   let primaryError: unknown
+  let detectionContext: AccountDetectionContext
 
   try {
-    const detectionContext = await env.prepareDetectableSite(sitePage)
+    detectionContext = await env.prepareDetectableSite(sitePage)
     const savedAccount = await saveAutoDetectedAccountFromApp({
       page: env.extensionPage,
       extensionId: env.extensionId,
@@ -105,6 +107,9 @@ export async function runAccountAutoDetectScenario(
   let cleanupError: unknown
   try {
     await runFinalizers([
+      async () => {
+        await detectionContext?.cleanupDetectableSite?.()
+      },
       async () => {
         await env.cleanup?.()
       },

--- a/e2e/utils/commonUserFlows.ts
+++ b/e2e/utils/commonUserFlows.ts
@@ -79,7 +79,15 @@ type StubNewApiSiteRoutesOptions = {
   pricingModels?: ModelPricing[]
   initialTokens?: ApiToken[]
   groups?: Record<string, { desc: string; ratio: number }>
+  dashboardAuthMode?: "legacy" | "auth-bundle"
 }
+
+export const E2E_NEW_API_RC22_AUTH = {
+  dashboardToken: "dashboard-jwt",
+  managementPat: "management-pat",
+  refreshCookie: "new-api-refresh=refresh-cookie",
+  sessionId: "rc22-session",
+} as const
 
 /** Scenario-specific console-error patterns that should not fail the test. */
 export type ExtensionPageGuardOptions = {
@@ -601,6 +609,8 @@ export async function stubNewApiSiteRoutes(
     default: { desc: "Default", ratio: 1 },
     vip: { desc: "VIP", ratio: 1.5 },
   }
+  const usesAuthBundle = options.dashboardAuthMode === "auth-bundle"
+  let dashboardSessionActive = usesAuthBundle
 
   let nextTokenId =
     Math.max(0, ...(options.initialTokens ?? []).map((token) => token.id)) + 1
@@ -616,6 +626,13 @@ export async function stubNewApiSiteRoutes(
       await route.fulfill({
         status: 200,
         contentType: "text/html",
+        ...(usesAuthBundle
+          ? {
+              headers: {
+                "set-cookie": `${E2E_NEW_API_RC22_AUTH.refreshCookie}; HttpOnly; Secure; SameSite=Lax; Path=/`,
+              },
+            }
+          : {}),
         body: `<!doctype html><html><head><title>${title}</title></head><body>${systemName}</body></html>`,
       })
       return
@@ -640,7 +657,124 @@ export async function stubNewApiSiteRoutes(
       return
     }
 
+    if (
+      usesAuthBundle &&
+      method === "POST" &&
+      url.pathname === "/api/user/auth/refresh"
+    ) {
+      const hasRefreshCookie = request
+        .headers()
+        ["cookie"]?.includes(E2E_NEW_API_RC22_AUTH.refreshCookie)
+
+      if (!dashboardSessionActive || !hasRefreshCookie) {
+        await route.fulfill({
+          status: 401,
+          contentType: "application/json",
+          body: JSON.stringify({
+            success: false,
+            code: "AUTH_REQUIRED",
+            message: "Dashboard session is unavailable",
+          }),
+        })
+        return
+      }
+
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: true,
+          data: {
+            access_token: E2E_NEW_API_RC22_AUTH.dashboardToken,
+            token_type: "Bearer",
+            access_expires_at: Math.floor(Date.now() / 1000) + 900,
+            user: {
+              id: userId,
+              username,
+              quota: accountQuota,
+            },
+            session: {
+              sid: E2E_NEW_API_RC22_AUTH.sessionId,
+              current: true,
+            },
+          },
+        }),
+      })
+      return
+    }
+
+    if (
+      usesAuthBundle &&
+      method === "POST" &&
+      url.pathname === "/api/user/auth/logout"
+    ) {
+      const headers = request.headers()
+      const isOwnedSession =
+        dashboardSessionActive &&
+        headers["authorization"] ===
+          `Bearer ${E2E_NEW_API_RC22_AUTH.dashboardToken}` &&
+        headers["x-auth-session"] === E2E_NEW_API_RC22_AUTH.sessionId &&
+        headers["origin"] === origin
+
+      if (!isOwnedSession) {
+        await route.fulfill({
+          status: 401,
+          contentType: "application/json",
+          body: JSON.stringify({
+            success: false,
+            code: "AUTH_REQUIRED",
+            message: "Dashboard session is unavailable",
+          }),
+        })
+        return
+      }
+
+      dashboardSessionActive = false
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ success: true, message: "logged out" }),
+      })
+      return
+    }
+
     if (method === "GET" && url.pathname === "/api/user/self") {
+      if (usesAuthBundle) {
+        const authorization = request.headers()["authorization"]
+        const isDashboardRequest =
+          dashboardSessionActive &&
+          authorization === `Bearer ${E2E_NEW_API_RC22_AUTH.dashboardToken}`
+        const isPatRequest = authorization === `Bearer ${accessToken}`
+
+        if (!isDashboardRequest && !isPatRequest) {
+          await route.fulfill({
+            status: 401,
+            contentType: "application/json",
+            body: JSON.stringify({
+              success: false,
+              message: "Authentication required",
+            }),
+          })
+          return
+        }
+
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            success: true,
+            message: "ok",
+            data: {
+              id: userId,
+              username,
+              ...(isPatRequest ? { access_token: accessToken } : {}),
+              quota: accountQuota,
+            },
+          }),
+        })
+        return
+      }
+
       await route.fulfill({
         status: 200,
         contentType: "application/json",
@@ -658,6 +792,39 @@ export async function stubNewApiSiteRoutes(
       return
     }
 
+    if (
+      usesAuthBundle &&
+      method === "GET" &&
+      url.pathname === "/api/user/token"
+    ) {
+      const isDashboardRequest =
+        dashboardSessionActive &&
+        request.headers()["authorization"] ===
+          `Bearer ${E2E_NEW_API_RC22_AUTH.dashboardToken}`
+
+      await route.fulfill(
+        isDashboardRequest
+          ? {
+              status: 200,
+              contentType: "application/json",
+              body: JSON.stringify({
+                success: true,
+                message: "ok",
+                data: accessToken,
+              }),
+            }
+          : {
+              status: 401,
+              contentType: "application/json",
+              body: JSON.stringify({
+                success: false,
+                message: "Dashboard authentication required",
+              }),
+            },
+      )
+      return
+    }
+
     if (method === "GET" && url.pathname === "/api/status") {
       await route.fulfill({
         status: 200,
@@ -670,6 +837,21 @@ export async function stubNewApiSiteRoutes(
             price: exchangeRate,
             checkin_enabled: false,
           },
+        }),
+      })
+      return
+    }
+
+    if (
+      usesAuthBundle &&
+      request.headers()["authorization"] !== `Bearer ${accessToken}`
+    ) {
+      await route.fulfill({
+        status: 401,
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: false,
+          message: "Management PAT required",
         }),
       })
       return

--- a/e2e/utils/commonUserFlows.ts
+++ b/e2e/utils/commonUserFlows.ts
@@ -621,6 +621,10 @@ export async function stubNewApiSiteRoutes(
     const request = route.request()
     const url = new URL(request.url())
     const method = request.method()
+    const isDashboardAuthorized =
+      dashboardSessionActive &&
+      request.headers()["authorization"] ===
+        `Bearer ${E2E_NEW_API_RC22_AUTH.dashboardToken}`
 
     if (method === "GET" && url.pathname === "/") {
       await route.fulfill({
@@ -710,9 +714,7 @@ export async function stubNewApiSiteRoutes(
     ) {
       const headers = request.headers()
       const isOwnedSession =
-        dashboardSessionActive &&
-        headers["authorization"] ===
-          `Bearer ${E2E_NEW_API_RC22_AUTH.dashboardToken}` &&
+        isDashboardAuthorized &&
         headers["x-auth-session"] === E2E_NEW_API_RC22_AUTH.sessionId &&
         headers["origin"] === origin
 
@@ -741,12 +743,9 @@ export async function stubNewApiSiteRoutes(
     if (method === "GET" && url.pathname === "/api/user/self") {
       if (usesAuthBundle) {
         const authorization = request.headers()["authorization"]
-        const isDashboardRequest =
-          dashboardSessionActive &&
-          authorization === `Bearer ${E2E_NEW_API_RC22_AUTH.dashboardToken}`
         const isPatRequest = authorization === `Bearer ${accessToken}`
 
-        if (!isDashboardRequest && !isPatRequest) {
+        if (!isDashboardAuthorized && !isPatRequest) {
           await route.fulfill({
             status: 401,
             contentType: "application/json",
@@ -797,13 +796,8 @@ export async function stubNewApiSiteRoutes(
       method === "GET" &&
       url.pathname === "/api/user/token"
     ) {
-      const isDashboardRequest =
-        dashboardSessionActive &&
-        request.headers()["authorization"] ===
-          `Bearer ${E2E_NEW_API_RC22_AUTH.dashboardToken}`
-
       await route.fulfill(
-        isDashboardRequest
+        isDashboardAuthorized
           ? {
               status: 200,
               contentType: "application/json",

--- a/e2e/utils/realSite/accountSaveFlow.ts
+++ b/e2e/utils/realSite/accountSaveFlow.ts
@@ -17,6 +17,7 @@ type ServiceWorker = Awaited<ReturnType<typeof getServiceWorker>>
 
 type RealSiteAccountSaveLoginResult = void | {
   prepareDetectedDialog?: (dialog: AccountAddDialog) => Promise<void>
+  cleanupDetectableSite?: () => Promise<void>
 }
 
 const REAL_SITE_ACCOUNT_DETECTION_CONSOLE_ERROR_PATTERNS = [

--- a/e2e/utils/realSite/compatibleAccountSaveFlow.ts
+++ b/e2e/utils/realSite/compatibleAccountSaveFlow.ts
@@ -12,6 +12,7 @@ type ServiceWorker = Awaited<ReturnType<typeof getServiceWorker>>
 
 type CompatibleRealSiteLoginResult = {
   user: Record<string, unknown>
+  cleanupOwnedSession?: () => Promise<void>
 }
 
 export async function runCompatibleRealSiteAccountSaveFlow(params: {
@@ -40,6 +41,9 @@ export async function runCompatibleRealSiteAccountSaveFlow(params: {
     login: async (sitePage) => {
       const loginResult = await params.login(sitePage, params.config)
       expect(loginResult.user).toBeTruthy()
+      return {
+        cleanupDetectableSite: loginResult.cleanupOwnedSession,
+      }
     },
   })
 }

--- a/e2e/utils/realSite/compatibleApi.ts
+++ b/e2e/utils/realSite/compatibleApi.ts
@@ -20,6 +20,13 @@ import {
 const DEFAULT_LOGIN_PATH = "/login"
 const DEFAULT_LOGIN_API_PATH = "/api/user/login"
 const DEFAULT_LOGIN_2FA_API_PATH = "/api/user/login/2fa"
+const AUTH_REFRESH_PATH = "/api/user/auth/refresh"
+const AUTH_LOGOUT_PATH = "/api/user/auth/logout"
+const AUTH_BUNDLE_MARKER_FIELDS = [
+  "access_token",
+  "token_type",
+  "access_expires_at",
+] as const
 
 type RequiredRealSiteEnvKey<TPrefix extends string> =
   | `AAH_E2E_${TPrefix}_BASE_URL`
@@ -48,6 +55,7 @@ export interface CompatibleApiRealSiteConfig {
 export interface CompatibleApiRealSiteLoginResult {
   reusedSession: boolean
   user: Record<string, unknown>
+  cleanupOwnedSession?: () => Promise<void>
 }
 
 type CompatibleApiLoginApiPayload = {
@@ -61,7 +69,29 @@ type CompatibleApiResolverOptions<TPrefix extends string> = {
 type CompatibleApiLoginOptions = {
   label: string
   envPrefix: string
+  authBundle?: boolean
 }
+
+type CompatibleAuthBundle = {
+  kind: "authBundle"
+  user: Record<string, unknown>
+  accessToken: string
+  sessionId: string
+}
+
+type CompatibleLegacyUser = {
+  kind: "legacyUser"
+  user: Record<string, unknown>
+}
+
+type CompatibleLoginPayload = CompatibleAuthBundle | CompatibleLegacyUser
+type CompatibleLoginPayloadMode = "authBundleFirst" | "legacyFirst"
+
+type AuthBundleProbeResult =
+  | CompatibleAuthBundle
+  | { kind: "anonymous" | "legacyFallback" }
+
+class TerminalCompatibleApiLoginError extends Error {}
 
 export function resolveCompatibleApiRealSiteConfig<TPrefix extends string>({
   envPrefix,
@@ -129,25 +159,50 @@ export async function loginToCompatibleApiRealSite(
   options: CompatibleApiLoginOptions,
 ): Promise<CompatibleApiRealSiteLoginResult> {
   await ensureRealSiteOriginPage(page, config.loginUrl)
+  let loginPayloadMode: CompatibleLoginPayloadMode = options.authBundle
+    ? "authBundleFirst"
+    : "legacyFirst"
 
-  const existingUser = await waitForStoredUser(page, 2_500)
-  if (existingUser) {
-    return {
-      reusedSession: true,
-      user: existingUser,
+  if (options.authBundle) {
+    const probeResult = await probeCompatibleAuthBundle(page, config, options)
+    if (probeResult.kind === "authBundle") {
+      return createAuthBundleLoginResult(
+        page,
+        config,
+        options,
+        probeResult,
+        true,
+      )
+    }
+
+    if (probeResult.kind === "legacyFallback") {
+      loginPayloadMode = "legacyFirst"
+      const existingUser = await waitForStoredUser(page, 2_500)
+      if (existingUser) {
+        return {
+          reusedSession: true,
+          user: existingUser,
+        }
+      }
+    }
+  } else {
+    const existingUser = await waitForStoredUser(page, 2_500)
+    if (existingUser) {
+      return {
+        reusedSession: true,
+        user: existingUser,
+      }
     }
   }
 
-  const apiUser = await tryLoginToCompatibleApiRealSiteViaApi(
+  const apiLoginResult = await tryLoginToCompatibleApiRealSiteViaApi(
     page,
     config,
     options,
+    loginPayloadMode,
   )
-  if (apiUser) {
-    return {
-      reusedSession: false,
-      user: apiUser,
-    }
+  if (apiLoginResult) {
+    return apiLoginResult
   }
 
   const locatorFactory = createLocatorFactory(`AAH_E2E_${options.envPrefix}`)
@@ -186,6 +241,25 @@ export async function loginToCompatibleApiRealSite(
 
   await maybeSubmitTotp(page, config, options)
 
+  if (options.authBundle) {
+    const probeResult = await probeCompatibleAuthBundle(page, config, options)
+    if (probeResult.kind === "authBundle") {
+      return createAuthBundleLoginResult(
+        page,
+        config,
+        options,
+        probeResult,
+        false,
+      )
+    }
+
+    if (probeResult.kind === "anonymous") {
+      throw new TerminalCompatibleApiLoginError(
+        `Real ${options.label} login did not create an authenticated session.`,
+      )
+    }
+  }
+
   const user = await waitForStoredUser(page, 30_000)
   if (!user) {
     throw new Error(
@@ -203,7 +277,8 @@ async function tryLoginToCompatibleApiRealSiteViaApi(
   page: Page,
   config: CompatibleApiRealSiteConfig,
   options: CompatibleApiLoginOptions,
-): Promise<Record<string, unknown> | null> {
+  payloadMode: CompatibleLoginPayloadMode,
+): Promise<CompatibleApiRealSiteLoginResult | null> {
   const loginApiUrls = Array.from(
     new Set([
       config.loginApiUrl,
@@ -222,15 +297,46 @@ async function tryLoginToCompatibleApiRealSiteViaApi(
         },
         failOnStatusCode: false,
       })
-      const responseText = await response.text()
-      const payload = extractCompatibleApiPayload(safeParseJson(responseText))
+      let responseText = await response.text()
+      let responseStatus = response.status()
+      let responseOk = response.ok()
+      let payload = extractCompatibleApiPayload(safeParseJson(responseText))
       const loginPayload = payload as CompatibleApiLoginApiPayload | null
 
       if (loginPayload?.require_2fa) {
-        await completeCompatibleApiLogin2fa(page, config, options)
-      } else if (!response.ok()) {
-        lastErrorMessage = buildCompatibleApiLoginApiErrorMessage(
-          response.status(),
+        let twoFactorResponse
+        try {
+          twoFactorResponse = await completeCompatibleApiLogin2fa(
+            page,
+            config,
+            options,
+          )
+        } catch (error) {
+          if (
+            options.authBundle &&
+            !(error instanceof TerminalCompatibleApiLoginError)
+          ) {
+            throw new TerminalCompatibleApiLoginError(
+              `Real ${options.label} 2FA request failed.`,
+            )
+          }
+          throw error
+        }
+        responseText = twoFactorResponse.responseText
+        responseStatus = twoFactorResponse.status
+        responseOk = twoFactorResponse.ok
+        payload = extractCompatibleApiPayload(safeParseJson(responseText))
+      } else if (!responseOk) {
+        if (options.authBundle && isTerminalAuthBundleStatus(responseStatus)) {
+          throw createAuthSessionStatusError(
+            options,
+            responseStatus,
+            responseText,
+          )
+        }
+
+        lastErrorMessage = buildCompatibleApiAttemptErrorMessage(
+          responseStatus,
           responseText,
           loginApiUrl,
           options,
@@ -238,12 +344,32 @@ async function tryLoginToCompatibleApiRealSiteViaApi(
         continue
       }
 
+      const parsedPayload = parseCompatibleLoginPayload(payload, payloadMode)
+      if (options.authBundle && responseOk) {
+        if (parsedPayload?.kind === "authBundle") {
+          return createAuthBundleLoginResult(
+            page,
+            config,
+            options,
+            parsedPayload,
+            false,
+          )
+        }
+
+        if (!parsedPayload) {
+          throw new TerminalCompatibleApiLoginError(
+            `Real ${options.label} auth session response is invalid.`,
+          )
+        }
+      }
+
       const user =
-        parseCompatibleApiUser(payload) ??
-        (await fetchCompatibleApiUser(page, config))
+        parsedPayload?.kind === "legacyUser"
+          ? parsedPayload.user
+          : await fetchCompatibleApiUser(page, config)
       if (!user) {
-        lastErrorMessage = buildCompatibleApiLoginApiErrorMessage(
-          response.status(),
+        lastErrorMessage = buildCompatibleApiAttemptErrorMessage(
+          responseStatus,
           responseText,
           loginApiUrl,
           options,
@@ -256,10 +382,21 @@ async function tryLoginToCompatibleApiRealSiteViaApi(
         user: JSON.stringify(user),
       })
 
-      return user
+      return {
+        reusedSession: false,
+        user,
+      }
     } catch (error) {
+      if (error instanceof TerminalCompatibleApiLoginError) {
+        throw error
+      }
+
       lastErrorMessage = `${options.label} login API request failed at ${loginApiUrl}: ${
-        error instanceof Error ? error.message : String(error)
+        options.authBundle
+          ? "request failed"
+          : error instanceof Error
+            ? error.message
+            : String(error)
       }`
     }
   }
@@ -292,15 +429,100 @@ function parseCompatibleApiUser(payload: unknown) {
   return user
 }
 
+function parseCompatibleLoginPayload(
+  payload: unknown,
+  mode: CompatibleLoginPayloadMode,
+): CompatibleLoginPayload | null {
+  if (!isRecord(payload)) {
+    return null
+  }
+
+  const legacyUser = parseCompatibleApiUser(payload)
+  if (mode === "legacyFirst" && legacyUser) {
+    return { kind: "legacyUser", user: legacyUser }
+  }
+
+  if (isRecognizableAuthBundleAttempt(payload)) {
+    const accessToken = getNonBlankString(payload.access_token)
+    const tokenType = payload.token_type
+    const accessExpiresAt = payload.access_expires_at
+    const user = parseAuthBundleUser(payload.user)
+    const session = isRecord(payload.session) ? payload.session : null
+    const sessionId = session ? getNonBlankString(session.sid) : null
+
+    if (
+      !accessToken ||
+      tokenType !== "Bearer" ||
+      typeof accessExpiresAt !== "number" ||
+      !Number.isFinite(accessExpiresAt) ||
+      accessExpiresAt <= Date.now() / 1_000 ||
+      !user ||
+      !sessionId ||
+      session?.current !== true
+    ) {
+      return null
+    }
+
+    return {
+      kind: "authBundle",
+      user,
+      accessToken,
+      sessionId,
+    }
+  }
+
+  if (legacyUser) {
+    return { kind: "legacyUser", user: legacyUser }
+  }
+
+  return null
+}
+
+function parseAuthBundleUser(payload: unknown) {
+  if (!isRecord(payload)) {
+    return null
+  }
+
+  const username = getNonBlankString(payload.username)
+  if (payload.id == null && !username) {
+    return null
+  }
+
+  return payload
+}
+
+function isRecognizableAuthBundleAttempt(payload: unknown) {
+  if (!isRecord(payload)) {
+    return false
+  }
+
+  if (
+    AUTH_BUNDLE_MARKER_FIELDS.some((field) =>
+      Object.prototype.hasOwnProperty.call(payload, field),
+    )
+  ) {
+    return true
+  }
+
+  return Boolean(
+    isRecord(payload.session) &&
+      (Object.prototype.hasOwnProperty.call(payload.session, "sid") ||
+        Object.prototype.hasOwnProperty.call(payload.session, "current")),
+  )
+}
+
 async function completeCompatibleApiLogin2fa(
   page: Page,
   config: Pick<CompatibleApiRealSiteConfig, "login2faApiUrl" | "totpSecret">,
   options: CompatibleApiLoginOptions,
-) {
+): Promise<{ ok: boolean; status: number; responseText: string }> {
   if (!config.totpSecret) {
-    throw new Error(
+    const error = new Error(
       `Real ${options.label} login requires 2FA, but AAH_E2E_${options.envPrefix}_TOTP_SECRET is not set.`,
     )
+    throw options.authBundle
+      ? new TerminalCompatibleApiLoginError(error.message)
+      : error
   }
 
   const response = await page.request.post(config.login2faApiUrl, {
@@ -310,8 +532,17 @@ async function completeCompatibleApiLogin2fa(
     failOnStatusCode: false,
   })
 
+  const responseText = await response.text()
+
   if (!response.ok()) {
-    const responseText = await response.text()
+    if (options.authBundle) {
+      throw createAuthSessionStatusError(
+        options,
+        response.status(),
+        responseText,
+      )
+    }
+
     throw new Error(
       buildCompatibleApiLoginApiErrorMessage(
         response.status(),
@@ -321,6 +552,171 @@ async function completeCompatibleApiLogin2fa(
       ),
     )
   }
+
+  return {
+    ok: true,
+    status: response.status(),
+    responseText,
+  }
+}
+
+async function probeCompatibleAuthBundle(
+  page: Page,
+  config: Pick<CompatibleApiRealSiteConfig, "baseUrl">,
+  options: CompatibleApiLoginOptions,
+): Promise<AuthBundleProbeResult> {
+  // Pinned rc.22 contract: https://github.com/QuantumNous/new-api/blob/v1.0.0-rc.22/docs/authentication.md
+  const origin = new URL(config.baseUrl).origin
+  let response
+
+  try {
+    response = await page.request.post(
+      resolveRealSiteUrl(config.baseUrl, AUTH_REFRESH_PATH),
+      {
+        failOnStatusCode: false,
+        headers: { Origin: origin },
+      },
+    )
+  } catch {
+    throw new TerminalCompatibleApiLoginError(
+      `Real ${options.label} auth session refresh request failed.`,
+    )
+  }
+
+  const status = response.status()
+  if (status === 401) {
+    return { kind: "anonymous" }
+  }
+  if (status === 404 || status === 405) {
+    return { kind: "legacyFallback" }
+  }
+
+  const responseText = await response.text()
+  if (!response.ok()) {
+    throw createAuthSessionStatusError(options, status, responseText)
+  }
+
+  const rawResponse = safeParseJson(responseText)
+  const rawPayload =
+    isRecord(rawResponse) && "data" in rawResponse
+      ? rawResponse.data
+      : rawResponse
+  const payload = extractCompatibleApiPayload(rawResponse)
+  const parsedPayload = parseCompatibleLoginPayload(payload, "authBundleFirst")
+  if (parsedPayload?.kind === "authBundle") {
+    return parsedPayload
+  }
+
+  if (
+    isRecognizableAuthBundleAttempt(payload) ||
+    isRecognizableAuthBundleAttempt(rawPayload)
+  ) {
+    throw new TerminalCompatibleApiLoginError(
+      `Real ${options.label} auth session response is invalid.`,
+    )
+  }
+
+  return { kind: "legacyFallback" }
+}
+
+function createAuthBundleLoginResult(
+  page: Page,
+  config: Pick<CompatibleApiRealSiteConfig, "baseUrl">,
+  options: CompatibleApiLoginOptions,
+  authBundle: CompatibleAuthBundle,
+  reusedSession: boolean,
+): CompatibleApiRealSiteLoginResult {
+  return {
+    reusedSession,
+    user: authBundle.user,
+    ...(reusedSession
+      ? {}
+      : {
+          cleanupOwnedSession: createOwnedAuthSessionCleanup(
+            page,
+            config,
+            options,
+            authBundle,
+          ),
+        }),
+  }
+}
+
+function createOwnedAuthSessionCleanup(
+  page: Page,
+  config: Pick<CompatibleApiRealSiteConfig, "baseUrl">,
+  options: CompatibleApiLoginOptions,
+  authBundle: CompatibleAuthBundle,
+) {
+  return async () => {
+    const origin = new URL(config.baseUrl).origin
+    let response
+
+    try {
+      response = await page.request.post(
+        resolveRealSiteUrl(config.baseUrl, AUTH_LOGOUT_PATH),
+        {
+          failOnStatusCode: false,
+          headers: {
+            Origin: origin,
+            Authorization: `Bearer ${authBundle.accessToken}`,
+            "X-Auth-Session": authBundle.sessionId,
+          },
+        },
+      )
+    } catch {
+      throw new Error(`Real ${options.label} auth session cleanup failed.`)
+    }
+
+    if (!response.ok()) {
+      const responseText = await response.text()
+      throw createAuthSessionStatusError(
+        options,
+        response.status(),
+        responseText,
+        "cleanup",
+      )
+    }
+  }
+}
+
+function createAuthSessionStatusError(
+  options: CompatibleApiLoginOptions,
+  status: number,
+  responseText: string,
+  action = "request",
+) {
+  const code = getSafeAuthErrorCode(responseText)
+  return new TerminalCompatibleApiLoginError(
+    `${options.label} auth session ${action} failed (HTTP ${status}${code ? `, ${code}` : ""})`,
+  )
+}
+
+function getSafeAuthErrorCode(responseText: string) {
+  const parsed = safeParseJson(responseText)
+  if (!isRecord(parsed)) {
+    return null
+  }
+
+  const code = getNonBlankString(parsed.code)
+  return code && /^[A-Z][A-Z0-9_]{0,79}$/u.test(code) ? code : null
+}
+
+function isTerminalAuthBundleStatus(status: number) {
+  return status === 409 || status === 429 || status >= 500
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value))
+}
+
+function getNonBlankString(value: unknown) {
+  if (typeof value !== "string") {
+    return null
+  }
+
+  const trimmed = value.trim()
+  return trimmed || null
 }
 
 async function fetchCompatibleApiUser(
@@ -502,6 +898,32 @@ function buildCompatibleApiLoginApiErrorMessage(
   }
 
   return `${options.label} login API at ${loginApiUrl} returned HTTP ${status}: ${normalizedText.slice(0, 280)}`
+}
+
+function buildCompatibleApiAttemptErrorMessage(
+  status: number,
+  responseText: string,
+  loginApiUrl: string,
+  options: CompatibleApiLoginOptions,
+) {
+  if (!options.authBundle) {
+    return buildCompatibleApiLoginApiErrorMessage(
+      status,
+      responseText,
+      loginApiUrl,
+      options,
+    )
+  }
+
+  if (
+    /verify you are human|performing security verification|cloudflare/iu.test(
+      responseText,
+    )
+  ) {
+    return `${options.label} login API at ${loginApiUrl} is blocked by a security verification page (HTTP ${status}).`
+  }
+
+  return `${options.label} login API at ${loginApiUrl} returned HTTP ${status}.`
 }
 
 async function looksLikeSecurityVerificationPage(page: Page) {

--- a/e2e/utils/realSite/compatibleApi.ts
+++ b/e2e/utils/realSite/compatibleApi.ts
@@ -22,6 +22,8 @@ const DEFAULT_LOGIN_API_PATH = "/api/user/login"
 const DEFAULT_LOGIN_2FA_API_PATH = "/api/user/login/2fa"
 const AUTH_REFRESH_PATH = "/api/user/auth/refresh"
 const AUTH_LOGOUT_PATH = "/api/user/auth/logout"
+const SECURITY_VERIFICATION_BODY_PATTERN =
+  /verify you are human|performing security verification|cloudflare/iu
 const AUTH_BUNDLE_MARKER_FIELDS = [
   "access_token",
   "token_type",
@@ -299,7 +301,7 @@ async function tryLoginToCompatibleApiRealSiteViaApi(
       })
       let responseText = await response.text()
       let responseStatus = response.status()
-      let responseOk = response.ok()
+      const responseOk = response.ok()
       let payload = extractCompatibleApiPayload(safeParseJson(responseText))
       const loginPayload = payload as CompatibleApiLoginApiPayload | null
 
@@ -324,7 +326,6 @@ async function tryLoginToCompatibleApiRealSiteViaApi(
         }
         responseText = twoFactorResponse.responseText
         responseStatus = twoFactorResponse.status
-        responseOk = twoFactorResponse.ok
         payload = extractCompatibleApiPayload(safeParseJson(responseText))
       } else if (!responseOk) {
         if (options.authBundle && isTerminalAuthBundleStatus(responseStatus)) {
@@ -345,7 +346,7 @@ async function tryLoginToCompatibleApiRealSiteViaApi(
       }
 
       const parsedPayload = parseCompatibleLoginPayload(payload, payloadMode)
-      if (options.authBundle && responseOk) {
+      if (options.authBundle) {
         if (parsedPayload?.kind === "authBundle") {
           return createAuthBundleLoginResult(
             page,
@@ -881,11 +882,7 @@ function buildCompatibleApiLoginApiErrorMessage(
 ) {
   const normalizedText = responseText.trim()
 
-  if (
-    /verify you are human|performing security verification|cloudflare/iu.test(
-      normalizedText,
-    )
-  ) {
+  if (SECURITY_VERIFICATION_BODY_PATTERN.test(normalizedText)) {
     return `${options.label} login API at ${loginApiUrl} is blocked by a security verification page (HTTP ${status}).`
   }
 
@@ -915,11 +912,7 @@ function buildCompatibleApiAttemptErrorMessage(
     )
   }
 
-  if (
-    /verify you are human|performing security verification|cloudflare/iu.test(
-      responseText,
-    )
-  ) {
+  if (SECURITY_VERIFICATION_BODY_PATTERN.test(responseText)) {
     return `${options.label} login API at ${loginApiUrl} is blocked by a security verification page (HTTP ${status}).`
   }
 
@@ -936,7 +929,5 @@ async function looksLikeSecurityVerificationPage(page: Page) {
     .locator("body")
     .textContent()
     .catch(() => "")
-  return /verify you are human|performing security verification|cloudflare/iu.test(
-    bodyText ?? "",
-  )
+  return SECURITY_VERIFICATION_BODY_PATTERN.test(bodyText ?? "")
 }

--- a/e2e/utils/realSite/newApi.ts
+++ b/e2e/utils/realSite/newApi.ts
@@ -61,5 +61,6 @@ export async function loginToRealNewApiSite(
   return await loginToCompatibleApiRealSite(page, config, {
     label: NEW_API_LABEL,
     envPrefix: NEW_API_ENV_PREFIX,
+    authBundle: true,
   })
 }

--- a/src/entrypoints/background/tempWindowPool.ts
+++ b/src/entrypoints/background/tempWindowPool.ts
@@ -1960,6 +1960,7 @@ async function getSiteDataFromTab(
       userId: userResponse.data?.userId,
       user: userResponse.data?.user,
       accessToken: userResponse.data?.accessToken,
+      transientAuth: userResponse.data?.transientAuth,
       sub2apiAuth: userResponse.data?.sub2apiAuth,
       siteTypeHint: userResponse.data?.siteTypeHint,
     }

--- a/src/services/accountBrowserSession/sessionReader.ts
+++ b/src/services/accountBrowserSession/sessionReader.ts
@@ -11,6 +11,7 @@ import {
 import { createLogger } from "~/utils/core/logger"
 import { tryParseOrigin } from "~/utils/core/urlParsing"
 
+import { normalizeContentSessionTransientAuth } from "./transientAuth"
 import type {
   AccountBrowserSession,
   AccountBrowserSessionFetchContext,
@@ -95,6 +96,7 @@ const normalizeSessionData = (
   data: unknown,
   options: {
     source: AccountBrowserSession["source"]
+    baseUrl: string
     siteType: AccountBrowserSession["siteType"]
     fetchContext?: AccountBrowserSessionFetchContext
   },
@@ -107,6 +109,7 @@ const normalizeSessionData = (
     accessToken?: unknown
     siteTypeHint?: unknown
     siteType?: unknown
+    transientAuth?: unknown
     sub2apiAuth?: unknown
     fetchContext?: unknown
   }
@@ -127,6 +130,13 @@ const normalizeSessionData = (
       ? payload.siteType
       : undefined
   const sub2apiAuth = normalizeSub2ApiAuth(payload.sub2apiAuth)
+  const transientAuth = normalizeContentSessionTransientAuth(
+    payload.transientAuth,
+    {
+      baseUrl: options.baseUrl,
+      siteType: options.siteType,
+    },
+  )
   const fetchContext =
     options.fetchContext ?? normalizeFetchContext(payload.fetchContext)
 
@@ -137,6 +147,7 @@ const normalizeSessionData = (
     userId,
     user,
     ...(accessToken ? { accessToken } : {}),
+    ...(transientAuth ? { transientAuth } : {}),
     ...(sub2apiAuth ? { sub2apiAuth } : {}),
     ...(fetchContext ? { fetchContext } : {}),
   }
@@ -159,6 +170,7 @@ export async function readAccountBrowserSessionFromTab(
 
     return normalizeSessionData(response.data, {
       source: options.source,
+      baseUrl: options.baseUrl,
       siteType: options.siteType,
       fetchContext: options.fetchContext,
     })
@@ -294,6 +306,7 @@ const readAccountBrowserSessionFromTempWindow = async (
 
     return normalizeSessionData(response.data, {
       source: ACCOUNT_BROWSER_SESSION_SOURCES.TEMP_WINDOW,
+      baseUrl: options.baseUrl,
       siteType: options.siteType,
     })
   } catch (error) {

--- a/src/services/accountBrowserSession/transientAuth.ts
+++ b/src/services/accountBrowserSession/transientAuth.ts
@@ -1,0 +1,75 @@
+import { SITE_TYPES, type AccountSiteType } from "~/constants/siteType"
+import {
+  NEW_API_DASHBOARD_TRANSIENT_AUTH_KIND,
+  type ContentSessionTransientAuth,
+} from "~/services/accountSiteOnboarding/contracts"
+
+const REQUIRED_TRANSIENT_AUTH_FIELDS = [
+  "kind",
+  "token",
+  "expiresAt",
+  "sessionId",
+  "origin",
+] as const
+
+type NormalizeTransientAuthOptions = {
+  baseUrl: string
+  siteType: AccountSiteType
+}
+
+/**
+ * Validates completion-only dashboard auth against the requested New API site.
+ */
+export function normalizeContentSessionTransientAuth(
+  value: unknown,
+  options: NormalizeTransientAuthOptions,
+): ContentSessionTransientAuth | undefined {
+  if (
+    options.siteType !== SITE_TYPES.NEW_API ||
+    !value ||
+    typeof value !== "object" ||
+    Array.isArray(value) ||
+    !REQUIRED_TRANSIENT_AUTH_FIELDS.every((field) =>
+      Object.prototype.hasOwnProperty.call(value, field),
+    )
+  ) {
+    return undefined
+  }
+
+  const candidate = value as Record<
+    (typeof REQUIRED_TRANSIENT_AUTH_FIELDS)[number],
+    unknown
+  >
+
+  try {
+    if (
+      candidate.kind !== NEW_API_DASHBOARD_TRANSIENT_AUTH_KIND ||
+      typeof candidate.token !== "string" ||
+      typeof candidate.sessionId !== "string" ||
+      typeof candidate.origin !== "string" ||
+      typeof candidate.expiresAt !== "number" ||
+      !Number.isFinite(candidate.expiresAt)
+    ) {
+      return undefined
+    }
+
+    const token = candidate.token.trim()
+    const sessionId = candidate.sessionId.trim()
+    const originValue = candidate.origin.trim()
+    if (!token || !sessionId || !originValue) return undefined
+
+    const origin = new URL(originValue).origin
+    const expectedOrigin = new URL(options.baseUrl).origin
+    if (origin !== expectedOrigin) return undefined
+
+    return {
+      kind: NEW_API_DASHBOARD_TRANSIENT_AUTH_KIND,
+      token,
+      expiresAt: candidate.expiresAt,
+      sessionId,
+      origin,
+    }
+  } catch {
+    return undefined
+  }
+}

--- a/src/services/accountBrowserSession/types.ts
+++ b/src/services/accountBrowserSession/types.ts
@@ -1,4 +1,5 @@
 import type { AccountSiteType } from "~/constants/siteType"
+import type { ContentSessionTransientAuth } from "~/services/accountSiteOnboarding/contracts"
 import type { ApiServiceFetchContext } from "~/services/apiTransport/type"
 import type { Sub2ApiAuthConfig } from "~/types"
 import type { TempWindowRequestSource } from "~/types/tempWindowFetch"
@@ -21,6 +22,7 @@ export type AccountBrowserSession = {
   userId: string
   user: Record<string, unknown>
   accessToken?: string
+  transientAuth?: ContentSessionTransientAuth
   sub2apiAuth?: Sub2ApiAuthConfig
   fetchContext?: AccountBrowserSessionFetchContext
 }

--- a/src/services/accountSiteOnboarding/contentSession/newApiAuthBundle.ts
+++ b/src/services/accountSiteOnboarding/contentSession/newApiAuthBundle.ts
@@ -1,0 +1,170 @@
+import { SITE_TYPES } from "~/constants/siteType"
+import { resolveStoredAccountUserIdentity } from "~/services/accounts/accountIdentity"
+
+import {
+  NEW_API_DASHBOARD_TRANSIENT_AUTH_KIND,
+  type ContentSessionExtractionResult,
+  type ContentSessionExtractor,
+} from "../contracts"
+
+const NEW_API_AUTH_REFRESH_PATH = "/api/user/auth/refresh"
+const CONTROLLED_ERROR_STATUSES = new Set([401, 409, 429])
+const AUTH_BUNDLE_TOKEN_FIELDS = [
+  "access_token",
+  "token_type",
+  "access_expires_at",
+] as const
+const INVALID_AUTH_BUNDLE_ERROR =
+  "New API dashboard session response is invalid"
+const AUTH_REFRESH_REQUEST_ERROR = "New API session refresh request failed"
+
+type UnknownRecord = Record<string, unknown>
+
+/** Checks that an unknown JSON value is a plain object record. */
+function isRecord(value: unknown): value is UnknownRecord {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value))
+}
+
+/** Returns a trimmed string only when the unknown value is nonblank. */
+function getNonBlankString(value: unknown): string | null {
+  if (typeof value !== "string") return null
+
+  const trimmed = value.trim()
+  return trimmed ? trimmed : null
+}
+
+/** Detects whether a successful response attempted the rc.22 AuthBundle shape. */
+function isRecognizableAuthBundleAttempt(body: unknown): boolean {
+  if (!isRecord(body) || !isRecord(body.data)) return false
+
+  const hasTokenMarker = AUTH_BUNDLE_TOKEN_FIELDS.some((field) =>
+    Object.prototype.hasOwnProperty.call(body.data, field),
+  )
+  if (hasTokenMarker) return true
+
+  const session = body.data.session
+  return Boolean(
+    isRecord(session) &&
+      (Object.prototype.hasOwnProperty.call(session, "sid") ||
+        Object.prototype.hasOwnProperty.call(session, "current")),
+  )
+}
+
+/** Validates and normalizes an rc.22 AuthBundle response. */
+function parseAuthBundle(
+  body: unknown,
+  origin: string,
+): ContentSessionExtractionResult | null {
+  if (!isRecord(body) || body.success !== true || !isRecord(body.data)) {
+    return null
+  }
+
+  const data = body.data
+  const token = getNonBlankString(data.access_token)
+  const expiresAt = data.access_expires_at
+  if (
+    data.token_type !== "Bearer" ||
+    !token ||
+    typeof expiresAt !== "number" ||
+    !Number.isFinite(expiresAt) ||
+    expiresAt <= Date.now() / 1000
+  ) {
+    return null
+  }
+
+  const identity = resolveStoredAccountUserIdentity(
+    data.user,
+    SITE_TYPES.NEW_API,
+  )
+  if (!identity || !isRecord(data.session)) return null
+
+  const sessionId = getNonBlankString(data.session.sid)
+  if (!sessionId || data.session.current !== true) return null
+
+  return {
+    userId: identity.userId,
+    user: identity.user,
+    siteTypeHint: SITE_TYPES.NEW_API,
+    transientAuth: {
+      kind: NEW_API_DASHBOARD_TRANSIENT_AUTH_KIND,
+      token,
+      expiresAt,
+      sessionId,
+      origin,
+    },
+  }
+}
+
+/** Builds a status-only error without exposing the response body. */
+function createRefreshStatusError(status: number): Error {
+  return new Error(`New API session refresh failed (${status})`)
+}
+
+/** Builds a controlled error using only the response's safe public fields. */
+async function createControlledRefreshError(
+  response: Response,
+): Promise<Error> {
+  let body: unknown
+  try {
+    body = await response.json()
+  } catch {
+    body = null
+  }
+
+  const code = isRecord(body) ? getNonBlankString(body.code) : null
+  const message = isRecord(body) ? getNonBlankString(body.message) : null
+  if (code && message) return new Error(`${code}: ${message}`)
+  if (code) return new Error(code)
+  if (message) return new Error(message)
+
+  return createRefreshStatusError(response.status)
+}
+
+/**
+ * Pinned rc.22 AuthBundle contract:
+ * https://github.com/QuantumNous/new-api/blob/v1.0.0-rc.22/docs/authentication.md
+ * https://github.com/QuantumNous/new-api/blob/v1.0.0-rc.22/controller/user.go
+ */
+async function extractNewApiAuthBundle(): Promise<ContentSessionExtractionResult | null> {
+  const origin = location.origin
+  let response: Response
+
+  try {
+    response = await fetch(`${origin}${NEW_API_AUTH_REFRESH_PATH}`, {
+      credentials: "include",
+      method: "POST",
+    })
+  } catch {
+    throw new Error(AUTH_REFRESH_REQUEST_ERROR)
+  }
+
+  if (response.status === 404 || response.status === 405) return null
+  if (!response.ok && CONTROLLED_ERROR_STATUSES.has(response.status)) {
+    throw await createControlledRefreshError(response)
+  }
+  if (!response.ok) {
+    throw createRefreshStatusError(response.status)
+  }
+
+  let body: unknown
+  try {
+    body = await response.json()
+  } catch {
+    throw new Error(INVALID_AUTH_BUNDLE_ERROR)
+  }
+
+  const result = parseAuthBundle(body, origin)
+  if (result) return result
+  if (isRecognizableAuthBundleAttempt(body)) {
+    throw new Error(INVALID_AUTH_BUNDLE_ERROR)
+  }
+
+  return null
+}
+
+export const newApiAuthBundleContentSessionExtractor: ContentSessionExtractor =
+  {
+    id: "new-api-auth-bundle",
+    canExtract: (context) => context.siteTypeHint === SITE_TYPES.NEW_API,
+    extract: extractNewApiAuthBundle,
+  }

--- a/src/services/accountSiteOnboarding/contracts.ts
+++ b/src/services/accountSiteOnboarding/contracts.ts
@@ -10,11 +10,28 @@ export type ContentSessionExtractionContext = {
   siteTypeHint?: AccountSiteType
 }
 
+export const NEW_API_DASHBOARD_TRANSIENT_AUTH_KIND = "new_api_dashboard_bearer"
+
+/**
+ * Completion-only New API dashboard authentication. This must never be
+ * persisted as `account_info.access_token`, which is reserved for the PAT.
+ */
+export type NewApiDashboardTransientAuth = {
+  kind: typeof NEW_API_DASHBOARD_TRANSIENT_AUTH_KIND
+  token: string
+  expiresAt: number
+  sessionId: string
+  origin: string
+}
+
+export type ContentSessionTransientAuth = NewApiDashboardTransientAuth
+
 export type ContentSessionExtractionResult = {
   userId: string | number
   user: Record<string, unknown>
   accessToken?: string
   siteTypeHint?: AccountSiteType
+  transientAuth?: ContentSessionTransientAuth
   sub2apiAuth?: {
     refreshToken: string
     tokenExpiresAt?: number

--- a/src/services/accountSiteOnboarding/registry.ts
+++ b/src/services/accountSiteOnboarding/registry.ts
@@ -5,6 +5,7 @@ import {
 } from "~/services/accountSiteOnboarding/metadata"
 
 import { compatibleUserContentSessionExtractor } from "./contentSession/compatibleUser"
+import { newApiAuthBundleContentSessionExtractor } from "./contentSession/newApiAuthBundle"
 import { sharedChatContentSessionExtractor } from "./contentSession/sharedchat"
 import { sub2ApiContentSessionExtractor } from "./contentSession/sub2api"
 import { voApiV2ContentSessionExtractor } from "./contentSession/voapiV2"
@@ -39,6 +40,7 @@ export function getContentSessionExtractors(): readonly ContentSessionExtractor[
     sub2ApiContentSessionExtractor,
     sharedChatContentSessionExtractor,
     voApiV2ContentSessionExtractor,
+    newApiAuthBundleContentSessionExtractor,
     compatibleUserContentSessionExtractor,
   ]
 }

--- a/src/services/accounts/autoDetectCompletion/types.ts
+++ b/src/services/accounts/autoDetectCompletion/types.ts
@@ -3,6 +3,7 @@ import type {
   AutoDetectFailureReason,
 } from "~/constants/autoDetect"
 import type { AccountSiteType } from "~/constants/siteType"
+import type { ContentSessionTransientAuth } from "~/services/accountSiteOnboarding/contracts"
 import type { ApiServiceFetchContext } from "~/services/apiTransport/type"
 import type { AuthTypeEnum, CheckInConfig, Sub2ApiAuthConfig } from "~/types"
 import { getErrorMessage } from "~/utils/core/error"
@@ -15,6 +16,7 @@ export interface DetectedAccountIdentity {
   }
   siteType: AccountSiteType
   accessToken?: string
+  transientAuth?: ContentSessionTransientAuth
   sub2apiAuth?: Sub2ApiAuthConfig
   fetchContext?: ApiServiceFetchContext
 }

--- a/src/services/apiAdapters/newApi/accountBootstrap.ts
+++ b/src/services/apiAdapters/newApi/accountBootstrap.ts
@@ -9,6 +9,12 @@ import { resolveStaticAccountRoutePath } from "../accountRoutes"
 type AccountBootstrapImplementation =
   typeof accountBootstrap.defaultAccountBootstrapImplementation
 
+interface NewApiAccountBootstrapOptions {
+  accessTokenCreationPolicy?: Parameters<
+    typeof accountBootstrap.getOrCreateAccessToken
+  >[1]
+}
+
 const accountBootstrapOverrides: Partial<
   Record<AccountSiteType, Partial<AccountBootstrapImplementation>>
 > = {
@@ -25,6 +31,7 @@ const accountBootstrapOverrides: Partial<
  */
 export function createNewApiAccountBootstrap(
   siteType: AccountSiteType,
+  options?: NewApiAccountBootstrapOptions,
 ): AccountBootstrapCapability {
   const implementation = {
     ...accountBootstrap.defaultAccountBootstrapImplementation,
@@ -34,7 +41,12 @@ export function createNewApiAccountBootstrap(
   return {
     fetchUserInfo: (request) => implementation.fetchUserInfo(request),
     getOrCreateAccessToken: (request) =>
-      implementation.getOrCreateAccessToken(request),
+      options?.accessTokenCreationPolicy
+        ? implementation.getOrCreateAccessToken(
+            request,
+            options.accessTokenCreationPolicy,
+          )
+        : implementation.getOrCreateAccessToken(request),
     fetchSiteStatus: (request) => implementation.fetchSiteStatus(request),
     fetchCheckInSupport: (request) =>
       implementation.fetchSupportCheckIn(request),

--- a/src/services/apiAdapters/newApi/accountCompletion.ts
+++ b/src/services/apiAdapters/newApi/accountCompletion.ts
@@ -1,14 +1,84 @@
 import { AUTO_DETECT_FAILURE_REASONS } from "~/constants/autoDetect"
+import { SITE_TYPES } from "~/constants/siteType"
 import { UI_CONSTANTS } from "~/constants/ui"
+import { NEW_API_DASHBOARD_TRANSIENT_AUTH_KIND } from "~/services/accountSiteOnboarding/contracts"
+import { ApiError } from "~/services/apiTransport/errors"
 import { AuthTypeEnum } from "~/types"
 
 import type { AccountCompletionCapability } from "../contracts/accountCompletion"
 import { createNewApiAccountBootstrap } from "./accountBootstrap"
 
+const MODERN_AUTH_FRESHNESS_MARGIN_SECONDS = 30
+const MODERN_AUTH_INVALID_MESSAGE =
+  "New API dashboard authentication is invalid"
+const MODERN_AUTH_EXCHANGE_FAILED_MESSAGE =
+  "New API dashboard authentication could not be exchanged"
+
+/** Rebuilds a token-free completion error while retaining safe API categories. */
+function createModernAuthExchangeError(error: unknown): Error {
+  if (!(error instanceof ApiError)) {
+    return new Error(MODERN_AUTH_EXCHANGE_FAILED_MESSAGE)
+  }
+
+  const safeError = new ApiError(
+    MODERN_AUTH_EXCHANGE_FAILED_MESSAGE,
+    error.statusCode,
+    error.endpoint,
+    error.code,
+  )
+  safeError.originalCode = error.originalCode
+  return safeError
+}
+
 export const newApiAccountCompletion: AccountCompletionCapability = {
   async complete(request, helpers) {
     const { url, requestedAuthType, detected, context } = request
-    const accountBootstrap = createNewApiAccountBootstrap(detected.siteType)
+    const modernDashboardAuth =
+      detected.siteType === SITE_TYPES.NEW_API &&
+      detected.transientAuth?.kind === NEW_API_DASHBOARD_TRANSIENT_AUTH_KIND
+        ? detected.transientAuth
+        : undefined
+
+    if (modernDashboardAuth) {
+      let targetOrigin: string
+      try {
+        targetOrigin = new URL(url).origin
+      } catch {
+        throw helpers.createCompletionError(
+          AUTO_DETECT_FAILURE_REASONS.UnexpectedException,
+          new Error(MODERN_AUTH_INVALID_MESSAGE),
+        )
+      }
+
+      if (
+        modernDashboardAuth.origin !== targetOrigin ||
+        !(
+          modernDashboardAuth.expiresAt >
+          Math.floor(Date.now() / 1000) + MODERN_AUTH_FRESHNESS_MARGIN_SECONDS
+        )
+      ) {
+        throw helpers.createCompletionError(
+          AUTO_DETECT_FAILURE_REASONS.TokenFetchFailed,
+          new Error("New API dashboard authentication is no longer valid"),
+        )
+      }
+    }
+
+    const accountBootstrap = modernDashboardAuth
+      ? createNewApiAccountBootstrap(detected.siteType, {
+          // New API rc.22 regenerates and overwrites the management PAT here,
+          // so this dashboard-Bearer exchange must not replay via transports.
+          // https://github.com/QuantumNous/new-api/blob/v1.0.0-rc.22/controller/user.go
+          accessTokenCreationPolicy: {
+            currentTabTransport: "disabled",
+            tempWindowFallback: { statusCodes: [], codes: [] },
+          },
+        })
+      : createNewApiAccountBootstrap(detected.siteType)
+
+    const effectiveAuthType = modernDashboardAuth
+      ? AuthTypeEnum.AccessToken
+      : requestedAuthType
 
     const createRequest = (
       auth: Parameters<typeof helpers.createServiceRequest>[0]["auth"],
@@ -20,6 +90,18 @@ export const newApiAccountCompletion: AccountCompletionCapability = {
       })
 
     const fetchTokenInfo = () => {
+      if (modernDashboardAuth) {
+        // New API rc.22 dashboard Bearers are completion-only; exchange one
+        // without New-Api-User and persist only the returned management PAT.
+        // https://github.com/QuantumNous/new-api/blob/v1.0.0-rc.22/docs/authentication.md
+        return accountBootstrap.getOrCreateAccessToken(
+          createRequest({
+            authType: AuthTypeEnum.AccessToken,
+            accessToken: modernDashboardAuth.token,
+          }),
+        )
+      }
+
       if (requestedAuthType === AuthTypeEnum.Cookie) {
         return accountBootstrap.fetchUserInfo(
           createRequest({
@@ -72,7 +154,7 @@ export const newApiAccountCompletion: AccountCompletionCapability = {
       tokenPromise.catch((error) => {
         throw helpers.createCompletionError(
           AUTO_DETECT_FAILURE_REASONS.TokenFetchFailed,
-          error,
+          modernDashboardAuth ? createModernAuthExchangeError(error) : error,
         )
       }),
       siteStatusPromise,
@@ -87,7 +169,7 @@ export const newApiAccountCompletion: AccountCompletionCapability = {
     const username = helpers.trimString(tokenData.username)
     const accessToken = helpers.trimString(tokenData.access_token)
 
-    if (requestedAuthType === AuthTypeEnum.AccessToken && !accessToken) {
+    if (effectiveAuthType === AuthTypeEnum.AccessToken && !accessToken) {
       throw helpers.createCompletionError(
         AUTO_DETECT_FAILURE_REASONS.AccessTokenMissing,
         new Error("Access token is missing"),
@@ -109,7 +191,7 @@ export const newApiAccountCompletion: AccountCompletionCapability = {
       exchangeRate:
         accountBootstrap.extractDefaultExchangeRate(siteStatus) ??
         UI_CONSTANTS.EXCHANGE_RATE.DEFAULT,
-      authType: requestedAuthType,
+      authType: effectiveAuthType,
       checkIn: helpers.createInitialCheckInConfig({
         enableDetection: checkSupport ?? false,
         autoCheckInEnabled: true,

--- a/src/services/apiService/newApiFamily/default/accountBootstrap.ts
+++ b/src/services/apiService/newApiFamily/default/accountBootstrap.ts
@@ -6,12 +6,20 @@ import type {
 } from "~/services/apiAdapters/contracts/accountBootstrap"
 import { ApiError } from "~/services/apiTransport/errors"
 import { fetchApiData } from "~/services/apiTransport/request"
-import type { ApiServiceRequest } from "~/services/apiTransport/type"
+import type {
+  ApiServiceRequest,
+  FetchApiOptions,
+} from "~/services/apiTransport/type"
 import { AuthTypeEnum } from "~/types"
 import { createLogger } from "~/utils/core/logger"
 import { t } from "~/utils/i18n/core"
 
 const logger = createLogger("NewApiFamilyAccountBootstrap")
+
+type AccessTokenCreationPolicy = Pick<
+  FetchApiOptions,
+  "currentTabTransport" | "tempWindowFallback"
+>
 
 interface AccountBootstrapImplementation {
   fetchUserInfo: typeof fetchUserInfo
@@ -107,9 +115,11 @@ export async function fetchUserInfo(request: ApiServiceRequest): Promise<{
  */
 export async function createAccessToken(
   request: ApiServiceRequest,
+  creationPolicy?: AccessTokenCreationPolicy,
 ): Promise<string> {
   const accessToken = await fetchApiData<string>(request, {
     endpoint: "/api/user/token",
+    ...creationPolicy,
   })
 
   const normalizedAccessToken =
@@ -131,6 +141,7 @@ export async function createAccessToken(
  */
 export async function getOrCreateAccessToken(
   request: ApiServiceRequest,
+  creationPolicy?: AccessTokenCreationPolicy,
 ): Promise<AccessTokenInfo> {
   const userInfo = await fetchUserInfo(request)
 
@@ -138,7 +149,7 @@ export async function getOrCreateAccessToken(
 
   if (!accessToken) {
     logger.info("访问令牌为空，尝试自动创建")
-    accessToken = await createAccessToken(request)
+    accessToken = await createAccessToken(request, creationPolicy)
     logger.info("自动创建访问令牌成功")
   }
 

--- a/src/services/apiTransport/request.ts
+++ b/src/services/apiTransport/request.ts
@@ -63,6 +63,16 @@ interface ContentFetchResponse<T> {
   code?: ApiErrorCode
 }
 
+/** Redacts the exact request credential before emitting transport diagnostics. */
+function getSafeTransportErrorMessage(
+  error: unknown,
+  requestAccessToken: string | undefined,
+): string {
+  const message = getErrorMessage(error)
+  if (!requestAccessToken?.trim()) return message
+  return message.split(requestAccessToken).join("[REDACTED]")
+}
+
 const logger = createLogger("ApiTransportRequest")
 
 interface BackendErrorDetails {
@@ -392,7 +402,10 @@ async function executeWithCurrentTabContentPreference<T>(
     logger.debug("Current-tab content fetch failed; falling back", {
       endpoint: context.endpoint,
       url: context.url,
-      error: getErrorMessage(error),
+      error: getSafeTransportErrorMessage(
+        error,
+        context.request.auth.accessToken,
+      ),
     })
     // Keep current-tab fallback behavior aligned with temp-window fallback for
     // now. If mutating-request replay becomes a real issue, handle it in the

--- a/src/services/siteDetection/autoDetectService.ts
+++ b/src/services/siteDetection/autoDetectService.ts
@@ -25,7 +25,9 @@ import {
   ACCOUNT_BROWSER_SESSION_SOURCES,
   readAccountBrowserSessionFromTab,
 } from "~/services/accountBrowserSession"
+import { normalizeContentSessionTransientAuth } from "~/services/accountBrowserSession/transientAuth"
 import { normalizeAccountIdentity } from "~/services/accounts/accountIdentity"
+import type { ContentSessionTransientAuth } from "~/services/accountSiteOnboarding/contracts"
 import { getSiteTypeCapabilities } from "~/services/apiAdapters/registry"
 import {
   API_SERVICE_FETCH_CONTEXT_KINDS,
@@ -70,6 +72,7 @@ interface AutoDetectResult {
     user: any
     siteType: AccountSiteType
     accessToken?: string
+    transientAuth?: ContentSessionTransientAuth
     sub2apiAuth?: Sub2ApiAuthConfig
     fetchContext?: AutoDetectFetchContext
   }
@@ -81,6 +84,7 @@ interface UserDataResult {
   userId: string
   user: any
   accessToken?: string
+  transientAuth?: ContentSessionTransientAuth
   sub2apiAuth?: Sub2ApiAuthConfig
   siteTypeHint?: AccountSiteType
   fetchContext?: AutoDetectFetchContext
@@ -223,6 +227,9 @@ async function combineUserDataAndSiteType(
         user: userData.user,
         siteType,
         accessToken: userData.accessToken,
+        ...(userData.transientAuth
+          ? { transientAuth: userData.transientAuth }
+          : {}),
         sub2apiAuth: userData.sub2apiAuth,
         ...(userData.fetchContext
           ? { fetchContext: userData.fetchContext }
@@ -435,10 +442,16 @@ async function getUserDataViaBackground(
       )
     }
 
+    const transientAuth = normalizeContentSessionTransientAuth(
+      response.data.transientAuth,
+      { baseUrl: url, siteType },
+    )
+
     return {
       userId,
       user: response.data.user,
       accessToken: response.data.accessToken,
+      ...(transientAuth ? { transientAuth } : {}),
       sub2apiAuth: response.data.sub2apiAuth,
       siteTypeHint: normalizeSiteTypeHint(response.data.siteTypeHint),
       ...(fetchContext ? { fetchContext } : {}),
@@ -554,6 +567,9 @@ async function getUserDataFromCurrentTab(
           userId: session.userId,
           user: session.user,
           accessToken: session.accessToken,
+          ...(session.transientAuth
+            ? { transientAuth: session.transientAuth }
+            : {}),
           sub2apiAuth: session.sub2apiAuth,
           siteTypeHint: normalizeSiteTypeHint(session.siteTypeHint),
           fetchContext,

--- a/src/utils/browser/tempWindowFetch.ts
+++ b/src/utils/browser/tempWindowFetch.ts
@@ -546,7 +546,8 @@ export function matchesTempWindowFallbackAllowlist(
 }
 
 /**
- * Allows 401 fallback only for cookie-auth requests that can replay a stored account cookie.
+ * Matches the default 401 fallback for cookie-auth requests that can replay a
+ * stored account cookie. Explicit request allowlists are handled separately.
  */
 function isCookieAuthUnauthorizedFallback(
   error: ApiError,
@@ -656,10 +657,15 @@ async function shouldUseTempWindowFallback(
     return false
   }
 
-  if (
-    !matchesTempWindowFallbackAllowlist(error, context.tempWindowFallback) &&
-    !isCookieAuthUnauthorizedFallback(error, context)
-  ) {
+  const matchesAllowlist = matchesTempWindowFallbackAllowlist(
+    error,
+    context.tempWindowFallback,
+  )
+  const matchesDefaultCookieAuthFallback =
+    typeof context.tempWindowFallback === "undefined" &&
+    isCookieAuthUnauthorizedFallback(error, context)
+
+  if (!matchesAllowlist && !matchesDefaultCookieAuthFallback) {
     logSkipTempWindowFallback(
       "Error does not match any temp window fallback codes or statuses.",
       context,

--- a/tests/entrypoints/background/tempWindowPoolWindowFallback.test.ts
+++ b/tests/entrypoints/background/tempWindowPoolWindowFallback.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { RuntimeActionIds } from "~/constants/runtimeActions"
+import { NEW_API_DASHBOARD_TRANSIENT_AUTH_KIND } from "~/services/accountSiteOnboarding/contracts"
 import { API_ERROR_CODES } from "~/services/apiTransport/errors"
 import {
   PRODUCT_ANALYTICS_ACTION_IDS,
@@ -1297,6 +1298,69 @@ describe("tempWindowPool window fallback", () => {
 
     await vi.advanceTimersByTimeAsync(2500)
     expect(removeTabMock).toHaveBeenCalledWith(508)
+  })
+
+  it("projects transient dashboard auth from the temp context", async () => {
+    tempContextMode = "tab"
+    createTabMock.mockResolvedValueOnce({ id: 509 })
+    const defaultSendMessage = sendMessageMock.getMockImplementation() as
+      | ((tabId: number, message: { action: string }) => unknown)
+      | undefined
+    sendMessageMock.mockImplementation(async (tabId, message) => {
+      if (message.action === RuntimeActionIds.ContentGetUserFromLocalStorage) {
+        return {
+          success: true,
+          data: {
+            userId: "user-2",
+            user: "example-user",
+            transientAuth: {
+              kind: NEW_API_DASHBOARD_TRANSIENT_AUTH_KIND,
+              token: "placeholder-background-token",
+              expiresAt: 2_000_000_000,
+              sessionId: "placeholder-background-session",
+              origin: "https://dashboard.example.invalid",
+            },
+          },
+        }
+      }
+
+      return defaultSendMessage?.(tabId, message)
+    })
+
+    const { handleAutoDetectSite } = await import(
+      "~/entrypoints/background/tempWindowPool"
+    )
+
+    const sendResponse = vi.fn()
+    const request = handleAutoDetectSite(
+      {
+        url: "https://dashboard.example.invalid/account",
+        requestId: "req-auto-detect-transient-auth",
+      },
+      sendResponse,
+    )
+
+    await vi.advanceTimersByTimeAsync(500)
+    await request
+
+    expect(sendResponse).toHaveBeenCalledWith({
+      success: true,
+      data: {
+        siteType: "new-api",
+        userId: "user-2",
+        user: "example-user",
+        accessToken: undefined,
+        sub2apiAuth: undefined,
+        siteTypeHint: undefined,
+        transientAuth: {
+          kind: NEW_API_DASHBOARD_TRANSIENT_AUTH_KIND,
+          token: "placeholder-background-token",
+          expiresAt: 2_000_000_000,
+          sessionId: "placeholder-background-session",
+          origin: "https://dashboard.example.invalid",
+        },
+      },
+    })
   })
 
   it("uses an incognito temp context for incognito auto-detect requests", async () => {

--- a/tests/entrypoints/content/messageHandlers/handlers/storage.test.ts
+++ b/tests/entrypoints/content/messageHandlers/handlers/storage.test.ts
@@ -5,6 +5,7 @@ import {
   handleGetUserFromLocalStorage,
 } from "~/entrypoints/content/messageHandlers/handlers/storage"
 import { compatibleUserContentSessionExtractor } from "~/services/accountSiteOnboarding/contentSession/compatibleUser"
+import { newApiAuthBundleContentSessionExtractor } from "~/services/accountSiteOnboarding/contentSession/newApiAuthBundle"
 import { sharedChatContentSessionExtractor } from "~/services/accountSiteOnboarding/contentSession/sharedchat"
 import {
   sub2ApiContentSessionExtractor,
@@ -653,6 +654,149 @@ describe("content storage handler", () => {
         },
       })
     })
+
+    it("does not fall through to stale compatible-user storage for an invalid rc.22 AuthBundle", async () => {
+      const nowSeconds = 1_800_000_000
+      vi.spyOn(Date, "now").mockReturnValue(nowSeconds * 1000)
+      localStorage.setItem(
+        "user",
+        JSON.stringify({ id: "stale-user", username: "stale" }),
+      )
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          new Response(
+            JSON.stringify({
+              success: true,
+              data: {
+                access_token: "dashboard-token-placeholder",
+                token_type: "Bearer",
+                access_expires_at: nowSeconds - 1,
+                user: { id: "current-user", username: "current" },
+                session: { sid: "session-placeholder", current: true },
+              },
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        ),
+      )
+      const compatibleExtractSpy = vi.spyOn(
+        compatibleUserContentSessionExtractor,
+        "extract",
+      )
+      mockGetContentSessionExtractors.mockReturnValue([
+        newApiAuthBundleContentSessionExtractor,
+        compatibleUserContentSessionExtractor,
+      ])
+
+      const response = await new Promise<any>((resolve) => {
+        handleGetUserFromLocalStorage(
+          {
+            url: "https://message-origin.example.invalid",
+            siteType: "new-api",
+          },
+          resolve,
+        )
+      })
+
+      expect(response).toEqual({
+        success: false,
+        error: "New API dashboard session response is invalid",
+      })
+      expect(compatibleExtractSpy).not.toHaveBeenCalled()
+    })
+
+    it.each([
+      ["generic user", { user: { id: "unrelated-user" } }],
+      ["generic session", { session: { state: "active" } }],
+    ])(
+      "falls through to compatible-user storage for an unrelated %s response",
+      async (_description, data) => {
+        localStorage.setItem(
+          "user",
+          JSON.stringify({ id: "legacy-user", username: "legacy" }),
+        )
+        vi.stubGlobal(
+          "fetch",
+          vi.fn().mockResolvedValue(
+            new Response(JSON.stringify({ success: true, data }), {
+              status: 200,
+              headers: { "Content-Type": "application/json" },
+            }),
+          ),
+        )
+        const compatibleExtractSpy = vi.spyOn(
+          compatibleUserContentSessionExtractor,
+          "extract",
+        )
+        mockGetContentSessionExtractors.mockReturnValue([
+          newApiAuthBundleContentSessionExtractor,
+          compatibleUserContentSessionExtractor,
+        ])
+
+        const response = await new Promise<any>((resolve) => {
+          handleGetUserFromLocalStorage(
+            {
+              url: "https://message-origin.example.invalid",
+              siteType: "new-api",
+            },
+            resolve,
+          )
+        })
+
+        expect(response).toEqual({
+          success: true,
+          data: {
+            userId: "legacy-user",
+            user: { id: "legacy-user", username: "legacy" },
+            siteTypeHint: "new-api",
+          },
+        })
+        expect(compatibleExtractSpy).toHaveBeenCalledTimes(1)
+      },
+    )
+
+    it.each([404, 405])(
+      "falls through to compatible-user storage for legacy HTTP %i",
+      async (status) => {
+        localStorage.setItem(
+          "user",
+          JSON.stringify({ id: "legacy-user", username: "legacy" }),
+        )
+        vi.stubGlobal(
+          "fetch",
+          vi.fn().mockResolvedValue(new Response(null, { status })),
+        )
+        const compatibleExtractSpy = vi.spyOn(
+          compatibleUserContentSessionExtractor,
+          "extract",
+        )
+        mockGetContentSessionExtractors.mockReturnValue([
+          newApiAuthBundleContentSessionExtractor,
+          compatibleUserContentSessionExtractor,
+        ])
+
+        const response = await new Promise<any>((resolve) => {
+          handleGetUserFromLocalStorage(
+            {
+              url: "https://message-origin.example.invalid",
+              siteType: "new-api",
+            },
+            resolve,
+          )
+        })
+
+        expect(response).toEqual({
+          success: true,
+          data: {
+            userId: "legacy-user",
+            user: { id: "legacy-user", username: "legacy" },
+            siteTypeHint: "new-api",
+          },
+        })
+        expect(compatibleExtractSpy).toHaveBeenCalledTimes(1)
+      },
+    )
 
     it("returns userInfoNotFound when no extractor returns a result", async () => {
       mockGetContentSessionExtractors.mockReturnValue([

--- a/tests/services/accountBrowserSession/sessionReader.test.ts
+++ b/tests/services/accountBrowserSession/sessionReader.test.ts
@@ -8,6 +8,7 @@ import {
   readAccountBrowserSessionFromTab,
   resolveAccountBrowserSession,
 } from "~/services/accountBrowserSession"
+import { NEW_API_DASHBOARD_TRANSIENT_AUTH_KIND } from "~/services/accountSiteOnboarding/contracts"
 import { API_SERVICE_FETCH_CONTEXT_KINDS } from "~/services/apiTransport/type"
 import { TEMP_WINDOW_REQUEST_SOURCES } from "~/types/tempWindowFetch"
 
@@ -94,6 +95,154 @@ describe("account browser-session reader", () => {
       siteType: SITE_TYPES.SUB2API,
     })
   })
+
+  it("normalizes a valid transient dashboard auth payload", async () => {
+    mockSendTabMessage.mockResolvedValueOnce({
+      success: true,
+      data: {
+        userId: "user-42",
+        user: { username: "example-user" },
+        transientAuth: {
+          kind: NEW_API_DASHBOARD_TRANSIENT_AUTH_KIND,
+          token: " placeholder-token ",
+          expiresAt: 2_000_000_000,
+          sessionId: " placeholder-session ",
+          origin: " HTTPS://DASHBOARD.EXAMPLE.INVALID:443/ ",
+          untrusted: "drop-me",
+        },
+      },
+    })
+
+    const session = await readAccountBrowserSessionFromTab({
+      tabId: 13,
+      baseUrl: "https://dashboard.example.invalid/account",
+      siteType: SITE_TYPES.NEW_API,
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB,
+    })
+
+    expect(session).toEqual({
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB,
+      siteType: SITE_TYPES.NEW_API,
+      userId: "user-42",
+      user: { username: "example-user" },
+      transientAuth: {
+        kind: NEW_API_DASHBOARD_TRANSIENT_AUTH_KIND,
+        token: "placeholder-token",
+        expiresAt: 2_000_000_000,
+        sessionId: "placeholder-session",
+        origin: "https://dashboard.example.invalid",
+      },
+    })
+  })
+
+  it.each([
+    ["an unknown kind", { kind: "unknown_kind" }],
+    ["a blank token", { token: "   " }],
+    ["a blank session id", { sessionId: "   " }],
+    ["a mismatched origin", { origin: "https://other.example.invalid" }],
+    ["a non-finite expiry", { expiresAt: Number.POSITIVE_INFINITY }],
+  ])(
+    "drops transient dashboard auth with %s while preserving identity",
+    async (_label, override) => {
+      mockSendTabMessage.mockResolvedValueOnce({
+        success: true,
+        data: {
+          userId: "user-42",
+          user: { username: "example-user" },
+          transientAuth: {
+            kind: NEW_API_DASHBOARD_TRANSIENT_AUTH_KIND,
+            token: "placeholder-token",
+            expiresAt: 2_000_000_000,
+            sessionId: "placeholder-session",
+            origin: "https://dashboard.example.invalid",
+            ...override,
+          },
+        },
+      })
+
+      const session = await readAccountBrowserSessionFromTab({
+        tabId: 14,
+        baseUrl: "https://dashboard.example.invalid",
+        siteType: SITE_TYPES.NEW_API,
+        source: ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB,
+      })
+
+      expect(session).toEqual(
+        expect.objectContaining({
+          userId: "user-42",
+          user: { username: "example-user" },
+        }),
+      )
+      expect(session).not.toHaveProperty("transientAuth")
+    },
+  )
+
+  it("drops transient dashboard auth for non-New API sites while preserving identity", async () => {
+    mockSendTabMessage.mockResolvedValueOnce({
+      success: true,
+      data: {
+        userId: "user-42",
+        transientAuth: {
+          kind: NEW_API_DASHBOARD_TRANSIENT_AUTH_KIND,
+          token: "placeholder-token",
+          expiresAt: 2_000_000_000,
+          sessionId: "placeholder-session",
+          origin: "https://dashboard.example.invalid",
+        },
+      },
+    })
+
+    const session = await readAccountBrowserSessionFromTab({
+      tabId: 15,
+      baseUrl: "https://dashboard.example.invalid/account",
+      siteType: SITE_TYPES.VELOERA,
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB,
+    })
+
+    expect(session).toEqual(
+      expect.objectContaining({
+        userId: "user-42",
+        siteType: SITE_TYPES.VELOERA,
+      }),
+    )
+    expect(session).not.toHaveProperty("transientAuth")
+  })
+
+  it.each(["kind", "token", "expiresAt", "sessionId", "origin"])(
+    "drops transient dashboard auth when %s is inherited",
+    async (inheritedField) => {
+      const fields: Record<string, unknown> = {
+        kind: NEW_API_DASHBOARD_TRANSIENT_AUTH_KIND,
+        token: "placeholder-token",
+        expiresAt: 2_000_000_000,
+        sessionId: "placeholder-session",
+        origin: "https://dashboard.example.invalid",
+      }
+      const transientAuth = Object.assign(
+        Object.create({ [inheritedField]: fields[inheritedField] }),
+        Object.fromEntries(
+          Object.entries(fields).filter(([field]) => field !== inheritedField),
+        ),
+      )
+      mockSendTabMessage.mockResolvedValueOnce({
+        success: true,
+        data: {
+          userId: "user-42",
+          transientAuth,
+        },
+      })
+
+      const session = await readAccountBrowserSessionFromTab({
+        tabId: 16,
+        baseUrl: "https://dashboard.example.invalid/account",
+        siteType: SITE_TYPES.NEW_API,
+        source: ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB,
+      })
+
+      expect(session).toEqual(expect.objectContaining({ userId: "user-42" }))
+      expect(session).not.toHaveProperty("transientAuth")
+    },
+  )
 
   it("returns null for failed or unusable tab responses", async () => {
     mockSendTabMessage

--- a/tests/services/accountBrowserSession/sessionReader.test.ts
+++ b/tests/services/accountBrowserSession/sessionReader.test.ts
@@ -139,6 +139,7 @@ describe("account browser-session reader", () => {
     ["an unknown kind", { kind: "unknown_kind" }],
     ["a blank token", { token: "   " }],
     ["a blank session id", { sessionId: "   " }],
+    ["a malformed origin", { origin: "not a valid URL" }],
     ["a mismatched origin", { origin: "https://other.example.invalid" }],
     ["a non-finite expiry", { expiresAt: Number.POSITIVE_INFINITY }],
   ])(

--- a/tests/services/accountOperations.autoDetectAccount.test.ts
+++ b/tests/services/accountOperations.autoDetectAccount.test.ts
@@ -12,6 +12,7 @@ import {
   AUTO_DETECT_FAILURE_REASONS,
   AutoDetectErrorType,
 } from "~/services/accounts/utils/autoDetectUtils"
+import { NEW_API_DASHBOARD_TRANSIENT_AUTH_KIND } from "~/services/accountSiteOnboarding/contracts"
 import { API_SERVICE_FETCH_CONTEXT_KINDS } from "~/services/apiTransport/type"
 import { AuthTypeEnum } from "~/types"
 
@@ -25,6 +26,7 @@ const {
   mockFetchSharedChatUserInfo,
   mockCreateNewApiAccountBootstrap,
   mockGetOrCreateAccessToken,
+  mockLoggerError,
 } = vi.hoisted(() => ({
   mockAutoDetectSmart: vi.fn(),
   mockSendRuntimeMessage: vi.fn(),
@@ -35,10 +37,20 @@ const {
   mockFetchSharedChatUserInfo: vi.fn(),
   mockCreateNewApiAccountBootstrap: vi.fn(),
   mockGetOrCreateAccessToken: vi.fn(),
+  mockLoggerError: vi.fn(),
 }))
 
 vi.mock("~/services/siteDetection/autoDetectService", () => ({
   autoDetectSmart: mockAutoDetectSmart,
+}))
+
+vi.mock("~/utils/core/logger", () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    error: mockLoggerError,
+    info: vi.fn(),
+    warn: vi.fn(),
+  }),
 }))
 
 vi.mock("~/utils/browser/browserApi", async (importOriginal) => {
@@ -105,7 +117,16 @@ const browserFetchContext = () => ({
 
 describe("accountOperations autoDetectAccount", () => {
   beforeEach(() => {
-    vi.clearAllMocks()
+    mockAutoDetectSmart.mockReset()
+    mockSendRuntimeMessage.mockReset()
+    mockFetchSiteStatus.mockReset()
+    mockFetchSupportCheckIn.mockReset()
+    mockExtractDefaultExchangeRate.mockReset()
+    mockFetchUserInfo.mockReset()
+    mockFetchSharedChatUserInfo.mockReset()
+    mockCreateNewApiAccountBootstrap.mockReset()
+    mockGetOrCreateAccessToken.mockReset()
+    mockLoggerError.mockReset()
     mockCreateNewApiAccountBootstrap.mockReturnValue({
       extractDefaultExchangeRate: mockExtractDefaultExchangeRate,
       fetchCheckInSupport: mockFetchSupportCheckIn,
@@ -322,6 +343,101 @@ describe("accountOperations autoDetectAccount", () => {
       ...autoDetectContext,
       siteType: SITE_TYPES.NEW_API,
     })
+  })
+
+  it("returns only the management PAT from rc22 dashboard completion", async () => {
+    mockSendRuntimeMessage.mockResolvedValueOnce(null)
+    mockAutoDetectSmart.mockResolvedValueOnce({
+      success: true,
+      data: {
+        userId: "42",
+        siteType: SITE_TYPES.NEW_API,
+        transientAuth: {
+          kind: NEW_API_DASHBOARD_TRANSIENT_AUTH_KIND,
+          token: "dashboard-jwt",
+          expiresAt: 4_102_444_800,
+          sessionId: "session-example",
+          origin: "https://panel.example.invalid",
+        },
+        fetchContext: currentTabFetchContext("https://panel.example.invalid"),
+      },
+    })
+    mockGetOrCreateAccessToken.mockResolvedValueOnce({
+      username: "rc22-user",
+      access_token: "management-pat",
+    })
+    mockFetchSiteStatus.mockResolvedValueOnce({
+      system_name: "rc22 portal",
+      checkin_enabled: false,
+    })
+    mockExtractDefaultExchangeRate.mockReturnValueOnce(null)
+
+    const result = await autoDetectAccount(
+      "https://panel.example.invalid",
+      AuthTypeEnum.Cookie,
+    )
+
+    expect(result.success).toBe(true)
+    expect(result.data).toMatchObject({
+      accessToken: "management-pat",
+      authType: AuthTypeEnum.AccessToken,
+    })
+    expect(result.data).not.toHaveProperty("transientAuth")
+    expect(JSON.stringify(result.data)).not.toContain("dashboard-jwt")
+  })
+
+  it("does not expose or log reflected rc22 dashboard credentials", async () => {
+    const dashboardToken = "dashboard-jwt-sensitive-example"
+    const reflectedMessage = `upstream reflected ${dashboardToken}`
+    mockSendRuntimeMessage.mockResolvedValueOnce(null)
+    mockAutoDetectSmart.mockResolvedValueOnce({
+      success: true,
+      data: {
+        userId: "42",
+        siteType: SITE_TYPES.NEW_API,
+        transientAuth: {
+          kind: NEW_API_DASHBOARD_TRANSIENT_AUTH_KIND,
+          token: dashboardToken,
+          expiresAt: 4_102_444_800,
+          sessionId: "session-example",
+          origin: "https://panel.example.invalid",
+        },
+      },
+    })
+    mockGetOrCreateAccessToken.mockRejectedValueOnce(
+      new Error(reflectedMessage),
+    )
+    mockFetchSiteStatus.mockResolvedValueOnce({
+      system_name: "rc22 portal",
+      checkin_enabled: false,
+    })
+
+    const result = await autoDetectAccount(
+      "https://panel.example.invalid",
+      AuthTypeEnum.Cookie,
+    )
+
+    expect(result).toMatchObject({
+      success: false,
+      autoDetectFailureReason: AUTO_DETECT_FAILURE_REASONS.TokenFetchFailed,
+      detailedError: expect.objectContaining({
+        type: AutoDetectErrorType.UNKNOWN,
+      }),
+    })
+    expect(JSON.stringify(result)).not.toContain(dashboardToken)
+    expect(JSON.stringify(result)).not.toContain(reflectedMessage)
+    expect(mockLoggerError).toHaveBeenCalledTimes(1)
+    const [logMessage, logError] = mockLoggerError.mock.calls[0]
+    expect(String(logMessage)).not.toContain(dashboardToken)
+    expect(String(logMessage)).not.toContain(reflectedMessage)
+    expect(logError).toMatchObject({
+      message: "New API dashboard authentication could not be exchanged",
+      cause: {
+        message: "New API dashboard authentication could not be exchanged",
+      },
+    })
+    expect(String(logError.cause)).not.toContain(dashboardToken)
+    expect(String(logError.cause)).not.toContain(reflectedMessage)
   })
 
   it("preserves privacy-safe auto-detect metadata in failure responses", async () => {

--- a/tests/services/accountOperations.autoDetectAccount.test.ts
+++ b/tests/services/accountOperations.autoDetectAccount.test.ts
@@ -62,6 +62,26 @@ vi.mock("~/utils/browser/browserApi", async (importOriginal) => {
   }
 })
 
+function snapshotOwnProperties(
+  value: unknown,
+  seen = new WeakSet<object>(),
+): unknown {
+  if (!value || typeof value !== "object") return value
+  if (seen.has(value)) return "[Circular]"
+  seen.add(value)
+
+  return Object.fromEntries(
+    Reflect.ownKeys(value).map((key) => {
+      const descriptor = Object.getOwnPropertyDescriptor(value, key)
+      const propertyValue =
+        descriptor && "value" in descriptor
+          ? snapshotOwnProperties(descriptor.value, seen)
+          : "[Accessor]"
+      return [String(key), propertyValue]
+    }),
+  )
+}
+
 vi.mock("~/services/apiAdapters/newApi/accountBootstrap", () => ({
   createNewApiAccountBootstrap: mockCreateNewApiAccountBootstrap,
 }))
@@ -436,8 +456,9 @@ describe("accountOperations autoDetectAccount", () => {
         message: "New API dashboard authentication could not be exchanged",
       },
     })
-    expect(String(logError.cause)).not.toContain(dashboardToken)
-    expect(String(logError.cause)).not.toContain(reflectedMessage)
+    const serializedLogError = JSON.stringify(snapshotOwnProperties(logError))
+    expect(serializedLogError).not.toContain(dashboardToken)
+    expect(serializedLogError).not.toContain(reflectedMessage)
   })
 
   it("preserves privacy-safe auto-detect metadata in failure responses", async () => {

--- a/tests/services/accountSiteOnboarding/contentSession/newApiAuthBundle.test.ts
+++ b/tests/services/accountSiteOnboarding/contentSession/newApiAuthBundle.test.ts
@@ -223,6 +223,51 @@ describe("newApiAuthBundleContentSessionExtractor", () => {
     ).rejects.toEqual(new Error("New API session refresh failed (500)"))
   })
 
+  it("falls back to status details when a controlled error response is not JSON", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+        json: vi.fn().mockRejectedValue(new SyntaxError("invalid JSON")),
+      }),
+    )
+
+    await expect(
+      newApiAuthBundleContentSessionExtractor.extract({
+        siteTypeHint: SITE_TYPES.NEW_API,
+      }),
+    ).rejects.toEqual(new Error("New API session refresh failed (401)"))
+  })
+
+  it.each([
+    ["only a code", { code: "AUTH_REQUIRED" }, "AUTH_REQUIRED"],
+    [
+      "only a message",
+      { message: "Session unavailable" },
+      "Session unavailable",
+    ],
+    [
+      "no public fields",
+      { success: false },
+      "New API session refresh failed (409)",
+    ],
+  ])(
+    "keeps useful upstream diagnostics for a controlled response with %s",
+    async (_description, body, expectedMessage) => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(createResponse(body, 409)),
+      )
+
+      await expect(
+        newApiAuthBundleContentSessionExtractor.extract({
+          siteTypeHint: SITE_TYPES.NEW_API,
+        }),
+      ).rejects.toEqual(new Error(expectedMessage))
+    },
+  )
+
   it.each([404, 405])(
     "returns null for legacy-compatible HTTP %i responses",
     async (status) => {

--- a/tests/services/accountSiteOnboarding/contentSession/newApiAuthBundle.test.ts
+++ b/tests/services/accountSiteOnboarding/contentSession/newApiAuthBundle.test.ts
@@ -1,0 +1,280 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { SITE_TYPES } from "~/constants/siteType"
+import { newApiAuthBundleContentSessionExtractor } from "~/services/accountSiteOnboarding/contentSession/newApiAuthBundle"
+
+const NOW_SECONDS = 1_800_000_000
+const PAGE_ORIGIN = "https://panel.example.invalid"
+const INVALID_AUTH_BUNDLE_ERROR =
+  "New API dashboard session response is invalid"
+
+function createAuthBundle(overrides: Record<string, unknown> = {}) {
+  return {
+    success: true,
+    data: {
+      access_token: "dashboard-token-placeholder",
+      token_type: "Bearer",
+      access_expires_at: NOW_SECONDS + 900,
+      user: {
+        id: 42,
+        username: "example-user",
+      },
+      session: {
+        sid: "session-placeholder",
+        current: true,
+      },
+      ...overrides,
+    },
+  }
+}
+
+function createResponse(body: unknown, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: vi.fn().mockResolvedValue(body),
+  }
+}
+
+function createLocalStorageMock() {
+  return {
+    clear: vi.fn(),
+    getItem: vi.fn().mockReturnValue(null),
+    key: vi.fn().mockReturnValue(null),
+    removeItem: vi.fn(),
+    setItem: vi.fn(),
+    length: 0,
+  }
+}
+
+describe("newApiAuthBundleContentSessionExtractor", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+    vi.spyOn(Date, "now").mockReturnValue(NOW_SECONDS * 1000)
+    vi.stubGlobal("location", { origin: PAGE_ORIGIN })
+    vi.stubGlobal("localStorage", createLocalStorageMock())
+  })
+
+  it("only extracts an exact New API site-type hint", () => {
+    expect(
+      newApiAuthBundleContentSessionExtractor.canExtract({
+        siteTypeHint: SITE_TYPES.NEW_API,
+      }),
+    ).toBe(true)
+    expect(
+      newApiAuthBundleContentSessionExtractor.canExtract({
+        siteTypeHint: SITE_TYPES.ONE_API,
+      }),
+    ).toBe(false)
+    expect(
+      newApiAuthBundleContentSessionExtractor.canExtract({
+        siteTypeHint: SITE_TYPES.VELOERA,
+      }),
+    ).toBe(false)
+    expect(newApiAuthBundleContentSessionExtractor.canExtract({})).toBe(false)
+  })
+
+  it("extracts a future, current AuthBundle from the actual page origin without writing storage", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(createResponse(createAuthBundle()))
+    vi.stubGlobal("fetch", fetchMock)
+
+    await expect(
+      newApiAuthBundleContentSessionExtractor.extract({
+        url: "https://message-origin.example.invalid/console",
+        siteTypeHint: SITE_TYPES.NEW_API,
+      }),
+    ).resolves.toEqual({
+      userId: "42",
+      user: {
+        id: 42,
+        username: "example-user",
+      },
+      siteTypeHint: SITE_TYPES.NEW_API,
+      transientAuth: {
+        kind: "new_api_dashboard_bearer",
+        token: "dashboard-token-placeholder",
+        expiresAt: NOW_SECONDS + 900,
+        sessionId: "session-placeholder",
+        origin: PAGE_ORIGIN,
+      },
+    })
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${PAGE_ORIGIN}/api/user/auth/refresh`,
+      {
+        credentials: "include",
+        method: "POST",
+      },
+    )
+    expect(localStorage.setItem).not.toHaveBeenCalled()
+    expect(localStorage.removeItem).not.toHaveBeenCalled()
+    expect(localStorage.clear).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ["a non-object envelope", null],
+    ["an unsuccessful envelope", { success: false, data: {} }],
+    ["an unrelated object", { success: true, data: { greeting: "hello" } }],
+    [
+      "an unrelated generic user",
+      { success: true, data: { user: { id: "example-user" } } },
+    ],
+    [
+      "an unrelated generic session",
+      { success: true, data: { session: { state: "active" } } },
+    ],
+  ])("returns null for %s", async (_description, body) => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(createResponse(body)))
+
+    await expect(
+      newApiAuthBundleContentSessionExtractor.extract({
+        siteTypeHint: SITE_TYPES.NEW_API,
+      }),
+    ).resolves.toBeNull()
+  })
+
+  it.each([
+    [
+      "an incomplete token-marked response",
+      { success: true, data: { access_token: "token-placeholder" } },
+    ],
+    [
+      "an incomplete session-signature response",
+      { success: true, data: { session: { sid: "session-placeholder" } } },
+    ],
+    ["a non-Bearer token type", createAuthBundle({ token_type: "bearer" })],
+    ["a blank access token", createAuthBundle({ access_token: "   " })],
+    [
+      "a non-finite access expiry",
+      createAuthBundle({ access_expires_at: Number.NaN }),
+    ],
+    [
+      "an expired access token",
+      createAuthBundle({ access_expires_at: NOW_SECONDS }),
+    ],
+    ["a user without identity", createAuthBundle({ user: { name: "No ID" } })],
+    ["a blank session id", createAuthBundle({ session: { sid: " " } })],
+    [
+      "a non-current session",
+      createAuthBundle({
+        session: { sid: "session-placeholder", current: false },
+      }),
+    ],
+  ])("rejects %s", async (_description, body) => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(createResponse(body)))
+
+    await expect(
+      newApiAuthBundleContentSessionExtractor.extract({
+        siteTypeHint: SITE_TYPES.NEW_API,
+      }),
+    ).rejects.toThrow(INVALID_AUTH_BUNDLE_ERROR)
+  })
+
+  it("rejects a successful response that is not JSON", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: vi.fn().mockRejectedValue(new SyntaxError("invalid JSON")),
+      }),
+    )
+
+    await expect(
+      newApiAuthBundleContentSessionExtractor.extract({
+        siteTypeHint: SITE_TYPES.NEW_API,
+      }),
+    ).rejects.toThrow(INVALID_AUTH_BUNDLE_ERROR)
+  })
+
+  it("throws a controlled error when the refresh request is rejected", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new Error("sensitive transport details")),
+    )
+
+    await expect(
+      newApiAuthBundleContentSessionExtractor.extract({
+        siteTypeHint: SITE_TYPES.NEW_API,
+      }),
+    ).rejects.toEqual(new Error("New API session refresh request failed"))
+  })
+
+  it("throws a controlled error for other non-legacy HTTP failures", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        createResponse(
+          {
+            message: "must-not-leak-server-details",
+            access_token: "must-not-leak-token",
+          },
+          500,
+        ),
+      ),
+    )
+
+    await expect(
+      newApiAuthBundleContentSessionExtractor.extract({
+        siteTypeHint: SITE_TYPES.NEW_API,
+      }),
+    ).rejects.toEqual(new Error("New API session refresh failed (500)"))
+  })
+
+  it.each([404, 405])(
+    "returns null for legacy-compatible HTTP %i responses",
+    async (status) => {
+      const response = createResponse({ unexpected: "body" }, status)
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(response))
+
+      await expect(
+        newApiAuthBundleContentSessionExtractor.extract({
+          siteTypeHint: SITE_TYPES.NEW_API,
+        }),
+      ).resolves.toBeNull()
+      expect(response.json).not.toHaveBeenCalled()
+    },
+  )
+
+  it.each([
+    [401, "AUTH_UNAUTHORIZED", "Unauthorized"],
+    [409, "AUTH_SESSION_MISMATCH", "Conflict"],
+    [429, "AUTH_SESSION_ISSUANCE_LIMIT", "Too Many Requests"],
+  ])(
+    "throws a controlled safe error for HTTP %i",
+    async (status, code, message) => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          createResponse(
+            {
+              success: false,
+              code,
+              message,
+              data: {
+                access_token: "must-not-leak-token",
+                session: { sid: "must-not-leak-session" },
+              },
+            },
+            status,
+          ),
+        ),
+      )
+
+      let caught: unknown
+      try {
+        await newApiAuthBundleContentSessionExtractor.extract({
+          siteTypeHint: SITE_TYPES.NEW_API,
+        })
+      } catch (error) {
+        caught = error
+      }
+
+      expect(caught).toEqual(new Error(`${code}: ${message}`))
+      expect((caught as Error).message).not.toContain("must-not-leak-token")
+      expect((caught as Error).message).not.toContain("must-not-leak-session")
+    },
+  )
+})

--- a/tests/services/accountSiteOnboarding/registry.test.ts
+++ b/tests/services/accountSiteOnboarding/registry.test.ts
@@ -157,7 +157,13 @@ describe("account site onboarding registry", () => {
   it("returns content session extractors in onboarding order", () => {
     expect(
       getContentSessionExtractors().map((extractor) => extractor.id),
-    ).toEqual(["sub2api", "sharedchat", "voapi-v2", "compatible-user"])
+    ).toEqual([
+      "sub2api",
+      "sharedchat",
+      "voapi-v2",
+      "new-api-auth-bundle",
+      "compatible-user",
+    ])
   })
 
   it("returns default routes for site types without route metadata", () => {

--- a/tests/services/apiAdapters/newApi/accountBootstrap.test.ts
+++ b/tests/services/apiAdapters/newApi/accountBootstrap.test.ts
@@ -118,6 +118,30 @@ describe("createNewApiAccountBootstrap", () => {
     ).resolves.toBe("/login")
   })
 
+  it("forwards an explicit token creation policy through the factory closure", async () => {
+    const accessToken = {
+      username: "Example User",
+      access_token: "created-token",
+    }
+    const accessTokenCreationPolicy = {
+      currentTabTransport: "disabled" as const,
+      tempWindowFallback: { statusCodes: [], codes: [] },
+    }
+    mockGetOrCreateAccessToken.mockResolvedValueOnce(accessToken)
+
+    const accountBootstrap = createNewApiAccountBootstrap(SITE_TYPES.NEW_API, {
+      accessTokenCreationPolicy,
+    })
+
+    await expect(
+      accountBootstrap.getOrCreateAccessToken(request),
+    ).resolves.toBe(accessToken)
+    expect(mockGetOrCreateAccessToken).toHaveBeenCalledWith(
+      request,
+      accessTokenCreationPolicy,
+    )
+  })
+
   it.each([
     [SITE_TYPES.ANYROUTER, anyrouterFetchSupportCheckIn],
     [SITE_TYPES.WONG_GONGYI, wongFetchSupportCheckIn],

--- a/tests/services/apiAdapters/newApi/accountCompletion.test.ts
+++ b/tests/services/apiAdapters/newApi/accountCompletion.test.ts
@@ -7,8 +7,10 @@ import {
 import { SITE_TYPES } from "~/constants/siteType"
 import { UI_CONSTANTS } from "~/constants/ui"
 import { AutoDetectCompletionError } from "~/services/accounts/autoDetectCompletion/types"
+import { NEW_API_DASHBOARD_TRANSIENT_AUTH_KIND } from "~/services/accountSiteOnboarding/contracts"
 import type { AccountCompletionHelpers } from "~/services/apiAdapters/contracts/accountCompletion"
 import { newApiAccountCompletion } from "~/services/apiAdapters/newApi/accountCompletion"
+import { API_ERROR_CODES, ApiError } from "~/services/apiTransport/errors"
 import { API_SERVICE_FETCH_CONTEXT_KINDS } from "~/services/apiTransport/type"
 import { AuthTypeEnum } from "~/types"
 
@@ -94,7 +96,18 @@ const helpers = {
 
 describe("newApiAccountCompletion", () => {
   beforeEach(() => {
-    vi.clearAllMocks()
+    mockCreateNewApiAccountBootstrap.mockReset()
+    mockExtractDefaultExchangeRate.mockReset()
+    mockFetchCheckInSupport.mockReset()
+    mockFetchSiteStatus.mockReset()
+    mockFetchUserInfo.mockReset()
+    mockGetOrCreateAccessToken.mockReset()
+    createServiceRequest.mockClear()
+    fetchSiteName.mockClear()
+    createCompletionError.mockClear()
+    trimString.mockClear()
+    createInitialCheckInConfig.mockClear()
+    handleCheckInSupportFetchFailure.mockClear()
     mockCreateNewApiAccountBootstrap.mockReturnValue({
       extractDefaultExchangeRate: mockExtractDefaultExchangeRate,
       fetchCheckInSupport: mockFetchCheckInSupport,
@@ -181,6 +194,291 @@ describe("newApiAccountCompletion", () => {
         },
       },
     })
+  })
+
+  it("uses the rc22 dashboard bearer to get or create the persisted PAT", async () => {
+    mockGetOrCreateAccessToken.mockResolvedValueOnce({
+      username: "  rc22-user  ",
+      access_token: "  management-pat  ",
+    })
+    mockFetchSiteStatus.mockResolvedValueOnce({
+      system_name: "  rc22 portal  ",
+      checkin_enabled: false,
+    })
+    mockExtractDefaultExchangeRate.mockReturnValueOnce(null)
+
+    const result = await newApiAccountCompletion.complete(
+      {
+        url: "https://panel.example.invalid/settings",
+        requestedAuthType: AuthTypeEnum.Cookie,
+        detected: {
+          userId: "42",
+          siteType: SITE_TYPES.NEW_API,
+          transientAuth: {
+            kind: NEW_API_DASHBOARD_TRANSIENT_AUTH_KIND,
+            token: "dashboard-jwt",
+            expiresAt: 4_102_444_800,
+            sessionId: "session-example",
+            origin: "https://panel.example.invalid",
+          },
+        },
+        context: {
+          fetchContext: currentTabFetchContext,
+        },
+      },
+      helpers,
+    )
+
+    expect(mockCreateNewApiAccountBootstrap).toHaveBeenCalledWith(
+      SITE_TYPES.NEW_API,
+      {
+        accessTokenCreationPolicy: {
+          currentTabTransport: "disabled",
+          tempWindowFallback: { statusCodes: [], codes: [] },
+        },
+      },
+    )
+    expect(mockGetOrCreateAccessToken).toHaveBeenCalledWith({
+      baseUrl: "https://panel.example.invalid/settings",
+      fetchContext: currentTabFetchContext,
+      auth: {
+        authType: AuthTypeEnum.AccessToken,
+        accessToken: "dashboard-jwt",
+      },
+    })
+    expect(mockFetchUserInfo).not.toHaveBeenCalled()
+    expect(result).toMatchObject({
+      username: "rc22-user",
+      accessToken: "management-pat",
+      authType: AuthTypeEnum.AccessToken,
+    })
+    expect(result).not.toHaveProperty("transientAuth")
+    expect(JSON.stringify(result)).not.toContain("dashboard-jwt")
+  })
+
+  it.each([
+    [
+      "expired",
+      {
+        expiresAt: 1,
+        origin: "https://panel.example.invalid",
+      },
+    ],
+    [
+      "bound to another origin",
+      {
+        expiresAt: 4_102_444_800,
+        origin: "https://other.example.invalid",
+      },
+    ],
+  ])(
+    "rejects %s rc22 dashboard auth before token bootstrap",
+    async (_case, transientAuthOverrides) => {
+      await expect(
+        newApiAccountCompletion.complete(
+          {
+            url: "https://panel.example.invalid",
+            requestedAuthType: AuthTypeEnum.Cookie,
+            detected: {
+              userId: "42",
+              siteType: SITE_TYPES.NEW_API,
+              transientAuth: {
+                kind: NEW_API_DASHBOARD_TRANSIENT_AUTH_KIND,
+                token: "dashboard-jwt",
+                sessionId: "session-example",
+                ...transientAuthOverrides,
+              },
+            },
+            context: {},
+          },
+          helpers,
+        ),
+      ).rejects.toMatchObject({
+        reason: AUTO_DETECT_FAILURE_REASONS.TokenFetchFailed,
+      })
+
+      expect(mockGetOrCreateAccessToken).not.toHaveBeenCalled()
+      expect(mockFetchUserInfo).not.toHaveBeenCalled()
+      expect(mockFetchSiteStatus).not.toHaveBeenCalled()
+    },
+  )
+
+  it("rejects rc22 dashboard auth that expires within the completion margin", async () => {
+    const dateNowSpy = vi.spyOn(Date, "now").mockReturnValue(2_000_000_000_000)
+    mockGetOrCreateAccessToken.mockResolvedValueOnce({
+      username: "rc22-user",
+      access_token: "management-pat",
+    })
+    mockFetchSiteStatus.mockResolvedValueOnce({
+      system_name: "rc22 portal",
+      checkin_enabled: false,
+    })
+
+    try {
+      await expect(
+        newApiAccountCompletion.complete(
+          {
+            url: "https://panel.example.invalid",
+            requestedAuthType: AuthTypeEnum.Cookie,
+            detected: {
+              userId: "42",
+              siteType: SITE_TYPES.NEW_API,
+              transientAuth: {
+                kind: NEW_API_DASHBOARD_TRANSIENT_AUTH_KIND,
+                token: "dashboard-jwt",
+                expiresAt: 2_000_000_030,
+                sessionId: "session-example",
+                origin: "https://panel.example.invalid",
+              },
+            },
+            context: {},
+          },
+          helpers,
+        ),
+      ).rejects.toMatchObject({
+        reason: AUTO_DETECT_FAILURE_REASONS.TokenFetchFailed,
+      })
+    } finally {
+      dateNowSpy.mockRestore()
+    }
+
+    expect(mockGetOrCreateAccessToken).not.toHaveBeenCalled()
+    expect(mockFetchSiteStatus).not.toHaveBeenCalled()
+  })
+
+  it("sanitizes rc22 bootstrap failures before creating the completion error", async () => {
+    const dashboardToken = "dashboard-jwt-sensitive-example"
+    const reflectedMessage = `upstream reflected ${dashboardToken}`
+    mockGetOrCreateAccessToken.mockRejectedValueOnce(
+      new ApiError(
+        reflectedMessage,
+        503,
+        "/api/user/token",
+        API_ERROR_CODES.HTTP_OTHER,
+      ),
+    )
+    mockFetchSiteStatus.mockResolvedValueOnce({
+      system_name: "rc22 portal",
+      checkin_enabled: false,
+    })
+
+    const error = await newApiAccountCompletion
+      .complete(
+        {
+          url: "https://panel.example.invalid",
+          requestedAuthType: AuthTypeEnum.Cookie,
+          detected: {
+            userId: "42",
+            siteType: SITE_TYPES.NEW_API,
+            transientAuth: {
+              kind: NEW_API_DASHBOARD_TRANSIENT_AUTH_KIND,
+              token: dashboardToken,
+              expiresAt: 4_102_444_800,
+              sessionId: "session-example",
+              origin: "https://panel.example.invalid",
+            },
+          },
+          context: {},
+        },
+        helpers,
+      )
+      .catch((cause: unknown) => cause)
+
+    expect(error).toBeInstanceOf(AutoDetectCompletionError)
+    const completionError = error as AutoDetectCompletionError
+    expect(completionError).toMatchObject({
+      reason: AUTO_DETECT_FAILURE_REASONS.TokenFetchFailed,
+      message: "New API dashboard authentication could not be exchanged",
+      cause: {
+        name: "ApiError",
+        message: "New API dashboard authentication could not be exchanged",
+        statusCode: 503,
+        endpoint: "/api/user/token",
+        code: API_ERROR_CODES.HTTP_OTHER,
+      },
+    })
+    expect(completionError.cause).toBeInstanceOf(Error)
+    expect(String(completionError.cause)).not.toContain(dashboardToken)
+    expect(String(completionError.cause)).not.toContain(reflectedMessage)
+  })
+
+  it("classifies an invalid rc22 target URL without retaining parser details", async () => {
+    const error = await newApiAccountCompletion
+      .complete(
+        {
+          url: "not a valid URL",
+          requestedAuthType: AuthTypeEnum.Cookie,
+          detected: {
+            userId: "42",
+            siteType: SITE_TYPES.NEW_API,
+            transientAuth: {
+              kind: NEW_API_DASHBOARD_TRANSIENT_AUTH_KIND,
+              token: "dashboard-jwt",
+              expiresAt: 4_102_444_800,
+              sessionId: "session-example",
+              origin: "https://panel.example.invalid",
+            },
+          },
+          context: {},
+        },
+        helpers,
+      )
+      .catch((cause: unknown) => cause)
+
+    expect(error).toBeInstanceOf(AutoDetectCompletionError)
+    const completionError = error as AutoDetectCompletionError
+    expect(completionError).toMatchObject({
+      reason: AUTO_DETECT_FAILURE_REASONS.UnexpectedException,
+      message: "New API dashboard authentication is invalid",
+      cause: {
+        message: "New API dashboard authentication is invalid",
+      },
+    })
+    expect(String(completionError.cause)).not.toContain("not a valid URL")
+    expect(mockGetOrCreateAccessToken).not.toHaveBeenCalled()
+    expect(mockFetchSiteStatus).not.toHaveBeenCalled()
+  })
+
+  it("ignores dashboard transient auth for other New API-family variants", async () => {
+    mockFetchUserInfo.mockResolvedValueOnce({
+      username: "legacy-family-user",
+      access_token: "legacy-visible-token",
+    })
+    mockFetchSiteStatus.mockResolvedValueOnce({
+      system_name: "Legacy Family Portal",
+      checkin_enabled: false,
+    })
+    mockExtractDefaultExchangeRate.mockReturnValueOnce(null)
+
+    const result = await newApiAccountCompletion.complete(
+      {
+        url: "https://family.example.invalid",
+        requestedAuthType: AuthTypeEnum.Cookie,
+        detected: {
+          userId: "43",
+          siteType: SITE_TYPES.VELOERA,
+          transientAuth: {
+            kind: NEW_API_DASHBOARD_TRANSIENT_AUTH_KIND,
+            token: "dashboard-jwt",
+            expiresAt: 4_102_444_800,
+            sessionId: "session-example",
+            origin: "https://family.example.invalid",
+          },
+        },
+        context: {},
+      },
+      helpers,
+    )
+
+    expect(mockFetchUserInfo).toHaveBeenCalledWith({
+      baseUrl: "https://family.example.invalid",
+      auth: {
+        authType: AuthTypeEnum.Cookie,
+        userId: "43",
+      },
+    })
+    expect(mockGetOrCreateAccessToken).not.toHaveBeenCalled()
+    expect(result.authType).toBe(AuthTypeEnum.Cookie)
   })
 
   it("completes cookie accounts with support probing and default exchange rate", async () => {

--- a/tests/services/apiService/newApiFamily/accountBootstrap.test.ts
+++ b/tests/services/apiService/newApiFamily/accountBootstrap.test.ts
@@ -44,7 +44,7 @@ describe("newApiFamily accountBootstrap", () => {
   }
 
   beforeEach(() => {
-    vi.clearAllMocks()
+    mockFetchApiData.mockReset()
   })
 
   it("fetchUserInfo returns the normalized public shape", async () => {
@@ -90,6 +90,22 @@ describe("newApiFamily accountBootstrap", () => {
     })
   })
 
+  it("createAccessToken applies an explicit no-replay transport policy", async () => {
+    mockFetchApiData.mockResolvedValueOnce("new-token")
+
+    await expect(
+      createAccessToken(request, {
+        currentTabTransport: "disabled",
+        tempWindowFallback: { statusCodes: [], codes: [] },
+      }),
+    ).resolves.toBe("new-token")
+    expect(mockFetchApiData).toHaveBeenCalledWith(request, {
+      endpoint: "/api/user/token",
+      currentTabTransport: "disabled",
+      tempWindowFallback: { statusCodes: [], codes: [] },
+    })
+  })
+
   it("getOrCreateAccessToken reuses the existing token when present", async () => {
     mockFetchApiData.mockResolvedValueOnce({
       id: 1,
@@ -119,6 +135,31 @@ describe("newApiFamily accountBootstrap", () => {
     })
     expect(mockFetchApiData).toHaveBeenNthCalledWith(2, request, {
       endpoint: "/api/user/token",
+    })
+  })
+
+  it("getOrCreateAccessToken forwards an explicit no-replay policy when creating a token", async () => {
+    mockFetchApiData
+      .mockResolvedValueOnce({
+        id: 1,
+        username: "alice",
+        access_token: "",
+      })
+      .mockResolvedValueOnce("generated-token")
+
+    await expect(
+      getOrCreateAccessToken(request, {
+        currentTabTransport: "disabled",
+        tempWindowFallback: { statusCodes: [], codes: [] },
+      }),
+    ).resolves.toEqual({
+      username: "alice",
+      access_token: "generated-token",
+    })
+    expect(mockFetchApiData).toHaveBeenNthCalledWith(2, request, {
+      endpoint: "/api/user/token",
+      currentTabTransport: "disabled",
+      tempWindowFallback: { statusCodes: [], codes: [] },
     })
   })
 

--- a/tests/services/apiTransport/request.test.ts
+++ b/tests/services/apiTransport/request.test.ts
@@ -59,6 +59,19 @@ const { mockIsProtectionBypassFirefoxEnv } = vi.hoisted(() => ({
   mockIsProtectionBypassFirefoxEnv: vi.fn(() => true),
 }))
 
+const { mockLoggerDebug } = vi.hoisted(() => ({
+  mockLoggerDebug: vi.fn(),
+}))
+
+vi.mock("~/utils/core/logger", () => ({
+  createLogger: () => ({
+    debug: mockLoggerDebug,
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  }),
+}))
+
 vi.mock("~/utils/browser/browserApi", async (importOriginal) => {
   const actual =
     await importOriginal<typeof import("~/utils/browser/browserApi")>()
@@ -897,6 +910,52 @@ describe("apiTransport request helpers", () => {
     ).resolves.toEqual({ ok: true })
 
     expect(mockSendTabMessageWithRetry).toHaveBeenCalledTimes(1)
+  })
+
+  it("redacts the request access token from current-tab fallback diagnostics", async () => {
+    const dashboardBearer = "dashboard-bearer-sensitive-example"
+    mockSendTabMessageWithRetry.mockResolvedValueOnce({
+      success: false,
+      status: 503,
+      error: `safe diagnostic: Authorization: Bearer ${dashboardBearer}`,
+    })
+    server.use(
+      http.get(API_URL, () =>
+        HttpResponse.json({
+          success: true,
+          data: { ok: true },
+          message: "direct",
+        }),
+      ),
+    )
+
+    await expect(
+      fetchApiData<{ ok: boolean }>(
+        {
+          baseUrl: BASE_URL,
+          auth: {
+            authType: AuthTypeEnum.AccessToken,
+            accessToken: dashboardBearer,
+          },
+          fetchContext: {
+            kind: API_TRANSPORT_FETCH_CONTEXT_KINDS.CURRENT_TAB,
+            tabId: 456,
+            origin: "https://example.com",
+          },
+        },
+        { endpoint: ENDPOINT },
+      ),
+    ).resolves.toEqual({ ok: true })
+
+    expect(mockLoggerDebug).toHaveBeenCalledWith(
+      "Current-tab content fetch failed; falling back",
+      expect.objectContaining({
+        error: expect.stringContaining("safe diagnostic"),
+      }),
+    )
+    const serializedLoggerArguments = JSON.stringify(mockLoggerDebug.mock.calls)
+    expect(serializedLoggerArguments).not.toContain(dashboardBearer)
+    expect(serializedLoggerArguments).toContain("Bearer [REDACTED]")
   })
 
   it("fetchApiData preserves the popup temp window source through fallback context", async () => {

--- a/tests/services/autoDetectService.test.ts
+++ b/tests/services/autoDetectService.test.ts
@@ -7,6 +7,7 @@ import {
 } from "~/constants/autoDetect"
 import { SITE_TYPES } from "~/constants/siteType"
 import { ACCOUNT_BROWSER_SESSION_SOURCES } from "~/services/accountBrowserSession/types"
+import { NEW_API_DASHBOARD_TRANSIENT_AUTH_KIND } from "~/services/accountSiteOnboarding/contracts"
 import { API_SERVICE_FETCH_CONTEXT_KINDS } from "~/services/apiTransport/type"
 import { autoDetectSmart } from "~/services/siteDetection/autoDetectService"
 import { AuthTypeEnum } from "~/types"
@@ -128,38 +129,54 @@ describe("autoDetectSmart", () => {
       {
         id: 1,
         active: true,
-        url: "https://example.com/dashboard",
+        url: "https://example.invalid/dashboard",
       },
     ])
     mockGetActiveTabs.mockResolvedValue([{ id: 1 }])
     mockReadAccountBrowserSessionFromTab.mockResolvedValueOnce({
       source: ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB,
       siteType: SITE_TYPES.NEW_API,
-      siteTypeHint: SITE_TYPES.VELOERA,
+      siteTypeHint: SITE_TYPES.NEW_API,
       userId: "12",
       user: { id: 12, username: "alice" },
       accessToken: "current-tab-token",
+      transientAuth: {
+        kind: NEW_API_DASHBOARD_TRANSIENT_AUTH_KIND,
+        token: "placeholder-current-tab-token",
+        expiresAt: 2_000_000_000,
+        sessionId: "placeholder-current-tab-session",
+        origin: "https://example.invalid",
+      },
       fetchContext: {
         kind: API_SERVICE_FETCH_CONTEXT_KINDS.CURRENT_TAB,
         tabId: 1,
-        origin: "https://example.com",
+        origin: "https://example.invalid",
       },
     })
 
-    const result = await autoDetectSmart("https://example.com/api/user/self")
+    const result = await autoDetectSmart(
+      "https://example.invalid/api/user/self",
+    )
 
     expect(result).toMatchObject({
       success: true,
       data: {
         userId: "12",
         user: { id: 12, username: "alice" },
-        siteType: SITE_TYPES.VELOERA,
+        siteType: SITE_TYPES.NEW_API,
         accessToken: "current-tab-token",
+        transientAuth: {
+          kind: NEW_API_DASHBOARD_TRANSIENT_AUTH_KIND,
+          token: "placeholder-current-tab-token",
+          expiresAt: 2_000_000_000,
+          sessionId: "placeholder-current-tab-session",
+          origin: "https://example.invalid",
+        },
         sub2apiAuth: undefined,
         fetchContext: {
           kind: API_SERVICE_FETCH_CONTEXT_KINDS.CURRENT_TAB,
           tabId: 1,
-          origin: "https://example.com",
+          origin: "https://example.invalid",
         },
       },
     })
@@ -242,6 +259,13 @@ describe("autoDetectSmart", () => {
       siteType: SITE_TYPES.NEW_API,
       userId: "12",
       user: { id: 12, username: "alice" },
+      transientAuth: {
+        kind: NEW_API_DASHBOARD_TRANSIENT_AUTH_KIND,
+        token: "placeholder-private-token",
+        expiresAt: 2_000_000_000,
+        sessionId: "placeholder-private-session",
+        origin: "https://example.com",
+      },
       fetchContext: {
         kind: API_SERVICE_FETCH_CONTEXT_KINDS.CURRENT_TAB,
         tabId: 101,
@@ -260,6 +284,13 @@ describe("autoDetectSmart", () => {
       currentTabMatched: true,
       siteType: SITE_TYPES.NEW_API,
     })
+    expect(JSON.stringify(result.autoDetectContext)).not.toContain(
+      "placeholder-private-token",
+    )
+    expect(JSON.stringify(result.autoDetectContext)).not.toContain(
+      "placeholder-private-session",
+    )
+    expect(result.autoDetectContext).not.toHaveProperty("transientAuth")
   })
 
   it("keeps incognito current-tab context on API fallback when content user data is missing", async () => {
@@ -813,7 +844,7 @@ describe("autoDetectSmart", () => {
       {
         id: 10,
         active: true,
-        url: "https://other.example.com/profile",
+        url: "https://other.example.invalid/profile",
       },
     ])
     mockSendRuntimeMessage.mockResolvedValue({
@@ -822,11 +853,18 @@ describe("autoDetectSmart", () => {
         userId: "88",
         user: { id: 88, username: "background-user" },
         accessToken: "background-token",
+        transientAuth: {
+          kind: NEW_API_DASHBOARD_TRANSIENT_AUTH_KIND,
+          token: "placeholder-background-token",
+          expiresAt: 2_000_000_000,
+          sessionId: "placeholder-background-session",
+          origin: "HTTPS://EXAMPLE.INVALID:443/",
+        },
         siteTypeHint: SITE_TYPES.NEW_API,
       },
     })
 
-    const result = await autoDetectSmart("https://example.com/console")
+    const result = await autoDetectSmart("https://example.invalid/console")
 
     expect(result).toMatchObject({
       success: true,
@@ -835,10 +873,55 @@ describe("autoDetectSmart", () => {
         user: { id: 88, username: "background-user" },
         siteType: SITE_TYPES.NEW_API,
         accessToken: "background-token",
+        transientAuth: {
+          kind: NEW_API_DASHBOARD_TRANSIENT_AUTH_KIND,
+          token: "placeholder-background-token",
+          expiresAt: 2_000_000_000,
+          sessionId: "placeholder-background-session",
+          origin: "https://example.invalid",
+        },
         sub2apiAuth: undefined,
       },
     })
     expect(result.data).not.toHaveProperty("fetchContext")
+    expect(mockFetchUserInfo).not.toHaveBeenCalled()
+  })
+
+  it("drops malformed transient auth from a background response while preserving identity", async () => {
+    mockGetActiveOrAllTabs.mockResolvedValue([
+      {
+        id: 11,
+        active: true,
+        url: "https://other.example.invalid/profile",
+      },
+    ])
+    mockSendRuntimeMessage.mockResolvedValue({
+      success: true,
+      data: {
+        userId: "89",
+        user: { id: 89, username: "background-user" },
+        transientAuth: {
+          kind: NEW_API_DASHBOARD_TRANSIENT_AUTH_KIND,
+          token: "   ",
+          expiresAt: 2_000_000_000,
+          sessionId: "placeholder-background-session",
+          origin: "https://example.invalid",
+        },
+        siteTypeHint: SITE_TYPES.NEW_API,
+      },
+    })
+
+    const result = await autoDetectSmart("https://example.invalid/console")
+
+    expect(result).toMatchObject({
+      success: true,
+      data: {
+        userId: "89",
+        user: { id: 89, username: "background-user" },
+        siteType: SITE_TYPES.NEW_API,
+      },
+    })
+    expect(result.data).not.toHaveProperty("transientAuth")
     expect(mockFetchUserInfo).not.toHaveBeenCalled()
   })
 
@@ -961,6 +1044,7 @@ describe("autoDetectSmart", () => {
       },
     })
     expect(result.data).not.toHaveProperty("fetchContext")
+    expect(result.data).not.toHaveProperty("transientAuth")
   })
 
   it("preserves popup temp-window source when background auto-detect throws", async () => {

--- a/tests/utils/accountScenarios.test.ts
+++ b/tests/utils/accountScenarios.test.ts
@@ -114,6 +114,81 @@ describe("account E2E scenarios", () => {
     expect(cleanup).toHaveBeenCalledOnce()
   })
 
+  it("runs dynamic, environment, and page cleanup in order after saving", async () => {
+    const events: string[] = []
+    const sitePage = {
+      close: vi.fn().mockImplementation(async () => {
+        events.push("page")
+      }),
+    } as any
+
+    vi.mocked(saveAutoDetectedAccountFromApp).mockImplementation(async () => {
+      events.push("save")
+      return {
+        accountId: "account-1",
+        siteType: SITE_TYPES.NEW_API,
+        baseUrl: "https://panel.example.invalid",
+      }
+    })
+
+    await runAccountAutoDetectScenario({
+      extensionId: "extension-id",
+      extensionPage: {} as any,
+      baseUrl: "https://panel.example.invalid",
+      siteType: SITE_TYPES.NEW_API,
+      getServiceWorker: vi.fn().mockResolvedValue({} as any),
+      openSitePage: vi.fn().mockResolvedValue(sitePage),
+      prepareDetectableSite: vi.fn().mockResolvedValue({
+        cleanupDetectableSite: async () => {
+          events.push("dynamic")
+        },
+      }),
+      cleanup: async () => {
+        events.push("environment")
+      },
+    })
+
+    expect(events).toEqual(["save", "dynamic", "environment", "page"])
+  })
+
+  it("runs dynamic cleanup after a failed save and preserves both failures", async () => {
+    const events: string[] = []
+    const primaryError = new Error("save failed")
+    const cleanupError = new Error("dynamic cleanup failed")
+    const sitePage = {
+      close: vi.fn().mockImplementation(async () => {
+        events.push("page")
+      }),
+    } as any
+
+    vi.mocked(saveAutoDetectedAccountFromApp).mockImplementation(async () => {
+      events.push("save")
+      throw primaryError
+    })
+
+    await expect(
+      runAccountAutoDetectScenario({
+        extensionId: "extension-id",
+        extensionPage: {} as any,
+        baseUrl: "https://panel.example.invalid",
+        siteType: SITE_TYPES.NEW_API,
+        getServiceWorker: vi.fn().mockResolvedValue({} as any),
+        openSitePage: vi.fn().mockResolvedValue(sitePage),
+        prepareDetectableSite: vi.fn().mockResolvedValue({
+          cleanupDetectableSite: async () => {
+            events.push("dynamic")
+            throw cleanupError
+          },
+        }),
+        cleanup: async () => {
+          events.push("environment")
+        },
+      }),
+    ).rejects.toMatchObject({ errors: [primaryError, cleanupError] })
+
+    expect(events).toEqual(["save", "dynamic", "environment", "page"])
+  })
+
   it("uses an existing fixture for key lifecycle without auto-detecting an account", async () => {
     const extensionPage = {} as any
     const keyPage = {} as any

--- a/tests/utils/realSiteCompatibleApi.test.ts
+++ b/tests/utils/realSiteCompatibleApi.test.ts
@@ -1,0 +1,561 @@
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  loginToCompatibleApiRealSite,
+  type CompatibleApiRealSiteConfig,
+} from "~~/e2e/utils/realSite/compatibleApi"
+import { loginToRealNewApiSite } from "~~/e2e/utils/realSite/newApi"
+
+const ORIGIN = "https://panel.example.invalid"
+const AUTH_REFRESH_URL = `${ORIGIN}/api/user/auth/refresh`
+const AUTH_LOGOUT_URL = `${ORIGIN}/api/user/auth/logout`
+const FUTURE_EXPIRY = Math.floor(Date.now() / 1000) + 3_600
+
+const config: CompatibleApiRealSiteConfig = {
+  baseUrl: ORIGIN,
+  loginUrl: `${ORIGIN}/login`,
+  loginApiUrl: `${ORIGIN}/api/user/login`,
+  login2faApiUrl: `${ORIGIN}/api/user/login/2fa`,
+  username: "example-user",
+  password: "example-password",
+}
+
+function createResponse(status: number, body: unknown) {
+  return {
+    ok: () => status >= 200 && status < 300,
+    status: () => status,
+    text: vi.fn().mockResolvedValue(JSON.stringify(body)),
+  }
+}
+
+function createAuthBundle(overrides: Record<string, unknown> = {}) {
+  return {
+    success: true,
+    data: {
+      access_token: "access-token-placeholder",
+      token_type: "Bearer",
+      access_expires_at: FUTURE_EXPIRY,
+      user: {
+        id: 42,
+        username: "example-user",
+      },
+      session: {
+        sid: "session-id-placeholder",
+        current: true,
+      },
+      ...overrides,
+    },
+  }
+}
+
+function createPage(
+  post: ReturnType<typeof vi.fn>,
+  options: { storedUser?: Record<string, unknown> } = {},
+) {
+  const evaluate = vi.fn().mockResolvedValue(undefined)
+  const waitForFunction = options.storedUser
+    ? vi.fn().mockResolvedValue({
+        jsonValue: vi.fn().mockResolvedValue(options.storedUser),
+      })
+    : vi.fn().mockRejectedValue(new Error("no stored user"))
+
+  return {
+    page: {
+      url: vi.fn().mockReturnValue(`${ORIGIN}/login`),
+      goto: vi.fn().mockResolvedValue(undefined),
+      evaluate,
+      waitForFunction,
+      request: {
+        post,
+        get: vi.fn(),
+      },
+    } as any,
+    evaluate,
+    waitForFunction,
+  }
+}
+
+describe("compatible real-site login", () => {
+  it("keeps legacy user responses and localStorage seeding unchanged", async () => {
+    const user = { id: 7, username: "legacy-user" }
+    const post = vi.fn().mockResolvedValue(
+      createResponse(200, {
+        success: true,
+        data: user,
+      }),
+    )
+    const { page, evaluate } = createPage(post)
+
+    await expect(
+      loginToCompatibleApiRealSite(page, config, {
+        label: "Legacy API",
+        envPrefix: "LEGACY_API",
+      }),
+    ).resolves.toEqual({ reusedSession: false, user })
+
+    expect(evaluate).toHaveBeenCalledWith(expect.any(Function), {
+      user: JSON.stringify(user),
+    })
+    expect(post).toHaveBeenCalledTimes(1)
+  })
+
+  it("keeps marker-shaped legacy users unchanged for non-opt-in wrappers", async () => {
+    const user = {
+      id: 7,
+      username: "legacy-user",
+      access_token: "legacy-access-token-placeholder",
+      session: { sid: "legacy-session-value", current: false },
+    }
+    const post = vi.fn().mockResolvedValue(
+      createResponse(200, {
+        success: true,
+        data: user,
+      }),
+    )
+    const { page, evaluate } = createPage(post)
+
+    await expect(
+      loginToCompatibleApiRealSite(page, config, {
+        label: "Legacy API",
+        envPrefix: "LEGACY_API",
+      }),
+    ).resolves.toEqual({ reusedSession: false, user })
+
+    expect(evaluate).toHaveBeenCalledWith(expect.any(Function), {
+      user: JSON.stringify(user),
+    })
+    expect(post).toHaveBeenCalledTimes(1)
+  })
+
+  it("returns a fresh rc.22 AuthBundle without storage seeding or UI fallback", async () => {
+    const post = vi
+      .fn()
+      .mockResolvedValueOnce(createResponse(401, { code: "AUTH_UNAUTHORIZED" }))
+      .mockResolvedValueOnce(createResponse(200, createAuthBundle()))
+    const { page, evaluate, waitForFunction } = createPage(post)
+
+    const result = await loginToRealNewApiSite(page, config)
+
+    expect(result).toMatchObject({
+      reusedSession: false,
+      user: { id: 42, username: "example-user" },
+      cleanupOwnedSession: expect.any(Function),
+    })
+    expect(evaluate).not.toHaveBeenCalled()
+    expect(waitForFunction).not.toHaveBeenCalled()
+    expect(post).toHaveBeenCalledTimes(2)
+  })
+
+  it("reuses an existing AuthBundle session without taking cleanup ownership", async () => {
+    const post = vi
+      .fn()
+      .mockResolvedValue(createResponse(200, createAuthBundle()))
+    const { page, evaluate, waitForFunction } = createPage(post)
+
+    const result = await loginToRealNewApiSite(page, config)
+
+    expect(result).toEqual({
+      reusedSession: true,
+      user: { id: 42, username: "example-user" },
+    })
+    expect(result.cleanupOwnedSession).toBeUndefined()
+    expect(evaluate).not.toHaveBeenCalled()
+    expect(waitForFunction).not.toHaveBeenCalled()
+    expect(post).toHaveBeenCalledTimes(1)
+  })
+
+  it("logs out only the fresh owned session with exact safe headers", async () => {
+    const post = vi
+      .fn()
+      .mockResolvedValueOnce(createResponse(401, { code: "AUTH_UNAUTHORIZED" }))
+      .mockResolvedValueOnce(createResponse(200, createAuthBundle()))
+      .mockResolvedValueOnce(createResponse(200, { success: true }))
+    const { page } = createPage(post)
+
+    const result = await loginToRealNewApiSite(page, config)
+    await result.cleanupOwnedSession?.()
+
+    expect(post).toHaveBeenLastCalledWith(AUTH_LOGOUT_URL, {
+      failOnStatusCode: false,
+      headers: {
+        Origin: ORIGIN,
+        Authorization: "Bearer access-token-placeholder",
+        "X-Auth-Session": "session-id-placeholder",
+      },
+    })
+  })
+
+  it("uses the successful 2FA AuthBundle response as the login result", async () => {
+    const post = vi
+      .fn()
+      .mockResolvedValueOnce(createResponse(401, { code: "AUTH_UNAUTHORIZED" }))
+      .mockResolvedValueOnce(
+        createResponse(200, { success: true, data: { require_2fa: true } }),
+      )
+      .mockResolvedValueOnce(createResponse(200, createAuthBundle()))
+    const { page, evaluate, waitForFunction } = createPage(post)
+
+    const result = await loginToRealNewApiSite(page, {
+      ...config,
+      totpSecret: "JBSWY3DPEHPK3PXP",
+    })
+
+    expect(result).toMatchObject({
+      reusedSession: false,
+      user: { id: 42, username: "example-user" },
+      cleanupOwnedSession: expect.any(Function),
+    })
+    expect(post).toHaveBeenNthCalledWith(3, config.login2faApiUrl, {
+      data: { code: expect.stringMatching(/^\d{6}$/u) },
+      failOnStatusCode: false,
+    })
+    expect(evaluate).not.toHaveBeenCalled()
+    expect(waitForFunction).not.toHaveBeenCalled()
+  })
+
+  it("treats a rejected 2FA request as terminal without exposing its cause", async () => {
+    const post = vi
+      .fn()
+      .mockResolvedValueOnce(createResponse(401, { code: "AUTH_UNAUTHORIZED" }))
+      .mockResolvedValueOnce(
+        createResponse(200, { success: true, data: { require_2fa: true } }),
+      )
+      .mockRejectedValueOnce(new Error("must-not-leak-transport-details"))
+    const { page, evaluate, waitForFunction } = createPage(post)
+
+    await expect(
+      loginToRealNewApiSite(page, {
+        ...config,
+        totpSecret: "JBSWY3DPEHPK3PXP",
+      }),
+    ).rejects.toMatchObject({ message: "Real New API 2FA request failed." })
+
+    expect(post).toHaveBeenCalledTimes(3)
+    expect(evaluate).not.toHaveBeenCalled()
+    expect(waitForFunction).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    ["a missing token type", { token_type: undefined }],
+    ["a missing access expiry", { access_expires_at: undefined }],
+    [
+      "an expired access token",
+      { access_expires_at: Math.floor(Date.now() / 1000) - 1 },
+    ],
+    [
+      "a session without a current marker",
+      { session: { sid: "session-id-placeholder" } },
+    ],
+    [
+      "a non-current session",
+      { session: { sid: "session-id-placeholder", current: false } },
+    ],
+  ])("treats %s as a terminal malformed refresh", async (_label, overrides) => {
+    const post = vi
+      .fn()
+      .mockResolvedValue(createResponse(200, createAuthBundle(overrides)))
+    const { page, evaluate, waitForFunction } = createPage(post)
+
+    await expect(loginToRealNewApiSite(page, config)).rejects.toMatchObject({
+      message: "Real New API auth session response is invalid.",
+    })
+
+    expect(post).toHaveBeenCalledTimes(1)
+    expect(evaluate).not.toHaveBeenCalled()
+    expect(waitForFunction).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    [409, "AUTH_SESSION_LIMIT"],
+    [429, "AUTH_SESSION_ISSUANCE_LIMIT"],
+    [503, null],
+  ])(
+    "treats login HTTP %i as terminal without falling back to UI",
+    async (status, code) => {
+      const post = vi
+        .fn()
+        .mockResolvedValueOnce(
+          createResponse(401, { code: "AUTH_UNAUTHORIZED" }),
+        )
+        .mockResolvedValueOnce(
+          createResponse(status, {
+            success: false,
+            code,
+            message: "must-not-leak-server-message",
+          }),
+        )
+      const { page, evaluate, waitForFunction } = createPage(post)
+
+      await expect(loginToRealNewApiSite(page, config)).rejects.toMatchObject({
+        message: `New API auth session request failed (HTTP ${status}${code ? `, ${code}` : ""})`,
+      })
+      expect(post).toHaveBeenCalledTimes(2)
+      expect(evaluate).not.toHaveBeenCalled()
+      expect(waitForFunction).not.toHaveBeenCalled()
+    },
+  )
+
+  it("keeps a non-successful 2FA response terminal and sanitized", async () => {
+    const post = vi
+      .fn()
+      .mockResolvedValueOnce(createResponse(401, { code: "AUTH_UNAUTHORIZED" }))
+      .mockResolvedValueOnce(
+        createResponse(200, { success: true, data: { require_2fa: true } }),
+      )
+      .mockResolvedValueOnce(
+        createResponse(409, {
+          code: "AUTH_SESSION_LIMIT",
+          message: "must-not-leak-server-message",
+        }),
+      )
+    const { page, evaluate, waitForFunction } = createPage(post)
+
+    await expect(
+      loginToRealNewApiSite(page, {
+        ...config,
+        totpSecret: "JBSWY3DPEHPK3PXP",
+      }),
+    ).rejects.toMatchObject({
+      message:
+        "New API auth session request failed (HTTP 409, AUTH_SESSION_LIMIT)",
+    })
+    expect(post).toHaveBeenCalledTimes(3)
+    expect(evaluate).not.toHaveBeenCalled()
+    expect(waitForFunction).not.toHaveBeenCalled()
+  })
+
+  it("falls back to the legacy flow for an unrelated successful refresh", async () => {
+    const user = { id: 7, username: "legacy-user" }
+    const post = vi
+      .fn()
+      .mockResolvedValueOnce(
+        createResponse(200, { success: true, data: { greeting: "hello" } }),
+      )
+      .mockResolvedValueOnce(createResponse(200, { success: true, data: user }))
+    const { page, evaluate, waitForFunction } = createPage(post)
+
+    await expect(loginToRealNewApiSite(page, config)).resolves.toEqual({
+      reusedSession: false,
+      user,
+    })
+
+    expect(waitForFunction).toHaveBeenCalledTimes(1)
+    expect(evaluate).toHaveBeenCalledWith(expect.any(Function), {
+      user: JSON.stringify(user),
+    })
+  })
+
+  it("keeps marker-bearing unsuccessful envelopes terminal on HTTP 2xx", async () => {
+    const post = vi
+      .fn()
+      .mockResolvedValueOnce(
+        createResponse(200, {
+          success: false,
+          data: {
+            access_token: "must-not-leak-token",
+            session: { sid: "must-not-leak-session" },
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        createResponse(200, {
+          success: true,
+          data: { id: 7, username: "must-not-reach-legacy-login" },
+        }),
+      )
+    const { page, evaluate, waitForFunction } = createPage(post)
+
+    let caught: unknown
+    try {
+      await loginToRealNewApiSite(page, config)
+    } catch (error) {
+      caught = error
+    }
+
+    expect(caught).toMatchObject({
+      message: "Real New API auth session response is invalid.",
+    })
+    expect((caught as Error).message).not.toContain("must-not-leak")
+    expect(post).toHaveBeenCalledTimes(1)
+    expect(evaluate).not.toHaveBeenCalled()
+    expect(waitForFunction).not.toHaveBeenCalled()
+  })
+
+  it("treats a malformed successful 2FA bundle as terminal", async () => {
+    const post = vi
+      .fn()
+      .mockResolvedValueOnce(createResponse(401, { code: "AUTH_UNAUTHORIZED" }))
+      .mockResolvedValueOnce(
+        createResponse(200, { success: true, data: { require_2fa: true } }),
+      )
+      .mockResolvedValueOnce(
+        createResponse(200, {
+          success: true,
+          data: {
+            id: 42,
+            username: "legacy-shaped-user",
+            access_token: "must-not-leak-token",
+            token_type: "bearer",
+            access_expires_at: FUTURE_EXPIRY,
+            user: { id: 42, username: "example-user" },
+            session: {
+              sid: "must-not-leak-session",
+              current: false,
+            },
+          },
+        }),
+      )
+    const { page, evaluate, waitForFunction } = createPage(post)
+
+    let caught: unknown
+    try {
+      await loginToRealNewApiSite(page, {
+        ...config,
+        totpSecret: "JBSWY3DPEHPK3PXP",
+      })
+    } catch (error) {
+      caught = error
+    }
+
+    expect(caught).toMatchObject({
+      message: "Real New API auth session response is invalid.",
+    })
+    expect((caught as Error).message).not.toContain("must-not-leak")
+    expect(post).toHaveBeenCalledTimes(3)
+    expect(evaluate).not.toHaveBeenCalled()
+    expect(waitForFunction).not.toHaveBeenCalled()
+  })
+
+  it("treats a malformed successful AuthBundle login as terminal and sanitized", async () => {
+    const post = vi
+      .fn()
+      .mockResolvedValueOnce(createResponse(401, { code: "AUTH_UNAUTHORIZED" }))
+      .mockResolvedValueOnce(
+        createResponse(200, {
+          success: true,
+          data: {
+            id: 42,
+            username: "legacy-shaped-user",
+            access_token: "must-not-leak-token",
+            token_type: "bearer",
+            access_expires_at: FUTURE_EXPIRY,
+            user: { id: 42 },
+            session: { sid: "must-not-leak-session", current: true },
+          },
+        }),
+      )
+    const { page, evaluate, waitForFunction } = createPage(post)
+
+    let caught: unknown
+    try {
+      await loginToRealNewApiSite(page, config)
+    } catch (error) {
+      caught = error
+    }
+
+    expect(caught).toBeInstanceOf(Error)
+    expect((caught as Error).message).toContain("invalid")
+    expect((caught as Error).message).not.toContain("must-not-leak-token")
+    expect((caught as Error).message).not.toContain("must-not-leak-session")
+    expect(evaluate).not.toHaveBeenCalled()
+    expect(waitForFunction).not.toHaveBeenCalled()
+    expect(post).toHaveBeenCalledTimes(2)
+  })
+
+  it("accepts a marker-shaped top-level legacy user after New API refresh fallback", async () => {
+    const user = {
+      id: 7,
+      username: "legacy-shaped-user",
+      access_token: "legacy-access-token-placeholder",
+      session: { sid: "legacy-session-value", current: false },
+    }
+    const post = vi
+      .fn()
+      .mockResolvedValueOnce(createResponse(404, { success: false }))
+      .mockResolvedValueOnce(
+        createResponse(200, {
+          success: true,
+          data: user,
+        }),
+      )
+    const { page, evaluate, waitForFunction } = createPage(post)
+
+    await expect(loginToRealNewApiSite(page, config)).resolves.toEqual({
+      reusedSession: false,
+      user,
+    })
+    expect(evaluate).toHaveBeenCalledWith(expect.any(Function), {
+      user: JSON.stringify(user),
+    })
+    expect(waitForFunction).toHaveBeenCalledTimes(1)
+    expect(post).toHaveBeenCalledTimes(2)
+  })
+
+  it.each([
+    [409, "AUTH_SESSION_LIMIT"],
+    [429, "AUTH_SESSION_ISSUANCE_LIMIT"],
+  ])(
+    "treats refresh HTTP %i as a controlled terminal error",
+    async (status, code) => {
+      const post = vi.fn().mockResolvedValue(
+        createResponse(status, {
+          success: false,
+          code,
+          message: "must-not-leak-server-message",
+          data: {
+            access_token: "must-not-leak-token",
+            session: { sid: "must-not-leak-session" },
+          },
+        }),
+      )
+      const { page, evaluate, waitForFunction } = createPage(post)
+
+      let caught: unknown
+      try {
+        await loginToRealNewApiSite(page, config)
+      } catch (error) {
+        caught = error
+      }
+
+      expect(caught).toMatchObject({
+        message: `New API auth session request failed (HTTP ${status}, ${code})`,
+      })
+      expect((caught as Error).message).not.toContain("must-not-leak")
+      expect(evaluate).not.toHaveBeenCalled()
+      expect(waitForFunction).not.toHaveBeenCalled()
+      expect(post).toHaveBeenCalledTimes(1)
+      expect(post).toHaveBeenCalledWith(AUTH_REFRESH_URL, {
+        failOnStatusCode: false,
+        headers: { Origin: ORIGIN },
+      })
+    },
+  )
+
+  it("sanitizes owned-session cleanup failures", async () => {
+    const post = vi
+      .fn()
+      .mockResolvedValueOnce(createResponse(401, { code: "AUTH_UNAUTHORIZED" }))
+      .mockResolvedValueOnce(createResponse(200, createAuthBundle()))
+      .mockResolvedValueOnce(
+        createResponse(500, {
+          message: "must-not-leak-server-message",
+          access_token: "must-not-leak-token",
+          session: { sid: "must-not-leak-session" },
+        }),
+      )
+    const { page } = createPage(post)
+    const result = await loginToRealNewApiSite(page, config)
+
+    let caught: unknown
+    try {
+      await result.cleanupOwnedSession?.()
+    } catch (error) {
+      caught = error
+    }
+
+    expect(caught).toMatchObject({
+      message: "New API auth session cleanup failed (HTTP 500)",
+    })
+    expect((caught as Error).message).not.toContain("must-not-leak")
+  })
+})

--- a/tests/utils/realSiteCompatibleApi.test.ts
+++ b/tests/utils/realSiteCompatibleApi.test.ts
@@ -531,6 +531,31 @@ describe("compatible real-site login", () => {
     },
   )
 
+  it("sanitizes auth refresh transport failures", async () => {
+    const transportDetails = "must-not-leak-transport-details"
+    const post = vi.fn().mockRejectedValue(new Error(transportDetails))
+    const { page, evaluate, waitForFunction } = createPage(post)
+
+    let caught: unknown
+    try {
+      await loginToRealNewApiSite(page, config)
+    } catch (error) {
+      caught = error
+    }
+
+    expect(caught).toMatchObject({
+      message: "Real New API auth session refresh request failed.",
+    })
+    expect((caught as Error).message).not.toContain(transportDetails)
+    expect(evaluate).not.toHaveBeenCalled()
+    expect(waitForFunction).not.toHaveBeenCalled()
+    expect(post).toHaveBeenCalledTimes(1)
+    expect(post).toHaveBeenCalledWith(AUTH_REFRESH_URL, {
+      failOnStatusCode: false,
+      headers: { Origin: ORIGIN },
+    })
+  })
+
   it("sanitizes owned-session cleanup failures", async () => {
     const post = vi
       .fn()

--- a/tests/utils/tempWindowFetch.fallback.test.ts
+++ b/tests/utils/tempWindowFetch.fallback.test.ts
@@ -708,7 +708,33 @@ describe("tempWindowFetch runtime helpers and fallback gating", () => {
     )
   })
 
-  it("falls back on 401 cookie-auth failures even when a request has a custom fallback allowlist", async () => {
+  it("does not fall back on cookie-auth 401 when an explicit empty allowlist is provided", async () => {
+    const error = new ApiError(
+      "current browser session is unauthorized",
+      401,
+      "/api/models",
+      API_ERROR_CODES.HTTP_401,
+    )
+
+    await expect(
+      executeWithTempWindowFallback(
+        buildContext({
+          onlyData: true,
+          accountId: "acct-1",
+          authType: AuthTypeEnum.Cookie,
+          cookieAuthSessionCookie: "session=stored-account",
+          tempWindowFallback: { statusCodes: [], codes: [] },
+        }),
+        async () => {
+          throw error
+        },
+      ),
+    ).rejects.toBe(error)
+
+    expect(mocks.sendRuntimeMessageMock).not.toHaveBeenCalled()
+  })
+
+  it("honors an explicit cookie-auth 401 allowlist", async () => {
     mocks.sendRuntimeMessageMock.mockResolvedValue({
       success: true,
       status: 200,
@@ -725,10 +751,7 @@ describe("tempWindowFetch runtime helpers and fallback gating", () => {
         accountId: "acct-1",
         authType: AuthTypeEnum.Cookie,
         cookieAuthSessionCookie: "session=stored-account",
-        tempWindowFallback: {
-          statusCodes: [429],
-          codes: [API_ERROR_CODES.HTTP_429],
-        },
+        tempWindowFallback: { statusCodes: [401], codes: [] },
       }),
       async () => {
         throw new ApiError(
@@ -741,14 +764,7 @@ describe("tempWindowFetch runtime helpers and fallback gating", () => {
     )
 
     expect(result).toEqual({ account: "stored-cookie" })
-    expect(mocks.sendRuntimeMessageMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        action: RuntimeActionIds.TempWindowFetch,
-        accountId: "acct-1",
-        authType: AuthTypeEnum.Cookie,
-        cookieAuthSessionCookie: "session=stored-account",
-      }),
-    )
+    expect(mocks.sendRuntimeMessageMock).toHaveBeenCalledOnce()
   })
 
   it("does not fall back on 401 token-auth failures", async () => {


### PR DESCRIPTION
## Summary

New API rc.22 changed dashboard authentication from the legacy `localStorage.user`/cookie flow to an AuthBundle with a short-lived Bearer token. Account auto-detection still expected the legacy shape, so successful logins could fall through into repeated login attempts and eventually hit the dashboard session limit.

This PR:

- detects rc.22 AuthBundles at runtime while preserving the legacy New API path
- carries dashboard authentication only as transient onboarding state
- exchanges the dashboard Bearer once for the management PAT and persists only that PAT
- keeps 404/405 refresh responses as the capability signal for legacy deployments
- hardens credential fallback boundaries so non-replayable exchanges are not retried through another browser transport
- updates deterministic and real-site E2E helpers for both authentication contracts

Triggered by [Actions run 30218636126](https://github.com/qixing-jk/all-api-hub/actions/runs/30218636126).

## Validation

- `pnpm exec vitest run <14 affected test files>` — 403 passed
- `pnpm run i18n:extract:ci` — no files updated
- `pnpm exec playwright test e2e/accountOnboardingCommonFlows.spec.ts --project=chromium --reporter=list --workers=1` — 7 passed, including legacy and rc.22 onboarding
- `pnpm run validate:push` — TypeScript compile and Knip passed
- Git pre-push validation — passed

## Compatibility

Legacy accounts and existing saved PATs continue through the previous path. The rc.22 dashboard Bearer and session metadata are not persisted as account credentials.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Restored New API rc.22 account auto-detection for modern dashboard authentication.
  * Automatically refreshes and exchanges temporary dashboard credentials for a management access token during account completion.
* **Bug Fixes**
  * Preserved legacy New API behavior when modern authentication is unavailable.
  * Ensured temporary dashboard credentials are never persisted, displayed, or emitted in logs/telemetry.
  * Improved cleanup sequencing and tightened security checks (origin, expiry, and safe error handling).
* **Tests**
  * Added unit and end-to-end coverage for rc.22 vs legacy flows, cleanup ordering, and privacy/error-sanitization invariants.
* **Documentation**
  * Added New API rc.22 auto-detect compatibility plan and design spec.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->