### PR TITLE
fix(ui): prevent modal drag-out dismissal

### DIFF
--- a/e2e/accountManagementCommonFlows.spec.ts
+++ b/e2e/accountManagementCommonFlows.spec.ts
@@ -147,6 +147,49 @@ test.beforeEach(async ({ context, page }) => {
   await stubLlmMetadataIndex(context)
 })
 
+test("keeps the add account dialog open when text selection ends over its backdrop", async ({
+  extensionId,
+  page,
+}) => {
+  await page.goto(
+    `chrome-extension://${extensionId}/${OPTIONS_PAGE_PATH}#account`,
+  )
+  await waitForExtensionRoot(page)
+  await expectPermissionOnboardingHidden(page)
+
+  await page.getByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.addAccountButton).click()
+
+  const panel = page.getByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.accountDialog)
+  const positioner = page.locator('[data-slot="modal-positioner"]')
+  const heading = panel.getByRole("heading", { name: "Add Account" })
+  await expect(panel).toBeVisible()
+  await expect(positioner).toBeVisible()
+  await expect(heading).toBeVisible()
+
+  const [headingBox, panelBox, positionerBox] = await Promise.all([
+    heading.boundingBox(),
+    panel.boundingBox(),
+    positioner.boundingBox(),
+  ])
+  if (!headingBox || !panelBox || !positionerBox) {
+    throw new Error("Could not resolve add account dialog geometry")
+  }
+
+  await page.mouse.move(
+    headingBox.x + headingBox.width / 2,
+    headingBox.y + headingBox.height / 2,
+  )
+  await page.mouse.down()
+  await page.mouse.move(
+    Math.max(positionerBox.x + 1, panelBox.x - 8),
+    headingBox.y + headingBox.height / 2,
+    { steps: 10 },
+  )
+  await page.mouse.up()
+
+  await expect(panel).toBeVisible()
+})
+
 test("disables and re-enables a stored account from account management", async ({
   context,
   extensionId,

--- a/src/components/ui/Dialog/Modal.tsx
+++ b/src/components/ui/Dialog/Modal.tsx
@@ -1,6 +1,6 @@
 import { XIcon } from "lucide-react"
 import { Dialog as DialogPrimitive } from "radix-ui"
-import { ReactNode, useRef, type MouseEvent } from "react"
+import { ReactNode, useRef, type MouseEvent, type PointerEvent } from "react"
 
 import { Z_INDEX } from "~/constants/designTokens"
 import { cn } from "~/lib/utils"
@@ -73,10 +73,29 @@ export function Modal({
   size = "md",
 }: ModalProps) {
   const contentRef = useRef<HTMLDivElement>(null)
+  const backdropPointerDownTargetRef = useRef<HTMLDivElement | null>(null)
+
+  const handleBackdropPointerDown = (event: PointerEvent<HTMLDivElement>) => {
+    backdropPointerDownTargetRef.current =
+      event.target === event.currentTarget ? event.currentTarget : null
+  }
 
   const handleBackdropClick = (event: MouseEvent<HTMLDivElement>) => {
-    if (event.target !== event.currentTarget || !closeOnBackdropClick) return
-    onClose()
+    const pointerDownTarget = backdropPointerDownTargetRef.current
+    // Keep programmatic and assistive click dismissal compatible even though
+    // those clicks do not have a preceding pointer event.
+    const isNonPointerClick = pointerDownTarget === null && event.detail === 0
+    const shouldClose =
+      closeOnBackdropClick &&
+      event.target === event.currentTarget &&
+      (pointerDownTarget === event.currentTarget || isNonPointerClick)
+
+    backdropPointerDownTargetRef.current = null
+    if (shouldClose) onClose()
+  }
+
+  const handleBackdropPointerCancel = () => {
+    backdropPointerDownTargetRef.current = null
   }
 
   const shouldCloseOnEscape = () => {
@@ -109,6 +128,8 @@ export function Modal({
             "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 bg-black/30 backdrop-blur-sm",
             Z_INDEX.modal,
           )}
+          onPointerDown={handleBackdropPointerDown}
+          onPointerCancel={handleBackdropPointerCancel}
           onClick={handleBackdropClick}
         />
 
@@ -137,6 +158,8 @@ export function Modal({
             <div
               className="flex items-center justify-center p-4"
               data-slot="modal-positioner"
+              onPointerDown={handleBackdropPointerDown}
+              onPointerCancel={handleBackdropPointerCancel}
               onClick={handleBackdropClick}
             >
               <div

--- a/tests/components/FloatingLayerPrimitives.test.tsx
+++ b/tests/components/FloatingLayerPrimitives.test.tsx
@@ -31,7 +31,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "~/components/ui/dropdown-menu"
-import { render, screen } from "~~/tests/test-utils/render"
+import { fireEvent, render, screen } from "~~/tests/test-utils/render"
 
 /**
  * Minimal legacy Modal host for select-layer assertions.
@@ -228,6 +228,45 @@ describe("floating layer primitives inside dialogs", () => {
     await user.click(positioner as HTMLElement)
 
     expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it("preserves non-pointer backdrop dismissal", async () => {
+    const onClose = vi.fn()
+
+    render(
+      <Modal isOpen={true} onClose={onClose}>
+        <button type="button">Inside modal</button>
+      </Modal>,
+    )
+
+    await screen.findByRole("dialog")
+
+    const positioner = document.querySelector('[data-slot="modal-positioner"]')
+    expect(positioner).toBeInTheDocument()
+
+    fireEvent.click(positioner as HTMLElement)
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it("keeps Modal open when a pointer drag starts inside the panel", async () => {
+    const onClose = vi.fn()
+
+    render(
+      <Modal isOpen={true} onClose={onClose}>
+        <span>Selectable modal content</span>
+      </Modal>,
+    )
+
+    const content = await screen.findByText("Selectable modal content")
+    const positioner = document.querySelector('[data-slot="modal-positioner"]')
+    expect(positioner).toBeInTheDocument()
+
+    fireEvent.pointerDown(content)
+    fireEvent.pointerUp(positioner as HTMLElement)
+    fireEvent.click(positioner as HTMLElement, { detail: 1 })
+
+    expect(onClose).not.toHaveBeenCalled()
   })
 
   it("uses Modal title as the dialog name without duplicating visible headings", async () => {

--- a/tests/components/FloatingLayerPrimitives.test.tsx
+++ b/tests/components/FloatingLayerPrimitives.test.tsx
@@ -211,7 +211,6 @@ describe("floating layer primitives inside dialogs", () => {
   })
 
   it("requests Modal close when clicking the visual backdrop around the panel", async () => {
-    const user = userEvent.setup()
     const onClose = vi.fn()
 
     render(
@@ -225,7 +224,8 @@ describe("floating layer primitives inside dialogs", () => {
     const positioner = document.querySelector('[data-slot="modal-positioner"]')
     expect(positioner).toBeInTheDocument()
 
-    await user.click(positioner as HTMLElement)
+    fireEvent.pointerDown(positioner as HTMLElement)
+    fireEvent.click(positioner as HTMLElement, { detail: 1 })
 
     expect(onClose).toHaveBeenCalledTimes(1)
   })

--- a/tests/components/FloatingLayerPrimitives.test.tsx
+++ b/tests/components/FloatingLayerPrimitives.test.tsx
@@ -249,6 +249,27 @@ describe("floating layer primitives inside dialogs", () => {
     expect(onClose).toHaveBeenCalledTimes(1)
   })
 
+  it("clears backdrop pointer origin when the pointer is canceled", async () => {
+    const onClose = vi.fn()
+
+    render(
+      <Modal isOpen={true} onClose={onClose}>
+        <button type="button">Inside modal</button>
+      </Modal>,
+    )
+
+    await screen.findByRole("dialog")
+
+    const positioner = document.querySelector('[data-slot="modal-positioner"]')
+    expect(positioner).toBeInTheDocument()
+
+    fireEvent.pointerDown(positioner as HTMLElement)
+    fireEvent.pointerCancel(positioner as HTMLElement)
+    fireEvent.click(positioner as HTMLElement, { detail: 1 })
+
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
   it("keeps Modal open when a pointer drag starts inside the panel", async () => {
     const onClose = vi.fn()
 


### PR DESCRIPTION
## Summary

- prevent legacy modals from treating a drag that starts inside the panel and ends over the outer shadow/backdrop area as a dismissal
- preserve normal pointer and non-pointer backdrop dismissal behavior
- add focused component coverage and a real Chromium regression for the native drag/click event sequence

## Root cause

The legacy `Modal` only inspected the final `click` target. Chromium retargets the click from an inside-to-outside text drag to the shared positioner, so the backdrop handler incorrectly called `onClose`. The fix records where the pointer sequence started and accepts the final backdrop click only when it began on the same dismissal surface.

## Validation

- `pnpm exec vitest run tests/components/FloatingLayerPrimitives.test.tsx` — 14 passed
- `pnpm exec playwright test e2e/accountManagementCommonFlows.spec.ts --project=chromium --grep "keeps the add account dialog open" --workers=1` — extension build and Chromium regression passed
- `pnpm run validate:staged` — passed
- `pnpm run validate:push` — TypeScript and Knip passed

An exploratory `vitest related src/components/ui/Dialog/Modal.tsx --run` expanded beyond the focused scope and exceeded the 184-second tool timeout without reporting a test failure; the targeted suite and repository gates above completed successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dialog/backdrop dismissal logic so pointer-based interactions (like drag or text selection) don’t incorrectly close the modal when they end over the backdrop.
  * Preserved expected dismissal behavior for non-pointer interactions, including correct handling of pointer cancellation cases.
* **Tests**
  * Added an end-to-end test for the “Add Account” flow to confirm the dialog remains open after a drag-selection interaction over the backdrop.
  * Expanded modal/backdrop interaction tests using precise pointer event sequences to ensure consistent open/close behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->