### PR TITLE
fix(managed-sites): confirm native bulk deletion

### DIFF
--- a/e2e/fixtures/managedSiteChannelsIntercepted.ts
+++ b/e2e/fixtures/managedSiteChannelsIntercepted.ts
@@ -19,7 +19,9 @@ const INTERCEPTED_AXON_HUB_ORIGIN = "https://axonhub.example.invalid"
 
 const AXON_HUB_PRIMARY_ID = "gid://axonhub/Channel/opaque-primary"
 const AXON_HUB_SECONDARY_ID = "gid://axonhub/Channel/opaque-secondary"
+const AXON_HUB_CREATED_ID = "gid://axonhub/Channel/opaque-created"
 const AXON_HUB_NEXT_CURSOR = "axonhub-cursor-page-2"
+const AXON_HUB_CREATED_CURSOR = "axonhub-cursor-page-3"
 
 const channel = (overrides: Partial<ManagedSiteChannel>): ManagedSiteChannel =>
   ({
@@ -55,6 +57,13 @@ let interceptedAxonHubPrimaryName = "Example primary"
 let interceptedAxonHubPrimaryTags = ["fixture-tag"]
 let interceptedAxonHubUpdateVariables: Record<string, unknown> | null = null
 let interceptedAxonHubListRequestCount = 0
+let interceptedAxonHubDeleteRequestCount = 0
+let interceptedAxonHubCreatedChannel: {
+  name: string
+  baseURL: string
+  supportedModels: string[]
+  tags: string[]
+} | null = null
 
 const axonHubSummary = (params: {
   id: string
@@ -158,6 +167,15 @@ function getAxonHubSecondarySummary() {
   })
 }
 
+function getAxonHubCreatedSummary() {
+  if (!interceptedAxonHubCreatedChannel) return null
+
+  return axonHubSummary({
+    id: AXON_HUB_CREATED_ID,
+    ...interceptedAxonHubCreatedChannel,
+  })
+}
+
 function getAxonHubPrimaryDetail() {
   return axonHubDetail({
     id: AXON_HUB_PRIMARY_ID,
@@ -168,12 +186,25 @@ function getAxonHubPrimaryDetail() {
   })
 }
 
+function getAxonHubCreatedDetail() {
+  if (!interceptedAxonHubCreatedChannel) return null
+
+  return axonHubDetail({
+    id: AXON_HUB_CREATED_ID,
+    ...interceptedAxonHubCreatedChannel,
+  })
+}
+
 export function getInterceptedAxonHubUpdateVariables() {
   return interceptedAxonHubUpdateVariables
 }
 
 export function getInterceptedAxonHubListRequestCount() {
   return interceptedAxonHubListRequestCount
+}
+
+export function getInterceptedAxonHubDeleteRequestCount() {
+  return interceptedAxonHubDeleteRequestCount
 }
 
 async function fulfill(route: Route, body: unknown) {
@@ -230,6 +261,8 @@ async function installAxonHubIntercepts(context: BrowserContext) {
   interceptedAxonHubPrimaryTags = ["fixture-tag"]
   interceptedAxonHubUpdateVariables = null
   interceptedAxonHubListRequestCount = 0
+  interceptedAxonHubDeleteRequestCount = 0
+  interceptedAxonHubCreatedChannel = null
 
   await context.route(`${INTERCEPTED_AXON_HUB_ORIGIN}/**`, async (route) => {
     const url = new URL(route.request().url())
@@ -255,31 +288,44 @@ async function installAxonHubIntercepts(context: BrowserContext) {
         | { after?: string | null }
         | undefined
       const after = input?.after
-      if (
-        after !== undefined &&
-        after !== null &&
-        after !== AXON_HUB_NEXT_CURSOR
-      ) {
+      const createdSummary = getAxonHubCreatedSummary()
+      const summaries = [
+        getAxonHubPrimarySummary(),
+        getAxonHubSecondarySummary(),
+        ...(createdSummary ? [createdSummary] : []),
+      ]
+      const pageIndex =
+        after === undefined || after === null
+          ? 0
+          : after === AXON_HUB_NEXT_CURSOR
+            ? 1
+            : after === AXON_HUB_CREATED_CURSOR
+              ? 2
+              : -1
+      if (pageIndex < 0 || pageIndex >= summaries.length) {
         await fulfillGraphQLError(route, "Unsupported fixture page cursor.")
         return
       }
-      const isSecondPage = after === AXON_HUB_NEXT_CURSOR
+      const hasNextPage = pageIndex < summaries.length - 1
+      const endCursor = hasNextPage
+        ? pageIndex === 0
+          ? AXON_HUB_NEXT_CURSOR
+          : AXON_HUB_CREATED_CURSOR
+        : null
       await fulfill(route, {
         data: {
           queryChannels: {
             edges: [
               {
-                node: isSecondPage
-                  ? getAxonHubSecondarySummary()
-                  : getAxonHubPrimarySummary(),
-                cursor: isSecondPage ? "axonhub-edge-2" : "axonhub-edge-1",
+                node: summaries[pageIndex],
+                cursor: `axonhub-edge-${pageIndex + 1}`,
               },
             ],
             pageInfo: {
-              hasNextPage: !isSecondPage,
-              endCursor: isSecondPage ? null : AXON_HUB_NEXT_CURSOR,
+              hasNextPage,
+              endCursor,
             },
-            totalCount: 2,
+            totalCount: summaries.length,
           },
         },
       })
@@ -288,7 +334,11 @@ async function installAxonHubIntercepts(context: BrowserContext) {
 
     if (query.includes("query GetAxonHubChannel")) {
       const id = body.variables?.id
-      if (id !== AXON_HUB_PRIMARY_ID && id !== AXON_HUB_SECONDARY_ID) {
+      if (
+        id !== AXON_HUB_PRIMARY_ID &&
+        id !== AXON_HUB_SECONDARY_ID &&
+        (id !== AXON_HUB_CREATED_ID || !interceptedAxonHubCreatedChannel)
+      ) {
         await fulfillGraphQLError(route, "Unknown fixture channel ID.")
         return
       }
@@ -297,33 +347,92 @@ async function installAxonHubIntercepts(context: BrowserContext) {
           node:
             id === AXON_HUB_PRIMARY_ID
               ? getAxonHubPrimaryDetail()
-              : axonHubDetail({
-                  id: AXON_HUB_SECONDARY_ID,
-                  name: "Example secondary",
-                  tags: ["secondary-tag"],
-                  baseURL: "https://secondary.example.invalid/v1",
-                  supportedModels: ["model-beta"],
-                }),
+              : id === AXON_HUB_SECONDARY_ID
+                ? axonHubDetail({
+                    id: AXON_HUB_SECONDARY_ID,
+                    name: "Example secondary",
+                    tags: ["secondary-tag"],
+                    baseURL: "https://secondary.example.invalid/v1",
+                    supportedModels: ["model-beta"],
+                  })
+                : getAxonHubCreatedDetail(),
         },
+      })
+      return
+    }
+
+    if (query.includes("mutation CreateChannel(")) {
+      const input = (body.variables?.input ?? {}) as {
+        name?: string
+        baseURL?: string | null
+        supportedModels?: string[]
+        tags?: string[] | null
+      }
+      interceptedAxonHubCreatedChannel = {
+        name: input.name ?? "Fixture created channel",
+        baseURL: input.baseURL ?? "https://upstream.example.invalid/v1",
+        supportedModels: input.supportedModels ?? ["model-alpha"],
+        tags: input.tags ?? [],
+      }
+      await fulfill(route, {
+        data: { createChannel: getAxonHubCreatedDetail() },
       })
       return
     }
 
     if (query.includes("mutation UpdateChannel(")) {
       interceptedAxonHubUpdateVariables = body.variables ?? null
+      const id = body.variables?.id
       const input = (body.variables?.input ?? {}) as {
         name?: string
         tags?: string[]
       }
-      if (typeof input.name === "string") {
-        interceptedAxonHubPrimaryName = input.name
-      }
-      if (Array.isArray(input.tags)) {
-        interceptedAxonHubPrimaryTags = input.tags
+      if (id === AXON_HUB_CREATED_ID && interceptedAxonHubCreatedChannel) {
+        if (typeof input.name === "string") {
+          interceptedAxonHubCreatedChannel.name = input.name
+        }
+        if (Array.isArray(input.tags)) {
+          interceptedAxonHubCreatedChannel.tags = input.tags
+        }
+      } else {
+        if (typeof input.name === "string") {
+          interceptedAxonHubPrimaryName = input.name
+        }
+        if (Array.isArray(input.tags)) {
+          interceptedAxonHubPrimaryTags = input.tags
+        }
       }
       await fulfill(route, {
-        data: { updateChannel: getAxonHubPrimaryDetail() },
+        data: {
+          updateChannel:
+            id === AXON_HUB_CREATED_ID
+              ? getAxonHubCreatedDetail()
+              : getAxonHubPrimaryDetail(),
+        },
       })
+      return
+    }
+
+    if (query.includes("mutation UpdateChannelStatus(")) {
+      await fulfill(route, {
+        data: {
+          updateChannelStatus: {
+            __typename: "Channel",
+            id: body.variables?.id,
+            status: body.variables?.status,
+          },
+        },
+      })
+      return
+    }
+
+    if (query.includes("mutation DeleteChannel(")) {
+      interceptedAxonHubDeleteRequestCount += 1
+      const deleted =
+        body.variables?.id === AXON_HUB_CREATED_ID &&
+        interceptedAxonHubCreatedChannel !== null
+      if (deleted) interceptedAxonHubCreatedChannel = null
+      await fulfill(route, { data: { deleteChannel: deleted } })
       return
     }
 

--- a/e2e/managedSiteChannelsParity.spec.ts
+++ b/e2e/managedSiteChannelsParity.spec.ts
@@ -1,4 +1,5 @@
 import { CHANNEL_DIALOG_TEST_IDS } from "~/components/dialogs/ChannelDialog/testIds"
+import { SITE_TYPES } from "~/constants/siteType"
 import {
   getManagedSiteChannelRowActionsButtonTestId,
   getManagedSiteChannelRowEditActionTestId,
@@ -6,11 +7,13 @@ import {
 } from "~/features/ManagedSiteChannels/testIds"
 import { expect, test } from "~~/e2e/fixtures/extensionTest"
 import {
+  getInterceptedAxonHubDeleteRequestCount,
   getInterceptedAxonHubListRequestCount,
   getInterceptedAxonHubUpdateVariables,
   openInterceptedAxonHubManagedSiteChannels,
   openInterceptedManagedSiteChannels,
 } from "~~/e2e/fixtures/managedSiteChannelsIntercepted"
+import { runManagedSiteChannelsCrudScenario } from "~~/e2e/scenarios/managedSiteChannels"
 import { waitForExtensionRoot } from "~~/e2e/utils/lazyLoading"
 
 test.use({
@@ -233,6 +236,67 @@ test("runs the AxonHub native edit and migration preview through the shared UI",
   await expect(
     migrationDialog.getByText("Available Models", { exact: true }),
   ).toBeVisible()
+})
+
+test("runs shared AxonHub CRUD without depending on name-derived row tokens", async ({
+  context,
+  extensionId,
+  page,
+}) => {
+  test.setTimeout(120_000)
+
+  await openInterceptedAxonHubManagedSiteChannels({
+    context,
+    extensionId,
+    page,
+  })
+
+  await runManagedSiteChannelsCrudScenario({
+    page,
+    extensionId,
+    siteType: SITE_TYPES.AXON_HUB,
+    label: "AxonHub intercepted",
+    runPrefix: "AAH E2E AxonHub intercepted",
+    beforeDeleteConfirm: () => {
+      expect(getInterceptedAxonHubDeleteRequestCount()).toBe(0)
+    },
+  })
+
+  expect(getInterceptedAxonHubDeleteRequestCount()).toBe(1)
+})
+
+test("cancels native bulk-delete confirmation without dispatching a request", async ({
+  context,
+  extensionId,
+  page,
+}) => {
+  await openInterceptedAxonHubManagedSiteChannels({
+    context,
+    extensionId,
+    page,
+  })
+  await waitForExtensionRoot(page)
+
+  const row = page
+    .getByRole("row")
+    .filter({ has: page.getByText("Example primary", { exact: true }) })
+  await row.getByTestId(/-select$/u).click()
+  await page
+    .getByTestId(MANAGED_SITE_CHANNELS_TEST_IDS.deleteSelectedButton)
+    .click()
+
+  const confirmButton = page.getByTestId(
+    MANAGED_SITE_CHANNELS_TEST_IDS.deleteChannelConfirmButton,
+  )
+  await expect(confirmButton).toBeEnabled()
+  expect(getInterceptedAxonHubDeleteRequestCount()).toBe(0)
+
+  await page
+    .getByTestId(MANAGED_SITE_CHANNELS_TEST_IDS.deleteChannelCancelButton)
+    .click()
+  await expect(confirmButton).toBeHidden()
+  await expect(row).toBeVisible()
+  expect(getInterceptedAxonHubDeleteRequestCount()).toBe(0)
 })
 
 test.describe("mobile legacy parity", () => {

--- a/e2e/managedSiteChannelsParity.spec.ts
+++ b/e2e/managedSiteChannelsParity.spec.ts
@@ -3,6 +3,7 @@ import { SITE_TYPES } from "~/constants/siteType"
 import {
   getManagedSiteChannelRowActionsButtonTestId,
   getManagedSiteChannelRowEditActionTestId,
+  getManagedSiteChannelRowSelectTestId,
   MANAGED_SITE_CHANNELS_TEST_IDS,
 } from "~/features/ManagedSiteChannels/testIds"
 import { expect, test } from "~~/e2e/fixtures/extensionTest"
@@ -13,7 +14,11 @@ import {
   openInterceptedAxonHubManagedSiteChannels,
   openInterceptedManagedSiteChannels,
 } from "~~/e2e/fixtures/managedSiteChannelsIntercepted"
-import { runManagedSiteChannelsCrudScenario } from "~~/e2e/scenarios/managedSiteChannels"
+import {
+  channelRowByName,
+  getChannelRowTestToken,
+  runManagedSiteChannelsCrudScenario,
+} from "~~/e2e/scenarios/managedSiteChannels"
 import { waitForExtensionRoot } from "~~/e2e/utils/lazyLoading"
 
 test.use({
@@ -277,10 +282,11 @@ test("cancels native bulk-delete confirmation without dispatching a request", as
   })
   await waitForExtensionRoot(page)
 
-  const row = page
-    .getByRole("row")
-    .filter({ has: page.getByText("Example primary", { exact: true }) })
-  await row.getByTestId(/-select$/u).click()
+  const row = channelRowByName(page, "Example primary")
+  const rowTestToken = await getChannelRowTestToken(row)
+  await page
+    .getByTestId(getManagedSiteChannelRowSelectTestId(rowTestToken))
+    .click()
   await page
     .getByTestId(MANAGED_SITE_CHANNELS_TEST_IDS.deleteSelectedButton)
     .click()

--- a/e2e/scenarios/managedSiteChannels.ts
+++ b/e2e/scenarios/managedSiteChannels.ts
@@ -58,6 +58,18 @@ const channelsUrl = (extensionId: string, params?: Record<string, string>) => {
   return url.toString()
 }
 
+async function expectManagedSiteChannelsIdle(page: Page) {
+  const refreshButton = page.getByTestId(
+    MANAGED_SITE_CHANNELS_TEST_IDS.refreshButton,
+  )
+  await expect(refreshButton).toHaveAttribute(
+    MANAGED_SITE_CHANNELS_REFRESH_STATE_ATTRIBUTE,
+    MANAGED_SITE_CHANNELS_REFRESH_STATES.Idle,
+    { timeout: 60_000 },
+  )
+  return refreshButton
+}
+
 async function cleanupManagedSiteChannelsByPrefix<
   TSiteType extends ManagedSiteType,
 >(params: {
@@ -70,6 +82,7 @@ async function cleanupManagedSiteChannelsByPrefix<
     channelsUrl(params.extensionId, { search: params.prefix }),
   )
   await waitForExtensionRoot(params.page)
+  await expectManagedSiteChannelsIdle(params.page)
 
   for (let attempt = 0; attempt < 20; attempt += 1) {
     const row = channelRowByText(params.page, params.prefix).first()
@@ -83,6 +96,7 @@ async function cleanupManagedSiteChannelsByPrefix<
       channelsUrl(params.extensionId, { search: params.prefix }),
     )
     await waitForExtensionRoot(params.page)
+    await expectManagedSiteChannelsIdle(params.page)
   }
 
   throw new Error(
@@ -312,42 +326,13 @@ async function expectManagedSiteChannelVisibleAfterRefresh(params: {
   channelName: string
 }) {
   await expect(async () => {
+    const refreshButton = await expectManagedSiteChannelsIdle(params.page)
     const row = channelRowByName(params.page, params.channelName)
     if ((await row.count()) > 0) {
       await expect(row).toBeVisible({ timeout: 10_000 })
       return
     }
 
-    const refreshButton = params.page.getByTestId(
-      MANAGED_SITE_CHANNELS_TEST_IDS.refreshButton,
-    )
-    await expect(refreshButton).toHaveAttribute(
-      MANAGED_SITE_CHANNELS_REFRESH_STATE_ATTRIBUTE,
-      new RegExp(
-        `${MANAGED_SITE_CHANNELS_REFRESH_STATES.Idle}|${MANAGED_SITE_CHANNELS_REFRESH_STATES.Loading}`,
-      ),
-      { timeout: 10_000 },
-    )
-    if (
-      (await refreshButton.getAttribute(
-        MANAGED_SITE_CHANNELS_REFRESH_STATE_ATTRIBUTE,
-      )) === MANAGED_SITE_CHANNELS_REFRESH_STATES.Loading
-    ) {
-      await expect(refreshButton).toHaveAttribute(
-        MANAGED_SITE_CHANNELS_REFRESH_STATE_ATTRIBUTE,
-        MANAGED_SITE_CHANNELS_REFRESH_STATES.Idle,
-        {
-          timeout: 10_000,
-        },
-      )
-    }
-    await expect(refreshButton).toHaveAttribute(
-      MANAGED_SITE_CHANNELS_REFRESH_STATE_ATTRIBUTE,
-      MANAGED_SITE_CHANNELS_REFRESH_STATES.Idle,
-      {
-        timeout: 10_000,
-      },
-    )
     await expect(refreshButton).toBeEnabled({ timeout: 10_000 })
     await refreshButton.click()
     await expect(refreshButton)
@@ -357,13 +342,7 @@ async function expectManagedSiteChannelVisibleAfterRefresh(params: {
         { timeout: 5_000 },
       )
       .catch(() => undefined)
-    await expect(refreshButton).toHaveAttribute(
-      MANAGED_SITE_CHANNELS_REFRESH_STATE_ATTRIBUTE,
-      MANAGED_SITE_CHANNELS_REFRESH_STATES.Idle,
-      {
-        timeout: 30_000,
-      },
-    )
+    await expectManagedSiteChannelsIdle(params.page)
     await expect(row).toBeVisible({ timeout: 20_000 })
   }).toPass({
     intervals: [1_000, 3_000, 5_000],
@@ -428,7 +407,9 @@ async function deleteVisibleChannelByName(
   channelName: string,
   beforeConfirm?: () => void | Promise<void>,
 ) {
+  const refreshButton = await expectManagedSiteChannelsIdle(page)
   const row = channelRowByName(page, channelName)
+  await expect(row).toBeVisible({ timeout: 30_000 })
   const rowTestToken = await getChannelRowTestToken(row)
   await row
     .getByTestId(getManagedSiteChannelRowSelectTestId(rowTestToken))
@@ -446,7 +427,17 @@ async function deleteVisibleChannelByName(
   await expect(confirmButton).toBeEnabled({ timeout: 10_000 })
   await beforeConfirm?.()
   await confirmButton.click()
-  await expect(row).toHaveCount(0, { timeout: 30_000 })
+  await expect(async () => {
+    expect(
+      await refreshButton.getAttribute(
+        MANAGED_SITE_CHANNELS_REFRESH_STATE_ATTRIBUTE,
+      ),
+    ).toBe(MANAGED_SITE_CHANNELS_REFRESH_STATES.Idle)
+    expect(await row.count()).toBe(0)
+  }).toPass({
+    intervals: [500, 1_000, 3_000],
+    timeout: 60_000,
+  })
 }
 
 async function createManagedSiteChannelFromUi(

--- a/e2e/scenarios/managedSiteChannels.ts
+++ b/e2e/scenarios/managedSiteChannels.ts
@@ -552,13 +552,13 @@ async function expectPaginationSummary(
   ).toHaveAttribute("data-total", total, { timeout: 30_000 })
 }
 
-function channelRowByName(page: Page, channelName: string) {
+export function channelRowByName(page: Page, channelName: string) {
   return page
     .locator(`[data-testid^="${MANAGED_SITE_CHANNEL_ROW_TEST_ID_PREFIX}"]`)
     .filter({ has: page.getByText(channelName, { exact: true }) })
 }
 
-async function getChannelRowTestToken(row: Locator) {
+export async function getChannelRowTestToken(row: Locator) {
   const testId = await row.getAttribute("data-testid")
   if (!testId?.startsWith(MANAGED_SITE_CHANNEL_ROW_TEST_ID_PREFIX)) {
     throw new Error("Managed-site channel row is missing its stable test token")

--- a/e2e/scenarios/managedSiteChannels.ts
+++ b/e2e/scenarios/managedSiteChannels.ts
@@ -9,7 +9,6 @@ import {
   getManagedSiteChannelRowActionsButtonTestId,
   getManagedSiteChannelRowEditActionTestId,
   getManagedSiteChannelRowSelectTestId,
-  getManagedSiteChannelRowTestId,
   MANAGED_SITE_CHANNEL_ROW_TEST_ID_PREFIX,
   MANAGED_SITE_CHANNELS_REFRESH_STATE_ATTRIBUTE,
   MANAGED_SITE_CHANNELS_REFRESH_STATES,
@@ -36,6 +35,7 @@ type ManagedSiteChannelScenarioContext<TSiteType extends ManagedSiteType> = {
   sourceAccountSkipReason?: string
   tokenName?: string
   tokenCleanupPrefix?: string
+  beforeDeleteConfirm?: () => void | Promise<void>
 }
 
 const CRUD_MODEL = "gpt-4o-mini"
@@ -155,7 +155,11 @@ export async function runManagedSiteChannelsCrudScenario<
     await expect(channelRowByName(context.page, channelName)).toHaveCount(0)
     await expectPaginationSummary(context.page, "1", "1", "1")
 
-    await deleteVisibleChannelByName(context.page, editedChannelName)
+    await deleteVisibleChannelByName(
+      context.page,
+      editedChannelName,
+      context.beforeDeleteConfirm,
+    )
   } finally {
     await cleanupManagedSiteChannelsByPrefix({
       page: context.page,
@@ -419,10 +423,15 @@ async function cleanupKeyManagementTokensByPrefix(params: {
   )
 }
 
-async function deleteVisibleChannelByName(page: Page, channelName: string) {
+async function deleteVisibleChannelByName(
+  page: Page,
+  channelName: string,
+  beforeConfirm?: () => void | Promise<void>,
+) {
   const row = channelRowByName(page, channelName)
+  const rowTestToken = await getChannelRowTestToken(row)
   await row
-    .getByTestId(getManagedSiteChannelRowSelectTestId(channelName))
+    .getByTestId(getManagedSiteChannelRowSelectTestId(rowTestToken))
     .click()
   await expect(
     page.getByTestId(MANAGED_SITE_CHANNELS_TEST_IDS.deleteSelectedButton),
@@ -430,9 +439,13 @@ async function deleteVisibleChannelByName(page: Page, channelName: string) {
   await page
     .getByTestId(MANAGED_SITE_CHANNELS_TEST_IDS.deleteSelectedButton)
     .click()
-  await page
-    .getByTestId(MANAGED_SITE_CHANNELS_TEST_IDS.deleteChannelConfirmButton)
-    .click()
+  const confirmButton = page.getByTestId(
+    MANAGED_SITE_CHANNELS_TEST_IDS.deleteChannelConfirmButton,
+  )
+  await expect(confirmButton).toBeVisible({ timeout: 10_000 })
+  await expect(confirmButton).toBeEnabled({ timeout: 10_000 })
+  await beforeConfirm?.()
+  await confirmButton.click()
   await expect(row).toHaveCount(0, { timeout: 30_000 })
 }
 
@@ -485,14 +498,15 @@ async function openSingleVisibleChannelEditDialog(page: Page, rowText: string) {
   await expect(async () => {
     const row = channelRowByName(page, rowText)
     await expect(row).toBeVisible({ timeout: 10_000 })
+    const rowTestToken = await getChannelRowTestToken(row)
     const actionsButton = row.getByTestId(
-      getManagedSiteChannelRowActionsButtonTestId(rowText),
+      getManagedSiteChannelRowActionsButtonTestId(rowTestToken),
     )
     await expect(actionsButton).toBeEnabled({ timeout: 10_000 })
     await actionsButton.click({ timeout: 10_000 })
 
     const editAction = page.getByTestId(
-      getManagedSiteChannelRowEditActionTestId(rowText),
+      getManagedSiteChannelRowEditActionTestId(rowTestToken),
     )
     await expect(editAction).toBeVisible({ timeout: 10_000 })
     await editAction.click({ timeout: 10_000 })
@@ -539,7 +553,17 @@ async function expectPaginationSummary(
 }
 
 function channelRowByName(page: Page, channelName: string) {
-  return page.getByTestId(getManagedSiteChannelRowTestId(channelName))
+  return page
+    .locator(`[data-testid^="${MANAGED_SITE_CHANNEL_ROW_TEST_ID_PREFIX}"]`)
+    .filter({ has: page.getByText(channelName, { exact: true }) })
+}
+
+async function getChannelRowTestToken(row: Locator) {
+  const testId = await row.getAttribute("data-testid")
+  if (!testId?.startsWith(MANAGED_SITE_CHANNEL_ROW_TEST_ID_PREFIX)) {
+    throw new Error("Managed-site channel row is missing its stable test token")
+  }
+  return testId.slice(MANAGED_SITE_CHANNEL_ROW_TEST_ID_PREFIX.length)
 }
 
 async function getChannelRowName(row: ReturnType<typeof channelRowByText>) {

--- a/src/components/ui/Dialog/DestructiveConfirmDialog.tsx
+++ b/src/components/ui/Dialog/DestructiveConfirmDialog.tsx
@@ -58,6 +58,10 @@ interface DestructiveConfirmDialogProps {
    * Optional stable selector for the destructive confirmation action.
    */
   confirmButtonTestId?: string
+  /**
+   * Optional stable selector for the cancel action.
+   */
+  cancelButtonTestId?: string
 }
 
 /**
@@ -80,6 +84,7 @@ export function DestructiveConfirmDialog({
   isWorking = false,
   size = "sm",
   confirmButtonTestId,
+  cancelButtonTestId,
 }: DestructiveConfirmDialogProps) {
   return (
     <Modal
@@ -108,6 +113,7 @@ export function DestructiveConfirmDialog({
             variant="secondary"
             className="flex-1"
             disabled={isWorking}
+            data-testid={cancelButtonTestId}
           >
             {cancelLabel}
           </Button>

--- a/src/features/ManagedSiteChannels/ManagedSiteChannelsRoute.tsx
+++ b/src/features/ManagedSiteChannels/ManagedSiteChannelsRoute.tsx
@@ -535,10 +535,6 @@ function NativeManagedSiteChannels({
       })),
     [canMigrate, list.allRows],
   )
-  const nativeRowsByKey = useMemo(
-    () => new Map(nativeRows.map((row) => [row.rowKey, row])),
-    [nativeRows],
-  )
   const confirmedDeleteLabels = useRef(new Map<string, string>())
   const editorPageFailure = (() => {
     switch (mutation.editorFeedback?.kind) {
@@ -698,7 +694,7 @@ function NativeManagedSiteChannels({
     onDeleteConfirm: () => {
       confirmedDeleteLabels.current = new Map(
         mutation.deleteState.rowKeys.flatMap((rowKey) => {
-          const row = nativeRowsByKey.get(rowKey)
+          const row = rowsByKey.get(rowKey)
           return row ? [[rowKey, row.name] as const] : []
         }),
       )

--- a/src/features/ManagedSiteChannels/ManagedSiteChannelsRoute.tsx
+++ b/src/features/ManagedSiteChannels/ManagedSiteChannelsRoute.tsx
@@ -535,6 +535,11 @@ function NativeManagedSiteChannels({
       })),
     [canMigrate, list.allRows],
   )
+  const nativeRowsByKey = useMemo(
+    () => new Map(nativeRows.map((row) => [row.rowKey, row])),
+    [nativeRows],
+  )
+  const confirmedDeleteLabels = useRef(new Map<string, string>())
   const editorPageFailure = (() => {
     switch (mutation.editorFeedback?.kind) {
       case "open-failed":
@@ -591,6 +596,7 @@ function NativeManagedSiteChannels({
     total: list.totalRows,
     isLoading: list.isLoading,
     isRefreshing: list.isLoading,
+    isResourceInteractionBlocked: mutation.deleteState.requiresFreshRead,
     failure,
     isConfigurationMissing,
     migrationMode,
@@ -601,7 +607,10 @@ function NativeManagedSiteChannels({
       rowKeys: mutation.deleteState.rowKeys,
       results: mutation.deleteState.results.map((result) => ({
         ...result,
-        displayLabel: rowsByKey.get(result.rowKey)?.name ?? "",
+        displayLabel:
+          rowsByKey.get(result.rowKey)?.name ??
+          confirmedDeleteLabels.current.get(result.rowKey) ??
+          "",
       })),
       requiresRefresh: mutation.deleteState.requiresRefresh,
       failure: getFailureMessage(t, mutation.deleteState.failure),
@@ -679,14 +688,22 @@ function NativeManagedSiteChannels({
     onOpenSync: async () => undefined,
     onFilters: () => undefined,
     onDeleteSelected: () => {
-      void mutation.bulkDelete(
+      void mutation.openBulkDelete(
         Object.keys(list.selectedRowKeys).filter(
           (rowKey) => list.selectedRowKeys[rowKey],
         ),
       )
     },
     onSyncSelected: async () => undefined,
-    onDeleteConfirm: () => void mutation.confirmDelete(),
+    onDeleteConfirm: () => {
+      confirmedDeleteLabels.current = new Map(
+        mutation.deleteState.rowKeys.flatMap((rowKey) => {
+          const row = nativeRowsByKey.get(rowKey)
+          return row ? [[rowKey, row.name] as const] : []
+        }),
+      )
+      void mutation.confirmDelete()
+    },
     onDeleteCancel: mutation.cancelDelete,
   }
 

--- a/src/features/ManagedSiteChannels/controllers/useManagedResourceMutationController.ts
+++ b/src/features/ManagedSiteChannels/controllers/useManagedResourceMutationController.ts
@@ -117,8 +117,16 @@ export function useManagedResourceMutationController({
   const deleteGeneration = useRef(0)
   const deleteAbortControllers = useRef<Set<AbortController>>(new Set())
   const deleteSession = useRef<{
-    rowKey: string
-    ref: ManagedResourceRef
+    targets: Array<{
+      rowKey: string
+      ref: ManagedResourceRef
+    }>
+    actionId:
+      | typeof PRODUCT_ANALYTICS_ACTION_IDS.DeleteManagedSiteChannel
+      | typeof PRODUCT_ANALYTICS_ACTION_IDS.DeleteSelectedManagedSiteChannels
+    surfaceId:
+      | typeof PRODUCT_ANALYTICS_SURFACE_IDS.OptionsManagedSiteChannelsRowActions
+      | typeof PRODUCT_ANALYTICS_SURFACE_IDS.OptionsManagedSiteChannelsToolbar
   } | null>(null)
   const deletePromise = useRef<Promise<DeleteResult[]> | undefined>(undefined)
   const freshReadPromise = useRef<Promise<boolean> | undefined>(undefined)
@@ -603,7 +611,7 @@ export function useManagedResourceMutationController({
     [analytics, endMutationSession, onMutationStart, refresh, workspace],
   )
 
-  const bulkDelete = useCallback(
+  const openBulkDelete = useCallback(
     (rowKeys: readonly string[]) => {
       if (
         !workspace ||
@@ -637,18 +645,31 @@ export function useManagedResourceMutationController({
         return Promise.resolve([])
       }
       if (!beginMutationSession("delete")) return Promise.resolve([])
-      sessionPhase.current = "delete-execution"
-      return executeDeleteTargets(
-        resolvedTargets as { rowKey: string; ref: ManagedResourceRef }[],
-        PRODUCT_ANALYTICS_ACTION_IDS.DeleteSelectedManagedSiteChannels,
-        PRODUCT_ANALYTICS_SURFACE_IDS.OptionsManagedSiteChannelsToolbar,
-      )
+      sessionPhase.current = "delete-confirmation"
+      deleteSession.current = {
+        targets: resolvedTargets as {
+          rowKey: string
+          ref: ManagedResourceRef
+        }[],
+        actionId:
+          PRODUCT_ANALYTICS_ACTION_IDS.DeleteSelectedManagedSiteChannels,
+        surfaceId:
+          PRODUCT_ANALYTICS_SURFACE_IDS.OptionsManagedSiteChannelsToolbar,
+      }
+      setDeleteState((current) => ({
+        ...current,
+        isOpen: true,
+        isExecuting: false,
+        rowKeys: [...rowKeys],
+        results: [],
+        failure: null,
+      }))
+      return Promise.resolve([])
     },
     [
       capabilities.canDelete,
       beginMutationSession,
       deleteState.requiresFreshRead,
-      executeDeleteTargets,
       resolveRef,
       workspace,
     ],
@@ -678,7 +699,12 @@ export function useManagedResourceMutationController({
       }
       if (!beginMutationSession("delete")) return false
       sessionPhase.current = "delete-confirmation"
-      deleteSession.current = { rowKey, ref: { ...ref } }
+      deleteSession.current = {
+        targets: [{ rowKey, ref: { ...ref } }],
+        actionId: PRODUCT_ANALYTICS_ACTION_IDS.DeleteManagedSiteChannel,
+        surfaceId:
+          PRODUCT_ANALYTICS_SURFACE_IDS.OptionsManagedSiteChannelsRowActions,
+      }
       setDeleteState((current) => ({
         ...current,
         isOpen: true,
@@ -705,8 +731,11 @@ export function useManagedResourceMutationController({
     }
     if (sessionPhase.current !== "delete-confirmation")
       return Promise.resolve([])
-    const currentRef = resolveRef?.(session.rowKey)
-    if (!currentRef || refIdentity(currentRef) !== refIdentity(session.ref)) {
+    const isSessionCurrent = session.targets.every(({ rowKey, ref }) => {
+      const currentRef = resolveRef?.(rowKey)
+      return currentRef && refIdentity(currentRef) === refIdentity(ref)
+    })
+    if (!isSessionCurrent) {
       deleteSession.current = null
       endMutationSession("delete")
       sessionPhase.current = "idle"
@@ -720,9 +749,9 @@ export function useManagedResourceMutationController({
     }
     sessionPhase.current = "delete-execution"
     return executeDeleteTargets(
-      [session],
-      PRODUCT_ANALYTICS_ACTION_IDS.DeleteManagedSiteChannel,
-      PRODUCT_ANALYTICS_SURFACE_IDS.OptionsManagedSiteChannelsRowActions,
+      session.targets,
+      session.actionId,
+      session.surfaceId,
     )
   }, [
     capabilities.canDelete,
@@ -826,6 +855,6 @@ export function useManagedResourceMutationController({
     confirmDelete,
     cancelDelete,
     recoverFreshRead,
-    bulkDelete,
+    openBulkDelete,
   }
 }

--- a/src/features/ManagedSiteChannels/presentation/ManagedSiteChannelsView.tsx
+++ b/src/features/ManagedSiteChannels/presentation/ManagedSiteChannelsView.tsx
@@ -476,6 +476,16 @@ export function ManagedSiteChannelsView({
   const filteredRows = table.getFilteredRowModel().rows
   const selectedCount = selectedRows.length
   const filteredCount = filteredRows.length
+  const renderDeleteRefreshAction = () => (
+    <Button
+      type="button"
+      variant="outline"
+      onClick={callbacks.onRefresh}
+      disabled={state.isRefreshing || !capabilities.canRefresh}
+    >
+      {labels.deleteRefreshAction}
+    </Button>
+  )
   const emptyTableMessage =
     state.searchValue.trim() ||
     state.channelIdFilterValue.trim() ||
@@ -615,16 +625,9 @@ export function ManagedSiteChannelsView({
               <AlertTitle>{state.deleteState.failure.category}</AlertTitle>
               <AlertDescription className="space-y-3">
                 <p>{state.deleteState.failure.message}</p>
-                {state.deleteState.requiresRefresh ? (
-                  <Button
-                    type="button"
-                    variant="outline"
-                    onClick={callbacks.onRefresh}
-                    disabled={state.isRefreshing || !capabilities.canRefresh}
-                  >
-                    {labels.deleteRefreshAction}
-                  </Button>
-                ) : null}
+                {state.deleteState.requiresRefresh
+                  ? renderDeleteRefreshAction()
+                  : null}
               </AlertDescription>
             </Alert>
           ) : null}
@@ -666,16 +669,9 @@ export function ManagedSiteChannelsView({
                   </li>
                 ))}
               </ol>
-              {state.deleteState.requiresRefresh ? (
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={callbacks.onRefresh}
-                  disabled={state.isRefreshing || !capabilities.canRefresh}
-                >
-                  {labels.deleteRefreshAction}
-                </Button>
-              ) : null}
+              {state.deleteState.requiresRefresh
+                ? renderDeleteRefreshAction()
+                : null}
             </section>
           ) : null}
 

--- a/src/features/ManagedSiteChannels/presentation/ManagedSiteChannelsView.tsx
+++ b/src/features/ManagedSiteChannels/presentation/ManagedSiteChannelsView.tsx
@@ -209,6 +209,8 @@ export function ManagedSiteChannelsView({
 }: ManagedSiteChannelsViewProps) {
   const searchInputRef = useRef<HTMLInputElement | null>(null)
   const isDeleteReplayBlocked = state.deleteState.requiresRefresh
+  const isResourceInteractionBlocked =
+    state.isResourceInteractionBlocked ?? false
   const columns = useMemo<ColumnDef<ManagedChannelsRowViewModel, unknown>[]>(
     () =>
       state.columns.map((column) => {
@@ -255,40 +257,41 @@ export function ManagedSiteChannelsView({
               extension: column.extension,
             },
             header: () => <span className="sr-only">{column.label}</span>,
-            cell: ({ row }: { row: Row<ManagedChannelsRowViewModel> }) => (
-              <RowActions
-                rowKey={row.original.rowKey}
-                displayName={row.original.name}
-                capabilities={{
-                  ...row.original.capabilities,
-                  canDelete:
-                    row.original.capabilities.canDelete &&
-                    !isDeleteReplayBlocked,
-                }}
-                onEdit={callbacks.onEdit}
-                onView={callbacks.onView}
-                onMigrate={callbacks.onMigrate}
-                onDelete={callbacks.onDelete}
-                onSync={callbacks.onSync}
-                onOpenSync={callbacks.onOpenSync}
-                onFilters={callbacks.onFilters}
-                showMigrationAction={state.migrationMode}
-                showNewApiOnlyActions={capabilities.showNewApiOnlyActions}
-                isSyncing={Boolean(row.original.isSyncing)}
-                labels={labels.rowActions}
-                testIds={{
-                  trigger: getManagedSiteChannelRowActionsButtonTestId(
-                    row.original.testToken,
-                  ),
-                  edit: getManagedSiteChannelRowEditActionTestId(
-                    row.original.testToken,
-                  ),
-                  delete: getManagedSiteChannelRowDeleteActionTestId(
-                    row.original.testToken,
-                  ),
-                }}
-              />
-            ),
+            cell: ({ row }: { row: Row<ManagedChannelsRowViewModel> }) =>
+              isResourceInteractionBlocked ? null : (
+                <RowActions
+                  rowKey={row.original.rowKey}
+                  displayName={row.original.name}
+                  capabilities={{
+                    ...row.original.capabilities,
+                    canDelete:
+                      row.original.capabilities.canDelete &&
+                      !isDeleteReplayBlocked,
+                  }}
+                  onEdit={callbacks.onEdit}
+                  onView={callbacks.onView}
+                  onMigrate={callbacks.onMigrate}
+                  onDelete={callbacks.onDelete}
+                  onSync={callbacks.onSync}
+                  onOpenSync={callbacks.onOpenSync}
+                  onFilters={callbacks.onFilters}
+                  showMigrationAction={state.migrationMode}
+                  showNewApiOnlyActions={capabilities.showNewApiOnlyActions}
+                  isSyncing={Boolean(row.original.isSyncing)}
+                  labels={labels.rowActions}
+                  testIds={{
+                    trigger: getManagedSiteChannelRowActionsButtonTestId(
+                      row.original.testToken,
+                    ),
+                    edit: getManagedSiteChannelRowEditActionTestId(
+                      row.original.testToken,
+                    ),
+                    delete: getManagedSiteChannelRowDeleteActionTestId(
+                      row.original.testToken,
+                    ),
+                  }}
+                />
+              ),
             size: column.size,
             enableSorting: false,
             enableHiding: false,
@@ -363,6 +366,7 @@ export function ManagedSiteChannelsView({
       callbacks,
       capabilities.showNewApiOnlyActions,
       isDeleteReplayBlocked,
+      isResourceInteractionBlocked,
       labels,
       state.columns,
       state.migrationMode,
@@ -603,6 +607,28 @@ export function ManagedSiteChannelsView({
             </Alert>
           ) : null}
 
+          {state.deleteState.failure ? (
+            <Alert
+              role="alert"
+              variant={state.deleteState.failure.variant ?? "destructive"}
+            >
+              <AlertTitle>{state.deleteState.failure.category}</AlertTitle>
+              <AlertDescription className="space-y-3">
+                <p>{state.deleteState.failure.message}</p>
+                {state.deleteState.requiresRefresh ? (
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={callbacks.onRefresh}
+                    disabled={state.isRefreshing || !capabilities.canRefresh}
+                  >
+                    {labels.deleteRefreshAction}
+                  </Button>
+                ) : null}
+              </AlertDescription>
+            </Alert>
+          ) : null}
+
           {state.deleteState.results.length > 0 ? (
             <section
               role="status"
@@ -835,6 +861,7 @@ export function ManagedSiteChannelsView({
                 {!state.migrationMode && capabilities.canCreate ? (
                   <Button
                     onClick={callbacks.onCreate}
+                    disabled={isResourceInteractionBlocked}
                     leftIcon={<Plus className="h-4 w-4" />}
                     data-testid={
                       MANAGED_SITE_CHANNELS_TEST_IDS.addChannelButton
@@ -946,6 +973,9 @@ export function ManagedSiteChannelsView({
         workingLabel={labels.deleting}
         confirmButtonTestId={
           MANAGED_SITE_CHANNELS_TEST_IDS.deleteChannelConfirmButton
+        }
+        cancelButtonTestId={
+          MANAGED_SITE_CHANNELS_TEST_IDS.deleteChannelCancelButton
         }
         onConfirm={callbacks.onDeleteConfirm}
         isWorking={state.deleteState.isWorking}

--- a/src/features/ManagedSiteChannels/presentation/contracts.ts
+++ b/src/features/ManagedSiteChannels/presentation/contracts.ts
@@ -117,6 +117,7 @@ export type ManagedChannelsPresentationState = {
   total: number
   isLoading: boolean
   isRefreshing: boolean
+  isResourceInteractionBlocked?: boolean
   failure?: ManagedChannelsFailureState | null
   isConfigurationMissing: boolean
   migrationMode: boolean

--- a/src/features/ManagedSiteChannels/testIds.ts
+++ b/src/features/ManagedSiteChannels/testIds.ts
@@ -7,6 +7,7 @@ export const MANAGED_SITE_CHANNELS_TEST_IDS = {
   searchInput: "managed-site-channels-search-input",
   paginationSummary: "managed-site-channels-pagination-summary",
   deleteChannelConfirmButton: "managed-site-channels-delete-confirm-button",
+  deleteChannelCancelButton: "managed-site-channels-delete-cancel-button",
   deleteSelectedButton: "managed-site-channels-delete-selected-button",
 } as const
 

--- a/tests/components/DestructiveConfirmDialog.test.tsx
+++ b/tests/components/DestructiveConfirmDialog.test.tsx
@@ -52,4 +52,23 @@ describe("DestructiveConfirmDialog", () => {
       await screen.findByRole("button", { name: "Delete" }),
     ).toHaveTextContent("Delete")
   })
+
+  it("exposes optional stable selectors for both dialog actions", async () => {
+    render(
+      <DestructiveConfirmDialog
+        isOpen
+        onClose={vi.fn()}
+        title="Delete item"
+        description="This cannot be undone."
+        confirmLabel="Delete"
+        cancelLabel="Cancel"
+        onConfirm={vi.fn()}
+        confirmButtonTestId="delete-confirm"
+        cancelButtonTestId="delete-cancel"
+      />,
+    )
+
+    expect(await screen.findByTestId("delete-confirm")).toBeInTheDocument()
+    expect(screen.getByTestId("delete-cancel")).toBeInTheDocument()
+  })
 })

--- a/tests/features/ManagedSiteChannels/ManagedSiteChannelsRoute.test.tsx
+++ b/tests/features/ManagedSiteChannels/ManagedSiteChannelsRoute.test.tsx
@@ -483,7 +483,7 @@ const installNativeControllers = (
     confirmDelete: vi.fn(),
     cancelDelete: vi.fn(),
     recoverFreshRead: vi.fn(),
-    bulkDelete: vi.fn(),
+    openBulkDelete: vi.fn(),
     ...overrides.mutation,
   })
   useMigrationController.mockReturnValue({
@@ -925,12 +925,85 @@ describe("ManagedSiteChannelsRoute", () => {
       "managedSiteChannels:alerts.savedRefreshError.description",
     )
     expect(alert.querySelector(".lucide-triangle-alert")).toBeInTheDocument()
+    expect(
+      screen.getByTestId(MANAGED_SITE_CHANNELS_TEST_IDS.addChannelButton),
+    ).toBeDisabled()
+    expect(
+      screen.queryByTestId(
+        getManagedSiteChannelRowActionsButtonTestId(nativeRow.testToken),
+      ),
+    ).toBeNull()
 
     await user.click(
       screen.getByTestId(MANAGED_SITE_CHANNELS_TEST_IDS.refreshButton),
     )
     expect(recoverFreshRead).toHaveBeenCalledOnce()
     expect(refresh).not.toHaveBeenCalled()
+  })
+
+  it("snapshots native delete labels when confirmation starts", async () => {
+    const user = userEvent.setup()
+    const confirmDelete = vi.fn(async () => [])
+    installNativeDefinition(SITE_TYPES.AXON_HUB)
+    installNativeControllers({
+      mutation: {
+        deleteState: {
+          isOpen: true,
+          isExecuting: false,
+          rowKeys: [nativeRow.rowKey],
+          results: [],
+          requiresRefresh: false,
+          requiresFreshRead: false,
+          failure: null,
+        },
+        confirmDelete,
+      },
+    })
+    configureNativePreferences(SITE_TYPES.AXON_HUB)
+
+    const route = (
+      <ManagedSiteChannelsRoute
+        siteType={SITE_TYPES.AXON_HUB}
+        onReplaceRouteQuery={vi.fn()}
+      />
+    )
+    const { rerender } = render(route)
+
+    await user.click(
+      screen.getByTestId(
+        MANAGED_SITE_CHANNELS_TEST_IDS.deleteChannelConfirmButton,
+      ),
+    )
+    expect(confirmDelete).toHaveBeenCalledOnce()
+
+    installNativeControllers({
+      list: { rows: [], allRows: [], totalRows: 0 },
+      mutation: {
+        deleteState: {
+          isOpen: false,
+          isExecuting: false,
+          rowKeys: [nativeRow.rowKey],
+          results: [
+            {
+              rowKey: nativeRow.rowKey,
+              status: "success",
+              resultKey: "delete_success",
+            },
+          ],
+          requiresRefresh: false,
+          requiresFreshRead: false,
+          failure: null,
+        },
+      },
+    })
+    rerender(
+      <ManagedSiteChannelsRoute
+        siteType={SITE_TYPES.AXON_HUB}
+        onReplaceRouteQuery={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByText(nativeRow.name)).toBeVisible()
   })
 
   it("cancels an active list refresh before attempting locked recovery", async () => {

--- a/tests/features/ManagedSiteChannels/ManagedSiteChannelsRoute.test.tsx
+++ b/tests/features/ManagedSiteChannels/ManagedSiteChannelsRoute.test.tsx
@@ -1006,6 +1006,73 @@ describe("ManagedSiteChannelsRoute", () => {
     expect(screen.getByText(nativeRow.name)).toBeVisible()
   })
 
+  it("opens native bulk-delete confirmation for selected opaque row keys", async () => {
+    const user = userEvent.setup()
+    const openBulkDelete = vi.fn()
+    installNativeDefinition(SITE_TYPES.AXON_HUB)
+    installNativeControllers({
+      list: {
+        selectedRowKeys: {
+          [nativeRow.rowKey]: true,
+          "opaque:not-selected": false,
+        },
+      },
+      mutation: { openBulkDelete },
+    })
+    configureNativePreferences(SITE_TYPES.AXON_HUB)
+
+    render(
+      <ManagedSiteChannelsRoute
+        siteType={SITE_TYPES.AXON_HUB}
+        onReplaceRouteQuery={vi.fn()}
+      />,
+    )
+
+    await user.click(
+      screen.getByTestId(MANAGED_SITE_CHANNELS_TEST_IDS.deleteSelectedButton),
+    )
+
+    expect(openBulkDelete).toHaveBeenCalledWith([nativeRow.rowKey])
+  })
+
+  it("does not expose an opaque identifier for an unlabeled delete result", () => {
+    const unknownRowKey = "opaque:missing"
+    installNativeDefinition(SITE_TYPES.AXON_HUB)
+    installNativeControllers({
+      list: { rows: [], allRows: [], totalRows: 0 },
+      mutation: {
+        deleteState: {
+          isOpen: false,
+          isExecuting: false,
+          rowKeys: [unknownRowKey],
+          results: [
+            {
+              rowKey: unknownRowKey,
+              status: "success",
+              resultKey: "delete_success",
+            },
+          ],
+          requiresRefresh: false,
+          requiresFreshRead: false,
+          failure: null,
+        },
+      },
+    })
+    configureNativePreferences(SITE_TYPES.AXON_HUB)
+
+    render(
+      <ManagedSiteChannelsRoute
+        siteType={SITE_TYPES.AXON_HUB}
+        onReplaceRouteQuery={vi.fn()}
+      />,
+    )
+
+    const resultRegion = screen.getByRole("status")
+    expect(within(resultRegion).getByRole("listitem")).not.toHaveTextContent(
+      unknownRowKey,
+    )
+  })
+
   it("cancels an active list refresh before attempting locked recovery", async () => {
     const user = userEvent.setup()
     const refresh = vi.fn(async () => true)

--- a/tests/features/ManagedSiteChannels/controllers/useManagedResourceControllers.test.tsx
+++ b/tests/features/ManagedSiteChannels/controllers/useManagedResourceControllers.test.tsx
@@ -1480,7 +1480,7 @@ describe("useManagedResourceMutationController", () => {
     act(() => {
       result.current.openDelete(rowKey)
     })
-    await act(async () => result.current.bulkDelete([rowKey]))
+    await act(async () => result.current.openBulkDelete([rowKey]))
     expect(workspace.openCreateEditor).not.toHaveBeenCalled()
     expect(workspace.openEditEditor).toHaveBeenCalledOnce()
     expect(workspace.delete).not.toHaveBeenCalled()
@@ -1527,7 +1527,7 @@ describe("useManagedResourceMutationController", () => {
       act(() => {
         result.current.openDelete(rowKey)
       })
-      await act(async () => result.current.bulkDelete([rowKey]))
+      await act(async () => result.current.openBulkDelete([rowKey]))
       expect(workspace.openCreateEditor).not.toHaveBeenCalled()
       expect(workspace.delete).not.toHaveBeenCalled()
     },
@@ -1827,7 +1827,7 @@ describe("useManagedResourceMutationController", () => {
       opened = result.current.openDelete("opaque-row")
     })
     expect(opened).toBe(false)
-    await act(async () => result.current.bulkDelete(["opaque-row"]))
+    await act(async () => result.current.openBulkDelete(["opaque-row"]))
     expect(workspace.delete).toHaveBeenCalledOnce()
 
     await act(async () => result.current.recoverFreshRead())
@@ -1958,6 +1958,97 @@ describe("useManagedResourceMutationController", () => {
     )
   })
 
+  it("opens bulk-delete confirmation without dispatch and cancels without side effects", async () => {
+    const workspace = createManagedResourceWorkspace()
+    const analytics = createAnalytics()
+    const onMutationStart = vi.fn()
+    const refs = {
+      first: EXAMPLE_MANAGED_RESOURCE_REF,
+      second: { ...EXAMPLE_MANAGED_RESOURCE_REF, resourceId: "second" },
+    }
+    const { result } = renderHook(() =>
+      useManagedResourceMutationController({
+        workspace,
+        resolveRef: (rowKey) => refs[rowKey as keyof typeof refs],
+        analytics: analytics.analytics,
+        onMutationStart,
+      }),
+    )
+
+    await act(async () => result.current.openBulkDelete(["first", "second"]))
+
+    expect(workspace.delete).not.toHaveBeenCalled()
+    expect(analytics.startAction).not.toHaveBeenCalled()
+    expect(onMutationStart).not.toHaveBeenCalled()
+    expect(result.current.deleteState).toMatchObject({
+      isOpen: true,
+      isExecuting: false,
+      rowKeys: ["first", "second"],
+    })
+
+    act(() => result.current.cancelDelete())
+
+    expect(workspace.delete).not.toHaveBeenCalled()
+    expect(analytics.startAction).not.toHaveBeenCalled()
+    expect(onMutationStart).not.toHaveBeenCalled()
+    expect(result.current.deleteState).toMatchObject({
+      isOpen: false,
+      rowKeys: [],
+    })
+  })
+
+  it("rejects the entire confirmed bulk delete when any ref identity changes", async () => {
+    const firstRef = EXAMPLE_MANAGED_RESOURCE_REF
+    let secondRef = { ...EXAMPLE_MANAGED_RESOURCE_REF, resourceId: "second" }
+    const workspace = createManagedResourceWorkspace()
+    const { result } = renderHook(() =>
+      useManagedResourceMutationController({
+        workspace,
+        resolveRef: (rowKey) => (rowKey === "first" ? firstRef : secondRef),
+      }),
+    )
+
+    await act(async () => result.current.openBulkDelete(["first", "second"]))
+    secondRef = { ...secondRef, resourceId: "replacement" }
+    await act(async () => result.current.confirmDelete())
+
+    expect(workspace.delete).not.toHaveBeenCalled()
+    expect(result.current.deleteState).toMatchObject({
+      isOpen: false,
+      rowKeys: [],
+      failure: { code: MANAGED_RESOURCE_FAILURE_CODES.ValidationFailed },
+    })
+  })
+
+  it("coalesces repeated confirmation of one bulk-delete session", async () => {
+    const pending = deferred<void>()
+    const workspace = createManagedResourceWorkspace({
+      delete: vi.fn(() => pending.promise),
+    })
+    const { result } = renderHook(() =>
+      useManagedResourceMutationController({
+        workspace,
+        refresh: vi.fn(async () => true),
+        resolveRef: () => EXAMPLE_MANAGED_RESOURCE_REF,
+      }),
+    )
+
+    await act(async () => result.current.openBulkDelete(["opaque-row"]))
+    let first!: ReturnType<typeof result.current.confirmDelete>
+    let second!: ReturnType<typeof result.current.confirmDelete>
+    act(() => {
+      first = result.current.confirmDelete()
+      second = result.current.confirmDelete()
+    })
+
+    expect(second).toBe(first)
+    await waitFor(() => expect(workspace.delete).toHaveBeenCalledOnce())
+    await act(async () => {
+      pending.resolve()
+      await first
+    })
+  })
+
   it("snapshots row keys, limits deletes to four, preserves order, and refreshes once", async () => {
     let active = 0
     let peak = 0
@@ -1991,11 +2082,12 @@ describe("useManagedResourceMutationController", () => {
       useManagedResourceMutationController({ workspace, refresh, resolveRef }),
     )
 
-    let execution!: ReturnType<typeof result.current.bulkDelete>
+    await act(async () =>
+      result.current.openBulkDelete(refs.map((_, index) => `row-${index}`)),
+    )
+    let execution!: ReturnType<typeof result.current.confirmDelete>
     act(() => {
-      execution = result.current.bulkDelete(
-        refs.map((_, index) => `row-${index}`),
-      )
+      execution = result.current.confirmDelete()
     })
     await waitFor(() => expect(workspace.delete).toHaveBeenCalledTimes(4))
     expect(peak).toBe(4)
@@ -2015,7 +2107,7 @@ describe("useManagedResourceMutationController", () => {
     ])
     expect(refresh).toHaveBeenCalledOnce()
     expect(result.current.deleteState.requiresRefresh).toBe(true)
-    await act(async () => result.current.bulkDelete(["row-0"]))
+    await act(async () => result.current.openBulkDelete(["row-0"]))
     expect(workspace.delete).toHaveBeenCalledTimes(6)
   })
 
@@ -2032,7 +2124,9 @@ describe("useManagedResourceMutationController", () => {
       }),
     )
 
-    await act(async () => result.current.bulkDelete(["opaque-row"]))
+    await act(async () => result.current.openBulkDelete(["opaque-row"]))
+    expect(workspace.delete).not.toHaveBeenCalled()
+    await act(async () => result.current.confirmDelete())
 
     expect(analytics.startAction).toHaveBeenCalledOnce()
     expect(analytics.startAction).toHaveBeenCalledWith({
@@ -2070,9 +2164,9 @@ describe("useManagedResourceMutationController", () => {
       }),
     )
 
-    await act(async () => result.current.bulkDelete([]))
-    await act(async () => result.current.bulkDelete(["same", "same"]))
-    await act(async () => result.current.bulkDelete(["first", "second"]))
+    await act(async () => result.current.openBulkDelete([]))
+    await act(async () => result.current.openBulkDelete(["same", "same"]))
+    await act(async () => result.current.openBulkDelete(["first", "second"]))
 
     expect(workspace.delete).not.toHaveBeenCalled()
     expect(refresh).not.toHaveBeenCalled()
@@ -2098,7 +2192,7 @@ describe("useManagedResourceMutationController", () => {
       }),
     )
     expect(result.current.capabilities.canDelete).toBe(false)
-    await act(async () => result.current.bulkDelete(["crafted-row"]))
+    await act(async () => result.current.openBulkDelete(["crafted-row"]))
     expect(workspace.delete).not.toHaveBeenCalled()
     expect(result.current.deleteState.failure).toEqual({
       code: MANAGED_RESOURCE_FAILURE_CODES.ValidationFailed,
@@ -2123,9 +2217,10 @@ describe("useManagedResourceMutationController", () => {
         }),
       { initialProps: { workspace: oldWorkspace } },
     )
-    let execution!: ReturnType<typeof result.current.bulkDelete>
+    await act(async () => result.current.openBulkDelete(["row-one"]))
+    let execution!: ReturnType<typeof result.current.confirmDelete>
     act(() => {
-      execution = result.current.bulkDelete(["row-one"])
+      execution = result.current.confirmDelete()
     })
     await waitFor(() => expect(oldWorkspace.delete).toHaveBeenCalledOnce())
     const signal = (oldWorkspace.delete as ReturnType<typeof vi.fn>).mock
@@ -2169,16 +2264,18 @@ describe("useManagedResourceMutationController", () => {
         }),
       { initialProps: { workspace: oldWorkspace } },
     )
-    let oldExecution!: ReturnType<typeof result.current.bulkDelete>
+    await act(async () => result.current.openBulkDelete(["old-row"]))
+    let oldExecution!: ReturnType<typeof result.current.confirmDelete>
     act(() => {
-      oldExecution = result.current.bulkDelete(["old-row"])
+      oldExecution = result.current.confirmDelete()
     })
     await waitFor(() => expect(oldWorkspace.delete).toHaveBeenCalledOnce())
 
     rerender({ workspace: newWorkspace })
-    let newExecution!: ReturnType<typeof result.current.bulkDelete>
+    await act(async () => result.current.openBulkDelete(["new-row"]))
+    let newExecution!: ReturnType<typeof result.current.confirmDelete>
     act(() => {
-      newExecution = result.current.bulkDelete(["new-row"])
+      newExecution = result.current.confirmDelete()
     })
     await waitFor(() => expect(newWorkspace.delete).toHaveBeenCalledOnce())
 

--- a/tests/features/ManagedSiteChannels/presentation/ManagedSiteChannelsView.test.tsx
+++ b/tests/features/ManagedSiteChannels/presentation/ManagedSiteChannelsView.test.tsx
@@ -681,6 +681,94 @@ describe("ManagedSiteChannelsView", () => {
     expect(onRefresh).toHaveBeenCalledTimes(1)
   })
 
+  it("renders a controlled delete failure without implying refresh recovery", () => {
+    const onRefresh = vi.fn()
+
+    render(
+      <ManagedSiteChannelsView
+        {...commonProps}
+        state={createState({
+          deleteState: {
+            isOpen: false,
+            isWorking: false,
+            rowKeys: [],
+            results: [],
+            requiresRefresh: false,
+            failure: {
+              category: "Delete failed",
+              message: "Refresh the channels and try again.",
+            },
+          },
+        })}
+        callbacks={createCallbacks({ onRefresh })}
+      />,
+    )
+
+    const alert = screen.getByRole("alert")
+    expect(alert).toHaveTextContent("Delete failed")
+    expect(alert).toHaveTextContent("Refresh the channels and try again.")
+    expect(
+      within(alert).queryByRole("button", { name: "Refresh channels" }),
+    ).toBeNull()
+    expect(onRefresh).not.toHaveBeenCalled()
+  })
+
+  it("offers delete failure refresh recovery only when a fresh read is required", async () => {
+    const user = userEvent.setup()
+    const onRefresh = vi.fn()
+
+    render(
+      <ManagedSiteChannelsView
+        {...commonProps}
+        state={createState({
+          deleteState: {
+            isOpen: false,
+            isWorking: false,
+            rowKeys: [],
+            results: [],
+            requiresRefresh: true,
+            failure: {
+              category: "Delete state uncertain",
+              message: "Refresh before continuing.",
+            },
+          },
+        })}
+        callbacks={createCallbacks({ onRefresh })}
+      />,
+    )
+
+    const alert = screen.getByRole("alert")
+    await user.click(
+      within(alert).getByRole("button", { name: "Refresh channels" }),
+    )
+    expect(onRefresh).toHaveBeenCalledOnce()
+  })
+
+  it("makes native create and row actions visibly unavailable while a fresh read is required", () => {
+    render(
+      <ManagedSiteChannelsView
+        {...commonProps}
+        state={createState({
+          isResourceInteractionBlocked: true,
+          deleteState: {
+            isOpen: false,
+            isWorking: false,
+            rowKeys: [],
+            results: [],
+            requiresRefresh: true,
+          },
+        })}
+        callbacks={createCallbacks()}
+      />,
+    )
+
+    expect(screen.getByRole("button", { name: "Add channel" })).toBeDisabled()
+    expect(screen.queryByRole("button", { name: "Open actions" })).toBeNull()
+    expect(
+      screen.getByRole("button", { name: "Delete selected" }),
+    ).toBeDisabled()
+  })
+
   it("uses registry visibility, sort missing order, status facet, and safe native extension cells", async () => {
     const user = userEvent.setup()
     const onStatusFilterChange = vi.fn()

--- a/tests/utils/realSiteCompatibleApi.test.ts
+++ b/tests/utils/realSiteCompatibleApi.test.ts
@@ -1,10 +1,20 @@
 import { describe, expect, it, vi } from "vitest"
 
+import { SITE_TYPES } from "~/constants/siteType"
+import { runCompatibleRealSiteAccountSaveFlow } from "~~/e2e/utils/realSite/compatibleAccountSaveFlow"
 import {
   loginToCompatibleApiRealSite,
   type CompatibleApiRealSiteConfig,
 } from "~~/e2e/utils/realSite/compatibleApi"
 import { loginToRealNewApiSite } from "~~/e2e/utils/realSite/newApi"
+
+const mocks = vi.hoisted(() => ({
+  saveAutoDetectedAccountFromApp: vi.fn(),
+}))
+
+vi.mock("~~/e2e/utils/accountLifecycle", () => ({
+  saveAutoDetectedAccountFromApp: mocks.saveAutoDetectedAccountFromApp,
+}))
 
 const ORIGIN = "https://panel.example.invalid"
 const AUTH_REFRESH_URL = `${ORIGIN}/api/user/auth/refresh`
@@ -69,6 +79,7 @@ function createPage(
         post,
         get: vi.fn(),
       },
+      close: vi.fn().mockResolvedValue(undefined),
     } as any,
     evaluate,
     waitForFunction,
@@ -183,6 +194,50 @@ describe("compatible real-site login", () => {
         "X-Auth-Session": "session-id-placeholder",
       },
     })
+  })
+
+  it("logs out the fresh owned session once when downstream account saving fails", async () => {
+    const saveError = new Error("account save failed")
+    const post = vi
+      .fn()
+      .mockResolvedValueOnce(createResponse(401, { code: "AUTH_UNAUTHORIZED" }))
+      .mockResolvedValueOnce(createResponse(200, createAuthBundle()))
+      .mockResolvedValueOnce(createResponse(200, { success: true }))
+    const { page: sitePage } = createPage(post)
+
+    mocks.saveAutoDetectedAccountFromApp.mockRejectedValueOnce(saveError)
+
+    await expect(
+      runCompatibleRealSiteAccountSaveFlow({
+        page: { on: vi.fn() } as any,
+        extensionId: "extension-id",
+        serviceWorker: {} as any,
+        sitePage,
+        config,
+        siteType: SITE_TYPES.NEW_API,
+        login: loginToRealNewApiSite,
+      }),
+    ).rejects.toBe(saveError)
+
+    expect(post.mock.calls.filter(([url]) => url === AUTH_LOGOUT_URL)).toEqual([
+      [
+        AUTH_LOGOUT_URL,
+        {
+          failOnStatusCode: false,
+          headers: {
+            Origin: ORIGIN,
+            Authorization: "Bearer access-token-placeholder",
+            "X-Auth-Session": "session-id-placeholder",
+          },
+        },
+      ],
+    ])
+    expect(
+      post.mock.calls.some(([url]) =>
+        String(url).includes("/api/user/sessions/revoke-others"),
+      ),
+    ).toBe(false)
+    expect(sitePage.close).toHaveBeenCalledOnce()
   })
 
   it("uses the successful 2FA AuthBundle response as the login result", async () => {


### PR DESCRIPTION
## Why

AxonHub native managed-channel bulk deletion bypassed the confirmation step used by the legacy managed-site flow. The shared E2E path also derived selectors from resource names even though native resources use opaque row tokens, so cancellation coverage could miss the real native behavior.

A separate New API regression guard covers failed saves: cleanup must end only a fresh session owned by that E2E attempt, without affecting an existing remote login session.

## What changed

- route native single and bulk deletion through the shared confirmation-controlled mutation session
- revalidate selected resource references before confirmed deletion and block unsafe replay until a fresh read
- surface deletion failures and disable conflicting create/row mutations while recovery is required
- use stable native cancel targeting and opaque row tokens in browser coverage
- verify AxonHub cancellation performs zero delete requests and confirmation performs exactly one
- cover New API save failure cleanup without revoking an unrelated existing session

## Validation

- [Test](https://github.com/qixing-jk/all-api-hub/actions/runs/30443227291)
- [E2E](https://github.com/qixing-jk/all-api-hub/actions/runs/30443227297)
- [Managed-site real-site E2E](https://github.com/qixing-jk/all-api-hub/actions/runs/30449633759)
- [Account real-site E2E](https://github.com/qixing-jk/all-api-hub/actions/runs/30449875368)
- local focused Vitest: 147 passed
- local managed-site Playwright parity: 7 passed
- local `pnpm run validate:push`

## Compatibility and maintainability

The confirmation boundary is implemented in the generic native resource controller/presentation path, so future native resource migrations inherit it without site-type branching. The legacy managed-site behavior remains unchanged. Existing delete analytics begin only after confirmation; cancellation remains side-effect free. No documentation or migration is required.

Follow-up to #1226.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved managed site channel deletion with a confirmation session that validates targets before executing.
  - Blocked resource interactions when a fresh read is required (row actions/add-channel/delete-selected).
  - Preserved readable channel labels during delete results and added clearer delete failure handling with an optional “Refresh channels” action.

- **New Features**
  - Added optional stable selectors for destructive confirm dialog cancel/confirm buttons.

- **Tests**
  - Expanded coverage for single/bulk delete open/confirm flows, cancellation behavior, recovery states, stable row selection tokens, and AxonHub delete-request tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->