### PR TITLE
fix(product-announcements): prefer bundled notices in development

### DIFF
--- a/src/services/productAnnouncements/service.ts
+++ b/src/services/productAnnouncements/service.ts
@@ -57,12 +57,16 @@ interface GetCurrentProductAnnouncementStateOptions {
   now?: number
 }
 
+type ValidProductAnnouncementFeed = RawProductAnnouncementFeed & {
+  announcements: unknown[]
+}
+
 /**
  * Checks the feed-level shape before trusting remote or persisted catalog data.
  */
 function isValidProductAnnouncementFeed(
   feed: RawProductAnnouncementFeed,
-): boolean {
+): feed is ValidProductAnnouncementFeed {
   return (
     isPlainObject(feed) &&
     (feed.defaultLocale == null || typeof feed.defaultLocale === "string") &&
@@ -86,15 +90,13 @@ function getRawAnnouncementId(announcement: unknown): string | null {
  * Adds local bundled notices and development examples without persisting them.
  */
 function getRuntimeProductAnnouncementFeed(
-  feed: RawProductAnnouncementFeed,
-): RawProductAnnouncementFeed {
+  feed: ValidProductAnnouncementFeed,
+): ValidProductAnnouncementFeed {
   if (!isDevelopmentMode()) {
     return feed
   }
 
-  const bundledAnnouncements = Array.isArray(bundledFeed.announcements)
-    ? bundledFeed.announcements
-    : []
+  const bundledAnnouncements = bundledFeed.announcements
   const devAnnouncements = Array.isArray(
     bundledFeed._examples?.devAnnouncements,
   )
@@ -110,9 +112,7 @@ function getRuntimeProductAnnouncementFeed(
       .map(getRawAnnouncementId)
       .filter((id): id is string => id !== null),
   )
-  const feedAnnouncements = Array.isArray(feed.announcements)
-    ? feed.announcements
-    : []
+  const feedAnnouncements = feed.announcements
 
   return {
     ...feed,

--- a/src/services/productAnnouncements/service.ts
+++ b/src/services/productAnnouncements/service.ts
@@ -71,7 +71,19 @@ function isValidProductAnnouncementFeed(
 }
 
 /**
- * Adds bundled development examples to the runtime view without persisting them.
+ * Reads an announcement id for development-only feed replacement.
+ */
+function getRawAnnouncementId(announcement: unknown): string | null {
+  if (!isPlainObject(announcement)) return null
+
+  const id = announcement.id
+  if (typeof id !== "string") return null
+
+  return id.trim() || null
+}
+
+/**
+ * Adds local bundled notices and development examples without persisting them.
  */
 function getRuntimeProductAnnouncementFeed(
   feed: RawProductAnnouncementFeed,
@@ -80,20 +92,36 @@ function getRuntimeProductAnnouncementFeed(
     return feed
   }
 
+  const bundledAnnouncements = Array.isArray(bundledFeed.announcements)
+    ? bundledFeed.announcements
+    : []
   const devAnnouncements = Array.isArray(
     bundledFeed._examples?.devAnnouncements,
   )
     ? bundledFeed._examples.devAnnouncements
     : []
-  if (devAnnouncements.length === 0) {
+  const localAnnouncements = [...bundledAnnouncements, ...devAnnouncements]
+  if (localAnnouncements.length === 0) {
     return feed
   }
+
+  const localAnnouncementIds = new Set(
+    localAnnouncements
+      .map(getRawAnnouncementId)
+      .filter((id): id is string => id !== null),
+  )
+  const feedAnnouncements = Array.isArray(feed.announcements)
+    ? feed.announcements
+    : []
 
   return {
     ...feed,
     announcements: [
-      ...(Array.isArray(feed.announcements) ? feed.announcements : []),
-      ...devAnnouncements,
+      ...feedAnnouncements.filter((announcement) => {
+        const id = getRawAnnouncementId(announcement)
+        return id === null || !localAnnouncementIds.has(id)
+      }),
+      ...localAnnouncements,
     ],
   }
 }

--- a/tests/services/productAnnouncements/service.test.ts
+++ b/tests/services/productAnnouncements/service.test.ts
@@ -271,6 +271,58 @@ describe("product announcement service", () => {
     ])
   })
 
+  it("keeps valid cached notices when sibling ids are malformed", async () => {
+    vi.stubEnv("MODE", "development")
+    await productAnnouncementStorage.updateState((state) => {
+      state.lastFetchedAt = Date.parse("2026-06-06T00:00:00Z")
+      state.cachedFeed = {
+        schemaVersion: 1,
+        defaultLocale: "zh-CN",
+        announcements: [
+          null,
+          { id: 123 },
+          { id: "   " },
+          {
+            id: "cached-info",
+            revision: 1,
+            severity: "info",
+            priority: 1,
+            affectedVersions: "*",
+            startsAt: "2026-01-01T00:00:00Z",
+            expiresAt: "2027-01-01T00:00:00Z",
+            content: {
+              "zh-CN": {
+                title: "Cached info",
+                message: "Cached remote notice",
+              },
+            },
+          },
+        ],
+      }
+    })
+
+    const state = await productAnnouncementService.getCurrentState({
+      locale: "zh-CN",
+      currentVersion: "3.44.0",
+      now: Date.parse("2026-06-06T00:00:00Z"),
+    })
+
+    expect(state.view.notices.map((notice) => notice.id)).toEqual([
+      "dev-critical-announcement",
+      "bundled-notice",
+      "cached-info",
+    ])
+    await expect(productAnnouncementStorage.getState()).resolves.toMatchObject({
+      cachedFeed: {
+        announcements: expect.arrayContaining([
+          null,
+          { id: 123 },
+          { id: "   " },
+        ]),
+      },
+    })
+  })
+
   it("ignores whitespace-only dismiss ids", async () => {
     await productAnnouncementService.dismiss("   ", 2)
 

--- a/tests/services/productAnnouncements/service.test.ts
+++ b/tests/services/productAnnouncements/service.test.ts
@@ -228,6 +228,49 @@ describe("product announcement service", () => {
     )
   })
 
+  it("prefers local bundled announcements over cached copies in development", async () => {
+    vi.stubEnv("MODE", "development")
+    await productAnnouncementStorage.updateState((state) => {
+      state.lastFetchedAt = Date.parse("2026-06-06T00:00:00Z")
+      state.cachedFeed = {
+        schemaVersion: 1,
+        defaultLocale: "zh-CN",
+        announcements: [
+          {
+            id: "bundled-notice",
+            revision: 1,
+            severity: "warning",
+            priority: 1,
+            affectedVersions: ">=3.0.0",
+            startsAt: "2026-01-01T00:00:00Z",
+            expiresAt: "2027-01-01T00:00:00Z",
+            content: {
+              "zh-CN": {
+                title: "Cached notice",
+                message: "Cached remote content",
+              },
+            },
+          },
+        ],
+      }
+    })
+
+    const state = await productAnnouncementService.getCurrentState({
+      locale: "zh-CN",
+      currentVersion: "3.44.0",
+      now: Date.parse("2026-06-06T00:00:00Z"),
+    })
+
+    expect(
+      state.view.notices.filter((notice) => notice.id === "bundled-notice"),
+    ).toEqual([
+      expect.objectContaining({
+        title: "Bundled notice",
+        message: "Bundled fallback notice",
+      }),
+    ])
+  })
+
   it("ignores whitespace-only dismiss ids", async () => {
     await productAnnouncementService.dismiss("   ", 2)
 
@@ -369,7 +412,7 @@ describe("product announcement service", () => {
     expect(state.view.primaryRiskNotice?.id).toBe("dev-critical-announcement")
   })
 
-  it("merges bundled development examples with cached remote notices in development mode", async () => {
+  it("merges local bundled and cached remote notices in development mode", async () => {
     vi.stubEnv("MODE", "development")
     await productAnnouncementStorage.updateState((state) => {
       state.lastFetchedAt = 100
@@ -404,6 +447,7 @@ describe("product announcement service", () => {
 
     expect(state.view.notices.map((notice) => notice.id)).toEqual([
       "dev-critical-announcement",
+      "bundled-notice",
       "cached-info",
     ])
     await expect(productAnnouncementStorage.getState()).resolves.toMatchObject({


### PR DESCRIPTION
## Summary

- include locally bundled product notices in the development runtime feed even when a cached remote feed exists
- prefer the local bundled copy when announcement IDs collide, while preserving remote-only notices and development examples
- keep production feed behavior unchanged

## Validation

- `pnpm exec vitest run tests/services/productAnnouncements` — 59 tests passed
- `pnpm run validate:staged`
- Full-suite and cross-platform validation will run in CI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * In development environments, bundled announcement content now correctly overrides cached content when IDs match.
  * Development-mode announcements are merged with cached announcements without duplicating valid entries.
  * Announcement entries with missing or invalid IDs remain included, and malformed announcement payloads are handled more robustly.
  * Feed validation was tightened to ensure reliable runtime handling, with expanded test coverage for malformed cached notices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->