### PR TITLE
feat(sub2api): repair missing group key coverage

### DIFF
--- a/openspec/specs/account-key-auto-provisioning/spec.md
+++ b/openspec/specs/account-key-auto-provisioning/spec.md
@@ -75,21 +75,25 @@ create-key follow-up action.
 - **THEN** the system MUST skip that account
 
 ### Requirement: Key auto-provisioning ensures at least one token
-For an eligible account, the system MUST determine the remote token inventory and MUST create a default token when the account has zero tokens.
+Key auto-provisioning MUST determine the remote token inventory for an eligible
+account whose adapter permits ungrouped default-token creation, and MUST create
+a default token when the account has zero tokens. Group-aware repair flows MUST
+instead follow their group-coverage requirements, including the Sub2API
+behavior above.
 
 #### Scenario: Account already has tokens
-- **GIVEN** an eligible account has one or more tokens
+- **GIVEN** an eligible account using ungrouped default-token creation has one or more tokens
 - **WHEN** key auto-provisioning runs for that account
 - **THEN** the system MUST NOT create a new token
 
 #### Scenario: Account has no tokens
-- **GIVEN** an eligible account has zero tokens
+- **GIVEN** an eligible account using ungrouped default-token creation has zero tokens
 - **WHEN** key auto-provisioning runs for that account
 - **THEN** the system MUST create a default token for that account
 - **AND** subsequent token inventory fetches MUST return at least one token
 
 ### Requirement: Default token definition remains stable
-When key auto-provisioning creates a default token, it MUST use the existing default token definition:
+When key auto-provisioning creates an ungrouped default token, it MUST use the existing default token definition:
 - `name = "user group (auto)"`
 - `unlimited_quota = true`
 - `remain_quota = 0`
@@ -100,7 +104,7 @@ When key auto-provisioning creates a default token, it MUST use the existing def
 - `group = ""` (follow user group)
 
 #### Scenario: Created token uses the default definition
-- **GIVEN** an eligible account has zero tokens
+- **GIVEN** an eligible account using ungrouped default-token creation has zero tokens
 - **WHEN** the system creates a default token via key auto-provisioning
 - **THEN** the created token MUST use the default token definition
 
@@ -109,14 +113,14 @@ The system MUST provide a user-initiated action to run key auto-provisioning acr
 
 The manual repair MUST:
 - Evaluate all enabled accounts, applying eligibility gating
-- Create default tokens for eligible accounts that have zero tokens
+- Create ungrouped default tokens or group-specific tokens according to each eligible account's repair capabilities
 - Be resilient to partial failures (continue processing remaining accounts)
 - Apply rate limiting per site origin (the limiter MUST be keyed by normalized `site_url` origin, not global)
 
 #### Scenario: Bulk repair creates tokens for accounts missing keys
-- **GIVEN** multiple stored accounts exist and at least one eligible account has zero tokens
+- **GIVEN** multiple stored accounts exist and at least one eligible account requires a missing token
 - **WHEN** the user runs the manual key repair action
-- **THEN** the system MUST create a default token for each eligible account that has zero tokens
+- **THEN** the system MUST create tokens according to each eligible account's default-token or group-coverage requirements
 
 #### Scenario: Bulk repair continues when one account fails
 - **GIVEN** multiple eligible accounts exist

--- a/openspec/specs/account-key-auto-provisioning/spec.md
+++ b/openspec/specs/account-key-auto-provisioning/spec.md
@@ -28,12 +28,13 @@ When auto-provisioning on add is enabled, token inventory fetch and/or token cre
 - **THEN** the system MUST keep the added account persisted
 
 ### Requirement: Eligibility gating for key auto-provisioning
-Key auto-provisioning (both on-add and manual repair) MUST only operate on eligible accounts.
+Key auto-provisioning MUST only operate on accounts that are eligible for the
+current workflow.
 
-An account is eligible when all of the following are true:
+An account is eligible for manual repair when all of the following are true:
 - The account is enabled (`disabled = false`)
 - The account has credentials suitable for token management (`authType != "none"`)
-- The account is not `site_type = "sub2api"`
+- The site adapter's repair policy marks the account as eligible
 
 #### Scenario: Disabled accounts are skipped and not shown
 - **GIVEN** an account is disabled (`disabled = true`)
@@ -41,15 +42,27 @@ An account is eligible when all of the following are true:
 - **THEN** the system MUST exclude the disabled account from the repair operation
 - **AND** the system MUST NOT show the disabled account in the repair operation UI or results
 
-#### Scenario: Sub2API accounts are skipped
+#### Scenario: Automatic account-add provisioning skips Sub2API accounts
 - **GIVEN** an account has `site_type = "sub2api"`
-- **WHEN** key auto-provisioning is triggered (on-add or manual repair)
-- **THEN** the system MUST skip that account and MUST NOT call token-management endpoints for it
+- **WHEN** implicit account-add key auto-provisioning is triggered
+- **THEN** the system MUST NOT create a key or guess a group without an explicit group selection
 
-Automated account-add provisioning and background repair MUST continue skipping `sub2api` accounts. However, when the manual repair UI reports a skipped `sub2api` account and the underlying account record remains available in the current results view, the system MUST expose an explicit user-triggered create-key follow-up action that drives the shared Sub2API token creation flow instead of silently ignoring the row.
+#### Scenario: User-triggered repair covers every available Sub2API group
+- **GIVEN** an enabled `sub2api` account has credentials suitable for token management
+- **AND** one or more current Sub2API groups do not have a key
+- **WHEN** the user explicitly starts the manual key repair action
+- **THEN** the system MUST inspect the account's current available groups and complete paginated key inventory
+- **AND** it MUST create one key for each currently uncovered group
+- **AND** it MUST NOT guess a single default group or require a separate choice for each uncovered group
 
-#### Scenario: Manual repair offers explicit follow-up key creation for skipped Sub2API accounts
-- **GIVEN** the manual repair flow reports a skipped `sub2api` account
+Automatic account-add provisioning MUST continue skipping `sub2api` accounts.
+For backward compatibility, when a current manual repair result reports a
+legacy skipped `sub2api` account and the underlying account record remains
+available, the system MUST continue exposing the explicit group-aware
+create-key follow-up action.
+
+#### Scenario: Current legacy repair results retain Sub2API follow-up key creation
+- **GIVEN** a current manual repair result reports a skipped `sub2api` account
 - **AND** the underlying account record is available in the current results view
 - **WHEN** the user reviews the repair results
 - **THEN** the UI MUST offer an explicit create-key action for that account

--- a/src/services/accounts/accountKeyAutoProvisioning/groupCoverage.ts
+++ b/src/services/accounts/accountKeyAutoProvisioning/groupCoverage.ts
@@ -125,7 +125,9 @@ export async function ensureAccountKeysForAvailableGroups(params: {
     : accountContext.request
   const accountId = account.id
 
-  const tokens = await keyManagement.fetchTokens(request)
+  const tokens = keyManagement.fetchAllTokens
+    ? await keyManagement.fetchAllTokens(request)
+    : await keyManagement.fetchTokens(request)
   const groupsData = keyManagement.userGroups
     ? await keyManagement.userGroups.fetch(request)
     : {}

--- a/src/services/apiAdapters/contracts/keyManagement.ts
+++ b/src/services/apiAdapters/contracts/keyManagement.ts
@@ -38,6 +38,7 @@ export type KeyManagementCapability = {
     request: ApiServiceRequest,
     options?: FetchAccountTokensOptions,
   ): Promise<ApiToken[]>
+  fetchAllTokens?(request: ApiServiceRequest): Promise<ApiToken[]>
   createToken(
     request: ApiServiceRequest,
     tokenData: CreateTokenRequest,

--- a/src/services/apiAdapters/sub2api/keyManagement.ts
+++ b/src/services/apiAdapters/sub2api/keyManagement.ts
@@ -4,6 +4,7 @@ import {
   deleteApiToken,
   fetchAccountAvailableModels,
   fetchAccountTokens,
+  fetchAllAccountTokens,
   fetchUserGroups,
   resolveApiTokenKey,
   updateApiToken,
@@ -12,6 +13,7 @@ import {
 export const sub2ApiKeyManagement: KeyManagementCapability = {
   fetchTokens: (request, options) =>
     fetchAccountTokens(request, options?.page, options?.size),
+  fetchAllTokens: (request) => fetchAllAccountTokens(request),
   createToken: (request, tokenData) => createApiToken(request, tokenData),
   updateToken: ({ request, tokenId, tokenData }) =>
     updateApiToken(request, tokenId, tokenData),

--- a/src/services/apiAdapters/sub2api/tokenProvisioning.ts
+++ b/src/services/apiAdapters/sub2api/tokenProvisioning.ts
@@ -9,7 +9,6 @@ import {
   TOKEN_PROVISIONING_WORKFLOWS,
   type TokenProvisioningCapability,
 } from "~/services/apiAdapters/contracts/tokenProvisioning"
-import { ACCOUNT_KEY_REPAIR_SKIP_REASONS } from "~/types/accountKeyAutoProvisioning"
 
 const createWithGroup = (
   defaultTokenData: CreateTokenRequest,
@@ -102,7 +101,6 @@ export const sub2ApiTokenProvisioning: TokenProvisioningCapability = {
     }
   },
   getRepairPolicy: () => ({
-    kind: TOKEN_PROVISIONING_REPAIR_POLICY_KINDS.Skipped,
-    skipReason: ACCOUNT_KEY_REPAIR_SKIP_REASONS.Sub2Api,
+    kind: TOKEN_PROVISIONING_REPAIR_POLICY_KINDS.Eligible,
   }),
 }

--- a/src/services/apiService/sub2api/index.ts
+++ b/src/services/apiService/sub2api/index.ts
@@ -90,6 +90,7 @@ import {
 const logger = createLogger("ApiService.Sub2API")
 const DEFAULT_KEYS_PAGE = 1
 const DEFAULT_KEYS_PAGE_SIZE = 100
+const FULL_KEYS_PAGE_SIZE = 1000
 const SUB2API_RUNTIME_MODELS_ENDPOINT = "/v1/models"
 const sub2ApiAuthMutationLocks = new Map<string, Promise<void>>()
 
@@ -1407,14 +1408,16 @@ export async function refreshAccountData(
   }
 }
 
-/**
- * Fetch the list of API tokens for the account, with pagination support.
- */
-export async function fetchAccountTokens(
+type Sub2ApiKeyPage = {
+  tokens: ApiToken[]
+  totalPages: number
+}
+
+const fetchAccountTokenPage = async (
   request: ApiServiceRequest,
-  page: number = DEFAULT_KEYS_PAGE,
-  size: number = DEFAULT_KEYS_PAGE_SIZE,
-): Promise<ApiToken[]> {
+  page: number,
+  size: number,
+): Promise<Sub2ApiKeyPage> => {
   const endpoint = createSub2ApiKeysEndpoint(page, size)
 
   try {
@@ -1424,12 +1427,17 @@ export async function fetchAccountTokens(
         cache: "no-store",
       })
 
-    return extractSub2ApiKeyItems(data).map((item) =>
-      parseSub2ApiKey(item, {
-        defaultUserId: hydratedRequest.auth?.userId,
-        endpoint,
-      }),
-    )
+    return {
+      tokens: extractSub2ApiKeyItems(data).map((item) =>
+        parseSub2ApiKey(item, {
+          defaultUserId: hydratedRequest.auth?.userId,
+          endpoint,
+        }),
+      ),
+      totalPages: Array.isArray(data)
+        ? DEFAULT_KEYS_PAGE
+        : Math.max(page, normalizePositiveInteger(data.pages ?? page, page)),
+    }
   } catch (error) {
     logger.error("Failed to fetch Sub2API keys", {
       accountId: request.accountId,
@@ -1437,6 +1445,44 @@ export async function fetchAccountTokens(
       error: getSafeErrorMessage(error),
     })
     throw error
+  }
+}
+
+/**
+ * Fetch the requested API-token inventory page.
+ */
+export async function fetchAccountTokens(
+  request: ApiServiceRequest,
+  page: number = DEFAULT_KEYS_PAGE,
+  size: number = DEFAULT_KEYS_PAGE_SIZE,
+): Promise<ApiToken[]> {
+  return (await fetchAccountTokenPage(request, page, size)).tokens
+}
+
+/**
+ * Fetch the complete API-token inventory for coverage checks.
+ */
+export async function fetchAllAccountTokens(
+  request: ApiServiceRequest,
+): Promise<ApiToken[]> {
+  const tokens: ApiToken[] = []
+  let page = DEFAULT_KEYS_PAGE
+
+  // Upstream paginates this endpoint and caps page_size at 1000:
+  // https://github.com/Wei-Shaw/sub2api/blob/main/backend/internal/pkg/response/response.go
+  while (true) {
+    const result = await fetchAccountTokenPage(
+      request,
+      page,
+      FULL_KEYS_PAGE_SIZE,
+    )
+    tokens.push(...result.tokens)
+
+    if (page >= result.totalPages) {
+      return tokens
+    }
+
+    page += 1
   }
 }
 

--- a/tests/services/accountKeyGroupCoverage.test.ts
+++ b/tests/services/accountKeyGroupCoverage.test.ts
@@ -28,6 +28,7 @@ import {
 } from "~~/tests/test-utils/factories"
 
 const mocks = vi.hoisted(() => ({
+  fetchAllAccountTokens: vi.fn(),
   fetchAccountTokens: vi.fn(),
   fetchUserGroups: vi.fn(),
   createApiToken: vi.fn(),
@@ -42,6 +43,8 @@ vi.mock("~/services/apiAdapters/registry", () => ({
     siteType: SITE_TYPES.NEW_API,
     account: {
       keyManagement: {
+        fetchAllTokens: (...args: unknown[]) =>
+          mocks.fetchAllAccountTokens(...args),
         fetchTokens: (...args: unknown[]) => mocks.fetchAccountTokens(...args),
         userGroups: {
           fetch: (...args: unknown[]) => mocks.fetchUserGroups(...args),
@@ -106,7 +109,11 @@ const runCoverage = (abortSignal?: AbortSignal) =>
 
 describe("ensureAccountKeysForAvailableGroups", () => {
   beforeEach(() => {
+    mocks.fetchAllAccountTokens.mockReset()
     mocks.fetchAccountTokens.mockReset()
+    mocks.fetchAllAccountTokens.mockImplementation((...args: unknown[]) =>
+      mocks.fetchAccountTokens(...args),
+    )
     mocks.fetchUserGroups.mockReset()
     mocks.createApiToken.mockReset()
     mocks.updateApiToken.mockReset()
@@ -180,6 +187,7 @@ describe("ensureAccountKeysForAvailableGroups", () => {
       }),
       buildGroupDefaultTokenRequest("vip"),
     )
+    expect(mocks.fetchAllAccountTokens).toHaveBeenCalledOnce()
   })
 
   it("uses stored account context for group coverage token APIs and adapter lookup", async () => {

--- a/tests/services/accountKeyRepair.test.ts
+++ b/tests/services/accountKeyRepair.test.ts
@@ -113,26 +113,19 @@ vi.mock("~/services/apiAdapters/registry", () => ({
               userGroups: { fetch: async () => ({}) },
             },
             tokenProvisioning:
-              siteType === SITE_TYPES.SUB2API
+              siteType === SITE_TYPES.AIHUBMIX
                 ? {
                     getRepairPolicy: () => ({
                       kind: TOKEN_PROVISIONING_REPAIR_POLICY_KINDS.Skipped,
-                      skipReason: ACCOUNT_KEY_REPAIR_SKIP_REASONS.Sub2Api,
+                      skipReason:
+                        ACCOUNT_KEY_REPAIR_SKIP_REASONS.AihubmixOneTimeKey,
                     }),
                   }
-                : siteType === SITE_TYPES.AIHUBMIX
-                  ? {
-                      getRepairPolicy: () => ({
-                        kind: TOKEN_PROVISIONING_REPAIR_POLICY_KINDS.Skipped,
-                        skipReason:
-                          ACCOUNT_KEY_REPAIR_SKIP_REASONS.AihubmixOneTimeKey,
-                      }),
-                    }
-                  : {
-                      getRepairPolicy: () => ({
-                        kind: TOKEN_PROVISIONING_REPAIR_POLICY_KINDS.Eligible,
-                      }),
-                    },
+                : {
+                    getRepairPolicy: () => ({
+                      kind: TOKEN_PROVISIONING_REPAIR_POLICY_KINDS.Eligible,
+                    }),
+                  },
           }),
     },
   })),
@@ -232,7 +225,7 @@ describe("accountKeyRepair", () => {
     })
   })
 
-  it("records skipped, created, and failed outcomes during a repair run", async () => {
+  it("repairs Sub2API accounts and records other repair outcomes", async () => {
     const sub2apiAccount = buildSiteAccount({
       id: "sub2api-1",
       site_type: SITE_TYPES.SUB2API,
@@ -363,6 +356,14 @@ describe("accountKeyRepair", () => {
     mocks.ensureAccountKeysForAvailableGroups
       .mockResolvedValueOnce({
         created: true,
+        availableGroups: ["default", "vip"],
+        coveredGroups: ["default", "vip"],
+        createdGroups: ["vip"],
+        missingGroups: [],
+        invalidTokens: [],
+      })
+      .mockResolvedValueOnce({
+        created: true,
         availableGroups: [],
         coveredGroups: [],
         createdGroups: [""],
@@ -397,18 +398,18 @@ describe("accountKeyRepair", () => {
     const progress = await accountKeyRepairRunner.getProgress()
     expect(progress.totals).toMatchObject({
       enabledAccounts: 5,
-      eligibleAccounts: 2,
-      processedAccounts: 2,
-      processedEligibleAccounts: 2,
+      eligibleAccounts: 3,
+      processedAccounts: 3,
+      processedEligibleAccounts: 3,
     })
     expect(progress.summary).toEqual({
-      created: 2,
+      created: 3,
       alreadyHad: 0,
-      skipped: 3,
+      skipped: 2,
       failed: 0,
-      availableGroups: 0,
-      coveredGroups: 0,
-      createdKeys: 2,
+      availableGroups: 2,
+      coveredGroups: 2,
+      createdKeys: 3,
       renamedKeys: 0,
       renameFailed: 0,
       invalidKeys: 0,
@@ -419,8 +420,10 @@ describe("accountKeyRepair", () => {
       expect.arrayContaining([
         expect.objectContaining({
           accountId: "sub2api-1",
-          outcome: ACCOUNT_KEY_REPAIR_OUTCOMES.Skipped,
-          skipReason: ACCOUNT_KEY_REPAIR_SKIP_REASONS.Sub2Api,
+          outcome: ACCOUNT_KEY_REPAIR_OUTCOMES.Created,
+          availableGroups: ["default", "vip"],
+          coveredGroups: ["default", "vip"],
+          createdGroups: ["vip"],
           siteUrlOrigin: "https://sub2api.example.com",
         }),
         expect.objectContaining({
@@ -448,7 +451,14 @@ describe("accountKeyRepair", () => {
         }),
       ]),
     )
-    expect(mocks.ensureAccountKeysForAvailableGroups).toHaveBeenCalledTimes(2)
+    expect(mocks.ensureAccountKeysForAvailableGroups).toHaveBeenCalledTimes(3)
+    expect(mocks.ensureAccountKeysForAvailableGroups).toHaveBeenCalledWith(
+      expect.objectContaining({
+        account: sub2apiAccount,
+        accountName: "Sub2API",
+        siteUrlOrigin: "https://sub2api.example.com",
+      }),
+    )
     expect(mocks.sendRuntimeMessage).toHaveBeenCalledWith(
       {
         type: RuntimeMessageTypes.AccountKeyRepairProgress,

--- a/tests/services/apiAdapters/keyManagement.test.ts
+++ b/tests/services/apiAdapters/keyManagement.test.ts
@@ -26,6 +26,7 @@ const {
   mockSub2ApiCreateApiToken,
   mockSub2ApiDeleteApiToken,
   mockSub2ApiFetchAccountAvailableModels,
+  mockSub2ApiFetchAllAccountTokens,
   mockSub2ApiFetchAccountTokens,
   mockSub2ApiFetchUserGroups,
   mockSub2ApiResolveApiTokenKey,
@@ -58,6 +59,7 @@ const {
   mockSub2ApiCreateApiToken: vi.fn(),
   mockSub2ApiDeleteApiToken: vi.fn(),
   mockSub2ApiFetchAccountAvailableModels: vi.fn(),
+  mockSub2ApiFetchAllAccountTokens: vi.fn(),
   mockSub2ApiFetchAccountTokens: vi.fn(),
   mockSub2ApiFetchUserGroups: vi.fn(),
   mockSub2ApiResolveApiTokenKey: vi.fn(),
@@ -89,6 +91,7 @@ vi.mock("~/services/apiService/sub2api", () => ({
   createApiToken: mockSub2ApiCreateApiToken,
   deleteApiToken: mockSub2ApiDeleteApiToken,
   fetchAccountAvailableModels: mockSub2ApiFetchAccountAvailableModels,
+  fetchAllAccountTokens: mockSub2ApiFetchAllAccountTokens,
   fetchAccountTokens: mockSub2ApiFetchAccountTokens,
   fetchUserGroups: mockSub2ApiFetchUserGroups,
   resolveApiTokenKey: mockSub2ApiResolveApiTokenKey,
@@ -266,6 +269,7 @@ describe("apiAdapter keyManagement", () => {
   it("delegates Sub2API key operations to backend key helpers", async () => {
     const expectedTokens = [token]
     mockSub2ApiFetchAccountTokens.mockResolvedValueOnce(expectedTokens)
+    mockSub2ApiFetchAllAccountTokens.mockResolvedValueOnce(expectedTokens)
     mockSub2ApiCreateApiToken.mockResolvedValueOnce(token)
     mockSub2ApiUpdateApiToken.mockResolvedValueOnce(true)
     mockSub2ApiResolveApiTokenKey.mockResolvedValueOnce("sk-sub2api")
@@ -278,6 +282,9 @@ describe("apiAdapter keyManagement", () => {
     await expect(
       sub2ApiKeyManagement.fetchTokens(request, { page: 3, size: 50 }),
     ).resolves.toBe(expectedTokens)
+    await expect(sub2ApiKeyManagement.fetchAllTokens?.(request)).resolves.toBe(
+      expectedTokens,
+    )
     await expect(
       sub2ApiKeyManagement.createToken(request, tokenData),
     ).resolves.toBe(token)
@@ -302,6 +309,7 @@ describe("apiAdapter keyManagement", () => {
     ).resolves.toBe(availableModels)
 
     expect(mockSub2ApiFetchAccountTokens).toHaveBeenCalledWith(request, 3, 50)
+    expect(mockSub2ApiFetchAllAccountTokens).toHaveBeenCalledWith(request)
     expect(mockSub2ApiCreateApiToken).toHaveBeenCalledWith(request, tokenData)
     expect(mockSub2ApiUpdateApiToken).toHaveBeenCalledWith(
       request,

--- a/tests/services/apiAdapters/tokenProvisioning.test.ts
+++ b/tests/services/apiAdapters/tokenProvisioning.test.ts
@@ -169,7 +169,7 @@ describe("apiAdapter tokenProvisioning", () => {
     ).toEqual(["default", "vip"])
   })
 
-  it("requires Sub2API groups before creating default tokens", () => {
+  it("keeps implicit Sub2API creation blocked while allowing repair coverage", () => {
     expect(
       sub2ApiTokenProvisioning.resolveDefaultTokenCreation({
         workflow: TOKEN_PROVISIONING_WORKFLOWS.SharedEnsure,
@@ -234,8 +234,7 @@ describe("apiAdapter tokenProvisioning", () => {
     })
 
     expect(sub2ApiTokenProvisioning.getRepairPolicy()).toEqual({
-      kind: TOKEN_PROVISIONING_REPAIR_POLICY_KINDS.Skipped,
-      skipReason: ACCOUNT_KEY_REPAIR_SKIP_REASONS.Sub2Api,
+      kind: TOKEN_PROVISIONING_REPAIR_POLICY_KINDS.Eligible,
     })
   })
 

--- a/tests/services/apiService/sub2api/keyManagement.test.ts
+++ b/tests/services/apiService/sub2api/keyManagement.test.ts
@@ -6,6 +6,7 @@ import {
   createApiToken,
   fetchAccountAvailableModels,
   fetchAccountTokens,
+  fetchAllAccountTokens,
   fetchSub2ApiGroupRates,
   fetchTokenById,
   fetchUserGroups,
@@ -246,6 +247,58 @@ describe("apiService sub2api key management service", () => {
     await expect(fetchAccountAvailableModels(createRequest())).resolves.toEqual(
       [],
     )
+  })
+
+  it("fetches every key inventory page for group coverage", async () => {
+    fetchApiMock
+      .mockResolvedValueOnce({
+        code: 0,
+        message: "ok",
+        data: {
+          items: [
+            {
+              id: 1,
+              key: "default-key",
+              name: "Default key",
+              status: "active",
+              group: { id: 1, name: "default" },
+            },
+          ],
+          total: 1001,
+          page: 1,
+          page_size: 1000,
+          pages: 2,
+        },
+      })
+      .mockResolvedValueOnce({
+        code: 0,
+        message: "ok",
+        data: {
+          items: [
+            {
+              id: 2,
+              key: "vip-key",
+              name: "VIP key",
+              status: "active",
+              group: { id: 9, name: "vip" },
+            },
+          ],
+          total: 1001,
+          page: 2,
+          page_size: 1000,
+          pages: 2,
+        },
+      })
+
+    await expect(fetchAllAccountTokens(createRequest())).resolves.toEqual([
+      expect.objectContaining({ id: 1, group: "default" }),
+      expect.objectContaining({ id: 2, group: "vip" }),
+    ])
+
+    expect(fetchApiMock.mock.calls.map((call) => call[1]?.endpoint)).toEqual([
+      "/api/v1/keys?page=1&page_size=1000",
+      "/api/v1/keys?page=2&page_size=1000",
+    ])
   })
 
   it("keeps key-creation available models empty even with Sub2API form metadata", async () => {


### PR DESCRIPTION
## Summary

- Enable user-triggered key coverage repair for Sub2API accounts.
- Create one key for each currently uncovered available group.
- Read the complete paginated Sub2API key inventory to avoid duplicate creation beyond the first 100 keys.
- Keep implicit account-add provisioning blocked from guessing a group or creating a Sub2API key.

## Validation

- Focused Vitest suite: 6 files, 179 tests passed
- `pnpm run validate:staged`
- `pnpm run validate:push`
- i18n extraction and locale completeness checks

Full PR CI and coverage remain pending.

## Notes

Existing partial-success result semantics remain unchanged: successful group creation may produce a `Created` outcome while failed groups remain listed in `missingGroups`.

Fixes #1233


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved account key repair using adapter-specific policies and group coverage.
  * Manual repair now creates default or group-specific keys based on account capabilities.
  * Sub2API key inventories now retrieve all available keys across paginated results.

* **Bug Fixes**
  * Sub2API accounts can now receive eligible repair coverage while remaining excluded from automatic account-add provisioning.
  * Preserved safeguards preventing implicit key creation for unsupported ungrouped accounts.

* **Tests**
  * Expanded coverage for pagination, group coverage, provisioning policies, and repair outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->