### PR TITLE
fix(api-credentials): support custom telemetry endpoints

### DIFF
--- a/src/features/ApiCredentialProfiles/components/ApiCredentialProfileDialog.tsx
+++ b/src/features/ApiCredentialProfiles/components/ApiCredentialProfileDialog.tsx
@@ -151,6 +151,7 @@ export function ApiCredentialProfileDialog({
       DEFAULT_API_CREDENTIAL_TELEMETRY_CONFIG.mode,
     )
   const [customEndpoint, setCustomEndpoint] = useState("")
+  const [customBearerToken, setCustomBearerToken] = useState("")
   const [customJsonPaths, setCustomJsonPaths] =
     useState<ApiCredentialTelemetryJsonPathMap>({})
 
@@ -172,6 +173,8 @@ export function ApiCredentialProfileDialog({
   const telemetryModeInputId = "api-credential-profile-telemetry-mode"
   const customEndpointInputId =
     "api-credential-profile-telemetry-custom-endpoint"
+  const customBearerTokenInputId =
+    "api-credential-profile-telemetry-bearer-token"
 
   useEffect(() => {
     if (!isOpen) return
@@ -188,6 +191,9 @@ export function ApiCredentialProfileDialog({
       setExpiresAtInput(formatDatePickerTimestamp(profile.expiresAt))
       setTelemetryMode(normalizeTelemetryMode(profile.telemetryConfig?.mode))
       setCustomEndpoint(profile.telemetryConfig?.customEndpoint?.endpoint ?? "")
+      setCustomBearerToken(
+        profile.telemetryConfig?.customEndpoint?.bearerToken ?? "",
+      )
       setCustomJsonPaths(
         profile.telemetryConfig?.customEndpoint?.jsonPaths ?? {},
       )
@@ -203,6 +209,7 @@ export function ApiCredentialProfileDialog({
     setExpiresAtInput("")
     setTelemetryMode(DEFAULT_API_CREDENTIAL_TELEMETRY_CONFIG.mode)
     setCustomEndpoint("")
+    setCustomBearerToken("")
     setCustomJsonPaths({})
   }, [addPrefill, isOpen, profile])
 
@@ -344,6 +351,9 @@ export function ApiCredentialProfileDialog({
       mode: "customReadOnlyEndpoint",
       customEndpoint: {
         endpoint: customEndpoint.trim(),
+        ...(customBearerToken.trim()
+          ? { bearerToken: customBearerToken.trim() }
+          : {}),
         jsonPaths: coerceApiCredentialTelemetryJsonPathMap(customJsonPaths),
       },
     }
@@ -719,6 +729,35 @@ export function ApiCredentialProfileDialog({
                       "apiCredentialProfiles:dialog.placeholders.telemetryEndpoint",
                     )}
                     disabled={isSaving}
+                  />
+                </FormField>
+
+                <FormField
+                  label={t(
+                    "apiCredentialProfiles:dialog.fields.telemetryBearerToken",
+                  )}
+                  description={t(
+                    "apiCredentialProfiles:dialog.hints.telemetryBearerToken",
+                  )}
+                  htmlFor={customBearerTokenInputId}
+                >
+                  <Input
+                    id={customBearerTokenInputId}
+                    type="password"
+                    revealable
+                    revealLabels={{
+                      show: t("keyManagement:actions.showKey"),
+                      hide: t("keyManagement:actions.hideKey"),
+                    }}
+                    value={customBearerToken}
+                    onChange={(event) =>
+                      setCustomBearerToken(event.target.value)
+                    }
+                    placeholder={t(
+                      "apiCredentialProfiles:dialog.placeholders.telemetryBearerToken",
+                    )}
+                    disabled={isSaving}
+                    leftIcon={<KeyIcon className="h-5 w-5" />}
                   />
                 </FormField>
 

--- a/src/locales/en/apiCredentialProfiles.json
+++ b/src/locales/en/apiCredentialProfiles.json
@@ -53,7 +53,7 @@
       "baseUrlNormalized": "Will be saved as: {{baseUrl}}",
       "expiresAt": "Optional. Record when this key is expected to stop working.",
       "tags": "Optional. Shared with accounts and bookmarks.",
-      "telemetryBearerToken": "Optional. Used only for this read-only query. Leave blank to use the API key above.",
+      "telemetryBearerToken": "Optional. Used only for this read-only query. If left blank, same-origin endpoints use the API key above; cross-origin requests are sent without authentication.",
       "telemetryEndpoint": "Use a read-only GET path such as /usage or a complete HTTP(S) URL.",
       "telemetryJsonPaths": "Enter dot-separated paths in the response JSON. At least one path is required. Empty metrics remain not provided.",
       "telemetryPreset": "Auto probes the built-in presets in order. You can also pin this key to one query method."

--- a/src/locales/en/apiCredentialProfiles.json
+++ b/src/locales/en/apiCredentialProfiles.json
@@ -32,7 +32,7 @@
       "baseUrlInvalid": "Base URL is invalid.",
       "keyRequired": "API key is required.",
       "nameRequired": "Name is required.",
-      "telemetryEndpointInvalid": "Custom telemetry endpoint must be a root-relative path or same-origin HTTP(S) URL.",
+      "telemetryEndpointInvalid": "Custom telemetry endpoint must be a root-relative path or HTTP(S) URL.",
       "telemetryEndpointRequired": "Custom telemetry endpoint is required.",
       "telemetryJsonPathInvalid": "JSON paths must use dot-separated fields, for example data.balance.",
       "telemetryJsonPathRequired": "Configure at least one JSON path mapping."
@@ -44,6 +44,7 @@
       "name": "Name",
       "notes": "Notes",
       "tags": "Tags",
+      "telemetryBearerToken": "Query Bearer token",
       "telemetryEndpoint": "Custom telemetry endpoint",
       "telemetryPreset": "Balance/usage query method"
     },
@@ -52,7 +53,8 @@
       "baseUrlNormalized": "Will be saved as: {{baseUrl}}",
       "expiresAt": "Optional. Record when this key is expected to stop working.",
       "tags": "Optional. Shared with accounts and bookmarks.",
-      "telemetryEndpoint": "Only read-only GET paths under the profile base URL origin are allowed. Use a path such as /usage or a same-origin URL.",
+      "telemetryBearerToken": "Optional. Used only for this read-only query. Leave blank to use the API key above.",
+      "telemetryEndpoint": "Use a read-only GET path such as /usage or a complete HTTP(S) URL.",
       "telemetryJsonPaths": "Enter dot-separated paths in the response JSON. At least one path is required. Empty metrics remain not provided.",
       "telemetryPreset": "Auto probes the built-in presets in order. You can also pin this key to one query method."
     },
@@ -65,6 +67,7 @@
       "name": "My API key",
       "notes": "Optional notes",
       "tags": "Select tags",
+      "telemetryBearerToken": "Paste a dedicated Bearer token",
       "telemetryEndpoint": "/api/usage",
       "telemetryJsonPath": "data.balance",
       "telemetryPreset": "Select query method"

--- a/src/locales/es-419/apiCredentialProfiles.json
+++ b/src/locales/es-419/apiCredentialProfiles.json
@@ -32,7 +32,7 @@
       "baseUrlInvalid": "La URL base no es válida.",
       "keyRequired": "La clave de API es obligatoria.",
       "nameRequired": "El nombre es obligatorio.",
-      "telemetryEndpointInvalid": "El endpoint de telemetría personalizado debe ser una ruta relativa a la raíz o una URL HTTP(S) del mismo origen.",
+      "telemetryEndpointInvalid": "El endpoint de telemetría personalizado debe ser una ruta relativa a la raíz o una URL HTTP(S).",
       "telemetryEndpointRequired": "El endpoint de telemetría personalizado es obligatorio.",
       "telemetryJsonPathInvalid": "Las rutas JSON deben usar campos separados por puntos, por ejemplo data.balance.",
       "telemetryJsonPathRequired": "Configura al menos un mapeo de ruta JSON."
@@ -44,6 +44,7 @@
       "name": "Nombre",
       "notes": "Notas",
       "tags": "Etiquetas",
+      "telemetryBearerToken": "Token Bearer para la consulta",
       "telemetryEndpoint": "Endpoint de telemetría personalizado",
       "telemetryPreset": "Método de consulta de saldo/uso"
     },
@@ -52,7 +53,8 @@
       "baseUrlNormalized": "Se guardará como: {{baseUrl}}",
       "expiresAt": "Opcional. Registra cuándo se espera que esta clave deje de funcionar.",
       "tags": "Opcional. Compartidas con cuentas y marcadores.",
-      "telemetryEndpoint": "Solo se permiten rutas GET de solo lectura bajo el origen de la URL base del perfil. Usa una ruta como /usage o una URL del mismo origen.",
+      "telemetryBearerToken": "Opcional. Se usa solo para esta consulta de solo lectura. Déjalo vacío para usar la clave de API anterior.",
+      "telemetryEndpoint": "Usa una ruta GET de solo lectura, como /usage, o una URL HTTP(S) completa.",
       "telemetryJsonPaths": "Ingresa rutas separadas por puntos en el JSON de respuesta. Se requiere al menos una ruta. Las métricas vacías quedan como no proporcionadas.",
       "telemetryPreset": "Prueba automáticamente los presets integrados en orden. También puedes fijar esta clave a un método de consulta."
     },
@@ -65,6 +67,7 @@
       "name": "Mi clave de API",
       "notes": "Notas opcionales",
       "tags": "Seleccionar etiquetas",
+      "telemetryBearerToken": "Pega un token Bearer dedicado",
       "telemetryEndpoint": "/api/usage",
       "telemetryJsonPath": "data.balance",
       "telemetryPreset": "Seleccionar método de consulta"

--- a/src/locales/es-419/apiCredentialProfiles.json
+++ b/src/locales/es-419/apiCredentialProfiles.json
@@ -53,7 +53,7 @@
       "baseUrlNormalized": "Se guardará como: {{baseUrl}}",
       "expiresAt": "Opcional. Registra cuándo se espera que esta clave deje de funcionar.",
       "tags": "Opcional. Compartidas con cuentas y marcadores.",
-      "telemetryBearerToken": "Opcional. Se usa solo para esta consulta de solo lectura. Déjalo vacío para usar la clave de API anterior.",
+      "telemetryBearerToken": "Opcional. Se usa solo para esta consulta de solo lectura. Si se deja vacío, los endpoints del mismo origen usan la clave de API anterior; las solicitudes entre orígenes se envían sin autenticación.",
       "telemetryEndpoint": "Usa una ruta GET de solo lectura, como /usage, o una URL HTTP(S) completa.",
       "telemetryJsonPaths": "Ingresa rutas separadas por puntos en el JSON de respuesta. Se requiere al menos una ruta. Las métricas vacías quedan como no proporcionadas.",
       "telemetryPreset": "Prueba automáticamente los presets integrados en orden. También puedes fijar esta clave a un método de consulta."

--- a/src/locales/ja/apiCredentialProfiles.json
+++ b/src/locales/ja/apiCredentialProfiles.json
@@ -32,7 +32,7 @@
       "baseUrlInvalid": "Base URL が不正です。",
       "keyRequired": "API キーは必須です。",
       "nameRequired": "名前は必須です。",
-      "telemetryEndpointInvalid": "カスタム使用量取得エンドポイントはルート相対パス、または同一オリジンの HTTP(S) URL である必要があります。",
+      "telemetryEndpointInvalid": "カスタム使用量取得エンドポイントはルート相対パス、または HTTP(S) URL である必要があります。",
       "telemetryEndpointRequired": "カスタム使用量取得エンドポイントは必須です。",
       "telemetryJsonPathInvalid": "JSON path は data.balance のようなドット区切りフィールドで入力してください。",
       "telemetryJsonPathRequired": "少なくとも 1 つの JSON path マッピングを設定してください。"
@@ -44,6 +44,7 @@
       "name": "名前",
       "notes": "メモ",
       "tags": "タグ",
+      "telemetryBearerToken": "クエリ用 Bearer トークン",
       "telemetryEndpoint": "カスタム使用量取得エンドポイント",
       "telemetryPreset": "残高/使用量の取得方法"
     },
@@ -52,7 +53,8 @@
       "baseUrlNormalized": "保存時の値: {{baseUrl}}",
       "expiresAt": "任意。このキーが使えなくなる見込みの日付を記録します。",
       "tags": "任意です。アカウントやブックマークと共有されます。",
-      "telemetryEndpoint": "プロファイルの Base URL と同一オリジンの読み取り専用 GET パスのみ許可されます。/usage のようなパス、または同一オリジン URL を使用してください。",
+      "telemetryBearerToken": "任意。この読み取り専用クエリだけに使用します。空欄の場合は上の API Key を使用します。",
+      "telemetryEndpoint": "/usage のような読み取り専用 GET パス、または完全な HTTP(S) URL を使用してください。",
       "telemetryJsonPaths": "レスポンス JSON 内のドット区切りパスを入力してください。少なくとも 1 つ必要です。空欄の指標は未提供のままになります。",
       "telemetryPreset": "Auto は内蔵プリセットを順番に試します。このキーで使う取得方法を固定することもできます。"
     },
@@ -65,6 +67,7 @@
       "name": "マイプロファイル",
       "notes": "任意のメモ",
       "tags": "タグを選択",
+      "telemetryBearerToken": "専用 Bearer トークンを貼り付け",
       "telemetryEndpoint": "/api/usage",
       "telemetryJsonPath": "data.balance",
       "telemetryPreset": "取得方法を選択"

--- a/src/locales/ja/apiCredentialProfiles.json
+++ b/src/locales/ja/apiCredentialProfiles.json
@@ -53,7 +53,7 @@
       "baseUrlNormalized": "保存時の値: {{baseUrl}}",
       "expiresAt": "任意。このキーが使えなくなる見込みの日付を記録します。",
       "tags": "任意です。アカウントやブックマークと共有されます。",
-      "telemetryBearerToken": "任意。この読み取り専用クエリだけに使用します。空欄の場合は上の API Key を使用します。",
+      "telemetryBearerToken": "任意。この読み取り専用クエリだけに使用します。空欄の場合、同一オリジンでは上の API Key を使用し、クロスオリジンのリクエストは認証なしで送信します。",
       "telemetryEndpoint": "/usage のような読み取り専用 GET パス、または完全な HTTP(S) URL を使用してください。",
       "telemetryJsonPaths": "レスポンス JSON 内のドット区切りパスを入力してください。少なくとも 1 つ必要です。空欄の指標は未提供のままになります。",
       "telemetryPreset": "Auto は内蔵プリセットを順番に試します。このキーで使う取得方法を固定することもできます。"

--- a/src/locales/pt-BR/apiCredentialProfiles.json
+++ b/src/locales/pt-BR/apiCredentialProfiles.json
@@ -53,7 +53,7 @@
       "baseUrlNormalized": "Será salva como: {{baseUrl}}",
       "expiresAt": "Opcional. Registre quando esta chave deve deixar de funcionar.",
       "tags": "Opcional. Compartilhadas com contas e marcadores.",
-      "telemetryBearerToken": "Opcional. Usado somente nesta consulta de leitura. Deixe em branco para usar a chave de API acima.",
+      "telemetryBearerToken": "Opcional. Usado somente nesta consulta de leitura. Se ficar em branco, endpoints da mesma origem usam a chave de API acima; solicitações entre origens são enviadas sem autenticação.",
       "telemetryEndpoint": "Use um caminho GET somente leitura, como /usage, ou uma URL HTTP(S) completa.",
       "telemetryJsonPaths": "Insira caminhos separados por pontos na resposta JSON. É necessário informar pelo menos um caminho. Métricas vazias continuarão como não fornecidas.",
       "telemetryPreset": "Testa automaticamente as predefinições integradas, na ordem. Você também pode fixar esta chave em um único método de consulta."

--- a/src/locales/pt-BR/apiCredentialProfiles.json
+++ b/src/locales/pt-BR/apiCredentialProfiles.json
@@ -32,7 +32,7 @@
       "baseUrlInvalid": "A URL base é inválida.",
       "keyRequired": "A chave de API é obrigatória.",
       "nameRequired": "O nome é obrigatório.",
-      "telemetryEndpointInvalid": "O endpoint de telemetria personalizado deve ser um caminho relativo à raiz ou uma URL HTTP(S) da mesma origem.",
+      "telemetryEndpointInvalid": "O endpoint de telemetria personalizado deve ser um caminho relativo à raiz ou uma URL HTTP(S).",
       "telemetryEndpointRequired": "O endpoint de telemetria personalizado é obrigatório.",
       "telemetryJsonPathInvalid": "Os caminhos JSON devem usar campos separados por pontos, por exemplo, data.balance.",
       "telemetryJsonPathRequired": "Configure pelo menos um mapeamento de caminho JSON."
@@ -44,6 +44,7 @@
       "name": "Nome",
       "notes": "Notas",
       "tags": "Tags",
+      "telemetryBearerToken": "Token Bearer da consulta",
       "telemetryEndpoint": "Endpoint de telemetria personalizado",
       "telemetryPreset": "Método de consulta de saldo/uso"
     },
@@ -52,7 +53,8 @@
       "baseUrlNormalized": "Será salva como: {{baseUrl}}",
       "expiresAt": "Opcional. Registre quando esta chave deve deixar de funcionar.",
       "tags": "Opcional. Compartilhadas com contas e marcadores.",
-      "telemetryEndpoint": "Somente caminhos GET de leitura na origem da URL base do perfil são permitidos. Use um caminho como /usage ou uma URL da mesma origem.",
+      "telemetryBearerToken": "Opcional. Usado somente nesta consulta de leitura. Deixe em branco para usar a chave de API acima.",
+      "telemetryEndpoint": "Use um caminho GET somente leitura, como /usage, ou uma URL HTTP(S) completa.",
       "telemetryJsonPaths": "Insira caminhos separados por pontos na resposta JSON. É necessário informar pelo menos um caminho. Métricas vazias continuarão como não fornecidas.",
       "telemetryPreset": "Testa automaticamente as predefinições integradas, na ordem. Você também pode fixar esta chave em um único método de consulta."
     },
@@ -65,6 +67,7 @@
       "name": "Minha chave de API",
       "notes": "Notas opcionais",
       "tags": "Selecione tags",
+      "telemetryBearerToken": "Cole um token Bearer dedicado",
       "telemetryEndpoint": "/api/usage",
       "telemetryJsonPath": "data.balance",
       "telemetryPreset": "Selecione o método de consulta"

--- a/src/locales/vi/apiCredentialProfiles.json
+++ b/src/locales/vi/apiCredentialProfiles.json
@@ -53,7 +53,7 @@
       "baseUrlNormalized": "Sau khi lưu sẽ được chuẩn hóa thành: {{baseUrl}}",
       "expiresAt": "Tùy chọn. Ghi lại ngày mã khóa dự kiến ngừng hoạt động.",
       "tags": "Tùy chọn. Dùng chung các thẻ toàn cục với tài khoản/dấu trang.",
-      "telemetryBearerToken": "Tùy chọn. Chỉ dùng cho truy vấn chỉ đọc này. Để trống để dùng API Key ở trên.",
+      "telemetryBearerToken": "Tùy chọn. Chỉ dùng cho truy vấn chỉ đọc này. Nếu để trống, endpoint cùng nguồn sẽ dùng API Key ở trên; yêu cầu khác nguồn được gửi mà không xác thực.",
       "telemetryEndpoint": "Sử dụng đường dẫn GET chỉ đọc như /usage hoặc URL HTTP(S) đầy đủ.",
       "telemetryJsonPaths": "Điền đường dẫn trường được phân tách bằng dấu chấm trong JSON phản hồi, điền ít nhất một đường dẫn. Các số liệu không được điền sẽ ở trạng thái không được cung cấp.",
       "telemetryPreset": "Auto sẽ tự động dò tìm theo thứ tự tích hợp; hoặc có thể cố định một phương thức truy vấn cho mã khóa hiện tại."

--- a/src/locales/vi/apiCredentialProfiles.json
+++ b/src/locales/vi/apiCredentialProfiles.json
@@ -32,7 +32,7 @@
       "baseUrlInvalid": "Base URL không hợp lệ.",
       "keyRequired": "Mã khóa không được để trống.",
       "nameRequired": "Tên không được để trống.",
-      "telemetryEndpointInvalid": "Địa chỉ truy vấn tùy chỉnh phải là đường dẫn tương đối gốc hoặc URL HTTP(S) cùng nguồn gốc.",
+      "telemetryEndpointInvalid": "Địa chỉ truy vấn tùy chỉnh phải là đường dẫn tương đối gốc hoặc URL HTTP(S).",
       "telemetryEndpointRequired": "Địa chỉ truy vấn tùy chỉnh không được để trống.",
       "telemetryJsonPathInvalid": "JSON path cần sử dụng các trường được phân tách bằng dấu chấm, ví dụ: data.balance.",
       "telemetryJsonPathRequired": "Định cấu hình ít nhất một ánh xạ JSON path."
@@ -44,6 +44,7 @@
       "name": "Tên",
       "notes": "Ghi chú",
       "tags": "Thẻ",
+      "telemetryBearerToken": "Bearer Token truy vấn",
       "telemetryEndpoint": "Địa chỉ truy vấn tùy chỉnh",
       "telemetryPreset": "Phương thức truy vấn số dư/mức sử dụng"
     },
@@ -52,7 +53,8 @@
       "baseUrlNormalized": "Sau khi lưu sẽ được chuẩn hóa thành: {{baseUrl}}",
       "expiresAt": "Tùy chọn. Ghi lại ngày mã khóa dự kiến ngừng hoạt động.",
       "tags": "Tùy chọn. Dùng chung các thẻ toàn cục với tài khoản/dấu trang.",
-      "telemetryEndpoint": "Chỉ cho phép các địa chỉ GET chỉ đọc có cùng nguồn gốc với profile Base URL, có thể sử dụng /usage hoặc URL cùng nguồn gốc đầy đủ.",
+      "telemetryBearerToken": "Tùy chọn. Chỉ dùng cho truy vấn chỉ đọc này. Để trống để dùng API Key ở trên.",
+      "telemetryEndpoint": "Sử dụng đường dẫn GET chỉ đọc như /usage hoặc URL HTTP(S) đầy đủ.",
       "telemetryJsonPaths": "Điền đường dẫn trường được phân tách bằng dấu chấm trong JSON phản hồi, điền ít nhất một đường dẫn. Các số liệu không được điền sẽ ở trạng thái không được cung cấp.",
       "telemetryPreset": "Auto sẽ tự động dò tìm theo thứ tự tích hợp; hoặc có thể cố định một phương thức truy vấn cho mã khóa hiện tại."
     },
@@ -65,6 +67,7 @@
       "name": "Ví dụ: Thông tin xác thực của tôi",
       "notes": "Ghi chú tùy chọn",
       "tags": "Chọn thẻ",
+      "telemetryBearerToken": "Dán Bearer Token chuyên dụng",
       "telemetryEndpoint": "/api/usage",
       "telemetryJsonPath": "data.balance",
       "telemetryPreset": "Chọn phương thức truy vấn"

--- a/src/locales/zh-CN/apiCredentialProfiles.json
+++ b/src/locales/zh-CN/apiCredentialProfiles.json
@@ -53,7 +53,7 @@
       "baseUrlNormalized": "保存后将规范化为：{{baseUrl}}",
       "expiresAt": "可选。用于记录这枚密钥预计失效的日期。",
       "tags": "可选。与账号/书签共用全局标签。",
-      "telemetryBearerToken": "仅用于该只读查询。留空时使用上方 API Key。",
+      "telemetryBearerToken": "仅用于该只读查询。留空时，仅同源端点使用上方 API Key；跨域请求不携带认证信息。",
       "telemetryEndpoint": "请输入只读 GET 地址，可使用 /usage 之类的根相对路径或完整 HTTP(S) URL。",
       "telemetryJsonPaths": "填写响应 JSON 中的点分隔字段路径，至少填写一个。未填写的指标会保持未提供。",
       "telemetryPreset": "Auto 会按内置顺序探测；也可以为当前密钥固定一种查询方式。"

--- a/src/locales/zh-CN/apiCredentialProfiles.json
+++ b/src/locales/zh-CN/apiCredentialProfiles.json
@@ -32,7 +32,7 @@
       "baseUrlInvalid": "Base URL 无效。",
       "keyRequired": "密钥不能为空。",
       "nameRequired": "名称不能为空。",
-      "telemetryEndpointInvalid": "自定义查询地址必须是根相对路径或同源 HTTP(S) URL。",
+      "telemetryEndpointInvalid": "自定义查询地址必须是根相对路径或 HTTP(S) URL。",
       "telemetryEndpointRequired": "自定义查询地址不能为空。",
       "telemetryJsonPathInvalid": "JSON path 需使用点分隔字段，例如 data.balance。",
       "telemetryJsonPathRequired": "至少配置一个 JSON path 映射。"
@@ -44,6 +44,7 @@
       "name": "名称",
       "notes": "备注",
       "tags": "标签",
+      "telemetryBearerToken": "查询凭证（可选）",
       "telemetryEndpoint": "自定义查询地址",
       "telemetryPreset": "余额/用量查询方式"
     },
@@ -52,7 +53,8 @@
       "baseUrlNormalized": "保存后将规范化为：{{baseUrl}}",
       "expiresAt": "可选。用于记录这枚密钥预计失效的日期。",
       "tags": "可选。与账号/书签共用全局标签。",
-      "telemetryEndpoint": "仅允许 profile Base URL 同源下的只读 GET 地址，可使用 /usage 或完整同源 URL。",
+      "telemetryBearerToken": "仅用于该只读查询。留空时使用上方 API Key。",
+      "telemetryEndpoint": "请输入只读 GET 地址，可使用 /usage 之类的根相对路径或完整 HTTP(S) URL。",
       "telemetryJsonPaths": "填写响应 JSON 中的点分隔字段路径，至少填写一个。未填写的指标会保持未提供。",
       "telemetryPreset": "Auto 会按内置顺序探测；也可以为当前密钥固定一种查询方式。"
     },
@@ -65,6 +67,7 @@
       "name": "例如：我的凭证",
       "notes": "可选备注",
       "tags": "选择标签",
+      "telemetryBearerToken": "粘贴专用 Bearer Token",
       "telemetryEndpoint": "/api/usage",
       "telemetryJsonPath": "data.balance",
       "telemetryPreset": "选择查询方式"

--- a/src/locales/zh-TW/apiCredentialProfiles.json
+++ b/src/locales/zh-TW/apiCredentialProfiles.json
@@ -32,7 +32,7 @@
       "baseUrlInvalid": "Base URL 無效。",
       "keyRequired": "金鑰不能為空。",
       "nameRequired": "名稱不能為空。",
-      "telemetryEndpointInvalid": "自訂查詢地址必須是根相對路徑或同源 HTTP(S) URL。",
+      "telemetryEndpointInvalid": "自訂查詢地址必須是根相對路徑或 HTTP(S) URL。",
       "telemetryEndpointRequired": "自訂查詢地址不能為空。",
       "telemetryJsonPathInvalid": "JSON path 需使用點分隔欄位，例如 data.balance。",
       "telemetryJsonPathRequired": "至少設定一個 JSON path 映射。"
@@ -44,6 +44,7 @@
       "name": "名稱",
       "notes": "備註",
       "tags": "標籤",
+      "telemetryBearerToken": "查詢憑證（選填）",
       "telemetryEndpoint": "自訂查詢地址",
       "telemetryPreset": "餘額/用量查詢方式"
     },
@@ -52,7 +53,8 @@
       "baseUrlNormalized": "儲存後將規範化為：{{baseUrl}}",
       "expiresAt": "可選。用於記錄這枚金鑰預計失效的日期。",
       "tags": "可選。與帳號/書籤共用全域性標籤。",
-      "telemetryEndpoint": "僅允許 profile Base URL 同源下的唯讀 GET 地址，可使用 /usage 或完整同源 URL。",
+      "telemetryBearerToken": "僅用於此唯讀查詢。留空時使用上方 API Key。",
+      "telemetryEndpoint": "請輸入唯讀 GET 地址，可使用 /usage 之類的根相對路徑或完整 HTTP(S) URL。",
       "telemetryJsonPaths": "填寫回應 JSON 中的點分隔欄位路徑，至少填寫一個。未填寫的指標會保持未提供。",
       "telemetryPreset": "Auto 會按內建順序探測；也可以為當前金鑰固定一種查詢方式。"
     },
@@ -65,6 +67,7 @@
       "name": "例如：我的憑證",
       "notes": "可選備註",
       "tags": "選擇標籤",
+      "telemetryBearerToken": "貼上專用 Bearer Token",
       "telemetryEndpoint": "/api/usage",
       "telemetryJsonPath": "data.balance",
       "telemetryPreset": "選擇查詢方式"

--- a/src/locales/zh-TW/apiCredentialProfiles.json
+++ b/src/locales/zh-TW/apiCredentialProfiles.json
@@ -53,7 +53,7 @@
       "baseUrlNormalized": "儲存後將規範化為：{{baseUrl}}",
       "expiresAt": "可選。用於記錄這枚金鑰預計失效的日期。",
       "tags": "可選。與帳號/書籤共用全域性標籤。",
-      "telemetryBearerToken": "僅用於此唯讀查詢。留空時使用上方 API Key。",
+      "telemetryBearerToken": "僅用於此唯讀查詢。留空時，只有同源端點使用上方 API Key；跨來源請求不會攜帶驗證資訊。",
       "telemetryEndpoint": "請輸入唯讀 GET 地址，可使用 /usage 之類的根相對路徑或完整 HTTP(S) URL。",
       "telemetryJsonPaths": "填寫回應 JSON 中的點分隔欄位路徑，至少填寫一個。未填寫的指標會保持未提供。",
       "telemetryPreset": "Auto 會按內建順序探測；也可以為當前金鑰固定一種查詢方式。"

--- a/src/services/apiCredentialProfiles/apiCredentialProfilesStorage.ts
+++ b/src/services/apiCredentialProfiles/apiCredentialProfilesStorage.ts
@@ -341,23 +341,26 @@ function mergeTelemetrySnapshot(
  * Preserves explicit telemetry config when duplicate profiles are merged.
  */
 function mergeTelemetryConfig(
-  newer: ApiCredentialTelemetryConfig | undefined,
-  older: ApiCredentialTelemetryConfig | undefined,
-  baseUrl?: string,
+  newer: ApiCredentialTelemetryConfig,
+  older: ApiCredentialTelemetryConfig,
 ): ApiCredentialTelemetryConfig {
-  const normalizedNewer = coerceApiCredentialTelemetryConfig(newer, {
-    baseUrl,
-  })
-  const normalizedOlder = coerceApiCredentialTelemetryConfig(older, {
-    baseUrl,
-  })
-  if (normalizedNewer.mode !== DEFAULT_API_CREDENTIAL_TELEMETRY_CONFIG.mode) {
-    return normalizedNewer
+  if (newer.mode !== DEFAULT_API_CREDENTIAL_TELEMETRY_CONFIG.mode) {
+    return newer
   }
-  if (normalizedOlder.mode !== DEFAULT_API_CREDENTIAL_TELEMETRY_CONFIG.mode) {
-    return normalizedOlder
+  if (older.mode !== DEFAULT_API_CREDENTIAL_TELEMETRY_CONFIG.mode) {
+    return older
   }
-  return normalizedNewer
+  return newer
+}
+
+/**
+ * Compares telemetry configs after boundary coercion has made key order stable.
+ */
+function isSameTelemetryConfig(
+  first: ApiCredentialTelemetryConfig,
+  second: ApiCredentialTelemetryConfig,
+): boolean {
+  return JSON.stringify(first) === JSON.stringify(second)
 }
 
 /**
@@ -420,21 +423,34 @@ function dedupeProfiles(profiles: ApiCredentialProfile[]): {
       ...(Array.isArray(newer.tagIds) ? newer.tagIds : []),
       ...(Array.isArray(older.tagIds) ? older.tagIds : []),
     ])
+    const newerTelemetryConfig = coerceApiCredentialTelemetryConfig(
+      newer.telemetryConfig,
+      { baseUrl: newer.baseUrl },
+    )
+    const olderTelemetryConfig = coerceApiCredentialTelemetryConfig(
+      older.telemetryConfig,
+      { baseUrl: older.baseUrl },
+    )
+    const telemetryConfig = mergeTelemetryConfig(
+      newerTelemetryConfig,
+      olderTelemetryConfig,
+    )
+    const telemetrySnapshot = mergeTelemetrySnapshot(
+      isSameTelemetryConfig(newerTelemetryConfig, telemetryConfig)
+        ? newer.telemetrySnapshot
+        : undefined,
+      isSameTelemetryConfig(olderTelemetryConfig, telemetryConfig)
+        ? older.telemetrySnapshot
+        : undefined,
+    )
 
     byIdentity.set(key, {
       ...newer,
       createdAt:
         Math.min(newer.createdAt || 0, older.createdAt || 0) || newer.createdAt,
       tagIds: mergedTagIds,
-      telemetryConfig: mergeTelemetryConfig(
-        newer.telemetryConfig,
-        older.telemetryConfig,
-        newer.baseUrl,
-      ),
-      telemetrySnapshot: mergeTelemetrySnapshot(
-        newer.telemetrySnapshot,
-        older.telemetrySnapshot,
-      ),
+      telemetryConfig,
+      telemetrySnapshot,
     })
   }
 
@@ -766,6 +782,22 @@ class ApiCredentialProfilesStorageService {
         updates.telemetryConfig !== undefined ||
         nextApiType !== current.apiType ||
         nextBaseUrl !== current.baseUrl
+      const currentTelemetryConfig = coerceApiCredentialTelemetryConfig(
+        current.telemetryConfig,
+        { baseUrl: current.baseUrl },
+      )
+      const nextTelemetryConfig = shouldReCoerceTelemetryConfig
+        ? coerceApiCredentialTelemetryConfig(
+            updates.telemetryConfig !== undefined
+              ? updates.telemetryConfig
+              : current.telemetryConfig,
+            { baseUrl: nextBaseUrl },
+          )
+        : currentTelemetryConfig
+      const hasTelemetryConfigChanged = !isSameTelemetryConfig(
+        nextTelemetryConfig,
+        currentTelemetryConfig,
+      )
       const nextExpiresAt =
         updates.expiresAt !== undefined
           ? coerceOptionalTimestamp(updates.expiresAt)
@@ -788,20 +820,12 @@ class ApiCredentialProfilesStorageService {
             ? updates.notes.trim()
             : current.notes,
         ...(nextExpiresAt !== undefined ? { expiresAt: nextExpiresAt } : {}),
-        telemetryConfig: shouldReCoerceTelemetryConfig
-          ? coerceApiCredentialTelemetryConfig(
-              updates.telemetryConfig !== undefined
-                ? updates.telemetryConfig
-                : current.telemetryConfig,
-              {
-                baseUrl: nextBaseUrl,
-              },
-            )
-          : current.telemetryConfig,
+        telemetryConfig: nextTelemetryConfig,
         telemetrySnapshot:
           nextApiType !== current.apiType ||
           nextBaseUrl !== current.baseUrl ||
-          nextApiKey !== current.apiKey
+          nextApiKey !== current.apiKey ||
+          hasTelemetryConfigChanged
             ? undefined
             : current.telemetrySnapshot,
         updatedAt: Date.now(),

--- a/src/services/apiCredentialProfiles/telemetry.ts
+++ b/src/services/apiCredentialProfiles/telemetry.ts
@@ -191,19 +191,21 @@ function createOpenAiBillingUsageEndpoint(start: string, end: string): string {
 }
 
 /**
- * Fetches a read-only telemetry endpoint with bearer-token authentication.
+ * Fetches a read-only telemetry endpoint with optional bearer authentication.
  */
 async function fetchJson(params: {
   baseUrl: string
   endpoint: string
-  bearerToken: string
+  bearerToken?: string
 }): Promise<JsonFetchResult> {
   try {
     const json = await fetchApi<unknown>(
       {
         baseUrl: params.baseUrl,
         auth: {
-          authType: AuthTypeEnum.AccessToken,
+          authType: params.bearerToken
+            ? AuthTypeEnum.AccessToken
+            : AuthTypeEnum.None,
           accessToken: params.bearerToken,
         },
       },
@@ -539,7 +541,9 @@ async function queryCustomReadOnlyEndpoint(
   const result = await fetchJson({
     baseUrl: requestTarget.baseUrl,
     endpoint: requestTarget.endpoint,
-    bearerToken: config.customEndpoint.bearerToken ?? profile.apiKey,
+    bearerToken:
+      config.customEndpoint.bearerToken ??
+      (requestTarget.isCrossOrigin ? undefined : profile.apiKey),
   })
 
   return {
@@ -703,19 +707,10 @@ export async function refreshApiCredentialProfileTelemetry(
 
   const modelSucceeded = Boolean(models && models.count > 0)
   const usageSucceeded = Boolean(usageResult)
-  const customEndpointError = attempts.find((attempt) => {
-    if (
-      attempt.status !== "error" ||
-      attempt.source !== "customReadOnlyEndpoint"
-    ) {
-      return false
-    }
-
-    return (
-      attempt.message === "Custom endpoint is not configured" ||
-      attempt.endpoint === config.customEndpoint?.endpoint
-    )
-  })?.message
+  const customEndpointError = attempts.find(
+    (attempt) =>
+      attempt.status === "error" && attempt.source === "customReadOnlyEndpoint",
+  )?.message
   const lastError =
     usageSucceeded || modelSucceeded
       ? undefined

--- a/src/services/apiCredentialProfiles/telemetry.ts
+++ b/src/services/apiCredentialProfiles/telemetry.ts
@@ -4,7 +4,7 @@ import {
   coerceApiCredentialTelemetryConfig,
 } from "~/services/apiCredentialProfiles/apiCredentialProfilesStorage"
 import { fetchApiCredentialModelIds } from "~/services/apiCredentialProfiles/modelCatalog"
-import { resolveApiCredentialTelemetryEndpoint } from "~/services/apiCredentialProfiles/telemetryConfig"
+import { resolveApiCredentialTelemetryRequestTarget } from "~/services/apiCredentialProfiles/telemetryConfig"
 import { ApiError } from "~/services/apiTransport/errors"
 import { fetchApi } from "~/services/apiTransport/request"
 import { toSanitizedErrorSummary } from "~/services/verification/aiApiVerification/utils"
@@ -166,6 +166,15 @@ function sanitizeTelemetryEndpoint(
 }
 
 /**
+ * Removes duplicate secrets and orders overlapping values for full redaction.
+ */
+function prepareTelemetrySecrets(secrets: Array<string | undefined>): string[] {
+  return Array.from(
+    new Set(secrets.filter((secret): secret is string => !!secret)),
+  ).sort((first, second) => second.length - first.length)
+}
+
+/**
  * Resolves the model catalog endpoint used for telemetry attempts.
  */
 function getModelsEndpoint(profile: ApiCredentialProfile): string {
@@ -187,7 +196,7 @@ function createOpenAiBillingUsageEndpoint(start: string, end: string): string {
 async function fetchJson(params: {
   baseUrl: string
   endpoint: string
-  apiKey: string
+  bearerToken: string
 }): Promise<JsonFetchResult> {
   try {
     const json = await fetchApi<unknown>(
@@ -195,7 +204,7 @@ async function fetchJson(params: {
         baseUrl: params.baseUrl,
         auth: {
           authType: AuthTypeEnum.AccessToken,
-          accessToken: params.apiKey,
+          accessToken: params.bearerToken,
         },
       },
       {
@@ -329,7 +338,7 @@ async function queryOpenAiBilling(
   const subscription = await fetchJson({
     baseUrl: profile.baseUrl,
     endpoint: TELEMETRY_ENDPOINTS.openAiBilling.subscription,
-    apiKey: profile.apiKey,
+    bearerToken: profile.apiKey,
   })
   const subscriptionData = dataLike(subscription.json)
   const directBalance = readNumber(subscriptionData.balance)
@@ -348,7 +357,7 @@ async function queryOpenAiBilling(
   const usage = await fetchJson({
     baseUrl: profile.baseUrl,
     endpoint: usageEndpoint,
-    apiKey: profile.apiKey,
+    bearerToken: profile.apiKey,
   })
 
   return {
@@ -367,7 +376,7 @@ async function queryNewApiTokenUsage(
   const result = await fetchJson({
     baseUrl: profile.baseUrl,
     endpoint: TELEMETRY_ENDPOINTS.newApiTokenUsage,
-    apiKey: profile.apiKey,
+    bearerToken: profile.apiKey,
   })
   const data = dataLike(result.json)
   const totalGranted = readNumber(data.total_granted)
@@ -412,7 +421,7 @@ async function querySub2ApiUsage(
   const result = await fetchJson({
     baseUrl: profile.baseUrl,
     endpoint: TELEMETRY_ENDPOINTS.sub2ApiUsage,
-    apiKey: profile.apiKey,
+    bearerToken: profile.apiKey,
   })
   const data = dataLike(result.json)
   const usage = isRecord(data.usage) ? data.usage : {}
@@ -523,14 +532,14 @@ async function queryCustomReadOnlyEndpoint(
     throw new Error("Custom endpoint is not configured")
   }
 
-  const endpoint = resolveApiCredentialTelemetryEndpoint(
+  const requestTarget = resolveApiCredentialTelemetryRequestTarget(
     profile.baseUrl,
     config.customEndpoint.endpoint,
   )
   const result = await fetchJson({
-    baseUrl: profile.baseUrl,
-    endpoint,
-    apiKey: profile.apiKey,
+    baseUrl: requestTarget.baseUrl,
+    endpoint: requestTarget.endpoint,
+    bearerToken: config.customEndpoint.bearerToken ?? profile.apiKey,
   })
 
   return {
@@ -642,6 +651,10 @@ export async function refreshApiCredentialProfileTelemetry(
   const config = coerceApiCredentialTelemetryConfig(profile.telemetryConfig, {
     baseUrl: profile.baseUrl,
   })
+  const secrets = prepareTelemetrySecrets([
+    profile.apiKey,
+    config.customEndpoint?.bearerToken,
+  ])
   const modes = resolveModes(config)
   const attempts: ApiCredentialTelemetryAttempt[] = []
   const now = Date.now()
@@ -660,7 +673,7 @@ export async function refreshApiCredentialProfileTelemetry(
             result.endpoint,
             "success",
             "Fetched usage",
-            [profile.apiKey],
+            secrets,
           ),
         )
         break
@@ -672,7 +685,7 @@ export async function refreshApiCredentialProfileTelemetry(
           result.endpoint,
           "unsupported",
           "No usage fields returned",
-          [profile.apiKey],
+          secrets,
         ),
       )
     } catch (error) {
@@ -684,7 +697,7 @@ export async function refreshApiCredentialProfileTelemetry(
             : mode === "sub2apiUsage"
               ? TELEMETRY_ENDPOINTS.sub2ApiUsage
               : config.customEndpoint?.endpoint || "custom"
-      attempts.push(attemptFromError(mode, endpoint, error, [profile.apiKey]))
+      attempts.push(attemptFromError(mode, endpoint, error, secrets))
     }
   }
 

--- a/src/services/apiCredentialProfiles/telemetryConfig.ts
+++ b/src/services/apiCredentialProfiles/telemetryConfig.ts
@@ -62,12 +62,12 @@ export function coerceApiCredentialTelemetryJsonPathMap(
 }
 
 /**
- * Resolves a custom endpoint while keeping it on the profile origin.
+ * Resolves a custom endpoint into a request target on the profile origin.
  */
-export function resolveApiCredentialTelemetryEndpoint(
+export function resolveApiCredentialTelemetryRequestTarget(
   baseUrl: string,
   endpoint: string,
-): string {
+): { baseUrl: string; endpoint: string } {
   const trimmed = endpoint.trim()
   if (!trimmed) throw new Error("Custom endpoint is empty")
 
@@ -76,26 +76,25 @@ export function resolveApiCredentialTelemetryEndpoint(
     ? new URL(trimmed, profileBaseUrl.origin)
     : new URL(trimmed)
 
-  if (resolved.origin !== profileBaseUrl.origin) {
-    throw new Error("Custom endpoint must stay on the profile base URL origin")
-  }
-
   if (resolved.protocol !== "http:" && resolved.protocol !== "https:") {
     throw new Error("Custom endpoint must use HTTP(S)")
   }
 
-  return `${resolved.pathname}${resolved.search}`
+  return {
+    baseUrl: resolved.origin,
+    endpoint: `${resolved.pathname}${resolved.search}`,
+  }
 }
 
 /**
- * Accepts only root-relative paths or same-origin HTTP(S) telemetry URLs.
+ * Accepts root-relative paths or absolute HTTP(S) telemetry URLs.
  */
 export function isSupportedApiCredentialTelemetryEndpoint(
   baseUrl: string,
   endpoint: string,
 ): boolean {
   try {
-    resolveApiCredentialTelemetryEndpoint(baseUrl, endpoint)
+    resolveApiCredentialTelemetryRequestTarget(baseUrl, endpoint)
     return true
   } catch {
     return false
@@ -115,6 +114,10 @@ export function coerceApiCredentialTelemetryCustomEndpoint(
     typeof obj.endpoint === "string" && obj.endpoint.trim()
       ? obj.endpoint.trim()
       : ""
+  const bearerToken =
+    typeof obj.bearerToken === "string" && obj.bearerToken.trim()
+      ? obj.bearerToken.trim()
+      : ""
   const jsonPaths = coerceApiCredentialTelemetryJsonPathMap(obj.jsonPaths)
 
   if (
@@ -125,5 +128,9 @@ export function coerceApiCredentialTelemetryCustomEndpoint(
     return undefined
   }
 
-  return { endpoint, jsonPaths }
+  return {
+    endpoint,
+    ...(bearerToken ? { bearerToken } : {}),
+    jsonPaths,
+  }
 }

--- a/src/services/apiCredentialProfiles/telemetryConfig.ts
+++ b/src/services/apiCredentialProfiles/telemetryConfig.ts
@@ -70,6 +70,9 @@ export function resolveApiCredentialTelemetryRequestTarget(
 ): { baseUrl: string; endpoint: string; isCrossOrigin: boolean } {
   const trimmed = endpoint.trim()
   if (!trimmed) throw new Error("Custom endpoint is empty")
+  if (trimmed.startsWith("//")) {
+    throw new Error("Custom endpoint must not be protocol-relative")
+  }
 
   const profileBaseUrl = new URL(baseUrl)
   const resolved = trimmed.startsWith("/")

--- a/src/services/apiCredentialProfiles/telemetryConfig.ts
+++ b/src/services/apiCredentialProfiles/telemetryConfig.ts
@@ -62,12 +62,12 @@ export function coerceApiCredentialTelemetryJsonPathMap(
 }
 
 /**
- * Resolves a custom endpoint into a request target on the profile origin.
+ * Resolves a root-relative or absolute custom endpoint into a request target.
  */
 export function resolveApiCredentialTelemetryRequestTarget(
   baseUrl: string,
   endpoint: string,
-): { baseUrl: string; endpoint: string } {
+): { baseUrl: string; endpoint: string; isCrossOrigin: boolean } {
   const trimmed = endpoint.trim()
   if (!trimmed) throw new Error("Custom endpoint is empty")
 
@@ -83,6 +83,7 @@ export function resolveApiCredentialTelemetryRequestTarget(
   return {
     baseUrl: resolved.origin,
     endpoint: `${resolved.pathname}${resolved.search}`,
+    isCrossOrigin: resolved.origin !== profileBaseUrl.origin,
   }
 }
 

--- a/src/types/apiCredentialProfiles.ts
+++ b/src/types/apiCredentialProfiles.ts
@@ -29,12 +29,13 @@ export type ApiCredentialTelemetryJsonPathMap = {
 
 export type ApiCredentialTelemetryCustomEndpoint = {
   /**
-   * Read-only endpoint path or URL under the profile base URL origin.
+   * Root-relative path or absolute HTTP(S) URL for a read-only endpoint.
    */
   endpoint: string
   /**
    * Optional dedicated Bearer token stored in extension local storage.
-   * Falls back to the profile API key and must never be logged.
+   * Same-origin requests fall back to the profile API key; cross-origin
+   * requests remain unauthenticated when this is omitted. Never log it.
    */
   bearerToken?: string
   jsonPaths: ApiCredentialTelemetryJsonPathMap

--- a/src/types/apiCredentialProfiles.ts
+++ b/src/types/apiCredentialProfiles.ts
@@ -4,7 +4,7 @@ import type { HealthStatus, TokenUsage } from "~/types"
 /**
  * Current schema version for the API credential profiles storage payload.
  */
-export const API_CREDENTIAL_PROFILES_CONFIG_VERSION = 3
+export const API_CREDENTIAL_PROFILES_CONFIG_VERSION = 4
 
 export type ApiCredentialTelemetryCapabilityMode =
   | "disabled"
@@ -32,6 +32,11 @@ export type ApiCredentialTelemetryCustomEndpoint = {
    * Read-only endpoint path or URL under the profile base URL origin.
    */
   endpoint: string
+  /**
+   * Optional dedicated Bearer token stored in extension local storage.
+   * Falls back to the profile API key and must never be logged.
+   */
+  bearerToken?: string
   jsonPaths: ApiCredentialTelemetryJsonPathMap
 }
 

--- a/tests/features/ApiCredentialProfiles/components/ApiCredentialProfileDialog.test.tsx
+++ b/tests/features/ApiCredentialProfiles/components/ApiCredentialProfileDialog.test.tsx
@@ -276,7 +276,7 @@ describe("ApiCredentialProfileDialog", () => {
         "apiCredentialProfiles:dialog.placeholders.telemetryEndpoint",
       ),
       {
-        target: { value: "https://evil.example.com/usage/read-only" },
+        target: { value: "ftp://telemetry.example.com/usage/read-only" },
       },
     )
     fireEvent.change(
@@ -307,7 +307,15 @@ describe("ApiCredentialProfileDialog", () => {
         "apiCredentialProfiles:dialog.placeholders.telemetryEndpoint",
       ),
       {
-        target: { value: "https://custom.example.com/usage/read-only" },
+        target: { value: "https://telemetry.example.com/usage/read-only" },
+      },
+    )
+    fireEvent.change(
+      screen.getByPlaceholderText(
+        "apiCredentialProfiles:dialog.placeholders.telemetryBearerToken",
+      ),
+      {
+        target: { value: " dedicated-telemetry-token " },
       },
     )
     fireEvent.change(
@@ -332,7 +340,8 @@ describe("ApiCredentialProfileDialog", () => {
           telemetryConfig: {
             mode: "customReadOnlyEndpoint",
             customEndpoint: {
-              endpoint: "https://custom.example.com/usage/read-only",
+              endpoint: "https://telemetry.example.com/usage/read-only",
+              bearerToken: "dedicated-telemetry-token",
               jsonPaths: {
                 balanceUsd: "data.balance",
               },
@@ -351,6 +360,7 @@ describe("ApiCredentialProfileDialog", () => {
           mode: "customReadOnlyEndpoint",
           customEndpoint: {
             endpoint: "/usage/totals",
+            bearerToken: "saved-telemetry-token",
             jsonPaths: {
               balanceUsd: "data.balance",
               totalUsedUsd: "data.total.used",
@@ -371,6 +381,10 @@ describe("ApiCredentialProfileDialog", () => {
     ).toHaveValue("customReadOnlyEndpoint")
     expect(screen.getByDisplayValue("/usage/totals")).toHaveValue(
       "/usage/totals",
+    )
+    expect(screen.getByDisplayValue("saved-telemetry-token")).toHaveAttribute(
+      "type",
+      "password",
     )
     expect(screen.getByDisplayValue("data.balance")).toHaveValue("data.balance")
     expect(screen.getByDisplayValue("data.total.used")).toHaveValue(

--- a/tests/features/ApiCredentialProfiles/components/ApiCredentialProfileDialog.test.tsx
+++ b/tests/features/ApiCredentialProfiles/components/ApiCredentialProfileDialog.test.tsx
@@ -352,6 +352,69 @@ describe("ApiCredentialProfileDialog", () => {
     })
   })
 
+  it("omits a whitespace-only custom telemetry bearer token", async () => {
+    const { onSave } = renderDialog()
+
+    fireEvent.change(
+      screen.getByPlaceholderText(
+        "apiCredentialProfiles:dialog.placeholders.name",
+      ),
+      { target: { value: "Unauthenticated telemetry" } },
+    )
+    fireEvent.change(
+      screen.getByPlaceholderText(
+        "apiCredentialProfiles:dialog.placeholders.baseUrl",
+      ),
+      { target: { value: "https://api.example.com" } },
+    )
+    fireEvent.change(
+      screen.getByPlaceholderText(
+        "apiCredentialProfiles:dialog.placeholders.apiKey",
+      ),
+      { target: { value: "sk-profile" } },
+    )
+    fireEvent.change(
+      screen.getByLabelText(
+        "apiCredentialProfiles:dialog.fields.telemetryPreset",
+      ),
+      { target: { value: "customReadOnlyEndpoint" } },
+    )
+    fireEvent.change(
+      screen.getByPlaceholderText(
+        "apiCredentialProfiles:dialog.placeholders.telemetryEndpoint",
+      ),
+      { target: { value: "https://telemetry.example.com/usage" } },
+    )
+    fireEvent.change(
+      screen.getByPlaceholderText(
+        "apiCredentialProfiles:dialog.placeholders.telemetryBearerToken",
+      ),
+      { target: { value: "   " } },
+    )
+    fireEvent.change(
+      screen.getAllByPlaceholderText(
+        "apiCredentialProfiles:dialog.placeholders.telemetryJsonPath",
+      )[0]!,
+      { target: { value: "data.balance" } },
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "common:actions.save" }))
+
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledWith(
+        expect.objectContaining({
+          telemetryConfig: {
+            mode: "customReadOnlyEndpoint",
+            customEndpoint: {
+              endpoint: "https://telemetry.example.com/usage",
+              jsonPaths: { balanceUsd: "data.balance" },
+            },
+          },
+        }),
+      )
+    })
+  })
+
   it("replays stored telemetry config when editing an existing profile", () => {
     renderDialog({
       profile: buildProfile({

--- a/tests/services/apiCredentialProfilesStorage.more.test.ts
+++ b/tests/services/apiCredentialProfilesStorage.more.test.ts
@@ -378,7 +378,7 @@ describe("apiCredentialProfilesStorage additional flows", () => {
             telemetryConfig: {
               mode: "customReadOnlyEndpoint",
               customEndpoint: {
-                endpoint: "https://evil.example.com/usage",
+                endpoint: "https://telemetry.example.com/usage",
                 jsonPaths: {
                   balanceUsd: "data.balance",
                 },
@@ -395,7 +395,7 @@ describe("apiCredentialProfilesStorage additional flows", () => {
         telemetryConfig: {
           mode: "customReadOnlyEndpoint",
           customEndpoint: {
-            endpoint: "https://evil.example.com/usage",
+            endpoint: "https://telemetry.example.com/usage",
             jsonPaths: {
               balanceUsd: "data.balance",
             },
@@ -641,6 +641,70 @@ describe("apiCredentialProfilesStorage additional flows", () => {
       expect.objectContaining({
         id: "incoming-1",
         telemetrySnapshot: expect.objectContaining({ balanceUsd: 2 }),
+      }),
+    )
+  })
+
+  it("keeps an older explicit config and its snapshot over a newer automatic duplicate", () => {
+    const olderSnapshot = {
+      health: { status: SiteHealthStatus.Healthy },
+      lastSyncTime: 9000,
+      lastSuccessTime: 9000,
+      balanceUsd: 3,
+      attempts: [],
+    }
+    const merged = mergeApiCredentialProfilesConfigs({
+      now: 67890,
+      local: {
+        version: API_CREDENTIAL_PROFILES_CONFIG_VERSION,
+        lastUpdated: 1,
+        profiles: [
+          {
+            id: "older-explicit",
+            name: "Older explicit",
+            apiType: API_TYPES.OPENAI_COMPATIBLE,
+            baseUrl: "https://example.com",
+            apiKey: "sk-1",
+            tagIds: [],
+            notes: "",
+            createdAt: 1,
+            updatedAt: 10,
+            telemetryConfig: { mode: "newApiTokenUsage" },
+            telemetrySnapshot: olderSnapshot,
+          },
+        ],
+      },
+      incoming: {
+        version: API_CREDENTIAL_PROFILES_CONFIG_VERSION,
+        lastUpdated: 2,
+        profiles: [
+          {
+            id: "newer-auto",
+            name: "Newer automatic",
+            apiType: API_TYPES.OPENAI_COMPATIBLE,
+            baseUrl: "https://example.com",
+            apiKey: "sk-1",
+            tagIds: [],
+            notes: "",
+            createdAt: 2,
+            updatedAt: 20,
+            telemetryConfig: { mode: "auto" },
+            telemetrySnapshot: {
+              ...olderSnapshot,
+              balanceUsd: 9,
+              lastSyncTime: 10000,
+              lastSuccessTime: 10000,
+            },
+          },
+        ],
+      },
+    })
+
+    expect(merged.profiles[0]).toEqual(
+      expect.objectContaining({
+        id: "newer-auto",
+        telemetryConfig: { mode: "newApiTokenUsage" },
+        telemetrySnapshot: expect.objectContaining({ balanceUsd: 3 }),
       }),
     )
   })

--- a/tests/services/apiCredentialProfilesStorage.more.test.ts
+++ b/tests/services/apiCredentialProfilesStorage.more.test.ts
@@ -336,6 +336,7 @@ describe("apiCredentialProfilesStorage additional flows", () => {
               mode: "customReadOnlyEndpoint",
               customEndpoint: {
                 endpoint: " https://example.com/usage?cursor=1 ",
+                bearerToken: " dedicated-telemetry-token ",
                 jsonPaths: {
                   balanceUsd: " data. balance ",
                 },
@@ -354,6 +355,7 @@ describe("apiCredentialProfilesStorage additional flows", () => {
           mode: "customReadOnlyEndpoint",
           customEndpoint: {
             endpoint: "https://example.com/usage?cursor=1",
+            bearerToken: "dedicated-telemetry-token",
             jsonPaths: {
               balanceUsd: "data.balance",
             },
@@ -363,7 +365,7 @@ describe("apiCredentialProfilesStorage additional flows", () => {
     )
   })
 
-  it("drops cross-origin custom telemetry endpoint details while keeping the selected mode", () => {
+  it("keeps cross-origin HTTP(S) custom telemetry endpoint details", () => {
     const coerced = coerceApiCredentialProfilesConfig(
       {
         profiles: [
@@ -392,6 +394,12 @@ describe("apiCredentialProfilesStorage additional flows", () => {
       expect.objectContaining({
         telemetryConfig: {
           mode: "customReadOnlyEndpoint",
+          customEndpoint: {
+            endpoint: "https://evil.example.com/usage",
+            jsonPaths: {
+              balanceUsd: "data.balance",
+            },
+          },
         },
       }),
     )
@@ -431,11 +439,11 @@ describe("apiCredentialProfilesStorage additional flows", () => {
     )
   })
 
-  it("rejects custom telemetry endpoints when the profile origin is not HTTP(S)", () => {
+  it("rejects non-HTTP(S) custom telemetry endpoints", () => {
     expect(
       isSupportedApiCredentialTelemetryEndpoint(
-        "ftp://example.com/root",
-        "/usage/read-only",
+        "https://example.com/root",
+        "ftp://telemetry.example.com/usage/read-only",
       ),
     ).toBe(false)
   })
@@ -501,6 +509,138 @@ describe("apiCredentialProfilesStorage additional flows", () => {
         id: "incoming-1",
         telemetryConfig: { mode: "newApiTokenUsage" },
         telemetrySnapshot: expect.objectContaining({ balanceUsd: 9 }),
+      }),
+    )
+  })
+
+  it("clears a stale telemetry snapshot when a duplicate selects a different config", () => {
+    const merged = mergeApiCredentialProfilesConfigs({
+      now: 67890,
+      local: {
+        version: API_CREDENTIAL_PROFILES_CONFIG_VERSION,
+        lastUpdated: 1,
+        profiles: [
+          {
+            id: "local-1",
+            name: "Local",
+            apiType: API_TYPES.OPENAI_COMPATIBLE,
+            baseUrl: "https://example.com",
+            apiKey: "sk-1",
+            tagIds: [],
+            notes: "",
+            createdAt: 1,
+            updatedAt: 10,
+            telemetryConfig: {
+              mode: "customReadOnlyEndpoint",
+              customEndpoint: {
+                endpoint: "/usage",
+                bearerToken: "old-token",
+                jsonPaths: { balanceUsd: "balance" },
+              },
+            },
+            telemetrySnapshot: {
+              health: { status: SiteHealthStatus.Healthy },
+              lastSyncTime: 5000,
+              lastSuccessTime: 5000,
+              balanceUsd: 1,
+              attempts: [],
+            },
+          },
+        ],
+      },
+      incoming: {
+        version: API_CREDENTIAL_PROFILES_CONFIG_VERSION,
+        lastUpdated: 2,
+        profiles: [
+          {
+            id: "incoming-1",
+            name: "Incoming",
+            apiType: API_TYPES.OPENAI_COMPATIBLE,
+            baseUrl: "https://example.com",
+            apiKey: "sk-1",
+            tagIds: [],
+            notes: "",
+            createdAt: 2,
+            updatedAt: 20,
+            telemetryConfig: {
+              mode: "customReadOnlyEndpoint",
+              customEndpoint: {
+                endpoint: "/usage",
+                bearerToken: "new-token",
+                jsonPaths: { balanceUsd: "balance" },
+              },
+            },
+          },
+        ],
+      },
+    })
+
+    expect(merged.profiles[0]).toEqual(
+      expect.objectContaining({
+        id: "incoming-1",
+        telemetryConfig: expect.objectContaining({
+          customEndpoint: expect.objectContaining({ bearerToken: "new-token" }),
+        }),
+      }),
+    )
+    expect(merged.profiles[0]).toEqual(
+      expect.not.objectContaining({
+        telemetrySnapshot: expect.anything(),
+      }),
+    )
+  })
+
+  it("keeps only the snapshot belonging to the selected duplicate config", () => {
+    const createProfile = (
+      id: string,
+      updatedAt: number,
+      bearerToken: string,
+      balanceUsd: number,
+      lastSyncTime: number,
+    ) => ({
+      id,
+      name: id,
+      apiType: API_TYPES.OPENAI_COMPATIBLE,
+      baseUrl: "https://example.com",
+      apiKey: "sk-1",
+      tagIds: [],
+      notes: "",
+      createdAt: updatedAt,
+      updatedAt,
+      telemetryConfig: {
+        mode: "customReadOnlyEndpoint" as const,
+        customEndpoint: {
+          endpoint: "/usage",
+          bearerToken,
+          jsonPaths: { balanceUsd: "balance" },
+        },
+      },
+      telemetrySnapshot: {
+        health: { status: SiteHealthStatus.Healthy },
+        lastSyncTime,
+        lastSuccessTime: lastSyncTime,
+        balanceUsd,
+        attempts: [],
+      },
+    })
+    const merged = mergeApiCredentialProfilesConfigs({
+      now: 67890,
+      local: {
+        version: API_CREDENTIAL_PROFILES_CONFIG_VERSION,
+        lastUpdated: 1,
+        profiles: [createProfile("local-1", 10, "old-token", 1, 9000)],
+      },
+      incoming: {
+        version: API_CREDENTIAL_PROFILES_CONFIG_VERSION,
+        lastUpdated: 2,
+        profiles: [createProfile("incoming-1", 20, "new-token", 2, 1000)],
+      },
+    })
+
+    expect(merged.profiles[0]).toEqual(
+      expect.objectContaining({
+        id: "incoming-1",
+        telemetrySnapshot: expect.objectContaining({ balanceUsd: 2 }),
       }),
     )
   })
@@ -713,7 +853,7 @@ describe("apiCredentialProfilesStorage additional flows", () => {
     expect(profiles.map((profile) => profile.id)).toEqual(["newer", "older"])
   })
 
-  it("re-coerces stored telemetry config when the profile base URL changes", async () => {
+  it("preserves an absolute HTTP(S) telemetry endpoint when the profile base URL changes", async () => {
     const profile = await apiCredentialProfilesStorage.createProfile({
       name: "Custom telemetry profile",
       apiType: API_TYPES.OPENAI_COMPATIBLE,
@@ -739,6 +879,12 @@ describe("apiCredentialProfilesStorage additional flows", () => {
 
     expect(updated.telemetryConfig).toEqual({
       mode: "customReadOnlyEndpoint",
+      customEndpoint: {
+        endpoint: "https://old.example.com/usage/read-only",
+        jsonPaths: {
+          balanceUsd: "data.balance",
+        },
+      },
     })
     await expect(
       apiCredentialProfilesStorage.getProfileById(profile.id),
@@ -746,7 +892,114 @@ describe("apiCredentialProfilesStorage additional flows", () => {
       expect.objectContaining({
         telemetryConfig: {
           mode: "customReadOnlyEndpoint",
+          customEndpoint: {
+            endpoint: "https://old.example.com/usage/read-only",
+            jsonPaths: {
+              balanceUsd: "data.balance",
+            },
+          },
         },
+      }),
+    )
+  })
+
+  it("clears stale telemetry when the dedicated bearer token changes", async () => {
+    const profile = await apiCredentialProfilesStorage.createProfile({
+      name: "Custom telemetry credentials",
+      apiType: API_TYPES.OPENAI_COMPATIBLE,
+      baseUrl: "https://telemetry-credentials.example.com",
+      apiKey: "sk-runtime",
+      telemetryConfig: {
+        mode: "customReadOnlyEndpoint",
+        customEndpoint: {
+          endpoint: "/usage",
+          bearerToken: "old-telemetry-token",
+          jsonPaths: {
+            balanceUsd: "balance",
+          },
+        },
+      },
+    })
+    await apiCredentialProfilesStorage.updateTelemetrySnapshot(profile.id, {
+      health: { status: SiteHealthStatus.Healthy },
+      lastSyncTime: 1000,
+      lastSuccessTime: 1000,
+      balanceUsd: 8,
+      attempts: [],
+    })
+
+    const updated = await apiCredentialProfilesStorage.updateProfile(
+      profile.id,
+      {
+        telemetryConfig: {
+          mode: "customReadOnlyEndpoint",
+          customEndpoint: {
+            endpoint: "/usage",
+            bearerToken: "new-telemetry-token",
+            jsonPaths: {
+              balanceUsd: "balance",
+            },
+          },
+        },
+      },
+    )
+
+    expect(updated.telemetryConfig).toEqual({
+      mode: "customReadOnlyEndpoint",
+      customEndpoint: {
+        endpoint: "/usage",
+        bearerToken: "new-telemetry-token",
+        jsonPaths: {
+          balanceUsd: "balance",
+        },
+      },
+    })
+    expect(updated).toEqual(
+      expect.not.objectContaining({
+        telemetrySnapshot: expect.anything(),
+      }),
+    )
+  })
+
+  it("clears stale telemetry when the dedicated bearer token is removed", async () => {
+    const profile = await apiCredentialProfilesStorage.createProfile({
+      name: "Custom telemetry credentials",
+      apiType: API_TYPES.OPENAI_COMPATIBLE,
+      baseUrl: "https://example.com",
+      apiKey: "sk-runtime",
+      telemetryConfig: {
+        mode: "customReadOnlyEndpoint",
+        customEndpoint: {
+          endpoint: "/usage",
+          bearerToken: "old-token",
+          jsonPaths: { balanceUsd: "balance" },
+        },
+      },
+    })
+    await apiCredentialProfilesStorage.updateTelemetrySnapshot(profile.id, {
+      health: { status: SiteHealthStatus.Healthy },
+      lastSyncTime: 1000,
+      lastSuccessTime: 1000,
+      balanceUsd: 8,
+      attempts: [],
+    })
+
+    const updated = await apiCredentialProfilesStorage.updateProfile(
+      profile.id,
+      {
+        telemetryConfig: {
+          mode: "customReadOnlyEndpoint",
+          customEndpoint: {
+            endpoint: "/usage",
+            jsonPaths: { balanceUsd: "balance" },
+          },
+        },
+      },
+    )
+
+    expect(updated).toEqual(
+      expect.not.objectContaining({
+        telemetrySnapshot: expect.anything(),
       }),
     )
   })

--- a/tests/services/apiCredentialProfilesStorage.more.test.ts
+++ b/tests/services/apiCredentialProfilesStorage.more.test.ts
@@ -448,6 +448,15 @@ describe("apiCredentialProfilesStorage additional flows", () => {
     ).toBe(false)
   })
 
+  it("rejects protocol-relative custom telemetry endpoints", () => {
+    expect(
+      isSupportedApiCredentialTelemetryEndpoint(
+        "https://example.com/root",
+        "//telemetry.example.com/usage/read-only",
+      ),
+    ).toBe(false)
+  })
+
   it("merges telemetry snapshots by newest successful query without changing identity winner", () => {
     const merged = mergeApiCredentialProfilesConfigs({
       now: 67890,

--- a/tests/services/apiCredentialProfilesTelemetry.test.ts
+++ b/tests/services/apiCredentialProfilesTelemetry.test.ts
@@ -479,12 +479,12 @@ describe("api credential profile telemetry", () => {
     )
   })
 
-  it("uses the profile API key for a cross-origin custom telemetry URL when no dedicated token is set", async () => {
+  it("omits authentication for a cross-origin custom telemetry URL when no dedicated token is set", async () => {
     const profile = await apiCredentialProfilesStorage.createProfile({
-      name: "Custom Cross-Origin Fallback",
+      name: "Custom Cross-Origin Anonymous",
       apiType: API_TYPES.OPENAI_COMPATIBLE,
       baseUrl: "https://api.example.com/v1/models",
-      apiKey: "sk-cross-origin-fallback",
+      apiKey: "sk-cross-origin-profile",
       telemetryConfig: {
         mode: "customReadOnlyEndpoint",
         customEndpoint: {
@@ -503,8 +503,8 @@ describe("api credential profile telemetry", () => {
     expect(fetchMock).toHaveBeenCalledWith(
       "https://telemetry.example.com/usage",
       expect.objectContaining({
-        headers: expect.objectContaining({
-          Authorization: "Bearer sk-cross-origin-fallback",
+        headers: expect.not.objectContaining({
+          Authorization: expect.any(String),
         }),
       }),
     )
@@ -619,5 +619,45 @@ describe("api credential profile telemetry", () => {
         }),
       ]),
     )
+  })
+
+  it("prefers an absolute custom endpoint error when model discovery also fails", async () => {
+    const profile = await apiCredentialProfilesStorage.createProfile({
+      name: "Absolute Custom Error",
+      apiType: API_TYPES.OPENAI_COMPATIBLE,
+      baseUrl: "https://api.example.com/v1",
+      apiKey: "sk-absolute-custom-error",
+      telemetryConfig: {
+        mode: "customReadOnlyEndpoint",
+        customEndpoint: {
+          endpoint: "https://telemetry.example.com/usage",
+          bearerToken: "dedicated-token",
+          jsonPaths: {
+            balanceUsd: "balance",
+          },
+        },
+      },
+    })
+
+    fetchApiCredentialModelIdsMock.mockRejectedValueOnce(
+      new Error("models failed"),
+    )
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => jsonResponse({ message: "custom failed" }, 500)),
+    )
+
+    const snapshot = await refreshApiCredentialProfileTelemetry(profile.id)
+    const customAttempt = snapshot.attempts.find(
+      (attempt) => attempt.source === "customReadOnlyEndpoint",
+    )
+
+    expect(customAttempt).toEqual(
+      expect.objectContaining({
+        status: "error",
+        message: expect.stringContaining("custom failed"),
+      }),
+    )
+    expect(snapshot.lastError).toBe(customAttempt?.message)
   })
 })

--- a/tests/services/apiCredentialProfilesTelemetry.test.ts
+++ b/tests/services/apiCredentialProfilesTelemetry.test.ts
@@ -415,6 +415,101 @@ describe("api credential profile telemetry", () => {
     )
   })
 
+  it("resolves root-relative custom telemetry endpoints from the profile origin", async () => {
+    const profile = await apiCredentialProfilesStorage.createProfile({
+      name: "Custom Subpath",
+      apiType: API_TYPES.OPENAI_COMPATIBLE,
+      baseUrl: "https://custom-subpath.example.com/api/agents",
+      apiKey: "sk-custom-subpath",
+      telemetryConfig: {
+        mode: "customReadOnlyEndpoint",
+        customEndpoint: {
+          endpoint: "/api/telemetry/usage",
+          jsonPaths: {
+            balanceUsd: "balance",
+          },
+        },
+      },
+    })
+    const fetchMock = vi.fn(async () => jsonResponse({ balance: 6.25 }))
+    vi.stubGlobal("fetch", fetchMock)
+
+    await refreshApiCredentialProfileTelemetry(profile.id)
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://custom-subpath.example.com/api/telemetry/usage",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer sk-custom-subpath",
+        }),
+      }),
+    )
+  })
+
+  it("uses a dedicated bearer token for a cross-origin custom telemetry URL", async () => {
+    const profile = await apiCredentialProfilesStorage.createProfile({
+      name: "Custom Bearer",
+      apiType: API_TYPES.OPENAI_COMPATIBLE,
+      baseUrl: "https://custom-bearer.example.com/api/agents",
+      apiKey: "sk-custom-bearer",
+      telemetryConfig: {
+        mode: "customReadOnlyEndpoint",
+        customEndpoint: {
+          endpoint:
+            "https://telemetry.example.com/api/telemetry/usage?period=today",
+          bearerToken: "dedicated-telemetry-token",
+          jsonPaths: {
+            balanceUsd: "balance",
+          },
+        },
+      },
+    })
+    const fetchMock = vi.fn(async () => jsonResponse({ balance: 7.5 }))
+    vi.stubGlobal("fetch", fetchMock)
+
+    await refreshApiCredentialProfileTelemetry(profile.id)
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://telemetry.example.com/api/telemetry/usage?period=today",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer dedicated-telemetry-token",
+        }),
+      }),
+    )
+  })
+
+  it("uses the profile API key for a cross-origin custom telemetry URL when no dedicated token is set", async () => {
+    const profile = await apiCredentialProfilesStorage.createProfile({
+      name: "Custom Cross-Origin Fallback",
+      apiType: API_TYPES.OPENAI_COMPATIBLE,
+      baseUrl: "https://api.example.com/v1/models",
+      apiKey: "sk-cross-origin-fallback",
+      telemetryConfig: {
+        mode: "customReadOnlyEndpoint",
+        customEndpoint: {
+          endpoint: "https://telemetry.example.com/usage",
+          jsonPaths: {
+            balanceUsd: "balance",
+          },
+        },
+      },
+    })
+    const fetchMock = vi.fn(async () => jsonResponse({ balance: 8.5 }))
+    vi.stubGlobal("fetch", fetchMock)
+
+    await refreshApiCredentialProfileTelemetry(profile.id)
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://telemetry.example.com/usage",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer sk-cross-origin-fallback",
+        }),
+      }),
+    )
+  })
+
   it("redacts custom endpoint query values before persisting attempts", async () => {
     const profile = await apiCredentialProfilesStorage.createProfile({
       name: "Custom Query",
@@ -446,6 +541,43 @@ describe("api credential profile telemetry", () => {
     expect(customAttempt?.endpoint).not.toContain("sk-custom-query")
     expect(customAttempt?.endpoint).not.toContain("secret-cursor")
     expect(customAttempt?.endpoint).toContain("REDACTED")
+  })
+
+  it("redacts the dedicated bearer token from custom telemetry errors", async () => {
+    const apiKey = "shared-telemetry-secret"
+    const dedicatedBearerToken = `${apiKey}-private-tail`
+    const profile = await apiCredentialProfilesStorage.createProfile({
+      name: "Custom Error Redaction",
+      apiType: API_TYPES.OPENAI_COMPATIBLE,
+      baseUrl: "https://custom-error.example.com",
+      apiKey,
+      telemetryConfig: {
+        mode: "customReadOnlyEndpoint",
+        customEndpoint: {
+          endpoint: "/usage",
+          bearerToken: dedicatedBearerToken,
+          jsonPaths: {
+            balanceUsd: "balance",
+          },
+        },
+      },
+    })
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        jsonResponse(
+          { message: `Authorization: Bearer ${dedicatedBearerToken}` },
+          401,
+        ),
+      ),
+    )
+
+    const snapshot = await refreshApiCredentialProfileTelemetry(profile.id)
+    const serializedSnapshot = JSON.stringify(snapshot)
+
+    expect(serializedSnapshot).not.toContain(dedicatedBearerToken)
+    expect(serializedSnapshot).not.toContain("private-tail")
+    expect(serializedSnapshot).toContain("[REDACTED]")
   })
 
   it("prefers the custom configuration error when malformed custom endpoints are dropped during coercion", async () => {


### PR DESCRIPTION
## Summary

- Resolve root-relative custom telemetry paths from the profile origin and honor absolute HTTP(S) URLs, including cross-origin endpoints.
- Support an optional dedicated Bearer token while retaining API-key fallback behavior.
- Redact both credentials from persisted telemetry diagnostics and invalidate stale snapshots when telemetry configuration changes.
- Add a masked, localized Bearer-token field and keep all seven application locales synchronized.
- Preserve compatibility with existing profiles through configuration version 4.

## Validation

- Focused Vitest coverage: 4 files, 64 tests passed.
- `pnpm run validate:staged`
- `pnpm run validate:push`
- i18n extraction and locale completeness checks passed.
- Read-only live contract verification confirmed the reported usage endpoint and OpenAI-compatible models endpoint return successfully with Bearer authentication.

Current-build browser E2E was not run because the connected Edge profile has extension version 3.53.0 installed. Full-suite coverage and browser CI remain pending until the PR is created.

Fixes #1247


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional dedicated Bearer token support for custom telemetry endpoints.
  - Custom telemetry endpoints now support root-relative paths and HTTP(S) URLs across origins.
  - Telemetry requests can use separate authentication and endpoint settings.

- **Bug Fixes**
  - Improved credential and telemetry configuration handling when profiles change or are merged.
  - Prevented sensitive telemetry credentials from appearing in stored errors.
  - Updated endpoint validation to reject unsupported URL schemes.

- **Documentation**
  - Updated endpoint and Bearer token guidance across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->