### PR TITLE
fix(background): make toolbar sidepanel routing cold-start safe

### DIFF
--- a/docs/superpowers/plans/2026-08-03-toolbar-sidepanel-cold-start.md
+++ b/docs/superpowers/plans/2026-08-03-toolbar-sidepanel-cold-start.md
@@ -1,0 +1,773 @@
+# Toolbar Side Panel Cold-Start Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make a configured Chromium/Edge side panel open on the first toolbar click even when the Manifest V3 service worker is cold, while preserving popup, options, Firefox, and fallback behavior.
+
+**Architecture:** Keep `actionClickBehavior` in extension storage as the source of truth and project it into browser-owned popup/side-panel configuration. Register one stable toolbar listener synchronously for extension-managed routes, use Chromium's native `openPanelOnActionClick` path for the reported mode, and serialize/await configuration changes so stale asynchronous work cannot win.
+
+**Tech Stack:** TypeScript, WXT, Chrome/Firefox extension APIs, React context, Vitest, Playwright.
+
+---
+
+## File Map
+
+- Modify `src/utils/browser/browserApi.ts`: expose a symmetric native Chromium side-panel action configuration helper.
+- Modify `src/entrypoints/background/actionClickBehavior.ts`: own stable dispatch, native/manual routing, and serialized browser configuration.
+- Modify `src/entrypoints/background/index.ts`: register the listener synchronously and reconcile toolbar behavior before unrelated services.
+- Modify `src/services/preferences/runtimePreferencesService.ts`: await browser configuration before acknowledging a setting message.
+- Modify `src/contexts/UserPreferencesContext.tsx`: wait for the background acknowledgement while retaining durable-write fallback semantics.
+- Modify `tests/utils/browserApi.test.ts`: cover native enable, disable, unsupported, and rejected API calls.
+- Modify `tests/entrypoints/background/actionClickBehavior.test.ts`: cover routing, native fallback, and serialization.
+- Modify `tests/entrypoints/background/backgroundSuspendCleanup.test.ts`: prove synchronous listener registration and early reconciliation order.
+- Modify `tests/services/runtimePreferencesService.test.ts`: prove async completion and rejection are reflected in the response.
+- Modify `tests/contexts/UserPreferencesContext.test.tsx`: prove the provider update waits for runtime application.
+- Modify `e2e/basicSettingsCommonFlows.spec.ts`: assert the browser-native side-panel projection in a real extension context.
+
+### Task 1: Symmetric Chromium Native Side-Panel Configuration
+
+**Files:**
+
+- Modify: `tests/utils/browserApi.test.ts:15-75,1721-1752`
+- Modify: `src/utils/browser/browserApi.ts:958-979`
+
+- [ ] **Step 1: Write the failing browser API tests**
+
+Replace the `disableNativeSidePanelActionClick` import and its three tests with assertions for a boolean-result helper:
+
+```ts
+import { setNativeSidePanelActionClick } from "~/utils/browser/browserApi"
+
+it.each([true, false])(
+  "sets native Chromium side-panel action clicks to %s when supported",
+  async (enabled) => {
+    const setPanelBehavior = vi.fn().mockResolvedValue(undefined)
+    ;(globalThis as any).chrome = { sidePanel: { setPanelBehavior } }
+
+    await expect(setNativeSidePanelActionClick(enabled)).resolves.toBe(true)
+    expect(setPanelBehavior).toHaveBeenCalledWith({
+      openPanelOnActionClick: enabled,
+    })
+  },
+)
+
+it("reports unavailable native Chromium side-panel action behavior", async () => {
+  ;(globalThis as any).chrome = { sidePanel: {} }
+
+  await expect(setNativeSidePanelActionClick(true)).resolves.toBe(false)
+})
+
+it("reports rejected native Chromium side-panel action behavior", async () => {
+  ;(globalThis as any).chrome = {
+    sidePanel: {
+      setPanelBehavior: vi.fn().mockRejectedValue(new Error("unsupported")),
+    },
+  }
+
+  await expect(setNativeSidePanelActionClick(true)).resolves.toBe(false)
+})
+```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run:
+
+```bash
+pnpm exec vitest run tests/utils/browserApi.test.ts
+```
+
+Expected: FAIL because `setNativeSidePanelActionClick` is not exported.
+
+- [ ] **Step 3: Implement the minimal symmetric helper**
+
+Replace `disableNativeSidePanelActionClick` with:
+
+```ts
+/**
+ * Projects toolbar clicks into Chromium's browser-owned side-panel behavior.
+ * Returns false when the runtime cannot apply the requested behavior so callers
+ * can retain an extension-managed fallback.
+ */
+export async function setNativeSidePanelActionClick(
+  enabled: boolean,
+): Promise<boolean> {
+  const setPanelBehavior = (globalThis as any).chrome?.sidePanel
+    ?.setPanelBehavior
+
+  if (typeof setPanelBehavior !== "function") {
+    return false
+  }
+
+  try {
+    await setPanelBehavior({ openPanelOnActionClick: enabled })
+    return true
+  } catch (error) {
+    logger.warn(
+      `sidePanel.setPanelBehavior not available:\n${getErrorMessage(error)}`,
+    )
+    return false
+  }
+}
+```
+
+- [ ] **Step 4: Run the focused test and verify GREEN**
+
+Run `pnpm exec vitest run tests/utils/browserApi.test.ts`.
+
+Expected: PASS with no new warnings other than the deliberately exercised logged rejection.
+
+- [ ] **Step 5: Commit the browser API seam**
+
+```bash
+git add src/utils/browser/browserApi.ts tests/utils/browserApi.test.ts
+git commit -m "refactor(browser): expose native sidepanel action control"
+```
+
+### Task 2: Stable Toolbar Dispatcher and Serialized Projection
+
+**Files:**
+
+- Modify: `tests/entrypoints/background/actionClickBehavior.test.ts`
+- Modify: `src/entrypoints/background/actionClickBehavior.ts`
+
+- [ ] **Step 1: Rewrite the action behavior tests for the desired public contract**
+
+Extend the existing hoisted mocks with `userPreferences.getPreferences`, replace
+the disable-native mock with `setNativeSidePanelActionClick`, and add focused
+tests with these observable assertions:
+
+```ts
+it("registers one stable toolbar listener", async () => {
+  const { setupActionClickBehaviorListener } = await import(
+    "~/entrypoints/background/actionClickBehavior"
+  )
+
+  setupActionClickBehaviorListener()
+  setupActionClickBehaviorListener()
+
+  expect(addActionClickListener).toHaveBeenCalledTimes(2)
+  expect(addActionClickListener.mock.calls[0]?.[0]).toBe(
+    addActionClickListener.mock.calls[1]?.[0],
+  )
+})
+
+it("uses Chromium native routing for sidepanel mode", async () => {
+  getSidePanelSupport.mockReturnValue({
+    supported: true,
+    kind: "chromium-side-panel",
+  })
+  setNativeSidePanelActionClick.mockResolvedValue(true)
+  const { applyActionClickBehavior } = await import(
+    "~/entrypoints/background/actionClickBehavior"
+  )
+
+  await applyActionClickBehavior("sidepanel")
+
+  expect(setActionPopup).toHaveBeenCalledWith("")
+  expect(setNativeSidePanelActionClick).toHaveBeenCalledWith(true)
+  expect(openSidePanelWithFallback).not.toHaveBeenCalled()
+})
+
+it("uses the stable dispatcher when Chromium native routing fails", async () => {
+  getSidePanelSupport.mockReturnValue({
+    supported: true,
+    kind: "chromium-side-panel",
+  })
+  setNativeSidePanelActionClick.mockResolvedValue(false)
+  const { applyActionClickBehavior, setupActionClickBehaviorListener } =
+    await import("~/entrypoints/background/actionClickBehavior")
+  setupActionClickBehaviorListener()
+  await applyActionClickBehavior("sidepanel")
+
+  const clickHandler = addActionClickListener.mock.calls[0]?.[0]
+  const clickedTab = { id: 123, windowId: 456 } as browser.tabs.Tab
+  await clickHandler(clickedTab)
+
+  expect(openSidePanelWithFallback).toHaveBeenCalledWith(clickedTab)
+})
+
+it("routes a cold options click from the durable preference", async () => {
+  userPreferences.getPreferences.mockResolvedValue({
+    actionClickBehavior: "options",
+  })
+  getSidePanelSupport.mockReturnValue({
+    supported: true,
+    kind: "chromium-side-panel",
+  })
+  const { setupActionClickBehaviorListener } = await import(
+    "~/entrypoints/background/actionClickBehavior"
+  )
+  setupActionClickBehaviorListener()
+
+  const clickHandler = addActionClickListener.mock.calls[0]?.[0]
+  await clickHandler({ id: 123, windowId: 456 } as browser.tabs.Tab)
+
+  expect(openOptionsPage).toHaveBeenCalledTimes(1)
+})
+
+it("serializes browser action projections in request order", async () => {
+  getSidePanelSupport.mockReturnValue({
+    supported: true,
+    kind: "chromium-side-panel",
+  })
+  let releaseFirstPopup!: () => void
+  setActionPopup.mockImplementationOnce(
+    () => new Promise<void>((resolve) => (releaseFirstPopup = resolve)),
+  )
+  const { applyActionClickBehavior } = await import(
+    "~/entrypoints/background/actionClickBehavior"
+  )
+
+  const first = applyActionClickBehavior("sidepanel")
+  const second = applyActionClickBehavior("options")
+  await vi.waitFor(() => expect(setActionPopup).toHaveBeenCalledTimes(1))
+
+  releaseFirstPopup()
+  await Promise.all([first, second])
+
+  expect(setActionPopup.mock.calls.map(([popup]) => popup)).toEqual(["", ""])
+  expect(setNativeSidePanelActionClick.mock.calls.map(([enabled]) => enabled)).toEqual([
+    true,
+    false,
+  ])
+})
+```
+
+Retain and adapt the existing popup fallback, Firefox side-panel, options,
+analytics-success, analytics-failure, and tracker-failure tests. Popup and
+options must assert `setNativeSidePanelActionClick(false)`; Firefox must assert
+manual dispatch; unsupported side-panel must still restore `POPUP_PAGE_PATH`.
+
+- [ ] **Step 2: Run the focused action tests and verify RED**
+
+Run:
+
+```bash
+pnpm exec vitest run tests/entrypoints/background/actionClickBehavior.test.ts
+```
+
+Expected: FAIL because the stable setup export, native enable path, durable
+cold-dispatch path, and serialization do not exist.
+
+- [ ] **Step 3: Implement a stable dispatcher and serialized reconciler**
+
+In `actionClickBehavior.ts`, import `userPreferences`, replace listener removal
+with one stable handler, and keep the existing analytics wrapper for manual
+side-panel opens:
+
+```ts
+let appliedBehavior: ToolbarActionClickBehavior | null = null
+let shouldManuallyOpenSidePanel = false
+let actionBehaviorQueue: Promise<void> = Promise.resolve()
+
+async function getEffectiveClickBehavior(): Promise<ToolbarActionClickBehavior> {
+  if (appliedBehavior) return appliedBehavior
+
+  const preferences = await userPreferences.getPreferences()
+  return resolveToolbarActionClickBehavior(
+    preferences.actionClickBehavior ?? TOOLBAR_ACTION_CLICK_BEHAVIORS.Popup,
+    getSidePanelSupport().supported,
+  )
+}
+
+const handleToolbarActionClick = async (tab: browser.tabs.Tab) => {
+  const wasUnreconciled = appliedBehavior === null
+  const behavior = await getEffectiveClickBehavior()
+  if (behavior === TOOLBAR_ACTION_CLICK_BEHAVIORS.Options) {
+    await openOptionsPage()
+    return
+  }
+
+  if (behavior !== TOOLBAR_ACTION_CLICK_BEHAVIORS.SidePanel) return
+
+  const support = getSidePanelSupport()
+  if (
+    support.supported &&
+    (support.kind === "firefox-sidebar-action" ||
+      shouldManuallyOpenSidePanel ||
+      wasUnreconciled)
+  ) {
+    await handleOpenSidePanelActionClick(tab)
+  }
+}
+
+export function setupActionClickBehaviorListener(): () => void {
+  return addActionClickListener(handleToolbarActionClick)
+}
+```
+
+Move existing projection code into an internal operation and serialize the
+public function:
+
+```ts
+async function reconcileActionClickBehavior(
+  behavior: ToolbarActionClickBehavior,
+): Promise<void> {
+  const support = getSidePanelSupport()
+  const effectiveBehavior = resolveToolbarActionClickBehavior(
+    behavior,
+    support.supported,
+  )
+  const isSidePanel =
+    effectiveBehavior === TOOLBAR_ACTION_CLICK_BEHAVIORS.SidePanel
+  const isChromiumSidePanel =
+    isSidePanel && support.supported && support.kind === "chromium-side-panel"
+
+  appliedBehavior = effectiveBehavior
+  shouldManuallyOpenSidePanel = isSidePanel
+
+  if (!isChromiumSidePanel) {
+    await setNativeSidePanelActionClick(false)
+  }
+
+  try {
+    await setActionPopup(
+      isSidePanel || effectiveBehavior === TOOLBAR_ACTION_CLICK_BEHAVIORS.Options
+        ? ""
+        : POPUP_PAGE_PATH,
+    )
+  } catch (error) {
+    logger.warn(`action.setPopup not available:\n${getErrorMessage(error)}`)
+  }
+
+  if (isChromiumSidePanel) {
+    shouldManuallyOpenSidePanel = !(await setNativeSidePanelActionClick(true))
+  }
+}
+
+export function applyActionClickBehavior(
+  behavior: ToolbarActionClickBehavior,
+): Promise<void> {
+  const operation = actionBehaviorQueue.then(() =>
+    reconcileActionClickBehavior(behavior),
+  )
+  actionBehaviorQueue = operation.catch(() => undefined)
+  return operation
+}
+```
+
+Delete `removeActionClickListener`, both conditional listener registrations, and
+the separate options click handler. Preserve the existing manual side-panel
+analytics behavior unchanged. `wasUnreconciled` is a best-effort cold fallback:
+Chromium normally consumes the click when native behavior is enabled, so a cold
+worker receiving `action.onClicked` indicates that extension-managed routing is
+still needed.
+
+- [ ] **Step 4: Run the focused action tests and verify GREEN**
+
+Run `pnpm exec vitest run tests/entrypoints/background/actionClickBehavior.test.ts`.
+
+Expected: all action projection, fallback, dispatcher, serialization, and
+analytics tests PASS.
+
+- [ ] **Step 5: Commit the background action behavior**
+
+```bash
+git add src/entrypoints/background/actionClickBehavior.ts tests/entrypoints/background/actionClickBehavior.test.ts
+git commit -m "fix(background): make sidepanel clicks cold-start safe"
+```
+
+### Task 3: Synchronous Registration and Early Startup Reconciliation
+
+**Files:**
+
+- Modify: `tests/entrypoints/background/backgroundSuspendCleanup.test.ts`
+- Modify: `src/entrypoints/background/index.ts:40,63-78,205-220`
+
+- [ ] **Step 1: Write the failing background entrypoint ordering test**
+
+Hoist named mocks for `setupActionClickBehaviorListener`,
+`applyActionClickBehavior`, `getPreferences`, and `initializeServices`, then add:
+
+```ts
+it("registers toolbar clicks before asynchronous startup reconciliation", async () => {
+  await import("~/entrypoints/background/index")
+
+  await vi.waitFor(() => {
+    expect(applyActionClickBehaviorMock).toHaveBeenCalledWith("popup")
+  })
+  expect(setupActionClickBehaviorListenerMock).toHaveBeenCalledTimes(1)
+  expect(
+    setupActionClickBehaviorListenerMock.mock.invocationCallOrder[0],
+  ).toBeLessThan(getPreferencesMock.mock.invocationCallOrder[0])
+  expect(
+    applyActionClickBehaviorMock.mock.invocationCallOrder[0],
+  ).toBeLessThan(initializeServicesMock.mock.invocationCallOrder[0])
+})
+```
+
+Update the action behavior mock in both
+`backgroundSuspendCleanup.test.ts` and `changelogOnUpdate.test.ts` to export both
+functions:
+
+```ts
+vi.doMock("~/entrypoints/background/actionClickBehavior", () => ({
+  applyActionClickBehavior: applyActionClickBehaviorMock,
+  setupActionClickBehaviorListener: setupActionClickBehaviorListenerMock,
+}))
+```
+
+- [ ] **Step 2: Run the entrypoint test and verify RED**
+
+Run:
+
+```bash
+pnpm exec vitest run tests/entrypoints/background/backgroundSuspendCleanup.test.ts
+```
+
+Expected: FAIL because `index.ts` does not call the setup function and currently
+initializes services before applying toolbar behavior.
+
+- [ ] **Step 3: Register synchronously and reorder `main`**
+
+Update the import and entrypoint body:
+
+```ts
+import {
+  applyActionClickBehavior,
+  setupActionClickBehaviorListener,
+} from "./actionClickBehavior"
+
+export default defineBackground(() => {
+  logger.debug("Hello background", { id: getRuntimeId() })
+  setupActionClickBehaviorListener()
+  // existing synchronous listener setup follows
+  // ...
+})
+```
+
+Move toolbar reconciliation ahead of unrelated service initialization:
+
+```ts
+async function main() {
+  const prefs = await userPreferences.getPreferences()
+  await applyActionClickBehavior(prefs.actionClickBehavior ?? "popup")
+
+  await initializeServices()
+  await initializeCookieInterceptors()
+  triggerStartupSiteEcosystemSnapshot()
+  triggerStartupSettingsSnapshot()
+  triggerStartupShieldBypassDailySummary()
+  triggerStartupSponsorRecommendationsDailySummary()
+}
+```
+
+- [ ] **Step 4: Run affected background tests and verify GREEN**
+
+Run:
+
+```bash
+pnpm exec vitest run tests/entrypoints/background/backgroundSuspendCleanup.test.ts tests/entrypoints/background/changelogOnUpdate.test.ts
+```
+
+Expected: PASS. Do not weaken the new order assertion.
+
+- [ ] **Step 5: Commit startup wiring**
+
+```bash
+git add src/entrypoints/background/index.ts tests/entrypoints/background/backgroundSuspendCleanup.test.ts tests/entrypoints/background/changelogOnUpdate.test.ts
+git commit -m "fix(background): reconcile toolbar behavior before services"
+```
+
+### Task 4: Await Setting Application End to End
+
+**Files:**
+
+- Modify: `tests/services/runtimePreferencesService.test.ts:59-83`
+- Modify: `src/services/preferences/runtimePreferencesService.ts:33-45`
+- Modify: `tests/contexts/UserPreferencesContext.test.tsx:928-967`
+- Modify: `src/contexts/UserPreferencesContext.tsx:650-672`
+
+- [ ] **Step 1: Write the failing runtime message tests**
+
+Add a deferred completion test and convert the synchronous failure assertion to
+an asynchronous rejection:
+
+```ts
+it("waits for action behavior application before acknowledging", async () => {
+  let finishApply!: () => void
+  mocks.applyActionClickBehavior.mockReturnValueOnce(
+    new Promise<void>((resolve) => (finishApply = resolve)),
+  )
+  const { setupPreferencesMessagingListeners } = await importService()
+  setupPreferencesMessagingListeners()
+  const handler = mocks.handlers.get(
+    PreferencesMessageTypes.UpdateActionClickBehavior,
+  )
+
+  let settled = false
+  const response = handler?.({ data: { behavior: "sidepanel" } }).then((value) => {
+    settled = true
+    return value
+  })
+  await Promise.resolve()
+  expect(settled).toBe(false)
+
+  finishApply()
+  await expect(response).resolves.toEqual({ success: true, data: undefined })
+})
+
+it("reports asynchronous action behavior failures", async () => {
+  mocks.applyActionClickBehavior.mockRejectedValueOnce(new Error("action failed"))
+  const { setupPreferencesMessagingListeners } = await importService()
+  setupPreferencesMessagingListeners()
+  const handler = mocks.handlers.get(
+    PreferencesMessageTypes.UpdateActionClickBehavior,
+  )
+
+  await expect(handler?.({ data: { behavior: "popup" } })).resolves.toEqual({
+    success: false,
+    error: "action failed",
+  })
+})
+```
+
+- [ ] **Step 2: Run the service test and verify RED**
+
+Run `pnpm exec vitest run tests/services/runtimePreferencesService.test.ts`.
+
+Expected: the deferred handler settles early and the rejected promise is not
+converted into a failure response.
+
+- [ ] **Step 3: Await the background application**
+
+Change the handler body to:
+
+```ts
+try {
+  await applyActionClickBehavior(request.behavior)
+  return { success: true, data: undefined }
+} catch (error) {
+  return createRuntimeMessageFailure(getErrorMessage(error))
+}
+```
+
+- [ ] **Step 4: Verify the runtime service GREEN**
+
+Run `pnpm exec vitest run tests/services/runtimePreferencesService.test.ts`.
+
+Expected: PASS.
+
+- [ ] **Step 5: Write the failing provider wait test**
+
+Add beside the existing action behavior provider tests:
+
+```ts
+it("waits for background action behavior application before settling", async () => {
+  let finishNotification!: (
+    value: { success: true; data: undefined },
+  ) => void
+  mockedSendPreferencesMessage.mockReturnValueOnce(
+    new Promise((resolve) => (finishNotification = resolve)),
+  )
+  const context = await renderProvider()
+
+  let settled = false
+  const update = context.updateActionClickBehavior("sidepanel").then((value) => {
+    settled = true
+    return value
+  })
+  await act(async () => Promise.resolve())
+  expect(settled).toBe(false)
+
+  finishNotification({ success: true, data: undefined })
+  await act(async () => {
+    await expect(update).resolves.toMatchObject({ ok: true })
+  })
+})
+```
+
+In the shared `beforeEach`, replace the current undefined default with the typed
+success response so every existing provider call sees the real protocol shape:
+
+```ts
+mockedSendPreferencesMessage.mockResolvedValue({
+  success: true,
+  data: undefined,
+})
+```
+
+- [ ] **Step 6: Run the provider test and verify RED**
+
+Run `pnpm exec vitest run tests/contexts/UserPreferencesContext.test.tsx`.
+
+Expected: FAIL because `updateActionClickBehavior` currently starts the message
+as fire-and-forget work and settles immediately.
+
+- [ ] **Step 7: Await the notification without rolling back durable storage**
+
+Replace the fire-and-forget block with:
+
+```ts
+try {
+  const response = await sendPreferencesMessage(
+    PreferencesMessageTypes.UpdateActionClickBehavior,
+    { behavior },
+  )
+  if (!response.success) {
+    logger.warn(
+      "Failed to apply action click behavior update",
+      new Error(response.error),
+    )
+  }
+} catch (error) {
+  logger.warn("Failed to notify action click behavior update", error)
+}
+```
+
+Keep returning the successful storage `result`. This preserves the existing
+contract tested by “keeps action behavior writes successful when the runtime
+notification fails”; the next background load retries from durable storage.
+
+- [ ] **Step 8: Run the provider and service tests and verify GREEN**
+
+Run:
+
+```bash
+pnpm exec vitest run tests/services/runtimePreferencesService.test.ts tests/contexts/UserPreferencesContext.test.tsx
+```
+
+Expected: PASS, including both delayed acknowledgement and notification-failure
+fallback behavior.
+
+- [ ] **Step 9: Commit awaited settings projection**
+
+```bash
+git add src/services/preferences/runtimePreferencesService.ts src/contexts/UserPreferencesContext.tsx tests/services/runtimePreferencesService.test.ts tests/contexts/UserPreferencesContext.test.tsx
+git commit -m "fix(preferences): await toolbar behavior application"
+```
+
+### Task 5: Real Extension-State Regression Coverage and Final Validation
+
+**Files:**
+
+- Modify: `e2e/basicSettingsCommonFlows.spec.ts:36-88,196-232`
+
+- [ ] **Step 1: Extend the existing E2E flow with native behavior inspection**
+
+Add a helper that uses the real Chromium extension API:
+
+```ts
+async function getNativeSidePanelActionClickState(
+  serviceWorker: Awaited<ReturnType<typeof getServiceWorker>>,
+): Promise<boolean | null> {
+  return await serviceWorker.evaluate(async () => {
+    const sidePanel = (globalThis as any).chrome?.sidePanel
+    if (typeof sidePanel?.getPanelBehavior !== "function") return null
+    const behavior = await sidePanel.getPanelBehavior()
+    return behavior.openPanelOnActionClick === true
+  })
+}
+
+async function expectNativeSidePanelActionClickState(
+  serviceWorker: Awaited<ReturnType<typeof getServiceWorker>>,
+  expected: boolean,
+) {
+  await expect
+    .poll(async () => getNativeSidePanelActionClickState(serviceWorker))
+    .toBe(expected)
+}
+```
+
+Update `updates toolbar action behavior from settings into the live extension
+action` so the Chromium-supported side-panel transition asserts:
+
+```ts
+await expectConfiguredActionPopup(serviceWorker, "")
+await expectActionClickListenerState(serviceWorker, true)
+await expectNativeSidePanelActionClickState(serviceWorker, true)
+```
+
+After switching back to popup, assert:
+
+```ts
+await expectConfiguredActionPopup(serviceWorker, POPUP_PAGE_PATH)
+await expectActionClickListenerState(serviceWorker, true)
+await expectNativeSidePanelActionClickState(serviceWorker, false)
+```
+
+Keep the unsupported-runtime branch limited to the popup fallback and skip the
+native assertion when `getPanelBehavior` returns `null`.
+
+- [ ] **Step 2: Run the focused browser E2E**
+
+Run:
+
+```bash
+pnpm exec playwright test e2e/basicSettingsCommonFlows.spec.ts --grep "updates toolbar action behavior"
+```
+
+Expected: PASS in the Chromium extension harness. This proves the persisted
+setting is projected into the real browser-owned side-panel behavior.
+
+- [ ] **Step 3: Run all focused unit regressions**
+
+Run:
+
+```bash
+pnpm exec vitest run tests/utils/browserApi.test.ts tests/entrypoints/background/actionClickBehavior.test.ts tests/entrypoints/background/backgroundSuspendCleanup.test.ts tests/entrypoints/background/changelogOnUpdate.test.ts tests/services/runtimePreferencesService.test.ts tests/contexts/UserPreferencesContext.test.tsx
+```
+
+Expected: PASS with no unhandled rejection or unexpected warning.
+
+- [ ] **Step 4: Run TypeScript validation**
+
+Run `pnpm compile`.
+
+Expected: exit code 0.
+
+- [ ] **Step 5: Inspect maintainability and telemetry scope**
+
+Run:
+
+```bash
+git diff --check
+git diff --stat HEAD~4..HEAD
+rg -n "disableNativeSidePanelActionClick|removeActionClickListener" src tests
+```
+
+Expected: no whitespace errors; no stale use of the replaced helper or dynamic
+toolbar listener removal. Confirm the existing analytics helper is reused only
+for manual Firefox/fallback opens, no new event payload or privacy allow-list is
+needed, and settings search/i18n files are unchanged.
+
+- [ ] **Step 6: Run the staged and push-equivalent gates**
+
+Stage only the remaining task-scoped E2E change and run:
+
+```bash
+git add e2e/basicSettingsCommonFlows.spec.ts
+pnpm run validate:staged
+pnpm run validate:push
+```
+
+Expected: all staged checks, compile, and knip gates PASS. Inspect the index
+after hooks in case formatting changed the E2E file.
+
+- [ ] **Step 7: Commit E2E coverage**
+
+```bash
+git commit -m "test(e2e): verify native sidepanel action routing"
+```
+
+- [ ] **Step 8: Perform the manual Edge cold-worker check**
+
+Build/load the extension in Edge, choose **Side panel**, close the panel, let the
+MV3 worker become inactive from `edge://extensions`, and click the toolbar icon
+once. Expected: the side panel opens on the first click. Repeat after an Edge
+restart and after reloading the unpacked extension to verify startup
+reconciliation. Record browser version and which lifecycle cases were observed;
+do not describe unperformed cases as passing.
+
+- [ ] **Step 9: Final diff and status audit**
+
+Run:
+
+```bash
+git status --porcelain
+git log -5 --oneline
+git diff HEAD~5..HEAD --check
+```
+
+Expected: clean worktree, only the design/plan and task-scoped implementation
+commits, no temporary tests, build outputs, or unrelated files.

--- a/docs/superpowers/plans/2026-08-03-toolbar-sidepanel-cold-start.md
+++ b/docs/superpowers/plans/2026-08-03-toolbar-sidepanel-cold-start.md
@@ -292,7 +292,7 @@ const handleToolbarActionClick = async (tab: browser.tabs.Tab) => {
   if (behavior !== TOOLBAR_ACTION_CLICK_BEHAVIORS.SidePanel) return
 
   if (wasUnreconciled) {
-    await openSettingsPage()
+    await handleOpenSidePanelActionClick(tab)
   }
 }
 
@@ -356,9 +356,10 @@ the separate options click handler. Preserve the existing manual side-panel
 analytics behavior unchanged. Reconciled Firefox and Chromium manual fallback
 routes must call the side-panel helper before the listener crosses any `await`.
 An unreconciled listener may read durable state for `options`, but if that read
-resolves to `sidepanel`, it opens Basic settings because the user gesture has
-already been lost. Chromium normally consumes a genuine cold side-panel click
-through its persisted native action configuration.
+resolves to `sidepanel`, it preserves the previous best-effort side-panel open;
+the shared helper falls back to Basic settings if the browser rejects the call.
+Chromium normally consumes a genuine cold side-panel click through its persisted
+native action configuration.
 
 - [ ] **Step 4: Run the focused action tests and verify GREEN**
 

--- a/docs/superpowers/plans/2026-08-03-toolbar-sidepanel-cold-start.md
+++ b/docs/superpowers/plans/2026-08-03-toolbar-sidepanel-cold-start.md
@@ -181,9 +181,11 @@ it("uses the stable dispatcher when Chromium native routing fails", async () => 
 
   const clickHandler = addActionClickListener.mock.calls[0]?.[0]
   const clickedTab = { id: 123, windowId: 456 } as browser.tabs.Tab
-  await clickHandler(clickedTab)
+  const clickResult = clickHandler(clickedTab)
 
   expect(openSidePanelWithFallback).toHaveBeenCalledWith(clickedTab)
+
+  await clickResult
 })
 
 it("routes a cold options click from the durable preference", async () => {
@@ -271,6 +273,15 @@ async function getEffectiveClickBehavior(): Promise<ToolbarActionClickBehavior> 
 }
 
 const handleToolbarActionClick = async (tab: browser.tabs.Tab) => {
+  const support = getSidePanelSupport()
+  if (
+    appliedBehavior === TOOLBAR_ACTION_CLICK_BEHAVIORS.SidePanel &&
+    (shouldManuallyOpenSidePanel ||
+      (support.supported && support.kind === "firefox-sidebar-action"))
+  ) {
+    return handleOpenSidePanelActionClick(tab)
+  }
+
   const wasUnreconciled = appliedBehavior === null
   const behavior = await getEffectiveClickBehavior()
   if (behavior === TOOLBAR_ACTION_CLICK_BEHAVIORS.Options) {
@@ -280,14 +291,8 @@ const handleToolbarActionClick = async (tab: browser.tabs.Tab) => {
 
   if (behavior !== TOOLBAR_ACTION_CLICK_BEHAVIORS.SidePanel) return
 
-  const support = getSidePanelSupport()
-  if (
-    support.supported &&
-    (support.kind === "firefox-sidebar-action" ||
-      shouldManuallyOpenSidePanel ||
-      wasUnreconciled)
-  ) {
-    await handleOpenSidePanelActionClick(tab)
+  if (wasUnreconciled) {
+    await openSettingsPage()
   }
 }
 
@@ -348,10 +353,12 @@ export function applyActionClickBehavior(
 
 Delete `removeActionClickListener`, both conditional listener registrations, and
 the separate options click handler. Preserve the existing manual side-panel
-analytics behavior unchanged. `wasUnreconciled` is a best-effort cold fallback:
-Chromium normally consumes the click when native behavior is enabled, so a cold
-worker receiving `action.onClicked` indicates that extension-managed routing is
-still needed.
+analytics behavior unchanged. Reconciled Firefox and Chromium manual fallback
+routes must call the side-panel helper before the listener crosses any `await`.
+An unreconciled listener may read durable state for `options`, but if that read
+resolves to `sidepanel`, it opens Basic settings because the user gesture has
+already been lost. Chromium normally consumes a genuine cold side-panel click
+through its persisted native action configuration.
 
 - [ ] **Step 4: Run the focused action tests and verify GREEN**
 

--- a/docs/superpowers/specs/2026-08-03-toolbar-sidepanel-cold-start-design.md
+++ b/docs/superpowers/specs/2026-08-03-toolbar-sidepanel-cold-start-design.md
@@ -65,10 +65,11 @@ The applied behavior is cached only as runtime routing state. On a fresh
 background context, the dispatcher may load the durable preference if early
 reconciliation has not completed. That asynchronous read can safely recover an
 `options` click, but it cannot retain the user gesture required by either
-manual side-panel API. If it resolves to `sidepanel`, the dispatcher opens Basic
-settings as a reliable fallback instead of attempting a gesture-gated call.
-Chromium's persisted native projection remains the primary cold-start route.
-The runtime cache must not be treated as persistence.
+manual side-panel API. If it resolves to `sidepanel`, the dispatcher preserves
+the previous best-effort side-panel attempt; the shared navigation helper falls
+back to Basic settings if the browser rejects it. Chromium's persisted native
+projection remains the primary reliable cold-start route. The runtime cache
+must not be treated as persistence.
 
 ### Browser configuration projection
 
@@ -133,7 +134,8 @@ Focused Vitest coverage will prove:
   modes that require extension code.
 - reconciled Firefox and Chromium manual side-panel routes invoke the browser
   API before the listener crosses an asynchronous boundary, while an
-  unreconciled side-panel click falls back to Basic settings.
+  unreconciled side-panel click retains the existing best-effort open with its
+  Basic settings fallback.
 - concurrent configuration calls finish in request order.
 - the runtime preference response waits for configuration and reports an
   asynchronous failure.

--- a/docs/superpowers/specs/2026-08-03-toolbar-sidepanel-cold-start-design.md
+++ b/docs/superpowers/specs/2026-08-03-toolbar-sidepanel-cold-start-design.md
@@ -63,7 +63,12 @@ need extension code:
 
 The applied behavior is cached only as runtime routing state. On a fresh
 background context, the dispatcher may load the durable preference if early
-reconciliation has not completed. It must not treat the cache as persistence.
+reconciliation has not completed. That asynchronous read can safely recover an
+`options` click, but it cannot retain the user gesture required by either
+manual side-panel API. If it resolves to `sidepanel`, the dispatcher opens Basic
+settings as a reliable fallback instead of attempting a gesture-gated call.
+Chromium's persisted native projection remains the primary cold-start route.
+The runtime cache must not be treated as persistence.
 
 ### Browser configuration projection
 
@@ -126,6 +131,9 @@ Focused Vitest coverage will prove:
 - popup/options/unsupported/Firefox paths retain their expected routing.
 - the stable dispatcher exists before asynchronous reconciliation and can route
   modes that require extension code.
+- reconciled Firefox and Chromium manual side-panel routes invoke the browser
+  API before the listener crosses an asynchronous boundary, while an
+  unreconciled side-panel click falls back to Basic settings.
 - concurrent configuration calls finish in request order.
 - the runtime preference response waits for configuration and reports an
   asynchronous failure.

--- a/docs/superpowers/specs/2026-08-03-toolbar-sidepanel-cold-start-design.md
+++ b/docs/superpowers/specs/2026-08-03-toolbar-sidepanel-cold-start-design.md
@@ -1,0 +1,148 @@
+# Toolbar Side Panel Cold-Start Design
+
+## Context
+
+GitHub issue #1245 reports that Edge can require two toolbar-icon clicks before
+the configured side panel opens. The current Manifest V3 background entrypoint
+registers the action-click listener only after unrelated asynchronous service
+initialization and a preference read. If the service worker is asleep, the
+first click can wake the worker before that listener exists, so the event is
+lost. A separate race lets the settings UI finish before the background has
+actually applied the new browser action configuration.
+
+The saved `actionClickBehavior` preference remains the product source of truth.
+Browser action popup state and Chromium side-panel behavior are an execution
+projection that must be reconciled from that preference whenever the background
+context loads and whenever the setting changes.
+
+## Considered Approaches
+
+### 1. Use Chromium's native action-to-side-panel behavior (recommended)
+
+For Chromium side-panel mode, clear the popup and enable
+`sidePanel.setPanelBehavior({ openPanelOnActionClick: true })`. The browser can
+then open the panel without waiting for the extension service worker. Register
+one stable action listener synchronously for modes and browsers that still need
+extension-managed routing.
+
+This directly removes the cold-worker dependency from the reported path. It
+also preserves Firefox through its existing `sidebarAction` path and permits a
+manual fallback when native Chromium configuration cannot be applied. The
+trade-off is that Chromium no longer provides reliable toolbar-click attribution
+to the current manual click telemetry.
+
+### 2. Keep manual opening but register a dispatcher synchronously
+
+A top-level listener could read the saved preference and call `sidePanel.open`
+for every click. It would receive the cold-start event, but an asynchronous
+storage read before `sidePanel.open` can leave the original user-gesture scope.
+That makes the central browser API call unreliable, so this does not fully fix
+the reported failure.
+
+### 3. Move the current asynchronous setup earlier
+
+Loading preferences before the other services would shorten the race window,
+but the listener would still be absent during an asynchronous storage read. This
+reduces frequency without removing the root cause.
+
+## Design
+
+### Stable event registration
+
+The background entrypoint will synchronously register a single toolbar action
+listener before starting any asynchronous initialization. The listener will not
+be added and removed as preferences change. It will dispatch only the modes that
+need extension code:
+
+- `options`: open the options page.
+- Firefox `sidepanel`: use the existing sidebar-opening path.
+- Chromium manual fallback: use the existing side-panel-or-options fallback if
+  native action behavior could not be enabled.
+- `popup` and Chromium native `sidepanel`: do nothing in the listener because
+  the browser owns those clicks.
+
+The applied behavior is cached only as runtime routing state. On a fresh
+background context, the dispatcher may load the durable preference if early
+reconciliation has not completed. It must not treat the cache as persistence.
+
+### Browser configuration projection
+
+The browser API wrapper will expose a symmetric operation for enabling or
+disabling Chromium's native side-panel action behavior and report whether the
+configuration was applied. The action behavior reconciler will project each
+effective mode as follows:
+
+| Effective mode | Popup | Chromium native side panel | Extension dispatcher |
+| --- | --- | --- | --- |
+| `popup` | `popup.html` | disabled | no-op |
+| Chromium `sidepanel` | empty | enabled | no-op, or manual fallback if enabling fails |
+| Firefox `sidepanel` | empty | unavailable/disabled | open Firefox sidebar |
+| `options` | empty | disabled | open options |
+| unsupported `sidepanel` | `popup.html` | disabled | no-op |
+
+The current unsupported-side-panel fallback to the popup remains unchanged.
+
+### Startup and update ordering
+
+Toolbar configuration reconciliation will start before unrelated background
+services. On browser startup, extension update, or extension reload, it restores
+the runtime projection from `chrome.storage`. Chromium's native side-panel
+preference survives service-worker suspension, so ordinary worker cold starts no
+longer depend on this asynchronous reconciliation; early reconciliation covers
+extension/browser lifecycle reloads where dynamic action state may be rebuilt.
+
+Calls that apply action behavior will be serialized. A later setting change
+cannot be overwritten by an older, slower browser API call.
+
+### Settings acknowledgement and failures
+
+The background preferences message handler will await the complete browser
+configuration operation before responding. The React preferences provider will
+also await that response before its update promise settles.
+
+The durable preference write remains successful if the runtime message channel
+is unavailable. The failure is logged, and the next background startup retries
+projection from storage. A rejected browser configuration operation produces a
+failure response instead of an early success response.
+
+### Telemetry
+
+No new telemetry fields or events will be added. Existing exact
+`OpenSidepanelFromToolbarAction` tracking remains for Firefox and Chromium's
+manual fallback. The Chromium native path will not claim exact click attribution
+because the action listener is not a reliable source once the browser owns the
+open. Existing side-panel entrypoint/navigation telemetry remains available for
+overall usage. Reliability takes precedence over preserving an ambiguous event.
+
+No settings search or localization changes are required because the setting and
+its copy do not change.
+
+## Validation
+
+Focused Vitest coverage will prove:
+
+- Chromium side-panel mode clears the popup and enables native action behavior
+  without installing a conditional listener.
+- popup/options/unsupported/Firefox paths retain their expected routing.
+- the stable dispatcher exists before asynchronous reconciliation and can route
+  modes that require extension code.
+- concurrent configuration calls finish in request order.
+- the runtime preference response waits for configuration and reports an
+  asynchronous failure.
+- the preferences provider waits for the runtime response while preserving its
+  current durable-write fallback semantics.
+
+The existing Playwright settings flow will be updated to assert the native
+Chromium panel behavior in addition to popup state. Playwright cannot reliably
+click the browser toolbar in the current extension harness, so the final browser
+check for this regression will be a manual Edge cold-worker scenario: select
+Side panel, allow the worker to stop, and verify one toolbar click opens it. The
+focused tests cover the architectural invariant that prevents the first event
+from depending on late listener registration.
+
+## Scope Boundaries
+
+This change will not remove the manifest popup, redesign settings UI, add a
+service-worker keepalive, change side-panel content, or introduce new analytics
+contracts. Broader toolbar telemetry attribution through browser-specific
+side-panel lifecycle events is a separate concern.

--- a/e2e/basicSettingsCommonFlows.spec.ts
+++ b/e2e/basicSettingsCommonFlows.spec.ts
@@ -1,5 +1,6 @@
 import { OPTIONS_PAGE_PATH, POPUP_PAGE_PATH } from "~/constants/extensionPages"
 import { MENU_ITEM_IDS } from "~/constants/optionsMenuIds"
+import { BASIC_SETTINGS_TEST_IDS } from "~/features/BasicSettings/testIds"
 import { STORAGE_KEYS } from "~/services/core/storageKeys"
 import { expect, test } from "~~/e2e/fixtures/extensionTest"
 import {
@@ -253,7 +254,9 @@ test("updates toolbar action behavior from settings into the live extension acti
     await expectActionClickListenerState(serviceWorker, true)
   }
 
-  await page.getByRole("button", { name: "Popup" }).click()
+  await page
+    .getByTestId(BASIC_SETTINGS_TEST_IDS.actionClickBehaviorPopupButton)
+    .click()
 
   await expectStoredPreference(serviceWorker, "actionClickBehavior", "popup")
   await expectConfiguredActionPopup(serviceWorker, POPUP_PAGE_PATH)

--- a/e2e/basicSettingsCommonFlows.spec.ts
+++ b/e2e/basicSettingsCommonFlows.spec.ts
@@ -80,6 +80,26 @@ async function hasSidePanelOpenSupport(
   })
 }
 
+async function getNativeSidePanelActionClickState(
+  serviceWorker: Awaited<ReturnType<typeof getServiceWorker>>,
+): Promise<boolean | null> {
+  return await serviceWorker.evaluate(async () => {
+    const sidePanel = (globalThis as any).chrome?.sidePanel
+    if (typeof sidePanel?.getPanelBehavior !== "function") return null
+    const behavior = await sidePanel.getPanelBehavior()
+    return behavior.openPanelOnActionClick === true
+  })
+}
+
+async function expectNativeSidePanelActionClickState(
+  serviceWorker: Awaited<ReturnType<typeof getServiceWorker>>,
+  expected: boolean,
+) {
+  await expect
+    .poll(async () => getNativeSidePanelActionClickState(serviceWorker))
+    .toBe(expected)
+}
+
 async function hasActionClickListeners(
   serviceWorker: Awaited<ReturnType<typeof getServiceWorker>>,
 ): Promise<boolean> {
@@ -204,7 +224,7 @@ test("updates toolbar action behavior from settings into the live extension acti
   })
 
   await expectConfiguredActionPopup(serviceWorker, POPUP_PAGE_PATH)
-  await expectActionClickListenerState(serviceWorker, false)
+  await expectActionClickListenerState(serviceWorker, true)
 
   await page.goto(
     `chrome-extension://${extensionId}/${OPTIONS_PAGE_PATH}#${MENU_ITEM_IDS.BASIC}`,
@@ -219,15 +239,26 @@ test("updates toolbar action behavior from settings into the live extension acti
     "sidepanel",
   )
   const sidePanelOpenSupported = await hasSidePanelOpenSupport(serviceWorker)
-  await expectConfiguredActionPopup(
-    serviceWorker,
-    sidePanelOpenSupported ? "" : POPUP_PAGE_PATH,
-  )
-  await expectActionClickListenerState(serviceWorker, sidePanelOpenSupported)
+  const nativeSidePanelActionClickState =
+    await getNativeSidePanelActionClickState(serviceWorker)
+
+  if (sidePanelOpenSupported) {
+    await expectConfiguredActionPopup(serviceWorker, "")
+    await expectActionClickListenerState(serviceWorker, true)
+    if (nativeSidePanelActionClickState !== null) {
+      await expectNativeSidePanelActionClickState(serviceWorker, true)
+    }
+  } else {
+    await expectConfiguredActionPopup(serviceWorker, POPUP_PAGE_PATH)
+    await expectActionClickListenerState(serviceWorker, true)
+  }
 
   await page.getByRole("button", { name: "Popup" }).click()
 
   await expectStoredPreference(serviceWorker, "actionClickBehavior", "popup")
   await expectConfiguredActionPopup(serviceWorker, POPUP_PAGE_PATH)
-  await expectActionClickListenerState(serviceWorker, false)
+  await expectActionClickListenerState(serviceWorker, true)
+  if (nativeSidePanelActionClickState !== null) {
+    await expectNativeSidePanelActionClickState(serviceWorker, false)
+  }
 })

--- a/src/components/ResponsiveButtonGroup.tsx
+++ b/src/components/ResponsiveButtonGroup.tsx
@@ -49,6 +49,7 @@ export interface ResponsiveToggleGroupOption<Value extends string> {
   ariaLabel?: string
   title?: string
   disabled?: boolean
+  testId?: string
   buttonClassName?: string
   leftIcon?: ReactNode
   rightIcon?: ReactNode
@@ -87,6 +88,7 @@ export function ResponsiveToggleGroup<Value extends string>({
           showActiveIndicator={showActiveIndicator}
           title={option.title}
           aria-label={option.ariaLabel}
+          data-testid={option.testId}
           leftIcon={option.leftIcon}
           rightIcon={option.rightIcon}
           className={cn(

--- a/src/contexts/UserPreferencesContext.tsx
+++ b/src/contexts/UserPreferencesContext.tsx
@@ -657,14 +657,22 @@ export const UserPreferencesProvider = ({
           actionClickBehavior: behavior,
         })
       ) {
-        void sendPreferencesMessage(
-          PreferencesMessageTypes.UpdateActionClickBehavior,
-          {
-            behavior,
-          },
-        ).catch((error) => {
+        try {
+          const response = await sendPreferencesMessage(
+            PreferencesMessageTypes.UpdateActionClickBehavior,
+            {
+              behavior,
+            },
+          )
+          if (!response.success) {
+            logger.warn(
+              "Failed to apply action click behavior update",
+              new Error(response.error),
+            )
+          }
+        } catch (error) {
           logger.warn("Failed to notify action click behavior update", error)
-        })
+        }
       }
       return result
     },

--- a/src/entrypoints/background/actionClickBehavior.ts
+++ b/src/entrypoints/background/actionClickBehavior.ts
@@ -22,11 +22,7 @@ import {
 } from "~/utils/browser/browserApi"
 import { getErrorMessage } from "~/utils/core/error"
 import { createLogger } from "~/utils/core/logger"
-import {
-  openOptionsPage,
-  openSettingsPage,
-  openSidePanelWithFallback,
-} from "~/utils/navigation"
+import { openOptionsPage, openSidePanelWithFallback } from "~/utils/navigation"
 
 /**
  * Unified logger scoped to toolbar action click behavior wiring.
@@ -128,10 +124,10 @@ const handleToolbarActionClick = async (tab: browser.tabs.Tab) => {
   }
 
   if (wasUnreconciled) {
-    // Storage resolution has already crossed the user-gesture boundary. The
-    // browser-native Chromium route owns real cold starts; manual routing can
-    // only fall back to a destination that does not require that gesture.
-    await openSettingsPage()
+    // The durable read may have crossed the user-gesture boundary, but retain
+    // the previous best-effort behavior: try the side panel, then let the
+    // shared helper fall back to Basic settings if the browser rejects it.
+    await handleOpenSidePanelActionClick(tab)
   }
 }
 

--- a/src/entrypoints/background/actionClickBehavior.ts
+++ b/src/entrypoints/background/actionClickBehavior.ts
@@ -22,7 +22,11 @@ import {
 } from "~/utils/browser/browserApi"
 import { getErrorMessage } from "~/utils/core/error"
 import { createLogger } from "~/utils/core/logger"
-import { openOptionsPage, openSidePanelWithFallback } from "~/utils/navigation"
+import {
+  openOptionsPage,
+  openSettingsPage,
+  openSidePanelWithFallback,
+} from "~/utils/navigation"
 
 /**
  * Unified logger scoped to toolbar action click behavior wiring.
@@ -99,8 +103,8 @@ const handleToolbarActionClick = async (tab: browser.tabs.Tab) => {
   const support = getSidePanelSupport()
   if (
     appliedBehavior === TOOLBAR_ACTION_CLICK_BEHAVIORS.SidePanel &&
-    support.supported &&
-    support.kind === "firefox-sidebar-action"
+    (shouldManuallyOpenSidePanel ||
+      (support.supported && support.kind === "firefox-sidebar-action"))
   ) {
     return handleOpenSidePanelActionClick(tab)
   }
@@ -123,12 +127,11 @@ const handleToolbarActionClick = async (tab: browser.tabs.Tab) => {
     return
   }
 
-  if (
-    shouldManuallyOpenSidePanel ||
-    (support.supported &&
-      (support.kind === "firefox-sidebar-action" || wasUnreconciled))
-  ) {
-    await handleOpenSidePanelActionClick(tab)
+  if (wasUnreconciled) {
+    // Storage resolution has already crossed the user-gesture boundary. The
+    // browser-native Chromium route owns real cold starts; manual routing can
+    // only fall back to a destination that does not require that gesture.
+    await openSettingsPage()
   }
 }
 

--- a/src/entrypoints/background/actionClickBehavior.ts
+++ b/src/entrypoints/background/actionClickBehavior.ts
@@ -1,6 +1,7 @@
 import { POPUP_PAGE_PATH } from "~/constants/extensionPages"
 import {
   TOOLBAR_ACTION_CLICK_BEHAVIORS,
+  userPreferences,
   type ToolbarActionClickBehavior,
 } from "~/services/preferences/userPreferences"
 import { startProductAnalyticsAction } from "~/services/productAnalytics/actions"
@@ -14,10 +15,10 @@ import {
 } from "~/services/productAnalytics/contracts"
 import {
   addActionClickListener,
-  disableNativeSidePanelActionClick,
   getSidePanelSupport,
-  removeActionClickListener,
+  NATIVE_SIDE_PANEL_ACTION_CLICK_RESULTS,
   setActionPopup,
+  setNativeSidePanelActionClick,
 } from "~/utils/browser/browserApi"
 import { getErrorMessage } from "~/utils/core/error"
 import { createLogger } from "~/utils/core/logger"
@@ -27,6 +28,10 @@ import { openOptionsPage, openSidePanelWithFallback } from "~/utils/navigation"
  * Unified logger scoped to toolbar action click behavior wiring.
  */
 const logger = createLogger("ActionClickBehavior")
+
+let appliedBehavior: ToolbarActionClickBehavior | null = null
+let shouldManuallyOpenSidePanel = false
+let actionBehaviorQueue: Promise<void> = Promise.resolve()
 
 /**
  * Singleton click handler used when the action is configured to open the side panel.
@@ -53,10 +58,6 @@ const handleOpenSidePanelActionClick = async (tab: browser.tabs.Tab) => {
   }
 }
 
-const handleOpenOptionsActionClick = async () => {
-  await openOptionsPage()
-}
-
 const resolveToolbarActionClickBehavior = (
   behavior: ToolbarActionClickBehavior,
   sidePanelSupported: boolean,
@@ -76,41 +77,158 @@ const resolveToolbarActionClickBehavior = (
 }
 
 /**
- * Apply toolbar click behavior at runtime.
- * - "popup": restores the popup.html UI and removes side-panel click listeners.
- * - "sidepanel": disables the popup so onClicked fires and opens the shared
- *   side-panel-or-settings fallback path.
- * - "options": disables the popup so onClicked opens the standard options page.
+ * Resolves the current behavior from memory or durable preferences.
  */
-export async function applyActionClickBehavior(
+async function getEffectiveClickBehavior(): Promise<ToolbarActionClickBehavior> {
+  if (appliedBehavior) {
+    return appliedBehavior
+  }
+
+  const preferences = await userPreferences.getPreferencesStrict()
+  return resolveToolbarActionClickBehavior(
+    preferences.actionClickBehavior ?? TOOLBAR_ACTION_CLICK_BEHAVIORS.Popup,
+    getSidePanelSupport().supported,
+  )
+}
+
+/**
+ * Routes toolbar clicks through the last reconciled behavior, or the durable
+ * preference when an MV3 worker receives a click before reconciliation.
+ */
+const handleToolbarActionClick = async (tab: browser.tabs.Tab) => {
+  const support = getSidePanelSupport()
+  if (
+    appliedBehavior === TOOLBAR_ACTION_CLICK_BEHAVIORS.SidePanel &&
+    support.supported &&
+    support.kind === "firefox-sidebar-action"
+  ) {
+    return handleOpenSidePanelActionClick(tab)
+  }
+
+  const wasUnreconciled = appliedBehavior === null
+  let behavior: ToolbarActionClickBehavior
+  try {
+    behavior = await getEffectiveClickBehavior()
+  } catch (error) {
+    logger.warn("Failed to resolve toolbar action click behavior", error)
+    return
+  }
+
+  if (behavior === TOOLBAR_ACTION_CLICK_BEHAVIORS.Options) {
+    await openOptionsPage()
+    return
+  }
+
+  if (behavior !== TOOLBAR_ACTION_CLICK_BEHAVIORS.SidePanel) {
+    return
+  }
+
+  if (
+    shouldManuallyOpenSidePanel ||
+    (support.supported &&
+      (support.kind === "firefox-sidebar-action" || wasUnreconciled))
+  ) {
+    await handleOpenSidePanelActionClick(tab)
+  }
+}
+
+/**
+ * Registers the stable dispatcher used for every toolbar behavior.
+ */
+export function setupActionClickBehaviorListener(): () => void {
+  return addActionClickListener(handleToolbarActionClick)
+}
+
+/**
+ * Projects one requested behavior into the browser action APIs.
+ */
+async function reconcileActionClickBehavior(
   behavior: ToolbarActionClickBehavior,
 ): Promise<void> {
-  const sidePanelSupport = getSidePanelSupport()
+  const support = getSidePanelSupport()
   const effectiveBehavior = resolveToolbarActionClickBehavior(
     behavior,
-    sidePanelSupport.supported,
+    support.supported,
   )
   const isSidePanel =
     effectiveBehavior === TOOLBAR_ACTION_CLICK_BEHAVIORS.SidePanel
-  const isOptions = effectiveBehavior === TOOLBAR_ACTION_CLICK_BEHAVIORS.Options
+  const isChromiumSidePanel =
+    isSidePanel && support.supported && support.kind === "chromium-side-panel"
+  const requiresNativeSidePanelDisable =
+    appliedBehavior === null &&
+    !isChromiumSidePanel &&
+    support.kind === "chromium-side-panel"
+  const wasUsingNativeSidePanel =
+    appliedBehavior === TOOLBAR_ACTION_CLICK_BEHAVIORS.SidePanel &&
+    !shouldManuallyOpenSidePanel
+  const previousAppliedBehavior = appliedBehavior
+  const previousShouldManuallyOpenSidePanel = shouldManuallyOpenSidePanel
 
-  // 清理旧的点击监听
-  removeActionClickListener(handleOpenSidePanelActionClick)
-  removeActionClickListener(handleOpenOptionsActionClick)
+  if (!isChromiumSidePanel) {
+    const nativeSidePanelDisabled = await setNativeSidePanelActionClick(false)
+    if (
+      (wasUsingNativeSidePanel &&
+        nativeSidePanelDisabled !==
+          NATIVE_SIDE_PANEL_ACTION_CLICK_RESULTS.Applied) ||
+      (requiresNativeSidePanelDisable &&
+        nativeSidePanelDisabled ===
+          NATIVE_SIDE_PANEL_ACTION_CLICK_RESULTS.Rejected)
+    ) {
+      throw new Error("Failed to disable native side-panel action click")
+    }
 
-  await disableNativeSidePanelActionClick()
+    if (wasUsingNativeSidePanel) {
+      // Keep the old side-panel route manual between native disable and popup
+      // commit so clicks remain viable during, or after failure of, this swap.
+      shouldManuallyOpenSidePanel = true
+    }
+  }
+
+  if (isChromiumSidePanel) {
+    // Once the popup clears, clicks reach the stable listener. Publish a manual
+    // side-panel route before native enable, then finalize it from that result.
+    appliedBehavior = effectiveBehavior
+    shouldManuallyOpenSidePanel = true
+  }
 
   try {
-    await setActionPopup(isSidePanel || isOptions ? "" : POPUP_PAGE_PATH)
+    await setActionPopup(
+      isSidePanel ||
+        effectiveBehavior === TOOLBAR_ACTION_CLICK_BEHAVIORS.Options
+        ? ""
+        : POPUP_PAGE_PATH,
+    )
   } catch (error) {
+    if (isChromiumSidePanel) {
+      appliedBehavior = previousAppliedBehavior
+      shouldManuallyOpenSidePanel = previousShouldManuallyOpenSidePanel
+    }
     logger.warn(`action.setPopup not available:\n${getErrorMessage(error)}`)
+    throw error
   }
 
-  if (isSidePanel) {
-    addActionClickListener(handleOpenSidePanelActionClick)
+  let manuallyOpenSidePanel = isSidePanel
+  if (isChromiumSidePanel) {
+    manuallyOpenSidePanel =
+      (await setNativeSidePanelActionClick(true)) !==
+      NATIVE_SIDE_PANEL_ACTION_CLICK_RESULTS.Applied
   }
 
-  if (isOptions) {
-    addActionClickListener(handleOpenOptionsActionClick)
-  }
+  appliedBehavior = effectiveBehavior
+  shouldManuallyOpenSidePanel = manuallyOpenSidePanel
+}
+
+/**
+ * Apply toolbar click behavior at runtime.
+ * Browser action projections are serialized so rapid preference changes cannot
+ * leave popup and native side-panel behavior out of sync.
+ */
+export function applyActionClickBehavior(
+  behavior: ToolbarActionClickBehavior,
+): Promise<void> {
+  const operation = actionBehaviorQueue.then(() =>
+    reconcileActionClickBehavior(behavior),
+  )
+  actionBehaviorQueue = operation.catch(() => undefined)
+  return operation
 }

--- a/src/entrypoints/background/index.ts
+++ b/src/entrypoints/background/index.ts
@@ -14,7 +14,10 @@ import {
   hasPermissions,
   OPTIONAL_PERMISSIONS,
 } from "~/services/permissions/permissionManager"
-import { userPreferences } from "~/services/preferences/userPreferences"
+import {
+  TOOLBAR_ACTION_CLICK_BEHAVIORS,
+  userPreferences,
+} from "~/services/preferences/userPreferences"
 import {
   setupProductAnalyticsAccountChangeListener,
   setupProductAnalyticsPreferencesChangeListener,
@@ -222,7 +225,9 @@ async function main() {
   const toolbarReconciliation = (async () => {
     try {
       const prefs = await userPreferences.getPreferencesStrict()
-      await applyActionClickBehavior(prefs.actionClickBehavior ?? "popup")
+      await applyActionClickBehavior(
+        prefs.actionClickBehavior ?? TOOLBAR_ACTION_CLICK_BEHAVIORS.Popup,
+      )
     } catch (error) {
       logger.warn("Failed to reconcile toolbar action click behavior", error)
     }

--- a/src/entrypoints/background/index.ts
+++ b/src/entrypoints/background/index.ts
@@ -37,7 +37,10 @@ import { isTestMode } from "~/utils/core/environment"
 import { createLogger } from "~/utils/core/logger"
 import { openOrFocusOptionsMenuItem } from "~/utils/navigation"
 
-import { applyActionClickBehavior } from "./actionClickBehavior"
+import {
+  applyActionClickBehavior,
+  setupActionClickBehaviorListener,
+} from "./actionClickBehavior"
 import { setupContextMenus } from "./contextMenus"
 import {
   initializeCookieInterceptors,
@@ -62,6 +65,8 @@ function shouldAutoOpenPermissionsOnboarding(): boolean {
 
 export default defineBackground(() => {
   logger.debug("Hello background", { id: getRuntimeId() })
+
+  setupActionClickBehaviorListener()
 
   // Apply dev-only branding early so the toolbar action is visually distinguishable.
   void applyDevActionBranding()
@@ -202,19 +207,28 @@ export default defineBackground(() => {
     })
   })
 
-  main()
+  void main().catch((error) => {
+    logger.error("Failed to initialize background startup", error)
+  })
 })
 
 /**
  * Entrypoint invoked at background startup.
- * Ensures services are initialized before installing cookie interceptors so that downstream requests have localization and config ready.
+ * Starts services before the first await so alarm listeners are registered during
+ * MV3 startup, then awaits them before installing cookie interceptors.
  */
 async function main() {
-  await initializeServices()
+  const servicesInitialization = initializeServices()
+  const toolbarReconciliation = (async () => {
+    try {
+      const prefs = await userPreferences.getPreferencesStrict()
+      await applyActionClickBehavior(prefs.actionClickBehavior ?? "popup")
+    } catch (error) {
+      logger.warn("Failed to reconcile toolbar action click behavior", error)
+    }
+  })()
 
-  const prefs = await userPreferences.getPreferences()
-  await applyActionClickBehavior(prefs.actionClickBehavior ?? "popup")
-
+  await Promise.all([servicesInitialization, toolbarReconciliation])
   await initializeCookieInterceptors()
   triggerStartupSiteEcosystemSnapshot()
   triggerStartupSettingsSnapshot()

--- a/src/features/BasicSettings/components/tabs/General/ActionClickBehaviorSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/General/ActionClickBehaviorSettings.tsx
@@ -5,6 +5,7 @@ import { ResponsiveToggleGroup } from "~/components/ResponsiveButtonGroup"
 import { SettingSection } from "~/components/SettingSection"
 import { Card, CardItem, CardList } from "~/components/ui"
 import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
+import { BASIC_SETTINGS_TEST_IDS } from "~/features/BasicSettings/testIds"
 import {
   TOOLBAR_ACTION_CLICK_BEHAVIORS,
   type ToolbarActionClickBehavior,
@@ -71,6 +72,8 @@ export default function ActionClickBehaviorSettings() {
                     value: TOOLBAR_ACTION_CLICK_BEHAVIORS.Popup,
                     label: t("actionClick.popupLabel"),
                     ariaLabel: t("actionClick.popupTitle"),
+                    testId:
+                      BASIC_SETTINGS_TEST_IDS.actionClickBehaviorPopupButton,
                   },
                   {
                     value: TOOLBAR_ACTION_CLICK_BEHAVIORS.SidePanel,

--- a/src/features/BasicSettings/testIds.ts
+++ b/src/features/BasicSettings/testIds.ts
@@ -1,5 +1,6 @@
 export const BASIC_SETTINGS_TEST_IDS = {
   page: "basic-settings-page",
+  actionClickBehaviorPopupButton: "action-click-behavior-popup-button",
   taskNotificationsBrowserTestButton: "task-notifications-browser-test-button",
   taskNotificationsPermissionGrantButton:
     "task-notifications-permission-grant-button",

--- a/src/services/preferences/runtimePreferencesService.ts
+++ b/src/services/preferences/runtimePreferencesService.ts
@@ -37,7 +37,7 @@ async function resolvePreferencesUpdateActionClickBehaviorMessage(
   request: PreferencesUpdateActionClickBehaviorRequest,
 ): Promise<RuntimeMessageResponse<undefined>> {
   try {
-    applyActionClickBehavior(request.behavior)
+    await applyActionClickBehavior(request.behavior)
     return { success: true, data: undefined }
   } catch (error) {
     return createRuntimeMessageFailure(getErrorMessage(error))

--- a/src/utils/browser/browserApi.ts
+++ b/src/utils/browser/browserApi.ts
@@ -955,26 +955,38 @@ export const openSidePanel = async (targetTab?: browser.tabs.Tab | null) => {
   }
 }
 
+export const NATIVE_SIDE_PANEL_ACTION_CLICK_RESULTS = {
+  Applied: "applied",
+  Unavailable: "unavailable",
+  Rejected: "rejected",
+} as const
+
+export type NativeSidePanelActionClickResult =
+  (typeof NATIVE_SIDE_PANEL_ACTION_CLICK_RESULTS)[keyof typeof NATIVE_SIDE_PANEL_ACTION_CLICK_RESULTS]
+
 /**
- * Keeps Chromium toolbar action clicks on the extension-managed listener path
- * so fallback behavior can run when side panel opening is unavailable.
+ * Projects toolbar clicks into Chromium's browser-owned side-panel behavior.
+ * Distinguishes a missing control from a rejected attempt so callers can retain
+ * compatible manual routing without acknowledging failed projections.
  */
-export async function disableNativeSidePanelActionClick(): Promise<void> {
+export async function setNativeSidePanelActionClick(
+  enabled: boolean,
+): Promise<NativeSidePanelActionClickResult> {
   const setPanelBehavior = (globalThis as any).chrome?.sidePanel
     ?.setPanelBehavior
 
   if (typeof setPanelBehavior !== "function") {
-    return
+    return NATIVE_SIDE_PANEL_ACTION_CLICK_RESULTS.Unavailable
   }
 
   try {
-    await setPanelBehavior({
-      openPanelOnActionClick: false,
-    })
+    await setPanelBehavior({ openPanelOnActionClick: enabled })
+    return NATIVE_SIDE_PANEL_ACTION_CLICK_RESULTS.Applied
   } catch (error) {
     logger.warn(
       `sidePanel.setPanelBehavior not available:\n${getErrorMessage(error)}`,
     )
+    return NATIVE_SIDE_PANEL_ACTION_CLICK_RESULTS.Rejected
   }
 }
 
@@ -1474,18 +1486,6 @@ export function addActionClickListener(
     if (action.onClicked.hasListener(listener)) {
       action.onClicked.removeListener(listener)
     }
-  }
-}
-
-/**
- * 移除工具栏按钮点击监听（兼容 MV2/MV3）。
- */
-export function removeActionClickListener(
-  listener: (tab: browser.tabs.Tab, info?: any) => void,
-): void {
-  const action = getActionApi()
-  if (action.onClicked.hasListener(listener)) {
-    action.onClicked.removeListener(listener)
   }
 }
 

--- a/tests/components/ResponsiveButtonGroup.test.tsx
+++ b/tests/components/ResponsiveButtonGroup.test.tsx
@@ -59,6 +59,7 @@ describe("ResponsiveToggleGroup", () => {
             value: "CNY",
             label: "CNY",
             ariaLabel: "Chinese Yuan",
+            testId: "currency-cny-option",
           },
         ]}
       />,
@@ -75,6 +76,7 @@ describe("ResponsiveToggleGroup", () => {
     )
     expect(usdButton).not.toHaveClass("scale-105")
     expect(usdButton).toHaveAttribute("aria-pressed", "true")
+    expect(cnyButton).toHaveAttribute("data-testid", "currency-cny-option")
 
     fireEvent.click(cnyButton)
 

--- a/tests/contexts/UserPreferencesContext.test.tsx
+++ b/tests/contexts/UserPreferencesContext.test.tsx
@@ -438,7 +438,10 @@ describe("UserPreferencesContext", () => {
     mockedSendAutoRefreshMessage.mockResolvedValue(undefined)
     mockedSendBalanceHistoryMessage.mockResolvedValue(undefined)
     mockedSendModelSyncMessage.mockResolvedValue(undefined)
-    mockedSendPreferencesMessage.mockResolvedValue(undefined)
+    mockedSendPreferencesMessage.mockResolvedValue({
+      success: true,
+      data: undefined,
+    })
     mockedSendRedemptionAssistMessage.mockResolvedValue(undefined)
     mockedSendSiteAnnouncementsMessage.mockResolvedValue(undefined)
     mockedSendWebdavAutoSyncMessage.mockResolvedValue(undefined)
@@ -942,6 +945,29 @@ describe("UserPreferencesContext", () => {
     )
   })
 
+  it("waits for background action behavior application before settling", async () => {
+    let finishNotification!: (value: { success: true; data: undefined }) => void
+    mockedSendPreferencesMessage.mockReturnValueOnce(
+      new Promise((resolve) => (finishNotification = resolve)),
+    )
+    const context = await renderProvider()
+
+    let settled = false
+    const update = context
+      .updateActionClickBehavior("sidepanel")
+      .then((value) => {
+        settled = true
+        return value
+      })
+    await act(async () => Promise.resolve())
+    expect(settled).toBe(false)
+
+    finishNotification({ success: true, data: undefined })
+    await act(async () => {
+      await expect(update).resolves.toMatchObject({ ok: true })
+    })
+  })
+
   it("keeps action behavior writes successful when the runtime notification fails", async () => {
     const notifyError = new Error("runtime closed")
     mockedSendPreferencesMessage.mockRejectedValueOnce(notifyError)
@@ -964,6 +990,38 @@ describe("UserPreferencesContext", () => {
         notifyError,
       )
     })
+  })
+
+  it("keeps action behavior writes successful when background application fails", async () => {
+    mockedSendPreferencesMessage.mockResolvedValueOnce({
+      success: false,
+      error: "action failed",
+    })
+    const context = await renderProvider()
+
+    let result!: PreferenceWriteResult
+    await act(async () => {
+      result = await context.updateActionClickBehavior("sidepanel")
+    })
+
+    expect(result).toMatchObject({ ok: true })
+    expect((latestContext as any)?.actionClickBehavior).toBe("sidepanel")
+    expect(mockedSendPreferencesMessage).toHaveBeenCalledWith(
+      "preferences:updateActionClickBehavior",
+      { behavior: "sidepanel" },
+    )
+    expect(loggerMocks.warn).toHaveBeenCalledWith(
+      "Failed to apply action click behavior update",
+      expect.any(Error),
+    )
+    const applicationWarning = loggerMocks.warn.mock.calls.find(
+      ([message]) => message === "Failed to apply action click behavior update",
+    )
+    expect((applicationWarning?.[1] as Error).message).toBe("action failed")
+    expect(loggerMocks.warn).not.toHaveBeenCalledWith(
+      "Failed to notify action click behavior update",
+      expect.anything(),
+    )
   })
 
   it("persists active tab changes through both tab update helpers", async () => {

--- a/tests/entrypoints/background/actionClickBehavior.test.ts
+++ b/tests/entrypoints/background/actionClickBehavior.test.ts
@@ -9,13 +9,16 @@ import {
   PRODUCT_ANALYTICS_RESULTS,
   PRODUCT_ANALYTICS_SURFACE_IDS,
 } from "~/services/productAnalytics/contracts"
+import { NATIVE_SIDE_PANEL_ACTION_CLICK_RESULTS } from "~/utils/browser/browserApi"
 
 describe("background applyActionClickBehavior", () => {
   let addActionClickListener: ReturnType<typeof vi.fn>
-  let removeActionClickListener: ReturnType<typeof vi.fn>
   let setActionPopup: ReturnType<typeof vi.fn>
-  let disableNativeSidePanelActionClick: ReturnType<typeof vi.fn>
+  let setNativeSidePanelActionClick: ReturnType<typeof vi.fn>
   let getSidePanelSupport: ReturnType<typeof vi.fn>
+  let getPreferences: ReturnType<typeof vi.fn>
+  let getPreferencesStrict: ReturnType<typeof vi.fn>
+  let loggerWarn: ReturnType<typeof vi.fn>
   let openSidePanelWithFallback: ReturnType<typeof vi.fn>
   let openOptionsPage: ReturnType<typeof vi.fn>
   let startProductAnalyticsAction: ReturnType<typeof vi.fn>
@@ -23,10 +26,16 @@ describe("background applyActionClickBehavior", () => {
 
   beforeEach(() => {
     addActionClickListener = vi.fn()
-    removeActionClickListener = vi.fn()
     setActionPopup = vi.fn().mockResolvedValue(undefined)
-    disableNativeSidePanelActionClick = vi.fn().mockResolvedValue(undefined)
+    setNativeSidePanelActionClick = vi
+      .fn()
+      .mockResolvedValue(NATIVE_SIDE_PANEL_ACTION_CLICK_RESULTS.Unavailable)
     getSidePanelSupport = vi.fn()
+    getPreferences = vi.fn().mockResolvedValue({
+      actionClickBehavior: "popup",
+    })
+    getPreferencesStrict = vi.fn()
+    loggerWarn = vi.fn()
     openSidePanelWithFallback = vi.fn().mockResolvedValue(undefined)
     openOptionsPage = vi.fn().mockResolvedValue(undefined)
     trackerComplete = vi.fn().mockResolvedValue(undefined)
@@ -38,10 +47,33 @@ describe("background applyActionClickBehavior", () => {
 
     vi.doMock("~/utils/browser/browserApi", () => ({
       addActionClickListener,
-      disableNativeSidePanelActionClick,
       getSidePanelSupport,
-      removeActionClickListener,
+      NATIVE_SIDE_PANEL_ACTION_CLICK_RESULTS,
       setActionPopup,
+      setNativeSidePanelActionClick,
+    }))
+
+    vi.doMock("~/services/preferences/userPreferences", async () => {
+      const actual = await vi.importActual<
+        typeof import("~/services/preferences/userPreferences")
+      >("~/services/preferences/userPreferences")
+
+      return {
+        ...actual,
+        userPreferences: {
+          getPreferences,
+          getPreferencesStrict,
+        },
+      }
+    })
+
+    vi.doMock("~/utils/core/logger", () => ({
+      createLogger: vi.fn(() => ({
+        debug: vi.fn(),
+        error: vi.fn(),
+        info: vi.fn(),
+        warn: loggerWarn,
+      })),
     }))
 
     vi.doMock("~/utils/navigation", () => ({
@@ -56,10 +88,26 @@ describe("background applyActionClickBehavior", () => {
 
   afterEach(() => {
     vi.doUnmock("~/utils/browser/browserApi")
+    vi.doUnmock("~/services/preferences/userPreferences")
+    vi.doUnmock("~/utils/core/logger")
     vi.doUnmock("~/utils/navigation")
     vi.doUnmock("~/services/productAnalytics/actions")
     vi.resetModules()
     vi.restoreAllMocks()
+  })
+
+  it("registers one stable toolbar listener", async () => {
+    const { setupActionClickBehaviorListener } = await import(
+      "~/entrypoints/background/actionClickBehavior"
+    )
+
+    setupActionClickBehaviorListener()
+    setupActionClickBehaviorListener()
+
+    expect(addActionClickListener).toHaveBeenCalledTimes(2)
+    expect(addActionClickListener.mock.calls[0]?.[0]).toBe(
+      addActionClickListener.mock.calls[1]?.[0],
+    )
   })
 
   it("falls back to popup wiring when sidepanel is requested but unsupported", async () => {
@@ -75,49 +123,121 @@ describe("background applyActionClickBehavior", () => {
 
     await applyActionClickBehavior("sidepanel")
 
-    expect(removeActionClickListener).toHaveBeenCalledTimes(2)
-    expect(disableNativeSidePanelActionClick).toHaveBeenCalledTimes(1)
+    expect(setNativeSidePanelActionClick).toHaveBeenCalledWith(false)
     expect(setActionPopup).toHaveBeenCalledWith(POPUP_PAGE_PATH)
-    expect(addActionClickListener).not.toHaveBeenCalled()
   })
 
-  it("installs sidepanel wiring when side panel is supported", async () => {
+  it("uses Chromium native routing for sidepanel mode", async () => {
     getSidePanelSupport.mockReturnValue({
       supported: true,
       kind: "chromium-side-panel",
     })
-
+    setNativeSidePanelActionClick.mockResolvedValue(
+      NATIVE_SIDE_PANEL_ACTION_CLICK_RESULTS.Applied,
+    )
     const { applyActionClickBehavior } = await import(
       "~/entrypoints/background/actionClickBehavior"
     )
 
     await applyActionClickBehavior("sidepanel")
 
-    expect(removeActionClickListener).toHaveBeenCalledTimes(2)
-    expect(disableNativeSidePanelActionClick).toHaveBeenCalledTimes(1)
     expect(setActionPopup).toHaveBeenCalledWith("")
-    expect(addActionClickListener).toHaveBeenCalledTimes(1)
+    expect(setNativeSidePanelActionClick).toHaveBeenCalledWith(true)
+    expect(openSidePanelWithFallback).not.toHaveBeenCalled()
   })
 
-  it("installs sidepanel wiring when Firefox sidebarAction is supported", async () => {
+  it("uses the stable dispatcher when Chromium native routing fails", async () => {
+    getSidePanelSupport.mockReturnValue({
+      supported: true,
+      kind: "chromium-side-panel",
+    })
+    setNativeSidePanelActionClick.mockResolvedValue(
+      NATIVE_SIDE_PANEL_ACTION_CLICK_RESULTS.Rejected,
+    )
+    const { applyActionClickBehavior, setupActionClickBehaviorListener } =
+      await import("~/entrypoints/background/actionClickBehavior")
+    setupActionClickBehaviorListener()
+    await applyActionClickBehavior("sidepanel")
+
+    const clickHandler = addActionClickListener.mock.calls[0]?.[0]
+    const clickedTab = { id: 123, windowId: 456 } as browser.tabs.Tab
+    await clickHandler(clickedTab)
+
+    expect(openSidePanelWithFallback).toHaveBeenCalledWith(clickedTab)
+  })
+
+  it("allows a known manual sidepanel fallback to transition to options", async () => {
+    getSidePanelSupport.mockReturnValue({
+      supported: true,
+      kind: "chromium-side-panel",
+    })
+    setNativeSidePanelActionClick.mockResolvedValue(
+      NATIVE_SIDE_PANEL_ACTION_CLICK_RESULTS.Rejected,
+    )
+    const { applyActionClickBehavior } = await import(
+      "~/entrypoints/background/actionClickBehavior"
+    )
+
+    await applyActionClickBehavior("sidepanel")
+    await expect(applyActionClickBehavior("options")).resolves.toBeUndefined()
+
+    expect(
+      setNativeSidePanelActionClick.mock.calls.map(([enabled]) => enabled),
+    ).toEqual([true, false])
+    expect(setActionPopup.mock.calls.map(([popup]) => popup)).toEqual(["", ""])
+  })
+
+  it("keeps manual side-panel fallback available after support degrades", async () => {
+    let support: ReturnType<typeof getSidePanelSupport> = {
+      supported: true,
+      kind: "chromium-side-panel",
+    }
+    getSidePanelSupport.mockImplementation(() => support)
+    setNativeSidePanelActionClick.mockResolvedValue(
+      NATIVE_SIDE_PANEL_ACTION_CLICK_RESULTS.Rejected,
+    )
+    openSidePanelWithFallback.mockImplementationOnce(async () => {
+      support = {
+        supported: false,
+        kind: "unsupported",
+        reason: "open-failed",
+      }
+    })
+    const { applyActionClickBehavior, setupActionClickBehaviorListener } =
+      await import("~/entrypoints/background/actionClickBehavior")
+    setupActionClickBehaviorListener()
+    await applyActionClickBehavior("sidepanel")
+
+    const clickHandler = addActionClickListener.mock.calls[0]?.[0]
+    const clickedTab = { id: 123, windowId: 456 } as browser.tabs.Tab
+    await clickHandler(clickedTab)
+    await clickHandler(clickedTab)
+
+    expect(openSidePanelWithFallback).toHaveBeenCalledTimes(2)
+  })
+
+  it("uses manual routing when Firefox sidebarAction is supported", async () => {
     getSidePanelSupport.mockReturnValue({
       supported: true,
       kind: "firefox-sidebar-action",
     })
-
-    const { applyActionClickBehavior } = await import(
-      "~/entrypoints/background/actionClickBehavior"
-    )
+    const { applyActionClickBehavior, setupActionClickBehaviorListener } =
+      await import("~/entrypoints/background/actionClickBehavior")
+    setupActionClickBehaviorListener()
 
     await applyActionClickBehavior("sidepanel")
+    const clickHandler = addActionClickListener.mock.calls[0]?.[0]
+    const clickedTab = { id: 123, windowId: 456 } as browser.tabs.Tab
+    const clickResult = clickHandler(clickedTab)
 
-    expect(removeActionClickListener).toHaveBeenCalledTimes(2)
-    expect(disableNativeSidePanelActionClick).toHaveBeenCalledTimes(1)
+    expect(setNativeSidePanelActionClick).toHaveBeenCalledWith(false)
     expect(setActionPopup).toHaveBeenCalledWith("")
-    expect(addActionClickListener).toHaveBeenCalledTimes(1)
+    expect(openSidePanelWithFallback).toHaveBeenCalledWith(clickedTab)
+
+    await clickResult
   })
 
-  it("installs options-page wiring when options behavior is selected", async () => {
+  it("disables Chromium native routing when options behavior is selected", async () => {
     getSidePanelSupport.mockReturnValue({
       supported: false,
       kind: "unsupported",
@@ -130,50 +250,326 @@ describe("background applyActionClickBehavior", () => {
 
     await applyActionClickBehavior("options")
 
-    expect(removeActionClickListener).toHaveBeenCalledTimes(2)
-    expect(disableNativeSidePanelActionClick).toHaveBeenCalledTimes(1)
+    expect(setNativeSidePanelActionClick).toHaveBeenCalledWith(false)
     expect(setActionPopup).toHaveBeenCalledWith("")
-    expect(addActionClickListener).toHaveBeenCalledTimes(1)
   })
 
-  it("routes options-page toolbar clicks through the standard options opener", async () => {
+  it("rejects a cold Chromium options projection when native routing cannot be disabled", async () => {
     getSidePanelSupport.mockReturnValue({
       supported: true,
       kind: "chromium-side-panel",
     })
-
+    setNativeSidePanelActionClick.mockResolvedValue(
+      NATIVE_SIDE_PANEL_ACTION_CLICK_RESULTS.Rejected,
+    )
     const { applyActionClickBehavior } = await import(
       "~/entrypoints/background/actionClickBehavior"
     )
 
-    await applyActionClickBehavior("options")
+    await expect(applyActionClickBehavior("options")).rejects.toThrow(
+      "Failed to disable native side-panel action click",
+    )
 
-    const clickHandler = addActionClickListener.mock.calls[0]?.[0]
-    expect(typeof clickHandler).toBe("function")
-
-    await clickHandler?.({ id: 123, windowId: 456 } as browser.tabs.Tab)
-
-    expect(openOptionsPage).toHaveBeenCalledTimes(1)
-    expect(openSidePanelWithFallback).not.toHaveBeenCalled()
+    expect(setActionPopup).not.toHaveBeenCalled()
   })
 
-  it("routes action clicks through the shared side-panel fallback helper", async () => {
+  it("allows a cold Chromium options projection when native control is unavailable", async () => {
     getSidePanelSupport.mockReturnValue({
       supported: true,
       kind: "chromium-side-panel",
     })
-    const clickedTab = { id: 123, windowId: 456 } as browser.tabs.Tab
+    const { applyActionClickBehavior } = await import(
+      "~/entrypoints/background/actionClickBehavior"
+    )
 
+    await expect(applyActionClickBehavior("options")).resolves.toBeUndefined()
+
+    expect(setActionPopup).toHaveBeenCalledWith("")
+  })
+
+  it("routes a cold options click from the durable preference", async () => {
+    getPreferencesStrict.mockResolvedValue({
+      actionClickBehavior: "options",
+    })
+    getSidePanelSupport.mockReturnValue({
+      supported: true,
+      kind: "chromium-side-panel",
+    })
+    const { setupActionClickBehaviorListener } = await import(
+      "~/entrypoints/background/actionClickBehavior"
+    )
+    setupActionClickBehaviorListener()
+
+    const clickHandler = addActionClickListener.mock.calls[0]?.[0]
+    await clickHandler({ id: 123, windowId: 456 } as browser.tabs.Tab)
+
+    expect(openOptionsPage).toHaveBeenCalledTimes(1)
+  })
+
+  it("routes a cold sidepanel click from the durable preference", async () => {
+    getPreferencesStrict.mockResolvedValue({
+      actionClickBehavior: "sidepanel",
+    })
+    getSidePanelSupport.mockReturnValue({
+      supported: true,
+      kind: "chromium-side-panel",
+    })
+    const { setupActionClickBehaviorListener } = await import(
+      "~/entrypoints/background/actionClickBehavior"
+    )
+    setupActionClickBehaviorListener()
+
+    const clickHandler = addActionClickListener.mock.calls[0]?.[0]
+    const clickedTab = { id: 123, windowId: 456 } as browser.tabs.Tab
+    await clickHandler(clickedTab)
+
+    expect(openSidePanelWithFallback).toHaveBeenCalledWith(clickedTab)
+  })
+
+  it("ignores a cold click when strict preference storage fails", async () => {
+    const storageError = new Error("preference storage unavailable")
+    getPreferencesStrict.mockRejectedValueOnce(storageError)
+    getSidePanelSupport.mockReturnValue({
+      supported: true,
+      kind: "chromium-side-panel",
+    })
+    const { setupActionClickBehaviorListener } = await import(
+      "~/entrypoints/background/actionClickBehavior"
+    )
+    setupActionClickBehaviorListener()
+
+    const clickHandler = addActionClickListener.mock.calls[0]?.[0]
+    await expect(
+      clickHandler({ id: 123, windowId: 456 } as browser.tabs.Tab),
+    ).resolves.toBeUndefined()
+
+    expect(getPreferencesStrict).toHaveBeenCalledTimes(1)
+    expect(getPreferences).not.toHaveBeenCalled()
+    expect(loggerWarn).toHaveBeenCalledWith(
+      "Failed to resolve toolbar action click behavior",
+      storageError,
+    )
+    expect(openOptionsPage).not.toHaveBeenCalled()
+    expect(openSidePanelWithFallback).not.toHaveBeenCalled()
+    expect(setActionPopup).not.toHaveBeenCalled()
+    expect(setNativeSidePanelActionClick).not.toHaveBeenCalled()
+  })
+
+  it("keeps sidepanel clicks manual while Chromium native enable is pending", async () => {
+    getSidePanelSupport.mockReturnValue({
+      supported: true,
+      kind: "chromium-side-panel",
+    })
+    let releaseNativeEnable!: () => void
+    setNativeSidePanelActionClick
+      .mockResolvedValueOnce(NATIVE_SIDE_PANEL_ACTION_CLICK_RESULTS.Applied)
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            releaseNativeEnable = () =>
+              resolve(NATIVE_SIDE_PANEL_ACTION_CLICK_RESULTS.Applied)
+          }),
+      )
+    const { applyActionClickBehavior, setupActionClickBehaviorListener } =
+      await import("~/entrypoints/background/actionClickBehavior")
+    setupActionClickBehaviorListener()
+    await applyActionClickBehavior("popup")
+
+    const transition = applyActionClickBehavior("sidepanel")
+    await vi.waitFor(() =>
+      expect(setNativeSidePanelActionClick).toHaveBeenCalledTimes(2),
+    )
+
+    const clickHandler = addActionClickListener.mock.calls[0]?.[0]
+    const clickedTab = { id: 123, windowId: 456 } as browser.tabs.Tab
+    await clickHandler(clickedTab)
+    expect(openSidePanelWithFallback).toHaveBeenCalledWith(clickedTab)
+
+    releaseNativeEnable()
+    await transition
+    await clickHandler(clickedTab)
+
+    expect(openSidePanelWithFallback).toHaveBeenCalledTimes(1)
+  })
+
+  it("rejects a failed popup projection without committing the requested behavior", async () => {
+    const popupError = new Error("action popup unavailable")
+    getSidePanelSupport.mockReturnValue({
+      supported: true,
+      kind: "chromium-side-panel",
+    })
+    setNativeSidePanelActionClick.mockResolvedValue(
+      NATIVE_SIDE_PANEL_ACTION_CLICK_RESULTS.Applied,
+    )
+    const { applyActionClickBehavior, setupActionClickBehaviorListener } =
+      await import("~/entrypoints/background/actionClickBehavior")
+    setupActionClickBehaviorListener()
+
+    await applyActionClickBehavior("options")
+    setActionPopup.mockRejectedValueOnce(popupError)
+
+    await expect(applyActionClickBehavior("sidepanel")).rejects.toThrow(
+      popupError,
+    )
+
+    const clickHandler = addActionClickListener.mock.calls[0]?.[0]
+    await clickHandler({ id: 123, windowId: 456 } as browser.tabs.Tab)
+
+    expect(openOptionsPage).toHaveBeenCalledTimes(1)
+  })
+
+  it("keeps sidepanel clicks viable when a replacement popup projection fails", async () => {
+    const popupError = new Error("action popup unavailable")
+    getSidePanelSupport.mockReturnValue({
+      supported: true,
+      kind: "chromium-side-panel",
+    })
+    setNativeSidePanelActionClick
+      .mockResolvedValueOnce(NATIVE_SIDE_PANEL_ACTION_CLICK_RESULTS.Applied)
+      .mockResolvedValueOnce(NATIVE_SIDE_PANEL_ACTION_CLICK_RESULTS.Applied)
+    const { applyActionClickBehavior, setupActionClickBehaviorListener } =
+      await import("~/entrypoints/background/actionClickBehavior")
+    setupActionClickBehaviorListener()
+
+    await applyActionClickBehavior("sidepanel")
+    setActionPopup.mockRejectedValueOnce(popupError)
+
+    await expect(applyActionClickBehavior("options")).rejects.toThrow(
+      popupError,
+    )
+
+    const clickHandler = addActionClickListener.mock.calls[0]?.[0]
+    const clickedTab = { id: 123, windowId: 456 } as browser.tabs.Tab
+    await clickHandler(clickedTab)
+
+    expect(
+      setNativeSidePanelActionClick.mock.calls.map(([enabled]) => enabled),
+    ).toEqual([true, false])
+    expect(openSidePanelWithFallback).toHaveBeenCalledWith(clickedTab)
+  })
+
+  it("rejects a native sidepanel transition when native disable fails", async () => {
+    getSidePanelSupport.mockReturnValue({
+      supported: true,
+      kind: "chromium-side-panel",
+    })
+    setNativeSidePanelActionClick.mockResolvedValueOnce(
+      NATIVE_SIDE_PANEL_ACTION_CLICK_RESULTS.Applied,
+    )
+    const { applyActionClickBehavior, setupActionClickBehaviorListener } =
+      await import("~/entrypoints/background/actionClickBehavior")
+    setupActionClickBehaviorListener()
+
+    await applyActionClickBehavior("sidepanel")
+
+    await expect(applyActionClickBehavior("options")).rejects.toThrow(
+      "Failed to disable native side-panel action click",
+    )
+
+    const clickHandler = addActionClickListener.mock.calls[0]?.[0]
+    await clickHandler({ id: 123, windowId: 456 } as browser.tabs.Tab)
+
+    expect(setActionPopup).toHaveBeenCalledTimes(1)
+    expect(openOptionsPage).not.toHaveBeenCalled()
+    expect(openSidePanelWithFallback).not.toHaveBeenCalled()
+  })
+
+  it("rejects a known native sidepanel transition after support degrades", async () => {
+    let support: ReturnType<typeof getSidePanelSupport> = {
+      supported: true,
+      kind: "chromium-side-panel",
+    }
+    getSidePanelSupport.mockImplementation(() => support)
+    setNativeSidePanelActionClick
+      .mockResolvedValueOnce(NATIVE_SIDE_PANEL_ACTION_CLICK_RESULTS.Applied)
+      .mockResolvedValueOnce(NATIVE_SIDE_PANEL_ACTION_CLICK_RESULTS.Rejected)
     const { applyActionClickBehavior } = await import(
       "~/entrypoints/background/actionClickBehavior"
     )
 
     await applyActionClickBehavior("sidepanel")
+    support = {
+      supported: false,
+      kind: "unsupported",
+      reason: "open-failed",
+    }
+
+    await expect(applyActionClickBehavior("options")).rejects.toThrow(
+      "Failed to disable native side-panel action click",
+    )
+
+    expect(setActionPopup).toHaveBeenCalledTimes(1)
+  })
+
+  it("serializes browser action projections in request order", async () => {
+    getSidePanelSupport.mockReturnValue({
+      supported: true,
+      kind: "chromium-side-panel",
+    })
+    let releaseFirstPopup!: () => void
+    setActionPopup.mockImplementationOnce(
+      () => new Promise<void>((resolve) => (releaseFirstPopup = resolve)),
+    )
+    setNativeSidePanelActionClick.mockResolvedValue(
+      NATIVE_SIDE_PANEL_ACTION_CLICK_RESULTS.Applied,
+    )
+    const { applyActionClickBehavior } = await import(
+      "~/entrypoints/background/actionClickBehavior"
+    )
+
+    const first = applyActionClickBehavior("sidepanel")
+    const second = applyActionClickBehavior("options")
+    await vi.waitFor(() => expect(setActionPopup).toHaveBeenCalledTimes(1))
+
+    releaseFirstPopup()
+    await Promise.all([first, second])
+
+    expect(setActionPopup.mock.calls.map(([popup]) => popup)).toEqual(["", ""])
+    expect(
+      setNativeSidePanelActionClick.mock.calls.map(([enabled]) => enabled),
+    ).toEqual([true, false])
+  })
+
+  it("continues queued projections after a rejected projection", async () => {
+    const popupError = new Error("action popup unavailable")
+    getSidePanelSupport.mockReturnValue({
+      supported: false,
+      kind: "unsupported",
+      reason: "missing",
+    })
+    setActionPopup.mockRejectedValueOnce(popupError)
+    const { applyActionClickBehavior } = await import(
+      "~/entrypoints/background/actionClickBehavior"
+    )
+
+    const failed = applyActionClickBehavior("sidepanel")
+    const next = applyActionClickBehavior("options")
+
+    await expect(failed).rejects.toThrow(popupError)
+    await expect(next).resolves.toBeUndefined()
+    expect(setActionPopup.mock.calls.map(([popup]) => popup)).toEqual([
+      POPUP_PAGE_PATH,
+      "",
+    ])
+  })
+
+  it("records successful manual side-panel opens", async () => {
+    getSidePanelSupport.mockReturnValue({
+      supported: true,
+      kind: "chromium-side-panel",
+    })
+    setNativeSidePanelActionClick.mockResolvedValue(
+      NATIVE_SIDE_PANEL_ACTION_CLICK_RESULTS.Rejected,
+    )
+    const clickedTab = { id: 123, windowId: 456 } as browser.tabs.Tab
+
+    const { applyActionClickBehavior, setupActionClickBehaviorListener } =
+      await import("~/entrypoints/background/actionClickBehavior")
+    setupActionClickBehaviorListener()
+    await applyActionClickBehavior("sidepanel")
 
     const clickHandler = addActionClickListener.mock.calls[0]?.[0]
-    expect(typeof clickHandler).toBe("function")
-
-    await clickHandler?.(clickedTab)
+    await clickHandler(clickedTab)
 
     expect(openSidePanelWithFallback).toHaveBeenCalledWith(clickedTab)
     expect(startProductAnalyticsAction).toHaveBeenCalledWith({
@@ -190,18 +586,20 @@ describe("background applyActionClickBehavior", () => {
       supported: true,
       kind: "chromium-side-panel",
     })
+    setNativeSidePanelActionClick.mockResolvedValue(
+      NATIVE_SIDE_PANEL_ACTION_CLICK_RESULTS.Rejected,
+    )
     trackerComplete.mockRejectedValueOnce(new Error("analytics unavailable"))
 
-    const { applyActionClickBehavior } = await import(
-      "~/entrypoints/background/actionClickBehavior"
-    )
-
+    const { applyActionClickBehavior, setupActionClickBehaviorListener } =
+      await import("~/entrypoints/background/actionClickBehavior")
+    setupActionClickBehaviorListener()
     await applyActionClickBehavior("sidepanel")
 
     const clickHandler = addActionClickListener.mock.calls[0]?.[0]
 
     await expect(
-      clickHandler?.({ id: 123, windowId: 456 } as browser.tabs.Tab),
+      clickHandler({ id: 123, windowId: 456 } as browser.tabs.Tab),
     ).resolves.toBeUndefined()
 
     expect(openSidePanelWithFallback).toHaveBeenCalledTimes(1)
@@ -213,20 +611,22 @@ describe("background applyActionClickBehavior", () => {
       supported: true,
       kind: "chromium-side-panel",
     })
+    setNativeSidePanelActionClick.mockResolvedValue(
+      NATIVE_SIDE_PANEL_ACTION_CLICK_RESULTS.Rejected,
+    )
     const sidePanelError = new Error("side panel unavailable")
     openSidePanelWithFallback.mockRejectedValueOnce(sidePanelError)
     trackerComplete.mockRejectedValueOnce(new Error("analytics unavailable"))
 
-    const { applyActionClickBehavior } = await import(
-      "~/entrypoints/background/actionClickBehavior"
-    )
-
+    const { applyActionClickBehavior, setupActionClickBehaviorListener } =
+      await import("~/entrypoints/background/actionClickBehavior")
+    setupActionClickBehaviorListener()
     await applyActionClickBehavior("sidepanel")
 
     const clickHandler = addActionClickListener.mock.calls[0]?.[0]
 
     await expect(
-      clickHandler?.({ id: 123, windowId: 456 } as browser.tabs.Tab),
+      clickHandler({ id: 123, windowId: 456 } as browser.tabs.Tab),
     ).rejects.toThrow(sidePanelError)
 
     expect(trackerComplete).toHaveBeenCalledWith(

--- a/tests/entrypoints/background/actionClickBehavior.test.ts
+++ b/tests/entrypoints/background/actionClickBehavior.test.ts
@@ -21,6 +21,7 @@ describe("background applyActionClickBehavior", () => {
   let loggerWarn: ReturnType<typeof vi.fn>
   let openSidePanelWithFallback: ReturnType<typeof vi.fn>
   let openOptionsPage: ReturnType<typeof vi.fn>
+  let openSettingsPage: ReturnType<typeof vi.fn>
   let startProductAnalyticsAction: ReturnType<typeof vi.fn>
   let trackerComplete: ReturnType<typeof vi.fn>
 
@@ -38,6 +39,7 @@ describe("background applyActionClickBehavior", () => {
     loggerWarn = vi.fn()
     openSidePanelWithFallback = vi.fn().mockResolvedValue(undefined)
     openOptionsPage = vi.fn().mockResolvedValue(undefined)
+    openSettingsPage = vi.fn().mockResolvedValue(undefined)
     trackerComplete = vi.fn().mockResolvedValue(undefined)
     startProductAnalyticsAction = vi.fn().mockReturnValue({
       complete: trackerComplete,
@@ -79,6 +81,7 @@ describe("background applyActionClickBehavior", () => {
     vi.doMock("~/utils/navigation", () => ({
       openSidePanelWithFallback,
       openOptionsPage,
+      openSettingsPage,
     }))
 
     vi.doMock("~/services/productAnalytics/actions", () => ({
@@ -161,9 +164,11 @@ describe("background applyActionClickBehavior", () => {
 
     const clickHandler = addActionClickListener.mock.calls[0]?.[0]
     const clickedTab = { id: 123, windowId: 456 } as browser.tabs.Tab
-    await clickHandler(clickedTab)
+    const clickResult = clickHandler(clickedTab)
 
     expect(openSidePanelWithFallback).toHaveBeenCalledWith(clickedTab)
+
+    await clickResult
   })
 
   it("allows a known manual sidepanel fallback to transition to options", async () => {
@@ -306,7 +311,7 @@ describe("background applyActionClickBehavior", () => {
     expect(openOptionsPage).toHaveBeenCalledTimes(1)
   })
 
-  it("routes a cold sidepanel click from the durable preference", async () => {
+  it("falls back to basic settings when a cold preference read resolves to sidepanel", async () => {
     getPreferencesStrict.mockResolvedValue({
       actionClickBehavior: "sidepanel",
     })
@@ -323,7 +328,29 @@ describe("background applyActionClickBehavior", () => {
     const clickedTab = { id: 123, windowId: 456 } as browser.tabs.Tab
     await clickHandler(clickedTab)
 
-    expect(openSidePanelWithFallback).toHaveBeenCalledWith(clickedTab)
+    expect(openSettingsPage).toHaveBeenCalledTimes(1)
+    expect(openSidePanelWithFallback).not.toHaveBeenCalled()
+  })
+
+  it("leaves a cold popup click to the browser", async () => {
+    getPreferencesStrict.mockResolvedValue({
+      actionClickBehavior: "popup",
+    })
+    getSidePanelSupport.mockReturnValue({
+      supported: true,
+      kind: "chromium-side-panel",
+    })
+    const { setupActionClickBehaviorListener } = await import(
+      "~/entrypoints/background/actionClickBehavior"
+    )
+    setupActionClickBehaviorListener()
+
+    const clickHandler = addActionClickListener.mock.calls[0]?.[0]
+    await clickHandler({ id: 123, windowId: 456 } as browser.tabs.Tab)
+
+    expect(openOptionsPage).not.toHaveBeenCalled()
+    expect(openSettingsPage).not.toHaveBeenCalled()
+    expect(openSidePanelWithFallback).not.toHaveBeenCalled()
   })
 
   it("ignores a cold click when strict preference storage fails", async () => {

--- a/tests/entrypoints/background/actionClickBehavior.test.ts
+++ b/tests/entrypoints/background/actionClickBehavior.test.ts
@@ -21,7 +21,6 @@ describe("background applyActionClickBehavior", () => {
   let loggerWarn: ReturnType<typeof vi.fn>
   let openSidePanelWithFallback: ReturnType<typeof vi.fn>
   let openOptionsPage: ReturnType<typeof vi.fn>
-  let openSettingsPage: ReturnType<typeof vi.fn>
   let startProductAnalyticsAction: ReturnType<typeof vi.fn>
   let trackerComplete: ReturnType<typeof vi.fn>
 
@@ -39,7 +38,6 @@ describe("background applyActionClickBehavior", () => {
     loggerWarn = vi.fn()
     openSidePanelWithFallback = vi.fn().mockResolvedValue(undefined)
     openOptionsPage = vi.fn().mockResolvedValue(undefined)
-    openSettingsPage = vi.fn().mockResolvedValue(undefined)
     trackerComplete = vi.fn().mockResolvedValue(undefined)
     startProductAnalyticsAction = vi.fn().mockReturnValue({
       complete: trackerComplete,
@@ -81,7 +79,6 @@ describe("background applyActionClickBehavior", () => {
     vi.doMock("~/utils/navigation", () => ({
       openSidePanelWithFallback,
       openOptionsPage,
-      openSettingsPage,
     }))
 
     vi.doMock("~/services/productAnalytics/actions", () => ({
@@ -311,7 +308,7 @@ describe("background applyActionClickBehavior", () => {
     expect(openOptionsPage).toHaveBeenCalledTimes(1)
   })
 
-  it("falls back to basic settings when a cold preference read resolves to sidepanel", async () => {
+  it("best-effort routes a cold sidepanel click from the durable preference", async () => {
     getPreferencesStrict.mockResolvedValue({
       actionClickBehavior: "sidepanel",
     })
@@ -328,8 +325,7 @@ describe("background applyActionClickBehavior", () => {
     const clickedTab = { id: 123, windowId: 456 } as browser.tabs.Tab
     await clickHandler(clickedTab)
 
-    expect(openSettingsPage).toHaveBeenCalledTimes(1)
-    expect(openSidePanelWithFallback).not.toHaveBeenCalled()
+    expect(openSidePanelWithFallback).toHaveBeenCalledWith(clickedTab)
   })
 
   it("leaves a cold popup click to the browser", async () => {
@@ -349,7 +345,6 @@ describe("background applyActionClickBehavior", () => {
     await clickHandler({ id: 123, windowId: 456 } as browser.tabs.Tab)
 
     expect(openOptionsPage).not.toHaveBeenCalled()
-    expect(openSettingsPage).not.toHaveBeenCalled()
     expect(openSidePanelWithFallback).not.toHaveBeenCalled()
   })
 

--- a/tests/entrypoints/background/backgroundSuspendCleanup.test.ts
+++ b/tests/entrypoints/background/backgroundSuspendCleanup.test.ts
@@ -1,5 +1,33 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
+const {
+  applyActionClickBehaviorMock,
+  getPreferencesMock,
+  getPreferencesStrictMock,
+  initializeCookieInterceptorsMock,
+  initializeServicesMock,
+  loggerErrorMock,
+  loggerWarnMock,
+  setupActionClickBehaviorListenerMock,
+  triggerStartupSettingsSnapshotMock,
+  triggerStartupShieldBypassDailySummaryMock,
+  triggerStartupSiteEcosystemSnapshotMock,
+  triggerStartupSponsorRecommendationsDailySummaryMock,
+} = vi.hoisted(() => ({
+  applyActionClickBehaviorMock: vi.fn(),
+  getPreferencesMock: vi.fn(),
+  getPreferencesStrictMock: vi.fn(),
+  initializeCookieInterceptorsMock: vi.fn(),
+  initializeServicesMock: vi.fn(),
+  loggerErrorMock: vi.fn(),
+  loggerWarnMock: vi.fn(),
+  setupActionClickBehaviorListenerMock: vi.fn(),
+  triggerStartupSettingsSnapshotMock: vi.fn(),
+  triggerStartupShieldBypassDailySummaryMock: vi.fn(),
+  triggerStartupSiteEcosystemSnapshotMock: vi.fn(),
+  triggerStartupSponsorRecommendationsDailySummaryMock: vi.fn(),
+}))
+
 const originalBrowser = (globalThis as any).browser
 
 describe("background onSuspend temp-context cleanup", () => {
@@ -9,6 +37,22 @@ describe("background onSuspend temp-context cleanup", () => {
   beforeEach(() => {
     onSuspendListener = undefined
     cleanupTempContextsOnSuspendMock = vi.fn().mockResolvedValue(undefined)
+    applyActionClickBehaviorMock.mockReset().mockResolvedValue(undefined)
+    getPreferencesMock.mockReset().mockResolvedValue({
+      actionClickBehavior: "popup",
+    })
+    getPreferencesStrictMock.mockReset().mockResolvedValue({
+      actionClickBehavior: "popup",
+    })
+    initializeCookieInterceptorsMock.mockReset().mockResolvedValue(undefined)
+    initializeServicesMock.mockReset().mockResolvedValue(undefined)
+    loggerErrorMock.mockReset()
+    loggerWarnMock.mockReset()
+    setupActionClickBehaviorListenerMock.mockReset()
+    triggerStartupSettingsSnapshotMock.mockReset()
+    triggerStartupShieldBypassDailySummaryMock.mockReset()
+    triggerStartupSiteEcosystemSnapshotMock.mockReset()
+    triggerStartupSponsorRecommendationsDailySummaryMock.mockReset()
 
     vi.resetModules()
     ;(globalThis as any).browser = {
@@ -44,23 +88,34 @@ describe("background onSuspend temp-context cleanup", () => {
       setupContextMenus: vi.fn(),
     }))
     vi.doMock("~/entrypoints/background/cookieInterceptor", () => ({
-      initializeCookieInterceptors: vi.fn().mockResolvedValue(undefined),
+      initializeCookieInterceptors: initializeCookieInterceptorsMock,
       setupCookieInterceptorListeners: vi.fn(),
     }))
     vi.doMock("~/entrypoints/background/devActionBranding", () => ({
       applyDevActionBranding: vi.fn().mockResolvedValue(undefined),
     }))
     vi.doMock("~/entrypoints/background/servicesInit", () => ({
-      initializeServices: vi.fn().mockResolvedValue(undefined),
+      initializeServices: initializeServicesMock,
     }))
     vi.doMock("~/entrypoints/background/actionClickBehavior", () => ({
-      applyActionClickBehavior: vi.fn().mockResolvedValue(undefined),
+      applyActionClickBehavior: applyActionClickBehaviorMock,
+      setupActionClickBehaviorListener: setupActionClickBehaviorListenerMock,
+    }))
+    vi.doMock("~/services/productAnalytics/runtime", () => ({
+      setupProductAnalyticsAccountChangeListener: vi.fn(),
+      setupProductAnalyticsPreferencesChangeListener: vi.fn(),
+      triggerStartupSettingsSnapshot: triggerStartupSettingsSnapshotMock,
+      triggerStartupShieldBypassDailySummary:
+        triggerStartupShieldBypassDailySummaryMock,
+      triggerStartupSiteEcosystemSnapshot:
+        triggerStartupSiteEcosystemSnapshotMock,
+      triggerStartupSponsorRecommendationsDailySummary:
+        triggerStartupSponsorRecommendationsDailySummaryMock,
     }))
     vi.doMock("~/services/preferences/userPreferences", () => ({
       userPreferences: {
-        getPreferences: vi.fn().mockResolvedValue({
-          actionClickBehavior: "popup",
-        }),
+        getPreferences: getPreferencesMock,
+        getPreferencesStrict: getPreferencesStrictMock,
       },
     }))
     vi.doMock("~/services/tags/tagStorage", () => ({
@@ -94,6 +149,14 @@ describe("background onSuspend temp-context cleanup", () => {
         setPendingVersion: vi.fn().mockResolvedValue(undefined),
       },
     }))
+    vi.doMock("~/utils/core/logger", () => ({
+      createLogger: vi.fn(() => ({
+        debug: vi.fn(),
+        error: loggerErrorMock,
+        info: vi.fn(),
+        warn: loggerWarnMock,
+      })),
+    }))
     vi.doMock("~/utils/navigation", () => ({
       openOrFocusOptionsMenuItem: vi.fn(),
     }))
@@ -111,6 +174,7 @@ describe("background onSuspend temp-context cleanup", () => {
     vi.doUnmock("~/entrypoints/background/devActionBranding")
     vi.doUnmock("~/entrypoints/background/servicesInit")
     vi.doUnmock("~/entrypoints/background/actionClickBehavior")
+    vi.doUnmock("~/services/productAnalytics/runtime")
     vi.doUnmock("~/services/preferences/userPreferences")
     vi.doUnmock("~/services/tags/tagStorage")
     vi.doUnmock("~/services/accounts/accountStorage")
@@ -118,6 +182,7 @@ describe("background onSuspend temp-context cleanup", () => {
     vi.doUnmock("~/services/permissions/permissionManager")
     vi.doUnmock("~/services/permissions/optionalPermissionState")
     vi.doUnmock("~/services/updates/changelogOnUpdateState")
+    vi.doUnmock("~/utils/core/logger")
     vi.doUnmock("~/utils/navigation")
 
     vi.resetModules()
@@ -132,5 +197,84 @@ describe("background onSuspend temp-context cleanup", () => {
     onSuspendListener?.()
 
     expect(cleanupTempContextsOnSuspendMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("registers toolbar clicks and starts services before background startup awaits", async () => {
+    await import("~/entrypoints/background/index")
+
+    await vi.waitFor(() => {
+      expect(initializeCookieInterceptorsMock).toHaveBeenCalledTimes(1)
+    })
+    expect(setupActionClickBehaviorListenerMock).toHaveBeenCalledTimes(1)
+    expect(
+      setupActionClickBehaviorListenerMock.mock.invocationCallOrder[0],
+    ).toBeLessThan(initializeServicesMock.mock.invocationCallOrder[0])
+    expect(initializeServicesMock.mock.invocationCallOrder[0]).toBeLessThan(
+      getPreferencesStrictMock.mock.invocationCallOrder[0],
+    )
+    expect(applyActionClickBehaviorMock).toHaveBeenCalledWith("popup")
+  })
+
+  it("continues background startup when toolbar reconciliation fails", async () => {
+    applyActionClickBehaviorMock.mockRejectedValueOnce(
+      new Error("toolbar projection failed"),
+    )
+
+    await import("~/entrypoints/background/index")
+
+    await vi.waitFor(() => {
+      expect(initializeCookieInterceptorsMock).toHaveBeenCalledTimes(1)
+    })
+
+    expect(initializeServicesMock).toHaveBeenCalledTimes(1)
+    expect(triggerStartupSiteEcosystemSnapshotMock).toHaveBeenCalledTimes(1)
+    expect(triggerStartupSettingsSnapshotMock).toHaveBeenCalledTimes(1)
+    expect(triggerStartupShieldBypassDailySummaryMock).toHaveBeenCalledTimes(1)
+    expect(
+      triggerStartupSponsorRecommendationsDailySummaryMock,
+    ).toHaveBeenCalledTimes(1)
+  })
+
+  it("continues background startup when strict toolbar preference storage fails", async () => {
+    const storageError = new Error("preference storage unavailable")
+    getPreferencesStrictMock.mockRejectedValueOnce(storageError)
+
+    await import("~/entrypoints/background/index")
+
+    await vi.waitFor(() => {
+      expect(initializeCookieInterceptorsMock).toHaveBeenCalledTimes(1)
+    })
+
+    expect(applyActionClickBehaviorMock).not.toHaveBeenCalled()
+    expect(initializeServicesMock).toHaveBeenCalledTimes(1)
+    expect(triggerStartupSiteEcosystemSnapshotMock).toHaveBeenCalledTimes(1)
+    expect(triggerStartupSettingsSnapshotMock).toHaveBeenCalledTimes(1)
+    expect(triggerStartupShieldBypassDailySummaryMock).toHaveBeenCalledTimes(1)
+    expect(
+      triggerStartupSponsorRecommendationsDailySummaryMock,
+    ).toHaveBeenCalledTimes(1)
+    expect(loggerWarnMock).toHaveBeenCalledWith(
+      "Failed to reconcile toolbar action click behavior",
+      storageError,
+    )
+  })
+
+  it("logs an essential service initialization failure without an unhandled rejection", async () => {
+    const serviceInitializationError = new Error(
+      "service initialization failed",
+    )
+    initializeServicesMock.mockRejectedValueOnce(serviceInitializationError)
+    getPreferencesStrictMock.mockImplementationOnce(() => new Promise(() => {}))
+
+    await import("~/entrypoints/background/index")
+
+    await vi.waitFor(() => {
+      expect(loggerErrorMock).toHaveBeenCalledWith(
+        "Failed to initialize background startup",
+        serviceInitializationError,
+      )
+    })
+
+    expect(initializeCookieInterceptorsMock).not.toHaveBeenCalled()
   })
 })

--- a/tests/entrypoints/background/changelogOnUpdate.test.ts
+++ b/tests/entrypoints/background/changelogOnUpdate.test.ts
@@ -7,6 +7,12 @@ type InstalledListener = (details: {
 
 const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0))
 
+const { applyActionClickBehaviorMock, setupActionClickBehaviorListenerMock } =
+  vi.hoisted(() => ({
+    applyActionClickBehaviorMock: vi.fn(),
+    setupActionClickBehaviorListenerMock: vi.fn(),
+  }))
+
 /**
  * Background entrypoint tests for the "open changelog after update" preference.
  *
@@ -24,6 +30,7 @@ describe("background onInstalled changelog opening", () => {
   let getDocsChangelogUrlMock: ReturnType<typeof vi.fn>
   let getManifestMock: ReturnType<typeof vi.fn>
   let getPreferencesMock: ReturnType<typeof vi.fn>
+  let getPreferencesStrictMock: ReturnType<typeof vi.fn>
   let hasPermissionsMock: ReturnType<typeof vi.fn>
   let hasNewOptionalPermissionsMock: ReturnType<typeof vi.fn>
   let openOrFocusOptionsMenuItemMock: ReturnType<typeof vi.fn>
@@ -52,6 +59,10 @@ describe("background onInstalled changelog opening", () => {
       actionClickBehavior: "popup",
       openChangelogOnUpdate: true,
     })
+    getPreferencesStrictMock = vi.fn().mockResolvedValue({
+      actionClickBehavior: "popup",
+      openChangelogOnUpdate: true,
+    })
     hasPermissionsMock = vi.fn().mockResolvedValue(true)
     hasNewOptionalPermissionsMock = vi.fn().mockResolvedValue(false)
     openOrFocusOptionsMenuItemMock = vi.fn()
@@ -61,6 +72,8 @@ describe("background onInstalled changelog opening", () => {
     shouldAutoOpenChangelogForUpdateMock = vi.fn().mockResolvedValue(true)
     triggerStartupSponsorRecommendationsDailySummaryMock = vi.fn()
     isTestModeMock = vi.fn().mockReturnValue(true)
+    applyActionClickBehaviorMock.mockReset().mockResolvedValue(undefined)
+    setupActionClickBehaviorListenerMock.mockReset()
 
     vi.resetModules()
     ;(globalThis as any).defineBackground = (factory: () => unknown) =>
@@ -93,7 +106,10 @@ describe("background onInstalled changelog opening", () => {
     }))
 
     vi.doMock("~/services/preferences/userPreferences", () => ({
-      userPreferences: { getPreferences: getPreferencesMock },
+      userPreferences: {
+        getPreferences: getPreferencesMock,
+        getPreferencesStrict: getPreferencesStrictMock,
+      },
     }))
 
     vi.doMock("~/services/updates/changelogOnUpdateState", () => ({
@@ -129,7 +145,8 @@ describe("background onInstalled changelog opening", () => {
       initializeServices: vi.fn().mockResolvedValue(undefined),
     }))
     vi.doMock("~/entrypoints/background/actionClickBehavior", () => ({
-      applyActionClickBehavior: vi.fn().mockResolvedValue(undefined),
+      applyActionClickBehavior: applyActionClickBehaviorMock,
+      setupActionClickBehaviorListener: setupActionClickBehaviorListenerMock,
     }))
     vi.doMock("~/services/productAnalytics/runtime", () => ({
       setupProductAnalyticsAccountChangeListener: vi.fn(),

--- a/tests/services/runtimePreferencesService.test.ts
+++ b/tests/services/runtimePreferencesService.test.ts
@@ -82,6 +82,47 @@ describe("runtime preference messaging", () => {
     })
   })
 
+  it("waits for action behavior application before acknowledging", async () => {
+    let finishApply!: () => void
+    mocks.applyActionClickBehavior.mockReturnValueOnce(
+      new Promise<void>((resolve) => (finishApply = resolve)),
+    )
+    const { setupPreferencesMessagingListeners } = await importService()
+    setupPreferencesMessagingListeners()
+    const handler = mocks.handlers.get(
+      PreferencesMessageTypes.UpdateActionClickBehavior,
+    )
+
+    let settled = false
+    const response = handler?.({ data: { behavior: "sidepanel" } }).then(
+      (value) => {
+        settled = true
+        return value
+      },
+    )
+    await Promise.resolve()
+    expect(settled).toBe(false)
+
+    finishApply()
+    await expect(response).resolves.toEqual({ success: true, data: undefined })
+  })
+
+  it("reports asynchronous action behavior failures", async () => {
+    mocks.applyActionClickBehavior.mockRejectedValueOnce(
+      new Error("action failed"),
+    )
+    const { setupPreferencesMessagingListeners } = await importService()
+    setupPreferencesMessagingListeners()
+    const handler = mocks.handlers.get(
+      PreferencesMessageTypes.UpdateActionClickBehavior,
+    )
+
+    await expect(handler?.({ data: { behavior: "popup" } })).resolves.toEqual({
+      success: false,
+      error: "action failed",
+    })
+  })
+
   it("refreshes context menus through the listener", async () => {
     const { setupPreferencesMessagingListeners } = await importService()
 

--- a/tests/utils/browserApi.test.ts
+++ b/tests/utils/browserApi.test.ts
@@ -12,7 +12,6 @@ import {
   createContextMenu,
   createNotification,
   createWindow,
-  disableNativeSidePanelActionClick,
   focusTab,
   getActionApi,
   getActiveOrAllTabs,
@@ -41,6 +40,7 @@ import {
   hasStorageChangedListener,
   isAllowedIncognitoAccess,
   isMessageReceiverUnavailableError,
+  NATIVE_SIDE_PANEL_ACTION_CLICK_RESULTS,
   onAlarm,
   onContextMenuClicked,
   onInstalled,
@@ -59,7 +59,6 @@ import {
   PERMISSION_OPERATION_FAILURE_REASONS,
   reloadRuntime,
   reloadTab,
-  removeActionClickListener,
   removeContextMenu,
   removePermissions,
   removePermissionsDetailed,
@@ -72,6 +71,7 @@ import {
   sendRuntimeActionMessage,
   sendTabMessageWithRetry,
   setActionPopup,
+  setNativeSidePanelActionClick,
   updateWindow,
   WINDOW_CREATION_FAILURE_REASONS,
 } from "~/utils/browser/browserApi"
@@ -1699,9 +1699,6 @@ describe("browserApi action and permissions helpers", () => {
     actionApi.onClicked.hasListener.mockReturnValue(true)
     cleanup()
     expect(actionApi.onClicked.removeListener).toHaveBeenCalledWith(listener)
-
-    removeActionClickListener(listener)
-    expect(actionApi.onClicked.removeListener).toHaveBeenCalledWith(listener)
   })
 
   it("does not add duplicate action listeners and skips removals when absent", () => {
@@ -1714,41 +1711,43 @@ describe("browserApi action and permissions helpers", () => {
 
     actionApi.onClicked.hasListener.mockReturnValue(false)
     cleanup()
-    removeActionClickListener(listener)
     expect(actionApi.onClicked.removeListener).not.toHaveBeenCalled()
   })
 
-  it("disables native Chromium side-panel action clicks when supported", async () => {
-    const setPanelBehavior = vi.fn().mockResolvedValue(undefined)
-    ;(globalThis as any).chrome = {
-      sidePanel: {
-        setPanelBehavior,
-      },
-    }
+  it.each([true, false])(
+    "sets native Chromium side-panel action clicks to %s when supported",
+    async (enabled) => {
+      const setPanelBehavior = vi.fn().mockResolvedValue(undefined)
+      ;(globalThis as any).chrome = { sidePanel: { setPanelBehavior } }
 
-    await disableNativeSidePanelActionClick()
+      await expect(setNativeSidePanelActionClick(enabled)).resolves.toBe(
+        NATIVE_SIDE_PANEL_ACTION_CLICK_RESULTS.Applied,
+      )
+      expect(setPanelBehavior).toHaveBeenCalledWith({
+        openPanelOnActionClick: enabled,
+      })
+    },
+  )
 
-    expect(setPanelBehavior).toHaveBeenCalledWith({
-      openPanelOnActionClick: false,
-    })
+  it("reports unavailable native Chromium side-panel action behavior", async () => {
+    ;(globalThis as any).chrome = { sidePanel: {} }
+
+    await expect(setNativeSidePanelActionClick(true)).resolves.toBe(
+      NATIVE_SIDE_PANEL_ACTION_CLICK_RESULTS.Unavailable,
+    )
   })
 
-  it("ignores missing native Chromium side-panel action behavior support", async () => {
-    ;(globalThis as any).chrome = {
-      sidePanel: {},
-    }
-
-    await expect(disableNativeSidePanelActionClick()).resolves.toBeUndefined()
-  })
-
-  it("swallows native Chromium side-panel action behavior failures", async () => {
+  it("reports rejected native Chromium side-panel action behavior", async () => {
     ;(globalThis as any).chrome = {
       sidePanel: {
         setPanelBehavior: vi.fn().mockRejectedValue(new Error("unsupported")),
       },
     }
 
-    await expect(disableNativeSidePanelActionClick()).resolves.toBeUndefined()
+    await expect(setNativeSidePanelActionClick(true)).resolves.toBe(
+      NATIVE_SIDE_PANEL_ACTION_CLICK_RESULTS.Rejected,
+    )
+    expect(loggerMock.warn).toHaveBeenCalled()
   })
 
   it("returns permission helper fallbacks when runtime or permissions APIs fail", async () => {


### PR DESCRIPTION
Fixes #1245

## Summary

- Make Chromium/Edge toolbar sidepanel behavior survive an MV3 service-worker cold start by projecting the saved preference into browser-native action configuration.
- Preserve Firefox's synchronous, listener-based sidebar path and keep popup/options fallbacks available when native sidepanel behavior is unavailable.
- Await live preference application so settings updates acknowledge the runtime behavior change.

## What changed

- Centralize browser capability checks and native popup/sidepanel projection.
- Keep one stable toolbar listener with serialized transition state and startup reconciliation.
- Add focused regression coverage for cold starts, Firefox user-gesture handling, preference updates, and browser API fallbacks.
- Extend the existing extension E2E flow to verify native sidepanel action routing.

## Validation

- `pnpm exec vitest run tests/utils/browserApi.test.ts tests/entrypoints/background/actionClickBehavior.test.ts tests/entrypoints/background/backgroundSuspendCleanup.test.ts tests/entrypoints/background/changelogOnUpdate.test.ts tests/services/runtimePreferencesService.test.ts tests/contexts/UserPreferencesContext.test.tsx` — 189 passed.
- `pnpm exec playwright test e2e/basicSettingsCommonFlows.spec.ts --grep "updates toolbar action behavior"` — 2 passed.
- `pnpm run validate:push` — passed (`tsc --noEmit` and `knip`); the pre-push hook repeated this successfully.
- `pnpm build:firefox` — passed.
- Per-commit `validate:staged` hooks — passed.

## Compatibility and residual risk

Firefox remains on the synchronous listener path because opening its sidebar must stay within the toolbar click's user gesture. Actual manual cold-start toolbar clicks in Firefox and Edge were not performed; the affected paths are covered by focused tests, Chromium extension E2E, and a Firefox production build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added native Chromium/Edge side-panel support with fallback routing where unavailable.
  - Toolbar clicks now reliably open the configured popup, options page, or side panel, including after browser startup.

- **Bug Fixes**
  - Preference changes now wait for background confirmation and report application failures.
  - Improved recovery when side-panel configuration or startup initialization encounters errors.

- **Tests**
  - Expanded automated and end-to-end coverage for routing, startup behavior, failures, and browser compatibility.

- **Documentation**
  - Added implementation and design documentation for toolbar side-panel cold-start handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
