### PR TITLE
fix(ai-api): fall back to unversioned model endpoint

### DIFF
--- a/src/services/aiApi/openaiCompatible/index.ts
+++ b/src/services/aiApi/openaiCompatible/index.ts
@@ -12,7 +12,10 @@ import { createLogger } from "~/utils/core/logger"
  */
 const logger = createLogger("AiApi.OpenAICompatible")
 
-const OPENAI_COMPATIBLE_MODELS_ENDPOINT = "/v1/models"
+// Some OpenAI-compatible Base URLs already include their complete API prefix,
+// so model discovery must also try `/models` without changing that Base URL.
+// Volcengine Ark Coding Plan: https://docs.volcengine.com/docs/82379/2160841
+const OPENAI_COMPATIBLE_MODELS_ENDPOINTS = ["/v1/models", "/models"] as const
 
 export const fetchOpenAICompatibleModels = async (params: OpenAIAuthParams) => {
   const request = {
@@ -22,17 +25,28 @@ export const fetchOpenAICompatibleModels = async (params: OpenAIAuthParams) => {
       accessToken: params.apiKey,
     },
   }
-  try {
-    return await fetchApiData<UpstreamModelList>(request, {
-      endpoint: OPENAI_COMPATIBLE_MODELS_ENDPOINT,
-      ...(params.abortSignal
-        ? { options: { signal: params.abortSignal } }
-        : {}),
-    })
-  } catch (error) {
-    logger.error("Failed to fetch upstream model list", error)
-    throw error
+  let lastError: unknown
+  for (const endpoint of OPENAI_COMPATIBLE_MODELS_ENDPOINTS) {
+    try {
+      return await fetchApiData<UpstreamModelList>(request, {
+        endpoint,
+        ...(params.abortSignal
+          ? { options: { signal: params.abortSignal } }
+          : {}),
+      })
+    } catch (error) {
+      if (
+        params.abortSignal?.aborted ||
+        (error instanceof Error && error.name === "AbortError")
+      ) {
+        throw error
+      }
+      lastError = error
+    }
   }
+
+  logger.error("Failed to fetch upstream model list", lastError)
+  throw lastError
 }
 
 export const fetchOpenAICompatibleModelIds = async (

--- a/tests/services/aiApi/openaiCompatible.index.test.ts
+++ b/tests/services/aiApi/openaiCompatible.index.test.ts
@@ -37,6 +37,7 @@ describe("OpenAI-compatible model fetchers", () => {
 
     await expect(fetchOpenAICompatibleModels(params)).resolves.toEqual(models)
 
+    expect(mockFetchApiData).toHaveBeenCalledTimes(1)
     expect(mockFetchApiData).toHaveBeenCalledWith(
       {
         baseUrl: "https://openai-compatible.example.com",
@@ -49,6 +50,31 @@ describe("OpenAI-compatible model fetchers", () => {
         endpoint: "/v1/models",
       },
     )
+  })
+
+  it("accepts an empty canonical model list without trying another endpoint", async () => {
+    mockFetchApiData.mockResolvedValueOnce([])
+
+    await expect(fetchOpenAICompatibleModels(params)).resolves.toEqual([])
+
+    expect(mockFetchApiData).toHaveBeenCalledTimes(1)
+  })
+
+  it("falls back to /models when the canonical model endpoint fails", async () => {
+    const canonicalError = new Error("canonical endpoint unavailable")
+    const models = [{ id: "custom-model" }]
+    mockFetchApiData
+      .mockRejectedValueOnce(canonicalError)
+      .mockResolvedValueOnce(models)
+
+    await expect(fetchOpenAICompatibleModels(params)).resolves.toEqual(models)
+
+    expect(mockFetchApiData).toHaveBeenNthCalledWith(1, expect.any(Object), {
+      endpoint: "/v1/models",
+    })
+    expect(mockFetchApiData).toHaveBeenNthCalledWith(2, expect.any(Object), {
+      endpoint: "/models",
+    })
   })
 
   it("passes caller abort signals to the model-list request", async () => {
@@ -80,6 +106,27 @@ describe("OpenAI-compatible model fetchers", () => {
     )
   })
 
+  it("does not try another model endpoint after the request is aborted", async () => {
+    const abortController = new AbortController()
+    const abortError = new DOMException(
+      "The operation was aborted",
+      "AbortError",
+    )
+    mockFetchApiData.mockImplementationOnce(async () => {
+      abortController.abort()
+      throw abortError
+    })
+
+    await expect(
+      fetchOpenAICompatibleModels({
+        ...params,
+        abortSignal: abortController.signal,
+      }),
+    ).rejects.toBe(abortError)
+
+    expect(mockFetchApiData).toHaveBeenCalledTimes(1)
+  })
+
   it("maps upstream models into plain model id lists", async () => {
     mockFetchApiData.mockResolvedValueOnce([
       { id: "gpt-4.1", owned_by: "openai" },
@@ -92,14 +139,20 @@ describe("OpenAI-compatible model fetchers", () => {
     ])
   })
 
-  it("logs and rethrows fetch failures", async () => {
-    const error = new Error("upstream unavailable")
-    mockFetchApiData.mockRejectedValueOnce(error)
+  it("logs and rethrows after both model endpoints fail", async () => {
+    const canonicalError = new Error("canonical endpoint unavailable")
+    const fallbackError = new Error("fallback endpoint unavailable")
+    mockFetchApiData
+      .mockRejectedValueOnce(canonicalError)
+      .mockRejectedValueOnce(fallbackError)
 
-    await expect(fetchOpenAICompatibleModels(params)).rejects.toThrow(error)
+    await expect(fetchOpenAICompatibleModels(params)).rejects.toBe(
+      fallbackError,
+    )
+    expect(mockFetchApiData).toHaveBeenCalledTimes(2)
     expect(mockLoggerError).toHaveBeenCalledWith(
       "Failed to fetch upstream model list",
-      error,
+      fallbackError,
     )
   })
 })


### PR DESCRIPTION
## Summary

The OpenAI-compatible model helper always requested `/v1/models`, which produced an invalid nested path for Base URLs that already contain a complete API prefix.

- Preserve `/v1/models` as the canonical first attempt for existing providers.
- Fall back to `/models` without rewriting or persisting a different Base URL.
- Treat an empty catalog as a successful response and stop fallback after cancellation.

## Validation

- `pnpm exec vitest tests/services/aiApi/openaiCompatible.index.test.ts --run` — 7 tests passed
- `pnpm run validate:staged`
- `pnpm run validate:push`

Browser E2E was not run because this change is isolated to service-layer request routing and is covered by focused Vitest tests.

Fixes #1251


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility when discovering models from OpenAI-compatible services by supporting both standard model endpoints.
  * Added fallback handling when the primary endpoint is unavailable.
  * Preserved immediate cancellation behavior for aborted requests.
  * Improved error reporting when model discovery fails across all available endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->