### PR TITLE
fix(key-management): stabilize native key editor footer and loading

### DIFF
--- a/e2e/openRouterKeyManagement.spec.ts
+++ b/e2e/openRouterKeyManagement.spec.ts
@@ -185,6 +185,11 @@ test("manages an OpenRouter key through its native one-time-secret lifecycle", a
   })
   await createByokSwitch.click()
   await expect(createByokSwitch).toBeChecked()
+  const editorFooter = editor.getByTestId(
+    KEY_MANAGEMENT_TEST_IDS.nativeEditorFooter,
+  )
+  await expect(editorFooter).toBeVisible()
+  await expect(editorFooter).toBeInViewport()
   await editor
     .getByTestId(KEY_MANAGEMENT_TEST_IDS.nativeEditorSubmitButton)
     .click()

--- a/src/features/KeyManagement/components/AccountKeyResource/AccountKeyResourceEditorDialog.tsx
+++ b/src/features/KeyManagement/components/AccountKeyResource/AccountKeyResourceEditorDialog.tsx
@@ -8,6 +8,11 @@ import {
   NativeResourceEditorBody,
   type ResourceEditorControlledOptionState,
 } from "~/features/ResourceEditor/NativeResourceEditorBody"
+import {
+  NativeResourceEditorLoadingSkeleton,
+  useNativeResourceEditorLoadingVisibility,
+} from "~/features/ResourceEditor/NativeResourceEditorLoading"
+import type { NativeResourceEditorOpeningState } from "~/features/ResourceEditor/nativeResourceEditorOpeningState"
 import type {
   EditableResourceProjection,
   ResourceFailure,
@@ -46,9 +51,7 @@ export type AccountKeyResourceEditorDialogState = {
 }
 
 export type AccountKeyResourceEditorOpeningState =
-  | { attemptId: number; status: "idle" }
-  | { attemptId: number; status: "loading" }
-  | { attemptId: number; status: "failure"; failure: ResourceFailure }
+  NativeResourceEditorOpeningState<OpenRouterKeyEditorMode, ResourceFailure>
 
 export type AccountKeyResourceEditorDialogProps = {
   editor: AccountKeyResourceEditorDialogState | null
@@ -221,13 +224,23 @@ export function AccountKeyResourceEditorDialog({
       setCommittedCloseOpeningAttemptId(null)
   }, [committedCloseOpeningAttemptId, opening.attemptId])
   const activeEditor = editor ?? terminalCloseEditor
-  const isOpen = activeEditor !== null || opening.status !== "idle"
+  const isLoadingVisible = useNativeResourceEditorLoadingVisibility(
+    opening.status === "loading"
+      ? { attemptId: opening.attemptId, reveal: opening.reveal }
+      : null,
+  )
+  const activeOpening =
+    opening.status === "failure"
+      ? opening
+      : opening.status === "loading" && isLoadingVisible
+        ? opening
+        : null
+  const isOpen = activeEditor !== null || activeOpening !== null
   if (!isOpen) return null
-  const activeOpening = opening.status === "idle" ? null : opening
   const isOpening = activeEditor === null
-  const title = isOpening
-    ? t("keyManagement:openRouter.editor.opening.title")
-    : activeEditor.mode === "create"
+  const editorMode = activeEditor?.mode ?? activeOpening?.mode
+  const title =
+    editorMode === "create"
       ? t("keyManagement:openRouter.editor.title.create")
       : t("keyManagement:openRouter.editor.title.edit")
   const requestClose = () => {
@@ -262,7 +275,7 @@ export function AccountKeyResourceEditorDialog({
       isOpen
       onClose={requestClose}
       title={title}
-      size={isOpening ? "sm" : "lg"}
+      size="lg"
       header={<h2 className="text-base font-semibold">{title}</h2>}
       footer={
         isOpening ? (
@@ -337,23 +350,24 @@ function AccountKeyResourceEditorOpeningContent({
   opening: Exclude<AccountKeyResourceEditorOpeningState, { status: "idle" }>
 }) {
   const { t } = useTranslation()
-  const isLoading = opening.status === "loading"
+  if (opening.status === "loading") {
+    return (
+      <NativeResourceEditorLoadingSkeleton
+        accessibleLabel={t("keyManagement:openRouter.editor.opening.loading")}
+        testId={KEY_MANAGEMENT_TEST_IDS.nativeEditorLoading}
+      />
+    )
+  }
 
   return (
     <Alert
-      variant={isLoading ? "info" : "destructive"}
+      variant="destructive"
       compact
-      role={isLoading ? "status" : "alert"}
+      role="alert"
       aria-live="polite"
       aria-atomic="true"
-      title={
-        isLoading
-          ? t("keyManagement:openRouter.editor.opening.loading")
-          : t("keyManagement:openRouter.editor.opening.failed")
-      }
-      description={
-        isLoading ? undefined : feedbackDescription(opening.failure, t)
-      }
+      title={t("keyManagement:openRouter.editor.opening.failed")}
+      description={feedbackDescription(opening.failure, t)}
     />
   )
 }

--- a/src/features/KeyManagement/components/AccountKeyResource/AccountKeyResourceEditorDialog.tsx
+++ b/src/features/KeyManagement/components/AccountKeyResource/AccountKeyResourceEditorDialog.tsx
@@ -1,5 +1,6 @@
 import type { TFunction } from "i18next"
 import { useEffect, useRef, useState } from "react"
+import { createPortal } from "react-dom"
 import { useTranslation } from "react-i18next"
 
 import { Alert, Button, Modal } from "~/components/ui"
@@ -198,6 +199,8 @@ export function AccountKeyResourceEditorDialog({
 }: AccountKeyResourceEditorDialogProps) {
   const { t } = useTranslation()
   const editorCloseRequestRef = useRef<(() => void) | null>(null)
+  const [editorFooterHost, setEditorFooterHost] =
+    useState<HTMLDivElement | null>(null)
   const [committedCloseEditorId, setCommittedCloseEditorId] = useState<
     number | null
   >(null)
@@ -288,8 +291,11 @@ export function AccountKeyResourceEditorDialog({
               </Button>
             ) : null}
           </div>
+        ) : activeEditor && !activeEditor.terminalClose ? (
+          <div ref={setEditorFooterHost} className="contents" />
         ) : undefined
       }
+      footerTestId={KEY_MANAGEMENT_TEST_IDS.nativeEditorFooter}
       focusFallbackKey={
         activeEditor
           ? activeEditor.editorId
@@ -310,12 +316,12 @@ export function AccountKeyResourceEditorDialog({
         <AccountKeyResourceEditorDialogSession
           key={activeEditor.editorId}
           editor={activeEditor}
-          onClose={onClose}
           onSubmit={onSubmit}
           onValuesChange={onValuesChange}
           onLoadOptions={onLoadOptions}
           onRequestCloseRef={editorCloseRequestRef}
           onCommitClose={(editorId) => setCommittedCloseEditorId(editorId)}
+          footerHost={editorFooterHost}
         />
       ) : activeOpening ? (
         <AccountKeyResourceEditorOpeningContent opening={activeOpening} />
@@ -352,13 +358,14 @@ function AccountKeyResourceEditorOpeningContent({
   )
 }
 
-type AccountKeyResourceEditorDialogSessionProps = Omit<
+type AccountKeyResourceEditorDialogSessionProps = Pick<
   AccountKeyResourceEditorDialogProps,
-  "editor"
+  "onSubmit" | "onValuesChange" | "onLoadOptions"
 > & {
   editor: AccountKeyResourceEditorDialogState
   onRequestCloseRef: { current: (() => void) | null }
   onCommitClose: (editorId: number) => void
+  footerHost: HTMLDivElement | null
 }
 
 /** Owns local UI state for one immutable editor session. */
@@ -369,6 +376,7 @@ function AccountKeyResourceEditorDialogSession({
   onLoadOptions,
   onRequestCloseRef,
   onCommitClose,
+  footerHost,
 }: AccountKeyResourceEditorDialogSessionProps) {
   const { t, i18n } = useTranslation()
   const [values, setValues] = useState<EditableResourceProjection>(() =>
@@ -517,6 +525,31 @@ function AccountKeyResourceEditorDialogSession({
   const fieldIssues = editor.feedback?.fieldIssues
   return (
     <>
+      {/* Keep the keyed session state local while using Modal's fixed footer. */}
+      {footerHost
+        ? createPortal(
+            <div className="flex flex-wrap justify-end gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                disabled={isSubmitting}
+                onClick={requestClose}
+              >
+                {t("keyManagement:openRouter.editor.actions.cancel")}
+              </Button>
+              <Button
+                type="button"
+                loading={isSubmitting}
+                disabled={hasUnresolvedDependentOptions}
+                onClick={() => void submit()}
+                data-testid={KEY_MANAGEMENT_TEST_IDS.nativeEditorSubmitButton}
+              >
+                {t("keyManagement:openRouter.editor.actions.save")}
+              </Button>
+            </div>,
+            footerHost,
+          )
+        : null}
       <Alert
         variant="info"
         compact
@@ -592,25 +625,6 @@ function AccountKeyResourceEditorDialogSession({
           ) : undefined
         }
       />
-      <div className="flex flex-wrap justify-end gap-2">
-        <Button
-          type="button"
-          variant="outline"
-          disabled={isSubmitting}
-          onClick={requestClose}
-        >
-          {t("keyManagement:openRouter.editor.actions.cancel")}
-        </Button>
-        <Button
-          type="button"
-          loading={isSubmitting}
-          disabled={hasUnresolvedDependentOptions}
-          onClick={() => void submit()}
-          data-testid={KEY_MANAGEMENT_TEST_IDS.nativeEditorSubmitButton}
-        >
-          {t("keyManagement:openRouter.editor.actions.save")}
-        </Button>
-      </div>
     </>
   )
 }

--- a/src/features/KeyManagement/controllers/useAccountKeyResourceController.ts
+++ b/src/features/KeyManagement/controllers/useAccountKeyResourceController.ts
@@ -1,6 +1,10 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 
 import { KEY_MANAGEMENT_ALL_ACCOUNTS_VALUE } from "~/features/KeyManagement/constants"
+import {
+  NATIVE_RESOURCE_EDITOR_LOADING_REVEALS,
+  type NativeResourceEditorOpeningState,
+} from "~/features/ResourceEditor/nativeResourceEditorOpeningState"
 import type { CreatedRuntimeSecret } from "~/services/accounts/createdRuntimeSecret"
 import {
   createDisplayAccountApiContext,
@@ -84,10 +88,10 @@ type EditorState = {
   terminalRetainsFocusWorkflow?: boolean
 } | null
 
-type EditorOpeningState =
-  | { attemptId: number; status: "idle" }
-  | { attemptId: number; status: "loading" }
-  | { attemptId: number; status: "failure"; failure: ResourceFailure }
+type EditorOpeningState = NativeResourceEditorOpeningState<
+  EditorMode,
+  ResourceFailure
+>
 
 type EditorOpenRequest = {
   mode: EditorMode
@@ -1758,7 +1762,15 @@ export function useAccountKeyResourceController({
       }
       const attemptId = ++editorOpeningAttemptId.current
       editorOpeningRequestRef.current = { mode: editorMode, ref, boundary }
-      transitionEditorOpening({ attemptId, status: "loading" })
+      transitionEditorOpening({
+        attemptId,
+        status: "loading",
+        mode: editorMode,
+        reveal:
+          retryAttemptId === undefined
+            ? NATIVE_RESOURCE_EDITOR_LOADING_REVEALS.Delayed
+            : NATIVE_RESOURCE_EDITOR_LOADING_REVEALS.Immediate,
+      })
       const controller = new AbortController()
       actionAbort.current = controller
       const current = generation.current
@@ -1833,6 +1845,7 @@ export function useAccountKeyResourceController({
         transitionEditorOpening({
           attemptId,
           status: "failure",
+          mode: editorMode,
           failure,
         })
       }

--- a/src/features/KeyManagement/testIds.ts
+++ b/src/features/KeyManagement/testIds.ts
@@ -39,6 +39,7 @@ export const KEY_MANAGEMENT_TEST_IDS = {
   openRouterWorkspaceSelect: "key-management-openrouter-workspace-select",
   nativeEditor: "key-management-native-editor",
   nativeEditorFooter: "key-management-native-editor-footer",
+  nativeEditorLoading: "key-management-native-editor-loading",
   nativeStatusFilter: "key-management-native-status-filter",
   nativeEditorSubmitButton: "key-management-native-editor-submit-button",
   nativeKeyRow: "key-management-native-key-row",

--- a/src/features/KeyManagement/testIds.ts
+++ b/src/features/KeyManagement/testIds.ts
@@ -38,6 +38,7 @@ export const KEY_MANAGEMENT_TEST_IDS = {
   expandAllButton: "key-management-expand-all-button",
   openRouterWorkspaceSelect: "key-management-openrouter-workspace-select",
   nativeEditor: "key-management-native-editor",
+  nativeEditorFooter: "key-management-native-editor-footer",
   nativeStatusFilter: "key-management-native-status-filter",
   nativeEditorSubmitButton: "key-management-native-editor-submit-button",
   nativeKeyRow: "key-management-native-key-row",

--- a/src/features/ResourceEditor/NativeResourceEditorLoading.tsx
+++ b/src/features/ResourceEditor/NativeResourceEditorLoading.tsx
@@ -1,0 +1,83 @@
+import { useEffect, useState } from "react"
+
+import {
+  NATIVE_RESOURCE_EDITOR_LOADING_REVEALS,
+  type NativeResourceEditorLoadingReveal,
+} from "./nativeResourceEditorOpeningState"
+
+/** Brief grace period that prevents fast editor launches from flashing a skeleton. */
+const EDITOR_LOADING_GRACE_PERIOD_MS = 150
+
+type NativeResourceEditorLoadingRequest = {
+  attemptId: number
+  reveal: NativeResourceEditorLoadingReveal
+} | null
+
+/** Resolves whether a native resource editor launch should expose its loading UI. */
+export function useNativeResourceEditorLoadingVisibility(
+  request: NativeResourceEditorLoadingRequest,
+) {
+  const [revealedAttemptId, setRevealedAttemptId] = useState<number | null>(
+    null,
+  )
+  const attemptId = request?.attemptId
+  const reveal = request?.reveal
+
+  useEffect(() => {
+    if (
+      attemptId === undefined ||
+      reveal === NATIVE_RESOURCE_EDITOR_LOADING_REVEALS.Immediate
+    )
+      return
+    const timeoutId = window.setTimeout(
+      () => setRevealedAttemptId(attemptId),
+      EDITOR_LOADING_GRACE_PERIOD_MS,
+    )
+    return () => window.clearTimeout(timeoutId)
+  }, [attemptId, reveal])
+
+  return (
+    attemptId !== undefined &&
+    (reveal === NATIVE_RESOURCE_EDITOR_LOADING_REVEALS.Immediate ||
+      revealedAttemptId === attemptId)
+  )
+}
+
+type NativeResourceEditorLoadingSkeletonProps = {
+  accessibleLabel: string
+  testId?: string
+  sectionFieldCounts?: readonly number[]
+}
+
+/** Form-shaped loading state shared by native resource editor projections. */
+export function NativeResourceEditorLoadingSkeleton({
+  accessibleLabel,
+  testId,
+  sectionFieldCounts = [2, 2, 1],
+}: NativeResourceEditorLoadingSkeletonProps) {
+  return (
+    <div data-testid={testId} aria-busy="true">
+      <span className="sr-only" role="status" aria-live="polite">
+        {accessibleLabel}
+      </span>
+      <div
+        aria-hidden="true"
+        className="animate-pulse space-y-5 motion-reduce:animate-none"
+      >
+        <div className="dark:bg-dark-bg-tertiary h-16 rounded-lg bg-gray-200" />
+        {sectionFieldCounts.map((fieldCount, sectionIndex) => (
+          <div key={sectionIndex} className="space-y-4">
+            <div className="dark:bg-dark-bg-tertiary h-4 w-28 rounded bg-gray-200" />
+            {Array.from({ length: fieldCount }, (_, fieldIndex) => (
+              <div key={fieldIndex} className="space-y-2">
+                <div className="dark:bg-dark-bg-tertiary h-3 w-24 rounded bg-gray-200" />
+                <div className="dark:bg-dark-bg-tertiary h-9 rounded-md bg-gray-200" />
+              </div>
+            ))}
+          </div>
+        ))}
+        <div className="dark:bg-dark-bg-tertiary h-4 w-32 rounded bg-gray-200" />
+      </div>
+    </div>
+  )
+}

--- a/src/features/ResourceEditor/nativeResourceEditorOpeningState.ts
+++ b/src/features/ResourceEditor/nativeResourceEditorOpeningState.ts
@@ -1,0 +1,23 @@
+export const NATIVE_RESOURCE_EDITOR_LOADING_REVEALS = {
+  Delayed: "delayed",
+  Immediate: "immediate",
+} as const
+
+export type NativeResourceEditorLoadingReveal =
+  (typeof NATIVE_RESOURCE_EDITOR_LOADING_REVEALS)[keyof typeof NATIVE_RESOURCE_EDITOR_LOADING_REVEALS]
+
+/** Provider-neutral launch state for an asynchronously prepared native editor. */
+export type NativeResourceEditorOpeningState<TMode extends string, TFailure> =
+  | { attemptId: number; status: "idle" }
+  | {
+      attemptId: number
+      status: "loading"
+      mode: TMode
+      reveal: NativeResourceEditorLoadingReveal
+    }
+  | {
+      attemptId: number
+      status: "failure"
+      mode: TMode
+      failure: TFailure
+    }

--- a/src/locales/en/keyManagement.json
+++ b/src/locales/en/keyManagement.json
@@ -407,8 +407,7 @@
       "opening": {
         "failed": "Could not open key editor",
         "loading": "Opening key editor...",
-        "retry": "Try again",
-        "title": "Open API Key Editor"
+        "retry": "Try again"
       },
       "options": {
         "creator": {

--- a/src/locales/es-419/keyManagement.json
+++ b/src/locales/es-419/keyManagement.json
@@ -416,8 +416,7 @@
       "opening": {
         "failed": "No se pudo abrir el editor de claves",
         "loading": "Abriendo el editor de claves...",
-        "retry": "Intentar de nuevo",
-        "title": "Abrir editor de clave API"
+        "retry": "Intentar de nuevo"
       },
       "options": {
         "creator": {

--- a/src/locales/ja/keyManagement.json
+++ b/src/locales/ja/keyManagement.json
@@ -398,8 +398,7 @@
       "opening": {
         "failed": "キーエディターを開けませんでした",
         "loading": "キーエディターを開いています...",
-        "retry": "再試行",
-        "title": "API キーエディターを開く"
+        "retry": "再試行"
       },
       "options": {
         "creator": {

--- a/src/locales/pt-BR/keyManagement.json
+++ b/src/locales/pt-BR/keyManagement.json
@@ -416,8 +416,7 @@
       "opening": {
         "failed": "Não foi possível abrir o editor de chaves",
         "loading": "Abrindo o editor de chaves...",
-        "retry": "Tentar novamente",
-        "title": "Abrir editor de chaves de API"
+        "retry": "Tentar novamente"
       },
       "options": {
         "creator": {

--- a/src/locales/vi/keyManagement.json
+++ b/src/locales/vi/keyManagement.json
@@ -398,8 +398,7 @@
       "opening": {
         "failed": "Không thể mở trình chỉnh sửa khóa",
         "loading": "Đang mở trình chỉnh sửa khóa...",
-        "retry": "Thử lại",
-        "title": "Mở trình chỉnh sửa khóa API"
+        "retry": "Thử lại"
       },
       "options": {
         "creator": {

--- a/src/locales/zh-CN/keyManagement.json
+++ b/src/locales/zh-CN/keyManagement.json
@@ -398,8 +398,7 @@
       "opening": {
         "failed": "无法打开密钥编辑器",
         "loading": "正在打开密钥编辑器...",
-        "retry": "重试",
-        "title": "打开 API 密钥编辑器"
+        "retry": "重试"
       },
       "options": {
         "creator": {

--- a/src/locales/zh-TW/keyManagement.json
+++ b/src/locales/zh-TW/keyManagement.json
@@ -398,8 +398,7 @@
       "opening": {
         "failed": "無法開啟金鑰編輯器",
         "loading": "正在開啟金鑰編輯器...",
-        "retry": "重試",
-        "title": "開啟 API 金鑰編輯器"
+        "retry": "重試"
       },
       "options": {
         "creator": {

--- a/tests/features/KeyManagement/components/AccountKeyResourceEditorDialog.test.tsx
+++ b/tests/features/KeyManagement/components/AccountKeyResourceEditorDialog.test.tsx
@@ -5,9 +5,11 @@ import { describe, expect, it, vi } from "vitest"
 
 import {
   AccountKeyResourceEditorDialog,
+  type AccountKeyResourceEditorDialogProps,
   type AccountKeyResourceEditorDialogState,
 } from "~/features/KeyManagement/components/AccountKeyResource/AccountKeyResourceEditorDialog"
 import { KEY_MANAGEMENT_TEST_IDS } from "~/features/KeyManagement/testIds"
+import { NATIVE_RESOURCE_EDITOR_LOADING_REVEALS } from "~/features/ResourceEditor/nativeResourceEditorOpeningState"
 import { OneTimeSecretDialog } from "~/features/TokenProvisioning/components/OneTimeSecretDialog"
 import {
   OPENROUTER_KEY_FIELD_IDS,
@@ -96,18 +98,105 @@ const editor = (mode: "create" | "edit" = "create") => ({
 })
 
 describe("AccountKeyResourceEditorDialog", () => {
+  it("delays the initial loading skeleton and uses the final editor frame when it appears", () => {
+    vi.useFakeTimers()
+    try {
+      render(
+        <AccountKeyResourceEditorDialog
+          editor={null}
+          opening={{
+            attemptId: 1,
+            status: "loading",
+            mode: "edit",
+            reveal: NATIVE_RESOURCE_EDITOR_LOADING_REVEALS.Delayed,
+          }}
+          onCancelOpening={() => undefined}
+          onClose={() => undefined}
+          onSubmit={() => undefined}
+          onValuesChange={() => undefined}
+        />,
+        { withUserPreferencesProvider: false, withThemeProvider: false },
+      )
+
+      expect(screen.queryByRole("dialog")).toBeNull()
+      act(() => vi.advanceTimersByTime(149))
+      expect(screen.queryByRole("dialog")).toBeNull()
+      act(() => vi.advanceTimersByTime(1))
+
+      expect(
+        screen.getByTestId(KEY_MANAGEMENT_TEST_IDS.nativeEditor),
+      ).toHaveClass("max-w-2xl")
+      expect(
+        screen.getByTestId(KEY_MANAGEMENT_TEST_IDS.nativeEditorLoading),
+      ).toBeVisible()
+      expect(
+        screen.getAllByText("keyManagement:openRouter.editor.title.edit"),
+      ).not.toHaveLength(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it("opens a fast editor directly without flashing the delayed skeleton", () => {
+    vi.useFakeTimers()
+    try {
+      const { rerender } = render(
+        <AccountKeyResourceEditorDialog
+          editor={null}
+          opening={{
+            attemptId: 1,
+            status: "loading",
+            mode: "edit",
+            reveal: NATIVE_RESOURCE_EDITOR_LOADING_REVEALS.Delayed,
+          }}
+          onCancelOpening={() => undefined}
+          onClose={() => undefined}
+          onSubmit={() => undefined}
+          onValuesChange={() => undefined}
+        />,
+        { withUserPreferencesProvider: false, withThemeProvider: false },
+      )
+
+      expect(screen.queryByRole("dialog")).toBeNull()
+      rerender(
+        <AccountKeyResourceEditorDialog
+          editor={editor("edit")}
+          opening={{ attemptId: 1, status: "idle" }}
+          onClose={() => undefined}
+          onSubmit={() => undefined}
+          onValuesChange={() => undefined}
+        />,
+      )
+
+      expect(screen.getByRole("dialog")).toBeVisible()
+      expect(
+        screen.queryByTestId(KEY_MANAGEMENT_TEST_IDS.nativeEditorLoading),
+      ).toBeNull()
+      act(() => vi.advanceTimersByTime(150))
+      expect(
+        screen.queryByTestId(KEY_MANAGEMENT_TEST_IDS.nativeEditorLoading),
+      ).toBeNull()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it("lets the user dismiss loading and failed launches while preserving retry", async () => {
     const retry = vi.fn()
     const cancel = vi.fn()
-    const openingProps: any = {
+    const openingProps = {
       opening: {
         attemptId: 4,
         status: "failure",
+        mode: "create",
         failure: { code: "unavailable" },
       },
       onRetryOpening: retry,
       onCancelOpening: cancel,
-    }
+    } satisfies Pick<
+      AccountKeyResourceEditorDialogProps,
+      "opening" | "onRetryOpening" | "onCancelOpening"
+    >
     const { rerender } = render(
       <AccountKeyResourceEditorDialog
         editor={null}
@@ -138,13 +227,21 @@ describe("AccountKeyResourceEditorDialog", () => {
     rerender(
       <AccountKeyResourceEditorDialog
         editor={null}
-        opening={{ attemptId: 5, status: "loading" }}
+        opening={{
+          attemptId: 5,
+          status: "loading",
+          mode: "create",
+          reveal: NATIVE_RESOURCE_EDITOR_LOADING_REVEALS.Immediate,
+        }}
         onCancelOpening={cancel}
         onClose={() => undefined}
         onSubmit={() => undefined}
         onValuesChange={() => undefined}
       />,
     )
+    expect(
+      screen.getByTestId(KEY_MANAGEMENT_TEST_IDS.nativeEditorLoading),
+    ).toBeVisible()
     fireEvent.click(
       screen.getByRole("button", {
         name: "common:actions.cancel",
@@ -155,7 +252,12 @@ describe("AccountKeyResourceEditorDialog", () => {
     rerender(
       <AccountKeyResourceEditorDialog
         editor={null}
-        opening={{ attemptId: 6, status: "loading" }}
+        opening={{
+          attemptId: 6,
+          status: "loading",
+          mode: "create",
+          reveal: NATIVE_RESOURCE_EDITOR_LOADING_REVEALS.Immediate,
+        }}
         onCancelOpening={cancel}
         onClose={() => undefined}
         onSubmit={() => undefined}
@@ -171,6 +273,7 @@ describe("AccountKeyResourceEditorDialog", () => {
         opening={{
           attemptId: 7,
           status: "failure",
+          mode: "create",
           failure: { code: "unavailable" },
         }}
         onCancelOpening={cancel}
@@ -695,6 +798,7 @@ describe("AccountKeyResourceEditorDialog", () => {
         opening={{
           attemptId: 1,
           status: "failure",
+          mode: "create",
           failure: { code: "unavailable" },
         }}
         onRetryOpening={() => undefined}
@@ -713,7 +817,12 @@ describe("AccountKeyResourceEditorDialog", () => {
     rerender(
       <AccountKeyResourceEditorDialog
         editor={null}
-        opening={{ attemptId: 1, status: "loading" }}
+        opening={{
+          attemptId: 1,
+          status: "loading",
+          mode: "create",
+          reveal: NATIVE_RESOURCE_EDITOR_LOADING_REVEALS.Immediate,
+        }}
         onCancelOpening={cancel}
         onClose={close}
         onSubmit={() => undefined}
@@ -749,6 +858,7 @@ describe("AccountKeyResourceEditorDialog", () => {
         opening={{
           attemptId: 1,
           status: "failure",
+          mode: "edit",
           failure: {
             code: "permission_denied",
             message: "Workspace policy blocks this key.",
@@ -1403,7 +1513,12 @@ describe("AccountKeyResourceEditorDialog", () => {
             editor={phase === "editor" ? { ...editor(), editorId } : null}
             opening={
               phase === "opening"
-                ? { attemptId: 1, status: "loading" }
+                ? {
+                    attemptId: 1,
+                    status: "loading",
+                    mode: "create",
+                    reveal: NATIVE_RESOURCE_EDITOR_LOADING_REVEALS.Immediate,
+                  }
                 : { attemptId: 1, status: "idle" }
             }
             onCancelOpening={() => setPhase("idle")}

--- a/tests/features/KeyManagement/components/AccountKeyResourceEditorDialog.test.tsx
+++ b/tests/features/KeyManagement/components/AccountKeyResourceEditorDialog.test.tsx
@@ -7,6 +7,7 @@ import {
   AccountKeyResourceEditorDialog,
   type AccountKeyResourceEditorDialogState,
 } from "~/features/KeyManagement/components/AccountKeyResource/AccountKeyResourceEditorDialog"
+import { KEY_MANAGEMENT_TEST_IDS } from "~/features/KeyManagement/testIds"
 import { OneTimeSecretDialog } from "~/features/TokenProvisioning/components/OneTimeSecretDialog"
 import {
   OPENROUTER_KEY_FIELD_IDS,
@@ -243,6 +244,12 @@ describe("AccountKeyResourceEditorDialog", () => {
     })
     expect(cancel.parentElement).toBe(save.parentElement)
     expect(cancel.parentElement).toHaveClass("flex-wrap")
+    const footer = screen.getByTestId(
+      KEY_MANAGEMENT_TEST_IDS.nativeEditorFooter,
+    )
+    expect(footer).toBeVisible()
+    expect(footer).toContainElement(cancel)
+    expect(footer).toContainElement(save)
   })
 
   it("keeps edit-only workspace, creator, and expiry fields read-only and associates field issues", () => {

--- a/tests/features/KeyManagement/controllers/useAccountKeyResourceController.test.tsx
+++ b/tests/features/KeyManagement/controllers/useAccountKeyResourceController.test.tsx
@@ -9,6 +9,7 @@ import {
   isAccountKeyResourceRouteTransitionAcknowledged,
   useAccountKeyResourceController,
 } from "~/features/KeyManagement/controllers/useAccountKeyResourceController"
+import { NATIVE_RESOURCE_EDITOR_LOADING_REVEALS } from "~/features/ResourceEditor/nativeResourceEditorOpeningState"
 import {
   ACCOUNT_KEY_RESOURCE_FAILURE_CODES,
   AccountKeyResourceError,
@@ -4832,6 +4833,7 @@ describe("useAccountKeyResourceController", () => {
 
   it("exposes one failed editor-opening attempt and retries its bound request", async () => {
     const opening = deferred<any>()
+    const retryOpening = deferred<any>()
     const editor = {
       fields: [],
       initialValues: {},
@@ -4842,7 +4844,7 @@ describe("useAccountKeyResourceController", () => {
     const openCreateEditor = vi
       .fn()
       .mockImplementationOnce(() => opening.promise)
-      .mockResolvedValueOnce(editor)
+      .mockImplementationOnce(() => retryOpening.promise)
     mockNativeResourceSession(
       vi.fn().mockResolvedValue({
         resolveDefaultScope: vi.fn().mockResolvedValue({
@@ -4888,6 +4890,7 @@ describe("useAccountKeyResourceController", () => {
     expect(result.current.editorOpening).toEqual({
       attemptId: expect.any(Number),
       status: "failure",
+      mode: "create",
       failure: {
         code: ACCOUNT_KEY_RESOURCE_FAILURE_CODES.Unavailable,
         message: "private provider message",
@@ -4897,6 +4900,13 @@ describe("useAccountKeyResourceController", () => {
     act(() =>
       result.current.retryEditorOpening(result.current.editorOpening.attemptId),
     )
+    expect(result.current.editorOpening).toEqual({
+      attemptId: expect.any(Number),
+      status: "loading",
+      mode: "create",
+      reveal: NATIVE_RESOURCE_EDITOR_LOADING_REVEALS.Immediate,
+    })
+    await act(async () => retryOpening.resolve(editor))
     await waitFor(() => expect(result.current.editor).not.toBeNull())
     expect(openCreateEditor).toHaveBeenCalledTimes(2)
     expect(result.current.editorOpening.status).toBe("idle")
@@ -4955,6 +4965,8 @@ describe("useAccountKeyResourceController", () => {
     expect(result.current.editorOpening).toEqual({
       attemptId: secondAttemptId,
       status: "loading",
+      mode: "create",
+      reveal: NATIVE_RESOURCE_EDITOR_LOADING_REVEALS.Delayed,
     })
 
     await act(async () => secondOpening.resolve(secondEditor))

--- a/tests/features/ResourceEditor/NativeResourceEditorLoading.test.tsx
+++ b/tests/features/ResourceEditor/NativeResourceEditorLoading.test.tsx
@@ -1,0 +1,62 @@
+import { act, renderHook } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  NativeResourceEditorLoadingSkeleton,
+  useNativeResourceEditorLoadingVisibility,
+} from "~/features/ResourceEditor/NativeResourceEditorLoading"
+import { NATIVE_RESOURCE_EDITOR_LOADING_REVEALS } from "~/features/ResourceEditor/nativeResourceEditorOpeningState"
+import { render, screen } from "~~/tests/test-utils/render"
+
+describe("NativeResourceEditorLoading", () => {
+  it("reveals delayed launches only after the grace period", () => {
+    vi.useFakeTimers()
+    try {
+      const { result } = renderHook(() =>
+        useNativeResourceEditorLoadingVisibility({
+          attemptId: 1,
+          reveal: NATIVE_RESOURCE_EDITOR_LOADING_REVEALS.Delayed,
+        }),
+      )
+
+      expect(result.current).toBe(false)
+      act(() => vi.advanceTimersByTime(149))
+      expect(result.current).toBe(false)
+      act(() => vi.advanceTimersByTime(1))
+      expect(result.current).toBe(true)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it("reveals retries immediately", () => {
+    const { result } = renderHook(() =>
+      useNativeResourceEditorLoadingVisibility({
+        attemptId: 2,
+        reveal: NATIVE_RESOURCE_EDITOR_LOADING_REVEALS.Immediate,
+      }),
+    )
+
+    expect(result.current).toBe(true)
+  })
+
+  it("provides an accessible status while keeping placeholders decorative", () => {
+    render(
+      <NativeResourceEditorLoadingSkeleton
+        accessibleLabel="Opening editor"
+        testId="native-editor-loading"
+      />,
+      { withUserPreferencesProvider: false, withThemeProvider: false },
+    )
+
+    expect(screen.getByTestId("native-editor-loading")).toHaveAttribute(
+      "aria-busy",
+      "true",
+    )
+    expect(screen.getByRole("status")).toHaveTextContent("Opening editor")
+    expect(screen.getByRole("status").nextElementSibling).toHaveAttribute(
+      "aria-hidden",
+      "true",
+    )
+  })
+})


### PR DESCRIPTION
## Summary

Follow-up to #1255.

- Keep native key editor cancel/save actions in the fixed modal footer while preserving keyed editor state and focus restoration.
- Replace the transient compact loading dialog with the final-size editor frame, showing a form-shaped skeleton only when opening takes long enough to be noticeable; retries surface loading immediately.
- Keep editor opening state, loading presentation, and skeleton contracts provider-neutral. OpenRouter supplies only its field projection and localized copy.

## Validation

- `pnpm run validate:push` — passed
- `pnpm vitest related --run src/features/ResourceEditor/NativeResourceEditorLoading.tsx src/features/ResourceEditor/nativeResourceEditorOpeningState.ts src/features/KeyManagement/components/AccountKeyResource/AccountKeyResourceEditorDialog.tsx src/features/KeyManagement/controllers/useAccountKeyResourceController.ts` — 13 files, 215 tests passed
- `pnpm run i18n:extract:ci` — no files updated
- `pnpm exec playwright test e2e/openRouterKeyManagement.spec.ts --project=chromium --workers=1` — 2 tests passed

## Reviewer notes

The two commits are intended to be reviewed in order: footer/focus behavior first, then loading UX and the shared opening-state contract. This changes presentation only; it does not add persistence, permission, protocol, migration, or telemetry behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the key editor opening experience with a consistent loading state and accessible skeleton.
  * Added a fixed footer for cancel and save actions.
  * Loading feedback now appears immediately for retries and after a brief delay for standard openings.
  * Editor dialogs use a larger layout for improved usability.

* **Bug Fixes**
  * Improved error recovery and retry behavior when opening the key editor.
  * Verified footer visibility and positioning within the viewport.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->