### PR TITLE
feat(account-keys): add OpenRouter inventory and capability-aware quick actions

### DIFF
--- a/e2e/openRouterKeyManagement.spec.ts
+++ b/e2e/openRouterKeyManagement.spec.ts
@@ -249,7 +249,7 @@ test("manages an OpenRouter key through its native one-time-secret lifecycle", a
   await expect(lifecycleSummary).toContainText("50")
   await expect(
     lifecycleRow.getByTestId(KEY_MANAGEMENT_TEST_IDS.keyResourceSecretDisplay),
-  ).toContainText("full key cannot be viewed again")
+  ).toContainText("full key only when it is created")
   await expect(
     lifecycleRow.getByRole("button", { name: "Copy Key" }),
   ).toHaveCount(0)

--- a/src/features/AccountManagement/components/AccountActionButtons/index.tsx
+++ b/src/features/AccountManagement/components/AccountActionButtons/index.tsx
@@ -51,6 +51,10 @@ import {
 } from "~/services/accounts/accountRuntimeKeys"
 import { isAccountTodayMetricComplete } from "~/services/accounts/accountTodayStats"
 import {
+  canResolveAccountRuntimeKeySecret,
+  supportsRecoverableAccountRuntimeKeySecrets,
+} from "~/services/accounts/keyProductCapabilities"
+import {
   canFetchDisplayAccountInviteLink,
   fetchDisplayAccountRuntimeKeys,
   InvalidTokenPayloadError,
@@ -303,6 +307,15 @@ export default function AccountActionButtons({
   const isMountedRef = useRef(true)
 
   const isAccountDisabled = site.disabled === true
+  const supportsSmartCopyKey = supportsRecoverableAccountRuntimeKeySecrets(
+    site.siteType,
+  )
+  const canSmartCopyKey =
+    canResolveAccountRuntimeKeySecret(site) ||
+    (isAccountDisabled && supportsSmartCopyKey)
+  const primaryKeyActionLabel = canSmartCopyKey
+    ? t("actions.copyKey")
+    : t("actions.keyList")
   const canCopyInviteLink = canFetchDisplayAccountInviteLink(site)
   const isQuickCheckinEligible =
     !isAccountDisabled &&
@@ -362,18 +375,27 @@ export default function AccountActionButtons({
     }
   }
 
-  // Smart copy key logic - check runtime-key count before deciding action
-  const handleSmartCopyKey = async (e: React.MouseEvent) => {
+  // Resolve a single recoverable key immediately; otherwise open inventory.
+  const handlePrimaryKeyAction = async (e: React.MouseEvent) => {
     e.stopPropagation()
 
     if (isCheckingTokens) return
 
     const tracker = startProductAnalyticsAction({
       featureId: PRODUCT_ANALYTICS_FEATURE_IDS.AccountManagement,
-      actionId: PRODUCT_ANALYTICS_ACTION_IDS.CopyApiKey,
+      actionId: canSmartCopyKey
+        ? PRODUCT_ANALYTICS_ACTION_IDS.CopyApiKey
+        : PRODUCT_ANALYTICS_ACTION_IDS.OpenKeyList,
       surfaceId: rowActionsSurface,
       entrypoint: optionsEntrypoint,
     })
+
+    if (!canSmartCopyKey) {
+      onCopyKey(site)
+      tracker.complete(PRODUCT_ANALYTICS_RESULTS.Success)
+      return
+    }
+
     setIsCheckingTokens(true)
     const secretsToRedact = new Set<string>()
     addRedactionSecrets(secretsToRedact, [
@@ -985,17 +1007,21 @@ export default function AccountActionButtons({
         </IconButton>
 
         <IconButton
-          onClick={handleSmartCopyKey}
+          onClick={handlePrimaryKeyAction}
           variant="ghost"
           size="sm"
           className="touch-manipulation"
           loading={isCheckingTokens}
           disabled={isAccountDisabled}
-          aria-label={t("actions.copyKey")}
+          aria-label={primaryKeyActionLabel}
           data-testid={ACCOUNT_MANAGEMENT_TEST_IDS.rowCopyKeyButton}
-          title={t("actions.copyKey")}
+          title={primaryKeyActionLabel}
         >
-          <KeyIcon className="h-4 w-4" />
+          {canSmartCopyKey ? (
+            <KeyIcon className="h-4 w-4" />
+          ) : (
+            <ListBulletIcon className="h-4 w-4" />
+          )}
         </IconButton>
 
         <IconButton

--- a/src/features/AccountManagement/components/AccountActionButtons/index.tsx
+++ b/src/features/AccountManagement/components/AccountActionButtons/index.tsx
@@ -1017,11 +1017,7 @@ export default function AccountActionButtons({
           data-testid={ACCOUNT_MANAGEMENT_TEST_IDS.rowCopyKeyButton}
           title={primaryKeyActionLabel}
         >
-          {canSmartCopyKey ? (
-            <KeyIcon className="h-4 w-4" />
-          ) : (
-            <ListBulletIcon className="h-4 w-4" />
-          )}
+          <KeyIcon className="h-4 w-4" />
         </IconButton>
 
         <IconButton

--- a/src/features/AccountManagement/components/CopyKeyDialog/DialogFooter.tsx
+++ b/src/features/AccountManagement/components/CopyKeyDialog/DialogFooter.tsx
@@ -2,20 +2,26 @@ import { KeyIcon } from "@heroicons/react/24/outline"
 import { useTranslation } from "react-i18next"
 
 import { Button } from "~/components/ui"
+import { PRODUCT_ANALYTICS_ACTION_IDS } from "~/services/productAnalytics/contracts"
 
 interface DialogFooterProps {
   keyCount: number
   onClose: () => void
+  onOpenKeyManagement?: () => void
 }
 
 /**
  * Footer section for copy key dialog, showing key count summary and close action.
  */
-export function DialogFooter({ keyCount, onClose }: DialogFooterProps) {
-  const { t } = useTranslation(["ui", "common"])
+export function DialogFooter({
+  keyCount,
+  onClose,
+  onOpenKeyManagement,
+}: DialogFooterProps) {
+  const { t } = useTranslation(["ui", "common", "account"])
 
   return (
-    <div className="dark:bg-dark-bg-secondary flex items-center justify-between bg-gray-50/50">
+    <div className="flex items-center justify-between">
       <div className="flex items-center space-x-2">
         {keyCount > 0 && (
           <div className="dark:text-dark-text-secondary flex items-center space-x-1.5 text-xs text-gray-500">
@@ -24,9 +30,23 @@ export function DialogFooter({ keyCount, onClose }: DialogFooterProps) {
           </div>
         )}
       </div>
-      <Button onClick={onClose} variant="secondary" size="sm">
-        {t("common:actions.close")}
-      </Button>
+      <div className="flex items-center gap-2">
+        {onOpenKeyManagement ? (
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={onOpenKeyManagement}
+            analyticsAction={PRODUCT_ANALYTICS_ACTION_IDS.OpenKeyManagement}
+          >
+            <KeyIcon aria-hidden="true" className="h-4 w-4" />
+            {t("account:actions.keyManagement")}
+          </Button>
+        ) : null}
+        <Button onClick={onClose} variant="secondary" size="sm">
+          {t("common:actions.close")}
+        </Button>
+      </div>
     </div>
   )
 }

--- a/src/features/AccountManagement/components/CopyKeyDialog/KeyInventoryList.tsx
+++ b/src/features/AccountManagement/components/CopyKeyDialog/KeyInventoryList.tsx
@@ -6,13 +6,16 @@ import {
 import { useTranslation } from "react-i18next"
 
 import { Alert, EmptyState } from "~/components/ui"
+import type { NativeKeyManagementRow } from "~/features/KeyManagement/types"
 import type { AccountRuntimeKey } from "~/services/accounts/accountRuntimeKeys"
 import type { ApiToken, DisplaySiteData } from "~/types"
 
+import { OpenRouterKeyResourceItem } from "./OpenRouterKeyResourceItem"
 import { RuntimeKeyItem } from "./RuntimeKeyItem"
 
-interface RuntimeKeyListProps {
+interface KeyInventoryListProps {
   runtimeKeys: AccountRuntimeKey[]
+  nativeKeyRows?: NativeKeyManagementRow[]
   expandedRuntimeKeys: Set<string>
   copiedRuntimeKeyId: string | null
   onToggleRuntimeKey: (id: string) => void
@@ -24,13 +27,15 @@ interface RuntimeKeyListProps {
   createError?: string | null
   onCreateDefaultKey?: () => void
   onOpenAddTokenDialog?: () => void
+  supportsApiTokenCreation?: boolean
 }
 
 /**
- * List view wrapper for RuntimeKeyItem elements, handling empty states and expansion toggles.
+ * Renders legacy runtime keys and provider-native key inventory in one quick list.
  */
-export function RuntimeKeyList({
+export function KeyInventoryList({
   runtimeKeys,
+  nativeKeyRows = [],
   expandedRuntimeKeys,
   copiedRuntimeKeyId,
   onToggleRuntimeKey,
@@ -42,35 +47,41 @@ export function RuntimeKeyList({
   createError,
   onCreateDefaultKey,
   onOpenAddTokenDialog,
-}: RuntimeKeyListProps) {
+  supportsApiTokenCreation = false,
+}: KeyInventoryListProps) {
   const { t } = useTranslation("ui")
 
-  if (!Array.isArray(runtimeKeys) || runtimeKeys.length === 0) {
-    const actions = [
-      ...(onCreateDefaultKey
-        ? [
-            {
-              label: t("dialog.copyKey.createKey"),
-              loadingLabel: t("dialog.copyKey.creatingKey"),
-              onClick: onCreateDefaultKey,
-              icon: <PlusIcon className="h-4 w-4" />,
-              disabled: !canCreateDefaultKey || isCreating,
-              loading: isCreating,
-            },
-          ]
-        : []),
-      ...(onOpenAddTokenDialog
-        ? [
-            {
-              label: t("dialog.copyKey.createCustomKey"),
-              onClick: onOpenAddTokenDialog,
-              icon: <PencilSquareIcon className="h-4 w-4" />,
-              variant: "outline" as const,
-              disabled: !canCreateDefaultKey || isCreating,
-            },
-          ]
-        : []),
-    ]
+  if (
+    (!Array.isArray(runtimeKeys) || runtimeKeys.length === 0) &&
+    nativeKeyRows.length === 0
+  ) {
+    const actions = supportsApiTokenCreation
+      ? [
+          ...(onCreateDefaultKey
+            ? [
+                {
+                  label: t("dialog.copyKey.createKey"),
+                  loadingLabel: t("dialog.copyKey.creatingKey"),
+                  onClick: onCreateDefaultKey,
+                  icon: <PlusIcon className="h-4 w-4" />,
+                  disabled: !canCreateDefaultKey || isCreating,
+                  loading: isCreating,
+                },
+              ]
+            : []),
+          ...(onOpenAddTokenDialog
+            ? [
+                {
+                  label: t("dialog.copyKey.createCustomKey"),
+                  onClick: onOpenAddTokenDialog,
+                  icon: <PencilSquareIcon className="h-4 w-4" />,
+                  variant: "outline" as const,
+                  disabled: !canCreateDefaultKey || isCreating,
+                },
+              ]
+            : []),
+        ]
+      : []
 
     return (
       <div className="space-y-4">
@@ -100,6 +111,9 @@ export function RuntimeKeyList({
           account={account}
           onOpenCCSwitchDialog={onOpenCCSwitchDialog}
         />
+      ))}
+      {nativeKeyRows.map((row) => (
+        <OpenRouterKeyResourceItem key={row.rowKey} row={row} />
       ))}
     </div>
   )

--- a/src/features/AccountManagement/components/CopyKeyDialog/LoadingIndicator.tsx
+++ b/src/features/AccountManagement/components/CopyKeyDialog/LoadingIndicator.tsx
@@ -1,16 +1,19 @@
 import { useTranslation } from "react-i18next"
 
+import { Spinner } from "~/components/ui"
+
 /**
- * Spinner placeholder shown while copy key data is being fetched.
+ * Loading state shown while copy key data is being fetched.
  */
 export function LoadingIndicator() {
   const { t } = useTranslation("ui")
+  const loadingLabel = t("dialog.copyKey.loading")
 
   return (
     <div className="flex flex-col items-center justify-center py-8">
-      <div className="mb-4 h-8 w-8 animate-spin rounded-full border-2 border-purple-300 border-t-purple-600" />
+      <Spinner size="lg" className="mb-4" aria-label={loadingLabel} />
       <p className="dark:text-dark-text-secondary text-sm text-gray-500">
-        {t("dialog.copyKey.loading")}
+        {loadingLabel}
       </p>
     </div>
   )

--- a/src/features/AccountManagement/components/CopyKeyDialog/OpenRouterKeyResourceItem.tsx
+++ b/src/features/AccountManagement/components/CopyKeyDialog/OpenRouterKeyResourceItem.tsx
@@ -1,0 +1,30 @@
+import { useState } from "react"
+import { useTranslation } from "react-i18next"
+
+import { buildReadOnlyOpenRouterKeyResourceCardPresentation } from "~/features/KeyManagement/presentation/openRouterKeyResourceCard"
+import type { NativeKeyManagementRow } from "~/features/KeyManagement/types"
+
+import { QuickKeyResourceCard } from "./QuickKeyResourceCard"
+
+/** Renders a provider-native key as read-only inventory in the quick list. */
+export function OpenRouterKeyResourceItem({
+  row,
+}: {
+  row: NativeKeyManagementRow
+}) {
+  const { t } = useTranslation(["keyManagement", "common"])
+  const [isExpanded, setIsExpanded] = useState(false)
+  const presentation = buildReadOnlyOpenRouterKeyResourceCardPresentation(
+    row,
+    t,
+  )
+
+  return (
+    <QuickKeyResourceCard
+      presentation={presentation}
+      secret={presentation.maskedLabel}
+      isExpanded={isExpanded}
+      onExpandedChange={setIsExpanded}
+    />
+  )
+}

--- a/src/features/AccountManagement/components/CopyKeyDialog/QuickKeyResourceCard.tsx
+++ b/src/features/AccountManagement/components/CopyKeyDialog/QuickKeyResourceCard.tsx
@@ -46,6 +46,7 @@ export function QuickKeyResourceCard({
 }: QuickKeyResourceCardProps) {
   const { t } = useTranslation("keyManagement")
   const detailsPanelId = useId()
+  const detailsTriggerId = useId()
   const headerFact = presentation.contextFact
   const expandedSummaryFacts = presentation.summaryFacts.filter(
     (fact) => fact.id !== headerFact?.id,
@@ -60,6 +61,7 @@ export function QuickKeyResourceCard({
   return (
     <Card variant="interactive" padding="none" data-testid={testId}>
       <button
+        id={detailsTriggerId}
         type="button"
         className="dark:hover:bg-dark-bg-tertiary flex w-full items-center justify-between gap-3 rounded-lg p-3 text-left transition-colors hover:bg-gray-50"
         aria-label={t("actions.detailsFor", { name: presentation.title })}
@@ -99,6 +101,7 @@ export function QuickKeyResourceCard({
         <CardContent
           id={detailsPanelId}
           role="region"
+          aria-labelledby={detailsTriggerId}
           padding="sm"
           spacing="sm"
           className="dark:border-dark-bg-tertiary border-t border-gray-200"
@@ -107,7 +110,6 @@ export function QuickKeyResourceCard({
             label={t("keyDetails.key")}
             secret={secret}
             controls={secretControls}
-            message={presentation.secretAvailabilityMessage}
             layout={KEY_RESOURCE_CONTENT_LAYOUTS.Adaptive}
           />
           {expandedSummaryFacts.length > 0 ? (

--- a/src/features/AccountManagement/components/CopyKeyDialog/QuickKeyResourceCard.tsx
+++ b/src/features/AccountManagement/components/CopyKeyDialog/QuickKeyResourceCard.tsx
@@ -1,0 +1,131 @@
+import { ChevronDownIcon, ChevronRightIcon } from "@heroicons/react/24/outline"
+import { useId, type ReactNode } from "react"
+import { useTranslation } from "react-i18next"
+
+import { Badge, Card, CardContent } from "~/components/ui"
+import {
+  KEY_RESOURCE_CONTENT_LAYOUTS,
+  KeyResourceFactList,
+  KeyResourceSecretDisplay,
+} from "~/features/KeyManagement/components/KeyResourceCard"
+import type { KeyResourceCardPresentation } from "~/features/KeyManagement/presentation/keyResourceCard"
+
+type QuickKeyResourceCardProps = {
+  presentation: KeyResourceCardPresentation
+  secret?: ReactNode
+  secretControls?: ReactNode
+  isExpanded: boolean
+  onExpandedChange: (isExpanded: boolean) => void
+  testId?: string
+}
+
+const getStatusVariant = (
+  status: KeyResourceCardPresentation["status"],
+): "success" | "secondary" | "outline" => {
+  switch (status) {
+    case "active":
+      return "success"
+    case "inactive":
+      return "secondary"
+    default:
+      return "outline"
+  }
+}
+
+/**
+ * Keeps the quick-list density and disclosure interaction while rendering the
+ * normalized facts and capability-governed controls owned by each provider.
+ */
+export function QuickKeyResourceCard({
+  presentation,
+  secret,
+  secretControls,
+  isExpanded,
+  onExpandedChange,
+  testId,
+}: QuickKeyResourceCardProps) {
+  const { t } = useTranslation("keyManagement")
+  const detailsPanelId = useId()
+  const headerFact = presentation.contextFact
+  const expandedSummaryFacts = presentation.summaryFacts.filter(
+    (fact) => fact.id !== headerFact?.id,
+  )
+  const summaryFactIds = new Set(
+    presentation.summaryFacts.map((fact) => fact.id),
+  )
+  const expandedDetailFacts = presentation.detailFacts.filter(
+    (fact) => !summaryFactIds.has(fact.id),
+  )
+
+  return (
+    <Card variant="interactive" padding="none" data-testid={testId}>
+      <button
+        type="button"
+        className="dark:hover:bg-dark-bg-tertiary flex w-full items-center justify-between gap-3 rounded-lg p-3 text-left transition-colors hover:bg-gray-50"
+        aria-label={t("actions.detailsFor", { name: presentation.title })}
+        aria-controls={detailsPanelId}
+        aria-expanded={isExpanded}
+        onClick={() => onExpandedChange(!isExpanded)}
+      >
+        <span className="flex min-w-0 flex-1 flex-wrap items-center gap-1.5">
+          <span className="dark:text-dark-text-primary max-w-full truncate text-sm font-medium text-gray-900">
+            {presentation.title}
+          </span>
+          {headerFact ? (
+            <Badge
+              variant="outline"
+              size="sm"
+              className="max-w-full truncate"
+              title={`${headerFact.label}: ${headerFact.value}`}
+            >
+              {headerFact.value}
+            </Badge>
+          ) : null}
+        </span>
+
+        <span className="flex shrink-0 items-center gap-2">
+          <Badge variant={getStatusVariant(presentation.status)} size="sm">
+            {presentation.statusLabel}
+          </Badge>
+          {isExpanded ? (
+            <ChevronDownIcon aria-hidden="true" className="h-4 w-4" />
+          ) : (
+            <ChevronRightIcon aria-hidden="true" className="h-4 w-4" />
+          )}
+        </span>
+      </button>
+
+      {isExpanded ? (
+        <CardContent
+          id={detailsPanelId}
+          role="region"
+          padding="sm"
+          spacing="sm"
+          className="dark:border-dark-bg-tertiary border-t border-gray-200"
+        >
+          <KeyResourceSecretDisplay
+            label={t("keyDetails.key")}
+            secret={secret}
+            controls={secretControls}
+            message={presentation.secretAvailabilityMessage}
+            layout={KEY_RESOURCE_CONTENT_LAYOUTS.Adaptive}
+          />
+          {expandedSummaryFacts.length > 0 ? (
+            <KeyResourceFactList
+              facts={expandedSummaryFacts}
+              layout={KEY_RESOURCE_CONTENT_LAYOUTS.Adaptive}
+            />
+          ) : null}
+          {expandedDetailFacts.length > 0 ? (
+            <div className="dark:border-dark-bg-tertiary border-t border-gray-200 pt-3">
+              <KeyResourceFactList
+                facts={expandedDetailFacts}
+                layout={KEY_RESOURCE_CONTENT_LAYOUTS.Adaptive}
+              />
+            </div>
+          ) : null}
+        </CardContent>
+      ) : null}
+    </Card>
+  )
+}

--- a/src/features/AccountManagement/components/CopyKeyDialog/RuntimeKeyActionControls.tsx
+++ b/src/features/AccountManagement/components/CopyKeyDialog/RuntimeKeyActionControls.tsx
@@ -186,40 +186,52 @@ export function RuntimeKeyActionControls({
       entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Options,
     })
 
-    const result = serviceCredentialProfile
-      ? await openWithCredentials(
-          {
-            name: serviceCredentialProfile.name,
-            baseUrl: serviceCredentialProfile.baseUrl,
-            apiKey: serviceCredentialProfile.apiKey,
-          },
-          (channelResult) => {
-            showResultToast(channelResult)
-            if (channelResult?.success) {
-              void markGatewayGuidanceOnboardingCompleted()
-            }
-          },
-          {
-            managedSiteStatus: undefined,
-          },
-        )
-      : await openWithAccount(
-          account,
-          accountRuntimeKeyToLegacyAccountToken(runtimeKey),
-          (channelResult) => {
-            showResultToast(channelResult)
-            if (channelResult?.success) {
-              void markGatewayGuidanceOnboardingCompleted()
-            }
-          },
-        )
+    try {
+      const result = serviceCredentialProfile
+        ? await openWithCredentials(
+            {
+              name: serviceCredentialProfile.name,
+              baseUrl: serviceCredentialProfile.baseUrl,
+              apiKey: serviceCredentialProfile.apiKey,
+            },
+            (channelResult) => {
+              showResultToast(channelResult)
+              if (channelResult?.success) {
+                void markGatewayGuidanceOnboardingCompleted()
+              }
+            },
+            {
+              managedSiteStatus: undefined,
+            },
+          )
+        : await openWithAccount(
+            account,
+            accountRuntimeKeyToLegacyAccountToken(runtimeKey),
+            (channelResult) => {
+              showResultToast(channelResult)
+              if (channelResult?.success) {
+                void markGatewayGuidanceOnboardingCompleted()
+              }
+            },
+          )
 
-    if (result.opened || result.deferred) {
-      tracker.complete(PRODUCT_ANALYTICS_RESULTS.Success)
-      return
+      if (result.opened || result.deferred) {
+        tracker.complete(PRODUCT_ANALYTICS_RESULTS.Success)
+        return
+      }
+
+      tracker.complete(PRODUCT_ANALYTICS_RESULTS.Skipped)
+    } catch (error) {
+      tracker.complete(PRODUCT_ANALYTICS_RESULTS.Failure, {
+        errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
+      })
+      showResultToast({
+        success: false,
+        message: t("messages:errors.operation.failed", {
+          error: getErrorMessage(error, t("messages:errors.unknown")),
+        }),
+      })
     }
-
-    tracker.complete(PRODUCT_ANALYTICS_RESULTS.Skipped)
   }
 
   const handleOpenCliProxyDialog = (event: MouseEvent) => {

--- a/src/features/AccountManagement/components/CopyKeyDialog/RuntimeKeyActionControls.tsx
+++ b/src/features/AccountManagement/components/CopyKeyDialog/RuntimeKeyActionControls.tsx
@@ -1,0 +1,428 @@
+import { CheckIcon } from "@heroicons/react/24/outline"
+import { Copy } from "lucide-react"
+import { MouseEvent, useMemo, useState } from "react"
+import { useTranslation } from "react-i18next"
+
+import { ClaudeCodeRouterImportDialog } from "~/components/ClaudeCodeRouterImportDialog"
+import { CliProxyExportDialog } from "~/components/CliProxyExportDialog"
+import { useChannelDialog } from "~/components/dialogs/ChannelDialog"
+import { CCSwitchIcon } from "~/components/icons/CCSwitchIcon"
+import { CherryIcon } from "~/components/icons/CherryIcon"
+import { ClaudeCodeRouterIcon } from "~/components/icons/ClaudeCodeRouterIcon"
+import { CliProxyIcon } from "~/components/icons/CliProxyIcon"
+import { KiloCodeIcon } from "~/components/icons/KiloCodeIcon"
+import { ManagedSiteIcon } from "~/components/icons/ManagedSiteIcon"
+import { KiloCodeExportDialog } from "~/components/KiloCodeExportDialog"
+import { IconButton } from "~/components/ui"
+import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
+import { ACCOUNT_MANAGEMENT_TEST_IDS } from "~/features/AccountManagement/testIds"
+import { KiloCodeProfileExportDialog } from "~/features/ApiCredentialProfiles/components/KiloCodeProfileExportDialog"
+import {
+  createCliProxyExportPayload,
+  createExportAccount,
+  createExportToken,
+} from "~/features/ApiCredentialProfiles/utils/exportShims"
+import type { KeyResourceActionPolicy } from "~/features/KeyManagement/presentation/keyResourceCard"
+import {
+  accountRuntimeKeyToLegacyAccountToken,
+  isAccountTokenRuntimeKey,
+  isServiceCredentialRuntimeKey,
+  type AccountRuntimeKey,
+  type ServiceCredentialRuntimeKey,
+} from "~/services/accounts/accountRuntimeKeys"
+import { resolveDisplayAccountRuntimeKeySecret } from "~/services/accounts/utils/apiServiceRequest"
+import { buildApiCredentialProfileName } from "~/services/apiCredentialProfiles/accountTokenProfileName"
+import { OpenInCherryStudio } from "~/services/integrations/cherryStudio"
+import { getManagedSiteLabel } from "~/services/managedSites/utils/managedSite"
+import { startProductAnalyticsAction } from "~/services/productAnalytics/actions"
+import {
+  PRODUCT_ANALYTICS_ACTION_IDS,
+  PRODUCT_ANALYTICS_ENTRYPOINTS,
+  PRODUCT_ANALYTICS_ERROR_CATEGORIES,
+  PRODUCT_ANALYTICS_FEATURE_IDS,
+  PRODUCT_ANALYTICS_RESULTS,
+  PRODUCT_ANALYTICS_SURFACE_IDS,
+} from "~/services/productAnalytics/contracts"
+import { API_TYPES } from "~/services/verification/aiApiVerification"
+import type { ApiToken, DisplaySiteData } from "~/types"
+import type { ApiCredentialProfile } from "~/types/apiCredentialProfiles"
+import { getErrorMessage } from "~/utils/core/error"
+import { showResultToast } from "~/utils/core/toastHelpers"
+
+interface RuntimeKeyActionControlsProps {
+  runtimeKey: AccountRuntimeKey
+  actionPolicy: Pick<KeyResourceActionPolicy, "copySecret" | "exportSecret">
+  copiedRuntimeKeyId: string | null
+  onCopyKey: (runtimeKey: AccountRuntimeKey) => void
+  account: DisplaySiteData
+  onOpenCCSwitchDialog?: (token: ApiToken, account: DisplaySiteData) => void
+}
+
+const buildServiceCredentialExportProfile = (
+  account: DisplaySiteData,
+  runtimeKey: ServiceCredentialRuntimeKey,
+): ApiCredentialProfile => {
+  const now = Date.now()
+  return {
+    id: `service-credential:${account.id}:${runtimeKey.service}`,
+    name: buildApiCredentialProfileName({
+      accountName: account.name,
+      fallbackAccountName: account.name,
+      tokenName: runtimeKey.label,
+    }),
+    apiType: API_TYPES.OPENAI_COMPATIBLE,
+    baseUrl: runtimeKey.baseUrl,
+    apiKey: runtimeKey.secret,
+    tagIds: account.tagIds ?? [],
+    notes: "",
+    createdAt: now,
+    updatedAt: now,
+  }
+}
+
+/**
+ * Renders quick-list actions that are permitted by the normalized key policy.
+ */
+export function RuntimeKeyActionControls({
+  runtimeKey,
+  actionPolicy,
+  copiedRuntimeKeyId,
+  onCopyKey,
+  account,
+  onOpenCCSwitchDialog,
+}: RuntimeKeyActionControlsProps) {
+  const { t } = useTranslation(["ui", "keyManagement", "settings"])
+  const {
+    managedSiteType,
+    claudeCodeRouterBaseUrl,
+    claudeCodeRouterApiKey,
+    cliProxyBaseUrl,
+    cliProxyManagementKey,
+    markGatewayGuidanceOnboardingCompleted,
+  } = useUserPreferencesContext()
+  const { openWithAccount, openWithCredentials } = useChannelDialog()
+
+  const [isClaudeCodeRouterOpen, setIsClaudeCodeRouterOpen] = useState(false)
+  const [isCliProxyDialogOpen, setIsCliProxyDialogOpen] = useState(false)
+  const [isKiloCodeDialogOpen, setIsKiloCodeDialogOpen] = useState(false)
+
+  const managedSiteLabel = getManagedSiteLabel(t, managedSiteType)
+  const accountToken = isAccountTokenRuntimeKey(runtimeKey)
+    ? runtimeKey.token
+    : null
+  const serviceCredentialProfile = useMemo(
+    () =>
+      isServiceCredentialRuntimeKey(runtimeKey)
+        ? buildServiceCredentialExportProfile(account, runtimeKey)
+        : null,
+    [account, runtimeKey],
+  )
+  const handleCopy = (event: MouseEvent) => {
+    event.stopPropagation()
+    void onCopyKey(runtimeKey)
+  }
+
+  const handleUseInCherry = async (event: MouseEvent) => {
+    event.stopPropagation()
+    const tracker = startProductAnalyticsAction({
+      featureId: PRODUCT_ANALYTICS_FEATURE_IDS.AccountManagement,
+      actionId: PRODUCT_ANALYTICS_ACTION_IDS.ExportAccountTokenToCherryStudio,
+      surfaceId:
+        PRODUCT_ANALYTICS_SURFACE_IDS.OptionsAccountManagementRowActions,
+      entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Options,
+    })
+
+    try {
+      if (serviceCredentialProfile) {
+        OpenInCherryStudio(
+          createExportAccount(serviceCredentialProfile),
+          createExportToken(serviceCredentialProfile),
+        )
+      } else {
+        const resolvedRuntimeKey = await resolveDisplayAccountRuntimeKeySecret(
+          account,
+          runtimeKey,
+        )
+        OpenInCherryStudio(
+          account,
+          accountRuntimeKeyToLegacyAccountToken(resolvedRuntimeKey),
+        )
+      }
+      tracker.complete(PRODUCT_ANALYTICS_RESULTS.Success)
+    } catch (error) {
+      tracker.complete(PRODUCT_ANALYTICS_RESULTS.Failure, {
+        errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
+      })
+      showResultToast({
+        success: false,
+        message: t("messages:errors.operation.failed", {
+          error: getErrorMessage(error, t("messages:errors.unknown")),
+        }),
+      })
+    }
+  }
+
+  const handleExportToCCSwitch = (event: MouseEvent) => {
+    event.stopPropagation()
+    if (serviceCredentialProfile) {
+      onOpenCCSwitchDialog?.(
+        createExportToken(serviceCredentialProfile),
+        createExportAccount(serviceCredentialProfile),
+      )
+      return
+    }
+
+    const legacyToken = accountRuntimeKeyToLegacyAccountToken(runtimeKey)
+    onOpenCCSwitchDialog?.(legacyToken, account)
+  }
+
+  const handleImportToManagedSite = async (event: MouseEvent) => {
+    event.stopPropagation()
+    const tracker = startProductAnalyticsAction({
+      featureId: PRODUCT_ANALYTICS_FEATURE_IDS.ManagedSiteChannels,
+      actionId: PRODUCT_ANALYTICS_ACTION_IDS.ImportManagedSiteSingleToken,
+      surfaceId:
+        PRODUCT_ANALYTICS_SURFACE_IDS.OptionsAccountManagementRowActions,
+      entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Options,
+    })
+
+    const result = serviceCredentialProfile
+      ? await openWithCredentials(
+          {
+            name: serviceCredentialProfile.name,
+            baseUrl: serviceCredentialProfile.baseUrl,
+            apiKey: serviceCredentialProfile.apiKey,
+          },
+          (channelResult) => {
+            showResultToast(channelResult)
+            if (channelResult?.success) {
+              void markGatewayGuidanceOnboardingCompleted()
+            }
+          },
+          {
+            managedSiteStatus: undefined,
+          },
+        )
+      : await openWithAccount(
+          account,
+          accountRuntimeKeyToLegacyAccountToken(runtimeKey),
+          (channelResult) => {
+            showResultToast(channelResult)
+            if (channelResult?.success) {
+              void markGatewayGuidanceOnboardingCompleted()
+            }
+          },
+        )
+
+    if (result.opened || result.deferred) {
+      tracker.complete(PRODUCT_ANALYTICS_RESULTS.Success)
+      return
+    }
+
+    tracker.complete(PRODUCT_ANALYTICS_RESULTS.Skipped)
+  }
+
+  const handleOpenCliProxyDialog = (event: MouseEvent) => {
+    event.stopPropagation()
+    if (!cliProxyBaseUrl?.trim() || !cliProxyManagementKey?.trim()) {
+      showResultToast({
+        success: false,
+        message: t("messages:cliproxy.configMissing"),
+      })
+      return
+    }
+    setIsCliProxyDialogOpen(true)
+  }
+
+  const handleOpenClaudeCodeRouter = (event: MouseEvent) => {
+    event.stopPropagation()
+    if (!claudeCodeRouterBaseUrl) {
+      showResultToast({
+        success: false,
+        message: t("messages:claudeCodeRouter.configMissing"),
+      })
+      return
+    }
+    setIsClaudeCodeRouterOpen(true)
+  }
+
+  const renderKiloCodeExportDialog = () => {
+    if (!isKiloCodeDialogOpen) return null
+
+    if (serviceCredentialProfile) {
+      return (
+        <KiloCodeProfileExportDialog
+          isOpen={true}
+          onClose={() => setIsKiloCodeDialogOpen(false)}
+          profile={serviceCredentialProfile}
+        />
+      )
+    }
+
+    if (!accountToken) return null
+
+    return (
+      <KiloCodeExportDialog
+        isOpen={true}
+        onClose={() => setIsKiloCodeDialogOpen(false)}
+        initialSelectedSiteIds={[account.id]}
+        initialSelectedTokenIdsBySite={{
+          [account.id]: [`${accountToken.id}`],
+        }}
+      />
+    )
+  }
+
+  const renderClaudeCodeRouterImportDialog = () => {
+    if (!isClaudeCodeRouterOpen) return null
+
+    if (serviceCredentialProfile) {
+      return (
+        <ClaudeCodeRouterImportDialog
+          isOpen={true}
+          onClose={() => setIsClaudeCodeRouterOpen(false)}
+          account={createExportAccount(serviceCredentialProfile)}
+          token={createExportToken(serviceCredentialProfile)}
+          routerBaseUrl={claudeCodeRouterBaseUrl}
+          routerApiKey={claudeCodeRouterApiKey}
+        />
+      )
+    }
+
+    const legacyToken = accountRuntimeKeyToLegacyAccountToken(runtimeKey)
+
+    return (
+      <ClaudeCodeRouterImportDialog
+        isOpen={true}
+        onClose={() => setIsClaudeCodeRouterOpen(false)}
+        account={account}
+        token={legacyToken}
+        routerBaseUrl={claudeCodeRouterBaseUrl}
+        routerApiKey={claudeCodeRouterApiKey}
+      />
+    )
+  }
+
+  const renderCliProxyExportDialog = () => {
+    if (!isCliProxyDialogOpen) return null
+
+    if (serviceCredentialProfile) {
+      const cliProxyPayload = createCliProxyExportPayload(
+        serviceCredentialProfile,
+      )
+
+      return (
+        <CliProxyExportDialog
+          isOpen={true}
+          onClose={() => setIsCliProxyDialogOpen(false)}
+          account={cliProxyPayload.account}
+          token={cliProxyPayload.token}
+          apiTypeHint={cliProxyPayload.apiTypeHint}
+        />
+      )
+    }
+
+    const legacyToken = accountRuntimeKeyToLegacyAccountToken(runtimeKey)
+
+    return (
+      <CliProxyExportDialog
+        isOpen={true}
+        onClose={() => setIsCliProxyDialogOpen(false)}
+        account={account}
+        token={legacyToken}
+      />
+    )
+  }
+
+  if (!actionPolicy.copySecret && !actionPolicy.exportSecret) return null
+
+  return (
+    <>
+      {renderKiloCodeExportDialog()}
+      {renderClaudeCodeRouterImportDialog()}
+      {renderCliProxyExportDialog()}
+      <div className="flex flex-wrap items-center gap-1 sm:gap-1.5">
+        {actionPolicy.copySecret ? (
+          <IconButton
+            aria-label={
+              copiedRuntimeKeyId === runtimeKey.id
+                ? t("dialog.copyKey.copied")
+                : t("dialog.copyKey.copy")
+            }
+            variant="ghost"
+            size="sm"
+            onClick={handleCopy}
+          >
+            {copiedRuntimeKeyId === runtimeKey.id ? (
+              <CheckIcon className="h-4 w-4 text-green-500" />
+            ) : (
+              <Copy className="dark:text-dark-text-tertiary h-4 w-4 text-gray-500" />
+            )}
+          </IconButton>
+        ) : null}
+        {actionPolicy.exportSecret ? (
+          <>
+            <IconButton
+              aria-label={t("dialog.copyKey.useInCherry")}
+              variant="ghost"
+              size="sm"
+              onClick={handleUseInCherry}
+            >
+              <CherryIcon />
+            </IconButton>
+            {onOpenCCSwitchDialog && (
+              <IconButton
+                aria-label={t("dialog.copyKey.exportToCCSwitch")}
+                variant="ghost"
+                size="sm"
+                data-testid={
+                  ACCOUNT_MANAGEMENT_TEST_IDS.copyKeyDialogExportToCCSwitchButton
+                }
+                onClick={handleExportToCCSwitch}
+              >
+                <CCSwitchIcon />
+              </IconButton>
+            )}
+            <IconButton
+              aria-label={t("keyManagement:actions.exportToKiloCode")}
+              variant="ghost"
+              size="sm"
+              onClick={(event) => {
+                event.stopPropagation()
+                setIsKiloCodeDialogOpen(true)
+              }}
+            >
+              <KiloCodeIcon className="dark:text-dark-text-tertiary text-gray-500" />
+            </IconButton>
+            <IconButton
+              aria-label={t("keyManagement:actions.importToCliProxy")}
+              variant="ghost"
+              size="sm"
+              onClick={handleOpenCliProxyDialog}
+            >
+              <CliProxyIcon size="sm" />
+            </IconButton>
+            <IconButton
+              aria-label={t("keyManagement:actions.importToClaudeCodeRouter")}
+              variant="ghost"
+              size="sm"
+              onClick={handleOpenClaudeCodeRouter}
+            >
+              <ClaudeCodeRouterIcon size="sm" />
+            </IconButton>
+            <IconButton
+              aria-label={t("keyManagement:actions.importToManagedSite", {
+                site: managedSiteLabel,
+              })}
+              variant="ghost"
+              size="sm"
+              onClick={handleImportToManagedSite}
+            >
+              <ManagedSiteIcon siteType={managedSiteType} size="sm" />
+            </IconButton>
+          </>
+        ) : null}
+      </div>
+    </>
+  )
+}

--- a/src/features/AccountManagement/components/CopyKeyDialog/RuntimeKeyDetails.tsx
+++ b/src/features/AccountManagement/components/CopyKeyDialog/RuntimeKeyDetails.tsx
@@ -1,11 +1,11 @@
-import type { AccountRuntimeKey } from "~/services/accounts/accountRuntimeKeys"
+import type {
+  AccountRuntimeKey,
+  ServiceCredentialRuntimeKey,
+} from "~/services/accounts/accountRuntimeKeys"
 import type { ApiToken, DisplaySiteData } from "~/types"
+import { maskSecretForDisplay } from "~/utils/core/formatters"
 
 import { RuntimeKeyActionControls } from "./RuntimeKeyActionControls"
-
-const SECRET_PREVIEW_PREFIX_LENGTH = 16
-const SECRET_PREVIEW_SUFFIX_LENGTH = 6
-const SECRET_PREVIEW_MASK_LENGTH = 6
 
 const SERVICE_CREDENTIAL_ACTION_POLICY = {
   copySecret: true,
@@ -14,34 +14,15 @@ const SERVICE_CREDENTIAL_ACTION_POLICY = {
 
 /** Renders the bounded secret preview shared by quick-list key sources. */
 export function RuntimeKeySecretPreview({ secret }: { secret: string }) {
-  const shouldElide =
-    secret.length > SECRET_PREVIEW_PREFIX_LENGTH + SECRET_PREVIEW_SUFFIX_LENGTH
-  const prefix = shouldElide
-    ? secret.slice(0, SECRET_PREVIEW_PREFIX_LENGTH)
-    : secret
-  const suffix = shouldElide ? secret.slice(-SECRET_PREVIEW_SUFFIX_LENGTH) : ""
-
   return (
     <code className="dark:text-dark-text-secondary text-gray-700">
-      <span className="dark:text-dark-text-primary text-gray-900">
-        {prefix}
-      </span>
-      {suffix ? (
-        <>
-          <span className="text-gray-400 dark:text-gray-600">
-            {"•".repeat(SECRET_PREVIEW_MASK_LENGTH)}
-          </span>
-          <span className="dark:text-dark-text-primary text-gray-900">
-            {suffix}
-          </span>
-        </>
-      ) : null}
+      {maskSecretForDisplay(secret)}
     </code>
   )
 }
 
 interface RuntimeKeyDetailsProps {
-  runtimeKey: AccountRuntimeKey
+  runtimeKey: ServiceCredentialRuntimeKey
   copiedRuntimeKeyId: string | null
   onCopyKey: (runtimeKey: AccountRuntimeKey) => void
   account: DisplaySiteData

--- a/src/features/AccountManagement/components/CopyKeyDialog/RuntimeKeyDetails.tsx
+++ b/src/features/AccountManagement/components/CopyKeyDialog/RuntimeKeyDetails.tsx
@@ -1,57 +1,44 @@
-import { CheckIcon, ClockIcon } from "@heroicons/react/24/outline"
-import { Copy } from "lucide-react"
-import { MouseEvent, useMemo, useState } from "react"
-import { useTranslation } from "react-i18next"
-
-import { ClaudeCodeRouterImportDialog } from "~/components/ClaudeCodeRouterImportDialog"
-import { CliProxyExportDialog } from "~/components/CliProxyExportDialog"
-import { useChannelDialog } from "~/components/dialogs/ChannelDialog"
-import { CCSwitchIcon } from "~/components/icons/CCSwitchIcon"
-import { CherryIcon } from "~/components/icons/CherryIcon"
-import { ClaudeCodeRouterIcon } from "~/components/icons/ClaudeCodeRouterIcon"
-import { CliProxyIcon } from "~/components/icons/CliProxyIcon"
-import { KiloCodeIcon } from "~/components/icons/KiloCodeIcon"
-import { ManagedSiteIcon } from "~/components/icons/ManagedSiteIcon"
-import { KiloCodeExportDialog } from "~/components/KiloCodeExportDialog"
-import { IconButton } from "~/components/ui"
-import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
-import { ACCOUNT_MANAGEMENT_TEST_IDS } from "~/features/AccountManagement/testIds"
-import { KiloCodeProfileExportDialog } from "~/features/ApiCredentialProfiles/components/KiloCodeProfileExportDialog"
-import {
-  createCliProxyExportPayload,
-  createExportAccount,
-  createExportToken,
-} from "~/features/ApiCredentialProfiles/utils/exportShims"
-import {
-  accountRuntimeKeyToLegacyAccountToken,
-  isAccountTokenRuntimeKey,
-  isServiceCredentialRuntimeKey,
-  type AccountRuntimeKey,
-  type ServiceCredentialRuntimeKey,
-} from "~/services/accounts/accountRuntimeKeys"
-import { resolveDisplayAccountRuntimeKeySecret } from "~/services/accounts/utils/apiServiceRequest"
-import { buildApiCredentialProfileName } from "~/services/apiCredentialProfiles/accountTokenProfileName"
-import { OpenInCherryStudio } from "~/services/integrations/cherryStudio"
-import { getManagedSiteLabel } from "~/services/managedSites/utils/managedSite"
-import { startProductAnalyticsAction } from "~/services/productAnalytics/actions"
-import {
-  PRODUCT_ANALYTICS_ACTION_IDS,
-  PRODUCT_ANALYTICS_ENTRYPOINTS,
-  PRODUCT_ANALYTICS_ERROR_CATEGORIES,
-  PRODUCT_ANALYTICS_FEATURE_IDS,
-  PRODUCT_ANALYTICS_RESULTS,
-  PRODUCT_ANALYTICS_SURFACE_IDS,
-} from "~/services/productAnalytics/contracts"
-import { API_TYPES } from "~/services/verification/aiApiVerification"
+import type { AccountRuntimeKey } from "~/services/accounts/accountRuntimeKeys"
 import type { ApiToken, DisplaySiteData } from "~/types"
-import type { ApiCredentialProfile } from "~/types/apiCredentialProfiles"
-import { getErrorMessage } from "~/utils/core/error"
-import {
-  formatKeyTime,
-  formatQuota,
-  formatUsedQuota,
-} from "~/utils/core/formatters"
-import { showResultToast } from "~/utils/core/toastHelpers"
+
+import { RuntimeKeyActionControls } from "./RuntimeKeyActionControls"
+
+const SECRET_PREVIEW_PREFIX_LENGTH = 16
+const SECRET_PREVIEW_SUFFIX_LENGTH = 6
+const SECRET_PREVIEW_MASK_LENGTH = 6
+
+const SERVICE_CREDENTIAL_ACTION_POLICY = {
+  copySecret: true,
+  exportSecret: true,
+} as const
+
+/** Renders the bounded secret preview shared by quick-list key sources. */
+export function RuntimeKeySecretPreview({ secret }: { secret: string }) {
+  const shouldElide =
+    secret.length > SECRET_PREVIEW_PREFIX_LENGTH + SECRET_PREVIEW_SUFFIX_LENGTH
+  const prefix = shouldElide
+    ? secret.slice(0, SECRET_PREVIEW_PREFIX_LENGTH)
+    : secret
+  const suffix = shouldElide ? secret.slice(-SECRET_PREVIEW_SUFFIX_LENGTH) : ""
+
+  return (
+    <code className="dark:text-dark-text-secondary text-gray-700">
+      <span className="dark:text-dark-text-primary text-gray-900">
+        {prefix}
+      </span>
+      {suffix ? (
+        <>
+          <span className="text-gray-400 dark:text-gray-600">
+            {"•".repeat(SECRET_PREVIEW_MASK_LENGTH)}
+          </span>
+          <span className="dark:text-dark-text-primary text-gray-900">
+            {suffix}
+          </span>
+        </>
+      ) : null}
+    </code>
+  )
+}
 
 interface RuntimeKeyDetailsProps {
   runtimeKey: AccountRuntimeKey
@@ -61,52 +48,7 @@ interface RuntimeKeyDetailsProps {
   onOpenCCSwitchDialog?: (token: ApiToken, account: DisplaySiteData) => void
 }
 
-const SECRET_PREVIEW_PREFIX_LENGTH = 16
-const SECRET_PREVIEW_SUFFIX_LENGTH = 6
-const SECRET_PREVIEW_MASK_LENGTH = 6
-
-const getSecretPreviewParts = (secret: string) => {
-  if (
-    secret.length <=
-    SECRET_PREVIEW_PREFIX_LENGTH + SECRET_PREVIEW_SUFFIX_LENGTH
-  ) {
-    return {
-      prefix: secret,
-      suffix: "",
-    }
-  }
-
-  return {
-    prefix: secret.slice(0, SECRET_PREVIEW_PREFIX_LENGTH),
-    suffix: secret.slice(-SECRET_PREVIEW_SUFFIX_LENGTH),
-  }
-}
-
-const buildServiceCredentialExportProfile = (
-  account: DisplaySiteData,
-  runtimeKey: ServiceCredentialRuntimeKey,
-): ApiCredentialProfile => {
-  const now = Date.now()
-  return {
-    id: `service-credential:${account.id}:${runtimeKey.service}`,
-    name: buildApiCredentialProfileName({
-      accountName: account.name,
-      fallbackAccountName: account.name,
-      tokenName: runtimeKey.label,
-    }),
-    apiType: API_TYPES.OPENAI_COMPATIBLE,
-    baseUrl: runtimeKey.baseUrl,
-    apiKey: runtimeKey.secret,
-    tagIds: account.tagIds ?? [],
-    notes: "",
-    createdAt: now,
-    updatedAt: now,
-  }
-}
-
-/**
- * Displays detailed runtime key metadata, quota information, and export actions inside copy key dialog.
- */
+/** Preserves the service-credential detail surface outside account-key migration. */
 export function RuntimeKeyDetails({
   runtimeKey,
   copiedRuntimeKeyId,
@@ -114,393 +56,18 @@ export function RuntimeKeyDetails({
   account,
   onOpenCCSwitchDialog,
 }: RuntimeKeyDetailsProps) {
-  const { t } = useTranslation(["ui", "keyManagement", "settings"])
-  const {
-    managedSiteType,
-    claudeCodeRouterBaseUrl,
-    claudeCodeRouterApiKey,
-    cliProxyBaseUrl,
-    cliProxyManagementKey,
-    markGatewayGuidanceOnboardingCompleted,
-  } = useUserPreferencesContext()
-  const { openWithAccount, openWithCredentials } = useChannelDialog()
-
-  const [isClaudeCodeRouterOpen, setIsClaudeCodeRouterOpen] = useState(false)
-  const [isCliProxyDialogOpen, setIsCliProxyDialogOpen] = useState(false)
-  const [isKiloCodeDialogOpen, setIsKiloCodeDialogOpen] = useState(false)
-
-  const managedSiteLabel = getManagedSiteLabel(t, managedSiteType)
-  const accountToken = isAccountTokenRuntimeKey(runtimeKey)
-    ? runtimeKey.token
-    : null
-  const serviceCredentialProfile = useMemo(
-    () =>
-      isServiceCredentialRuntimeKey(runtimeKey)
-        ? buildServiceCredentialExportProfile(account, runtimeKey)
-        : null,
-    [account, runtimeKey],
-  )
-  const secretPreview = getSecretPreviewParts(runtimeKey.secret)
-
-  const handleCopy = (event: MouseEvent) => {
-    event.stopPropagation()
-    void onCopyKey(runtimeKey)
-  }
-
-  const handleUseInCherry = async (event: MouseEvent) => {
-    event.stopPropagation()
-    const tracker = startProductAnalyticsAction({
-      featureId: PRODUCT_ANALYTICS_FEATURE_IDS.AccountManagement,
-      actionId: PRODUCT_ANALYTICS_ACTION_IDS.ExportAccountTokenToCherryStudio,
-      surfaceId:
-        PRODUCT_ANALYTICS_SURFACE_IDS.OptionsAccountManagementRowActions,
-      entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Options,
-    })
-
-    try {
-      if (serviceCredentialProfile) {
-        OpenInCherryStudio(
-          createExportAccount(serviceCredentialProfile),
-          createExportToken(serviceCredentialProfile),
-        )
-      } else {
-        const resolvedRuntimeKey = await resolveDisplayAccountRuntimeKeySecret(
-          account,
-          runtimeKey,
-        )
-        OpenInCherryStudio(
-          account,
-          accountRuntimeKeyToLegacyAccountToken(resolvedRuntimeKey),
-        )
-      }
-      tracker.complete(PRODUCT_ANALYTICS_RESULTS.Success)
-    } catch (error) {
-      tracker.complete(PRODUCT_ANALYTICS_RESULTS.Failure, {
-        errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
-      })
-      showResultToast({
-        success: false,
-        message: t("messages:errors.operation.failed", {
-          error: getErrorMessage(error, t("messages:errors.unknown")),
-        }),
-      })
-    }
-  }
-
-  const handleExportToCCSwitch = (event: MouseEvent) => {
-    event.stopPropagation()
-    if (serviceCredentialProfile) {
-      onOpenCCSwitchDialog?.(
-        createExportToken(serviceCredentialProfile),
-        createExportAccount(serviceCredentialProfile),
-      )
-      return
-    }
-
-    const legacyToken = accountRuntimeKeyToLegacyAccountToken(runtimeKey)
-    onOpenCCSwitchDialog?.(legacyToken, account)
-  }
-
-  const handleImportToManagedSite = async (event: MouseEvent) => {
-    event.stopPropagation()
-    const tracker = startProductAnalyticsAction({
-      featureId: PRODUCT_ANALYTICS_FEATURE_IDS.ManagedSiteChannels,
-      actionId: PRODUCT_ANALYTICS_ACTION_IDS.ImportManagedSiteSingleToken,
-      surfaceId:
-        PRODUCT_ANALYTICS_SURFACE_IDS.OptionsAccountManagementRowActions,
-      entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Options,
-    })
-
-    const result = serviceCredentialProfile
-      ? await openWithCredentials(
-          {
-            name: serviceCredentialProfile.name,
-            baseUrl: serviceCredentialProfile.baseUrl,
-            apiKey: serviceCredentialProfile.apiKey,
-          },
-          (channelResult) => {
-            showResultToast(channelResult)
-            if (channelResult?.success) {
-              void markGatewayGuidanceOnboardingCompleted()
-            }
-          },
-          {
-            managedSiteStatus: undefined,
-          },
-        )
-      : await openWithAccount(
-          account,
-          accountRuntimeKeyToLegacyAccountToken(runtimeKey),
-          (channelResult) => {
-            showResultToast(channelResult)
-            if (channelResult?.success) {
-              void markGatewayGuidanceOnboardingCompleted()
-            }
-          },
-        )
-
-    if (result.opened || result.deferred) {
-      tracker.complete(PRODUCT_ANALYTICS_RESULTS.Success)
-      return
-    }
-
-    tracker.complete(PRODUCT_ANALYTICS_RESULTS.Skipped)
-  }
-
-  const handleOpenCliProxyDialog = (event: MouseEvent) => {
-    event.stopPropagation()
-    if (!cliProxyBaseUrl?.trim() || !cliProxyManagementKey?.trim()) {
-      showResultToast({
-        success: false,
-        message: t("messages:cliproxy.configMissing"),
-      })
-      return
-    }
-    setIsCliProxyDialogOpen(true)
-  }
-
-  const handleOpenClaudeCodeRouter = (event: MouseEvent) => {
-    event.stopPropagation()
-    if (!claudeCodeRouterBaseUrl) {
-      showResultToast({
-        success: false,
-        message: t("messages:claudeCodeRouter.configMissing"),
-      })
-      return
-    }
-    setIsClaudeCodeRouterOpen(true)
-  }
-
-  const renderKiloCodeExportDialog = () => {
-    if (!isKiloCodeDialogOpen) return null
-
-    if (serviceCredentialProfile) {
-      return (
-        <KiloCodeProfileExportDialog
-          isOpen={true}
-          onClose={() => setIsKiloCodeDialogOpen(false)}
-          profile={serviceCredentialProfile}
-        />
-      )
-    }
-
-    if (!accountToken) return null
-
-    return (
-      <KiloCodeExportDialog
-        isOpen={true}
-        onClose={() => setIsKiloCodeDialogOpen(false)}
-        initialSelectedSiteIds={[account.id]}
-        initialSelectedTokenIdsBySite={{
-          [account.id]: [`${accountToken.id}`],
-        }}
-      />
-    )
-  }
-
-  const renderClaudeCodeRouterImportDialog = () => {
-    if (!isClaudeCodeRouterOpen) return null
-
-    if (serviceCredentialProfile) {
-      return (
-        <ClaudeCodeRouterImportDialog
-          isOpen={true}
-          onClose={() => setIsClaudeCodeRouterOpen(false)}
-          account={createExportAccount(serviceCredentialProfile)}
-          token={createExportToken(serviceCredentialProfile)}
-          routerBaseUrl={claudeCodeRouterBaseUrl}
-          routerApiKey={claudeCodeRouterApiKey}
-        />
-      )
-    }
-
-    const legacyToken = accountRuntimeKeyToLegacyAccountToken(runtimeKey)
-
-    return (
-      <ClaudeCodeRouterImportDialog
-        isOpen={true}
-        onClose={() => setIsClaudeCodeRouterOpen(false)}
-        account={account}
-        token={legacyToken}
-        routerBaseUrl={claudeCodeRouterBaseUrl}
-        routerApiKey={claudeCodeRouterApiKey}
-      />
-    )
-  }
-
-  const renderCliProxyExportDialog = () => {
-    if (!isCliProxyDialogOpen) return null
-
-    if (serviceCredentialProfile) {
-      const cliProxyPayload = createCliProxyExportPayload(
-        serviceCredentialProfile,
-      )
-
-      return (
-        <CliProxyExportDialog
-          isOpen={true}
-          onClose={() => setIsCliProxyDialogOpen(false)}
-          account={cliProxyPayload.account}
-          token={cliProxyPayload.token}
-          apiTypeHint={cliProxyPayload.apiTypeHint}
-        />
-      )
-    }
-
-    const legacyToken = accountRuntimeKeyToLegacyAccountToken(runtimeKey)
-
-    return (
-      <CliProxyExportDialog
-        isOpen={true}
-        onClose={() => setIsCliProxyDialogOpen(false)}
-        account={account}
-        token={legacyToken}
-      />
-    )
-  }
-
   return (
-    <div className="dark:border-dark-bg-tertiary dark:bg-dark-bg-primary border-t border-gray-100 bg-gray-50/30 px-3 pb-3">
-      {renderKiloCodeExportDialog()}
-      {renderClaudeCodeRouterImportDialog()}
-      {renderCliProxyExportDialog()}
-      {accountToken ? (
-        <div className="dark:text-dark-text-secondary mb-3 flex items-center space-x-1 pt-3 text-xs text-gray-500">
-          <ClockIcon className="h-3 w-3" />
-          <span>
-            {t("dialog.copyKey.expireTime", {
-              time: formatKeyTime(accountToken.expired_time),
-            })}
-          </span>
-        </div>
-      ) : null}
-
-      {accountToken ? (
-        <div className="mb-3 grid grid-cols-2 gap-2">
-          <div className="dark:border-dark-bg-tertiary dark:bg-dark-bg-secondary rounded border border-gray-100 bg-white p-2">
-            <div className="dark:text-dark-text-secondary mb-0.5 text-xs text-gray-500">
-              {t("dialog.copyKey.usedQuota")}
-            </div>
-            <div className="dark:text-dark-text-primary text-sm font-semibold text-gray-900">
-              {formatUsedQuota(accountToken)}
-            </div>
-          </div>
-          <div className="dark:border-dark-bg-tertiary dark:bg-dark-bg-secondary rounded border border-gray-100 bg-white p-2">
-            <div className="dark:text-dark-text-secondary mb-0.5 text-xs text-gray-500">
-              {t("dialog.copyKey.remainingQuota")}
-            </div>
-            <div
-              className={`text-sm font-semibold ${
-                accountToken.unlimited_quota || accountToken.remain_quota < 0
-                  ? "text-green-600"
-                  : accountToken.remain_quota < 1000000
-                    ? "text-orange-600"
-                    : "dark:text-dark-text-primary text-gray-900"
-              }`}
-            >
-              {formatQuota(accountToken)}
-            </div>
-          </div>
-        </div>
-      ) : null}
-
-      <div className="dark:border-dark-bg-tertiary dark:bg-dark-bg-secondary rounded border border-gray-100 bg-white p-2">
-        <div className="mb-1 flex flex-wrap items-center justify-between gap-2">
-          <span className="dark:text-dark-text-secondary text-xs font-medium tracking-wide text-gray-500 uppercase">
-            {t("dialog.copyKey.apiKey")}
-          </span>
-          <div className="flex flex-wrap items-center gap-1 sm:gap-1.5">
-            <IconButton
-              aria-label={
-                copiedRuntimeKeyId === runtimeKey.id
-                  ? t("dialog.copyKey.copied")
-                  : t("dialog.copyKey.copy")
-              }
-              variant="ghost"
-              size="sm"
-              onClick={handleCopy}
-            >
-              {copiedRuntimeKeyId === runtimeKey.id ? (
-                <CheckIcon className="h-4 w-4 text-green-500" />
-              ) : (
-                <Copy className="dark:text-dark-text-tertiary h-4 w-4 text-gray-500" />
-              )}
-            </IconButton>
-            <IconButton
-              aria-label={t("dialog.copyKey.useInCherry")}
-              variant="ghost"
-              size="sm"
-              onClick={handleUseInCherry}
-            >
-              <CherryIcon />
-            </IconButton>
-            {onOpenCCSwitchDialog && (
-              <IconButton
-                aria-label={t("dialog.copyKey.exportToCCSwitch")}
-                variant="ghost"
-                size="sm"
-                data-testid={
-                  ACCOUNT_MANAGEMENT_TEST_IDS.copyKeyDialogExportToCCSwitchButton
-                }
-                onClick={handleExportToCCSwitch}
-              >
-                <CCSwitchIcon />
-              </IconButton>
-            )}
-            <IconButton
-              aria-label={t("keyManagement:actions.exportToKiloCode")}
-              variant="ghost"
-              size="sm"
-              onClick={(event) => {
-                event.stopPropagation()
-                setIsKiloCodeDialogOpen(true)
-              }}
-            >
-              <KiloCodeIcon className="dark:text-dark-text-tertiary text-gray-500" />
-            </IconButton>
-            <IconButton
-              aria-label={t("keyManagement:actions.importToCliProxy")}
-              variant="ghost"
-              size="sm"
-              onClick={handleOpenCliProxyDialog}
-            >
-              <CliProxyIcon size="sm" />
-            </IconButton>
-            <IconButton
-              aria-label={t("keyManagement:actions.importToClaudeCodeRouter")}
-              variant="ghost"
-              size="sm"
-              onClick={handleOpenClaudeCodeRouter}
-            >
-              <ClaudeCodeRouterIcon size="sm" />
-            </IconButton>
-            <IconButton
-              aria-label={t("keyManagement:actions.importToManagedSite", {
-                site: managedSiteLabel,
-              })}
-              variant="ghost"
-              size="sm"
-              onClick={handleImportToManagedSite}
-            >
-              <ManagedSiteIcon siteType={managedSiteType} size="sm" />
-            </IconButton>
-          </div>
-        </div>
-        <div className="dark:border-dark-bg-tertiary dark:bg-dark-bg-primary dark:text-dark-text-secondary rounded border border-gray-200 bg-gray-50 px-2 py-1 font-mono text-xs break-all text-gray-700">
-          <span className="dark:text-dark-text-primary text-gray-900">
-            {secretPreview.prefix}
-          </span>
-          {secretPreview.suffix ? (
-            <>
-              <span className="text-gray-400 dark:text-gray-600">
-                {"•".repeat(SECRET_PREVIEW_MASK_LENGTH)}
-              </span>
-              <span className="dark:text-dark-text-primary text-gray-900">
-                {secretPreview.suffix}
-              </span>
-            </>
-          ) : null}
-        </div>
+    <div className="dark:border-dark-bg-tertiary dark:bg-dark-bg-primary border-t border-gray-100 bg-gray-50/30 px-3 py-3">
+      <div className="dark:border-dark-bg-tertiary dark:bg-dark-bg-secondary flex min-w-0 flex-wrap items-center justify-between gap-2 rounded border border-gray-100 bg-white p-2">
+        <RuntimeKeySecretPreview secret={runtimeKey.secret} />
+        <RuntimeKeyActionControls
+          runtimeKey={runtimeKey}
+          actionPolicy={SERVICE_CREDENTIAL_ACTION_POLICY}
+          copiedRuntimeKeyId={copiedRuntimeKeyId}
+          onCopyKey={onCopyKey}
+          account={account}
+          onOpenCCSwitchDialog={onOpenCCSwitchDialog}
+        />
       </div>
     </div>
   )

--- a/src/features/AccountManagement/components/CopyKeyDialog/RuntimeKeyItem.tsx
+++ b/src/features/AccountManagement/components/CopyKeyDialog/RuntimeKeyItem.tsx
@@ -7,7 +7,6 @@ import { useTranslation } from "react-i18next"
 
 import { Badge, Card, CardContent, IconButton } from "~/components/ui"
 import { getCopyKeyDialogRuntimeKeyItemTestId } from "~/features/AccountManagement/testIds"
-import { KeyResourceCard } from "~/features/KeyManagement/components/KeyResourceCard"
 import { buildLegacyKeyResourceCardPresentation } from "~/features/KeyManagement/presentation/legacyKeyResourceCard"
 import {
   ACCOUNT_RUNTIME_KEY_STATUSES,
@@ -18,6 +17,7 @@ import {
 import type { ApiToken, DisplaySiteData } from "~/types"
 import { getGroupBadgeStyle } from "~/utils/core/formatters"
 
+import { QuickKeyResourceCard } from "./QuickKeyResourceCard"
 import { RuntimeKeyActionControls } from "./RuntimeKeyActionControls"
 import { RuntimeKeyDetails, RuntimeKeySecretPreview } from "./RuntimeKeyDetails"
 
@@ -151,7 +151,7 @@ function AccountTokenRuntimeKeyItem({
   const presentation = buildLegacyKeyResourceCardPresentation(runtimeKey, t)
 
   return (
-    <KeyResourceCard
+    <QuickKeyResourceCard
       presentation={presentation}
       secret={
         presentation.actions.copySecret ? (
@@ -170,9 +170,8 @@ function AccountTokenRuntimeKeyItem({
           onOpenCCSwitchDialog={onOpenCCSwitchDialog}
         />
       }
-      details={{ status: "ready", facts: presentation.detailFacts }}
-      isDetailsExpanded={isExpanded}
-      onDetailsExpandedChange={() => onToggle()}
+      isExpanded={isExpanded}
+      onExpandedChange={() => onToggle()}
       testId={getCopyKeyDialogRuntimeKeyItemTestId(runtimeKey.id)}
     />
   )

--- a/src/features/AccountManagement/components/CopyKeyDialog/RuntimeKeyItem.tsx
+++ b/src/features/AccountManagement/components/CopyKeyDialog/RuntimeKeyItem.tsx
@@ -7,15 +7,19 @@ import { useTranslation } from "react-i18next"
 
 import { Badge, Card, CardContent, IconButton } from "~/components/ui"
 import { getCopyKeyDialogRuntimeKeyItemTestId } from "~/features/AccountManagement/testIds"
+import { KeyResourceCard } from "~/features/KeyManagement/components/KeyResourceCard"
+import { buildLegacyKeyResourceCardPresentation } from "~/features/KeyManagement/presentation/legacyKeyResourceCard"
 import {
   ACCOUNT_RUNTIME_KEY_STATUSES,
   isAccountTokenRuntimeKey,
   type AccountRuntimeKey,
+  type AccountTokenRuntimeKey,
 } from "~/services/accounts/accountRuntimeKeys"
 import type { ApiToken, DisplaySiteData } from "~/types"
 import { getGroupBadgeStyle } from "~/utils/core/formatters"
 
-import { RuntimeKeyDetails } from "./RuntimeKeyDetails"
+import { RuntimeKeyActionControls } from "./RuntimeKeyActionControls"
+import { RuntimeKeyDetails, RuntimeKeySecretPreview } from "./RuntimeKeyDetails"
 
 const getRuntimeKeyStatusBadgeStyle = (
   runtimeKey: Pick<AccountRuntimeKey, "status">,
@@ -47,9 +51,22 @@ export function RuntimeKeyItem({
   onOpenCCSwitchDialog,
 }: RuntimeKeyItemProps) {
   const { t } = useTranslation("ui")
-  const group = isAccountTokenRuntimeKey(runtimeKey)
-    ? runtimeKey.token.group
-    : ""
+
+  if (isAccountTokenRuntimeKey(runtimeKey)) {
+    return (
+      <AccountTokenRuntimeKeyItem
+        runtimeKey={runtimeKey}
+        isExpanded={isExpanded}
+        copiedRuntimeKeyId={copiedRuntimeKeyId}
+        onToggle={onToggle}
+        onCopyKey={onCopyKey}
+        account={account}
+        onOpenCCSwitchDialog={onOpenCCSwitchDialog}
+      />
+    )
+  }
+
+  const group = ""
   const isActive = runtimeKey.status === ACCOUNT_RUNTIME_KEY_STATUSES.Active
 
   return (
@@ -115,5 +132,48 @@ export function RuntimeKeyItem({
         />
       )}
     </Card>
+  )
+}
+
+/** Composes a legacy account runtime key through the shared key-resource card. */
+function AccountTokenRuntimeKeyItem({
+  runtimeKey,
+  isExpanded,
+  copiedRuntimeKeyId,
+  onToggle,
+  onCopyKey,
+  account,
+  onOpenCCSwitchDialog,
+}: Omit<RuntimeKeyItemProps, "runtimeKey"> & {
+  runtimeKey: AccountTokenRuntimeKey
+}) {
+  const { t } = useTranslation("keyManagement")
+  const presentation = buildLegacyKeyResourceCardPresentation(runtimeKey, t)
+
+  return (
+    <KeyResourceCard
+      presentation={presentation}
+      secret={
+        presentation.actions.copySecret ? (
+          <RuntimeKeySecretPreview secret={runtimeKey.secret} />
+        ) : presentation.maskedLabel ? (
+          <code>{presentation.maskedLabel}</code>
+        ) : undefined
+      }
+      secretControls={
+        <RuntimeKeyActionControls
+          runtimeKey={runtimeKey}
+          actionPolicy={presentation.actions}
+          copiedRuntimeKeyId={copiedRuntimeKeyId}
+          onCopyKey={onCopyKey}
+          account={account}
+          onOpenCCSwitchDialog={onOpenCCSwitchDialog}
+        />
+      }
+      details={{ status: "ready", facts: presentation.detailFacts }}
+      isDetailsExpanded={isExpanded}
+      onDetailsExpandedChange={() => onToggle()}
+      testId={getCopyKeyDialogRuntimeKeyItemTestId(runtimeKey.id)}
+    />
   )
 }

--- a/src/features/AccountManagement/components/CopyKeyDialog/RuntimeKeyItem.tsx
+++ b/src/features/AccountManagement/components/CopyKeyDialog/RuntimeKeyItem.tsx
@@ -66,7 +66,6 @@ export function RuntimeKeyItem({
     )
   }
 
-  const group = ""
   const isActive = runtimeKey.status === ACCOUNT_RUNTIME_KEY_STATUSES.Active
 
   return (
@@ -87,9 +86,9 @@ export function RuntimeKeyItem({
               <Badge
                 variant="outline"
                 size="sm"
-                className={getGroupBadgeStyle(group || "")}
+                className={getGroupBadgeStyle("")}
               >
-                {group || t("dialog.copyKey.defaultGroup")}
+                {t("dialog.copyKey.defaultGroup")}
               </Badge>
             </div>
           </div>

--- a/src/features/AccountManagement/components/CopyKeyDialog/hooks/useCopyKeyDialog.ts
+++ b/src/features/AccountManagement/components/CopyKeyDialog/hooks/useCopyKeyDialog.ts
@@ -2,6 +2,11 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import toast from "react-hot-toast"
 import { useTranslation } from "react-i18next"
 
+import {
+  KEY_MANAGEMENT_DISPLAY_ROW_KINDS,
+  type NativeKeyManagementRow,
+} from "~/features/KeyManagement/types"
+import { fetchDisplayAccountKeyResourceInventory } from "~/services/accounts/accountKeyResourceInventory"
 import { resolveDefaultTokenQuickCreateResolution } from "~/services/accounts/accountOperations"
 import {
   appendOrReplaceAccountRuntimeKey,
@@ -11,7 +16,9 @@ import {
 import { shouldShowOneTimeKeyDialogForCreatedToken } from "~/services/accounts/createdTokenSecretHandling"
 import {
   canCreateAccountApiTokens,
+  canListAccountKeyResources,
   canListAccountRuntimeKeys,
+  supportsAccountApiTokenCreation,
 } from "~/services/accounts/keyProductCapabilities"
 import { TOKEN_QUICK_CREATE_RESOLUTION_KINDS } from "~/services/accounts/tokenQuickCreateResolution"
 import {
@@ -51,7 +58,7 @@ const copyKeyAnalyticsContext = {
 }
 
 /**
- * CopyKeyDialog 核心逻辑 hook，负责加载 runtime key、处理复制与展开状态。
+ * CopyKeyDialog 核心逻辑 hook，负责加载密钥清单、处理复制与展开状态。
  * @param isOpen 对话框是否打开
  * @param account 当前账号（可能为空）
  * @returns runtime key 数据、加载状态、错误以及相关操作方法
@@ -62,6 +69,9 @@ export function useCopyKeyDialog(
 ) {
   const { t } = useTranslation(["ui", "messages"])
   const [runtimeKeys, setRuntimeKeys] = useState<AccountRuntimeKey[]>([])
+  const [nativeKeyRows, setNativeKeyRows] = useState<NativeKeyManagementRow[]>(
+    [],
+  )
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [isCreating, setIsCreating] = useState(false)
@@ -78,8 +88,9 @@ export function useCopyKeyDialog(
   const copiedRuntimeKeyResetTimeoutRef = useRef<ReturnType<
     typeof setTimeout
   > | null>(null)
-  // Incremented to invalidate slower runtime-key inventory requests after account eligibility changes.
+  // Incremented to invalidate slower inventory requests after account eligibility changes.
   const fetchRequestIdRef = useRef(0)
+  const inventoryAbortControllerRef = useRef<AbortController | null>(null)
 
   const canCreateDefaultKey = useMemo(
     () => canCreateAccountApiTokens(account),
@@ -88,6 +99,16 @@ export function useCopyKeyDialog(
 
   const canLoadRuntimeKeys = useMemo(
     () => canListAccountRuntimeKeys(account),
+    [account],
+  )
+
+  const canLoadNativeKeys = useMemo(
+    () => canListAccountKeyResources(account),
+    [account],
+  )
+
+  const supportsApiTokenCreation = useMemo(
+    () => Boolean(account && supportsAccountApiTokenCreation(account.siteType)),
     [account],
   )
 
@@ -102,11 +123,14 @@ export function useCopyKeyDialog(
     setDefaultTokenCreateAllowedGroups(null)
   }, [])
 
-  const fetchRuntimeKeys = useCallback(async () => {
+  const fetchKeyInventory = useCallback(async () => {
     if (!account) return
-    if (!canLoadRuntimeKeys) {
+    inventoryAbortControllerRef.current?.abort()
+
+    if (!canLoadRuntimeKeys && !canLoadNativeKeys) {
       fetchRequestIdRef.current += 1
       setRuntimeKeys([])
+      setNativeKeyRows([])
       setError(null)
       setCreateError(null)
       setOneTimeToken(null)
@@ -118,17 +142,45 @@ export function useCopyKeyDialog(
     }
 
     const requestId = (fetchRequestIdRef.current += 1)
+    const controller = new AbortController()
+    inventoryAbortControllerRef.current = controller
     setIsLoading(true)
     setError(null)
     setCreateError(null)
     clearDefaultTokenCreateAllowedGroups()
 
     try {
+      if (canLoadNativeKeys) {
+        const inventory = await fetchDisplayAccountKeyResourceInventory(
+          account,
+          { signal: controller.signal },
+        )
+        if (fetchRequestIdRef.current !== requestId) return
+        setRuntimeKeys([])
+        setNativeKeyRows(
+          inventory.items.map((facts, index) => ({
+            kind: KEY_MANAGEMENT_DISPLAY_ROW_KINDS.AccountKeyResource,
+            rowKey: `copy-key-native-${requestId}-${index}`,
+            accountId: account.id,
+            accountName: account.name,
+            workspaceName: inventory.scope.displayName,
+            facts,
+          })),
+        )
+        return
+      }
+
       const loadedRuntimeKeys = await fetchDisplayAccountRuntimeKeys(account)
       if (fetchRequestIdRef.current !== requestId) return
+      setNativeKeyRows([])
       setRuntimeKeys(loadedRuntimeKeys)
     } catch (error) {
-      if (fetchRequestIdRef.current !== requestId) return
+      if (
+        fetchRequestIdRef.current !== requestId ||
+        controller.signal.aborted
+      ) {
+        return
+      }
       logger.error("Failed to load key list", {
         error,
         accountId: account.id,
@@ -142,17 +194,29 @@ export function useCopyKeyDialog(
       setError(t("ui:dialog.copyKey.loadFailed", { error: errorMessage }))
     } finally {
       if (fetchRequestIdRef.current === requestId) {
+        if (inventoryAbortControllerRef.current === controller) {
+          inventoryAbortControllerRef.current = null
+        }
         setIsLoading(false)
       }
     }
-  }, [account, canLoadRuntimeKeys, clearDefaultTokenCreateAllowedGroups, t])
+  }, [
+    account,
+    canLoadNativeKeys,
+    canLoadRuntimeKeys,
+    clearDefaultTokenCreateAllowedGroups,
+    t,
+  ])
 
   useEffect(() => {
     if (isOpen && account) {
-      fetchRuntimeKeys()
+      fetchKeyInventory()
     } else {
+      inventoryAbortControllerRef.current?.abort()
+      inventoryAbortControllerRef.current = null
       clearCopiedRuntimeKeyResetTimeout()
       setRuntimeKeys([])
+      setNativeKeyRows([])
       setError(null)
       setIsCreating(false)
       setCreateError(null)
@@ -165,12 +229,13 @@ export function useCopyKeyDialog(
     account,
     clearCopiedRuntimeKeyResetTimeout,
     clearDefaultTokenCreateAllowedGroups,
-    fetchRuntimeKeys,
+    fetchKeyInventory,
     isOpen,
   ])
 
   useEffect(() => {
     return () => {
+      inventoryAbortControllerRef.current?.abort()
       clearCopiedRuntimeKeyResetTimeout()
     }
   }, [clearCopiedRuntimeKeyResetTimeout])
@@ -368,6 +433,7 @@ export function useCopyKeyDialog(
 
   return {
     runtimeKeys,
+    nativeKeyRows,
     isLoading,
     error,
     isCreating,
@@ -377,7 +443,8 @@ export function useCopyKeyDialog(
     copiedRuntimeKeyId,
     expandedRuntimeKeys,
     canCreateDefaultKey,
-    fetchRuntimeKeys,
+    supportsApiTokenCreation,
+    fetchKeyInventory,
     copyKey,
     createDefaultKey,
     refreshRuntimeKeysAfterCreate,

--- a/src/features/AccountManagement/components/CopyKeyDialog/index.tsx
+++ b/src/features/AccountManagement/components/CopyKeyDialog/index.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 
 import { CCSwitchExportDialog } from "~/components/CCSwitchExportDialog"
-import { Modal } from "~/components/ui"
+import { Alert, Modal } from "~/components/ui"
 import { useCopyKeyDialog } from "~/features/AccountManagement/components/CopyKeyDialog/hooks/useCopyKeyDialog"
 import { ACCOUNT_MANAGEMENT_TEST_IDS } from "~/features/AccountManagement/testIds"
 import AddTokenDialog from "~/features/TokenProvisioning/components/AddTokenDialog"
@@ -10,6 +10,7 @@ import { buildDefaultTokenCreatePrefill } from "~/features/TokenProvisioning/com
 import { OneTimeSecretDialog } from "~/features/TokenProvisioning/components/OneTimeSecretDialog"
 import { useLegacyApiTokenSecretResult } from "~/features/TokenProvisioning/hooks/useLegacyApiTokenSecretResult"
 import { buildOneTimeApiKeyProfileSaveAction } from "~/features/TokenProvisioning/utils/apiCredentialProfileSaveAction"
+import { supportsRecoverableAccountRuntimeKeySecrets } from "~/services/accounts/keyProductCapabilities"
 import type { ApiToken, DisplaySiteData } from "~/types"
 import { createLogger } from "~/utils/core/logger"
 import { openKeysPage } from "~/utils/navigation"
@@ -77,6 +78,9 @@ export default function CopyKeyDialog({
         })
       : undefined
   const oneTimeSecretResult = useLegacyApiTokenSecretResult(oneTimeToken)
+  const showCreateResponseOnlyWarning =
+    account !== null &&
+    !supportsRecoverableAccountRuntimeKeySecrets(account.siteType)
 
   const handleOpenAddTokenDialog = () => {
     clearDefaultTokenCreateAllowedGroups()
@@ -186,7 +190,18 @@ export default function CopyKeyDialog({
           />
         }
       >
-        <div className="flex-1 overflow-y-auto">{renderContent()}</div>
+        <div className="flex-1 space-y-3 overflow-y-auto">
+          {showCreateResponseOnlyWarning ? (
+            <Alert
+              compact
+              variant="warning"
+              description={keyManagementT(
+                "keyDetails.createResponseOnlySecret",
+              )}
+            />
+          ) : null}
+          {renderContent()}
+        </div>
       </Modal>
       {ccSwitchContext && (
         <CCSwitchExportDialog

--- a/src/features/AccountManagement/components/CopyKeyDialog/index.tsx
+++ b/src/features/AccountManagement/components/CopyKeyDialog/index.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next"
 import { CCSwitchExportDialog } from "~/components/CCSwitchExportDialog"
 import { Modal } from "~/components/ui"
 import { useCopyKeyDialog } from "~/features/AccountManagement/components/CopyKeyDialog/hooks/useCopyKeyDialog"
+import { ACCOUNT_MANAGEMENT_TEST_IDS } from "~/features/AccountManagement/testIds"
 import AddTokenDialog from "~/features/TokenProvisioning/components/AddTokenDialog"
 import { buildDefaultTokenCreatePrefill } from "~/features/TokenProvisioning/components/AddTokenDialog/defaultTokenCreatePrefill"
 import { OneTimeSecretDialog } from "~/features/TokenProvisioning/components/OneTimeSecretDialog"
@@ -11,12 +12,13 @@ import { useLegacyApiTokenSecretResult } from "~/features/TokenProvisioning/hook
 import { buildOneTimeApiKeyProfileSaveAction } from "~/features/TokenProvisioning/utils/apiCredentialProfileSaveAction"
 import type { ApiToken, DisplaySiteData } from "~/types"
 import { createLogger } from "~/utils/core/logger"
+import { openKeysPage } from "~/utils/navigation"
 
 import { DialogFooter } from "./DialogFooter"
 import { DialogHeader } from "./DialogHeader"
 import { ErrorDisplay } from "./ErrorDisplay"
+import { KeyInventoryList } from "./KeyInventoryList"
 import { LoadingIndicator } from "./LoadingIndicator"
-import { RuntimeKeyList } from "./RuntimeKeyList"
 
 interface CopyKeyDialogProps {
   isOpen: boolean
@@ -42,6 +44,7 @@ export default function CopyKeyDialog({
   } | null>(null)
   const {
     runtimeKeys,
+    nativeKeyRows,
     isLoading,
     error,
     isCreating,
@@ -51,7 +54,8 @@ export default function CopyKeyDialog({
     copiedRuntimeKeyId,
     expandedRuntimeKeys,
     canCreateDefaultKey,
-    fetchRuntimeKeys,
+    supportsApiTokenCreation,
+    fetchKeyInventory,
     copyKey,
     createDefaultKey,
     refreshRuntimeKeysAfterCreate,
@@ -129,19 +133,26 @@ export default function CopyKeyDialog({
 
   const handleCloseCCSwitchDialog = () => setCCSwitchContext(null)
 
+  const handleOpenKeyManagement = () => {
+    if (!account) return
+    onClose()
+    void openKeysPage(account.id)
+  }
+
   const renderContent = () => {
     if (isLoading) {
       return <LoadingIndicator />
     }
     if (error) {
-      return <ErrorDisplay error={error} onRetry={fetchRuntimeKeys} />
+      return <ErrorDisplay error={error} onRetry={fetchKeyInventory} />
     }
     if (!account) {
       return null
     }
     return (
-      <RuntimeKeyList
+      <KeyInventoryList
         runtimeKeys={runtimeKeys}
+        nativeKeyRows={nativeKeyRows}
         expandedRuntimeKeys={expandedRuntimeKeys}
         copiedRuntimeKeyId={copiedRuntimeKeyId}
         onToggleRuntimeKey={toggleRuntimeKeyExpansion}
@@ -153,6 +164,7 @@ export default function CopyKeyDialog({
         createError={createError}
         onCreateDefaultKey={createDefaultKey}
         onOpenAddTokenDialog={handleOpenAddTokenDialog}
+        supportsApiTokenCreation={supportsApiTokenCreation}
       />
     )
   }
@@ -162,10 +174,16 @@ export default function CopyKeyDialog({
       <Modal
         isOpen={isOpen}
         onClose={onClose}
+        size="lg"
         panelClassName="max-h-[85vh] overflow-hidden flex flex-col"
+        footerTestId={ACCOUNT_MANAGEMENT_TEST_IDS.copyKeyDialogFooter}
         header={<DialogHeader account={account} />}
         footer={
-          <DialogFooter keyCount={runtimeKeys.length} onClose={onClose} />
+          <DialogFooter
+            keyCount={runtimeKeys.length + nativeKeyRows.length}
+            onClose={onClose}
+            onOpenKeyManagement={account ? handleOpenKeyManagement : undefined}
+          />
         }
       >
         <div className="flex-1 overflow-y-auto">{renderContent()}</div>

--- a/src/features/AccountManagement/testIds.ts
+++ b/src/features/AccountManagement/testIds.ts
@@ -36,6 +36,7 @@ export const ACCOUNT_MANAGEMENT_TEST_IDS = {
   rowCopyKeyButton: "account-management-row-copy-key-button",
   copyKeyDialogRuntimeKeyItem:
     "account-management-copy-key-dialog-runtime-key-item",
+  copyKeyDialogFooter: "account-management-copy-key-dialog-footer",
   copyKeyDialogExportToCCSwitchButton:
     "account-management-copy-key-dialog-export-to-cc-switch-button",
   rowEditButton: "account-management-row-edit-button",

--- a/src/features/ApiCredentialProfiles/components/ApiCredentialProfileListItem.tsx
+++ b/src/features/ApiCredentialProfiles/components/ApiCredentialProfileListItem.tsx
@@ -50,25 +50,14 @@ import { getApiVerificationApiTypeLabel } from "~/services/verification/aiApiVer
 import type { ApiVerificationHistorySummary } from "~/services/verification/verificationResultHistory"
 import { SiteHealthStatus } from "~/types"
 import type { ApiCredentialProfile } from "~/types/apiCredentialProfiles"
-import { formatLocaleDateTime, formatTokenCount } from "~/utils/core/formatters"
+import {
+  formatLocaleDateTime,
+  formatTokenCount,
+  maskSecretForDisplay,
+} from "~/utils/core/formatters"
 import { formatTelemetryMoney } from "~/utils/core/money"
 
 import { API_CREDENTIAL_PROFILES_TEST_IDS } from "../testIds"
-
-/**
- * Formats a secret for display (masked by default, revealable per-profile).
- */
-function formatSecret(
-  secret: string,
-  id: string,
-  visibleIds: Set<string>,
-): string {
-  if (visibleIds.has(id)) return secret
-  if (secret.length < 12) return "******"
-  return `${secret.substring(0, 8)}${"*".repeat(16)}${secret.substring(
-    secret.length - 4,
-  )}`
-}
 
 export type ApiCredentialProfileExportAction =
   | "cherryStudio"
@@ -347,7 +336,9 @@ export function ApiCredentialProfileListItem({
                   </span>
                   <div className="flex w-full min-w-0 items-center gap-0.5 sm:flex-1">
                     <code className="dark:bg-dark-bg-tertiary dark:text-dark-text-secondary min-w-0 flex-1 truncate rounded bg-gray-100 px-2 py-1 font-mono text-[10px] text-gray-800 sm:text-xs">
-                      {formatSecret(profile.apiKey, profile.id, visibleKeys)}
+                      {visibleKeys.has(profile.id)
+                        ? profile.apiKey
+                        : maskSecretForDisplay(profile.apiKey)}
                     </code>
                     <IconButton
                       variant="ghost"

--- a/src/features/KeyManagement/components/KeyResourceCard.tsx
+++ b/src/features/KeyManagement/components/KeyResourceCard.tsx
@@ -19,6 +19,15 @@ import type {
   KeyResourceFact,
 } from "~/features/KeyManagement/presentation/keyResourceCard"
 import { KEY_MANAGEMENT_TEST_IDS } from "~/features/KeyManagement/testIds"
+import { cn } from "~/lib/utils"
+
+export const KEY_RESOURCE_CONTENT_LAYOUTS = {
+  Default: "default",
+  Adaptive: "adaptive",
+} as const
+
+type KeyResourceContentLayout =
+  (typeof KEY_RESOURCE_CONTENT_LAYOUTS)[keyof typeof KEY_RESOURCE_CONTENT_LAYOUTS]
 
 export type KeyResourceCardProps = {
   presentation: KeyResourceCardPresentation
@@ -54,6 +63,7 @@ export type KeyResourceCardHeaderProps = {
 export type KeyResourceFactListProps = {
   facts: KeyResourceFact[]
   testId?: string
+  layout?: KeyResourceContentLayout
 }
 
 export type KeyResourceSecretDisplayProps = {
@@ -61,6 +71,7 @@ export type KeyResourceSecretDisplayProps = {
   secret?: ReactNode
   controls?: ReactNode
   message?: ReactNode
+  layout?: KeyResourceContentLayout
 }
 
 /**
@@ -120,11 +131,17 @@ export function KeyResourceCardHeader({
 export function KeyResourceFactList({
   facts,
   testId,
+  layout = KEY_RESOURCE_CONTENT_LAYOUTS.Default,
 }: KeyResourceFactListProps) {
   return (
     <div
       data-testid={testId}
-      className="xs:grid-cols-2 grid grid-cols-1 gap-2.5 sm:grid-cols-4 sm:gap-3.5"
+      className={cn(
+        "grid",
+        layout === KEY_RESOURCE_CONTENT_LAYOUTS.Adaptive
+          ? "grid-cols-[repeat(auto-fit,minmax(11rem,1fr))] gap-3.5"
+          : "xs:grid-cols-2 grid-cols-1 gap-2.5 sm:grid-cols-4 sm:gap-3.5",
+      )}
     >
       {facts.map((fact) => (
         <div
@@ -151,9 +168,49 @@ export function KeyResourceSecretDisplay({
   secret,
   controls,
   message,
+  layout = KEY_RESOURCE_CONTENT_LAYOUTS.Default,
 }: KeyResourceSecretDisplayProps) {
   if (!secret && !controls && !message) {
     return null
+  }
+
+  const labelContent = label ? (
+    <span className="dark:text-dark-text-tertiary shrink-0 whitespace-nowrap text-gray-500">
+      {label}
+    </span>
+  ) : null
+  const secretContent = secret ? (
+    <div className="max-w-full min-w-0 font-mono text-xs break-all">
+      {secret}
+    </div>
+  ) : null
+  const controlsContent = controls ? (
+    <div className="flex flex-wrap items-center gap-1.5">{controls}</div>
+  ) : null
+  const messageContent = message ? (
+    <span className="dark:text-dark-text-tertiary min-w-0 text-xs break-words text-gray-500 sm:text-sm">
+      {message}
+    </span>
+  ) : null
+
+  if (layout === KEY_RESOURCE_CONTENT_LAYOUTS.Adaptive) {
+    return (
+      <div
+        data-testid={KEY_MANAGEMENT_TEST_IDS.keyResourceSecretDisplay}
+        className="grid min-w-0 grid-cols-1 gap-2 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-center"
+      >
+        <div className="flex min-w-0 flex-wrap items-center gap-2">
+          {labelContent}
+          {secretContent}
+        </div>
+        {controlsContent ? (
+          <div className="min-w-0 sm:justify-self-end">{controlsContent}</div>
+        ) : null}
+        {messageContent ? (
+          <div className="min-w-0 sm:col-span-2">{messageContent}</div>
+        ) : null}
+      </div>
+    )
   }
 
   return (
@@ -161,24 +218,10 @@ export function KeyResourceSecretDisplay({
       data-testid={KEY_MANAGEMENT_TEST_IDS.keyResourceSecretDisplay}
       className="flex min-w-0 flex-wrap items-center gap-2"
     >
-      {label ? (
-        <span className="dark:text-dark-text-tertiary shrink-0 whitespace-nowrap text-gray-500">
-          {label}
-        </span>
-      ) : null}
-      {secret ? (
-        <div className="max-w-full min-w-0 font-mono text-xs break-all">
-          {secret}
-        </div>
-      ) : null}
-      {controls ? (
-        <div className="flex flex-wrap items-center gap-1.5">{controls}</div>
-      ) : null}
-      {message ? (
-        <span className="dark:text-dark-text-tertiary min-w-0 text-xs break-words text-gray-500 sm:text-sm">
-          {message}
-        </span>
-      ) : null}
+      {labelContent}
+      {secretContent}
+      {controlsContent}
+      {messageContent}
     </div>
   )
 }

--- a/src/features/KeyManagement/controllers/useAccountKeyResourceController.ts
+++ b/src/features/KeyManagement/controllers/useAccountKeyResourceController.ts
@@ -25,6 +25,10 @@ import {
   type ResourceFieldDescriptor,
   type ResourceFieldOption,
 } from "~/services/apiAdapters/contracts/accountKeyResource"
+import {
+  accountKeyResourceRefIdentity,
+  collectAccountKeyResourceInventory,
+} from "~/services/apiAdapters/nativeResources/accountKeyResourceInventory"
 import { mapSettledWithConcurrency } from "~/services/apiAdapters/nativeResources/concurrency"
 import { getSiteTypeCapabilities } from "~/services/apiAdapters/registry"
 import { startProductAnalyticsAction } from "~/services/productAnalytics/actions"
@@ -46,7 +50,6 @@ import {
   KEY_MANAGEMENT_ROUTE_PARAMS,
 } from "../constants"
 
-const MAX_COLLECTION_PAGES = 100
 const ALL_ACCOUNT_CONCURRENCY = 4
 let nextAccountKeyResourceControllerInstanceId = 0
 
@@ -215,8 +218,7 @@ const toFailure = (error: unknown): ResourceFailure =>
     ? error.failure
     : { code: ACCOUNT_KEY_RESOURCE_FAILURE_CODES.Unexpected }
 
-const refIdentity = (ref: AccountKeyResourceRef) =>
-  JSON.stringify([ref.accountId, ref.siteType, ref.scopeKey, ref.resourceId])
+const refIdentity = accountKeyResourceRefIdentity
 
 const refMatchesBoundary = (
   ref: AccountKeyResourceRef,
@@ -402,52 +404,6 @@ const readScopeInventory = async (
   session.listScopeInventory
     ? await session.listScopeInventory(options)
     : { scopes: await session.listScopes(options) }
-
-const collectAll = async (
-  collection: AccountKeyResourceCollection,
-  search: string,
-  signal: AbortSignal,
-) => {
-  const rows: AccountKeyResourceFacts[] = []
-  const refs = new Set<string>()
-  const cursors = new Set<string>()
-  let cursor: string | undefined
-
-  for (let pageCount = 0; pageCount < MAX_COLLECTION_PAGES; pageCount += 1) {
-    const page = await awaitAbortable(
-      collection.list(
-        {
-          ...(search ? { search } : {}),
-          ...(cursor ? { cursor } : {}),
-        },
-        { signal },
-      ),
-      signal,
-    )
-    for (const item of page.items) {
-      const identity = refIdentity(item.ref)
-      if (refs.has(identity)) {
-        throw new AccountKeyResourceError({
-          code: ACCOUNT_KEY_RESOURCE_FAILURE_CODES.Unexpected,
-        })
-      }
-      refs.add(identity)
-      rows.push(item)
-    }
-    if (!page.nextCursor) return rows
-    if (cursors.has(page.nextCursor)) {
-      throw new AccountKeyResourceError({
-        code: ACCOUNT_KEY_RESOURCE_FAILURE_CODES.Unexpected,
-      })
-    }
-    cursors.add(page.nextCursor)
-    cursor = page.nextCursor
-  }
-
-  throw new AccountKeyResourceError({
-    code: ACCOUNT_KEY_RESOURCE_FAILURE_CODES.Unexpected,
-  })
-}
 
 type IndexedAccount = { account: DisplaySiteData; index: number }
 
@@ -1091,11 +1047,10 @@ export function useAccountKeyResourceController({
               }),
               controller.signal,
             )
-            const rows = await collectAll(
-              collection,
-              search.trim(),
-              controller.signal,
-            )
+            const rows = await collectAccountKeyResourceInventory(collection, {
+              search: search.trim(),
+              signal: controller.signal,
+            })
             if (current === generation.current && !controller.signal.aborted) {
               acceptFreshRead({
                 accountId: account.id,
@@ -1245,11 +1200,10 @@ export function useAccountKeyResourceController({
           session.openCollection(scope.scopeKey, { signal: controller.signal }),
           controller.signal,
         )
-        const rows = await collectAll(
-          collection,
-          search.trim(),
-          controller.signal,
-        )
+        const rows = await collectAccountKeyResourceInventory(collection, {
+          search: search.trim(),
+          signal: controller.signal,
+        })
         if (current !== generation.current) return false
         let rehydratedEditor: {
           nativeEditor: AccountKeyResourceEditor

--- a/src/features/KeyManagement/presentation/keyResourceCard.ts
+++ b/src/features/KeyManagement/presentation/keyResourceCard.ts
@@ -25,6 +25,8 @@ export type KeyResourceCardPresentation = {
   secretAvailability: InventorySecretAvailability
   maskedLabel?: string
   secretAvailabilityMessage?: string
+  /** Preferred compact-list context, such as a group or workspace. */
+  contextFact?: KeyResourceFact
   summaryFacts: KeyResourceFact[]
   detailFacts: KeyResourceFact[]
   actions: KeyResourceActionPolicy

--- a/src/features/KeyManagement/presentation/legacyKeyResourceCard.ts
+++ b/src/features/KeyManagement/presentation/legacyKeyResourceCard.ts
@@ -163,6 +163,7 @@ export const buildLegacyKeyResourceCardPresentation = (
   const modelRestrictions =
     token.model_limits_enabled === true ? token.model_limits : token.models
   const isUnlimitedQuota = token.unlimited_quota || token.remain_quota < 0
+  const contextFact = getGroupFact(runtimeKey, t, keyManagement)
   const detailFacts = [
     createFact(
       "quota-policy",
@@ -213,8 +214,9 @@ export const buildLegacyKeyResourceCardPresentation = (
       secretAvailability,
       t,
     ),
+    contextFact,
     summaryFacts: [
-      getGroupFact(runtimeKey, t, keyManagement),
+      contextFact,
       createFact(
         "used-quota",
         t("keyManagement:keyDetails.usedQuota"),

--- a/src/features/KeyManagement/presentation/openRouterKeyResourceCard.ts
+++ b/src/features/KeyManagement/presentation/openRouterKeyResourceCard.ts
@@ -232,6 +232,11 @@ export const buildOpenRouterKeyResourceCardPresentation = (
     OPENROUTER_KEY_FIELD_IDS.LimitRemaining,
   )
   const usage = usdFactValue(row.facts, OPENROUTER_KEY_FIELD_IDS.Usage)
+  const contextFact = {
+    id: OPENROUTER_KEY_FIELD_IDS.Workspace,
+    label: fieldLabel(OPENROUTER_KEY_FIELD_IDS.Workspace, t),
+    value: row.workspaceName,
+  }
 
   return {
     id: row.rowKey,
@@ -243,12 +248,9 @@ export const buildOpenRouterKeyResourceCardPresentation = (
     secretAvailabilityMessage: t(
       "keyManagement:keyDetails.createResponseOnlySecret",
     ),
+    contextFact,
     summaryFacts: [
-      {
-        id: OPENROUTER_KEY_FIELD_IDS.Workspace,
-        label: fieldLabel(OPENROUTER_KEY_FIELD_IDS.Workspace, t),
-        value: row.workspaceName,
-      },
+      contextFact,
       {
         id: OPENROUTER_KEY_FIELD_IDS.Limit,
         label: fieldLabel(OPENROUTER_KEY_FIELD_IDS.Limit, t),
@@ -273,6 +275,27 @@ export const buildOpenRouterKeyResourceCardPresentation = (
       exportSecret: false,
       edit: row.facts.actions.canUpdate,
       delete: row.facts.actions.canDelete,
+      batchSelect: false,
+    },
+  }
+}
+
+/** Projects an OpenRouter key into inventory-only actions for compact read views. */
+export const buildReadOnlyOpenRouterKeyResourceCardPresentation = (
+  row: NativeKeyManagementRow,
+  t: TFunction,
+): KeyResourceCardPresentation => {
+  const presentation = buildOpenRouterKeyResourceCardPresentation(row, t)
+
+  return {
+    ...presentation,
+    actions: {
+      copySecret: false,
+      revealSecret: false,
+      verifySecret: false,
+      exportSecret: false,
+      edit: false,
+      delete: false,
       batchSelect: false,
     },
   }

--- a/src/features/KeyManagement/utils.ts
+++ b/src/features/KeyManagement/utils.ts
@@ -13,6 +13,7 @@ import type {
 } from "~/services/apiAdapters/contracts/serviceCredential"
 import type { ApiServiceRequest } from "~/services/apiTransport/type"
 import type { AccountToken, DisplaySiteData } from "~/types"
+import { maskSecretForDisplay } from "~/utils/core/formatters"
 import { t } from "~/utils/i18n/core"
 
 import type { KeyManagementEntry, ServiceCredentialState } from "./types"
@@ -146,12 +147,7 @@ export const formatKey = (
   if (visibleKeys.has(tokenIdentityKey)) {
     return key
   }
-  if (key.length < 12) {
-    return "******"
-  }
-  return `${key.substring(0, 8)}${"*".repeat(16)}${key.substring(
-    key.length - 4,
-  )}`
+  return maskSecretForDisplay(key)
 }
 
 // 格式化额度

--- a/src/locales/en/keyManagement.json
+++ b/src/locales/en/keyManagement.json
@@ -194,7 +194,7 @@
   "enabledCount_one": "Enabled {{count}}",
   "enabledCount_other": "Enabled {{count}}",
   "keyDetails": {
-    "createResponseOnlySecret": "This site provides only a masked value after creation, so the full key cannot be viewed again.",
+    "createResponseOnlySecret": "This site shows the full key only when it is created. If you did not save it, open Key Management and create a replacement key.",
     "createTime": "Create Time:",
     "expireTime": "Expire Time:",
     "followsAccountGroup": "Follows account group",

--- a/src/locales/en/ui.json
+++ b/src/locales/en/ui.json
@@ -188,7 +188,6 @@
     },
     "collapse": "Collapse",
     "copyKey": {
-      "apiKey": "API Key",
       "copied": "Copied",
       "copy": "Copy",
       "copyFailedManual": "Copy failed, please copy manually",
@@ -201,7 +200,6 @@
       "defaultGroup": "Default Group",
       "disabled": "Disabled",
       "enabled": "Enabled",
-      "expireTime": "Expire time: {{time}}",
       "exportToCCSwitch": "Export to CC Switch",
       "getFailed": "Failed to get",
       "keyCopied": "Key copied to clipboard",
@@ -210,12 +208,10 @@
       "noKeyFoundAfterCreate": "No key was found after creating one. Please try again.",
       "noKeys": "No key data yet",
       "noKeysDescription": "Create a default key quickly, or create a custom key with advanced settings.",
-      "remainingQuota": "Remaining Quota",
       "retry": "Retry",
       "title": "Key List",
       "totalKeys_one": "Total {{count}} key",
       "totalKeys_other": "Total {{count}} keys",
-      "usedQuota": "Used Quota",
       "useInCherry": "Use in Cherry Studio"
     },
     "dedupeAccounts": {

--- a/src/locales/es-419/keyManagement.json
+++ b/src/locales/es-419/keyManagement.json
@@ -201,7 +201,7 @@
   "enabledCount_many": "{{count}} habilitadas",
   "enabledCount_other": "{{count}} habilitadas",
   "keyDetails": {
-    "createResponseOnlySecret": "Este sitio solo proporciona un valor oculto después de la creación, por lo que la clave completa no puede volver a verse.",
+    "createResponseOnlySecret": "Este sitio muestra la clave completa solo al crearla. Si no la guardaste, abre Gestión de claves y crea una clave de reemplazo.",
     "createTime": "Hora de creación:",
     "expireTime": "Hora de expiración:",
     "followsAccountGroup": "Usa el grupo de la cuenta",

--- a/src/locales/es-419/ui.json
+++ b/src/locales/es-419/ui.json
@@ -193,7 +193,6 @@
     },
     "collapse": "Contraer",
     "copyKey": {
-      "apiKey": "API Key",
       "copied": "Copiado",
       "copy": "Copiar",
       "copyFailedManual": "Error al copiar, copia manualmente",
@@ -206,7 +205,6 @@
       "defaultGroup": "Grupo predeterminado",
       "disabled": "Deshabilitado",
       "enabled": "Habilitado",
-      "expireTime": "Hora de expiración: {{time}}",
       "exportToCCSwitch": "Exportar a CC Switch",
       "getFailed": "No se pudo obtener",
       "keyCopied": "Clave copiada al portapapeles",
@@ -215,13 +213,11 @@
       "noKeyFoundAfterCreate": "No se encontró ninguna clave después de crear una. Inténtalo de nuevo.",
       "noKeys": "Aún no hay datos de claves",
       "noKeysDescription": "Crea rápidamente una clave predeterminada o crea una clave personalizada con ajustes avanzados.",
-      "remainingQuota": "Cuota restante",
       "retry": "Reintentar",
       "title": "Lista de claves",
       "totalKeys_one": "Total {{count}} clave",
       "totalKeys_many": "Total {{count}} claves",
       "totalKeys_other": "Total {{count}} claves",
-      "usedQuota": "Cuota usada",
       "useInCherry": "Usar en Cherry Studio"
     },
     "dedupeAccounts": {

--- a/src/locales/ja/keyManagement.json
+++ b/src/locales/ja/keyManagement.json
@@ -187,7 +187,7 @@
   },
   "enabledCount_other": "{{count}} 件有効",
   "keyDetails": {
-    "createResponseOnlySecret": "このサイトでは作成後はマスクされた値のみ提供されるため、完全なキーを再表示できません。",
+    "createResponseOnlySecret": "このサイトで完全なキーが表示されるのは作成時だけです。保存していない場合は、キー管理を開いて新しいキーを作成してください。",
     "createTime": "作成時刻:",
     "expireTime": "有効期限:",
     "followsAccountGroup": "アカウントのグループに従う",

--- a/src/locales/ja/ui.json
+++ b/src/locales/ja/ui.json
@@ -186,7 +186,6 @@
     },
     "collapse": "折りたたむ",
     "copyKey": {
-      "apiKey": "API キー",
       "copied": "コピー済み",
       "copy": "コピー",
       "copyFailedManual": "コピーに失敗しました。手動でコピーしてください",
@@ -199,7 +198,6 @@
       "defaultGroup": "既定グループ",
       "disabled": "無効",
       "enabled": "有効",
-      "expireTime": "有効期限: {{time}}",
       "exportToCCSwitch": "CC Switch にエクスポート",
       "getFailed": "取得に失敗しました",
       "keyCopied": "キーをクリップボードにコピーしました",
@@ -208,11 +206,9 @@
       "noKeyFoundAfterCreate": "作成後にキーが見つかりませんでした。再試行してください。",
       "noKeys": "まだキーデータがありません",
       "noKeysDescription": "既定キーをすばやく作成するか、詳細設定付きのカスタムキーを作成してください。",
-      "remainingQuota": "残りクォータ",
       "retry": "再試行",
       "title": "キー一覧",
       "totalKeys_other": "合計 {{count}} キー",
-      "usedQuota": "使用済みクォータ",
       "useInCherry": "Cherry Studio で使う"
     },
     "dedupeAccounts": {

--- a/src/locales/pt-BR/keyManagement.json
+++ b/src/locales/pt-BR/keyManagement.json
@@ -201,7 +201,7 @@
   "enabledCount_many": "{{count}} ativas",
   "enabledCount_other": "{{count}} ativas",
   "keyDetails": {
-    "createResponseOnlySecret": "Este site fornece apenas um valor mascarado após a criação, portanto, a chave completa não pode ser vista novamente.",
+    "createResponseOnlySecret": "Este site mostra a chave completa somente na criação. Se você não a salvou, abra o Gerenciamento de Chaves e crie uma chave substituta.",
     "createTime": "Criada em:",
     "expireTime": "Expira em:",
     "followsAccountGroup": "Usa o grupo da conta",

--- a/src/locales/pt-BR/ui.json
+++ b/src/locales/pt-BR/ui.json
@@ -193,7 +193,6 @@
     },
     "collapse": "Recolher",
     "copyKey": {
-      "apiKey": "Chave API",
       "copied": "Copiado",
       "copy": "Copiar",
       "copyFailedManual": "Falha na cópia, copie manualmente",
@@ -206,7 +205,6 @@
       "defaultGroup": "Grupo padrão",
       "disabled": "Desativado",
       "enabled": "Ativado",
-      "expireTime": "Prazo de validade: {{time}}",
       "exportToCCSwitch": "Exportar para o CC Switch",
       "getFailed": "Falha ao obter",
       "keyCopied": "Chave copiada para a área de transferência",
@@ -215,13 +213,11 @@
       "noKeyFoundAfterCreate": "Nenhuma chave foi encontrada após a criação de uma. Por favor, tente novamente.",
       "noKeys": "Ainda não há chaves",
       "noKeysDescription": "Crie uma chave padrão rapidamente ou crie uma chave personalizada com configurações avançadas.",
-      "remainingQuota": "Cota restante",
       "retry": "Tentar novamente",
       "title": "Lista de chaves",
       "totalKeys_one": "{{count}} chave no total",
       "totalKeys_many": "{{count}} chaves no total",
       "totalKeys_other": "{{count}} chaves no total",
-      "usedQuota": "Cota usada",
       "useInCherry": "Usar no Cherry Studio"
     },
     "dedupeAccounts": {

--- a/src/locales/vi/keyManagement.json
+++ b/src/locales/vi/keyManagement.json
@@ -187,7 +187,7 @@
   },
   "enabledCount_other": "Đã bật {{count}}",
   "keyDetails": {
-    "createResponseOnlySecret": "Trang web này chỉ cung cấp giá trị đã che sau khi tạo, nên không thể xem lại khóa đầy đủ.",
+    "createResponseOnlySecret": "Trang web này chỉ hiển thị khóa đầy đủ khi tạo. Nếu bạn chưa lưu khóa, hãy mở Quản lý khóa và tạo khóa thay thế.",
     "createTime": "Thời gian tạo:",
     "expireTime": "Thời gian hết hạn:",
     "followsAccountGroup": "Theo nhóm tài khoản",

--- a/src/locales/vi/ui.json
+++ b/src/locales/vi/ui.json
@@ -186,7 +186,6 @@
     },
     "collapse": "Thu gọn",
     "copyKey": {
-      "apiKey": "API Key",
       "copied": "Đã sao chép",
       "copy": "Sao chép",
       "copyFailedManual": "Sao chép thất bại, vui lòng sao chép thủ công",
@@ -199,7 +198,6 @@
       "defaultGroup": "Nhóm mặc định",
       "disabled": "Vô hiệu hóa",
       "enabled": "Kích hoạt",
-      "expireTime": "Thời gian hết hạn: {{time}}",
       "exportToCCSwitch": "Xuất sang CC Switch",
       "getFailed": "Lấy dữ liệu thất bại",
       "keyCopied": "Đã sao chép API Key vào khay nhớ tạm",
@@ -208,11 +206,9 @@
       "noKeyFoundAfterCreate": "Tạo thành công nhưng không lấy được API Key, vui lòng thử lại.",
       "noKeys": "Chưa có dữ liệu API Key",
       "noKeysDescription": "Tài khoản này hiện không có API Key khả dụng, bạn có thể tạo nhanh API Key mặc định hoặc tạo tùy chỉnh rồi sao chép.",
-      "remainingQuota": "Hạn mức còn lại",
       "retry": "Thử lại",
       "title": "Danh sách API Key",
       "totalKeys_other": "Tổng cộng {{count}} API Key",
-      "usedQuota": "Hạn mức đã dùng",
       "useInCherry": "Sử dụng trong Cherry Studio"
     },
     "dedupeAccounts": {

--- a/src/locales/zh-CN/keyManagement.json
+++ b/src/locales/zh-CN/keyManagement.json
@@ -187,7 +187,7 @@
   },
   "enabledCount": "启用 {{count}} 个",
   "keyDetails": {
-    "createResponseOnlySecret": "该站点创建后仅提供密钥掩码，因此无法再次查看完整密钥。",
+    "createResponseOnlySecret": "该站点仅在创建时显示完整密钥。如果当时没有保存，请前往密钥管理创建替代密钥。",
     "createTime": "创建时间：",
     "expireTime": "过期时间：",
     "followsAccountGroup": "跟随账号分组",

--- a/src/locales/zh-CN/ui.json
+++ b/src/locales/zh-CN/ui.json
@@ -183,7 +183,6 @@
     },
     "collapse": "收起",
     "copyKey": {
-      "apiKey": "API 密钥",
       "copied": "已复制",
       "copy": "复制",
       "copyFailedManual": "复制失败，请手动复制",
@@ -196,7 +195,6 @@
       "defaultGroup": "默认组",
       "disabled": "禁用",
       "enabled": "启用",
-      "expireTime": "过期时间: {{time}}",
       "exportToCCSwitch": "导出到 CC Switch",
       "getFailed": "获取失败",
       "keyCopied": "密钥已复制到剪贴板",
@@ -205,11 +203,9 @@
       "noKeyFoundAfterCreate": "创建成功但未获取到密钥，请重试。",
       "noKeys": "暂无密钥数据",
       "noKeysDescription": "该账号暂无可用密钥，可快速创建默认密钥或自定义创建后再复制。",
-      "remainingQuota": "剩余额度",
       "retry": "重试",
       "title": "密钥列表",
       "totalKeys": "共 {{count}} 个密钥",
-      "usedQuota": "已用额度",
       "useInCherry": "在 Cherry Studio 中使用"
     },
     "dedupeAccounts": {

--- a/src/locales/zh-TW/keyManagement.json
+++ b/src/locales/zh-TW/keyManagement.json
@@ -187,7 +187,7 @@
   },
   "enabledCount_other": "啟用 {{count}} 個",
   "keyDetails": {
-    "createResponseOnlySecret": "此站點建立後僅提供金鑰遮罩值，因此無法再次查看完整金鑰。",
+    "createResponseOnlySecret": "此站點僅在建立時顯示完整金鑰。如果當時沒有儲存，請前往金鑰管理建立替代金鑰。",
     "createTime": "建立時間：",
     "expireTime": "過期時間：",
     "followsAccountGroup": "跟隨帳號分組",

--- a/src/locales/zh-TW/ui.json
+++ b/src/locales/zh-TW/ui.json
@@ -186,7 +186,6 @@
     },
     "collapse": "收起",
     "copyKey": {
-      "apiKey": "API 金鑰",
       "copied": "已複製",
       "copy": "複製",
       "copyFailedManual": "複製失敗，請手動複製",
@@ -199,7 +198,6 @@
       "defaultGroup": "預設組",
       "disabled": "禁用",
       "enabled": "啟用",
-      "expireTime": "過期時間: {{time}}",
       "exportToCCSwitch": "匯出到 CC Switch",
       "getFailed": "獲取失敗",
       "keyCopied": "金鑰已複製到剪貼簿",
@@ -208,11 +206,9 @@
       "noKeyFoundAfterCreate": "建立成功但未獲取到金鑰，請重試。",
       "noKeys": "暫無金鑰資料",
       "noKeysDescription": "該帳號暫無可用金鑰，可快速建立預設金鑰或自定義建立後再複製。",
-      "remainingQuota": "剩餘額度",
       "retry": "重試",
       "title": "金鑰列表",
       "totalKeys_other": "共 {{count}} 個金鑰",
-      "usedQuota": "已用額度",
       "useInCherry": "在 Cherry Studio 中使用"
     },
     "dedupeAccounts": {

--- a/src/services/accounts/accountKeyResourceInventory.ts
+++ b/src/services/accounts/accountKeyResourceInventory.ts
@@ -6,7 +6,10 @@ import type {
   AccountKeyResourceFacts,
   AccountKeyScope,
 } from "~/services/apiAdapters/contracts/accountKeyResource"
-import { collectAccountKeyResourceInventory } from "~/services/apiAdapters/nativeResources/accountKeyResourceInventory"
+import {
+  awaitAbortableAccountKeyResourceOperation,
+  collectAccountKeyResourceInventory,
+} from "~/services/apiAdapters/nativeResources/accountKeyResourceInventory"
 
 type DisplayAccountKeyResourceInventory = {
   scope: AccountKeyScope
@@ -29,21 +32,28 @@ export async function fetchDisplayAccountKeyResourceInventory(
   }
 
   const operationOptions = { signal: options.signal }
-  const session = await accountKeyResources.open(
-    {
-      account: {
-        id: account.id,
-        name: account.name,
-        siteType: account.siteType,
-      },
-      request,
-    },
-    operationOptions,
+  const session = await awaitAbortableAccountKeyResourceOperation(
+    () =>
+      accountKeyResources.open(
+        {
+          account: {
+            id: account.id,
+            name: account.name,
+            siteType: account.siteType,
+          },
+          request,
+        },
+        operationOptions,
+      ),
+    options.signal,
   )
-  const scope = await session.resolveDefaultScope(operationOptions)
-  const collection = await session.openCollection(
-    scope.scopeKey,
-    operationOptions,
+  const scope = await awaitAbortableAccountKeyResourceOperation(
+    () => session.resolveDefaultScope(operationOptions),
+    options.signal,
+  )
+  const collection = await awaitAbortableAccountKeyResourceOperation(
+    () => session.openCollection(scope.scopeKey, operationOptions),
+    options.signal,
   )
   const items = await collectAccountKeyResourceInventory(collection, options)
 

--- a/src/services/accounts/accountKeyResourceInventory.ts
+++ b/src/services/accounts/accountKeyResourceInventory.ts
@@ -1,0 +1,51 @@
+import {
+  createDisplayAccountApiContext,
+  type DisplayAccountApiSnapshot,
+} from "~/services/accounts/utils/apiServiceRequest"
+import type {
+  AccountKeyResourceFacts,
+  AccountKeyScope,
+} from "~/services/apiAdapters/contracts/accountKeyResource"
+import { collectAccountKeyResourceInventory } from "~/services/apiAdapters/nativeResources/accountKeyResourceInventory"
+
+type DisplayAccountKeyResourceInventory = {
+  scope: AccountKeyScope
+  items: readonly AccountKeyResourceFacts[]
+}
+
+/**
+ * Opens an account's native key-resource boundary and reads its default scope.
+ * Editor and mutation capabilities deliberately remain outside this interface.
+ */
+export async function fetchDisplayAccountKeyResourceInventory(
+  account: DisplayAccountApiSnapshot & { name?: string },
+  options: { signal?: AbortSignal } = {},
+): Promise<DisplayAccountKeyResourceInventory> {
+  const { accountKeyResources, request } =
+    createDisplayAccountApiContext(account)
+
+  if (!accountKeyResources) {
+    throw new Error("Account key resource inventory is not supported")
+  }
+
+  const operationOptions = { signal: options.signal }
+  const session = await accountKeyResources.open(
+    {
+      account: {
+        id: account.id,
+        name: account.name,
+        siteType: account.siteType,
+      },
+      request,
+    },
+    operationOptions,
+  )
+  const scope = await session.resolveDefaultScope(operationOptions)
+  const collection = await session.openCollection(
+    scope.scopeKey,
+    operationOptions,
+  )
+  const items = await collectAccountKeyResourceInventory(collection, options)
+
+  return { scope, items }
+}

--- a/src/services/accounts/keyProductCapabilities.ts
+++ b/src/services/accounts/keyProductCapabilities.ts
@@ -1,4 +1,8 @@
 import type { SiteType } from "~/constants/siteType"
+import {
+  getInventorySecretAvailability,
+  INVENTORY_SECRET_AVAILABILITIES,
+} from "~/services/apiAdapters/contracts/keyManagement"
 import { getSiteTypeCapabilities } from "~/services/apiAdapters/registry"
 import { AuthTypeEnum, type DisplaySiteData, type SiteAccount } from "~/types"
 
@@ -75,6 +79,21 @@ const NO_ACCOUNT_KEY_PRODUCT_CAPABILITIES: AccountKeyProductCapabilities = {
   },
 }
 
+const supportsRecoverableRuntimeKeySecrets = (
+  accountCapabilities: ReturnType<typeof getSiteTypeCapabilities>["account"],
+): boolean => {
+  const keyManagement = accountCapabilities?.keyManagement
+
+  if (keyManagement) {
+    return (
+      getInventorySecretAvailability(keyManagement) ===
+      INVENTORY_SECRET_AVAILABILITIES.Recoverable
+    )
+  }
+
+  return Boolean(accountCapabilities?.serviceCredential)
+}
+
 /**
  * Product-level readiness for account key features. This intentionally covers
  * account/auth completeness only; backend feature support is projected below.
@@ -132,6 +151,14 @@ export const createStoredAccountKeyProductContext = (
 export const supportsAccountApiTokenCreation = (siteType: SiteType) =>
   Boolean(getSiteTypeCapabilities(siteType).account?.keyManagement)
 
+/** Whether existing account runtime keys can yield a usable plaintext secret. */
+export const supportsRecoverableAccountRuntimeKeySecrets = (
+  siteType: SiteType,
+) =>
+  supportsRecoverableRuntimeKeySecrets(
+    getSiteTypeCapabilities(siteType).account,
+  )
+
 export const getAccountKeyProductCapabilities = (
   account: AccountKeyProductCapabilityContext | null | undefined,
 ): AccountKeyProductCapabilities => {
@@ -146,6 +173,8 @@ export const getAccountKeyProductCapabilities = (
   const hasKeyManagement = Boolean(keyManagement)
   const hasServiceCredential = Boolean(serviceCredential)
   const hasTokenProvisioning = Boolean(accountCapabilities?.tokenProvisioning)
+  const canResolveRuntimeSecret =
+    supportsRecoverableRuntimeKeySecrets(accountCapabilities)
 
   return {
     resourceKeys: {
@@ -156,7 +185,7 @@ export const getAccountKeyProductCapabilities = (
     },
     runtimeKeys: {
       list: hasKeyManagement || hasServiceCredential,
-      resolveSecret: hasKeyManagement || hasServiceCredential,
+      resolveSecret: canResolveRuntimeSecret,
     },
     apiTokens: {
       create: hasKeyManagement,

--- a/src/services/accounts/keyProductCapabilities.ts
+++ b/src/services/accounts/keyProductCapabilities.ts
@@ -1,3 +1,4 @@
+import type { SiteType } from "~/constants/siteType"
 import { getSiteTypeCapabilities } from "~/services/apiAdapters/registry"
 import { AuthTypeEnum, type DisplaySiteData, type SiteAccount } from "~/types"
 
@@ -127,6 +128,10 @@ export const createStoredAccountKeyProductContext = (
   disabled: account.disabled,
 })
 
+/** Whether the provider exposes the legacy account API-token creation surface. */
+export const supportsAccountApiTokenCreation = (siteType: SiteType) =>
+  Boolean(getSiteTypeCapabilities(siteType).account?.keyManagement)
+
 export const getAccountKeyProductCapabilities = (
   account: AccountKeyProductCapabilityContext | null | undefined,
 ): AccountKeyProductCapabilities => {
@@ -178,6 +183,13 @@ export const canListAccountRuntimeKeys = <
   account: TAccount | null | undefined,
 ): account is TAccount =>
   getAccountKeyProductCapabilities(account).runtimeKeys.list
+
+export const canListAccountKeyResources = <
+  TAccount extends AccountKeyProductCapabilityContext,
+>(
+  account: TAccount | null | undefined,
+): account is TAccount =>
+  getAccountKeyProductCapabilities(account).resourceKeys.list
 
 export const canResolveAccountRuntimeKeySecret = <
   TAccount extends AccountKeyProductCapabilityContext,

--- a/src/services/apiAdapters/nativeResources/accountKeyResourceInventory.ts
+++ b/src/services/apiAdapters/nativeResources/accountKeyResourceInventory.ts
@@ -1,0 +1,102 @@
+import {
+  ACCOUNT_KEY_RESOURCE_FAILURE_CODES,
+  AccountKeyResourceError,
+  type AccountKeyResourceCollection,
+  type AccountKeyResourceFacts,
+  type AccountKeyResourceRef,
+} from "~/services/apiAdapters/contracts/accountKeyResource"
+
+const MAX_COLLECTION_PAGES = 100
+
+/** Returns a stable comparison key for a provider-native account-key reference. */
+export const accountKeyResourceRefIdentity = (
+  ref: AccountKeyResourceRef,
+): string =>
+  JSON.stringify([ref.accountId, ref.siteType, ref.scopeKey, ref.resourceId])
+
+const awaitAbortablePage = <T>(
+  promise: Promise<T>,
+  signal?: AbortSignal,
+): Promise<T> => {
+  if (!signal) return promise
+
+  return new Promise<T>((resolve, reject) => {
+    if (signal.aborted) {
+      reject(
+        new AccountKeyResourceError({
+          code: ACCOUNT_KEY_RESOURCE_FAILURE_CODES.Aborted,
+        }),
+      )
+      return
+    }
+
+    const abort = () =>
+      reject(
+        new AccountKeyResourceError({
+          code: ACCOUNT_KEY_RESOURCE_FAILURE_CODES.Aborted,
+        }),
+      )
+    signal.addEventListener("abort", abort, { once: true })
+    promise.then(
+      (value) => {
+        signal.removeEventListener("abort", abort)
+        resolve(value)
+      },
+      (error) => {
+        signal.removeEventListener("abort", abort)
+        reject(error)
+      },
+    )
+  })
+}
+
+/**
+ * Loads a complete native key collection while rejecting duplicate resources,
+ * cursor cycles, and unexpectedly deep pagination.
+ */
+export async function collectAccountKeyResourceInventory(
+  collection: AccountKeyResourceCollection,
+  options: { search?: string; signal?: AbortSignal } = {},
+): Promise<AccountKeyResourceFacts[]> {
+  const rows: AccountKeyResourceFacts[] = []
+  const refs = new Set<string>()
+  const cursors = new Set<string>()
+  let cursor: string | undefined
+
+  for (let pageCount = 0; pageCount < MAX_COLLECTION_PAGES; pageCount += 1) {
+    const page = await awaitAbortablePage(
+      collection.list(
+        {
+          ...(options.search ? { search: options.search } : {}),
+          ...(cursor ? { cursor } : {}),
+        },
+        { signal: options.signal },
+      ),
+      options.signal,
+    )
+
+    for (const item of page.items) {
+      const identity = accountKeyResourceRefIdentity(item.ref)
+      if (refs.has(identity)) {
+        throw new AccountKeyResourceError({
+          code: ACCOUNT_KEY_RESOURCE_FAILURE_CODES.Unexpected,
+        })
+      }
+      refs.add(identity)
+      rows.push(item)
+    }
+
+    if (!page.nextCursor) return rows
+    if (cursors.has(page.nextCursor)) {
+      throw new AccountKeyResourceError({
+        code: ACCOUNT_KEY_RESOURCE_FAILURE_CODES.Unexpected,
+      })
+    }
+    cursors.add(page.nextCursor)
+    cursor = page.nextCursor
+  }
+
+  throw new AccountKeyResourceError({
+    code: ACCOUNT_KEY_RESOURCE_FAILURE_CODES.Unexpected,
+  })
+}

--- a/src/services/apiAdapters/nativeResources/accountKeyResourceInventory.ts
+++ b/src/services/apiAdapters/nativeResources/accountKeyResourceInventory.ts
@@ -14,29 +14,33 @@ export const accountKeyResourceRefIdentity = (
 ): string =>
   JSON.stringify([ref.accountId, ref.siteType, ref.scopeKey, ref.resourceId])
 
-const awaitAbortablePage = <T>(
-  promise: Promise<T>,
+const createAbortedError = () =>
+  new AccountKeyResourceError({
+    code: ACCOUNT_KEY_RESOURCE_FAILURE_CODES.Aborted,
+  })
+
+export const awaitAbortableAccountKeyResourceOperation = <T>(
+  operation: () => Promise<T>,
   signal?: AbortSignal,
 ): Promise<T> => {
-  if (!signal) return promise
+  if (!signal) return operation()
 
   return new Promise<T>((resolve, reject) => {
     if (signal.aborted) {
-      reject(
-        new AccountKeyResourceError({
-          code: ACCOUNT_KEY_RESOURCE_FAILURE_CODES.Aborted,
-        }),
-      )
+      reject(createAbortedError())
       return
     }
 
-    const abort = () =>
-      reject(
-        new AccountKeyResourceError({
-          code: ACCOUNT_KEY_RESOURCE_FAILURE_CODES.Aborted,
-        }),
-      )
+    const abort = () => reject(createAbortedError())
     signal.addEventListener("abort", abort, { once: true })
+    let promise: Promise<T>
+    try {
+      promise = operation()
+    } catch (error) {
+      signal.removeEventListener("abort", abort)
+      reject(error)
+      return
+    }
     promise.then(
       (value) => {
         signal.removeEventListener("abort", abort)
@@ -64,14 +68,15 @@ export async function collectAccountKeyResourceInventory(
   let cursor: string | undefined
 
   for (let pageCount = 0; pageCount < MAX_COLLECTION_PAGES; pageCount += 1) {
-    const page = await awaitAbortablePage(
-      collection.list(
-        {
-          ...(options.search ? { search: options.search } : {}),
-          ...(cursor ? { cursor } : {}),
-        },
-        { signal: options.signal },
-      ),
+    const page = await awaitAbortableAccountKeyResourceOperation(
+      () =>
+        collection.list(
+          {
+            ...(options.search ? { search: options.search } : {}),
+            ...(cursor ? { cursor } : {}),
+          },
+          { signal: options.signal },
+        ),
       options.signal,
     )
 

--- a/src/utils/core/formatters.ts
+++ b/src/utils/core/formatters.ts
@@ -60,7 +60,7 @@ export const formatTokenCount = (count: number): string => {
 
 /** Masks a secret consistently while retaining enough context to identify it. */
 export const maskSecretForDisplay = (secret: string): string => {
-  if (secret.length < 12) return "******"
+  if (secret.length <= 12) return "******"
 
   return `${secret.substring(0, 8)}${"*".repeat(16)}${secret.substring(
     secret.length - 4,

--- a/src/utils/core/formatters.ts
+++ b/src/utils/core/formatters.ts
@@ -58,6 +58,15 @@ export const formatTokenCount = (count: number): string => {
   return count.toString()
 }
 
+/** Masks a secret consistently while retaining enough context to identify it. */
+export const maskSecretForDisplay = (secret: string): string => {
+  if (secret.length < 12) return "******"
+
+  return `${secret.substring(0, 8)}${"*".repeat(16)}${secret.substring(
+    secret.length - 4,
+  )}`
+}
+
 export function normalizeToMs(input: number | string | Date): number | null
 export function normalizeToMs(input: null | undefined): null
 export function normalizeToMs(

--- a/tests/components/ManagedSiteLogo.test.tsx
+++ b/tests/components/ManagedSiteLogo.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from "vitest"
 
 import { SITE_TYPES } from "~/constants/siteType"
 import { RuntimeKeyDetails } from "~/features/AccountManagement/components/CopyKeyDialog/RuntimeKeyDetails"
-import { buildDisplayAccountTokenRuntimeKey } from "~/services/accounts/accountRuntimeKeys"
+import { buildServiceCredentialRuntimeKey } from "~/services/accounts/accountRuntimeKeys"
 import { AuthTypeEnum, SiteHealthStatus, type DisplaySiteData } from "~/types"
 import { buildCompleteTodayStatsAvailability } from "~~/tests/test-utils/accountTodayStats"
 import { TokenHeaderHarness as TokenHeader } from "~~/tests/test-utils/keyManagement/TokenHeaderHarness"
@@ -78,7 +78,14 @@ function createTokenStub(overrides: Record<string, unknown> = {}) {
 }
 
 function createRuntimeKeyStub(account = createAccountStub()) {
-  return buildDisplayAccountTokenRuntimeKey(account, createTokenStub())
+  return buildServiceCredentialRuntimeKey(account, {
+    kind: "singleton_service_key",
+    service: "codex",
+    label: "Codex",
+    key: "sk-service-credential-secret",
+    isAuthenticated: true,
+    baseUrl: "https://api.example.invalid/v1",
+  })
 }
 
 describe("Managed site logo", () => {

--- a/tests/features/AccountManagement/components/AccountActionButtons.test.tsx
+++ b/tests/features/AccountManagement/components/AccountActionButtons.test.tsx
@@ -1274,6 +1274,49 @@ describe("AccountActionButtons", () => {
     )
   })
 
+  it.each([SITE_TYPES.OPENROUTER, SITE_TYPES.AIHUBMIX])(
+    "labels %s as a key list and opens it without probing unavailable secrets",
+    async (siteType) => {
+      const user = userEvent.setup()
+      const onCopyKey = vi.fn()
+
+      render(
+        <AccountActionButtons
+          site={buildDisplaySiteData({
+            id: `${siteType}-non-recoverable-keys`,
+            disabled: false,
+            name: "Non-recoverable keys",
+            siteType,
+          })}
+          onCopyKey={onCopyKey}
+          onDeleteAccount={vi.fn()}
+        />,
+      )
+
+      expect(
+        screen.queryByRole("button", { name: "account:actions.copyKey" }),
+      ).not.toBeInTheDocument()
+      await user.click(
+        screen.getByRole("button", { name: "account:actions.keyList" }),
+      )
+
+      expect(onCopyKey).toHaveBeenCalledWith(
+        expect.objectContaining({ id: `${siteType}-non-recoverable-keys` }),
+      )
+      expect(fetchAccountTokensMock).not.toHaveBeenCalled()
+      expect(toastErrorMock).not.toHaveBeenCalled()
+      expect(clipboardWriteTextMock).not.toHaveBeenCalled()
+      expect(startProductAnalyticsActionMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actionId: PRODUCT_ANALYTICS_ACTION_IDS.OpenKeyList,
+        }),
+      )
+      expect(completeProductAnalyticsActionMock).toHaveBeenCalledWith(
+        PRODUCT_ANALYTICS_RESULTS.Success,
+      )
+    },
+  )
+
   it("copies a single token directly when smart copy finds exactly one key", async () => {
     fetchAccountTokensMock.mockResolvedValueOnce([{ key: "sk-single" }])
 

--- a/tests/features/AccountManagement/components/CopyKeyDialog.test.tsx
+++ b/tests/features/AccountManagement/components/CopyKeyDialog.test.tsx
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { SITE_TYPES } from "~/constants/siteType"
 import CopyKeyDialog from "~/features/AccountManagement/components/CopyKeyDialog"
+import { ACCOUNT_MANAGEMENT_TEST_IDS } from "~/features/AccountManagement/testIds"
 import { TOKEN_PROVISIONING_TEST_IDS } from "~/features/TokenProvisioning/testIds"
 import { generateDefaultTokenRequest } from "~/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken"
 import * as accountOperations from "~/services/accounts/accountOperations"
@@ -29,7 +30,13 @@ import {
 import { API_TYPES } from "~/services/verification/aiApiVerification"
 import { AuthTypeEnum } from "~/types"
 import { ACCOUNT_KEY_REPAIR_SKIP_REASONS } from "~/types/accountKeyAutoProvisioning"
-import { act, render, screen, waitFor } from "~~/tests/test-utils/render"
+import {
+  act,
+  render,
+  screen,
+  waitFor,
+  within,
+} from "~~/tests/test-utils/render"
 
 const {
   fetchAccountTokensMock,
@@ -51,6 +58,11 @@ const {
   kiloCodeExportDialogMock,
   kiloCodeProfileExportDialogMock,
   openWithCredentialsMock,
+  openAccountKeyResourcesMock,
+  resolveDefaultAccountKeyScopeMock,
+  openAccountKeyCollectionMock,
+  listAccountKeyResourcesMock,
+  openKeysPageMock,
   userPreferencesContextMock,
 } = vi.hoisted(() => ({
   fetchAccountTokensMock: vi.fn(),
@@ -72,6 +84,11 @@ const {
   kiloCodeExportDialogMock: vi.fn(),
   kiloCodeProfileExportDialogMock: vi.fn(),
   openWithCredentialsMock: vi.fn(),
+  openAccountKeyResourcesMock: vi.fn(),
+  resolveDefaultAccountKeyScopeMock: vi.fn(),
+  openAccountKeyCollectionMock: vi.fn(),
+  listAccountKeyResourcesMock: vi.fn(),
+  openKeysPageMock: vi.fn(),
   userPreferencesContextMock: {
     claudeCodeRouterApiKey: "ccr-management-key",
     claudeCodeRouterBaseUrl: "https://router.example.invalid",
@@ -171,6 +188,16 @@ vi.mock("react-hot-toast", () => ({
 
 vi.mock("~/services/apiAdapters/registry", () => ({
   getSiteTypeCapabilities: (siteType: string) => {
+    if (siteType === SITE_TYPES.OPENROUTER) {
+      return {
+        account: {
+          keyResources: {
+            open: (...args: any[]) => openAccountKeyResourcesMock(...args),
+          },
+        },
+      }
+    }
+
     if (siteType === SITE_TYPES.SHAREDCHAT) {
       return {
         account: {
@@ -203,6 +230,15 @@ vi.mock("~/services/apiAdapters/registry", () => ({
     }
   },
 }))
+
+vi.mock("~/utils/navigation", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("~/utils/navigation")>()
+
+  return {
+    ...actual,
+    openKeysPage: (...args: unknown[]) => openKeysPageMock(...args),
+  }
+})
 
 vi.mock("~/components/dialogs/ChannelDialog", () => ({
   ChannelDialogProvider: ({ children }: { children: ReactNode }) => children,
@@ -309,6 +345,35 @@ const AIHUBMIX_ACCOUNT = {
   baseUrl: "https://aihubmix.com",
 }
 
+const OPENROUTER_ACCOUNT = {
+  ...ACCOUNT,
+  id: "openrouter-account",
+  name: "OpenRouter",
+  siteType: SITE_TYPES.OPENROUTER,
+  baseUrl: "https://openrouter.example.invalid",
+}
+
+const OPENROUTER_SCOPE = {
+  scopeKey: "default-workspace",
+  routeKey: "default-workspace",
+  displayName: "Default workspace",
+  isDefault: true,
+}
+
+const OPENROUTER_KEY_FACTS = {
+  ref: {
+    accountId: OPENROUTER_ACCOUNT.id,
+    siteType: SITE_TYPES.OPENROUTER,
+    scopeKey: OPENROUTER_SCOPE.scopeKey,
+    resourceId: "key-example",
+  },
+  displayName: "Example native key",
+  maskedLabel: "sk-or-v1-...example",
+  status: "enabled" as const,
+  fields: [],
+  actions: { canUpdate: true, canDelete: true },
+}
+
 const TOKEN = {
   id: 1,
   user_id: 1,
@@ -389,6 +454,11 @@ describe("CopyKeyDialog", () => {
     kiloCodeExportDialogMock.mockReset()
     kiloCodeProfileExportDialogMock.mockReset()
     openWithCredentialsMock.mockReset()
+    openAccountKeyResourcesMock.mockReset()
+    resolveDefaultAccountKeyScopeMock.mockReset()
+    openAccountKeyCollectionMock.mockReset()
+    listAccountKeyResourcesMock.mockReset()
+    openKeysPageMock.mockReset()
     resolveApiTokenKeyMock.mockReset()
     openInCherryStudioMock.mockReset()
     openWithAccountMock.mockReset()
@@ -421,6 +491,21 @@ describe("CopyKeyDialog", () => {
     toastSuccessMock.mockReset()
     toastErrorMock.mockReset()
     openWithCredentialsMock.mockResolvedValue({ opened: true })
+    resolveDefaultAccountKeyScopeMock.mockResolvedValue(OPENROUTER_SCOPE)
+    listAccountKeyResourcesMock.mockResolvedValue({
+      items: [OPENROUTER_KEY_FACTS],
+    })
+    openAccountKeyCollectionMock.mockResolvedValue({
+      scope: OPENROUTER_SCOPE,
+      list: (...args: unknown[]) => listAccountKeyResourcesMock(...args),
+    })
+    openAccountKeyResourcesMock.mockResolvedValue({
+      resolveDefaultScope: (...args: unknown[]) =>
+        resolveDefaultAccountKeyScopeMock(...args),
+      openCollection: (...args: unknown[]) =>
+        openAccountKeyCollectionMock(...args),
+    })
+    openKeysPageMock.mockResolvedValue(undefined)
     userPreferencesContextMock.claudeCodeRouterApiKey = "ccr-management-key"
     userPreferencesContextMock.claudeCodeRouterBaseUrl =
       "https://router.example.invalid"
@@ -525,6 +610,8 @@ describe("CopyKeyDialog", () => {
       },
     ])
 
+    const user = userEvent.setup()
+
     render(
       <CopyKeyDialog
         isOpen={true}
@@ -534,6 +621,17 @@ describe("CopyKeyDialog", () => {
     )
 
     expect(await screen.findByText("Saved masked key")).toBeVisible()
+    const detailsButton = screen.getByRole("button", {
+      name: "keyManagement:actions.detailsFor",
+    })
+    expect(detailsButton).toHaveAttribute("aria-expanded", "false")
+    expect(
+      screen.queryByText("keyManagement:keyDetails.createResponseOnlySecret"),
+    ).not.toBeInTheDocument()
+
+    await user.click(detailsButton)
+
+    expect(detailsButton).toHaveAttribute("aria-expanded", "true")
     expect(
       screen.getByText("keyManagement:keyDetails.createResponseOnlySecret"),
     ).toBeVisible()
@@ -553,6 +651,134 @@ describe("CopyKeyDialog", () => {
         name: "keyManagement:actions.importToManagedSite",
       }),
     ).not.toBeInTheDocument()
+  })
+
+  it("shows OpenRouter native keys read-only and links to full key management", async () => {
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+
+    render(
+      <CopyKeyDialog
+        isOpen={true}
+        onClose={onClose}
+        account={OPENROUTER_ACCOUNT}
+      />,
+    )
+
+    expect(await screen.findByText("Example native key")).toBeVisible()
+    expect(screen.getByText("Default workspace")).toBeVisible()
+    expect(screen.queryByText("sk-or-v1-...example")).not.toBeInTheDocument()
+    expect(
+      screen.queryByText("keyManagement:keyDetails.createResponseOnlySecret"),
+    ).not.toBeInTheDocument()
+    expect(fetchAccountTokensMock).not.toHaveBeenCalled()
+    expect(
+      screen.queryByRole("button", { name: "ui:dialog.copyKey.copy" }),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: "ui:dialog.copyKey.useInCherry" }),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", {
+        name: "keyManagement:openRouter.list.actions.edit",
+      }),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", {
+        name: "keyManagement:openRouter.list.actions.delete",
+      }),
+    ).not.toBeInTheDocument()
+
+    const detailsButton = screen.getByRole("button", {
+      name: "keyManagement:actions.detailsFor",
+    })
+    expect(detailsButton).toHaveAttribute("aria-expanded", "false")
+    await user.click(detailsButton)
+
+    expect(detailsButton).toHaveAttribute("aria-expanded", "true")
+    expect(screen.getByText("sk-or-v1-...example")).toBeVisible()
+    expect(
+      screen.getByText("keyManagement:keyDetails.createResponseOnlySecret"),
+    ).toBeVisible()
+
+    await user.click(
+      screen.getByRole("button", { name: "account:actions.keyManagement" }),
+    )
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+    expect(openKeysPageMock).toHaveBeenCalledWith(OPENROUTER_ACCOUNT.id)
+  })
+
+  it("offers account-level key management from the footer for regular accounts", async () => {
+    fetchAccountTokensMock.mockResolvedValueOnce([TOKEN])
+    const user = userEvent.setup()
+    const onClose = vi.fn()
+
+    render(<CopyKeyDialog isOpen={true} onClose={onClose} account={ACCOUNT} />)
+
+    const footer = await screen.findByTestId(
+      ACCOUNT_MANAGEMENT_TEST_IDS.copyKeyDialogFooter,
+    )
+    await user.click(
+      within(footer).getByRole("button", {
+        name: "account:actions.keyManagement",
+      }),
+    )
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+    expect(openKeysPageMock).toHaveBeenCalledWith(ACCOUNT.id)
+  })
+
+  it("offers full key management instead of legacy create actions for an empty OpenRouter inventory", async () => {
+    listAccountKeyResourcesMock.mockResolvedValueOnce({ items: [] })
+
+    render(
+      <CopyKeyDialog
+        isOpen={true}
+        onClose={() => {}}
+        account={OPENROUTER_ACCOUNT}
+      />,
+    )
+
+    expect(await screen.findByText("ui:dialog.copyKey.noKeys")).toBeVisible()
+    expect(
+      screen.getByRole("button", { name: "account:actions.keyManagement" }),
+    ).toBeEnabled()
+    expect(
+      screen.queryByRole("button", {
+        name: "ui:dialog.copyKey.createKey",
+      }),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", {
+        name: "ui:dialog.copyKey.createCustomKey",
+      }),
+    ).not.toBeInTheDocument()
+  })
+
+  it("keeps OpenRouter inventory load failures retryable", async () => {
+    listAccountKeyResourcesMock
+      .mockRejectedValueOnce(new Error("inventory unavailable"))
+      .mockResolvedValueOnce({ items: [OPENROUTER_KEY_FACTS] })
+    const user = userEvent.setup()
+
+    render(
+      <CopyKeyDialog
+        isOpen={true}
+        onClose={() => {}}
+        account={OPENROUTER_ACCOUNT}
+      />,
+    )
+
+    expect(
+      await screen.findByText("ui:dialog.copyKey.loadFailed"),
+    ).toBeVisible()
+    await user.click(
+      screen.getByRole("button", { name: "ui:dialog.copyKey.retry" }),
+    )
+
+    expect(await screen.findByText("Example native key")).toBeVisible()
+    expect(listAccountKeyResourcesMock).toHaveBeenCalledTimes(2)
   })
 
   it("refreshes instead of showing a one-time key when AIHubMix create returns a masked key", async () => {
@@ -1005,7 +1231,11 @@ describe("CopyKeyDialog", () => {
 
     render(<CopyKeyDialog isOpen={true} onClose={() => {}} account={ACCOUNT} />)
 
-    await user.click(await screen.findByText("default"))
+    await user.click(
+      await screen.findByRole("button", {
+        name: "keyManagement:actions.detailsFor",
+      }),
+    )
     await user.click(
       await screen.findByRole("button", { name: "ui:dialog.copyKey.copy" }),
     )
@@ -1034,7 +1264,11 @@ describe("CopyKeyDialog", () => {
 
     render(<CopyKeyDialog isOpen={true} onClose={() => {}} account={ACCOUNT} />)
 
-    await user.click(await screen.findByText("default"))
+    await user.click(
+      await screen.findByRole("button", {
+        name: "keyManagement:actions.detailsFor",
+      }),
+    )
     await user.click(
       await screen.findByRole("button", {
         name: "ui:dialog.copyKey.useInCherry",
@@ -1072,7 +1306,11 @@ describe("CopyKeyDialog", () => {
 
     render(<CopyKeyDialog isOpen={true} onClose={() => {}} account={ACCOUNT} />)
 
-    await user.click(await screen.findByText("default"))
+    await user.click(
+      await screen.findByRole("button", {
+        name: "keyManagement:actions.detailsFor",
+      }),
+    )
     await user.click(
       await screen.findByRole("button", {
         name: "keyManagement:actions.importToManagedSite",
@@ -1109,7 +1347,11 @@ describe("CopyKeyDialog", () => {
 
     render(<CopyKeyDialog isOpen={true} onClose={() => {}} account={ACCOUNT} />)
 
-    await user.click(await screen.findByText("default"))
+    await user.click(
+      await screen.findByRole("button", {
+        name: "keyManagement:actions.detailsFor",
+      }),
+    )
     await user.click(
       await screen.findByRole("button", { name: "ui:dialog.copyKey.copy" }),
     )
@@ -1150,7 +1392,11 @@ describe("CopyKeyDialog", () => {
 
     render(<CopyKeyDialog isOpen={true} onClose={() => {}} account={ACCOUNT} />)
 
-    await user.click(await screen.findByText("default"))
+    await user.click(
+      await screen.findByRole("button", {
+        name: "keyManagement:actions.detailsFor",
+      }),
+    )
 
     expect(screen.getByText(shortSecret)).toBeInTheDocument()
     expect(screen.queryByText("••••••")).not.toBeInTheDocument()
@@ -1173,23 +1419,32 @@ describe("CopyKeyDialog", () => {
     expect(await screen.findByText("default")).toBeInTheDocument()
     expect(screen.getByText("common:status.disabled")).toBeInTheDocument()
     expect(
+      screen.queryByText("keyManagement:keyDetails.usedQuota"),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: "ui:dialog.copyKey.copy" }),
+    ).not.toBeInTheDocument()
+    expect(
       screen.queryByText("keyManagement:keyDetails.quotaPolicy"),
     ).not.toBeInTheDocument()
 
-    await user.click(
-      screen.getByRole("button", {
-        name: "keyManagement:actions.detailsFor",
-      }),
-    )
+    const detailsButton = screen.getByRole("button", {
+      name: "keyManagement:actions.detailsFor",
+    })
+    expect(detailsButton).toHaveAttribute("aria-expanded", "false")
+    await user.click(detailsButton)
+
+    expect(detailsButton).toHaveAttribute("aria-expanded", "true")
+    expect(screen.getByText("keyManagement:keyDetails.usedQuota")).toBeVisible()
+    expect(
+      screen.getByRole("button", { name: "ui:dialog.copyKey.copy" }),
+    ).toBeVisible()
     expect(
       screen.getByText("keyManagement:keyDetails.quotaPolicy"),
     ).toBeVisible()
 
-    await user.click(
-      screen.getByRole("button", {
-        name: "keyManagement:actions.detailsFor",
-      }),
-    )
+    await user.click(detailsButton)
+    expect(detailsButton).toHaveAttribute("aria-expanded", "false")
     expect(
       screen.queryByText("keyManagement:keyDetails.quotaPolicy"),
     ).not.toBeInTheDocument()
@@ -1202,7 +1457,11 @@ describe("CopyKeyDialog", () => {
 
     render(<CopyKeyDialog isOpen={true} onClose={() => {}} account={ACCOUNT} />)
 
-    await user.click(await screen.findByText("default"))
+    await user.click(
+      await screen.findByRole("button", {
+        name: "keyManagement:actions.detailsFor",
+      }),
+    )
 
     await user.click(
       screen.getByRole("button", {
@@ -1459,7 +1718,11 @@ describe("CopyKeyDialog", () => {
 
     render(<CopyKeyDialog isOpen={true} onClose={() => {}} account={ACCOUNT} />)
 
-    await user.click(await screen.findByText("default"))
+    await user.click(
+      await screen.findByRole("button", {
+        name: "keyManagement:actions.detailsFor",
+      }),
+    )
     await user.click(
       await screen.findByRole("button", { name: "ui:dialog.copyKey.copy" }),
     )
@@ -1500,7 +1763,11 @@ describe("CopyKeyDialog", () => {
 
     render(<CopyKeyDialog isOpen={true} onClose={() => {}} account={ACCOUNT} />)
 
-    await user.click(await screen.findByText("default"))
+    await user.click(
+      await screen.findByRole("button", {
+        name: "keyManagement:actions.detailsFor",
+      }),
+    )
     await user.click(
       await screen.findByRole("button", { name: "ui:dialog.copyKey.copy" }),
     )

--- a/tests/features/AccountManagement/components/CopyKeyDialog.test.tsx
+++ b/tests/features/AccountManagement/components/CopyKeyDialog.test.tsx
@@ -8,6 +8,7 @@ import { TOKEN_PROVISIONING_TEST_IDS } from "~/features/TokenProvisioning/testId
 import { generateDefaultTokenRequest } from "~/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken"
 import * as accountOperations from "~/services/accounts/accountOperations"
 import { TOKEN_QUICK_CREATE_RESOLUTION_KINDS } from "~/services/accounts/tokenQuickCreateResolution"
+import { INVENTORY_SECRET_AVAILABILITIES } from "~/services/apiAdapters/contracts/keyManagement"
 import {
   CREATED_TOKEN_SECRET_DECISION_KINDS,
   DEFAULT_TOKEN_CREATION_DECISION_KINDS,
@@ -192,6 +193,10 @@ vi.mock("~/services/apiAdapters/registry", () => ({
           userGroups: {
             fetch: (...args: any[]) => fetchUserGroupsMock(...args),
           },
+          inventorySecretAvailability:
+            siteType === SITE_TYPES.AIHUBMIX
+              ? INVENTORY_SECRET_AVAILABILITIES.CreateResponseOnly
+              : INVENTORY_SECRET_AVAILABILITIES.Recoverable,
         },
         tokenProvisioning: createSub2ApiTokenProvisioningMock(),
       },
@@ -509,6 +514,45 @@ describe("CopyKeyDialog", () => {
       expect(fetchAccountTokensMock).toHaveBeenCalledTimes(1)
       expect(writeText).toHaveBeenCalledWith("sk-created-full-secret")
     })
+  })
+
+  it("keeps AIHubMix saved keys visible without secret-dependent actions", async () => {
+    fetchAccountTokensMock.mockResolvedValueOnce([
+      {
+        ...TOKEN,
+        key: "sk-created********masked",
+        name: "Saved masked key",
+      },
+    ])
+
+    render(
+      <CopyKeyDialog
+        isOpen={true}
+        onClose={() => {}}
+        account={AIHUBMIX_ACCOUNT}
+      />,
+    )
+
+    expect(await screen.findByText("Saved masked key")).toBeVisible()
+    expect(
+      screen.getByText("keyManagement:keyDetails.createResponseOnlySecret"),
+    ).toBeVisible()
+    expect(
+      screen.queryByRole("button", { name: "ui:dialog.copyKey.copy" }),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: "ui:dialog.copyKey.useInCherry" }),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", {
+        name: "ui:dialog.copyKey.exportToCCSwitch",
+      }),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", {
+        name: "keyManagement:actions.importToManagedSite",
+      }),
+    ).not.toBeInTheDocument()
   })
 
   it("refreshes instead of showing a one-time key when AIHubMix create returns a masked key", async () => {
@@ -1112,7 +1156,7 @@ describe("CopyKeyDialog", () => {
     expect(screen.queryByText("••••••")).not.toBeInTheDocument()
   })
 
-  it("renders disabled token state and collapses expanded token details", async () => {
+  it("renders disabled token state and toggles shared key details", async () => {
     fetchAccountTokensMock.mockResolvedValueOnce([
       {
         ...TOKEN,
@@ -1127,16 +1171,27 @@ describe("CopyKeyDialog", () => {
     render(<CopyKeyDialog isOpen={true} onClose={() => {}} account={ACCOUNT} />)
 
     expect(await screen.findByText("default")).toBeInTheDocument()
-    expect(screen.getByText("ui:dialog.copyKey.disabled")).toBeInTheDocument()
-
-    await user.click(screen.getByRole("button", { name: "ui:dialog.expand" }))
+    expect(screen.getByText("common:status.disabled")).toBeInTheDocument()
     expect(
-      screen.getByRole("button", { name: "ui:dialog.copyKey.copy" }),
-    ).toBeInTheDocument()
+      screen.queryByText("keyManagement:keyDetails.quotaPolicy"),
+    ).not.toBeInTheDocument()
 
-    await user.click(screen.getByRole("button", { name: "ui:dialog.collapse" }))
+    await user.click(
+      screen.getByRole("button", {
+        name: "keyManagement:actions.detailsFor",
+      }),
+    )
     expect(
-      screen.queryByRole("button", { name: "ui:dialog.copyKey.copy" }),
+      screen.getByText("keyManagement:keyDetails.quotaPolicy"),
+    ).toBeVisible()
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "keyManagement:actions.detailsFor",
+      }),
+    )
+    expect(
+      screen.queryByText("keyManagement:keyDetails.quotaPolicy"),
     ).not.toBeInTheDocument()
   })
 

--- a/tests/features/AccountManagement/components/CopyKeyDialog.test.tsx
+++ b/tests/features/AccountManagement/components/CopyKeyDialog.test.tsx
@@ -4,10 +4,16 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { SITE_TYPES } from "~/constants/siteType"
 import CopyKeyDialog from "~/features/AccountManagement/components/CopyKeyDialog"
+import { DialogFooter } from "~/features/AccountManagement/components/CopyKeyDialog/DialogFooter"
+import { KeyInventoryList } from "~/features/AccountManagement/components/CopyKeyDialog/KeyInventoryList"
+import { QuickKeyResourceCard } from "~/features/AccountManagement/components/CopyKeyDialog/QuickKeyResourceCard"
+import { RuntimeKeyActionControls } from "~/features/AccountManagement/components/CopyKeyDialog/RuntimeKeyActionControls"
 import { ACCOUNT_MANAGEMENT_TEST_IDS } from "~/features/AccountManagement/testIds"
+import type { KeyResourceCardPresentation } from "~/features/KeyManagement/presentation/keyResourceCard"
 import { TOKEN_PROVISIONING_TEST_IDS } from "~/features/TokenProvisioning/testIds"
 import { generateDefaultTokenRequest } from "~/services/accounts/accountKeyAutoProvisioning/ensureDefaultToken"
 import * as accountOperations from "~/services/accounts/accountOperations"
+import { buildDisplayAccountTokenRuntimeKey } from "~/services/accounts/accountRuntimeKeys"
 import { TOKEN_QUICK_CREATE_RESOLUTION_KINDS } from "~/services/accounts/tokenQuickCreateResolution"
 import { INVENTORY_SECRET_AVAILABILITIES } from "~/services/apiAdapters/contracts/keyManagement"
 import {
@@ -515,6 +521,120 @@ describe("CopyKeyDialog", () => {
     userPreferencesContextMock.managedSiteType = SITE_TYPES.NEW_API
   })
 
+  it("omits optional empty-state and footer actions when callbacks are unavailable", () => {
+    render(
+      <>
+        <KeyInventoryList
+          runtimeKeys={[]}
+          expandedRuntimeKeys={new Set()}
+          copiedRuntimeKeyId={null}
+          onToggleRuntimeKey={() => {}}
+          onCopyKey={() => {}}
+          account={ACCOUNT}
+          supportsApiTokenCreation
+        />
+        <DialogFooter keyCount={0} onClose={() => {}} />
+      </>,
+    )
+
+    expect(screen.getByText("ui:dialog.copyKey.noKeys")).toBeVisible()
+    expect(
+      screen.queryByRole("button", { name: "ui:dialog.copyKey.createKey" }),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", {
+        name: "ui:dialog.copyKey.createCustomKey",
+      }),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: "account:actions.keyManagement" }),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "common:actions.close" }),
+    ).toBeEnabled()
+  })
+
+  it("renders unknown quick-key status without duplicating its header fact", () => {
+    const contextFact = {
+      id: "workspace",
+      label: "Workspace",
+      value: "Example workspace",
+    }
+    const quickPresentation: KeyResourceCardPresentation = {
+      id: "quick-key-example",
+      title: "Example quick key",
+      accountLabel: "Example account",
+      status: "unknown",
+      statusLabel: "Unknown",
+      secretAvailability: "unavailable",
+      contextFact,
+      summaryFacts: [contextFact],
+      detailFacts: [],
+      actions: {
+        copySecret: false,
+        revealSecret: false,
+        verifySecret: false,
+        exportSecret: false,
+        edit: false,
+        delete: false,
+        batchSelect: false,
+      },
+    }
+
+    render(
+      <QuickKeyResourceCard
+        presentation={quickPresentation}
+        isExpanded
+        onExpandedChange={() => {}}
+      />,
+    )
+
+    expect(screen.getByText("Unknown")).toBeVisible()
+    expect(screen.getAllByText("Example workspace")).toHaveLength(1)
+    expect(
+      screen.getByRole("region", {
+        name: "keyManagement:actions.detailsFor",
+      }),
+    ).toBeVisible()
+  })
+
+  it("keeps copy and export action policies independent", () => {
+    const runtimeKey = buildDisplayAccountTokenRuntimeKey(ACCOUNT, TOKEN)
+    const { rerender } = render(
+      <RuntimeKeyActionControls
+        runtimeKey={runtimeKey}
+        actionPolicy={{ copySecret: true, exportSecret: false }}
+        copiedRuntimeKeyId={null}
+        onCopyKey={() => {}}
+        account={ACCOUNT}
+      />,
+    )
+
+    expect(
+      screen.getByRole("button", { name: "ui:dialog.copyKey.copy" }),
+    ).toBeVisible()
+    expect(
+      screen.queryByRole("button", { name: "ui:dialog.copyKey.useInCherry" }),
+    ).not.toBeInTheDocument()
+
+    rerender(
+      <RuntimeKeyActionControls
+        runtimeKey={runtimeKey}
+        actionPolicy={{ copySecret: false, exportSecret: true }}
+        copiedRuntimeKeyId={null}
+        onCopyKey={() => {}}
+        account={ACCOUNT}
+      />,
+    )
+
+    expect(
+      screen.queryByRole("button", { name: "ui:dialog.copyKey.copy" }),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "ui:dialog.copyKey.useInCherry" }),
+    ).toBeVisible()
+  })
+
   it("creates token then refreshes and auto-copies when exactly one token exists", async () => {
     fetchAccountTokensMock
       .mockResolvedValueOnce([])
@@ -650,6 +770,39 @@ describe("CopyKeyDialog", () => {
       screen.queryByRole("button", {
         name: "keyManagement:actions.importToManagedSite",
       }),
+    ).not.toBeInTheDocument()
+  })
+
+  it("renders an AIHubMix key without inventing a masked secret", async () => {
+    fetchAccountTokensMock.mockResolvedValueOnce([
+      {
+        ...TOKEN,
+        key: "",
+        name: "Saved key without a preview",
+      },
+    ])
+    const user = userEvent.setup()
+
+    render(
+      <CopyKeyDialog
+        isOpen={true}
+        onClose={() => {}}
+        account={AIHUBMIX_ACCOUNT}
+      />,
+    )
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "keyManagement:actions.detailsFor",
+      }),
+    )
+
+    expect(screen.getByText("Saved key without a preview")).toBeVisible()
+    expect(
+      screen.getByText("keyManagement:keyDetails.createResponseOnlySecret"),
+    ).toBeVisible()
+    expect(
+      screen.queryByRole("button", { name: "ui:dialog.copyKey.copy" }),
     ).not.toBeInTheDocument()
   })
 
@@ -1083,6 +1236,29 @@ describe("CopyKeyDialog", () => {
     expect(fetchAccountTokensMock).toHaveBeenCalledTimes(1)
   })
 
+  it("ignores rejected token fetches after the request is cancelled", async () => {
+    const pendingTokens = createDeferred<(typeof TOKEN)[]>()
+    fetchAccountTokensMock.mockReturnValueOnce(pendingTokens.promise)
+
+    const { rerender } = render(
+      <CopyKeyDialog isOpen={true} onClose={() => {}} account={ACCOUNT} />,
+    )
+
+    await screen.findByText("ui:dialog.copyKey.loading")
+    rerender(
+      <CopyKeyDialog isOpen={false} onClose={() => {}} account={ACCOUNT} />,
+    )
+
+    await act(async () => {
+      pendingTokens.reject(new Error("cancelled request failed late"))
+      await pendingTokens.promise.catch(() => undefined)
+    })
+
+    expect(
+      screen.queryByText("ui:dialog.copyKey.loadFailed"),
+    ).not.toBeInTheDocument()
+  })
+
   it("opens a generic constrained Add Token dialog when default token policy requires selection", async () => {
     fetchAccountTokensMock.mockResolvedValueOnce([])
     resolveDefaultTokenQuickCreateResolutionSpy.mockResolvedValueOnce({
@@ -1297,6 +1473,35 @@ describe("CopyKeyDialog", () => {
     })
   })
 
+  it("reports Cherry Studio export failures without leaving the action pending", async () => {
+    fetchAccountTokensMock.mockResolvedValueOnce([TOKEN])
+    openInCherryStudioMock.mockImplementationOnce(() => {
+      throw new Error("Cherry Studio is unavailable")
+    })
+    const user = userEvent.setup()
+
+    render(<CopyKeyDialog isOpen={true} onClose={() => {}} account={ACCOUNT} />)
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "keyManagement:actions.detailsFor",
+      }),
+    )
+    await user.click(
+      screen.getByRole("button", { name: "ui:dialog.copyKey.useInCherry" }),
+    )
+
+    await waitFor(() => {
+      expect(completeProductAnalyticsActionMock).toHaveBeenCalledWith(
+        PRODUCT_ANALYTICS_RESULTS.Failure,
+        { errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown },
+      )
+      expect(toastErrorMock).toHaveBeenCalledWith(
+        "messages:errors.operation.failed",
+      )
+    })
+  })
+
   it("tracks managed-site single token import when the copied token flow opens", async () => {
     fetchAccountTokensMock.mockResolvedValueOnce([TOKEN])
     openWithAccountMock.mockImplementationOnce(
@@ -1373,6 +1578,75 @@ describe("CopyKeyDialog", () => {
         "messages:errors.operation.failed",
       )
     })
+  })
+
+  it("marks successful managed-site onboarding even when no flow opens", async () => {
+    fetchAccountTokensMock.mockResolvedValueOnce([TOKEN])
+    userPreferencesContextMock.markGatewayGuidanceOnboardingCompleted.mockReset()
+    openWithAccountMock.mockImplementationOnce(
+      async (_account, _token, onResult) => {
+        onResult({ success: true })
+        return { opened: false, deferred: false }
+      },
+    )
+    const user = userEvent.setup()
+
+    render(<CopyKeyDialog isOpen={true} onClose={() => {}} account={ACCOUNT} />)
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "keyManagement:actions.detailsFor",
+      }),
+    )
+    await user.click(
+      screen.getByRole("button", {
+        name: "keyManagement:actions.importToManagedSite",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(
+        userPreferencesContextMock.markGatewayGuidanceOnboardingCompleted,
+      ).toHaveBeenCalledTimes(1)
+      expect(completeProductAnalyticsActionMock).toHaveBeenCalledWith(
+        PRODUCT_ANALYTICS_RESULTS.Skipped,
+      )
+    })
+  })
+
+  it("explains missing external-tool configuration before opening imports", async () => {
+    fetchAccountTokensMock.mockResolvedValueOnce([TOKEN])
+    userPreferencesContextMock.cliProxyBaseUrl = ""
+    userPreferencesContextMock.cliProxyManagementKey = ""
+    userPreferencesContextMock.claudeCodeRouterBaseUrl = ""
+    const user = userEvent.setup()
+
+    render(<CopyKeyDialog isOpen={true} onClose={() => {}} account={ACCOUNT} />)
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "keyManagement:actions.detailsFor",
+      }),
+    )
+    await user.click(
+      screen.getByRole("button", {
+        name: "keyManagement:actions.importToCliProxy",
+      }),
+    )
+    await user.click(
+      screen.getByRole("button", {
+        name: "keyManagement:actions.importToClaudeCodeRouter",
+      }),
+    )
+
+    expect(toastErrorMock).toHaveBeenCalledWith(
+      "messages:cliproxy.configMissing",
+    )
+    expect(toastErrorMock).toHaveBeenCalledWith(
+      "messages:claudeCodeRouter.configMissing",
+    )
+    expect(cliProxyDialogMock).not.toHaveBeenCalled()
+    expect(claudeCodeRouterDialogMock).not.toHaveBeenCalled()
   })
 
   it("resets copied state after showing the copied action label", async () => {

--- a/tests/features/AccountManagement/components/CopyKeyDialog.test.tsx
+++ b/tests/features/AccountManagement/components/CopyKeyDialog.test.tsx
@@ -621,13 +621,13 @@ describe("CopyKeyDialog", () => {
     )
 
     expect(await screen.findByText("Saved masked key")).toBeVisible()
+    expect(
+      screen.getByText("keyManagement:keyDetails.createResponseOnlySecret"),
+    ).toBeVisible()
     const detailsButton = screen.getByRole("button", {
       name: "keyManagement:actions.detailsFor",
     })
     expect(detailsButton).toHaveAttribute("aria-expanded", "false")
-    expect(
-      screen.queryByText("keyManagement:keyDetails.createResponseOnlySecret"),
-    ).not.toBeInTheDocument()
 
     await user.click(detailsButton)
 
@@ -669,8 +669,8 @@ describe("CopyKeyDialog", () => {
     expect(screen.getByText("Default workspace")).toBeVisible()
     expect(screen.queryByText("sk-or-v1-...example")).not.toBeInTheDocument()
     expect(
-      screen.queryByText("keyManagement:keyDetails.createResponseOnlySecret"),
-    ).not.toBeInTheDocument()
+      screen.getByText("keyManagement:keyDetails.createResponseOnlySecret"),
+    ).toBeVisible()
     expect(fetchAccountTokensMock).not.toHaveBeenCalled()
     expect(
       screen.queryByRole("button", { name: "ui:dialog.copyKey.copy" }),
@@ -715,6 +715,10 @@ describe("CopyKeyDialog", () => {
     const onClose = vi.fn()
 
     render(<CopyKeyDialog isOpen={true} onClose={onClose} account={ACCOUNT} />)
+
+    expect(
+      screen.queryByText("keyManagement:keyDetails.createResponseOnlySecret"),
+    ).not.toBeInTheDocument()
 
     const footer = await screen.findByTestId(
       ACCOUNT_MANAGEMENT_TEST_IDS.copyKeyDialogFooter,
@@ -1337,6 +1341,40 @@ describe("CopyKeyDialog", () => {
     })
   })
 
+  it("tracks managed-site import failure when opening the flow rejects", async () => {
+    fetchAccountTokensMock.mockResolvedValueOnce([TOKEN])
+    openWithAccountMock.mockRejectedValueOnce(
+      new Error("managed import unavailable"),
+    )
+
+    const user = userEvent.setup()
+
+    render(<CopyKeyDialog isOpen={true} onClose={() => {}} account={ACCOUNT} />)
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "keyManagement:actions.detailsFor",
+      }),
+    )
+    await user.click(
+      screen.getByRole("button", {
+        name: "keyManagement:actions.importToManagedSite",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(completeProductAnalyticsActionMock).toHaveBeenCalledWith(
+        PRODUCT_ANALYTICS_RESULTS.Failure,
+        {
+          errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
+        },
+      )
+      expect(toastErrorMock).toHaveBeenCalledWith(
+        "messages:errors.operation.failed",
+      )
+    })
+  })
+
   it("resets copied state after showing the copied action label", async () => {
     fetchAccountTokensMock.mockResolvedValueOnce([TOKEN])
 
@@ -1379,7 +1417,7 @@ describe("CopyKeyDialog", () => {
     ).not.toBeInTheDocument()
   })
 
-  it("does not mask short secrets when the preview would not elide characters", async () => {
+  it("keeps short secrets masked in the expanded preview", async () => {
     const shortSecret = "abcdefghijklmnopqrstuv"
     fetchAccountTokensMock.mockResolvedValueOnce([
       {
@@ -1398,8 +1436,8 @@ describe("CopyKeyDialog", () => {
       }),
     )
 
-    expect(screen.getByText(shortSecret)).toBeInTheDocument()
-    expect(screen.queryByText("••••••")).not.toBeInTheDocument()
+    expect(screen.queryByText(shortSecret)).not.toBeInTheDocument()
+    expect(screen.getByText("abcdefgh****************stuv")).toBeInTheDocument()
   })
 
   it("renders disabled token state and toggles shared key details", async () => {
@@ -1435,6 +1473,11 @@ describe("CopyKeyDialog", () => {
     await user.click(detailsButton)
 
     expect(detailsButton).toHaveAttribute("aria-expanded", "true")
+    expect(
+      screen.getByRole("region", {
+        name: "keyManagement:actions.detailsFor",
+      }),
+    ).toBeVisible()
     expect(screen.getByText("keyManagement:keyDetails.usedQuota")).toBeVisible()
     expect(
       screen.getByRole("button", { name: "ui:dialog.copyKey.copy" }),
@@ -1548,8 +1591,10 @@ describe("CopyKeyDialog", () => {
         name: "keyManagement:actions.exportToKiloCode",
       }),
     ).toBeInTheDocument()
-    expect(screen.getByText("sk-service-crede")).toBeInTheDocument()
-    expect(screen.getByText("secret")).toBeInTheDocument()
+    expect(screen.getByText("sk-servi****************cret")).toBeInTheDocument()
+    expect(
+      screen.queryByText("sk-service-credential-secret"),
+    ).not.toBeInTheDocument()
     expect(
       screen.queryByText("ui:dialog.copyKey.expireTime"),
     ).not.toBeInTheDocument()

--- a/tests/features/AccountManagement/components/LoadingIndicator.test.tsx
+++ b/tests/features/AccountManagement/components/LoadingIndicator.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import { LoadingIndicator } from "~/features/AccountManagement/components/CopyKeyDialog/LoadingIndicator"
+
+vi.mock("react-i18next", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-i18next")>()
+
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (key: string) => `ui:${key}`,
+    }),
+  }
+})
+
+describe("LoadingIndicator", () => {
+  it("uses the shared loading presentation without legacy purple colors", () => {
+    render(<LoadingIndicator />)
+
+    const loadingStatus = screen.getByRole("status", {
+      name: "ui:dialog.copyKey.loading",
+    })
+
+    expect(loadingStatus).toHaveClass("text-[var(--spinner-default-color)]")
+    expect(loadingStatus).not.toHaveClass(
+      "border-purple-300",
+      "border-t-purple-600",
+    )
+    expect(screen.getByText("ui:dialog.copyKey.loading")).toBeVisible()
+  })
+})

--- a/tests/features/ApiCredentialProfiles/components/ApiCredentialProfileListItem.test.tsx
+++ b/tests/features/ApiCredentialProfiles/components/ApiCredentialProfileListItem.test.tsx
@@ -142,6 +142,8 @@ function renderListItem(
   overrides: {
     isTelemetryRefreshing?: boolean
     onRefreshTelemetry?: (profile: ApiCredentialProfile) => void
+    visibleKeys?: Set<string>
+    toggleKeyVisibility?: (profileId: string) => void
   } = {},
 ) {
   const onRefreshTelemetry = overrides.onRefreshTelemetry ?? vi.fn()
@@ -150,8 +152,8 @@ function renderListItem(
       profile={profile}
       verificationSummary={null}
       tagNames={[]}
-      visibleKeys={new Set()}
-      toggleKeyVisibility={vi.fn()}
+      visibleKeys={overrides.visibleKeys ?? new Set()}
+      toggleKeyVisibility={overrides.toggleKeyVisibility ?? vi.fn()}
       onCopyBaseUrl={vi.fn()}
       onCopyApiKey={vi.fn()}
       onCopyBundle={vi.fn()}
@@ -212,6 +214,22 @@ describe("ApiCredentialProfileListItem", () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+  })
+
+  it("shows a full API key only when its visibility is enabled", () => {
+    const profile = buildProfile()
+    const toggleKeyVisibility = vi.fn()
+    renderListItem(profile, {
+      visibleKeys: new Set([profile.id]),
+      toggleKeyVisibility,
+    })
+
+    expect(screen.getByText("sk-newapi")).toBeVisible()
+    const hideButton = screen.getByRole("button", {
+      name: "keyManagement:actions.hideKey",
+    })
+    fireEvent.click(hideButton)
+    expect(toggleKeyVisibility).toHaveBeenCalledWith(profile.id)
   })
 
   it("declares controlled analytics metadata for profile row actions", () => {

--- a/tests/features/KeyManagement/components/KeyResourceCard.test.tsx
+++ b/tests/features/KeyManagement/components/KeyResourceCard.test.tsx
@@ -3,8 +3,11 @@ import { useState, type ReactElement } from "react"
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest"
 
 import {
+  KEY_RESOURCE_CONTENT_LAYOUTS,
   KeyResourceCard,
   KeyResourceCardHeader,
+  KeyResourceFactList,
+  KeyResourceSecretDisplay,
 } from "~/features/KeyManagement/components/KeyResourceCard"
 import type { KeyResourceCardPresentation } from "~/features/KeyManagement/presentation/keyResourceCard"
 import { KEY_MANAGEMENT_TEST_IDS } from "~/features/KeyManagement/testIds"
@@ -219,6 +222,31 @@ describe("KeyResourceCard", () => {
     expect(
       screen.getAllByRole("button", { name: "Copy summary secret" }),
     ).toHaveLength(1)
+  })
+
+  it("supports the adaptive content layout used by quick key cards", () => {
+    renderKeyResourceCard(
+      <>
+        <KeyResourceSecretDisplay
+          label="Key"
+          secret={<code>sk-example</code>}
+          controls={<button type="button">Copy key</button>}
+          layout={KEY_RESOURCE_CONTENT_LAYOUTS.Adaptive}
+        />
+        <KeyResourceFactList
+          facts={presentation.summaryFacts}
+          layout={KEY_RESOURCE_CONTENT_LAYOUTS.Adaptive}
+          testId="adaptive-facts"
+        />
+      </>,
+    )
+
+    expect(
+      screen.getByTestId(KEY_MANAGEMENT_TEST_IDS.keyResourceSecretDisplay),
+    ).toHaveClass("grid", "sm:grid-cols-[minmax(0,1fr)_auto]")
+    expect(screen.getByTestId("adaptive-facts")).toHaveClass(
+      "grid-cols-[repeat(auto-fit,minmax(11rem,1fr))]",
+    )
   })
 
   it("announces loading and supports detail retry", async () => {

--- a/tests/features/KeyManagement/components/KeyResourceCard.test.tsx
+++ b/tests/features/KeyManagement/components/KeyResourceCard.test.tsx
@@ -249,6 +249,20 @@ describe("KeyResourceCard", () => {
     )
   })
 
+  it("renders adaptive availability guidance without requiring a secret label", () => {
+    renderKeyResourceCard(
+      <KeyResourceSecretDisplay
+        message="The saved secret cannot be retrieved."
+        layout={KEY_RESOURCE_CONTENT_LAYOUTS.Adaptive}
+      />,
+    )
+
+    expect(
+      screen.getByText("The saved secret cannot be retrieved."),
+    ).toBeVisible()
+    expect(screen.queryByText("Key")).not.toBeInTheDocument()
+  })
+
   it("announces loading and supports detail retry", async () => {
     const user = userEvent.setup()
     const onRetry = vi.fn()

--- a/tests/features/KeyManagement/presentation/legacyKeyResourceCard.test.ts
+++ b/tests/features/KeyManagement/presentation/legacyKeyResourceCard.test.ts
@@ -41,6 +41,7 @@ describe("buildLegacyKeyResourceCardPresentation", () => {
       "remaining-quota",
       "expires-at",
     ])
+    expect(presentation.contextFact).toEqual(presentation.summaryFacts[0])
     expect(presentation.detailFacts.map(({ id }) => id)).toEqual([
       "quota-policy",
       "last-used-at",
@@ -95,6 +96,7 @@ describe("buildLegacyKeyResourceCardPresentation", () => {
       "remaining-quota",
       "expires-at",
     ])
+    expect(presentation.contextFact).toBeUndefined()
     expect(presentation.secretAvailabilityMessage).toBe(
       "keyManagement:keyDetails.createResponseOnlySecret",
     )

--- a/tests/features/KeyManagement/presentation/openRouterKeyResourceCard.test.ts
+++ b/tests/features/KeyManagement/presentation/openRouterKeyResourceCard.test.ts
@@ -108,6 +108,7 @@ describe("buildOpenRouterKeyResourceCardPresentation", () => {
         value: formatUsd(22),
       },
     ])
+    expect(presentation.contextFact).toEqual(presentation.summaryFacts[0])
   })
 
   it("keeps every supported safe native fact in shared details", () => {

--- a/tests/features/KeyManagement/presentation/openRouterKeyResourceCard.test.ts
+++ b/tests/features/KeyManagement/presentation/openRouterKeyResourceCard.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest"
 import {
   buildOpenRouterKeyResourceCardPresentation,
   buildOpenRouterKeyResourceDetailFacts,
+  buildReadOnlyOpenRouterKeyResourceCardPresentation,
 } from "~/features/KeyManagement/presentation/openRouterKeyResourceCard"
 import type { NativeKeyManagementRow } from "~/features/KeyManagement/types"
 import { INVENTORY_SECRET_AVAILABILITIES } from "~/services/apiAdapters/contracts/keyManagement"
@@ -63,6 +64,29 @@ const row: NativeKeyManagementRow = {
 }
 
 describe("buildOpenRouterKeyResourceCardPresentation", () => {
+  it("removes every action from the read-only quick-list presentation", () => {
+    const presentation = buildReadOnlyOpenRouterKeyResourceCardPresentation(
+      {
+        ...row,
+        facts: {
+          ...row.facts,
+          actions: { canUpdate: true, canDelete: true },
+        },
+      },
+      t,
+    )
+
+    expect(presentation.actions).toEqual({
+      copySecret: false,
+      revealSecret: false,
+      verifySecret: false,
+      exportSecret: false,
+      edit: false,
+      delete: false,
+      batchSelect: false,
+    })
+  })
+
   it("projects native keys into the shared card without secret-dependent actions", () => {
     const presentation = buildOpenRouterKeyResourceCardPresentation(row, t)
 

--- a/tests/services/accounts/accountKeyResourceInventory.test.ts
+++ b/tests/services/accounts/accountKeyResourceInventory.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { SITE_TYPES } from "~/constants/siteType"
+import { fetchDisplayAccountKeyResourceInventory } from "~/services/accounts/accountKeyResourceInventory"
+import { AuthTypeEnum } from "~/types"
+
+const { createDisplayAccountApiContextMock } = vi.hoisted(() => ({
+  createDisplayAccountApiContextMock: vi.fn(),
+}))
+
+vi.mock("~/services/accounts/utils/apiServiceRequest", () => ({
+  createDisplayAccountApiContext: (...args: unknown[]) =>
+    createDisplayAccountApiContextMock(...args),
+}))
+
+describe("fetchDisplayAccountKeyResourceInventory", () => {
+  beforeEach(() => {
+    createDisplayAccountApiContextMock.mockReset()
+  })
+
+  it("rejects accounts without a native key-resource capability", async () => {
+    createDisplayAccountApiContextMock.mockReturnValue({
+      request: {},
+      accountKeyResources: undefined,
+    })
+
+    await expect(
+      fetchDisplayAccountKeyResourceInventory({
+        id: "account-example",
+        name: "Example account",
+        siteType: SITE_TYPES.NEW_API,
+        baseUrl: "https://example.invalid",
+        authType: AuthTypeEnum.AccessToken,
+        userId: "user-example",
+        token: "token-example",
+      }),
+    ).rejects.toThrow("Account key resource inventory is not supported")
+  })
+})

--- a/tests/services/accounts/keyProductCapabilities.test.ts
+++ b/tests/services/accounts/keyProductCapabilities.test.ts
@@ -9,6 +9,7 @@ import {
   canRunAccountDefaultTokenAutomation,
   createStoredAccountKeyProductContext,
   getAccountKeyProductCapabilities,
+  supportsAccountApiTokenCreation,
 } from "~/services/accounts/keyProductCapabilities"
 import { getSiteTypeCapabilities } from "~/services/apiAdapters/registry"
 import { AuthTypeEnum } from "~/types"
@@ -88,6 +89,17 @@ describe("account key product capabilities", () => {
     expect(canRunAccountDefaultTokenAutomation(ACCOUNT as any)).toBe(false)
     expect(canListAccountRuntimeKeys(ACCOUNT as any)).toBe(true)
     expect(canResolveAccountRuntimeKeySecret(ACCOUNT as any)).toBe(true)
+  })
+
+  it("reports API-token creation support independently of account readiness", () => {
+    expect(supportsAccountApiTokenCreation(SITE_TYPES.NEW_API)).toBe(true)
+
+    vi.mocked(getSiteTypeCapabilities).mockReturnValue({
+      siteType: SITE_TYPES.OPENROUTER,
+      account: { keyResources: {} },
+    } as any)
+
+    expect(supportsAccountApiTokenCreation(SITE_TYPES.OPENROUTER)).toBe(false)
   })
 
   it("maps default-token automation only when token provisioning is also available", () => {

--- a/tests/services/accounts/keyProductCapabilities.test.ts
+++ b/tests/services/accounts/keyProductCapabilities.test.ts
@@ -10,7 +10,9 @@ import {
   createStoredAccountKeyProductContext,
   getAccountKeyProductCapabilities,
   supportsAccountApiTokenCreation,
+  supportsRecoverableAccountRuntimeKeySecrets,
 } from "~/services/accounts/keyProductCapabilities"
+import { INVENTORY_SECRET_AVAILABILITIES } from "~/services/apiAdapters/contracts/keyManagement"
 import { getSiteTypeCapabilities } from "~/services/apiAdapters/registry"
 import { AuthTypeEnum } from "~/types"
 import { buildSiteAccount } from "~~/tests/test-utils/factories"
@@ -89,6 +91,30 @@ describe("account key product capabilities", () => {
     expect(canRunAccountDefaultTokenAutomation(ACCOUNT as any)).toBe(false)
     expect(canListAccountRuntimeKeys(ACCOUNT as any)).toBe(true)
     expect(canResolveAccountRuntimeKeySecret(ACCOUNT as any)).toBe(true)
+    expect(
+      supportsRecoverableAccountRuntimeKeySecrets(SITE_TYPES.NEW_API),
+    ).toBe(true)
+  })
+
+  it("lists create-response-only keys without claiming their secrets are recoverable", () => {
+    vi.mocked(getSiteTypeCapabilities).mockReturnValue({
+      siteType: SITE_TYPES.AIHUBMIX,
+      account: {
+        keyManagement: {
+          ...keyManagement,
+          inventorySecretAvailability:
+            INVENTORY_SECRET_AVAILABILITIES.CreateResponseOnly,
+        },
+      },
+    } as any)
+
+    const account = { ...ACCOUNT, siteType: SITE_TYPES.AIHUBMIX }
+
+    expect(canListAccountRuntimeKeys(account as any)).toBe(true)
+    expect(canResolveAccountRuntimeKeySecret(account as any)).toBe(false)
+    expect(
+      supportsRecoverableAccountRuntimeKeySecrets(SITE_TYPES.AIHUBMIX),
+    ).toBe(false)
   })
 
   it("reports API-token creation support independently of account readiness", () => {

--- a/tests/services/apiAdapters/nativeResources/accountKeyResourceInventory.test.ts
+++ b/tests/services/apiAdapters/nativeResources/accountKeyResourceInventory.test.ts
@@ -22,6 +22,22 @@ const createFacts = (resourceId: string): AccountKeyResourceFacts => ({
 })
 
 describe("collectAccountKeyResourceInventory", () => {
+  it("does not start listing when the request is already aborted", async () => {
+    const controller = new AbortController()
+    const list = vi.fn()
+    const collection = { list } as unknown as AccountKeyResourceCollection
+    controller.abort()
+
+    await expect(
+      collectAccountKeyResourceInventory(collection, {
+        signal: controller.signal,
+      }),
+    ).rejects.toMatchObject({
+      failure: { code: "aborted" },
+    })
+    expect(list).not.toHaveBeenCalled()
+  })
+
   it("collects cursor-paginated native key resources", async () => {
     const first = createFacts("first")
     const second = createFacts("second")

--- a/tests/services/apiAdapters/nativeResources/accountKeyResourceInventory.test.ts
+++ b/tests/services/apiAdapters/nativeResources/accountKeyResourceInventory.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { SITE_TYPES } from "~/constants/siteType"
+import type {
+  AccountKeyResourceCollection,
+  AccountKeyResourceFacts,
+} from "~/services/apiAdapters/contracts/accountKeyResource"
+import { collectAccountKeyResourceInventory } from "~/services/apiAdapters/nativeResources/accountKeyResourceInventory"
+
+const createFacts = (resourceId: string): AccountKeyResourceFacts => ({
+  ref: {
+    accountId: "account-example",
+    siteType: SITE_TYPES.OPENROUTER,
+    scopeKey: "scope-example",
+    resourceId,
+  },
+  displayName: `Key ${resourceId}`,
+  maskedLabel: "sk-example...masked",
+  status: "enabled",
+  fields: [],
+  actions: { canUpdate: true, canDelete: true },
+})
+
+describe("collectAccountKeyResourceInventory", () => {
+  it("collects cursor-paginated native key resources", async () => {
+    const first = createFacts("first")
+    const second = createFacts("second")
+    const list = vi
+      .fn()
+      .mockResolvedValueOnce({ items: [first], nextCursor: "next-page" })
+      .mockResolvedValueOnce({ items: [second] })
+    const collection = { list } as unknown as AccountKeyResourceCollection
+
+    await expect(
+      collectAccountKeyResourceInventory(collection),
+    ).resolves.toEqual([first, second])
+    expect(list).toHaveBeenNthCalledWith(
+      2,
+      { cursor: "next-page" },
+      { signal: undefined },
+    )
+  })
+
+  it("rejects repeated provider references across pages", async () => {
+    const duplicate = createFacts("duplicate")
+    const list = vi
+      .fn()
+      .mockResolvedValueOnce({ items: [duplicate], nextCursor: "next-page" })
+      .mockResolvedValueOnce({ items: [duplicate] })
+    const collection = { list } as unknown as AccountKeyResourceCollection
+
+    await expect(
+      collectAccountKeyResourceInventory(collection),
+    ).rejects.toMatchObject({
+      failure: { code: "unexpected" },
+    })
+  })
+})

--- a/tests/services/apiAdapters/nativeResources/accountKeyResourceInventory.test.ts
+++ b/tests/services/apiAdapters/nativeResources/accountKeyResourceInventory.test.ts
@@ -5,7 +5,10 @@ import type {
   AccountKeyResourceCollection,
   AccountKeyResourceFacts,
 } from "~/services/apiAdapters/contracts/accountKeyResource"
-import { collectAccountKeyResourceInventory } from "~/services/apiAdapters/nativeResources/accountKeyResourceInventory"
+import {
+  awaitAbortableAccountKeyResourceOperation,
+  collectAccountKeyResourceInventory,
+} from "~/services/apiAdapters/nativeResources/accountKeyResourceInventory"
 
 const createFacts = (resourceId: string): AccountKeyResourceFacts => ({
   ref: {
@@ -22,6 +25,17 @@ const createFacts = (resourceId: string): AccountKeyResourceFacts => ({
 })
 
 describe("collectAccountKeyResourceInventory", () => {
+  it("preserves synchronous provider failures while an abort signal is active", async () => {
+    const controller = new AbortController()
+    const failure = new Error("provider initialization failed")
+
+    await expect(
+      awaitAbortableAccountKeyResourceOperation(() => {
+        throw failure
+      }, controller.signal),
+    ).rejects.toBe(failure)
+  })
+
   it("does not start listing when the request is already aborted", async () => {
     const controller = new AbortController()
     const list = vi.fn()

--- a/tests/utils/formatters.test.ts
+++ b/tests/utils/formatters.test.ts
@@ -23,6 +23,7 @@ import {
   getOppositeCurrency,
   getStatusBadgeStyle,
   getTodayMetricPresentation,
+  maskSecretForDisplay,
   normalizeToDate,
   normalizeToMs,
 } from "~/utils/core/formatters"
@@ -30,6 +31,22 @@ import { buildCompleteTodayStatsAvailability } from "~~/tests/test-utils/account
 import { buildDisplaySiteData } from "~~/tests/test-utils/factories"
 
 describe("formatters utilities", () => {
+  describe("maskSecretForDisplay", () => {
+    it("fully masks short secrets", () => {
+      expect(maskSecretForDisplay("short-key")).toBe("******")
+    })
+
+    it("preserves the start and end of long secrets", () => {
+      const secret = "sk-1234567890abcdefghijklmnop"
+
+      expect(maskSecretForDisplay(secret)).toBe(
+        `${secret.substring(0, 8)}${"*".repeat(16)}${secret.substring(
+          secret.length - 4,
+        )}`,
+      )
+    })
+  })
+
   describe("getTodayMetricPresentation", () => {
     it("requires refresh for legacy-unclassified account availability", () => {
       expect(

--- a/tests/utils/formatters.test.ts
+++ b/tests/utils/formatters.test.ts
@@ -36,6 +36,10 @@ describe("formatters utilities", () => {
       expect(maskSecretForDisplay("short-key")).toBe("******")
     })
 
+    it("fully masks a 12-character secret", () => {
+      expect(maskSecretForDisplay("123456789012")).toBe("******")
+    })
+
     it("preserves the start and end of long secrets", () => {
       const secret = "sk-1234567890abcdefghijklmnop"
 


### PR DESCRIPTION
## Summary

This PR introduces two user-visible account-key changes:

1. **OpenRouter native key inventory**
   - Load and display all OpenRouter keys through its native resource API.
   - Show supported key metadata and actions without exposing incompatible legacy key-management capabilities.
   - Preserve the compact, collapsed-by-default quick-list experience.

2. **Capability-aware quick key actions**
   - Keep the existing **Copy key** shortcut for providers whose saved secrets can be retrieved.
   - Replace it with **Key list** for OpenRouter, AIHubMix, and other one-time-secret providers.
   - Open the inventory directly without attempting an unsupported secret lookup.
   - Prevent errors such as `keyManagement is not implemented for openrouter`.
   - When the original secret is unavailable, guide users to create a replacement through Key Management.

## Shared presentation migration

- Migrate the quick key list to the shared key-resource card presentation used by Key Management.
- Centralize provider capabilities and action availability instead of coupling navigation to native-key loading support.
- Reuse quota, metadata, status, and action presentation across native and legacy key resources.
- Improve the responsive details layout, dialog width, footer surface, and loading-state colors.

## Compatibility

- Recoverable runtime keys retain the existing one-click copy behavior.
- One-time secrets are never represented as retrievable after creation.
- Existing quick-list cards remain compact and collapsed by default.
- No data migration or breaking API change is required.

## Validation

- `pnpm run validate:staged`
- `pnpm run validate:push`
  - TypeScript compilation
  - Knip unused-code and dependency analysis
- Affected component, capability, presentation, and native-resource Vitest tests passed.
- Full browser E2E was not run; PR CI remains pending.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native account key resources alongside runtime keys.
  * Added expandable key cards with status, context, details, previews, and available actions.
  * Added capability-aware copy, key-list, and Key Management navigation actions.
  * Added supported credential export and import integrations.
  * Added read-only key views and clearer empty-state handling.
  * Improved responsive layouts and loading indicators.

* **Bug Fixes**
  * Standardized secret masking for safer, clearer key previews.

* **Documentation**
  * Clarified in multiple languages that complete keys are shown only during creation and replacement is required if not saved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->