### PR TITLE
fix(new-api): support modern managed-site verification

### DIFF
--- a/src/components/dialogs/ChannelDialog/components/ChannelDialog.tsx
+++ b/src/components/dialogs/ChannelDialog/components/ChannelDialog.tsx
@@ -303,14 +303,32 @@ export function ChannelDialog({
     const requestId = requestIdRef.current + 1
     requestIdRef.current = requestId
     let resolvedKey: string | null = null
+    let requestSettled = false
+    let requestFailed = false
+
+    const applyResolvedKey = (key: string) => {
+      resolvedKey = key
+
+      // New API may return from the initial request after opening its
+      // verification dialog. The same setter is then invoked later by the
+      // verification callback, so apply it after either timing.
+      if (
+        requestSettled &&
+        !requestFailed &&
+        requestId === requestIdRef.current
+      ) {
+        updateField("key", key)
+        setShowKey(true)
+      }
+    }
 
     setIsLoadingRealKey(true)
     try {
       await onRequestRealKey({
-        setKey: (key) => {
-          resolvedKey = key
-        },
+        setKey: applyResolvedKey,
       })
+
+      requestSettled = true
 
       if (requestId !== requestIdRef.current || resolvedKey === null) {
         return
@@ -319,6 +337,7 @@ export function ChannelDialog({
       updateField("key", resolvedKey)
       setShowKey(true)
     } catch (error) {
+      requestFailed = true
       toast.error(
         t("channelDialog:messages.loadRealKeyFailed", {
           error: error instanceof Error ? error.message : String(error ?? ""),

--- a/src/services/accountSiteOnboarding/contentSession/newApiAuthBundle.ts
+++ b/src/services/accountSiteOnboarding/contentSession/newApiAuthBundle.ts
@@ -5,6 +5,8 @@ import {
   NEW_API_DASHBOARD_AUTH_REFRESH_PATH,
   parseNewApiDashboardAuthBundleResponse,
 } from "~/services/apiService/newApi/dashboardAuth"
+import { isRecord } from "~/utils/core/object"
+import { trimToNull } from "~/utils/core/string"
 
 import {
   NEW_API_DASHBOARD_TRANSIENT_AUTH_KIND,
@@ -14,21 +16,6 @@ import {
 
 const CONTROLLED_ERROR_STATUSES = new Set([401, 409, 429])
 const AUTH_REFRESH_REQUEST_ERROR = "New API session refresh request failed"
-
-type UnknownRecord = Record<string, unknown>
-
-/** Checks that an unknown JSON value is a plain object record. */
-function isRecord(value: unknown): value is UnknownRecord {
-  return Boolean(value && typeof value === "object" && !Array.isArray(value))
-}
-
-/** Returns a trimmed string only when the unknown value is nonblank. */
-function getNonBlankString(value: unknown): string | null {
-  if (typeof value !== "string") return null
-
-  const trimmed = value.trim()
-  return trimmed ? trimmed : null
-}
 
 /** Builds a status-only error without exposing the response body. */
 function createRefreshStatusError(status: number): Error {
@@ -46,8 +33,8 @@ async function createControlledRefreshError(
     body = null
   }
 
-  const code = isRecord(body) ? getNonBlankString(body.code) : null
-  const message = isRecord(body) ? getNonBlankString(body.message) : null
+  const code = isRecord(body) ? trimToNull(body.code) : null
+  const message = isRecord(body) ? trimToNull(body.message) : null
   if (code && message) return new Error(`${code}: ${message}`)
   if (code) return new Error(code)
   if (message) return new Error(message)

--- a/src/services/accountSiteOnboarding/contentSession/newApiAuthBundle.ts
+++ b/src/services/accountSiteOnboarding/contentSession/newApiAuthBundle.ts
@@ -1,5 +1,10 @@
 import { SITE_TYPES } from "~/constants/siteType"
 import { resolveStoredAccountUserIdentity } from "~/services/accounts/accountIdentity"
+import {
+  NEW_API_DASHBOARD_AUTH_INVALID_RESPONSE,
+  NEW_API_DASHBOARD_AUTH_REFRESH_PATH,
+  parseNewApiDashboardAuthBundleResponse,
+} from "~/services/apiService/newApi/dashboardAuth"
 
 import {
   NEW_API_DASHBOARD_TRANSIENT_AUTH_KIND,
@@ -7,15 +12,7 @@ import {
   type ContentSessionExtractor,
 } from "../contracts"
 
-const NEW_API_AUTH_REFRESH_PATH = "/api/user/auth/refresh"
 const CONTROLLED_ERROR_STATUSES = new Set([401, 409, 429])
-const AUTH_BUNDLE_TOKEN_FIELDS = [
-  "access_token",
-  "token_type",
-  "access_expires_at",
-] as const
-const INVALID_AUTH_BUNDLE_ERROR =
-  "New API dashboard session response is invalid"
 const AUTH_REFRESH_REQUEST_ERROR = "New API session refresh request failed"
 
 type UnknownRecord = Record<string, unknown>
@@ -31,68 +28,6 @@ function getNonBlankString(value: unknown): string | null {
 
   const trimmed = value.trim()
   return trimmed ? trimmed : null
-}
-
-/** Detects whether a successful response attempted the rc.22 AuthBundle shape. */
-function isRecognizableAuthBundleAttempt(body: unknown): boolean {
-  if (!isRecord(body) || !isRecord(body.data)) return false
-
-  const hasTokenMarker = AUTH_BUNDLE_TOKEN_FIELDS.some((field) =>
-    Object.prototype.hasOwnProperty.call(body.data, field),
-  )
-  if (hasTokenMarker) return true
-
-  const session = body.data.session
-  return Boolean(
-    isRecord(session) &&
-      (Object.prototype.hasOwnProperty.call(session, "sid") ||
-        Object.prototype.hasOwnProperty.call(session, "current")),
-  )
-}
-
-/** Validates and normalizes an rc.22 AuthBundle response. */
-function parseAuthBundle(
-  body: unknown,
-  origin: string,
-): ContentSessionExtractionResult | null {
-  if (!isRecord(body) || body.success !== true || !isRecord(body.data)) {
-    return null
-  }
-
-  const data = body.data
-  const token = getNonBlankString(data.access_token)
-  const expiresAt = data.access_expires_at
-  if (
-    data.token_type !== "Bearer" ||
-    !token ||
-    typeof expiresAt !== "number" ||
-    !Number.isFinite(expiresAt) ||
-    expiresAt <= Date.now() / 1000
-  ) {
-    return null
-  }
-
-  const identity = resolveStoredAccountUserIdentity(
-    data.user,
-    SITE_TYPES.NEW_API,
-  )
-  if (!identity || !isRecord(data.session)) return null
-
-  const sessionId = getNonBlankString(data.session.sid)
-  if (!sessionId || data.session.current !== true) return null
-
-  return {
-    userId: identity.userId,
-    user: identity.user,
-    siteTypeHint: SITE_TYPES.NEW_API,
-    transientAuth: {
-      kind: NEW_API_DASHBOARD_TRANSIENT_AUTH_KIND,
-      token,
-      expiresAt,
-      sessionId,
-      origin,
-    },
-  }
 }
 
 /** Builds a status-only error without exposing the response body. */
@@ -130,7 +65,7 @@ async function extractNewApiAuthBundle(): Promise<ContentSessionExtractionResult
   let response: Response
 
   try {
-    response = await fetch(`${origin}${NEW_API_AUTH_REFRESH_PATH}`, {
+    response = await fetch(`${origin}${NEW_API_DASHBOARD_AUTH_REFRESH_PATH}`, {
       credentials: "include",
       method: "POST",
     })
@@ -150,16 +85,33 @@ async function extractNewApiAuthBundle(): Promise<ContentSessionExtractionResult
   try {
     body = await response.json()
   } catch {
-    throw new Error(INVALID_AUTH_BUNDLE_ERROR)
+    throw new Error(NEW_API_DASHBOARD_AUTH_INVALID_RESPONSE)
   }
 
-  const result = parseAuthBundle(body, origin)
-  if (result) return result
-  if (isRecognizableAuthBundleAttempt(body)) {
-    throw new Error(INVALID_AUTH_BUNDLE_ERROR)
+  const parsed = parseNewApiDashboardAuthBundleResponse(body)
+  if (parsed.kind === "malformed") {
+    throw new Error(NEW_API_DASHBOARD_AUTH_INVALID_RESPONSE)
   }
+  if (parsed.kind === "unrelated") return null
 
-  return null
+  const identity = resolveStoredAccountUserIdentity(
+    parsed.bundle.user,
+    SITE_TYPES.NEW_API,
+  )
+  if (!identity) throw new Error(NEW_API_DASHBOARD_AUTH_INVALID_RESPONSE)
+
+  return {
+    userId: identity.userId,
+    user: identity.user,
+    siteTypeHint: SITE_TYPES.NEW_API,
+    transientAuth: {
+      kind: NEW_API_DASHBOARD_TRANSIENT_AUTH_KIND,
+      token: parsed.bundle.token,
+      expiresAt: parsed.bundle.expiresAt,
+      sessionId: parsed.bundle.sessionId,
+      origin,
+    },
+  }
 }
 
 export const newApiAuthBundleContentSessionExtractor: ContentSessionExtractor =

--- a/src/services/apiService/newApi/dashboardAuth.ts
+++ b/src/services/apiService/newApi/dashboardAuth.ts
@@ -1,0 +1,102 @@
+export const NEW_API_DASHBOARD_AUTH_REFRESH_PATH = "/api/user/auth/refresh"
+
+export const NEW_API_DASHBOARD_AUTH_INVALID_RESPONSE =
+  "New API dashboard session response is invalid"
+
+const AUTH_BUNDLE_TOKEN_FIELDS = [
+  "access_token",
+  "token_type",
+  "access_expires_at",
+] as const
+
+type UnknownRecord = Record<string, unknown>
+
+export interface NewApiDashboardAuthBundle {
+  token: string
+  expiresAt: number
+  sessionId: string
+  user: UnknownRecord
+}
+
+type NewApiDashboardAuthBundleParseResult =
+  | { kind: "valid"; bundle: NewApiDashboardAuthBundle }
+  | { kind: "malformed" }
+  | { kind: "unrelated" }
+
+/** Checks that an unknown JSON value is a plain object record. */
+function isRecord(value: unknown): value is UnknownRecord {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value))
+}
+
+/** Returns a trimmed string only when the unknown value is nonblank. */
+function getNonBlankString(value: unknown): string | null {
+  if (typeof value !== "string") return null
+
+  const trimmed = value.trim()
+  return trimmed ? trimmed : null
+}
+
+/** Detects whether a response attempted the modern New API AuthBundle shape. */
+function isRecognizableAuthBundleAttempt(data: unknown): boolean {
+  if (!isRecord(data)) return false
+
+  const hasTokenMarker = AUTH_BUNDLE_TOKEN_FIELDS.some((field) =>
+    Object.prototype.hasOwnProperty.call(data, field),
+  )
+  if (hasTokenMarker) return true
+
+  const session = data.session
+  return Boolean(
+    isRecord(session) &&
+      (Object.prototype.hasOwnProperty.call(session, "sid") ||
+        Object.prototype.hasOwnProperty.call(session, "current")),
+  )
+}
+
+/**
+ * Validates the modern dashboard AuthBundle without applying account identity
+ * rules. Callers keep the returned credential process-local and transient.
+ *
+ * Upstream contract:
+ * https://github.com/QuantumNous/new-api/commit/31d70fca393ff2e09bbae012af2e3ccefdd389a1
+ */
+export function parseNewApiDashboardAuthBundleResponse(
+  body: unknown,
+  nowMs: number = Date.now(),
+): NewApiDashboardAuthBundleParseResult {
+  const data = isRecord(body) ? body.data : undefined
+  const recognizable = isRecognizableAuthBundleAttempt(data)
+
+  if (!isRecord(body) || body.success !== true || !isRecord(data)) {
+    return recognizable ? { kind: "malformed" } : { kind: "unrelated" }
+  }
+
+  const token = getNonBlankString(data.access_token)
+  const expiresAt = data.access_expires_at
+  const session = data.session
+  const sessionId = isRecord(session) ? getNonBlankString(session.sid) : null
+
+  if (
+    data.token_type !== "Bearer" ||
+    !token ||
+    typeof expiresAt !== "number" ||
+    !Number.isFinite(expiresAt) ||
+    expiresAt <= nowMs / 1000 ||
+    !isRecord(data.user) ||
+    !isRecord(session) ||
+    !sessionId ||
+    session.current !== true
+  ) {
+    return recognizable ? { kind: "malformed" } : { kind: "unrelated" }
+  }
+
+  return {
+    kind: "valid",
+    bundle: {
+      token,
+      expiresAt,
+      sessionId,
+      user: data.user,
+    },
+  }
+}

--- a/src/services/apiService/newApi/dashboardAuth.ts
+++ b/src/services/apiService/newApi/dashboardAuth.ts
@@ -65,6 +65,8 @@ export function parseNewApiDashboardAuthBundleResponse(
   const session = data.session
   const sessionId = isRecord(session) ? trimToNull(session.sid) : null
 
+  // Upstream AuthBundle requires a live Bearer token and a current sid session.
+  // Recognizable markers that fail this contract are malformed, not legacy.
   if (
     data.token_type !== "Bearer" ||
     !token ||

--- a/src/services/apiService/newApi/dashboardAuth.ts
+++ b/src/services/apiService/newApi/dashboardAuth.ts
@@ -1,3 +1,6 @@
+import { isRecord } from "~/utils/core/object"
+import { trimToNull } from "~/utils/core/string"
+
 export const NEW_API_DASHBOARD_AUTH_REFRESH_PATH = "/api/user/auth/refresh"
 
 export const NEW_API_DASHBOARD_AUTH_INVALID_RESPONSE =
@@ -9,32 +12,18 @@ const AUTH_BUNDLE_TOKEN_FIELDS = [
   "access_expires_at",
 ] as const
 
-type UnknownRecord = Record<string, unknown>
-
 export interface NewApiDashboardAuthBundle {
   token: string
+  /** Epoch seconds, matching the upstream AuthBundle `access_expires_at`. */
   expiresAt: number
   sessionId: string
-  user: UnknownRecord
+  user: Record<string, unknown>
 }
 
 type NewApiDashboardAuthBundleParseResult =
   | { kind: "valid"; bundle: NewApiDashboardAuthBundle }
   | { kind: "malformed" }
   | { kind: "unrelated" }
-
-/** Checks that an unknown JSON value is a plain object record. */
-function isRecord(value: unknown): value is UnknownRecord {
-  return Boolean(value && typeof value === "object" && !Array.isArray(value))
-}
-
-/** Returns a trimmed string only when the unknown value is nonblank. */
-function getNonBlankString(value: unknown): string | null {
-  if (typeof value !== "string") return null
-
-  const trimmed = value.trim()
-  return trimmed ? trimmed : null
-}
 
 /** Detects whether a response attempted the modern New API AuthBundle shape. */
 function isRecognizableAuthBundleAttempt(data: unknown): boolean {
@@ -71,10 +60,10 @@ export function parseNewApiDashboardAuthBundleResponse(
     return recognizable ? { kind: "malformed" } : { kind: "unrelated" }
   }
 
-  const token = getNonBlankString(data.access_token)
+  const token = trimToNull(data.access_token)
   const expiresAt = data.access_expires_at
   const session = data.session
-  const sessionId = isRecord(session) ? getNonBlankString(session.sid) : null
+  const sessionId = isRecord(session) ? trimToNull(session.sid) : null
 
   if (
     data.token_type !== "Bearer" ||

--- a/src/services/managedSites/providers/newApiSession.ts
+++ b/src/services/managedSites/providers/newApiSession.ts
@@ -20,6 +20,8 @@ import { AuthTypeEnum } from "~/types"
 import type { NewApiConfig } from "~/types/newApiConfig"
 import { safeRandomUUID } from "~/utils/core/identifier"
 import { createLogger } from "~/utils/core/logger"
+import { isRecord } from "~/utils/core/object"
+import { trimToNull } from "~/utils/core/string"
 import { normalizeUrlForOriginKey } from "~/utils/core/urlParsing"
 import { t } from "~/utils/i18n/core"
 
@@ -131,11 +133,13 @@ interface NewApiSessionState {
   }
   dashboardAuth?: {
     token: string
+    /** Epoch seconds, matching the upstream AuthBundle `access_expires_at`. */
     expiresAt: number
     sessionId: string
   }
   securityProof?: {
     token: string
+    /** Epoch milliseconds, matching the normalized verified-until timestamp. */
     expiresAt: number
   }
   loginPromise?: Promise<EnsureNewApiLoginResult>
@@ -145,8 +149,6 @@ interface NewApiSessionState {
 }
 
 type NewApiDashboardRefreshResult = "refreshed" | "unavailable"
-
-type UnknownRecord = Record<string, unknown>
 
 const NEW_API_DASHBOARD_REFRESH_CONTROLLED_STATUSES = new Set([409, 429])
 const NEW_API_DASHBOARD_REFRESH_REQUEST_ERROR =
@@ -241,18 +243,6 @@ const createManagedSessionRequest = (
   return dashboardAuth
     ? createDashboardAuthRequest(baseUrl, dashboardAuth)
     : createCookieAuthRequest(baseUrl, userId)
-}
-
-/** Checks that an unknown response value is a plain object record. */
-function isRecord(value: unknown): value is UnknownRecord {
-  return Boolean(value && typeof value === "object" && !Array.isArray(value))
-}
-
-/** Returns a trimmed string only when the value is nonblank. */
-function getNonBlankString(value: unknown): string | null {
-  if (typeof value !== "string") return null
-  const trimmed = value.trim()
-  return trimmed ? trimmed : null
 }
 
 const isUnauthorizedError = (error: unknown) =>
@@ -416,7 +406,8 @@ const markVerified = (
   state.hasLoggedInSession = true
   state.verifiedUntil =
     verifiedUntil ?? Date.now() + NEW_API_VERIFIED_SESSION_WINDOW_MS
-  state.securityProof = securityProof
+  // Successful reads confirm the session but do not issue a replacement proof.
+  if (securityProof) state.securityProof = securityProof
 }
 
 const getActiveSecurityProof = (baseUrl: string) => {
@@ -458,8 +449,8 @@ const createControlledDashboardRefreshError = (
   body: unknown,
   status: number,
 ) => {
-  const code = isRecord(body) ? getNonBlankString(body.code) : null
-  const message = isRecord(body) ? getNonBlankString(body.message) : null
+  const code = isRecord(body) ? trimToNull(body.code) : null
+  const message = isRecord(body) ? trimToNull(body.message) : null
   if (code && message) return new Error(`${code}: ${message}`)
   if (code) return new Error(code)
   if (message) return new Error(message)
@@ -699,7 +690,7 @@ async function readNewApiVerificationMethodsWithRefresh(
     throw new ApiError(
       NEW_API_DASHBOARD_AUTH_UNAUTHORIZED,
       401,
-      "/api/user/auth/refresh",
+      NEW_API_DASHBOARD_AUTH_REFRESH_PATH,
       API_ERROR_CODES.HTTP_401,
     )
   }
@@ -758,7 +749,8 @@ async function postNewApiLogin(
 
   if (response.success === false) {
     throw new ApiError(
-      response.message || t("messages:errors.api.invalidResponseFormat"),
+      trimToNull(response.message) ??
+        t("messages:errors.api.invalidResponseFormat"),
       undefined,
       "/api/user/login",
       API_ERROR_CODES.BUSINESS_ERROR,
@@ -792,7 +784,7 @@ async function postNewApiLogin(
   if (authBundleKind !== "valid" && responseData?.require_2fa) {
     // Modern New API returns a flow token; its absence is the legacy contract.
     // https://github.com/QuantumNous/new-api/commit/31d70fca393ff2e09bbae012af2e3ccefdd389a1
-    const flowToken = getNonBlankString(responseData.flow_token)
+    const flowToken = trimToNull(responseData.flow_token)
     if (flowToken) {
       storePendingLoginFlow(config.baseUrl, flowToken, responseData.expires_at)
     } else {
@@ -881,7 +873,7 @@ async function verifyNewApiSession(
       throw sanitizeNewApiErrorForOrigin(error, config.baseUrl)
     }
 
-    const proofToken = getNonBlankString(response?.proof_token)
+    const proofToken = trimToNull(response?.proof_token)
     const verifiedUntil = toVerifiedUntilTimestamp(response?.expires_at)
     markVerified(
       config.baseUrl,
@@ -1061,10 +1053,20 @@ export async function submitNewApiLoginTwoFactorCode(
     },
   })
 
+  if (!isRecord(response)) {
+    throw new ApiError(
+      t("messages:errors.api.invalidResponseFormat"),
+      undefined,
+      "/api/user/login/2fa",
+      API_ERROR_CODES.JSON_PARSE_ERROR,
+    )
+  }
+
   if (response.success === false) {
     throw new ApiError(
       sanitizeNewApiSessionError(
-        response.message || t("messages:errors.api.invalidResponseFormat"),
+        trimToNull(response.message) ??
+          t("messages:errors.api.invalidResponseFormat"),
         [trimmedCode, ...getTransientSessionSecrets(config.baseUrl)],
       ),
       undefined,

--- a/src/services/managedSites/providers/newApiSession.ts
+++ b/src/services/managedSites/providers/newApiSession.ts
@@ -1,5 +1,15 @@
+import {
+  NEW_API_DASHBOARD_AUTH_INVALID_RESPONSE,
+  NEW_API_DASHBOARD_AUTH_REFRESH_PATH,
+  parseNewApiDashboardAuthBundleResponse,
+  type NewApiDashboardAuthBundle,
+} from "~/services/apiService/newApi/dashboardAuth"
 import { API_ERROR_CODES, ApiError } from "~/services/apiTransport/errors"
-import { fetchApi, fetchApiData } from "~/services/apiTransport/request"
+import {
+  fetchApi,
+  fetchApiData,
+  fetchApiResponse,
+} from "~/services/apiTransport/request"
 import type { ApiServiceRequest } from "~/services/apiTransport/type"
 import {
   NEW_API_SESSION_READ_ACTIONS,
@@ -18,6 +28,14 @@ import { generateNewApiTotpCode, hasNewApiTotpSecret } from "./newApiTotp"
 const logger = createLogger("NewApiManagedSession")
 
 export const NEW_API_VERIFIED_SESSION_WINDOW_MS = 5 * 60 * 1000
+
+/**
+ * Security-proof scopes introduced by New API's stateless dashboard auth.
+ * https://github.com/QuantumNous/new-api/commit/31d70fca393ff2e09bbae012af2e3ccefdd389a1
+ */
+export const NEW_API_SECURITY_PROOF_SCOPES = {
+  CHANNEL_KEY_READ: "channel.key.read",
+} as const
 
 export const NEW_API_MANAGED_SESSION_STATUSES = {
   VERIFIED: "verified",
@@ -84,6 +102,8 @@ export class NewApiChannelKeyRequirementError extends Error {
 
 interface NewApiLoginResponse {
   require_2fa?: boolean
+  flow_token?: string
+  expires_at?: number
 }
 
 interface NewApiTwoFactorStatusResponse {
@@ -97,15 +117,42 @@ interface NewApiPasskeyStatusResponse {
 interface NewApiVerifyResponse {
   verified?: boolean
   expires_at?: number
+  proof_token?: string
+  method?: string
+  scope?: string
 }
 
 interface NewApiSessionState {
   hasLoggedInSession: boolean
   verifiedUntil?: number
+  pendingLoginFlow?: {
+    token: string
+    expiresAt?: number
+  }
+  dashboardAuth?: {
+    token: string
+    expiresAt: number
+    sessionId: string
+  }
+  securityProof?: {
+    token: string
+    expiresAt: number
+  }
   loginPromise?: Promise<EnsureNewApiLoginResult>
+  refreshPromise?: Promise<NewApiDashboardRefreshResult>
   methodsPromise?: Promise<NewApiVerificationMethods | null>
   verificationPromise?: Promise<VerifyNewApiSessionResult>
 }
+
+type NewApiDashboardRefreshResult = "refreshed" | "unavailable"
+
+type UnknownRecord = Record<string, unknown>
+
+const NEW_API_DASHBOARD_REFRESH_CONTROLLED_STATUSES = new Set([409, 429])
+const NEW_API_DASHBOARD_REFRESH_REQUEST_ERROR =
+  "New API session refresh request failed"
+const NEW_API_DASHBOARD_AUTH_UNAUTHORIZED =
+  "New API dashboard session could not be authenticated"
 
 type EnsureNewApiLoginResult =
   | {
@@ -157,6 +204,57 @@ const createCookieAuthRequest = (
   },
 })
 
+const getActiveDashboardAuth = (baseUrl: string) => {
+  const state = getSessionState(baseUrl)
+  const dashboardAuth = state.dashboardAuth
+  if (!dashboardAuth) return undefined
+
+  if (dashboardAuth.expiresAt > Date.now() / 1000) {
+    return dashboardAuth
+  }
+
+  state.dashboardAuth = undefined
+  state.securityProof = undefined
+  state.hasLoggedInSession = false
+  state.verifiedUntil = undefined
+  return undefined
+}
+
+const createDashboardAuthRequest = (
+  baseUrl: string,
+  dashboardAuth: NonNullable<NewApiSessionState["dashboardAuth"]>,
+): ApiServiceRequest => ({
+  baseUrl: baseUrl.trim(),
+  accountId: `managed-site:new-api-session:${normalizeSessionScopeKey(baseUrl)}`,
+  auth: {
+    authType: AuthTypeEnum.AccessToken,
+    accessToken: dashboardAuth.token,
+  },
+})
+
+/** Selects the response-detected dashboard Bearer or the legacy Cookie path. */
+const createManagedSessionRequest = (
+  baseUrl: string,
+  userId?: number | string,
+): ApiServiceRequest => {
+  const dashboardAuth = getActiveDashboardAuth(baseUrl)
+  return dashboardAuth
+    ? createDashboardAuthRequest(baseUrl, dashboardAuth)
+    : createCookieAuthRequest(baseUrl, userId)
+}
+
+/** Checks that an unknown response value is a plain object record. */
+function isRecord(value: unknown): value is UnknownRecord {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value))
+}
+
+/** Returns a trimmed string only when the value is nonblank. */
+function getNonBlankString(value: unknown): string | null {
+  if (typeof value !== "string") return null
+  const trimmed = value.trim()
+  return trimmed ? trimmed : null
+}
+
 const isUnauthorizedError = (error: unknown) =>
   error instanceof ApiError &&
   (error.statusCode === 401 || error.code === API_ERROR_CODES.HTTP_401)
@@ -183,12 +281,27 @@ const sanitizeNewApiSessionError = (error: unknown, secrets: string[] = []) => {
 const clearVerifiedState = (baseUrl: string) => {
   const state = getSessionState(baseUrl)
   state.verifiedUntil = undefined
+  state.securityProof = undefined
 }
 
 const clearLoggedInState = (baseUrl: string) => {
   const state = getSessionState(baseUrl)
   state.hasLoggedInSession = false
   state.verifiedUntil = undefined
+  state.dashboardAuth = undefined
+  state.securityProof = undefined
+}
+
+const clearPendingLoginFlow = (baseUrl: string) => {
+  getSessionState(baseUrl).pendingLoginFlow = undefined
+}
+
+const toOptionalExpiryTimestamp = (expiresAt: unknown) => {
+  if (typeof expiresAt !== "number" || !Number.isFinite(expiresAt)) {
+    return undefined
+  }
+
+  return expiresAt > 1_000_000_000_000 ? expiresAt : expiresAt * 1000
 }
 
 const toVerifiedUntilTimestamp = (expiresAt?: number) => {
@@ -206,11 +319,222 @@ const markLoggedIn = (baseUrl: string) => {
   state.hasLoggedInSession = true
 }
 
-const markVerified = (baseUrl: string, verifiedUntil?: number) => {
+const storeDashboardAuth = (
+  baseUrl: string,
+  bundle: NewApiDashboardAuthBundle,
+) => {
+  const state = getSessionState(baseUrl)
+  state.dashboardAuth = {
+    token: bundle.token,
+    expiresAt: bundle.expiresAt,
+    sessionId: bundle.sessionId,
+  }
+  state.securityProof = undefined
+  state.verifiedUntil = undefined
+  state.pendingLoginFlow = undefined
+  state.hasLoggedInSession = true
+}
+
+const storePendingLoginFlow = (
+  baseUrl: string,
+  token: string,
+  expiresAt: unknown,
+) => {
+  const state = getSessionState(baseUrl)
+  state.pendingLoginFlow = {
+    token,
+    expiresAt: toOptionalExpiryTimestamp(expiresAt),
+  }
+}
+
+const getPendingLoginFlowForSubmission = (baseUrl: string) => {
+  const state = getSessionState(baseUrl)
+  const pending = state.pendingLoginFlow
+  if (!pending) return undefined
+
+  if (pending.expiresAt && pending.expiresAt <= Date.now()) {
+    state.pendingLoginFlow = undefined
+    throw new Error("New API login flow expired")
+  }
+
+  return pending
+}
+
+const hasActivePendingLoginFlow = (baseUrl: string) => {
+  const state = getSessionState(baseUrl)
+  const pending = state.pendingLoginFlow
+  if (!pending) return false
+  if (pending.expiresAt && pending.expiresAt <= Date.now()) {
+    state.pendingLoginFlow = undefined
+    return false
+  }
+  return true
+}
+
+const getTransientSessionSecrets = (baseUrl: string) => {
+  const state = getSessionState(baseUrl)
+  return [
+    state.pendingLoginFlow?.token ?? "",
+    state.dashboardAuth?.token ?? "",
+    state.securityProof?.token ?? "",
+  ]
+}
+
+/** Redacts transient session credentials while retaining error categories. */
+const sanitizeNewApiErrorForOrigin = (error: unknown, baseUrl: string) => {
+  const secrets = getTransientSessionSecrets(baseUrl).filter(Boolean)
+  if (!secrets.length) return error
+
+  const message = sanitizeNewApiSessionError(error, secrets)
+  if (error instanceof ApiError) {
+    const sanitized = new ApiError(
+      message,
+      error.statusCode,
+      error.endpoint,
+      error.code,
+      error.upstreamCode,
+    )
+    sanitized.originalCode = error.originalCode
+    return sanitized
+  }
+
+  if (error instanceof Error && message !== error.message) {
+    const sanitized = new Error(message)
+    sanitized.name = error.name
+    return sanitized
+  }
+
+  return error
+}
+
+const markVerified = (
+  baseUrl: string,
+  verifiedUntil?: number,
+  securityProof?: { token: string; expiresAt: number },
+) => {
   const state = getSessionState(baseUrl)
   state.hasLoggedInSession = true
   state.verifiedUntil =
     verifiedUntil ?? Date.now() + NEW_API_VERIFIED_SESSION_WINDOW_MS
+  state.securityProof = securityProof
+}
+
+const getActiveSecurityProof = (baseUrl: string) => {
+  const state = getSessionState(baseUrl)
+  const securityProof = state.securityProof
+  if (!securityProof) return undefined
+
+  if (securityProof.expiresAt > Date.now()) {
+    return securityProof
+  }
+
+  state.securityProof = undefined
+  state.verifiedUntil = undefined
+  return undefined
+}
+
+const applyDashboardAuthBundleResponse = (baseUrl: string, body: unknown) => {
+  const parsed = parseNewApiDashboardAuthBundleResponse(body)
+  if (parsed.kind === "valid") {
+    storeDashboardAuth(baseUrl, parsed.bundle)
+  }
+  return parsed.kind
+}
+
+const parseDashboardRefreshBody = (body: string): unknown | undefined => {
+  try {
+    return JSON.parse(body)
+  } catch {
+    // A successful non-JSON response is not recognizable as modern auth;
+    // preserve the legacy credential path for older/protected deployments.
+    return undefined
+  }
+}
+
+const createDashboardRefreshStatusError = (status: number) =>
+  new Error(`New API session refresh failed (${status})`)
+
+const createControlledDashboardRefreshError = (
+  body: unknown,
+  status: number,
+) => {
+  const code = isRecord(body) ? getNonBlankString(body.code) : null
+  const message = isRecord(body) ? getNonBlankString(body.message) : null
+  if (code && message) return new Error(`${code}: ${message}`)
+  if (code) return new Error(code)
+  if (message) return new Error(message)
+  return createDashboardRefreshStatusError(status)
+}
+
+/**
+ * Refreshes only the modern dashboard session. The request rotates auth state,
+ * so it is never replayed through current-tab or temporary-window transports.
+ */
+async function postNewApiDashboardRefresh(
+  baseUrl: string,
+): Promise<NewApiDashboardRefreshResult> {
+  let response
+  try {
+    response = await fetchApiResponse<string>(
+      createCookieAuthRequest(baseUrl),
+      {
+        endpoint: NEW_API_DASHBOARD_AUTH_REFRESH_PATH,
+        responseType: "text",
+        currentTabTransport: "disabled",
+        tempWindowFallback: { statusCodes: [], codes: [] },
+        options: { method: "POST" },
+      },
+    )
+  } catch {
+    throw new Error(NEW_API_DASHBOARD_REFRESH_REQUEST_ERROR)
+  }
+
+  if (
+    response.status === 401 ||
+    response.status === 404 ||
+    response.status === 405
+  ) {
+    return "unavailable"
+  }
+
+  if (!response.ok) {
+    if (NEW_API_DASHBOARD_REFRESH_CONTROLLED_STATUSES.has(response.status)) {
+      let body: unknown = null
+      try {
+        body = JSON.parse(response.body)
+      } catch {
+        // Status-only fallback remains useful and cannot expose response data.
+      }
+      throw createControlledDashboardRefreshError(body, response.status)
+    }
+
+    throw createDashboardRefreshStatusError(response.status)
+  }
+
+  const body = parseDashboardRefreshBody(response.body)
+  if (body === undefined) return "unavailable"
+  const parsedKind = applyDashboardAuthBundleResponse(baseUrl, body)
+  if (parsedKind === "valid") return "refreshed"
+  if (parsedKind === "malformed") {
+    throw new Error(NEW_API_DASHBOARD_AUTH_INVALID_RESPONSE)
+  }
+
+  return "unavailable"
+}
+
+/** Deduplicates refresh-cookie rotation per managed-site origin. */
+async function refreshNewApiDashboardSession(
+  baseUrl: string,
+): Promise<NewApiDashboardRefreshResult> {
+  const state = getSessionState(baseUrl)
+  if (state.refreshPromise) return state.refreshPromise
+
+  state.refreshPromise = postNewApiDashboardRefresh(baseUrl)
+  try {
+    return await state.refreshPromise
+  } finally {
+    state.refreshPromise = undefined
+  }
 }
 
 /**
@@ -230,7 +554,10 @@ export async function hasNewApiAuthenticatedBrowserSession(
   config: Pick<NewApiConfig, "baseUrl" | "userId">,
 ) {
   return Boolean(
-    await readNewApiVerificationMethods(config.baseUrl, config.userId),
+    await readNewApiVerificationMethodsWithRefresh(
+      config.baseUrl,
+      config.userId,
+    ),
   )
 }
 
@@ -238,7 +565,10 @@ export async function hasNewApiAuthenticatedBrowserSession(
  * Checks the cached verified-session window for the current runtime.
  */
 export const isNewApiVerifiedSessionActive = (baseUrl: string) => {
-  const verifiedUntil = getSessionState(baseUrl).verifiedUntil
+  const state = getSessionState(baseUrl)
+  if (state.dashboardAuth) getActiveDashboardAuth(baseUrl)
+  if (state.securityProof) getActiveSecurityProof(baseUrl)
+  const verifiedUntil = state.verifiedUntil
   return Boolean(verifiedUntil && verifiedUntil > Date.now())
 }
 
@@ -295,7 +625,7 @@ async function readNewApiVerificationMethods(
   }
 
   state.methodsPromise = (async () => {
-    const request = createCookieAuthRequest(baseUrl, userId)
+    const request = createManagedSessionRequest(baseUrl, userId)
     const results = await Promise.allSettled([
       fetchApiData<NewApiTwoFactorStatusResponse>(request, {
         endpoint: "/api/user/2fa/status",
@@ -351,13 +681,44 @@ async function readNewApiVerificationMethods(
 }
 
 /**
+ * Probes the active auth path, then uses a modern refresh cookie before any
+ * credential login. Legacy 401/404/405 or unrelated responses remain a miss.
+ */
+async function readNewApiVerificationMethodsWithRefresh(
+  baseUrl: string,
+  userId?: number | string,
+): Promise<NewApiVerificationMethods | null> {
+  const methods = await readNewApiVerificationMethods(baseUrl, userId)
+  if (methods) return methods
+
+  const refreshResult = await refreshNewApiDashboardSession(baseUrl)
+  if (refreshResult !== "refreshed") return null
+
+  const refreshedMethods = await readNewApiVerificationMethods(baseUrl, userId)
+  if (!refreshedMethods) {
+    throw new ApiError(
+      NEW_API_DASHBOARD_AUTH_UNAUTHORIZED,
+      401,
+      "/api/user/auth/refresh",
+      API_ERROR_CODES.HTTP_401,
+    )
+  }
+
+  return refreshedMethods
+}
+
+/**
  * Starts a New API login session with stored username/password when no browser
  * session is already available, and reports whether login 2FA is still needed.
  */
 async function postNewApiLogin(
   config: Pick<NewApiConfig, "baseUrl" | "userId" | "username" | "password">,
 ): Promise<EnsureNewApiLoginResult> {
-  const methods = await readNewApiVerificationMethods(
+  if (hasActivePendingLoginFlow(config.baseUrl)) {
+    return { status: "login-2fa-required" }
+  }
+
+  const methods = await readNewApiVerificationMethodsWithRefresh(
     config.baseUrl,
     config.userId,
   )
@@ -375,7 +736,7 @@ async function postNewApiLogin(
   }
 
   const request = createCookieAuthRequest(config.baseUrl, config.userId)
-  const response = await fetchApiData<NewApiLoginResponse>(request, {
+  const response = await fetchApi<NewApiLoginResponse>(request, {
     endpoint: "/api/user/login",
     options: {
       method: "POST",
@@ -386,13 +747,67 @@ async function postNewApiLogin(
     },
   })
 
-  if (response?.require_2fa) {
+  if (!isRecord(response)) {
+    throw new ApiError(
+      t("messages:errors.api.invalidResponseFormat"),
+      undefined,
+      "/api/user/login",
+      API_ERROR_CODES.JSON_PARSE_ERROR,
+    )
+  }
+
+  if (response.success === false) {
+    throw new ApiError(
+      response.message || t("messages:errors.api.invalidResponseFormat"),
+      undefined,
+      "/api/user/login",
+      API_ERROR_CODES.BUSINESS_ERROR,
+    )
+  }
+
+  if (
+    !Object.prototype.hasOwnProperty.call(response, "data") ||
+    response.data === undefined
+  ) {
+    throw new ApiError(
+      t("messages:errors.api.invalidResponseFormat"),
+      undefined,
+      "/api/user/login",
+      API_ERROR_CODES.JSON_PARSE_ERROR,
+    )
+  }
+
+  const authBundleKind = applyDashboardAuthBundleResponse(
+    config.baseUrl,
+    response,
+  )
+  if (authBundleKind === "malformed") {
+    throw new Error(NEW_API_DASHBOARD_AUTH_INVALID_RESPONSE)
+  }
+
+  const responseData = isRecord(response.data)
+    ? (response.data as NewApiLoginResponse)
+    : undefined
+
+  if (authBundleKind !== "valid" && responseData?.require_2fa) {
+    // Modern New API returns a flow token; its absence is the legacy contract.
+    // https://github.com/QuantumNous/new-api/commit/31d70fca393ff2e09bbae012af2e3ccefdd389a1
+    const flowToken = getNonBlankString(responseData.flow_token)
+    if (flowToken) {
+      storePendingLoginFlow(config.baseUrl, flowToken, responseData.expires_at)
+    } else {
+      clearPendingLoginFlow(config.baseUrl)
+    }
+
     return {
       status: "login-2fa-required",
     }
   }
 
-  markLoggedIn(config.baseUrl)
+  clearPendingLoginFlow(config.baseUrl)
+  if (authBundleKind === "unrelated") {
+    markLoggedIn(config.baseUrl)
+  }
 
   return {
     status: "logged-in",
@@ -442,17 +857,42 @@ async function verifyNewApiSession(
   }
 
   state.verificationPromise = (async () => {
-    const request = createCookieAuthRequest(config.baseUrl, config.userId)
-    const response = await fetchApiData<NewApiVerifyResponse>(request, {
-      endpoint: "/api/verify",
-      options: {
-        method: "POST",
-        body: JSON.stringify(params),
-      },
-    })
+    const request = createManagedSessionRequest(config.baseUrl, config.userId)
+    const usesDashboardAuth = request.auth.authType === AuthTypeEnum.AccessToken
+    const requestParams = usesDashboardAuth
+      ? {
+          ...params,
+          // New API stateless dashboard auth issues a proof scoped to the
+          // sensitive channel-key read. Older Cookie-auth deployments do not
+          // receive this field, preserving their original request contract.
+          scope: NEW_API_SECURITY_PROOF_SCOPES.CHANNEL_KEY_READ,
+        }
+      : params
+    let response: NewApiVerifyResponse
+    try {
+      response = await fetchApiData<NewApiVerifyResponse>(request, {
+        endpoint: "/api/verify",
+        options: {
+          method: "POST",
+          body: JSON.stringify(requestParams),
+        },
+      })
+    } catch (error) {
+      throw sanitizeNewApiErrorForOrigin(error, config.baseUrl)
+    }
 
+    const proofToken = getNonBlankString(response?.proof_token)
     const verifiedUntil = toVerifiedUntilTimestamp(response?.expires_at)
-    markVerified(config.baseUrl, verifiedUntil)
+    markVerified(
+      config.baseUrl,
+      verifiedUntil,
+      usesDashboardAuth && proofToken
+        ? {
+            token: proofToken,
+            expiresAt: verifiedUntil,
+          }
+        : undefined,
+    )
 
     return {
       methods: (await readNewApiVerificationMethods(
@@ -508,6 +948,7 @@ async function continueFromLoggedInSession(
       const errorMessage = sanitizeNewApiSessionError(error, [
         config.totpSecret ?? "",
         generatedCode,
+        ...getTransientSessionSecrets(config.baseUrl),
       ])
 
       logger.warn("Automatic New API secure verification failed", {
@@ -575,6 +1016,7 @@ export async function ensureNewApiManagedSession(
       const errorMessage = sanitizeNewApiSessionError(error, [
         config.totpSecret ?? "",
         generatedCode,
+        ...getTransientSessionSecrets(config.baseUrl),
       ])
 
       logger.warn("Automatic New API login 2FA failed", {
@@ -605,27 +1047,45 @@ export async function submitNewApiLoginTwoFactorCode(
   },
 ): Promise<EnsureNewApiManagedSessionResult> {
   const trimmedCode = code.trim()
+  const pendingLoginFlow = getPendingLoginFlowForSubmission(config.baseUrl)
 
   const request = createCookieAuthRequest(config.baseUrl, config.userId)
-  const response = await fetchApi(request, {
+  const response = await fetchApi<unknown>(request, {
     endpoint: "/api/user/login/2fa",
     options: {
       method: "POST",
       body: JSON.stringify({
         code: trimmedCode,
+        ...(pendingLoginFlow ? { flow_token: pendingLoginFlow.token } : {}),
       }),
     },
   })
 
   if (response.success === false) {
     throw new ApiError(
-      response.message || t("messages:errors.api.invalidResponseFormat"),
+      sanitizeNewApiSessionError(
+        response.message || t("messages:errors.api.invalidResponseFormat"),
+        [trimmedCode, ...getTransientSessionSecrets(config.baseUrl)],
+      ),
       undefined,
       "/api/user/login/2fa",
     )
   }
 
-  markLoggedIn(config.baseUrl)
+  const authBundleKind = applyDashboardAuthBundleResponse(
+    config.baseUrl,
+    response,
+  )
+  if (authBundleKind === "malformed") {
+    throw new Error(NEW_API_DASHBOARD_AUTH_INVALID_RESPONSE)
+  }
+
+  if (authBundleKind === "unrelated") {
+    // A partially upgraded fork may accept flow_token but still keep the
+    // legacy Cookie-auth success body; retain that compatibility path.
+    clearPendingLoginFlow(config.baseUrl)
+    markLoggedIn(config.baseUrl)
+  }
 
   const methods = (await readNewApiVerificationMethods(
     config.baseUrl,
@@ -673,9 +1133,8 @@ export async function submitNewApiSecureVerificationCode(
 }
 
 /**
- * Fetches a hidden New API channel key through the cookie-auth session flow and
- * classifies missing login or verification state for callers that need to stay
- * passive unless the user explicitly chooses recovery.
+ * Fetches a hidden New API channel key through the response-detected auth path
+ * and classifies missing login or verification state for passive callers.
  */
 export async function fetchNewApiChannelKey(params: {
   baseUrl: string
@@ -696,20 +1155,37 @@ export async function fetchNewApiChannelKey(params: {
 
   try {
     const endpoint = `/api/channel/${params.channelId}/key`
+    const sessionRequest = createManagedSessionRequest(
+      params.baseUrl,
+      params.userId,
+    )
+    const usesDashboardAuth =
+      sessionRequest.auth.authType === AuthTypeEnum.AccessToken
+    const securityProof = usesDashboardAuth
+      ? getActiveSecurityProof(params.baseUrl)
+      : undefined
     let response: { key?: string } | string
     try {
-      response = await fetchApiData<{ key?: string } | string>(
-        createCookieAuthRequest(params.baseUrl, params.userId),
-        {
-          endpoint,
-          options: {
-            method: "POST",
-            body: JSON.stringify({}),
-          },
+      response = await fetchApiData<{ key?: string } | string>(sessionRequest, {
+        endpoint,
+        options: {
+          method: "POST",
+          body: JSON.stringify({}),
+          ...(securityProof
+            ? {
+                // Modern New API channel-key routes validate this scoped proof
+                // separately from the dashboard Bearer.
+                // https://github.com/QuantumNous/new-api/commit/31d70fca393ff2e09bbae012af2e3ccefdd389a1
+                headers: { "X-Security-Proof": securityProof.token },
+              }
+            : {}),
         },
-      )
+      })
     } catch (error) {
       if (
+        // The protected NewApiSessionRead envelope is intentionally closed and
+        // Cookie-only; never copy a transient dashboard Bearer into it.
+        usesDashboardAuth ||
         !params.protectionBypassExecution ||
         !(error instanceof ApiError) ||
         error.code === API_ERROR_CODES.BUSINESS_ERROR ||
@@ -761,7 +1237,8 @@ export async function fetchNewApiChannelKey(params: {
 
     markVerified(params.baseUrl)
     return key
-  } catch (error) {
+  } catch (rawError) {
+    const error = sanitizeNewApiErrorForOrigin(rawError, params.baseUrl)
     if (isUnauthorizedError(error)) {
       clearLoggedInState(params.baseUrl)
       throw new NewApiChannelKeyRequirementError(

--- a/tests/components/dialogs/ChannelDialog/ChannelDialog.behavior.test.tsx
+++ b/tests/components/dialogs/ChannelDialog/ChannelDialog.behavior.test.tsx
@@ -1,4 +1,9 @@
-import { render as rtlRender, screen, waitFor } from "@testing-library/react"
+import {
+  act,
+  render as rtlRender,
+  screen,
+  waitFor,
+} from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import type { MouseEvent, ReactElement, ReactNode } from "react"
 import toast from "react-hot-toast"
@@ -553,6 +558,105 @@ describe("ChannelDialog behavior", () => {
     expect(
       screen.getByPlaceholderText("channelDialog:fields.key.placeholder"),
     ).toHaveAttribute("type", "text")
+  })
+
+  it("updates the key when verification completes after the initial request returns", async () => {
+    const user = userEvent.setup()
+    let setRealKey: ((key: string) => void) | undefined
+    const onRequestRealKey = vi.fn(
+      async ({ setKey }: { setKey: (key: string) => void }) => {
+        setRealKey = setKey
+      },
+    )
+
+    render(
+      <ChannelDialog
+        isOpen={true}
+        onClose={vi.fn()}
+        mode={DIALOG_MODES.EDIT}
+        onRequestRealKey={onRequestRealKey}
+      />,
+    )
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "channelDialog:actions.loadRealKey",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(onRequestRealKey).toHaveBeenCalledTimes(1)
+      expect(
+        screen.getByRole("button", {
+          name: "channelDialog:actions.loadRealKey",
+        }),
+      ).toBeEnabled()
+    })
+
+    act(() => {
+      setRealKey?.("sk-real-after-verification")
+    })
+
+    await waitFor(() => {
+      expect(updateFieldMock).toHaveBeenCalledWith(
+        "key",
+        "sk-real-after-verification",
+      )
+      expect(
+        screen.getByPlaceholderText("channelDialog:fields.key.placeholder"),
+      ).toHaveValue("sk-real-after-verification")
+    })
+
+    expect(
+      screen.getByPlaceholderText("channelDialog:fields.key.placeholder"),
+    ).toHaveAttribute("type", "text")
+  })
+
+  it("ignores a late key callback after the request fails", async () => {
+    const user = userEvent.setup()
+    let setRealKey: ((key: string) => void) | undefined
+    const onRequestRealKey = vi.fn(
+      async ({ setKey }: { setKey: (key: string) => void }) => {
+        setRealKey = setKey
+        throw new Error("verification failed")
+      },
+    )
+
+    render(
+      <ChannelDialog
+        isOpen={true}
+        onClose={vi.fn()}
+        mode={DIALOG_MODES.EDIT}
+        onRequestRealKey={onRequestRealKey}
+      />,
+    )
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "channelDialog:actions.loadRealKey",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(vi.mocked(toast.error)).toHaveBeenCalledTimes(1)
+      expect(
+        screen.getByRole("button", {
+          name: "channelDialog:actions.loadRealKey",
+        }),
+      ).toBeEnabled()
+    })
+
+    act(() => {
+      setRealKey?.("sk-late-after-failure")
+    })
+
+    expect(updateFieldMock).not.toHaveBeenCalledWith(
+      "key",
+      "sk-late-after-failure",
+    )
+    expect(
+      screen.getByPlaceholderText("channelDialog:fields.key.placeholder"),
+    ).toHaveValue("sk-masked")
   })
 
   it("keeps the masked key unchanged when the real-key request resolves without data", async () => {

--- a/tests/components/dialogs/ChannelDialog/ChannelDialog.behavior.test.tsx
+++ b/tests/components/dialogs/ChannelDialog/ChannelDialog.behavior.test.tsx
@@ -612,6 +612,71 @@ describe("ChannelDialog behavior", () => {
     ).toHaveAttribute("type", "text")
   })
 
+  it("ignores a deferred key callback from a superseded request", async () => {
+    const user = userEvent.setup()
+    const setRealKeyCallbacks: Array<(key: string) => void> = []
+    const onRequestRealKey = vi.fn(
+      async ({ setKey }: { setKey: (key: string) => void }) => {
+        setRealKeyCallbacks.push(setKey)
+      },
+    )
+
+    render(
+      <ChannelDialog
+        isOpen={true}
+        onClose={vi.fn()}
+        mode={DIALOG_MODES.EDIT}
+        onRequestRealKey={onRequestRealKey}
+      />,
+    )
+
+    const getLoadButton = () =>
+      screen.getByRole("button", {
+        name: "channelDialog:actions.loadRealKey",
+      })
+
+    await user.click(getLoadButton())
+    await waitFor(() => {
+      expect(onRequestRealKey).toHaveBeenCalledTimes(1)
+      expect(getLoadButton()).toBeEnabled()
+    })
+
+    await user.click(getLoadButton())
+    await waitFor(() => {
+      expect(onRequestRealKey).toHaveBeenCalledTimes(2)
+      expect(getLoadButton()).toBeEnabled()
+    })
+
+    act(() => {
+      setRealKeyCallbacks[0]?.("sk-superseded-real-key")
+    })
+
+    expect(updateFieldMock).not.toHaveBeenCalledWith(
+      "key",
+      "sk-superseded-real-key",
+    )
+    expect(
+      screen.getByPlaceholderText("channelDialog:fields.key.placeholder"),
+    ).toHaveValue("sk-masked")
+    expect(
+      screen.getByPlaceholderText("channelDialog:fields.key.placeholder"),
+    ).toHaveAttribute("type", "password")
+
+    act(() => {
+      setRealKeyCallbacks[1]?.("sk-current-real-key")
+    })
+
+    await waitFor(() => {
+      expect(updateFieldMock).toHaveBeenCalledWith("key", "sk-current-real-key")
+      expect(
+        screen.getByPlaceholderText("channelDialog:fields.key.placeholder"),
+      ).toHaveValue("sk-current-real-key")
+    })
+    expect(
+      screen.getByPlaceholderText("channelDialog:fields.key.placeholder"),
+    ).toHaveAttribute("type", "text")
+  })
+
   it("ignores a late key callback after the request fails", async () => {
     const user = userEvent.setup()
     let setRealKey: ((key: string) => void) | undefined

--- a/tests/services/managedSites/providers/newApiSession.test.ts
+++ b/tests/services/managedSites/providers/newApiSession.test.ts
@@ -2,6 +2,7 @@ import { http, HttpResponse } from "msw"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { RuntimeActionIds } from "~/constants/runtimeActions"
+import { NEW_API_DASHBOARD_AUTH_INVALID_RESPONSE } from "~/services/apiService/newApi/dashboardAuth"
 import { API_ERROR_CODES, type ApiError } from "~/services/apiTransport/errors"
 import {
   clearNewApiManagedSessionState,
@@ -901,7 +902,7 @@ describe("newApiSession", () => {
     )
 
     await expect(ensureNewApiManagedSession(BASE_CONFIG)).rejects.toThrow(
-      "New API dashboard session response is invalid",
+      NEW_API_DASHBOARD_AUTH_INVALID_RESPONSE,
     )
     expect(loginCalls).toBe(0)
   })
@@ -1265,7 +1266,25 @@ describe("newApiSession", () => {
 
     await expect(
       submitNewApiLoginTwoFactorCode(BASE_CONFIG, "123456"),
-    ).rejects.toThrow("New API dashboard session response is invalid")
+    ).rejects.toThrow(NEW_API_DASHBOARD_AUTH_INVALID_RESPONSE)
+  })
+
+  it("uses the stable fallback when login 2FA failure messages are not strings", async () => {
+    server.use(
+      http.post(`${BASE_CONFIG.baseUrl}/api/user/login/2fa`, () =>
+        HttpResponse.json({
+          success: false,
+          message: { detail: "unexpected shape" },
+          data: null,
+        }),
+      ),
+    )
+
+    await expect(
+      submitNewApiLoginTwoFactorCode(BASE_CONFIG, "123456"),
+    ).rejects.toMatchObject({
+      message: "messages:errors.api.invalidResponseFormat",
+    } satisfies Pick<ApiError, "message">)
   })
 
   it("uses the stable fallback when login failure messages are not strings", async () => {

--- a/tests/services/managedSites/providers/newApiSession.test.ts
+++ b/tests/services/managedSites/providers/newApiSession.test.ts
@@ -364,12 +364,12 @@ describe("newApiSession", () => {
       code: "111111",
       flow_token: flowToken,
     })
-    expect(authenticatedProbeHeaders).toEqual([
-      `Bearer ${dashboardToken}`,
-      `Bearer ${dashboardToken}`,
-      `Bearer ${dashboardToken}`,
-      `Bearer ${dashboardToken}`,
-    ])
+    expect(authenticatedProbeHeaders.length).toBeGreaterThan(0)
+    expect(
+      authenticatedProbeHeaders.every(
+        (header) => header === `Bearer ${dashboardToken}`,
+      ),
+    ).toBe(true)
     expect(verifyAuthorization).toBe(`Bearer ${dashboardToken}`)
   })
 
@@ -405,6 +405,94 @@ describe("newApiSession", () => {
       status: NEW_API_MANAGED_SESSION_STATUSES.LOGIN_2FA_REQUIRED,
     })
     expect(loginCalls).toBe(1)
+  })
+
+  it("treats a malformed login-flow expiry as an unbounded manual flow", async () => {
+    const flowToken = "example-malformed-expiry-flow"
+    let loginTwoFactorPayload: Record<string, unknown> | null = null
+
+    server.use(
+      http.get(`${BASE_CONFIG.baseUrl}/api/user/2fa/status`, () =>
+        unauthorizedResponse(),
+      ),
+      http.get(`${BASE_CONFIG.baseUrl}/api/user/passkey`, () =>
+        unauthorizedResponse(),
+      ),
+      http.post(`${BASE_CONFIG.baseUrl}/api/user/login`, () =>
+        jsonData({
+          require_2fa: true,
+          flow_token: flowToken,
+          expires_at: "not-a-timestamp",
+        }),
+      ),
+      http.post(
+        `${BASE_CONFIG.baseUrl}/api/user/login/2fa`,
+        async ({ request }) => {
+          loginTwoFactorPayload = (await request.json()) as Record<
+            string,
+            unknown
+          >
+          return jsonData({})
+        },
+      ),
+    )
+
+    const manualConfig = { ...BASE_CONFIG, totpSecret: "" }
+    await expect(ensureNewApiManagedSession(manualConfig)).resolves.toEqual({
+      status: NEW_API_MANAGED_SESSION_STATUSES.LOGIN_2FA_REQUIRED,
+      automaticAttempted: false,
+    })
+
+    await expect(
+      submitNewApiLoginTwoFactorCode(manualConfig, "123456"),
+    ).resolves.toMatchObject({
+      status: NEW_API_MANAGED_SESSION_STATUSES.SECURE_VERIFICATION_REQUIRED,
+    })
+    expect(loginTwoFactorPayload).toMatchObject({ flow_token: flowToken })
+  })
+
+  it("clears expired login flows before manual submission and retrying login", async () => {
+    let loginCalls = 0
+    const expiredAt = Math.floor(Date.now() / 1000) - 1
+
+    server.use(
+      http.get(`${BASE_CONFIG.baseUrl}/api/user/2fa/status`, () =>
+        unauthorizedResponse(),
+      ),
+      http.get(`${BASE_CONFIG.baseUrl}/api/user/passkey`, () =>
+        unauthorizedResponse(),
+      ),
+      http.post(`${BASE_CONFIG.baseUrl}/api/user/login`, () => {
+        loginCalls += 1
+        return jsonData({
+          require_2fa: true,
+          flow_token: `example-expired-flow-${loginCalls}`,
+          expires_at: expiredAt,
+        })
+      }),
+    )
+
+    const manualConfig = { ...BASE_CONFIG, totpSecret: "" }
+    await expect(
+      ensureNewApiManagedSession(manualConfig),
+    ).resolves.toMatchObject({
+      status: NEW_API_MANAGED_SESSION_STATUSES.LOGIN_2FA_REQUIRED,
+    })
+    await expect(
+      submitNewApiLoginTwoFactorCode(manualConfig, "123456"),
+    ).rejects.toThrow("New API login flow expired")
+
+    await expect(
+      ensureNewApiManagedSession(manualConfig),
+    ).resolves.toMatchObject({
+      status: NEW_API_MANAGED_SESSION_STATUSES.LOGIN_2FA_REQUIRED,
+    })
+    await expect(
+      ensureNewApiManagedSession(manualConfig),
+    ).resolves.toMatchObject({
+      status: NEW_API_MANAGED_SESSION_STATUSES.LOGIN_2FA_REQUIRED,
+    })
+    expect(loginCalls).toBe(3)
   })
 
   it("accepts a direct modern login AuthBundle without entering the legacy login-2FA path", async () => {
@@ -685,6 +773,114 @@ describe("newApiSession", () => {
     expect(loginCalls).toBe(1)
   })
 
+  it.each([
+    [{ code: "ONLY_CODE", message: "" }, "ONLY_CODE"],
+    [{ code: "", message: "Only refresh message" }, "Only refresh message"],
+    [{}, "New API session refresh failed (409)"],
+  ] as const)(
+    "preserves the useful controlled refresh diagnostic when the body has %j",
+    async (body, expectedMessage) => {
+      server.use(
+        http.get(`${BASE_CONFIG.baseUrl}/api/user/2fa/status`, () =>
+          unauthorizedResponse(),
+        ),
+        http.get(`${BASE_CONFIG.baseUrl}/api/user/passkey`, () =>
+          unauthorizedResponse(),
+        ),
+        http.post(
+          `${BASE_CONFIG.baseUrl}/api/user/auth/refresh`,
+          () =>
+            new HttpResponse(JSON.stringify(body), {
+              status: 409,
+              headers: { "content-type": "application/json" },
+            }),
+        ),
+      )
+
+      await expect(ensureNewApiManagedSession(BASE_CONFIG)).rejects.toEqual(
+        new Error(expectedMessage),
+      )
+    },
+  )
+
+  it("reports an unexpected dashboard refresh status without starting login", async () => {
+    let loginCalls = 0
+
+    server.use(
+      http.get(`${BASE_CONFIG.baseUrl}/api/user/2fa/status`, () =>
+        unauthorizedResponse(),
+      ),
+      http.get(`${BASE_CONFIG.baseUrl}/api/user/passkey`, () =>
+        unauthorizedResponse(),
+      ),
+      http.post(
+        `${BASE_CONFIG.baseUrl}/api/user/auth/refresh`,
+        () => new HttpResponse("upstream failure", { status: 500 }),
+      ),
+      http.post(`${BASE_CONFIG.baseUrl}/api/user/login`, () => {
+        loginCalls += 1
+        return jsonData({ require_2fa: true })
+      }),
+    )
+
+    await expect(ensureNewApiManagedSession(BASE_CONFIG)).rejects.toEqual(
+      new Error("New API session refresh failed (500)"),
+    )
+    expect(loginCalls).toBe(0)
+  })
+
+  it("falls back to credential login when refresh returns unrelated JSON", async () => {
+    let loginCalls = 0
+
+    server.use(
+      http.get(`${BASE_CONFIG.baseUrl}/api/user/2fa/status`, () =>
+        unauthorizedResponse(),
+      ),
+      http.get(`${BASE_CONFIG.baseUrl}/api/user/passkey`, () =>
+        unauthorizedResponse(),
+      ),
+      http.post(`${BASE_CONFIG.baseUrl}/api/user/auth/refresh`, () =>
+        jsonData({ legacy: true }),
+      ),
+      http.post(`${BASE_CONFIG.baseUrl}/api/user/login`, () => {
+        loginCalls += 1
+        return jsonData({ require_2fa: true })
+      }),
+    )
+
+    await expect(
+      ensureNewApiManagedSession({ ...BASE_CONFIG, totpSecret: "" }),
+    ).resolves.toMatchObject({
+      status: NEW_API_MANAGED_SESSION_STATUSES.LOGIN_2FA_REQUIRED,
+    })
+    expect(loginCalls).toBe(1)
+  })
+
+  it("returns a stable error when dashboard refresh cannot be dispatched", async () => {
+    let loginCalls = 0
+
+    server.use(
+      http.get(`${BASE_CONFIG.baseUrl}/api/user/2fa/status`, () =>
+        unauthorizedResponse(),
+      ),
+      http.get(`${BASE_CONFIG.baseUrl}/api/user/passkey`, () =>
+        unauthorizedResponse(),
+      ),
+      http.post(`${BASE_CONFIG.baseUrl}/api/user/auth/refresh`, () =>
+        HttpResponse.error(),
+      ),
+      http.post(`${BASE_CONFIG.baseUrl}/api/user/login`, () => {
+        loginCalls += 1
+        return jsonData({ require_2fa: true })
+      }),
+    )
+
+    await expect(ensureNewApiManagedSession(BASE_CONFIG)).rejects.toEqual(
+      new Error("New API session refresh request failed"),
+    )
+    expect(loginCalls).toBe(0)
+  })
+
   it("rejects a recognizable but malformed modern dashboard response without starting another login", async () => {
     let loginCalls = 0
 
@@ -888,6 +1084,96 @@ describe("newApiSession", () => {
     expect(endpointCalls.get("/api/user/passkey")).toBe(2)
   })
 
+  it("rejects a non-record login response with a stable error", async () => {
+    server.use(
+      http.get(`${BASE_CONFIG.baseUrl}/api/user/2fa/status`, () =>
+        unauthorizedResponse(),
+      ),
+      http.get(`${BASE_CONFIG.baseUrl}/api/user/passkey`, () =>
+        unauthorizedResponse(),
+      ),
+      http.post(`${BASE_CONFIG.baseUrl}/api/user/login`, () =>
+        HttpResponse.json(null),
+      ),
+    )
+
+    await expect(ensureNewApiManagedSession(BASE_CONFIG)).rejects.toMatchObject(
+      {
+        message: "messages:errors.api.invalidResponseFormat",
+        code: API_ERROR_CODES.JSON_PARSE_ERROR,
+      } satisfies Pick<ApiError, "code" | "message">,
+    )
+  })
+
+  it("rejects a successful login response that omits data", async () => {
+    server.use(
+      http.get(`${BASE_CONFIG.baseUrl}/api/user/2fa/status`, () =>
+        unauthorizedResponse(),
+      ),
+      http.get(`${BASE_CONFIG.baseUrl}/api/user/passkey`, () =>
+        unauthorizedResponse(),
+      ),
+      http.post(`${BASE_CONFIG.baseUrl}/api/user/login`, () =>
+        jsonSuccessWithoutData(),
+      ),
+    )
+
+    await expect(ensureNewApiManagedSession(BASE_CONFIG)).rejects.toMatchObject(
+      {
+        message: "messages:errors.api.invalidResponseFormat",
+        code: API_ERROR_CODES.JSON_PARSE_ERROR,
+      } satisfies Pick<ApiError, "code" | "message">,
+    )
+  })
+
+  it("rejects a malformed modern AuthBundle returned by login", async () => {
+    let loginTwoFactorCalls = 0
+
+    server.use(
+      http.get(`${BASE_CONFIG.baseUrl}/api/user/2fa/status`, () =>
+        unauthorizedResponse(),
+      ),
+      http.get(`${BASE_CONFIG.baseUrl}/api/user/passkey`, () =>
+        unauthorizedResponse(),
+      ),
+      http.post(`${BASE_CONFIG.baseUrl}/api/user/login`, () =>
+        jsonData({ access_token: "incomplete-login-dashboard-token" }),
+      ),
+      http.post(`${BASE_CONFIG.baseUrl}/api/user/login/2fa`, () => {
+        loginTwoFactorCalls += 1
+        return jsonData({})
+      }),
+    )
+
+    await expect(ensureNewApiManagedSession(BASE_CONFIG)).rejects.toThrow(
+      "New API dashboard session response is invalid",
+    )
+    expect(loginTwoFactorCalls).toBe(0)
+  })
+
+  it("uses logged-in compatibility defaults when login data is not a record", async () => {
+    server.use(
+      http.get(`${BASE_CONFIG.baseUrl}/api/user/2fa/status`, () =>
+        unauthorizedResponse(),
+      ),
+      http.get(`${BASE_CONFIG.baseUrl}/api/user/passkey`, () =>
+        unauthorizedResponse(),
+      ),
+      http.post(`${BASE_CONFIG.baseUrl}/api/user/login`, () =>
+        jsonData("legacy-login-payload"),
+      ),
+    )
+
+    await expect(ensureNewApiManagedSession(BASE_CONFIG)).resolves.toEqual({
+      status: NEW_API_MANAGED_SESSION_STATUSES.SECURE_VERIFICATION_REQUIRED,
+      methods: {
+        twoFactorEnabled: false,
+        passkeyEnabled: false,
+      },
+      automaticAttempted: false,
+    })
+  })
+
   it("redacts TOTP material when automatic secure verification fails after login succeeds", async () => {
     generateNewApiTotpCodeMock.mockReturnValue("222222")
 
@@ -968,6 +1254,58 @@ describe("newApiSession", () => {
       },
       automaticAttempted: false,
     })
+  })
+
+  it("rejects a malformed modern AuthBundle returned by login 2FA", async () => {
+    server.use(
+      http.post(`${BASE_CONFIG.baseUrl}/api/user/login/2fa`, () =>
+        jsonData({ access_token: "incomplete-login-2fa-dashboard-token" }),
+      ),
+    )
+
+    await expect(
+      submitNewApiLoginTwoFactorCode(BASE_CONFIG, "123456"),
+    ).rejects.toThrow("New API dashboard session response is invalid")
+  })
+
+  it("uses the stable fallback when login failure messages are not strings", async () => {
+    server.use(
+      http.get(`${BASE_CONFIG.baseUrl}/api/user/2fa/status`, () =>
+        unauthorizedResponse(),
+      ),
+      http.get(`${BASE_CONFIG.baseUrl}/api/user/passkey`, () =>
+        unauthorizedResponse(),
+      ),
+      http.post(`${BASE_CONFIG.baseUrl}/api/user/login`, () =>
+        HttpResponse.json({
+          success: false,
+          message: { detail: "unexpected shape" },
+          data: null,
+        }),
+      ),
+    )
+
+    await expect(ensureNewApiManagedSession(BASE_CONFIG)).rejects.toMatchObject(
+      {
+        message: "messages:errors.api.invalidResponseFormat",
+        code: API_ERROR_CODES.BUSINESS_ERROR,
+      } satisfies Pick<ApiError, "code" | "message">,
+    )
+  })
+
+  it("rejects non-record login 2FA responses with a stable error", async () => {
+    server.use(
+      http.post(`${BASE_CONFIG.baseUrl}/api/user/login/2fa`, () =>
+        HttpResponse.json(null),
+      ),
+    )
+
+    await expect(
+      submitNewApiLoginTwoFactorCode(BASE_CONFIG, "123456"),
+    ).rejects.toMatchObject({
+      message: "messages:errors.api.invalidResponseFormat",
+      code: API_ERROR_CODES.JSON_PARSE_ERROR,
+    } satisfies Pick<ApiError, "code" | "message">)
   })
 
   it("redacts TOTP material from automatic 2FA failure messages", async () => {
@@ -1105,6 +1443,212 @@ describe("newApiSession", () => {
     })
     expect(keyProof).toBe(proofToken)
     expect(sendRuntimeMessageMock).not.toHaveBeenCalled()
+  })
+
+  it("preserves the scoped proof across repeated hidden channel-key reads", async () => {
+    const dashboardToken = "example-reused-dashboard-token"
+    const proofToken = "example-reused-channel-key-proof"
+    const observedProofs: Array<string | null> = []
+    let keyReadCount = 0
+
+    generateNewApiTotpCodeMock.mockReturnValue("777777")
+
+    server.use(
+      http.get(`${BASE_CONFIG.baseUrl}/api/user/2fa/status`, ({ request }) =>
+        request.headers.get("authorization") === `Bearer ${dashboardToken}`
+          ? jsonData({ enabled: true })
+          : unauthorizedResponse(),
+      ),
+      http.get(`${BASE_CONFIG.baseUrl}/api/user/passkey`, ({ request }) =>
+        request.headers.get("authorization") === `Bearer ${dashboardToken}`
+          ? jsonData({ enabled: false })
+          : unauthorizedResponse(),
+      ),
+      http.post(`${BASE_CONFIG.baseUrl}/api/user/login`, () =>
+        jsonData(createDashboardAuthBundle(dashboardToken)),
+      ),
+      http.post(`${BASE_CONFIG.baseUrl}/api/verify`, () =>
+        jsonData({
+          proof_token: proofToken,
+          expires_at: Math.floor(Date.now() / 1000) + 300,
+        }),
+      ),
+      http.post(`${BASE_CONFIG.baseUrl}/api/channel/12/key`, ({ request }) => {
+        const proof = request.headers.get("X-Security-Proof")
+        observedProofs.push(proof)
+        if (proof !== proofToken) {
+          return HttpResponse.json({
+            success: false,
+            message: "verification required",
+            data: null,
+          })
+        }
+
+        keyReadCount += 1
+        return jsonData(`reused-proof-key-${keyReadCount}`)
+      }),
+    )
+
+    await ensureNewApiManagedSession(BASE_CONFIG)
+
+    const keyRequest = {
+      ...BASE_CONFIG,
+      channelId: 12,
+      protectionBypassExecution: MANAGE_API_KEYS_EXECUTION,
+    }
+    await expect(fetchNewApiChannelKey(keyRequest)).resolves.toBe(
+      "reused-proof-key-1",
+    )
+    await expect(fetchNewApiChannelKey(keyRequest)).resolves.toBe(
+      "reused-proof-key-2",
+    )
+
+    expect(observedProofs).toEqual([proofToken, proofToken])
+  })
+
+  it("clears an expired security proof together with the verified window", async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"))
+
+    const dashboardToken = "example-expiring-proof-dashboard-token"
+    const proofToken = "example-expiring-security-proof"
+    generateNewApiTotpCodeMock.mockReturnValue("999999")
+
+    server.use(
+      http.get(`${BASE_CONFIG.baseUrl}/api/user/2fa/status`, ({ request }) =>
+        request.headers.get("authorization") === `Bearer ${dashboardToken}`
+          ? jsonData({ enabled: true })
+          : unauthorizedResponse(),
+      ),
+      http.get(`${BASE_CONFIG.baseUrl}/api/user/passkey`, ({ request }) =>
+        request.headers.get("authorization") === `Bearer ${dashboardToken}`
+          ? jsonData({ enabled: false })
+          : unauthorizedResponse(),
+      ),
+      http.post(`${BASE_CONFIG.baseUrl}/api/user/login`, () =>
+        jsonData(createDashboardAuthBundle(dashboardToken)),
+      ),
+      http.post(`${BASE_CONFIG.baseUrl}/api/verify`, () =>
+        jsonData({
+          proof_token: proofToken,
+          expires_at: Math.floor(Date.now() / 1000) + 60,
+        }),
+      ),
+    )
+
+    await expect(
+      ensureNewApiManagedSession(BASE_CONFIG),
+    ).resolves.toMatchObject({
+      status: NEW_API_MANAGED_SESSION_STATUSES.VERIFIED,
+    })
+    expect(isNewApiVerifiedSessionActive(BASE_CONFIG.baseUrl)).toBe(true)
+
+    vi.advanceTimersByTime(61_000)
+
+    expect(isNewApiVerifiedSessionActive(BASE_CONFIG.baseUrl)).toBe(false)
+    await expect(
+      ensureNewApiManagedSession({ ...BASE_CONFIG, totpSecret: "" }),
+    ).resolves.toMatchObject({
+      status: NEW_API_MANAGED_SESSION_STATUSES.SECURE_VERIFICATION_REQUIRED,
+    })
+  })
+
+  it("redacts transient dashboard credentials from generic channel-read errors", async () => {
+    const dashboardToken = "example-generic-error-dashboard-token"
+    const proofToken = "example-generic-error-proof-token"
+    generateNewApiTotpCodeMock.mockReturnValue("121212")
+
+    server.use(
+      http.get(`${BASE_CONFIG.baseUrl}/api/user/2fa/status`, ({ request }) =>
+        request.headers.get("authorization") === `Bearer ${dashboardToken}`
+          ? jsonData({ enabled: true })
+          : unauthorizedResponse(),
+      ),
+      http.get(`${BASE_CONFIG.baseUrl}/api/user/passkey`, ({ request }) =>
+        request.headers.get("authorization") === `Bearer ${dashboardToken}`
+          ? jsonData({ enabled: false })
+          : unauthorizedResponse(),
+      ),
+      http.post(`${BASE_CONFIG.baseUrl}/api/user/login`, () =>
+        jsonData(createDashboardAuthBundle(dashboardToken)),
+      ),
+      http.post(`${BASE_CONFIG.baseUrl}/api/verify`, () =>
+        jsonData({
+          proof_token: proofToken,
+          expires_at: Math.floor(Date.now() / 1000) + 300,
+        }),
+      ),
+    )
+
+    await ensureNewApiManagedSession(BASE_CONFIG)
+
+    const transientError = new Error(
+      `${dashboardToken} ${proofToken} channel read failed`,
+    )
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockRejectedValueOnce(transientError)
+
+    try {
+      await expect(
+        fetchNewApiChannelKey({
+          baseUrl: BASE_CONFIG.baseUrl,
+          userId: BASE_CONFIG.userId,
+          channelId: 12,
+        }),
+      ).rejects.toMatchObject({
+        name: "Error",
+        message: "[REDACTED] [REDACTED] channel read failed",
+      })
+    } finally {
+      fetchSpy.mockRestore()
+    }
+  })
+
+  it("preserves an ordinary generic channel-read error when it has no secret", async () => {
+    const dashboardToken = "example-ordinary-error-dashboard-token"
+    generateNewApiTotpCodeMock.mockReturnValue("343434")
+
+    server.use(
+      http.get(`${BASE_CONFIG.baseUrl}/api/user/2fa/status`, ({ request }) =>
+        request.headers.get("authorization") === `Bearer ${dashboardToken}`
+          ? jsonData({ enabled: true })
+          : unauthorizedResponse(),
+      ),
+      http.get(`${BASE_CONFIG.baseUrl}/api/user/passkey`, ({ request }) =>
+        request.headers.get("authorization") === `Bearer ${dashboardToken}`
+          ? jsonData({ enabled: false })
+          : unauthorizedResponse(),
+      ),
+      http.post(`${BASE_CONFIG.baseUrl}/api/user/login`, () =>
+        jsonData(createDashboardAuthBundle(dashboardToken)),
+      ),
+      http.post(`${BASE_CONFIG.baseUrl}/api/verify`, () =>
+        jsonData({
+          verified: true,
+          expires_at: Math.floor(Date.now() / 1000) + 300,
+        }),
+      ),
+    )
+
+    await ensureNewApiManagedSession(BASE_CONFIG)
+
+    const ordinaryError = new Error("ordinary channel read failure")
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockRejectedValueOnce(ordinaryError)
+
+    try {
+      await expect(
+        fetchNewApiChannelKey({
+          baseUrl: BASE_CONFIG.baseUrl,
+          userId: BASE_CONFIG.userId,
+          channelId: 12,
+        }),
+      ).rejects.toBe(ordinaryError)
+    } finally {
+      fetchSpy.mockRestore()
+    }
   })
 
   it("does not put modern dashboard credentials into the legacy temp-context fallback task", async () => {

--- a/tests/services/managedSites/providers/newApiSession.test.ts
+++ b/tests/services/managedSites/providers/newApiSession.test.ts
@@ -12,6 +12,7 @@ import {
   isNewApiVerifiedSessionActive,
   NEW_API_CHANNEL_KEY_ERROR_KINDS,
   NEW_API_MANAGED_SESSION_STATUSES,
+  NEW_API_SECURITY_PROOF_SCOPES,
   NEW_API_VERIFIED_SESSION_WINDOW_MS,
   NewApiChannelKeyRequirementError,
   submitNewApiLoginTwoFactorCode,
@@ -95,17 +96,43 @@ const unauthorizedResponse = () =>
     },
   })
 
+const createDashboardAuthBundle = (
+  token: string,
+  overrides: Record<string, unknown> = {},
+) => ({
+  access_token: token,
+  token_type: "Bearer",
+  access_expires_at: Math.floor(Date.now() / 1000) + 15 * 60,
+  session: {
+    sid: "example-session-id",
+    current: true,
+  },
+  user: {
+    id: 1,
+    username: "example-admin",
+  },
+  ...overrides,
+})
+
 describe("newApiSession", () => {
   beforeEach(() => {
     clearNewApiManagedSessionState()
     generateNewApiTotpCodeMock.mockReset()
     sendRuntimeMessageMock.mockReset()
     vi.useRealTimers()
+    server.use(
+      http.post(
+        `${BASE_CONFIG.baseUrl}/api/user/auth/refresh`,
+        () => new HttpResponse(null, { status: 404 }),
+      ),
+    )
   })
 
   it("automatically completes login 2FA and secure verification when a TOTP secret is configured", async () => {
     const endpointCalls = new Map<string, number>()
     let loginPayload: Record<string, string> | null = null
+    let loginTwoFactorPayload: Record<string, string> | null = null
+    let verifyPayload: Record<string, string> | null = null
     let firstProbeUserHeader: string | null = null
 
     generateNewApiTotpCodeMock
@@ -137,12 +164,20 @@ describe("newApiSession", () => {
           return jsonData({ require_2fa: true })
         },
       ),
-      http.post(`${BASE_CONFIG.baseUrl}/api/user/login/2fa`, () =>
-        jsonData({}),
+      http.post(
+        `${BASE_CONFIG.baseUrl}/api/user/login/2fa`,
+        async ({ request }) => {
+          loginTwoFactorPayload = (await request.json()) as Record<
+            string,
+            string
+          >
+          return jsonData({})
+        },
       ),
-      http.post(`${BASE_CONFIG.baseUrl}/api/verify`, () =>
-        jsonData({ verified: true, expires_at: 1_700_000_000 }),
-      ),
+      http.post(`${BASE_CONFIG.baseUrl}/api/verify`, async ({ request }) => {
+        verifyPayload = (await request.json()) as Record<string, string>
+        return jsonData({ verified: true, expires_at: 1_700_000_000 })
+      }),
     )
 
     const result = await ensureNewApiManagedSession({
@@ -154,6 +189,11 @@ describe("newApiSession", () => {
     expect(loginPayload).toEqual({
       username: "admin",
       password: "  secret-password  ",
+    })
+    expect(loginTwoFactorPayload).toEqual({ code: "111111" })
+    expect(verifyPayload).toEqual({
+      method: "2fa",
+      code: "222222",
     })
     expect(result).toEqual({
       status: NEW_API_MANAGED_SESSION_STATUSES.VERIFIED,
@@ -238,6 +278,482 @@ describe("newApiSession", () => {
       verifiedUntil: 1_700_000_123_000,
     })
   })
+
+  it("continues the current login flow and manages the session with its dashboard bearer", async () => {
+    const flowToken = "example-flow-token"
+    const dashboardToken = "example-dashboard-token"
+    let loginTwoFactorPayload: Record<string, unknown> | null = null
+    let verifyAuthorization: string | null = null
+    const authenticatedProbeHeaders: Array<string | null> = []
+
+    generateNewApiTotpCodeMock
+      .mockReturnValueOnce("111111")
+      .mockReturnValueOnce("222222")
+
+    server.use(
+      http.get(`${BASE_CONFIG.baseUrl}/api/user/2fa/status`, ({ request }) => {
+        const authorization = request.headers.get("authorization")
+        if (authorization !== `Bearer ${dashboardToken}`) {
+          return unauthorizedResponse()
+        }
+
+        authenticatedProbeHeaders.push(authorization)
+        return jsonData({ enabled: true })
+      }),
+      http.get(`${BASE_CONFIG.baseUrl}/api/user/passkey`, ({ request }) => {
+        const authorization = request.headers.get("authorization")
+        if (authorization !== `Bearer ${dashboardToken}`) {
+          return unauthorizedResponse()
+        }
+
+        authenticatedProbeHeaders.push(authorization)
+        return jsonData({ enabled: false })
+      }),
+      http.post(`${BASE_CONFIG.baseUrl}/api/user/login`, () =>
+        jsonData({
+          require_2fa: true,
+          flow_token: flowToken,
+          expires_at: Math.floor(Date.now() / 1000) + 5 * 60,
+        }),
+      ),
+      http.post(
+        `${BASE_CONFIG.baseUrl}/api/user/login/2fa`,
+        async ({ request }) => {
+          loginTwoFactorPayload = (await request.json()) as Record<
+            string,
+            unknown
+          >
+          if (loginTwoFactorPayload.flow_token !== flowToken) {
+            return HttpResponse.json({
+              success: false,
+              message: "Login flow expired",
+              data: null,
+            })
+          }
+
+          return jsonData({
+            access_token: dashboardToken,
+            token_type: "Bearer",
+            access_expires_at: Math.floor(Date.now() / 1000) + 15 * 60,
+            session: {
+              sid: "example-session-id",
+              current: true,
+            },
+            user: {
+              id: 1,
+              username: "example-admin",
+            },
+          })
+        },
+      ),
+      http.post(`${BASE_CONFIG.baseUrl}/api/verify`, ({ request }) => {
+        verifyAuthorization = request.headers.get("authorization")
+        return jsonData({ verified: true, expires_at: 1_700_000_456 })
+      }),
+    )
+
+    await expect(ensureNewApiManagedSession(BASE_CONFIG)).resolves.toEqual({
+      status: NEW_API_MANAGED_SESSION_STATUSES.VERIFIED,
+      methods: {
+        twoFactorEnabled: true,
+        passkeyEnabled: false,
+      },
+      verifiedUntil: 1_700_000_456_000,
+    })
+    expect(loginTwoFactorPayload).toEqual({
+      code: "111111",
+      flow_token: flowToken,
+    })
+    expect(authenticatedProbeHeaders).toEqual([
+      `Bearer ${dashboardToken}`,
+      `Bearer ${dashboardToken}`,
+      `Bearer ${dashboardToken}`,
+      `Bearer ${dashboardToken}`,
+    ])
+    expect(verifyAuthorization).toBe(`Bearer ${dashboardToken}`)
+  })
+
+  it("does not replace an unexpired modern login flow when the session check repeats", async () => {
+    let loginCalls = 0
+    const flowToken = "example-reused-flow-token"
+
+    server.use(
+      http.get(`${BASE_CONFIG.baseUrl}/api/user/2fa/status`, () =>
+        unauthorizedResponse(),
+      ),
+      http.get(`${BASE_CONFIG.baseUrl}/api/user/passkey`, () =>
+        unauthorizedResponse(),
+      ),
+      http.post(`${BASE_CONFIG.baseUrl}/api/user/login`, () => {
+        loginCalls += 1
+        return jsonData({
+          require_2fa: true,
+          flow_token: flowToken,
+          expires_at: Math.floor(Date.now() / 1000) + 300,
+        })
+      }),
+    )
+
+    await expect(
+      ensureNewApiManagedSession({ ...BASE_CONFIG, totpSecret: "" }),
+    ).resolves.toMatchObject({
+      status: NEW_API_MANAGED_SESSION_STATUSES.LOGIN_2FA_REQUIRED,
+    })
+    await expect(
+      ensureNewApiManagedSession({ ...BASE_CONFIG, totpSecret: "" }),
+    ).resolves.toMatchObject({
+      status: NEW_API_MANAGED_SESSION_STATUSES.LOGIN_2FA_REQUIRED,
+    })
+    expect(loginCalls).toBe(1)
+  })
+
+  it("accepts a direct modern login AuthBundle without entering the legacy login-2FA path", async () => {
+    const dashboardToken = "example-direct-dashboard-token"
+    let loginCalls = 0
+    let loginTwoFactorCalls = 0
+    let verifyAuthorization: string | null = null
+    let verifyUserHeader: string | null = null
+
+    generateNewApiTotpCodeMock.mockReturnValue("333333")
+
+    server.use(
+      http.get(`${BASE_CONFIG.baseUrl}/api/user/2fa/status`, ({ request }) =>
+        request.headers.get("authorization") === `Bearer ${dashboardToken}`
+          ? jsonData({ enabled: true })
+          : unauthorizedResponse(),
+      ),
+      http.get(`${BASE_CONFIG.baseUrl}/api/user/passkey`, ({ request }) =>
+        request.headers.get("authorization") === `Bearer ${dashboardToken}`
+          ? jsonData({ enabled: false })
+          : unauthorizedResponse(),
+      ),
+      http.post(`${BASE_CONFIG.baseUrl}/api/user/login`, () => {
+        loginCalls += 1
+        return jsonData(createDashboardAuthBundle(dashboardToken))
+      }),
+      http.post(`${BASE_CONFIG.baseUrl}/api/user/login/2fa`, () => {
+        loginTwoFactorCalls += 1
+        return jsonData({})
+      }),
+      http.post(`${BASE_CONFIG.baseUrl}/api/verify`, ({ request }) => {
+        verifyAuthorization = request.headers.get("authorization")
+        verifyUserHeader = request.headers.get("New-API-User")
+        return jsonData({ verified: true, expires_at: 1_700_000_789 })
+      }),
+    )
+
+    await expect(ensureNewApiManagedSession(BASE_CONFIG)).resolves.toEqual({
+      status: NEW_API_MANAGED_SESSION_STATUSES.VERIFIED,
+      methods: {
+        twoFactorEnabled: true,
+        passkeyEnabled: false,
+      },
+      verifiedUntil: 1_700_000_789_000,
+    })
+    expect(loginCalls).toBe(1)
+    expect(loginTwoFactorCalls).toBe(0)
+    expect(verifyAuthorization).toBe(`Bearer ${dashboardToken}`)
+    expect(verifyUserHeader).toBeNull()
+  })
+
+  it("refreshes a modern dashboard session before creating another login session", async () => {
+    const dashboardToken = "example-refreshed-dashboard-token"
+    let refreshCalls = 0
+    let loginCalls = 0
+
+    generateNewApiTotpCodeMock.mockReturnValue("444444")
+
+    server.use(
+      http.get(`${BASE_CONFIG.baseUrl}/api/user/2fa/status`, ({ request }) =>
+        request.headers.get("authorization") === `Bearer ${dashboardToken}`
+          ? jsonData({ enabled: true })
+          : unauthorizedResponse(),
+      ),
+      http.get(`${BASE_CONFIG.baseUrl}/api/user/passkey`, ({ request }) =>
+        request.headers.get("authorization") === `Bearer ${dashboardToken}`
+          ? jsonData({ enabled: false })
+          : unauthorizedResponse(),
+      ),
+      http.post(`${BASE_CONFIG.baseUrl}/api/user/auth/refresh`, () => {
+        refreshCalls += 1
+        return jsonData(createDashboardAuthBundle(dashboardToken))
+      }),
+      http.post(`${BASE_CONFIG.baseUrl}/api/user/login`, () => {
+        loginCalls += 1
+        return jsonData({ require_2fa: true })
+      }),
+      http.post(`${BASE_CONFIG.baseUrl}/api/verify`, ({ request }) => {
+        if (
+          request.headers.get("authorization") !== `Bearer ${dashboardToken}`
+        ) {
+          return unauthorizedResponse()
+        }
+        return jsonData({ verified: true, expires_at: 1_700_000_890 })
+      }),
+    )
+
+    await expect(ensureNewApiManagedSession(BASE_CONFIG)).resolves.toEqual({
+      status: NEW_API_MANAGED_SESSION_STATUSES.VERIFIED,
+      methods: {
+        twoFactorEnabled: true,
+        passkeyEnabled: false,
+      },
+      verifiedUntil: 1_700_000_890_000,
+    })
+    expect(refreshCalls).toBe(1)
+    expect(loginCalls).toBe(0)
+  })
+
+  it("does not create another credential session when a valid refresh bundle cannot authenticate probes", async () => {
+    let loginCalls = 0
+
+    server.use(
+      http.get(`${BASE_CONFIG.baseUrl}/api/user/2fa/status`, () =>
+        unauthorizedResponse(),
+      ),
+      http.get(`${BASE_CONFIG.baseUrl}/api/user/passkey`, () =>
+        unauthorizedResponse(),
+      ),
+      http.post(`${BASE_CONFIG.baseUrl}/api/user/auth/refresh`, () =>
+        jsonData(createDashboardAuthBundle("example-unusable-token")),
+      ),
+      http.post(`${BASE_CONFIG.baseUrl}/api/user/login`, () => {
+        loginCalls += 1
+        return jsonData({ require_2fa: true })
+      }),
+    )
+
+    await expect(ensureNewApiManagedSession(BASE_CONFIG)).rejects.toMatchObject(
+      {
+        message: "New API dashboard session could not be authenticated",
+        code: API_ERROR_CODES.HTTP_401,
+      },
+    )
+    expect(loginCalls).toBe(0)
+  })
+
+  it("refreshes instead of sending an expired cached dashboard bearer", async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"))
+
+    const firstToken = "example-expiring-dashboard-token"
+    const refreshedToken = "example-after-refresh-dashboard-token"
+    const observedAuthorizations: string[] = []
+    let refreshCalls = 0
+    let loginCalls = 0
+
+    generateNewApiTotpCodeMock
+      .mockReturnValueOnce("777777")
+      .mockReturnValueOnce("888888")
+
+    const bearerMethods =
+      (tokens: string[], enabled: boolean) =>
+      ({ request }: { request: Request }) => {
+        const authorization = request.headers.get("authorization")
+        if (authorization) observedAuthorizations.push(authorization)
+        return tokens.some((token) => authorization === `Bearer ${token}`)
+          ? jsonData({ enabled })
+          : unauthorizedResponse()
+      }
+
+    server.use(
+      http.get(
+        `${BASE_CONFIG.baseUrl}/api/user/2fa/status`,
+        bearerMethods([firstToken, refreshedToken], true),
+      ),
+      http.get(
+        `${BASE_CONFIG.baseUrl}/api/user/passkey`,
+        bearerMethods([firstToken, refreshedToken], false),
+      ),
+      http.post(`${BASE_CONFIG.baseUrl}/api/user/login`, () => {
+        loginCalls += 1
+        return jsonData(
+          createDashboardAuthBundle(firstToken, {
+            access_expires_at: Math.floor(Date.now() / 1000) + 60,
+          }),
+        )
+      }),
+      http.post(`${BASE_CONFIG.baseUrl}/api/user/auth/refresh`, () => {
+        refreshCalls += 1
+        if (refreshCalls === 1) {
+          return new HttpResponse(null, { status: 404 })
+        }
+        return jsonData(
+          createDashboardAuthBundle(refreshedToken, {
+            access_expires_at: Math.floor(Date.now() / 1000) + 900,
+          }),
+        )
+      }),
+      http.post(`${BASE_CONFIG.baseUrl}/api/verify`, ({ request }) =>
+        [firstToken, refreshedToken].some(
+          (token) => request.headers.get("authorization") === `Bearer ${token}`,
+        )
+          ? jsonData({
+              verified: true,
+              expires_at: Math.floor(Date.now() / 1000) + 120,
+            })
+          : unauthorizedResponse(),
+      ),
+    )
+
+    await expect(
+      ensureNewApiManagedSession(BASE_CONFIG),
+    ).resolves.toMatchObject({
+      status: NEW_API_MANAGED_SESSION_STATUSES.VERIFIED,
+    })
+
+    const initialAuthorizationCount = observedAuthorizations.length
+
+    vi.advanceTimersByTime(61_000)
+
+    await expect(
+      ensureNewApiManagedSession(BASE_CONFIG),
+    ).resolves.toMatchObject({
+      status: NEW_API_MANAGED_SESSION_STATUSES.VERIFIED,
+    })
+    expect(refreshCalls).toBe(2)
+    expect(loginCalls).toBe(1)
+    expect(
+      observedAuthorizations.slice(initialAuthorizationCount),
+    ).not.toContain(`Bearer ${firstToken}`)
+    expect(observedAuthorizations.slice(initialAuthorizationCount)).toContain(
+      `Bearer ${refreshedToken}`,
+    )
+  })
+
+  it.each([401, 404, 405])(
+    "keeps credential login compatible when dashboard refresh returns HTTP %i",
+    async (status) => {
+      let loginCalls = 0
+
+      server.use(
+        http.get(`${BASE_CONFIG.baseUrl}/api/user/2fa/status`, () =>
+          unauthorizedResponse(),
+        ),
+        http.get(`${BASE_CONFIG.baseUrl}/api/user/passkey`, () =>
+          unauthorizedResponse(),
+        ),
+        http.post(
+          `${BASE_CONFIG.baseUrl}/api/user/auth/refresh`,
+          () => new HttpResponse(null, { status }),
+        ),
+        http.post(`${BASE_CONFIG.baseUrl}/api/user/login`, () => {
+          loginCalls += 1
+          return jsonData({ require_2fa: true })
+        }),
+      )
+
+      await expect(
+        ensureNewApiManagedSession({ ...BASE_CONFIG, totpSecret: "" }),
+      ).resolves.toEqual({
+        status: NEW_API_MANAGED_SESSION_STATUSES.LOGIN_2FA_REQUIRED,
+        automaticAttempted: false,
+      })
+      expect(loginCalls).toBe(1)
+    },
+  )
+
+  it("keeps credential login compatible when refresh returns an unrelated successful body", async () => {
+    let loginCalls = 0
+
+    server.use(
+      http.get(`${BASE_CONFIG.baseUrl}/api/user/2fa/status`, () =>
+        unauthorizedResponse(),
+      ),
+      http.get(`${BASE_CONFIG.baseUrl}/api/user/passkey`, () =>
+        unauthorizedResponse(),
+      ),
+      http.post(
+        `${BASE_CONFIG.baseUrl}/api/user/auth/refresh`,
+        () =>
+          new HttpResponse("<html>legacy page</html>", {
+            status: 200,
+            headers: { "content-type": "text/html" },
+          }),
+      ),
+      http.post(`${BASE_CONFIG.baseUrl}/api/user/login`, () => {
+        loginCalls += 1
+        return jsonData({ require_2fa: true })
+      }),
+    )
+
+    await expect(
+      ensureNewApiManagedSession({ ...BASE_CONFIG, totpSecret: "" }),
+    ).resolves.toMatchObject({
+      status: NEW_API_MANAGED_SESSION_STATUSES.LOGIN_2FA_REQUIRED,
+    })
+    expect(loginCalls).toBe(1)
+  })
+
+  it("rejects a recognizable but malformed modern dashboard response without starting another login", async () => {
+    let loginCalls = 0
+
+    server.use(
+      http.get(`${BASE_CONFIG.baseUrl}/api/user/2fa/status`, () =>
+        unauthorizedResponse(),
+      ),
+      http.get(`${BASE_CONFIG.baseUrl}/api/user/passkey`, () =>
+        unauthorizedResponse(),
+      ),
+      http.post(`${BASE_CONFIG.baseUrl}/api/user/auth/refresh`, () =>
+        jsonData({ access_token: "incomplete-dashboard-token" }),
+      ),
+      http.post(`${BASE_CONFIG.baseUrl}/api/user/login`, () => {
+        loginCalls += 1
+        return jsonData({ require_2fa: true })
+      }),
+    )
+
+    await expect(ensureNewApiManagedSession(BASE_CONFIG)).rejects.toThrow(
+      "New API dashboard session response is invalid",
+    )
+    expect(loginCalls).toBe(0)
+  })
+
+  it.each([409, 429])(
+    "preserves safe dashboard refresh diagnostics for HTTP %i without issuing another session",
+    async (status) => {
+      let loginCalls = 0
+      const sensitiveToken = "must-not-leak-dashboard-token"
+
+      server.use(
+        http.get(`${BASE_CONFIG.baseUrl}/api/user/2fa/status`, () =>
+          unauthorizedResponse(),
+        ),
+        http.get(`${BASE_CONFIG.baseUrl}/api/user/passkey`, () =>
+          unauthorizedResponse(),
+        ),
+        http.post(`${BASE_CONFIG.baseUrl}/api/user/auth/refresh`, () =>
+          HttpResponse.json(
+            {
+              success: false,
+              code: `AUTH_${status}`,
+              message: "Session issuance unavailable",
+              data: { access_token: sensitiveToken },
+            },
+            { status },
+          ),
+        ),
+        http.post(`${BASE_CONFIG.baseUrl}/api/user/login`, () => {
+          loginCalls += 1
+          return jsonData({ require_2fa: true })
+        }),
+      )
+
+      let caught: unknown
+      try {
+        await ensureNewApiManagedSession(BASE_CONFIG)
+      } catch (error) {
+        caught = error
+      }
+
+      expect(caught).toEqual(
+        new Error(`AUTH_${status}: Session issuance unavailable`),
+      )
+      expect((caught as Error).message).not.toContain(sensitiveToken)
+      expect(loginCalls).toBe(0)
+    },
+  )
 
   it("reuses an active verified session until the expiry window passes", async () => {
     vi.useFakeTimers()
@@ -509,6 +1025,144 @@ describe("newApiSession", () => {
         protectionBypassExecution: MANAGE_API_KEYS_EXECUTION,
       }),
     ).resolves.toBe("hidden-channel-key")
+  })
+
+  it("uses the modern dashboard bearer for hidden channel-key reads", async () => {
+    const dashboardToken = "example-key-dashboard-token"
+    const proofToken = "example-channel-key-proof-token"
+    let verifyPayload: Record<string, string> | null = null
+    let keyAuthorization: string | null = null
+    let keyUserHeader: string | null = null
+    let keyProof: string | null = null
+
+    generateNewApiTotpCodeMock.mockReturnValue("555555")
+
+    server.use(
+      http.get(`${BASE_CONFIG.baseUrl}/api/user/2fa/status`, ({ request }) =>
+        request.headers.get("authorization") === `Bearer ${dashboardToken}`
+          ? jsonData({ enabled: true })
+          : unauthorizedResponse(),
+      ),
+      http.get(`${BASE_CONFIG.baseUrl}/api/user/passkey`, ({ request }) =>
+        request.headers.get("authorization") === `Bearer ${dashboardToken}`
+          ? jsonData({ enabled: false })
+          : unauthorizedResponse(),
+      ),
+      http.post(`${BASE_CONFIG.baseUrl}/api/user/login`, () =>
+        jsonData(createDashboardAuthBundle(dashboardToken)),
+      ),
+      http.post(`${BASE_CONFIG.baseUrl}/api/verify`, async ({ request }) => {
+        if (
+          request.headers.get("authorization") !== `Bearer ${dashboardToken}`
+        ) {
+          return unauthorizedResponse()
+        }
+        verifyPayload = (await request.json()) as Record<string, string>
+        if (
+          verifyPayload.scope !== NEW_API_SECURITY_PROOF_SCOPES.CHANNEL_KEY_READ
+        ) {
+          return HttpResponse.json({
+            success: false,
+            message: "不支持的安全验证范围",
+            data: null,
+          })
+        }
+        return jsonData({
+          proof_token: proofToken,
+          expires_at: Math.floor(Date.now() / 1000) + 300,
+          method: "2fa",
+          scope: NEW_API_SECURITY_PROOF_SCOPES.CHANNEL_KEY_READ,
+        })
+      }),
+      http.post(`${BASE_CONFIG.baseUrl}/api/channel/12/key`, ({ request }) => {
+        keyAuthorization = request.headers.get("authorization")
+        keyUserHeader = request.headers.get("New-API-User")
+        keyProof = request.headers.get("X-Security-Proof")
+        return jsonData("modern-hidden-channel-key")
+      }),
+    )
+
+    await expect(
+      ensureNewApiManagedSession(BASE_CONFIG),
+    ).resolves.toMatchObject({
+      status: NEW_API_MANAGED_SESSION_STATUSES.VERIFIED,
+    })
+
+    await expect(
+      fetchNewApiChannelKey({
+        ...BASE_CONFIG,
+        channelId: 12,
+        protectionBypassExecution: MANAGE_API_KEYS_EXECUTION,
+      }),
+    ).resolves.toBe("modern-hidden-channel-key")
+
+    expect(keyAuthorization).toBe(`Bearer ${dashboardToken}`)
+    expect(keyUserHeader).toBeNull()
+    expect(verifyPayload).toEqual({
+      method: "2fa",
+      code: "555555",
+      scope: NEW_API_SECURITY_PROOF_SCOPES.CHANNEL_KEY_READ,
+    })
+    expect(keyProof).toBe(proofToken)
+    expect(sendRuntimeMessageMock).not.toHaveBeenCalled()
+  })
+
+  it("does not put modern dashboard credentials into the legacy temp-context fallback task", async () => {
+    const dashboardToken = "example-blocked-dashboard-token"
+    const proofToken = "example-blocked-channel-key-proof"
+
+    generateNewApiTotpCodeMock.mockReturnValue("666666")
+
+    server.use(
+      http.get(`${BASE_CONFIG.baseUrl}/api/user/2fa/status`, ({ request }) =>
+        request.headers.get("authorization") === `Bearer ${dashboardToken}`
+          ? jsonData({ enabled: true })
+          : unauthorizedResponse(),
+      ),
+      http.get(`${BASE_CONFIG.baseUrl}/api/user/passkey`, ({ request }) =>
+        request.headers.get("authorization") === `Bearer ${dashboardToken}`
+          ? jsonData({ enabled: false })
+          : unauthorizedResponse(),
+      ),
+      http.post(`${BASE_CONFIG.baseUrl}/api/user/login`, () =>
+        jsonData(createDashboardAuthBundle(dashboardToken)),
+      ),
+      http.post(`${BASE_CONFIG.baseUrl}/api/verify`, ({ request }) =>
+        request.headers.get("authorization") === `Bearer ${dashboardToken}`
+          ? jsonData({
+              proof_token: proofToken,
+              expires_at: Math.floor(Date.now() / 1000) + 300,
+            })
+          : unauthorizedResponse(),
+      ),
+      http.post(
+        `${BASE_CONFIG.baseUrl}/api/channel/12/key`,
+        () =>
+          new HttpResponse("<html>blocked</html>", {
+            status: 403,
+            headers: { "content-type": "text/html" },
+          }),
+      ),
+    )
+
+    await ensureNewApiManagedSession(BASE_CONFIG)
+
+    await expect(
+      fetchNewApiChannelKey({
+        ...BASE_CONFIG,
+        channelId: 12,
+        protectionBypassExecution: MANAGE_API_KEYS_EXECUTION,
+      }),
+    ).rejects.toMatchObject({
+      kind: NEW_API_CHANNEL_KEY_ERROR_KINDS.SECURE_VERIFICATION_REQUIRED,
+    })
+    expect(sendRuntimeMessageMock).not.toHaveBeenCalled()
+    expect(JSON.stringify(sendRuntimeMessageMock.mock.calls)).not.toContain(
+      dashboardToken,
+    )
+    expect(JSON.stringify(sendRuntimeMessageMock.mock.calls)).not.toContain(
+      proofToken,
+    )
   })
 
   it("retries hidden channel-key reads through the shared temp-context pipeline when the direct request is blocked", async () => {


### PR DESCRIPTION
## Summary

Modern New API deployments changed managed dashboard authentication and security verification, leaving the extension on legacy cookie and unscoped verification paths. This caused managed-site login to stop at two-factor authentication or `/api/verify` to reject the request with an unsupported verification scope.

A separate timing issue meant a successfully resolved channel key could arrive after the editor's initial request completed and never reach the UI.

This change restores New API channel administration while preserving older deployment contracts.

## What changed

- Handle New API login `flow_token`, TOTP continuation, dashboard AuthBundle refresh, and Bearer-authenticated protected requests.
- Request the `channel.key.read` scope from `/api/verify`, retain the returned `proof_token`, and send it as `X-Security-Proof` when revealing channel keys.
- Preserve legacy Cookie sessions, `{ method, code }` verification payloads, and proof-free key retrieval for older deployments and partially upgraded forks.
- Apply deferred real-key callbacks to the channel editor while ignoring callbacks from failed or superseded requests.
- Keep the new authentication and proof protocol scoped to the New API managed-site provider. The shared dialog change preserves immediate behavior for other site types while supporting delayed key delivery.

## Validation

- Focused regression suite: 10 files, 133 tests passed.
- `pnpm run validate:push` passed:
  - `pnpm compile`
  - `pnpm knip`
- Both commits passed the pre-commit `pnpm run validate:staged` gate.
- Additional finishing check: 6 critical test files, 109 tests passed with one worker.

Not run locally:

- Full test suite and coverage
- Browser E2E against a real New API deployment

PR CI remains the authoritative full-suite and coverage check. A real-deployment smoke test is still recommended.

## Compatibility and release notes

- Compatibility is selected from runtime response and session capabilities rather than a hard-coded backend version.
- No storage migration or breaking configuration change is required.
- Existing managed-site verification telemetry is reused; no new analytics event or sensitive authentication field is recorded.
- No new Playwright test was added because the changed protocol and callback-ordering behavior is covered at the service and component layers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added modern dashboard authentication with bearer tokens, session refresh, expiration tracking, and secure verification.
  * Improved login, two-factor authentication, channel-key retrieval, and session recovery flows.
  * Added scoped security protections for sensitive requests.

* **Bug Fixes**
  * Asynchronously delivered channel keys now display correctly, while late keys from failed or outdated requests are ignored.
  * Improved handling of malformed authentication responses and safer error reporting.

* **Tests**
  * Expanded coverage for authentication, refresh, two-factor verification, channel keys, and asynchronous key delivery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->