### PR TITLE
fix(e2e): prevent repeated New API session-limit logins

### DIFF
--- a/.github/workflows/e2e-real-site.yml
+++ b/.github/workflows/e2e-real-site.yml
@@ -13,6 +13,11 @@ on:
           - account
           - managed-site
           - webdav
+      target:
+        description: Optional target ID from scripts/real-site-e2e-matrix.mjs (for example new-api-account); all keeps category selection
+        required: false
+        default: all
+        type: string
   schedule:
     - cron: "17 19 * * *"
 
@@ -39,7 +44,8 @@ jobs:
         id: matrix
         env:
           REAL_SITE_CATEGORY: ${{ github.event.inputs.category || 'all' }}
-        run: node scripts/github-real-site-e2e-matrix.mjs "$REAL_SITE_CATEGORY"
+          REAL_SITE_TARGET: ${{ github.event.inputs.target || 'all' }}
+        run: node scripts/github-real-site-e2e-matrix.mjs "$REAL_SITE_CATEGORY" "$REAL_SITE_TARGET"
 
   real-site-e2e:
     name: ${{ matrix.label }}

--- a/e2e/realSite/newApiAccountAdd.spec.ts
+++ b/e2e/realSite/newApiAccountAdd.spec.ts
@@ -23,6 +23,13 @@ import {
 } from "~~/e2e/utils/realSite/sharedAccountFixture"
 
 test.describe("real-site E2E: New API account add flow", () => {
+  // All checks share one real account. A terminal session-limit failure must
+  // not restart workers and issue another login against the same account.
+  test.describe.configure({
+    mode: "serial",
+    retries: 0,
+  })
+
   const sharedAccountCache = createSharedRealSiteAccountFixtureCache()
 
   test.beforeEach(async ({ context, page }) => {

--- a/e2e/utils/realSite/compatibleApi.ts
+++ b/e2e/utils/realSite/compatibleApi.ts
@@ -22,6 +22,7 @@ const DEFAULT_LOGIN_API_PATH = "/api/user/login"
 const DEFAULT_LOGIN_2FA_API_PATH = "/api/user/login/2fa"
 const AUTH_REFRESH_PATH = "/api/user/auth/refresh"
 const AUTH_LOGOUT_PATH = "/api/user/auth/logout"
+const AUTH_SESSION_PATH = "/api/user/sessions"
 const SECURITY_VERIFICATION_BODY_PATTERN =
   /verify you are human|performing security verification|cloudflare/iu
 const AUTH_BUNDLE_MARKER_FIELDS = [
@@ -671,6 +672,14 @@ function createOwnedAuthSessionCleanup(
 
     if (!response.ok()) {
       const responseText = await response.text()
+      if (
+        response.status() === 409 &&
+        getSafeAuthErrorCode(responseText) === "AUTH_SESSION_MISMATCH"
+      ) {
+        await revokeOwnedAuthSession(page, config, options, authBundle)
+        return
+      }
+
       throw createAuthSessionStatusError(
         options,
         response.status(),
@@ -678,6 +687,47 @@ function createOwnedAuthSessionCleanup(
         "cleanup",
       )
     }
+  }
+}
+
+async function revokeOwnedAuthSession(
+  page: Page,
+  config: Pick<CompatibleApiRealSiteConfig, "baseUrl">,
+  options: CompatibleApiLoginOptions,
+  authBundle: CompatibleAuthBundle,
+) {
+  // Pinned rc.22 contract: https://github.com/QuantumNous/new-api/blob/v1.0.0-rc.22/docs/authentication.md
+  // AUTH_SESSION_MISMATCH means the refresh cookie and in-memory SID diverged;
+  // revoke this run's exact SID with its Bearer instead of touching other sessions.
+  const origin = new URL(config.baseUrl).origin
+  let response
+
+  try {
+    response = await page.request.delete(
+      resolveRealSiteUrl(
+        config.baseUrl,
+        `${AUTH_SESSION_PATH}/${encodeURIComponent(authBundle.sessionId)}`,
+      ),
+      {
+        failOnStatusCode: false,
+        headers: {
+          Origin: origin,
+          Authorization: `Bearer ${authBundle.accessToken}`,
+        },
+      },
+    )
+  } catch {
+    throw new Error(`Real ${options.label} auth session cleanup failed.`)
+  }
+
+  if (!response.ok()) {
+    const responseText = await response.text()
+    throw createAuthSessionStatusError(
+      options,
+      response.status(),
+      responseText,
+      "cleanup",
+    )
   }
 }
 

--- a/e2e/utils/realSite/compatibleApi.ts
+++ b/e2e/utils/realSite/compatibleApi.ts
@@ -73,6 +73,7 @@ type CompatibleApiLoginOptions = {
   label: string
   envPrefix: string
   authBundle?: boolean
+  logSessionDiagnostics?: boolean
 }
 
 type CompatibleAuthBundle = {
@@ -169,7 +170,7 @@ export async function loginToCompatibleApiRealSite(
   if (options.authBundle) {
     const probeResult = await probeCompatibleAuthBundle(page, config, options)
     if (probeResult.kind === "authBundle") {
-      return createAuthBundleLoginResult(
+      return await createAuthBundleLoginResult(
         page,
         config,
         options,
@@ -247,7 +248,7 @@ export async function loginToCompatibleApiRealSite(
   if (options.authBundle) {
     const probeResult = await probeCompatibleAuthBundle(page, config, options)
     if (probeResult.kind === "authBundle") {
-      return createAuthBundleLoginResult(
+      return await createAuthBundleLoginResult(
         page,
         config,
         options,
@@ -349,7 +350,7 @@ async function tryLoginToCompatibleApiRealSiteViaApi(
       const parsedPayload = parseCompatibleLoginPayload(payload, payloadMode)
       if (options.authBundle) {
         if (parsedPayload?.kind === "authBundle") {
-          return createAuthBundleLoginResult(
+          return await createAuthBundleLoginResult(
             page,
             config,
             options,
@@ -621,14 +622,14 @@ async function probeCompatibleAuthBundle(
   return { kind: "legacyFallback" }
 }
 
-function createAuthBundleLoginResult(
+async function createAuthBundleLoginResult(
   page: Page,
   config: Pick<CompatibleApiRealSiteConfig, "baseUrl">,
   options: CompatibleApiLoginOptions,
   authBundle: CompatibleAuthBundle,
   reusedSession: boolean,
-): CompatibleApiRealSiteLoginResult {
-  return {
+): Promise<CompatibleApiRealSiteLoginResult> {
+  const result = {
     reusedSession,
     user: authBundle.user,
     ...(reusedSession
@@ -642,6 +643,82 @@ function createAuthBundleLoginResult(
           ),
         }),
   }
+
+  if (options.logSessionDiagnostics) {
+    await logVisibleAuthSessionCount(
+      page,
+      config,
+      options,
+      authBundle,
+      reusedSession,
+    )
+  }
+
+  return result
+}
+
+async function logVisibleAuthSessionCount(
+  page: Page,
+  config: Pick<CompatibleApiRealSiteConfig, "baseUrl">,
+  options: CompatibleApiLoginOptions,
+  authBundle: CompatibleAuthBundle,
+  reusedSession: boolean,
+) {
+  // New API contract: this Bearer-only endpoint lists current-version active
+  // sessions (up to 100); log counts only because the response contains SIDs,
+  // IPs, and user agents. See https://github.com/QuantumNous/new-api/blob/main/docs/authentication.md.
+  let response
+
+  try {
+    response = await page.request.get(
+      resolveRealSiteUrl(config.baseUrl, AUTH_SESSION_PATH),
+      {
+        failOnStatusCode: false,
+        timeout: 10_000,
+        headers: {
+          Authorization: `Bearer ${authBundle.accessToken}`,
+        },
+      },
+    )
+  } catch {
+    return
+  }
+
+  if (!response) {
+    return
+  }
+
+  if (!response.ok()) {
+    console.info(
+      `[real-site] ${options.label} session diagnostic unavailable: HTTP ${response.status()}`,
+    )
+    return
+  }
+
+  let payload
+  try {
+    payload = extractCompatibleApiPayload(safeParseJson(await response.text()))
+  } catch {
+    console.info(
+      `[real-site] ${options.label} session diagnostic unavailable: malformed response`,
+    )
+    return
+  }
+
+  if (!Array.isArray(payload)) {
+    console.info(
+      `[real-site] ${options.label} session diagnostic unavailable: unexpected response shape`,
+    )
+    return
+  }
+
+  const currentCount = payload.filter(
+    (session) => isRecord(session) && session.current === true,
+  ).length
+
+  console.info(
+    `[real-site] ${options.label} session diagnostic: visible_active=${payload.length} current=${currentCount} login=${reusedSession ? "reused" : "fresh"}`,
+  )
 }
 
 function createOwnedAuthSessionCleanup(

--- a/e2e/utils/realSite/compatibleApi.ts
+++ b/e2e/utils/realSite/compatibleApi.ts
@@ -693,6 +693,9 @@ async function logVisibleAuthSessionCount(
       },
     )
   } catch {
+    console.info(
+      `[real-site] ${options.label} session diagnostic unavailable: request failed`,
+    )
     return
   }
 

--- a/e2e/utils/realSite/compatibleApi.ts
+++ b/e2e/utils/realSite/compatibleApi.ts
@@ -30,6 +30,18 @@ const AUTH_BUNDLE_MARKER_FIELDS = [
   "token_type",
   "access_expires_at",
 ] as const
+const SESSION_DIAGNOSTIC_DIGIT_WORDS = [
+  "zero",
+  "one",
+  "two",
+  "three",
+  "four",
+  "five",
+  "six",
+  "seven",
+  "eight",
+  "nine",
+] as const
 
 type RequiredRealSiteEnvKey<TPrefix extends string> =
   | `AAH_E2E_${TPrefix}_BASE_URL`
@@ -717,8 +729,17 @@ async function logVisibleAuthSessionCount(
   ).length
 
   console.info(
-    `[real-site] ${options.label} session diagnostic: visible_active=${payload.length} current=${currentCount} login=${reusedSession ? "reused" : "fresh"}`,
+    `[real-site] ${options.label} session diagnostic: visible_active=${formatSessionDiagnosticCount(payload.length)} current=${formatSessionDiagnosticCount(currentCount)} login=${reusedSession ? "reused" : "fresh"}`,
   )
+}
+
+function formatSessionDiagnosticCount(count: number) {
+  // GitHub masks standalone numeric secret values (for example a user ID),
+  // so spell each digit to keep non-sensitive counts readable in CI logs.
+  return String(count)
+    .split("")
+    .map((digit) => SESSION_DIAGNOSTIC_DIGIT_WORDS[Number(digit)])
+    .join("-")
 }
 
 function createOwnedAuthSessionCleanup(

--- a/e2e/utils/realSite/newApi.ts
+++ b/e2e/utils/realSite/newApi.ts
@@ -62,5 +62,6 @@ export async function loginToRealNewApiSite(
     label: NEW_API_LABEL,
     envPrefix: NEW_API_ENV_PREFIX,
     authBundle: true,
+    logSessionDiagnostics: true,
   })
 }

--- a/scripts/github-real-site-e2e-matrix.mjs
+++ b/scripts/github-real-site-e2e-matrix.mjs
@@ -4,7 +4,8 @@ import { appendFileSync } from "node:fs"
 import { filterRealSiteE2eMatrix } from "./real-site-e2e-matrix.mjs"
 
 const category = process.argv[2] ?? "all"
-const include = filterRealSiteE2eMatrix(category)
+const target = process.argv[3] ?? "all"
+const include = filterRealSiteE2eMatrix(category, target)
 const matrix = JSON.stringify({ include })
 const outputFile = process.env.GITHUB_OUTPUT
 

--- a/scripts/real-site-e2e-matrix.mjs
+++ b/scripts/real-site-e2e-matrix.mjs
@@ -6,6 +6,7 @@ const REAL_SITE_E2E_CATEGORIES = {
 
 const REAL_SITE_E2E_MATRIX = [
   {
+    id: "new-api-account",
     category: REAL_SITE_E2E_CATEGORIES.account,
     label: "Account / New API",
     env_prefix: "NEW_API",
@@ -13,6 +14,7 @@ const REAL_SITE_E2E_MATRIX = [
     spec: "e2e/realSite/newApiAccountAdd.spec.ts",
   },
   {
+    id: "one-hub-account",
     category: REAL_SITE_E2E_CATEGORIES.account,
     label: "Account / OneHub",
     env_prefix: "ONE_HUB",
@@ -20,6 +22,7 @@ const REAL_SITE_E2E_MATRIX = [
     spec: "e2e/realSite/oneHubAccountAdd.spec.ts",
   },
   {
+    id: "done-hub-account",
     category: REAL_SITE_E2E_CATEGORIES.account,
     label: "Account / DoneHub",
     env_prefix: "DONE_HUB",
@@ -27,6 +30,7 @@ const REAL_SITE_E2E_MATRIX = [
     spec: "e2e/realSite/doneHubAccountAdd.spec.ts",
   },
   {
+    id: "veloera-account",
     category: REAL_SITE_E2E_CATEGORIES.account,
     label: "Account / Veloera",
     env_prefix: "VELOERA",
@@ -34,6 +38,7 @@ const REAL_SITE_E2E_MATRIX = [
     spec: "e2e/realSite/veloeraAccountAdd.spec.ts",
   },
   {
+    id: "sub2api-account",
     category: REAL_SITE_E2E_CATEGORIES.account,
     label: "Account / Sub2API",
     env_prefix: "SUB2API",
@@ -41,6 +46,7 @@ const REAL_SITE_E2E_MATRIX = [
     spec: "e2e/realSite/sub2apiAccountAdd.spec.ts",
   },
   {
+    id: "new-api-managed-site",
     category: REAL_SITE_E2E_CATEGORIES.managedSite,
     label: "Managed Site / New API Channels",
     env_prefix: "NEW_API",
@@ -49,6 +55,7 @@ const REAL_SITE_E2E_MATRIX = [
     spec: "e2e/realSite/managedSiteChannels.spec.ts",
   },
   {
+    id: "veloera-managed-site",
     category: REAL_SITE_E2E_CATEGORIES.managedSite,
     label: "Managed Site / Veloera Channels",
     env_prefix: "VELOERA",
@@ -57,6 +64,7 @@ const REAL_SITE_E2E_MATRIX = [
     spec: "e2e/realSite/managedSiteChannels.spec.ts",
   },
   {
+    id: "done-hub-managed-site",
     category: REAL_SITE_E2E_CATEGORIES.managedSite,
     label: "Managed Site / DoneHub Channels",
     env_prefix: "DONE_HUB",
@@ -65,6 +73,7 @@ const REAL_SITE_E2E_MATRIX = [
     spec: "e2e/realSite/managedSiteChannels.spec.ts",
   },
   {
+    id: "octopus-managed-site",
     category: REAL_SITE_E2E_CATEGORIES.managedSite,
     label: "Managed Site / Octopus Channels",
     env_prefix: "OCTOPUS",
@@ -73,6 +82,7 @@ const REAL_SITE_E2E_MATRIX = [
     spec: "e2e/realSite/managedSiteChannels.spec.ts",
   },
   {
+    id: "axonhub-managed-site",
     category: REAL_SITE_E2E_CATEGORIES.managedSite,
     label: "Managed Site / AxonHub Channels",
     env_prefix: "AXON_HUB",
@@ -81,6 +91,7 @@ const REAL_SITE_E2E_MATRIX = [
     spec: "e2e/realSite/managedSiteChannels.spec.ts",
   },
   {
+    id: "claude-code-hub-managed-site",
     category: REAL_SITE_E2E_CATEGORIES.managedSite,
     label: "Managed Site / Claude Code Hub Channels",
     env_prefix: "CLAUDE_CODE_HUB",
@@ -89,6 +100,7 @@ const REAL_SITE_E2E_MATRIX = [
     spec: "e2e/realSite/managedSiteChannels.spec.ts",
   },
   {
+    id: "nutstore-webdav",
     category: REAL_SITE_E2E_CATEGORIES.webdav,
     label: "WebDAV / Nutstore",
     env_prefix: "NUTSTORE_WEBDAV",
@@ -98,6 +110,7 @@ const REAL_SITE_E2E_MATRIX = [
     spec: "e2e/realSite/webdavProviderFlow.spec.ts",
   },
   {
+    id: "ctfile-webdav",
     category: REAL_SITE_E2E_CATEGORIES.webdav,
     label: "WebDAV / CTFile",
     env_prefix: "CTFILE_WEBDAV",
@@ -118,11 +131,28 @@ export function normalizeRealSiteE2eCategory(category = "all") {
   return normalized
 }
 
-export function filterRealSiteE2eMatrix(category = "all") {
+function normalizeRealSiteE2eTarget(target = "all") {
+  return target.trim().toLowerCase().replaceAll("_", "-")
+}
+
+export function filterRealSiteE2eMatrix(category = "all", target = "all") {
   const normalized = normalizeRealSiteE2eCategory(category)
+  const normalizedTarget = normalizeRealSiteE2eTarget(target)
 
   if (normalized === "all") {
-    return REAL_SITE_E2E_MATRIX
+    if (normalizedTarget === "all") {
+      return REAL_SITE_E2E_MATRIX
+    }
+
+    const targetEntry = REAL_SITE_E2E_MATRIX.find(
+      (entry) => entry.id === normalizedTarget,
+    )
+
+    if (!targetEntry) {
+      throwUnknownTarget(target)
+    }
+
+    return [targetEntry]
   }
 
   const allowedCategories = new Set(Object.values(REAL_SITE_E2E_CATEGORIES))
@@ -132,5 +162,33 @@ export function filterRealSiteE2eMatrix(category = "all") {
     )
   }
 
-  return REAL_SITE_E2E_MATRIX.filter((entry) => entry.category === normalized)
+  if (normalizedTarget === "all") {
+    return REAL_SITE_E2E_MATRIX.filter((entry) => entry.category === normalized)
+  }
+
+  const targetEntry = REAL_SITE_E2E_MATRIX.find(
+    (entry) => entry.id === normalizedTarget,
+  )
+
+  if (!targetEntry) {
+    throwUnknownTarget(target)
+  }
+
+  if (targetEntry.category !== normalized) {
+    throw new Error(
+      `Real-site E2E target ${target} does not belong to category ${category}.`,
+    )
+  }
+
+  return [targetEntry]
+}
+
+function throwUnknownTarget(target) {
+  const availableTargets = REAL_SITE_E2E_MATRIX.map((entry) => entry.id).join(
+    ", ",
+  )
+
+  throw new Error(
+    `Unknown real-site E2E target: ${target}. Expected all or one of: ${availableTargets}.`,
+  )
 }

--- a/tests/scripts/realSiteE2eMatrix.test.ts
+++ b/tests/scripts/realSiteE2eMatrix.test.ts
@@ -8,10 +8,16 @@ function runMatrix(...args: string[]) {
     "scripts",
     "github-real-site-e2e-matrix.mjs",
   )
+  const testEnv = { ...process.env }
+
+  // GitHub Actions sets GITHUB_OUTPUT for every step; unset it so this test
+  // exercises the script's stdout CLI contract instead of its workflow output.
+  delete testEnv.GITHUB_OUTPUT
 
   return JSON.parse(
     execFileSync(process.execPath, [scriptPath, ...args], {
       encoding: "utf8",
+      env: testEnv,
       stdio: ["ignore", "pipe", "pipe"],
     }),
   ) as { include: Array<Record<string, unknown>> }

--- a/tests/scripts/realSiteE2eMatrix.test.ts
+++ b/tests/scripts/realSiteE2eMatrix.test.ts
@@ -23,6 +23,10 @@ function runMatrix(...args: string[]) {
   ) as { include: Array<Record<string, unknown>> }
 }
 
+function selectedIds(matrix: ReturnType<typeof runMatrix>) {
+  return matrix.include.map((entry) => entry.id)
+}
+
 describe("GitHub real-site E2E matrix selection", () => {
   it("selects one concrete target without expanding the account category", () => {
     const matrix = runMatrix("all", "new-api-account")
@@ -37,8 +41,12 @@ describe("GitHub real-site E2E matrix selection", () => {
 
   it("keeps category selection unchanged when target is all", () => {
     const matrix = runMatrix("account", "all")
+    const allTargets = runMatrix()
+    const expectedAccountIds = allTargets.include
+      .filter((entry) => entry.category === "account")
+      .map((entry) => entry.id)
 
-    expect(matrix.include).toHaveLength(5)
+    expect(selectedIds(matrix)).toEqual(expectedAccountIds)
     expect(matrix.include.every((entry) => entry.category === "account")).toBe(
       true,
     )
@@ -46,8 +54,11 @@ describe("GitHub real-site E2E matrix selection", () => {
 
   it("keeps the default all-category matrix unchanged", () => {
     const matrix = runMatrix()
+    const expectedIds = ["account", "managed-site", "webdav"].flatMap(
+      (category) => selectedIds(runMatrix(category, "all")),
+    )
 
-    expect(matrix.include).toHaveLength(13)
+    expect(selectedIds(matrix)).toEqual(expectedIds)
   })
 
   it("rejects a target from a different category", () => {

--- a/tests/scripts/realSiteE2eMatrix.test.ts
+++ b/tests/scripts/realSiteE2eMatrix.test.ts
@@ -1,0 +1,52 @@
+import { execFileSync } from "node:child_process"
+import path from "node:path"
+import { describe, expect, it } from "vitest"
+
+function runMatrix(...args: string[]) {
+  const scriptPath = path.resolve(
+    process.cwd(),
+    "scripts",
+    "github-real-site-e2e-matrix.mjs",
+  )
+
+  return JSON.parse(
+    execFileSync(process.execPath, [scriptPath, ...args], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }),
+  ) as { include: Array<Record<string, unknown>> }
+}
+
+describe("GitHub real-site E2E matrix selection", () => {
+  it("selects one concrete target without expanding the account category", () => {
+    const matrix = runMatrix("all", "new-api-account")
+
+    expect(matrix.include).toHaveLength(1)
+    expect(matrix.include[0]).toMatchObject({
+      id: "new-api-account",
+      label: "Account / New API",
+      category: "account",
+    })
+  })
+
+  it("keeps category selection unchanged when target is all", () => {
+    const matrix = runMatrix("account", "all")
+
+    expect(matrix.include).toHaveLength(5)
+    expect(matrix.include.every((entry) => entry.category === "account")).toBe(
+      true,
+    )
+  })
+
+  it("keeps the default all-category matrix unchanged", () => {
+    const matrix = runMatrix()
+
+    expect(matrix.include).toHaveLength(13)
+  })
+
+  it("rejects a target from a different category", () => {
+    expect(() => runMatrix("account", "new-api-managed-site")).toThrow(
+      /does not belong to category account/,
+    )
+  })
+})

--- a/tests/utils/realSiteCompatibleApi.test.ts
+++ b/tests/utils/realSiteCompatibleApi.test.ts
@@ -63,6 +63,7 @@ function createPage(
   post: ReturnType<typeof vi.fn>,
   options: {
     storedUser?: Record<string, unknown>
+    getRequest?: ReturnType<typeof vi.fn>
     deleteRequest?: ReturnType<typeof vi.fn>
   } = {},
 ) {
@@ -81,7 +82,7 @@ function createPage(
       waitForFunction,
       request: {
         post,
-        get: vi.fn(),
+        get: options.getRequest ?? vi.fn(),
         delete: options.deleteRequest ?? vi.fn(),
       },
       close: vi.fn().mockResolvedValue(undefined),
@@ -160,6 +161,45 @@ describe("compatible real-site login", () => {
     expect(evaluate).not.toHaveBeenCalled()
     expect(waitForFunction).not.toHaveBeenCalled()
     expect(post).toHaveBeenCalledTimes(2)
+  })
+
+  it("logs only the visible New API session counts after login", async () => {
+    const post = vi
+      .fn()
+      .mockResolvedValueOnce(createResponse(401, { code: "AUTH_UNAUTHORIZED" }))
+      .mockResolvedValueOnce(createResponse(200, createAuthBundle()))
+    const getRequest = vi.fn().mockResolvedValue(
+      createResponse(200, {
+        success: true,
+        data: [
+          { sid: "must-not-leak-current-sid", current: true },
+          { sid: "must-not-leak-other-sid", current: false },
+        ],
+      }),
+    )
+    const info = vi.spyOn(console, "info").mockImplementation(() => undefined)
+    const { page } = createPage(post, { getRequest })
+    let messages = ""
+
+    try {
+      await loginToRealNewApiSite(page, config)
+      messages = info.mock.calls.flat().join(" ")
+    } finally {
+      info.mockRestore()
+    }
+
+    expect(getRequest).toHaveBeenCalledWith(
+      `${ORIGIN}/api/user/sessions`,
+      expect.objectContaining({
+        failOnStatusCode: false,
+        headers: {
+          Authorization: "Bearer access-token-placeholder",
+        },
+      }),
+    )
+    expect(messages).toContain("visible_active=2")
+    expect(messages).toContain("current=1")
+    expect(messages).not.toContain("must-not-leak")
   })
 
   it("reuses an existing AuthBundle session without taking cleanup ownership", async () => {

--- a/tests/utils/realSiteCompatibleApi.test.ts
+++ b/tests/utils/realSiteCompatibleApi.test.ts
@@ -197,8 +197,8 @@ describe("compatible real-site login", () => {
         },
       }),
     )
-    expect(messages).toContain("visible_active=2")
-    expect(messages).toContain("current=1")
+    expect(messages).toContain("visible_active=two")
+    expect(messages).toContain("current=one")
     expect(messages).not.toContain("must-not-leak")
   })
 

--- a/tests/utils/realSiteCompatibleApi.test.ts
+++ b/tests/utils/realSiteCompatibleApi.test.ts
@@ -202,6 +202,31 @@ describe("compatible real-site login", () => {
     expect(messages).not.toContain("must-not-leak")
   })
 
+  it("logs a sanitized status when the session diagnostic request fails", async () => {
+    const post = vi
+      .fn()
+      .mockResolvedValueOnce(createResponse(401, { code: "AUTH_UNAUTHORIZED" }))
+      .mockResolvedValueOnce(createResponse(200, createAuthBundle()))
+    const getRequest = vi
+      .fn()
+      .mockRejectedValue(new Error("must-not-leak-transport-details"))
+    const info = vi.spyOn(console, "info").mockImplementation(() => undefined)
+    const { page } = createPage(post, { getRequest })
+    let messages = ""
+
+    try {
+      await loginToRealNewApiSite(page, config)
+      messages = info.mock.calls.flat().join(" ")
+    } finally {
+      info.mockRestore()
+    }
+
+    expect(messages).toContain(
+      "New API session diagnostic unavailable: request failed",
+    )
+    expect(messages).not.toContain("must-not-leak")
+  })
+
   it("reuses an existing AuthBundle session without taking cleanup ownership", async () => {
     const post = vi
       .fn()

--- a/tests/utils/realSiteCompatibleApi.test.ts
+++ b/tests/utils/realSiteCompatibleApi.test.ts
@@ -19,6 +19,7 @@ vi.mock("~~/e2e/utils/accountLifecycle", () => ({
 const ORIGIN = "https://panel.example.invalid"
 const AUTH_REFRESH_URL = `${ORIGIN}/api/user/auth/refresh`
 const AUTH_LOGOUT_URL = `${ORIGIN}/api/user/auth/logout`
+const AUTH_SESSION_DELETE_URL = `${ORIGIN}/api/user/sessions/session-id-placeholder`
 const FUTURE_EXPIRY = Math.floor(Date.now() / 1000) + 3_600
 
 const config: CompatibleApiRealSiteConfig = {
@@ -60,7 +61,10 @@ function createAuthBundle(overrides: Record<string, unknown> = {}) {
 
 function createPage(
   post: ReturnType<typeof vi.fn>,
-  options: { storedUser?: Record<string, unknown> } = {},
+  options: {
+    storedUser?: Record<string, unknown>
+    deleteRequest?: ReturnType<typeof vi.fn>
+  } = {},
 ) {
   const evaluate = vi.fn().mockResolvedValue(undefined)
   const waitForFunction = options.storedUser
@@ -78,6 +82,7 @@ function createPage(
       request: {
         post,
         get: vi.fn(),
+        delete: options.deleteRequest ?? vi.fn(),
       },
       close: vi.fn().mockResolvedValue(undefined),
     } as any,
@@ -194,6 +199,37 @@ describe("compatible real-site login", () => {
         "X-Auth-Session": "session-id-placeholder",
       },
     })
+  })
+
+  it("revokes only the fresh owned session when logout detects a cookie mismatch", async () => {
+    const post = vi
+      .fn()
+      .mockResolvedValueOnce(createResponse(401, { code: "AUTH_UNAUTHORIZED" }))
+      .mockResolvedValueOnce(createResponse(200, createAuthBundle()))
+      .mockResolvedValueOnce(
+        createResponse(409, {
+          code: "AUTH_SESSION_MISMATCH",
+          message: "must-not-leak-server-message",
+        }),
+      )
+    const deleteRequest = vi.fn().mockResolvedValue(createResponse(200, {}))
+    const { page } = createPage(post, { deleteRequest })
+
+    const result = await loginToRealNewApiSite(page, config)
+    await result.cleanupOwnedSession?.()
+
+    expect(deleteRequest).toHaveBeenCalledWith(AUTH_SESSION_DELETE_URL, {
+      failOnStatusCode: false,
+      headers: {
+        Origin: ORIGIN,
+        Authorization: "Bearer access-token-placeholder",
+      },
+    })
+    expect(
+      post.mock.calls.some(([url]) =>
+        String(url).includes("/api/user/sessions/revoke-others"),
+      ),
+    ).toBe(false)
   })
 
   it("logs out the fresh owned session once when downstream account saving fails", async () => {

--- a/tests/utils/realSiteSharedAccountFixture.test.ts
+++ b/tests/utils/realSiteSharedAccountFixture.test.ts
@@ -159,4 +159,15 @@ describe("real-site account spec structure", () => {
 
     expect(specsWithoutSharedFixture).toEqual([])
   })
+
+  it("keeps the New API split suite serial and non-retrying after terminal setup failure", () => {
+    const source = readFileSync(
+      path.join(process.cwd(), "e2e", "realSite", "newApiAccountAdd.spec.ts"),
+      "utf8",
+    )
+
+    expect(source).toMatch(
+      /test\.describe\.configure\(\{\s*mode:\s*"serial",\s*retries:\s*0,\s*\}\)/u,
+    )
+  })
 })


### PR DESCRIPTION
## Summary

- run the five New API real-site account checks serially with retries disabled, preventing terminal session-limit failures from triggering additional worker or retry logins
- when logout reports `AUTH_SESSION_MISMATCH`, revoke only the exact session created by the current run instead of signing out unrelated sessions
- add target-level Real-Site workflow dispatch and privacy-safe post-login session-count diagnostics
- keep the matrix-selection test isolated from GitHub Actions' workflow-output environment

## Why

Repeated worker restarts and retries could amplify New API login-session usage. This allowed one CI run to pass but caused later runs to fail again with `409 AUTH_SESSION_LIMIT`.

The cleanup path must also avoid `revoke-others`, because the test account may contain sessions that are not owned by the current CI attempt.

## Validation

Current HEAD `e6deaa6b2`:

- matrix-selection test: 4/4 passed with `GITHUB_OUTPUT` present, matching the GitHub Actions environment
- related Vitest validation: 4/4 passed
- `pnpm compile`
- `pnpm knip`
- `pnpm run validate:staged`
- `pnpm run validate:push`
- pre-push hook passed while publishing the current head
- PR Test run 31222737437: all quality, unit shards, coverage merge, and Codecov patch checks passed
- PR E2E run 31222737403: 163 passed, 44 skipped; DNR smoke passed
- CodeRabbit completed successfully

Real-Site evidence on parent runtime head `927b3b0d9` (the follow-up commit changes test harness code only):

- targeted `new-api-account` runs 31220109757 and 31220362920: 5/5 passed each
- both reported `visible_active=one current=one`
- core-fix Test, general E2E, and complete account Real-Site matrix all passed on `30ef6b159`

## CI follow-up

The first PR run (31221456414) exposed that the matrix test inherited `GITHUB_OUTPUT` and therefore received empty stdout from the CLI script; 3 matrix assertions failed while 6,730 other tests passed. Commit `e6deaa6b2` removes that inherited variable only in the test child process, preserving the workflow's normal `GITHUB_OUTPUT` behavior.

## Notes

- session diagnostics log counts only; SIDs, IP addresses, and user agents are not emitted
- `/api/user/sessions` exposes sessions visible to the current authentication version, so the count does not prove that no historical database rows exist
- diagnostics are available only after a successful login; a pre-login `409` cannot be inspected through this endpoint
- the new target input preserves existing category, default, and scheduled workflow behavior


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Real-site end-to-end checks can now target a specific account, managed-site, or WebDAV scenario.
  * Added optional login session diagnostics, including active session counts.
* **Bug Fixes**
  * Improved cleanup when logout encounters a session mismatch by revoking only the affected session.
  * Shared-account checks now run sequentially without retries.
* **Tests**
  * Expanded coverage for target selection, session diagnostics, and safe session cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->