### PR TITLE
feat(new-api): manage extension-owned sessions

### DIFF
--- a/src/entrypoints/background/runtimeMessages.ts
+++ b/src/entrypoints/background/runtimeMessages.ts
@@ -14,6 +14,7 @@ import {
 import { setupUsageHistoryMessagingListeners } from "~/services/history/usageHistory/scheduler"
 import { setupLdohSiteLookupMessagingListeners } from "~/services/integrations/ldohSiteLookup/background"
 import { setupChannelConfigMessagingListeners } from "~/services/managedSites/channelConfigStorage"
+import { isNewApiOwnedSessionRequest } from "~/services/managedSites/newApiOwnedSession/contracts"
 import { setupManagedSiteModelSyncMessagingListeners } from "~/services/models/modelSync"
 import { setupTaskNotificationMessagingListeners } from "~/services/notifications/taskNotificationService"
 import { setupPreferencesMessagingListeners } from "~/services/preferences/runtimePreferencesService"
@@ -122,6 +123,19 @@ export function setupRuntimeMessageListeners() {
   // 处理来自 popup 的消息
   onRuntimeMessage((request, sender, sendResponse) => {
     try {
+      if (isNewApiOwnedSessionRequest(request)) {
+        void import("~/services/managedSites/newApiOwnedSession/background")
+          .then(({ handleNewApiOwnedSessionRequest }) =>
+            handleNewApiOwnedSessionRequest(request),
+          )
+          .then(sendResponse)
+          .catch((error) => {
+            logger.warn("New API owned-session command failed", { error })
+            sendResponse({ success: false })
+          })
+        return true
+      }
+
       if (request.action === RuntimeActionIds.PermissionsCheck) {
         void containsPermissions(request.permissions)
           .then((hasPermission) => {

--- a/src/entrypoints/background/runtimeMessages.ts
+++ b/src/entrypoints/background/runtimeMessages.ts
@@ -14,7 +14,7 @@ import {
 import { setupUsageHistoryMessagingListeners } from "~/services/history/usageHistory/scheduler"
 import { setupLdohSiteLookupMessagingListeners } from "~/services/integrations/ldohSiteLookup/background"
 import { setupChannelConfigMessagingListeners } from "~/services/managedSites/channelConfigStorage"
-import { isNewApiOwnedSessionRequest } from "~/services/managedSites/newApiOwnedSession/contracts"
+import { parseNewApiOwnedSessionRequest } from "~/services/managedSites/newApiOwnedSession/contracts"
 import { setupManagedSiteModelSyncMessagingListeners } from "~/services/models/modelSync"
 import { setupTaskNotificationMessagingListeners } from "~/services/notifications/taskNotificationService"
 import { setupPreferencesMessagingListeners } from "~/services/preferences/runtimePreferencesService"
@@ -123,10 +123,11 @@ export function setupRuntimeMessageListeners() {
   // 处理来自 popup 的消息
   onRuntimeMessage((request, sender, sendResponse) => {
     try {
-      if (isNewApiOwnedSessionRequest(request)) {
+      const newApiOwnedSessionRequest = parseNewApiOwnedSessionRequest(request)
+      if (newApiOwnedSessionRequest) {
         void import("~/services/managedSites/newApiOwnedSession/background")
           .then(({ handleNewApiOwnedSessionRequest }) =>
-            handleNewApiOwnedSessionRequest(request),
+            handleNewApiOwnedSessionRequest(newApiOwnedSessionRequest),
           )
           .then(sendResponse)
           .catch((error) => {

--- a/src/entrypoints/background/servicesInit.ts
+++ b/src/entrypoints/background/servicesInit.ts
@@ -2,6 +2,7 @@ import { autoRefreshService } from "~/services/accounts/autoRefreshService"
 import { autoCheckinScheduler } from "~/services/checkin/autoCheckin/scheduler"
 import { dailyBalanceHistoryScheduler } from "~/services/history/dailyBalanceHistory/scheduler"
 import { usageHistoryScheduler } from "~/services/history/usageHistory/scheduler"
+import { newApiOwnedSessionLifecycle } from "~/services/managedSites/newApiOwnedSession/background"
 import { modelMetadataService } from "~/services/models/modelMetadata"
 import { modelSyncScheduler } from "~/services/models/modelSync"
 import { initializeTaskNotificationService } from "~/services/notifications/taskNotificationService"
@@ -61,6 +62,7 @@ export async function initializeServices() {
         siteAnnouncementScheduler.initialize(),
         productAnnouncementService.initialize(),
         releaseUpdateService.initialize(),
+        newApiOwnedSessionLifecycle.initialize(),
       ])
       initializeTaskNotificationService()
 

--- a/src/features/ManagedSiteVerification/NewApiManagedVerificationDialog.tsx
+++ b/src/features/ManagedSiteVerification/NewApiManagedVerificationDialog.tsx
@@ -52,6 +52,14 @@ const getStepBodyCopy = (
       return t("newApiManagedVerification:dialog.body.secureVerification")
     case NEW_API_MANAGED_VERIFICATION_STEPS.PASSKEY_MANUAL:
       return t("newApiManagedVerification:dialog.body.passkeyManual")
+    case NEW_API_MANAGED_VERIFICATION_STEPS.SESSION_ACTIVE_LIMIT:
+      return t("newApiManagedVerification:dialog.body.sessionActiveLimit")
+    case NEW_API_MANAGED_VERIFICATION_STEPS.SESSION_ACTIVE_LIMIT_CLEANUP:
+      return t(
+        "newApiManagedVerification:dialog.body.sessionActiveLimitCleanup",
+      )
+    case NEW_API_MANAGED_VERIFICATION_STEPS.SESSION_ISSUANCE_LIMIT:
+      return t("newApiManagedVerification:dialog.body.sessionIssuanceLimit")
     case NEW_API_MANAGED_VERIFICATION_STEPS.SUCCESS:
       return request?.kind === "token"
         ? t("newApiManagedVerification:dialog.body.successToken", {
@@ -135,8 +143,15 @@ export function NewApiManagedVerificationDialog(
     (props.step === NEW_API_MANAGED_VERIFICATION_STEPS.FAILURE &&
       !props.request?.config.baseUrl.trim())
   const shouldShowRetryAction =
-    props.step === NEW_API_MANAGED_VERIFICATION_STEPS.FAILURE &&
-    !shouldShowSettingsAction
+    (props.step === NEW_API_MANAGED_VERIFICATION_STEPS.FAILURE &&
+      !shouldShowSettingsAction) ||
+    props.step ===
+      NEW_API_MANAGED_VERIFICATION_STEPS.SESSION_ACTIVE_LIMIT_CLEANUP
+  const shouldShowLimitOpenSiteAction =
+    props.step === NEW_API_MANAGED_VERIFICATION_STEPS.SESSION_ACTIVE_LIMIT ||
+    props.step ===
+      NEW_API_MANAGED_VERIFICATION_STEPS.SESSION_ACTIVE_LIMIT_CLEANUP ||
+    props.step === NEW_API_MANAGED_VERIFICATION_STEPS.SESSION_ISSUANCE_LIMIT
   const shouldShowQuickConfig = shouldShowSettingsAction && !props.isBusy
   const needsBaseUrl = useMemo(
     () =>
@@ -250,8 +265,21 @@ export function NewApiManagedVerificationDialog(
 
       {shouldShowRetryAction ? (
         <Button onClick={props.onRetry} disabled={props.isBusy}>
-          {t("dialog.actions.retry")}
+          {props.step ===
+          NEW_API_MANAGED_VERIFICATION_STEPS.SESSION_ACTIVE_LIMIT_CLEANUP
+            ? t("dialog.actions.cleanupOwnedSessionAndRetry")
+            : t("dialog.actions.retry")}
         </Button>
+      ) : null}
+
+      {shouldShowLimitOpenSiteAction ? (
+        <WorkflowTransitionButton
+          variant="outline"
+          onClick={props.onOpenSite}
+          disabled={props.isBusy}
+        >
+          {t("dialog.actions.openSite")}
+        </WorkflowTransitionButton>
       ) : null}
 
       {isCodeEntryStep ? (

--- a/src/features/ManagedSiteVerification/useNewApiManagedVerification.tsx
+++ b/src/features/ManagedSiteVerification/useNewApiManagedVerification.tsx
@@ -388,8 +388,15 @@ export function useNewApiManagedVerification() {
         ),
         errorMessage: undefined,
       }))
-      const cleanup = await cleanupNewApiOwnedSession(request.config.baseUrl)
-      if (cleanup.status !== "cleaned") {
+      let cleanupSucceeded = false
+      try {
+        cleanupSucceeded =
+          (await cleanupNewApiOwnedSession(request.config.baseUrl)).status ===
+          "cleaned"
+      } catch {
+        // Use the same local recovery state for transport and result failures.
+      }
+      if (!cleanupSucceeded) {
         setState((prev) => ({
           ...prev,
           isBusy: false,

--- a/src/features/ManagedSiteVerification/useNewApiManagedVerification.tsx
+++ b/src/features/ManagedSiteVerification/useNewApiManagedVerification.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useRef, useState } from "react"
 import toast from "react-hot-toast"
 
+import { cleanupNewApiOwnedSession } from "~/services/managedSites/newApiOwnedSession/client"
 import {
   ensureNewApiManagedSession,
   NEW_API_MANAGED_SESSION_STATUSES,
@@ -23,6 +24,9 @@ export const NEW_API_MANAGED_VERIFICATION_STEPS = {
   LOGIN_2FA: "login-2fa",
   SECURE_VERIFICATION: "secure-verification",
   PASSKEY_MANUAL: "passkey-manual",
+  SESSION_ACTIVE_LIMIT: "session-active-limit",
+  SESSION_ACTIVE_LIMIT_CLEANUP: "session-active-limit-cleanup",
+  SESSION_ISSUANCE_LIMIT: "session-issuance-limit",
   SUCCESS: "success",
   FAILURE: "failure",
 } as const
@@ -117,6 +121,12 @@ const mapSessionResultToStep = (
       return NEW_API_MANAGED_VERIFICATION_STEPS.SECURE_VERIFICATION
     case NEW_API_MANAGED_SESSION_STATUSES.PASSKEY_MANUAL_REQUIRED:
       return NEW_API_MANAGED_VERIFICATION_STEPS.PASSKEY_MANUAL
+    case NEW_API_MANAGED_SESSION_STATUSES.SESSION_ACTIVE_LIMIT:
+      return result.cleanupAvailable
+        ? NEW_API_MANAGED_VERIFICATION_STEPS.SESSION_ACTIVE_LIMIT_CLEANUP
+        : NEW_API_MANAGED_VERIFICATION_STEPS.SESSION_ACTIVE_LIMIT
+    case NEW_API_MANAGED_SESSION_STATUSES.SESSION_ISSUANCE_LIMIT:
+      return NEW_API_MANAGED_VERIFICATION_STEPS.SESSION_ISSUANCE_LIMIT
     case NEW_API_MANAGED_SESSION_STATUSES.VERIFIED:
     default:
       return NEW_API_MANAGED_VERIFICATION_STEPS.SUCCESS
@@ -365,8 +375,35 @@ export function useNewApiManagedVerification() {
   const retryVerification = useCallback(async () => {
     const request = requestRef.current ?? state.request
     if (!request) return
+
+    if (
+      state.step ===
+      NEW_API_MANAGED_VERIFICATION_STEPS.SESSION_ACTIVE_LIMIT_CLEANUP
+    ) {
+      setState((prev) => ({
+        ...prev,
+        isBusy: true,
+        busyMessage: t(
+          "newApiManagedVerification:dialog.messages.cleaningOwnedSession",
+        ),
+        errorMessage: undefined,
+      }))
+      const cleanup = await cleanupNewApiOwnedSession(request.config.baseUrl)
+      if (cleanup.status !== "cleaned") {
+        setState((prev) => ({
+          ...prev,
+          isBusy: false,
+          busyMessage: undefined,
+          errorMessage: t(
+            "newApiManagedVerification:dialog.messages.ownedSessionCleanupFailed",
+          ),
+        }))
+        return
+      }
+    }
+
     await runInitialFlow(request)
-  }, [runInitialFlow, state.request])
+  }, [runInitialFlow, state.request, state.step])
 
   const patchRequestConfig = useCallback(
     (updates: NewApiManagedVerificationConfigUpdate) => {

--- a/src/locales/de/newApiManagedVerification.json
+++ b/src/locales/de/newApiManagedVerification.json
@@ -1,6 +1,7 @@
 {
   "dialog": {
     "actions": {
+      "cleanupOwnedSessionAndRetry": "Erweiterungssitzungen bereinigen und erneut versuchen",
       "close": "Schließen",
       "openSite": "Website öffnen",
       "retry": "Wiederholen",
@@ -16,6 +17,9 @@
       "loginTwoFactor": "Der Anmeldeschritt New API erfordert einen Bestätigungscode, bevor die browsergestützte Admin-Sitzung fortgesetzt werden kann.",
       "passkeyManual": "Dieses Konto stellt derzeit die Passkey-Verifizierung für den sicheren Schritt zur Verfügung. Führen Sie die Passkey-Überprüfung auf der Website durch, kehren Sie dann hierher zurück und versuchen Sie es erneut.",
       "secureVerification": "Die Admin-Sitzung ist angemeldet, aber New API erfordert immer noch einen sicheren Bestätigungscode, bevor versteckte Kanalschlüssel gelesen werden können.",
+      "sessionActiveLimit": "New API hat das Limit aktiver Sitzungen erreicht. Die Erweiterung kann keine eigene Sitzung sicher entfernen. Widerrufen Sie auf der Website eine nicht mehr verwendete Sitzung.",
+      "sessionActiveLimitCleanup": "New API hat das Limit aktiver Sitzungen erreicht. Die Erweiterung kann gezielt nur die von ihr erstellten Sitzungen widerrufen und den Vorgang erneut versuchen.",
+      "sessionIssuanceLimit": "New API hat das 24-Stunden-Limit für neue Sitzungen erreicht. Das Entfernen aktiver Sitzungen setzt dieses Limit nicht zurück; warten Sie, bis sich das Zeitfenster erholt.",
       "successChannel": "Verifizierung für {{label}} erfolgreich. Der echte Kanalschlüssel wurde geladen.",
       "successSettings": "Der New API-Anmelde- und Verifizierungsvorgang wurde erfolgreich abgeschlossen. Sie können nun mit Aktionen fortfahren, die eine Anmeldung und Verifizierung erfordern.",
       "successToken": "Die Überprüfung für {{label}} war erfolgreich. Der Status der verwalteten Website wurde aktualisiert."
@@ -29,10 +33,12 @@
       "passkey": "Öffnen Sie die Website, bestätigen Sie dort die Passkey-Aufforderung, kehren Sie anschließend hierher zurück und versuchen Sie es erneut."
     },
     "messages": {
+      "cleaningOwnedSession": "Die von der Erweiterung erstellten New API-Sitzungen werden bereinigt...",
       "completeRequiredConfig": "Füllen Sie zunächst die fehlenden Konfigurationsfelder aus.",
       "finishing": "New API-Sitzungsprüfung wird abgeschlossen...",
       "missingBaseUrl": "Fügen Sie die Basis-URL New API hinzu, bevor Sie den Sitzungsablauf testen.",
       "missingCode": "Geben Sie zuerst den Bestätigungscode ein.",
+      "ownedSessionCleanupFailed": "Nicht alle von der Erweiterung erstellten Sitzungen konnten entfernt werden. Öffnen Sie die Sitzungsverwaltung der Website und widerrufen Sie ungenutzte Sitzungen manuell.",
       "quickConfigSaveFailed": "Die Schnellkonfiguration konnte nicht gespeichert werden. Bitte versuchen Sie es erneut.",
       "refreshingChannel": "Laden des echten Kanalschlüssels...",
       "refreshingToken": "Der Status der verwalteten Website dieses Tokens wird aktualisiert...",

--- a/src/locales/en/newApiManagedVerification.json
+++ b/src/locales/en/newApiManagedVerification.json
@@ -1,6 +1,7 @@
 {
   "dialog": {
     "actions": {
+      "cleanupOwnedSessionAndRetry": "Clean up extension sessions and retry",
       "close": "Close",
       "openSite": "Open site",
       "retry": "Retry",
@@ -16,6 +17,9 @@
       "loginTwoFactor": "The New API login step requires a verification code before the browser-backed admin session can continue.",
       "passkeyManual": "This account currently exposes passkey verification for the secure step. Complete the passkey check on the site, then return here and retry.",
       "secureVerification": "The admin session is logged in, but New API still requires a secure verification code before hidden channel keys can be read.",
+      "sessionActiveLimit": "New API has reached its active-session limit. The extension has no session it can safely remove, so revoke an unused session on the site before retrying.",
+      "sessionActiveLimitCleanup": "New API has reached its active-session limit. The extension can revoke only the sessions it created, then retry this action.",
+      "sessionIssuanceLimit": "New API has reached its 24-hour session issuance limit. Removing active sessions will not reset it; wait for the issuance window to recover.",
       "successChannel": "Verification succeeded for {{label}}. The real channel key has been loaded.",
       "successSettings": "The New API login and verification flow completed successfully. You can now continue with actions that require login and verification.",
       "successToken": "Verification succeeded for {{label}}. The managed-site status has been refreshed."
@@ -29,10 +33,12 @@
       "passkey": "Open the site, complete the passkey prompt there, then come back here and retry."
     },
     "messages": {
+      "cleaningOwnedSession": "Cleaning up the New API sessions created by the extension...",
       "completeRequiredConfig": "Complete the missing configuration fields first.",
       "finishing": "Finalizing the New API session check...",
       "missingBaseUrl": "Add the New API base URL before testing the session flow.",
       "missingCode": "Enter the verification code first.",
+      "ownedSessionCleanupFailed": "The extension-created sessions could not all be removed. Open session management on the site and revoke unused sessions manually.",
       "quickConfigSaveFailed": "Failed to save the quick configuration. Please try again.",
       "refreshingChannel": "Loading the real channel key...",
       "refreshingToken": "Refreshing this token's managed-site status...",

--- a/src/locales/es-419/newApiManagedVerification.json
+++ b/src/locales/es-419/newApiManagedVerification.json
@@ -1,6 +1,7 @@
 {
   "dialog": {
     "actions": {
+      "cleanupOwnedSessionAndRetry": "Limpiar sesiones de la extensión y reintentar",
       "close": "Cerrar",
       "openSite": "Abrir sitio",
       "retry": "Reintentar",
@@ -16,6 +17,9 @@
       "loginTwoFactor": "El paso de inicio de sesión de New API requiere un código de verificación antes de que la sesión de administrador respaldada por el navegador pueda continuar.",
       "passkeyManual": "Esta cuenta expone actualmente verificación con passkey para el paso seguro. Completa la comprobación de passkey en el sitio, vuelve aquí y reintenta.",
       "secureVerification": "La sesión de administrador ya inició sesión, pero New API todavía requiere un código de verificación seguro antes de poder leer las claves ocultas de canales.",
+      "sessionActiveLimit": "New API alcanzó el límite de sesiones activas. La extensión no tiene una sesión propia que pueda quitar con seguridad; revoca una sesión sin uso en el sitio antes de reintentar.",
+      "sessionActiveLimitCleanup": "New API alcanzó el límite de sesiones activas. La extensión puede revocar únicamente las sesiones que creó y luego reintentar esta acción.",
+      "sessionIssuanceLimit": "New API alcanzó el límite de emisión de sesiones de 24 horas. Quitar sesiones activas no lo restablece; espera a que se recupere el período de emisión.",
       "successChannel": "La verificación de {{label}} se completó correctamente. Se cargó la clave real del canal.",
       "successSettings": "El flujo de inicio de sesión y verificación de New API se completó correctamente. Ahora puedes continuar con acciones que requieren inicio de sesión y verificación.",
       "successToken": "La verificación de {{label}} se completó correctamente. Se actualizó el estado del sitio administrado."
@@ -29,10 +33,12 @@
       "passkey": "Abre el sitio, completa allí la solicitud de passkey, vuelve aquí y reintenta."
     },
     "messages": {
+      "cleaningOwnedSession": "Limpiando las sesiones de New API creadas por la extensión...",
       "completeRequiredConfig": "Primero completa los campos de configuración faltantes.",
       "finishing": "Finalizando la comprobación de sesión de New API...",
       "missingBaseUrl": "Agrega la URL base de New API antes de probar el flujo de sesión.",
       "missingCode": "Primero ingresa el código de verificación.",
+      "ownedSessionCleanupFailed": "No se pudieron quitar todas las sesiones creadas por la extensión. Abre la administración de sesiones del sitio y revoca manualmente las sesiones sin uso.",
       "quickConfigSaveFailed": "No se pudo guardar la configuración rápida. Inténtalo de nuevo.",
       "refreshingChannel": "Cargando la clave real del canal...",
       "refreshingToken": "Actualizando el estado de sitio administrado de este token...",

--- a/src/locales/ja/newApiManagedVerification.json
+++ b/src/locales/ja/newApiManagedVerification.json
@@ -1,6 +1,7 @@
 {
   "dialog": {
     "actions": {
+      "cleanupOwnedSessionAndRetry": "拡張機能のセッションを削除して再試行",
       "close": "閉じる",
       "openSite": "サイトを開く",
       "retry": "再試行",
@@ -16,6 +17,9 @@
       "loginTwoFactor": "ブラウザ依存の管理セッションを続行するには、New API のログイン手順で認証コードが必要です。",
       "passkeyManual": "このアカウントでは現在、保護手順にパスキー認証が表示されます。サイト上でパスキー認証を完了してから、ここに戻って再試行してください。",
       "secureVerification": "管理セッションにはログイン済みですが、非表示のチャネルキーを読み取る前に、New API で追加の認証コードが必要です。",
+      "sessionActiveLimit": "New API のアクティブセッション数が上限に達しました。拡張機能が安全に削除できるセッションはありません。サイトで不要なセッションを取り消してから再試行してください。",
+      "sessionActiveLimitCleanup": "New API のアクティブセッション数が上限に達しました。拡張機能が作成したセッションだけを取り消してから再試行できます。",
+      "sessionIssuanceLimit": "New API の24時間あたりのセッション発行上限に達しました。既存セッションを削除しても解除されないため、制限期間が終わるまでお待ちください。",
       "successChannel": "{{label}} の検証に成功しました。実際のチャネルキーを読み込みました。",
       "successSettings": "New API のログインと検証フローが正常に完了しました。これでログインと検証が必要な操作を続けられます。",
       "successToken": "{{label}} の検証に成功しました。管理対象サイトの状態を更新しました。"
@@ -29,10 +33,12 @@
       "passkey": "サイトを開いてパスキー認証を完了した後、ここに戻って再試行してください。"
     },
     "messages": {
+      "cleaningOwnedSession": "拡張機能が作成した New API セッションを削除しています...",
       "completeRequiredConfig": "不足している設定項目を先に入力してください。",
       "finishing": "New API セッション確認を完了しています...",
       "missingBaseUrl": "セッションフローをテストする前に New API の Base URL を追加してください。",
       "missingCode": "先に認証コードを入力してください。",
+      "ownedSessionCleanupFailed": "拡張機能が作成したセッションを削除できませんでした。サイトのセッション管理を開き、不要なセッションを手動で取り消してください。",
       "quickConfigSaveFailed": "クイック設定の保存に失敗しました。しばらくしてから再試行してください。",
       "refreshingChannel": "実際のチャネルキーを読み込み中...",
       "refreshingToken": "このトークンの管理対象サイト状態を更新中...",

--- a/src/locales/pt-BR/newApiManagedVerification.json
+++ b/src/locales/pt-BR/newApiManagedVerification.json
@@ -1,6 +1,7 @@
 {
   "dialog": {
     "actions": {
+      "cleanupOwnedSessionAndRetry": "Limpar sessões da extensão e tentar novamente",
       "close": "Fechar",
       "openSite": "Abrir site",
       "retry": "Tentar novamente",
@@ -16,6 +17,9 @@
       "loginTwoFactor": "A etapa de login do New API exige um código de verificação para que a sessão administrativa baseada no navegador possa continuar.",
       "passkeyManual": "No momento, esta conta exige verificação por chave de acesso para a etapa segura. Conclua a verificação da chave de acesso no site, volte aqui e tente novamente.",
       "secureVerification": "A sessão administrativa está conectada, mas o New API ainda exige um código de verificação segura para que as chaves ocultas dos canais possam ser lidas.",
+      "sessionActiveLimit": "A New API atingiu o limite de sessões ativas. A extensão não tem uma sessão própria que possa remover com segurança; revogue uma sessão sem uso no site antes de tentar novamente.",
+      "sessionActiveLimitCleanup": "A New API atingiu o limite de sessões ativas. A extensão pode revogar somente as sessões que criou e então tentar novamente.",
+      "sessionIssuanceLimit": "A New API atingiu o limite de emissão de sessões em 24 horas. Remover sessões ativas não redefine esse limite; aguarde a recuperação da janela de emissão.",
       "successChannel": "Verificação de {{label}} concluída. A chave real do canal foi carregada.",
       "successSettings": "O fluxo de login e verificação do New API foi concluído com sucesso. Agora você pode continuar com as ações que exigem login e verificação.",
       "successToken": "Verificação de {{label}} concluída. O status do site gerenciado foi atualizado."
@@ -29,10 +33,12 @@
       "passkey": "Abra o site, conclua a solicitação da chave de acesso, volte aqui e tente novamente."
     },
     "messages": {
+      "cleaningOwnedSession": "Limpando as sessões da New API criadas pela extensão...",
       "completeRequiredConfig": "Preencha primeiro os campos de configuração obrigatórios.",
       "finishing": "Finalizando a verificação da sessão do New API...",
       "missingBaseUrl": "Adicione a URL base do New API antes de testar o fluxo da sessão.",
       "missingCode": "Insira primeiro o código de verificação.",
+      "ownedSessionCleanupFailed": "Não foi possível remover todas as sessões criadas pela extensão. Abra o gerenciamento de sessões do site e revogue manualmente as sessões sem uso.",
       "quickConfigSaveFailed": "Falha ao salvar a configuração rápida. Tente novamente.",
       "refreshingChannel": "Carregando a chave real do canal...",
       "refreshingToken": "Atualizando o status de site gerenciado deste token...",

--- a/src/locales/vi/newApiManagedVerification.json
+++ b/src/locales/vi/newApiManagedVerification.json
@@ -1,6 +1,7 @@
 {
   "dialog": {
     "actions": {
+      "cleanupOwnedSessionAndRetry": "Dọn phiên của tiện ích và thử lại",
       "close": "Đóng",
       "openSite": "Mở trang web",
       "retry": "Thử lại",
@@ -16,6 +17,9 @@
       "loginTwoFactor": "Bước đăng nhập New API yêu cầu gửi mã xác minh trước khi phiên duyệt web có thể tiếp tục.",
       "passkeyManual": "Tài khoản hiện tại sử dụng xác minh Passkey ở bước này. Vui lòng hoàn thành xác minh Passkey trên trang web trước, sau đó quay lại đây và thử lại.",
       "secureVerification": "Phiên quản trị viên đã đăng nhập, nhưng trước khi đọc khóa kênh ẩn, New API vẫn cần xác minh mã bảo mật một lần.",
+      "sessionActiveLimit": "New API đã đạt giới hạn phiên đang hoạt động. Tiện ích không có phiên riêng có thể xóa an toàn; hãy thu hồi một phiên không còn dùng trên trang web rồi thử lại.",
+      "sessionActiveLimitCleanup": "New API đã đạt giới hạn phiên đang hoạt động. Tiện ích chỉ có thể thu hồi phiên do chính nó tạo rồi thử lại thao tác này.",
+      "sessionIssuanceLimit": "New API đã đạt giới hạn cấp phiên trong 24 giờ. Xóa phiên đang hoạt động không đặt lại giới hạn này; hãy chờ cửa sổ cấp phiên phục hồi.",
       "successChannel": "Xác minh cho {{label}} đã thành công và key kênh thực đã được tải.",
       "successSettings": "Quy trình đăng nhập và xác minh New API đã hoàn tất thành công. Bây giờ bạn có thể tiếp tục thực hiện các thao tác liên quan yêu cầu đăng nhập và xác minh.",
       "successToken": "Xác minh cho {{label}} đã thành công và trạng thái trang web quản lý đã được làm mới."
@@ -29,10 +33,12 @@
       "passkey": "Vui lòng mở trang web, hoàn thành lời nhắc Passkey ở đó, sau đó quay lại đây và thử lại."
     },
     "messages": {
+      "cleaningOwnedSession": "Đang dọn phiên New API do tiện ích tạo...",
       "completeRequiredConfig": "Vui lòng hoàn thành các mục cấu hình còn thiếu trước.",
       "finishing": "Đang hoàn tất quá trình phát hiện phiên New API...",
       "missingBaseUrl": "Vui lòng điền URL cơ sở của New API trước khi kiểm tra quy trình phiên.",
       "missingCode": "Vui lòng nhập mã xác minh trước.",
+      "ownedSessionCleanupFailed": "Không thể xóa phiên do tiện ích tạo. Hãy mở phần quản lý phiên trên trang web và thu hồi thủ công một phiên không còn dùng.",
       "quickConfigSaveFailed": "Lưu cấu hình nhanh không thành công, vui lòng thử lại sau.",
       "refreshingChannel": "Đang tải key kênh thực...",
       "refreshingToken": "Đang làm mới trạng thái trang web quản lý cho khóa này...",

--- a/src/locales/zh-CN/newApiManagedVerification.json
+++ b/src/locales/zh-CN/newApiManagedVerification.json
@@ -1,6 +1,7 @@
 {
   "dialog": {
     "actions": {
+      "cleanupOwnedSessionAndRetry": "清理扩展会话并重试",
       "close": "关闭",
       "openSite": "打开站点",
       "retry": "重试",
@@ -16,6 +17,9 @@
       "loginTwoFactor": "New API 登录步骤需要先提交一次验证码，浏览器会话才能继续。",
       "passkeyManual": "当前账号在该步骤使用 Passkey 验证。请先在站点上完成 Passkey 校验，然后返回这里重试。",
       "secureVerification": "管理员会话已经登录，但在读取隐藏渠道密钥之前，New API 仍需要一次安全验证码验证。",
+      "sessionActiveLimit": "New API 的活动会话已达上限。当前没有可由扩展安全清理的会话，请在站点的会话管理中撤销不再使用的会话后重试。",
+      "sessionActiveLimitCleanup": "New API 的活动会话已达上限。扩展可以先精确撤销自己创建的会话，再重试当前操作。",
+      "sessionIssuanceLimit": "New API 已达到 24 小时会话签发上限。清理现有会话不会解除此限制，请等待限制窗口恢复。",
       "successChannel": "{{label}} 的验证已成功，真实渠道 key 已加载。",
       "successSettings": "New API 登录与验证流程已成功完成。现在可以继续执行需要登录与验证的相关操作。",
       "successToken": "{{label}} 的验证已成功，管理站点状态已刷新。"
@@ -29,10 +33,12 @@
       "passkey": "请打开站点，在那里完成 Passkey 提示后，再返回这里重试。"
     },
     "messages": {
+      "cleaningOwnedSession": "正在清理扩展创建的 New API 会话...",
       "completeRequiredConfig": "请先补全当前缺失的配置项。",
       "finishing": "正在完成 New API 会话检测...",
       "missingBaseUrl": "请先填写 New API 基础 URL，再测试会话流程。",
       "missingCode": "请先输入验证码。",
+      "ownedSessionCleanupFailed": "未能清理扩展创建的会话。请打开站点的会话管理，手动撤销不再使用的会话。",
       "quickConfigSaveFailed": "保存快捷配置失败，请稍后重试。",
       "refreshingChannel": "正在加载真实渠道 key...",
       "refreshingToken": "正在刷新该密钥的管理站点状态...",

--- a/src/locales/zh-TW/newApiManagedVerification.json
+++ b/src/locales/zh-TW/newApiManagedVerification.json
@@ -1,6 +1,7 @@
 {
   "dialog": {
     "actions": {
+      "cleanupOwnedSessionAndRetry": "清理擴充功能會話並重試",
       "close": "關閉",
       "openSite": "開啟站點",
       "retry": "重試",
@@ -16,6 +17,9 @@
       "loginTwoFactor": "New API 登入步驟需要先提交一次驗證碼，瀏覽器會話才能繼續。",
       "passkeyManual": "當前帳號在該步驟使用 Passkey 驗證。請先在站點上完成 Passkey 校驗，然後返回這裡重試。",
       "secureVerification": "管理員會話已經登入，但在讀取隱藏渠道金鑰之前，New API 仍需要一次安全驗證碼驗證。",
+      "sessionActiveLimit": "New API 的作用中會話已達上限。目前沒有可由擴充功能安全清理的會話，請在站點的會話管理中撤銷不再使用的會話後重試。",
+      "sessionActiveLimitCleanup": "New API 的作用中會話已達上限。擴充功能可以先精確撤銷自己建立的會話，再重試目前操作。",
+      "sessionIssuanceLimit": "New API 已達到 24 小時會話簽發上限。清理現有會話不會解除此限制，請等待限制視窗恢復。",
       "successChannel": "{{label}} 的驗證已成功，真實渠道 key 已載入。",
       "successSettings": "New API 登入與驗證流程已成功完成。現在可以繼續執行需要登入與驗證的相關操作。",
       "successToken": "{{label}} 的驗證已成功，管理站點狀態已重新整理。"
@@ -29,10 +33,12 @@
       "passkey": "請開啟站點，在那裡完成 Passkey 提示後，再返回這裡重試。"
     },
     "messages": {
+      "cleaningOwnedSession": "正在清理擴充功能建立的 New API 會話...",
       "completeRequiredConfig": "請先補齊目前缺失的設定項目。",
       "finishing": "正在完成 New API 會話檢測...",
       "missingBaseUrl": "請先填寫 New API 基礎 URL，再測試會話流程。",
       "missingCode": "請先輸入驗證碼。",
+      "ownedSessionCleanupFailed": "無法清理擴充功能建立的會話。請開啟站點的會話管理並手動撤銷不再使用的會話。",
       "quickConfigSaveFailed": "儲存快捷設定失敗，請稍後再試。",
       "refreshingChannel": "正在載入真實渠道 key...",
       "refreshingToken": "正在重新整理該金鑰的管理站點狀態...",

--- a/src/services/apiTransport/request.ts
+++ b/src/services/apiTransport/request.ts
@@ -188,6 +188,7 @@ function extractBackendErrorDetails(body: unknown): BackendErrorDetails | null {
       isBackendError: Boolean(
         (body as { success?: unknown }).success === false || isBusinessEnvelope,
       ),
+      upstreamCode: getSafeUpstreamCode(code),
     }
   }
 

--- a/src/services/managedSites/newApiOwnedSession/background.ts
+++ b/src/services/managedSites/newApiOwnedSession/background.ts
@@ -64,7 +64,6 @@ export async function revokeNewApiOwnedSession(
         tempWindowFallback: { statusCodes: [], codes: [] },
         options: {
           method: "DELETE",
-          headers: { Origin: receipt.origin },
         },
       },
     )

--- a/src/services/managedSites/newApiOwnedSession/background.ts
+++ b/src/services/managedSites/newApiOwnedSession/background.ts
@@ -1,0 +1,132 @@
+import { fetchApiResponse } from "~/services/apiTransport/request"
+import { AuthTypeEnum } from "~/types"
+import {
+  clearAlarm,
+  createAlarm,
+  getSessionStorageValues,
+  hasSessionStorageArea,
+  onAlarm,
+  setSessionStorageValues,
+} from "~/utils/browser/browserApi"
+import { createLogger } from "~/utils/core/logger"
+
+import {
+  NEW_API_OWNED_SESSION_ACTIONS,
+  type NewApiOwnedSessionRequest,
+  type NewApiOwnedSessionResponse,
+} from "./contracts"
+import {
+  createNewApiOwnedSessionLifecycle,
+  type NewApiOwnedSessionReceipt,
+} from "./lifecycle"
+
+const logger = createLogger("NewApiOwnedSessionBackground")
+const STORAGE_KEY = "new_api_owned_session_receipts_v1"
+let memoryFallback: unknown
+
+/** Reads the ephemeral registry with an in-memory compatibility fallback. */
+async function readStoredReceipts() {
+  if (!hasSessionStorageArea()) return memoryFallback
+  const result = await getSessionStorageValues(STORAGE_KEY)
+  return result?.[STORAGE_KEY]
+}
+
+/** Writes the ephemeral registry without falling back to disk storage. */
+async function writeStoredReceipts(value: unknown) {
+  if (!(await setSessionStorageValues({ [STORAGE_KEY]: value }))) {
+    memoryFallback = value
+  }
+}
+
+/**
+ * Revokes only the SID recorded from the extension's own fresh login; it never
+ * calls the upstream revoke-others operation.
+ * https://github.com/QuantumNous/new-api/blob/v1.0.0-rc.22/docs/authentication.md
+ */
+export async function revokeNewApiOwnedSession(
+  receipt: NewApiOwnedSessionReceipt,
+) {
+  const endpoint = `/api/user/sessions/${encodeURIComponent(receipt.sessionId)}`
+  try {
+    const response = await fetchApiResponse<string>(
+      {
+        baseUrl: receipt.origin,
+        accountId: `managed-site:new-api-owned-session:${receipt.origin}`,
+        auth: {
+          authType: AuthTypeEnum.AccessToken,
+          accessToken: receipt.accessToken,
+        },
+      },
+      {
+        endpoint,
+        responseType: "text",
+        currentTabTransport: "disabled",
+        tempWindowFallback: { statusCodes: [], codes: [] },
+        options: {
+          method: "DELETE",
+          headers: { Origin: receipt.origin },
+        },
+      },
+    )
+
+    if (response.ok || response.status === 404) {
+      return { status: "cleaned" as const }
+    }
+    if (response.status === 401) {
+      return { status: "unavailable" as const }
+    }
+    return { status: "retry" as const }
+  } catch (error) {
+    logger.warn("Exact New API owned-session cleanup failed", {
+      status: "transport-error",
+      error,
+    })
+    return { status: "retry" as const }
+  }
+}
+
+export const newApiOwnedSessionLifecycle = createNewApiOwnedSessionLifecycle({
+  now: () => Date.now(),
+  readStoredReceipts,
+  writeStoredReceipts,
+  createAlarm: async (name, info) => await createAlarm(name, info),
+  clearAlarm,
+  onAlarm,
+  reportError: (error) =>
+    logger.warn("New API owned-session alarm cleanup failed", { error }),
+  revokeSession: revokeNewApiOwnedSession,
+})
+
+/** Executes the validated runtime command behind the background-owned seam. */
+export async function handleNewApiOwnedSessionRequest(
+  request: NewApiOwnedSessionRequest,
+): Promise<NewApiOwnedSessionResponse> {
+  switch (request.action) {
+    case NEW_API_OWNED_SESSION_ACTIONS.Capture:
+      await newApiOwnedSessionLifecycle.capture(request.bundle)
+      return { success: true }
+    case NEW_API_OWNED_SESSION_ACTIONS.Refresh:
+      return {
+        success: true,
+        ...(await newApiOwnedSessionLifecycle.refresh(request.bundle)),
+      }
+    case NEW_API_OWNED_SESSION_ACTIONS.Touch:
+      return {
+        success: true,
+        ...(await newApiOwnedSessionLifecycle.touch(
+          request.baseUrl,
+          request.sessionId,
+        )),
+      }
+    case NEW_API_OWNED_SESSION_ACTIONS.GetStatus:
+      return {
+        success: true,
+        ...(await newApiOwnedSessionLifecycle.getStatus(request.baseUrl)),
+      }
+    case NEW_API_OWNED_SESSION_ACTIONS.Cleanup:
+      return {
+        success: true,
+        ...(await newApiOwnedSessionLifecycle.cleanup(request.baseUrl)),
+      }
+  }
+}

--- a/src/services/managedSites/newApiOwnedSession/client.ts
+++ b/src/services/managedSites/newApiOwnedSession/client.ts
@@ -3,9 +3,9 @@ import { createLogger } from "~/utils/core/logger"
 
 import {
   NEW_API_OWNED_SESSION_ACTIONS,
+  type NewApiOwnedSessionBundle,
   type NewApiOwnedSessionResponse,
 } from "./contracts"
-import type { NewApiOwnedSessionBundle } from "./lifecycle"
 
 const logger = createLogger("NewApiOwnedSessionClient")
 

--- a/src/services/managedSites/newApiOwnedSession/client.ts
+++ b/src/services/managedSites/newApiOwnedSession/client.ts
@@ -1,0 +1,61 @@
+import { sendRuntimeMessage } from "~/utils/browser/browserApi"
+import { createLogger } from "~/utils/core/logger"
+
+import {
+  NEW_API_OWNED_SESSION_ACTIONS,
+  type NewApiOwnedSessionResponse,
+} from "./contracts"
+import type { NewApiOwnedSessionBundle } from "./lifecycle"
+
+const logger = createLogger("NewApiOwnedSessionClient")
+
+/** Sends one non-retrying ownership command without breaking the caller. */
+async function sendBestEffort(message: unknown) {
+  try {
+    return await sendRuntimeMessage<NewApiOwnedSessionResponse>(message, {
+      maxAttempts: 1,
+    })
+  } catch (error) {
+    logger.warn("New API owned-session background request failed", { error })
+    return { success: false } as const
+  }
+}
+
+export const captureNewApiOwnedSession = (bundle: NewApiOwnedSessionBundle) =>
+  sendBestEffort({
+    action: NEW_API_OWNED_SESSION_ACTIONS.Capture,
+    bundle,
+  })
+
+export const refreshNewApiOwnedSession = (bundle: NewApiOwnedSessionBundle) =>
+  sendBestEffort({
+    action: NEW_API_OWNED_SESSION_ACTIONS.Refresh,
+    bundle,
+  })
+
+export const touchNewApiOwnedSession = (baseUrl: string, sessionId?: string) =>
+  sendBestEffort({
+    action: NEW_API_OWNED_SESSION_ACTIONS.Touch,
+    baseUrl,
+    sessionId,
+  })
+
+/** Reports whether the background registry owns a session for an origin. */
+export async function getNewApiOwnedSessionStatus(baseUrl: string) {
+  const response = await sendBestEffort({
+    action: NEW_API_OWNED_SESSION_ACTIONS.GetStatus,
+    baseUrl,
+  })
+  return { owned: response.success && response.owned === true }
+}
+
+/** Requests exact cleanup of every extension-owned SID for an origin. */
+export async function cleanupNewApiOwnedSession(baseUrl: string) {
+  const response = await sendBestEffort({
+    action: NEW_API_OWNED_SESSION_ACTIONS.Cleanup,
+    baseUrl,
+  })
+  return response.success
+    ? { status: response.status ?? ("failed" as const) }
+    : { status: "failed" as const }
+}

--- a/src/services/managedSites/newApiOwnedSession/client.ts
+++ b/src/services/managedSites/newApiOwnedSession/client.ts
@@ -12,9 +12,13 @@ const logger = createLogger("NewApiOwnedSessionClient")
 /** Sends one non-retrying ownership command without breaking the caller. */
 async function sendBestEffort(message: unknown) {
   try {
-    return await sendRuntimeMessage<NewApiOwnedSessionResponse>(message, {
-      maxAttempts: 1,
-    })
+    const response = await sendRuntimeMessage<NewApiOwnedSessionResponse>(
+      message,
+      {
+        maxAttempts: 1,
+      },
+    )
+    return response ?? ({ success: false } as const)
   } catch (error) {
     logger.warn("New API owned-session background request failed", { error })
     return { success: false } as const

--- a/src/services/managedSites/newApiOwnedSession/contracts.ts
+++ b/src/services/managedSites/newApiOwnedSession/contracts.ts
@@ -1,0 +1,63 @@
+import type { NewApiOwnedSessionBundle } from "./lifecycle"
+
+export const NEW_API_OWNED_SESSION_ACTIONS = {
+  Capture: "new-api-owned-session:capture",
+  Refresh: "new-api-owned-session:refresh",
+  Touch: "new-api-owned-session:touch",
+  GetStatus: "new-api-owned-session:get-status",
+  Cleanup: "new-api-owned-session:cleanup",
+} as const
+
+export type NewApiOwnedSessionRequest =
+  | {
+      action: typeof NEW_API_OWNED_SESSION_ACTIONS.Capture
+      bundle: NewApiOwnedSessionBundle
+    }
+  | {
+      action: typeof NEW_API_OWNED_SESSION_ACTIONS.Refresh
+      bundle: NewApiOwnedSessionBundle
+    }
+  | {
+      action: typeof NEW_API_OWNED_SESSION_ACTIONS.Touch
+      baseUrl: string
+      sessionId?: string
+    }
+  | {
+      action:
+        | typeof NEW_API_OWNED_SESSION_ACTIONS.GetStatus
+        | typeof NEW_API_OWNED_SESSION_ACTIONS.Cleanup
+      baseUrl: string
+    }
+
+export type NewApiOwnedSessionResponse =
+  | { success: true; owned?: boolean; status?: "cleaned" | "none" | "failed" }
+  | { success: false }
+
+export const isNewApiOwnedSessionRequest = (
+  value: unknown,
+): value is NewApiOwnedSessionRequest => {
+  if (!value || typeof value !== "object") return false
+  const request = value as Record<string, unknown>
+
+  if (
+    request.action === NEW_API_OWNED_SESSION_ACTIONS.Capture ||
+    request.action === NEW_API_OWNED_SESSION_ACTIONS.Refresh
+  ) {
+    return Boolean(request.bundle && typeof request.bundle === "object")
+  }
+
+  if (
+    request.action === NEW_API_OWNED_SESSION_ACTIONS.Touch &&
+    request.sessionId !== undefined &&
+    typeof request.sessionId !== "string"
+  ) {
+    return false
+  }
+
+  return (
+    (request.action === NEW_API_OWNED_SESSION_ACTIONS.Touch ||
+      request.action === NEW_API_OWNED_SESSION_ACTIONS.GetStatus ||
+      request.action === NEW_API_OWNED_SESSION_ACTIONS.Cleanup) &&
+    typeof request.baseUrl === "string"
+  )
+}

--- a/src/services/managedSites/newApiOwnedSession/contracts.ts
+++ b/src/services/managedSites/newApiOwnedSession/contracts.ts
@@ -33,6 +33,19 @@ export type NewApiOwnedSessionResponse =
   | { success: true; owned?: boolean; status?: "cleaned" | "none" | "failed" }
   | { success: false }
 
+const isNewApiOwnedSessionBundle = (
+  value: unknown,
+): value is NewApiOwnedSessionBundle => {
+  if (!value || typeof value !== "object") return false
+  const bundle = value as Record<string, unknown>
+  return (
+    typeof bundle.baseUrl === "string" &&
+    typeof bundle.sessionId === "string" &&
+    typeof bundle.accessToken === "string" &&
+    typeof bundle.accessExpiresAt === "number"
+  )
+}
+
 export const isNewApiOwnedSessionRequest = (
   value: unknown,
 ): value is NewApiOwnedSessionRequest => {
@@ -43,7 +56,7 @@ export const isNewApiOwnedSessionRequest = (
     request.action === NEW_API_OWNED_SESSION_ACTIONS.Capture ||
     request.action === NEW_API_OWNED_SESSION_ACTIONS.Refresh
   ) {
-    return Boolean(request.bundle && typeof request.bundle === "object")
+    return isNewApiOwnedSessionBundle(request.bundle)
   }
 
   if (

--- a/src/services/managedSites/newApiOwnedSession/contracts.ts
+++ b/src/services/managedSites/newApiOwnedSession/contracts.ts
@@ -1,4 +1,12 @@
-import type { NewApiOwnedSessionBundle } from "./lifecycle"
+import { normalizeUrlForOriginKey } from "~/utils/core/urlParsing"
+
+export interface NewApiOwnedSessionBundle {
+  baseUrl: string
+  sessionId: string
+  accessToken: string
+  /** Epoch seconds, matching New API's AuthBundle response. */
+  accessExpiresAt: number
+}
 
 export const NEW_API_OWNED_SESSION_ACTIONS = {
   Capture: "new-api-owned-session:capture",
@@ -33,44 +41,91 @@ export type NewApiOwnedSessionResponse =
   | { success: true; owned?: boolean; status?: "cleaned" | "none" | "failed" }
   | { success: false }
 
-const isNewApiOwnedSessionBundle = (
-  value: unknown,
-): value is NewApiOwnedSessionBundle => {
-  if (!value || typeof value !== "object") return false
-  const bundle = value as Record<string, unknown>
-  return (
-    typeof bundle.baseUrl === "string" &&
-    typeof bundle.sessionId === "string" &&
-    typeof bundle.accessToken === "string" &&
-    typeof bundle.accessExpiresAt === "number"
-  )
+export const normalizeNewApiOwnedSessionOrigin = (value: unknown) => {
+  if (typeof value !== "string" || !value.trim()) return null
+  const normalized = normalizeUrlForOriginKey(value, {
+    stripTrailingSlashes: true,
+  })
+  if (!normalized) return null
+
+  try {
+    const url = new URL(normalized)
+    return url.protocol === "http:" || url.protocol === "https:"
+      ? url.origin
+      : null
+  } catch {
+    return null
+  }
 }
 
-export const isNewApiOwnedSessionRequest = (
+const normalizeNonBlankString = (value: unknown) => {
+  if (typeof value !== "string") return null
+  const normalized = value.trim()
+  return normalized || null
+}
+
+export const normalizeNewApiOwnedSessionBundle = (
   value: unknown,
-): value is NewApiOwnedSessionRequest => {
-  if (!value || typeof value !== "object") return false
+): NewApiOwnedSessionBundle | null => {
+  if (!value || typeof value !== "object") return null
+  const bundle = value as Record<string, unknown>
+  const baseUrl = normalizeNewApiOwnedSessionOrigin(bundle.baseUrl)
+  const sessionId = normalizeNonBlankString(bundle.sessionId)
+  const accessToken = normalizeNonBlankString(bundle.accessToken)
+  if (
+    !baseUrl ||
+    !sessionId ||
+    !accessToken ||
+    typeof bundle.accessExpiresAt !== "number" ||
+    !Number.isFinite(bundle.accessExpiresAt)
+  ) {
+    return null
+  }
+
+  return {
+    baseUrl,
+    sessionId,
+    accessToken,
+    accessExpiresAt: bundle.accessExpiresAt,
+  }
+}
+
+export const parseNewApiOwnedSessionRequest = (
+  value: unknown,
+): NewApiOwnedSessionRequest | null => {
+  if (!value || typeof value !== "object") return null
   const request = value as Record<string, unknown>
 
   if (
     request.action === NEW_API_OWNED_SESSION_ACTIONS.Capture ||
     request.action === NEW_API_OWNED_SESSION_ACTIONS.Refresh
   ) {
-    return isNewApiOwnedSessionBundle(request.bundle)
+    const bundle = normalizeNewApiOwnedSessionBundle(request.bundle)
+    return bundle ? { action: request.action, bundle } : null
+  }
+
+  const baseUrl = normalizeNewApiOwnedSessionOrigin(request.baseUrl)
+  if (!baseUrl) return null
+
+  if (request.action === NEW_API_OWNED_SESSION_ACTIONS.Touch) {
+    if (request.sessionId === undefined) {
+      return { action: request.action, baseUrl }
+    }
+    const sessionId = normalizeNonBlankString(request.sessionId)
+    return sessionId ? { action: request.action, baseUrl, sessionId } : null
   }
 
   if (
-    request.action === NEW_API_OWNED_SESSION_ACTIONS.Touch &&
-    request.sessionId !== undefined &&
-    typeof request.sessionId !== "string"
+    request.action === NEW_API_OWNED_SESSION_ACTIONS.GetStatus ||
+    request.action === NEW_API_OWNED_SESSION_ACTIONS.Cleanup
   ) {
-    return false
+    return { action: request.action, baseUrl }
   }
 
-  return (
-    (request.action === NEW_API_OWNED_SESSION_ACTIONS.Touch ||
-      request.action === NEW_API_OWNED_SESSION_ACTIONS.GetStatus ||
-      request.action === NEW_API_OWNED_SESSION_ACTIONS.Cleanup) &&
-    typeof request.baseUrl === "string"
-  )
+  return null
 }
+
+export const isNewApiOwnedSessionRequest = (
+  value: unknown,
+): value is NewApiOwnedSessionRequest =>
+  parseNewApiOwnedSessionRequest(value) !== null

--- a/src/services/managedSites/newApiOwnedSession/lifecycle.ts
+++ b/src/services/managedSites/newApiOwnedSession/lifecycle.ts
@@ -1,4 +1,8 @@
-import { normalizeUrlForOriginKey } from "~/utils/core/urlParsing"
+import {
+  normalizeNewApiOwnedSessionBundle,
+  normalizeNewApiOwnedSessionOrigin,
+  type NewApiOwnedSessionBundle,
+} from "./contracts"
 
 export const NEW_API_OWNED_SESSION_ALARM_NAME = "new-api-owned-session-cleanup"
 
@@ -6,14 +10,6 @@ const RECEIPT_VERSION = 1 as const
 const IDLE_CLEANUP_DELAY_MS = 10 * 60 * 1000
 const CLEANUP_EXPIRY_SAFETY_MS = 30 * 1000
 const CLEANUP_RETRY_DELAY_MS = 60 * 1000
-
-export interface NewApiOwnedSessionBundle {
-  baseUrl: string
-  sessionId: string
-  accessToken: string
-  /** Epoch seconds, matching New API's AuthBundle response. */
-  accessExpiresAt: number
-}
 
 export interface NewApiOwnedSessionReceipt {
   version: typeof RECEIPT_VERSION
@@ -43,43 +39,6 @@ export interface NewApiOwnedSessionLifecycleDependencies {
   revokeSession: (
     receipt: NewApiOwnedSessionReceipt,
   ) => Promise<{ status: "cleaned" | "retry" | "unavailable" }>
-}
-
-const normalizeOrigin = (baseUrl: string) => {
-  const normalized = normalizeUrlForOriginKey(baseUrl, {
-    stripTrailingSlashes: true,
-  })
-  if (!normalized) return null
-
-  try {
-    const url = new URL(normalized)
-    return url.protocol === "http:" || url.protocol === "https:"
-      ? url.origin
-      : null
-  } catch {
-    return null
-  }
-}
-
-const normalizeBundle = (bundle: NewApiOwnedSessionBundle) => {
-  const origin = normalizeOrigin(bundle.baseUrl)
-  const sessionId = bundle.sessionId.trim()
-  const accessToken = bundle.accessToken.trim()
-  if (
-    !origin ||
-    !sessionId ||
-    !accessToken ||
-    !Number.isFinite(bundle.accessExpiresAt)
-  ) {
-    return null
-  }
-
-  return {
-    origin,
-    sessionId,
-    accessToken,
-    accessExpiresAt: bundle.accessExpiresAt,
-  }
 }
 
 const getReceiptKey = (origin: string, sessionId: string) =>
@@ -245,16 +204,16 @@ export function createNewApiOwnedSessionLifecycle(
 
     capture(bundle: NewApiOwnedSessionBundle) {
       return exclusively(async () => {
-        const normalized = normalizeBundle(bundle)
+        const normalized = normalizeNewApiOwnedSessionBundle(bundle)
         if (!normalized) return
 
         const now = dependencies.now()
         const stored = await read()
         stored.receipts[
-          getReceiptKey(normalized.origin, normalized.sessionId)
+          getReceiptKey(normalized.baseUrl, normalized.sessionId)
         ] = {
           version: RECEIPT_VERSION,
-          origin: normalized.origin,
+          origin: normalized.baseUrl,
           sessionId: normalized.sessionId,
           accessToken: normalized.accessToken,
           accessExpiresAt: normalized.accessExpiresAt,
@@ -267,12 +226,12 @@ export function createNewApiOwnedSessionLifecycle(
 
     refresh(bundle: NewApiOwnedSessionBundle) {
       return exclusively(async () => {
-        const normalized = normalizeBundle(bundle)
+        const normalized = normalizeNewApiOwnedSessionBundle(bundle)
         if (!normalized) return { owned: false }
 
         const stored = await read()
         const receiptKey = getReceiptKey(
-          normalized.origin,
+          normalized.baseUrl,
           normalized.sessionId,
         )
         const receipt = stored.receipts[receiptKey]
@@ -295,7 +254,7 @@ export function createNewApiOwnedSessionLifecycle(
 
     touch(baseUrl: string, sessionId?: string) {
       return exclusively(async () => {
-        const origin = normalizeOrigin(baseUrl)
+        const origin = normalizeNewApiOwnedSessionOrigin(baseUrl)
         if (!origin) return { owned: false }
         const stored = await read()
         const entries = getReceiptEntriesForOrigin(stored, origin).filter(
@@ -318,7 +277,7 @@ export function createNewApiOwnedSessionLifecycle(
 
     getStatus(baseUrl: string) {
       return exclusively(async () => {
-        const origin = normalizeOrigin(baseUrl)
+        const origin = normalizeNewApiOwnedSessionOrigin(baseUrl)
         if (!origin) return { owned: false }
         const stored = await read()
         return {
@@ -329,7 +288,7 @@ export function createNewApiOwnedSessionLifecycle(
 
     cleanup(baseUrl: string) {
       return exclusively(async () => {
-        const origin = normalizeOrigin(baseUrl)
+        const origin = normalizeNewApiOwnedSessionOrigin(baseUrl)
         if (!origin) return { status: "none" as const }
         const stored = await read()
         const entries = getReceiptEntriesForOrigin(stored, origin)

--- a/src/services/managedSites/newApiOwnedSession/lifecycle.ts
+++ b/src/services/managedSites/newApiOwnedSession/lifecycle.ts
@@ -1,0 +1,341 @@
+import { normalizeUrlForOriginKey } from "~/utils/core/urlParsing"
+
+export const NEW_API_OWNED_SESSION_ALARM_NAME = "new-api-owned-session-cleanup"
+
+const RECEIPT_VERSION = 1 as const
+const IDLE_CLEANUP_DELAY_MS = 10 * 60 * 1000
+const CLEANUP_EXPIRY_SAFETY_MS = 30 * 1000
+const CLEANUP_RETRY_DELAY_MS = 60 * 1000
+
+export interface NewApiOwnedSessionBundle {
+  baseUrl: string
+  sessionId: string
+  accessToken: string
+  /** Epoch seconds, matching New API's AuthBundle response. */
+  accessExpiresAt: number
+}
+
+export interface NewApiOwnedSessionReceipt {
+  version: typeof RECEIPT_VERSION
+  origin: string
+  sessionId: string
+  accessToken: string
+  accessExpiresAt: number
+  lastUsedAt: number
+  cleanupAt: number
+}
+
+interface StoredReceipts {
+  version: typeof RECEIPT_VERSION
+  receipts: Record<string, NewApiOwnedSessionReceipt>
+}
+
+export interface NewApiOwnedSessionLifecycleDependencies {
+  now: () => number
+  readStoredReceipts: () => Promise<unknown>
+  writeStoredReceipts: (value: StoredReceipts) => Promise<void>
+  createAlarm: (name: string, alarmInfo: { when: number }) => Promise<void>
+  clearAlarm: (name: string) => Promise<boolean>
+  onAlarm: (
+    listener: (alarm: { name: string }) => void | Promise<void>,
+  ) => () => void
+  reportError: (error: unknown) => void
+  revokeSession: (
+    receipt: NewApiOwnedSessionReceipt,
+  ) => Promise<{ status: "cleaned" | "retry" | "unavailable" }>
+}
+
+const normalizeOrigin = (baseUrl: string) => {
+  const normalized = normalizeUrlForOriginKey(baseUrl, {
+    stripTrailingSlashes: true,
+  })
+  if (!normalized) return null
+
+  try {
+    const url = new URL(normalized)
+    return url.protocol === "http:" || url.protocol === "https:"
+      ? url.origin
+      : null
+  } catch {
+    return null
+  }
+}
+
+const normalizeBundle = (bundle: NewApiOwnedSessionBundle) => {
+  const origin = normalizeOrigin(bundle.baseUrl)
+  const sessionId = bundle.sessionId.trim()
+  const accessToken = bundle.accessToken.trim()
+  if (
+    !origin ||
+    !sessionId ||
+    !accessToken ||
+    !Number.isFinite(bundle.accessExpiresAt)
+  ) {
+    return null
+  }
+
+  return {
+    origin,
+    sessionId,
+    accessToken,
+    accessExpiresAt: bundle.accessExpiresAt,
+  }
+}
+
+const getReceiptKey = (origin: string, sessionId: string) =>
+  `${origin}\n${sessionId}`
+
+const isReceipt = (value: unknown): value is NewApiOwnedSessionReceipt => {
+  if (!value || typeof value !== "object") return false
+  const receipt = value as Partial<NewApiOwnedSessionReceipt>
+  return (
+    receipt.version === RECEIPT_VERSION &&
+    typeof receipt.origin === "string" &&
+    typeof receipt.sessionId === "string" &&
+    typeof receipt.accessToken === "string" &&
+    typeof receipt.accessExpiresAt === "number" &&
+    typeof receipt.lastUsedAt === "number" &&
+    typeof receipt.cleanupAt === "number"
+  )
+}
+
+const parseStoredReceipts = (value: unknown): StoredReceipts => {
+  if (!value || typeof value !== "object") {
+    return { version: RECEIPT_VERSION, receipts: {} }
+  }
+
+  const candidate = value as Partial<StoredReceipts>
+  if (
+    candidate.version !== RECEIPT_VERSION ||
+    !candidate.receipts ||
+    typeof candidate.receipts !== "object"
+  ) {
+    return { version: RECEIPT_VERSION, receipts: {} }
+  }
+
+  const receipts = Object.fromEntries(
+    Object.entries(candidate.receipts).filter(
+      ([receiptKey, receipt]) =>
+        isReceipt(receipt) &&
+        getReceiptKey(receipt.origin, receipt.sessionId) === receiptKey,
+    ),
+  )
+  return { version: RECEIPT_VERSION, receipts }
+}
+
+const getCleanupAt = (now: number, accessExpiresAt: number) =>
+  Math.min(
+    now + IDLE_CLEANUP_DELAY_MS,
+    accessExpiresAt * 1000 - CLEANUP_EXPIRY_SAFETY_MS,
+  )
+
+const getReceiptEntriesForOrigin = (stored: StoredReceipts, origin: string) =>
+  Object.entries(stored.receipts).filter(
+    ([, receipt]) => receipt.origin === origin,
+  )
+
+/**
+ * Owns only sessions explicitly captured from a fresh credential login. The
+ * persisted receipt lives in browser.storage.session, which Chrome documents
+ * as memory-only and cleared when the browser stops.
+ * https://developer.chrome.com/docs/extensions/reference/api/storage#storage-areas
+ */
+export function createNewApiOwnedSessionLifecycle(
+  dependencies: NewApiOwnedSessionLifecycleDependencies,
+) {
+  let operation = Promise.resolve()
+  let initialized = false
+
+  const exclusively = async <T>(task: () => Promise<T>): Promise<T> => {
+    const previous = operation
+    let release: () => void = () => {}
+    operation = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    await previous
+    try {
+      return await task()
+    } finally {
+      release()
+    }
+  }
+
+  const read = async () =>
+    parseStoredReceipts(await dependencies.readStoredReceipts())
+
+  const schedule = async (stored: StoredReceipts) => {
+    const cleanupTimes = Object.values(stored.receipts).map(
+      (receipt) => receipt.cleanupAt,
+    )
+    if (cleanupTimes.length === 0) {
+      await dependencies.clearAlarm(NEW_API_OWNED_SESSION_ALARM_NAME)
+      return
+    }
+
+    await dependencies.createAlarm(NEW_API_OWNED_SESSION_ALARM_NAME, {
+      when: Math.max(dependencies.now(), Math.min(...cleanupTimes)),
+    })
+  }
+
+  const persistAndSchedule = async (stored: StoredReceipts) => {
+    await dependencies.writeStoredReceipts(stored)
+    await schedule(stored)
+  }
+
+  const cleanupReceipt = async (
+    stored: StoredReceipts,
+    receiptKey: string,
+  ): Promise<"cleaned" | "failed"> => {
+    const receipt = stored.receipts[receiptKey]
+    if (!receipt) return "cleaned"
+
+    const result = await dependencies.revokeSession(receipt)
+    if (result.status === "cleaned" || result.status === "unavailable") {
+      delete stored.receipts[receiptKey]
+      return result.status === "cleaned" ? "cleaned" : "failed"
+    }
+
+    const retryAt = dependencies.now() + CLEANUP_RETRY_DELAY_MS
+    if (retryAt >= receipt.accessExpiresAt * 1000) {
+      delete stored.receipts[receiptKey]
+      return "failed"
+    }
+
+    stored.receipts[receiptKey] = { ...receipt, cleanupAt: retryAt }
+    return "failed"
+  }
+
+  const cleanupDue = async () =>
+    exclusively(async () => {
+      const stored = await read()
+      const now = dependencies.now()
+      for (const [receiptKey, receipt] of Object.entries(stored.receipts)) {
+        if (receipt.cleanupAt <= now) {
+          await cleanupReceipt(stored, receiptKey)
+        }
+      }
+      await persistAndSchedule(stored)
+    })
+
+  return {
+    initialize() {
+      if (!initialized) {
+        initialized = true
+        // Register synchronously so an MV3 worker cannot miss the wake event
+        // while storage reconciliation is awaiting its first promise.
+        dependencies.onAlarm((alarm) => {
+          if (alarm.name === NEW_API_OWNED_SESSION_ALARM_NAME) {
+            void cleanupDue().catch(dependencies.reportError)
+          }
+        })
+      }
+
+      return exclusively(async () => {
+        await schedule(await read())
+      })
+    },
+
+    capture(bundle: NewApiOwnedSessionBundle) {
+      return exclusively(async () => {
+        const normalized = normalizeBundle(bundle)
+        if (!normalized) return
+
+        const now = dependencies.now()
+        const stored = await read()
+        stored.receipts[
+          getReceiptKey(normalized.origin, normalized.sessionId)
+        ] = {
+          version: RECEIPT_VERSION,
+          origin: normalized.origin,
+          sessionId: normalized.sessionId,
+          accessToken: normalized.accessToken,
+          accessExpiresAt: normalized.accessExpiresAt,
+          lastUsedAt: now,
+          cleanupAt: getCleanupAt(now, normalized.accessExpiresAt),
+        }
+        await persistAndSchedule(stored)
+      })
+    },
+
+    refresh(bundle: NewApiOwnedSessionBundle) {
+      return exclusively(async () => {
+        const normalized = normalizeBundle(bundle)
+        if (!normalized) return { owned: false }
+
+        const stored = await read()
+        const receiptKey = getReceiptKey(
+          normalized.origin,
+          normalized.sessionId,
+        )
+        const receipt = stored.receipts[receiptKey]
+        if (!receipt) {
+          return { owned: false }
+        }
+
+        const now = dependencies.now()
+        stored.receipts[receiptKey] = {
+          ...receipt,
+          accessToken: normalized.accessToken,
+          accessExpiresAt: normalized.accessExpiresAt,
+          lastUsedAt: now,
+          cleanupAt: getCleanupAt(now, normalized.accessExpiresAt),
+        }
+        await persistAndSchedule(stored)
+        return { owned: true }
+      })
+    },
+
+    touch(baseUrl: string, sessionId?: string) {
+      return exclusively(async () => {
+        const origin = normalizeOrigin(baseUrl)
+        if (!origin) return { owned: false }
+        const stored = await read()
+        const entries = getReceiptEntriesForOrigin(stored, origin).filter(
+          ([, receipt]) => !sessionId || receipt.sessionId === sessionId,
+        )
+        if (entries.length === 0) return { owned: false }
+
+        const now = dependencies.now()
+        for (const [receiptKey, receipt] of entries) {
+          stored.receipts[receiptKey] = {
+            ...receipt,
+            lastUsedAt: now,
+            cleanupAt: getCleanupAt(now, receipt.accessExpiresAt),
+          }
+        }
+        await persistAndSchedule(stored)
+        return { owned: true }
+      })
+    },
+
+    getStatus(baseUrl: string) {
+      return exclusively(async () => {
+        const origin = normalizeOrigin(baseUrl)
+        if (!origin) return { owned: false }
+        const stored = await read()
+        return {
+          owned: getReceiptEntriesForOrigin(stored, origin).length > 0,
+        }
+      })
+    },
+
+    cleanup(baseUrl: string) {
+      return exclusively(async () => {
+        const origin = normalizeOrigin(baseUrl)
+        if (!origin) return { status: "none" as const }
+        const stored = await read()
+        const entries = getReceiptEntriesForOrigin(stored, origin)
+        if (entries.length === 0) return { status: "none" as const }
+
+        let status: "cleaned" | "failed" = "cleaned"
+        for (const [receiptKey] of entries) {
+          if ((await cleanupReceipt(stored, receiptKey)) === "failed") {
+            status = "failed"
+          }
+        }
+        await persistAndSchedule(stored)
+        return { status }
+      })
+    },
+  }
+}

--- a/src/services/managedSites/newApiOwnedSession/lifecycle.ts
+++ b/src/services/managedSites/newApiOwnedSession/lifecycle.ts
@@ -189,7 +189,15 @@ export function createNewApiOwnedSessionLifecycle(
     const receipt = stored.receipts[receiptKey]
     if (!receipt) return "cleaned"
 
-    const result = await dependencies.revokeSession(receipt)
+    let result: Awaited<
+      ReturnType<NewApiOwnedSessionLifecycleDependencies["revokeSession"]>
+    >
+    try {
+      result = await dependencies.revokeSession(receipt)
+    } catch (error) {
+      dependencies.reportError(error)
+      result = { status: "retry" }
+    }
     if (result.status === "cleaned" || result.status === "unavailable") {
       delete stored.receipts[receiptKey]
       return result.status === "cleaned" ? "cleaned" : "failed"

--- a/src/services/managedSites/providers/newApiSession.ts
+++ b/src/services/managedSites/providers/newApiSession.ts
@@ -12,6 +12,13 @@ import {
 } from "~/services/apiTransport/request"
 import type { ApiServiceRequest } from "~/services/apiTransport/type"
 import {
+  captureNewApiOwnedSession,
+  cleanupNewApiOwnedSession,
+  getNewApiOwnedSessionStatus,
+  refreshNewApiOwnedSession,
+  touchNewApiOwnedSession,
+} from "~/services/managedSites/newApiOwnedSession/client"
+import {
   NEW_API_SESSION_READ_ACTIONS,
   type ProtectionBypassExecution,
 } from "~/services/protectionBypass/contracts"
@@ -45,6 +52,8 @@ export const NEW_API_MANAGED_SESSION_STATUSES = {
   LOGIN_2FA_REQUIRED: "login-2fa-required",
   SECURE_VERIFICATION_REQUIRED: "secure-verification-required",
   PASSKEY_MANUAL_REQUIRED: "passkey-manual-required",
+  SESSION_ACTIVE_LIMIT: "session-active-limit",
+  SESSION_ISSUANCE_LIMIT: "session-issuance-limit",
 } as const
 
 export interface NewApiVerificationMethods {
@@ -76,10 +85,18 @@ export type EnsureNewApiManagedSessionResult =
       status: typeof NEW_API_MANAGED_SESSION_STATUSES.PASSKEY_MANUAL_REQUIRED
       methods: NewApiVerificationMethods
     }
+  | {
+      status: typeof NEW_API_MANAGED_SESSION_STATUSES.SESSION_ACTIVE_LIMIT
+      cleanupAvailable: boolean
+    }
+  | {
+      status: typeof NEW_API_MANAGED_SESSION_STATUSES.SESSION_ISSUANCE_LIMIT
+    }
 
 export const NEW_API_CHANNEL_KEY_ERROR_KINDS = {
   LOGIN_REQUIRED: "login-required",
   SECURE_VERIFICATION_REQUIRED: "secure-verification-required",
+  SESSION_LIMIT: "session-limit",
 } as const
 
 type NewApiChannelKeyErrorKind =
@@ -155,6 +172,10 @@ const NEW_API_DASHBOARD_REFRESH_REQUEST_ERROR =
   "New API session refresh request failed"
 const NEW_API_DASHBOARD_AUTH_UNAUTHORIZED =
   "New API dashboard session could not be authenticated"
+const NEW_API_SESSION_LIMIT_CODES = {
+  ACTIVE: "AUTH_SESSION_LIMIT",
+  ISSUANCE: "AUTH_SESSION_ISSUANCE_LIMIT",
+} as const
 
 type EnsureNewApiLoginResult =
   | {
@@ -451,11 +472,61 @@ const createControlledDashboardRefreshError = (
 ) => {
   const code = isRecord(body) ? trimToNull(body.code) : null
   const message = isRecord(body) ? trimToNull(body.message) : null
-  if (code && message) return new Error(`${code}: ${message}`)
-  if (code) return new Error(code)
-  if (message) return new Error(message)
-  return createDashboardRefreshStatusError(status)
+  const diagnostic =
+    code && message
+      ? `${code}: ${message}`
+      : code || message || `New API session refresh failed (${status})`
+  const error = new Error(diagnostic)
+  Object.defineProperties(error, {
+    statusCode: { value: status },
+    upstreamCode: { value: code ?? undefined },
+  })
+  return error
 }
+
+/** Maps only the two upstream session-limit codes to product recovery states. */
+async function classifyNewApiSessionLimit(
+  error: unknown,
+  baseUrl: string,
+): Promise<EnsureNewApiManagedSessionResult | null> {
+  if (!(error instanceof Error)) return null
+  const structured = error as Error & {
+    statusCode?: number
+    upstreamCode?: string
+  }
+
+  if (
+    structured.statusCode === 409 &&
+    structured.upstreamCode === NEW_API_SESSION_LIMIT_CODES.ACTIVE
+  ) {
+    const { owned } = await getNewApiOwnedSessionStatus(baseUrl)
+    return {
+      status: NEW_API_MANAGED_SESSION_STATUSES.SESSION_ACTIVE_LIMIT,
+      cleanupAvailable: owned,
+    }
+  }
+
+  if (
+    structured.statusCode === 429 &&
+    structured.upstreamCode === NEW_API_SESSION_LIMIT_CODES.ISSUANCE
+  ) {
+    return {
+      status: NEW_API_MANAGED_SESSION_STATUSES.SESSION_ISSUANCE_LIMIT,
+    }
+  }
+
+  return null
+}
+
+const toOwnedSessionBundle = (
+  baseUrl: string,
+  dashboardAuth: NonNullable<NewApiSessionState["dashboardAuth"]>,
+) => ({
+  baseUrl,
+  sessionId: dashboardAuth.sessionId,
+  accessToken: dashboardAuth.token,
+  accessExpiresAt: dashboardAuth.expiresAt,
+})
 
 /**
  * Refreshes only the modern dashboard session. The request rotates auth state,
@@ -505,7 +576,15 @@ async function postNewApiDashboardRefresh(
   const body = parseDashboardRefreshBody(response.body)
   if (body === undefined) return "unavailable"
   const parsedKind = applyDashboardAuthBundleResponse(baseUrl, body)
-  if (parsedKind === "valid") return "refreshed"
+  if (parsedKind === "valid") {
+    const dashboardAuth = getActiveDashboardAuth(baseUrl)
+    if (dashboardAuth) {
+      await refreshNewApiOwnedSession(
+        toOwnedSessionBundle(baseUrl, dashboardAuth),
+      )
+    }
+    return "refreshed"
+  }
   if (parsedKind === "malformed") {
     throw new Error(NEW_API_DASHBOARD_AUTH_INVALID_RESPONSE)
   }
@@ -572,6 +651,10 @@ const getNewApiChannelKeyRequirementKind = (
       return NEW_API_CHANNEL_KEY_ERROR_KINDS.SECURE_VERIFICATION_REQUIRED
     case NEW_API_MANAGED_SESSION_STATUSES.CREDENTIALS_MISSING:
     case NEW_API_MANAGED_SESSION_STATUSES.LOGIN_2FA_REQUIRED:
+      return NEW_API_CHANNEL_KEY_ERROR_KINDS.LOGIN_REQUIRED
+    case NEW_API_MANAGED_SESSION_STATUSES.SESSION_ACTIVE_LIMIT:
+    case NEW_API_MANAGED_SESSION_STATUSES.SESSION_ISSUANCE_LIMIT:
+      return NEW_API_CHANNEL_KEY_ERROR_KINDS.SESSION_LIMIT
     default:
       return NEW_API_CHANNEL_KEY_ERROR_KINDS.LOGIN_REQUIRED
   }
@@ -726,6 +809,11 @@ async function postNewApiLogin(
     }
   }
 
+  // A lost/mismatched refresh cookie must not let this extension accumulate a
+  // second owned session for the same origin. Cleanup remains best-effort so a
+  // stale receipt or transient network failure cannot block legacy login.
+  await cleanupNewApiOwnedSession(config.baseUrl)
+
   const request = createCookieAuthRequest(config.baseUrl, config.userId)
   const response = await fetchApi<NewApiLoginResponse>(request, {
     endpoint: "/api/user/login",
@@ -775,6 +863,14 @@ async function postNewApiLogin(
   )
   if (authBundleKind === "malformed") {
     throw new Error(NEW_API_DASHBOARD_AUTH_INVALID_RESPONSE)
+  }
+  if (authBundleKind === "valid") {
+    const dashboardAuth = getActiveDashboardAuth(config.baseUrl)
+    if (dashboardAuth) {
+      await captureNewApiOwnedSession(
+        toOwnedSessionBundle(config.baseUrl, dashboardAuth),
+      )
+    }
   }
 
   const responseData = isRecord(response.data)
@@ -981,7 +1077,14 @@ export async function ensureNewApiManagedSession(
     "baseUrl" | "userId" | "username" | "password" | "totpSecret"
   >,
 ): Promise<EnsureNewApiManagedSessionResult> {
-  const loginResult = await ensureNewApiLoginSession(config)
+  let loginResult: EnsureNewApiLoginResult
+  try {
+    loginResult = await ensureNewApiLoginSession(config)
+  } catch (error) {
+    const limit = await classifyNewApiSessionLimit(error, config.baseUrl)
+    if (limit) return limit
+    throw error
+  }
 
   if (loginResult.status === "credentials-missing") {
     return {
@@ -1042,16 +1145,23 @@ export async function submitNewApiLoginTwoFactorCode(
   const pendingLoginFlow = getPendingLoginFlowForSubmission(config.baseUrl)
 
   const request = createCookieAuthRequest(config.baseUrl, config.userId)
-  const response = await fetchApi<unknown>(request, {
-    endpoint: "/api/user/login/2fa",
-    options: {
-      method: "POST",
-      body: JSON.stringify({
-        code: trimmedCode,
-        ...(pendingLoginFlow ? { flow_token: pendingLoginFlow.token } : {}),
-      }),
-    },
-  })
+  let response
+  try {
+    response = await fetchApi<unknown>(request, {
+      endpoint: "/api/user/login/2fa",
+      options: {
+        method: "POST",
+        body: JSON.stringify({
+          code: trimmedCode,
+          ...(pendingLoginFlow ? { flow_token: pendingLoginFlow.token } : {}),
+        }),
+      },
+    })
+  } catch (error) {
+    const limit = await classifyNewApiSessionLimit(error, config.baseUrl)
+    if (limit) return limit
+    throw error
+  }
 
   if (!isRecord(response)) {
     throw new ApiError(
@@ -1080,6 +1190,14 @@ export async function submitNewApiLoginTwoFactorCode(
   )
   if (authBundleKind === "malformed") {
     throw new Error(NEW_API_DASHBOARD_AUTH_INVALID_RESPONSE)
+  }
+  if (authBundleKind === "valid") {
+    const dashboardAuth = getActiveDashboardAuth(config.baseUrl)
+    if (dashboardAuth) {
+      await captureNewApiOwnedSession(
+        toOwnedSessionBundle(config.baseUrl, dashboardAuth),
+      )
+    }
   }
 
   if (authBundleKind === "unrelated") {
@@ -1238,6 +1356,10 @@ export async function fetchNewApiChannelKey(params: {
     }
 
     markVerified(params.baseUrl)
+    await touchNewApiOwnedSession(
+      params.baseUrl,
+      getActiveDashboardAuth(params.baseUrl)?.sessionId,
+    )
     return key
   } catch (rawError) {
     const error = sanitizeNewApiErrorForOrigin(rawError, params.baseUrl)

--- a/src/utils/browser/browserApi.ts
+++ b/src/utils/browser/browserApi.ts
@@ -713,8 +713,12 @@ export async function setSessionStorageValues(
   values: Record<string, unknown>,
 ): Promise<boolean> {
   if (!hasSessionStorageArea()) return false
-  await (globalThis as any).browser.storage.session.set(values)
-  return true
+  try {
+    await (globalThis as any).browser.storage.session.set(values)
+    return true
+  } catch {
+    return false
+  }
 }
 
 /**

--- a/src/utils/browser/browserApi.ts
+++ b/src/utils/browser/browserApi.ts
@@ -687,6 +687,37 @@ export async function removeLocalStorage(keys: string | string[]) {
 }
 
 /**
+ * Reports whether this browser exposes the memory-only storage.session area.
+ */
+export function hasSessionStorageArea(): boolean {
+  const session = (globalThis as any).browser?.storage?.session
+  return (
+    typeof session?.get === "function" && typeof session?.set === "function"
+  )
+}
+
+/**
+ * Reads keys from browser.storage.session through the guarded browser adapter.
+ */
+export async function getSessionStorageValues(
+  keys?: string | string[] | Record<string, unknown> | null,
+): Promise<Record<string, unknown>> {
+  if (!hasSessionStorageArea()) return {}
+  return await (globalThis as any).browser.storage.session.get(keys)
+}
+
+/**
+ * Writes values to browser.storage.session through the guarded browser adapter.
+ */
+export async function setSessionStorageValues(
+  values: Record<string, unknown>,
+): Promise<boolean> {
+  if (!hasSessionStorageArea()) return false
+  await (globalThis as any).browser.storage.session.set(values)
+  return true
+}
+
+/**
  * 监听标签页激活事件
  * 返回清理函数
  * @param callback 激活信息发生变化时调用的回调函数。

--- a/tests/entrypoints/background/runtimeMessages.more.test.ts
+++ b/tests/entrypoints/background/runtimeMessages.more.test.ts
@@ -295,13 +295,16 @@ describe("setupRuntimeMessageListeners additional routing", () => {
     const sendResponse = vi.fn()
     const request = {
       action: NEW_API_OWNED_SESSION_ACTIONS.Cleanup,
-      baseUrl: "https://managed.example",
+      baseUrl: " https://managed.example/dashboard/ ",
     }
 
     expect(runtimeMessageListener?.(request, {}, sendResponse)).toBe(true)
 
     await vi.waitFor(() => {
-      expect(mocks.handleOwnedSessionRequest).toHaveBeenCalledWith(request)
+      expect(mocks.handleOwnedSessionRequest).toHaveBeenCalledWith({
+        action: NEW_API_OWNED_SESSION_ACTIONS.Cleanup,
+        baseUrl: "https://managed.example",
+      })
       expect(sendResponse).toHaveBeenCalledWith({
         success: true,
         status: "cleaned",

--- a/tests/entrypoints/background/runtimeMessages.more.test.ts
+++ b/tests/entrypoints/background/runtimeMessages.more.test.ts
@@ -64,22 +64,18 @@ const mocks = vi.hoisted(() => ({
   markTempWindowOpenRouterManagementKeyDispatched: vi.fn(),
   openBugReportPage: vi.fn(),
   executeProtectionBypassTask: vi.fn(),
-  cleanupOwnedSession: vi.fn(),
+  handleOwnedSessionRequest: vi.fn(),
 }))
 
 vi.mock("~/services/managedSites/newApiOwnedSession/background", () => ({
-  handleNewApiOwnedSessionRequest: vi.fn(
-    async (request: { baseUrl: string }) => ({
-      success: true,
-      ...(await mocks.cleanupOwnedSession(request.baseUrl)),
-    }),
-  ),
+  handleNewApiOwnedSessionRequest: (...args: unknown[]) =>
+    mocks.handleOwnedSessionRequest(...args),
   newApiOwnedSessionLifecycle: {
     capture: vi.fn(),
     refresh: vi.fn(),
     touch: vi.fn(),
     getStatus: vi.fn(),
-    cleanup: mocks.cleanupOwnedSession,
+    cleanup: vi.fn(),
   },
 }))
 
@@ -292,13 +288,38 @@ describe("setupRuntimeMessageListeners additional routing", () => {
 
   it("routes exact New API owned-session cleanup through the background lifecycle", async () => {
     await loadListener()
-    mocks.cleanupOwnedSession.mockResolvedValue({ status: "cleaned" })
+    mocks.handleOwnedSessionRequest.mockResolvedValue({
+      success: true,
+      status: "cleaned",
+    })
+    const sendResponse = vi.fn()
+    const request = {
+      action: NEW_API_OWNED_SESSION_ACTIONS.Cleanup,
+      baseUrl: "https://managed.example",
+    }
+
+    expect(runtimeMessageListener?.(request, {}, sendResponse)).toBe(true)
+
+    await vi.waitFor(() => {
+      expect(mocks.handleOwnedSessionRequest).toHaveBeenCalledWith(request)
+      expect(sendResponse).toHaveBeenCalledWith({
+        success: true,
+        status: "cleaned",
+      })
+    })
+  })
+
+  it("returns a safe response when an owned-session command rejects", async () => {
+    await loadListener()
+    mocks.handleOwnedSessionRequest.mockRejectedValue(
+      new Error("background command failed"),
+    )
     const sendResponse = vi.fn()
 
     expect(
       runtimeMessageListener?.(
         {
-          action: NEW_API_OWNED_SESSION_ACTIONS.Cleanup,
+          action: NEW_API_OWNED_SESSION_ACTIONS.GetStatus,
           baseUrl: "https://managed.example",
         },
         {},
@@ -307,13 +328,7 @@ describe("setupRuntimeMessageListeners additional routing", () => {
     ).toBe(true)
 
     await vi.waitFor(() => {
-      expect(mocks.cleanupOwnedSession).toHaveBeenCalledWith(
-        "https://managed.example",
-      )
-      expect(sendResponse).toHaveBeenCalledWith({
-        success: true,
-        status: "cleaned",
-      })
+      expect(sendResponse).toHaveBeenCalledWith({ success: false })
     })
   })
 

--- a/tests/entrypoints/background/runtimeMessages.more.test.ts
+++ b/tests/entrypoints/background/runtimeMessages.more.test.ts
@@ -4,6 +4,7 @@ import { COOKIE_IMPORT_FAILURE_REASONS } from "~/constants/cookieImport"
 import { MENU_ITEM_IDS } from "~/constants/optionsMenuIds"
 import { RuntimeActionIds } from "~/constants/runtimeActions"
 import { WEB_AI_API_CHECK_TARGET_IDS } from "~/features/BasicSettings/components/tabs/WebAiApiCheck/searchTargets"
+import { NEW_API_OWNED_SESSION_ACTIONS } from "~/services/managedSites/newApiOwnedSession/contracts"
 import { ProductAnalyticsMessageTypes } from "~/services/productAnalytics/messaging"
 import { RedemptionAssistMessageTypes } from "~/services/redemption/redemptionAssistMessaging"
 
@@ -63,6 +64,23 @@ const mocks = vi.hoisted(() => ({
   markTempWindowOpenRouterManagementKeyDispatched: vi.fn(),
   openBugReportPage: vi.fn(),
   executeProtectionBypassTask: vi.fn(),
+  cleanupOwnedSession: vi.fn(),
+}))
+
+vi.mock("~/services/managedSites/newApiOwnedSession/background", () => ({
+  handleNewApiOwnedSessionRequest: vi.fn(
+    async (request: { baseUrl: string }) => ({
+      success: true,
+      ...(await mocks.cleanupOwnedSession(request.baseUrl)),
+    }),
+  ),
+  newApiOwnedSessionLifecycle: {
+    capture: vi.fn(),
+    refresh: vi.fn(),
+    touch: vi.fn(),
+    getStatus: vi.fn(),
+    cleanup: mocks.cleanupOwnedSession,
+  },
 }))
 
 vi.mock("~/utils/browser/browserApi", () => ({
@@ -271,6 +289,33 @@ describe("setupRuntimeMessageListeners additional routing", () => {
     )
     return runtimeMessageListener!
   }
+
+  it("routes exact New API owned-session cleanup through the background lifecycle", async () => {
+    await loadListener()
+    mocks.cleanupOwnedSession.mockResolvedValue({ status: "cleaned" })
+    const sendResponse = vi.fn()
+
+    expect(
+      runtimeMessageListener?.(
+        {
+          action: NEW_API_OWNED_SESSION_ACTIONS.Cleanup,
+          baseUrl: "https://managed.example",
+        },
+        {},
+        sendResponse,
+      ),
+    ).toBe(true)
+
+    await vi.waitFor(() => {
+      expect(mocks.cleanupOwnedSession).toHaveBeenCalledWith(
+        "https://managed.example",
+      )
+      expect(sendResponse).toHaveBeenCalledWith({
+        success: true,
+        status: "cleaned",
+      })
+    })
+  })
 
   async function waitForAsyncResponse() {
     await new Promise((resolve) => setTimeout(resolve, 0))

--- a/tests/entrypoints/background/servicesInit.test.ts
+++ b/tests/entrypoints/background/servicesInit.test.ts
@@ -13,6 +13,7 @@ const {
   redemptionAssistInitMock,
   releaseUpdateInitMock,
   productAnnouncementInitMock,
+  newApiOwnedSessionInitMock,
   initBackgroundI18nMock,
 } = vi.hoisted(() => ({
   usageInitMock: vi.fn(),
@@ -25,7 +26,12 @@ const {
   redemptionAssistInitMock: vi.fn(),
   releaseUpdateInitMock: vi.fn(),
   productAnnouncementInitMock: vi.fn(),
+  newApiOwnedSessionInitMock: vi.fn(),
   initBackgroundI18nMock: vi.fn(),
+}))
+
+vi.mock("~/services/managedSites/newApiOwnedSession/background", () => ({
+  newApiOwnedSessionLifecycle: { initialize: newApiOwnedSessionInitMock },
 }))
 
 vi.mock("~/services/history/usageHistory/scheduler", () => ({
@@ -91,6 +97,7 @@ describe("initializeServices alarm bootstrap ordering", () => {
       dailyBalance: false,
       releaseUpdate: false,
       productAnnouncement: false,
+      newApiOwnedSession: false,
     }
 
     let i18nObservedAllAlarmInits = false
@@ -120,6 +127,9 @@ describe("initializeServices alarm bootstrap ordering", () => {
     const productAnnouncementInit: InitMock = vi.fn(async () => {
       alarmInitCalled.productAnnouncement = true
     })
+    const newApiOwnedSessionInit: InitMock = vi.fn(async () => {
+      alarmInitCalled.newApiOwnedSession = true
+    })
 
     const modelMetadataInit: InitMock = vi.fn(async () => {})
     const autoRefreshInit: InitMock = vi.fn(async () => {})
@@ -132,6 +142,7 @@ describe("initializeServices alarm bootstrap ordering", () => {
     dailyBalanceInitMock.mockImplementation(dailyBalanceInit)
     releaseUpdateInitMock.mockImplementation(releaseUpdateInit)
     productAnnouncementInitMock.mockImplementation(productAnnouncementInit)
+    newApiOwnedSessionInitMock.mockImplementation(newApiOwnedSessionInit)
     modelMetadataInitMock.mockImplementation(modelMetadataInit)
     autoRefreshInitMock.mockImplementation(autoRefreshInit)
     redemptionAssistInitMock.mockImplementation(redemptionAssistInit)
@@ -144,7 +155,8 @@ describe("initializeServices alarm bootstrap ordering", () => {
         alarmInitCalled.autoCheckin &&
         alarmInitCalled.dailyBalance &&
         alarmInitCalled.releaseUpdate &&
-        alarmInitCalled.productAnnouncement
+        alarmInitCalled.productAnnouncement &&
+        alarmInitCalled.newApiOwnedSession
       return i18nPromise
     })
 
@@ -157,6 +169,7 @@ describe("initializeServices alarm bootstrap ordering", () => {
     expect(dailyBalanceInit).toHaveBeenCalledTimes(1)
     expect(releaseUpdateInit).toHaveBeenCalledTimes(1)
     expect(productAnnouncementInit).toHaveBeenCalledTimes(1)
+    expect(newApiOwnedSessionInit).toHaveBeenCalledTimes(1)
     expect(i18nObservedAllAlarmInits).toBe(true)
 
     resolveI18n?.()
@@ -187,6 +200,7 @@ describe("initializeServices alarm bootstrap ordering", () => {
     dailyBalanceInitMock.mockResolvedValue(undefined)
     releaseUpdateInitMock.mockResolvedValue(undefined)
     productAnnouncementInitMock.mockResolvedValue(undefined)
+    newApiOwnedSessionInitMock.mockResolvedValue(undefined)
     modelMetadataInitMock.mockResolvedValue(undefined)
     autoRefreshInitMock.mockResolvedValue(undefined)
     redemptionAssistInitMock.mockResolvedValue(undefined)
@@ -201,6 +215,7 @@ describe("initializeServices alarm bootstrap ordering", () => {
     expect(dailyBalanceInitMock).toHaveBeenCalledTimes(1)
     expect(releaseUpdateInitMock).toHaveBeenCalledTimes(1)
     expect(productAnnouncementInitMock).toHaveBeenCalledTimes(1)
+    expect(newApiOwnedSessionInitMock).toHaveBeenCalledTimes(1)
     expect(initBackgroundI18nMock).toHaveBeenCalledTimes(1)
 
     resolveI18n?.()
@@ -219,6 +234,7 @@ describe("initializeServices alarm bootstrap ordering", () => {
     expect(dailyBalanceInitMock).toHaveBeenCalledTimes(1)
     expect(releaseUpdateInitMock).toHaveBeenCalledTimes(1)
     expect(productAnnouncementInitMock).toHaveBeenCalledTimes(1)
+    expect(newApiOwnedSessionInitMock).toHaveBeenCalledTimes(1)
     expect(initBackgroundI18nMock).toHaveBeenCalledTimes(1)
     expect(modelMetadataInitMock).toHaveBeenCalledTimes(1)
     expect(autoRefreshInitMock).toHaveBeenCalledTimes(1)
@@ -238,6 +254,7 @@ describe("initializeServices alarm bootstrap ordering", () => {
     dailyBalanceInitMock.mockResolvedValue(undefined)
     releaseUpdateInitMock.mockResolvedValue(undefined)
     productAnnouncementInitMock.mockResolvedValue(undefined)
+    newApiOwnedSessionInitMock.mockResolvedValue(undefined)
     modelMetadataInitMock.mockResolvedValue(undefined)
     autoRefreshInitMock.mockResolvedValue(undefined)
     redemptionAssistInitMock.mockResolvedValue(undefined)
@@ -251,6 +268,7 @@ describe("initializeServices alarm bootstrap ordering", () => {
     expect(dailyBalanceInitMock).toHaveBeenCalledTimes(1)
     expect(releaseUpdateInitMock).toHaveBeenCalledTimes(1)
     expect(productAnnouncementInitMock).toHaveBeenCalledTimes(1)
+    expect(newApiOwnedSessionInitMock).toHaveBeenCalledTimes(1)
     expect(initBackgroundI18nMock).toHaveBeenCalledTimes(1)
     expect(modelMetadataInitMock).toHaveBeenCalledTimes(1)
     expect(autoRefreshInitMock).toHaveBeenCalledTimes(1)

--- a/tests/features/ManagedSiteVerification/NewApiManagedVerificationDialog.test.tsx
+++ b/tests/features/ManagedSiteVerification/NewApiManagedVerificationDialog.test.tsx
@@ -173,6 +173,49 @@ describe("NewApiManagedVerificationDialog", () => {
     updateNewApiPasswordMock.mockResolvedValue(preferenceWriteSuccess())
   })
 
+  it("offers exact extension-session cleanup for a recoverable active limit", () => {
+    const props = createProps({
+      step: NEW_API_MANAGED_VERIFICATION_STEPS.SESSION_ACTIVE_LIMIT_CLEANUP,
+    })
+
+    render(<NewApiManagedVerificationDialog {...props} />)
+
+    expect(
+      screen.getByRole("button", {
+        name: "newApiManagedVerification:dialog.actions.cleanupOwnedSessionAndRetry",
+      }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", {
+        name: "newApiManagedVerification:dialog.actions.openSite",
+      }),
+    ).toBeInTheDocument()
+  })
+
+  it("does not suggest cleanup or immediate retry for the issuance limit", () => {
+    const props = createProps({
+      step: NEW_API_MANAGED_VERIFICATION_STEPS.SESSION_ISSUANCE_LIMIT,
+    })
+
+    render(<NewApiManagedVerificationDialog {...props} />)
+
+    expect(
+      screen.queryByRole("button", {
+        name: "newApiManagedVerification:dialog.actions.cleanupOwnedSessionAndRetry",
+      }),
+    ).toBeNull()
+    expect(
+      screen.queryByRole("button", {
+        name: "newApiManagedVerification:dialog.actions.retry",
+      }),
+    ).toBeNull()
+    expect(
+      screen.getByRole("button", {
+        name: "newApiManagedVerification:dialog.actions.openSite",
+      }),
+    ).toBeInTheDocument()
+  })
+
   it("shows inline quick-config fields when login-assist settings are missing", () => {
     render(<NewApiManagedVerificationDialog {...createProps()} />)
 

--- a/tests/features/ManagedSiteVerification/NewApiManagedVerificationDialog.test.tsx
+++ b/tests/features/ManagedSiteVerification/NewApiManagedVerificationDialog.test.tsx
@@ -192,6 +192,44 @@ describe("NewApiManagedVerificationDialog", () => {
     ).toBeInTheDocument()
   })
 
+  it("directs an unrecoverable active limit to site session management", () => {
+    const props = createProps({
+      step: NEW_API_MANAGED_VERIFICATION_STEPS.SESSION_ACTIVE_LIMIT,
+    })
+
+    render(<NewApiManagedVerificationDialog {...props} />)
+
+    expect(
+      screen.getByText(
+        "newApiManagedVerification:dialog.body.sessionActiveLimit",
+      ),
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", {
+        name: "newApiManagedVerification:dialog.actions.retry",
+      }),
+    ).toBeNull()
+    expect(
+      screen.getByRole("button", {
+        name: "newApiManagedVerification:dialog.actions.openSite",
+      }),
+    ).toBeInTheDocument()
+  })
+
+  it("offers a plain retry for a recoverable generic failure", () => {
+    const props = createProps({
+      step: NEW_API_MANAGED_VERIFICATION_STEPS.FAILURE,
+    })
+
+    render(<NewApiManagedVerificationDialog {...props} />)
+
+    expect(
+      screen.getByRole("button", {
+        name: "newApiManagedVerification:dialog.actions.retry",
+      }),
+    ).toBeInTheDocument()
+  })
+
   it("does not suggest cleanup or immediate retry for the issuance limit", () => {
     const props = createProps({
       step: NEW_API_MANAGED_VERIFICATION_STEPS.SESSION_ISSUANCE_LIMIT,

--- a/tests/features/ManagedSiteVerification/useNewApiManagedVerification.test.tsx
+++ b/tests/features/ManagedSiteVerification/useNewApiManagedVerification.test.tsx
@@ -15,12 +15,14 @@ const {
   submitNewApiLoginTwoFactorCodeMock,
   submitNewApiSecureVerificationCodeMock,
   createTabMock,
+  cleanupOwnedSessionMock,
   loggerWarnMock,
 } = vi.hoisted(() => ({
   ensureNewApiManagedSessionMock: vi.fn(),
   submitNewApiLoginTwoFactorCodeMock: vi.fn(),
   submitNewApiSecureVerificationCodeMock: vi.fn(),
   createTabMock: vi.fn(),
+  cleanupOwnedSessionMock: vi.fn(),
   loggerWarnMock: vi.fn(),
 }))
 
@@ -31,6 +33,11 @@ vi.mock("react-hot-toast", () => ({
   },
 }))
 
+vi.mock("~/services/managedSites/newApiOwnedSession/client", () => ({
+  cleanupNewApiOwnedSession: (...args: unknown[]) =>
+    cleanupOwnedSessionMock(...args),
+}))
+
 vi.mock("~/services/managedSites/providers/newApiSession", async () => {
   return {
     NEW_API_MANAGED_SESSION_STATUSES: {
@@ -39,6 +46,8 @@ vi.mock("~/services/managedSites/providers/newApiSession", async () => {
       LOGIN_2FA_REQUIRED: "login-2fa-required",
       SECURE_VERIFICATION_REQUIRED: "secure-verification-required",
       PASSKEY_MANUAL_REQUIRED: "passkey-manual-required",
+      SESSION_ACTIVE_LIMIT: "session-active-limit",
+      SESSION_ISSUANCE_LIMIT: "session-issuance-limit",
     },
     ensureNewApiManagedSession: (...args: unknown[]) =>
       ensureNewApiManagedSessionMock(...args),
@@ -77,9 +86,72 @@ describe("useNewApiManagedVerification", () => {
     submitNewApiLoginTwoFactorCodeMock.mockReset()
     submitNewApiSecureVerificationCodeMock.mockReset()
     createTabMock.mockReset()
+    cleanupOwnedSessionMock.mockReset().mockResolvedValue({ status: "cleaned" })
     loggerWarnMock.mockReset()
     vi.mocked(toast.success).mockReset()
     vi.mocked(toast.error).mockReset()
+  })
+
+  it("cleans an extension-owned session before retrying an active-session limit", async () => {
+    ensureNewApiManagedSessionMock.mockResolvedValueOnce({
+      status: NEW_API_MANAGED_SESSION_STATUSES.VERIFIED,
+      methods: { twoFactorEnabled: false, passkeyEnabled: false },
+    })
+    const { result } = renderHook(() => useNewApiManagedVerification())
+
+    act(() => {
+      result.current.openNewApiManagedVerification({
+        ...BASE_REQUEST,
+        initialSessionResult: {
+          status: NEW_API_MANAGED_SESSION_STATUSES.SESSION_ACTIVE_LIMIT,
+          cleanupAvailable: true,
+        },
+      })
+    })
+
+    await waitFor(() => {
+      expect(result.current.dialogState.step).toBe(
+        NEW_API_MANAGED_VERIFICATION_STEPS.SESSION_ACTIVE_LIMIT_CLEANUP,
+      )
+    })
+
+    await act(async () => {
+      await result.current.retryVerification()
+    })
+
+    expect(cleanupOwnedSessionMock).toHaveBeenCalledWith(
+      BASE_REQUEST.config.baseUrl,
+    )
+    expect(ensureNewApiManagedSessionMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not retry when owned-session cleanup cannot be completed", async () => {
+    cleanupOwnedSessionMock.mockResolvedValue({ status: "failed" })
+    const { result } = renderHook(() => useNewApiManagedVerification())
+
+    act(() => {
+      result.current.openNewApiManagedVerification({
+        ...BASE_REQUEST,
+        initialSessionResult: {
+          status: NEW_API_MANAGED_SESSION_STATUSES.SESSION_ACTIVE_LIMIT,
+          cleanupAvailable: true,
+        },
+      })
+    })
+    await waitFor(() => {
+      expect(result.current.dialogState.step).toBe(
+        NEW_API_MANAGED_VERIFICATION_STEPS.SESSION_ACTIVE_LIMIT_CLEANUP,
+      )
+    })
+
+    await act(async () => {
+      await result.current.retryVerification()
+    })
+
+    expect(ensureNewApiManagedSessionMock).not.toHaveBeenCalled()
+    expect(result.current.dialogState.errorMessage).toBe(
+      "newApiManagedVerification:dialog.messages.ownedSessionCleanupFailed",
+    )
   })
 
   it("shows a success toast and closes the dialog after a verified token retry", async () => {

--- a/tests/features/ManagedSiteVerification/useNewApiManagedVerification.test.tsx
+++ b/tests/features/ManagedSiteVerification/useNewApiManagedVerification.test.tsx
@@ -123,6 +123,9 @@ describe("useNewApiManagedVerification", () => {
       BASE_REQUEST.config.baseUrl,
     )
     expect(ensureNewApiManagedSessionMock).toHaveBeenCalledTimes(1)
+    expect(cleanupOwnedSessionMock.mock.invocationCallOrder[0]).toBeLessThan(
+      ensureNewApiManagedSessionMock.mock.invocationCallOrder[0],
+    )
   })
 
   it("does not retry when owned-session cleanup cannot be completed", async () => {
@@ -153,6 +156,69 @@ describe("useNewApiManagedVerification", () => {
       "newApiManagedVerification:dialog.messages.ownedSessionCleanupFailed",
     )
   })
+
+  it("recovers when the owned-session cleanup request rejects", async () => {
+    cleanupOwnedSessionMock.mockRejectedValue(new Error("runtime unavailable"))
+    const { result } = renderHook(() => useNewApiManagedVerification())
+
+    act(() => {
+      result.current.openNewApiManagedVerification({
+        ...BASE_REQUEST,
+        initialSessionResult: {
+          status: NEW_API_MANAGED_SESSION_STATUSES.SESSION_ACTIVE_LIMIT,
+          cleanupAvailable: true,
+        },
+      })
+    })
+    await waitFor(() => {
+      expect(result.current.dialogState.step).toBe(
+        NEW_API_MANAGED_VERIFICATION_STEPS.SESSION_ACTIVE_LIMIT_CLEANUP,
+      )
+    })
+
+    await act(async () => {
+      await result.current.retryVerification()
+    })
+
+    expect(ensureNewApiManagedSessionMock).not.toHaveBeenCalled()
+    expect(result.current.dialogState).toMatchObject({
+      isBusy: false,
+      busyMessage: undefined,
+      errorMessage:
+        "newApiManagedVerification:dialog.messages.ownedSessionCleanupFailed",
+    })
+  })
+
+  it.each([
+    [
+      {
+        status: NEW_API_MANAGED_SESSION_STATUSES.SESSION_ACTIVE_LIMIT,
+        cleanupAvailable: false,
+      },
+      NEW_API_MANAGED_VERIFICATION_STEPS.SESSION_ACTIVE_LIMIT,
+    ],
+    [
+      { status: NEW_API_MANAGED_SESSION_STATUSES.SESSION_ISSUANCE_LIMIT },
+      NEW_API_MANAGED_VERIFICATION_STEPS.SESSION_ISSUANCE_LIMIT,
+    ],
+  ] as const)(
+    "opens the terminal session-limit step",
+    async (sessionResult, step) => {
+      const { result } = renderHook(() => useNewApiManagedVerification())
+
+      act(() => {
+        result.current.openNewApiManagedVerification({
+          ...BASE_REQUEST,
+          initialSessionResult: sessionResult,
+        })
+      })
+
+      await waitFor(() => {
+        expect(result.current.dialogState.step).toBe(step)
+      })
+      expect(ensureNewApiManagedSessionMock).not.toHaveBeenCalled()
+    },
+  )
 
   it("shows a success toast and closes the dialog after a verified token retry", async () => {
     ensureNewApiManagedSessionMock.mockResolvedValue({

--- a/tests/services/apiTransport/request.test.ts
+++ b/tests/services/apiTransport/request.test.ts
@@ -3201,6 +3201,36 @@ describe("apiTransport request helpers", () => {
     })
   })
 
+  it("preserves a safe top-level backend code for provider recovery logic", async () => {
+    server.use(
+      http.get(API_URL, () =>
+        HttpResponse.json(
+          {
+            success: false,
+            code: "AUTH_SESSION_LIMIT",
+            message: "Active session limit reached",
+          },
+          { status: 409 },
+        ),
+      ),
+    )
+
+    await expect(
+      fetchApiData(
+        {
+          baseUrl: BASE_URL,
+          auth: { authType: AuthTypeEnum.Cookie },
+        },
+        { endpoint: ENDPOINT },
+      ),
+    ).rejects.toMatchObject({
+      statusCode: 409,
+      code: ApiErrorCodes.HTTP_OTHER,
+      upstreamCode: "AUTH_SESSION_LIMIT",
+      message: "Active session limit reached",
+    })
+  })
+
   it("preserves a generic nested provider message and safe code", async () => {
     server.use(
       http.get(API_URL, () =>

--- a/tests/services/managedSites/newApiOwnedSession/background.test.ts
+++ b/tests/services/managedSites/newApiOwnedSession/background.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { fetchApiResponse } from "~/services/apiTransport/request"
+import { revokeNewApiOwnedSession } from "~/services/managedSites/newApiOwnedSession/background"
+import type { NewApiOwnedSessionReceipt } from "~/services/managedSites/newApiOwnedSession/lifecycle"
+import { AuthTypeEnum } from "~/types"
+
+vi.mock("~/services/apiTransport/request", () => ({
+  fetchApiResponse: vi.fn(),
+}))
+
+const receipt: NewApiOwnedSessionReceipt = {
+  version: 1,
+  origin: "https://managed.example",
+  sessionId: "owned/session-placeholder",
+  accessToken: "owned-token-placeholder",
+  accessExpiresAt: 1_900_000_000,
+  lastUsedAt: 1_800_000_000_000,
+  cleanupAt: 1_800_000_600_000,
+}
+
+describe("revokeNewApiOwnedSession", () => {
+  beforeEach(() => {
+    vi.mocked(fetchApiResponse).mockReset()
+  })
+
+  it("deletes only the captured SID without broad session revocation", async () => {
+    vi.mocked(fetchApiResponse).mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: {},
+      body: "",
+    })
+
+    await expect(revokeNewApiOwnedSession(receipt)).resolves.toEqual({
+      status: "cleaned",
+    })
+    expect(fetchApiResponse).toHaveBeenCalledWith(
+      {
+        baseUrl: receipt.origin,
+        accountId: `managed-site:new-api-owned-session:${receipt.origin}`,
+        auth: {
+          authType: AuthTypeEnum.AccessToken,
+          accessToken: receipt.accessToken,
+        },
+      },
+      expect.objectContaining({
+        endpoint: "/api/user/sessions/owned%2Fsession-placeholder",
+        options: expect.objectContaining({ method: "DELETE" }),
+      }),
+    )
+    expect(
+      JSON.stringify(vi.mocked(fetchApiResponse).mock.calls),
+    ).not.toContain("revoke-others")
+  })
+
+  it.each([
+    [404, "cleaned"],
+    [401, "unavailable"],
+    [500, "retry"],
+  ] as const)("maps HTTP %s to %s", async (status, expected) => {
+    vi.mocked(fetchApiResponse).mockResolvedValue({
+      ok: false,
+      status,
+      headers: {},
+      body: "",
+    })
+
+    await expect(revokeNewApiOwnedSession(receipt)).resolves.toEqual({
+      status: expected,
+    })
+  })
+})

--- a/tests/services/managedSites/newApiOwnedSession/background.test.ts
+++ b/tests/services/managedSites/newApiOwnedSession/background.test.ts
@@ -1,12 +1,47 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { fetchApiResponse } from "~/services/apiTransport/request"
-import { revokeNewApiOwnedSession } from "~/services/managedSites/newApiOwnedSession/background"
+import {
+  handleNewApiOwnedSessionRequest,
+  newApiOwnedSessionLifecycle,
+  revokeNewApiOwnedSession,
+} from "~/services/managedSites/newApiOwnedSession/background"
+import { NEW_API_OWNED_SESSION_ACTIONS } from "~/services/managedSites/newApiOwnedSession/contracts"
 import type { NewApiOwnedSessionReceipt } from "~/services/managedSites/newApiOwnedSession/lifecycle"
 import { AuthTypeEnum } from "~/types"
 
+const mocks = vi.hoisted(() => ({
+  alarmListener: undefined as
+    | ((alarm: { name: string }) => void | Promise<void>)
+    | undefined,
+  clearAlarm: vi.fn(async () => true),
+  createAlarm: vi.fn(async () => {}),
+  getSessionStorageValues: vi.fn(async () => ({})),
+  hasSessionStorageArea: vi.fn(() => false),
+  loggerWarn: vi.fn(),
+  setSessionStorageValues: vi.fn(async () => false),
+}))
+
 vi.mock("~/services/apiTransport/request", () => ({
   fetchApiResponse: vi.fn(),
+}))
+
+vi.mock("~/utils/browser/browserApi", () => ({
+  clearAlarm: mocks.clearAlarm,
+  createAlarm: mocks.createAlarm,
+  getSessionStorageValues: mocks.getSessionStorageValues,
+  hasSessionStorageArea: mocks.hasSessionStorageArea,
+  onAlarm: vi.fn(
+    (listener: (alarm: { name: string }) => void | Promise<void>) => {
+      mocks.alarmListener = listener
+      return () => {}
+    },
+  ),
+  setSessionStorageValues: mocks.setSessionStorageValues,
+}))
+
+vi.mock("~/utils/core/logger", () => ({
+  createLogger: () => ({ warn: mocks.loggerWarn }),
 }))
 
 const receipt: NewApiOwnedSessionReceipt = {
@@ -21,7 +56,12 @@ const receipt: NewApiOwnedSessionReceipt = {
 
 describe("revokeNewApiOwnedSession", () => {
   beforeEach(() => {
-    vi.mocked(fetchApiResponse).mockReset()
+    vi.clearAllMocks()
+    mocks.hasSessionStorageArea.mockReturnValue(false)
+    mocks.getSessionStorageValues.mockResolvedValue({})
+    mocks.setSessionStorageValues.mockResolvedValue(false)
+    mocks.clearAlarm.mockResolvedValue(true)
+    mocks.createAlarm.mockResolvedValue(undefined)
   })
 
   it("deletes only the captured SID without broad session revocation", async () => {
@@ -46,7 +86,7 @@ describe("revokeNewApiOwnedSession", () => {
       },
       expect.objectContaining({
         endpoint: "/api/user/sessions/owned%2Fsession-placeholder",
-        options: expect.objectContaining({ method: "DELETE" }),
+        options: { method: "DELETE" },
       }),
     )
     expect(
@@ -68,6 +108,129 @@ describe("revokeNewApiOwnedSession", () => {
 
     await expect(revokeNewApiOwnedSession(receipt)).resolves.toEqual({
       status: expected,
+    })
+  })
+
+  it("maps a transport failure to a bounded retry", async () => {
+    vi.mocked(fetchApiResponse).mockRejectedValue(new Error("network failed"))
+
+    await expect(revokeNewApiOwnedSession(receipt)).resolves.toEqual({
+      status: "retry",
+    })
+    expect(mocks.loggerWarn).toHaveBeenCalledWith(
+      "Exact New API owned-session cleanup failed",
+      expect.objectContaining({ status: "transport-error" }),
+    )
+  })
+})
+
+describe("New API owned-session background commands", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.hasSessionStorageArea.mockReturnValue(false)
+    mocks.getSessionStorageValues.mockResolvedValue({})
+    mocks.setSessionStorageValues.mockResolvedValue(false)
+    mocks.clearAlarm.mockResolvedValue(true)
+    mocks.createAlarm.mockResolvedValue(undefined)
+    vi.mocked(fetchApiResponse).mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: {},
+      body: "",
+    })
+  })
+
+  it("routes every validated ownership command through the lifecycle", async () => {
+    const baseUrl = "https://commands.example.invalid"
+    const bundle = {
+      baseUrl,
+      sessionId: "owned-command-session",
+      accessToken: "owned-command-token",
+      accessExpiresAt: Math.floor((Date.now() + 15 * 60_000) / 1000),
+    }
+
+    await expect(
+      handleNewApiOwnedSessionRequest({
+        action: NEW_API_OWNED_SESSION_ACTIONS.Capture,
+        bundle,
+      }),
+    ).resolves.toEqual({ success: true })
+    await expect(
+      handleNewApiOwnedSessionRequest({
+        action: NEW_API_OWNED_SESSION_ACTIONS.Refresh,
+        bundle: { ...bundle, accessToken: "rotated-command-token" },
+      }),
+    ).resolves.toEqual({ success: true, owned: true })
+    await expect(
+      handleNewApiOwnedSessionRequest({
+        action: NEW_API_OWNED_SESSION_ACTIONS.Touch,
+        baseUrl,
+        sessionId: bundle.sessionId,
+      }),
+    ).resolves.toEqual({ success: true, owned: true })
+    await expect(
+      handleNewApiOwnedSessionRequest({
+        action: NEW_API_OWNED_SESSION_ACTIONS.GetStatus,
+        baseUrl,
+      }),
+    ).resolves.toEqual({ success: true, owned: true })
+    await expect(
+      handleNewApiOwnedSessionRequest({
+        action: NEW_API_OWNED_SESSION_ACTIONS.Cleanup,
+        baseUrl,
+      }),
+    ).resolves.toEqual({ success: true, status: "cleaned" })
+
+    expect(mocks.setSessionStorageValues).toHaveBeenCalled()
+    expect(fetchApiResponse).toHaveBeenCalledTimes(1)
+  })
+
+  it("reads an owned receipt from storage.session when available", async () => {
+    const origin = "https://stored.example.invalid"
+    const storedReceipt = {
+      ...receipt,
+      origin,
+      sessionId: "stored-owned-session",
+    }
+    mocks.hasSessionStorageArea.mockReturnValue(true)
+    mocks.getSessionStorageValues.mockResolvedValue({
+      new_api_owned_session_receipts_v1: {
+        version: 1,
+        receipts: {
+          [`${origin}\nstored-owned-session`]: storedReceipt,
+        },
+      },
+    })
+
+    await expect(
+      handleNewApiOwnedSessionRequest({
+        action: NEW_API_OWNED_SESSION_ACTIONS.GetStatus,
+        baseUrl: origin,
+      }),
+    ).resolves.toEqual({ success: true, owned: true })
+    expect(mocks.getSessionStorageValues).toHaveBeenCalledWith(
+      "new_api_owned_session_receipts_v1",
+    )
+  })
+
+  it("reports alarm reconciliation failures without leaking the rejection", async () => {
+    mocks.hasSessionStorageArea.mockReturnValue(true)
+    mocks.getSessionStorageValues.mockResolvedValue({})
+    await newApiOwnedSessionLifecycle.initialize()
+    mocks.getSessionStorageValues.mockRejectedValue(
+      new Error("session storage unavailable"),
+    )
+
+    mocks.alarmListener?.({ name: "new-api-owned-session-cleanup" })
+    await vi.waitFor(() => {
+      expect(mocks.loggerWarn).toHaveBeenCalledWith(
+        "New API owned-session alarm cleanup failed",
+        expect.objectContaining({
+          error: expect.objectContaining({
+            message: "session storage unavailable",
+          }),
+        }),
+      )
     })
   })
 })

--- a/tests/services/managedSites/newApiOwnedSession/client.test.ts
+++ b/tests/services/managedSites/newApiOwnedSession/client.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+  captureNewApiOwnedSession,
+  cleanupNewApiOwnedSession,
+  getNewApiOwnedSessionStatus,
+  refreshNewApiOwnedSession,
+  touchNewApiOwnedSession,
+} from "~/services/managedSites/newApiOwnedSession/client"
+import { NEW_API_OWNED_SESSION_ACTIONS } from "~/services/managedSites/newApiOwnedSession/contracts"
+import { sendRuntimeMessage } from "~/utils/browser/browserApi"
+
+const loggerWarnMock = vi.hoisted(() => vi.fn())
+
+vi.mock("~/utils/browser/browserApi", () => ({
+  sendRuntimeMessage: vi.fn(),
+}))
+
+vi.mock("~/utils/core/logger", () => ({
+  createLogger: () => ({ warn: loggerWarnMock }),
+}))
+
+const bundle = {
+  baseUrl: "https://managed.example.invalid",
+  sessionId: "owned-session-placeholder",
+  accessToken: "owned-token-placeholder",
+  accessExpiresAt: 1_900_000_000,
+}
+
+describe("New API owned-session client", () => {
+  beforeEach(() => {
+    vi.mocked(sendRuntimeMessage).mockReset()
+    loggerWarnMock.mockReset()
+  })
+
+  it("sends each ownership command without transport retries", async () => {
+    vi.mocked(sendRuntimeMessage).mockResolvedValue({ success: true })
+
+    await captureNewApiOwnedSession(bundle)
+    await refreshNewApiOwnedSession(bundle)
+    await touchNewApiOwnedSession(bundle.baseUrl, bundle.sessionId)
+
+    expect(sendRuntimeMessage).toHaveBeenNthCalledWith(
+      1,
+      { action: NEW_API_OWNED_SESSION_ACTIONS.Capture, bundle },
+      { maxAttempts: 1 },
+    )
+    expect(sendRuntimeMessage).toHaveBeenNthCalledWith(
+      2,
+      { action: NEW_API_OWNED_SESSION_ACTIONS.Refresh, bundle },
+      { maxAttempts: 1 },
+    )
+    expect(sendRuntimeMessage).toHaveBeenNthCalledWith(
+      3,
+      {
+        action: NEW_API_OWNED_SESSION_ACTIONS.Touch,
+        baseUrl: bundle.baseUrl,
+        sessionId: bundle.sessionId,
+      },
+      { maxAttempts: 1 },
+    )
+  })
+
+  it("normalizes ownership status and cleanup responses", async () => {
+    vi.mocked(sendRuntimeMessage)
+      .mockResolvedValueOnce({ success: true, owned: true })
+      .mockResolvedValueOnce({ success: true, status: "cleaned" })
+      .mockResolvedValueOnce({ success: true })
+
+    await expect(getNewApiOwnedSessionStatus(bundle.baseUrl)).resolves.toEqual({
+      owned: true,
+    })
+    await expect(cleanupNewApiOwnedSession(bundle.baseUrl)).resolves.toEqual({
+      status: "cleaned",
+    })
+    await expect(cleanupNewApiOwnedSession(bundle.baseUrl)).resolves.toEqual({
+      status: "failed",
+    })
+  })
+
+  it("returns safe fallbacks for missing and rejected runtime responses", async () => {
+    vi.mocked(sendRuntimeMessage)
+      .mockResolvedValueOnce(undefined as never)
+      .mockRejectedValueOnce(new Error("worker unavailable"))
+
+    await expect(getNewApiOwnedSessionStatus(bundle.baseUrl)).resolves.toEqual({
+      owned: false,
+    })
+    await expect(cleanupNewApiOwnedSession(bundle.baseUrl)).resolves.toEqual({
+      status: "failed",
+    })
+    expect(loggerWarnMock).toHaveBeenCalledWith(
+      "New API owned-session background request failed",
+      expect.objectContaining({
+        error: expect.objectContaining({ message: "worker unavailable" }),
+      }),
+    )
+  })
+})

--- a/tests/services/managedSites/newApiOwnedSession/contracts.test.ts
+++ b/tests/services/managedSites/newApiOwnedSession/contracts.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest"
 import {
   isNewApiOwnedSessionRequest,
   NEW_API_OWNED_SESSION_ACTIONS,
+  parseNewApiOwnedSessionRequest,
 } from "~/services/managedSites/newApiOwnedSession/contracts"
 
 const validBundle = {
@@ -33,6 +34,39 @@ describe("isNewApiOwnedSessionRequest", () => {
       ).toBe(false)
     },
   )
+
+  it.each([
+    ["blank base URL", { baseUrl: "   " }],
+    ["non-HTTP base URL", { baseUrl: "ftp://managed.example.invalid" }],
+    ["blank session ID", { sessionId: "\t" }],
+    ["blank access token", { accessToken: " " }],
+    ["NaN expiry", { accessExpiresAt: Number.NaN }],
+    ["infinite expiry", { accessExpiresAt: Number.POSITIVE_INFINITY }],
+  ])("rejects a bundle with a %s", (_description, invalidFields) => {
+    expect(
+      isNewApiOwnedSessionRequest({
+        action: NEW_API_OWNED_SESSION_ACTIONS.Capture,
+        bundle: { ...validBundle, ...invalidFields },
+      }),
+    ).toBe(false)
+  })
+
+  it("normalizes a valid bundle at the runtime boundary", () => {
+    expect(
+      parseNewApiOwnedSessionRequest({
+        action: NEW_API_OWNED_SESSION_ACTIONS.Capture,
+        bundle: {
+          ...validBundle,
+          baseUrl: " https://managed.example.invalid/dashboard/ ",
+          sessionId: " owned-session-placeholder ",
+          accessToken: " owned-token-placeholder ",
+        },
+      }),
+    ).toEqual({
+      action: NEW_API_OWNED_SESSION_ACTIONS.Capture,
+      bundle: validBundle,
+    })
+  })
 
   it("validates optional touch SIDs and base URLs", () => {
     expect(

--- a/tests/services/managedSites/newApiOwnedSession/contracts.test.ts
+++ b/tests/services/managedSites/newApiOwnedSession/contracts.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  isNewApiOwnedSessionRequest,
+  NEW_API_OWNED_SESSION_ACTIONS,
+} from "~/services/managedSites/newApiOwnedSession/contracts"
+
+const validBundle = {
+  baseUrl: "https://managed.example.invalid",
+  sessionId: "owned-session-placeholder",
+  accessToken: "owned-token-placeholder",
+  accessExpiresAt: 1_900_000_000,
+}
+
+describe("isNewApiOwnedSessionRequest", () => {
+  it.each([
+    NEW_API_OWNED_SESSION_ACTIONS.Capture,
+    NEW_API_OWNED_SESSION_ACTIONS.Refresh,
+  ])("accepts a complete %s bundle", (action) => {
+    expect(isNewApiOwnedSessionRequest({ action, bundle: validBundle })).toBe(
+      true,
+    )
+  })
+
+  it.each(["baseUrl", "sessionId", "accessToken", "accessExpiresAt"])(
+    "rejects a bundle with an invalid %s field",
+    (field) => {
+      expect(
+        isNewApiOwnedSessionRequest({
+          action: NEW_API_OWNED_SESSION_ACTIONS.Capture,
+          bundle: { ...validBundle, [field]: null },
+        }),
+      ).toBe(false)
+    },
+  )
+
+  it("validates optional touch SIDs and base URLs", () => {
+    expect(
+      isNewApiOwnedSessionRequest({
+        action: NEW_API_OWNED_SESSION_ACTIONS.Touch,
+        baseUrl: validBundle.baseUrl,
+      }),
+    ).toBe(true)
+    expect(
+      isNewApiOwnedSessionRequest({
+        action: NEW_API_OWNED_SESSION_ACTIONS.Touch,
+        baseUrl: validBundle.baseUrl,
+        sessionId: 42,
+      }),
+    ).toBe(false)
+    expect(
+      isNewApiOwnedSessionRequest({
+        action: NEW_API_OWNED_SESSION_ACTIONS.GetStatus,
+        baseUrl: 42,
+      }),
+    ).toBe(false)
+  })
+})

--- a/tests/services/managedSites/newApiOwnedSession/contracts.test.ts
+++ b/tests/services/managedSites/newApiOwnedSession/contracts.test.ts
@@ -89,4 +89,13 @@ describe("isNewApiOwnedSessionRequest", () => {
       }),
     ).toBe(false)
   })
+
+  it("rejects an unknown owned-session action", () => {
+    expect(
+      parseNewApiOwnedSessionRequest({
+        action: "new-api-owned-session:unknown",
+        baseUrl: validBundle.baseUrl,
+      }),
+    ).toBeNull()
+  })
 })

--- a/tests/services/managedSites/newApiOwnedSession/lifecycle.test.ts
+++ b/tests/services/managedSites/newApiOwnedSession/lifecycle.test.ts
@@ -1,0 +1,193 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+  createNewApiOwnedSessionLifecycle,
+  NEW_API_OWNED_SESSION_ALARM_NAME,
+  type NewApiOwnedSessionLifecycleDependencies,
+} from "~/services/managedSites/newApiOwnedSession/lifecycle"
+
+const ORIGIN = "https://managed.example"
+const NOW = 1_800_000_000_000
+const OWNED_RECEIPT_KEY = `${ORIGIN}\nowned-session-placeholder`
+
+function createHarness() {
+  let stored: unknown
+  let alarmListener: ((alarm: { name: string }) => void) | undefined
+  const dependencies: NewApiOwnedSessionLifecycleDependencies = {
+    now: () => NOW,
+    readStoredReceipts: vi.fn(async () => stored),
+    writeStoredReceipts: vi.fn(async (value) => {
+      stored = value
+    }),
+    createAlarm: vi.fn(async () => {}),
+    clearAlarm: vi.fn(async () => true),
+    onAlarm: vi.fn((listener) => {
+      alarmListener = listener
+      return () => {}
+    }),
+    reportError: vi.fn(),
+    revokeSession: vi.fn(async () => ({ status: "cleaned" as const })),
+  }
+
+  return {
+    dependencies,
+    getStored: () => stored,
+    fireAlarm: () =>
+      alarmListener?.({ name: NEW_API_OWNED_SESSION_ALARM_NAME }),
+  }
+}
+
+const freshBundle = (overrides: Record<string, unknown> = {}) => ({
+  baseUrl: `${ORIGIN}/`,
+  sessionId: "owned-session-placeholder",
+  accessToken: "owned-token-placeholder",
+  accessExpiresAt: Math.floor((NOW + 15 * 60_000) / 1000),
+  ...overrides,
+})
+
+describe("NewApiOwnedSessionLifecycle", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("persists only a fresh login bundle and schedules exact-session cleanup", async () => {
+    const harness = createHarness()
+    const lifecycle = createNewApiOwnedSessionLifecycle(harness.dependencies)
+
+    await lifecycle.capture(freshBundle())
+
+    expect(harness.getStored()).toEqual({
+      version: 1,
+      receipts: {
+        [OWNED_RECEIPT_KEY]: expect.objectContaining({
+          origin: ORIGIN,
+          sessionId: "owned-session-placeholder",
+          accessToken: "owned-token-placeholder",
+        }),
+      },
+    })
+    expect(harness.dependencies.createAlarm).toHaveBeenCalledWith(
+      NEW_API_OWNED_SESSION_ALARM_NAME,
+      { when: NOW + 10 * 60_000 },
+    )
+  })
+
+  it("updates a refreshed credential only when its SID is already owned", async () => {
+    const harness = createHarness()
+    const lifecycle = createNewApiOwnedSessionLifecycle(harness.dependencies)
+    await lifecycle.capture(freshBundle())
+
+    await expect(
+      lifecycle.refresh(
+        freshBundle({
+          sessionId: "borrowed-session-placeholder",
+          accessToken: "borrowed-token-placeholder",
+        }),
+      ),
+    ).resolves.toEqual({ owned: false })
+
+    await expect(
+      lifecycle.refresh(
+        freshBundle({ accessToken: "rotated-token-placeholder" }),
+      ),
+    ).resolves.toEqual({ owned: true })
+    expect(harness.getStored()).toEqual({
+      version: 1,
+      receipts: {
+        [OWNED_RECEIPT_KEY]: expect.objectContaining({
+          sessionId: "owned-session-placeholder",
+          accessToken: "rotated-token-placeholder",
+        }),
+      },
+    })
+  })
+
+  it("restores the desired alarm and cleans a due receipt after worker restart", async () => {
+    const harness = createHarness()
+    const firstWorker = createNewApiOwnedSessionLifecycle(harness.dependencies)
+    await firstWorker.capture(freshBundle())
+
+    const restartedDependencies = {
+      ...harness.dependencies,
+      now: () => NOW + 11 * 60_000,
+    }
+    const restartedWorker = createNewApiOwnedSessionLifecycle(
+      restartedDependencies,
+    )
+    const initializePromise = restartedWorker.initialize()
+
+    expect(restartedDependencies.onAlarm).toHaveBeenCalledTimes(1)
+    await initializePromise
+    harness.fireAlarm()
+    await vi.waitFor(() => {
+      expect(restartedDependencies.revokeSession).toHaveBeenCalledWith(
+        expect.objectContaining({
+          origin: ORIGIN,
+          sessionId: "owned-session-placeholder",
+        }),
+      )
+    })
+    await vi.waitFor(() => {
+      expect(harness.getStored()).toEqual({ version: 1, receipts: {} })
+    })
+  })
+
+  it("offers manual cleanup only for an owned origin and never broadens the target", async () => {
+    const harness = createHarness()
+    const lifecycle = createNewApiOwnedSessionLifecycle(harness.dependencies)
+    await lifecycle.capture(freshBundle())
+
+    await expect(lifecycle.getStatus(ORIGIN)).resolves.toEqual({ owned: true })
+    await expect(lifecycle.cleanup(ORIGIN)).resolves.toEqual({
+      status: "cleaned",
+    })
+    expect(harness.dependencies.revokeSession).toHaveBeenCalledTimes(1)
+    expect(harness.dependencies.revokeSession).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: "owned-session-placeholder" }),
+    )
+    await expect(lifecycle.getStatus(ORIGIN)).resolves.toEqual({ owned: false })
+  })
+
+  it("retains and cleans every extension-owned SID for the same origin", async () => {
+    const harness = createHarness()
+    const lifecycle = createNewApiOwnedSessionLifecycle(harness.dependencies)
+    await lifecycle.capture(freshBundle())
+    await lifecycle.capture(
+      freshBundle({ sessionId: "second-owned-session-placeholder" }),
+    )
+
+    await expect(lifecycle.cleanup(ORIGIN)).resolves.toEqual({
+      status: "cleaned",
+    })
+    expect(harness.dependencies.revokeSession).toHaveBeenCalledTimes(2)
+    expect(harness.dependencies.revokeSession).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: "owned-session-placeholder" }),
+    )
+    expect(harness.dependencies.revokeSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: "second-owned-session-placeholder",
+      }),
+    )
+  })
+
+  it("retains a failed cleanup briefly for a bounded best-effort retry", async () => {
+    const harness = createHarness()
+    vi.mocked(harness.dependencies.revokeSession).mockResolvedValue({
+      status: "retry",
+    })
+    const lifecycle = createNewApiOwnedSessionLifecycle(harness.dependencies)
+    await lifecycle.capture(freshBundle())
+
+    await expect(lifecycle.cleanup(ORIGIN)).resolves.toEqual({
+      status: "failed",
+    })
+    expect(harness.getStored()).toEqual({
+      version: 1,
+      receipts: {
+        [OWNED_RECEIPT_KEY]: expect.objectContaining({
+          cleanupAt: NOW + 60_000,
+        }),
+      },
+    })
+  })
+})

--- a/tests/services/managedSites/newApiOwnedSession/lifecycle.test.ts
+++ b/tests/services/managedSites/newApiOwnedSession/lifecycle.test.ts
@@ -12,9 +12,10 @@ const OWNED_RECEIPT_KEY = `${ORIGIN}\nowned-session-placeholder`
 
 function createHarness() {
   let stored: unknown
+  let currentNow = NOW
   let alarmListener: ((alarm: { name: string }) => void) | undefined
   const dependencies: NewApiOwnedSessionLifecycleDependencies = {
-    now: () => NOW,
+    now: () => currentNow,
     readStoredReceipts: vi.fn(async () => stored),
     writeStoredReceipts: vi.fn(async (value) => {
       stored = value
@@ -32,6 +33,12 @@ function createHarness() {
   return {
     dependencies,
     getStored: () => stored,
+    setNow: (value: number) => {
+      currentNow = value
+    },
+    setStored: (value: unknown) => {
+      stored = value
+    },
     fireAlarm: () =>
       alarmListener?.({ name: NEW_API_OWNED_SESSION_ALARM_NAME }),
   }
@@ -186,6 +193,125 @@ describe("NewApiOwnedSessionLifecycle", () => {
       receipts: {
         [OWNED_RECEIPT_KEY]: expect.objectContaining({
           cleanupAt: NOW + 60_000,
+        }),
+      },
+    })
+  })
+
+  it.each([
+    ["a non-http origin", { baseUrl: "ftp://managed.example" }],
+    ["a malformed origin", { baseUrl: "not a valid URL" }],
+    ["an empty SID", { sessionId: "  " }],
+    ["an empty access token", { accessToken: "  " }],
+    ["a non-finite expiry", { accessExpiresAt: Number.NaN }],
+  ])("ignores %s without mutating storage", async (_label, overrides) => {
+    const harness = createHarness()
+    const lifecycle = createNewApiOwnedSessionLifecycle(harness.dependencies)
+
+    await lifecycle.capture(freshBundle(overrides))
+
+    expect(harness.dependencies.writeStoredReceipts).not.toHaveBeenCalled()
+    expect(harness.getStored()).toBeUndefined()
+  })
+
+  it("normalizes invalid persisted state before scheduling", async () => {
+    const harness = createHarness()
+    harness.setStored({ version: 2, receipts: { stale: {} } })
+    const lifecycle = createNewApiOwnedSessionLifecycle(harness.dependencies)
+
+    await lifecycle.initialize()
+
+    expect(harness.dependencies.clearAlarm).toHaveBeenCalledWith(
+      NEW_API_OWNED_SESSION_ALARM_NAME,
+    )
+    expect(harness.dependencies.createAlarm).not.toHaveBeenCalled()
+  })
+
+  it("touches only the requested owned SID", async () => {
+    const harness = createHarness()
+    const lifecycle = createNewApiOwnedSessionLifecycle(harness.dependencies)
+    await lifecycle.capture(freshBundle())
+
+    await expect(lifecycle.touch("ftp://managed.example")).resolves.toEqual({
+      owned: false,
+    })
+    await expect(
+      lifecycle.touch(ORIGIN, "borrowed-session-placeholder"),
+    ).resolves.toEqual({ owned: false })
+
+    harness.setNow(NOW + 1_000)
+    await expect(
+      lifecycle.touch(ORIGIN, "owned-session-placeholder"),
+    ).resolves.toEqual({ owned: true })
+    expect(harness.getStored()).toEqual({
+      version: 1,
+      receipts: {
+        [OWNED_RECEIPT_KEY]: expect.objectContaining({
+          lastUsedAt: NOW + 1_000,
+          cleanupAt: NOW + 1_000 + 10 * 60_000,
+        }),
+      },
+    })
+  })
+
+  it("deletes a receipt when exact cleanup authentication is unavailable", async () => {
+    const harness = createHarness()
+    vi.mocked(harness.dependencies.revokeSession).mockResolvedValue({
+      status: "unavailable",
+    })
+    const lifecycle = createNewApiOwnedSessionLifecycle(harness.dependencies)
+    await lifecycle.capture(freshBundle())
+
+    await expect(lifecycle.cleanup(ORIGIN)).resolves.toEqual({
+      status: "failed",
+    })
+    expect(harness.getStored()).toEqual({ version: 1, receipts: {} })
+  })
+
+  it("stops retrying when the next cleanup would exceed credential expiry", async () => {
+    const harness = createHarness()
+    vi.mocked(harness.dependencies.revokeSession).mockResolvedValue({
+      status: "retry",
+    })
+    const lifecycle = createNewApiOwnedSessionLifecycle(harness.dependencies)
+    await lifecycle.capture(
+      freshBundle({ accessExpiresAt: Math.floor((NOW + 30_000) / 1000) }),
+    )
+
+    await expect(lifecycle.cleanup(ORIGIN)).resolves.toEqual({
+      status: "failed",
+    })
+    expect(harness.getStored()).toEqual({ version: 1, receipts: {} })
+  })
+
+  it("continues alarm cleanup when one revoke dependency rejects", async () => {
+    const harness = createHarness()
+    const lifecycle = createNewApiOwnedSessionLifecycle(harness.dependencies)
+    await lifecycle.initialize()
+    await lifecycle.capture(freshBundle())
+    await lifecycle.capture(
+      freshBundle({ sessionId: "second-owned-session-placeholder" }),
+    )
+    vi.mocked(harness.dependencies.revokeSession)
+      .mockRejectedValueOnce(new Error("transport escaped adapter"))
+      .mockResolvedValue({ status: "cleaned" })
+    harness.setNow(NOW + 11 * 60_000)
+
+    harness.fireAlarm()
+
+    await vi.waitFor(() => {
+      expect(harness.dependencies.revokeSession).toHaveBeenCalledTimes(2)
+    })
+    await vi.waitFor(() => {
+      expect(harness.dependencies.reportError).toHaveBeenCalledWith(
+        expect.objectContaining({ message: "transport escaped adapter" }),
+      )
+    })
+    expect(harness.getStored()).toEqual({
+      version: 1,
+      receipts: {
+        [OWNED_RECEIPT_KEY]: expect.objectContaining({
+          cleanupAt: NOW + 12 * 60_000,
         }),
       },
     })

--- a/tests/services/managedSites/providers/newApiSession.test.ts
+++ b/tests/services/managedSites/providers/newApiSession.test.ts
@@ -1440,6 +1440,45 @@ describe("newApiSession", () => {
     })
   })
 
+  it("maps an active-session limit returned by login 2FA", async () => {
+    getOwnedSessionStatusMock.mockResolvedValue({ owned: true })
+    server.use(
+      http.post(`${BASE_CONFIG.baseUrl}/api/user/login/2fa`, () =>
+        HttpResponse.json(
+          {
+            code: "AUTH_SESSION_LIMIT",
+            message: "too many active sessions",
+          },
+          { status: 409 },
+        ),
+      ),
+    )
+
+    await expect(
+      submitNewApiLoginTwoFactorCode(BASE_CONFIG, "123456"),
+    ).resolves.toEqual({
+      status: NEW_API_MANAGED_SESSION_STATUSES.SESSION_ACTIVE_LIMIT,
+      cleanupAvailable: true,
+    })
+    expect(getOwnedSessionStatusMock).toHaveBeenCalledWith(BASE_CONFIG.baseUrl)
+  })
+
+  it("rethrows a non-limit login 2FA transport error", async () => {
+    server.use(
+      http.post(`${BASE_CONFIG.baseUrl}/api/user/login/2fa`, () =>
+        HttpResponse.json(
+          { code: "UPSTREAM_UNAVAILABLE", message: "try later" },
+          { status: 503 },
+        ),
+      ),
+    )
+
+    await expect(
+      submitNewApiLoginTwoFactorCode(BASE_CONFIG, "123456"),
+    ).rejects.toMatchObject({ statusCode: 503 })
+    expect(getOwnedSessionStatusMock).not.toHaveBeenCalled()
+  })
+
   it("rejects a malformed modern AuthBundle returned by login 2FA", async () => {
     server.use(
       http.post(`${BASE_CONFIG.baseUrl}/api/user/login/2fa`, () =>

--- a/tests/services/managedSites/providers/newApiSession.test.ts
+++ b/tests/services/managedSites/providers/newApiSession.test.ts
@@ -27,12 +27,36 @@ const MANAGE_API_KEYS_EXECUTION = userCommandExecution(
   PROTECTION_BYPASS_USER_COMMANDS.ManageApiKeys,
 )
 
-const { generateNewApiTotpCodeMock, sendRuntimeMessageMock } = vi.hoisted(
-  () => ({
-    generateNewApiTotpCodeMock: vi.fn<(secret: string) => string>(),
-    sendRuntimeMessageMock: vi.fn(),
-  }),
-)
+const {
+  generateNewApiTotpCodeMock,
+  sendRuntimeMessageMock,
+  captureOwnedSessionMock,
+  cleanupOwnedSessionMock,
+  refreshOwnedSessionMock,
+  touchOwnedSessionMock,
+  getOwnedSessionStatusMock,
+} = vi.hoisted(() => ({
+  generateNewApiTotpCodeMock: vi.fn<(secret: string) => string>(),
+  sendRuntimeMessageMock: vi.fn(),
+  captureOwnedSessionMock: vi.fn(),
+  cleanupOwnedSessionMock: vi.fn(),
+  refreshOwnedSessionMock: vi.fn(),
+  touchOwnedSessionMock: vi.fn(),
+  getOwnedSessionStatusMock: vi.fn(),
+}))
+
+vi.mock("~/services/managedSites/newApiOwnedSession/client", () => ({
+  captureNewApiOwnedSession: (...args: unknown[]) =>
+    captureOwnedSessionMock(...args),
+  cleanupNewApiOwnedSession: (...args: unknown[]) =>
+    cleanupOwnedSessionMock(...args),
+  refreshNewApiOwnedSession: (...args: unknown[]) =>
+    refreshOwnedSessionMock(...args),
+  touchNewApiOwnedSession: (...args: unknown[]) =>
+    touchOwnedSessionMock(...args),
+  getNewApiOwnedSessionStatus: (...args: unknown[]) =>
+    getOwnedSessionStatusMock(...args),
+}))
 
 vi.mock(
   "~/services/managedSites/providers/newApiTotp",
@@ -120,6 +144,17 @@ describe("newApiSession", () => {
     clearNewApiManagedSessionState()
     generateNewApiTotpCodeMock.mockReset()
     sendRuntimeMessageMock.mockReset()
+    captureOwnedSessionMock.mockReset().mockResolvedValue({ success: true })
+    cleanupOwnedSessionMock.mockReset().mockResolvedValue({ status: "none" })
+    refreshOwnedSessionMock.mockReset().mockResolvedValue({
+      success: true,
+      owned: false,
+    })
+    touchOwnedSessionMock.mockReset().mockResolvedValue({
+      success: true,
+      owned: false,
+    })
+    getOwnedSessionStatusMock.mockReset().mockResolvedValue({ owned: false })
     vi.useRealTimers()
     server.use(
       http.post(
@@ -127,6 +162,154 @@ describe("newApiSession", () => {
         () => new HttpResponse(null, { status: 404 }),
       ),
     )
+  })
+
+  it("classifies the active-session cap and reports whether owned cleanup is available", async () => {
+    getOwnedSessionStatusMock.mockResolvedValue({ owned: true })
+    server.use(
+      http.get(`${BASE_CONFIG.baseUrl}/api/user/2fa/status`, () =>
+        unauthorizedResponse(),
+      ),
+      http.get(`${BASE_CONFIG.baseUrl}/api/user/passkey`, () =>
+        unauthorizedResponse(),
+      ),
+      http.post(`${BASE_CONFIG.baseUrl}/api/user/auth/refresh`, () =>
+        HttpResponse.json(
+          {
+            code: "AUTH_SESSION_LIMIT",
+            message: "too many active sessions",
+          },
+          { status: 409 },
+        ),
+      ),
+    )
+
+    await expect(ensureNewApiManagedSession(BASE_CONFIG)).resolves.toEqual({
+      status: NEW_API_MANAGED_SESSION_STATUSES.SESSION_ACTIVE_LIMIT,
+      cleanupAvailable: true,
+    })
+    expect(getOwnedSessionStatusMock).toHaveBeenCalledWith(BASE_CONFIG.baseUrl)
+  })
+
+  it("propagates the active-session cap through hidden-key recovery", async () => {
+    getOwnedSessionStatusMock.mockResolvedValue({ owned: true })
+    server.use(
+      http.get(`${BASE_CONFIG.baseUrl}/api/user/2fa/status`, () =>
+        unauthorizedResponse(),
+      ),
+      http.get(`${BASE_CONFIG.baseUrl}/api/user/passkey`, () =>
+        unauthorizedResponse(),
+      ),
+      http.post(`${BASE_CONFIG.baseUrl}/api/user/auth/refresh`, () =>
+        HttpResponse.json(
+          {
+            code: "AUTH_SESSION_LIMIT",
+            message: "too many active sessions",
+          },
+          { status: 409 },
+        ),
+      ),
+    )
+
+    await expect(
+      fetchNewApiChannelKey({ ...BASE_CONFIG, channelId: 12 }),
+    ).rejects.toMatchObject({
+      kind: NEW_API_CHANNEL_KEY_ERROR_KINDS.SESSION_LIMIT,
+      sessionResult: {
+        status: NEW_API_MANAGED_SESSION_STATUSES.SESSION_ACTIVE_LIMIT,
+        cleanupAvailable: true,
+      },
+    } satisfies Pick<
+      NewApiChannelKeyRequirementError,
+      "kind" | "sessionResult"
+    >)
+  })
+
+  it("classifies the daily issuance cap without suggesting session cleanup", async () => {
+    server.use(
+      http.get(`${BASE_CONFIG.baseUrl}/api/user/2fa/status`, () =>
+        unauthorizedResponse(),
+      ),
+      http.get(`${BASE_CONFIG.baseUrl}/api/user/passkey`, () =>
+        unauthorizedResponse(),
+      ),
+      http.post(`${BASE_CONFIG.baseUrl}/api/user/login`, () =>
+        HttpResponse.json(
+          {
+            code: "AUTH_SESSION_ISSUANCE_LIMIT",
+            message: "daily issuance cap reached",
+          },
+          { status: 429 },
+        ),
+      ),
+    )
+
+    await expect(ensureNewApiManagedSession(BASE_CONFIG)).resolves.toEqual({
+      status: NEW_API_MANAGED_SESSION_STATUSES.SESSION_ISSUANCE_LIMIT,
+    })
+    expect(getOwnedSessionStatusMock).not.toHaveBeenCalled()
+  })
+
+  it("captures a modern AuthBundle only when credential login creates it", async () => {
+    const token = "fresh-owned-dashboard-token"
+    server.use(
+      http.get(`${BASE_CONFIG.baseUrl}/api/user/2fa/status`, ({ request }) =>
+        request.headers.get("authorization") === `Bearer ${token}`
+          ? jsonData({ enabled: false })
+          : unauthorizedResponse(),
+      ),
+      http.get(`${BASE_CONFIG.baseUrl}/api/user/passkey`, ({ request }) =>
+        request.headers.get("authorization") === `Bearer ${token}`
+          ? jsonData({ enabled: false })
+          : unauthorizedResponse(),
+      ),
+      http.post(`${BASE_CONFIG.baseUrl}/api/user/login`, () =>
+        jsonData(createDashboardAuthBundle(token)),
+      ),
+    )
+
+    await ensureNewApiManagedSession(BASE_CONFIG)
+
+    expect(cleanupOwnedSessionMock).toHaveBeenCalledWith(BASE_CONFIG.baseUrl)
+    expect(captureOwnedSessionMock).toHaveBeenCalledWith({
+      baseUrl: BASE_CONFIG.baseUrl,
+      sessionId: "example-session-id",
+      accessToken: token,
+      accessExpiresAt: expect.any(Number),
+    })
+    expect(cleanupOwnedSessionMock.mock.invocationCallOrder[0]).toBeLessThan(
+      captureOwnedSessionMock.mock.invocationCallOrder[0],
+    )
+    expect(refreshOwnedSessionMock).not.toHaveBeenCalled()
+  })
+
+  it("refreshes ownership only through the matching-receipt path", async () => {
+    const token = "refreshed-owned-dashboard-token"
+    server.use(
+      http.get(`${BASE_CONFIG.baseUrl}/api/user/2fa/status`, ({ request }) =>
+        request.headers.get("authorization") === `Bearer ${token}`
+          ? jsonData({ enabled: false })
+          : unauthorizedResponse(),
+      ),
+      http.get(`${BASE_CONFIG.baseUrl}/api/user/passkey`, ({ request }) =>
+        request.headers.get("authorization") === `Bearer ${token}`
+          ? jsonData({ enabled: false })
+          : unauthorizedResponse(),
+      ),
+      http.post(`${BASE_CONFIG.baseUrl}/api/user/auth/refresh`, () =>
+        jsonData(createDashboardAuthBundle(token)),
+      ),
+    )
+
+    await ensureNewApiManagedSession(BASE_CONFIG)
+
+    expect(refreshOwnedSessionMock).toHaveBeenCalledWith({
+      baseUrl: BASE_CONFIG.baseUrl,
+      sessionId: "example-session-id",
+      accessToken: token,
+      accessExpiresAt: expect.any(Number),
+    })
+    expect(captureOwnedSessionMock).not.toHaveBeenCalled()
   })
 
   it("automatically completes login 2FA and secure verification when a TOTP secret is configured", async () => {
@@ -1461,6 +1644,10 @@ describe("newApiSession", () => {
       scope: NEW_API_SECURITY_PROOF_SCOPES.CHANNEL_KEY_READ,
     })
     expect(keyProof).toBe(proofToken)
+    expect(touchOwnedSessionMock).toHaveBeenCalledWith(
+      BASE_CONFIG.baseUrl,
+      "example-session-id",
+    )
     expect(sendRuntimeMessageMock).not.toHaveBeenCalled()
   })
 

--- a/tests/utils/browserApi.test.ts
+++ b/tests/utils/browserApi.test.ts
@@ -30,6 +30,7 @@ import {
   getManifest,
   getManifestVersion,
   getRuntimeId,
+  getSessionStorageValues,
   getTab,
   getWindow,
   hasAlarmsAPI,
@@ -37,6 +38,7 @@ import {
   hasContextMenusAPI,
   hasCookieStoresAPI,
   hasNotificationsAPI,
+  hasSessionStorageArea,
   hasStorageChangedListener,
   isAllowedIncognitoAccess,
   isMessageReceiverUnavailableError,
@@ -72,6 +74,7 @@ import {
   sendTabMessageWithRetry,
   setActionPopup,
   setNativeSidePanelActionClick,
+  setSessionStorageValues,
   updateWindow,
   WINDOW_CREATION_FAILURE_REASONS,
 } from "~/utils/browser/browserApi"
@@ -240,6 +243,33 @@ describe("browserApi alarms helpers", () => {
   afterAll(() => {
     ;(globalThis as any).browser = originalBrowser
     ;(globalThis as any).chrome = originalChrome
+  })
+})
+
+describe("browserApi session storage helpers", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    ;(globalThis as any).browser = {}
+  })
+
+  it("returns compatibility fallbacks when storage.session is unavailable", async () => {
+    expect(hasSessionStorageArea()).toBe(false)
+    await expect(getSessionStorageValues("key")).resolves.toEqual({})
+    await expect(setSessionStorageValues({ key: "value" })).resolves.toBe(false)
+  })
+
+  it("reads and writes through storage.session when supported", async () => {
+    const get = vi.fn().mockResolvedValue({ key: "value" })
+    const set = vi.fn().mockResolvedValue(undefined)
+    ;(globalThis as any).browser = { storage: { session: { get, set } } }
+
+    expect(hasSessionStorageArea()).toBe(true)
+    await expect(getSessionStorageValues("key")).resolves.toEqual({
+      key: "value",
+    })
+    await expect(setSessionStorageValues({ key: "next" })).resolves.toBe(true)
+    expect(get).toHaveBeenCalledWith("key")
+    expect(set).toHaveBeenCalledWith({ key: "next" })
   })
 })
 

--- a/tests/utils/browserApi.test.ts
+++ b/tests/utils/browserApi.test.ts
@@ -1,4 +1,12 @@
-import { afterAll, beforeEach, describe, expect, it, vi } from "vitest"
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest"
 
 import { RuntimeActionIds } from "~/constants/runtimeActions"
 import {
@@ -247,9 +255,16 @@ describe("browserApi alarms helpers", () => {
 })
 
 describe("browserApi session storage helpers", () => {
+  let previousBrowser: unknown
+
   beforeEach(() => {
     vi.restoreAllMocks()
+    previousBrowser = (globalThis as any).browser
     ;(globalThis as any).browser = {}
+  })
+
+  afterEach(() => {
+    ;(globalThis as any).browser = previousBrowser
   })
 
   it("returns compatibility fallbacks when storage.session is unavailable", async () => {
@@ -270,6 +285,15 @@ describe("browserApi session storage helpers", () => {
     await expect(setSessionStorageValues({ key: "next" })).resolves.toBe(true)
     expect(get).toHaveBeenCalledWith("key")
     expect(set).toHaveBeenCalledWith({ key: "next" })
+  })
+
+  it("returns false when storage.session rejects a write", async () => {
+    const set = vi.fn().mockRejectedValue(new Error("session quota exceeded"))
+    ;(globalThis as any).browser = {
+      storage: { session: { get: vi.fn(), set } },
+    }
+
+    await expect(setSessionStorageValues({ key: "next" })).resolves.toBe(false)
   })
 })
 


### PR DESCRIPTION
## Summary

Modern New API deployments limit both active login sessions and sessions issued within a 24-hour window. Sessions created by extension-managed dashboard logins could remain active and eventually block later operations with `409 AUTH_SESSION_LIMIT`, while `429 AUTH_SESSION_ISSUANCE_LIMIT` requires a different recovery path.

This change tracks only sessions created by the extension, cleans them up on a best-effort basis, and gives users actionable recovery guidance without revoking unrelated browser sessions.

## What changed

- Add a background-owned lifecycle for extension-created New API sessions:
  - keep an ephemeral receipt for each owned session
  - restore cleanup scheduling after an MV3 service-worker restart
  - clean idle sessions after 10 minutes
  - revoke sessions by their exact SID
  - retry cleanup within the remaining credential lifetime
- Capture only fresh credential-login sessions and retain ownership across refresh only when the SID still matches.
- Keep existing browser sessions and other sessions outside the ownership registry.
- Clean extension-owned sessions before starting another fresh login when possible.
- Preserve safe upstream error codes and map:
  - `409 AUTH_SESSION_LIMIT` to active-session recovery
  - `429 AUTH_SESSION_ISSUANCE_LIMIT` to issuance-window guidance
- Extend the managed-verification dialog:
  - offer “Clean up extension sessions and retry” only when safe cleanup is available
  - otherwise direct users to the site's session management
  - explain that deleting active sessions does not reset the 24-hour issuance limit
  - show cleanup progress and failures inside the dialog
- Add localized guidance for all supported application locales.

## Safety and compatibility

- The extension never calls `revoke-others` and never claims sessions it did not create.
- Cleanup uses the exact owned SID together with its short-lived authentication receipt.
- Cleanup is best effort: closing the browser clears `storage.session`, and expired credentials or persistent network failures may require manual session management.
- Legacy deployments and existing borrowed browser sessions retain their previous behavior.
- No storage migration or breaking configuration change is required.
- No new telemetry was added because this flow handles authentication recovery state; existing telemetry remains unchanged.

## Validation

Current HEAD `1155d3ddc`:

- Focused Vitest regression: 9 files, 351 tests passed
- Both logical commits passed `pnpm run validate:staged`
- `pnpm run validate:push` passed:
  - `pnpm compile`
  - `pnpm knip`
- The actual push reran and passed the pre-push `validate:push` gate
- Locale extraction and completeness checks passed through the commit gates
- Final tree matches the original validated feature commit

Not run locally:

- Full Vitest suite and coverage
- Browser or real-site product E2E

No new product E2E was added because lifecycle, runtime messaging, error mapping, and dialog behavior are covered at the Vitest layer. PR #1265 already covers the exact-session revocation protocol in the real-site harness, while additional live-login scenarios would consume the same issuance quota this change handles.

PR CI remains the authoritative full-suite and coverage check.

## Related work

Related to #1263 and #1265.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic management and cleanup of extension-owned sessions.
  * Added handling for active-session and daily issuance limits.
  * Added cleanup-and-retry and open-site actions to verification dialogs.
  * Added localized guidance for session limits and cleanup errors across supported languages.

* **Bug Fixes**
  * Cleanup now targets only the recorded session and retries temporary failures.
  * Session ownership refreshes during authentication and dashboard flows.
  * Improved recovery when session storage is unavailable or cleanup fails.
  * Improved session-limit error details and recovery handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->