### PR TITLE
feat(model-list): present OpenRouter native model details

### DIFF
--- a/e2e/alarmSchedulers.spec.ts
+++ b/e2e/alarmSchedulers.spec.ts
@@ -49,6 +49,7 @@ import {
   setPlasmoStorageValue,
 } from "~~/e2e/utils/extensionState"
 import { waitForExtensionRoot } from "~~/e2e/utils/lazyLoading"
+import { sendTypedRuntimeMessageFromPage } from "~~/e2e/utils/runtimeMessaging"
 
 const AUTO_CHECKIN_LEGACY_ALARM_NAME = "autoCheckin"
 const AUTO_CHECKIN_DAILY_ALARM_NAME = "autoCheckinDaily"
@@ -151,26 +152,6 @@ async function openExtensionPage(page: Page, extensionId: string) {
   await page.goto(`chrome-extension://${extensionId}/${OPTIONS_PAGE_PATH}`)
   await waitForExtensionRoot(page)
   await expectPermissionOnboardingHidden(page)
-}
-
-async function sendTypedRuntimeMessageFromPage<TResponse>(
-  page: Page,
-  type: string,
-  data?: Record<string, unknown>,
-): Promise<TResponse> {
-  return await page.evaluate(
-    async ({ type, data }) => {
-      const chromeApi = (globalThis as any).chrome
-      const response = await chromeApi.runtime.sendMessage({
-        id: Date.now(),
-        type,
-        data,
-        timestamp: Date.now(),
-      })
-      return response?.res ?? response
-    },
-    { type, data },
-  )
 }
 
 async function getAlarm(

--- a/e2e/autoCheckinQuickRun.spec.ts
+++ b/e2e/autoCheckinQuickRun.spec.ts
@@ -24,6 +24,7 @@ import {
   getServiceWorker,
 } from "~~/e2e/utils/extensionState"
 import { waitForExtensionRoot } from "~~/e2e/utils/lazyLoading"
+import { sendTypedRuntimeMessageFromPage } from "~~/e2e/utils/runtimeMessaging"
 
 const AUTO_CHECKIN_E2E_STATE_KEY = "__aah_auto_checkin_e2e_state__"
 const AUTO_CHECKIN_STATUS_STORAGE_KEY = "autoCheckin_status"
@@ -94,26 +95,6 @@ async function getDailyAlarm(
         }
       : null
   }, AUTO_CHECKIN_DAILY_ALARM_NAME)
-}
-
-async function sendTypedRuntimeMessageFromPage<TResponse>(
-  page: Page,
-  type: string,
-  data?: Record<string, unknown>,
-): Promise<TResponse> {
-  return await page.evaluate(
-    async ({ type, data }) => {
-      const chromeApi = (globalThis as any).chrome
-      const response = await chromeApi.runtime.sendMessage({
-        id: Date.now(),
-        type,
-        data,
-        timestamp: Date.now(),
-      })
-      return response?.res ?? response
-    },
-    { type, data },
-  )
 }
 
 async function openAutoCheckinOptionsPage(page: Page, extensionId: string) {

--- a/e2e/modelListCommonFlows.spec.ts
+++ b/e2e/modelListCommonFlows.spec.ts
@@ -184,9 +184,48 @@ async function seedMixedOpenRouterModelList(context: BrowserContext) {
             pricing: {
               prompt: "0.000001",
               completion: "0.000002",
+              request: "0.005",
+              image_output: "0.02",
+              overrides: [
+                {
+                  min_prompt_tokens: 200_000,
+                  prompt: "0.000003",
+                },
+              ],
             },
-            architecture: { output_modalities: ["text"] },
-            top_provider: { max_completion_tokens: 4096 },
+            architecture: {
+              input_modalities: ["text", "image"],
+              output_modalities: ["text"],
+              tokenizer: "Example tokenizer",
+            },
+            supported_parameters: ["temperature", "tools"],
+            reasoning: {
+              default_enabled: true,
+              supported_efforts: ["medium", "high"],
+            },
+            top_provider: {
+              context_length: 48_000,
+              max_completion_tokens: 4096,
+              is_moderated: true,
+            },
+            per_request_limits: {
+              prompt_tokens: 32_000,
+              completion_tokens: 2048,
+            },
+            benchmarks: {
+              design_arena: [
+                {
+                  arena: "models",
+                  category: "website",
+                  elo: 1385.2,
+                  win_rate: 62.5,
+                  rank: 5,
+                },
+              ],
+            },
+            links: {
+              details: `/api/v1/models/${OPENROUTER_MODEL_ID}/endpoints`,
+            },
           },
         ],
         total_count: 1,
@@ -264,6 +303,35 @@ test("loads one public OpenRouter catalog and keeps it provider-wide in all-acco
   await expect(
     page.getByTestId(MODEL_LIST_TEST_IDS.batchVerifyButton),
   ).toHaveCount(0)
+
+  await page.getByTestId(MODEL_LIST_TEST_IDS.modelExpandButton).click()
+  await expect(
+    page.getByRole("heading", { name: "Pricing", exact: true }),
+  ).toBeVisible()
+  await expect(
+    page.getByText("Conditional prices", { exact: true }),
+  ).toBeVisible()
+  await expect(
+    page.getByText("More than 200,000 prompt tokens", { exact: true }),
+  ).toBeVisible()
+  await expect(
+    page.getByRole("heading", { name: "Routing provider" }),
+  ).toBeVisible()
+  await expect(
+    page.getByText("Content moderation", { exact: true }),
+  ).toBeVisible()
+  await expect(
+    page.getByLabel("Routing provider").getByText("Yes", { exact: true }),
+  ).toBeVisible()
+  await expect(
+    page.getByRole("heading", { name: "Benchmarks", exact: true }),
+  ).toBeVisible()
+  await expect(
+    page.getByRole("link", { name: "Open provider details" }),
+  ).toHaveAttribute(
+    "href",
+    `${OPENROUTER_WEB_ORIGIN}/api/v1/models/${OPENROUTER_MODEL_ID}/endpoints`,
+  )
 
   await expect.poll(() => publicCatalogRequests.length).toBe(1)
   const publicRequest = publicCatalogRequests[0]!

--- a/e2e/productAnnouncementsUserFlows.spec.ts
+++ b/e2e/productAnnouncementsUserFlows.spec.ts
@@ -25,6 +25,7 @@ import {
   setPlasmoStorageValue,
 } from "~~/e2e/utils/extensionState"
 import { waitForExtensionRoot } from "~~/e2e/utils/lazyLoading"
+import { sendTypedRuntimeMessageFromPage } from "~~/e2e/utils/runtimeMessaging"
 
 const RISK_ANNOUNCEMENT_ID = "e2e-critical-product-risk"
 const INFO_ANNOUNCEMENT_ID = "e2e-info-product-update"
@@ -114,16 +115,10 @@ async function readProductAnnouncementState(
 async function waitForBackgroundProductAnnouncementRefresh(
   page: Parameters<typeof forceExtensionLanguage>[0],
 ) {
-  const response = await page.evaluate(async (type) => {
-    const chromeApi = (globalThis as any).chrome
-    const runtimeResponse = await chromeApi.runtime.sendMessage({
-      id: Date.now(),
-      type,
-      timestamp: Date.now(),
-    })
-
-    return runtimeResponse?.res ?? runtimeResponse
-  }, ProductAnnouncementsMessageTypes.Refresh)
+  const response = await sendTypedRuntimeMessageFromPage<{
+    success: boolean
+    data?: boolean
+  }>(page, ProductAnnouncementsMessageTypes.Refresh)
 
   expect(response).toMatchObject({ success: true })
 }

--- a/e2e/productAnnouncementsUserFlows.spec.ts
+++ b/e2e/productAnnouncementsUserFlows.spec.ts
@@ -11,6 +11,7 @@ import type {
   ProductAnnouncementState,
   RawProductAnnouncementFeed,
 } from "~/services/productAnnouncements/types"
+import { ProductAnnouncementsMessageTypes } from "~/services/runtimeMessaging/messageTypes"
 import { expect, test } from "~~/e2e/fixtures/extensionTest"
 import {
   forceExtensionLanguage,
@@ -110,6 +111,23 @@ async function readProductAnnouncementState(
     : null
 }
 
+async function waitForBackgroundProductAnnouncementRefresh(
+  page: Parameters<typeof forceExtensionLanguage>[0],
+) {
+  const response = await page.evaluate(async (type) => {
+    const chromeApi = (globalThis as any).chrome
+    const runtimeResponse = await chromeApi.runtime.sendMessage({
+      id: Date.now(),
+      type,
+      timestamp: Date.now(),
+    })
+
+    return runtimeResponse?.res ?? runtimeResponse
+  }, ProductAnnouncementsMessageTypes.Refresh)
+
+  expect(response).toMatchObject({ success: true })
+}
+
 test.beforeEach(async ({ context, page }) => {
   installExtensionPageGuards(page)
   await forceExtensionLanguage(page, "en")
@@ -129,11 +147,15 @@ test("persists product announcement seen, dismiss, and restore state across opti
   page,
 }) => {
   const serviceWorker = await getServiceWorker(context)
+  const optionsUrl = `chrome-extension://${extensionId}/${OPTIONS_PAGE_PATH}#${MENU_ITEM_IDS.OVERVIEW}`
+
+  await page.goto(optionsUrl)
+  // Service startup may already be refreshing before this test installs its route.
+  // Await that shared refresh promise so it cannot overwrite the seeded state.
+  await waitForBackgroundProductAnnouncementRefresh(page)
   await seedProductAnnouncementState(serviceWorker)
 
-  await page.goto(
-    `chrome-extension://${extensionId}/${OPTIONS_PAGE_PATH}#${MENU_ITEM_IDS.OVERVIEW}`,
-  )
+  await page.reload()
   await waitForExtensionRoot(page)
   await expectPermissionOnboardingHidden(page)
 

--- a/e2e/siteAnnouncementsUserFlows.spec.ts
+++ b/e2e/siteAnnouncementsUserFlows.spec.ts
@@ -25,6 +25,7 @@ import {
   getServiceWorker,
 } from "~~/e2e/utils/extensionState"
 import { waitForExtensionRoot } from "~~/e2e/utils/lazyLoading"
+import { sendTypedRuntimeMessageFromPage } from "~~/e2e/utils/runtimeMessaging"
 
 const SITE_ANNOUNCEMENTS_URL = (extensionId: string) =>
   `chrome-extension://${extensionId}/${OPTIONS_PAGE_PATH}#${MENU_ITEM_IDS.SITE_ANNOUNCEMENTS}`
@@ -130,26 +131,6 @@ async function seedPollingAnnouncementScenario(
       },
     }),
   ])
-}
-
-async function sendTypedRuntimeMessageFromPage<TResponse>(
-  page: Parameters<typeof forceExtensionLanguage>[0],
-  type: string,
-  data?: Record<string, unknown>,
-): Promise<TResponse> {
-  return await page.evaluate(
-    async ({ type, data }) => {
-      const chromeApi = (globalThis as any).chrome
-      const response = await chromeApi.runtime.sendMessage({
-        id: Date.now(),
-        type,
-        data,
-        timestamp: Date.now(),
-      })
-      return response?.res ?? response
-    },
-    { type, data },
-  )
 }
 
 function createAnnouncementStore(): SiteAnnouncementStoreState["sites"] {

--- a/e2e/utils/runtimeMessaging.ts
+++ b/e2e/utils/runtimeMessaging.ts
@@ -1,5 +1,9 @@
 import type { Page } from "@playwright/test"
 
+// Each Playwright worker owns its module instance, so this mirrors the production
+// transport's randomized monotonic sequence without cross-context coordination.
+let runtimeMessageIdSeq = Math.floor(Math.random() * 10_000)
+
 /**
  * Sends a typed WebExtension runtime envelope from an extension page.
  */
@@ -8,18 +12,21 @@ export async function sendTypedRuntimeMessageFromPage<TResponse>(
   type: string,
   data?: Record<string, unknown>,
 ): Promise<TResponse> {
+  const id = runtimeMessageIdSeq++
+  const timestamp = Date.now()
+
   return await page.evaluate(
-    async ({ type, data }) => {
+    async ({ id, type, data, timestamp }) => {
       const chromeApi = (globalThis as any).chrome
       const response = await chromeApi.runtime.sendMessage({
-        id: Date.now(),
+        id,
         type,
         data,
-        timestamp: Date.now(),
+        timestamp,
       })
 
       return response?.res ?? response
     },
-    { type, data },
+    { id, type, data, timestamp },
   )
 }

--- a/e2e/utils/runtimeMessaging.ts
+++ b/e2e/utils/runtimeMessaging.ts
@@ -1,0 +1,25 @@
+import type { Page } from "@playwright/test"
+
+/**
+ * Sends a typed WebExtension runtime envelope from an extension page.
+ */
+export async function sendTypedRuntimeMessageFromPage<TResponse>(
+  page: Page,
+  type: string,
+  data?: Record<string, unknown>,
+): Promise<TResponse> {
+  return await page.evaluate(
+    async ({ type, data }) => {
+      const chromeApi = (globalThis as any).chrome
+      const response = await chromeApi.runtime.sendMessage({
+        id: Date.now(),
+        type,
+        data,
+        timestamp: Date.now(),
+      })
+
+      return response?.res ?? response
+    },
+    { type, data },
+  )
+}

--- a/src/features/ModelList/components/ModelItem/ModelItemExpandButton.tsx
+++ b/src/features/ModelList/components/ModelItem/ModelItemExpandButton.tsx
@@ -3,6 +3,7 @@ import React from "react"
 import { useTranslation } from "react-i18next"
 
 import { IconButton } from "~/components/ui"
+import { MODEL_LIST_TEST_IDS } from "~/features/ModelList/testIds"
 import type { ProductAnalyticsScopedActionConfig } from "~/services/productAnalytics/actionConfig"
 
 interface ModelItemExpandButtonProps {
@@ -25,6 +26,7 @@ export const ModelItemExpandButton: React.FC<ModelItemExpandButtonProps> = ({
       title={isExpanded ? t("collapseDetails") : t("expandDetails")}
       aria-label={isExpanded ? t("collapseDetails") : t("expandDetails")}
       aria-expanded={isExpanded}
+      data-testid={MODEL_LIST_TEST_IDS.modelExpandButton}
       analyticsAction={analyticsAction}
     >
       {isExpanded ? (

--- a/src/features/ModelList/components/ModelItem/ModelPresentationFacts.tsx
+++ b/src/features/ModelList/components/ModelItem/ModelPresentationFacts.tsx
@@ -77,6 +77,12 @@ function useModelDisplayFactText() {
       maximumFractionDigits: 8,
     }).format(value)
 
+  const formatPercent = (value: number) =>
+    new Intl.NumberFormat(i18n.language, {
+      style: "percent",
+      maximumFractionDigits: 2,
+    }).format(value / 100)
+
   const formatCurrency = (price: ModelDisplayPrice) =>
     new Intl.NumberFormat(i18n.language, {
       style: "currency",
@@ -100,6 +106,7 @@ function useModelDisplayFactText() {
     }).format(new Date(`${value}T00:00:00Z`))
 
   const formatClock = (value: number) => {
+    // OpenRouter encodes UTC pricing bounds as base-100 HHMM integers.
     const padded = value.toString().padStart(4, "0")
     return `${padded.slice(0, 2)}:${padded.slice(2)}`
   }
@@ -124,6 +131,7 @@ function useModelDisplayFactText() {
   return {
     formatDate,
     formatNumber,
+    formatPercent,
     formatPrice,
     formatPriceCondition,
     resolveLabel,
@@ -136,6 +144,7 @@ function ModelDisplayFactValue({ fact }: { fact: ModelDisplayFact }) {
   const {
     formatDate,
     formatNumber,
+    formatPercent,
     formatPrice,
     formatPriceCondition,
     resolveLabel,
@@ -280,7 +289,7 @@ function ModelDisplayFactValue({ fact }: { fact: ModelDisplayFact }) {
                     {formatNumber(entry.rank)}
                   </td>
                   <td className="border-t py-1">
-                    {formatNumber(entry.winRatePercent)}%
+                    {formatPercent(entry.winRatePercent)}
                   </td>
                 </tr>
               ))}

--- a/src/features/ModelList/components/ModelItem/ModelPresentationFacts.tsx
+++ b/src/features/ModelList/components/ModelItem/ModelPresentationFacts.tsx
@@ -5,10 +5,63 @@ import { Badge } from "~/components/ui"
 import {
   isModelDisplayTranslationKey,
   MODEL_DISPLAY_FACT_TYPES,
+  MODEL_DISPLAY_PRICE_UNITS,
   type ModelDisplayFact,
   type ModelDisplayLabel,
+  type ModelDisplayPrice,
+  type ModelDisplayPriceCondition,
+  type ModelDisplayPriceUnit,
   type ModelPresentation,
 } from "~/services/models/modelDisplayFacts"
+
+const PRICE_UNIT_TRANSLATION_KEYS: Record<ModelDisplayPriceUnit, string> = {
+  [MODEL_DISPLAY_PRICE_UNITS.MillionInputTokens]:
+    "displayFacts.priceUnits.millionInputTokens",
+  [MODEL_DISPLAY_PRICE_UNITS.MillionOutputTokens]:
+    "displayFacts.priceUnits.millionOutputTokens",
+  [MODEL_DISPLAY_PRICE_UNITS.MillionCachedInputTokens]:
+    "displayFacts.priceUnits.millionCachedInputTokens",
+  [MODEL_DISPLAY_PRICE_UNITS.MillionCacheWriteTokens]:
+    "displayFacts.priceUnits.millionCacheWriteTokens",
+  [MODEL_DISPLAY_PRICE_UNITS.MillionCacheWriteOneHourTokens]:
+    "displayFacts.priceUnits.millionCacheWriteOneHourTokens",
+  [MODEL_DISPLAY_PRICE_UNITS.MillionReasoningTokens]:
+    "displayFacts.priceUnits.millionReasoningTokens",
+  [MODEL_DISPLAY_PRICE_UNITS.MillionImageTokens]:
+    "displayFacts.priceUnits.millionImageTokens",
+  [MODEL_DISPLAY_PRICE_UNITS.MillionAudioInputTokens]:
+    "displayFacts.priceUnits.millionAudioInputTokens",
+  [MODEL_DISPLAY_PRICE_UNITS.MillionAudioOutputTokens]:
+    "displayFacts.priceUnits.millionAudioOutputTokens",
+  [MODEL_DISPLAY_PRICE_UNITS.MillionCachedAudioInputTokens]:
+    "displayFacts.priceUnits.millionCachedAudioInputTokens",
+  [MODEL_DISPLAY_PRICE_UNITS.Request]: "displayFacts.priceUnits.request",
+  [MODEL_DISPLAY_PRICE_UNITS.InputImage]: "displayFacts.priceUnits.inputImage",
+  [MODEL_DISPLAY_PRICE_UNITS.OutputImage]:
+    "displayFacts.priceUnits.outputImage",
+  [MODEL_DISPLAY_PRICE_UNITS.WebSearch]: "displayFacts.priceUnits.webSearch",
+}
+
+const PRICE_UNIT_FALLBACKS: Record<ModelDisplayPriceUnit, string> = {
+  [MODEL_DISPLAY_PRICE_UNITS.MillionInputTokens]: "1M input tokens",
+  [MODEL_DISPLAY_PRICE_UNITS.MillionOutputTokens]: "1M output tokens",
+  [MODEL_DISPLAY_PRICE_UNITS.MillionCachedInputTokens]:
+    "1M cached input tokens",
+  [MODEL_DISPLAY_PRICE_UNITS.MillionCacheWriteTokens]: "1M cache-write tokens",
+  [MODEL_DISPLAY_PRICE_UNITS.MillionCacheWriteOneHourTokens]:
+    "1M one-hour cache-write tokens",
+  [MODEL_DISPLAY_PRICE_UNITS.MillionReasoningTokens]: "1M reasoning tokens",
+  [MODEL_DISPLAY_PRICE_UNITS.MillionImageTokens]: "1M image tokens",
+  [MODEL_DISPLAY_PRICE_UNITS.MillionAudioInputTokens]: "1M audio input tokens",
+  [MODEL_DISPLAY_PRICE_UNITS.MillionAudioOutputTokens]:
+    "1M audio output tokens",
+  [MODEL_DISPLAY_PRICE_UNITS.MillionCachedAudioInputTokens]:
+    "1M cached audio input tokens",
+  [MODEL_DISPLAY_PRICE_UNITS.Request]: "request",
+  [MODEL_DISPLAY_PRICE_UNITS.InputImage]: "input image",
+  [MODEL_DISPLAY_PRICE_UNITS.OutputImage]: "output image",
+  [MODEL_DISPLAY_PRICE_UNITS.WebSearch]: "web search",
+}
 
 /** Resolves localized labels and value formatting for model display facts. */
 function useModelDisplayFactText() {
@@ -19,24 +72,88 @@ function useModelDisplayFactText() {
       ? t(label.translationKey, { defaultValue: label.fallback })
       : label.fallback
 
-  const formatTokenQuantity = (value: number) =>
-    t("displayFacts.tokenCount", {
-      count: value,
-      formattedCount: new Intl.NumberFormat(i18n.language).format(value),
+  const formatNumber = (value: number) =>
+    new Intl.NumberFormat(i18n.language, {
+      maximumFractionDigits: 8,
+    }).format(value)
+
+  const formatCurrency = (price: ModelDisplayPrice) =>
+    new Intl.NumberFormat(i18n.language, {
+      style: "currency",
+      currency: price.currency,
+      minimumFractionDigits: price.amount === 0 || price.amount >= 0.01 ? 2 : 0,
+      maximumFractionDigits: 8,
+    }).format(price.amount)
+
+  const formatPriceUnit = (unit: ModelDisplayPriceUnit) =>
+    t(PRICE_UNIT_TRANSLATION_KEYS[unit], {
+      defaultValue: PRICE_UNIT_FALLBACKS[unit],
     })
 
-  return { formatTokenQuantity, resolveLabel }
+  const formatPrice = (price: ModelDisplayPrice) =>
+    `${formatCurrency(price)} / ${formatPriceUnit(price.unit)}`
+
+  const formatDate = (value: string) =>
+    new Intl.DateTimeFormat(i18n.language, {
+      dateStyle: "medium",
+      timeZone: "UTC",
+    }).format(new Date(`${value}T00:00:00Z`))
+
+  const formatClock = (value: number) => {
+    const padded = value.toString().padStart(4, "0")
+    return `${padded.slice(0, 2)}:${padded.slice(2)}`
+  }
+
+  const formatPriceCondition = (condition: ModelDisplayPriceCondition) => {
+    switch (condition.type) {
+      case "minimum-prompt-tokens":
+        return t("displayFacts.priceConditions.minimumPromptTokens", {
+          count: condition.value,
+          formattedCount: formatNumber(condition.value),
+          defaultValue: "More than {{formattedCount}} prompt tokens",
+        })
+      case "utc-window":
+        return t("displayFacts.priceConditions.utcWindow", {
+          start: formatClock(condition.start),
+          end: formatClock(condition.end),
+          defaultValue: "{{start}}–{{end}} UTC",
+        })
+    }
+  }
+
+  return {
+    formatDate,
+    formatNumber,
+    formatPrice,
+    formatPriceCondition,
+    resolveLabel,
+    t,
+  }
 }
 
 /** Renders one typed model display fact value. */
 function ModelDisplayFactValue({ fact }: { fact: ModelDisplayFact }) {
-  const { formatTokenQuantity } = useModelDisplayFactText()
+  const {
+    formatDate,
+    formatNumber,
+    formatPrice,
+    formatPriceCondition,
+    resolveLabel,
+    t,
+  } = useModelDisplayFactText()
 
   switch (fact.type) {
     case MODEL_DISPLAY_FACT_TYPES.Text:
       return <span className="break-words">{fact.value}</span>
     case MODEL_DISPLAY_FACT_TYPES.TokenQuantity:
-      return <span>{formatTokenQuantity(fact.value)}</span>
+      return (
+        <span>
+          {t("displayFacts.tokenCount", {
+            count: fact.value,
+            formattedCount: formatNumber(fact.value),
+          })}
+        </span>
+      )
     case MODEL_DISPLAY_FACT_TYPES.StringList:
       return (
         <ul className="flex min-w-0 flex-wrap gap-1">
@@ -52,6 +169,124 @@ function ModelDisplayFactValue({ fact }: { fact: ModelDisplayFact }) {
             </li>
           ))}
         </ul>
+      )
+    case MODEL_DISPLAY_FACT_TYPES.Boolean:
+      return (
+        <span>
+          {fact.value
+            ? t("displayFacts.boolean.yes", { defaultValue: "Yes" })
+            : t("displayFacts.boolean.no", { defaultValue: "No" })}
+        </span>
+      )
+    case MODEL_DISPLAY_FACT_TYPES.Number:
+      return <span>{formatNumber(fact.value)}</span>
+    case MODEL_DISPLAY_FACT_TYPES.Date:
+      return <time dateTime={fact.value}>{formatDate(fact.value)}</time>
+    case MODEL_DISPLAY_FACT_TYPES.Link:
+      return (
+        <a
+          href={fact.href}
+          target="_blank"
+          rel="noreferrer noopener"
+          className="break-all text-blue-600 underline-offset-2 hover:underline dark:text-blue-400"
+        >
+          {resolveLabel(fact.text)}
+        </a>
+      )
+    case MODEL_DISPLAY_FACT_TYPES.CurrencyPrice:
+      return <span>{formatPrice(fact)}</span>
+    case MODEL_DISPLAY_FACT_TYPES.PriceOverrides:
+      return (
+        <ol className="space-y-3">
+          {fact.overrides.map((override, index) => (
+            <li
+              key={`${override.conditions.map(formatPriceCondition).join(":")}:${index}`}
+              className="rounded-md border border-amber-200 bg-amber-50 p-2 dark:border-amber-800 dark:bg-amber-950/30"
+            >
+              <ul className="mb-1 list-disc space-y-0.5 pl-5 text-xs text-amber-800 dark:text-amber-200">
+                {override.conditions.map((condition) => {
+                  const conditionText = formatPriceCondition(condition)
+                  return <li key={conditionText}>{conditionText}</li>
+                })}
+              </ul>
+              <ul className="space-y-1">
+                {override.prices.map((price) => (
+                  <li
+                    key={`${price.label.translationKey ?? price.label.fallback}:${price.unit}`}
+                    className="flex min-w-0 flex-wrap justify-between gap-x-3"
+                  >
+                    <span className="break-words">
+                      {resolveLabel(price.label)}
+                    </span>
+                    <span className="font-medium break-all">
+                      {formatPrice(price)}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </li>
+          ))}
+        </ol>
+      )
+    case MODEL_DISPLAY_FACT_TYPES.BenchmarkList:
+      return (
+        <div className="max-w-full overflow-x-auto">
+          <table
+            aria-label={resolveLabel(fact.label)}
+            className="w-full min-w-[32rem] border-collapse text-left text-xs"
+          >
+            <thead>
+              <tr>
+                <th className="pr-3 pb-1">
+                  {t("displayFacts.benchmarkTable.arena", {
+                    defaultValue: "Arena",
+                  })}
+                </th>
+                <th className="pr-3 pb-1">
+                  {t("displayFacts.benchmarkTable.category", {
+                    defaultValue: "Category",
+                  })}
+                </th>
+                <th className="pr-3 pb-1">
+                  {t("displayFacts.benchmarkTable.score", {
+                    defaultValue: "Score",
+                  })}
+                </th>
+                <th className="pr-3 pb-1">
+                  {t("displayFacts.benchmarkTable.rank", {
+                    defaultValue: "Rank",
+                  })}
+                </th>
+                <th className="pb-1">
+                  {t("displayFacts.benchmarkTable.winRate", {
+                    defaultValue: "Win rate",
+                  })}
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {fact.entries.map((entry) => (
+                <tr key={`${entry.arena}:${entry.category}`}>
+                  <td className="border-t py-1 pr-3 break-all">
+                    {entry.arena}
+                  </td>
+                  <td className="border-t py-1 pr-3 break-all">
+                    {entry.category}
+                  </td>
+                  <td className="border-t py-1 pr-3">
+                    {formatNumber(entry.score)}
+                  </td>
+                  <td className="border-t py-1 pr-3">
+                    {formatNumber(entry.rank)}
+                  </td>
+                  <td className="border-t py-1">
+                    {formatNumber(entry.winRatePercent)}%
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       )
   }
 }

--- a/src/features/ModelList/testIds.ts
+++ b/src/features/ModelList/testIds.ts
@@ -6,6 +6,7 @@ export const MODEL_LIST_TEST_IDS = {
   addApiCredentialProfileButton: "model-list-add-api-credential-profile-button",
   addFirstAccountButton: "model-list-add-first-account-button",
   modelKeyDialogButton: "model-list-model-key-dialog-button",
+  modelExpandButton: "model-list-model-expand-button",
   verifyApiButton: "model-list-verify-api-button",
   verifyCliSupportButton: "model-list-verify-cli-support-button",
   batchVerifyButton: "model-list-batch-verify-button",

--- a/src/locales/de/modelList.json
+++ b/src/locales/de/modelList.json
@@ -112,9 +112,121 @@
   "description": "Verfügbare KI-Modelle anzeigen und verwalten",
   "detailedPricing": "Detaillierte Preise",
   "displayFacts": {
+    "benchmarkTable": {
+      "arena": "Arena",
+      "category": "Kategorie",
+      "rank": "Rang",
+      "score": "Punktzahl",
+      "winRate": "Gewinnrate"
+    },
+    "boolean": {
+      "no": "Nein",
+      "yes": "Ja"
+    },
     "contextLimit": "Kontextlimit",
+    "inputModalities": "Eingabemodalitäten",
     "maximumOutputTokens": "Maximale Ausgabe-Token",
+    "openRouter": {
+      "architecture": {
+        "instructType": "Anweisungsformat",
+        "modality": "Primäre Modalität",
+        "tokenizer": "Tokenizer"
+      },
+      "benchmarks": {
+        "agenticIndex": "Agentenindex",
+        "codingIndex": "Programmierindex",
+        "designArena": "Design-Arena-Ranglisten",
+        "intelligenceIndex": "Intelligenzindex"
+      },
+      "capabilities": {
+        "reasoningDefaultEffort": "Standardmäßiger Denkaufwand",
+        "reasoningDefaultEnabled": "Reasoning standardmäßig aktiviert",
+        "reasoningMandatory": "Reasoning erforderlich",
+        "reasoningSupportedEfforts": "Unterstützte Reasoning-Stufen",
+        "reasoningSupportsMaxTokens": "Reasoning-Tokenlimit unterstützt",
+        "supportedParameters": "Unterstützte Parameter",
+        "supportedVoices": "Unterstützte Stimmen"
+      },
+      "defaults": {
+        "frequencyPenalty": "Standard-Frequenzstrafe",
+        "presencePenalty": "Standard-Anwesenheitsstrafe",
+        "repetitionPenalty": "Standard-Wiederholungsstrafe",
+        "temperature": "Standard-Temperatur",
+        "topK": "Standard-Top-k",
+        "topP": "Standard-Top-p"
+      },
+      "lifecycle": {
+        "aliasName": "Name des Aliasziels",
+        "aliasSlug": "Aliasziel",
+        "canonicalSlug": "Kanonischer Slug",
+        "created": "Modell erstellt",
+        "expirationDate": "Ablaufdatum",
+        "huggingFaceId": "Hugging-Face-ID",
+        "knowledgeCutoff": "Wissensstand"
+      },
+      "limits": {
+        "completionTokens": "Antwort-Tokenlimit",
+        "promptTokens": "Eingabe-Tokenlimit"
+      },
+      "links": {
+        "openProviderDetails": "Anbieterdetails öffnen",
+        "providerDetails": "Anbieterdetails"
+      },
+      "prices": {
+        "audioInput": "Preis für Audioeingabe",
+        "audioOutput": "Preis für Audioausgabe",
+        "cachedAudioInput": "Preis für zwischengespeicherte Audioeingabe",
+        "cacheRead": "Preis für Cache-Lesen",
+        "cacheWrite": "Preis für Cache-Schreiben",
+        "cacheWriteOneHour": "Preis für einstündiges Cache-Schreiben",
+        "conditional": "Bedingte Preise",
+        "imageInput": "Preis für Bildeingabe",
+        "imageOutput": "Preis für Bildausgabe",
+        "imageToken": "Preis für Bild-Token",
+        "input": "Eingabepreis",
+        "output": "Ausgabepreis",
+        "reasoning": "Preis für Reasoning-Token",
+        "request": "Preis pro Anfrage",
+        "webSearch": "Preis für Websuche"
+      },
+      "routing": {
+        "contextLimit": "Routing-Kontextlimit",
+        "moderation": "Inhaltsmoderation"
+      },
+      "sections": {
+        "architecture": "Architektur",
+        "benchmarks": "Benchmarks",
+        "capabilities": "Funktionen und Standardwerte",
+        "lifecycle": "Lebenszyklus und Aliase",
+        "links": "Links",
+        "pricing": "Preise",
+        "requestLimits": "Limits pro Anfrage",
+        "routing": "Routing-Anbieter"
+      }
+    },
     "outputModalities": "Ausgabemodalitäten",
+    "priceConditions": {
+      "minimumPromptTokens": "Mehr als {{formattedCount}} Eingabe-Token",
+      "minimumPromptTokens_one": "Mehr als {{formattedCount}} Eingabe-Token",
+      "minimumPromptTokens_other": "Mehr als {{formattedCount}} Eingabe-Token",
+      "utcWindow": "{{start}}–{{end}} UTC"
+    },
+    "priceUnits": {
+      "inputImage": "Eingabebild",
+      "millionAudioInputTokens": "1 Mio. Audioeingabe-Token",
+      "millionAudioOutputTokens": "1 Mio. Audioausgabe-Token",
+      "millionCachedAudioInputTokens": "1 Mio. zwischengespeicherte Audioeingabe-Token",
+      "millionCachedInputTokens": "1 Mio. zwischengespeicherte Eingabe-Token",
+      "millionCacheWriteOneHourTokens": "1 Mio. einstündige Cache-Schreib-Token",
+      "millionCacheWriteTokens": "1 Mio. Cache-Schreib-Token",
+      "millionImageTokens": "1 Mio. Bild-Token",
+      "millionInputTokens": "1 Mio. Eingabe-Token",
+      "millionOutputTokens": "1 Mio. Ausgabe-Token",
+      "millionReasoningTokens": "1 Mio. Reasoning-Token",
+      "outputImage": "Ausgabebild",
+      "request": "Anfrage",
+      "webSearch": "Websuche"
+    },
     "sections": {
       "specifications": "Spezifikationen"
     },

--- a/src/locales/en/modelList.json
+++ b/src/locales/en/modelList.json
@@ -112,9 +112,121 @@
   "description": "View and manage available AI models",
   "detailedPricing": "Detailed Pricing",
   "displayFacts": {
+    "benchmarkTable": {
+      "arena": "Arena",
+      "category": "Category",
+      "rank": "Rank",
+      "score": "Score",
+      "winRate": "Win rate"
+    },
+    "boolean": {
+      "no": "No",
+      "yes": "Yes"
+    },
     "contextLimit": "Context limit",
+    "inputModalities": "Input modalities",
     "maximumOutputTokens": "Maximum output tokens",
+    "openRouter": {
+      "architecture": {
+        "instructType": "Instruction format",
+        "modality": "Primary modality",
+        "tokenizer": "Tokenizer"
+      },
+      "benchmarks": {
+        "agenticIndex": "Agentic index",
+        "codingIndex": "Coding index",
+        "designArena": "Design Arena rankings",
+        "intelligenceIndex": "Intelligence index"
+      },
+      "capabilities": {
+        "reasoningDefaultEffort": "Default reasoning effort",
+        "reasoningDefaultEnabled": "Reasoning enabled by default",
+        "reasoningMandatory": "Reasoning required",
+        "reasoningSupportedEfforts": "Supported reasoning efforts",
+        "reasoningSupportsMaxTokens": "Reasoning token limit supported",
+        "supportedParameters": "Supported parameters",
+        "supportedVoices": "Supported voices"
+      },
+      "defaults": {
+        "frequencyPenalty": "Default frequency penalty",
+        "presencePenalty": "Default presence penalty",
+        "repetitionPenalty": "Default repetition penalty",
+        "temperature": "Default temperature",
+        "topK": "Default top-k",
+        "topP": "Default top-p"
+      },
+      "lifecycle": {
+        "aliasName": "Alias target name",
+        "aliasSlug": "Alias target",
+        "canonicalSlug": "Canonical slug",
+        "created": "Model created",
+        "expirationDate": "Expiration date",
+        "huggingFaceId": "Hugging Face ID",
+        "knowledgeCutoff": "Knowledge cutoff"
+      },
+      "limits": {
+        "completionTokens": "Completion token limit",
+        "promptTokens": "Prompt token limit"
+      },
+      "links": {
+        "openProviderDetails": "Open provider details",
+        "providerDetails": "Provider details"
+      },
+      "prices": {
+        "audioInput": "Audio input price",
+        "audioOutput": "Audio output price",
+        "cachedAudioInput": "Cached audio input price",
+        "cacheRead": "Cache read price",
+        "cacheWrite": "Cache write price",
+        "cacheWriteOneHour": "One-hour cache write price",
+        "conditional": "Conditional prices",
+        "imageInput": "Image input price",
+        "imageOutput": "Image output price",
+        "imageToken": "Image token price",
+        "input": "Input price",
+        "output": "Output price",
+        "reasoning": "Reasoning token price",
+        "request": "Request price",
+        "webSearch": "Web search price"
+      },
+      "routing": {
+        "contextLimit": "Routing context limit",
+        "moderation": "Content moderation"
+      },
+      "sections": {
+        "architecture": "Architecture",
+        "benchmarks": "Benchmarks",
+        "capabilities": "Capabilities and defaults",
+        "lifecycle": "Lifecycle and aliases",
+        "links": "Links",
+        "pricing": "Pricing",
+        "requestLimits": "Per-request limits",
+        "routing": "Routing provider"
+      }
+    },
     "outputModalities": "Output modalities",
+    "priceConditions": {
+      "minimumPromptTokens": "More than {{formattedCount}} prompt tokens",
+      "minimumPromptTokens_one": "More than {{formattedCount}} prompt token",
+      "minimumPromptTokens_other": "More than {{formattedCount}} prompt tokens",
+      "utcWindow": "{{start}}–{{end}} UTC"
+    },
+    "priceUnits": {
+      "inputImage": "input image",
+      "millionAudioInputTokens": "1M audio input tokens",
+      "millionAudioOutputTokens": "1M audio output tokens",
+      "millionCachedAudioInputTokens": "1M cached audio input tokens",
+      "millionCachedInputTokens": "1M cached input tokens",
+      "millionCacheWriteOneHourTokens": "1M one-hour cache-write tokens",
+      "millionCacheWriteTokens": "1M cache-write tokens",
+      "millionImageTokens": "1M image tokens",
+      "millionInputTokens": "1M input tokens",
+      "millionOutputTokens": "1M output tokens",
+      "millionReasoningTokens": "1M reasoning tokens",
+      "outputImage": "output image",
+      "request": "request",
+      "webSearch": "web search"
+    },
     "sections": {
       "specifications": "Specifications"
     },

--- a/src/locales/es-419/modelList.json
+++ b/src/locales/es-419/modelList.json
@@ -118,9 +118,122 @@
   "description": "Ver y administrar modelos de IA disponibles",
   "detailedPricing": "Precios detallados",
   "displayFacts": {
+    "benchmarkTable": {
+      "arena": "Arena",
+      "category": "Categoría",
+      "rank": "Posición",
+      "score": "Puntuación",
+      "winRate": "Tasa de victorias"
+    },
+    "boolean": {
+      "no": "No",
+      "yes": "Sí"
+    },
     "contextLimit": "Límite de contexto",
+    "inputModalities": "Modalidades de entrada",
     "maximumOutputTokens": "Máximo de tokens de salida",
+    "openRouter": {
+      "architecture": {
+        "instructType": "Formato de instrucciones",
+        "modality": "Modalidad principal",
+        "tokenizer": "Tokenizador"
+      },
+      "benchmarks": {
+        "agenticIndex": "Índice de agentes",
+        "codingIndex": "Índice de programación",
+        "designArena": "Clasificaciones de Design Arena",
+        "intelligenceIndex": "Índice de inteligencia"
+      },
+      "capabilities": {
+        "reasoningDefaultEffort": "Esfuerzo de razonamiento predeterminado",
+        "reasoningDefaultEnabled": "Razonamiento activado de forma predeterminada",
+        "reasoningMandatory": "Razonamiento obligatorio",
+        "reasoningSupportedEfforts": "Esfuerzos de razonamiento compatibles",
+        "reasoningSupportsMaxTokens": "Admite límite de tokens de razonamiento",
+        "supportedParameters": "Parámetros compatibles",
+        "supportedVoices": "Voces compatibles"
+      },
+      "defaults": {
+        "frequencyPenalty": "Penalización de frecuencia predeterminada",
+        "presencePenalty": "Penalización de presencia predeterminada",
+        "repetitionPenalty": "Penalización de repetición predeterminada",
+        "temperature": "Temperatura predeterminada",
+        "topK": "Top-k predeterminado",
+        "topP": "Top-p predeterminado"
+      },
+      "lifecycle": {
+        "aliasName": "Nombre de destino del alias",
+        "aliasSlug": "Destino del alias",
+        "canonicalSlug": "Slug canónico",
+        "created": "Modelo creado",
+        "expirationDate": "Fecha de vencimiento",
+        "huggingFaceId": "ID de Hugging Face",
+        "knowledgeCutoff": "Fecha límite de conocimiento"
+      },
+      "limits": {
+        "completionTokens": "Límite de tokens de respuesta",
+        "promptTokens": "Límite de tokens de entrada"
+      },
+      "links": {
+        "openProviderDetails": "Abrir detalles del proveedor",
+        "providerDetails": "Detalles del proveedor"
+      },
+      "prices": {
+        "audioInput": "Precio de entrada de audio",
+        "audioOutput": "Precio de salida de audio",
+        "cachedAudioInput": "Precio de entrada de audio en caché",
+        "cacheRead": "Precio de lectura de caché",
+        "cacheWrite": "Precio de escritura de caché",
+        "cacheWriteOneHour": "Precio de escritura de caché por una hora",
+        "conditional": "Precios condicionales",
+        "imageInput": "Precio de imagen de entrada",
+        "imageOutput": "Precio de imagen de salida",
+        "imageToken": "Precio de token de imagen",
+        "input": "Precio de entrada",
+        "output": "Precio de salida",
+        "reasoning": "Precio de token de razonamiento",
+        "request": "Precio por solicitud",
+        "webSearch": "Precio de búsqueda web"
+      },
+      "routing": {
+        "contextLimit": "Límite de contexto de enrutamiento",
+        "moderation": "Moderación de contenido"
+      },
+      "sections": {
+        "architecture": "Arquitectura",
+        "benchmarks": "Pruebas de rendimiento",
+        "capabilities": "Capacidades y valores predeterminados",
+        "lifecycle": "Ciclo de vida y alias",
+        "links": "Enlaces",
+        "pricing": "Precios",
+        "requestLimits": "Límites por solicitud",
+        "routing": "Proveedor de enrutamiento"
+      }
+    },
     "outputModalities": "Modalidades de salida",
+    "priceConditions": {
+      "minimumPromptTokens": "Más de {{formattedCount}} tokens de entrada",
+      "minimumPromptTokens_one": "Más de {{formattedCount}} token de entrada",
+      "minimumPromptTokens_many": "Más de {{formattedCount}} tokens de entrada",
+      "minimumPromptTokens_other": "Más de {{formattedCount}} tokens de entrada",
+      "utcWindow": "{{start}}–{{end}} UTC"
+    },
+    "priceUnits": {
+      "inputImage": "imagen de entrada",
+      "millionAudioInputTokens": "1 M de tokens de audio de entrada",
+      "millionAudioOutputTokens": "1 M de tokens de audio de salida",
+      "millionCachedAudioInputTokens": "1 M de tokens de audio de entrada en caché",
+      "millionCachedInputTokens": "1 M de tokens de entrada en caché",
+      "millionCacheWriteOneHourTokens": "1 M de tokens de escritura de caché por una hora",
+      "millionCacheWriteTokens": "1 M de tokens de escritura de caché",
+      "millionImageTokens": "1 M de tokens de imagen",
+      "millionInputTokens": "1 M de tokens de entrada",
+      "millionOutputTokens": "1 M de tokens de salida",
+      "millionReasoningTokens": "1 M de tokens de razonamiento",
+      "outputImage": "imagen de salida",
+      "request": "solicitud",
+      "webSearch": "búsqueda web"
+    },
     "sections": {
       "specifications": "Especificaciones"
     },

--- a/src/locales/ja/modelList.json
+++ b/src/locales/ja/modelList.json
@@ -106,9 +106,120 @@
   "description": "利用可能な AI モデルを確認・管理します",
   "detailedPricing": "詳細料金",
   "displayFacts": {
+    "benchmarkTable": {
+      "arena": "アリーナ",
+      "category": "カテゴリ",
+      "rank": "順位",
+      "score": "スコア",
+      "winRate": "勝率"
+    },
+    "boolean": {
+      "no": "いいえ",
+      "yes": "はい"
+    },
     "contextLimit": "コンテキスト上限",
+    "inputModalities": "入力モダリティ",
     "maximumOutputTokens": "最大出力トークン数",
+    "openRouter": {
+      "architecture": {
+        "instructType": "命令形式",
+        "modality": "主モダリティ",
+        "tokenizer": "トークナイザー"
+      },
+      "benchmarks": {
+        "agenticIndex": "エージェント指標",
+        "codingIndex": "コーディング指標",
+        "designArena": "Design Arena ランキング",
+        "intelligenceIndex": "知能指標"
+      },
+      "capabilities": {
+        "reasoningDefaultEffort": "既定の推論レベル",
+        "reasoningDefaultEnabled": "既定で推論を有効化",
+        "reasoningMandatory": "推論が必須",
+        "reasoningSupportedEfforts": "対応する推論レベル",
+        "reasoningSupportsMaxTokens": "推論トークン上限に対応",
+        "supportedParameters": "対応パラメーター",
+        "supportedVoices": "対応音声"
+      },
+      "defaults": {
+        "frequencyPenalty": "既定の頻度ペナルティ",
+        "presencePenalty": "既定の存在ペナルティ",
+        "repetitionPenalty": "既定の反復ペナルティ",
+        "temperature": "既定の Temperature",
+        "topK": "既定の top-k",
+        "topP": "既定の top-p"
+      },
+      "lifecycle": {
+        "aliasName": "エイリアス先の名前",
+        "aliasSlug": "エイリアス先",
+        "canonicalSlug": "正規スラッグ",
+        "created": "モデル作成日",
+        "expirationDate": "有効期限",
+        "huggingFaceId": "Hugging Face ID",
+        "knowledgeCutoff": "知識のカットオフ"
+      },
+      "limits": {
+        "completionTokens": "応答トークン上限",
+        "promptTokens": "入力トークン上限"
+      },
+      "links": {
+        "openProviderDetails": "プロバイダーの詳細を開く",
+        "providerDetails": "プロバイダーの詳細"
+      },
+      "prices": {
+        "audioInput": "音声入力料金",
+        "audioOutput": "音声出力料金",
+        "cachedAudioInput": "キャッシュ済み音声入力料金",
+        "cacheRead": "キャッシュ読み取り料金",
+        "cacheWrite": "キャッシュ書き込み料金",
+        "cacheWriteOneHour": "1 時間キャッシュ書き込み料金",
+        "conditional": "条件付き料金",
+        "imageInput": "画像入力料金",
+        "imageOutput": "画像出力料金",
+        "imageToken": "画像トークン料金",
+        "input": "入力料金",
+        "output": "出力料金",
+        "reasoning": "推論トークン料金",
+        "request": "リクエスト料金",
+        "webSearch": "ウェブ検索料金"
+      },
+      "routing": {
+        "contextLimit": "ルーティング時のコンテキスト上限",
+        "moderation": "コンテンツモデレーション"
+      },
+      "sections": {
+        "architecture": "アーキテクチャ",
+        "benchmarks": "ベンチマーク",
+        "capabilities": "機能と既定値",
+        "lifecycle": "ライフサイクルとエイリアス",
+        "links": "リンク",
+        "pricing": "料金",
+        "requestLimits": "リクエストごとの上限",
+        "routing": "ルーティングプロバイダー"
+      }
+    },
     "outputModalities": "出力モダリティ",
+    "priceConditions": {
+      "minimumPromptTokens": "入力が {{formattedCount}} トークンを超える場合",
+      "minimumPromptTokens_other": "入力が {{formattedCount}} トークンを超える場合",
+      "utcWindow": "{{start}}–{{end}} UTC"
+    },
+    "priceUnits": {
+      "inputImage": "入力画像",
+      "millionAudioInputTokens": "音声入力 100 万トークン",
+      "millionAudioOutputTokens": "音声出力 100 万トークン",
+      "millionCachedAudioInputTokens": "キャッシュ済み音声入力 100 万トークン",
+      "millionCachedInputTokens": "キャッシュ済み入力 100 万トークン",
+      "millionCacheWriteOneHourTokens": "1 時間キャッシュ書き込み 100 万トークン",
+      "millionCacheWriteTokens": "キャッシュ書き込み 100 万トークン",
+      "millionImageTokens": "画像 100 万トークン",
+      "millionInputTokens": "入力 100 万トークン",
+      "millionOutputTokens": "出力 100 万トークン",
+      "millionReasoningTokens": "推論 100 万トークン",
+      "outputImage": "出力画像",
+      "request": "リクエスト",
+      "webSearch": "ウェブ検索"
+    },
     "sections": {
       "specifications": "仕様"
     },

--- a/src/locales/pt-BR/modelList.json
+++ b/src/locales/pt-BR/modelList.json
@@ -118,9 +118,122 @@
   "description": "Veja e gerencie os modelos de IA disponíveis",
   "detailedPricing": "Preços detalhados",
   "displayFacts": {
+    "benchmarkTable": {
+      "arena": "Arena",
+      "category": "Categoria",
+      "rank": "Posição",
+      "score": "Pontuação",
+      "winRate": "Taxa de vitória"
+    },
+    "boolean": {
+      "no": "Não",
+      "yes": "Sim"
+    },
     "contextLimit": "Limite de contexto",
+    "inputModalities": "Modalidades de entrada",
     "maximumOutputTokens": "Máximo de tokens de saída",
+    "openRouter": {
+      "architecture": {
+        "instructType": "Formato de instrução",
+        "modality": "Modalidade principal",
+        "tokenizer": "Tokenizador"
+      },
+      "benchmarks": {
+        "agenticIndex": "Índice de agentes",
+        "codingIndex": "Índice de programação",
+        "designArena": "Classificações do Design Arena",
+        "intelligenceIndex": "Índice de inteligência"
+      },
+      "capabilities": {
+        "reasoningDefaultEffort": "Esforço de raciocínio padrão",
+        "reasoningDefaultEnabled": "Raciocínio ativado por padrão",
+        "reasoningMandatory": "Raciocínio obrigatório",
+        "reasoningSupportedEfforts": "Esforços de raciocínio compatíveis",
+        "reasoningSupportsMaxTokens": "Aceita limite de tokens de raciocínio",
+        "supportedParameters": "Parâmetros compatíveis",
+        "supportedVoices": "Vozes compatíveis"
+      },
+      "defaults": {
+        "frequencyPenalty": "Penalidade de frequência padrão",
+        "presencePenalty": "Penalidade de presença padrão",
+        "repetitionPenalty": "Penalidade de repetição padrão",
+        "temperature": "Temperatura padrão",
+        "topK": "Top-k padrão",
+        "topP": "Top-p padrão"
+      },
+      "lifecycle": {
+        "aliasName": "Nome de destino do alias",
+        "aliasSlug": "Destino do alias",
+        "canonicalSlug": "Slug canônico",
+        "created": "Modelo criado",
+        "expirationDate": "Data de expiração",
+        "huggingFaceId": "ID do Hugging Face",
+        "knowledgeCutoff": "Limite de conhecimento"
+      },
+      "limits": {
+        "completionTokens": "Limite de tokens de resposta",
+        "promptTokens": "Limite de tokens de entrada"
+      },
+      "links": {
+        "openProviderDetails": "Abrir detalhes do provedor",
+        "providerDetails": "Detalhes do provedor"
+      },
+      "prices": {
+        "audioInput": "Preço de entrada de áudio",
+        "audioOutput": "Preço de saída de áudio",
+        "cachedAudioInput": "Preço de entrada de áudio em cache",
+        "cacheRead": "Preço de leitura do cache",
+        "cacheWrite": "Preço de gravação no cache",
+        "cacheWriteOneHour": "Preço de gravação no cache por uma hora",
+        "conditional": "Preços condicionais",
+        "imageInput": "Preço de imagem de entrada",
+        "imageOutput": "Preço de imagem de saída",
+        "imageToken": "Preço de token de imagem",
+        "input": "Preço de entrada",
+        "output": "Preço de saída",
+        "reasoning": "Preço de token de raciocínio",
+        "request": "Preço por solicitação",
+        "webSearch": "Preço de busca na web"
+      },
+      "routing": {
+        "contextLimit": "Limite de contexto de roteamento",
+        "moderation": "Moderação de conteúdo"
+      },
+      "sections": {
+        "architecture": "Arquitetura",
+        "benchmarks": "Benchmarks",
+        "capabilities": "Recursos e padrões",
+        "lifecycle": "Ciclo de vida e aliases",
+        "links": "Links",
+        "pricing": "Preços",
+        "requestLimits": "Limites por solicitação",
+        "routing": "Provedor de roteamento"
+      }
+    },
     "outputModalities": "Modalidades de saída",
+    "priceConditions": {
+      "minimumPromptTokens": "Mais de {{formattedCount}} tokens de entrada",
+      "minimumPromptTokens_one": "Mais de {{formattedCount}} token de entrada",
+      "minimumPromptTokens_many": "Mais de {{formattedCount}} tokens de entrada",
+      "minimumPromptTokens_other": "Mais de {{formattedCount}} tokens de entrada",
+      "utcWindow": "{{start}}–{{end}} UTC"
+    },
+    "priceUnits": {
+      "inputImage": "imagem de entrada",
+      "millionAudioInputTokens": "1 milhão de tokens de áudio de entrada",
+      "millionAudioOutputTokens": "1 milhão de tokens de áudio de saída",
+      "millionCachedAudioInputTokens": "1 milhão de tokens de áudio de entrada em cache",
+      "millionCachedInputTokens": "1 milhão de tokens de entrada em cache",
+      "millionCacheWriteOneHourTokens": "1 milhão de tokens de gravação no cache por uma hora",
+      "millionCacheWriteTokens": "1 milhão de tokens de gravação no cache",
+      "millionImageTokens": "1 milhão de tokens de imagem",
+      "millionInputTokens": "1 milhão de tokens de entrada",
+      "millionOutputTokens": "1 milhão de tokens de saída",
+      "millionReasoningTokens": "1 milhão de tokens de raciocínio",
+      "outputImage": "imagem de saída",
+      "request": "solicitação",
+      "webSearch": "busca na web"
+    },
     "sections": {
       "specifications": "Especificações"
     },

--- a/src/locales/vi/modelList.json
+++ b/src/locales/vi/modelList.json
@@ -106,9 +106,120 @@
   "description": "Xem và quản lý các mô hình AI khả dụng",
   "detailedPricing": "Định giá chi tiết",
   "displayFacts": {
+    "benchmarkTable": {
+      "arena": "Đấu trường",
+      "category": "Danh mục",
+      "rank": "Thứ hạng",
+      "score": "Điểm",
+      "winRate": "Tỷ lệ thắng"
+    },
+    "boolean": {
+      "no": "Không",
+      "yes": "Có"
+    },
     "contextLimit": "Giới hạn ngữ cảnh",
+    "inputModalities": "Phương thức đầu vào",
     "maximumOutputTokens": "Số token đầu ra tối đa",
+    "openRouter": {
+      "architecture": {
+        "instructType": "Định dạng hướng dẫn",
+        "modality": "Phương thức chính",
+        "tokenizer": "Bộ tách token"
+      },
+      "benchmarks": {
+        "agenticIndex": "Chỉ số tác nhân",
+        "codingIndex": "Chỉ số lập trình",
+        "designArena": "Xếp hạng Design Arena",
+        "intelligenceIndex": "Chỉ số trí tuệ"
+      },
+      "capabilities": {
+        "reasoningDefaultEffort": "Mức suy luận mặc định",
+        "reasoningDefaultEnabled": "Bật suy luận theo mặc định",
+        "reasoningMandatory": "Bắt buộc suy luận",
+        "reasoningSupportedEfforts": "Các mức suy luận được hỗ trợ",
+        "reasoningSupportsMaxTokens": "Hỗ trợ giới hạn token suy luận",
+        "supportedParameters": "Tham số được hỗ trợ",
+        "supportedVoices": "Giọng nói được hỗ trợ"
+      },
+      "defaults": {
+        "frequencyPenalty": "Phạt tần suất mặc định",
+        "presencePenalty": "Phạt hiện diện mặc định",
+        "repetitionPenalty": "Phạt lặp lại mặc định",
+        "temperature": "Temperature mặc định",
+        "topK": "Top-k mặc định",
+        "topP": "Top-p mặc định"
+      },
+      "lifecycle": {
+        "aliasName": "Tên đích bí danh",
+        "aliasSlug": "Đích bí danh",
+        "canonicalSlug": "Slug chuẩn",
+        "created": "Ngày tạo mô hình",
+        "expirationDate": "Ngày hết hạn",
+        "huggingFaceId": "ID Hugging Face",
+        "knowledgeCutoff": "Mốc kiến thức"
+      },
+      "limits": {
+        "completionTokens": "Giới hạn token hoàn thành",
+        "promptTokens": "Giới hạn token đầu vào"
+      },
+      "links": {
+        "openProviderDetails": "Mở chi tiết nhà cung cấp",
+        "providerDetails": "Chi tiết nhà cung cấp"
+      },
+      "prices": {
+        "audioInput": "Giá đầu vào âm thanh",
+        "audioOutput": "Giá đầu ra âm thanh",
+        "cachedAudioInput": "Giá đầu vào âm thanh đã lưu đệm",
+        "cacheRead": "Giá đọc bộ nhớ đệm",
+        "cacheWrite": "Giá ghi bộ nhớ đệm",
+        "cacheWriteOneHour": "Giá ghi bộ nhớ đệm một giờ",
+        "conditional": "Giá có điều kiện",
+        "imageInput": "Giá hình ảnh đầu vào",
+        "imageOutput": "Giá hình ảnh đầu ra",
+        "imageToken": "Giá token hình ảnh",
+        "input": "Giá đầu vào",
+        "output": "Giá đầu ra",
+        "reasoning": "Giá token suy luận",
+        "request": "Giá mỗi yêu cầu",
+        "webSearch": "Giá tìm kiếm web"
+      },
+      "routing": {
+        "contextLimit": "Giới hạn ngữ cảnh định tuyến",
+        "moderation": "Kiểm duyệt nội dung"
+      },
+      "sections": {
+        "architecture": "Kiến trúc",
+        "benchmarks": "Điểm chuẩn",
+        "capabilities": "Khả năng và giá trị mặc định",
+        "lifecycle": "Vòng đời và bí danh",
+        "links": "Liên kết",
+        "pricing": "Giá",
+        "requestLimits": "Giới hạn mỗi yêu cầu",
+        "routing": "Nhà cung cấp định tuyến"
+      }
+    },
     "outputModalities": "Phương thức đầu ra",
+    "priceConditions": {
+      "minimumPromptTokens": "Hơn {{formattedCount}} token đầu vào",
+      "minimumPromptTokens_other": "Hơn {{formattedCount}} token đầu vào",
+      "utcWindow": "{{start}}–{{end}} UTC"
+    },
+    "priceUnits": {
+      "inputImage": "hình ảnh đầu vào",
+      "millionAudioInputTokens": "1 triệu token âm thanh đầu vào",
+      "millionAudioOutputTokens": "1 triệu token âm thanh đầu ra",
+      "millionCachedAudioInputTokens": "1 triệu token âm thanh đầu vào đã lưu đệm",
+      "millionCachedInputTokens": "1 triệu token đầu vào đã lưu đệm",
+      "millionCacheWriteOneHourTokens": "1 triệu token ghi bộ nhớ đệm một giờ",
+      "millionCacheWriteTokens": "1 triệu token ghi bộ nhớ đệm",
+      "millionImageTokens": "1 triệu token hình ảnh",
+      "millionInputTokens": "1 triệu token đầu vào",
+      "millionOutputTokens": "1 triệu token đầu ra",
+      "millionReasoningTokens": "1 triệu token suy luận",
+      "outputImage": "hình ảnh đầu ra",
+      "request": "yêu cầu",
+      "webSearch": "lần tìm kiếm web"
+    },
     "sections": {
       "specifications": "Thông số kỹ thuật"
     },

--- a/src/locales/zh-CN/modelList.json
+++ b/src/locales/zh-CN/modelList.json
@@ -106,9 +106,119 @@
   "description": "查看和管理可用的AI模型",
   "detailedPricing": "详细定价",
   "displayFacts": {
+    "benchmarkTable": {
+      "arena": "竞技场",
+      "category": "类别",
+      "rank": "排名",
+      "score": "得分",
+      "winRate": "胜率"
+    },
+    "boolean": {
+      "no": "否",
+      "yes": "是"
+    },
     "contextLimit": "上下文上限",
+    "inputModalities": "输入模态",
     "maximumOutputTokens": "最大输出 Token 数",
+    "openRouter": {
+      "architecture": {
+        "instructType": "指令格式",
+        "modality": "主要模态",
+        "tokenizer": "分词器"
+      },
+      "benchmarks": {
+        "agenticIndex": "智能体指数",
+        "codingIndex": "编码指数",
+        "designArena": "Design Arena 排名",
+        "intelligenceIndex": "智能指数"
+      },
+      "capabilities": {
+        "reasoningDefaultEffort": "默认推理强度",
+        "reasoningDefaultEnabled": "默认启用推理",
+        "reasoningMandatory": "必须使用推理",
+        "reasoningSupportedEfforts": "支持的推理强度",
+        "reasoningSupportsMaxTokens": "支持推理 Token 上限",
+        "supportedParameters": "支持的参数",
+        "supportedVoices": "支持的语音"
+      },
+      "defaults": {
+        "frequencyPenalty": "默认频率惩罚",
+        "presencePenalty": "默认存在惩罚",
+        "repetitionPenalty": "默认重复惩罚",
+        "temperature": "默认温度",
+        "topK": "默认 top-k",
+        "topP": "默认 top-p"
+      },
+      "lifecycle": {
+        "aliasName": "别名目标名称",
+        "aliasSlug": "别名目标",
+        "canonicalSlug": "规范标识",
+        "created": "模型创建日期",
+        "expirationDate": "到期日期",
+        "huggingFaceId": "Hugging Face ID",
+        "knowledgeCutoff": "知识截止日期"
+      },
+      "limits": {
+        "completionTokens": "补全 Token 上限",
+        "promptTokens": "提示词 Token 上限"
+      },
+      "links": {
+        "openProviderDetails": "打开服务商详情",
+        "providerDetails": "服务商详情"
+      },
+      "prices": {
+        "audioInput": "音频输入价格",
+        "audioOutput": "音频输出价格",
+        "cachedAudioInput": "缓存音频输入价格",
+        "cacheRead": "缓存读取价格",
+        "cacheWrite": "缓存写入价格",
+        "cacheWriteOneHour": "一小时缓存写入价格",
+        "conditional": "条件价格",
+        "imageInput": "图片输入价格",
+        "imageOutput": "图片输出价格",
+        "imageToken": "图片 Token 价格",
+        "input": "输入价格",
+        "output": "输出价格",
+        "reasoning": "推理 Token 价格",
+        "request": "请求价格",
+        "webSearch": "网络搜索价格"
+      },
+      "routing": {
+        "contextLimit": "路由上下文上限",
+        "moderation": "内容审核"
+      },
+      "sections": {
+        "architecture": "架构",
+        "benchmarks": "基准测试",
+        "capabilities": "能力和默认值",
+        "lifecycle": "生命周期和别名",
+        "links": "链接",
+        "pricing": "价格",
+        "requestLimits": "单次请求限制",
+        "routing": "路由服务商"
+      }
+    },
     "outputModalities": "输出模态",
+    "priceConditions": {
+      "minimumPromptTokens": "提示词超过 {{formattedCount}} 个 Token",
+      "utcWindow": "UTC {{start}}–{{end}}"
+    },
+    "priceUnits": {
+      "inputImage": "张输入图片",
+      "millionAudioInputTokens": "100 万音频输入 Token",
+      "millionAudioOutputTokens": "100 万音频输出 Token",
+      "millionCachedAudioInputTokens": "100 万缓存音频输入 Token",
+      "millionCachedInputTokens": "100 万缓存输入 Token",
+      "millionCacheWriteOneHourTokens": "100 万一小时缓存写入 Token",
+      "millionCacheWriteTokens": "100 万缓存写入 Token",
+      "millionImageTokens": "100 万图片 Token",
+      "millionInputTokens": "100 万输入 Token",
+      "millionOutputTokens": "100 万输出 Token",
+      "millionReasoningTokens": "100 万推理 Token",
+      "outputImage": "张输出图片",
+      "request": "次请求",
+      "webSearch": "次网络搜索"
+    },
     "sections": {
       "specifications": "规格"
     },

--- a/src/locales/zh-TW/modelList.json
+++ b/src/locales/zh-TW/modelList.json
@@ -106,9 +106,120 @@
   "description": "檢視和管理可用的AI模型",
   "detailedPricing": "詳細定價",
   "displayFacts": {
+    "benchmarkTable": {
+      "arena": "競技場",
+      "category": "類別",
+      "rank": "排名",
+      "score": "得分",
+      "winRate": "勝率"
+    },
+    "boolean": {
+      "no": "否",
+      "yes": "是"
+    },
     "contextLimit": "上下文上限",
+    "inputModalities": "輸入模態",
     "maximumOutputTokens": "最大輸出 Token 數",
+    "openRouter": {
+      "architecture": {
+        "instructType": "指令格式",
+        "modality": "主要模態",
+        "tokenizer": "分詞器"
+      },
+      "benchmarks": {
+        "agenticIndex": "代理能力指數",
+        "codingIndex": "程式設計指數",
+        "designArena": "Design Arena 排名",
+        "intelligenceIndex": "智慧指數"
+      },
+      "capabilities": {
+        "reasoningDefaultEffort": "預設推理強度",
+        "reasoningDefaultEnabled": "預設啟用推理",
+        "reasoningMandatory": "必須使用推理",
+        "reasoningSupportedEfforts": "支援的推理強度",
+        "reasoningSupportsMaxTokens": "支援推理 Token 上限",
+        "supportedParameters": "支援的參數",
+        "supportedVoices": "支援的語音"
+      },
+      "defaults": {
+        "frequencyPenalty": "預設頻率懲罰",
+        "presencePenalty": "預設存在懲罰",
+        "repetitionPenalty": "預設重複懲罰",
+        "temperature": "預設溫度",
+        "topK": "預設 top-k",
+        "topP": "預設 top-p"
+      },
+      "lifecycle": {
+        "aliasName": "別名目標名稱",
+        "aliasSlug": "別名目標",
+        "canonicalSlug": "規範識別碼",
+        "created": "模型建立日期",
+        "expirationDate": "到期日期",
+        "huggingFaceId": "Hugging Face ID",
+        "knowledgeCutoff": "知識截止日期"
+      },
+      "limits": {
+        "completionTokens": "補全 Token 上限",
+        "promptTokens": "提示詞 Token 上限"
+      },
+      "links": {
+        "openProviderDetails": "開啟服務商詳細資訊",
+        "providerDetails": "服務商詳細資訊"
+      },
+      "prices": {
+        "audioInput": "音訊輸入價格",
+        "audioOutput": "音訊輸出價格",
+        "cachedAudioInput": "快取音訊輸入價格",
+        "cacheRead": "快取讀取價格",
+        "cacheWrite": "快取寫入價格",
+        "cacheWriteOneHour": "一小時快取寫入價格",
+        "conditional": "條件價格",
+        "imageInput": "圖片輸入價格",
+        "imageOutput": "圖片輸出價格",
+        "imageToken": "圖片 Token 價格",
+        "input": "輸入價格",
+        "output": "輸出價格",
+        "reasoning": "推理 Token 價格",
+        "request": "請求價格",
+        "webSearch": "網路搜尋價格"
+      },
+      "routing": {
+        "contextLimit": "路由上下文上限",
+        "moderation": "內容審核"
+      },
+      "sections": {
+        "architecture": "架構",
+        "benchmarks": "基準測試",
+        "capabilities": "能力與預設值",
+        "lifecycle": "生命週期與別名",
+        "links": "連結",
+        "pricing": "價格",
+        "requestLimits": "單次請求限制",
+        "routing": "路由服務商"
+      }
+    },
     "outputModalities": "輸出模態",
+    "priceConditions": {
+      "minimumPromptTokens": "提示詞超過 {{formattedCount}} 個 Token",
+      "minimumPromptTokens_other": "提示詞超過 {{formattedCount}} 個 Token",
+      "utcWindow": "UTC {{start}}–{{end}}"
+    },
+    "priceUnits": {
+      "inputImage": "張輸入圖片",
+      "millionAudioInputTokens": "100 萬音訊輸入 Token",
+      "millionAudioOutputTokens": "100 萬音訊輸出 Token",
+      "millionCachedAudioInputTokens": "100 萬快取音訊輸入 Token",
+      "millionCachedInputTokens": "100 萬快取輸入 Token",
+      "millionCacheWriteOneHourTokens": "100 萬一小時快取寫入 Token",
+      "millionCacheWriteTokens": "100 萬快取寫入 Token",
+      "millionImageTokens": "100 萬圖片 Token",
+      "millionInputTokens": "100 萬輸入 Token",
+      "millionOutputTokens": "100 萬輸出 Token",
+      "millionReasoningTokens": "100 萬推理 Token",
+      "outputImage": "張輸出圖片",
+      "request": "次請求",
+      "webSearch": "次網路搜尋"
+    },
     "sections": {
       "specifications": "規格"
     },

--- a/src/services/apiAdapters/openrouter/modelFieldInventory.ts
+++ b/src/services/apiAdapters/openrouter/modelFieldInventory.ts
@@ -1,4 +1,4 @@
-const OPENROUTER_MODEL_FIELD_CATEGORIES = {
+export const OPENROUTER_MODEL_FIELD_CATEGORIES = {
   ProductCanonicalModel: "product-canonical-model",
   NativeSummary: "native-summary",
   NativeDetail: "native-detail",

--- a/src/services/apiAdapters/openrouter/modelFieldInventory.ts
+++ b/src/services/apiAdapters/openrouter/modelFieldInventory.ts
@@ -1,0 +1,193 @@
+const OPENROUTER_MODEL_FIELD_CATEGORIES = {
+  ProductCanonicalModel: "product-canonical-model",
+  NativeSummary: "native-summary",
+  NativeDetail: "native-detail",
+  IntentionallyHidden: "intentionally-hidden",
+} as const
+
+/**
+ * Stable documented OpenRouter model leaf fields pinned on 2026-08-08.
+ *
+ * Sources:
+ * - https://openrouter.ai/docs/client-sdks/typescript/models/model
+ * - https://openrouter.ai/docs/client-sdks/typescript/models/publicpricing
+ * - https://openrouter.ai/docs/client-sdks/typescript/models/pricingoverride
+ */
+export const OPENROUTER_PINNED_MODEL_FIELD_PATHS = [
+  "alias_target.name",
+  "alias_target.slug",
+  "architecture.input_modalities",
+  "architecture.instruct_type",
+  "architecture.modality",
+  "architecture.output_modalities",
+  "architecture.tokenizer",
+  "benchmarks.artificial_analysis.agentic_index",
+  "benchmarks.artificial_analysis.coding_index",
+  "benchmarks.artificial_analysis.intelligence_index",
+  "benchmarks.design_arena[].arena",
+  "benchmarks.design_arena[].category",
+  "benchmarks.design_arena[].elo",
+  "benchmarks.design_arena[].rank",
+  "benchmarks.design_arena[].win_rate",
+  "canonical_slug",
+  "context_length",
+  "created",
+  "default_parameters.frequency_penalty",
+  "default_parameters.presence_penalty",
+  "default_parameters.repetition_penalty",
+  "default_parameters.temperature",
+  "default_parameters.top_k",
+  "default_parameters.top_p",
+  "description",
+  "expiration_date",
+  "hugging_face_id",
+  "id",
+  "knowledge_cutoff",
+  "links.details",
+  "name",
+  "per_request_limits.completion_tokens",
+  "per_request_limits.prompt_tokens",
+  "pricing.audio",
+  "pricing.audio_output",
+  "pricing.completion",
+  "pricing.discount",
+  "pricing.image",
+  "pricing.image_output",
+  "pricing.image_token",
+  "pricing.input_audio_cache",
+  "pricing.input_cache_read",
+  "pricing.input_cache_write",
+  "pricing.input_cache_write_1h",
+  "pricing.internal_reasoning",
+  "pricing.overrides[].audio",
+  "pricing.overrides[].completion",
+  "pricing.overrides[].input_audio_cache",
+  "pricing.overrides[].input_cache_read",
+  "pricing.overrides[].input_cache_write",
+  "pricing.overrides[].input_cache_write_1h",
+  "pricing.overrides[].min_prompt_tokens",
+  "pricing.overrides[].prompt",
+  "pricing.overrides[].utc_end",
+  "pricing.overrides[].utc_start",
+  "pricing.prompt",
+  "pricing.request",
+  "pricing.web_search",
+  "reasoning.default_effort",
+  "reasoning.default_enabled",
+  "reasoning.mandatory",
+  "reasoning.supported_efforts",
+  "reasoning.supports_max_tokens",
+  "supported_parameters",
+  "supported_voices",
+  "top_provider.context_length",
+  "top_provider.is_moderated",
+  "top_provider.max_completion_tokens",
+] as const
+
+type OpenRouterPinnedModelFieldPath =
+  (typeof OPENROUTER_PINNED_MODEL_FIELD_PATHS)[number]
+
+type VisibleFieldClassification = {
+  category:
+    | typeof OPENROUTER_MODEL_FIELD_CATEGORIES.ProductCanonicalModel
+    | typeof OPENROUTER_MODEL_FIELD_CATEGORIES.NativeSummary
+    | typeof OPENROUTER_MODEL_FIELD_CATEGORIES.NativeDetail
+}
+
+type HiddenFieldClassification = {
+  category: typeof OPENROUTER_MODEL_FIELD_CATEGORIES.IntentionallyHidden
+  reason: string
+}
+
+type OpenRouterModelFieldClassification =
+  | VisibleFieldClassification
+  | HiddenFieldClassification
+
+const canonical = {
+  category: OPENROUTER_MODEL_FIELD_CATEGORIES.ProductCanonicalModel,
+} as const
+const summary = {
+  category: OPENROUTER_MODEL_FIELD_CATEGORIES.NativeSummary,
+} as const
+const detail = {
+  category: OPENROUTER_MODEL_FIELD_CATEGORIES.NativeDetail,
+} as const
+
+/** Exhaustive product disposition for the pinned documented field inventory. */
+export const OPENROUTER_MODEL_FIELD_CLASSIFICATIONS = {
+  "alias_target.name": detail,
+  "alias_target.slug": detail,
+  "architecture.input_modalities": summary,
+  "architecture.instruct_type": detail,
+  "architecture.modality": detail,
+  "architecture.output_modalities": summary,
+  "architecture.tokenizer": detail,
+  "benchmarks.artificial_analysis.agentic_index": detail,
+  "benchmarks.artificial_analysis.coding_index": detail,
+  "benchmarks.artificial_analysis.intelligence_index": detail,
+  "benchmarks.design_arena[].arena": detail,
+  "benchmarks.design_arena[].category": detail,
+  "benchmarks.design_arena[].elo": detail,
+  "benchmarks.design_arena[].rank": detail,
+  "benchmarks.design_arena[].win_rate": detail,
+  canonical_slug: detail,
+  context_length: summary,
+  created: detail,
+  "default_parameters.frequency_penalty": detail,
+  "default_parameters.presence_penalty": detail,
+  "default_parameters.repetition_penalty": detail,
+  "default_parameters.temperature": detail,
+  "default_parameters.top_k": detail,
+  "default_parameters.top_p": detail,
+  description: canonical,
+  expiration_date: detail,
+  hugging_face_id: detail,
+  id: canonical,
+  knowledge_cutoff: detail,
+  "links.details": detail,
+  name: canonical,
+  "per_request_limits.completion_tokens": detail,
+  "per_request_limits.prompt_tokens": detail,
+  "pricing.audio": detail,
+  "pricing.audio_output": detail,
+  "pricing.completion": canonical,
+  "pricing.discount": {
+    category: OPENROUTER_MODEL_FIELD_CATEGORIES.IntentionallyHidden,
+    reason:
+      "Endpoint discount metadata is not safely comparable at the provider-model level.",
+  },
+  "pricing.image": detail,
+  "pricing.image_output": detail,
+  "pricing.image_token": detail,
+  "pricing.input_audio_cache": detail,
+  "pricing.input_cache_read": detail,
+  "pricing.input_cache_write": detail,
+  "pricing.input_cache_write_1h": detail,
+  "pricing.internal_reasoning": detail,
+  "pricing.overrides[].audio": detail,
+  "pricing.overrides[].completion": detail,
+  "pricing.overrides[].input_audio_cache": detail,
+  "pricing.overrides[].input_cache_read": detail,
+  "pricing.overrides[].input_cache_write": detail,
+  "pricing.overrides[].input_cache_write_1h": detail,
+  "pricing.overrides[].min_prompt_tokens": detail,
+  "pricing.overrides[].prompt": detail,
+  "pricing.overrides[].utc_end": detail,
+  "pricing.overrides[].utc_start": detail,
+  "pricing.prompt": canonical,
+  "pricing.request": detail,
+  "pricing.web_search": detail,
+  "reasoning.default_effort": detail,
+  "reasoning.default_enabled": detail,
+  "reasoning.mandatory": detail,
+  "reasoning.supported_efforts": detail,
+  "reasoning.supports_max_tokens": detail,
+  supported_parameters: detail,
+  supported_voices: detail,
+  "top_provider.context_length": detail,
+  "top_provider.is_moderated": detail,
+  "top_provider.max_completion_tokens": detail,
+} satisfies Record<
+  OpenRouterPinnedModelFieldPath,
+  OpenRouterModelFieldClassification
+>

--- a/src/services/apiAdapters/openrouter/modelPresentation.ts
+++ b/src/services/apiAdapters/openrouter/modelPresentation.ts
@@ -252,7 +252,7 @@ function createPrice(
       }
 }
 
-/** Checks an HHMM integer used by conditional pricing windows. */
+/** Checks OpenRouter's base-100 HHMM integer for a UTC pricing window. */
 function isValidUtcClock(value: number): boolean {
   const hours = Math.floor(value / 100)
   const minutes = value % 100
@@ -354,24 +354,17 @@ function normalizePricing(value: unknown): {
     })
   }
 
+  const cacheReadPrice = normalizeUsdPerMillionTokens(pricing.input_cache_read)
+  const cacheWritePrice = normalizeUsdPerMillionTokens(
+    pricing.input_cache_write,
+  )
+
   return {
     canonical: {
       ...(inputPrice !== undefined ? { inputPrice } : {}),
       ...(outputPrice !== undefined ? { outputPrice } : {}),
-      ...(normalizeUsdPerMillionTokens(pricing.input_cache_read) !== undefined
-        ? {
-            cacheReadPrice: normalizeUsdPerMillionTokens(
-              pricing.input_cache_read,
-            ),
-          }
-        : {}),
-      ...(normalizeUsdPerMillionTokens(pricing.input_cache_write) !== undefined
-        ? {
-            cacheWritePrice: normalizeUsdPerMillionTokens(
-              pricing.input_cache_write,
-            ),
-          }
-        : {}),
+      ...(cacheReadPrice !== undefined ? { cacheReadPrice } : {}),
+      ...(cacheWritePrice !== undefined ? { cacheWritePrice } : {}),
       hasInvalidPrimaryPrice: primaryStatuses.includes("invalid"),
     },
     facts,

--- a/src/services/apiAdapters/openrouter/modelPresentation.ts
+++ b/src/services/apiAdapters/openrouter/modelPresentation.ts
@@ -1,0 +1,849 @@
+import type { ZodType } from "zod"
+
+import { OPENROUTER_API_BASE_URL } from "~/services/accountSiteDefinitions/identifiers"
+import {
+  aliasTargetSchema,
+  architectureSchema,
+  artificialAnalysisSchema,
+  benchmarksSchema,
+  booleanSchema,
+  defaultParametersSchema,
+  designArenaEntrySchema,
+  finiteNumberSchema,
+  isoDateSchema,
+  linksSchema,
+  nonBlankStringSchema,
+  OPENROUTER_FACT_LABELS,
+  OPENROUTER_SECTION_LABELS,
+  perRequestLimitsSchema,
+  pricingSchema,
+  reasoningSchema,
+  tokenQuantitySchema,
+  topProviderSchema,
+  unknownArraySchema,
+  unknownRecordSchema,
+} from "~/services/apiAdapters/openrouter/modelPresentationContract"
+import type { OpenRouterPublicModel } from "~/services/apiService/openrouter/publicModelCatalogSchemas"
+import { MODEL_VENDOR_EVIDENCE_KINDS } from "~/services/models/modelDescriptor"
+import {
+  MODEL_DISPLAY_FACT_LABELS,
+  MODEL_DISPLAY_FACT_TYPES,
+  MODEL_DISPLAY_PRICE_UNITS,
+  type ModelDisplayFact,
+  type ModelDisplayLabel,
+  type ModelDisplayPrice,
+  type ModelDisplayPriceCondition,
+  type ModelDisplayPriceUnit,
+  type ModelDisplaySection,
+  type ModelPresentation,
+} from "~/services/models/modelDisplayFacts"
+
+/** Parses one optional provider field without coupling sibling validity. */
+function parseOptional<T>(schema: ZodType<T>, value: unknown): T | undefined {
+  const parsed = schema.safeParse(value)
+  return parsed.success ? parsed.data : undefined
+}
+
+/** Normalizes a nonblank provider string. */
+function normalizeString(value: unknown): string | undefined {
+  return parseOptional(nonBlankStringSchema, value)
+}
+
+/** Normalizes a nonnegative integral token quantity. */
+function normalizeTokenQuantity(value: unknown): number | undefined {
+  return parseOptional(tokenQuantitySchema, value)
+}
+
+/** Normalizes a finite numeric value while retaining zero. */
+function normalizeFiniteNumber(value: unknown): number | undefined {
+  return parseOptional(finiteNumberSchema, value)
+}
+
+/** Normalizes a strict provider boolean. */
+function normalizeBoolean(value: unknown): boolean | undefined {
+  return parseOptional(booleanSchema, value)
+}
+
+/** Normalizes a provider list into unique nonblank strings. */
+function normalizeStringList(value: unknown): string[] | undefined {
+  const values = parseOptional(unknownArraySchema, value)
+  if (!values) return undefined
+
+  const normalized = Array.from(
+    new Set(
+      values.map(normalizeString).filter((item): item is string => !!item),
+    ),
+  )
+  return normalized.length > 0 ? normalized : undefined
+}
+
+/** Normalizes a calendar date without accepting rollovers. */
+function normalizeDate(value: unknown): string | undefined {
+  return parseOptional(isoDateSchema, value)
+}
+
+/** Converts a Unix timestamp into a UTC calendar date. */
+function normalizeCreatedDate(value: unknown): string | undefined {
+  const timestamp = normalizeTokenQuantity(value)
+  if (timestamp === undefined) return undefined
+
+  const date = new Date(timestamp * 1000)
+  return Number.isNaN(date.getTime())
+    ? undefined
+    : date.toISOString().slice(0, 10)
+}
+
+/** Converts an official USD-per-token string to USD per million tokens. */
+function normalizeUsdPerMillionTokens(value: unknown): number | undefined {
+  const raw = normalizeString(value)
+  if (!raw) return undefined
+
+  const amount = Number(raw)
+  if (!Number.isFinite(amount) || amount < 0) return undefined
+
+  const perMillion = amount * 1_000_000
+  return Number.isFinite(perMillion) ? perMillion : undefined
+}
+
+/** Keeps a nonnegative direct USD price such as per request or per image. */
+function normalizeDirectUsd(value: unknown): number | undefined {
+  const raw = normalizeString(value)
+  if (!raw) return undefined
+
+  const amount = Number(raw)
+  return Number.isFinite(amount) && amount >= 0 ? amount : undefined
+}
+
+type PrimaryPriceStatus = "missing" | "invalid" | "valid"
+
+/** Distinguishes absent primary pricing from malformed and valid values. */
+function classifyPrimaryPrice(value: unknown): PrimaryPriceStatus {
+  if (value === undefined || value === null) return "missing"
+  return normalizeUsdPerMillionTokens(value) === undefined ? "invalid" : "valid"
+}
+
+interface OpenRouterCanonicalPricing {
+  inputPrice?: number
+  outputPrice?: number
+  cacheReadPrice?: number
+  cacheWritePrice?: number
+  hasInvalidPrimaryPrice: boolean
+}
+
+interface PriceFieldDefinition {
+  key: string
+  label: ModelDisplayLabel
+  unit: ModelDisplayPriceUnit
+  normalize: (value: unknown) => number | undefined
+}
+
+const BASE_PRICE_FIELDS: PriceFieldDefinition[] = [
+  {
+    key: "prompt",
+    label: OPENROUTER_FACT_LABELS.inputPrice,
+    unit: MODEL_DISPLAY_PRICE_UNITS.MillionInputTokens,
+    normalize: normalizeUsdPerMillionTokens,
+  },
+  {
+    key: "completion",
+    label: OPENROUTER_FACT_LABELS.outputPrice,
+    unit: MODEL_DISPLAY_PRICE_UNITS.MillionOutputTokens,
+    normalize: normalizeUsdPerMillionTokens,
+  },
+  {
+    key: "input_cache_read",
+    label: OPENROUTER_FACT_LABELS.cacheReadPrice,
+    unit: MODEL_DISPLAY_PRICE_UNITS.MillionCachedInputTokens,
+    normalize: normalizeUsdPerMillionTokens,
+  },
+  {
+    key: "input_cache_write",
+    label: OPENROUTER_FACT_LABELS.cacheWritePrice,
+    unit: MODEL_DISPLAY_PRICE_UNITS.MillionCacheWriteTokens,
+    normalize: normalizeUsdPerMillionTokens,
+  },
+  {
+    key: "input_cache_write_1h",
+    label: OPENROUTER_FACT_LABELS.cacheWriteOneHourPrice,
+    unit: MODEL_DISPLAY_PRICE_UNITS.MillionCacheWriteOneHourTokens,
+    normalize: normalizeUsdPerMillionTokens,
+  },
+  {
+    key: "internal_reasoning",
+    label: OPENROUTER_FACT_LABELS.reasoningPrice,
+    unit: MODEL_DISPLAY_PRICE_UNITS.MillionReasoningTokens,
+    normalize: normalizeUsdPerMillionTokens,
+  },
+  {
+    key: "request",
+    label: OPENROUTER_FACT_LABELS.requestPrice,
+    unit: MODEL_DISPLAY_PRICE_UNITS.Request,
+    normalize: normalizeDirectUsd,
+  },
+  {
+    key: "image",
+    label: OPENROUTER_FACT_LABELS.imageInputPrice,
+    unit: MODEL_DISPLAY_PRICE_UNITS.InputImage,
+    normalize: normalizeDirectUsd,
+  },
+  {
+    key: "image_output",
+    label: OPENROUTER_FACT_LABELS.imageOutputPrice,
+    unit: MODEL_DISPLAY_PRICE_UNITS.OutputImage,
+    normalize: normalizeDirectUsd,
+  },
+  {
+    key: "image_token",
+    label: OPENROUTER_FACT_LABELS.imageTokenPrice,
+    unit: MODEL_DISPLAY_PRICE_UNITS.MillionImageTokens,
+    normalize: normalizeUsdPerMillionTokens,
+  },
+  {
+    key: "audio",
+    label: OPENROUTER_FACT_LABELS.audioInputPrice,
+    unit: MODEL_DISPLAY_PRICE_UNITS.MillionAudioInputTokens,
+    normalize: normalizeUsdPerMillionTokens,
+  },
+  {
+    key: "audio_output",
+    label: OPENROUTER_FACT_LABELS.audioOutputPrice,
+    unit: MODEL_DISPLAY_PRICE_UNITS.MillionAudioOutputTokens,
+    normalize: normalizeUsdPerMillionTokens,
+  },
+  {
+    key: "input_audio_cache",
+    label: OPENROUTER_FACT_LABELS.cachedAudioInputPrice,
+    unit: MODEL_DISPLAY_PRICE_UNITS.MillionCachedAudioInputTokens,
+    normalize: normalizeUsdPerMillionTokens,
+  },
+  {
+    key: "web_search",
+    label: OPENROUTER_FACT_LABELS.webSearchPrice,
+    unit: MODEL_DISPLAY_PRICE_UNITS.WebSearch,
+    normalize: normalizeDirectUsd,
+  },
+]
+
+const OVERRIDE_PRICE_FIELDS = BASE_PRICE_FIELDS.filter((field) =>
+  [
+    "prompt",
+    "completion",
+    "audio",
+    "input_audio_cache",
+    "input_cache_read",
+    "input_cache_write",
+    "input_cache_write_1h",
+  ].includes(field.key),
+)
+
+/** Maps one documented price field into an explicit currency and meter. */
+function createPrice(
+  record: Record<string, unknown>,
+  definition: PriceFieldDefinition,
+): ModelDisplayPrice | undefined {
+  const amount = definition.normalize(record[definition.key])
+  return amount === undefined
+    ? undefined
+    : {
+        label: definition.label,
+        amount,
+        currency: "USD",
+        unit: definition.unit,
+      }
+}
+
+/** Checks an HHMM integer used by conditional pricing windows. */
+function isValidUtcClock(value: number): boolean {
+  const hours = Math.floor(value / 100)
+  const minutes = value % 100
+  return hours >= 0 && hours <= 23 && minutes >= 0 && minutes <= 59
+}
+
+/** Normalizes a complete conditional-pricing predicate set. */
+function normalizeOverrideConditions(
+  record: Record<string, unknown>,
+): ModelDisplayPriceCondition[] | undefined {
+  const conditions: ModelDisplayPriceCondition[] = []
+
+  if (record.min_prompt_tokens !== undefined) {
+    const value = normalizeTokenQuantity(record.min_prompt_tokens)
+    if (value === undefined) return undefined
+    conditions.push({ type: "minimum-prompt-tokens", value })
+  }
+
+  const hasUtcStart = record.utc_start !== undefined
+  const hasUtcEnd = record.utc_end !== undefined
+  if (hasUtcStart || hasUtcEnd) {
+    const start = normalizeTokenQuantity(record.utc_start)
+    const end = normalizeTokenQuantity(record.utc_end)
+    if (
+      start === undefined ||
+      end === undefined ||
+      !isValidUtcClock(start) ||
+      !isValidUtcClock(end)
+    ) {
+      return undefined
+    }
+    conditions.push({ type: "utc-window", start, end })
+  }
+
+  return conditions.length > 0 ? conditions : undefined
+}
+
+/** Normalizes independently valid conditional price entries. */
+function normalizePriceOverrides(value: unknown) {
+  const rawOverrides = parseOptional(unknownArraySchema, value)
+  if (!rawOverrides) return undefined
+
+  const overrides = rawOverrides.flatMap((rawOverride) => {
+    const record = parseOptional(unknownRecordSchema, rawOverride)
+    if (!record) return []
+
+    const conditions = normalizeOverrideConditions(record)
+    if (!conditions) return []
+
+    const prices = OVERRIDE_PRICE_FIELDS.map((definition) =>
+      createPrice(record, definition),
+    ).filter((price): price is ModelDisplayPrice => !!price)
+
+    return prices.length > 0 ? [{ conditions, prices }] : []
+  })
+
+  return overrides.length > 0 ? overrides : undefined
+}
+
+/** Normalizes native detail prices and canonical comparable token prices. */
+function normalizePricing(value: unknown): {
+  canonical: OpenRouterCanonicalPricing
+  facts: ModelDisplayFact[]
+} {
+  const parsed = pricingSchema.safeParse(value)
+  if (!parsed.success) {
+    return {
+      canonical: {
+        hasInvalidPrimaryPrice: value !== undefined && value !== null,
+      },
+      facts: [],
+    }
+  }
+
+  const pricing = parsed.data as Record<string, unknown>
+  const inputPrice = normalizeUsdPerMillionTokens(pricing.prompt)
+  const outputPrice = normalizeUsdPerMillionTokens(pricing.completion)
+  const primaryStatuses = [
+    classifyPrimaryPrice(pricing.prompt),
+    classifyPrimaryPrice(pricing.completion),
+  ]
+  const facts = BASE_PRICE_FIELDS.flatMap((definition): ModelDisplayFact[] => {
+    const price = createPrice(pricing, definition)
+    return price
+      ? [
+          {
+            type: MODEL_DISPLAY_FACT_TYPES.CurrencyPrice,
+            ...price,
+          },
+        ]
+      : []
+  })
+  const overrides = normalizePriceOverrides(pricing.overrides)
+  if (overrides) {
+    facts.push({
+      type: MODEL_DISPLAY_FACT_TYPES.PriceOverrides,
+      label: OPENROUTER_FACT_LABELS.conditionalPrices,
+      overrides,
+    })
+  }
+
+  return {
+    canonical: {
+      ...(inputPrice !== undefined ? { inputPrice } : {}),
+      ...(outputPrice !== undefined ? { outputPrice } : {}),
+      ...(normalizeUsdPerMillionTokens(pricing.input_cache_read) !== undefined
+        ? {
+            cacheReadPrice: normalizeUsdPerMillionTokens(
+              pricing.input_cache_read,
+            ),
+          }
+        : {}),
+      ...(normalizeUsdPerMillionTokens(pricing.input_cache_write) !== undefined
+        ? {
+            cacheWritePrice: normalizeUsdPerMillionTokens(
+              pricing.input_cache_write,
+            ),
+          }
+        : {}),
+      hasInvalidPrimaryPrice: primaryStatuses.includes("invalid"),
+    },
+    facts,
+  }
+}
+
+/** Creates a text fact when its provider value is usable. */
+function textFact(
+  factLabel: ModelDisplayLabel,
+  value: unknown,
+): ModelDisplayFact | undefined {
+  const normalized = normalizeString(value)
+  return normalized
+    ? {
+        type: MODEL_DISPLAY_FACT_TYPES.Text,
+        label: factLabel,
+        value: normalized,
+      }
+    : undefined
+}
+
+/** Creates a token-quantity fact while preserving zero. */
+function tokenFact(
+  factLabel: ModelDisplayLabel,
+  value: unknown,
+): ModelDisplayFact | undefined {
+  const normalized = normalizeTokenQuantity(value)
+  return normalized === undefined
+    ? undefined
+    : {
+        type: MODEL_DISPLAY_FACT_TYPES.TokenQuantity,
+        label: factLabel,
+        value: normalized,
+      }
+}
+
+/** Creates a strict boolean fact while preserving false. */
+function booleanFact(
+  factLabel: ModelDisplayLabel,
+  value: unknown,
+): ModelDisplayFact | undefined {
+  const normalized = normalizeBoolean(value)
+  return normalized === undefined
+    ? undefined
+    : {
+        type: MODEL_DISPLAY_FACT_TYPES.Boolean,
+        label: factLabel,
+        value: normalized,
+      }
+}
+
+/** Creates a finite numeric fact while preserving zero. */
+function numberFact(
+  factLabel: ModelDisplayLabel,
+  value: unknown,
+): ModelDisplayFact | undefined {
+  const normalized = normalizeFiniteNumber(value)
+  return normalized === undefined
+    ? undefined
+    : {
+        type: MODEL_DISPLAY_FACT_TYPES.Number,
+        label: factLabel,
+        value: normalized,
+      }
+}
+
+/** Creates a validated calendar-date fact. */
+function dateFact(
+  factLabel: ModelDisplayLabel,
+  value: unknown,
+): ModelDisplayFact | undefined {
+  const normalized = normalizeDate(value)
+  return normalized
+    ? {
+        type: MODEL_DISPLAY_FACT_TYPES.Date,
+        label: factLabel,
+        value: normalized,
+      }
+    : undefined
+}
+
+/** Creates a nonempty structured string-list fact. */
+function stringListFact(
+  factLabel: ModelDisplayLabel,
+  value: unknown,
+): ModelDisplayFact | undefined {
+  const values = normalizeStringList(value)
+  return values
+    ? { type: MODEL_DISPLAY_FACT_TYPES.StringList, label: factLabel, values }
+    : undefined
+}
+
+/** Removes unavailable optional facts without disturbing order. */
+function compactFacts(
+  facts: Array<ModelDisplayFact | undefined>,
+): ModelDisplayFact[] {
+  return facts.filter((fact): fact is ModelDisplayFact => !!fact)
+}
+
+/** Creates a presentation section only when it contains usable facts. */
+function createSection(
+  id: string,
+  sectionLabel: ModelDisplayLabel,
+  facts: ModelDisplayFact[],
+): ModelDisplaySection | undefined {
+  return facts.length > 0 ? { id, label: sectionLabel, facts } : undefined
+}
+
+/** Splits architecture fields between bounded summary and detail facts. */
+function normalizeArchitecture(value: unknown) {
+  const architecture = parseOptional(architectureSchema, value)
+  if (!architecture) return { summary: [], details: [] }
+
+  return {
+    summary: compactFacts([
+      stringListFact(
+        MODEL_DISPLAY_FACT_LABELS.InputModalities,
+        architecture.input_modalities,
+      ),
+      stringListFact(
+        MODEL_DISPLAY_FACT_LABELS.OutputModalities,
+        architecture.output_modalities,
+      ),
+    ]),
+    details: compactFacts([
+      textFact(OPENROUTER_FACT_LABELS.modality, architecture.modality),
+      textFact(OPENROUTER_FACT_LABELS.tokenizer, architecture.tokenizer),
+      textFact(OPENROUTER_FACT_LABELS.instructType, architecture.instruct_type),
+    ]),
+  }
+}
+
+/** Normalizes supported controls, reasoning behavior, and defaults. */
+function normalizeCapabilities(
+  model: OpenRouterPublicModel,
+): ModelDisplayFact[] {
+  const facts = compactFacts([
+    stringListFact(
+      OPENROUTER_FACT_LABELS.supportedParameters,
+      model.supported_parameters,
+    ),
+    stringListFact(
+      OPENROUTER_FACT_LABELS.supportedVoices,
+      model.supported_voices,
+    ),
+  ])
+
+  const reasoning = parseOptional(reasoningSchema, model.reasoning)
+  if (reasoning) {
+    facts.push(
+      ...compactFacts([
+        booleanFact(
+          OPENROUTER_FACT_LABELS.reasoningMandatory,
+          reasoning.mandatory,
+        ),
+        booleanFact(
+          OPENROUTER_FACT_LABELS.reasoningDefaultEnabled,
+          reasoning.default_enabled,
+        ),
+        textFact(
+          OPENROUTER_FACT_LABELS.reasoningDefaultEffort,
+          reasoning.default_effort,
+        ),
+        stringListFact(
+          OPENROUTER_FACT_LABELS.reasoningSupportedEfforts,
+          reasoning.supported_efforts,
+        ),
+        booleanFact(
+          OPENROUTER_FACT_LABELS.reasoningSupportsMaxTokens,
+          reasoning.supports_max_tokens,
+        ),
+      ]),
+    )
+  }
+
+  const defaults = parseOptional(
+    defaultParametersSchema,
+    model.default_parameters,
+  )
+  if (defaults) {
+    facts.push(
+      ...compactFacts([
+        numberFact(
+          OPENROUTER_FACT_LABELS.defaultTemperature,
+          defaults.temperature,
+        ),
+        numberFact(OPENROUTER_FACT_LABELS.defaultTopP, defaults.top_p),
+        numberFact(OPENROUTER_FACT_LABELS.defaultTopK, defaults.top_k),
+        numberFact(
+          OPENROUTER_FACT_LABELS.defaultFrequencyPenalty,
+          defaults.frequency_penalty,
+        ),
+        numberFact(
+          OPENROUTER_FACT_LABELS.defaultPresencePenalty,
+          defaults.presence_penalty,
+        ),
+        numberFact(
+          OPENROUTER_FACT_LABELS.defaultRepetitionPenalty,
+          defaults.repetition_penalty,
+        ),
+      ]),
+    )
+  }
+
+  return facts
+}
+
+/** Normalizes independently valid per-request limits. */
+function normalizeRequestLimits(value: unknown): ModelDisplayFact[] {
+  const limits = parseOptional(perRequestLimitsSchema, value)
+  return limits
+    ? compactFacts([
+        tokenFact(
+          OPENROUTER_FACT_LABELS.promptTokenLimit,
+          limits.prompt_tokens,
+        ),
+        tokenFact(
+          OPENROUTER_FACT_LABELS.completionTokenLimit,
+          limits.completion_tokens,
+        ),
+      ])
+    : []
+}
+
+/** Normalizes routing-provider facts separately from publisher identity. */
+function normalizeRouting(value: unknown): ModelDisplayFact[] {
+  const routing = parseOptional(topProviderSchema, value)
+  return routing
+    ? compactFacts([
+        tokenFact(
+          OPENROUTER_FACT_LABELS.routingContextLimit,
+          routing.context_length,
+        ),
+        tokenFact(
+          MODEL_DISPLAY_FACT_LABELS.MaximumOutputTokens,
+          routing.max_completion_tokens,
+        ),
+        booleanFact(OPENROUTER_FACT_LABELS.moderation, routing.is_moderated),
+      ])
+    : []
+}
+
+/** Normalizes documented lifecycle and alias metadata. */
+function normalizeLifecycle(model: OpenRouterPublicModel): ModelDisplayFact[] {
+  const alias = parseOptional(aliasTargetSchema, model.alias_target)
+  const created = normalizeCreatedDate(model.created)
+
+  return compactFacts([
+    textFact(OPENROUTER_FACT_LABELS.canonicalSlug, model.canonical_slug),
+    textFact(OPENROUTER_FACT_LABELS.huggingFaceId, model.hugging_face_id),
+    created
+      ? {
+          type: MODEL_DISPLAY_FACT_TYPES.Date,
+          label: OPENROUTER_FACT_LABELS.created,
+          value: created,
+        }
+      : undefined,
+    dateFact(OPENROUTER_FACT_LABELS.knowledgeCutoff, model.knowledge_cutoff),
+    dateFact(OPENROUTER_FACT_LABELS.expirationDate, model.expiration_date),
+    textFact(OPENROUTER_FACT_LABELS.aliasName, alias?.name),
+    textFact(OPENROUTER_FACT_LABELS.aliasSlug, alias?.slug),
+  ])
+}
+
+/** Normalizes independent index metrics and complete arena rows. */
+function normalizeBenchmarks(value: unknown): ModelDisplayFact[] {
+  const benchmarks = parseOptional(benchmarksSchema, value)
+  if (!benchmarks) return []
+
+  const facts: ModelDisplayFact[] = []
+  const artificialAnalysis = parseOptional(
+    artificialAnalysisSchema,
+    benchmarks.artificial_analysis,
+  )
+  if (artificialAnalysis) {
+    facts.push(
+      ...compactFacts([
+        numberFact(
+          OPENROUTER_FACT_LABELS.intelligenceIndex,
+          artificialAnalysis.intelligence_index,
+        ),
+        numberFact(
+          OPENROUTER_FACT_LABELS.codingIndex,
+          artificialAnalysis.coding_index,
+        ),
+        numberFact(
+          OPENROUTER_FACT_LABELS.agenticIndex,
+          artificialAnalysis.agentic_index,
+        ),
+      ]).filter(
+        (fact) =>
+          fact.type !== MODEL_DISPLAY_FACT_TYPES.Number || fact.value >= 0,
+      ),
+    )
+  }
+
+  const designArena = parseOptional(unknownArraySchema, benchmarks.design_arena)
+  const entries = (designArena ?? []).flatMap((rawEntry) => {
+    const entry = parseOptional(designArenaEntrySchema, rawEntry)
+    if (!entry) return []
+
+    const arena = normalizeString(entry.arena)
+    const category = normalizeString(entry.category)
+    const score = normalizeFiniteNumber(entry.elo)
+    const rank = normalizeTokenQuantity(entry.rank)
+    const winRatePercent = normalizeFiniteNumber(entry.win_rate)
+    if (
+      !arena ||
+      !category ||
+      score === undefined ||
+      score < 0 ||
+      rank === undefined ||
+      rank < 1 ||
+      winRatePercent === undefined ||
+      winRatePercent < 0 ||
+      winRatePercent > 100
+    ) {
+      return []
+    }
+
+    return [{ arena, category, score, rank, winRatePercent }]
+  })
+  if (entries.length > 0) {
+    facts.push({
+      type: MODEL_DISPLAY_FACT_TYPES.BenchmarkList,
+      label: OPENROUTER_FACT_LABELS.designArena,
+      entries,
+    })
+  }
+
+  return facts
+}
+
+/** Accepts only provider-owned endpoint detail links without credentials. */
+function normalizeTrustedDetailsLink(value: unknown): string | undefined {
+  const raw = normalizeString(value)
+  if (!raw) return undefined
+
+  try {
+    const baseUrl = new URL(OPENROUTER_API_BASE_URL)
+    const url = new URL(raw, `${baseUrl.origin}/`)
+    const isTrustedPath =
+      url.pathname.startsWith("/api/v1/models/") &&
+      url.pathname.endsWith("/endpoints")
+
+    return url.origin === baseUrl.origin &&
+      !url.username &&
+      !url.password &&
+      !url.search &&
+      !url.hash &&
+      isTrustedPath
+      ? url.toString()
+      : undefined
+  } catch {
+    return undefined
+  }
+}
+
+/** Normalizes the documented trusted provider-details link. */
+function normalizeLinks(value: unknown): ModelDisplayFact[] {
+  const links = parseOptional(linksSchema, value)
+  const href = normalizeTrustedDetailsLink(links?.details)
+  return href
+    ? [
+        {
+          type: MODEL_DISPLAY_FACT_TYPES.Link,
+          label: OPENROUTER_FACT_LABELS.providerDetails,
+          href,
+          text: OPENROUTER_FACT_LABELS.openProviderDetails,
+        },
+      ]
+    : []
+}
+
+/** Derives publisher evidence from the canonical provider model slug. */
+function derivePublisherEvidence(model: OpenRouterPublicModel) {
+  const canonicalSlug = normalizeString(model.canonical_slug)
+  const sourceId = canonicalSlug ?? model.id
+  const separatorIndex = sourceId.indexOf("/")
+  if (separatorIndex <= 0 || separatorIndex === sourceId.length - 1) {
+    return undefined
+  }
+
+  const publisher = sourceId.slice(0, separatorIndex)
+  if (!/^[a-z0-9][a-z0-9._-]*$/i.test(publisher)) {
+    return undefined
+  }
+
+  return {
+    kind: MODEL_VENDOR_EVIDENCE_KINDS.Publisher,
+    name: publisher,
+    externalId: publisher,
+  } as const
+}
+
+interface NormalizedOpenRouterModel {
+  displayName?: string
+  description?: string
+  vendorEvidence?: ReturnType<typeof derivePublisherEvidence>
+  pricing: OpenRouterCanonicalPricing
+  presentation?: ModelPresentation
+}
+
+/**
+ * Normalizes the documented OpenRouter model contract into product-owned facts.
+ * Optional siblings fail independently; unknown additive fields are ignored.
+ */
+export function normalizeOpenRouterModel(
+  model: OpenRouterPublicModel,
+): NormalizedOpenRouterModel {
+  const contextLimit = tokenFact(
+    MODEL_DISPLAY_FACT_LABELS.ContextLimit,
+    model.context_length,
+  )
+  const architecture = normalizeArchitecture(model.architecture)
+  const pricing = normalizePricing(model.pricing)
+  const summaryFacts = compactFacts([contextLimit, ...architecture.summary])
+  const sections = [
+    createSection("pricing", OPENROUTER_SECTION_LABELS.pricing, pricing.facts),
+    createSection(
+      "architecture",
+      OPENROUTER_SECTION_LABELS.architecture,
+      architecture.details,
+    ),
+    createSection(
+      "capabilities",
+      OPENROUTER_SECTION_LABELS.capabilities,
+      normalizeCapabilities(model),
+    ),
+    createSection(
+      "request-limits",
+      OPENROUTER_SECTION_LABELS.requestLimits,
+      normalizeRequestLimits(model.per_request_limits),
+    ),
+    createSection(
+      "routing",
+      OPENROUTER_SECTION_LABELS.routing,
+      normalizeRouting(model.top_provider),
+    ),
+    createSection(
+      "lifecycle",
+      OPENROUTER_SECTION_LABELS.lifecycle,
+      normalizeLifecycle(model),
+    ),
+    createSection(
+      "benchmarks",
+      OPENROUTER_SECTION_LABELS.benchmarks,
+      normalizeBenchmarks(model.benchmarks),
+    ),
+    createSection(
+      "links",
+      OPENROUTER_SECTION_LABELS.links,
+      normalizeLinks(model.links),
+    ),
+  ].filter((section): section is ModelDisplaySection => !!section)
+
+  const displayName = normalizeString(model.name)
+  const description = normalizeString(model.description)
+  const vendorEvidence = derivePublisherEvidence(model)
+
+  return {
+    ...(displayName ? { displayName } : {}),
+    ...(description ? { description } : {}),
+    ...(vendorEvidence ? { vendorEvidence } : {}),
+    pricing: pricing.canonical,
+    ...(summaryFacts.length > 0 || sections.length > 0
+      ? {
+          presentation: {
+            ...(summaryFacts.length > 0 ? { summaryFacts } : {}),
+            ...(sections.length > 0 ? { sections } : {}),
+          },
+        }
+      : {}),
+  }
+}

--- a/src/services/apiAdapters/openrouter/modelPresentationContract.ts
+++ b/src/services/apiAdapters/openrouter/modelPresentationContract.ts
@@ -1,5 +1,6 @@
 import { z } from "zod"
 
+import { isIsoCalendarDate } from "~/services/models/isoCalendarDate"
 import { createModelDisplayLabel } from "~/services/models/modelDisplayFacts"
 
 export const nonBlankStringSchema = z.string().trim().min(1)
@@ -8,16 +9,7 @@ export const tokenQuantitySchema = z.number().int().nonnegative()
 export const booleanSchema = z.boolean()
 export const unknownArraySchema = z.array(z.unknown())
 export const unknownRecordSchema = z.record(z.string(), z.unknown())
-export const isoDateSchema = z
-  .string()
-  .regex(/^\d{4}-\d{2}-\d{2}$/)
-  .refine((value) => {
-    const parsed = new Date(`${value}T00:00:00Z`)
-    return (
-      !Number.isNaN(parsed.getTime()) &&
-      parsed.toISOString().slice(0, 10) === value
-    )
-  })
+export const isoDateSchema = z.string().refine(isIsoCalendarDate)
 
 /**
  * OpenRouter's documented model contract supplies per-token USD strings,
@@ -26,108 +18,86 @@ export const isoDateSchema = z
  * https://openrouter.ai/docs/client-sdks/typescript/models/publicpricing
  * https://openrouter.ai/docs/client-sdks/typescript/models/pricingoverride
  */
-export const architectureSchema = z
-  .object({
-    input_modalities: z.unknown().optional(),
-    output_modalities: z.unknown().optional(),
-    modality: z.unknown().optional(),
-    tokenizer: z.unknown().optional(),
-    instruct_type: z.unknown().optional(),
-  })
-  .passthrough()
+export const architectureSchema = z.looseObject({
+  input_modalities: z.unknown().optional(),
+  output_modalities: z.unknown().optional(),
+  modality: z.unknown().optional(),
+  tokenizer: z.unknown().optional(),
+  instruct_type: z.unknown().optional(),
+})
 
-export const pricingSchema = z
-  .object({
-    prompt: z.unknown().optional(),
-    completion: z.unknown().optional(),
-    request: z.unknown().optional(),
-    image: z.unknown().optional(),
-    image_output: z.unknown().optional(),
-    image_token: z.unknown().optional(),
-    audio: z.unknown().optional(),
-    audio_output: z.unknown().optional(),
-    web_search: z.unknown().optional(),
-    internal_reasoning: z.unknown().optional(),
-    input_audio_cache: z.unknown().optional(),
-    input_cache_read: z.unknown().optional(),
-    input_cache_write: z.unknown().optional(),
-    input_cache_write_1h: z.unknown().optional(),
-    discount: z.unknown().optional(),
-    overrides: z.unknown().optional(),
-  })
-  .passthrough()
+export const pricingSchema = z.looseObject({
+  prompt: z.unknown().optional(),
+  completion: z.unknown().optional(),
+  request: z.unknown().optional(),
+  image: z.unknown().optional(),
+  image_output: z.unknown().optional(),
+  image_token: z.unknown().optional(),
+  audio: z.unknown().optional(),
+  audio_output: z.unknown().optional(),
+  web_search: z.unknown().optional(),
+  internal_reasoning: z.unknown().optional(),
+  input_audio_cache: z.unknown().optional(),
+  input_cache_read: z.unknown().optional(),
+  input_cache_write: z.unknown().optional(),
+  input_cache_write_1h: z.unknown().optional(),
+  discount: z.unknown().optional(),
+  overrides: z.unknown().optional(),
+})
 
-export const topProviderSchema = z
-  .object({
-    context_length: z.unknown().optional(),
-    max_completion_tokens: z.unknown().optional(),
-    is_moderated: z.unknown().optional(),
-  })
-  .passthrough()
+export const topProviderSchema = z.looseObject({
+  context_length: z.unknown().optional(),
+  max_completion_tokens: z.unknown().optional(),
+  is_moderated: z.unknown().optional(),
+})
 
-export const perRequestLimitsSchema = z
-  .object({
-    prompt_tokens: z.unknown().optional(),
-    completion_tokens: z.unknown().optional(),
-  })
-  .passthrough()
+export const perRequestLimitsSchema = z.looseObject({
+  prompt_tokens: z.unknown().optional(),
+  completion_tokens: z.unknown().optional(),
+})
 
-export const reasoningSchema = z
-  .object({
-    mandatory: z.unknown().optional(),
-    default_enabled: z.unknown().optional(),
-    default_effort: z.unknown().optional(),
-    supported_efforts: z.unknown().optional(),
-    supports_max_tokens: z.unknown().optional(),
-  })
-  .passthrough()
+export const reasoningSchema = z.looseObject({
+  mandatory: z.unknown().optional(),
+  default_enabled: z.unknown().optional(),
+  default_effort: z.unknown().optional(),
+  supported_efforts: z.unknown().optional(),
+  supports_max_tokens: z.unknown().optional(),
+})
 
-export const aliasTargetSchema = z
-  .object({
-    name: z.unknown().optional(),
-    slug: z.unknown().optional(),
-  })
-  .passthrough()
+export const aliasTargetSchema = z.looseObject({
+  name: z.unknown().optional(),
+  slug: z.unknown().optional(),
+})
 
-export const linksSchema = z
-  .object({ details: z.unknown().optional() })
-  .passthrough()
+export const linksSchema = z.looseObject({ details: z.unknown().optional() })
 
-export const benchmarksSchema = z
-  .object({
-    artificial_analysis: z.unknown().optional(),
-    design_arena: z.unknown().optional(),
-  })
-  .passthrough()
+export const benchmarksSchema = z.looseObject({
+  artificial_analysis: z.unknown().optional(),
+  design_arena: z.unknown().optional(),
+})
 
-export const artificialAnalysisSchema = z
-  .object({
-    intelligence_index: z.unknown().optional(),
-    coding_index: z.unknown().optional(),
-    agentic_index: z.unknown().optional(),
-  })
-  .passthrough()
+export const artificialAnalysisSchema = z.looseObject({
+  intelligence_index: z.unknown().optional(),
+  coding_index: z.unknown().optional(),
+  agentic_index: z.unknown().optional(),
+})
 
-export const designArenaEntrySchema = z
-  .object({
-    arena: z.unknown().optional(),
-    category: z.unknown().optional(),
-    elo: z.unknown().optional(),
-    rank: z.unknown().optional(),
-    win_rate: z.unknown().optional(),
-  })
-  .passthrough()
+export const designArenaEntrySchema = z.looseObject({
+  arena: z.unknown().optional(),
+  category: z.unknown().optional(),
+  elo: z.unknown().optional(),
+  rank: z.unknown().optional(),
+  win_rate: z.unknown().optional(),
+})
 
-export const defaultParametersSchema = z
-  .object({
-    temperature: z.unknown().optional(),
-    top_p: z.unknown().optional(),
-    top_k: z.unknown().optional(),
-    frequency_penalty: z.unknown().optional(),
-    presence_penalty: z.unknown().optional(),
-    repetition_penalty: z.unknown().optional(),
-  })
-  .passthrough()
+export const defaultParametersSchema = z.looseObject({
+  temperature: z.unknown().optional(),
+  top_p: z.unknown().optional(),
+  top_k: z.unknown().optional(),
+  frequency_penalty: z.unknown().optional(),
+  presence_penalty: z.unknown().optional(),
+  repetition_penalty: z.unknown().optional(),
+})
 
 const label = (key: string, fallback: string) =>
   createModelDisplayLabel(

--- a/src/services/apiAdapters/openrouter/modelPresentationContract.ts
+++ b/src/services/apiAdapters/openrouter/modelPresentationContract.ts
@@ -1,0 +1,242 @@
+import { z } from "zod"
+
+import { createModelDisplayLabel } from "~/services/models/modelDisplayFacts"
+
+export const nonBlankStringSchema = z.string().trim().min(1)
+export const finiteNumberSchema = z.number().finite()
+export const tokenQuantitySchema = z.number().int().nonnegative()
+export const booleanSchema = z.boolean()
+export const unknownArraySchema = z.array(z.unknown())
+export const unknownRecordSchema = z.record(z.string(), z.unknown())
+export const isoDateSchema = z
+  .string()
+  .regex(/^\d{4}-\d{2}-\d{2}$/)
+  .refine((value) => {
+    const parsed = new Date(`${value}T00:00:00Z`)
+    return (
+      !Number.isNaN(parsed.getTime()) &&
+      parsed.toISOString().slice(0, 10) === value
+    )
+  })
+
+/**
+ * OpenRouter's documented model contract supplies per-token USD strings,
+ * conditional pricing overrides, and provider-owned endpoint detail links.
+ * https://openrouter.ai/docs/client-sdks/typescript/models/model
+ * https://openrouter.ai/docs/client-sdks/typescript/models/publicpricing
+ * https://openrouter.ai/docs/client-sdks/typescript/models/pricingoverride
+ */
+export const architectureSchema = z
+  .object({
+    input_modalities: z.unknown().optional(),
+    output_modalities: z.unknown().optional(),
+    modality: z.unknown().optional(),
+    tokenizer: z.unknown().optional(),
+    instruct_type: z.unknown().optional(),
+  })
+  .passthrough()
+
+export const pricingSchema = z
+  .object({
+    prompt: z.unknown().optional(),
+    completion: z.unknown().optional(),
+    request: z.unknown().optional(),
+    image: z.unknown().optional(),
+    image_output: z.unknown().optional(),
+    image_token: z.unknown().optional(),
+    audio: z.unknown().optional(),
+    audio_output: z.unknown().optional(),
+    web_search: z.unknown().optional(),
+    internal_reasoning: z.unknown().optional(),
+    input_audio_cache: z.unknown().optional(),
+    input_cache_read: z.unknown().optional(),
+    input_cache_write: z.unknown().optional(),
+    input_cache_write_1h: z.unknown().optional(),
+    discount: z.unknown().optional(),
+    overrides: z.unknown().optional(),
+  })
+  .passthrough()
+
+export const topProviderSchema = z
+  .object({
+    context_length: z.unknown().optional(),
+    max_completion_tokens: z.unknown().optional(),
+    is_moderated: z.unknown().optional(),
+  })
+  .passthrough()
+
+export const perRequestLimitsSchema = z
+  .object({
+    prompt_tokens: z.unknown().optional(),
+    completion_tokens: z.unknown().optional(),
+  })
+  .passthrough()
+
+export const reasoningSchema = z
+  .object({
+    mandatory: z.unknown().optional(),
+    default_enabled: z.unknown().optional(),
+    default_effort: z.unknown().optional(),
+    supported_efforts: z.unknown().optional(),
+    supports_max_tokens: z.unknown().optional(),
+  })
+  .passthrough()
+
+export const aliasTargetSchema = z
+  .object({
+    name: z.unknown().optional(),
+    slug: z.unknown().optional(),
+  })
+  .passthrough()
+
+export const linksSchema = z
+  .object({ details: z.unknown().optional() })
+  .passthrough()
+
+export const benchmarksSchema = z
+  .object({
+    artificial_analysis: z.unknown().optional(),
+    design_arena: z.unknown().optional(),
+  })
+  .passthrough()
+
+export const artificialAnalysisSchema = z
+  .object({
+    intelligence_index: z.unknown().optional(),
+    coding_index: z.unknown().optional(),
+    agentic_index: z.unknown().optional(),
+  })
+  .passthrough()
+
+export const designArenaEntrySchema = z
+  .object({
+    arena: z.unknown().optional(),
+    category: z.unknown().optional(),
+    elo: z.unknown().optional(),
+    rank: z.unknown().optional(),
+    win_rate: z.unknown().optional(),
+  })
+  .passthrough()
+
+export const defaultParametersSchema = z
+  .object({
+    temperature: z.unknown().optional(),
+    top_p: z.unknown().optional(),
+    top_k: z.unknown().optional(),
+    frequency_penalty: z.unknown().optional(),
+    presence_penalty: z.unknown().optional(),
+    repetition_penalty: z.unknown().optional(),
+  })
+  .passthrough()
+
+const label = (key: string, fallback: string) =>
+  createModelDisplayLabel(
+    `displayFacts.openRouter.${key}` as `displayFacts.${string}`,
+    fallback,
+  )
+
+/** Reviewed labels for provider-native OpenRouter model facts. */
+export const OPENROUTER_FACT_LABELS = {
+  inputPrice: label("prices.input", "Input price"),
+  outputPrice: label("prices.output", "Output price"),
+  requestPrice: label("prices.request", "Request price"),
+  imageInputPrice: label("prices.imageInput", "Image input price"),
+  imageOutputPrice: label("prices.imageOutput", "Image output price"),
+  imageTokenPrice: label("prices.imageToken", "Image token price"),
+  audioInputPrice: label("prices.audioInput", "Audio input price"),
+  audioOutputPrice: label("prices.audioOutput", "Audio output price"),
+  webSearchPrice: label("prices.webSearch", "Web search price"),
+  reasoningPrice: label("prices.reasoning", "Reasoning token price"),
+  cachedAudioInputPrice: label(
+    "prices.cachedAudioInput",
+    "Cached audio input price",
+  ),
+  cacheReadPrice: label("prices.cacheRead", "Cache read price"),
+  cacheWritePrice: label("prices.cacheWrite", "Cache write price"),
+  cacheWriteOneHourPrice: label(
+    "prices.cacheWriteOneHour",
+    "One-hour cache write price",
+  ),
+  conditionalPrices: label("prices.conditional", "Conditional prices"),
+  modality: label("architecture.modality", "Primary modality"),
+  tokenizer: label("architecture.tokenizer", "Tokenizer"),
+  instructType: label("architecture.instructType", "Instruction format"),
+  supportedParameters: label(
+    "capabilities.supportedParameters",
+    "Supported parameters",
+  ),
+  supportedVoices: label("capabilities.supportedVoices", "Supported voices"),
+  reasoningMandatory: label(
+    "capabilities.reasoningMandatory",
+    "Reasoning required",
+  ),
+  reasoningDefaultEnabled: label(
+    "capabilities.reasoningDefaultEnabled",
+    "Reasoning enabled by default",
+  ),
+  reasoningDefaultEffort: label(
+    "capabilities.reasoningDefaultEffort",
+    "Default reasoning effort",
+  ),
+  reasoningSupportedEfforts: label(
+    "capabilities.reasoningSupportedEfforts",
+    "Supported reasoning efforts",
+  ),
+  reasoningSupportsMaxTokens: label(
+    "capabilities.reasoningSupportsMaxTokens",
+    "Reasoning token limit supported",
+  ),
+  defaultTemperature: label("defaults.temperature", "Default temperature"),
+  defaultTopP: label("defaults.topP", "Default top-p"),
+  defaultTopK: label("defaults.topK", "Default top-k"),
+  defaultFrequencyPenalty: label(
+    "defaults.frequencyPenalty",
+    "Default frequency penalty",
+  ),
+  defaultPresencePenalty: label(
+    "defaults.presencePenalty",
+    "Default presence penalty",
+  ),
+  defaultRepetitionPenalty: label(
+    "defaults.repetitionPenalty",
+    "Default repetition penalty",
+  ),
+  promptTokenLimit: label("limits.promptTokens", "Prompt token limit"),
+  completionTokenLimit: label(
+    "limits.completionTokens",
+    "Completion token limit",
+  ),
+  routingContextLimit: label("routing.contextLimit", "Routing context limit"),
+  moderation: label("routing.moderation", "Content moderation"),
+  canonicalSlug: label("lifecycle.canonicalSlug", "Canonical slug"),
+  huggingFaceId: label("lifecycle.huggingFaceId", "Hugging Face ID"),
+  created: label("lifecycle.created", "Model created"),
+  knowledgeCutoff: label("lifecycle.knowledgeCutoff", "Knowledge cutoff"),
+  expirationDate: label("lifecycle.expirationDate", "Expiration date"),
+  aliasName: label("lifecycle.aliasName", "Alias target name"),
+  aliasSlug: label("lifecycle.aliasSlug", "Alias target"),
+  intelligenceIndex: label(
+    "benchmarks.intelligenceIndex",
+    "Intelligence index",
+  ),
+  codingIndex: label("benchmarks.codingIndex", "Coding index"),
+  agenticIndex: label("benchmarks.agenticIndex", "Agentic index"),
+  designArena: label("benchmarks.designArena", "Design Arena rankings"),
+  providerDetails: label("links.providerDetails", "Provider details"),
+  openProviderDetails: label(
+    "links.openProviderDetails",
+    "Open provider details",
+  ),
+} as const
+
+/** Reviewed order and labels for provider-native OpenRouter sections. */
+export const OPENROUTER_SECTION_LABELS = {
+  pricing: label("sections.pricing", "Pricing"),
+  architecture: label("sections.architecture", "Architecture"),
+  capabilities: label("sections.capabilities", "Capabilities and defaults"),
+  requestLimits: label("sections.requestLimits", "Per-request limits"),
+  routing: label("sections.routing", "Routing provider"),
+  lifecycle: label("sections.lifecycle", "Lifecycle and aliases"),
+  benchmarks: label("sections.benchmarks", "Benchmarks"),
+  links: label("sections.links", "Links"),
+} as const

--- a/src/services/apiAdapters/openrouter/providerModelCatalog.ts
+++ b/src/services/apiAdapters/openrouter/providerModelCatalog.ts
@@ -1,6 +1,7 @@
 import { SITE_TYPES } from "~/constants/siteType"
 import { OPENROUTER_DISPLAY_NAME } from "~/services/accountSiteDefinitions/identifiers"
 import type { ProviderModelCatalogCapability } from "~/services/apiAdapters/contracts/providerModelCatalog"
+import { normalizeOpenRouterModel } from "~/services/apiAdapters/openrouter/modelPresentation"
 import { fetchOpenRouterPublicModelCatalog } from "~/services/apiService/openrouter/publicModelCatalog"
 import type { OpenRouterPublicModel } from "~/services/apiService/openrouter/publicModelCatalogSchemas"
 import {
@@ -10,151 +11,36 @@ import {
   MODEL_UNAVAILABLE_PRICE_REASONS,
 } from "~/services/modelList/pricingModel"
 import type { ProviderModelCatalogModel } from "~/services/modelList/providerCatalogAdmission"
-import {
-  MODEL_DISPLAY_FACT_LABELS,
-  MODEL_DISPLAY_FACT_TYPES,
-  MODEL_DISPLAY_SECTION_LABELS,
-  type ModelDisplayFact,
-} from "~/services/models/modelDisplayFacts"
 
 const OPENROUTER_PUBLIC_MODEL_CATALOG_CACHE_TTL_MS = 5 * 60 * 1000
 const OPENROUTER_PROVIDER_MODEL_CATALOG_SOURCE_ID = "openrouter-public"
-
-/** Reads a plain record while excluding arrays and primitive values. */
-function readRecord(value: unknown): Record<string, unknown> | undefined {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? (value as Record<string, unknown>)
-    : undefined
-}
-
-/** Trims provider text and omits blank or non-string values. */
-function normalizeNonBlankString(value: unknown): string | undefined {
-  if (typeof value !== "string") return undefined
-  const normalized = value.trim()
-  return normalized || undefined
-}
-
-/** Keeps nonnegative integer token quantities and omits malformed values. */
-function normalizeTokenQuantity(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isInteger(value) && value >= 0
-    ? value
-    : undefined
-}
-
-/** Normalizes a provider list to unique, nonblank strings. */
-function normalizeStringList(value: unknown): string[] | undefined {
-  if (!Array.isArray(value)) return undefined
-
-  const normalized = Array.from(
-    new Set(value.map(normalizeNonBlankString).filter(Boolean)),
-  ) as string[]
-  return normalized.length > 0 ? normalized : undefined
-}
-
-/** Converts a direct USD-per-token string to USD per million tokens. */
-function normalizeUsdPerToken(value: unknown): number | undefined {
-  if (typeof value !== "string" || !value.trim()) return undefined
-
-  const normalized = Number(value)
-  if (!Number.isFinite(normalized) || normalized < 0) return undefined
-
-  const perMillion = normalized * 1_000_000
-  return Number.isFinite(perMillion) ? perMillion : undefined
-}
-
-type PrimaryPriceStatus = "missing" | "invalid" | "valid"
-
-/** Distinguishes absent primary prices from malformed and usable values. */
-function classifyPrimaryPrice(value: unknown): PrimaryPriceStatus {
-  if (value === undefined || value === null) return "missing"
-  return normalizeUsdPerToken(value) === undefined ? "invalid" : "valid"
-}
-
-/**
- * OpenRouter public catalog contract:
- * https://openrouter.ai/docs/api/api-reference/models/list-all-models-and-their-properties
- * Pricing is USD per token; optional architecture/top-provider facts are
- * presentation-only, and public rows never enable account-key actions.
- */
-function createPresentation(model: OpenRouterPublicModel) {
-  const contextLimit = normalizeTokenQuantity(model.context_length)
-  const architecture = readRecord(model.architecture)
-  const outputModalities = normalizeStringList(architecture?.output_modalities)
-  const topProvider = readRecord(model.top_provider)
-  const maximumOutputTokens = normalizeTokenQuantity(
-    topProvider?.max_completion_tokens,
-  )
-  const summaryFacts: ModelDisplayFact[] = []
-
-  if (contextLimit !== undefined) {
-    summaryFacts.push({
-      type: MODEL_DISPLAY_FACT_TYPES.TokenQuantity,
-      label: MODEL_DISPLAY_FACT_LABELS.ContextLimit,
-      value: contextLimit,
-    })
-  }
-  if (outputModalities) {
-    summaryFacts.push({
-      type: MODEL_DISPLAY_FACT_TYPES.StringList,
-      label: MODEL_DISPLAY_FACT_LABELS.OutputModalities,
-      values: outputModalities,
-    })
-  }
-
-  const detailFacts: ModelDisplayFact[] = []
-  if (maximumOutputTokens !== undefined) {
-    detailFacts.push({
-      type: MODEL_DISPLAY_FACT_TYPES.TokenQuantity,
-      label: MODEL_DISPLAY_FACT_LABELS.MaximumOutputTokens,
-      value: maximumOutputTokens,
-    })
-  }
-
-  return {
-    ...(summaryFacts.length > 0 ? { summaryFacts } : {}),
-    ...(detailFacts.length > 0
-      ? {
-          sections: [
-            {
-              id: "specifications",
-              label: MODEL_DISPLAY_SECTION_LABELS.Specifications,
-              facts: detailFacts,
-            },
-          ],
-        }
-      : {}),
-  }
-}
 
 /** Maps one OpenRouter DTO into the product-owned canonical model shape. */
 function adaptOpenRouterPublicModel(
   model: OpenRouterPublicModel,
 ): ProviderModelCatalogModel {
-  const pricingValue = model.pricing
-  const pricing = readRecord(pricingValue)
-  const rawPromptPrice = pricing?.prompt
-  const rawCompletionPrice = pricing?.completion
-  const inputPrice = normalizeUsdPerToken(rawPromptPrice)
-  const outputPrice = normalizeUsdPerToken(rawCompletionPrice)
-  const cacheReadPrice = normalizeUsdPerToken(pricing?.input_cache_read)
-  const cacheWritePrice = normalizeUsdPerToken(pricing?.input_cache_write)
+  const normalized = normalizeOpenRouterModel(model)
+  const {
+    inputPrice,
+    outputPrice,
+    cacheReadPrice,
+    cacheWritePrice,
+    hasInvalidPrimaryPrice,
+  } = normalized.pricing
   const hasPrimaryPrice = inputPrice !== undefined && outputPrice !== undefined
-  const primaryPriceStatuses = [
-    classifyPrimaryPrice(rawPromptPrice),
-    classifyPrimaryPrice(rawCompletionPrice),
-  ]
-  const hasInvalidPrimaryPrice =
-    (pricingValue !== undefined && pricing === undefined) ||
-    primaryPriceStatuses.includes("invalid")
-  const displayName = normalizeNonBlankString(model.name)
-  const description = normalizeNonBlankString(model.description)
-  const presentation = createPresentation(model)
 
   return {
     model_name: model.id,
-    ...(displayName ? { display_name: displayName } : {}),
-    ...(description ? { model_description: description } : {}),
-    ...(Object.keys(presentation).length > 0 ? { presentation } : {}),
+    ...(normalized.displayName ? { display_name: normalized.displayName } : {}),
+    ...(normalized.description
+      ? { model_description: normalized.description }
+      : {}),
+    ...(normalized.vendorEvidence
+      ? { vendorEvidence: normalized.vendorEvidence }
+      : {}),
+    ...(normalized.presentation
+      ? { presentation: normalized.presentation }
+      : {}),
     quota_type: 0,
     model_ratio: 0,
     model_price: 0,

--- a/src/services/apiService/openrouter/publicModelCatalogSchemas.ts
+++ b/src/services/apiService/openrouter/publicModelCatalogSchemas.ts
@@ -3,11 +3,24 @@ import { z } from "zod"
 export const openRouterPublicModelSchema = z
   .object({
     id: z.string().trim().min(1),
+    alias_target: z.unknown().optional(),
+    benchmarks: z.unknown().optional(),
+    canonical_slug: z.unknown().optional(),
     name: z.unknown().optional(),
     description: z.unknown().optional(),
+    created: z.unknown().optional(),
     context_length: z.unknown().optional(),
+    default_parameters: z.unknown().optional(),
+    expiration_date: z.unknown().optional(),
+    hugging_face_id: z.unknown().optional(),
+    knowledge_cutoff: z.unknown().optional(),
+    links: z.unknown().optional(),
+    per_request_limits: z.unknown().optional(),
     pricing: z.unknown().optional(),
     architecture: z.unknown().optional(),
+    reasoning: z.unknown().optional(),
+    supported_parameters: z.unknown().optional(),
+    supported_voices: z.unknown().optional(),
     top_provider: z.unknown().optional(),
   })
   .passthrough()

--- a/src/services/modelList/providerCatalogAdmission.ts
+++ b/src/services/modelList/providerCatalogAdmission.ts
@@ -16,6 +16,7 @@ import { MODEL_VENDOR_EVIDENCE_KINDS } from "~/services/models/modelDescriptor"
 import {
   isModelDisplayTranslationKey,
   MODEL_DISPLAY_FACT_TYPES,
+  MODEL_DISPLAY_PRICE_UNITS,
 } from "~/services/models/modelDisplayFacts"
 
 /** A provider response must carry every action decision used by the UI. */
@@ -59,6 +60,28 @@ const trimmedNonBlankStringSchema = z
 
 const finiteNonnegativeNumberSchema = z.number().finite().nonnegative()
 
+const safeExternalUrlSchema = z.url().refine((value) => {
+  return new URL(value).protocol === "https:"
+})
+
+const utcClockSchema = z
+  .number()
+  .int()
+  .nonnegative()
+  .max(2359)
+  .refine((value) => value % 100 < 60)
+
+const isoCalendarDateSchema = z
+  .string()
+  .regex(/^\d{4}-\d{2}-\d{2}$/)
+  .refine((value) => {
+    const parsed = new Date(`${value}T00:00:00Z`)
+    return (
+      !Number.isNaN(parsed.getTime()) &&
+      parsed.toISOString().slice(0, 10) === value
+    )
+  })
+
 const modelDisplayLabelSchema = z.strictObject({
   translationKey: trimmedNonBlankStringSchema
     .refine(isModelDisplayTranslationKey)
@@ -69,6 +92,32 @@ const modelDisplayLabelSchema = z.strictObject({
 const stringListSchema = z
   .array(trimmedNonBlankStringSchema)
   .refine((values) => new Set(values).size === values.length)
+
+const modelDisplayPriceUnitSchema = z.enum(
+  Object.values(MODEL_DISPLAY_PRICE_UNITS) as [
+    (typeof MODEL_DISPLAY_PRICE_UNITS)[keyof typeof MODEL_DISPLAY_PRICE_UNITS],
+    ...(typeof MODEL_DISPLAY_PRICE_UNITS)[keyof typeof MODEL_DISPLAY_PRICE_UNITS][],
+  ],
+)
+
+const modelDisplayPriceSchema = z.strictObject({
+  label: modelDisplayLabelSchema,
+  amount: finiteNonnegativeNumberSchema,
+  currency: z.literal("USD"),
+  unit: modelDisplayPriceUnitSchema,
+})
+
+const modelDisplayPriceConditionSchema = z.discriminatedUnion("type", [
+  z.strictObject({
+    type: z.literal("minimum-prompt-tokens"),
+    value: z.number().int().nonnegative(),
+  }),
+  z.strictObject({
+    type: z.literal("utc-window"),
+    start: utcClockSchema,
+    end: utcClockSchema,
+  }),
+])
 
 const modelDisplayFactSchema = z.discriminatedUnion("type", [
   z.strictObject({
@@ -85,6 +134,58 @@ const modelDisplayFactSchema = z.discriminatedUnion("type", [
     type: z.literal(MODEL_DISPLAY_FACT_TYPES.StringList),
     label: modelDisplayLabelSchema,
     values: stringListSchema.min(1),
+  }),
+  z.strictObject({
+    type: z.literal(MODEL_DISPLAY_FACT_TYPES.Boolean),
+    label: modelDisplayLabelSchema,
+    value: z.boolean(),
+  }),
+  z.strictObject({
+    type: z.literal(MODEL_DISPLAY_FACT_TYPES.Number),
+    label: modelDisplayLabelSchema,
+    value: z.number().finite(),
+  }),
+  z.strictObject({
+    type: z.literal(MODEL_DISPLAY_FACT_TYPES.Date),
+    label: modelDisplayLabelSchema,
+    value: isoCalendarDateSchema,
+  }),
+  z.strictObject({
+    type: z.literal(MODEL_DISPLAY_FACT_TYPES.Link),
+    label: modelDisplayLabelSchema,
+    href: safeExternalUrlSchema,
+    text: modelDisplayLabelSchema,
+  }),
+  z.strictObject({
+    type: z.literal(MODEL_DISPLAY_FACT_TYPES.CurrencyPrice),
+    ...modelDisplayPriceSchema.shape,
+  }),
+  z.strictObject({
+    type: z.literal(MODEL_DISPLAY_FACT_TYPES.PriceOverrides),
+    label: modelDisplayLabelSchema,
+    overrides: z
+      .array(
+        z.strictObject({
+          conditions: z.array(modelDisplayPriceConditionSchema).min(1),
+          prices: z.array(modelDisplayPriceSchema).min(1),
+        }),
+      )
+      .min(1),
+  }),
+  z.strictObject({
+    type: z.literal(MODEL_DISPLAY_FACT_TYPES.BenchmarkList),
+    label: modelDisplayLabelSchema,
+    entries: z
+      .array(
+        z.strictObject({
+          arena: trimmedNonBlankStringSchema,
+          category: trimmedNonBlankStringSchema,
+          score: finiteNonnegativeNumberSchema,
+          rank: z.number().int().positive(),
+          winRatePercent: finiteNonnegativeNumberSchema.max(100),
+        }),
+      )
+      .min(1),
   }),
 ])
 

--- a/src/services/modelList/providerCatalogAdmission.ts
+++ b/src/services/modelList/providerCatalogAdmission.ts
@@ -12,6 +12,7 @@ import {
   type PricingResponse,
   type ProductCanonicalModel,
 } from "~/services/modelList/pricingModel"
+import { isIsoCalendarDate } from "~/services/models/isoCalendarDate"
 import { MODEL_VENDOR_EVIDENCE_KINDS } from "~/services/models/modelDescriptor"
 import {
   isModelDisplayTranslationKey,
@@ -71,16 +72,7 @@ const utcClockSchema = z
   .max(2359)
   .refine((value) => value % 100 < 60)
 
-const isoCalendarDateSchema = z
-  .string()
-  .regex(/^\d{4}-\d{2}-\d{2}$/)
-  .refine((value) => {
-    const parsed = new Date(`${value}T00:00:00Z`)
-    return (
-      !Number.isNaN(parsed.getTime()) &&
-      parsed.toISOString().slice(0, 10) === value
-    )
-  })
+const isoCalendarDateSchema = z.string().refine(isIsoCalendarDate)
 
 const modelDisplayLabelSchema = z.strictObject({
   translationKey: trimmedNonBlankStringSchema
@@ -93,12 +85,7 @@ const stringListSchema = z
   .array(trimmedNonBlankStringSchema)
   .refine((values) => new Set(values).size === values.length)
 
-const modelDisplayPriceUnitSchema = z.enum(
-  Object.values(MODEL_DISPLAY_PRICE_UNITS) as [
-    (typeof MODEL_DISPLAY_PRICE_UNITS)[keyof typeof MODEL_DISPLAY_PRICE_UNITS],
-    ...(typeof MODEL_DISPLAY_PRICE_UNITS)[keyof typeof MODEL_DISPLAY_PRICE_UNITS][],
-  ],
-)
+const modelDisplayPriceUnitSchema = z.enum(MODEL_DISPLAY_PRICE_UNITS)
 
 const modelDisplayPriceSchema = z.strictObject({
   label: modelDisplayLabelSchema,

--- a/src/services/models/isoCalendarDate.ts
+++ b/src/services/models/isoCalendarDate.ts
@@ -1,0 +1,12 @@
+const ISO_CALENDAR_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/
+
+/** Returns whether a value is a real ISO 8601 calendar date without rollover. */
+export function isIsoCalendarDate(value: string): boolean {
+  if (!ISO_CALENDAR_DATE_PATTERN.test(value)) return false
+
+  const parsed = new Date(`${value}T00:00:00Z`)
+  return (
+    !Number.isNaN(parsed.getTime()) &&
+    parsed.toISOString().slice(0, 10) === value
+  )
+}

--- a/src/services/models/modelDisplayFacts.ts
+++ b/src/services/models/modelDisplayFacts.ts
@@ -3,7 +3,35 @@ export const MODEL_DISPLAY_FACT_TYPES = {
   Text: "text",
   TokenQuantity: "token-quantity",
   StringList: "string-list",
+  Boolean: "boolean",
+  Number: "number",
+  Date: "date",
+  Link: "link",
+  CurrencyPrice: "currency-price",
+  PriceOverrides: "price-overrides",
+  BenchmarkList: "benchmark-list",
 } as const
+
+/** Meter units supported by the shared currency-price renderer. */
+export const MODEL_DISPLAY_PRICE_UNITS = {
+  MillionInputTokens: "million-input-tokens",
+  MillionOutputTokens: "million-output-tokens",
+  MillionCachedInputTokens: "million-cached-input-tokens",
+  MillionCacheWriteTokens: "million-cache-write-tokens",
+  MillionCacheWriteOneHourTokens: "million-cache-write-one-hour-tokens",
+  MillionReasoningTokens: "million-reasoning-tokens",
+  MillionImageTokens: "million-image-tokens",
+  MillionAudioInputTokens: "million-audio-input-tokens",
+  MillionAudioOutputTokens: "million-audio-output-tokens",
+  MillionCachedAudioInputTokens: "million-cached-audio-input-tokens",
+  Request: "request",
+  InputImage: "input-image",
+  OutputImage: "output-image",
+  WebSearch: "web-search",
+} as const
+
+export type ModelDisplayPriceUnit =
+  (typeof MODEL_DISPLAY_PRICE_UNITS)[keyof typeof MODEL_DISPLAY_PRICE_UNITS]
 
 /** Translation namespace reserved for provider-neutral display facts. */
 export const MODEL_DISPLAY_TRANSLATION_KEY_PREFIX = "displayFacts."
@@ -25,22 +53,26 @@ export interface ModelDisplayLabel {
   fallback: string
 }
 
-const createTranslatedLabel = (
+export const createModelDisplayLabel = (
   translationKey: ModelDisplayTranslationKey,
   fallback: string,
 ): ModelDisplayLabel => ({ translationKey, fallback })
 
 /** Canonical labels shared by provider presentation facts. */
 export const MODEL_DISPLAY_FACT_LABELS = {
-  ContextLimit: createTranslatedLabel(
+  ContextLimit: createModelDisplayLabel(
     "displayFacts.contextLimit",
     "Context limit",
   ),
-  MaximumOutputTokens: createTranslatedLabel(
+  MaximumOutputTokens: createModelDisplayLabel(
     "displayFacts.maximumOutputTokens",
     "Maximum output tokens",
   ),
-  OutputModalities: createTranslatedLabel(
+  InputModalities: createModelDisplayLabel(
+    "displayFacts.inputModalities",
+    "Input modalities",
+  ),
+  OutputModalities: createModelDisplayLabel(
     "displayFacts.outputModalities",
     "Output modalities",
   ),
@@ -48,11 +80,42 @@ export const MODEL_DISPLAY_FACT_LABELS = {
 
 /** Canonical section labels shared by provider presentation facts. */
 export const MODEL_DISPLAY_SECTION_LABELS = {
-  Specifications: createTranslatedLabel(
+  Specifications: createModelDisplayLabel(
     "displayFacts.sections.specifications",
     "Specifications",
   ),
 } as const
+
+export interface ModelDisplayPrice {
+  label: ModelDisplayLabel
+  amount: number
+  currency: "USD"
+  unit: ModelDisplayPriceUnit
+}
+
+export type ModelDisplayPriceCondition =
+  | {
+      type: "minimum-prompt-tokens"
+      value: number
+    }
+  | {
+      type: "utc-window"
+      start: number
+      end: number
+    }
+
+export interface ModelDisplayPriceOverride {
+  conditions: ModelDisplayPriceCondition[]
+  prices: ModelDisplayPrice[]
+}
+
+export interface ModelDisplayBenchmarkEntry {
+  arena: string
+  category: string
+  score: number
+  rank: number
+  winRatePercent: number
+}
 
 /** A typed, provider-neutral fact rendered in a model detail view. */
 export type ModelDisplayFact =
@@ -70,6 +133,41 @@ export type ModelDisplayFact =
       type: typeof MODEL_DISPLAY_FACT_TYPES.StringList
       label: ModelDisplayLabel
       values: string[]
+    }
+  | {
+      type: typeof MODEL_DISPLAY_FACT_TYPES.Boolean
+      label: ModelDisplayLabel
+      value: boolean
+    }
+  | {
+      type: typeof MODEL_DISPLAY_FACT_TYPES.Number
+      label: ModelDisplayLabel
+      value: number
+    }
+  | {
+      type: typeof MODEL_DISPLAY_FACT_TYPES.Date
+      label: ModelDisplayLabel
+      value: string
+    }
+  | {
+      type: typeof MODEL_DISPLAY_FACT_TYPES.Link
+      label: ModelDisplayLabel
+      href: string
+      text: ModelDisplayLabel
+    }
+  | ({
+      type: typeof MODEL_DISPLAY_FACT_TYPES.CurrencyPrice
+      label: ModelDisplayLabel
+    } & ModelDisplayPrice)
+  | {
+      type: typeof MODEL_DISPLAY_FACT_TYPES.PriceOverrides
+      label: ModelDisplayLabel
+      overrides: ModelDisplayPriceOverride[]
+    }
+  | {
+      type: typeof MODEL_DISPLAY_FACT_TYPES.BenchmarkList
+      label: ModelDisplayLabel
+      entries: ModelDisplayBenchmarkEntry[]
     }
 
 /** A labeled group of provider-neutral model facts. */

--- a/tests/features/ModelList/components/ModelPresentationFacts.test.tsx
+++ b/tests/features/ModelList/components/ModelPresentationFacts.test.tsx
@@ -260,6 +260,11 @@ describe("generic model presentation facts", () => {
                   value: false,
                 },
                 {
+                  type: MODEL_DISPLAY_FACT_TYPES.Boolean,
+                  label: { fallback: "Tool calling" },
+                  value: true,
+                },
+                {
                   type: MODEL_DISPLAY_FACT_TYPES.Number,
                   label: { fallback: "Default temperature" },
                   value: 0,
@@ -333,6 +338,7 @@ describe("generic model presentation facts", () => {
 
     expect(screen.getByText("$1.50 / 1M input tokens")).toBeInTheDocument()
     expect(screen.getByText("No")).toBeInTheDocument()
+    expect(screen.getByText("Yes")).toBeInTheDocument()
     expect(screen.getByText("0")).toBeInTheDocument()
     expect(screen.getByText("Jan 2, 2024")).toBeInTheDocument()
     expect(

--- a/tests/features/ModelList/components/ModelPresentationFacts.test.tsx
+++ b/tests/features/ModelList/components/ModelPresentationFacts.test.tsx
@@ -7,6 +7,7 @@ import {
 import {
   MODEL_DISPLAY_FACT_LABELS,
   MODEL_DISPLAY_FACT_TYPES,
+  MODEL_DISPLAY_PRICE_UNITS,
   MODEL_DISPLAY_SECTION_LABELS,
   type ModelDisplayTranslationKey,
   type ModelPresentation,
@@ -80,6 +81,22 @@ beforeAll(() => {
         maximumOutputTokens: "Maximum output tokens",
         outputModalities: "Output modalities",
         sections: { specifications: "Specifications" },
+        boolean: { no: "No", yes: "Yes" },
+        benchmarkTable: {
+          arena: "Arena",
+          category: "Category",
+          rank: "Rank",
+          score: "Score",
+          winRate: "Win rate",
+        },
+        priceConditions: {
+          minimumPromptTokens: "More than {{formattedCount}} prompt tokens",
+          utcWindow: "{{start}}–{{end}} UTC",
+        },
+        priceUnits: {
+          millionInputTokens: "1M input tokens",
+          request: "request",
+        },
         tokenCount_one: "{{formattedCount}} token",
         tokenCount_other: "{{formattedCount}} tokens",
       },
@@ -219,5 +236,127 @@ describe("generic model presentation facts", () => {
     )
 
     expect(screen.getByRole("term")).toHaveTextContent("Safe label")
+  })
+
+  it("renders typed prices, conditions, dates, booleans, links, and benchmarks accessibly", () => {
+    render(
+      <ModelPresentationDetails
+        presentation={{
+          sections: [
+            {
+              id: "rich-facts",
+              label: { fallback: "Rich facts" },
+              facts: [
+                {
+                  type: MODEL_DISPLAY_FACT_TYPES.CurrencyPrice,
+                  label: { fallback: "Input price" },
+                  amount: 1.5,
+                  currency: "USD",
+                  unit: MODEL_DISPLAY_PRICE_UNITS.MillionInputTokens,
+                },
+                {
+                  type: MODEL_DISPLAY_FACT_TYPES.Boolean,
+                  label: { fallback: "Moderated" },
+                  value: false,
+                },
+                {
+                  type: MODEL_DISPLAY_FACT_TYPES.Number,
+                  label: { fallback: "Default temperature" },
+                  value: 0,
+                },
+                {
+                  type: MODEL_DISPLAY_FACT_TYPES.Date,
+                  label: { fallback: "Added" },
+                  value: "2024-01-02",
+                },
+                {
+                  type: MODEL_DISPLAY_FACT_TYPES.Link,
+                  label: { fallback: "Details" },
+                  href: "https://docs.example.invalid/model",
+                  text: { fallback: "Open model details" },
+                },
+                {
+                  type: MODEL_DISPLAY_FACT_TYPES.PriceOverrides,
+                  label: { fallback: "Conditional prices" },
+                  overrides: [
+                    {
+                      conditions: [
+                        {
+                          type: "minimum-prompt-tokens",
+                          value: 200_000,
+                        },
+                      ],
+                      prices: [
+                        {
+                          label: { fallback: "Input price" },
+                          amount: 3,
+                          currency: "USD",
+                          unit: MODEL_DISPLAY_PRICE_UNITS.MillionInputTokens,
+                        },
+                      ],
+                    },
+                    {
+                      conditions: [
+                        { type: "utc-window", start: 1630, end: 30 },
+                      ],
+                      prices: [
+                        {
+                          label: { fallback: "Request price" },
+                          amount: 0,
+                          currency: "USD",
+                          unit: MODEL_DISPLAY_PRICE_UNITS.Request,
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  type: MODEL_DISPLAY_FACT_TYPES.BenchmarkList,
+                  label: { fallback: "Benchmark rankings" },
+                  entries: [
+                    {
+                      arena: "models",
+                      category: "website",
+                      score: 1385.2,
+                      rank: 5,
+                      winRatePercent: 62.5,
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        }}
+      />,
+      { withUserPreferencesProvider: false, withThemeProvider: false },
+    )
+
+    expect(screen.getByText("$1.50 / 1M input tokens")).toBeInTheDocument()
+    expect(screen.getByText("No")).toBeInTheDocument()
+    expect(screen.getByText("0")).toBeInTheDocument()
+    expect(screen.getByText("Jan 2, 2024")).toBeInTheDocument()
+    expect(
+      screen.getByRole("link", { name: "Open model details" }),
+    ).toHaveAttribute("href", "https://docs.example.invalid/model")
+    expect(
+      screen.getByRole("link", { name: "Open model details" }),
+    ).toHaveAttribute("rel", "noreferrer noopener")
+    expect(
+      screen.getByText("More than 200,000 prompt tokens"),
+    ).toBeInTheDocument()
+    expect(screen.getByText("16:30–00:30 UTC")).toBeInTheDocument()
+    expect(screen.getByText("$3.00 / 1M input tokens")).toBeInTheDocument()
+    expect(screen.getByText("$0.00 / request")).toBeInTheDocument()
+
+    const table = screen.getByRole("table", { name: "Benchmark rankings" })
+    expect(
+      within(table).getByRole("columnheader", { name: "Arena" }),
+    ).toBeInTheDocument()
+    expect(
+      within(table).getByRole("cell", { name: "models" }),
+    ).toBeInTheDocument()
+    expect(
+      within(table).getByRole("cell", { name: "62.5%" }),
+    ).toBeInTheDocument()
   })
 })

--- a/tests/services/apiAdapters/openrouter/modelFieldInventory.test.ts
+++ b/tests/services/apiAdapters/openrouter/modelFieldInventory.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 
 import {
+  OPENROUTER_MODEL_FIELD_CATEGORIES,
   OPENROUTER_MODEL_FIELD_CLASSIFICATIONS,
   OPENROUTER_PINNED_MODEL_FIELD_PATHS,
 } from "~/services/apiAdapters/openrouter/modelFieldInventory"
@@ -16,7 +17,10 @@ describe("OpenRouter documented model field inventory", () => {
     for (const classification of Object.values(
       OPENROUTER_MODEL_FIELD_CLASSIFICATIONS,
     )) {
-      if (classification.category === "intentionally-hidden") {
+      if (
+        classification.category ===
+        OPENROUTER_MODEL_FIELD_CATEGORIES.IntentionallyHidden
+      ) {
         expect(classification.reason.trim()).not.toBe("")
       } else {
         expect(classification).not.toHaveProperty("reason")

--- a/tests/services/apiAdapters/openrouter/modelFieldInventory.test.ts
+++ b/tests/services/apiAdapters/openrouter/modelFieldInventory.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  OPENROUTER_MODEL_FIELD_CLASSIFICATIONS,
+  OPENROUTER_PINNED_MODEL_FIELD_PATHS,
+} from "~/services/apiAdapters/openrouter/modelFieldInventory"
+
+describe("OpenRouter documented model field inventory", () => {
+  it("classifies every pinned documented field exactly once", () => {
+    expect(Object.keys(OPENROUTER_MODEL_FIELD_CLASSIFICATIONS).sort()).toEqual(
+      [...OPENROUTER_PINNED_MODEL_FIELD_PATHS].sort(),
+    )
+  })
+
+  it("records a reviewable reason for every intentionally hidden field", () => {
+    for (const classification of Object.values(
+      OPENROUTER_MODEL_FIELD_CLASSIFICATIONS,
+    )) {
+      if (classification.category === "intentionally-hidden") {
+        expect(classification.reason.trim()).not.toBe("")
+      } else {
+        expect(classification).not.toHaveProperty("reason")
+      }
+    }
+  })
+})

--- a/tests/services/apiAdapters/openrouter/providerModelCatalog.test.ts
+++ b/tests/services/apiAdapters/openrouter/providerModelCatalog.test.ts
@@ -473,8 +473,9 @@ describe("OpenRouter provider model catalog Adapter", () => {
           data: [
             {
               id: "publisher-example/model-partial",
+              canonical_slug: "invalid publisher/model-partial",
               context_length: 0,
-              created: -1,
+              created: Number.MAX_SAFE_INTEGER,
               knowledge_cutoff: "not-a-date",
               expiration_date: "2026-02-30",
               architecture: {
@@ -515,6 +516,7 @@ describe("OpenRouter provider model catalog Adapter", () => {
                 default_effort: " ",
                 supported_efforts: ["low", 4, " low "],
               },
+              default_parameters: { temperature: "invalid" },
               alias_target: { name: "Stable alias", slug: 4 },
               benchmarks: {
                 design_arena: [
@@ -535,8 +537,7 @@ describe("OpenRouter provider model catalog Adapter", () => {
                 ],
               },
               links: {
-                details:
-                  "https://catalog.example.invalid/api/v1/models/model/endpoints",
+                details: "https://[",
               },
             },
           ],
@@ -591,6 +592,7 @@ describe("OpenRouter provider model catalog Adapter", () => {
     ).toBe(false)
     expect(JSON.stringify(model.presentation)).not.toContain("not-a-date")
     expect(JSON.stringify(model.presentation)).not.toContain("2026-02-30")
+    expect(model.vendorEvidence).toBeUndefined()
   })
 
   it("does not infer publisher evidence from an unscoped model identifier", async () => {

--- a/tests/services/apiAdapters/openrouter/providerModelCatalog.test.ts
+++ b/tests/services/apiAdapters/openrouter/providerModelCatalog.test.ts
@@ -11,11 +11,36 @@ import {
   MODEL_PRICE_PRECISION_KINDS,
   MODEL_UNAVAILABLE_PRICE_REASONS,
 } from "~/services/modelList/pricingModel"
+import { MODEL_VENDOR_EVIDENCE_KINDS } from "~/services/models/modelDescriptor"
 import {
   MODEL_DISPLAY_FACT_LABELS,
   MODEL_DISPLAY_FACT_TYPES,
 } from "~/services/models/modelDisplayFacts"
 import { server } from "~~/tests/msw/server"
+
+function getSection(
+  model: Awaited<
+    ReturnType<typeof openRouterProviderModelCatalog.fetchPricing>
+  >["data"][number],
+  id: string,
+) {
+  const section = model.presentation?.sections?.find(
+    (candidate) => candidate.id === id,
+  )
+  expect(section, `Expected ${id} section`).toBeDefined()
+  return section!
+}
+
+function getFact(
+  section: ReturnType<typeof getSection>,
+  fallbackLabel: string,
+) {
+  const fact = section.facts.find(
+    (candidate) => candidate.label.fallback === fallbackLabel,
+  )
+  expect(fact, `Expected ${fallbackLabel} fact`).toBeDefined()
+  return fact!
+}
 
 describe("OpenRouter provider model catalog Adapter", () => {
   beforeEach(() => server.resetHandlers())
@@ -70,18 +95,17 @@ describe("OpenRouter provider model catalog Adapter", () => {
             values: ["text", "image"],
           },
         ],
-        sections: [
-          {
-            facts: [
-              {
-                type: MODEL_DISPLAY_FACT_TYPES.TokenQuantity,
-                label: MODEL_DISPLAY_FACT_LABELS.MaximumOutputTokens,
-                value: 8192,
-              },
-            ],
-          },
-        ],
       },
+    })
+    expect(
+      getFact(
+        getSection(response.data[0]!, "routing"),
+        "Maximum output tokens",
+      ),
+    ).toMatchObject({
+      type: MODEL_DISPLAY_FACT_TYPES.TokenQuantity,
+      label: MODEL_DISPLAY_FACT_LABELS.MaximumOutputTokens,
+      value: 8192,
     })
     expect(response.model_list_source).toEqual({
       kind: MODEL_LIST_SOURCE_KINDS.PROVIDER_CATALOG,
@@ -174,7 +198,15 @@ describe("OpenRouter provider model catalog Adapter", () => {
       })
       expect(models[modelId].token_price_usd_per_million).toBeUndefined()
     }
-    expect(models["example/negative-price"].presentation).toBeUndefined()
+    expect(
+      getSection(models["example/negative-price"], "pricing").facts,
+    ).toEqual([
+      expect.objectContaining({
+        type: MODEL_DISPLAY_FACT_TYPES.CurrencyPrice,
+        amount: 2,
+        unit: "million-output-tokens",
+      }),
+    ])
   })
 
   it("preserves cache-only prices without claiming comparable primary pricing", async () => {
@@ -209,5 +241,377 @@ describe("OpenRouter provider model catalog Adapter", () => {
           MODEL_UNAVAILABLE_PRICE_REASONS.OFFICIAL_PRICE_MISSING,
       },
     })
+  })
+
+  it("normalizes rich native facts with reviewed ordering, units, and publisher evidence", async () => {
+    server.use(
+      http.get(`${OPENROUTER_API_BASE_URL}/models`, () =>
+        HttpResponse.json({
+          data: [
+            {
+              id: "publisher-example/model-alpha",
+              canonical_slug: "publisher-example/model-alpha-stable",
+              name: "Model Alpha",
+              description: "A catalog model",
+              created: 1_704_067_200,
+              knowledge_cutoff: "2023-12-31",
+              expiration_date: "2026-12-31",
+              hugging_face_id: "publisher-example/model-alpha",
+              alias_target: {
+                name: "Model Alpha Stable",
+                slug: "publisher-example/model-alpha-stable",
+              },
+              context_length: 128_000,
+              architecture: {
+                input_modalities: ["text", "image", "text"],
+                output_modalities: ["text", "audio"],
+                modality: "text+image->text+audio",
+                tokenizer: "Example tokenizer",
+                instruct_type: "example-format",
+              },
+              pricing: {
+                prompt: "0.000001",
+                completion: "0.000002",
+                request: "0.005",
+                image: "0.01",
+                image_output: "0.02",
+                image_token: "0.0000003",
+                audio: "0.0000004",
+                audio_output: "0.0000005",
+                web_search: "0.006",
+                internal_reasoning: "0.0000007",
+                input_audio_cache: "0.0000008",
+                input_cache_read: "0.0000002",
+                input_cache_write: "0.0000009",
+                input_cache_write_1h: "0.0000011",
+                discount: 0.25,
+                overrides: [
+                  {
+                    min_prompt_tokens: 200_000,
+                    prompt: "0.000003",
+                    completion: "0.000004",
+                  },
+                  {
+                    utc_start: 1630,
+                    utc_end: 30,
+                    prompt: "0.0000005",
+                    input_cache_read: "0",
+                  },
+                ],
+              },
+              top_provider: {
+                context_length: 96_000,
+                max_completion_tokens: 8_192,
+                is_moderated: false,
+              },
+              per_request_limits: {
+                prompt_tokens: 64_000,
+                completion_tokens: 4_096,
+              },
+              supported_parameters: ["temperature", "reasoning", "tools"],
+              default_parameters: {
+                temperature: 0,
+                top_p: 0.9,
+                top_k: 40,
+                frequency_penalty: -0.2,
+                presence_penalty: 0.1,
+                repetition_penalty: 1.05,
+              },
+              reasoning: {
+                mandatory: false,
+                default_enabled: true,
+                default_effort: "medium",
+                supported_efforts: ["high", "medium", "low"],
+                supports_max_tokens: true,
+              },
+              supported_voices: ["voice-alpha", "voice-beta"],
+              benchmarks: {
+                artificial_analysis: {
+                  intelligence_index: 71.4,
+                  coding_index: 63.2,
+                  agentic_index: 55.8,
+                },
+                design_arena: [
+                  {
+                    arena: "models",
+                    category: "website",
+                    elo: 1385.2,
+                    win_rate: 62.5,
+                    rank: 5,
+                  },
+                ],
+              },
+              links: {
+                details:
+                  "/api/v1/models/publisher-example/model-alpha/endpoints",
+              },
+              additive_unknown_field: {
+                raw_secret: "must-not-reach-presentation",
+              },
+            },
+          ],
+          total_count: 1,
+          links: { next: null },
+        }),
+      ),
+    )
+
+    const response = await openRouterProviderModelCatalog.fetchPricing({})
+    const model = response.data[0]!
+
+    expect(model.vendorEvidence).toEqual({
+      kind: MODEL_VENDOR_EVIDENCE_KINDS.Publisher,
+      name: "publisher-example",
+      externalId: "publisher-example",
+    })
+    expect(
+      model.presentation?.summaryFacts?.map((fact) => fact.label.fallback),
+    ).toEqual(["Context limit", "Input modalities", "Output modalities"])
+    expect(model.presentation?.sections?.map((section) => section.id)).toEqual([
+      "pricing",
+      "architecture",
+      "capabilities",
+      "request-limits",
+      "routing",
+      "lifecycle",
+      "benchmarks",
+      "links",
+    ])
+
+    const pricing = getSection(model, "pricing")
+    expect(
+      pricing.facts
+        .filter((fact) => fact.type === "currency-price")
+        .map((fact) => [
+          fact.label.fallback,
+          Number(fact.amount.toFixed(8)),
+          fact.unit,
+        ]),
+    ).toEqual([
+      ["Input price", 1, "million-input-tokens"],
+      ["Output price", 2, "million-output-tokens"],
+      ["Cache read price", 0.2, "million-cached-input-tokens"],
+      ["Cache write price", 0.9, "million-cache-write-tokens"],
+      [
+        "One-hour cache write price",
+        1.1,
+        "million-cache-write-one-hour-tokens",
+      ],
+      ["Reasoning token price", 0.7, "million-reasoning-tokens"],
+      ["Request price", 0.005, "request"],
+      ["Image input price", 0.01, "input-image"],
+      ["Image output price", 0.02, "output-image"],
+      ["Image token price", 0.3, "million-image-tokens"],
+      ["Audio input price", 0.4, "million-audio-input-tokens"],
+      ["Audio output price", 0.5, "million-audio-output-tokens"],
+      ["Cached audio input price", 0.8, "million-cached-audio-input-tokens"],
+      ["Web search price", 0.006, "web-search"],
+    ])
+    expect(getFact(pricing, "Conditional prices")).toMatchObject({
+      type: "price-overrides",
+      overrides: [
+        {
+          conditions: [{ type: "minimum-prompt-tokens", value: 200_000 }],
+          prices: expect.arrayContaining([
+            expect.objectContaining({
+              label: expect.objectContaining({ fallback: "Input price" }),
+              amount: 3,
+              unit: "million-input-tokens",
+            }),
+          ]),
+        },
+        {
+          conditions: [{ type: "utc-window", start: 1630, end: 30 }],
+          prices: expect.arrayContaining([
+            expect.objectContaining({
+              label: expect.objectContaining({ fallback: "Cache read price" }),
+              amount: 0,
+            }),
+          ]),
+        },
+      ],
+    })
+    expect(
+      pricing.facts.some((fact) => fact.label.fallback === "Discount"),
+    ).toBe(false)
+
+    expect(
+      getFact(getSection(model, "request-limits"), "Prompt token limit"),
+    ).toMatchObject({ type: "token-quantity", value: 64_000 })
+    expect(
+      getFact(getSection(model, "routing"), "Content moderation"),
+    ).toMatchObject({ type: "boolean", value: false })
+    expect(
+      getFact(getSection(model, "benchmarks"), "Design Arena rankings"),
+    ).toMatchObject({
+      type: "benchmark-list",
+      entries: [
+        {
+          arena: "models",
+          category: "website",
+          score: 1385.2,
+          rank: 5,
+          winRatePercent: 62.5,
+        },
+      ],
+    })
+    expect(
+      getFact(getSection(model, "links"), "Provider details"),
+    ).toMatchObject({
+      type: "link",
+      href: `${OPENROUTER_API_BASE_URL}/models/publisher-example/model-alpha/endpoints`,
+    })
+    expect(JSON.stringify(model.presentation)).not.toContain(
+      "must-not-reach-presentation",
+    )
+  })
+
+  it("keeps valid nested facts while omitting malformed optional siblings", async () => {
+    server.use(
+      http.get(`${OPENROUTER_API_BASE_URL}/models`, () =>
+        HttpResponse.json({
+          data: [
+            {
+              id: "publisher-example/model-partial",
+              context_length: 0,
+              created: -1,
+              knowledge_cutoff: "not-a-date",
+              expiration_date: "2026-02-30",
+              architecture: {
+                input_modalities: ["text", 4, " text "],
+                output_modalities: "text",
+                tokenizer: "  Example tokenizer  ",
+              },
+              pricing: {
+                prompt: "0",
+                completion: "0",
+                request: "-1",
+                image: "NaN",
+                overrides: [
+                  { min_prompt_tokens: -1, prompt: "0.000001" },
+                  {
+                    min_prompt_tokens: 100,
+                    prompt: "invalid",
+                    completion: "0",
+                  },
+                  {
+                    utc_start: 1260,
+                    utc_end: 30,
+                    prompt: "0.000001",
+                  },
+                ],
+              },
+              top_provider: {
+                context_length: 4_096,
+                max_completion_tokens: -1,
+                is_moderated: "false",
+              },
+              per_request_limits: {
+                prompt_tokens: 0,
+                completion_tokens: "4096",
+              },
+              reasoning: {
+                mandatory: false,
+                default_effort: " ",
+                supported_efforts: ["low", 4, " low "],
+              },
+              alias_target: { name: "Stable alias", slug: 4 },
+              benchmarks: {
+                design_arena: [
+                  {
+                    arena: "models",
+                    category: "website",
+                    elo: -1,
+                    win_rate: 101,
+                    rank: 0,
+                  },
+                  {
+                    arena: "builders",
+                    category: "application",
+                    elo: 1200,
+                    win_rate: 0,
+                    rank: 1,
+                  },
+                ],
+              },
+              links: {
+                details:
+                  "https://catalog.example.invalid/api/v1/models/model/endpoints",
+              },
+            },
+          ],
+          total_count: 1,
+          links: { next: null },
+        }),
+      ),
+    )
+
+    const response = await openRouterProviderModelCatalog.fetchPricing({})
+    const model = response.data[0]!
+
+    expect(model.presentation?.summaryFacts).toEqual([
+      {
+        type: MODEL_DISPLAY_FACT_TYPES.TokenQuantity,
+        label: MODEL_DISPLAY_FACT_LABELS.ContextLimit,
+        value: 0,
+      },
+      expect.objectContaining({
+        type: MODEL_DISPLAY_FACT_TYPES.StringList,
+        values: ["text"],
+      }),
+    ])
+    const pricing = getSection(model, "pricing")
+    expect(pricing.facts.map((fact) => fact.label.fallback)).toEqual([
+      "Input price",
+      "Output price",
+      "Conditional prices",
+    ])
+    expect(getFact(pricing, "Conditional prices")).toMatchObject({
+      overrides: [
+        {
+          conditions: [{ type: "minimum-prompt-tokens", value: 100 }],
+          prices: [expect.objectContaining({ amount: 0 })],
+        },
+      ],
+    })
+    expect(
+      getFact(getSection(model, "request-limits"), "Prompt token limit"),
+    ).toMatchObject({ value: 0 })
+    expect(
+      getFact(getSection(model, "routing"), "Routing context limit"),
+    ).toMatchObject({ value: 4_096 })
+    expect(
+      getFact(getSection(model, "lifecycle"), "Alias target name"),
+    ).toMatchObject({ value: "Stable alias" })
+    expect(
+      getFact(getSection(model, "benchmarks"), "Design Arena rankings"),
+    ).toMatchObject({ entries: [expect.objectContaining({ rank: 1 })] })
+    expect(
+      model.presentation?.sections?.some((section) => section.id === "links"),
+    ).toBe(false)
+    expect(JSON.stringify(model.presentation)).not.toContain("not-a-date")
+    expect(JSON.stringify(model.presentation)).not.toContain("2026-02-30")
+  })
+
+  it("does not infer publisher evidence from an unscoped model identifier", async () => {
+    server.use(
+      http.get(`${OPENROUTER_API_BASE_URL}/models`, () =>
+        HttpResponse.json({
+          data: [
+            {
+              id: "model-alpha",
+              canonical_slug: "model-alpha",
+              pricing: { prompt: "0", completion: "0" },
+            },
+          ],
+          total_count: 1,
+          links: { next: null },
+        }),
+      ),
+    )
+
+    const response = await openRouterProviderModelCatalog.fetchPricing({})
+
+    expect(response.data[0]?.vendorEvidence).toBeUndefined()
   })
 })

--- a/tests/services/apiAdapters/openrouter/providerModelCatalog.test.ts
+++ b/tests/services/apiAdapters/openrouter/providerModelCatalog.test.ts
@@ -540,8 +540,16 @@ describe("OpenRouter provider model catalog Adapter", () => {
                 details: "https://[",
               },
             },
+            {
+              id: "publisher-example/model-untrusted-link",
+              pricing: { prompt: "0", completion: "0" },
+              links: {
+                details:
+                  "https://catalog.example.invalid/api/v1/models/model/endpoints",
+              },
+            },
           ],
-          total_count: 1,
+          total_count: 2,
           links: { next: null },
         }),
       ),
@@ -593,6 +601,11 @@ describe("OpenRouter provider model catalog Adapter", () => {
     expect(JSON.stringify(model.presentation)).not.toContain("not-a-date")
     expect(JSON.stringify(model.presentation)).not.toContain("2026-02-30")
     expect(model.vendorEvidence).toBeUndefined()
+    expect(
+      response.data[1]?.presentation?.sections?.some(
+        (section) => section.id === "links",
+      ),
+    ).toBe(false)
   })
 
   it("does not infer publisher evidence from an unscoped model identifier", async () => {

--- a/tests/services/modelList/providerCatalogAdmission.test.ts
+++ b/tests/services/modelList/providerCatalogAdmission.test.ts
@@ -52,6 +52,128 @@ function createProviderResponse(modelOverrides: Record<string, unknown> = {}) {
 }
 
 describe("provider model-catalog admission", () => {
+  it("accepts the extended provider-neutral presentation fact vocabulary", () => {
+    const label = { fallback: "Example fact" }
+    const price = {
+      label,
+      amount: 1.25,
+      currency: "USD",
+      unit: "million-input-tokens",
+    }
+
+    expect(
+      isValidProviderModelCatalogPricing(
+        createProviderResponse({
+          presentation: {
+            summaryFacts: [
+              { type: "boolean", label, value: true },
+              { type: "number", label, value: 42 },
+              { type: "date", label, value: "2026-08-08" },
+              {
+                type: "link",
+                label,
+                href: "https://provider.example.invalid/models/example",
+                text: { fallback: "Open details" },
+              },
+            ],
+            sections: [
+              {
+                id: "pricing",
+                label,
+                facts: [
+                  { type: "currency-price", ...price },
+                  {
+                    type: "price-overrides",
+                    label,
+                    overrides: [
+                      {
+                        conditions: [
+                          { type: "minimum-prompt-tokens", value: 200_000 },
+                        ],
+                        prices: [price],
+                      },
+                    ],
+                  },
+                  {
+                    type: "benchmark-list",
+                    label,
+                    entries: [
+                      {
+                        arena: "models",
+                        category: "example",
+                        score: 1200,
+                        rank: 3,
+                        winRatePercent: 62.5,
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+        }),
+        SITE_TYPES.OPENROUTER,
+      ),
+    ).toBe(true)
+  })
+
+  it.each([
+    {
+      name: "an unsafe link scheme",
+      fact: {
+        type: "link",
+        label: { fallback: "Provider details" },
+        href: "http://provider.example.invalid/models/example",
+        text: { fallback: "Open details" },
+      },
+    },
+    {
+      name: "an impossible calendar date",
+      fact: {
+        type: "date",
+        label: { fallback: "Expiration date" },
+        value: "2026-02-30",
+      },
+    },
+    {
+      name: "an invalid UTC clock",
+      fact: {
+        type: "price-overrides",
+        label: { fallback: "Conditional prices" },
+        overrides: [
+          {
+            conditions: [{ type: "utc-window", start: 1260, end: 30 }],
+            prices: [
+              {
+                label: { fallback: "Input price" },
+                amount: 1,
+                currency: "USD",
+                unit: "million-input-tokens",
+              },
+            ],
+          },
+        ],
+      },
+    },
+  ])("rejects $name in extended presentation facts", ({ fact }) => {
+    expect(
+      isValidProviderModelCatalogPricing(
+        createProviderResponse({
+          presentation: {
+            sections: [
+              {
+                id: "links",
+                label: { fallback: "Links" },
+                facts: [fact],
+              },
+            ],
+          },
+        }),
+        SITE_TYPES.OPENROUTER,
+      ),
+    ).toBe(false)
+  })
+
   it("accepts cache-only prices when comparable primary pricing is unavailable", () => {
     expect(
       isValidProviderModelCatalogPricing(

--- a/tests/utils/runtimeMessaging.test.ts
+++ b/tests/utils/runtimeMessaging.test.ts
@@ -5,26 +5,33 @@ import { sendTypedRuntimeMessageFromPage } from "~~/e2e/utils/runtimeMessaging"
 
 describe("sendTypedRuntimeMessageFromPage", () => {
   it("uses distinct numeric ids for messages created in the same millisecond", async () => {
-    vi.spyOn(Date, "now").mockReturnValue(1_234)
-    const evaluate = vi.fn(
-      async (_expression: unknown, envelope: Record<string, unknown>) =>
-        envelope,
-    )
-    const page = { evaluate } as unknown as Page
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1_234)
 
-    const envelopes = await Promise.all([
-      sendTypedRuntimeMessageFromPage<Record<string, unknown>>(
-        page,
-        "example:first",
-      ),
-      sendTypedRuntimeMessageFromPage<Record<string, unknown>>(
-        page,
-        "example:second",
-      ),
-    ])
+    try {
+      const evaluate = vi.fn(
+        async (_expression: unknown, envelope: Record<string, unknown>) =>
+          envelope,
+      )
+      const page = { evaluate } as unknown as Page
 
-    expect(envelopes.map(({ id }) => typeof id)).toEqual(["number", "number"])
-    expect(new Set(envelopes.map(({ id }) => id)).size).toBe(2)
-    expect(envelopes.map(({ timestamp }) => timestamp)).toEqual([1_234, 1_234])
+      const envelopes = await Promise.all([
+        sendTypedRuntimeMessageFromPage<Record<string, unknown>>(
+          page,
+          "example:first",
+        ),
+        sendTypedRuntimeMessageFromPage<Record<string, unknown>>(
+          page,
+          "example:second",
+        ),
+      ])
+
+      expect(envelopes.map(({ id }) => typeof id)).toEqual(["number", "number"])
+      expect(new Set(envelopes.map(({ id }) => id)).size).toBe(2)
+      expect(envelopes.map(({ timestamp }) => timestamp)).toEqual([
+        1_234, 1_234,
+      ])
+    } finally {
+      nowSpy.mockRestore()
+    }
   })
 })

--- a/tests/utils/runtimeMessaging.test.ts
+++ b/tests/utils/runtimeMessaging.test.ts
@@ -1,0 +1,30 @@
+import type { Page } from "@playwright/test"
+import { describe, expect, it, vi } from "vitest"
+
+import { sendTypedRuntimeMessageFromPage } from "~~/e2e/utils/runtimeMessaging"
+
+describe("sendTypedRuntimeMessageFromPage", () => {
+  it("uses distinct numeric ids for messages created in the same millisecond", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(1_234)
+    const evaluate = vi.fn(
+      async (_expression: unknown, envelope: Record<string, unknown>) =>
+        envelope,
+    )
+    const page = { evaluate } as unknown as Page
+
+    const envelopes = await Promise.all([
+      sendTypedRuntimeMessageFromPage<Record<string, unknown>>(
+        page,
+        "example:first",
+      ),
+      sendTypedRuntimeMessageFromPage<Record<string, unknown>>(
+        page,
+        "example:second",
+      ),
+    ])
+
+    expect(envelopes.map(({ id }) => typeof id)).toEqual(["number", "number"])
+    expect(new Set(envelopes.map(({ id }) => id)).size).toBe(2)
+    expect(envelopes.map(({ timestamp }) => timestamp)).toEqual([1_234, 1_234])
+  })
+})


### PR DESCRIPTION
## Summary

- present OpenRouter-native model details through provider-local normalization while keeping the shared model-card shell provider-neutral
- render explicit pricing units, conditional overrides, architecture, routing providers, limits, modalities, parameters, reasoning, voices, aliases, benchmarks, lifecycle data, and trusted links
- tolerate malformed optional upstream fields, preserve zero values, and keep publisher evidence distinct from routing-provider data
- maintain an exhaustive documented-field inventory and localized labels across all supported app locales
- extend the representative Chromium model-list flow for rich detail expansion

## Validation

- focused Vitest coverage: 4 files, 22 tests passed
- `pnpm run i18n:extract:ci`
- `pnpm run validate:push` (also passed again through the pre-push hook)
- targeted Chromium model-list E2E: 2 tests passed
- full Vitest suite: delegated to PR CI; the additional local rerun was cancelled and is not reported as pass or failure

## Scope boundary

Personalized `/models/user` fetching, account-isolated caching, fallback, and retry behavior remain a separate follow-up and are intentionally excluded from this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded model details with architecture, capabilities, limits, lifecycle, routing, reasoning, provider information, benchmarks, and supported links.
  * Added clearer pricing displays for multiple units, conditional rates, and formatted usage values.
  * Added moderation status, input modalities, benchmark tables, and provider detail links where available.
* **Localization**
  * Added translations for expanded model information and pricing details in eight supported languages.
* **Bug Fixes**
  * Invalid, unsafe, or incomplete provider metadata is now safely omitted instead of displayed incorrectly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->