### PR TITLE
test(e2e): harden real-site key lifecycle cleanup

### DIFF
--- a/e2e/accountOnboardingCommonFlows.spec.ts
+++ b/e2e/accountOnboardingCommonFlows.spec.ts
@@ -1048,10 +1048,11 @@ test("adds an AIHubMix account, preserves its one-time key, and opens managed-si
 
   await page.getByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.autoConfigButton).click()
 
-  await expect(page.getByText("Save the full key now")).toBeVisible()
-  await expect(
-    page.getByTestId(TOKEN_PROVISIONING_TEST_IDS.oneTimeKeyInput),
-  ).toHaveValue("sk-aihubmix-created-one-time-key")
+  const oneTimeKeyInput = page.getByTestId(
+    TOKEN_PROVISIONING_TEST_IDS.oneTimeKeyInput,
+  )
+  await expect(oneTimeKeyInput).toBeVisible({ timeout: 30_000 })
+  await expect(oneTimeKeyInput).toHaveValue("sk-aihubmix-created-one-time-key")
 
   await page
     .getByTestId(TOKEN_PROVISIONING_TEST_IDS.oneTimeKeyCloseButton)

--- a/e2e/keyManagementCommonFlow.spec.ts
+++ b/e2e/keyManagementCommonFlow.spec.ts
@@ -31,6 +31,7 @@ import {
 } from "~~/e2e/utils/extensionState"
 import { waitForExtensionRoot } from "~~/e2e/utils/lazyLoading"
 import { seedMockAccountFixture } from "~~/e2e/utils/mockedSite/accountFixtures"
+import { isRealSiteTestTokenName } from "~~/e2e/utils/realSite/keyManagement"
 
 function createStubApiToken(overrides: Partial<ApiToken> = {}): ApiToken {
   const nowSeconds = Math.floor(Date.now() / 1000)
@@ -155,6 +156,18 @@ test("cleans stale test-owned tokens before creating a new token", async ({
   extensionId,
   page,
 }) => {
+  const tokenMutationResponses: string[] = []
+  context.on("response", (response) => {
+    const request = response.request()
+    if (
+      response
+        .url()
+        .startsWith("https://stale-key-cleanup.example.invalid/api/token/") &&
+      ["DELETE", "POST"].includes(request.method())
+    ) {
+      tokenMutationResponses.push(request.method())
+    }
+  })
   const serviceWorker = await getServiceWorker(context)
   const accountFixture = await seedMockAccountFixture({
     serviceWorker,
@@ -167,8 +180,9 @@ test("cleans stale test-owned tokens before creating a new token", async ({
     baseUrl: "https://stale-key-cleanup.example.invalid",
     initialTokens: [
       createStubApiToken({ id: 1, name: "Personal Key" }),
-      createStubApiToken({ id: 2, name: "AAH E2E Previous stale-one" }),
-      createStubApiToken({ id: 3, name: "AAH E2E Previous stale-two" }),
+      createStubApiToken({ id: 2, name: "AAH E2E Personal" }),
+      createStubApiToken({ id: 3, name: "AAH E2E NewAPI abc123def4" }),
+      createStubApiToken({ id: 4, name: "AAH E2E NewAPI zyx987wvu6" }),
     ],
   })
 
@@ -179,16 +193,30 @@ test("cleans stale test-owned tokens before creating a new token", async ({
     account: accountFixture,
     openFromAccountRow: false,
     cleanupAccountFixture: false,
-    cleanupTokenNamePrefix: "AAH E2E",
-    buildTokenName: () => "AAH E2E Current run",
+    cleanupTokenNameMatcher: (tokenName) =>
+      isRealSiteTestTokenName({ tokenName, label: "New API" }),
+    buildTokenName: () => "AAH E2E NewAPI run123abcd",
   })
 
   await expect(
     page.getByRole("heading", { name: "Personal Key" }),
   ).toBeVisible()
   await expect(
-    page.getByRole("heading", { name: /^AAH E2E(?:\s|$)/ }),
+    page.getByRole("heading", { name: "AAH E2E Personal", exact: true }),
+  ).toBeVisible()
+  await expect(
+    page.getByRole("heading", {
+      name: "AAH E2E NewAPI abc123def4",
+      exact: true,
+    }),
   ).toHaveCount(0)
+  await expect(
+    page.getByRole("heading", {
+      name: "AAH E2E NewAPI zyx987wvu6",
+      exact: true,
+    }),
+  ).toHaveCount(0)
+  expect(tokenMutationResponses).toEqual(["DELETE", "DELETE", "POST", "DELETE"])
 })
 
 test("reports the create response instead of timing out on a missing token row", async ({

--- a/e2e/keyManagementCommonFlow.spec.ts
+++ b/e2e/keyManagementCommonFlow.spec.ts
@@ -150,6 +150,80 @@ test("creates a token from key management and reloads it into the visible list",
   })
 })
 
+test("cleans stale test-owned tokens before creating a new token", async ({
+  context,
+  extensionId,
+  page,
+}) => {
+  const serviceWorker = await getServiceWorker(context)
+  const accountFixture = await seedMockAccountFixture({
+    serviceWorker,
+    account: createStoredAccount({
+      id: "e2e-stale-key-cleanup-account",
+      site_url: "https://stale-key-cleanup.example.invalid",
+    }),
+  })
+  await stubNewApiSiteRoutes(context, {
+    baseUrl: "https://stale-key-cleanup.example.invalid",
+    initialTokens: [
+      createStubApiToken({ id: 1, name: "Personal Key" }),
+      createStubApiToken({ id: 2, name: "AAH E2E Previous stale-one" }),
+      createStubApiToken({ id: 3, name: "AAH E2E Previous stale-two" }),
+    ],
+  })
+
+  await verifyAccountKeyLifecycleUsage({
+    extensionId,
+    page,
+    serviceWorker,
+    account: accountFixture,
+    openFromAccountRow: false,
+    cleanupAccountFixture: false,
+    cleanupTokenNamePrefix: "AAH E2E",
+    buildTokenName: () => "AAH E2E Current run",
+  })
+
+  await expect(
+    page.getByRole("heading", { name: "Personal Key" }),
+  ).toBeVisible()
+  await expect(
+    page.getByRole("heading", { name: /^AAH E2E(?:\s|$)/ }),
+  ).toHaveCount(0)
+})
+
+test("reports the create response instead of timing out on a missing token row", async ({
+  context,
+  extensionId,
+  page,
+}) => {
+  const serviceWorker = await getServiceWorker(context)
+  const accountFixture = await seedMockAccountFixture({
+    serviceWorker,
+    account: createStoredAccount({
+      id: "e2e-key-create-error-account",
+      site_url: "https://key-create-error.example.invalid",
+    }),
+  })
+  await stubNewApiSiteRoutes(context, {
+    baseUrl: "https://key-create-error.example.invalid",
+    createTokenError: {
+      status: 200,
+      message: "Fixture token quota reached",
+    },
+  })
+
+  await expect(
+    verifyAccountKeyLifecycleUsage({
+      extensionId,
+      page,
+      serviceWorker,
+      account: accountFixture,
+      openFromAccountRow: false,
+      buildTokenName: () => "E2E Rejected Key",
+    }),
+  ).rejects.toThrow("API key creation failed: Fixture token quota reached")
+})
+
 test("opens the CC Switch model picker for an account API key", async ({
   context,
   extensionId,

--- a/e2e/scenarios/accountKeyLifecycle.ts
+++ b/e2e/scenarios/accountKeyLifecycle.ts
@@ -3,7 +3,7 @@ import type { Page } from "@playwright/test"
 import type { AccountFixture } from "~~/e2e/scenarios/accountFixtures"
 import {
   deleteTokenFromKeyManagementPage,
-  deleteTokensByNamePrefixFromKeyManagementPage,
+  deleteTokensMatchingNameFromKeyManagementPage,
   expectTokenCreatedInKeyManagementPage,
   openKeyManagementForAccount,
   submitTokenCreationFromKeyManagementPage,
@@ -64,7 +64,7 @@ type AccountKeyLifecycleEnvironment = {
   ) => Promise<AccountFixture>
   openFromAccountRow?: boolean
   buildTokenName: () => string
-  cleanupTokenNamePrefix?: string
+  cleanupTokenNameMatcher?: (tokenName: string) => boolean
   cleanupAccountFixture?: boolean
   cleanup?: () => Promise<void>
 }
@@ -89,10 +89,10 @@ export async function runAccountKeyLifecycleScenario(
       baseUrl: account.baseUrl,
       openFromAccountRow: env.openFromAccountRow ?? true,
     })
-    if (env.cleanupTokenNamePrefix) {
-      await deleteTokensByNamePrefixFromKeyManagementPage({
+    if (env.cleanupTokenNameMatcher) {
+      await deleteTokensMatchingNameFromKeyManagementPage({
         page: keyManagementPage,
-        namePrefix: env.cleanupTokenNamePrefix,
+        nameMatcher: env.cleanupTokenNameMatcher,
       })
     }
     await submitTokenCreationFromKeyManagementPage({

--- a/e2e/scenarios/accountKeyLifecycle.ts
+++ b/e2e/scenarios/accountKeyLifecycle.ts
@@ -3,6 +3,7 @@ import type { Page } from "@playwright/test"
 import type { AccountFixture } from "~~/e2e/scenarios/accountFixtures"
 import {
   deleteTokenFromKeyManagementPage,
+  deleteTokensByNamePrefixFromKeyManagementPage,
   expectTokenCreatedInKeyManagementPage,
   openKeyManagementForAccount,
   submitTokenCreationFromKeyManagementPage,
@@ -63,6 +64,7 @@ type AccountKeyLifecycleEnvironment = {
   ) => Promise<AccountFixture>
   openFromAccountRow?: boolean
   buildTokenName: () => string
+  cleanupTokenNamePrefix?: string
   cleanupAccountFixture?: boolean
   cleanup?: () => Promise<void>
 }
@@ -87,6 +89,12 @@ export async function runAccountKeyLifecycleScenario(
       baseUrl: account.baseUrl,
       openFromAccountRow: env.openFromAccountRow ?? true,
     })
+    if (env.cleanupTokenNamePrefix) {
+      await deleteTokensByNamePrefixFromKeyManagementPage({
+        page: keyManagementPage,
+        namePrefix: env.cleanupTokenNamePrefix,
+      })
+    }
     await submitTokenCreationFromKeyManagementPage({
       page: keyManagementPage,
       tokenName,

--- a/e2e/scenarios/accountUsage.ts
+++ b/e2e/scenarios/accountUsage.ts
@@ -145,6 +145,7 @@ async function runAccountTokenUiScenario(
 export async function verifyAccountKeyLifecycleUsage(
   context: AccountUsageScenarioContext & {
     buildTokenName: () => string
+    cleanupTokenNamePrefix?: string
     openFromAccountRow?: boolean
     cleanupAccountFixture?: boolean
   },
@@ -156,6 +157,7 @@ export async function verifyAccountKeyLifecycleUsage(
     resolveAccountFixture: async () => context.account,
     openFromAccountRow: context.openFromAccountRow,
     buildTokenName: context.buildTokenName,
+    cleanupTokenNamePrefix: context.cleanupTokenNamePrefix,
     cleanupAccountFixture: context.cleanupAccountFixture,
   })
 }

--- a/e2e/scenarios/accountUsage.ts
+++ b/e2e/scenarios/accountUsage.ts
@@ -145,7 +145,7 @@ async function runAccountTokenUiScenario(
 export async function verifyAccountKeyLifecycleUsage(
   context: AccountUsageScenarioContext & {
     buildTokenName: () => string
-    cleanupTokenNamePrefix?: string
+    cleanupTokenNameMatcher?: (tokenName: string) => boolean
     openFromAccountRow?: boolean
     cleanupAccountFixture?: boolean
   },
@@ -157,7 +157,7 @@ export async function verifyAccountKeyLifecycleUsage(
     resolveAccountFixture: async () => context.account,
     openFromAccountRow: context.openFromAccountRow,
     buildTokenName: context.buildTokenName,
-    cleanupTokenNamePrefix: context.cleanupTokenNamePrefix,
+    cleanupTokenNameMatcher: context.cleanupTokenNameMatcher,
     cleanupAccountFixture: context.cleanupAccountFixture,
   })
 }

--- a/e2e/utils/accountLifecycle.ts
+++ b/e2e/utils/accountLifecycle.ts
@@ -361,30 +361,23 @@ async function expectTokenVisibleInKeyManagementPage(params: {
   return heading.locator("xpath=ancestor::*[@data-testid][1]")
 }
 
-function escapeRegExp(value: string) {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
-}
-
-export async function deleteTokensByNamePrefixFromKeyManagementPage(params: {
+export async function deleteTokensMatchingNameFromKeyManagementPage(params: {
   page: Page
-  namePrefix: string
+  nameMatcher: (tokenName: string) => boolean
 }) {
-  const namePrefix = params.namePrefix.trim()
-  if (!namePrefix) {
-    throw new Error("A non-empty token name prefix is required for cleanup.")
-  }
-
   await closeTokenCreationDialogsIfPresent(params.page)
   await expect(
     params.page.getByRole("button", { name: "Refresh Key List" }),
   ).toBeEnabled({ timeout: 30_000 })
 
-  const ownedTokenHeadings = params.page.getByRole("heading", {
-    name: new RegExp(`^${escapeRegExp(namePrefix)}(?:\\s|$)`),
-  })
+  const tokenHeadings = params.page.getByRole("heading")
+  let ownedTokenName = (await tokenHeadings.allTextContents()).find(
+    params.nameMatcher,
+  )
 
-  while ((await ownedTokenHeadings.count()) > 0) {
-    const row = ownedTokenHeadings
+  while (ownedTokenName) {
+    const row = params.page
+      .getByRole("heading", { name: ownedTokenName, exact: true })
       .first()
       .locator("xpath=ancestor::*[@data-testid][1]")
     const rowTestId = await row.getAttribute("data-testid")
@@ -396,6 +389,9 @@ export async function deleteTokensByNamePrefixFromKeyManagementPage(params: {
       page: params.page,
       row: params.page.getByTestId(rowTestId),
     })
+    ownedTokenName = (await tokenHeadings.allTextContents()).find(
+      params.nameMatcher,
+    )
   }
 }
 

--- a/e2e/utils/accountLifecycle.ts
+++ b/e2e/utils/accountLifecycle.ts
@@ -38,6 +38,10 @@ type AccountTokenIdentity = {
   name: string
 }
 
+type TokenCreationOutcome =
+  | { status: "created" }
+  | { status: "failed"; message: string }
+
 export type SavedApiCredentialProfileExpectation = Partial<
   Pick<ApiCredentialProfile, "name" | "baseUrl" | "apiKey" | "tagIds">
 >
@@ -239,6 +243,11 @@ async function submitCreateTokenForm(params: {
   page: Page
   tokenName: string
 }) {
+  await params.page.getByRole("status").evaluateAll((elements) => {
+    for (const element of elements) {
+      element.setAttribute("data-aah-e2e-preexisting-status", "true")
+    }
+  })
   await params.page.getByRole("button", { name: "Add API Key" }).click()
   await expect(params.page.locator("#tokenName")).toBeVisible({
     timeout: 30_000,
@@ -247,6 +256,58 @@ async function submitCreateTokenForm(params: {
   await params.page
     .getByTestId(TOKEN_PROVISIONING_TEST_IDS.addTokenSubmitButton)
     .click()
+
+  const outcomeHandle = await params.page.waitForFunction(
+    ({
+      addTokenDialogTestId,
+      addTokenSubmitButtonTestId,
+      oneTimeCloseTestId,
+    }) => {
+      const addTokenDialog = document.querySelector(
+        `[data-testid="${addTokenDialogTestId}"]`,
+      )
+      const oneTimeCloseButton = document.querySelector(
+        `[data-testid="${oneTimeCloseTestId}"]`,
+      )
+
+      if (!addTokenDialog || oneTimeCloseButton) {
+        return { status: "created" } satisfies TokenCreationOutcome
+      }
+
+      const submitButton = document.querySelector(
+        `[data-testid="${addTokenSubmitButtonTestId}"]`,
+      )
+      if (
+        !(submitButton instanceof HTMLButtonElement) ||
+        submitButton.disabled
+      ) {
+        return null
+      }
+
+      const visibleStatusMessages = Array.from(
+        document.querySelectorAll<HTMLElement>(
+          '[role="status"]:not([data-aah-e2e-preexisting-status])',
+        ),
+      ).filter((element) => element.getClientRects().length > 0)
+      const message = visibleStatusMessages.at(-1)?.textContent?.trim()
+
+      return message
+        ? ({ status: "failed", message } satisfies TokenCreationOutcome)
+        : null
+    },
+    {
+      addTokenDialogTestId: TOKEN_PROVISIONING_TEST_IDS.addTokenDialog,
+      addTokenSubmitButtonTestId:
+        TOKEN_PROVISIONING_TEST_IDS.addTokenSubmitButton,
+      oneTimeCloseTestId: TOKEN_PROVISIONING_TEST_IDS.oneTimeKeyCloseButton,
+    },
+    { timeout: 30_000 },
+  )
+  const outcome = (await outcomeHandle.jsonValue()) as TokenCreationOutcome
+
+  if (outcome.status === "failed") {
+    throw new Error(`API key creation failed: ${outcome.message}`)
+  }
 }
 
 async function closeOneTimeKeyDialogIfPresent(page: Page) {
@@ -292,9 +353,62 @@ async function expectTokenVisibleInKeyManagementPage(params: {
   page: Page
   tokenName: string
 }): Promise<Locator> {
-  const heading = params.page.getByRole("heading", { name: params.tokenName })
+  const heading = params.page.getByRole("heading", {
+    name: params.tokenName,
+    exact: true,
+  })
   await expect(heading).toBeVisible({ timeout: 30_000 })
   return heading.locator("xpath=ancestor::*[@data-testid][1]")
+}
+
+function escapeRegExp(value: string) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+}
+
+export async function deleteTokensByNamePrefixFromKeyManagementPage(params: {
+  page: Page
+  namePrefix: string
+}) {
+  const namePrefix = params.namePrefix.trim()
+  if (!namePrefix) {
+    throw new Error("A non-empty token name prefix is required for cleanup.")
+  }
+
+  await closeTokenCreationDialogsIfPresent(params.page)
+  await expect(
+    params.page.getByRole("button", { name: "Refresh Key List" }),
+  ).toBeEnabled({ timeout: 30_000 })
+
+  const ownedTokenHeadings = params.page.getByRole("heading", {
+    name: new RegExp(`^${escapeRegExp(namePrefix)}(?:\\s|$)`),
+  })
+
+  while ((await ownedTokenHeadings.count()) > 0) {
+    const row = ownedTokenHeadings
+      .first()
+      .locator("xpath=ancestor::*[@data-testid][1]")
+    const rowTestId = await row.getAttribute("data-testid")
+    if (!rowTestId) {
+      throw new Error("Unable to identify an owned test token row for cleanup.")
+    }
+
+    await deleteTokenRowFromKeyManagementPage({
+      page: params.page,
+      row: params.page.getByTestId(rowTestId),
+    })
+  }
+}
+
+async function deleteTokenRowFromKeyManagementPage(params: {
+  page: Page
+  row: Locator
+}) {
+  await expect(params.row).toBeVisible({ timeout: 30_000 })
+  await params.row.getByRole("button", { name: "Delete Key" }).click()
+  await params.page
+    .getByTestId(KEY_MANAGEMENT_TEST_IDS.deleteTokenConfirmButton)
+    .click()
+  await expect(params.row).toHaveCount(0, { timeout: 30_000 })
 }
 
 export async function deleteTokenFromKeyManagementPage(params: {
@@ -310,13 +424,10 @@ export async function deleteTokenFromKeyManagementPage(params: {
           tokenName: params.token,
         })
       : params.page.getByTestId(getKeyManagementTokenRowTestId(params.token.id))
-  await expect(row).toBeVisible({ timeout: 30_000 })
-
-  await row.getByRole("button", { name: "Delete Key" }).click()
-  await params.page
-    .getByTestId(KEY_MANAGEMENT_TEST_IDS.deleteTokenConfirmButton)
-    .click()
-  await expect(row).toHaveCount(0, { timeout: 30_000 })
+  await deleteTokenRowFromKeyManagementPage({
+    page: params.page,
+    row,
+  })
 }
 
 export async function openKeyManagementForAccount(params: {

--- a/e2e/utils/commonUserFlows.ts
+++ b/e2e/utils/commonUserFlows.ts
@@ -78,6 +78,10 @@ type StubNewApiSiteRoutesOptions = {
   models?: string[]
   pricingModels?: ModelPricing[]
   initialTokens?: ApiToken[]
+  createTokenError?: {
+    status?: number
+    message: string
+  }
   groups?: Record<string, { desc: string; ratio: number }>
   dashboardAuthMode?: "legacy" | "auth-bundle"
 }
@@ -901,6 +905,18 @@ export async function stubNewApiSiteRoutes(
     }
 
     if (method === "POST" && url.pathname === "/api/token/") {
+      if (options.createTokenError) {
+        await route.fulfill({
+          status: options.createTokenError.status ?? 400,
+          contentType: "application/json",
+          body: JSON.stringify({
+            success: false,
+            message: options.createTokenError.message,
+          }),
+        })
+        return
+      }
+
       const payload = request.postDataJSON() as {
         name?: string
         remain_quota?: number

--- a/e2e/utils/realSite/accountUsage.ts
+++ b/e2e/utils/realSite/accountUsage.ts
@@ -24,6 +24,7 @@ import type { getServiceWorker } from "~~/e2e/utils/extensionState"
 import {
   buildRealSiteRunId,
   buildRealSiteTestTokenName,
+  REAL_SITE_TEST_TOKEN_NAME_PREFIX,
 } from "~~/e2e/utils/realSite/keyManagement"
 import {
   maybeRunRealSiteModelToKeyScenario,
@@ -70,6 +71,7 @@ export async function verifyRealSiteAccountKeyLifecycleUsage(
     serviceWorker: context.serviceWorker,
     account: context.account,
     cleanupAccountFixture: false,
+    cleanupTokenNamePrefix: REAL_SITE_TEST_TOKEN_NAME_PREFIX,
     buildTokenName: () => buildUsageTokenName(context.label),
   })
 }

--- a/e2e/utils/realSite/accountUsage.ts
+++ b/e2e/utils/realSite/accountUsage.ts
@@ -24,7 +24,7 @@ import type { getServiceWorker } from "~~/e2e/utils/extensionState"
 import {
   buildRealSiteRunId,
   buildRealSiteTestTokenName,
-  REAL_SITE_TEST_TOKEN_NAME_PREFIX,
+  isRealSiteTestTokenName,
 } from "~~/e2e/utils/realSite/keyManagement"
 import {
   maybeRunRealSiteModelToKeyScenario,
@@ -71,7 +71,8 @@ export async function verifyRealSiteAccountKeyLifecycleUsage(
     serviceWorker: context.serviceWorker,
     account: context.account,
     cleanupAccountFixture: false,
-    cleanupTokenNamePrefix: REAL_SITE_TEST_TOKEN_NAME_PREFIX,
+    cleanupTokenNameMatcher: (tokenName) =>
+      isRealSiteTestTokenName({ tokenName, label: context.label }),
     buildTokenName: () => buildUsageTokenName(context.label),
   })
 }

--- a/e2e/utils/realSite/keyManagement.ts
+++ b/e2e/utils/realSite/keyManagement.ts
@@ -8,7 +8,7 @@ import {
   submitTokenCreationFromKeyManagementPage,
 } from "~~/e2e/utils/accountLifecycle"
 
-const TEST_TOKEN_NAME_PREFIX = "AAH E2E"
+export const REAL_SITE_TEST_TOKEN_NAME_PREFIX = "AAH E2E"
 const MAX_TEST_TOKEN_NAME_LENGTH = 30
 const MAX_TEST_TOKEN_LABEL_LENGTH = 8
 const MAX_TEST_TOKEN_RUN_ID_LENGTH = 12
@@ -69,7 +69,7 @@ export function buildRealSiteTestTokenName(params: {
     MAX_TEST_TOKEN_RUN_ID_LENGTH,
   )
 
-  return [TEST_TOKEN_NAME_PREFIX, label, runId]
+  return [REAL_SITE_TEST_TOKEN_NAME_PREFIX, label, runId]
     .filter(Boolean)
     .join(" ")
     .slice(0, MAX_TEST_TOKEN_NAME_LENGTH)

--- a/e2e/utils/realSite/keyManagement.ts
+++ b/e2e/utils/realSite/keyManagement.ts
@@ -12,6 +12,7 @@ export const REAL_SITE_TEST_TOKEN_NAME_PREFIX = "AAH E2E"
 const MAX_TEST_TOKEN_NAME_LENGTH = 30
 const MAX_TEST_TOKEN_LABEL_LENGTH = 8
 const MAX_TEST_TOKEN_RUN_ID_LENGTH = 12
+const REAL_SITE_TEST_RUN_ID_PATTERN = /^[a-z0-9]{10}$/u
 
 export async function runRealSiteKeyLifecycleFromAccountRow(params: {
   page: Page
@@ -73,6 +74,25 @@ export function buildRealSiteTestTokenName(params: {
     .filter(Boolean)
     .join(" ")
     .slice(0, MAX_TEST_TOKEN_NAME_LENGTH)
+}
+
+export function isRealSiteTestTokenName(params: {
+  tokenName: string
+  label: string
+}) {
+  const label = truncateTokenNamePart(
+    normalizeTokenNameLabel(params.label),
+    MAX_TEST_TOKEN_LABEL_LENGTH,
+  )
+  const expectedPrefix = [REAL_SITE_TEST_TOKEN_NAME_PREFIX, label]
+    .filter(Boolean)
+    .join(" ")
+  const runId = params.tokenName.slice(expectedPrefix.length + 1)
+
+  return (
+    params.tokenName.startsWith(`${expectedPrefix} `) &&
+    REAL_SITE_TEST_RUN_ID_PATTERN.test(runId)
+  )
 }
 
 export function buildRealSiteRunId() {

--- a/e2e/utils/realSite/keyManagement.ts
+++ b/e2e/utils/realSite/keyManagement.ts
@@ -8,7 +8,7 @@ import {
   submitTokenCreationFromKeyManagementPage,
 } from "~~/e2e/utils/accountLifecycle"
 
-export const REAL_SITE_TEST_TOKEN_NAME_PREFIX = "AAH E2E"
+const REAL_SITE_TEST_TOKEN_NAME_PREFIX = "AAH E2E"
 const MAX_TEST_TOKEN_NAME_LENGTH = 30
 const MAX_TEST_TOKEN_LABEL_LENGTH = 8
 const MAX_TEST_TOKEN_RUN_ID_LENGTH = 12

--- a/tests/utils/accountScenarios.test.ts
+++ b/tests/utils/accountScenarios.test.ts
@@ -20,6 +20,7 @@ import {
 import {
   deleteApiCredentialProfileFromStorage,
   deleteTokenFromKeyManagementPage,
+  deleteTokensByNamePrefixFromKeyManagementPage,
   expectTokenCreatedInKeyManagementPage,
   openKeyManagementForAccount,
   saveAutoDetectedAccountFromApp,
@@ -31,6 +32,7 @@ const mocks = vi.hoisted(() => ({
   saveAutoDetectedAccountFromApp: vi.fn(),
   deleteApiCredentialProfileFromStorage: vi.fn(),
   deleteTokenFromKeyManagementPage: vi.fn(),
+  deleteTokensByNamePrefixFromKeyManagementPage: vi.fn(),
   expectTokenCreatedInKeyManagementPage: vi.fn(),
   openKeyManagementForAccount: vi.fn(),
   saveTokenToApiCredentialProfilesFromKeyManagementPage: vi.fn(),
@@ -44,6 +46,8 @@ vi.mock("~~/e2e/utils/accountLifecycle", () => ({
   deleteApiCredentialProfileFromStorage:
     mocks.deleteApiCredentialProfileFromStorage,
   deleteTokenFromKeyManagementPage: mocks.deleteTokenFromKeyManagementPage,
+  deleteTokensByNamePrefixFromKeyManagementPage:
+    mocks.deleteTokensByNamePrefixFromKeyManagementPage,
   expectTokenCreatedInKeyManagementPage:
     mocks.expectTokenCreatedInKeyManagementPage,
   openKeyManagementForAccount: mocks.openKeyManagementForAccount,
@@ -64,6 +68,9 @@ describe("account E2E scenarios", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.mocked(deleteTokenFromKeyManagementPage).mockResolvedValue(undefined)
+    vi.mocked(deleteTokensByNamePrefixFromKeyManagementPage).mockResolvedValue(
+      undefined,
+    )
   })
 
   it("runs account auto-detect and returns a fixture from the saved account", async () => {
@@ -217,6 +224,7 @@ describe("account E2E scenarios", () => {
       getServiceWorker: vi.fn().mockResolvedValue({} as any),
       resolveAccountFixture: vi.fn().mockResolvedValue(fixture),
       buildTokenName: () => "E2E Created Key",
+      cleanupTokenNamePrefix: "AAH E2E",
       cleanup: environmentCleanup,
     })
 
@@ -229,6 +237,17 @@ describe("account E2E scenarios", () => {
       baseUrl: "https://seeded.example.com",
       openFromAccountRow: true,
     })
+    expect(deleteTokensByNamePrefixFromKeyManagementPage).toHaveBeenCalledWith({
+      page: keyPage,
+      namePrefix: "AAH E2E",
+    })
+    expect(
+      vi.mocked(deleteTokensByNamePrefixFromKeyManagementPage).mock
+        .invocationCallOrder[0],
+    ).toBeLessThan(
+      vi.mocked(submitTokenCreationFromKeyManagementPage).mock
+        .invocationCallOrder[0],
+    )
     expect(submitTokenCreationFromKeyManagementPage).toHaveBeenCalledWith({
       page: keyPage,
       tokenName: "E2E Created Key",

--- a/tests/utils/accountScenarios.test.ts
+++ b/tests/utils/accountScenarios.test.ts
@@ -20,7 +20,7 @@ import {
 import {
   deleteApiCredentialProfileFromStorage,
   deleteTokenFromKeyManagementPage,
-  deleteTokensByNamePrefixFromKeyManagementPage,
+  deleteTokensMatchingNameFromKeyManagementPage,
   expectTokenCreatedInKeyManagementPage,
   openKeyManagementForAccount,
   saveAutoDetectedAccountFromApp,
@@ -32,7 +32,7 @@ const mocks = vi.hoisted(() => ({
   saveAutoDetectedAccountFromApp: vi.fn(),
   deleteApiCredentialProfileFromStorage: vi.fn(),
   deleteTokenFromKeyManagementPage: vi.fn(),
-  deleteTokensByNamePrefixFromKeyManagementPage: vi.fn(),
+  deleteTokensMatchingNameFromKeyManagementPage: vi.fn(),
   expectTokenCreatedInKeyManagementPage: vi.fn(),
   openKeyManagementForAccount: vi.fn(),
   saveTokenToApiCredentialProfilesFromKeyManagementPage: vi.fn(),
@@ -46,8 +46,8 @@ vi.mock("~~/e2e/utils/accountLifecycle", () => ({
   deleteApiCredentialProfileFromStorage:
     mocks.deleteApiCredentialProfileFromStorage,
   deleteTokenFromKeyManagementPage: mocks.deleteTokenFromKeyManagementPage,
-  deleteTokensByNamePrefixFromKeyManagementPage:
-    mocks.deleteTokensByNamePrefixFromKeyManagementPage,
+  deleteTokensMatchingNameFromKeyManagementPage:
+    mocks.deleteTokensMatchingNameFromKeyManagementPage,
   expectTokenCreatedInKeyManagementPage:
     mocks.expectTokenCreatedInKeyManagementPage,
   openKeyManagementForAccount: mocks.openKeyManagementForAccount,
@@ -68,7 +68,7 @@ describe("account E2E scenarios", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     vi.mocked(deleteTokenFromKeyManagementPage).mockResolvedValue(undefined)
-    vi.mocked(deleteTokensByNamePrefixFromKeyManagementPage).mockResolvedValue(
+    vi.mocked(deleteTokensMatchingNameFromKeyManagementPage).mockResolvedValue(
       undefined,
     )
   })
@@ -224,7 +224,7 @@ describe("account E2E scenarios", () => {
       getServiceWorker: vi.fn().mockResolvedValue({} as any),
       resolveAccountFixture: vi.fn().mockResolvedValue(fixture),
       buildTokenName: () => "E2E Created Key",
-      cleanupTokenNamePrefix: "AAH E2E",
+      cleanupTokenNameMatcher: (tokenName) => tokenName.startsWith("AAH E2E"),
       cleanup: environmentCleanup,
     })
 
@@ -237,17 +237,10 @@ describe("account E2E scenarios", () => {
       baseUrl: "https://seeded.example.com",
       openFromAccountRow: true,
     })
-    expect(deleteTokensByNamePrefixFromKeyManagementPage).toHaveBeenCalledWith({
+    expect(deleteTokensMatchingNameFromKeyManagementPage).toHaveBeenCalledWith({
       page: keyPage,
-      namePrefix: "AAH E2E",
+      nameMatcher: expect.any(Function),
     })
-    expect(
-      vi.mocked(deleteTokensByNamePrefixFromKeyManagementPage).mock
-        .invocationCallOrder[0],
-    ).toBeLessThan(
-      vi.mocked(submitTokenCreationFromKeyManagementPage).mock
-        .invocationCallOrder[0],
-    )
     expect(submitTokenCreationFromKeyManagementPage).toHaveBeenCalledWith({
       page: keyPage,
       tokenName: "E2E Created Key",

--- a/tests/utils/realSiteAccountUsage.test.ts
+++ b/tests/utils/realSiteAccountUsage.test.ts
@@ -24,7 +24,6 @@ import {
 import {
   buildRealSiteRunId,
   buildRealSiteTestTokenName,
-  REAL_SITE_TEST_TOKEN_NAME_PREFIX,
 } from "~~/e2e/utils/realSite/keyManagement"
 import { maybeRunRealSiteModelToKeyScenario } from "~~/e2e/utils/realSite/modelToKey"
 
@@ -114,8 +113,12 @@ describe("real-site account usage adapters", () => {
       serviceWorker,
       account,
       cleanupAccountFixture: false,
-      cleanupTokenNamePrefix: REAL_SITE_TEST_TOKEN_NAME_PREFIX,
+      cleanupTokenNameMatcher: expect.any(Function),
     })
+    expect(call.cleanupTokenNameMatcher?.("AAH E2E NewAPI abc123def4")).toBe(
+      true,
+    )
+    expect(call.cleanupTokenNameMatcher?.("AAH E2E Personal")).toBe(false)
     expect(call.buildTokenName()).toBe("New API:run-id")
   })
 

--- a/tests/utils/realSiteAccountUsage.test.ts
+++ b/tests/utils/realSiteAccountUsage.test.ts
@@ -24,6 +24,7 @@ import {
 import {
   buildRealSiteRunId,
   buildRealSiteTestTokenName,
+  REAL_SITE_TEST_TOKEN_NAME_PREFIX,
 } from "~~/e2e/utils/realSite/keyManagement"
 import { maybeRunRealSiteModelToKeyScenario } from "~~/e2e/utils/realSite/modelToKey"
 
@@ -48,7 +49,10 @@ vi.mock("~~/e2e/scenarios/accountUsage", () => ({
   verifyAccountModelCatalogUsage: mocks.verifyAccountModelCatalogUsage,
 }))
 
-vi.mock("~~/e2e/utils/realSite/keyManagement", () => ({
+vi.mock("~~/e2e/utils/realSite/keyManagement", async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import("~~/e2e/utils/realSite/keyManagement")
+  >()),
   buildRealSiteRunId: mocks.buildRealSiteRunId,
   buildRealSiteTestTokenName: mocks.buildRealSiteTestTokenName,
 }))
@@ -110,6 +114,7 @@ describe("real-site account usage adapters", () => {
       serviceWorker,
       account,
       cleanupAccountFixture: false,
+      cleanupTokenNamePrefix: REAL_SITE_TEST_TOKEN_NAME_PREFIX,
     })
     expect(call.buildTokenName()).toBe("New API:run-id")
   })

--- a/tests/utils/realSiteKeyManagement.test.ts
+++ b/tests/utils/realSiteKeyManagement.test.ts
@@ -9,6 +9,7 @@ import {
 } from "~~/e2e/utils/accountLifecycle"
 import {
   buildRealSiteTestTokenName,
+  isRealSiteTestTokenName,
   runRealSiteKeyLifecycleFromAccountRow,
 } from "~~/e2e/utils/realSite/keyManagement"
 
@@ -63,6 +64,27 @@ describe("real-site key management E2E helpers", () => {
 
     expect(name.length).toBeLessThanOrEqual(30)
     expect(name).toBe("AAH E2E VeryLong run-with-a-l")
+  })
+
+  it("recognizes only generated token names for the requested real-site label", () => {
+    expect(
+      isRealSiteTestTokenName({
+        tokenName: "AAH E2E NewAPI abc123def4",
+        label: "New API",
+      }),
+    ).toBe(true)
+    expect(
+      isRealSiteTestTokenName({
+        tokenName: "AAH E2E Personal",
+        label: "New API",
+      }),
+    ).toBe(false)
+    expect(
+      isRealSiteTestTokenName({
+        tokenName: "AAH E2E DoneHub abc123def4",
+        label: "New API",
+      }),
+    ).toBe(false)
   })
 
   it("attempts UI cleanup when token creation fails after submitting a live token name", async () => {


### PR DESCRIPTION
## Summary

Prevent real-site E2E API keys from accumulating after failed or interrupted key lifecycle runs, and preserve the actual creation failure instead of reporting two missing-row timeouts.

## What changed

- remove visible `AAH E2E` test-owned keys before the New API key lifecycle scenario
- wait for an explicit create success, one-time-key flow, or user-visible creation error
- delete keys through stable row identifiers instead of reconstructing a row lookup from DOM text
- add browser regressions for stale-key cleanup and rejected creation responses

Normal user keys are not included in the cleanup. The recovery pass is limited to keys fetched into the current Key Management inventory.

## Validation

- `pnpm compile`
- 33 focused Vitest tests
- Playwright regression: stale test-owned keys are removed while a normal key is preserved
- Playwright regression: a rejected create response is reported without a missing-row timeout
- real New API key lifecycle: stale cleanup, create, and delete passed
- `pnpm run validate:staged` via the commit hook
- `pnpm run validate:push` via the push hook


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account key lifecycle checks to report token creation errors promptly instead of timing out.
  * Prevented stale test-created tokens from interfering with subsequent token creation and verification.
  * Improved token selection by requiring exact matches.
  * Made onboarding key verification more reliable by waiting for the key to appear before checking its value.

* **Tests**
  * Added coverage for token cleanup, creation failures, unrelated token preservation, and real-site token validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->