### PR TITLE
fix(managed-sites): migrate channel configs to scoped storage

### DIFF
--- a/e2e/importExportCommonFlows.spec.ts
+++ b/e2e/importExportCommonFlows.spec.ts
@@ -338,7 +338,7 @@ test("exports a full backup containing accounts, user preferences, and API crede
     }
   }
 
-  expect(backup.version).toBe("3.0")
+  expect(backup.version).toBe(BACKUP_VERSION)
   expect(backup.accounts?.accounts).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -477,7 +477,7 @@ test("round-trips a full backup through export download and file import", async 
     apiCredentialProfiles?: ApiCredentialProfilesConfig
   }
 
-  expect(exportedBackup.version).toBe("3.0")
+  expect(exportedBackup.version).toBe(BACKUP_VERSION)
   expect(exportedBackup.accounts?.accounts).toEqual([
     expect.objectContaining({
       id: "round-trip-account",

--- a/e2e/importExportCommonFlows.spec.ts
+++ b/e2e/importExportCommonFlows.spec.ts
@@ -6,6 +6,7 @@ import {
   POPUP_PAGE_PATH,
   SIDEPANEL_PAGE_PATH,
 } from "~/constants/extensionPages"
+import { BACKUP_VERSION } from "~/constants/importExport"
 import { MENU_ITEM_IDS } from "~/constants/optionsMenuIds"
 import { getPopupViewTestId, POPUP_TEST_IDS } from "~/entrypoints/popup/testIds"
 import { API_CREDENTIAL_PROFILES_TEST_IDS } from "~/features/ApiCredentialProfiles/testIds"
@@ -22,7 +23,14 @@ import {
   API_CREDENTIAL_PROFILES_CONFIG_VERSION,
   type ApiCredentialProfilesConfig,
 } from "~/types/apiCredentialProfiles"
-import type { ChannelConfigMap } from "~/types/channelConfig"
+import type {
+  ChannelConfigSnapshot,
+  ChannelResourceConfigMap,
+} from "~/types/channelConfig"
+import {
+  createManagedUpstreamResourceRef,
+  getManagedUpstreamResourceRefKey,
+} from "~/types/managedUpstreamResource"
 import { WEBDAV_SYNC_STRATEGIES } from "~/types/webdav"
 import { expect, test } from "~~/e2e/fixtures/extensionTest"
 import {
@@ -44,8 +52,6 @@ import {
   setPlasmoStorageValue,
 } from "~~/e2e/utils/extensionState"
 import { waitForExtensionRoot } from "~~/e2e/utils/lazyLoading"
-
-const CHANNEL_CONFIGS_STORAGE_KEY = "channel_configs"
 
 async function chooseFullReplaceImport(page: Page) {
   for (const testId of [
@@ -109,10 +115,10 @@ async function readStoredApiCredentialProfiles(
 
 async function readStoredChannelConfigs(
   serviceWorker: Awaited<ReturnType<typeof getServiceWorker>>,
-): Promise<ChannelConfigMap> {
+): Promise<ChannelResourceConfigMap> {
   const raw = await getPlasmoStorageRawValue<unknown>(
     serviceWorker,
-    CHANNEL_CONFIGS_STORAGE_KEY,
+    STORAGE_KEYS.CHANNEL_RESOURCE_CONFIGS,
   )
 
   if (typeof raw !== "string") {
@@ -120,7 +126,7 @@ async function readStoredChannelConfigs(
   }
 
   try {
-    return JSON.parse(raw) as ChannelConfigMap
+    return JSON.parse(raw) as ChannelResourceConfigMap
   } catch {
     return {}
   }
@@ -332,7 +338,7 @@ test("exports a full backup containing accounts, user preferences, and API crede
     }
   }
 
-  expect(backup.version).toBe("2.0")
+  expect(backup.version).toBe("3.0")
   expect(backup.accounts?.accounts).toEqual(
     expect.arrayContaining([
       expect.objectContaining({
@@ -388,8 +394,16 @@ test("round-trips a full backup through export download and file import", async 
     createdAt: now,
     updatedAt: now,
   })
-  const roundTripChannelConfigs: ChannelConfigMap = {
-    42: {
+  const roundTripResourceRef = createManagedUpstreamResourceRef({
+    managedSiteType: "new-api",
+    scopeKey: "https://round-trip-admin.example.invalid",
+    resourceId: 42,
+  })
+  const roundTripResourceKey =
+    getManagedUpstreamResourceRefKey(roundTripResourceRef)
+  const roundTripChannelConfigs: ChannelResourceConfigMap = {
+    [roundTripResourceKey]: {
+      resourceRef: roundTripResourceRef,
       channelId: 42,
       modelFilterSettings: {
         rules: [
@@ -435,7 +449,7 @@ test("round-trips a full backup through export download and file import", async 
   })
   await setPlasmoStorageValue(
     serviceWorker,
-    CHANNEL_CONFIGS_STORAGE_KEY,
+    STORAGE_KEYS.CHANNEL_RESOURCE_CONFIGS,
     roundTripChannelConfigs,
   )
   await seedApiCredentialProfiles(serviceWorker, [roundTripProfile])
@@ -456,12 +470,14 @@ test("round-trips a full backup through export download and file import", async 
 
   const exportedBackupBuffer = await fs.readFile(downloadPath)
   const exportedBackup = JSON.parse(exportedBackupBuffer.toString("utf8")) as {
+    version?: string
     accounts?: AccountStorageConfig
     preferences?: Record<string, unknown>
-    channelConfigs?: ChannelConfigMap
+    channelConfigs?: ChannelConfigSnapshot
     apiCredentialProfiles?: ApiCredentialProfilesConfig
   }
 
+  expect(exportedBackup.version).toBe("3.0")
   expect(exportedBackup.accounts?.accounts).toEqual([
     expect.objectContaining({
       id: "round-trip-account",
@@ -480,17 +496,21 @@ test("round-trips a full backup through export download and file import", async 
     themeMode: "dark",
   })
   expect(exportedBackup.channelConfigs).toMatchObject({
-    42: {
-      channelId: 42,
-      modelFilterSettings: {
-        rules: [
-          expect.objectContaining({
-            id: "round-trip-filter",
-            name: "Round Trip Filter",
-            action: "include",
-            pattern: "gpt-4o",
-          }),
-        ],
+    schemaVersion: 1,
+    configs: {
+      [roundTripResourceKey]: {
+        resourceRef: roundTripResourceRef,
+        channelId: 42,
+        modelFilterSettings: {
+          rules: [
+            expect.objectContaining({
+              id: "round-trip-filter",
+              name: "Round Trip Filter",
+              action: "include",
+              pattern: "gpt-4o",
+            }),
+          ],
+        },
       },
     },
   })
@@ -518,17 +538,27 @@ test("round-trips a full backup through export download and file import", async 
     actionClickBehavior: "popup",
     themeMode: "system",
   })
-  await setPlasmoStorageValue(serviceWorker, CHANNEL_CONFIGS_STORAGE_KEY, {
-    43: {
-      channelId: 43,
-      modelFilterSettings: {
-        rules: [],
+  const replacedResourceRef = createManagedUpstreamResourceRef({
+    managedSiteType: "new-api",
+    scopeKey: "https://round-trip-admin.example.invalid",
+    resourceId: 43,
+  })
+  await setPlasmoStorageValue(
+    serviceWorker,
+    STORAGE_KEYS.CHANNEL_RESOURCE_CONFIGS,
+    {
+      [getManagedUpstreamResourceRefKey(replacedResourceRef)]: {
+        resourceRef: replacedResourceRef,
+        channelId: 43,
+        modelFilterSettings: {
+          rules: [],
+          updatedAt: now + 1,
+        },
+        createdAt: now + 1,
         updatedAt: now + 1,
       },
-      createdAt: now + 1,
-      updatedAt: now + 1,
-    },
-  } satisfies ChannelConfigMap)
+    } satisfies ChannelResourceConfigMap,
+  )
   await seedApiCredentialProfiles(serviceWorker, [
     createStoredApiCredentialProfile({
       id: "round-trip-old-profile",
@@ -568,9 +598,11 @@ test("round-trips a full backup through export download and file import", async 
         accountIds: accountConfig.accounts.map((account) => account.id),
         bookmarkIds: accountConfig.bookmarks.map((bookmark) => bookmark.id),
         profileIds: profileConfig.profiles.map((profile) => profile.id),
-        channelConfigIds: Object.keys(channelConfigs),
+        channelConfigIds: Object.values(channelConfigs).map(
+          (config) => config.channelId,
+        ),
         channelFilterNames:
-          channelConfigs[42]?.modelFilterSettings.rules.map(
+          channelConfigs[roundTripResourceKey]?.modelFilterSettings.rules.map(
             (rule) => rule.name,
           ) ?? [],
         currencyType: preferences.currencyType,
@@ -582,7 +614,7 @@ test("round-trips a full backup through export download and file import", async 
       accountIds: ["round-trip-account"],
       bookmarkIds: ["round-trip-bookmark"],
       profileIds: ["round-trip-profile"],
-      channelConfigIds: ["42"],
+      channelConfigIds: [42],
       channelFilterNames: ["Round Trip Filter"],
       currencyType: "CNY",
       actionClickBehavior: "sidepanel",
@@ -1325,7 +1357,7 @@ test("uploads a WebDAV backup and restores it through the WebDAV download flow",
   await expect.poll(() => uploadedPayloads.length).toBe(1)
   expect(tempDeleteUrls).toEqual([])
   expect(uploadedPayloads[0]).toMatchObject({
-    version: "2.0",
+    version: BACKUP_VERSION,
     accounts: {
       accounts: [
         expect.objectContaining({
@@ -1532,7 +1564,7 @@ test("runs WebDAV auto-sync from settings and uploads the local snapshot", async
   await expect.poll(() => uploadedPayloads.length).toBe(1)
   expect(tempDeleteUrls).toEqual([])
   expect(uploadedPayloads[0]).toMatchObject({
-    version: "2.0",
+    version: BACKUP_VERSION,
     accounts: {
       accounts: [
         expect.objectContaining({

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "react-i18next": "^16.0.1",
     "react-tooltip": "^5.30.0",
     "react-virtuoso": "^4.7.10",
+    "safe-regex2": "^5.1.1",
     "tailwind-merge": "^3.3.1",
     "tw-animate-css": "^1.4.0",
     "zod": "^4.3.5"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,6 +155,9 @@ importers:
       react-virtuoso:
         specifier: ^4.7.10
         version: 4.14.1(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      safe-regex2:
+        specifier: ^5.1.1
+        version: 5.1.1
       tailwind-merge:
         specifier: ^3.3.1
         version: 3.3.1
@@ -7875,6 +7878,10 @@ packages:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
     engines: {node: '>=18'}
 
+  ret@0.5.0:
+    resolution: {integrity: sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==}
+    engines: {node: '>=10'}
+
   rettime@0.7.0:
     resolution: {integrity: sha512-LPRKoHnLKd/r3dVxcwO7vhCW+orkOGj9ViueosEBK6ie89CijnfRlhaDhHq/3Hxu4CkWQtxwlBG0mzTQY6uQjw==}
 
@@ -7934,6 +7941,10 @@ packages:
 
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
+  safe-regex2@5.1.1:
+    resolution: {integrity: sha512-mOSBvHGDZMuIEZMdOz/aCEYDCv0E7nfcNsIhUF+/P+xC7Hyf3FkvymqgPbg9D1EdSGu+uKbJgy09K/RKKc7kJA==}
+    hasBin: true
 
   safe-stable-stringify@2.5.0:
     resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
@@ -17549,6 +17560,8 @@ snapshots:
       onetime: 7.0.0
       signal-exit: 4.1.0
 
+  ret@0.5.0: {}
+
   rettime@0.7.0: {}
 
   reusify@1.1.0: {}
@@ -17638,6 +17651,10 @@ snapshots:
   safe-buffer@5.1.2: {}
 
   safe-buffer@5.2.1: {}
+
+  safe-regex2@5.1.1:
+    dependencies:
+      ret: 0.5.0
 
   safe-stable-stringify@2.5.0: {}
 

--- a/src/constants/importExport.ts
+++ b/src/constants/importExport.ts
@@ -1,0 +1,2 @@
+/** Current backup envelope version written by exports and WebDAV sync. */
+export const BACKUP_VERSION = "3.0"

--- a/src/entrypoints/background/servicesInit.ts
+++ b/src/entrypoints/background/servicesInit.ts
@@ -2,6 +2,7 @@ import { autoRefreshService } from "~/services/accounts/autoRefreshService"
 import { autoCheckinScheduler } from "~/services/checkin/autoCheckin/scheduler"
 import { dailyBalanceHistoryScheduler } from "~/services/history/dailyBalanceHistory/scheduler"
 import { usageHistoryScheduler } from "~/services/history/usageHistory/scheduler"
+import { legacyChannelConfigMigration } from "~/services/managedSites/legacyChannelConfigMigration"
 import { newApiOwnedSessionLifecycle } from "~/services/managedSites/newApiOwnedSession/background"
 import { modelMetadataService } from "~/services/models/modelMetadata"
 import { modelSyncScheduler } from "~/services/models/modelSync"
@@ -80,6 +81,10 @@ export async function initializeServices() {
           rejectedCount: rejected.length,
         })
       }
+
+      await legacyChannelConfigMigration.initialize().catch((error) => {
+        logger.warn("Legacy channel config migration failed", error)
+      })
 
       await modelMetadataService.initialize().catch((error) => {
         logger.warn("Model metadata initialization failed", error)

--- a/src/entrypoints/background/servicesInit.ts
+++ b/src/entrypoints/background/servicesInit.ts
@@ -82,7 +82,9 @@ export async function initializeServices() {
         })
       }
 
-      await legacyChannelConfigMigration.initialize().catch((error) => {
+      // Scoped-only consumers wait on demand; startup must not wait for the
+      // per-site network inventory used by the opportunistic legacy migration.
+      void legacyChannelConfigMigration.initialize().catch((error) => {
         logger.warn("Legacy channel config migration failed", error)
       })
 

--- a/src/features/ImportExport/components/WebDAVSettings.tsx
+++ b/src/features/ImportExport/components/WebDAVSettings.tsx
@@ -807,7 +807,11 @@ export default function WebDAVSettings() {
       }
     } catch (e: any) {
       logger.error("Failed to decrypt/import WebDAV backup", e)
-      toast.error(e?.message || t("webdav.encryption.decryptFailed"))
+      toast.error(
+        getImportExportErrorMessage(e) ||
+          e?.message ||
+          t("webdav.encryption.decryptFailed"),
+      )
       tracker.complete(PRODUCT_ANALYTICS_RESULTS.Failure, {
         errorCategory: decryptCompleted
           ? getWebdavAnalyticsErrorCategory(e)

--- a/src/features/ImportExport/components/WebDAVSettings.tsx
+++ b/src/features/ImportExport/components/WebDAVSettings.tsx
@@ -27,6 +27,7 @@ import { usePreferenceDraft } from "~/hooks/usePreferenceDraft"
 import { accountStorage } from "~/services/accounts/accountStorage"
 import { apiCredentialProfilesStorage } from "~/services/apiCredentialProfiles/apiCredentialProfilesStorage"
 import { channelConfigStorage } from "~/services/managedSites/channelConfigStorage"
+import { ensureLegacyChannelConfigMigrationReady } from "~/services/managedSites/legacyChannelConfigMigration"
 import { userPreferences } from "~/services/preferences/userPreferences"
 import { startProductAnalyticsAction } from "~/services/productAnalytics/actions"
 import {
@@ -395,6 +396,7 @@ export default function WebDAVSettings() {
         options?.forceFullRebuild
           ? DEFAULT_WEBDAV_SYNC_DATA_SELECTION
           : syncDataSelection
+      await ensureLegacyChannelConfigMigrationReady({ bypassBackoff: true })
       const [
         accountData,
         tagStore,

--- a/src/features/ImportExport/components/WebDAVSettings.tsx
+++ b/src/features/ImportExport/components/WebDAVSettings.tsx
@@ -79,6 +79,7 @@ import { WEBDAV_TARGET_IDS } from "../searchTargets"
 import { IMPORT_EXPORT_TEST_IDS } from "../testIds"
 import {
   BACKUP_VERSION,
+  getImportExportErrorMessage,
   importFromBackupObject,
   type BackupFullV2,
 } from "../utils"
@@ -489,7 +490,9 @@ export default function WebDAVSettings() {
       toast.error(
         e instanceof PersistWebdavConfigError
           ? getPersistWebdavConfigErrorMessage(e, t)
-          : e?.message || t("webdav.uploadFailed"),
+          : getImportExportErrorMessage(e) ||
+              e?.message ||
+              t("webdav.uploadFailed"),
       )
       tracker.complete(PRODUCT_ANALYTICS_RESULTS.Failure, {
         errorCategory: getWebdavAnalyticsErrorCategory(e),
@@ -652,7 +655,9 @@ export default function WebDAVSettings() {
       toast.error(
         e instanceof PersistWebdavConfigError
           ? getPersistWebdavConfigErrorMessage(e, t)
-          : e?.message || t("importExport:import.downloadImportFailed"),
+          : getImportExportErrorMessage(e) ||
+              e?.message ||
+              t("importExport:import.downloadImportFailed"),
       )
       tracker.complete(PRODUCT_ANALYTICS_RESULTS.Failure, {
         errorCategory: getWebdavAnalyticsErrorCategory(e),

--- a/src/features/ImportExport/utils.ts
+++ b/src/features/ImportExport/utils.ts
@@ -53,6 +53,8 @@ export async function importFromBackupObject(
           throw new Error(t("importExport:import.importFailed"))
         case "NO_IMPORTABLE_DATA":
           throw new Error(t("importExport:import.noImportableData"))
+        case "VERSION_NOT_SUPPORTED":
+          throw new Error(t("importExport:import.versionNotSupported"))
       }
     }
 

--- a/src/features/ImportExport/utils.ts
+++ b/src/features/ImportExport/utils.ts
@@ -17,7 +17,10 @@ import {
   type RawBackupData,
 } from "~/services/importExport/importExportService"
 import { channelConfigStorage } from "~/services/managedSites/channelConfigStorage"
-import { ensureLegacyChannelConfigMigrationReady } from "~/services/managedSites/legacyChannelConfigMigration"
+import {
+  ensureLegacyChannelConfigMigrationReady,
+  LegacyChannelConfigMigrationDeferredError,
+} from "~/services/managedSites/legacyChannelConfigMigration"
 import { userPreferences } from "~/services/preferences/userPreferences"
 import { tagStorage } from "~/services/tags/tagStorage"
 import { createLogger } from "~/utils/core/logger"
@@ -36,6 +39,28 @@ export type {
   RawBackupData,
 }
 
+/** Maps owned backup and migration failures to user-facing localized copy. */
+export function getImportExportErrorMessage(error: unknown): string | null {
+  if (error instanceof ImportExportError) {
+    switch (error.code) {
+      case "FORMAT_NOT_CORRECT":
+        return t("importExport:import.formatNotCorrect")
+      case "IMPORT_FAILED":
+        return t("importExport:import.importFailed")
+      case "NO_IMPORTABLE_DATA":
+        return t("importExport:import.noImportableData")
+      case "VERSION_NOT_SUPPORTED":
+        return t("importExport:import.versionNotSupported")
+    }
+  }
+
+  if (error instanceof LegacyChannelConfigMigrationDeferredError) {
+    return t("importExport:import.channelConfigMigrationDeferred")
+  }
+
+  return null
+}
+
 /**
  * Import data from a backup object, which may be a full backup or a partial backup
  */
@@ -46,17 +71,9 @@ export async function importFromBackupObject(
   try {
     return await importFromBackupObjectService(data, options)
   } catch (error) {
-    if (error instanceof ImportExportError) {
-      switch (error.code) {
-        case "FORMAT_NOT_CORRECT":
-          throw new Error(t("importExport:import.formatNotCorrect"))
-        case "IMPORT_FAILED":
-          throw new Error(t("importExport:import.importFailed"))
-        case "NO_IMPORTABLE_DATA":
-          throw new Error(t("importExport:import.noImportableData"))
-        case "VERSION_NOT_SUPPORTED":
-          throw new Error(t("importExport:import.versionNotSupported"))
-      }
+    const message = getImportExportErrorMessage(error)
+    if (message) {
+      throw new Error(message)
     }
 
     throw error

--- a/src/features/ImportExport/utils.ts
+++ b/src/features/ImportExport/utils.ts
@@ -17,6 +17,7 @@ import {
   type RawBackupData,
 } from "~/services/importExport/importExportService"
 import { channelConfigStorage } from "~/services/managedSites/channelConfigStorage"
+import { ensureLegacyChannelConfigMigrationReady } from "~/services/managedSites/legacyChannelConfigMigration"
 import { userPreferences } from "~/services/preferences/userPreferences"
 import { tagStorage } from "~/services/tags/tagStorage"
 import { createLogger } from "~/utils/core/logger"
@@ -72,6 +73,7 @@ export const handleExportAll = async (
 ) => {
   try {
     setIsExporting(true)
+    await ensureLegacyChannelConfigMigrationReady({ bypassBackoff: true })
 
     // 获取账号数据、用户偏好设置以及通道配置
     const [

--- a/src/features/ImportExport/utils.ts
+++ b/src/features/ImportExport/utils.ts
@@ -46,7 +46,7 @@ export function getImportExportErrorMessage(error: unknown): string | null {
       case "FORMAT_NOT_CORRECT":
         return t("importExport:import.formatNotCorrect")
       case "IMPORT_FAILED":
-        return t("importExport:import.importFailed")
+        return t("importExport:import.importOperationFailed")
       case "NO_IMPORTABLE_DATA":
         return t("importExport:import.noImportableData")
       case "VERSION_NOT_SUPPORTED":

--- a/src/features/ManagedSiteChannels/ManagedSiteChannels.tsx
+++ b/src/features/ManagedSiteChannels/ManagedSiteChannels.tsx
@@ -47,10 +47,6 @@ import {
   getManagedSiteService,
   hasValidManagedSiteConfig,
 } from "~/services/managedSites/managedSiteService"
-import {
-  isManagedSiteFeatureResourceSliceEnabled,
-  MANAGED_UPSTREAM_RESOURCE_FEATURES,
-} from "~/services/managedSites/managedUpstreamResourceMigration"
 import { resolveManagedUpstreamResourceCapabilities } from "~/services/managedSites/managedUpstreamResourceService"
 import { toPrivateManagedSiteThrownErrorMessage } from "~/services/managedSites/mutations"
 import {
@@ -310,15 +306,6 @@ const attachChannelFilterResourceRefs = (params: {
   baseUrl: string
 }): ChannelRow[] => {
   const { channels, managedSiteType, baseUrl } = params
-  const isEnabled = isManagedSiteFeatureResourceSliceEnabled(
-    managedSiteType,
-    MANAGED_UPSTREAM_RESOURCE_FEATURES.ChannelFilters,
-  )
-
-  if (!isEnabled) {
-    return channels
-  }
-
   return channels.map((channel) =>
     attachChannelFilterResourceRef({
       channel,

--- a/src/features/ManagedSiteChannels/ManagedSiteChannels.tsx
+++ b/src/features/ManagedSiteChannels/ManagedSiteChannels.tsx
@@ -39,6 +39,7 @@ import { buildGuidedAccountKeyImportTarget } from "~/features/UnifiedApiGuidance
 import { accountStorage } from "~/services/accounts/accountStorage"
 import { canResolveAccountRuntimeKeySecret } from "~/services/accounts/keyProductCapabilities"
 import { apiCredentialProfilesStorage } from "~/services/apiCredentialProfiles/apiCredentialProfilesStorage"
+import { getManagedSiteChannelResourceId } from "~/services/managedSites/managedSiteChannelResourceIdentity"
 import {
   buildManagedSiteChannelConsoleUrl,
   buildManagedSiteTokenConsoleUrl,
@@ -262,22 +263,6 @@ function getManagedSiteChannelStatusFilterLabel(t: TFunction, value: string) {
   }
 }
 
-const getManagedUpstreamResourceId = (
-  managedSiteType: ManagedSiteType,
-  channel: ChannelRow,
-) => {
-  if (managedSiteType === SITE_TYPES.AXON_HUB) {
-    const nativeId = (
-      channel as ChannelRow & { _axonHubData?: { id?: string | number } }
-    )._axonHubData?.id
-    if (nativeId !== undefined && nativeId !== null) {
-      return nativeId
-    }
-  }
-
-  return channel.id
-}
-
 export const attachChannelFilterResourceRef = (params: {
   channel: ChannelRow
   managedSiteType: ManagedSiteType
@@ -295,7 +280,7 @@ export const attachChannelFilterResourceRef = (params: {
     resourceRef: createManagedUpstreamResourceRef({
       managedSiteType,
       scopeKey,
-      resourceId: getManagedUpstreamResourceId(managedSiteType, channel),
+      resourceId: getManagedSiteChannelResourceId(managedSiteType, channel),
     }),
   }
 }
@@ -869,7 +854,7 @@ export default function ManagedSiteChannels({
                       scopeKey: normalizeManagedUpstreamResourceScopeKey(
                         String((config as { baseUrl?: string }).baseUrl ?? ""),
                       ),
-                      resourceId: getManagedUpstreamResourceId(
+                      resourceId: getManagedSiteChannelResourceId(
                         managedSiteType,
                         channel,
                       ),
@@ -985,7 +970,7 @@ export default function ManagedSiteChannels({
                   scopeKey: normalizeManagedUpstreamResourceScopeKey(
                     String((config as { baseUrl?: string }).baseUrl ?? ""),
                   ),
-                  resourceId: getManagedUpstreamResourceId(
+                  resourceId: getManagedSiteChannelResourceId(
                     managedSiteType,
                     channel,
                   ),

--- a/src/features/ManagedSiteChannels/components/ChannelFilterDialog.tsx
+++ b/src/features/ManagedSiteChannels/components/ChannelFilterDialog.tsx
@@ -71,14 +71,14 @@ function moveFilterById(
 function getChannelFilterStorageIdentity(
   channel: ChannelRow,
 ): ChannelFilterStorageIdentity {
-  if (channel.resourceRef) {
-    return {
-      channelId: channel.id,
-      resourceRef: channel.resourceRef,
-    }
+  if (!channel.resourceRef) {
+    throw new Error("Channel resource reference is unavailable")
   }
 
-  return channel.id
+  return {
+    channelId: channel.id,
+    resourceRef: channel.resourceRef,
+  }
 }
 
 /**

--- a/src/features/ManagedSiteChannels/utils/channelFilters.ts
+++ b/src/features/ManagedSiteChannels/utils/channelFilters.ts
@@ -14,22 +14,9 @@ import { createLogger } from "~/utils/core/logger"
  */
 const logger = createLogger("ChannelFilters")
 
-export type ChannelFilterStorageIdentity =
-  | number
-  | {
-      channelId: number
-      resourceRef?: ManagedUpstreamResourceRef
-    }
-  | {
-      channelId?: number
-      resourceRef: ManagedUpstreamResourceRef
-    }
-
-/**
- * Normalizes legacy numeric ids and resource-aware identities into requests.
- */
-function toChannelFilterRequest(identity: ChannelFilterStorageIdentity) {
-  return typeof identity === "number" ? { channelId: identity } : identity
+export type ChannelFilterStorageIdentity = {
+  channelId?: number
+  resourceRef: ManagedUpstreamResourceRef
 }
 
 /**
@@ -45,7 +32,7 @@ export async function fetchChannelFilters(
   identity: ChannelFilterStorageIdentity,
 ): Promise<ChannelModelFilterRule[]> {
   let response: Awaited<ReturnType<typeof sendChannelConfigMessage>>
-  const request = toChannelFilterRequest(identity)
+  const request = identity
 
   try {
     response = await sendChannelConfigMessage(ChannelConfigMessageTypes.Get, {
@@ -61,12 +48,7 @@ export async function fetchChannelFilters(
       resourceRef: request.resourceRef,
       error: runtimeError,
     })
-    const config = request.resourceRef
-      ? await channelConfigStorage.getConfigByResourceRef(
-          request.resourceRef,
-          request.channelId,
-        )
-      : await channelConfigStorage.getConfig(request.channelId!)
+    const config = await channelConfigStorage.getConfig(request.resourceRef)
     return config.modelFilterSettings?.rules ?? []
   }
 
@@ -91,7 +73,7 @@ export async function saveChannelFilters(
   filters: ChannelModelFilterRule[],
 ): Promise<void> {
   let response: Awaited<ReturnType<typeof sendChannelConfigMessage>>
-  const request = toChannelFilterRequest(identity)
+  const request = identity
 
   try {
     response = await sendChannelConfigMessage(
@@ -108,16 +90,11 @@ export async function saveChannelFilters(
       resourceRef: request.resourceRef,
       error: runtimeError,
     })
-    const success = request.resourceRef
-      ? await channelConfigStorage.upsertResourceFilters(
-          request.resourceRef,
-          filters,
-          request.channelId,
-        )
-      : await channelConfigStorage.upsertFilters(request.channelId!, filters)
-    if (!success) {
-      throw new Error("Failed to persist filters locally")
-    }
+    await channelConfigStorage.upsertFilters(
+      request.resourceRef,
+      filters,
+      request.channelId,
+    )
     return
   }
 

--- a/src/locales/de/importExport.json
+++ b/src/locales/de/importExport.json
@@ -92,7 +92,8 @@
     },
     "selectBackupFile": "Sicherungsdatei auswählen",
     "selectFileImport": "Bitte wählen Sie eine Datei aus oder geben Sie die zu importierenden Daten ein.",
-    "title": "Daten importieren"
+    "title": "Daten importieren",
+    "versionNotSupported": "Dieses Backup wurde mit einer neueren Version erstellt. Aktualisieren Sie die App, bevor Sie es importieren."
   },
   "notice": {
     "importantNotice": "Wichtiger Hinweis",

--- a/src/locales/de/importExport.json
+++ b/src/locales/de/importExport.json
@@ -16,6 +16,7 @@
   },
   "import": {
     "backupTime": "Backup-Zeit",
+    "channelConfigMigrationDeferred": "Die Migration der Kanalkonfiguration konnte nicht abgeschlossen werden. Prüfe die Einstellungen der verwalteten Website und versuche es erneut.",
     "containsAccountData": "Enthält Kontodaten",
     "containsApiCredentialProfiles": "Enthält die API-Anmeldeinformationsbibliothek",
     "containsChannelConfigs": "Enthält die Kanalkonfiguration",

--- a/src/locales/de/importExport.json
+++ b/src/locales/de/importExport.json
@@ -16,7 +16,7 @@
   },
   "import": {
     "backupTime": "Backup-Zeit",
-    "channelConfigMigrationDeferred": "Die Migration der Kanalkonfiguration konnte nicht abgeschlossen werden. Prüfe die Einstellungen der verwalteten Website und versuche es erneut.",
+    "channelConfigMigrationDeferred": "Die Migration der Kanalkonfiguration konnte nicht abgeschlossen werden. Prüfen Sie die Einstellungen der verwalteten Website und versuchen Sie es erneut.",
     "containsAccountData": "Enthält Kontodaten",
     "containsApiCredentialProfiles": "Enthält die API-Anmeldeinformationsbibliothek",
     "containsChannelConfigs": "Enthält die Kanalkonfiguration",
@@ -29,6 +29,7 @@
     "formatError": "Datenformatfehler, bitte überprüfen Sie das JSON-Format",
     "formatNotCorrect": "Datenformat nicht korrekt",
     "importFailed": "Import fehlgeschlagen: {{error}}",
+    "importOperationFailed": "Der Import konnte nicht abgeschlossen werden. Versuchen Sie es erneut.",
     "importSelectedSuccess": "Ausgewählter Inhalt erfolgreich importiert",
     "importSuccess": "Daten erfolgreich importiert",
     "noImportableData": "Keine importierbaren Daten gefunden",

--- a/src/locales/en/importExport.json
+++ b/src/locales/en/importExport.json
@@ -29,6 +29,7 @@
     "formatError": "Data format error, please check JSON format",
     "formatNotCorrect": "Data format not correct",
     "importFailed": "Import failed: {{error}}",
+    "importOperationFailed": "The import could not be completed. Try again.",
     "importSelectedSuccess": "Selected content imported successfully",
     "importSuccess": "Data imported successfully",
     "noImportableData": "No importable data found",

--- a/src/locales/en/importExport.json
+++ b/src/locales/en/importExport.json
@@ -16,6 +16,7 @@
   },
   "import": {
     "backupTime": "Backup Time",
+    "channelConfigMigrationDeferred": "Channel configuration migration could not finish. Check your managed-site settings and try again.",
     "containsAccountData": "Contains account data",
     "containsApiCredentialProfiles": "Contains API credential library",
     "containsChannelConfigs": "Contains channel configuration",

--- a/src/locales/en/importExport.json
+++ b/src/locales/en/importExport.json
@@ -92,7 +92,8 @@
     },
     "selectBackupFile": "Select backup file",
     "selectFileImport": "Please select file or input data to import",
-    "title": "Import Data"
+    "title": "Import Data",
+    "versionNotSupported": "This backup was created by a newer version. Update the app before importing it."
   },
   "notice": {
     "importantNotice": "Important Notice",

--- a/src/locales/es-419/importExport.json
+++ b/src/locales/es-419/importExport.json
@@ -29,6 +29,7 @@
     "formatError": "Error de formato de datos, revisa el formato JSON",
     "formatNotCorrect": "El formato de datos no es correcto",
     "importFailed": "La importación falló: {{error}}",
+    "importOperationFailed": "No se pudo completar la importación. Inténtalo de nuevo.",
     "importSelectedSuccess": "El contenido seleccionado se importó correctamente",
     "importSuccess": "Los datos se importaron correctamente",
     "noImportableData": "No se encontraron datos importables",

--- a/src/locales/es-419/importExport.json
+++ b/src/locales/es-419/importExport.json
@@ -16,6 +16,7 @@
   },
   "import": {
     "backupTime": "Hora del respaldo",
+    "channelConfigMigrationDeferred": "No se pudo completar la migración de la configuración de canales. Revisa la configuración del sitio administrado e inténtalo de nuevo.",
     "containsAccountData": "Contiene datos de cuenta",
     "containsApiCredentialProfiles": "Contiene biblioteca de credenciales API",
     "containsChannelConfigs": "Contiene configuración de canales",

--- a/src/locales/es-419/importExport.json
+++ b/src/locales/es-419/importExport.json
@@ -92,7 +92,8 @@
     },
     "selectBackupFile": "Seleccionar archivo de respaldo",
     "selectFileImport": "Selecciona un archivo o ingresa datos para importar",
-    "title": "Importar datos"
+    "title": "Importar datos",
+    "versionNotSupported": "Este respaldo fue creado con una versión más reciente. Actualiza la aplicación antes de importarlo."
   },
   "notice": {
     "importantNotice": "Aviso importante",

--- a/src/locales/ja/importExport.json
+++ b/src/locales/ja/importExport.json
@@ -92,7 +92,8 @@
     },
     "selectBackupFile": "バックアップファイルを選択",
     "selectFileImport": "インポートするファイルを選択するか、データを入力してください",
-    "title": "データをインポート"
+    "title": "データをインポート",
+    "versionNotSupported": "このバックアップは新しいバージョンで作成されています。アプリを更新してからインポートしてください。"
   },
   "notice": {
     "importantNotice": "重要なお知らせ",

--- a/src/locales/ja/importExport.json
+++ b/src/locales/ja/importExport.json
@@ -16,7 +16,7 @@
   },
   "import": {
     "backupTime": "バックアップ時刻",
-    "channelConfigMigrationDeferred": "チャンネル設定の移行を完了できませんでした。管理サイトの設定を確認して、もう一度お試しください。",
+    "channelConfigMigrationDeferred": "チャネル設定の移行を完了できませんでした。管理サイトの設定を確認して、もう一度お試しください。",
     "containsAccountData": "アカウントデータを含む",
     "containsApiCredentialProfiles": "API 認証情報庫を含む",
     "containsChannelConfigs": "チャネル設定を含む",
@@ -29,6 +29,7 @@
     "formatError": "データ形式エラーです。JSON 形式を確認してください",
     "formatNotCorrect": "データ形式が正しくありません",
     "importFailed": "インポートに失敗しました: {{error}}",
+    "importOperationFailed": "インポートを完了できませんでした。もう一度お試しください。",
     "importSelectedSuccess": "選択した内容をインポートしました",
     "importSuccess": "データを正常にインポートしました",
     "noImportableData": "インポート可能なデータが見つかりません",

--- a/src/locales/ja/importExport.json
+++ b/src/locales/ja/importExport.json
@@ -16,6 +16,7 @@
   },
   "import": {
     "backupTime": "バックアップ時刻",
+    "channelConfigMigrationDeferred": "チャンネル設定の移行を完了できませんでした。管理サイトの設定を確認して、もう一度お試しください。",
     "containsAccountData": "アカウントデータを含む",
     "containsApiCredentialProfiles": "API 認証情報庫を含む",
     "containsChannelConfigs": "チャネル設定を含む",

--- a/src/locales/pt-BR/importExport.json
+++ b/src/locales/pt-BR/importExport.json
@@ -92,7 +92,8 @@
     },
     "selectBackupFile": "Selecionar arquivo de backup",
     "selectFileImport": "Selecione um arquivo ou insira os dados que deseja importar",
-    "title": "Importar dados"
+    "title": "Importar dados",
+    "versionNotSupported": "Este backup foi criado por uma versão mais recente. Atualize o aplicativo antes de importá-lo."
   },
   "notice": {
     "importantNotice": "Aviso importante",

--- a/src/locales/pt-BR/importExport.json
+++ b/src/locales/pt-BR/importExport.json
@@ -29,6 +29,7 @@
     "formatError": "Erro no formato dos dados. Verifique o formato JSON",
     "formatNotCorrect": "O formato dos dados está incorreto",
     "importFailed": "Falha na importação: {{error}}",
+    "importOperationFailed": "Não foi possível concluir a importação. Tente novamente.",
     "importSelectedSuccess": "Conteúdo selecionado importado com sucesso",
     "importSuccess": "Dados importados com sucesso",
     "noImportableData": "Nenhum dado que possa ser importado foi encontrado",

--- a/src/locales/pt-BR/importExport.json
+++ b/src/locales/pt-BR/importExport.json
@@ -16,6 +16,7 @@
   },
   "import": {
     "backupTime": "Data do backup",
+    "channelConfigMigrationDeferred": "Não foi possível concluir a migração da configuração de canais. Verifique as configurações do site gerenciado e tente novamente.",
     "containsAccountData": "Contém dados de contas",
     "containsApiCredentialProfiles": "Contém a biblioteca de credenciais de API",
     "containsChannelConfigs": "Contém configurações de canais",

--- a/src/locales/vi/importExport.json
+++ b/src/locales/vi/importExport.json
@@ -29,6 +29,7 @@
     "formatError": "Lỗi định dạng dữ liệu, vui lòng kiểm tra định dạng JSON",
     "formatNotCorrect": "Định dạng dữ liệu không chính xác",
     "importFailed": "Nhập thất bại: {{error}}",
+    "importOperationFailed": "Không thể hoàn tất quá trình nhập. Hãy thử lại.",
     "importSelectedSuccess": "Đã nhập nội dung đã chọn",
     "importSuccess": "Nhập dữ liệu thành công",
     "noImportableData": "Không tìm thấy dữ liệu có thể nhập",

--- a/src/locales/vi/importExport.json
+++ b/src/locales/vi/importExport.json
@@ -92,7 +92,8 @@
     },
     "selectBackupFile": "Chọn tệp sao lưu",
     "selectFileImport": "Vui lòng chọn tệp để nhập hoặc nhập dữ liệu",
-    "title": "Nhập dữ liệu"
+    "title": "Nhập dữ liệu",
+    "versionNotSupported": "Bản sao lưu này được tạo bằng phiên bản mới hơn. Hãy cập nhật ứng dụng trước khi nhập."
   },
   "notice": {
     "importantNotice": "Thông báo quan trọng",

--- a/src/locales/vi/importExport.json
+++ b/src/locales/vi/importExport.json
@@ -16,6 +16,7 @@
   },
   "import": {
     "backupTime": "Thời gian sao lưu",
+    "channelConfigMigrationDeferred": "Không thể hoàn tất quá trình di chuyển cấu hình kênh. Hãy kiểm tra cài đặt trang được quản lý rồi thử lại.",
     "containsAccountData": "Bao gồm dữ liệu tài khoản",
     "containsApiCredentialProfiles": "Bao gồm hồ sơ thông tin xác thực API",
     "containsChannelConfigs": "Bao gồm cấu hình kênh",

--- a/src/locales/zh-CN/importExport.json
+++ b/src/locales/zh-CN/importExport.json
@@ -92,7 +92,8 @@
     },
     "selectBackupFile": "选择备份文件",
     "selectFileImport": "请选择要导入的文件或输入数据",
-    "title": "导入数据"
+    "title": "导入数据",
+    "versionNotSupported": "此备份由较新版本创建。请先更新应用后再导入。"
   },
   "notice": {
     "importantNotice": "重要提示",

--- a/src/locales/zh-CN/importExport.json
+++ b/src/locales/zh-CN/importExport.json
@@ -16,6 +16,7 @@
   },
   "import": {
     "backupTime": "备份时间",
+    "channelConfigMigrationDeferred": "渠道配置迁移尚未完成。请检查管理站点配置后重试。",
     "containsAccountData": "包含账号数据",
     "containsApiCredentialProfiles": "包含 API 凭据库",
     "containsChannelConfigs": "包含渠道配置",

--- a/src/locales/zh-CN/importExport.json
+++ b/src/locales/zh-CN/importExport.json
@@ -29,6 +29,7 @@
     "formatError": "数据格式错误，请检查JSON格式",
     "formatNotCorrect": "数据格式不正确",
     "importFailed": "导入失败: {{error}}",
+    "importOperationFailed": "导入未能完成，请重试。",
     "importSelectedSuccess": "已导入所选内容",
     "importSuccess": "数据导入成功",
     "noImportableData": "没有找到可导入的数据",

--- a/src/locales/zh-TW/importExport.json
+++ b/src/locales/zh-TW/importExport.json
@@ -16,6 +16,7 @@
   },
   "import": {
     "backupTime": "備份時間",
+    "channelConfigMigrationDeferred": "頻道設定移轉尚未完成。請檢查管理站點設定後再試一次。",
     "containsAccountData": "包含帳號資料",
     "containsApiCredentialProfiles": "包含 API 憑據庫",
     "containsChannelConfigs": "包含渠道配置",

--- a/src/locales/zh-TW/importExport.json
+++ b/src/locales/zh-TW/importExport.json
@@ -92,7 +92,8 @@
     },
     "selectBackupFile": "選擇備份檔案",
     "selectFileImport": "請選擇要匯入的檔案或輸入資料",
-    "title": "匯入資料"
+    "title": "匯入資料",
+    "versionNotSupported": "此備份由較新版本建立。請先更新應用程式後再匯入。"
   },
   "notice": {
     "importantNotice": "重要提示",

--- a/src/locales/zh-TW/importExport.json
+++ b/src/locales/zh-TW/importExport.json
@@ -16,7 +16,7 @@
   },
   "import": {
     "backupTime": "備份時間",
-    "channelConfigMigrationDeferred": "頻道設定移轉尚未完成。請檢查管理站點設定後再試一次。",
+    "channelConfigMigrationDeferred": "渠道配置移轉尚未完成。請檢查管理站點設定後再試一次。",
     "containsAccountData": "包含帳號資料",
     "containsApiCredentialProfiles": "包含 API 憑據庫",
     "containsChannelConfigs": "包含渠道配置",
@@ -29,6 +29,7 @@
     "formatError": "資料格式錯誤，請檢查JSON格式",
     "formatNotCorrect": "資料格式不正確",
     "importFailed": "匯入失敗: {{error}}",
+    "importOperationFailed": "匯入未能完成，請再試一次。",
     "importSelectedSuccess": "已匯入所選內容",
     "importSuccess": "資料匯入成功",
     "noImportableData": "沒有找到可匯入的資料",

--- a/src/services/apiAdapters/contracts/managedSiteCapabilities.ts
+++ b/src/services/apiAdapters/contracts/managedSiteCapabilities.ts
@@ -18,6 +18,8 @@ import type {
 export type ManagedSiteChannelRequestOptions = {
   signal?: AbortSignal
   bypassSiteRequestLimit?: boolean
+  /** Fail instead of returning a pagination-capped partial inventory. */
+  requireCompleteInventory?: boolean
 }
 
 export type ManagedSiteChannelSecretReadOptions = {

--- a/src/services/apiAdapters/contracts/managedSiteCapabilities.ts
+++ b/src/services/apiAdapters/contracts/managedSiteCapabilities.ts
@@ -22,6 +22,14 @@ export type ManagedSiteChannelRequestOptions = {
   requireCompleteInventory?: boolean
 }
 
+export type ManagedSitePaginatedChannelRequestOptions =
+  ManagedSiteChannelRequestOptions & {
+    pageSize?: number
+    beforeRequest?: () => Promise<void>
+    endpoint?: string
+    pageStart?: number
+  }
+
 export type ManagedSiteChannelSecretReadOptions = {
   protectionBypassExecution: ProtectionBypassExecution
 }

--- a/src/services/apiService/doneHub/index.ts
+++ b/src/services/apiService/doneHub/index.ts
@@ -1,3 +1,4 @@
+import type { ManagedSitePaginatedChannelRequestOptions } from "~/services/apiAdapters/contracts/managedSiteCapabilities"
 import { REQUEST_CONFIG } from "~/services/apiTransport/constant"
 import { ApiError } from "~/services/apiTransport/errors"
 import { fetchAllItems } from "~/services/apiTransport/pagination"
@@ -128,14 +129,7 @@ export const normalizeDoneHubChannel = (
   }
 }
 
-type ChannelListAllOptions = {
-  pageSize?: number
-  beforeRequest?: () => Promise<void>
-  endpoint?: string
-  pageStart?: number
-  signal?: AbortSignal
-  requireCompleteInventory?: boolean
-}
+type ChannelListAllOptions = ManagedSitePaginatedChannelRequestOptions
 
 /**
  * Search channels for DoneHub-managed sites.

--- a/src/services/apiService/doneHub/index.ts
+++ b/src/services/apiService/doneHub/index.ts
@@ -134,6 +134,7 @@ type ChannelListAllOptions = {
   endpoint?: string
   pageStart?: number
   signal?: AbortSignal
+  requireCompleteInventory?: boolean
 }
 
 /**
@@ -345,6 +346,7 @@ export async function listAllChannels(
       pageSize,
       startPage: pageStart,
       maxPages: REQUEST_CONFIG.MAX_PAGES,
+      requireComplete: options?.requireCompleteInventory,
     },
   )
 

--- a/src/services/apiService/newApiFamily/channelManagement.ts
+++ b/src/services/apiService/newApiFamily/channelManagement.ts
@@ -1,3 +1,4 @@
+import type { ManagedSitePaginatedChannelRequestOptions } from "~/services/apiAdapters/contracts/managedSiteCapabilities"
 import { REQUEST_CONFIG } from "~/services/apiTransport/constant"
 import { ApiError } from "~/services/apiTransport/errors"
 import { fetchAllItems } from "~/services/apiTransport/pagination"
@@ -234,14 +235,7 @@ export async function deleteChannel(
   }
 }
 
-type ChannelListAllOptions = {
-  pageSize?: number
-  beforeRequest?: () => Promise<void>
-  endpoint?: string
-  pageStart?: number
-  signal?: AbortSignal
-  requireCompleteInventory?: boolean
-}
+type ChannelListAllOptions = ManagedSitePaginatedChannelRequestOptions
 
 /**
  * Fetch all channels from New API with pagination aggregation.

--- a/src/services/apiService/newApiFamily/channelManagement.ts
+++ b/src/services/apiService/newApiFamily/channelManagement.ts
@@ -240,6 +240,7 @@ type ChannelListAllOptions = {
   endpoint?: string
   pageStart?: number
   signal?: AbortSignal
+  requireCompleteInventory?: boolean
 }
 
 /**
@@ -305,7 +306,11 @@ export async function listAllChannels(
         total: total || 0,
       }
     },
-    { pageSize, startPage: pageStart },
+    {
+      pageSize,
+      startPage: pageStart,
+      requireComplete: options?.requireCompleteInventory,
+    },
   )
 
   return {

--- a/src/services/apiService/veloera/index.ts
+++ b/src/services/apiService/veloera/index.ts
@@ -1,3 +1,4 @@
+import type { ManagedSitePaginatedChannelRequestOptions } from "~/services/apiAdapters/contracts/managedSiteCapabilities"
 import { REQUEST_CONFIG } from "~/services/apiTransport/constant"
 import { ApiError } from "~/services/apiTransport/errors"
 import { fetchAllItems } from "~/services/apiTransport/pagination"
@@ -224,12 +225,7 @@ export async function deleteChannel(
  */
 export async function listAllChannels(
   request: ApiServiceRequest,
-  options?: {
-    pageSize?: number
-    beforeRequest?: () => Promise<void>
-    signal?: AbortSignal
-    requireCompleteInventory?: boolean
-  },
+  options?: ManagedSitePaginatedChannelRequestOptions,
 ): Promise<ManagedSiteChannelListData> {
   const pageSize = options?.pageSize ?? REQUEST_CONFIG.DEFAULT_PAGE_SIZE
   const beforeRequest = options?.beforeRequest
@@ -270,6 +266,8 @@ export async function listAllChannels(
 
   return {
     items: allItems,
+    // Veloera exposes no authoritative total; completeness comes from the
+    // requireComplete page-cap guard above rather than this derived count.
     total: allItems.length,
     type_counts: typeCounts,
   } as ManagedSiteChannelListData

--- a/src/services/apiService/veloera/index.ts
+++ b/src/services/apiService/veloera/index.ts
@@ -228,6 +228,7 @@ export async function listAllChannels(
     pageSize?: number
     beforeRequest?: () => Promise<void>
     signal?: AbortSignal
+    requireCompleteInventory?: boolean
   },
 ): Promise<ManagedSiteChannelListData> {
   const pageSize = options?.pageSize ?? REQUEST_CONFIG.DEFAULT_PAGE_SIZE
@@ -257,6 +258,7 @@ export async function listAllChannels(
       pageSize,
       startPage: 0,
       maxPages: REQUEST_CONFIG.MAX_PAGES,
+      requireComplete: options?.requireCompleteInventory,
     },
   )
 

--- a/src/services/apiTransport/pagination.ts
+++ b/src/services/apiTransport/pagination.ts
@@ -20,6 +20,14 @@ interface PageData<T> {
   hasMore?: boolean
 }
 
+/** Indicates that a caller-required complete inventory hit the page cap. */
+export class PaginationLimitError extends Error {
+  constructor() {
+    super("Pagination limit reached before the inventory completed")
+    this.name = "PaginationLimitError"
+  }
+}
+
 type ArrayOrItemsPayload<T> = T[] | { items?: T[] | null } | null | undefined
 
 /**
@@ -58,6 +66,7 @@ async function fetchAllPaginated<T, R>(
     pageSize = REQUEST_CONFIG.DEFAULT_PAGE_SIZE,
     maxPages = REQUEST_CONFIG.MAX_PAGES,
     startPage = 1,
+    requireComplete = false,
   } = options
 
   let aggregatedData = initialValue
@@ -89,10 +98,8 @@ async function fetchAllPaginated<T, R>(
 
     if (pageCount >= maxPages) {
       logger.warn("达到最大分页限制，数据可能不完整", { maxPages })
-      if (options.requireComplete) {
-        throw new Error(
-          "Pagination limit reached before the inventory completed",
-        )
+      if (requireComplete) {
+        throw new PaginationLimitError()
       }
     }
   }

--- a/src/services/apiTransport/pagination.ts
+++ b/src/services/apiTransport/pagination.ts
@@ -11,6 +11,7 @@ interface PaginationOptions {
   pageSize?: number
   maxPages?: number
   startPage?: number
+  requireComplete?: boolean
 }
 
 interface PageData<T> {
@@ -88,6 +89,11 @@ async function fetchAllPaginated<T, R>(
 
     if (pageCount >= maxPages) {
       logger.warn("达到最大分页限制，数据可能不完整", { maxPages })
+      if (options.requireComplete) {
+        throw new Error(
+          "Pagination limit reached before the inventory completed",
+        )
+      }
     }
   }
 

--- a/src/services/core/storageKeys.ts
+++ b/src/services/core/storageKeys.ts
@@ -31,6 +31,9 @@ export const STORAGE_LOCKS = {
    * managed-site channel configuration.
    */
   CHANNEL_CONFIG: "all-api-hub:channel-config",
+  /** Exclusive lock for cross-context legacy channel inventory discovery. */
+  LEGACY_CHANNEL_CONFIG_MIGRATION:
+    "all-api-hub:legacy-channel-config-migration",
   /**
    * Exclusive lock used for read-modify-write sequences touching persisted API
    * verification result history.
@@ -117,6 +120,8 @@ export const API_CREDENTIAL_PROFILES_STORAGE_KEYS = {
 export const CHANNEL_CONFIG_STORAGE_KEYS = {
   CHANNEL_CONFIGS: "channel_configs",
   CHANNEL_RESOURCE_CONFIGS: "channel_resource_configs",
+  LEGACY_MIGRATION_STATE: "channel_config_legacy_migration_state",
+  LEGACY_REPLACEMENT_STATE: "channel_config_legacy_replacement_state",
 } as const
 
 export const API_VERIFICATION_HISTORY_STORAGE_KEYS = {

--- a/src/services/core/storageKeys.ts
+++ b/src/services/core/storageKeys.ts
@@ -27,6 +27,11 @@ export const STORAGE_LOCKS = {
    */
   API_CREDENTIAL_PROFILES: "all-api-hub:api-credential-profiles",
   /**
+   * Exclusive lock used for read-modify-write sequences touching resource-scoped
+   * managed-site channel configuration.
+   */
+  CHANNEL_CONFIG: "all-api-hub:channel-config",
+  /**
    * Exclusive lock used for read-modify-write sequences touching persisted API
    * verification result history.
    */
@@ -109,6 +114,11 @@ export const API_CREDENTIAL_PROFILES_STORAGE_KEYS = {
   API_CREDENTIAL_PROFILES: "api_credential_profiles",
 } as const
 
+export const CHANNEL_CONFIG_STORAGE_KEYS = {
+  CHANNEL_CONFIGS: "channel_configs",
+  CHANNEL_RESOURCE_CONFIGS: "channel_resource_configs",
+} as const
+
 export const API_VERIFICATION_HISTORY_STORAGE_KEYS = {
   VERIFICATION_RESULT_HISTORY: "api_verification_result_history",
 } as const
@@ -168,6 +178,7 @@ export const STORAGE_KEYS = {
   ...ACCOUNT_STORAGE_KEYS,
   ...TAG_STORAGE_KEYS,
   ...API_CREDENTIAL_PROFILES_STORAGE_KEYS,
+  ...CHANNEL_CONFIG_STORAGE_KEYS,
   ...API_VERIFICATION_HISTORY_STORAGE_KEYS,
   ...WEB_AI_API_CHECK_STORAGE_KEYS,
   ...LDOH_SITE_LOOKUP_STORAGE_KEYS,

--- a/src/services/importExport/importExportService.ts
+++ b/src/services/importExport/importExportService.ts
@@ -1118,5 +1118,7 @@ export async function importFromBackupObject(
     return importV2Backup(data as BackupV2, options)
   }
 
-  throw new ImportExportError("VERSION_NOT_SUPPORTED")
+  // Compile-time exhaustiveness plus a defensive runtime guard for untyped data.
+  const exhaustiveVersion: never = version
+  throw new ImportExportError(exhaustiveVersion)
 }

--- a/src/services/importExport/importExportService.ts
+++ b/src/services/importExport/importExportService.ts
@@ -8,6 +8,7 @@ import {
   channelConfigStorage,
   coerceChannelConfigSnapshot,
 } from "~/services/managedSites/channelConfigStorage"
+import { ensureLegacyChannelConfigMigrationReady } from "~/services/managedSites/legacyChannelConfigMigration"
 import type { UserPreferences } from "~/services/preferences/userPreferences"
 import { userPreferences } from "~/services/preferences/userPreferences"
 import { tagStorage } from "~/services/tags/tagStorage"
@@ -1095,6 +1096,19 @@ export async function importFromBackupObject(
   }
 
   const version = getSupportedBackupVersion(data)
+
+  const incomingChannelConfigs = readChannelConfigSnapshot(data)
+  const channelConfigStrategy =
+    options?.plan?.channelConfigs ??
+    (options?.mode === IMPORT_SECTION_STRATEGIES.Merge
+      ? IMPORT_SECTION_STRATEGIES.Merge
+      : IMPORT_SECTION_STRATEGIES.Replace)
+  if (
+    incomingChannelConfigs !== null &&
+    channelConfigStrategy === IMPORT_SECTION_STRATEGIES.Merge
+  ) {
+    await ensureLegacyChannelConfigMigrationReady({ bypassBackoff: true })
+  }
 
   if (version === LEGACY_BACKUP_V1_VERSION) {
     return importV1Backup(data, options)

--- a/src/services/importExport/importExportService.ts
+++ b/src/services/importExport/importExportService.ts
@@ -1,16 +1,20 @@
+import { BACKUP_VERSION } from "~/constants/importExport"
 import { accountStorage } from "~/services/accounts/accountStorage"
 import {
   apiCredentialProfilesStorage,
   coerceApiCredentialProfilesConfig,
 } from "~/services/apiCredentialProfiles/apiCredentialProfilesStorage"
-import { channelConfigStorage } from "~/services/managedSites/channelConfigStorage"
+import {
+  channelConfigStorage,
+  coerceChannelConfigSnapshot,
+} from "~/services/managedSites/channelConfigStorage"
 import type { UserPreferences } from "~/services/preferences/userPreferences"
 import { userPreferences } from "~/services/preferences/userPreferences"
 import { tagStorage } from "~/services/tags/tagStorage"
 import { createDefaultTagStore } from "~/services/tags/tagStoreUtils"
 import type { AccountStorageConfig, TagStore } from "~/types"
 import type { ApiCredentialProfilesConfig } from "~/types/apiCredentialProfiles"
-import type { ChannelConfigMap } from "~/types/channelConfig"
+import type { ChannelConfigSnapshot } from "~/types/channelConfig"
 import { formatLocaleDateTime } from "~/utils/core/formatters"
 import { createLogger } from "~/utils/core/logger"
 
@@ -23,6 +27,7 @@ type ImportExportErrorCode =
   | "FORMAT_NOT_CORRECT"
   | "IMPORT_FAILED"
   | "NO_IMPORTABLE_DATA"
+  | "VERSION_NOT_SUPPORTED"
 
 export class ImportExportError extends Error {
   readonly code: ImportExportErrorCode
@@ -38,12 +43,36 @@ export class ImportExportError extends Error {
  * Current backup schema version.
  *
  * V1: legacy backups, may use nested structures (e.g. accounts.accounts, data.accounts).
- * V2: flat structure with accounts / preferences / channelConfigs on the root object.
+ * V2: flat structure with numeric channelConfigs on the root object.
+ * V3: keeps the flat structure and replaces channelConfigs with a scoped snapshot.
  *
- * When introducing V3+, prefer adding a dedicated import handler and updating
+ * When introducing V4+, prefer adding a dedicated import handler and updating
  * importFromBackupObject + normalizeBackupForMerge dispatch logic.
  */
-export const BACKUP_VERSION = "2.0"
+export { BACKUP_VERSION }
+const LEGACY_BACKUP_V2_VERSION = "2.0"
+const LEGACY_BACKUP_V1_VERSION = "1.0"
+
+type SupportedBackupVersion =
+  | typeof LEGACY_BACKUP_V1_VERSION
+  | typeof LEGACY_BACKUP_V2_VERSION
+  | typeof BACKUP_VERSION
+
+/** Classifies the backup envelope version for every read/import boundary. */
+function getSupportedBackupVersion(
+  data: RawBackupData,
+): SupportedBackupVersion {
+  const version =
+    data.version === undefined ? LEGACY_BACKUP_V1_VERSION : data.version
+  if (
+    version !== LEGACY_BACKUP_V1_VERSION &&
+    version !== LEGACY_BACKUP_V2_VERSION &&
+    version !== BACKUP_VERSION
+  ) {
+    throw new ImportExportError("VERSION_NOT_SUPPORTED")
+  }
+  return version
+}
 
 interface ParsedBackupSummary {
   valid: boolean
@@ -56,8 +85,8 @@ interface ParsedBackupSummary {
 }
 
 /**
- * V2 full backup payload (used by "export all" and WebDAV sync uploads).
- * This is the primary canonical structure we write from the app.
+ * Current flat backup payload (used by "export all" and WebDAV sync uploads).
+ * The V2 name is retained to avoid a broad public type rename; writers emit V3.
  */
 export interface BackupFullV2 {
   version: string
@@ -71,7 +100,7 @@ export interface BackupFullV2 {
    */
   tagStore?: TagStore
   preferences: UserPreferences
-  channelConfigs: ChannelConfigMap
+  channelConfigs: ChannelConfigSnapshot
   /**
    * Standalone API credential profiles snapshot (contains secrets).
    *
@@ -132,11 +161,56 @@ type LegacyBackupLike = {
  * Raw backup payload as stored in files / WebDAV.
  *
  * We keep this type deliberately tolerant (LegacyBackupLike) so that it can
- * accept both canonical V2 exports (BackupV2) and historical/unknown shapes.
- * The stricter V2 interfaces are still used at export call sites to guarantee
+ * accept both canonical flat exports (historically named BackupV2) and
+ * historical/unknown shapes. The stricter interfaces are used at export call
+ * sites to guarantee
  * that what we write conforms to the latest schema.
  */
 export type RawBackupData = LegacyBackupLike
+
+/** Finds a channel-config section without conflating absence with invalid data. */
+function readRawChannelConfigSection(data: RawBackupData): {
+  present: boolean
+  value: unknown
+} {
+  if (Object.prototype.hasOwnProperty.call(data, "channelConfigs")) {
+    return { present: true, value: data.channelConfigs }
+  }
+
+  const nestedData = data.data
+  if (
+    nestedData &&
+    typeof nestedData === "object" &&
+    Object.prototype.hasOwnProperty.call(nestedData, "channelConfigs")
+  ) {
+    return { present: true, value: nestedData.channelConfigs }
+  }
+
+  return { present: false, value: undefined }
+}
+
+/** Reads and validates the scoped channel-config snapshot from a backup envelope. */
+function readChannelConfigSnapshot(
+  data: RawBackupData,
+): ChannelConfigSnapshot | null {
+  const rawSection = readRawChannelConfigSection(data)
+  if (!rawSection.present) return null
+
+  const snapshot = coerceChannelConfigSnapshot(rawSection.value)
+  if (snapshot) return snapshot
+
+  const raw = rawSection.value
+  const looksLikeScopedSnapshot =
+    Boolean(raw) &&
+    typeof raw === "object" &&
+    ("schemaVersion" in (raw as object) || "configs" in (raw as object))
+  if (data.version === BACKUP_VERSION || looksLikeScopedSnapshot) {
+    throw new ImportExportError("FORMAT_NOT_CORRECT")
+  }
+
+  // V1/V2 numeric maps have no reliable scope identity and are intentionally ignored.
+  return null
+}
 
 export interface ImportResult {
   allImported: boolean
@@ -214,7 +288,7 @@ function toWriteStrategy(strategy: ImportSectionStrategy): ImportWriteStrategy {
 
 /**
  * Parse a raw backup JSON string into a lightweight summary used by the
- * import UI. This is tolerant of both legacy (V1) and V2 payload shapes and
+ * import UI. This is tolerant of legacy and current flat payload shapes and
  * never throws: on invalid JSON it returns `{ valid: false }`.
  */
 export function parseBackupSummary(
@@ -225,14 +299,13 @@ export function parseBackupSummary(
 
   try {
     const data = JSON.parse(importData) as RawBackupData
+    getSupportedBackupVersion(data)
 
     const hasAccounts = Boolean(data.accounts || data.type === "accounts")
     const hasPreferences = Boolean(
       data.preferences || data.type === "preferences",
     )
-    const hasChannelConfigs = Boolean(
-      data.channelConfigs || data.type === "channelConfigs",
-    )
+    const hasChannelConfigs = readChannelConfigSnapshot(data) !== null
     const hasTagStore = Boolean((data as any).tagStore)
     const hasApiCredentialProfiles = Boolean(
       (data as any).apiCredentialProfiles,
@@ -269,9 +342,8 @@ async function importV1Backup(
   const preferencesRequested = Boolean(
     data.preferences || data.type === "preferences",
   )
-  const channelConfigsRequested = Boolean(
-    data.channelConfigs || data.type === "channelConfigs",
-  )
+  const channelConfigSnapshot = readChannelConfigSnapshot(data)
+  const channelConfigsRequested = channelConfigSnapshot !== null
   const plan = options?.plan
 
   // accounts: support both legacy partial exports and older full exports
@@ -325,11 +397,8 @@ async function importV1Backup(
     channelConfigsRequested &&
     shouldImportSection(plan, IMPORT_SECTION_KEYS.ChannelConfigs)
   ) {
-    const channelConfigsData = data.channelConfigs || data.data?.channelConfigs
-    if (channelConfigsData) {
-      await channelConfigStorage.importConfigs(channelConfigsData)
-      channelConfigsImported = true
-    }
+    await channelConfigStorage.importConfigs(channelConfigSnapshot)
+    channelConfigsImported = true
   }
 
   const anyImported =
@@ -356,9 +425,9 @@ async function importV1Backup(
 }
 
 /**
- * Normalize an arbitrary backup payload (V1/V2/unknown) into a canonical
- * structure that `WebdavAutoSyncService` can merge. This is intentionally
- * tolerant so that older backups do not break newer clients.
+ * Normalize a supported backup payload into the structure used by WebDAV merge.
+ * Missing versions remain legacy V1; explicit unknown versions are rejected so
+ * a newer schema cannot be interpreted using older semantics.
  */
 export function normalizeBackupForMerge(
   data: RawBackupData | null,
@@ -371,7 +440,7 @@ export function normalizeBackupForMerge(
   deletedEntryRecords: AccountStorageConfig["deletedEntryRecords"]
   accountsTimestamp: number
   preferences: any | null
-  channelConfigs: ChannelConfigMap | null
+  channelConfigs: ChannelConfigSnapshot | null
   tagStore: TagStore | null
   apiCredentialProfiles: ApiCredentialProfilesConfig | null
 } {
@@ -390,19 +459,19 @@ export function normalizeBackupForMerge(
     }
   }
 
-  const version = data.version ?? "1.0"
+  const version = getSupportedBackupVersion(data)
 
-  if (version === BACKUP_VERSION) {
-    // For V2, we expect the canonical full-backup shape
+  if (version === BACKUP_VERSION || version === LEGACY_BACKUP_V2_VERSION) {
+    // V2 and V3 share the flat backup envelope; V3 changes channelConfigs.
     return normalizeV2BackupForMerge(data as BackupFullV2, localPreferences)
   }
 
-  // V1 and unknown versions: use tolerant legacy-normalization
+  // V1 uses tolerant legacy normalization.
   return normalizeV1BackupForMerge(data, localPreferences)
 }
 
 /**
- * Normalize canonical V2 backups into the shape WebDAV merge expects.
+ * Normalize flat V2/V3 backups into the shape WebDAV merge expects.
  */
 function normalizeV2BackupForMerge(
   data: BackupFullV2,
@@ -415,7 +484,7 @@ function normalizeV2BackupForMerge(
   deletedEntryRecords: AccountStorageConfig["deletedEntryRecords"]
   accountsTimestamp: number
   preferences: any | null
-  channelConfigs: ChannelConfigMap | null
+  channelConfigs: ChannelConfigSnapshot | null
   tagStore: TagStore | null
   apiCredentialProfiles: ApiCredentialProfilesConfig | null
 } {
@@ -445,11 +514,7 @@ function normalizeV2BackupForMerge(
       ? accountsConfig.last_updated
       : (data.timestamp as number) || 0
 
-  const rawChannelConfigs = data.channelConfigs
-  const channelConfigs: ChannelConfigMap | null =
-    rawChannelConfigs && typeof rawChannelConfigs === "object"
-      ? (rawChannelConfigs as ChannelConfigMap)
-      : null
+  const channelConfigs = readChannelConfigSnapshot(data)
 
   return {
     accounts,
@@ -468,7 +533,7 @@ function normalizeV2BackupForMerge(
 }
 
 /**
- * Normalize legacy (V1/unknown) backups into merge-friendly structure.
+ * Normalize legacy V1 backups into merge-friendly structure.
  */
 function normalizeV1BackupForMerge(
   data: RawBackupData,
@@ -481,7 +546,7 @@ function normalizeV1BackupForMerge(
   deletedEntryRecords: AccountStorageConfig["deletedEntryRecords"]
   accountsTimestamp: number
   preferences: any | null
-  channelConfigs: ChannelConfigMap | null
+  channelConfigs: ChannelConfigSnapshot | null
   tagStore: TagStore | null
   apiCredentialProfiles: ApiCredentialProfilesConfig | null
 } {
@@ -525,12 +590,7 @@ function normalizeV1BackupForMerge(
   const preferences =
     data.preferences || (data.data as any)?.preferences || localPreferences
 
-  const rawChannelConfigs =
-    (data as any).channelConfigs || (data.data as any)?.channelConfigs
-  const channelConfigs: ChannelConfigMap | null =
-    rawChannelConfigs && typeof rawChannelConfigs === "object"
-      ? (rawChannelConfigs as ChannelConfigMap)
-      : null
+  const channelConfigs = readChannelConfigSnapshot(data)
 
   return {
     accounts,
@@ -547,7 +607,7 @@ function normalizeV1BackupForMerge(
 }
 
 /**
- * Import a canonical V2 backup (full or partial) into local storage.
+ * Import a canonical flat V2/V3 backup (full or partial) into local storage.
  */
 async function importV2Backup(
   data: BackupV2,
@@ -577,13 +637,13 @@ async function importV2Backup(
 
   const accountsRequested = "accounts" in data
   const preferencesRequested = "preferences" in data
-  const channelConfigsRequested =
-    "channelConfigs" in data && Boolean((data as BackupFullV2).channelConfigs)
+  const channelConfigSnapshot = readChannelConfigSnapshot(data)
+  const channelConfigsRequested = channelConfigSnapshot !== null
   const apiCredentialProfilesRequested =
     "apiCredentialProfiles" in data &&
     Boolean((data as BackupFullV2).apiCredentialProfiles)
 
-  // V2 assumes flat structure: accounts / preferences / channelConfigs directly on root
+  // V2/V3 use a flat structure with sections directly on the root.
 
   if (accountsRequested) {
     await importV2AccountsWithReplace(data)
@@ -605,9 +665,7 @@ async function importV2Backup(
   }
 
   if (channelConfigsRequested) {
-    await channelConfigStorage.importConfigs(
-      (data as BackupFullV2).channelConfigs,
-    )
+    await channelConfigStorage.importConfigs(channelConfigSnapshot)
     channelConfigsImported = true
   }
 
@@ -734,9 +792,9 @@ async function importV2PreferencesWithReplace(
 
 /** Imports V2 channel configuration by replacing current channel configuration. */
 async function importV2ChannelConfigsWithReplace(data: BackupV2) {
-  await channelConfigStorage.importConfigs(
-    (data as BackupFullV2).channelConfigs,
-  )
+  const snapshot = readChannelConfigSnapshot(data)
+  if (!snapshot) return
+  await channelConfigStorage.importConfigs(snapshot)
 }
 
 /** Merges local and backup order lists while dropping ids absent from imported entries. */
@@ -781,36 +839,6 @@ function mergeByLatestUpdatedAt<T extends { id: string; updated_at?: number }>(
   }
 
   return Array.from(merged.values())
-}
-
-/** Merges channel configuration by channel id, preferring the newest updatedAt value. */
-function mergeChannelConfigs(
-  localChannelConfigs: ChannelConfigMap,
-  remoteChannelConfigs: ChannelConfigMap | null,
-) {
-  const merged: ChannelConfigMap = { ...localChannelConfigs }
-
-  if (!remoteChannelConfigs) {
-    return merged
-  }
-
-  for (const [key, value] of Object.entries(remoteChannelConfigs)) {
-    const channelId = Number(key)
-    if (!Number.isFinite(channelId) || channelId <= 0) continue
-
-    const localConfig = merged[channelId]
-    const remoteConfig = value as ChannelConfigMap[number]
-    const localUpdatedAt =
-      typeof localConfig?.updatedAt === "number" ? localConfig.updatedAt : 0
-    const remoteUpdatedAt =
-      typeof remoteConfig?.updatedAt === "number" ? remoteConfig.updatedAt : 0
-
-    if (!localConfig || remoteUpdatedAt > localUpdatedAt) {
-      merged[channelId] = remoteConfig
-    }
-  }
-
-  return merged
 }
 
 /** Merges V2 accounts/bookmarks into the current account storage. */
@@ -875,11 +903,9 @@ async function importV2AccountsWithMerge(
 
 /** Merges V2 channel configuration into current channel configuration. */
 async function importV2ChannelConfigsWithMerge(data: BackupV2) {
-  const localChannelConfigs = await channelConfigStorage.exportConfigs()
   const normalizedRemote = normalizeV2BackupForMerge(data as BackupFullV2, null)
-  await channelConfigStorage.importConfigs(
-    mergeChannelConfigs(localChannelConfigs, normalizedRemote.channelConfigs),
-  )
+  if (!normalizedRemote.channelConfigs) return
+  await channelConfigStorage.mergeConfigs(normalizedRemote.channelConfigs)
 }
 
 /** Imports V2 API credential profiles using either merge or replace semantics. */
@@ -960,8 +986,7 @@ async function importV2BackupWithPlan(
 
   const accountsRequested = "accounts" in data
   const preferencesRequested = "preferences" in data
-  const channelConfigsRequested =
-    "channelConfigs" in data && Boolean((data as BackupFullV2).channelConfigs)
+  const channelConfigsRequested = readChannelConfigSnapshot(data) !== null
   const apiCredentialProfilesRequested =
     "apiCredentialProfiles" in data &&
     Boolean((data as BackupFullV2).apiCredentialProfiles)
@@ -1055,11 +1080,10 @@ async function importV2BackupWithPlan(
  * Dispatches to specific handlers per version:
  * - V1 (or missing version): tolerant of legacy shapes and tries to import
  *   accounts, preferences and channelConfigs when present.
- * - V2 (BACKUP_VERSION): expects a flat structure with accounts / preferences /
- *   channelConfigs at root.
- * - Future versions: currently fall back to the tolerant V1-style import
- *   (importV1Backup). When adding V3+, define an importV3Backup and extend
- *   this dispatcher.
+ * - V2: imports flat account/preference sections and ignores numeric channel configs.
+ * - V3 (BACKUP_VERSION): imports the same flat sections plus scoped channel configs.
+ * - Future or otherwise unknown explicit versions are rejected so their data is
+ *   not interpreted through an older schema.
  */
 export async function importFromBackupObject(
   data: RawBackupData,
@@ -1070,16 +1094,15 @@ export async function importFromBackupObject(
     throw new ImportExportError("FORMAT_NOT_CORRECT")
   }
 
-  const version = data.version ?? "1.0"
+  const version = getSupportedBackupVersion(data)
 
-  if (version === "1.0") {
+  if (version === LEGACY_BACKUP_V1_VERSION) {
     return importV1Backup(data, options)
   }
 
-  if (version === BACKUP_VERSION) {
+  if (version === BACKUP_VERSION || version === LEGACY_BACKUP_V2_VERSION) {
     return importV2Backup(data as BackupV2, options)
   }
 
-  // Unknown future version: fall back to tolerant V1-style import
-  return importV1Backup(data, options)
+  throw new ImportExportError("VERSION_NOT_SUPPORTED")
 }

--- a/src/services/managedSites/channelConfigMessaging.ts
+++ b/src/services/managedSites/channelConfigMessaging.ts
@@ -1,10 +1,7 @@
 import { defineExtensionMessaging } from "~/services/runtimeMessaging/extensionMessaging"
 import { createRuntimeMessagingLogger } from "~/services/runtimeMessaging/logger"
 import type { RuntimeMessageResponse } from "~/services/runtimeMessaging/result"
-import type {
-  ChannelConfig,
-  ChannelResourceConfig,
-} from "~/types/channelConfig"
+import type { ChannelResourceConfig } from "~/types/channelConfig"
 import type { ChannelModelFilterRule } from "~/types/channelModelFilters"
 import type { ManagedUpstreamResourceRef } from "~/types/managedUpstreamResource"
 
@@ -17,18 +14,17 @@ export const ChannelConfigMessageTypes = {
 
 export interface ChannelConfigGetRequest {
   channelId?: number
-  resourceRef?: ManagedUpstreamResourceRef
+  resourceRef: ManagedUpstreamResourceRef
 }
 
 export interface ChannelConfigUpsertFiltersRequest {
   channelId?: number
-  resourceRef?: ManagedUpstreamResourceRef
+  resourceRef: ManagedUpstreamResourceRef
   filters: Array<IncomingChannelFilter | ChannelModelFilterRule>
 }
 
-export type ChannelConfigGetResponse = RuntimeMessageResponse<
-  ChannelConfig | ChannelResourceConfig
->
+export type ChannelConfigGetResponse =
+  RuntimeMessageResponse<ChannelResourceConfig>
 export type ChannelConfigUpsertFiltersResponse = RuntimeMessageResponse<
   ChannelModelFilterRule[]
 >

--- a/src/services/managedSites/channelConfigStorage.ts
+++ b/src/services/managedSites/channelConfigStorage.ts
@@ -35,6 +35,7 @@ import { getErrorMessage } from "~/utils/core/error"
 import { createLogger } from "~/utils/core/logger"
 
 import {
+  isSafeChannelModelFilterRegex,
   normalizeChannelFilters,
   sanitizeChannelFilter,
   type IncomingChannelFilter,
@@ -140,9 +141,7 @@ function isCanonicalChannelModelFilterRule(
   }
 
   if (value.isRegex) {
-    try {
-      new RegExp(value.pattern)
-    } catch {
+    if (!isSafeChannelModelFilterRegex(value.pattern)) {
       return false
     }
   }

--- a/src/services/managedSites/channelConfigStorage.ts
+++ b/src/services/managedSites/channelConfigStorage.ts
@@ -203,15 +203,6 @@ function sanitizeModelFilterSettings(
           }),
         )
         .filter((filter): filter is ChannelModelFilterRule => Boolean(filter))
-        .map((rule) => {
-          const updatedAt = isPositiveTimestamp(rule.updatedAt)
-            ? rule.updatedAt
-            : fallbackTimestamp
-          const createdAt = isPositiveTimestamp(rule.createdAt)
-            ? Math.min(rule.createdAt, updatedAt)
-            : fallbackTimestamp
-          return { ...rule, createdAt, updatedAt }
-        })
     : []
 
   const explicitUpdatedAt = isPositiveTimestamp(rawSettings?.updatedAt)
@@ -558,12 +549,16 @@ class ChannelConfigStorage {
         CHANNEL_CONFIG_STORAGE_KEYS.CHANNEL_CONFIGS,
       )
       const legacyConfigs = sanitizeLegacyNumericConfigMap(rawLegacyConfigs)
-      const resourceConfigs = await this.getAllConfigs()
       const result: LegacyChannelConfigMigrationResult = {
         migrated: 0,
         ambiguous: 0,
         unmatched: 0,
       }
+      if (!isRecord(rawLegacyConfigs)) {
+        return result
+      }
+
+      const resourceConfigs = await this.getAllConfigs()
       const migratedChannelIds = new Set<number>()
 
       for (const [channelIdKey, legacyConfig] of Object.entries(
@@ -608,9 +603,7 @@ class ChannelConfigStorage {
           resourceConfigs,
         )
 
-        const remainingLegacyConfigs = isRecord(rawLegacyConfigs)
-          ? { ...rawLegacyConfigs }
-          : {}
+        const remainingLegacyConfigs = { ...rawLegacyConfigs }
         for (const key of Object.keys(remainingLegacyConfigs)) {
           const channelId = toValidChannelId(key)
           if (channelId !== null && migratedChannelIds.has(channelId)) {

--- a/src/services/managedSites/channelConfigStorage.ts
+++ b/src/services/managedSites/channelConfigStorage.ts
@@ -49,10 +49,32 @@ type ManagedUpstreamResourceScope = Pick<
   "managedSiteType" | "scopeKey"
 >
 
+type LegacyNumericChannelConfig = Omit<ChannelResourceConfig, "resourceRef">
+type LegacyNumericChannelConfigMap = Record<number, LegacyNumericChannelConfig>
+type LegacyReplacementState =
+  | {
+      phase: "prepared"
+      snapshot: ChannelConfigSnapshot
+    }
+  | {
+      phase: "committed"
+    }
+
+export type LegacyChannelConfigMigrationCandidate = {
+  channelId: number
+  resourceRef: ManagedUpstreamResourceRef
+}
+
+export type LegacyChannelConfigMigrationResult = {
+  migrated: number
+  ambiguous: number
+  unmatched: number
+}
+
 /** Parses an optional positive numeric channel id used only as metadata. */
 function toValidChannelId(value: unknown): number | null {
   const channelId = Number(value)
-  return Number.isFinite(channelId) && channelId > 0 ? channelId : null
+  return Number.isSafeInteger(channelId) && channelId > 0 ? channelId : null
 }
 
 /** Checks for a plain object-shaped storage or snapshot value. */
@@ -253,6 +275,60 @@ function sanitizeResourceConfig(
   }
 }
 
+/** Sanitizes the obsolete numeric shape exclusively for one-time migration. */
+function sanitizeLegacyNumericConfigMap(
+  raw: unknown,
+): LegacyNumericChannelConfigMap {
+  if (!isRecord(raw)) {
+    return {}
+  }
+
+  const configs: LegacyNumericChannelConfigMap = {}
+  for (const [key, value] of Object.entries(raw)) {
+    const channelId = toValidChannelId(key)
+    if (channelId === null || !isRecord(value)) continue
+
+    const payload = value as Partial<LegacyNumericChannelConfig> & {
+      filters?: unknown
+      modelFilterSettings?: Partial<ChannelModelFilterSettings> & {
+        rules?: unknown
+      }
+    }
+    if (
+      !isRecord(payload.modelFilterSettings) &&
+      !Array.isArray(payload.filters)
+    ) {
+      continue
+    }
+    const modelFilterSettings = sanitizeModelFilterSettings(
+      payload.modelFilterSettings,
+      payload.filters,
+      HISTORICAL_CHANNEL_CONFIG_TIMESTAMP,
+    )
+    const updatedAt = Math.max(
+      isPositiveTimestamp(payload.updatedAt)
+        ? payload.updatedAt
+        : HISTORICAL_CHANNEL_CONFIG_TIMESTAMP,
+      modelFilterSettings.updatedAt,
+    )
+    const createdAt = Math.min(
+      isPositiveTimestamp(payload.createdAt)
+        ? payload.createdAt
+        : HISTORICAL_CHANNEL_CONFIG_TIMESTAMP,
+      updatedAt,
+    )
+
+    configs[channelId] = {
+      channelId,
+      modelFilterSettings,
+      createdAt,
+      updatedAt,
+    }
+  }
+
+  return configs
+}
+
 /** Strictly validates one externally supplied snapshot entry. */
 function coerceSnapshotResourceConfig(
   value: unknown,
@@ -376,23 +452,184 @@ class ChannelConfigStorage {
     return withExtensionStorageWriteLock(STORAGE_LOCKS.CHANNEL_CONFIG, work)
   }
 
-  /** Removes the obsolete numeric store without re-enabling it on cleanup failure. */
-  private async discardLegacyNumericConfigs(): Promise<void> {
-    try {
-      await this.storage.remove(CHANNEL_CONFIG_STORAGE_KEYS.CHANNEL_CONFIGS)
-    } catch (error) {
-      // The legacy key is never read again; retry cleanup on the next operation.
-      logger.warn("Failed to discard legacy numeric channel configs", error)
+  private async getLegacyReplacementState(): Promise<LegacyReplacementState | null> {
+    const rawState = await this.storage.get(
+      CHANNEL_CONFIG_STORAGE_KEYS.LEGACY_REPLACEMENT_STATE,
+    )
+    if (rawState === null || rawState === undefined) {
+      return null
     }
+    if (isRecord(rawState) && rawState.phase === "committed") {
+      return { phase: "committed" }
+    }
+    if (isRecord(rawState) && rawState.phase === "prepared") {
+      const snapshot = coerceChannelConfigSnapshot(rawState.snapshot)
+      if (snapshot) {
+        return { phase: "prepared", snapshot }
+      }
+    }
+    throw new Error("Channel config snapshot replacement state is invalid")
+  }
+
+  private async assertNoIncompleteLegacyReplacement(): Promise<void> {
+    if ((await this.getLegacyReplacementState()) !== null) {
+      throw new Error("Channel config snapshot replacement is incomplete")
+    }
+  }
+
+  /** Finalizes cleanup after a scoped replacement has been durably committed. */
+  private async finalizeCommittedLegacyReplacement(): Promise<void> {
+    await this.storage.remove(CHANNEL_CONFIG_STORAGE_KEYS.CHANNEL_CONFIGS)
+    await this.storage.remove(
+      CHANNEL_CONFIG_STORAGE_KEYS.LEGACY_REPLACEMENT_STATE,
+    )
+  }
+
+  /** Replays or finalizes a durable scoped-replacement transaction. */
+  private async recoverLegacyReplacement(
+    state: LegacyReplacementState,
+  ): Promise<void> {
+    if (state.phase === "prepared") {
+      await this.storage.set(
+        CHANNEL_CONFIG_STORAGE_KEYS.CHANNEL_RESOURCE_CONFIGS,
+        state.snapshot.configs,
+      )
+      await this.storage.set(
+        CHANNEL_CONFIG_STORAGE_KEYS.LEGACY_REPLACEMENT_STATE,
+        { phase: "committed" } satisfies LegacyReplacementState,
+      )
+    }
+    await this.finalizeCommittedLegacyReplacement()
   }
 
   /** Loads every resource-scoped configuration from authoritative storage. */
   private async getAllConfigs(): Promise<ChannelResourceConfigMap> {
-    await this.discardLegacyNumericConfigs()
+    await this.assertNoIncompleteLegacyReplacement()
     const stored = await this.storage.get(
       CHANNEL_CONFIG_STORAGE_KEYS.CHANNEL_RESOURCE_CONFIGS,
     )
     return sanitizeResourceConfigMap(stored)
+  }
+
+  /** Returns whether valid legacy numeric data remains available to migrate. */
+  async hasLegacyNumericConfigs(): Promise<boolean> {
+    return await this.withStorageWriteLock(async () => {
+      const replacementState = await this.getLegacyReplacementState()
+      if (replacementState) {
+        await this.recoverLegacyReplacement(replacementState)
+        return false
+      }
+
+      const stored = await this.storage.get(
+        CHANNEL_CONFIG_STORAGE_KEYS.CHANNEL_CONFIGS,
+      )
+      return Object.keys(sanitizeLegacyNumericConfigMap(stored)).length > 0
+    })
+  }
+
+  /**
+   * Resolves legacy numeric configs against a complete discovered inventory.
+   *
+   * Callers must supply candidates only after every configured deployment was
+   * enumerated successfully. Zero/multiple candidates are deliberately not
+   * guessed. Uniquely resolved configs are persisted before only their numeric
+   * predecessors are removed; unresolved entries remain retryable.
+   */
+  async migrateLegacyNumericConfigs(
+    candidates: LegacyChannelConfigMigrationCandidate[],
+  ): Promise<LegacyChannelConfigMigrationResult> {
+    const candidatesByChannelId = new Map<
+      number,
+      Map<string, ManagedUpstreamResourceRef>
+    >()
+
+    for (const candidate of candidates) {
+      const channelId = toValidChannelId(candidate.channelId)
+      const resourceRef = normalizeResourceRef(candidate.resourceRef)
+      if (channelId === null || !resourceRef) continue
+
+      const resources = candidatesByChannelId.get(channelId) ?? new Map()
+      resources.set(getManagedUpstreamResourceRefKey(resourceRef), resourceRef)
+      candidatesByChannelId.set(channelId, resources)
+    }
+
+    return this.withStorageWriteLock(async () => {
+      await this.assertNoIncompleteLegacyReplacement()
+      const rawLegacyConfigs = await this.storage.get<unknown>(
+        CHANNEL_CONFIG_STORAGE_KEYS.CHANNEL_CONFIGS,
+      )
+      const legacyConfigs = sanitizeLegacyNumericConfigMap(rawLegacyConfigs)
+      const resourceConfigs = await this.getAllConfigs()
+      const result: LegacyChannelConfigMigrationResult = {
+        migrated: 0,
+        ambiguous: 0,
+        unmatched: 0,
+      }
+      const migratedChannelIds = new Set<number>()
+
+      for (const [channelIdKey, legacyConfig] of Object.entries(
+        legacyConfigs,
+      )) {
+        const channelId = Number(channelIdKey)
+        const resources = Array.from(
+          candidatesByChannelId.get(channelId)?.values() ?? [],
+        )
+
+        if (resources.length === 0) {
+          result.unmatched += 1
+          continue
+        }
+        if (resources.length > 1) {
+          result.ambiguous += 1
+          continue
+        }
+
+        const resourceRef = resources[0]
+        const resourceKey = getManagedUpstreamResourceRefKey(resourceRef)
+        const existing = resourceConfigs[resourceKey]
+        if (!existing || legacyConfig.updatedAt > existing.updatedAt) {
+          resourceConfigs[resourceKey] = {
+            ...legacyConfig,
+            resourceRef,
+            channelId,
+            createdAt: existing
+              ? Math.min(existing.createdAt, legacyConfig.createdAt)
+              : legacyConfig.createdAt,
+          }
+        } else if (existing.channelId !== channelId) {
+          resourceConfigs[resourceKey] = { ...existing, channelId }
+        }
+        result.migrated += 1
+        migratedChannelIds.add(channelId)
+      }
+
+      if (result.migrated > 0) {
+        await this.storage.set(
+          CHANNEL_CONFIG_STORAGE_KEYS.CHANNEL_RESOURCE_CONFIGS,
+          resourceConfigs,
+        )
+
+        const remainingLegacyConfigs = isRecord(rawLegacyConfigs)
+          ? { ...rawLegacyConfigs }
+          : {}
+        for (const key of Object.keys(remainingLegacyConfigs)) {
+          const channelId = toValidChannelId(key)
+          if (channelId !== null && migratedChannelIds.has(channelId)) {
+            delete remainingLegacyConfigs[key]
+          }
+        }
+
+        if (Object.keys(remainingLegacyConfigs).length > 0) {
+          await this.storage.set(
+            CHANNEL_CONFIG_STORAGE_KEYS.CHANNEL_CONFIGS,
+            remainingLegacyConfigs,
+          )
+        } else {
+          await this.storage.remove(CHANNEL_CONFIG_STORAGE_KEYS.CHANNEL_CONFIGS)
+        }
+      }
+      return result
+    })
   }
 
   /** Loads configurations belonging to one managed-site type and deployment scope. */
@@ -463,11 +700,41 @@ class ChannelConfigStorage {
     }
 
     await this.withStorageWriteLock(async () => {
+      const replacementState = await this.getLegacyReplacementState()
+      if (replacementState) {
+        await this.recoverLegacyReplacement(replacementState)
+      }
+
+      const legacySource = await this.storage.get(
+        CHANNEL_CONFIG_STORAGE_KEYS.CHANNEL_CONFIGS,
+      )
+      const hasLegacySource = isRecord(legacySource)
+        ? Object.keys(legacySource).length > 0
+        : legacySource !== null && legacySource !== undefined
+      const needsLegacyCleanup = hasLegacySource
+
+      if (needsLegacyCleanup) {
+        await this.storage.set(
+          CHANNEL_CONFIG_STORAGE_KEYS.LEGACY_REPLACEMENT_STATE,
+          {
+            phase: "prepared",
+            snapshot,
+          } satisfies LegacyReplacementState,
+        )
+      }
       await this.storage.set(
         CHANNEL_CONFIG_STORAGE_KEYS.CHANNEL_RESOURCE_CONFIGS,
         snapshot.configs,
       )
-      await this.discardLegacyNumericConfigs()
+      if (needsLegacyCleanup) {
+        await this.storage.set(
+          CHANNEL_CONFIG_STORAGE_KEYS.LEGACY_REPLACEMENT_STATE,
+          { phase: "committed" } satisfies LegacyReplacementState,
+        )
+        // A committed replacement supersedes the obsolete migration source.
+        // The marker lets a later startup finish cleanup without resurrecting it.
+        await this.finalizeCommittedLegacyReplacement()
+      }
     })
     return Object.keys(snapshot.configs).length
   }
@@ -491,7 +758,6 @@ class ChannelConfigStorage {
         CHANNEL_CONFIG_STORAGE_KEYS.CHANNEL_RESOURCE_CONFIGS,
         merged.configs,
       )
-      await this.discardLegacyNumericConfigs()
       return merged
     })
   }

--- a/src/services/managedSites/channelConfigStorage.ts
+++ b/src/services/managedSites/channelConfigStorage.ts
@@ -1,6 +1,11 @@
 import { Storage } from "@plasmohq/storage"
 
-import { isManagedSiteType, SITE_TYPES } from "~/constants/siteType"
+import { isManagedSiteType } from "~/constants/siteType"
+import {
+  CHANNEL_CONFIG_STORAGE_KEYS,
+  STORAGE_LOCKS,
+} from "~/services/core/storageKeys"
+import { withExtensionStorageWriteLock } from "~/services/core/storageWriteLock"
 import {
   ChannelConfigMessageTypes,
   onChannelConfigMessage,
@@ -9,23 +14,21 @@ import {
   type ChannelConfigUpsertFiltersRequest,
   type ChannelConfigUpsertFiltersResponse,
 } from "~/services/managedSites/channelConfigMessaging"
-import {
-  isManagedSiteFeatureResourceSliceEnabled,
-  MANAGED_UPSTREAM_RESOURCE_FEATURES,
-} from "~/services/managedSites/managedUpstreamResourceMigration"
 import { createRuntimeMessageFailure } from "~/services/runtimeMessaging/result"
 import {
-  createDefaultChannelConfig,
+  CHANNEL_CONFIG_SNAPSHOT_VERSION,
   createDefaultChannelResourceConfig,
-  type ChannelConfig,
-  type ChannelConfigMap,
+  type ChannelConfigSnapshot,
   type ChannelModelFilterSettings,
   type ChannelResourceConfig,
   type ChannelResourceConfigMap,
 } from "~/types/channelConfig"
 import type { ChannelModelFilterRule } from "~/types/channelModelFilters"
+import { CHANNEL_MODEL_FILTER_PROBE_IDS } from "~/types/channelModelFilters"
 import {
+  createManagedUpstreamResourceRef,
   getManagedUpstreamResourceRefKey,
+  normalizeManagedUpstreamResourceScopeKey,
   type ManagedUpstreamResourceRef,
 } from "~/types/managedUpstreamResource"
 import { getErrorMessage } from "~/utils/core/error"
@@ -39,293 +42,498 @@ import {
 
 const logger = createLogger("ChannelConfigStorage")
 
-const STORAGE_KEYS = {
-  CHANNEL_CONFIGS: "channel_configs",
-  CHANNEL_RESOURCE_CONFIGS: "channel_resource_configs",
-} as const
+const HISTORICAL_CHANNEL_CONFIG_TIMESTAMP = 1
 
-const CHANNEL_CONFIG_MIRROR_RESOURCE_SITE_TYPES = new Set<string>([
-  SITE_TYPES.NEW_API,
-  SITE_TYPES.VELOERA,
-  SITE_TYPES.DONE_HUB,
-])
+type ManagedUpstreamResourceScope = Pick<
+  ManagedUpstreamResourceRef,
+  "managedSiteType" | "scopeKey"
+>
 
-/**
- * Parses a positive numeric channel id from runtime or storage inputs.
- */
+/** Parses an optional positive numeric channel id used only as metadata. */
 function toValidChannelId(value: unknown): number | null {
   const channelId = Number(value)
   return Number.isFinite(channelId) && channelId > 0 ? channelId : null
 }
 
-/**
- * Validates resource refs accepted at the channel-config runtime boundary.
- */
-function isManagedUpstreamResourceRef(
+/** Checks for a plain object-shaped storage or snapshot value. */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value)
+}
+
+/** Checks for a finite positive timestamp accepted by the snapshot schema. */
+function isPositiveTimestamp(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+}
+
+const supportedProbeIds = new Set<string>(CHANNEL_MODEL_FILTER_PROBE_IDS)
+
+/** Validates one canonical rule without applying behavior-changing fallbacks. */
+function isCanonicalChannelModelFilterRule(
   value: unknown,
-): value is ManagedUpstreamResourceRef {
-  if (!value || typeof value !== "object") {
+): value is ChannelModelFilterRule {
+  if (!isRecord(value)) return false
+
+  if (
+    typeof value.id !== "string" ||
+    !value.id.trim() ||
+    typeof value.name !== "string" ||
+    !value.name.trim() ||
+    (value.description !== undefined &&
+      typeof value.description !== "string") ||
+    (value.action !== "include" && value.action !== "exclude") ||
+    typeof value.enabled !== "boolean" ||
+    !isPositiveTimestamp(value.createdAt) ||
+    !isPositiveTimestamp(value.updatedAt) ||
+    value.createdAt > value.updatedAt
+  ) {
     return false
   }
 
-  const ref = value as Partial<ManagedUpstreamResourceRef>
-  return (
-    isManagedSiteType(ref.managedSiteType) &&
-    typeof ref.scopeKey === "string" &&
-    ref.scopeKey.trim().length > 0 &&
-    typeof ref.resourceId === "string" &&
-    ref.resourceId.trim().length > 0 &&
-    isManagedSiteFeatureResourceSliceEnabled(
-      ref.managedSiteType,
-      MANAGED_UPSTREAM_RESOURCE_FEATURES.ChannelConfigStorage,
+  if (value.kind === "probe") {
+    if (
+      !Array.isArray(value.probeIds) ||
+      value.probeIds.length === 0 ||
+      (value.match !== "all" && value.match !== "any")
+    ) {
+      return false
+    }
+
+    const probeIds = value.probeIds.filter(
+      (probeId): probeId is string => typeof probeId === "string",
     )
-  )
-}
+    return (
+      probeIds.length === value.probeIds.length &&
+      new Set(probeIds).size === probeIds.length &&
+      probeIds.every((probeId) => supportedProbeIds.has(probeId))
+    )
+  }
 
-/**
- * Keeps channel-shaped resource writes compatible with legacy numeric readers.
- */
-function shouldMirrorResourceConfigToChannelConfig(
-  resourceRef: ManagedUpstreamResourceRef,
-  channelId: number,
-): boolean {
-  return (
-    CHANNEL_CONFIG_MIRROR_RESOURCE_SITE_TYPES.has(
-      resourceRef.managedSiteType,
-    ) && resourceRef.resourceId === String(channelId)
-  )
-}
-
-/**
- * Projects channel-shaped resource configs for legacy numeric readers.
- */
-function toMirroredChannelConfig(
-  config: ChannelResourceConfig,
-): ChannelConfig | null {
-  const channelId = toValidChannelId(config.channelId)
   if (
-    channelId === null ||
-    !shouldMirrorResourceConfigToChannelConfig(config.resourceRef, channelId)
+    value.kind !== "pattern" ||
+    typeof value.pattern !== "string" ||
+    !value.pattern.trim() ||
+    typeof value.isRegex !== "boolean"
+  ) {
+    return false
+  }
+
+  if (value.isRegex) {
+    try {
+      new RegExp(value.pattern)
+    } catch {
+      return false
+    }
+  }
+
+  return true
+}
+
+/** Validates and canonicalizes a managed upstream resource identity. */
+function normalizeResourceRef(
+  value: unknown,
+): ManagedUpstreamResourceRef | null {
+  if (!value || typeof value !== "object") {
+    return null
+  }
+
+  const ref = value as Partial<ManagedUpstreamResourceRef>
+  if (
+    !isManagedSiteType(ref.managedSiteType) ||
+    typeof ref.scopeKey !== "string" ||
+    !ref.scopeKey.trim() ||
+    typeof ref.resourceId !== "string" ||
+    !ref.resourceId.trim()
   ) {
     return null
   }
 
+  return createManagedUpstreamResourceRef({
+    managedSiteType: ref.managedSiteType,
+    scopeKey: ref.scopeKey,
+    resourceId: ref.resourceId,
+  })
+}
+
+/** Checks whether a runtime value contains a valid resource identity. */
+function isManagedUpstreamResourceRef(
+  value: unknown,
+): value is ManagedUpstreamResourceRef {
+  return normalizeResourceRef(value) !== null
+}
+
+/** Sanitizes persisted model-filter settings and historical resource filter fields. */
+function sanitizeModelFilterSettings(
+  rawSettings:
+    | (Partial<ChannelModelFilterSettings> & { rules?: unknown })
+    | undefined,
+  legacyFilters: unknown,
+  fallbackTimestamp: number,
+): ChannelModelFilterSettings {
+  const rawRules =
+    rawSettings && typeof rawSettings === "object"
+      ? rawSettings.rules
+      : legacyFilters
+  const rules = Array.isArray(rawRules)
+    ? rawRules
+        .map((filter) =>
+          sanitizeChannelFilter(filter, {
+            fallbackTimestamp,
+            idPrefix: "channel-filter",
+          }),
+        )
+        .filter((filter): filter is ChannelModelFilterRule => Boolean(filter))
+        .map((rule) => {
+          const updatedAt = isPositiveTimestamp(rule.updatedAt)
+            ? rule.updatedAt
+            : fallbackTimestamp
+          const createdAt = isPositiveTimestamp(rule.createdAt)
+            ? Math.min(rule.createdAt, updatedAt)
+            : fallbackTimestamp
+          return { ...rule, createdAt, updatedAt }
+        })
+    : []
+
+  const explicitUpdatedAt = isPositiveTimestamp(rawSettings?.updatedAt)
+    ? rawSettings.updatedAt
+    : fallbackTimestamp
   return {
-    channelId,
-    modelFilterSettings: config.modelFilterSettings,
-    createdAt: config.createdAt,
-    updatedAt: config.updatedAt,
+    rules,
+    updatedAt: Math.max(
+      explicitUpdatedAt,
+      ...rules.map((rule) => rule.updatedAt),
+    ),
   }
 }
 
+/** Sanitizes one persisted resource-scoped channel configuration. */
+function sanitizeResourceConfig(
+  value: unknown,
+  fallbackTimestamp = HISTORICAL_CHANNEL_CONFIG_TIMESTAMP,
+): ChannelResourceConfig | null {
+  if (!value || typeof value !== "object") {
+    return null
+  }
+
+  const payload = value as Partial<ChannelResourceConfig> & {
+    filters?: unknown
+    modelFilterSettings?: Partial<ChannelModelFilterSettings> & {
+      rules?: unknown
+    }
+  }
+  const resourceRef = normalizeResourceRef(payload.resourceRef)
+  if (!resourceRef) {
+    return null
+  }
+
+  const modelFilterSettings = sanitizeModelFilterSettings(
+    payload.modelFilterSettings,
+    payload.filters,
+    fallbackTimestamp,
+  )
+  const channelId = toValidChannelId(payload.channelId)
+  const updatedAt = Math.max(
+    isPositiveTimestamp(payload.updatedAt)
+      ? payload.updatedAt
+      : fallbackTimestamp,
+    modelFilterSettings.updatedAt,
+  )
+  const createdAt = Math.min(
+    isPositiveTimestamp(payload.createdAt)
+      ? payload.createdAt
+      : fallbackTimestamp,
+    updatedAt,
+  )
+
+  return {
+    resourceRef,
+    ...(channelId !== null ? { channelId } : {}),
+    modelFilterSettings,
+    createdAt,
+    updatedAt,
+  }
+}
+
+/** Strictly validates one externally supplied snapshot entry. */
+function coerceSnapshotResourceConfig(
+  value: unknown,
+): ChannelResourceConfig | null {
+  if (!isRecord(value)) return null
+
+  const payload = value as Partial<ChannelResourceConfig>
+  const settings = payload.modelFilterSettings
+  if (
+    !normalizeResourceRef(payload.resourceRef) ||
+    (payload.channelId !== undefined &&
+      (typeof payload.channelId !== "number" ||
+        toValidChannelId(payload.channelId) === null)) ||
+    !isPositiveTimestamp(payload.createdAt) ||
+    !isPositiveTimestamp(payload.updatedAt) ||
+    payload.createdAt > payload.updatedAt ||
+    !isRecord(settings) ||
+    !isPositiveTimestamp(settings.updatedAt) ||
+    settings.updatedAt > payload.updatedAt ||
+    !Array.isArray(settings.rules) ||
+    settings.rules.some(
+      (rule) =>
+        !isCanonicalChannelModelFilterRule(rule) ||
+        rule.updatedAt > settings.updatedAt,
+    )
+  ) {
+    return null
+  }
+
+  return sanitizeResourceConfig(value, HISTORICAL_CHANNEL_CONFIG_TIMESTAMP)
+}
+
+/** Sanitizes and rekeys persisted configs from their structured resource refs. */
+function sanitizeResourceConfigMap(raw: unknown): ChannelResourceConfigMap {
+  if (!isRecord(raw)) {
+    return {}
+  }
+
+  const configs: ChannelResourceConfigMap = {}
+  for (const value of Object.values(raw as Record<string, unknown>)) {
+    const config = sanitizeResourceConfig(value)
+    if (!config) continue
+    configs[getManagedUpstreamResourceRefKey(config.resourceRef)] = config
+  }
+  return configs
+}
+
+/** Strictly validates and canonically rekeys an external snapshot map. */
+function coerceSnapshotResourceConfigMap(
+  raw: unknown,
+): ChannelResourceConfigMap | null {
+  if (!isRecord(raw)) return null
+
+  const configs: ChannelResourceConfigMap = {}
+  for (const value of Object.values(raw)) {
+    const config = coerceSnapshotResourceConfig(value)
+    if (!config) return null
+
+    const key = getManagedUpstreamResourceRefKey(config.resourceRef)
+    if (configs[key]) return null
+    configs[key] = config
+  }
+  return configs
+}
+
+/** Coerces an unknown backup value into the current scoped snapshot schema. */
+export function coerceChannelConfigSnapshot(
+  raw: unknown,
+): ChannelConfigSnapshot | null {
+  if (!raw || typeof raw !== "object") {
+    return null
+  }
+
+  const snapshot = raw as Partial<ChannelConfigSnapshot>
+  if (
+    snapshot.schemaVersion !== CHANNEL_CONFIG_SNAPSHOT_VERSION ||
+    !snapshot.configs ||
+    typeof snapshot.configs !== "object"
+  ) {
+    return null
+  }
+
+  const configs = coerceSnapshotResourceConfigMap(snapshot.configs)
+  if (!configs) return null
+
+  return {
+    schemaVersion: CHANNEL_CONFIG_SNAPSHOT_VERSION,
+    configs,
+  }
+}
+
+/** Merges snapshots by full resource identity, keeping the newest conflict. */
+function mergeChannelConfigSnapshots(
+  local: ChannelConfigSnapshot,
+  remote: ChannelConfigSnapshot | null,
+): ChannelConfigSnapshot {
+  const configs: ChannelResourceConfigMap = { ...local.configs }
+
+  for (const [key, remoteConfig] of Object.entries(remote?.configs ?? {})) {
+    const localConfig = configs[key]
+    if (!localConfig || remoteConfig.updatedAt > localConfig.updatedAt) {
+      configs[key] = remoteConfig
+    }
+  }
+
+  return {
+    schemaVersion: CHANNEL_CONFIG_SNAPSHOT_VERSION,
+    configs,
+  }
+}
+
+/** Owns the single resource-scoped persistence authority for channel settings. */
 class ChannelConfigStorage {
   private storage: Storage
 
   constructor() {
-    this.storage = new Storage({
-      area: "local",
+    this.storage = new Storage({ area: "local" })
+  }
+
+  private async withStorageWriteLock<T>(work: () => Promise<T>): Promise<T> {
+    return withExtensionStorageWriteLock(STORAGE_LOCKS.CHANNEL_CONFIG, work)
+  }
+
+  /** Removes the obsolete numeric store without re-enabling it on cleanup failure. */
+  private async discardLegacyNumericConfigs(): Promise<void> {
+    try {
+      await this.storage.remove(CHANNEL_CONFIG_STORAGE_KEYS.CHANNEL_CONFIGS)
+    } catch (error) {
+      // The legacy key is never read again; retry cleanup on the next operation.
+      logger.warn("Failed to discard legacy numeric channel configs", error)
+    }
+  }
+
+  /** Loads every resource-scoped configuration from authoritative storage. */
+  private async getAllConfigs(): Promise<ChannelResourceConfigMap> {
+    await this.discardLegacyNumericConfigs()
+    const stored = await this.storage.get(
+      CHANNEL_CONFIG_STORAGE_KEYS.CHANNEL_RESOURCE_CONFIGS,
+    )
+    return sanitizeResourceConfigMap(stored)
+  }
+
+  /** Loads configurations belonging to one managed-site type and deployment scope. */
+  async getConfigsForScope(
+    scope: ManagedUpstreamResourceScope,
+  ): Promise<ChannelResourceConfigMap> {
+    const configs = await this.getAllConfigs()
+    const normalizedScopeKey = normalizeManagedUpstreamResourceScopeKey(
+      scope.scopeKey,
+    )
+
+    return Object.fromEntries(
+      Object.entries(configs).filter(
+        ([, config]) =>
+          config.resourceRef.managedSiteType === scope.managedSiteType &&
+          config.resourceRef.scopeKey === normalizedScopeKey,
+      ),
+    )
+  }
+
+  /** Loads one resource configuration or returns an unsaved default. */
+  async getConfig(
+    resourceRef: ManagedUpstreamResourceRef,
+  ): Promise<ChannelResourceConfig> {
+    const normalizedRef = normalizeResourceRef(resourceRef)
+    if (!normalizedRef) {
+      throw new Error("resourceRef is invalid")
+    }
+
+    const configs = await this.getAllConfigs()
+    return (
+      configs[getManagedUpstreamResourceRefKey(normalizedRef)] ??
+      createDefaultChannelResourceConfig(normalizedRef)
+    )
+  }
+
+  /** Persists a validated config while the caller owns the storage write lock. */
+  private async saveSanitizedConfig(
+    sanitized: ChannelResourceConfig,
+  ): Promise<void> {
+    const configs = await this.getAllConfigs()
+    const resourceKey = getManagedUpstreamResourceRefKey(sanitized.resourceRef)
+    await this.storage.set(
+      CHANNEL_CONFIG_STORAGE_KEYS.CHANNEL_RESOURCE_CONFIGS,
+      {
+        ...configs,
+        [resourceKey]: {
+          ...sanitized,
+          updatedAt: Date.now(),
+        },
+      },
+    )
+  }
+
+  /** Exports the complete resource-scoped configuration snapshot. */
+  async exportConfigs(): Promise<ChannelConfigSnapshot> {
+    return {
+      schemaVersion: CHANNEL_CONFIG_SNAPSHOT_VERSION,
+      configs: await this.getAllConfigs(),
+    }
+  }
+
+  /** Replaces authoritative storage with a validated scoped snapshot. */
+  async importConfigs(rawSnapshot: unknown): Promise<number> {
+    const snapshot = coerceChannelConfigSnapshot(rawSnapshot)
+    if (!snapshot) {
+      throw new Error("Channel config snapshot is invalid")
+    }
+
+    await this.withStorageWriteLock(async () => {
+      await this.storage.set(
+        CHANNEL_CONFIG_STORAGE_KEYS.CHANNEL_RESOURCE_CONFIGS,
+        snapshot.configs,
+      )
+      await this.discardLegacyNumericConfigs()
+    })
+    return Object.keys(snapshot.configs).length
+  }
+
+  /** Atomically merges a validated snapshot with the latest persisted state. */
+  async mergeConfigs(rawSnapshot: unknown): Promise<ChannelConfigSnapshot> {
+    const incoming = coerceChannelConfigSnapshot(rawSnapshot)
+    if (!incoming) {
+      throw new Error("Channel config snapshot is invalid")
+    }
+
+    return this.withStorageWriteLock(async () => {
+      const merged = mergeChannelConfigSnapshots(
+        {
+          schemaVersion: CHANNEL_CONFIG_SNAPSHOT_VERSION,
+          configs: await this.getAllConfigs(),
+        },
+        incoming,
+      )
+      await this.storage.set(
+        CHANNEL_CONFIG_STORAGE_KEYS.CHANNEL_RESOURCE_CONFIGS,
+        merged.configs,
+      )
+      await this.discardLegacyNumericConfigs()
+      return merged
     })
   }
 
-  async getAllConfigs(): Promise<ChannelConfigMap> {
-    try {
-      const stored = (await this.storage.get(STORAGE_KEYS.CHANNEL_CONFIGS)) as
-        | ChannelConfigMap
-        | undefined
-      const resourceConfigs = await this.getAllResourceConfigs()
-      const merged: ChannelConfigMap = { ...(stored ?? {}) }
-
-      for (const resourceConfig of Object.values(resourceConfigs)) {
-        const mirrored = toMirroredChannelConfig(resourceConfig)
-        if (mirrored) {
-          merged[mirrored.channelId] = mirrored
-        }
-      }
-
-      return merged
-    } catch (error) {
-      logger.error("Failed to load configs", error)
-      return {}
-    }
-  }
-
-  async getAllResourceConfigs(): Promise<ChannelResourceConfigMap> {
-    try {
-      const stored = (await this.storage.get(
-        STORAGE_KEYS.CHANNEL_RESOURCE_CONFIGS,
-      )) as ChannelResourceConfigMap | undefined
-      return stored ?? {}
-    } catch (error) {
-      logger.error("Failed to load resource configs", error)
-      return {}
-    }
-  }
-
-  async getConfig(channelId: number): Promise<ChannelConfig> {
-    const configs = await this.getAllConfigs()
-    return configs[channelId] ?? createDefaultChannelConfig(channelId)
-  }
-
-  async getConfigByResourceRef(
-    resourceRef: ManagedUpstreamResourceRef,
-    fallbackChannelId?: number,
-  ): Promise<ChannelResourceConfig> {
-    const configs = await this.getAllResourceConfigs()
-    const resourceKey = getManagedUpstreamResourceRefKey(resourceRef)
-    const config = configs[resourceKey]
-    if (config) {
-      return config
-    }
-
-    const channelId = toValidChannelId(fallbackChannelId)
-    if (channelId !== null) {
-      const channelConfig = await this.getConfig(channelId)
-      return {
-        ...channelConfig,
-        resourceRef,
-      }
-    }
-
-    return createDefaultChannelResourceConfig(resourceRef)
-  }
-
-  async saveConfig(config: ChannelConfig): Promise<boolean> {
-    try {
-      const configs = await this.getAllConfigs()
-      const next: ChannelConfigMap = {
-        ...configs,
-        [config.channelId]: {
-          ...config,
-          updatedAt: Date.now(),
-        },
-      }
-      await this.storage.set(STORAGE_KEYS.CHANNEL_CONFIGS, next)
-      return true
-    } catch (error) {
-      logger.error("Failed to save config", error)
-      return false
-    }
-  }
-
-  async saveResourceConfig(config: ChannelResourceConfig): Promise<boolean> {
-    try {
-      const configs = await this.getAllResourceConfigs()
-      const resourceKey = getManagedUpstreamResourceRefKey(config.resourceRef)
-      const next: ChannelResourceConfigMap = {
-        ...configs,
-        [resourceKey]: {
-          ...config,
-          updatedAt: Date.now(),
-        },
-      }
-      await this.storage.set(STORAGE_KEYS.CHANNEL_RESOURCE_CONFIGS, next)
-      return true
-    } catch (error) {
-      logger.error("Failed to save resource config", error)
-      return false
-    }
-  }
-
-  async exportConfigs(): Promise<ChannelConfigMap> {
-    return this.getAllConfigs()
-  }
-
-  async importConfigs(rawConfigs: unknown): Promise<number> {
-    const sanitized = sanitizeChannelConfigMap(rawConfigs)
-    await this.storage.set(STORAGE_KEYS.CHANNEL_CONFIGS, sanitized)
-    return Object.keys(sanitized).length
-  }
-
+  /** Replaces model filter rules for one resource identity. */
   async upsertFilters(
-    channelId: number,
-    rules: ChannelModelFilterRule[],
-  ): Promise<boolean> {
-    const timestamp = Date.now()
-    const current = await this.getConfig(channelId)
-    const previousSettings =
-      current.modelFilterSettings ??
-      createDefaultChannelConfig(channelId).modelFilterSettings
-
-    const updated: ChannelConfig = {
-      ...current,
-      channelId,
-      modelFilterSettings: {
-        ...previousSettings,
-        rules,
-        updatedAt: timestamp,
-      },
-      updatedAt: timestamp,
-      createdAt: current.createdAt || timestamp,
-    }
-
-    return this.saveConfig(updated)
-  }
-
-  async upsertResourceFilters(
     resourceRef: ManagedUpstreamResourceRef,
     rules: ChannelModelFilterRule[],
-    fallbackChannelId?: number,
-  ): Promise<boolean> {
-    const timestamp = Date.now()
-    const channelId = toValidChannelId(fallbackChannelId)
-    const current = await this.getConfigByResourceRef(
-      resourceRef,
-      channelId ?? undefined,
-    )
-    const previousSettings =
-      current.modelFilterSettings ??
-      createDefaultChannelResourceConfig(resourceRef, channelId ?? undefined)
-        .modelFilterSettings
-
-    const updated: ChannelResourceConfig = {
-      ...current,
-      resourceRef,
-      ...(channelId !== null ? { channelId } : {}),
-      modelFilterSettings: {
-        ...previousSettings,
-        rules,
-        updatedAt: timestamp,
-      },
-      updatedAt: timestamp,
-      createdAt: current.createdAt || timestamp,
+    channelIdInput?: number,
+  ): Promise<void> {
+    const channelId = toValidChannelId(channelIdInput)
+    const normalizedRef = normalizeResourceRef(resourceRef)
+    if (!normalizedRef) {
+      throw new Error("resourceRef is invalid")
     }
 
-    const resourceSaved = await this.saveResourceConfig(updated)
-    if (!resourceSaved) {
-      return false
-    }
-
-    if (
-      channelId === null ||
-      !shouldMirrorResourceConfigToChannelConfig(resourceRef, channelId)
-    ) {
-      return true
-    }
-
-    const mirrorSaved = await this.upsertFilters(channelId, rules)
-    if (!mirrorSaved) {
-      logger.warn(
-        "Failed to mirror resource config to numeric channel config",
-        {
-          channelId,
-          resourceRef,
+    await this.withStorageWriteLock(async () => {
+      const timestamp = Date.now()
+      const current = await this.getConfig(normalizedRef)
+      const updated = sanitizeResourceConfig({
+        ...current,
+        resourceRef: normalizedRef,
+        ...(channelId !== null ? { channelId } : {}),
+        modelFilterSettings: {
+          ...current.modelFilterSettings,
+          rules,
+          updatedAt: timestamp,
         },
-      )
-    }
-
-    return true
+        updatedAt: timestamp,
+        createdAt: current.createdAt || timestamp,
+      })
+      if (!updated) {
+        throw new Error("Channel resource config is invalid")
+      }
+      await this.saveSanitizedConfig(updated)
+    })
   }
 }
 
 export const channelConfigStorage = new ChannelConfigStorage()
 
-/**
- * Normalize inbound filter payloads and ensure required fields are present.
- * Validates names/patterns and fills defaults for IDs and timestamps.
- * @param filters Incoming filter definitions from the UI or message bus.
- * @throws {Error} When required fields are missing or regex is invalid.
- * @returns Sanitized filter rules ready for persistence.
- */
+/** Normalizes filter inputs received through the runtime messaging boundary. */
 function normalizeFilters(
   filters: Array<IncomingChannelFilter | ChannelModelFilterRule>,
 ): ChannelModelFilterRule[] {
@@ -336,9 +544,7 @@ function normalizeFilters(
 
 let channelConfigMessagingCleanup: (() => void)[] | null = null
 
-/**
- * Background listeners for typed channel configuration messaging.
- */
+/** Registers channel-config runtime listeners once per background lifetime. */
 export function setupChannelConfigMessagingListeners() {
   if (channelConfigMessagingCleanup) {
     return
@@ -355,211 +561,43 @@ export function setupChannelConfigMessagingListeners() {
   ]
 }
 
-/**
- * Resolve typed runtime requests that fetch a channel configuration.
- */
+/** Resolves a resource-scoped channel-config read message. */
 export async function resolveChannelConfigGetMessage(
   request: ChannelConfigGetRequest,
 ): Promise<ChannelConfigGetResponse> {
   try {
-    const channelId = toValidChannelId(request.channelId)
-    if (
-      !request.resourceRef &&
-      request.channelId !== undefined &&
-      channelId === null
-    ) {
-      throw new Error("channelId is required")
+    if (!isManagedUpstreamResourceRef(request.resourceRef)) {
+      throw new Error("resourceRef is invalid")
     }
 
-    if (request.resourceRef) {
-      if (!isManagedUpstreamResourceRef(request.resourceRef)) {
-        throw new Error("resourceRef is invalid")
-      }
-
-      const config = await channelConfigStorage.getConfigByResourceRef(
-        request.resourceRef,
-        channelId ?? undefined,
-      )
-      return { success: true, data: config }
+    return {
+      success: true,
+      data: await channelConfigStorage.getConfig(request.resourceRef),
     }
-
-    if (channelId === null) {
-      throw new Error("channelId is required")
-    }
-
-    const config = await channelConfigStorage.getConfig(channelId)
-    return { success: true, data: config }
   } catch (error) {
     logger.error("Message handling failed", error)
     return createRuntimeMessageFailure(getErrorMessage(error))
   }
 }
 
-/**
- * Resolve typed runtime requests that persist channel filter rules.
- */
+/** Resolves a resource-scoped channel-filter write message. */
 export async function resolveChannelConfigUpsertFiltersMessage(
   request: ChannelConfigUpsertFiltersRequest,
 ): Promise<ChannelConfigUpsertFiltersResponse> {
   try {
-    const channelId = toValidChannelId(request.channelId)
-    if (
-      !request.resourceRef &&
-      request.channelId !== undefined &&
-      channelId === null
-    ) {
-      throw new Error("channelId is required")
+    if (!isManagedUpstreamResourceRef(request.resourceRef)) {
+      throw new Error("resourceRef is invalid")
     }
 
     const normalizedFilters = normalizeFilters(request.filters ?? [])
-    const success = request.resourceRef
-      ? isManagedUpstreamResourceRef(request.resourceRef)
-        ? await channelConfigStorage.upsertResourceFilters(
-            request.resourceRef,
-            normalizedFilters,
-            channelId ?? undefined,
-          )
-        : false
-      : channelId !== null
-        ? await channelConfigStorage.upsertFilters(channelId, normalizedFilters)
-        : false
-
-    if (!success) {
-      throw new Error(
-        request.resourceRef &&
-        !isManagedUpstreamResourceRef(request.resourceRef)
-          ? "resourceRef is invalid"
-          : "Failed to save channel filters",
-      )
-    }
-
+    await channelConfigStorage.upsertFilters(
+      request.resourceRef,
+      normalizedFilters,
+      request.channelId,
+    )
     return { success: true, data: normalizedFilters }
   } catch (error) {
     logger.error("Message handling failed", error)
     return createRuntimeMessageFailure(getErrorMessage(error))
   }
-}
-
-/**
- * Sanitize the raw config map received from import or storage.
- * Ensures keys are valid numeric channel IDs and values are cleaned configs.
- * @param rawConfigs Arbitrary raw object to be parsed as channel config map.
- * @returns Clean ChannelConfigMap keyed by channelId.
- */
-function sanitizeChannelConfigMap(rawConfigs: unknown): ChannelConfigMap {
-  if (!rawConfigs || typeof rawConfigs !== "object") {
-    return {}
-  }
-
-  const entries = Object.entries(rawConfigs as Record<string, unknown>)
-  return entries.reduce<ChannelConfigMap>((acc, [key, value]) => {
-    const channelId = Number(key)
-    if (!Number.isFinite(channelId) || channelId <= 0) {
-      return acc
-    }
-
-    acc[channelId] = sanitizeChannelConfig(value, channelId)
-    return acc
-  }, {})
-}
-
-/**
- * Sanitize a single channel config entry into the expected structure.
- * Applies default timestamps and cleans nested filter settings.
- * @param value Raw config object.
- * @param channelId Channel identifier for the config.
- * @returns Sanitized ChannelConfig.
- */
-function sanitizeChannelConfig(
-  value: unknown,
-  channelId: number,
-): ChannelConfig {
-  const timestamp = Date.now()
-  const payload = (value ?? {}) as Partial<ChannelConfig> & {
-    filters?: unknown
-    modelFilterSettings?: Partial<ChannelModelFilterSettings> & {
-      rules?: unknown
-    }
-  }
-
-  const modelFilterSettings = sanitizeModelFilterSettings(
-    payload.modelFilterSettings,
-    payload.filters,
-    timestamp,
-  )
-
-  return {
-    channelId,
-    modelFilterSettings,
-    createdAt:
-      typeof payload.createdAt === "number" && payload.createdAt > 0
-        ? payload.createdAt
-        : timestamp,
-    updatedAt:
-      typeof payload.updatedAt === "number" && payload.updatedAt > 0
-        ? payload.updatedAt
-        : modelFilterSettings.updatedAt,
-  }
-}
-
-/**
- * Sanitize filter settings including legacy filter arrays.
- * Converts raw rule entries into validated ChannelModelFilterRule items.
- * @param rawSettings Current stored settings with potential partial data.
- * @param legacyFilters Legacy filters array to migrate if rules are absent.
- * @param fallbackTimestamp Timestamp used when rule timestamps are missing.
- * @returns Clean ChannelModelFilterSettings with validated rules.
- */
-function sanitizeModelFilterSettings(
-  rawSettings:
-    | (Partial<ChannelModelFilterSettings> & { rules?: unknown })
-    | undefined,
-  legacyFilters: unknown,
-  fallbackTimestamp: number,
-): ChannelModelFilterSettings {
-  if (rawSettings && typeof rawSettings === "object") {
-    const rules = Array.isArray(rawSettings.rules)
-      ? rawSettings.rules
-          .map((filter) => sanitizeFilter(filter, fallbackTimestamp))
-          .filter((filter): filter is ChannelModelFilterRule => Boolean(filter))
-      : []
-
-    const updatedAt =
-      typeof rawSettings.updatedAt === "number" && rawSettings.updatedAt > 0
-        ? rawSettings.updatedAt
-        : fallbackTimestamp
-
-    return {
-      rules,
-      updatedAt,
-    }
-  }
-
-  const legacyRules = Array.isArray(legacyFilters)
-    ? legacyFilters
-        .map((filter) => sanitizeFilter(filter, fallbackTimestamp))
-        .filter((filter): filter is ChannelModelFilterRule => Boolean(filter))
-    : []
-
-  return {
-    rules: legacyRules,
-    updatedAt: fallbackTimestamp,
-  }
-}
-
-/**
- * Sanitize a single filter entry ensuring required fields and defaults.
- * Invalid or incomplete entries return null to be filtered out by callers.
- * @param filter Raw filter object.
- * @param fallbackTimestamp Timestamp used when per-rule timestamps are absent.
- * @returns Valid ChannelModelFilterRule or null when validation fails.
- */
-function sanitizeFilter(
-  filter: unknown,
-  fallbackTimestamp: number,
-): ChannelModelFilterRule | null {
-  return sanitizeChannelFilter(filter, {
-    fallbackTimestamp,
-    idPrefix: "channel-filter",
-  })
 }

--- a/src/services/managedSites/channelModelFilterRules.ts
+++ b/src/services/managedSites/channelModelFilterRules.ts
@@ -1,3 +1,5 @@
+import safeRegex from "safe-regex2"
+
 import type { ApiVerificationProbeId } from "~/services/verification/aiApiVerification"
 import type {
   ChannelFilterAction,
@@ -40,6 +42,15 @@ interface SanitizeChannelFilterOptions extends NormalizeChannelFiltersOptions {
 const supportedProbeIds = new Set<ApiVerificationProbeId>(
   CHANNEL_MODEL_FILTER_PROBE_IDS,
 )
+
+/** Rejects syntactically invalid or potentially exponential regex patterns. */
+export function isSafeChannelModelFilterRegex(pattern: string): boolean {
+  try {
+    return safeRegex(pattern)
+  } catch {
+    return false
+  }
+}
 
 /**
  * Normalize unknown rule action values into the supported include/exclude set.
@@ -132,10 +143,8 @@ function normalizePatternFilter(
   }
 
   if (payload.isRegex) {
-    try {
-      new RegExp(pattern)
-    } catch (error) {
-      throw new Error(`Invalid regex pattern: ${(error as Error).message}`)
+    if (!isSafeChannelModelFilterRegex(pattern)) {
+      throw new Error("Invalid or unsafe regex pattern")
     }
   }
 

--- a/src/services/managedSites/channelModelFilterRules.ts
+++ b/src/services/managedSites/channelModelFilterRules.ts
@@ -45,11 +45,7 @@ const supportedProbeIds = new Set<ApiVerificationProbeId>(
 
 /** Rejects syntactically invalid or potentially exponential regex patterns. */
 export function isSafeChannelModelFilterRegex(pattern: string): boolean {
-  try {
-    return safeRegex(pattern)
-  } catch {
-    return false
-  }
+  return safeRegex(pattern)
 }
 
 /**
@@ -256,11 +252,15 @@ export function sanitizeChannelFilter(
       idPrefix: options.idPrefix,
       now: options.fallbackTimestamp,
     })
+    const updatedAt = getTimestamp(payload.updatedAt, options.fallbackTimestamp)
 
     return {
       ...normalized,
-      createdAt: getTimestamp(payload.createdAt, options.fallbackTimestamp),
-      updatedAt: getTimestamp(payload.updatedAt, options.fallbackTimestamp),
+      createdAt: Math.min(
+        getTimestamp(payload.createdAt, options.fallbackTimestamp),
+        updatedAt,
+      ),
+      updatedAt,
     }
   } catch {
     return null

--- a/src/services/managedSites/legacyChannelConfigMigration.ts
+++ b/src/services/managedSites/legacyChannelConfigMigration.ts
@@ -1,0 +1,318 @@
+import { Storage } from "@plasmohq/storage"
+
+import { MANAGED_SITE_TYPES } from "~/constants/siteType"
+import { runAbortableTask } from "~/services/apiTransport/abortableTask"
+import {
+  CHANNEL_CONFIG_STORAGE_KEYS,
+  STORAGE_LOCKS,
+} from "~/services/core/storageKeys"
+import { withExtensionStorageWriteLock } from "~/services/core/storageWriteLock"
+import { channelConfigStorage } from "~/services/managedSites/channelConfigStorage"
+import {
+  getManagedSiteChannelResourceId,
+  getStableLegacyChannelId,
+} from "~/services/managedSites/managedSiteChannelResourceIdentity"
+import { getManagedSiteServiceForType } from "~/services/managedSites/managedSiteService"
+import {
+  hasManagedSiteRuntimeConfigInputForType,
+  resolveManagedSiteRuntimeConfigForType,
+  type ManagedSiteRuntimeConfig,
+} from "~/services/managedSites/runtimeConfig"
+import {
+  userPreferences,
+  type UserPreferences,
+} from "~/services/preferences/userPreferences"
+import {
+  createManagedUpstreamResourceRef,
+  normalizeManagedUpstreamResourceScopeKey,
+} from "~/types/managedUpstreamResource"
+import { createLogger } from "~/utils/core/logger"
+
+const logger = createLogger("LegacyChannelConfigMigration")
+const LEGACY_CHANNEL_INVENTORY_TIMEOUT_MS = 30_000
+const INITIAL_RETRY_DELAY_MS = 5 * 60_000
+const MAX_RETRY_DELAY_MS = 6 * 60 * 60_000
+
+type LegacyChannelConfigMigrationRetryState = {
+  attempt: number
+  retryAfter: number
+}
+
+type ManagedSiteInventoryTargets = {
+  targets: ManagedSiteRuntimeConfig[]
+  hasIncompleteConfig: boolean
+}
+
+/** Resolves complete deployment configs while detecting partial user input. */
+function resolveInventoryTargets(
+  preferences: UserPreferences,
+): ManagedSiteInventoryTargets {
+  const targets: ManagedSiteRuntimeConfig[] = []
+  let hasIncompleteConfig = false
+
+  for (const siteType of MANAGED_SITE_TYPES) {
+    const target = resolveManagedSiteRuntimeConfigForType(preferences, siteType)
+    if (target) {
+      targets.push(target)
+    } else if (hasManagedSiteRuntimeConfigInputForType(preferences, siteType)) {
+      hasIncompleteConfig = true
+    }
+  }
+
+  return { targets, hasIncompleteConfig }
+}
+
+/** Builds a deterministic identity for the deployment set being enumerated. */
+function getInventoryTargetFingerprint(
+  targets: ManagedSiteRuntimeConfig[],
+): string {
+  return targets
+    .map(
+      (target) =>
+        `${target.siteType}:${normalizeManagedUpstreamResourceScopeKey(target.config.baseUrl)}`,
+    )
+    .sort()
+    .join("\n")
+}
+
+export type LegacyChannelConfigMigrationOutcome =
+  | { status: "not-needed" }
+  | {
+      status: "completed"
+      migrated: number
+      ambiguous: number
+      unmatched: number
+    }
+  | {
+      status: "deferred"
+      reason:
+        | "no-configured-sites"
+        | "inventory-failed"
+        | "storage-failed"
+        | "backoff-active"
+        | "unresolved-identities"
+    }
+
+/**
+ * Discovers every configured deployment before resolving legacy numeric ids.
+ * A shared promise deduplicates callers within one extension context.
+ */
+class LegacyChannelConfigMigration {
+  private readonly storage = new Storage({ area: "local" })
+  private initializationPromise: Promise<LegacyChannelConfigMigrationOutcome> | null =
+    null
+
+  initialize(options?: {
+    bypassBackoff?: boolean
+  }): Promise<LegacyChannelConfigMigrationOutcome> {
+    if (!this.initializationPromise) {
+      const runPromise = this.run(options?.bypassBackoff ?? false)
+      this.initializationPromise = runPromise
+      void runPromise.then(
+        () => this.clearInitializationPromise(runPromise),
+        () => this.clearInitializationPromise(runPromise),
+      )
+    }
+    return this.initializationPromise
+  }
+
+  private clearInitializationPromise(
+    runPromise: Promise<LegacyChannelConfigMigrationOutcome>,
+  ): void {
+    if (this.initializationPromise === runPromise) {
+      this.initializationPromise = null
+    }
+  }
+
+  private async readRetryState(): Promise<LegacyChannelConfigMigrationRetryState | null> {
+    const raw = await this.storage.get(
+      CHANNEL_CONFIG_STORAGE_KEYS.LEGACY_MIGRATION_STATE,
+    )
+    if (!raw || typeof raw !== "object") return null
+
+    const candidate = raw as Partial<LegacyChannelConfigMigrationRetryState>
+    return Number.isInteger(candidate.attempt) &&
+      Number(candidate.attempt) >= 1 &&
+      Number.isFinite(candidate.retryAfter) &&
+      Number(candidate.retryAfter) > 0
+      ? {
+          attempt: Number(candidate.attempt),
+          retryAfter: Number(candidate.retryAfter),
+        }
+      : null
+  }
+
+  private async defer(
+    reason: Exclude<
+      Extract<
+        LegacyChannelConfigMigrationOutcome,
+        { status: "deferred" }
+      >["reason"],
+      "backoff-active"
+    >,
+  ): Promise<LegacyChannelConfigMigrationOutcome> {
+    try {
+      const previous = await this.readRetryState()
+      const attempt = Math.min((previous?.attempt ?? 0) + 1, 16)
+      const retryDelay = Math.min(
+        INITIAL_RETRY_DELAY_MS * 2 ** (attempt - 1),
+        MAX_RETRY_DELAY_MS,
+      )
+      await this.storage.set(
+        CHANNEL_CONFIG_STORAGE_KEYS.LEGACY_MIGRATION_STATE,
+        {
+          attempt,
+          retryAfter: Date.now() + retryDelay,
+        } satisfies LegacyChannelConfigMigrationRetryState,
+      )
+    } catch (error) {
+      logger.warn("Failed to persist legacy channel migration backoff", error)
+    }
+    return { status: "deferred", reason }
+  }
+
+  private async clearRetryState(): Promise<void> {
+    try {
+      await this.storage.remove(
+        CHANNEL_CONFIG_STORAGE_KEYS.LEGACY_MIGRATION_STATE,
+      )
+    } catch (error) {
+      logger.warn("Failed to clear legacy channel migration backoff", error)
+    }
+  }
+
+  private async run(
+    bypassBackoff: boolean,
+  ): Promise<LegacyChannelConfigMigrationOutcome> {
+    try {
+      return await withExtensionStorageWriteLock(
+        STORAGE_LOCKS.LEGACY_CHANNEL_CONFIG_MIGRATION,
+        async () => await this.runExclusive(bypassBackoff),
+      )
+    } catch (error) {
+      logger.warn("Legacy numeric channel config migration deferred", error)
+      return await this.defer("storage-failed")
+    }
+  }
+
+  private async runExclusive(
+    bypassBackoff: boolean,
+  ): Promise<LegacyChannelConfigMigrationOutcome> {
+    try {
+      if (!(await channelConfigStorage.hasLegacyNumericConfigs())) {
+        await this.clearRetryState()
+        return { status: "not-needed" }
+      }
+
+      const retryState = await this.readRetryState()
+      if (!bypassBackoff && retryState && retryState.retryAfter > Date.now()) {
+        return { status: "deferred", reason: "backoff-active" }
+      }
+
+      const preferences = await userPreferences.getPreferencesStrict()
+      const inventoryTargets = resolveInventoryTargets(preferences)
+      const { targets } = inventoryTargets
+
+      if (inventoryTargets.hasIncompleteConfig) {
+        return await this.defer("inventory-failed")
+      }
+
+      if (targets.length === 0) {
+        return await this.defer("no-configured-sites")
+      }
+
+      const inventoryResults = await Promise.allSettled(
+        targets.map(async (target) => {
+          const service = getManagedSiteServiceForType(target.siteType)
+          const channels = await runAbortableTask(
+            async (signal) =>
+              await service.listChannels(target.config, {
+                signal,
+                requireCompleteInventory: true,
+              }),
+            { timeoutMs: LEGACY_CHANNEL_INVENTORY_TIMEOUT_MS },
+          )
+
+          if (channels.items.length < channels.total) {
+            throw new Error("Managed-site channel inventory is incomplete")
+          }
+
+          return channels.items.flatMap((channel) => {
+            const channelId = getStableLegacyChannelId(target.siteType, channel)
+            return channelId === null
+              ? []
+              : [
+                  {
+                    channelId,
+                    resourceRef: createManagedUpstreamResourceRef({
+                      managedSiteType: target.siteType,
+                      scopeKey: target.config.baseUrl,
+                      resourceId: getManagedSiteChannelResourceId(
+                        target.siteType,
+                        channel,
+                      ),
+                    }),
+                  },
+                ]
+          })
+        }),
+      )
+
+      const failedCount = inventoryResults.filter(
+        (result) => result.status === "rejected",
+      ).length
+      if (failedCount > 0) {
+        logger.warn("Legacy channel config inventory is incomplete", {
+          configuredSiteCount: targets.length,
+          failedSiteCount: failedCount,
+        })
+        return await this.defer("inventory-failed")
+      }
+
+      const currentPreferences = await userPreferences.getPreferencesStrict()
+      const currentInventoryTargets =
+        resolveInventoryTargets(currentPreferences)
+      if (
+        currentInventoryTargets.hasIncompleteConfig ||
+        getInventoryTargetFingerprint(currentInventoryTargets.targets) !==
+          getInventoryTargetFingerprint(targets)
+      ) {
+        logger.warn("Managed-site configuration changed during migration")
+        return await this.defer("inventory-failed")
+      }
+
+      const candidates = inventoryResults.flatMap((result) =>
+        result.status === "fulfilled" ? result.value : [],
+      )
+      const migrated =
+        await channelConfigStorage.migrateLegacyNumericConfigs(candidates)
+      if (migrated.ambiguous > 0 || migrated.unmatched > 0) {
+        logger.warn(
+          "Legacy numeric channel configs remain unresolved",
+          migrated,
+        )
+        return await this.defer("unresolved-identities")
+      }
+      await this.clearRetryState()
+      logger.info("Legacy numeric channel config migration completed", migrated)
+      return { status: "completed", ...migrated }
+    } catch (error) {
+      logger.warn("Legacy numeric channel config migration deferred", error)
+      return await this.defer("storage-failed")
+    }
+  }
+}
+
+/** Ensures legacy numeric data is resolved before a scoped-only consumer runs. */
+export async function ensureLegacyChannelConfigMigrationReady(options?: {
+  bypassBackoff?: boolean
+}): Promise<void> {
+  const outcome = await legacyChannelConfigMigration.initialize(options)
+  if (outcome.status === "deferred") {
+    throw new Error(
+      `Legacy channel config migration deferred: ${outcome.reason}`,
+    )
+  }
+}
+
+export const legacyChannelConfigMigration = new LegacyChannelConfigMigration()

--- a/src/services/managedSites/legacyChannelConfigMigration.ts
+++ b/src/services/managedSites/legacyChannelConfigMigration.ts
@@ -102,11 +102,28 @@ class LegacyChannelConfigMigration {
   private initializationPromise: Promise<LegacyChannelConfigMigrationOutcome> | null =
     null
 
-  initialize(options?: {
+  async initialize(options?: {
     bypassBackoff?: boolean
   }): Promise<LegacyChannelConfigMigrationOutcome> {
+    const bypassBackoff = options?.bypassBackoff ?? false
+    const outcome = await this.start(bypassBackoff)
+    if (
+      bypassBackoff &&
+      outcome.status === "deferred" &&
+      outcome.reason === "backoff-active"
+    ) {
+      // The shared run may have been started by a background caller without
+      // bypass. Retry after it settles so this explicit action honors bypass.
+      return await this.start(true)
+    }
+    return outcome
+  }
+
+  private start(
+    bypassBackoff: boolean,
+  ): Promise<LegacyChannelConfigMigrationOutcome> {
     if (!this.initializationPromise) {
-      const runPromise = this.run(options?.bypassBackoff ?? false)
+      const runPromise = this.run(bypassBackoff)
       this.initializationPromise = runPromise
       void runPromise.then(
         () => this.clearInitializationPromise(runPromise),
@@ -303,15 +320,26 @@ class LegacyChannelConfigMigration {
   }
 }
 
+export type LegacyChannelConfigMigrationDeferredReason = Extract<
+  LegacyChannelConfigMigrationOutcome,
+  { status: "deferred" }
+>["reason"]
+
+/** Typed failure returned to scoped-only consumers when migration must retry. */
+export class LegacyChannelConfigMigrationDeferredError extends Error {
+  constructor(readonly reason: LegacyChannelConfigMigrationDeferredReason) {
+    super(`Legacy channel config migration deferred: ${reason}`)
+    this.name = "LegacyChannelConfigMigrationDeferredError"
+  }
+}
+
 /** Ensures legacy numeric data is resolved before a scoped-only consumer runs. */
 export async function ensureLegacyChannelConfigMigrationReady(options?: {
   bypassBackoff?: boolean
 }): Promise<void> {
   const outcome = await legacyChannelConfigMigration.initialize(options)
   if (outcome.status === "deferred") {
-    throw new Error(
-      `Legacy channel config migration deferred: ${outcome.reason}`,
-    )
+    throw new LegacyChannelConfigMigrationDeferredError(outcome.reason)
   }
 }
 

--- a/src/services/managedSites/managedSiteChannelResourceIdentity.ts
+++ b/src/services/managedSites/managedSiteChannelResourceIdentity.ts
@@ -1,0 +1,33 @@
+import { SITE_TYPES, type ManagedSiteType } from "~/constants/siteType"
+import type { ManagedSiteChannel } from "~/types/managedSite"
+
+/** Resolves the native resource id represented by a legacy channel row. */
+export function getManagedSiteChannelResourceId(
+  managedSiteType: ManagedSiteType,
+  channel: ManagedSiteChannel,
+): string | number {
+  if (managedSiteType === SITE_TYPES.AXON_HUB) {
+    const nativeId = (
+      channel as ManagedSiteChannel & {
+        _axonHubData?: { id?: string | number }
+      }
+    )._axonHubData?.id
+    if (nativeId !== undefined && nativeId !== null) {
+      return nativeId
+    }
+  }
+
+  return channel.id
+}
+
+/**
+ * Returns the stable numeric identity that an old channel-config key could
+ * have represented. AxonHub rows use process-local numeric projections, so
+ * even a numeric-looking native id is not sufficient migration evidence.
+ */
+export function getStableLegacyChannelId(
+  managedSiteType: ManagedSiteType,
+  channel: ManagedSiteChannel,
+): number | null {
+  return managedSiteType === SITE_TYPES.AXON_HUB ? null : channel.id
+}

--- a/src/services/managedSites/runtimeConfig.ts
+++ b/src/services/managedSites/runtimeConfig.ts
@@ -38,6 +38,42 @@ export type ManagedSiteRuntimeConfigValueForType<
 const hasText = (value: unknown): value is string =>
   typeof value === "string" && value.trim().length > 0
 
+/** Returns whether preferences contain any required-field input for a type. */
+export function hasManagedSiteRuntimeConfigInputForType(
+  preferences: UserPreferences,
+  siteType: ManagedSiteType,
+): boolean {
+  if (siteType === SITE_TYPES.OCTOPUS) {
+    const config = preferences.octopus
+    return Boolean(
+      config &&
+        [config.baseUrl, config.username, config.password].some(hasText),
+    )
+  }
+
+  if (siteType === SITE_TYPES.AXON_HUB) {
+    const config = preferences.axonHub
+    return Boolean(
+      config && [config.baseUrl, config.email, config.password].some(hasText),
+    )
+  }
+
+  if (siteType === SITE_TYPES.CLAUDE_CODE_HUB) {
+    const config = preferences.claudeCodeHub
+    return Boolean(config && [config.baseUrl, config.adminToken].some(hasText))
+  }
+
+  const config =
+    siteType === SITE_TYPES.DONE_HUB
+      ? preferences.doneHub
+      : siteType === SITE_TYPES.VELOERA
+        ? preferences.veloera
+        : preferences.newApi
+  return Boolean(
+    config && [config.baseUrl, config.adminToken, config.userId].some(hasText),
+  )
+}
+
 /**
  * Returns a complete access-token managed-site config when required fields exist.
  */

--- a/src/services/managedSites/runtimeConfig.ts
+++ b/src/services/managedSites/runtimeConfig.ts
@@ -63,15 +63,25 @@ export function hasManagedSiteRuntimeConfigInputForType(
     return Boolean(config && [config.baseUrl, config.adminToken].some(hasText))
   }
 
-  const config =
-    siteType === SITE_TYPES.DONE_HUB
-      ? preferences.doneHub
-      : siteType === SITE_TYPES.VELOERA
-        ? preferences.veloera
-        : preferences.newApi
-  return Boolean(
-    config && [config.baseUrl, config.adminToken, config.userId].some(hasText),
-  )
+  if (
+    siteType === SITE_TYPES.DONE_HUB ||
+    siteType === SITE_TYPES.VELOERA ||
+    siteType === SITE_TYPES.NEW_API
+  ) {
+    const config =
+      siteType === SITE_TYPES.DONE_HUB
+        ? preferences.doneHub
+        : siteType === SITE_TYPES.VELOERA
+          ? preferences.veloera
+          : preferences.newApi
+    return Boolean(
+      config &&
+        [config.baseUrl, config.adminToken, config.userId].some(hasText),
+    )
+  }
+
+  const exhaustiveSiteType: never = siteType
+  return exhaustiveSiteType
 }
 
 /**

--- a/src/services/managedSites/runtimeConfig.ts
+++ b/src/services/managedSites/runtimeConfig.ts
@@ -81,7 +81,8 @@ export function hasManagedSiteRuntimeConfigInputForType(
   }
 
   const exhaustiveSiteType: never = siteType
-  return exhaustiveSiteType
+  void exhaustiveSiteType
+  return false
 }
 
 /**

--- a/src/services/models/modelSync/channelModelFilterEvaluator.ts
+++ b/src/services/models/modelSync/channelModelFilterEvaluator.ts
@@ -13,8 +13,17 @@ import {
   type ApiVerificationApiType,
   type ApiVerificationProbeId,
 } from "~/services/verification/aiApiVerification"
-import type { ChannelModelFilterRule } from "~/types/channelModelFilters"
+import type { ChannelResourceConfigMap } from "~/types/channelConfig"
+import {
+  isPatternChannelModelFilterRule,
+  isProbeChannelModelFilterRule,
+  type ChannelModelFilterRule,
+} from "~/types/channelModelFilters"
 import type { ManagedSiteChannel } from "~/types/managedSite"
+import {
+  createManagedUpstreamResourceRef,
+  getManagedUpstreamResourceRefKey,
+} from "~/types/managedUpstreamResource"
 import { createLogger } from "~/utils/core/logger"
 
 const logger = createLogger("ManagedSiteModelSyncProbeFilters")
@@ -339,4 +348,114 @@ export async function matchesProbeFilterRule(
   return rule.match === "any"
     ? probeMatches.some(Boolean)
     : probeMatches.every(Boolean)
+}
+
+/** Evaluates one pattern or probe rule against a model name. */
+async function matchesChannelModelFilterRule(
+  rule: ChannelModelFilterRule,
+  model: string,
+  probeContext?: ProbeFilterContext,
+): Promise<boolean> {
+  if (isProbeChannelModelFilterRule(rule)) {
+    if (!probeContext) {
+      throw new ProbeFilterUnavailableError(
+        "provider-unsupported",
+        "Probe filtering cannot run without a managed-site channel context.",
+      )
+    }
+    return matchesProbeFilterRule(rule, model, probeContext)
+  }
+
+  if (!isPatternChannelModelFilterRule(rule)) {
+    return false
+  }
+
+  const pattern = rule.pattern?.trim()
+  if (!pattern) return false
+
+  try {
+    return rule.isRegex
+      ? new RegExp(pattern, "i").test(model)
+      : model.toLowerCase().includes(pattern.toLowerCase())
+  } catch (error) {
+    logger.warn("Invalid channel filter pattern for channel rule", {
+      ruleId: rule.id,
+      error,
+    })
+    return false
+  }
+}
+
+/** Keeps or removes models according to whether any supplied rule matches. */
+async function filterByRuleMatches(
+  models: string[],
+  rules: ChannelModelFilterRule[],
+  keepMatchingModels: boolean,
+  probeContext?: ProbeFilterContext,
+): Promise<string[]> {
+  const result: string[] = []
+
+  for (const model of models) {
+    let matched = false
+    for (const rule of rules) {
+      if (await matchesChannelModelFilterRule(rule, model, probeContext)) {
+        matched = true
+        break
+      }
+    }
+
+    if (matched === keepMatchingModels) {
+      result.push(model)
+    }
+  }
+
+  return result
+}
+
+/** Resolves model-filter rules through the canonical resource identity. */
+export function getChannelModelFilterRulesForResource(
+  configs: ChannelResourceConfigMap | null | undefined,
+  identity: Parameters<typeof createManagedUpstreamResourceRef>[0],
+): ChannelModelFilterRule[] {
+  const resourceRef = createManagedUpstreamResourceRef(identity)
+  return (
+    configs?.[getManagedUpstreamResourceRefKey(resourceRef)]
+      ?.modelFilterSettings.rules ?? []
+  )
+}
+
+/**
+ * Applies enabled include/exclude rules to a normalized model collection.
+ */
+export async function applyChannelModelFilters(
+  rules: ChannelModelFilterRule[] | null | undefined,
+  models: string[],
+  probeContext?: ProbeFilterContext,
+): Promise<string[]> {
+  const normalized = Array.from(
+    new Set(models.map((model) => model.trim()).filter(Boolean)),
+  )
+  if (!normalized.length) return normalized
+
+  const enabledRules = rules?.filter((rule) => rule.enabled) ?? []
+  if (!enabledRules.length) return normalized
+
+  const includeRules = enabledRules.filter((rule) => rule.action === "include")
+  const excludeRules = enabledRules.filter((rule) => rule.action === "exclude")
+  let result = normalized
+
+  if (includeRules.length) {
+    result = await filterByRuleMatches(result, includeRules, true, probeContext)
+  }
+
+  if (result.length && excludeRules.length) {
+    result = await filterByRuleMatches(
+      result,
+      excludeRules,
+      false,
+      probeContext,
+    )
+  }
+
+  return result
 }

--- a/src/services/models/modelSync/channelModelFilterEvaluator.ts
+++ b/src/services/models/modelSync/channelModelFilterEvaluator.ts
@@ -351,6 +351,43 @@ export async function matchesProbeFilterRule(
     : probeMatches.every(Boolean)
 }
 
+type CachedChannelModelFilterRegex = {
+  pattern: string
+  regex: RegExp | null
+}
+
+const channelModelFilterRegexCache = new WeakMap<
+  ChannelModelFilterRule,
+  CachedChannelModelFilterRegex
+>()
+
+/** Validates and compiles a regex once for each rule and pattern value. */
+function getChannelModelFilterRegex(
+  rule: ChannelModelFilterRule,
+  pattern: string,
+): RegExp | null {
+  const cached = channelModelFilterRegexCache.get(rule)
+  if (cached?.pattern === pattern) {
+    return cached.regex
+  }
+
+  let regex: RegExp | null = null
+  try {
+    if (!isSafeChannelModelFilterRegex(pattern)) {
+      throw new Error("Invalid or unsafe regex pattern")
+    }
+    regex = new RegExp(pattern, "i")
+  } catch (error) {
+    logger.warn("Invalid channel filter pattern for channel rule", {
+      ruleId: rule.id,
+      error,
+    })
+  }
+
+  channelModelFilterRegexCache.set(rule, { pattern, regex })
+  return regex
+}
+
 /** Evaluates one pattern or probe rule against a model name. */
 async function matchesChannelModelFilterRule(
   rule: ChannelModelFilterRule,
@@ -374,21 +411,11 @@ async function matchesChannelModelFilterRule(
   const pattern = rule.pattern?.trim()
   if (!pattern) return false
 
-  try {
-    if (!rule.isRegex) {
-      return model.toLowerCase().includes(pattern.toLowerCase())
-    }
-    if (!isSafeChannelModelFilterRegex(pattern)) {
-      throw new Error("Invalid or unsafe regex pattern")
-    }
-    return new RegExp(pattern, "i").test(model)
-  } catch (error) {
-    logger.warn("Invalid channel filter pattern for channel rule", {
-      ruleId: rule.id,
-      error,
-    })
-    return false
+  if (!rule.isRegex) {
+    return model.toLowerCase().includes(pattern.toLowerCase())
   }
+
+  return getChannelModelFilterRegex(rule, pattern)?.test(model) ?? false
 }
 
 /** Keeps or removes models according to whether any supplied rule matches. */

--- a/src/services/models/modelSync/channelModelFilterEvaluator.ts
+++ b/src/services/models/modelSync/channelModelFilterEvaluator.ts
@@ -2,6 +2,7 @@ import { AXON_HUB_CHANNEL_TYPE } from "~/constants/axonHub"
 import { CLAUDE_CODE_HUB_PROVIDER_TYPE } from "~/constants/claudeCodeHub"
 import { ChannelType } from "~/constants/newApi"
 import { SITE_TYPES } from "~/constants/siteType"
+import { isSafeChannelModelFilterRegex } from "~/services/managedSites/channelModelFilterRules"
 import { getManagedSiteServiceForType } from "~/services/managedSites/managedSiteService"
 import type { ManagedSiteRuntimeConfig } from "~/services/managedSites/runtimeConfig"
 import { hasUsableManagedSiteChannelKey } from "~/services/managedSites/utils/managedSite"
@@ -374,9 +375,13 @@ async function matchesChannelModelFilterRule(
   if (!pattern) return false
 
   try {
-    return rule.isRegex
-      ? new RegExp(pattern, "i").test(model)
-      : model.toLowerCase().includes(pattern.toLowerCase())
+    if (!rule.isRegex) {
+      return model.toLowerCase().includes(pattern.toLowerCase())
+    }
+    if (!isSafeChannelModelFilterRegex(pattern)) {
+      throw new Error("Invalid or unsafe regex pattern")
+    }
+    return new RegExp(pattern, "i").test(model)
   } catch (error) {
     logger.warn("Invalid channel filter pattern for channel rule", {
       ruleId: rule.id,

--- a/src/services/models/modelSync/modelSyncService.ts
+++ b/src/services/models/modelSync/modelSyncService.ts
@@ -19,12 +19,8 @@ import {
   collectManagedResourceSecrets,
 } from "~/services/managedSites/utils/managedSite"
 import type { ProtectionBypassExecution } from "~/services/protectionBypass/contracts"
-import type { ChannelConfigMap } from "~/types/channelConfig"
+import type { ChannelResourceConfigMap } from "~/types/channelConfig"
 import type { ChannelModelFilterRule } from "~/types/channelModelFilters"
-import {
-  isPatternChannelModelFilterRule,
-  isProbeChannelModelFilterRule,
-} from "~/types/channelModelFilters"
 import {
   type ChannelFormData,
   type ManagedSiteChannel,
@@ -43,7 +39,8 @@ import type {
 import { createLogger } from "~/utils/core/logger"
 
 import {
-  matchesProbeFilterRule,
+  applyChannelModelFilters,
+  getChannelModelFilterRulesForResource,
   ProbeFilterUnavailableError,
   type ProbeFilterContext,
 } from "./channelModelFilterEvaluator"
@@ -151,7 +148,7 @@ export class ModelSyncService {
   private managedSiteConfig: ManagedSiteRuntimeConfig
   private rateLimiter: RateLimiter | null = null
   private allowedModelSet: Set<string> | null = null
-  private channelConfigs: ChannelConfigMap | null = null
+  private channelConfigs: ChannelResourceConfigMap | null = null
   private globalChannelModelFilters: ChannelModelFilterRule[] | null = null
   private resourceCacheByChannelId = new Map<
     number,
@@ -173,7 +170,7 @@ export class ModelSyncService {
     managedSiteConfig: ManagedSiteRuntimeConfig,
     rateLimitConfig?: { requestsPerMinute: number; burst: number },
     allowedModels?: string[],
-    channelConfigs?: ChannelConfigMap | null,
+    channelConfigs?: ChannelResourceConfigMap | null,
     globalChannelModelFilters?: ChannelModelFilterRule[] | null,
     protectionBypassExecution?: ProtectionBypassExecution,
   ) {
@@ -202,7 +199,7 @@ export class ModelSyncService {
    * Update in-memory channel configs to be used by per-channel filters.
    * @param configs Cached channel configuration map; null clears cache.
    */
-  setChannelConfigs(configs: ChannelConfigMap | null) {
+  setChannelConfigs(configs: ChannelResourceConfigMap | null) {
     this.channelConfigs = configs
   }
 
@@ -673,13 +670,13 @@ export class ModelSyncService {
           protectionBypassExecution: this.protectionBypassExecution,
         }
         try {
-          const globallyScopedModels = await this.applyFilters(
+          const globallyScopedModels = await applyChannelModelFilters(
             this.globalChannelModelFilters,
             allowListedModels,
             probeContext,
           )
           const channelScopedModels = await this.applyChannelFilters(
-            channel.id,
+            channel,
             globallyScopedModels,
             probeContext,
           )
@@ -910,153 +907,26 @@ export class ModelSyncService {
   }
 
   /**
-   * Applies a list of include/exclude rules to the provided model list.
-   *
-   * Steps:
-   * 1. Normalize incoming model names (trim + dedupe).
-   * 2. If no enabled filters exist, return normalized models as-is.
-   * 3. Apply include rules (OR logic). At least one include must match when
-   *    include rules are present; otherwise the model is dropped.
-   * 4. Apply exclude rules (OR logic). Any match removes the model.
-   */
-  private async applyFilters(
-    rules: ChannelModelFilterRule[] | null | undefined,
-    models: string[],
-    probeContext?: ProbeFilterContext,
-  ): Promise<string[]> {
-    const normalized = Array.from(
-      new Set(models.map((model) => model.trim()).filter(Boolean)),
-    )
-    if (!normalized.length) {
-      return normalized
-    }
-
-    const filters = rules?.filter((rule) => rule.enabled)
-    if (!filters || filters.length === 0) {
-      return normalized
-    }
-
-    const includeRules = filters.filter((rule) => rule.action === "include")
-    const excludeRules = filters.filter((rule) => rule.action === "exclude")
-
-    let result = normalized
-
-    if (includeRules.length > 0) {
-      result = await this.filterByRuleMatches(
-        result,
-        includeRules,
-        true,
-        probeContext,
-      )
-    }
-
-    if (result.length === 0) {
-      return result
-    }
-
-    if (excludeRules.length > 0) {
-      result = await this.filterByRuleMatches(
-        result,
-        excludeRules,
-        false,
-        probeContext,
-      )
-    }
-
-    return result
-  }
-
-  /**
    * Applies the per-channel include/exclude filters defined in channel configs
    * to the provided models.
-   * @param channelId Channel id for looking up config rules.
+   * @param channel Channel used to resolve the scoped resource identity.
    * @param models Models after global filtering.
    */
   private applyChannelFilters(
-    channelId: number,
+    channel: ManagedSiteChannel,
     models: string[],
     probeContext: ProbeFilterContext,
   ): Promise<string[]> {
-    const rules =
-      this.channelConfigs?.[channelId]?.modelFilterSettings?.rules ?? []
-    return this.applyFilters(rules, models, probeContext)
-  }
-
-  private async filterByRuleMatches(
-    models: string[],
-    rules: ChannelModelFilterRule[],
-    keepMatchingModels: boolean,
-    probeContext?: ProbeFilterContext,
-  ): Promise<string[]> {
-    const result: string[] = []
-
-    for (const model of models) {
-      const matched = await this.anyRuleMatches(rules, model, probeContext)
-      if (matched === keepMatchingModels) {
-        result.push(model)
-      }
+    const resourceIdentity = this.resourceCacheByChannelId.get(channel.id)
+      ?.summary.ref ?? {
+      managedSiteType: this.managedSiteConfig.siteType,
+      scopeKey: this.managedSiteConfig.config.baseUrl,
+      resourceId: channel.id,
     }
-
-    return result
-  }
-
-  private async anyRuleMatches(
-    rules: ChannelModelFilterRule[],
-    model: string,
-    probeContext?: ProbeFilterContext,
-  ): Promise<boolean> {
-    for (const rule of rules) {
-      if (await this.matchesFilter(rule, model, probeContext)) {
-        return true
-      }
-    }
-
-    return false
-  }
-
-  /**
-   * Evaluates a model name against a filter rule. Regex patterns are compiled
-   * with `new RegExp(pattern, "i")`, enforcing case-insensitive matching and
-   * avoiding custom flags for predictability across browsers.
-   * @param rule Filter rule.
-   * @param model Model name to test.
-   * @returns Whether the model matches the rule.
-   */
-  private async matchesFilter(
-    rule: ChannelModelFilterRule,
-    model: string,
-    probeContext?: ProbeFilterContext,
-  ): Promise<boolean> {
-    if (isProbeChannelModelFilterRule(rule)) {
-      if (!probeContext) {
-        throw new ProbeFilterUnavailableError(
-          "provider-unsupported",
-          "Probe filtering cannot run without a managed-site channel context.",
-        )
-      }
-      return matchesProbeFilterRule(rule, model, probeContext)
-    }
-
-    if (!isPatternChannelModelFilterRule(rule)) {
-      return false
-    }
-
-    const pattern = rule.pattern?.trim()
-    if (!pattern) return false
-
-    try {
-      if (rule.isRegex) {
-        const regex = new RegExp(pattern, "i")
-        return regex.test(model)
-      }
-
-      return model.toLowerCase().includes(pattern.toLowerCase())
-    } catch (error) {
-      logger.warn("Invalid channel filter pattern for channel rule", {
-        ruleId: rule.id,
-        error,
-      })
-      return false
-    }
+    const rules = getChannelModelFilterRulesForResource(
+      this.channelConfigs,
+      resourceIdentity,
+    )
+    return applyChannelModelFilters(rules, models, probeContext)
   }
 }

--- a/src/services/models/modelSync/octopusModelSync.ts
+++ b/src/services/models/modelSync/octopusModelSync.ts
@@ -2,6 +2,7 @@
  * Octopus 模型同步服务
  * 实现 Octopus 站点的模型同步功能
  */
+import { SITE_TYPES } from "~/constants/siteType"
 import { octopusManagedSiteChannels } from "~/services/apiAdapters/managedSites/octopus"
 import * as octopusApi from "~/services/apiService/octopus"
 import { ApiError } from "~/services/apiTransport/errors"
@@ -11,6 +12,7 @@ import {
   type ManagedSiteMutationRetryDecision,
 } from "~/services/managedSites/mutations"
 import { collectManagedConfigSecrets } from "~/services/managedSites/utils/managedSite"
+import type { ChannelResourceConfigMap } from "~/types/channelConfig"
 import type {
   ManagedSiteChannel,
   OctopusChannelWithData,
@@ -26,6 +28,11 @@ import type { OctopusConfig } from "~/types/octopusConfig"
 import { getErrorMessage } from "~/utils/core/error"
 import { createLogger } from "~/utils/core/logger"
 
+import {
+  applyChannelModelFilters,
+  getChannelModelFilterRulesForResource,
+  ProbeFilterUnavailableError,
+} from "./channelModelFilterEvaluator"
 import { runWithChannelProcessingTimeout } from "./channelProcessingTimeout"
 import {
   createModelSyncWriteFailureBoundary,
@@ -165,6 +172,7 @@ async function runForChannel(
   maxRetries: number = 2,
   abortSignal?: AbortSignal,
   writeFailureBoundary: ModelSyncWriteFailureBoundary = createModelSyncWriteFailureBoundary(),
+  channelConfigs?: ChannelResourceConfigMap,
 ): Promise<ExecutionItemResult> {
   let attempts = 0
   let lastError: unknown = null
@@ -188,13 +196,28 @@ async function runForChannel(
       const normalizedModels = Array.from(
         new Set(fetchedModels.map((model) => model.trim()).filter(Boolean)),
       )
+      const rules = getChannelModelFilterRulesForResource(channelConfigs, {
+        managedSiteType: SITE_TYPES.OCTOPUS,
+        scopeKey: config.baseUrl,
+        resourceId: channel.id,
+      })
+      const channelScopedModels = await applyChannelModelFilters(
+        rules,
+        normalizedModels,
+        {
+          channel,
+          managedConfig: { siteType: SITE_TYPES.OCTOPUS, config },
+          cache: new Map(),
+          abortSignal,
+        },
+      )
 
-      if (haveModelsChanged(oldModels, normalizedModels)) {
+      if (haveModelsChanged(oldModels, channelScopedModels)) {
         try {
           await updateChannelModels(
             config,
             channel,
-            normalizedModels,
+            channelScopedModels,
             abortSignal,
           )
         } catch (error) {
@@ -212,13 +235,25 @@ async function runForChannel(
         attempts,
         finishedAt: Date.now(),
         oldModels,
-        newModels: normalizedModels,
+        newModels: channelScopedModels,
         message: "Success",
       }
     } catch (error: unknown) {
       if (writeFailureBoundary.matches(error)) throw error
       if (abortSignal?.aborted) {
         throw error
+      }
+
+      if (error instanceof ProbeFilterUnavailableError) {
+        return {
+          channelId: channel.id,
+          channelName: channel.name,
+          ok: false,
+          attempts: attempts + 1,
+          finishedAt: Date.now(),
+          oldModels,
+          message: error.message,
+        }
       }
 
       lastError = error
@@ -264,10 +299,17 @@ async function runForChannel(
 export async function runOctopusBatch(
   config: OctopusConfig,
   channels: ManagedSiteChannel[],
-  options: BatchExecutionOptions,
+  options: BatchExecutionOptions & {
+    channelConfigs?: ChannelResourceConfigMap
+  },
 ): Promise<ExecutionResult> {
-  const { concurrency, maxRetries, channelProcessingTimeout, onProgress } =
-    options
+  const {
+    concurrency,
+    maxRetries,
+    channelProcessingTimeout,
+    channelConfigs,
+    onProgress,
+  } = options
   const startedAt = Date.now()
   const total = channels.length
   const results: (ExecutionItemResult | undefined)[] = new Array(total)
@@ -296,6 +338,7 @@ export async function runOctopusBatch(
               maxRetries,
               abortSignal,
               writeFailureBoundary,
+              channelConfigs,
             ),
           channel,
           maxRetries,

--- a/src/services/models/modelSync/scheduler.ts
+++ b/src/services/models/modelSync/scheduler.ts
@@ -1,5 +1,6 @@
 import { SITE_TYPES } from "~/constants/siteType"
 import * as octopusApi from "~/services/apiService/octopus"
+import { ensureLegacyChannelConfigMigrationReady } from "~/services/managedSites/legacyChannelConfigMigration"
 import { getManagedSiteServiceForType } from "~/services/managedSites/managedSiteService"
 import {
   resolveCurrentManagedSiteRuntimeConfig,
@@ -210,6 +211,7 @@ class ModelSyncScheduler {
       userPrefs.managedSiteModelSync ??
       DEFAULT_PREFERENCES.managedSiteModelSync!
 
+    await ensureLegacyChannelConfigMigrationReady()
     const channelConfigs = await channelConfigStorage.getConfigsForScope({
       managedSiteType: managedConfig.siteType,
       scopeKey: managedConfig.config.baseUrl,
@@ -728,6 +730,7 @@ class ModelSyncScheduler {
 
     let result
     try {
+      await ensureLegacyChannelConfigMigrationReady()
       const channelConfigs = await channelConfigStorage.getConfigsForScope({
         managedSiteType: octopusRuntimeConfig.siteType,
         scopeKey: octopusRuntimeConfig.config.baseUrl,

--- a/src/services/models/modelSync/scheduler.ts
+++ b/src/services/models/modelSync/scheduler.ts
@@ -210,7 +210,10 @@ class ModelSyncScheduler {
       userPrefs.managedSiteModelSync ??
       DEFAULT_PREFERENCES.managedSiteModelSync!
 
-    const channelConfigs = await channelConfigStorage.getAllConfigs()
+    const channelConfigs = await channelConfigStorage.getConfigsForScope({
+      managedSiteType: managedConfig.siteType,
+      scopeKey: managedConfig.config.baseUrl,
+    })
 
     return new ModelSyncService(
       managedConfig,
@@ -725,11 +728,16 @@ class ModelSyncScheduler {
 
     let result
     try {
+      const channelConfigs = await channelConfigStorage.getConfigsForScope({
+        managedSiteType: octopusRuntimeConfig.siteType,
+        scopeKey: octopusRuntimeConfig.config.baseUrl,
+      })
       // Execute batch sync using Octopus-specific implementation
       result = await runOctopusBatch(octopusRuntimeConfig.config, channels, {
         concurrency,
         maxRetries,
         channelProcessingTimeout,
+        channelConfigs,
         onProgress: async (payload) => {
           if (!payload.lastResult.ok) {
             failureCount += 1

--- a/src/services/webdav/webdavAutoSyncService.ts
+++ b/src/services/webdav/webdavAutoSyncService.ts
@@ -7,6 +7,7 @@ import {
   normalizeBackupForMerge,
   type BackupFullV2,
 } from "~/services/importExport/importExportService"
+import { ensureLegacyChannelConfigMigrationReady } from "~/services/managedSites/legacyChannelConfigMigration"
 import { notifyTaskResult } from "~/services/notifications/taskNotificationService"
 import {
   getSharedPreferencesLastUpdated,
@@ -63,7 +64,6 @@ import { accountStorage } from "../accounts/accountStorage"
 import { ACCOUNT_STORAGE_KEYS, STORAGE_LOCKS } from "../core/storageKeys"
 import { withExtensionStorageWriteLock } from "../core/storageWriteLock"
 import { channelConfigStorage } from "../managedSites/channelConfigStorage"
-import { ensureLegacyChannelConfigMigrationReady } from "../managedSites/legacyChannelConfigMigration"
 import {
   userPreferences,
   type PreferenceWriteFailure,

--- a/src/services/webdav/webdavAutoSyncService.ts
+++ b/src/services/webdav/webdavAutoSyncService.ts
@@ -30,7 +30,10 @@ import {
   API_CREDENTIAL_PROFILES_CONFIG_VERSION,
   type ApiCredentialProfilesConfig,
 } from "~/types/apiCredentialProfiles"
-import type { ChannelConfigMap } from "~/types/channelConfig"
+import {
+  CHANNEL_CONFIG_SNAPSHOT_VERSION,
+  type ChannelConfigSnapshot,
+} from "~/types/channelConfig"
 import {
   TASK_NOTIFICATION_STATUSES,
   TASK_NOTIFICATION_TASKS,
@@ -538,7 +541,7 @@ class WebdavAutoSyncService {
     deletedEntryRecords?: AccountStorageConfig["deletedEntryRecords"]
     tagStore: TagStore
     preferences: UserPreferences
-    channelConfigs: ChannelConfigMap
+    channelConfigs: ChannelConfigSnapshot
     apiCredentialProfiles: ApiCredentialProfilesConfig
   }): BackupFullV2 {
     return {
@@ -629,7 +632,7 @@ class WebdavAutoSyncService {
    * 流程：
    * 1. 使用当前用户 WebDAV 配置测试连接。
    * 2. 从远程下载备份并通过 normalizeBackupForMerge 按版本规范化
-   *    （兼容 V1 旧结构和当前 V2 扁平结构，未来版本可扩展）。
+   *    （兼容 V1 旧结构和 V2/V3 扁平结构，未来版本可扩展）。
    *    - 如果远程备份是加密封套（envelope），downloadBackup 会尝试用
    *      当前 WebDAV 加密密码自动解密；缺失/错误密码会导致本次同步失败。
    * 3. 根据 syncStrategy 决定合并方式：
@@ -684,6 +687,9 @@ class WebdavAutoSyncService {
     // 决定同步策略
     const strategy =
       preferences.webdav.syncStrategy || WEBDAV_SYNC_STRATEGIES.MERGE
+    const mergeChannelConfigsOnApply =
+      strategy === WEBDAV_SYNC_STRATEGIES.MERGE ||
+      normalizedRemote.channelConfigs === null
 
     const emptyProfiles: ApiCredentialProfilesConfig = {
       version: API_CREDENTIAL_PROFILES_CONFIG_VERSION,
@@ -695,7 +701,7 @@ class WebdavAutoSyncService {
     let bookmarksToSave: SiteBookmark[] = localBookmarks
     let tagStoreToSave = localTagStore
     let preferencesToSave: UserPreferences = localPreferences
-    let channelConfigsToSave: ChannelConfigMap = localChannelConfigs
+    let channelConfigsToSave: ChannelConfigSnapshot = localChannelConfigs
     let apiCredentialProfilesToSave: ApiCredentialProfilesConfig =
       localApiCredentialProfiles
     let pinnedAccountIdsToSave: string[] = localPinnedAccountIds
@@ -718,7 +724,6 @@ class WebdavAutoSyncService {
           preferences: localPreferences,
           preferencesTimestamp:
             getSharedPreferencesLastUpdated(localPreferences),
-          channelConfigs: localChannelConfigs,
           apiCredentialProfiles: localApiCredentialProfiles,
         },
         {
@@ -731,7 +736,6 @@ class WebdavAutoSyncService {
           ),
           preferences: remotePreferences,
           preferencesTimestamp: remotePreferencesTimestamp,
-          channelConfigs: normalizedRemote.channelConfigs,
           apiCredentialProfiles:
             (remotePresence.hasApiCredentialProfiles &&
               normalizedRemote.apiCredentialProfiles) ||
@@ -744,7 +748,12 @@ class WebdavAutoSyncService {
       bookmarksToSave = mergeResult.bookmarks
       tagStoreToSave = mergeResult.tagStore
       preferencesToSave = mergeResult.preferences
-      channelConfigsToSave = mergeResult.channelConfigs
+      // Atomic merge must receive only remote incoming data. Including the
+      // startup-time local snapshot could resurrect entries deleted meanwhile.
+      channelConfigsToSave = normalizedRemote.channelConfigs ?? {
+        schemaVersion: CHANNEL_CONFIG_SNAPSHOT_VERSION,
+        configs: {},
+      }
       apiCredentialProfilesToSave = mergeResult.apiCredentialProfiles
       deletedEntryRecordsToSave = mergeResult.deletedEntryRecords
 
@@ -866,8 +875,10 @@ class WebdavAutoSyncService {
           ? remotePreferences
           : localPreferences
 
-      channelConfigsToSave =
-        normalizedRemote.channelConfigs || localChannelConfigs
+      channelConfigsToSave = normalizedRemote.channelConfigs ?? {
+        schemaVersion: CHANNEL_CONFIG_SNAPSHOT_VERSION,
+        configs: {},
+      }
 
       apiCredentialProfilesToSave =
         syncDataSelection.apiCredentialProfiles &&
@@ -973,7 +984,7 @@ class WebdavAutoSyncService {
       Boolean(remoteData) && strategy !== WEBDAV_SYNC_STRATEGIES.UPLOAD_ONLY
 
     if (shouldWriteLocal) {
-      await this.applyLocalSyncResult({
+      channelConfigsToSave = await this.applyLocalSyncResult({
         syncDataSelection,
         accountsToSave,
         bookmarksToSave,
@@ -983,11 +994,11 @@ class WebdavAutoSyncService {
         tagStoreToSave,
         preferencesToSave,
         channelConfigsToSave,
+        mergeChannelConfigsOnApply,
         apiCredentialProfilesToSave,
         localAccountsConfig,
         localTagStore,
         localPreferences,
-        localChannelConfigs,
         localApiCredentialProfiles,
       })
     }
@@ -1038,7 +1049,8 @@ class WebdavAutoSyncService {
     orderedAccountIdsToSave: string[]
     tagStoreToSave: TagStore
     preferencesToSave: UserPreferences
-    channelConfigsToSave: ChannelConfigMap
+    channelConfigsToSave: ChannelConfigSnapshot
+    mergeChannelConfigsOnApply: boolean
     apiCredentialProfilesToSave: ApiCredentialProfilesConfig
     localAccountsConfig: {
       accounts: SiteAccount[]
@@ -1049,14 +1061,13 @@ class WebdavAutoSyncService {
     }
     localTagStore: TagStore
     localPreferences: UserPreferences
-    localChannelConfigs: ChannelConfigMap
     localApiCredentialProfiles: ApiCredentialProfilesConfig
   }) {
     const rollbackSteps: Array<() => Promise<void>> = []
 
     this.suppressAccountStorageChangeHandling = true
     try {
-      await withExtensionStorageWriteLock(
+      return await withExtensionStorageWriteLock(
         STORAGE_LOCKS.WEBDAV_SYNC_APPLY,
         async () => {
           try {
@@ -1106,13 +1117,6 @@ class WebdavAutoSyncService {
               })
             }
 
-            await channelConfigStorage.importConfigs(input.channelConfigsToSave)
-            rollbackSteps.push(async () => {
-              await channelConfigStorage.importConfigs(
-                input.localChannelConfigs,
-              )
-            })
-
             if (input.syncDataSelection.apiCredentialProfiles) {
               await apiCredentialProfilesStorage.importConfig(
                 input.apiCredentialProfilesToSave,
@@ -1124,6 +1128,17 @@ class WebdavAutoSyncService {
                 )
               })
             }
+
+            // Apply channel configs last so a failure in another storage domain
+            // never requires replacing concurrent channel edits during rollback.
+            if (input.mergeChannelConfigsOnApply) {
+              return await channelConfigStorage.mergeConfigs(
+                input.channelConfigsToSave,
+              )
+            }
+
+            await channelConfigStorage.importConfigs(input.channelConfigsToSave)
+            return input.channelConfigsToSave
           } catch (error) {
             for (const rollback of rollbackSteps.reverse()) {
               try {
@@ -1147,8 +1162,8 @@ class WebdavAutoSyncService {
 
   /**
    * Merge local and remote data based on timestamps (latest wins).
-   * Also reconciles channel configs and deduplicates pinned ids.
-   * @returns Merged accounts, preferences, and channel configs.
+   * Channel configs are intentionally merged later at their locked storage seam.
+   * @returns Merged accounts, preferences, profiles, tags, and deletion metadata.
    */
   private mergeData(
     local: {
@@ -1159,7 +1174,6 @@ class WebdavAutoSyncService {
       tagStore: TagStore
       preferences: UserPreferences
       preferencesTimestamp: number
-      channelConfigs: ChannelConfigMap
       apiCredentialProfiles: ApiCredentialProfilesConfig
     },
     remote: {
@@ -1170,7 +1184,6 @@ class WebdavAutoSyncService {
       tagStore: TagStore
       preferences: UserPreferences
       preferencesTimestamp: number
-      channelConfigs: ChannelConfigMap | null
       apiCredentialProfiles: ApiCredentialProfilesConfig
     },
     selection: WebDAVSyncDataSelection = resolveWebdavSyncDataSelection(null),
@@ -1179,7 +1192,6 @@ class WebdavAutoSyncService {
     bookmarks: SiteBookmark[]
     tagStore: TagStore
     preferences: UserPreferences
-    channelConfigs: ChannelConfigMap
     apiCredentialProfiles: ApiCredentialProfilesConfig
     deletedEntryRecords: NonNullable<
       AccountStorageConfig["deletedEntryRecords"]
@@ -1374,39 +1386,6 @@ class WebdavAutoSyncService {
         : local.preferences
       : local.preferences
 
-    // 合并通道配置
-    const localChannelConfigs = local.channelConfigs
-    const remoteChannelConfigs = remote.channelConfigs
-    const mergedChannelConfigs: ChannelConfigMap = { ...localChannelConfigs }
-
-    if (remoteChannelConfigs && typeof remoteChannelConfigs === "object") {
-      for (const [key, value] of Object.entries(remoteChannelConfigs)) {
-        const channelId = Number(key)
-        if (!Number.isFinite(channelId) || channelId <= 0) {
-          continue
-        }
-
-        const localConfig = localChannelConfigs[channelId]
-        const remoteConfig = value as ChannelConfigMap[number]
-
-        if (!localConfig) {
-          mergedChannelConfigs[channelId] = remoteConfig
-        } else {
-          const localUpdatedAt =
-            typeof localConfig.updatedAt === "number"
-              ? localConfig.updatedAt
-              : 0
-          const remoteUpdatedAt =
-            typeof remoteConfig.updatedAt === "number"
-              ? remoteConfig.updatedAt
-              : 0
-
-          mergedChannelConfigs[channelId] =
-            remoteUpdatedAt > localUpdatedAt ? remoteConfig : localConfig
-        }
-      }
-    }
-
     logger.info("合并完成", {
       accountCount: mergedAccounts.length,
       preferencesSource:
@@ -1414,7 +1393,6 @@ class WebdavAutoSyncService {
         remote.preferencesTimestamp > local.preferencesTimestamp
           ? "remote"
           : "local",
-      channelConfigCount: Object.keys(mergedChannelConfigs).length,
     })
 
     return {
@@ -1427,7 +1405,6 @@ class WebdavAutoSyncService {
           ? tagMerge.tagStore
           : localTagStore,
       preferences,
-      channelConfigs: mergedChannelConfigs,
       apiCredentialProfiles,
       deletedEntryRecords: deletedEntryRecordsToKeep,
     }

--- a/src/services/webdav/webdavAutoSyncService.ts
+++ b/src/services/webdav/webdavAutoSyncService.ts
@@ -63,6 +63,7 @@ import { accountStorage } from "../accounts/accountStorage"
 import { ACCOUNT_STORAGE_KEYS, STORAGE_LOCKS } from "../core/storageKeys"
 import { withExtensionStorageWriteLock } from "../core/storageWriteLock"
 import { channelConfigStorage } from "../managedSites/channelConfigStorage"
+import { ensureLegacyChannelConfigMigrationReady } from "../managedSites/legacyChannelConfigMigration"
 import {
   userPreferences,
   type PreferenceWriteFailure,
@@ -507,6 +508,8 @@ class WebdavAutoSyncService {
     if (isWebdavSyncDataSelectionEmpty(syncDataSelection)) {
       throw new Error(t("messages:webdav.syncDataSelectionRequired"))
     }
+
+    await ensureLegacyChannelConfigMigrationReady()
 
     const [
       localAccountsConfig,

--- a/src/services/webdav/webdavSelectiveSync.ts
+++ b/src/services/webdav/webdavSelectiveSync.ts
@@ -12,6 +12,7 @@ import {
   normalizeBackupForMerge,
 } from "~/services/importExport/importExportService"
 import { channelConfigStorage } from "~/services/managedSites/channelConfigStorage"
+import { ensureLegacyChannelConfigMigrationReady } from "~/services/managedSites/legacyChannelConfigMigration"
 import {
   userPreferences,
   type UserPreferences,
@@ -962,6 +963,7 @@ export async function buildWebdavImportPayloadBySelection(input: {
   rawBackup: RawBackupData
   selection: WebDAVSyncDataSelection
 }): Promise<RawBackupData> {
+  await ensureLegacyChannelConfigMigrationReady({ bypassBackoff: true })
   const [
     accountsConfig,
     tagStore,

--- a/src/services/webdav/webdavSelectiveSync.ts
+++ b/src/services/webdav/webdavSelectiveSync.ts
@@ -38,14 +38,14 @@ import {
   type TagStore,
 } from "~/types"
 import type { ApiCredentialProfilesConfig } from "~/types/apiCredentialProfiles"
-import type { ChannelConfigMap } from "~/types/channelConfig"
+import type { ChannelConfigSnapshot } from "~/types/channelConfig"
 import { type WebDAVSyncDataSelection } from "~/types/webdav"
 
 type WebdavImportLocalState = {
   accountsConfig: AccountStorageConfig
   tagStore: TagStore
   preferences: UserPreferences
-  channelConfigs: ChannelConfigMap
+  channelConfigs: ChannelConfigSnapshot
   apiCredentialProfiles: ApiCredentialProfilesConfig
 }
 

--- a/src/types/channelConfig.ts
+++ b/src/types/channelConfig.ts
@@ -6,15 +6,6 @@ export interface ChannelModelFilterSettings {
   updatedAt: number
 }
 
-export interface ChannelConfig {
-  channelId: number
-  modelFilterSettings: ChannelModelFilterSettings
-  createdAt: number
-  updatedAt: number
-}
-
-export type ChannelConfigMap = Record<number, ChannelConfig>
-
 export interface ChannelResourceConfig {
   resourceRef: ManagedUpstreamResourceRef
   channelId?: number
@@ -25,25 +16,15 @@ export interface ChannelResourceConfig {
 
 export type ChannelResourceConfigMap = Record<string, ChannelResourceConfig>
 
-/**
- * Creates a default channel configuration with empty model filter rules and current timestamps.
- */
-export function createDefaultChannelConfig(channelId: number): ChannelConfig {
-  const timestamp = Date.now()
+export const CHANNEL_CONFIG_SNAPSHOT_VERSION = 1 as const
 
-  return {
-    channelId,
-    modelFilterSettings: {
-      rules: [],
-      updatedAt: timestamp,
-    },
-    createdAt: timestamp,
-    updatedAt: timestamp,
-  }
+export interface ChannelConfigSnapshot {
+  schemaVersion: typeof CHANNEL_CONFIG_SNAPSHOT_VERSION
+  configs: ChannelResourceConfigMap
 }
 
 /**
- * Creates a default resource-keyed channel configuration with empty model filter rules.
+ * Creates a default channel configuration with empty model filter rules and current timestamps.
  */
 export function createDefaultChannelResourceConfig(
   resourceRef: ManagedUpstreamResourceRef,

--- a/src/types/channelModelFilters.ts
+++ b/src/types/channelModelFilters.ts
@@ -63,5 +63,5 @@ export function isProbeChannelModelFilterRule(
 export function isPatternChannelModelFilterRule(
   rule: ChannelModelFilterRule,
 ): rule is ChannelModelPatternFilterRule {
-  return rule.kind !== "probe"
+  return rule.kind === "pattern"
 }

--- a/tests/entrypoints/background/servicesInit.test.ts
+++ b/tests/entrypoints/background/servicesInit.test.ts
@@ -14,6 +14,7 @@ const {
   releaseUpdateInitMock,
   productAnnouncementInitMock,
   newApiOwnedSessionInitMock,
+  legacyChannelConfigMigrationInitMock,
   initBackgroundI18nMock,
 } = vi.hoisted(() => ({
   usageInitMock: vi.fn(),
@@ -27,7 +28,14 @@ const {
   releaseUpdateInitMock: vi.fn(),
   productAnnouncementInitMock: vi.fn(),
   newApiOwnedSessionInitMock: vi.fn(),
+  legacyChannelConfigMigrationInitMock: vi.fn(),
   initBackgroundI18nMock: vi.fn(),
+}))
+
+vi.mock("~/services/managedSites/legacyChannelConfigMigration", () => ({
+  legacyChannelConfigMigration: {
+    initialize: legacyChannelConfigMigrationInitMock,
+  },
 }))
 
 vi.mock("~/services/managedSites/newApiOwnedSession/background", () => ({
@@ -134,6 +142,9 @@ describe("initializeServices alarm bootstrap ordering", () => {
     const modelMetadataInit: InitMock = vi.fn(async () => {})
     const autoRefreshInit: InitMock = vi.fn(async () => {})
     const redemptionAssistInit: InitMock = vi.fn(async () => {})
+    legacyChannelConfigMigrationInitMock.mockResolvedValue({
+      status: "not-needed",
+    })
 
     usageInitMock.mockImplementation(usageInit)
     webdavInitMock.mockImplementation(webdavInit)
@@ -178,6 +189,7 @@ describe("initializeServices alarm bootstrap ordering", () => {
     expect(modelMetadataInit).toHaveBeenCalledTimes(1)
     expect(autoRefreshInit).toHaveBeenCalledTimes(1)
     expect(redemptionAssistInit).toHaveBeenCalledTimes(1)
+    expect(legacyChannelConfigMigrationInitMock).toHaveBeenCalledTimes(1)
   })
 
   it("deduplicates concurrent initialization and skips re-initialization after success", async () => {
@@ -204,6 +216,9 @@ describe("initializeServices alarm bootstrap ordering", () => {
     modelMetadataInitMock.mockResolvedValue(undefined)
     autoRefreshInitMock.mockResolvedValue(undefined)
     redemptionAssistInitMock.mockResolvedValue(undefined)
+    legacyChannelConfigMigrationInitMock.mockResolvedValue({
+      status: "not-needed",
+    })
 
     const first = initializeServices()
     const second = initializeServices()
@@ -224,6 +239,7 @@ describe("initializeServices alarm bootstrap ordering", () => {
     expect(modelMetadataInitMock).toHaveBeenCalledTimes(1)
     expect(autoRefreshInitMock).toHaveBeenCalledTimes(1)
     expect(redemptionAssistInitMock).toHaveBeenCalledTimes(1)
+    expect(legacyChannelConfigMigrationInitMock).toHaveBeenCalledTimes(1)
 
     await initializeServices()
 
@@ -239,6 +255,7 @@ describe("initializeServices alarm bootstrap ordering", () => {
     expect(modelMetadataInitMock).toHaveBeenCalledTimes(1)
     expect(autoRefreshInitMock).toHaveBeenCalledTimes(1)
     expect(redemptionAssistInitMock).toHaveBeenCalledTimes(1)
+    expect(legacyChannelConfigMigrationInitMock).toHaveBeenCalledTimes(1)
   })
 
   it("continues initializing non-alarm services when i18n and an alarm scheduler fail", async () => {
@@ -258,6 +275,9 @@ describe("initializeServices alarm bootstrap ordering", () => {
     modelMetadataInitMock.mockResolvedValue(undefined)
     autoRefreshInitMock.mockResolvedValue(undefined)
     redemptionAssistInitMock.mockResolvedValue(undefined)
+    legacyChannelConfigMigrationInitMock.mockRejectedValueOnce(
+      new Error("migration failed"),
+    )
 
     await expect(initializeServices()).resolves.toBeUndefined()
 
@@ -273,5 +293,6 @@ describe("initializeServices alarm bootstrap ordering", () => {
     expect(modelMetadataInitMock).toHaveBeenCalledTimes(1)
     expect(autoRefreshInitMock).toHaveBeenCalledTimes(1)
     expect(redemptionAssistInitMock).toHaveBeenCalledTimes(1)
+    expect(legacyChannelConfigMigrationInitMock).toHaveBeenCalledTimes(1)
   })
 })

--- a/tests/entrypoints/background/servicesInit.test.ts
+++ b/tests/entrypoints/background/servicesInit.test.ts
@@ -192,6 +192,32 @@ describe("initializeServices alarm bootstrap ordering", () => {
     expect(legacyChannelConfigMigrationInitMock).toHaveBeenCalledTimes(1)
   })
 
+  it("does not block service startup on the network-backed legacy migration", async () => {
+    initBackgroundI18nMock.mockResolvedValue(undefined)
+    usageInitMock.mockResolvedValue(undefined)
+    webdavInitMock.mockResolvedValue(undefined)
+    modelSyncInitMock.mockResolvedValue(undefined)
+    autoCheckinInitMock.mockResolvedValue(undefined)
+    dailyBalanceInitMock.mockResolvedValue(undefined)
+    releaseUpdateInitMock.mockResolvedValue(undefined)
+    productAnnouncementInitMock.mockResolvedValue(undefined)
+    newApiOwnedSessionInitMock.mockResolvedValue(undefined)
+    modelMetadataInitMock.mockResolvedValue(undefined)
+    autoRefreshInitMock.mockResolvedValue(undefined)
+    redemptionAssistInitMock.mockResolvedValue(undefined)
+    legacyChannelConfigMigrationInitMock.mockReturnValue(new Promise(() => {}))
+    const { initializeServices } = await import(
+      "~/entrypoints/background/servicesInit"
+    )
+
+    await expect(initializeServices()).resolves.toBeUndefined()
+
+    expect(legacyChannelConfigMigrationInitMock).toHaveBeenCalledTimes(1)
+    expect(modelMetadataInitMock).toHaveBeenCalledTimes(1)
+    expect(autoRefreshInitMock).toHaveBeenCalledTimes(1)
+    expect(redemptionAssistInitMock).toHaveBeenCalledTimes(1)
+  })
+
   it("deduplicates concurrent initialization and skips re-initialization after success", async () => {
     const { initializeServices } = await import(
       "~/entrypoints/background/servicesInit"

--- a/tests/features/ImportExport/components/WebDAVSettings.test.tsx
+++ b/tests/features/ImportExport/components/WebDAVSettings.test.tsx
@@ -2072,6 +2072,27 @@ describe("WebDAVSettings", () => {
     })
   })
 
+  it("uses the stable decrypt fallback when a failure has no message", async () => {
+    render(<WebDAVSettings />)
+    await openManualDecryptDialog()
+    fireEvent.change(document.getElementById("decryptPassword")!, {
+      target: { value: "manual-secret" },
+    })
+    mockDecryptWebdavBackupEnvelope.mockRejectedValueOnce(null)
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "importExport:webdav.encryption.decryptAction",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        "importExport:webdav.encryption.decryptFailed",
+      )
+    })
+  })
+
   it("shows both import success and stale preference guidance when persisting the decrypt password is rejected by the version guard", async () => {
     mockDownloadBackupRaw.mockResolvedValueOnce("encrypted-payload")
     mockTryParseEncryptedWebdavBackupEnvelope.mockReturnValue(

--- a/tests/features/ImportExport/components/WebDAVSettings.test.tsx
+++ b/tests/features/ImportExport/components/WebDAVSettings.test.tsx
@@ -40,6 +40,10 @@ import {
   setupMockPreferencePersistence,
 } from "~~/tests/test-utils/mockPreferencePersistence"
 
+vi.mock("~/services/managedSites/legacyChannelConfigMigration", () => ({
+  ensureLegacyChannelConfigMigrationReady: vi.fn().mockResolvedValue(undefined),
+}))
+
 const createStalePreferenceWriteResult = (
   expectedLastUpdated: number,
   actualLastUpdated = expectedLastUpdated + 1,

--- a/tests/features/ImportExport/components/WebDAVSettings.test.tsx
+++ b/tests/features/ImportExport/components/WebDAVSettings.test.tsx
@@ -20,6 +20,7 @@ import jaImportExport from "~/locales/ja/importExport.json"
 import viImportExport from "~/locales/vi/importExport.json"
 import zhCnImportExport from "~/locales/zh-CN/importExport.json"
 import zhTwImportExport from "~/locales/zh-TW/importExport.json"
+import { ImportExportError } from "~/services/importExport/importExportService"
 import { resolveProductAnalyticsActionContext } from "~/services/productAnalytics/actionConfig"
 import {
   PRODUCT_ANALYTICS_ACTION_IDS,
@@ -40,9 +41,20 @@ import {
   setupMockPreferencePersistence,
 } from "~~/tests/test-utils/mockPreferencePersistence"
 
-vi.mock("~/services/managedSites/legacyChannelConfigMigration", () => ({
-  ensureLegacyChannelConfigMigrationReady: vi.fn().mockResolvedValue(undefined),
-}))
+vi.mock("~/services/managedSites/legacyChannelConfigMigration", () => {
+  class LegacyChannelConfigMigrationDeferredError extends Error {
+    constructor(readonly reason: string) {
+      super(`Legacy channel config migration deferred: ${reason}`)
+    }
+  }
+
+  return {
+    ensureLegacyChannelConfigMigrationReady: vi
+      .fn()
+      .mockResolvedValue(undefined),
+    LegacyChannelConfigMigrationDeferredError,
+  }
+})
 
 const createStalePreferenceWriteResult = (
   expectedLastUpdated: number,
@@ -813,6 +825,26 @@ describe("WebDAVSettings", () => {
             },
           },
         },
+      )
+    })
+  })
+
+  it("localizes unsupported remote backup versions during WebDAV upload", async () => {
+    mockMergeWebdavBackupPayloadBySelection.mockImplementationOnce(() => {
+      throw new ImportExportError("VERSION_NOT_SUPPORTED")
+    })
+
+    render(<WebDAVSettings />)
+
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "importExport:webdav.uploadBackup",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        "importExport:import.versionNotSupported",
       )
     })
   })

--- a/tests/features/ImportExport/components/WebDAVSettings.test.tsx
+++ b/tests/features/ImportExport/components/WebDAVSettings.test.tsx
@@ -21,6 +21,7 @@ import viImportExport from "~/locales/vi/importExport.json"
 import zhCnImportExport from "~/locales/zh-CN/importExport.json"
 import zhTwImportExport from "~/locales/zh-TW/importExport.json"
 import { ImportExportError } from "~/services/importExport/importExportService"
+import { LegacyChannelConfigMigrationDeferredError } from "~/services/managedSites/legacyChannelConfigMigration"
 import { resolveProductAnalyticsActionContext } from "~/services/productAnalytics/actionConfig"
 import {
   PRODUCT_ANALYTICS_ACTION_IDS,
@@ -845,6 +846,24 @@ describe("WebDAVSettings", () => {
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith(
         "importExport:import.versionNotSupported",
+      )
+    })
+  })
+
+  it("uses the stable upload fallback when a failure has no message", async () => {
+    mockUploadBackup.mockRejectedValueOnce(null)
+
+    render(<WebDAVSettings />)
+
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "importExport:webdav.uploadBackup",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        "importExport:webdav.uploadFailed",
       )
     })
   })
@@ -1935,6 +1954,21 @@ describe("WebDAVSettings", () => {
     })
   })
 
+  it("uses the stable download/import fallback when a failure has no message", async () => {
+    mockImportFromBackupObject.mockRejectedValueOnce(null)
+
+    render(<WebDAVSettings />)
+
+    expect(await screen.findByDisplayValue("alice")).toBeInTheDocument()
+    clickWebdavAction("webdav-download-import")
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        "importExport:import.downloadImportFailed",
+      )
+    })
+  })
+
   it("reopens the decrypt dialog with the stored password when automatic decrypt fails", async () => {
     mockDownloadBackupRaw.mockResolvedValueOnce("encrypted-payload")
     mockTryParseEncryptedWebdavBackupEnvelope.mockReturnValue(
@@ -2012,6 +2046,29 @@ describe("WebDAVSettings", () => {
 
     await waitFor(() => {
       expect(toast.error).toHaveBeenCalledWith("manual decrypt failed")
+    })
+  })
+
+  it("localizes deferred channel-config migration after manual decrypt", async () => {
+    render(<WebDAVSettings />)
+    await openManualDecryptDialog()
+    fireEvent.change(document.getElementById("decryptPassword")!, {
+      target: { value: "manual-secret" },
+    })
+    mockBuildWebdavImportPayloadBySelection.mockRejectedValueOnce(
+      new LegacyChannelConfigMigrationDeferredError("inventory-failed"),
+    )
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "importExport:webdav.encryption.decryptAction",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        "importExport:import.channelConfigMigrationDeferred",
+      )
     })
   })
 

--- a/tests/features/ManagedSiteChannels/components/ChannelFilterDialog.test.tsx
+++ b/tests/features/ManagedSiteChannels/components/ChannelFilterDialog.test.tsx
@@ -204,17 +204,23 @@ const mockedSaveChannelFilters = saveChannelFilters as unknown as ReturnType<
   typeof vi.fn
 >
 
-const sampleChannel = {
-  id: 42,
-  name: "Alpha",
-  type: "midjourney",
-} as any
-
 const sampleResourceRef = createManagedUpstreamResourceRef({
   managedSiteType: "axonhub",
   scopeKey: "https://admin.example.invalid",
   resourceId: "provider/native-id",
 })
+
+const sampleChannel = {
+  id: 42,
+  name: "Alpha",
+  type: "midjourney",
+  resourceRef: sampleResourceRef,
+} as any
+
+const sampleStorageIdentity = {
+  channelId: 42,
+  resourceRef: sampleResourceRef,
+}
 
 describe("ChannelFilterDialog", () => {
   beforeEach(() => {
@@ -251,7 +257,9 @@ describe("ChannelFilterDialog", () => {
     )
 
     await waitFor(() => {
-      expect(mockedFetchChannelFilters).toHaveBeenCalledWith(42)
+      expect(mockedFetchChannelFilters).toHaveBeenCalledWith(
+        sampleStorageIdentity,
+      )
     })
 
     await waitFor(() => {
@@ -357,6 +365,26 @@ describe("ChannelFilterDialog", () => {
     expect(onClose).toHaveBeenCalledTimes(1)
   })
 
+  it("fails closed when a channel row has no resource identity", async () => {
+    const onClose = vi.fn()
+
+    render(
+      <ChannelFilterDialog
+        channel={{ ...sampleChannel, resourceRef: undefined }}
+        open={true}
+        onClose={onClose}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        "managedSiteChannels:filters.messages.loadFailed",
+      )
+    })
+    expect(mockedFetchChannelFilters).not.toHaveBeenCalled()
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
   it("validates regex filters in visual mode before saving", async () => {
     render(
       <ChannelFilterDialog
@@ -443,20 +471,23 @@ describe("ChannelFilterDialog", () => {
     )
 
     await waitFor(() => {
-      expect(mockedSaveChannelFilters).toHaveBeenCalledWith(42, [
-        {
-          id: "generated-filter-id",
-          name: "Allow GPT",
-          description: "keep chat models",
-          kind: "pattern",
-          pattern: "^gpt",
-          isRegex: true,
-          action: "exclude",
-          enabled: false,
-          createdAt: 1_700_000_000_000,
-          updatedAt: 1_700_000_000_000,
-        },
-      ])
+      expect(mockedSaveChannelFilters).toHaveBeenCalledWith(
+        sampleStorageIdentity,
+        [
+          {
+            id: "generated-filter-id",
+            name: "Allow GPT",
+            description: "keep chat models",
+            kind: "pattern",
+            pattern: "^gpt",
+            isRegex: true,
+            action: "exclude",
+            enabled: false,
+            createdAt: 1_700_000_000_000,
+            updatedAt: 1_700_000_000_000,
+          },
+        ],
+      )
     })
 
     expect(toast.success).toHaveBeenCalledWith(
@@ -508,13 +539,16 @@ describe("ChannelFilterDialog", () => {
     )
 
     await waitFor(() => {
-      expect(mockedSaveChannelFilters).toHaveBeenCalledWith(42, [
-        expect.objectContaining({
-          kind: "probe",
-          name: "Rule",
-          probeIds: ["text-generation"],
-        }),
-      ])
+      expect(mockedSaveChannelFilters).toHaveBeenCalledWith(
+        sampleStorageIdentity,
+        [
+          expect.objectContaining({
+            kind: "probe",
+            name: "Rule",
+            probeIds: ["text-generation"],
+          }),
+        ],
+      )
     })
 
     expect(toast.success).toHaveBeenCalledWith(
@@ -678,18 +712,21 @@ describe("ChannelFilterDialog", () => {
     )
 
     await waitFor(() => {
-      expect(mockedSaveChannelFilters).toHaveBeenCalledWith(42, [
-        expect.objectContaining({
-          id: "rule-2",
-          name: "Second",
-          pattern: "second",
-        }),
-        expect.objectContaining({
-          id: "rule-1",
-          name: "First",
-          pattern: "first",
-        }),
-      ])
+      expect(mockedSaveChannelFilters).toHaveBeenCalledWith(
+        sampleStorageIdentity,
+        [
+          expect.objectContaining({
+            id: "rule-2",
+            name: "Second",
+            pattern: "second",
+          }),
+          expect.objectContaining({
+            id: "rule-1",
+            name: "First",
+            pattern: "first",
+          }),
+        ],
+      )
     })
 
     expect(toast.success).toHaveBeenCalledWith(

--- a/tests/features/ManagedSiteChannels/utils/channelFilters.test.ts
+++ b/tests/features/ManagedSiteChannels/utils/channelFilters.test.ts
@@ -11,16 +11,12 @@ import { createManagedUpstreamResourceRef } from "~/types/managedUpstreamResourc
 const {
   mockSendChannelConfigMessage,
   mockGetConfig,
-  mockGetResourceConfig,
   mockUpsertFilters,
-  mockUpsertResourceFilters,
   mockWarn,
 } = vi.hoisted(() => ({
   mockSendChannelConfigMessage: vi.fn(),
   mockGetConfig: vi.fn(),
-  mockGetResourceConfig: vi.fn(),
   mockUpsertFilters: vi.fn(),
-  mockUpsertResourceFilters: vi.fn(),
   mockWarn: vi.fn(),
 }))
 
@@ -41,9 +37,7 @@ vi.mock(
 vi.mock("~/services/managedSites/channelConfigStorage", () => ({
   channelConfigStorage: {
     getConfig: mockGetConfig,
-    getConfigByResourceRef: mockGetResourceConfig,
     upsertFilters: mockUpsertFilters,
-    upsertResourceFilters: mockUpsertResourceFilters,
   },
 }))
 
@@ -87,11 +81,13 @@ describe("channelFilters", () => {
       },
     })
 
-    await expect(fetchChannelFilters(9)).resolves.toEqual(sampleRules)
+    await expect(
+      fetchChannelFilters({ channelId: 9, resourceRef: sampleResourceRef }),
+    ).resolves.toEqual(sampleRules)
 
     expect(mockSendChannelConfigMessage).toHaveBeenCalledWith(
       ChannelConfigMessageTypes.Get,
-      { channelId: 9 },
+      { channelId: 9, resourceRef: sampleResourceRef },
     )
     expect(mockGetConfig).not.toHaveBeenCalled()
   })
@@ -121,7 +117,6 @@ describe("channelFilters", () => {
       },
     )
     expect(mockGetConfig).not.toHaveBeenCalled()
-    expect(mockGetResourceConfig).not.toHaveBeenCalled()
   })
 
   it("throws explicit runtime load failures instead of falling back to local storage", async () => {
@@ -130,7 +125,9 @@ describe("channelFilters", () => {
       error: "runtime unavailable",
     })
 
-    await expect(fetchChannelFilters(11)).rejects.toThrow("runtime unavailable")
+    await expect(
+      fetchChannelFilters({ channelId: 11, resourceRef: sampleResourceRef }),
+    ).rejects.toThrow("runtime unavailable")
 
     expect(mockGetConfig).not.toHaveBeenCalled()
     expect(mockWarn).not.toHaveBeenCalled()
@@ -146,9 +143,11 @@ describe("channelFilters", () => {
       },
     })
 
-    await expect(fetchChannelFilters(11)).resolves.toEqual(sampleRules)
+    await expect(
+      fetchChannelFilters({ channelId: 11, resourceRef: sampleResourceRef }),
+    ).resolves.toEqual(sampleRules)
 
-    expect(mockGetConfig).toHaveBeenCalledWith(11)
+    expect(mockGetConfig).toHaveBeenCalledWith(sampleResourceRef)
     expect(mockWarn).toHaveBeenCalledTimes(1)
   })
 
@@ -156,7 +155,7 @@ describe("channelFilters", () => {
     mockSendChannelConfigMessage.mockRejectedValue(
       new Error("Receiving end does not exist"),
     )
-    mockGetResourceConfig.mockResolvedValue({
+    mockGetConfig.mockResolvedValue({
       modelFilterSettings: {
         rules: sampleRules,
       },
@@ -169,20 +168,25 @@ describe("channelFilters", () => {
       }),
     ).resolves.toEqual(sampleRules)
 
-    expect(mockGetResourceConfig).toHaveBeenCalledWith(sampleResourceRef, 11)
-    expect(mockGetConfig).not.toHaveBeenCalled()
+    expect(mockGetConfig).toHaveBeenCalledWith(sampleResourceRef)
     expect(mockWarn).toHaveBeenCalledTimes(1)
   })
 
   it("saves through the runtime handler when available", async () => {
     mockSendChannelConfigMessage.mockResolvedValue({ success: true })
 
-    await expect(saveChannelFilters(15, sampleRules)).resolves.toBeUndefined()
+    await expect(
+      saveChannelFilters(
+        { channelId: 15, resourceRef: sampleResourceRef },
+        sampleRules,
+      ),
+    ).resolves.toBeUndefined()
 
     expect(mockSendChannelConfigMessage).toHaveBeenCalledWith(
       ChannelConfigMessageTypes.UpsertFilters,
       {
         channelId: 15,
+        resourceRef: sampleResourceRef,
         filters: sampleRules,
       },
     )
@@ -211,18 +215,26 @@ describe("channelFilters", () => {
       },
     )
     expect(mockUpsertFilters).not.toHaveBeenCalled()
-    expect(mockUpsertResourceFilters).not.toHaveBeenCalled()
   })
 
   it("falls back to local persistence when runtime saving fails", async () => {
     mockSendChannelConfigMessage.mockRejectedValue(
       new Error("Receiving end does not exist"),
     )
-    mockUpsertFilters.mockResolvedValue(true)
+    mockUpsertFilters.mockResolvedValue(undefined)
 
-    await expect(saveChannelFilters(19, sampleRules)).resolves.toBeUndefined()
+    await expect(
+      saveChannelFilters(
+        { channelId: 19, resourceRef: sampleResourceRef },
+        sampleRules,
+      ),
+    ).resolves.toBeUndefined()
 
-    expect(mockUpsertFilters).toHaveBeenCalledWith(19, sampleRules)
+    expect(mockUpsertFilters).toHaveBeenCalledWith(
+      sampleResourceRef,
+      sampleRules,
+      19,
+    )
     expect(mockWarn).toHaveBeenCalledTimes(1)
   })
 
@@ -230,7 +242,7 @@ describe("channelFilters", () => {
     mockSendChannelConfigMessage.mockRejectedValue(
       new Error("Receiving end does not exist"),
     )
-    mockUpsertResourceFilters.mockResolvedValue(true)
+    mockUpsertFilters.mockResolvedValue(undefined)
 
     await expect(
       saveChannelFilters(
@@ -242,12 +254,11 @@ describe("channelFilters", () => {
       ),
     ).resolves.toBeUndefined()
 
-    expect(mockUpsertResourceFilters).toHaveBeenCalledWith(
+    expect(mockUpsertFilters).toHaveBeenCalledWith(
       sampleResourceRef,
       sampleRules,
       19,
     )
-    expect(mockUpsertFilters).not.toHaveBeenCalled()
     expect(mockWarn).toHaveBeenCalledTimes(1)
   })
 
@@ -257,9 +268,12 @@ describe("channelFilters", () => {
       error: "save rejected",
     })
 
-    await expect(saveChannelFilters(21, sampleRules)).rejects.toThrow(
-      "save rejected",
-    )
+    await expect(
+      saveChannelFilters(
+        { channelId: 21, resourceRef: sampleResourceRef },
+        sampleRules,
+      ),
+    ).rejects.toThrow("save rejected")
 
     expect(mockUpsertFilters).not.toHaveBeenCalled()
     expect(mockWarn).not.toHaveBeenCalled()
@@ -269,12 +283,19 @@ describe("channelFilters", () => {
     mockSendChannelConfigMessage.mockRejectedValue(
       new Error("Receiving end does not exist"),
     )
-    mockUpsertFilters.mockResolvedValue(false)
+    mockUpsertFilters.mockRejectedValue(new Error("local write failed"))
 
-    await expect(saveChannelFilters(21, sampleRules)).rejects.toThrow(
-      "Failed to persist filters locally",
+    await expect(
+      saveChannelFilters(
+        { channelId: 21, resourceRef: sampleResourceRef },
+        sampleRules,
+      ),
+    ).rejects.toThrow("local write failed")
+
+    expect(mockUpsertFilters).toHaveBeenCalledWith(
+      sampleResourceRef,
+      sampleRules,
+      21,
     )
-
-    expect(mockUpsertFilters).toHaveBeenCalledWith(21, sampleRules)
   })
 })

--- a/tests/services/apiTransport/pagination.test.ts
+++ b/tests/services/apiTransport/pagination.test.ts
@@ -81,4 +81,21 @@ describe("API transport pagination helpers", () => {
       },
     )
   })
+
+  it("fetchAllItems fails closed when a caller requires a complete inventory", async () => {
+    const fetchPage = vi.fn().mockResolvedValue({
+      items: ["keep-going"],
+      hasMore: true,
+    })
+
+    await expect(
+      fetchAllItems(fetchPage, {
+        pageSize: 1,
+        maxPages: 1,
+        requireComplete: true,
+      }),
+    ).rejects.toThrow("Pagination limit reached before the inventory completed")
+
+    expect(fetchPage).toHaveBeenCalledTimes(1)
+  })
 })

--- a/tests/services/apiTransport/pagination.test.ts
+++ b/tests/services/apiTransport/pagination.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import {
   extractItemsFromArrayOrItemsPayload,
   fetchAllItems,
+  PaginationLimitError,
 } from "~/services/apiTransport/pagination"
 
 const { mockLoggerWarn } = vi.hoisted(() => ({
@@ -94,8 +95,24 @@ describe("API transport pagination helpers", () => {
         maxPages: 1,
         requireComplete: true,
       }),
-    ).rejects.toThrow("Pagination limit reached before the inventory completed")
+    ).rejects.toBeInstanceOf(PaginationLimitError)
 
+    expect(fetchPage).toHaveBeenCalledTimes(1)
+  })
+
+  it("accepts an explicitly complete inventory before the page cap", async () => {
+    const fetchPage = vi.fn().mockResolvedValue({
+      items: ["complete"],
+      hasMore: false,
+    })
+
+    await expect(
+      fetchAllItems(fetchPage, {
+        pageSize: 1,
+        maxPages: 1,
+        requireComplete: true,
+      }),
+    ).resolves.toEqual(["complete"])
     expect(fetchPage).toHaveBeenCalledTimes(1)
   })
 })

--- a/tests/services/channelConfigStorage.test.ts
+++ b/tests/services/channelConfigStorage.test.ts
@@ -1047,6 +1047,76 @@ describe("channelConfigStorage", () => {
     })
   })
 
+  it("discards malformed local entries while retaining valid scoped configs", async () => {
+    const valid = createConfig({
+      scopeKey: "https://valid.example.invalid",
+      ruleId: "valid-rule",
+    })
+    storageData.set(CHANNEL_CONFIG_STORAGE_KEYS.CHANNEL_RESOURCE_CONFIGS, {
+      primitive: "invalid",
+      invalidRef: {
+        ...valid,
+        resourceRef: { ...valid.resourceRef, scopeKey: "" },
+      },
+      invalidRules: {
+        ...valid,
+        resourceRef: createRef("https://invalid-rules.example.invalid"),
+        modelFilterSettings: { rules: "invalid" },
+      },
+      reversedRuleTimestamps: {
+        ...valid,
+        resourceRef: createRef("https://reversed-time.example.invalid"),
+        modelFilterSettings: {
+          rules: [
+            {
+              ...valid.modelFilterSettings.rules[0],
+              createdAt: 300,
+              updatedAt: 200,
+            },
+          ],
+        },
+      },
+      valid,
+    })
+
+    const configs = (await channelConfigStorage.exportConfigs()).configs
+
+    expect(Object.keys(configs)).toHaveLength(3)
+    expect(
+      configs[getManagedUpstreamResourceRefKey(valid.resourceRef)],
+    ).toEqual(valid)
+    expect(
+      configs[
+        getManagedUpstreamResourceRefKey(
+          createRef("https://invalid-rules.example.invalid"),
+        )
+      ].modelFilterSettings.rules,
+    ).toEqual([])
+    expect(
+      configs[
+        getManagedUpstreamResourceRefKey(
+          createRef("https://reversed-time.example.invalid"),
+        )
+      ].modelFilterSettings.rules[0],
+    ).toMatchObject({ createdAt: 200, updatedAt: 200 })
+  })
+
+  it("treats a non-map legacy value as having no migratable configs", async () => {
+    storageData.set(CHANNEL_CONFIG_STORAGE_KEYS.CHANNEL_CONFIGS, "invalid")
+
+    await expect(channelConfigStorage.hasLegacyNumericConfigs()).resolves.toBe(
+      false,
+    )
+    await expect(
+      channelConfigStorage.migrateLegacyNumericConfigs([
+        {
+          channelId: 9,
+          resourceRef: createRef("https://admin.example.invalid", 9),
+        },
+      ]),
+    ).resolves.toEqual({ migrated: 0, ambiguous: 0, unmatched: 0 })
+  })
+
   it("exports historical rules as a snapshot that the strict interface can restore", async () => {
     const resourceRef = createRef("https://historical.example.invalid")
     const rule = createConfig({

--- a/tests/services/channelConfigStorage.test.ts
+++ b/tests/services/channelConfigStorage.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
+import { Storage } from "@plasmohq/storage"
+
 import { CHANNEL_CONFIG_STORAGE_KEYS } from "~/services/core/storageKeys"
 import { ChannelConfigMessageTypes } from "~/services/managedSites/channelConfigMessaging"
 import {
@@ -307,7 +309,7 @@ describe("channelConfigStorage", () => {
   })
 
   it("propagates storage read failures instead of returning an empty map", async () => {
-    const storage = (channelConfigStorage as any).storage
+    const storage = Storage.prototype
     vi.spyOn(storage, "get").mockRejectedValueOnce(new Error("read failed"))
 
     await expect(channelConfigStorage.exportConfigs()).rejects.toThrow(
@@ -317,7 +319,7 @@ describe("channelConfigStorage", () => {
 
   it("propagates authoritative write failures", async () => {
     const resourceRef = createRef("https://admin.example.invalid")
-    const storage = (channelConfigStorage as any).storage
+    const storage = Storage.prototype
     vi.spyOn(storage, "set").mockRejectedValueOnce(new Error("write failed"))
 
     await expect(
@@ -361,6 +363,80 @@ describe("channelConfigStorage", () => {
         modelFilterSettings: expect.objectContaining({
           rules: [expect.objectContaining({ id: "numeric-newer" })],
         }),
+      }),
+    )
+  })
+
+  it("keeps newer scoped rules while attaching the resolved legacy channel id", async () => {
+    const resourceRef = createRef("https://admin.example.invalid", 9)
+    const existing = createConfig({
+      scopeKey: resourceRef.scopeKey,
+      resourceId: 9,
+      channelId: 8,
+      ruleId: "resource-newer",
+      updatedAt: 300,
+    })
+    const legacy = createConfig({
+      scopeKey: "https://legacy.example.invalid",
+      channelId: 9,
+      ruleId: "numeric-older",
+      updatedAt: 200,
+    })
+    storageData.set(CHANNEL_CONFIG_STORAGE_KEYS.CHANNEL_CONFIGS, { 9: legacy })
+    storageData.set(
+      CHANNEL_CONFIG_STORAGE_KEYS.CHANNEL_RESOURCE_CONFIGS,
+      snapshotOf(existing).configs,
+    )
+
+    await expect(
+      channelConfigStorage.migrateLegacyNumericConfigs([
+        { channelId: 9, resourceRef },
+      ]),
+    ).resolves.toEqual({ migrated: 1, ambiguous: 0, unmatched: 0 })
+    await expect(channelConfigStorage.getConfig(resourceRef)).resolves.toEqual(
+      expect.objectContaining({
+        channelId: 9,
+        modelFilterSettings: expect.objectContaining({
+          rules: [expect.objectContaining({ id: "resource-newer" })],
+        }),
+      }),
+    )
+  })
+
+  it("sanitizes historical numeric filters with deterministic timestamps", async () => {
+    const resourceRef = createRef("https://admin.example.invalid", 9)
+    storageData.set(CHANNEL_CONFIG_STORAGE_KEYS.CHANNEL_CONFIGS, {
+      9: {
+        channelId: 9,
+        filters: [
+          {
+            name: "Legacy filter",
+            pattern: "gpt",
+            isRegex: false,
+          },
+        ],
+      },
+    })
+
+    await expect(
+      channelConfigStorage.migrateLegacyNumericConfigs([
+        { channelId: 9, resourceRef },
+      ]),
+    ).resolves.toEqual({ migrated: 1, ambiguous: 0, unmatched: 0 })
+    await expect(channelConfigStorage.getConfig(resourceRef)).resolves.toEqual(
+      expect.objectContaining({
+        createdAt: 1,
+        updatedAt: 1,
+        modelFilterSettings: {
+          updatedAt: 1,
+          rules: [
+            expect.objectContaining({
+              name: "Legacy filter",
+              createdAt: 1,
+              updatedAt: 1,
+            }),
+          ],
+        },
       }),
     )
   })
@@ -473,7 +549,7 @@ describe("channelConfigStorage", () => {
       updatedAt: 300,
     })
     storageData.set(CHANNEL_CONFIG_STORAGE_KEYS.CHANNEL_CONFIGS, { 9: legacy })
-    const storage = (channelConfigStorage as any).storage
+    const storage = Storage.prototype
     vi.spyOn(storage, "set").mockRejectedValueOnce(new Error("write failed"))
 
     await expect(
@@ -495,7 +571,7 @@ describe("channelConfigStorage", () => {
       updatedAt: 300,
     })
     storageData.set(CHANNEL_CONFIG_STORAGE_KEYS.CHANNEL_CONFIGS, { 9: legacy })
-    const storage = (channelConfigStorage as any).storage
+    const storage = Storage.prototype
     vi.spyOn(storage, "remove").mockRejectedValueOnce(
       new Error("cleanup failed"),
     )
@@ -558,7 +634,7 @@ describe("channelConfigStorage", () => {
       ruleId: "site-a",
     })
     storageData.set(CHANNEL_CONFIG_STORAGE_KEYS.CHANNEL_CONFIGS, { 9: siteA })
-    const storage = (channelConfigStorage as any).storage
+    const storage = Storage.prototype
     vi.spyOn(storage, "remove").mockRejectedValueOnce(
       new Error("cleanup failed"),
     )
@@ -588,7 +664,7 @@ describe("channelConfigStorage", () => {
       ruleId: "site-a",
     })
     storageData.set(CHANNEL_CONFIG_STORAGE_KEYS.CHANNEL_CONFIGS, { 9: siteA })
-    const storage = (channelConfigStorage as any).storage
+    const storage = Storage.prototype
     const originalRemove = storage.remove.bind(storage)
     let failedMarkerCleanup = false
     vi.spyOn(storage, "remove").mockImplementation(
@@ -626,26 +702,51 @@ describe("channelConfigStorage", () => {
     )
   })
 
+  it("rejects malformed and incomplete replacement transaction markers", async () => {
+    storageData.set(CHANNEL_CONFIG_STORAGE_KEYS.LEGACY_REPLACEMENT_STATE, {
+      phase: "prepared",
+      snapshot: { schemaVersion: 99, configs: {} },
+    })
+    await expect(channelConfigStorage.exportConfigs()).rejects.toThrow(
+      "replacement state is invalid",
+    )
+
+    storageData.set(CHANNEL_CONFIG_STORAGE_KEYS.LEGACY_REPLACEMENT_STATE, {
+      phase: "prepared",
+      snapshot: { schemaVersion: CHANNEL_CONFIG_SNAPSHOT_VERSION, configs: {} },
+    })
+    await expect(channelConfigStorage.exportConfigs()).rejects.toThrow(
+      "replacement is incomplete",
+    )
+  })
+
   it.each([
-    ["before the resource write", 2],
-    ["before the commit marker", 3],
-  ])("replays a replacement interrupted %s", async (_label, failingSetCall) => {
+    ["before the resource write", "resource"],
+    ["before the commit marker", "commit"],
+  ] as const)("replays a replacement interrupted %s", async (_label, phase) => {
     const siteA = createConfig({
       scopeKey: "https://a.example.invalid",
       channelId: 9,
       ruleId: "site-a",
     })
     storageData.set(CHANNEL_CONFIG_STORAGE_KEYS.CHANNEL_CONFIGS, { 9: siteA })
-    const storage = (channelConfigStorage as any).storage
-    const originalSet = storage.set.bind(storage)
-    let setCallCount = 0
+    const storage = Storage.prototype
+    const originalSet = storage.set
+    let failed = false
     vi.spyOn(storage, "set").mockImplementation(async (...args: unknown[]) => {
       const [key, value] = args as [string, unknown]
-      setCallCount += 1
-      if (setCallCount === failingSetCall) {
+      const shouldFail =
+        phase === "resource"
+          ? key === CHANNEL_CONFIG_STORAGE_KEYS.CHANNEL_RESOURCE_CONFIGS
+          : key === CHANNEL_CONFIG_STORAGE_KEYS.LEGACY_REPLACEMENT_STATE &&
+            typeof value === "object" &&
+            value !== null &&
+            (value as { phase?: unknown }).phase === "committed"
+      if (!failed && shouldFail) {
+        failed = true
         throw new Error("write failed")
       }
-      await originalSet(key, value)
+      return await originalSet(key, value)
     })
 
     await expect(
@@ -683,6 +784,23 @@ describe("channelConfigStorage", () => {
     await expect(channelConfigStorage.importConfigs(legacy)).rejects.toThrow(
       "snapshot is invalid",
     )
+  })
+
+  it("rejects invalid refs and snapshots at direct storage boundaries", async () => {
+    const invalidRef = {
+      ...createRef("https://admin.example.invalid"),
+      scopeKey: "",
+    }
+
+    await expect(channelConfigStorage.getConfig(invalidRef)).rejects.toThrow(
+      "resourceRef is invalid",
+    )
+    await expect(
+      channelConfigStorage.upsertFilters(invalidRef, []),
+    ).rejects.toThrow("resourceRef is invalid")
+    await expect(
+      channelConfigStorage.mergeConfigs({ configs: {} }),
+    ).rejects.toThrow("snapshot is invalid")
   })
 
   it.each([
@@ -757,6 +875,98 @@ describe("channelConfigStorage", () => {
       "a non-boolean enabled flag",
       (config: any) => {
         config.modelFilterSettings.rules[0].enabled = "yes"
+      },
+    ],
+    [
+      "a non-string description",
+      (config: any) => {
+        config.modelFilterSettings.rules[0].description = 123
+      },
+    ],
+    [
+      "an unknown rule kind",
+      (config: any) => {
+        config.modelFilterSettings.rules[0].kind = "future-kind"
+      },
+    ],
+    [
+      "a blank pattern",
+      (config: any) => {
+        config.modelFilterSettings.rules[0].pattern = " "
+      },
+    ],
+    [
+      "a non-boolean regex flag",
+      (config: any) => {
+        config.modelFilterSettings.rules[0].isRegex = "yes"
+      },
+    ],
+    [
+      "an unsafe regex pattern",
+      (config: any) => {
+        config.modelFilterSettings.rules[0].pattern = "(a+)+$"
+        config.modelFilterSettings.rules[0].isRegex = true
+      },
+    ],
+    [
+      "an empty probe list",
+      (config: any) => {
+        const rule = config.modelFilterSettings.rules[0]
+        Object.assign(rule, { kind: "probe", probeIds: [], match: "all" })
+        delete rule.pattern
+        delete rule.isRegex
+      },
+    ],
+    [
+      "an invalid probe match mode",
+      (config: any) => {
+        const rule = config.modelFilterSettings.rules[0]
+        Object.assign(rule, {
+          kind: "probe",
+          probeIds: ["text-generation"],
+          match: "none",
+        })
+        delete rule.pattern
+        delete rule.isRegex
+      },
+    ],
+    [
+      "duplicate probe identifiers",
+      (config: any) => {
+        const rule = config.modelFilterSettings.rules[0]
+        Object.assign(rule, {
+          kind: "probe",
+          probeIds: ["text-generation", "text-generation"],
+          match: "all",
+        })
+        delete rule.pattern
+        delete rule.isRegex
+      },
+    ],
+    [
+      "an unsupported probe identifier",
+      (config: any) => {
+        const rule = config.modelFilterSettings.rules[0]
+        Object.assign(rule, {
+          kind: "probe",
+          probeIds: ["unknown-probe"],
+          match: "all",
+        })
+        delete rule.pattern
+        delete rule.isRegex
+      },
+    ],
+    [
+      "a non-string probe identifier",
+      (config: any) => {
+        const rule = config.modelFilterSettings.rules[0]
+        Object.assign(rule, {
+          kind: "probe",
+          probeIds: [123],
+          match: "all",
+        })
+        delete rule.pattern
+        delete rule.isRegex
       },
     ],
     [
@@ -970,8 +1180,15 @@ describe("channelConfigStorage", () => {
       }),
     ).resolves.toEqual({
       success: false,
-      error: expect.stringContaining("Invalid regex pattern"),
+      error: "Invalid or unsafe regex pattern",
     })
+
+    await expect(
+      resolveChannelConfigUpsertFiltersMessage({
+        resourceRef: { ...resourceRef, scopeKey: "" },
+        filters: [],
+      }),
+    ).resolves.toEqual({ success: false, error: "resourceRef is invalid" })
   })
 
   it("registers typed channel-config listeners once", () => {

--- a/tests/services/channelConfigStorage.test.ts
+++ b/tests/services/channelConfigStorage.test.ts
@@ -1,13 +1,23 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
+import { CHANNEL_CONFIG_STORAGE_KEYS } from "~/services/core/storageKeys"
 import { ChannelConfigMessageTypes } from "~/services/managedSites/channelConfigMessaging"
 import {
   channelConfigStorage,
+  coerceChannelConfigSnapshot,
   resolveChannelConfigGetMessage,
   resolveChannelConfigUpsertFiltersMessage,
   setupChannelConfigMessagingListeners,
 } from "~/services/managedSites/channelConfigStorage"
-import { createManagedUpstreamResourceRef } from "~/types/managedUpstreamResource"
+import {
+  CHANNEL_CONFIG_SNAPSHOT_VERSION,
+  type ChannelConfigSnapshot,
+  type ChannelResourceConfig,
+} from "~/types/channelConfig"
+import {
+  createManagedUpstreamResourceRef,
+  getManagedUpstreamResourceRefKey,
+} from "~/types/managedUpstreamResource"
 
 const storageData = new Map<string, any>()
 
@@ -24,6 +34,10 @@ vi.mock("@plasmohq/storage", () => {
 
     async set(key: string, value: any) {
       storageData.set(key, value)
+    }
+
+    async remove(key: string) {
+      storageData.delete(key)
     }
   }
 
@@ -48,6 +62,59 @@ vi.mock(
   },
 )
 
+const createRef = (scopeKey: string, resourceId: string | number = 9) =>
+  createManagedUpstreamResourceRef({
+    managedSiteType: "new-api",
+    scopeKey,
+    resourceId,
+  })
+
+const createConfig = (params: {
+  scopeKey: string
+  resourceId?: string | number
+  channelId?: number
+  ruleId?: string
+  updatedAt?: number
+}): ChannelResourceConfig => {
+  const updatedAt = params.updatedAt ?? 200
+  return {
+    resourceRef: createRef(params.scopeKey, params.resourceId),
+    ...(params.channelId === undefined ? {} : { channelId: params.channelId }),
+    createdAt: 100,
+    updatedAt,
+    modelFilterSettings: {
+      updatedAt,
+      rules: params.ruleId
+        ? [
+            {
+              id: params.ruleId,
+              kind: "pattern",
+              name: params.ruleId,
+              pattern: params.ruleId,
+              isRegex: false,
+              action: "include",
+              enabled: true,
+              createdAt: 100,
+              updatedAt,
+            },
+          ]
+        : [],
+    },
+  }
+}
+
+const snapshotOf = (
+  ...configs: ChannelResourceConfig[]
+): ChannelConfigSnapshot => ({
+  schemaVersion: CHANNEL_CONFIG_SNAPSHOT_VERSION,
+  configs: Object.fromEntries(
+    configs.map((config) => [
+      getManagedUpstreamResourceRefKey(config.resourceRef),
+      config,
+    ]),
+  ),
+})
+
 describe("channelConfigStorage", () => {
   beforeEach(() => {
     storageData.clear()
@@ -56,698 +123,488 @@ describe("channelConfigStorage", () => {
     vi.setSystemTime(new Date("2026-03-28T05:30:00.000Z"))
   })
 
-  it("stores native resource-keyed configs separately without forcing numeric channel conversion", async () => {
-    const resourceRef = createManagedUpstreamResourceRef({
-      managedSiteType: "axonhub",
-      scopeKey: "https://admin.example.invalid",
-      resourceId: "provider/native-id",
-    })
-    storageData.set("channel_configs", {
-      9: {
-        channelId: 9,
-        createdAt: 111,
-        updatedAt: 222,
-        modelFilterSettings: {
-          rules: [],
-          updatedAt: 222,
-        },
-      },
-    })
+  it("keeps equal numeric channel ids isolated by managed-site scope", async () => {
+    const siteARef = createRef("https://a.example.invalid", 9)
+    const siteBRef = createRef("https://b.example.invalid", 9)
 
-    const ok = await channelConfigStorage.upsertResourceFilters(
-      resourceRef,
-      [
-        {
-          id: "resource-rule",
-          name: "Resource Rule",
-          pattern: "gpt",
-          isRegex: false,
-          action: "include",
-          enabled: true,
-          createdAt: 50,
-          updatedAt: 60,
-        },
-      ],
+    await channelConfigStorage.upsertFilters(
+      siteARef,
+      createConfig({
+        scopeKey: siteARef.scopeKey,
+        ruleId: "site-a",
+      }).modelFilterSettings.rules,
       9,
     )
-
-    expect(ok).toBe(true)
-    expect(storageData.get("channel_configs")[9]).toEqual(
-      expect.objectContaining({
-        channelId: 9,
-        createdAt: 111,
-        modelFilterSettings: {
-          rules: [],
-          updatedAt: 222,
-        },
-      }),
+    await channelConfigStorage.upsertFilters(
+      siteBRef,
+      createConfig({
+        scopeKey: siteBRef.scopeKey,
+        ruleId: "site-b",
+      }).modelFilterSettings.rules,
+      9,
     )
-    expect(storageData.get("channel_resource_configs")).toEqual({
-      "axonhub:https%3A%2F%2Fadmin.example.invalid:provider%2Fnative-id":
-        expect.objectContaining({
-          channelId: 9,
-          resourceRef,
-          modelFilterSettings: {
-            updatedAt: Date.now(),
-            rules: [
-              expect.objectContaining({
-                id: "resource-rule",
-                name: "Resource Rule",
-              }),
-            ],
-          },
-        }),
-    })
 
     await expect(
-      channelConfigStorage.getConfigByResourceRef(resourceRef, 9),
-    ).resolves.toEqual(
-      expect.objectContaining({
-        channelId: 9,
-        resourceRef,
-        modelFilterSettings: {
-          updatedAt: Date.now(),
-          rules: [
-            expect.objectContaining({
-              id: "resource-rule",
-            }),
-          ],
-        },
+      channelConfigStorage.getConfigsForScope({
+        managedSiteType: "new-api",
+        scopeKey: "https://a.example.invalid/path",
       }),
-    )
-  })
-
-  it("mirrors channel-shaped resource configs to numeric storage for model sync fallback", async () => {
-    const resourceRef = createManagedUpstreamResourceRef({
-      managedSiteType: "new-api",
-      scopeKey: "https://admin.example.invalid",
-      resourceId: 9,
-    })
-
-    const ok = await channelConfigStorage.upsertResourceFilters(
-      resourceRef,
-      [
-        {
-          id: "channel-shaped-rule",
-          name: "Channel Shaped Rule",
-          pattern: "gpt",
-          isRegex: false,
-          action: "include",
-          enabled: true,
-          createdAt: 50,
-          updatedAt: 60,
-        },
-      ],
-      9,
-    )
-
-    expect(ok).toBe(true)
-    expect(storageData.get("channel_configs")[9]).toEqual(
-      expect.objectContaining({
-        channelId: 9,
-        modelFilterSettings: {
-          updatedAt: Date.now(),
-          rules: [
-            expect.objectContaining({
-              id: "channel-shaped-rule",
-              name: "Channel Shaped Rule",
-            }),
-          ],
-        },
-      }),
-    )
-    expect(storageData.get("channel_resource_configs")).toEqual({
-      "new-api:https%3A%2F%2Fadmin.example.invalid:9": expect.objectContaining({
-        channelId: 9,
-        resourceRef,
-        modelFilterSettings: {
-          updatedAt: Date.now(),
-          rules: [
-            expect.objectContaining({
-              id: "channel-shaped-rule",
-            }),
-          ],
-        },
-      }),
-    })
-  })
-
-  it("keeps a successful resource save when the legacy mirror write fails", async () => {
-    const resourceRef = createManagedUpstreamResourceRef({
-      managedSiteType: "new-api",
-      scopeKey: "https://admin.example.invalid",
-      resourceId: 9,
-    })
-    const upsertSpy = vi
-      .spyOn(channelConfigStorage, "upsertFilters")
-      .mockResolvedValueOnce(false)
-
-    const ok = await channelConfigStorage.upsertResourceFilters(
-      resourceRef,
-      [
-        {
-          id: "resource-primary-rule",
-          name: "Resource Primary Rule",
-          pattern: "gpt",
-          isRegex: false,
-          action: "include",
-          enabled: true,
-          createdAt: 50,
-          updatedAt: 60,
-        },
-      ],
-      9,
-    )
-
-    expect(ok).toBe(true)
-    expect(storageData.get("channel_resource_configs")).toEqual({
-      "new-api:https%3A%2F%2Fadmin.example.invalid:9": expect.objectContaining({
-        channelId: 9,
-        resourceRef,
+    ).resolves.toEqual({
+      [getManagedUpstreamResourceRefKey(siteARef)]: expect.objectContaining({
+        resourceRef: siteARef,
         modelFilterSettings: expect.objectContaining({
-          rules: [
-            expect.objectContaining({
-              id: "resource-primary-rule",
-            }),
-          ],
+          rules: [expect.objectContaining({ id: "site-a" })],
         }),
       }),
     })
-    await expect(channelConfigStorage.getAllConfigs()).resolves.toEqual({
-      9: expect.objectContaining({
-        channelId: 9,
+    await expect(channelConfigStorage.getConfig(siteBRef)).resolves.toEqual(
+      expect.objectContaining({
+        resourceRef: siteBRef,
         modelFilterSettings: expect.objectContaining({
-          rules: [expect.objectContaining({ id: "resource-primary-rule" })],
+          rules: [expect.objectContaining({ id: "site-b" })],
         }),
       }),
-    })
-
-    upsertSpy.mockRestore()
-  })
-
-  it("does not mirror native resource configs to numeric storage even when ids look numeric", async () => {
-    const resourceRef = createManagedUpstreamResourceRef({
-      managedSiteType: "axonhub",
-      scopeKey: "https://admin.example.invalid",
-      resourceId: 9,
-    })
-
-    const ok = await channelConfigStorage.upsertResourceFilters(
-      resourceRef,
-      [
-        {
-          id: "native-numeric-rule",
-          name: "Native Numeric Rule",
-          pattern: "gpt",
-          isRegex: false,
-          action: "include",
-          enabled: true,
-          createdAt: 50,
-          updatedAt: 60,
-        },
-      ],
-      9,
-    )
-
-    expect(ok).toBe(true)
-    expect(storageData.get("channel_configs")).toBeUndefined()
-    expect(storageData.get("channel_resource_configs")).toEqual({
-      "axonhub:https%3A%2F%2Fadmin.example.invalid:9": expect.objectContaining({
-        channelId: 9,
-        resourceRef,
-        modelFilterSettings: {
-          updatedAt: Date.now(),
-          rules: [
-            expect.objectContaining({
-              id: "native-numeric-rule",
-            }),
-          ],
-        },
-      }),
-    })
-  })
-
-  it("falls back to numeric channel config when a resource-keyed config is missing", async () => {
-    const resourceRef = createManagedUpstreamResourceRef({
-      managedSiteType: "new-api",
-      scopeKey: "https://admin.example.invalid",
-      resourceId: 9,
-    })
-    storageData.set("channel_configs", {
-      9: {
-        channelId: 9,
-        createdAt: 111,
-        updatedAt: 222,
-        modelFilterSettings: {
-          updatedAt: 222,
-          rules: [
-            {
-              id: "legacy-rule",
-              name: "Legacy Rule",
-              pattern: "legacy",
-              isRegex: false,
-              action: "include",
-              enabled: true,
-              createdAt: 50,
-              updatedAt: 60,
-            },
-          ],
-        },
-      },
-    })
-
-    await expect(
-      channelConfigStorage.getConfigByResourceRef(resourceRef, 9),
-    ).resolves.toEqual(
-      expect.objectContaining({
-        channelId: 9,
-        resourceRef,
-        modelFilterSettings: {
-          updatedAt: 222,
-          rules: [
-            expect.objectContaining({
-              id: "legacy-rule",
-              name: "Legacy Rule",
-            }),
-          ],
-        },
-      }),
     )
   })
 
-  it("supports resource-keyed configs without numeric channel ids", async () => {
-    const resourceRef = createManagedUpstreamResourceRef({
-      managedSiteType: "axonhub",
-      scopeKey: "https://admin.example.invalid",
-      resourceId: "provider/native-id",
-    })
-
-    const ok = await channelConfigStorage.upsertResourceFilters(resourceRef, [
-      {
-        id: "string-resource-rule",
-        name: "String Resource Rule",
-        pattern: "claude",
-        isRegex: false,
-        action: "exclude",
-        enabled: true,
-        createdAt: 50,
-        updatedAt: 60,
-      },
-    ])
-
-    expect(ok).toBe(true)
-
-    const stored =
-      await channelConfigStorage.getConfigByResourceRef(resourceRef)
-    expect(stored.channelId).toBeUndefined()
-    expect(stored).toEqual(
-      expect.objectContaining({
-        resourceRef,
-        modelFilterSettings: {
-          updatedAt: Date.now(),
-          rules: [
-            expect.objectContaining({
-              id: "string-resource-rule",
-              action: "exclude",
-            }),
-          ],
-        },
-      }),
-    )
-    expect(storageData.get("channel_configs")).toBeUndefined()
-  })
-
-  it("returns a default config when a channel has no stored entry", async () => {
-    const config = await channelConfigStorage.getConfig(42)
-
-    expect(config.channelId).toBe(42)
-    expect(config.modelFilterSettings.rules).toEqual([])
-    expect(config.createdAt).toBe(Date.now())
-    expect(config.updatedAt).toBe(Date.now())
-  })
-
-  it("saves configs with a refreshed updatedAt timestamp", async () => {
-    storageData.set("channel_configs", {
-      7: {
-        channelId: 7,
-        createdAt: 10,
-        updatedAt: 10,
-        modelFilterSettings: {
-          rules: [],
-          updatedAt: 10,
-        },
-      },
-    })
-
-    const ok = await channelConfigStorage.saveConfig({
+  it("preserves different resource entries across concurrent filter updates", async () => {
+    const siteA = createConfig({
+      scopeKey: "https://a.example.invalid",
       channelId: 9,
-      createdAt: 100,
-      updatedAt: 100,
-      modelFilterSettings: {
-        rules: [],
-        updatedAt: 100,
-      },
+      ruleId: "site-a",
+    })
+    const siteB = createConfig({
+      scopeKey: "https://b.example.invalid",
+      channelId: 9,
+      ruleId: "site-b",
     })
 
-    expect(ok).toBe(true)
-    expect(storageData.get("channel_configs")).toEqual({
-      7: expect.objectContaining({ channelId: 7 }),
-      9: expect.objectContaining({
-        channelId: 9,
-        createdAt: 100,
-        updatedAt: Date.now(),
-      }),
+    await Promise.all([
+      channelConfigStorage.upsertFilters(
+        siteA.resourceRef,
+        siteA.modelFilterSettings.rules,
+        siteA.channelId,
+      ),
+      channelConfigStorage.upsertFilters(
+        siteB.resourceRef,
+        siteB.modelFilterSettings.rules,
+        siteB.channelId,
+      ),
+    ])
+
+    const configs = (await channelConfigStorage.exportConfigs()).configs
+    expect(Object.keys(configs)).toHaveLength(2)
+    expect(configs).toMatchObject({
+      [getManagedUpstreamResourceRefKey(siteA.resourceRef)]: {
+        resourceRef: siteA.resourceRef,
+      },
+      [getManagedUpstreamResourceRefKey(siteB.resourceRef)]: {
+        resourceRef: siteB.resourceRef,
+      },
     })
   })
 
-  it("imports configs by sanitizing invalid keys, legacy filters, and malformed rules", async () => {
-    const count = await channelConfigStorage.importConfigs({
-      1: {
-        createdAt: 5,
-        filters: [
-          {
-            name: " Legacy Include ",
-            pattern: "gpt-4o",
-            isRegex: false,
-            action: "include",
-            enabled: true,
-          },
-          null,
-        ],
-      },
-      2: {
-        modelFilterSettings: {
-          updatedAt: 0,
-          rules: [
-            {
-              id: " explicit-id ",
-              name: " Block Legacy ",
-              description: "  trimmed description  ",
-              pattern: "^claude",
-              isRegex: true,
-              action: "exclude",
-              enabled: false,
-              createdAt: 123,
-              updatedAt: 456,
-            },
-            {
-              name: " ",
-              pattern: "ignored",
-            },
-          ],
-        },
-      },
-      broken: {
-        createdAt: 1,
-      },
-      "-3": {
-        createdAt: 1,
-      },
+  it("merges an incoming snapshot atomically with concurrent resource updates", async () => {
+    const local = createConfig({
+      scopeKey: "https://local.example.invalid",
+      channelId: 9,
+      ruleId: "local",
+      updatedAt: 300,
+    })
+    const remote = createConfig({
+      scopeKey: "https://remote.example.invalid",
+      channelId: 9,
+      ruleId: "remote",
+      updatedAt: 200,
     })
 
-    expect(count).toBe(2)
-
-    const imported = await channelConfigStorage.getAllConfigs()
-    expect(Object.keys(imported)).toEqual(["1", "2"])
-    expect(imported[1]).toEqual(
-      expect.objectContaining({
-        channelId: 1,
-        createdAt: 5,
-        updatedAt: Date.now(),
-        modelFilterSettings: {
-          updatedAt: Date.now(),
-          rules: [
-            expect.objectContaining({
-              id: "generated-filter-id",
-              name: "Legacy Include",
-              pattern: "gpt-4o",
-              action: "include",
-              enabled: true,
-            }),
-          ],
-        },
-      }),
-    )
-    expect(imported[2].modelFilterSettings.rules).toEqual([
-      {
-        id: "explicit-id",
-        name: "Block Legacy",
-        description: "trimmed description",
-        kind: "pattern",
-        pattern: "^claude",
-        isRegex: true,
-        action: "exclude",
-        enabled: false,
-        createdAt: 123,
-        updatedAt: 456,
-      },
+    await Promise.all([
+      channelConfigStorage.mergeConfigs(snapshotOf(remote)),
+      channelConfigStorage.upsertFilters(
+        local.resourceRef,
+        local.modelFilterSettings.rules,
+        local.channelId,
+      ),
     ])
+
+    await expect(channelConfigStorage.exportConfigs()).resolves.toMatchObject({
+      configs: {
+        [getManagedUpstreamResourceRefKey(local.resourceRef)]: {
+          resourceRef: local.resourceRef,
+        },
+        [getManagedUpstreamResourceRefKey(remote.resourceRef)]: {
+          resourceRef: remote.resourceRef,
+        },
+      },
+    })
   })
 
-  it("drops non-object imported filter entries instead of crashing import", async () => {
-    const count = await channelConfigStorage.importConfigs({
-      12: {
-        modelFilterSettings: {
-          rules: [
-            {
-              name: "Keep GPT",
-              pattern: "gpt",
-              isRegex: false,
-              action: "include",
-              enabled: true,
-            },
-            42 as any,
-          ],
-        },
-      },
+  it("discards legacy numeric configs without using them as fallback", async () => {
+    const resourceRef = createRef("https://admin.example.invalid", 9)
+    storageData.set(CHANNEL_CONFIG_STORAGE_KEYS.CHANNEL_CONFIGS, {
+      9: createConfig({
+        scopeKey: "https://legacy.example.invalid",
+        channelId: 9,
+        ruleId: "legacy",
+      }),
     })
 
-    expect(count).toBe(1)
+    const config = await channelConfigStorage.getConfig(resourceRef)
 
-    const imported = await channelConfigStorage.getAllConfigs()
-    expect(imported[12].modelFilterSettings.rules).toEqual([
-      expect.objectContaining({
-        name: "Keep GPT",
-        kind: "pattern",
-      }),
-    ])
-  })
-
-  it("upserts filters while preserving existing createdAt", async () => {
-    storageData.set("channel_configs", {
-      9: {
-        channelId: 9,
-        createdAt: 111,
-        updatedAt: 222,
-        modelFilterSettings: {
-          rules: [],
-          updatedAt: 222,
-        },
-      },
-    })
-
-    const ok = await channelConfigStorage.upsertFilters(9, [
-      {
-        id: "rule-1",
-        name: "Allow GPT",
-        pattern: "gpt",
-        isRegex: false,
-        action: "include",
-        enabled: true,
-        createdAt: 50,
-        updatedAt: 60,
-      },
-    ])
-
-    expect(ok).toBe(true)
-    expect(storageData.get("channel_configs")[9]).toEqual(
-      expect.objectContaining({
-        channelId: 9,
-        createdAt: 111,
-        updatedAt: Date.now(),
-        modelFilterSettings: {
-          updatedAt: Date.now(),
-          rules: [
-            expect.objectContaining({
-              id: "rule-1",
-              name: "Allow GPT",
-            }),
-          ],
-        },
-      }),
+    expect(config.resourceRef).toEqual(resourceRef)
+    expect(config.modelFilterSettings.rules).toEqual([])
+    expect(storageData.has(CHANNEL_CONFIG_STORAGE_KEYS.CHANNEL_CONFIGS)).toBe(
+      false,
     )
   })
 
-  it("creates missing filter settings and falls back to the current timestamp when createdAt is invalid", async () => {
-    storageData.set("channel_configs", {
-      15: {
-        channelId: 15,
-        createdAt: 0,
-        updatedAt: 0,
-      },
+  it("supports non-numeric native resource ids for every managed-site type", async () => {
+    const resourceRef = createManagedUpstreamResourceRef({
+      managedSiteType: "axonhub",
+      scopeKey: "https://admin.example.invalid",
+      resourceId: "provider/native-id",
     })
 
-    const ok = await channelConfigStorage.upsertFilters(15, [
+    await channelConfigStorage.upsertFilters(resourceRef, [
       {
-        id: "rule-2",
-        name: "Exclude Claude",
+        id: "native-rule",
+        kind: "pattern",
+        name: "Native rule",
         pattern: "claude",
         isRegex: false,
         action: "exclude",
-        enabled: false,
+        enabled: true,
+        createdAt: 10,
+        updatedAt: 20,
+      },
+    ])
+
+    await expect(channelConfigStorage.getConfig(resourceRef)).resolves.toEqual(
+      expect.objectContaining({
+        resourceRef,
+        modelFilterSettings: expect.objectContaining({
+          rules: [expect.objectContaining({ id: "native-rule" })],
+        }),
+      }),
+    )
+  })
+
+  it("propagates storage read failures instead of returning an empty map", async () => {
+    const storage = (channelConfigStorage as any).storage
+    vi.spyOn(storage, "get").mockRejectedValueOnce(new Error("read failed"))
+
+    await expect(channelConfigStorage.exportConfigs()).rejects.toThrow(
+      "read failed",
+    )
+  })
+
+  it("propagates authoritative write failures", async () => {
+    const resourceRef = createRef("https://admin.example.invalid")
+    const storage = (channelConfigStorage as any).storage
+    vi.spyOn(storage, "set").mockRejectedValueOnce(new Error("write failed"))
+
+    await expect(
+      channelConfigStorage.upsertFilters(resourceRef, []),
+    ).rejects.toThrow("write failed")
+  })
+
+  it("keeps authoritative writes successful when legacy cleanup fails", async () => {
+    const resourceRef = createRef("https://admin.example.invalid")
+    const storage = (channelConfigStorage as any).storage
+    vi.spyOn(storage, "remove").mockRejectedValueOnce(
+      new Error("legacy cleanup failed"),
+    )
+
+    await expect(
+      channelConfigStorage.upsertFilters(resourceRef, []),
+    ).resolves.toBeUndefined()
+    await expect(channelConfigStorage.getConfig(resourceRef)).resolves.toEqual(
+      expect.objectContaining({ resourceRef }),
+    )
+  })
+
+  it("exports and replaces complete scoped snapshots", async () => {
+    const siteA = createConfig({
+      scopeKey: "https://a.example.invalid",
+      channelId: 9,
+      ruleId: "site-a",
+    })
+    const siteB = createConfig({
+      scopeKey: "https://b.example.invalid",
+      channelId: 9,
+      ruleId: "site-b",
+    })
+    storageData.set(
+      CHANNEL_CONFIG_STORAGE_KEYS.CHANNEL_RESOURCE_CONFIGS,
+      snapshotOf(siteA).configs,
+    )
+
+    await expect(channelConfigStorage.exportConfigs()).resolves.toEqual(
+      snapshotOf(siteA),
+    )
+    await expect(
+      channelConfigStorage.importConfigs(snapshotOf(siteB)),
+    ).resolves.toBe(1)
+    await expect(channelConfigStorage.exportConfigs()).resolves.toEqual(
+      snapshotOf(siteB),
+    )
+  })
+
+  it("rejects legacy numeric maps as channel-config snapshots", async () => {
+    const legacy = {
+      9: {
+        channelId: 9,
         createdAt: 1,
         updatedAt: 2,
+        modelFilterSettings: { rules: [], updatedAt: 2 },
       },
-    ])
+    }
 
-    expect(ok).toBe(true)
-    expect(storageData.get("channel_configs")[15]).toEqual({
-      channelId: 15,
-      createdAt: Date.now(),
-      updatedAt: Date.now(),
-      modelFilterSettings: {
-        rules: [
-          expect.objectContaining({
-            id: "rule-2",
-            action: "exclude",
-            enabled: false,
-          }),
-        ],
-        updatedAt: Date.now(),
-      },
-    })
+    expect(coerceChannelConfigSnapshot(legacy)).toBeNull()
+    await expect(channelConfigStorage.importConfigs(legacy)).rejects.toThrow(
+      "snapshot is invalid",
+    )
   })
 
-  it("returns empty configs and false saves when storage operations fail", async () => {
-    const storage = (channelConfigStorage as any).storage
-    const getSpy = vi
-      .spyOn(storage, "get")
-      .mockRejectedValueOnce(new Error("read failed"))
-    const setSpy = vi
-      .spyOn(storage, "set")
-      .mockRejectedValueOnce(new Error("write failed"))
+  it.each([
+    [
+      "entirely malformed",
+      {
+        malformed: {
+          createdAt: 1,
+          updatedAt: 2,
+          modelFilterSettings: { rules: [], updatedAt: 2 },
+        },
+      },
+    ],
+    [
+      "partially malformed",
+      {
+        ...snapshotOf(
+          createConfig({ scopeKey: "https://valid.example.invalid" }),
+        ).configs,
+        malformed: {
+          createdAt: 1,
+          updatedAt: 2,
+          modelFilterSettings: { rules: [], updatedAt: 2 },
+        },
+      },
+    ],
+  ])(
+    "rejects %s non-empty snapshots without replacing authoritative storage",
+    async (_label, configs) => {
+      const existing = createConfig({
+        scopeKey: "https://existing.example.invalid",
+        ruleId: "existing",
+      })
+      await channelConfigStorage.importConfigs(snapshotOf(existing))
 
-    await expect(channelConfigStorage.getAllConfigs()).resolves.toEqual({})
-    await expect(
-      channelConfigStorage.saveConfig({
-        channelId: 99,
-        createdAt: 1,
-        updatedAt: 1,
-        modelFilterSettings: {
-          rules: [],
-          updatedAt: 1,
+      await expect(
+        channelConfigStorage.importConfigs({
+          schemaVersion: CHANNEL_CONFIG_SNAPSHOT_VERSION,
+          configs,
+        }),
+      ).rejects.toThrow("snapshot is invalid")
+      await expect(channelConfigStorage.exportConfigs()).resolves.toEqual(
+        snapshotOf(existing),
+      )
+    },
+  )
+
+  it("rejects snapshots whose conflict timestamps are missing", () => {
+    const resourceRef = createRef("https://admin.example.invalid")
+
+    expect(
+      coerceChannelConfigSnapshot({
+        schemaVersion: CHANNEL_CONFIG_SNAPSHOT_VERSION,
+        configs: {
+          missingTimestamps: {
+            resourceRef,
+            modelFilterSettings: { rules: [] },
+          },
         },
       }),
-    ).resolves.toBe(false)
-
-    getSpy.mockRestore()
-    setSpy.mockRestore()
+    ).toBeNull()
   })
 
-  it("handles typed get and upsert runtime messages", async () => {
-    const getResponse = await resolveChannelConfigGetMessage({
-      channelId: 12,
-    })
-
-    expect(getResponse).toEqual({
-      success: true,
-      data: expect.objectContaining({ channelId: 12 }),
-    })
-
-    const upsertResponse = await resolveChannelConfigUpsertFiltersMessage({
-      channelId: 12,
-      filters: [
-        {
-          name: " Include GPT ",
-          pattern: "gpt",
-          isRegex: false,
-          enabled: true,
-        },
-      ],
-    })
-
-    expect(upsertResponse).toEqual({
-      success: true,
-      data: [
-        expect.objectContaining({
-          id: "generated-filter-id",
-          name: "Include GPT",
-          pattern: "gpt",
-          action: "include",
-          enabled: true,
-        }),
-      ],
-    })
-  })
-
-  it("handles resource-aware typed get and upsert runtime messages", async () => {
-    const resourceRef = createManagedUpstreamResourceRef({
-      managedSiteType: "new-api",
+  it.each([
+    [
+      "an unknown rule action",
+      (config: any) => {
+        config.modelFilterSettings.rules[0].action = "archive"
+      },
+    ],
+    [
+      "a non-boolean enabled flag",
+      (config: any) => {
+        config.modelFilterSettings.rules[0].enabled = "yes"
+      },
+    ],
+    [
+      "a non-finite timestamp",
+      (config: any) => {
+        config.updatedAt = Number.POSITIVE_INFINITY
+      },
+    ],
+    [
+      "filter settings newer than the containing config",
+      (config: any) => {
+        config.updatedAt = config.modelFilterSettings.updatedAt - 1
+      },
+    ],
+    [
+      "a rule created after its last update",
+      (config: any) => {
+        config.modelFilterSettings.rules[0].createdAt =
+          config.modelFilterSettings.rules[0].updatedAt + 1
+      },
+    ],
+  ])("rejects snapshots with %s", (_label, mutate) => {
+    const config = createConfig({
       scopeKey: "https://admin.example.invalid",
-      resourceId: 12,
+      ruleId: "strict-rule",
+    })
+    mutate(config)
+
+    expect(coerceChannelConfigSnapshot(snapshotOf(config))).toBeNull()
+  })
+
+  it("rejects duplicate canonical resource identities", () => {
+    const first = createConfig({
+      scopeKey: "https://admin.example.invalid/path-a",
+      ruleId: "first",
+    })
+    const duplicate = createConfig({
+      scopeKey: "https://admin.example.invalid/path-b",
+      ruleId: "duplicate",
     })
 
-    const upsertResponse = await resolveChannelConfigUpsertFiltersMessage({
-      channelId: 12,
-      resourceRef,
-      filters: [
-        {
-          name: " Include GPT ",
-          pattern: "gpt",
-          isRegex: false,
-          enabled: true,
-        },
-      ],
-    })
+    expect(
+      coerceChannelConfigSnapshot({
+        schemaVersion: CHANNEL_CONFIG_SNAPSHOT_VERSION,
+        configs: { first, duplicate },
+      }),
+    ).toBeNull()
+  })
 
-    expect(upsertResponse).toEqual({
-      success: true,
-      data: [
-        expect.objectContaining({
-          id: "generated-filter-id",
-          name: "Include GPT",
-          pattern: "gpt",
-        }),
-      ],
-    })
-
-    const getResponse = await resolveChannelConfigGetMessage({
-      channelId: 12,
-      resourceRef,
-    })
-
-    expect(getResponse).toEqual({
-      success: true,
-      data: expect.objectContaining({
-        channelId: 12,
+  it("uses deterministic timestamps when sanitizing historical local data", async () => {
+    const resourceRef = createRef("https://admin.example.invalid")
+    storageData.set(CHANNEL_CONFIG_STORAGE_KEYS.CHANNEL_RESOURCE_CONFIGS, {
+      historical: {
         resourceRef,
-        modelFilterSettings: {
-          updatedAt: Date.now(),
-          rules: [
-            expect.objectContaining({
-              name: "Include GPT",
-            }),
-          ],
-        },
-      }),
+        modelFilterSettings: { rules: [] },
+      },
+    })
+
+    const first = (await channelConfigStorage.exportConfigs()).configs
+    vi.advanceTimersByTime(60_000)
+    const second = (await channelConfigStorage.exportConfigs()).configs
+
+    expect(first).toEqual(second)
+    expect(first[getManagedUpstreamResourceRefKey(resourceRef)]).toMatchObject({
+      createdAt: 1,
+      updatedAt: 1,
+      modelFilterSettings: { updatedAt: 1 },
+    })
+    await expect(channelConfigStorage.exportConfigs()).resolves.toEqual({
+      schemaVersion: CHANNEL_CONFIG_SNAPSHOT_VERSION,
+      configs: first,
+    })
+    expect(
+      coerceChannelConfigSnapshot(await channelConfigStorage.exportConfigs()),
+    ).toEqual({
+      schemaVersion: CHANNEL_CONFIG_SNAPSHOT_VERSION,
+      configs: first,
     })
   })
 
-  it("ignores invalid numeric fallbacks when a valid resource ref is supplied", async () => {
-    const resourceRef = createManagedUpstreamResourceRef({
-      managedSiteType: "new-api",
-      scopeKey: "https://admin.example.invalid",
-      resourceId: 12,
+  it("exports historical rules as a snapshot that the strict interface can restore", async () => {
+    const resourceRef = createRef("https://historical.example.invalid")
+    const rule = createConfig({
+      scopeKey: resourceRef.scopeKey,
+      ruleId: "historical-rule",
+      updatedAt: 200,
+    }).modelFilterSettings.rules[0]
+    storageData.set(CHANNEL_CONFIG_STORAGE_KEYS.CHANNEL_RESOURCE_CONFIGS, {
+      historical: {
+        resourceRef,
+        modelFilterSettings: { rules: [rule] },
+      },
     })
+
+    const snapshot = await channelConfigStorage.exportConfigs()
+
+    expect(
+      snapshot.configs[getManagedUpstreamResourceRefKey(resourceRef)],
+    ).toMatchObject({
+      createdAt: 1,
+      updatedAt: 200,
+      modelFilterSettings: {
+        updatedAt: 200,
+        rules: [expect.objectContaining({ updatedAt: 200 })],
+      },
+    })
+    expect(coerceChannelConfigSnapshot(snapshot)).toEqual(snapshot)
+    await expect(channelConfigStorage.importConfigs(snapshot)).resolves.toBe(1)
+  })
+
+  it("rekeys imported entries from their structured resource refs", () => {
+    const config = createConfig({
+      scopeKey: "https://admin.example.invalid/path",
+      ruleId: "normalized",
+    })
+
+    expect(
+      coerceChannelConfigSnapshot({
+        schemaVersion: CHANNEL_CONFIG_SNAPSHOT_VERSION,
+        configs: { "untrusted-key": config },
+      }),
+    ).toEqual(
+      snapshotOf({
+        ...config,
+        resourceRef: createRef("https://admin.example.invalid"),
+      }),
+    )
+  })
+
+  it("merges by complete resource identity and keeps the newest same-resource value", async () => {
+    const localA = createConfig({
+      scopeKey: "https://a.example.invalid",
+      ruleId: "local-a",
+      updatedAt: 200,
+    })
+    const remoteA = createConfig({
+      scopeKey: "https://a.example.invalid",
+      ruleId: "remote-a",
+      updatedAt: 300,
+    })
+    const remoteB = createConfig({
+      scopeKey: "https://b.example.invalid",
+      ruleId: "remote-b",
+      updatedAt: 100,
+    })
+
+    await channelConfigStorage.importConfigs(snapshotOf(localA))
+
+    await expect(
+      channelConfigStorage.mergeConfigs(snapshotOf(remoteA, remoteB)),
+    ).resolves.toEqual(snapshotOf(remoteA, remoteB))
+    await expect(channelConfigStorage.exportConfigs()).resolves.toEqual(
+      snapshotOf(remoteA, remoteB),
+    )
+  })
+
+  it("normalizes and persists resource-aware runtime messages", async () => {
+    const resourceRef = createRef("https://admin.example.invalid", 12)
 
     await expect(
       resolveChannelConfigUpsertFiltersMessage({
-        channelId: 0,
+        channelId: 12,
         resourceRef,
         filters: [
           {
             name: " Include GPT ",
-            pattern: "gpt",
+            pattern: " gpt ",
             isRegex: false,
             enabled: true,
           },
@@ -759,53 +616,46 @@ describe("channelConfigStorage", () => {
         expect.objectContaining({
           id: "generated-filter-id",
           name: "Include GPT",
+          pattern: "gpt",
         }),
       ],
     })
 
     await expect(
-      resolveChannelConfigGetMessage({
-        channelId: 0,
-        resourceRef,
-      }),
+      resolveChannelConfigGetMessage({ channelId: 12, resourceRef }),
     ).resolves.toEqual({
       success: true,
       data: expect.objectContaining({
         resourceRef,
+        channelId: 12,
+        modelFilterSettings: expect.objectContaining({
+          rules: [expect.objectContaining({ name: "Include GPT" })],
+        }),
       }),
     })
   })
 
-  it("rejects resource-aware runtime messages for ungated native resource refs", async () => {
-    const resourceRef = createManagedUpstreamResourceRef({
-      managedSiteType: "axonhub",
-      scopeKey: "https://admin.example.invalid",
-      resourceId: "provider/native-id",
-    })
-
-    await expect(
-      resolveChannelConfigUpsertFiltersMessage({
-        channelId: 12,
-        resourceRef,
-        filters: [],
-      }),
-    ).resolves.toEqual({
-      success: false,
-      error: "resourceRef is invalid",
-    })
+  it("rejects invalid refs and filter payloads through typed messages", async () => {
+    const resourceRef = createRef("https://admin.example.invalid", 12)
 
     await expect(
       resolveChannelConfigGetMessage({
-        channelId: 12,
+        resourceRef: { ...resourceRef, scopeKey: "" },
+      }),
+    ).resolves.toEqual({ success: false, error: "resourceRef is invalid" })
+
+    await expect(
+      resolveChannelConfigUpsertFiltersMessage({
         resourceRef,
+        filters: [{ name: "Broken regex", pattern: "[", isRegex: true }],
       }),
     ).resolves.toEqual({
       success: false,
-      error: "resourceRef is invalid",
+      error: expect.stringContaining("Invalid regex pattern"),
     })
   })
 
-  it("registers typed channel config listeners once", () => {
+  it("registers typed channel-config listeners once", () => {
     setupChannelConfigMessagingListeners()
     setupChannelConfigMessagingListeners()
 
@@ -820,175 +670,5 @@ describe("channelConfigStorage", () => {
       ChannelConfigMessageTypes.UpsertFilters,
       expect.any(Function),
     )
-  })
-
-  it("sanitizes empty imports and preserves explicit rule timestamps when provided", async () => {
-    await expect(channelConfigStorage.importConfigs(null)).resolves.toBe(0)
-    expect(storageData.get("channel_configs")).toEqual({})
-
-    const count = await channelConfigStorage.importConfigs({
-      8: {
-        updatedAt: 999,
-        modelFilterSettings: {
-          updatedAt: 777,
-          rules: [
-            {
-              id: " kept-id ",
-              name: " Keep GPT ",
-              pattern: " gpt ",
-              isRegex: false,
-              action: "unsupported",
-              enabled: undefined,
-              createdAt: 555,
-              updatedAt: 666,
-            },
-          ],
-        },
-      },
-    })
-
-    expect(count).toBe(1)
-    expect(storageData.get("channel_configs")[8]).toEqual({
-      channelId: 8,
-      createdAt: Date.now(),
-      updatedAt: 999,
-      modelFilterSettings: {
-        updatedAt: 777,
-        rules: [
-          {
-            id: "kept-id",
-            name: "Keep GPT",
-            description: undefined,
-            kind: "pattern",
-            pattern: "gpt",
-            isRegex: false,
-            action: "include",
-            enabled: true,
-            createdAt: 555,
-            updatedAt: 666,
-          },
-        ],
-      },
-    })
-  })
-
-  it("rejects invalid message payloads and unknown actions", async () => {
-    await expect(
-      resolveChannelConfigGetMessage({
-        channelId: 0,
-      }),
-    ).resolves.toEqual({
-      success: false,
-      error: "channelId is required",
-    })
-
-    await expect(
-      resolveChannelConfigUpsertFiltersMessage({
-        channelId: 12,
-        filters: [
-          {
-            name: "Broken Regex",
-            pattern: "[",
-            isRegex: true,
-          },
-        ],
-      }),
-    ).resolves.toEqual({
-      success: false,
-      error: expect.stringContaining("Invalid regex pattern"),
-    })
-  })
-
-  it("returns a typed failure when filter persistence is rejected", async () => {
-    const saveSpy = vi
-      .spyOn(channelConfigStorage, "upsertFilters")
-      .mockResolvedValueOnce(false)
-
-    await expect(
-      resolveChannelConfigUpsertFiltersMessage({
-        channelId: 12,
-        filters: [],
-      }),
-    ).resolves.toEqual({
-      success: false,
-      error: "Failed to save channel filters",
-    })
-
-    saveSpy.mockRestore()
-  })
-
-  it("normalizes probe rules and drops imported credential fields", async () => {
-    const count = await channelConfigStorage.importConfigs({
-      3: {
-        modelFilterSettings: {
-          rules: [
-            {
-              id: "probe-id",
-              kind: "probe",
-              name: "Text capable",
-              description: "  requires chat  ",
-              action: "include",
-              enabled: true,
-              probeIds: ["text-generation", "text-generation", "unknown-probe"],
-              match: "all",
-              apiKey: "sk-should-not-persist",
-              key: "sk-channel",
-              baseUrl: "https://manual.example.com",
-              createdAt: 10,
-              updatedAt: 20,
-            },
-            {
-              kind: "probe",
-              name: "Invalid",
-              probeIds: [],
-            },
-          ],
-        },
-      },
-    })
-
-    expect(count).toBe(1)
-    const imported = await channelConfigStorage.getAllConfigs()
-    expect(imported[3].modelFilterSettings.rules).toEqual([
-      {
-        id: "probe-id",
-        kind: "probe",
-        name: "Text capable",
-        description: "requires chat",
-        action: "include",
-        enabled: true,
-        probeIds: ["text-generation"],
-        match: "all",
-        createdAt: 10,
-        updatedAt: 20,
-      },
-    ])
-  })
-
-  it("surfaces non-array and missing-field filter validation errors through the message handler", async () => {
-    await expect(
-      resolveChannelConfigUpsertFiltersMessage({
-        channelId: 12,
-        filters: "not-an-array" as any,
-      }),
-    ).resolves.toEqual({
-      success: false,
-      error: "Filters must be an array",
-    })
-
-    await expect(
-      resolveChannelConfigUpsertFiltersMessage({
-        channelId: 12,
-        filters: [
-          {
-            name: "Missing Pattern",
-            pattern: "   ",
-          },
-        ],
-      }),
-    ).resolves.toEqual({
-      success: false,
-      error: "Filter pattern is required",
-    })
   })
 })

--- a/tests/services/channelConfigStorage.test.ts
+++ b/tests/services/channelConfigStorage.test.ts
@@ -8,6 +8,7 @@ import {
   resolveChannelConfigGetMessage,
   resolveChannelConfigUpsertFiltersMessage,
   setupChannelConfigMessagingListeners,
+  type LegacyChannelConfigMigrationCandidate,
 } from "~/services/managedSites/channelConfigStorage"
 import {
   CHANNEL_CONFIG_SNAPSHOT_VERSION,
@@ -118,6 +119,7 @@ const snapshotOf = (
 describe("channelConfigStorage", () => {
   beforeEach(() => {
     storageData.clear()
+    vi.restoreAllMocks()
     vi.clearAllMocks()
     vi.useFakeTimers()
     vi.setSystemTime(new Date("2026-03-28T05:30:00.000Z"))
@@ -239,7 +241,7 @@ describe("channelConfigStorage", () => {
     })
   })
 
-  it("discards legacy numeric configs without using them as fallback", async () => {
+  it("ignores legacy numeric configs without deleting them before migration", async () => {
     const resourceRef = createRef("https://admin.example.invalid", 9)
     storageData.set(CHANNEL_CONFIG_STORAGE_KEYS.CHANNEL_CONFIGS, {
       9: createConfig({
@@ -254,6 +256,21 @@ describe("channelConfigStorage", () => {
     expect(config.resourceRef).toEqual(resourceRef)
     expect(config.modelFilterSettings.rules).toEqual([])
     expect(storageData.has(CHANNEL_CONFIG_STORAGE_KEYS.CHANNEL_CONFIGS)).toBe(
+      true,
+    )
+  })
+
+  it("ignores non-integer ids and values without a recognizable legacy shape", async () => {
+    storageData.set(CHANNEL_CONFIG_STORAGE_KEYS.CHANNEL_CONFIGS, {
+      "1.5": {
+        modelFilterSettings: { rules: [], updatedAt: 2 },
+        createdAt: 1,
+        updatedAt: 2,
+      },
+      9: {},
+    })
+
+    await expect(channelConfigStorage.hasLegacyNumericConfigs()).resolves.toBe(
       false,
     )
   })
@@ -308,18 +325,196 @@ describe("channelConfigStorage", () => {
     ).rejects.toThrow("write failed")
   })
 
-  it("keeps authoritative writes successful when legacy cleanup fails", async () => {
-    const resourceRef = createRef("https://admin.example.invalid")
-    const storage = (channelConfigStorage as any).storage
-    vi.spyOn(storage, "remove").mockRejectedValueOnce(
-      new Error("legacy cleanup failed"),
+  it("migrates a uniquely discovered numeric config and keeps its newer rules", async () => {
+    const resourceRef = createRef("https://admin.example.invalid", 9)
+    const existing = createConfig({
+      scopeKey: resourceRef.scopeKey,
+      channelId: 9,
+      ruleId: "resource-older",
+      updatedAt: 200,
+    })
+    const legacy = createConfig({
+      scopeKey: "https://legacy.example.invalid",
+      channelId: 9,
+      ruleId: "numeric-newer",
+      updatedAt: 300,
+    })
+    storageData.set(CHANNEL_CONFIG_STORAGE_KEYS.CHANNEL_CONFIGS, { 9: legacy })
+    storageData.set(
+      CHANNEL_CONFIG_STORAGE_KEYS.CHANNEL_RESOURCE_CONFIGS,
+      snapshotOf(existing).configs,
     )
 
     await expect(
-      channelConfigStorage.upsertFilters(resourceRef, []),
-    ).resolves.toBeUndefined()
+      channelConfigStorage.migrateLegacyNumericConfigs([
+        { channelId: 9, resourceRef },
+      ]),
+    ).resolves.toEqual({ migrated: 1, ambiguous: 0, unmatched: 0 })
+
+    expect(storageData.has(CHANNEL_CONFIG_STORAGE_KEYS.CHANNEL_CONFIGS)).toBe(
+      false,
+    )
     await expect(channelConfigStorage.getConfig(resourceRef)).resolves.toEqual(
-      expect.objectContaining({ resourceRef }),
+      expect.objectContaining({
+        resourceRef,
+        channelId: 9,
+        modelFilterSettings: expect.objectContaining({
+          rules: [expect.objectContaining({ id: "numeric-newer" })],
+        }),
+      }),
+    )
+  })
+
+  it("keeps the newer resource config while resolving its numeric predecessor", async () => {
+    const resourceRef = createRef("https://admin.example.invalid", 9)
+    const existing = createConfig({
+      scopeKey: resourceRef.scopeKey,
+      channelId: 9,
+      ruleId: "resource-newer",
+      updatedAt: 400,
+    })
+    const legacy = createConfig({
+      scopeKey: "https://legacy.example.invalid",
+      channelId: 9,
+      ruleId: "numeric-older",
+      updatedAt: 300,
+    })
+    storageData.set(CHANNEL_CONFIG_STORAGE_KEYS.CHANNEL_CONFIGS, { 9: legacy })
+    storageData.set(
+      CHANNEL_CONFIG_STORAGE_KEYS.CHANNEL_RESOURCE_CONFIGS,
+      snapshotOf(existing).configs,
+    )
+
+    await channelConfigStorage.migrateLegacyNumericConfigs([
+      { channelId: 9, resourceRef },
+    ])
+
+    await expect(channelConfigStorage.getConfig(resourceRef)).resolves.toEqual(
+      expect.objectContaining({
+        modelFilterSettings: expect.objectContaining({
+          rules: [expect.objectContaining({ id: "resource-newer" })],
+        }),
+      }),
+    )
+  })
+
+  it("does not guess when complete discovery finds zero or multiple targets", async () => {
+    const legacy9 = createConfig({
+      scopeKey: "https://legacy.example.invalid",
+      channelId: 9,
+      ruleId: "ambiguous",
+      updatedAt: 300,
+    })
+    const legacy10 = createConfig({
+      scopeKey: "https://legacy.example.invalid",
+      channelId: 10,
+      ruleId: "unmatched",
+      updatedAt: 300,
+    })
+    const candidates: LegacyChannelConfigMigrationCandidate[] = [
+      { channelId: 9, resourceRef: createRef("https://a.example.invalid", 9) },
+      { channelId: 9, resourceRef: createRef("https://b.example.invalid", 9) },
+    ]
+    storageData.set(CHANNEL_CONFIG_STORAGE_KEYS.CHANNEL_CONFIGS, {
+      9: legacy9,
+      10: legacy10,
+    })
+
+    await expect(
+      channelConfigStorage.migrateLegacyNumericConfigs(candidates),
+    ).resolves.toEqual({ migrated: 0, ambiguous: 1, unmatched: 1 })
+    expect(storageData.has(CHANNEL_CONFIG_STORAGE_KEYS.CHANNEL_CONFIGS)).toBe(
+      true,
+    )
+    await expect(channelConfigStorage.exportConfigs()).resolves.toEqual({
+      schemaVersion: CHANNEL_CONFIG_SNAPSHOT_VERSION,
+      configs: {},
+    })
+  })
+
+  it("removes only uniquely migrated numeric entries", async () => {
+    const migrated = createConfig({
+      scopeKey: "https://legacy.example.invalid",
+      channelId: 9,
+      ruleId: "migrated",
+      updatedAt: 300,
+    })
+    const unresolved = createConfig({
+      scopeKey: "https://legacy.example.invalid",
+      channelId: 10,
+      ruleId: "unresolved",
+      updatedAt: 300,
+    })
+    storageData.set(CHANNEL_CONFIG_STORAGE_KEYS.CHANNEL_CONFIGS, {
+      9: migrated,
+      10: unresolved,
+    })
+
+    await expect(
+      channelConfigStorage.migrateLegacyNumericConfigs([
+        {
+          channelId: 9,
+          resourceRef: createRef("https://a.example.invalid", 9),
+        },
+      ]),
+    ).resolves.toEqual({ migrated: 1, ambiguous: 0, unmatched: 1 })
+
+    expect(
+      storageData.get(CHANNEL_CONFIG_STORAGE_KEYS.CHANNEL_CONFIGS),
+    ).toEqual({ 10: unresolved })
+  })
+
+  it("retains numeric data when the authoritative migration write fails", async () => {
+    const resourceRef = createRef("https://admin.example.invalid", 9)
+    const legacy = createConfig({
+      scopeKey: "https://legacy.example.invalid",
+      channelId: 9,
+      ruleId: "legacy",
+      updatedAt: 300,
+    })
+    storageData.set(CHANNEL_CONFIG_STORAGE_KEYS.CHANNEL_CONFIGS, { 9: legacy })
+    const storage = (channelConfigStorage as any).storage
+    vi.spyOn(storage, "set").mockRejectedValueOnce(new Error("write failed"))
+
+    await expect(
+      channelConfigStorage.migrateLegacyNumericConfigs([
+        { channelId: 9, resourceRef },
+      ]),
+    ).rejects.toThrow("write failed")
+    expect(storageData.has(CHANNEL_CONFIG_STORAGE_KEYS.CHANNEL_CONFIGS)).toBe(
+      true,
+    )
+  })
+
+  it("keeps a retryable numeric source when cleanup fails after the scoped write", async () => {
+    const resourceRef = createRef("https://admin.example.invalid", 9)
+    const legacy = createConfig({
+      scopeKey: "https://legacy.example.invalid",
+      channelId: 9,
+      ruleId: "legacy",
+      updatedAt: 300,
+    })
+    storageData.set(CHANNEL_CONFIG_STORAGE_KEYS.CHANNEL_CONFIGS, { 9: legacy })
+    const storage = (channelConfigStorage as any).storage
+    vi.spyOn(storage, "remove").mockRejectedValueOnce(
+      new Error("cleanup failed"),
+    )
+
+    await expect(
+      channelConfigStorage.migrateLegacyNumericConfigs([
+        { channelId: 9, resourceRef },
+      ]),
+    ).rejects.toThrow("cleanup failed")
+
+    expect(storageData.has(CHANNEL_CONFIG_STORAGE_KEYS.CHANNEL_CONFIGS)).toBe(
+      true,
+    )
+    await expect(channelConfigStorage.getConfig(resourceRef)).resolves.toEqual(
+      expect.objectContaining({
+        modelFilterSettings: expect.objectContaining({
+          rules: [expect.objectContaining({ id: "legacy" })],
+        }),
+      }),
     )
   })
 
@@ -338,6 +533,9 @@ describe("channelConfigStorage", () => {
       CHANNEL_CONFIG_STORAGE_KEYS.CHANNEL_RESOURCE_CONFIGS,
       snapshotOf(siteA).configs,
     )
+    storageData.set(CHANNEL_CONFIG_STORAGE_KEYS.CHANNEL_CONFIGS, {
+      9: siteA,
+    })
 
     await expect(channelConfigStorage.exportConfigs()).resolves.toEqual(
       snapshotOf(siteA),
@@ -347,6 +545,127 @@ describe("channelConfigStorage", () => {
     ).resolves.toBe(1)
     await expect(channelConfigStorage.exportConfigs()).resolves.toEqual(
       snapshotOf(siteB),
+    )
+    expect(storageData.has(CHANNEL_CONFIG_STORAGE_KEYS.CHANNEL_CONFIGS)).toBe(
+      false,
+    )
+  })
+
+  it("reports snapshot replacement failure when numeric cleanup fails", async () => {
+    const siteA = createConfig({
+      scopeKey: "https://a.example.invalid",
+      channelId: 9,
+      ruleId: "site-a",
+    })
+    storageData.set(CHANNEL_CONFIG_STORAGE_KEYS.CHANNEL_CONFIGS, { 9: siteA })
+    const storage = (channelConfigStorage as any).storage
+    vi.spyOn(storage, "remove").mockRejectedValueOnce(
+      new Error("cleanup failed"),
+    )
+
+    await expect(
+      channelConfigStorage.importConfigs(snapshotOf(siteA)),
+    ).rejects.toThrow("cleanup failed")
+    expect(storageData.has(CHANNEL_CONFIG_STORAGE_KEYS.CHANNEL_CONFIGS)).toBe(
+      true,
+    )
+
+    await expect(channelConfigStorage.hasLegacyNumericConfigs()).resolves.toBe(
+      false,
+    )
+    expect(storageData.has(CHANNEL_CONFIG_STORAGE_KEYS.CHANNEL_CONFIGS)).toBe(
+      false,
+    )
+    expect(
+      storageData.has(CHANNEL_CONFIG_STORAGE_KEYS.LEGACY_REPLACEMENT_STATE),
+    ).toBe(false)
+  })
+
+  it("finishes committed replacement cleanup before a direct import retry", async () => {
+    const siteA = createConfig({
+      scopeKey: "https://a.example.invalid",
+      channelId: 9,
+      ruleId: "site-a",
+    })
+    storageData.set(CHANNEL_CONFIG_STORAGE_KEYS.CHANNEL_CONFIGS, { 9: siteA })
+    const storage = (channelConfigStorage as any).storage
+    const originalRemove = storage.remove.bind(storage)
+    let failedMarkerCleanup = false
+    vi.spyOn(storage, "remove").mockImplementation(
+      async (...args: unknown[]) => {
+        const [key] = args as [string]
+        if (
+          key === CHANNEL_CONFIG_STORAGE_KEYS.LEGACY_REPLACEMENT_STATE &&
+          !failedMarkerCleanup
+        ) {
+          failedMarkerCleanup = true
+          throw new Error("marker cleanup failed")
+        }
+        await originalRemove(key)
+      },
+    )
+
+    await expect(
+      channelConfigStorage.importConfigs(snapshotOf(siteA)),
+    ).rejects.toThrow("marker cleanup failed")
+    expect(storageData.has(CHANNEL_CONFIG_STORAGE_KEYS.CHANNEL_CONFIGS)).toBe(
+      false,
+    )
+    expect(
+      storageData.get(CHANNEL_CONFIG_STORAGE_KEYS.LEGACY_REPLACEMENT_STATE),
+    ).toEqual({ phase: "committed" })
+
+    await expect(
+      channelConfigStorage.importConfigs(snapshotOf(siteA)),
+    ).resolves.toBe(1)
+    expect(
+      storageData.has(CHANNEL_CONFIG_STORAGE_KEYS.LEGACY_REPLACEMENT_STATE),
+    ).toBe(false)
+    await expect(channelConfigStorage.exportConfigs()).resolves.toEqual(
+      snapshotOf(siteA),
+    )
+  })
+
+  it.each([
+    ["before the resource write", 2],
+    ["before the commit marker", 3],
+  ])("replays a replacement interrupted %s", async (_label, failingSetCall) => {
+    const siteA = createConfig({
+      scopeKey: "https://a.example.invalid",
+      channelId: 9,
+      ruleId: "site-a",
+    })
+    storageData.set(CHANNEL_CONFIG_STORAGE_KEYS.CHANNEL_CONFIGS, { 9: siteA })
+    const storage = (channelConfigStorage as any).storage
+    const originalSet = storage.set.bind(storage)
+    let setCallCount = 0
+    vi.spyOn(storage, "set").mockImplementation(async (...args: unknown[]) => {
+      const [key, value] = args as [string, unknown]
+      setCallCount += 1
+      if (setCallCount === failingSetCall) {
+        throw new Error("write failed")
+      }
+      await originalSet(key, value)
+    })
+
+    await expect(
+      channelConfigStorage.importConfigs(snapshotOf(siteA)),
+    ).rejects.toThrow("write failed")
+    expect(
+      storageData.get(CHANNEL_CONFIG_STORAGE_KEYS.LEGACY_REPLACEMENT_STATE),
+    ).toEqual({ phase: "prepared", snapshot: snapshotOf(siteA) })
+
+    await expect(channelConfigStorage.hasLegacyNumericConfigs()).resolves.toBe(
+      false,
+    )
+    expect(storageData.has(CHANNEL_CONFIG_STORAGE_KEYS.CHANNEL_CONFIGS)).toBe(
+      false,
+    )
+    expect(
+      storageData.has(CHANNEL_CONFIG_STORAGE_KEYS.LEGACY_REPLACEMENT_STATE),
+    ).toBe(false)
+    await expect(channelConfigStorage.exportConfigs()).resolves.toEqual(
+      snapshotOf(siteA),
     )
   })
 

--- a/tests/services/legacyChannelConfigMigration.test.ts
+++ b/tests/services/legacyChannelConfigMigration.test.ts
@@ -1,0 +1,403 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const storageData = new Map<string, unknown>()
+
+const {
+  hasLegacyNumericConfigsMock,
+  migrateLegacyNumericConfigsMock,
+  getPreferencesStrictMock,
+  hasRuntimeConfigInputMock,
+  resolveRuntimeConfigMock,
+  getManagedSiteServiceForTypeMock,
+} = vi.hoisted(() => ({
+  hasLegacyNumericConfigsMock: vi.fn(),
+  migrateLegacyNumericConfigsMock: vi.fn(),
+  getPreferencesStrictMock: vi.fn(),
+  hasRuntimeConfigInputMock: vi.fn(),
+  resolveRuntimeConfigMock: vi.fn(),
+  getManagedSiteServiceForTypeMock: vi.fn(),
+}))
+
+vi.mock("@plasmohq/storage", () => {
+  class Storage {
+    async get(key: string) {
+      return storageData.get(key)
+    }
+
+    async set(key: string, value: unknown) {
+      storageData.set(key, value)
+    }
+
+    async remove(key: string) {
+      storageData.delete(key)
+    }
+  }
+
+  return { Storage }
+})
+
+vi.mock("~/services/managedSites/channelConfigStorage", () => ({
+  channelConfigStorage: {
+    hasLegacyNumericConfigs: hasLegacyNumericConfigsMock,
+    migrateLegacyNumericConfigs: migrateLegacyNumericConfigsMock,
+  },
+}))
+
+vi.mock("~/services/preferences/userPreferences", () => ({
+  userPreferences: { getPreferencesStrict: getPreferencesStrictMock },
+}))
+
+vi.mock("~/services/managedSites/runtimeConfig", () => ({
+  hasManagedSiteRuntimeConfigInputForType: hasRuntimeConfigInputMock,
+  resolveManagedSiteRuntimeConfigForType: resolveRuntimeConfigMock,
+}))
+
+vi.mock("~/services/managedSites/managedSiteService", () => ({
+  getManagedSiteServiceForType: getManagedSiteServiceForTypeMock,
+}))
+
+const loadMigration = async () => {
+  vi.resetModules()
+  return await import("~/services/managedSites/legacyChannelConfigMigration")
+}
+
+describe("legacyChannelConfigMigration", () => {
+  beforeEach(() => {
+    storageData.clear()
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-03-28T05:30:00.000Z"))
+    getPreferencesStrictMock.mockResolvedValue({})
+    hasRuntimeConfigInputMock.mockReturnValue(false)
+    migrateLegacyNumericConfigsMock.mockResolvedValue({
+      migrated: 0,
+      ambiguous: 0,
+      unmatched: 0,
+    })
+  })
+
+  it("does not load preferences or access the network without legacy data", async () => {
+    hasLegacyNumericConfigsMock.mockResolvedValue(false)
+    const { legacyChannelConfigMigration } = await loadMigration()
+
+    await expect(legacyChannelConfigMigration.initialize()).resolves.toEqual({
+      status: "not-needed",
+    })
+    expect(getPreferencesStrictMock).not.toHaveBeenCalled()
+    expect(getManagedSiteServiceForTypeMock).not.toHaveBeenCalled()
+  })
+
+  it("discovers all configured sites and migrates only after every list succeeds", async () => {
+    hasLegacyNumericConfigsMock.mockResolvedValue(true)
+    resolveRuntimeConfigMock.mockImplementation((_preferences, siteType) => {
+      if (siteType === "new-api" || siteType === "done-hub") {
+        return {
+          siteType,
+          config: { baseUrl: `https://${siteType}.example.invalid` },
+        }
+      }
+      return null
+    })
+    getManagedSiteServiceForTypeMock.mockImplementation((siteType) => ({
+      listChannels: vi.fn().mockResolvedValue({
+        items:
+          siteType === "new-api"
+            ? [{ id: 9, name: "Target" }]
+            : [{ id: 10, name: "Other" }],
+        total: 1,
+        type_counts: {},
+      }),
+    }))
+    migrateLegacyNumericConfigsMock.mockResolvedValue({
+      migrated: 1,
+      ambiguous: 0,
+      unmatched: 0,
+    })
+    const { legacyChannelConfigMigration } = await loadMigration()
+
+    await expect(legacyChannelConfigMigration.initialize()).resolves.toEqual({
+      status: "completed",
+      migrated: 1,
+      ambiguous: 0,
+      unmatched: 0,
+    })
+    expect(getManagedSiteServiceForTypeMock).toHaveBeenCalledTimes(2)
+    for (const service of getManagedSiteServiceForTypeMock.mock.results) {
+      expect(service.value.listChannels).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ requireCompleteInventory: true }),
+      )
+    }
+    expect(migrateLegacyNumericConfigsMock).toHaveBeenCalledWith([
+      {
+        channelId: 9,
+        resourceRef: {
+          managedSiteType: "new-api",
+          scopeKey: "https://new-api.example.invalid",
+          resourceId: "9",
+        },
+      },
+      {
+        channelId: 10,
+        resourceRef: {
+          managedSiteType: "done-hub",
+          scopeKey: "https://done-hub.example.invalid",
+          resourceId: "10",
+        },
+      },
+    ])
+  })
+
+  it("preserves legacy data when any configured site cannot be enumerated", async () => {
+    hasLegacyNumericConfigsMock.mockResolvedValue(true)
+    resolveRuntimeConfigMock.mockImplementation((_preferences, siteType) => {
+      if (siteType === "new-api" || siteType === "done-hub") {
+        return {
+          siteType,
+          config: { baseUrl: `https://${siteType}.example.invalid` },
+        }
+      }
+      return null
+    })
+    getManagedSiteServiceForTypeMock.mockImplementation((siteType) => ({
+      listChannels:
+        siteType === "new-api"
+          ? vi.fn().mockResolvedValue({
+              items: [{ id: 9, name: "Target" }],
+              total: 1,
+              type_counts: {},
+            })
+          : vi.fn().mockRejectedValue(new Error("site unavailable")),
+    }))
+    const { legacyChannelConfigMigration } = await loadMigration()
+
+    await expect(legacyChannelConfigMigration.initialize()).resolves.toEqual({
+      status: "deferred",
+      reason: "inventory-failed",
+    })
+    expect(migrateLegacyNumericConfigsMock).not.toHaveBeenCalled()
+    expect(hasLegacyNumericConfigsMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("persists a retry backoff across extension-context restarts", async () => {
+    hasLegacyNumericConfigsMock.mockResolvedValue(true)
+    resolveRuntimeConfigMock.mockImplementation((_preferences, siteType) =>
+      siteType === "new-api"
+        ? {
+            siteType,
+            config: { baseUrl: "https://new-api.example.invalid" },
+          }
+        : null,
+    )
+    const listChannels = vi.fn().mockRejectedValue(new Error("offline"))
+    getManagedSiteServiceForTypeMock.mockReturnValue({ listChannels })
+    const firstModule = await loadMigration()
+
+    await expect(
+      firstModule.legacyChannelConfigMigration.initialize(),
+    ).resolves.toEqual({
+      status: "deferred",
+      reason: "inventory-failed",
+    })
+    expect(listChannels).toHaveBeenCalledTimes(1)
+
+    getManagedSiteServiceForTypeMock.mockClear()
+    const secondModule = await loadMigration()
+    await expect(
+      secondModule.legacyChannelConfigMigration.initialize(),
+    ).resolves.toEqual({
+      status: "deferred",
+      reason: "backoff-active",
+    })
+    expect(getManagedSiteServiceForTypeMock).not.toHaveBeenCalled()
+
+    await expect(
+      secondModule.ensureLegacyChannelConfigMigrationReady({
+        bypassBackoff: true,
+      }),
+    ).rejects.toThrow(
+      "Legacy channel config migration deferred: inventory-failed",
+    )
+    expect(getManagedSiteServiceForTypeMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("fails closed when preferences cannot be read", async () => {
+    hasLegacyNumericConfigsMock.mockResolvedValue(true)
+    getPreferencesStrictMock.mockRejectedValue(new Error("storage unavailable"))
+    const { legacyChannelConfigMigration } = await loadMigration()
+
+    await expect(legacyChannelConfigMigration.initialize()).resolves.toEqual({
+      status: "deferred",
+      reason: "storage-failed",
+    })
+    expect(getManagedSiteServiceForTypeMock).not.toHaveBeenCalled()
+    expect(migrateLegacyNumericConfigsMock).not.toHaveBeenCalled()
+  })
+
+  it("does not ignore a partially configured managed site", async () => {
+    hasLegacyNumericConfigsMock.mockResolvedValue(true)
+    getPreferencesStrictMock.mockResolvedValue({
+      newApi: {
+        baseUrl: "https://new-api.example.invalid",
+        adminToken: "",
+        userId: "",
+      },
+    })
+    resolveRuntimeConfigMock.mockReturnValue(null)
+    hasRuntimeConfigInputMock.mockImplementation(
+      (_preferences, siteType) => siteType === "new-api",
+    )
+    const { legacyChannelConfigMigration } = await loadMigration()
+
+    await expect(legacyChannelConfigMigration.initialize()).resolves.toEqual({
+      status: "deferred",
+      reason: "inventory-failed",
+    })
+    expect(getManagedSiteServiceForTypeMock).not.toHaveBeenCalled()
+    expect(migrateLegacyNumericConfigsMock).not.toHaveBeenCalled()
+  })
+
+  it("restarts discovery when deployment identities change during inventory", async () => {
+    hasLegacyNumericConfigsMock.mockResolvedValue(true)
+    getPreferencesStrictMock
+      .mockResolvedValueOnce({ phase: "initial" })
+      .mockResolvedValueOnce({ phase: "changed" })
+    resolveRuntimeConfigMock.mockImplementation((preferences, siteType) =>
+      siteType === "new-api"
+        ? {
+            siteType,
+            config: {
+              baseUrl: `https://${preferences.phase}.example.invalid`,
+            },
+          }
+        : null,
+    )
+    getManagedSiteServiceForTypeMock.mockReturnValue({
+      listChannels: vi.fn().mockResolvedValue({
+        items: [{ id: 9, name: "Target" }],
+        total: 1,
+        type_counts: {},
+      }),
+    })
+    const { legacyChannelConfigMigration } = await loadMigration()
+
+    await expect(legacyChannelConfigMigration.initialize()).resolves.toEqual({
+      status: "deferred",
+      reason: "inventory-failed",
+    })
+    expect(migrateLegacyNumericConfigsMock).not.toHaveBeenCalled()
+  })
+
+  it("preserves legacy data when a provider reports a partial inventory", async () => {
+    hasLegacyNumericConfigsMock.mockResolvedValue(true)
+    resolveRuntimeConfigMock.mockImplementation((_preferences, siteType) =>
+      siteType === "new-api"
+        ? {
+            siteType,
+            config: { baseUrl: "https://new-api.example.invalid" },
+          }
+        : null,
+    )
+    getManagedSiteServiceForTypeMock.mockReturnValue({
+      listChannels: vi.fn().mockResolvedValue({
+        items: [{ id: 9, name: "Partial" }],
+        total: 2,
+        type_counts: {},
+      }),
+    })
+    const { legacyChannelConfigMigration } = await loadMigration()
+
+    await expect(legacyChannelConfigMigration.initialize()).resolves.toEqual({
+      status: "deferred",
+      reason: "inventory-failed",
+    })
+    expect(migrateLegacyNumericConfigsMock).not.toHaveBeenCalled()
+  })
+
+  it("does not treat any AxonHub numeric projection as stable legacy evidence", async () => {
+    hasLegacyNumericConfigsMock.mockResolvedValue(true)
+    resolveRuntimeConfigMock.mockImplementation((_preferences, siteType) =>
+      siteType === "axonhub"
+        ? {
+            siteType,
+            config: {
+              baseUrl: "https://axon.example.invalid",
+              email: "admin@example.invalid",
+              password: "secret",
+            },
+          }
+        : null,
+    )
+    getManagedSiteServiceForTypeMock.mockReturnValue({
+      listChannels: vi.fn().mockResolvedValue({
+        items: [
+          {
+            id: 123456,
+            name: "Numeric native id",
+            _axonHubData: { id: 123456 },
+          },
+        ],
+        total: 1,
+        type_counts: {},
+      }),
+    })
+    migrateLegacyNumericConfigsMock.mockResolvedValue({
+      migrated: 0,
+      ambiguous: 0,
+      unmatched: 1,
+    })
+    const { legacyChannelConfigMigration } = await loadMigration()
+
+    await expect(legacyChannelConfigMigration.initialize()).resolves.toEqual({
+      status: "deferred",
+      reason: "unresolved-identities",
+    })
+    expect(migrateLegacyNumericConfigsMock).toHaveBeenCalledWith([])
+  })
+
+  it("defers without deleting data when no configured site can be queried", async () => {
+    hasLegacyNumericConfigsMock.mockResolvedValue(true)
+    resolveRuntimeConfigMock.mockReturnValue(null)
+    const { legacyChannelConfigMigration } = await loadMigration()
+
+    await expect(legacyChannelConfigMigration.initialize()).resolves.toEqual({
+      status: "deferred",
+      reason: "no-configured-sites",
+    })
+    expect(getManagedSiteServiceForTypeMock).not.toHaveBeenCalled()
+    expect(migrateLegacyNumericConfigsMock).not.toHaveBeenCalled()
+  })
+
+  it("blocks scoped-only consumers while migration is deferred", async () => {
+    hasLegacyNumericConfigsMock.mockResolvedValue(true)
+    resolveRuntimeConfigMock.mockReturnValue(null)
+    const { ensureLegacyChannelConfigMigrationReady } = await loadMigration()
+
+    await expect(ensureLegacyChannelConfigMigrationReady()).rejects.toThrow(
+      "Legacy channel config migration deferred: no-configured-sites",
+    )
+  })
+
+  it("deduplicates concurrent initialization through one shared promise", async () => {
+    let resolveLegacyCheck: ((value: boolean) => void) | undefined
+    hasLegacyNumericConfigsMock.mockImplementation(
+      () =>
+        new Promise<boolean>((resolve) => {
+          resolveLegacyCheck = resolve
+        }),
+    )
+    const { legacyChannelConfigMigration } = await loadMigration()
+
+    const first = legacyChannelConfigMigration.initialize()
+    const second = legacyChannelConfigMigration.initialize()
+    await Promise.resolve()
+    await Promise.resolve()
+    resolveLegacyCheck?.(false)
+
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      { status: "not-needed" },
+      { status: "not-needed" },
+    ])
+    expect(hasLegacyNumericConfigsMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/services/legacyChannelConfigMigration.test.ts
+++ b/tests/services/legacyChannelConfigMigration.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
+import { Storage } from "@plasmohq/storage"
+
+import { CHANNEL_CONFIG_STORAGE_KEYS } from "~/services/core/storageKeys"
+
 const storageData = new Map<string, unknown>()
 
 const {
@@ -64,6 +68,7 @@ const loadMigration = async () => {
 describe("legacyChannelConfigMigration", () => {
   beforeEach(() => {
     storageData.clear()
+    vi.restoreAllMocks()
     vi.clearAllMocks()
     vi.useFakeTimers()
     vi.setSystemTime(new Date("2026-03-28T05:30:00.000Z"))
@@ -85,6 +90,48 @@ describe("legacyChannelConfigMigration", () => {
     })
     expect(getPreferencesStrictMock).not.toHaveBeenCalled()
     expect(getManagedSiteServiceForTypeMock).not.toHaveBeenCalled()
+  })
+
+  it("ignores malformed retry state instead of treating it as active backoff", async () => {
+    storageData.set(CHANNEL_CONFIG_STORAGE_KEYS.LEGACY_MIGRATION_STATE, {
+      attempt: 0,
+      retryAfter: "later",
+    })
+    hasLegacyNumericConfigsMock.mockResolvedValue(true)
+    const { legacyChannelConfigMigration } = await loadMigration()
+
+    await expect(legacyChannelConfigMigration.initialize()).resolves.toEqual({
+      status: "deferred",
+      reason: "no-configured-sites",
+    })
+    expect(
+      storageData.get(CHANNEL_CONFIG_STORAGE_KEYS.LEGACY_MIGRATION_STATE),
+    ).toEqual(expect.objectContaining({ attempt: 1 }))
+  })
+
+  it("preserves the migration outcome when backoff persistence fails", async () => {
+    hasLegacyNumericConfigsMock.mockResolvedValue(true)
+    vi.spyOn(Storage.prototype, "set").mockRejectedValueOnce(
+      new Error("storage unavailable"),
+    )
+    const { legacyChannelConfigMigration } = await loadMigration()
+
+    await expect(legacyChannelConfigMigration.initialize()).resolves.toEqual({
+      status: "deferred",
+      reason: "no-configured-sites",
+    })
+  })
+
+  it("does not turn retry-state cleanup failure into a migration failure", async () => {
+    hasLegacyNumericConfigsMock.mockResolvedValue(false)
+    vi.spyOn(Storage.prototype, "remove").mockRejectedValueOnce(
+      new Error("storage unavailable"),
+    )
+    const { legacyChannelConfigMigration } = await loadMigration()
+
+    await expect(legacyChannelConfigMigration.initialize()).resolves.toEqual({
+      status: "not-needed",
+    })
   })
 
   it("discovers all configured sites and migrates only after every list succeeds", async () => {
@@ -371,28 +418,97 @@ describe("legacyChannelConfigMigration", () => {
   it("blocks scoped-only consumers while migration is deferred", async () => {
     hasLegacyNumericConfigsMock.mockResolvedValue(true)
     resolveRuntimeConfigMock.mockReturnValue(null)
-    const { ensureLegacyChannelConfigMigrationReady } = await loadMigration()
+    const {
+      ensureLegacyChannelConfigMigrationReady,
+      LegacyChannelConfigMigrationDeferredError,
+    } = await loadMigration()
 
-    await expect(ensureLegacyChannelConfigMigrationReady()).rejects.toThrow(
-      "Legacy channel config migration deferred: no-configured-sites",
+    const failure = ensureLegacyChannelConfigMigrationReady()
+    await expect(failure).rejects.toBeInstanceOf(
+      LegacyChannelConfigMigrationDeferredError,
     )
+    await expect(failure).rejects.toMatchObject({
+      reason: "no-configured-sites",
+    })
+  })
+
+  it("honors an explicit bypass caller after it joins a backoff-blocked run", async () => {
+    storageData.set(CHANNEL_CONFIG_STORAGE_KEYS.LEGACY_MIGRATION_STATE, {
+      attempt: 1,
+      retryAfter: Date.now() + 60_000,
+    })
+    let resolveFirstLegacyCheck: ((value: boolean) => void) | undefined
+    hasLegacyNumericConfigsMock
+      .mockImplementationOnce(
+        () =>
+          new Promise<boolean>((resolve) => {
+            resolveFirstLegacyCheck = resolve
+          }),
+      )
+      .mockResolvedValueOnce(true)
+    resolveRuntimeConfigMock.mockImplementation((_preferences, siteType) =>
+      siteType === "new-api"
+        ? {
+            siteType,
+            config: { baseUrl: "https://new-api.example.invalid" },
+          }
+        : null,
+    )
+    getManagedSiteServiceForTypeMock.mockReturnValue({
+      listChannels: vi.fn().mockResolvedValue({
+        items: [{ id: 9, name: "Target" }],
+        total: 1,
+        type_counts: {},
+      }),
+    })
+    migrateLegacyNumericConfigsMock.mockResolvedValue({
+      migrated: 1,
+      ambiguous: 0,
+      unmatched: 0,
+    })
+    const { legacyChannelConfigMigration } = await loadMigration()
+
+    const background = legacyChannelConfigMigration.initialize()
+    const explicit = legacyChannelConfigMigration.initialize({
+      bypassBackoff: true,
+    })
+    await vi.waitFor(() =>
+      expect(resolveFirstLegacyCheck).toBeTypeOf("function"),
+    )
+    resolveFirstLegacyCheck?.(true)
+
+    await expect(background).resolves.toEqual({
+      status: "deferred",
+      reason: "backoff-active",
+    })
+    await expect(explicit).resolves.toEqual({
+      status: "completed",
+      migrated: 1,
+      ambiguous: 0,
+      unmatched: 0,
+    })
+    expect(hasLegacyNumericConfigsMock).toHaveBeenCalledTimes(2)
   })
 
   it("deduplicates concurrent initialization through one shared promise", async () => {
     let resolveLegacyCheck: ((value: boolean) => void) | undefined
+    let markLegacyCheckStarted: (() => void) | undefined
+    const legacyCheckStarted = new Promise<void>((resolve) => {
+      markLegacyCheckStarted = resolve
+    })
     hasLegacyNumericConfigsMock.mockImplementation(
       () =>
         new Promise<boolean>((resolve) => {
           resolveLegacyCheck = resolve
+          markLegacyCheckStarted?.()
         }),
     )
     const { legacyChannelConfigMigration } = await loadMigration()
 
     const first = legacyChannelConfigMigration.initialize()
     const second = legacyChannelConfigMigration.initialize()
-    await Promise.resolve()
-    await Promise.resolve()
-    resolveLegacyCheck?.(false)
+    await legacyCheckStarted
+    resolveLegacyCheck!(false)
 
     await expect(Promise.all([first, second])).resolves.toEqual([
       { status: "not-needed" },

--- a/tests/services/managedSites/channelModelFilterRules.test.ts
+++ b/tests/services/managedSites/channelModelFilterRules.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest"
 import {
   normalizeChannelFilters,
   sanitizeChannelFilter,
+  sanitizeChannelFiltersForStorage,
 } from "~/services/managedSites/channelModelFilterRules"
 
 vi.mock("~/utils/core/identifier", () => ({
@@ -108,5 +109,20 @@ describe("channelModelFilterRules", () => {
       createdAt: 123,
       updatedAt: 123,
     })
+  })
+
+  it("rejects regex patterns with potentially exponential backtracking", () => {
+    const unsafeFilter = {
+      name: "Unsafe regex",
+      pattern: "(a+)+$",
+      isRegex: true,
+    }
+
+    expect(() => normalizeChannelFilters([unsafeFilter])).toThrow(
+      "Invalid or unsafe regex pattern",
+    )
+    expect(
+      sanitizeChannelFiltersForStorage([unsafeFilter], { now: 123 }),
+    ).toEqual([])
   })
 })

--- a/tests/services/managedSites/managedSiteChannelResourceIdentity.test.ts
+++ b/tests/services/managedSites/managedSiteChannelResourceIdentity.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  getManagedSiteChannelResourceId,
+  getStableLegacyChannelId,
+} from "~/services/managedSites/managedSiteChannelResourceIdentity"
+import type { ManagedSiteChannel } from "~/types/managedSite"
+
+describe("managed-site channel resource identity", () => {
+  it("uses the AxonHub native id but never treats its numeric projection as legacy evidence", () => {
+    const channel = {
+      id: 42,
+      _axonHubData: { id: "native-provider-id" },
+    } as unknown as ManagedSiteChannel
+
+    expect(getManagedSiteChannelResourceId("axonhub", channel)).toBe(
+      "native-provider-id",
+    )
+    expect(getStableLegacyChannelId("axonhub", channel)).toBeNull()
+  })
+
+  it("falls back to the row id when AxonHub native detail is unavailable", () => {
+    const channel = { id: 42 } as ManagedSiteChannel
+
+    expect(getManagedSiteChannelResourceId("axonhub", channel)).toBe(42)
+  })
+
+  it("uses the stable row id for managed-site families with native numeric ids", () => {
+    const channel = { id: 9 } as ManagedSiteChannel
+
+    expect(getManagedSiteChannelResourceId("new-api", channel)).toBe(9)
+    expect(getStableLegacyChannelId("new-api", channel)).toBe(9)
+  })
+})

--- a/tests/services/managedSites/runtimeConfig.test.ts
+++ b/tests/services/managedSites/runtimeConfig.test.ts
@@ -251,6 +251,15 @@ describe("managed-site runtime config resolver", () => {
     ).toBe("future-managed-site")
   })
 
+  it("treats unknown managed-site types as having no configured input", () => {
+    expect(
+      hasManagedSiteRuntimeConfigInputForType(
+        buildUserPreferences(),
+        "future-managed-site" as any,
+      ),
+    ).toBe(false)
+  })
+
   it("returns null for non-numeric access-token managed-site user IDs", () => {
     const prefs = buildUserPreferences({
       newApi: {

--- a/tests/services/managedSites/runtimeConfig.test.ts
+++ b/tests/services/managedSites/runtimeConfig.test.ts
@@ -5,6 +5,7 @@ import {
   getCurrentManagedSiteRuntimeConfig,
   getManagedSiteLegacyAdminConfig,
   getManagedSiteRuntimeConfigForType,
+  hasManagedSiteRuntimeConfigInputForType,
   resolveCurrentManagedSiteRuntimeConfig,
   resolveManagedSiteRuntimeConfigForType,
 } from "~/services/managedSites/runtimeConfig"
@@ -154,6 +155,26 @@ describe("managed-site runtime config resolver", () => {
     expect(
       resolveManagedSiteRuntimeConfigForType(prefs, SITE_TYPES.CLAUDE_CODE_HUB),
     ).toBeNull()
+  })
+
+  it("distinguishes incomplete input from an unconfigured managed site", () => {
+    const incomplete = buildUserPreferences({
+      newApi: {
+        baseUrl: "https://new-api.example.com",
+        adminToken: "",
+        userId: "",
+      },
+    })
+    const unconfigured = buildUserPreferences({
+      newApi: { baseUrl: "", adminToken: "", userId: "" },
+    })
+
+    expect(
+      hasManagedSiteRuntimeConfigInputForType(incomplete, SITE_TYPES.NEW_API),
+    ).toBe(true)
+    expect(
+      hasManagedSiteRuntimeConfigInputForType(unconfigured, SITE_TYPES.NEW_API),
+    ).toBe(false)
   })
 
   it("returns unknown managed-site values from the exhaustive fallback", () => {

--- a/tests/services/managedSites/runtimeConfig.test.ts
+++ b/tests/services/managedSites/runtimeConfig.test.ts
@@ -158,23 +158,86 @@ describe("managed-site runtime config resolver", () => {
   })
 
   it("distinguishes incomplete input from an unconfigured managed site", () => {
-    const incomplete = buildUserPreferences({
-      newApi: {
-        baseUrl: "https://new-api.example.com",
-        adminToken: "",
-        userId: "",
+    const cases = [
+      {
+        siteType: SITE_TYPES.NEW_API,
+        incomplete: buildUserPreferences({
+          newApi: {
+            baseUrl: "https://new-api.example.invalid",
+            adminToken: "",
+            userId: "",
+          },
+        }),
+        unconfigured: buildUserPreferences({
+          newApi: { baseUrl: " ", adminToken: " ", userId: " " },
+        }),
       },
-    })
-    const unconfigured = buildUserPreferences({
-      newApi: { baseUrl: "", adminToken: "", userId: "" },
-    })
+      {
+        siteType: SITE_TYPES.DONE_HUB,
+        incomplete: buildUserPreferences({
+          doneHub: {
+            baseUrl: "https://done-hub.example.invalid",
+            adminToken: "",
+            userId: "",
+          },
+        }),
+        unconfigured: buildUserPreferences({ doneHub: undefined }),
+      },
+      {
+        siteType: SITE_TYPES.VELOERA,
+        incomplete: buildUserPreferences({
+          veloera: {
+            baseUrl: "https://veloera.example.invalid",
+            adminToken: "",
+            userId: "",
+          },
+        }),
+        unconfigured: buildUserPreferences({ veloera: undefined }),
+      },
+      {
+        siteType: SITE_TYPES.OCTOPUS,
+        incomplete: buildUserPreferences({
+          octopus: {
+            baseUrl: "https://octopus.example.invalid",
+            username: "",
+            password: "",
+          },
+        }),
+        unconfigured: buildUserPreferences({
+          octopus: { baseUrl: " ", username: " ", password: " " },
+        }),
+      },
+      {
+        siteType: SITE_TYPES.AXON_HUB,
+        incomplete: buildUserPreferences({
+          axonHub: {
+            baseUrl: "https://axon-hub.example.invalid",
+            email: "",
+            password: "",
+          },
+        }),
+        unconfigured: buildUserPreferences({ axonHub: undefined }),
+      },
+      {
+        siteType: SITE_TYPES.CLAUDE_CODE_HUB,
+        incomplete: buildUserPreferences({
+          claudeCodeHub: {
+            baseUrl: "https://claude-code-hub.example.invalid",
+            adminToken: "",
+          },
+        }),
+        unconfigured: buildUserPreferences({ claudeCodeHub: undefined }),
+      },
+    ]
 
-    expect(
-      hasManagedSiteRuntimeConfigInputForType(incomplete, SITE_TYPES.NEW_API),
-    ).toBe(true)
-    expect(
-      hasManagedSiteRuntimeConfigInputForType(unconfigured, SITE_TYPES.NEW_API),
-    ).toBe(false)
+    for (const { siteType, incomplete, unconfigured } of cases) {
+      expect(
+        hasManagedSiteRuntimeConfigInputForType(incomplete, siteType),
+      ).toBe(true)
+      expect(
+        hasManagedSiteRuntimeConfigInputForType(unconfigured, siteType),
+      ).toBe(false)
+    }
   })
 
   it("returns unknown managed-site values from the exhaustive fallback", () => {

--- a/tests/services/modelSync/modelSyncService.test.ts
+++ b/tests/services/modelSync/modelSyncService.test.ts
@@ -950,8 +950,9 @@ describe("ModelSyncService - global and channel filters", () => {
     ]
 
     await expect(
-      callApplyFilters(rules, ["a".repeat(40) + "z"]),
+      callApplyFilters(rules, ["a".repeat(40), "a".repeat(30)]),
     ).resolves.toEqual([])
+    expect(loggerMocks.warn).toHaveBeenCalledTimes(1)
   })
 
   it("fails closed when a probe rule is evaluated without channel context", async () => {

--- a/tests/services/modelSync/modelSyncService.test.ts
+++ b/tests/services/modelSync/modelSyncService.test.ts
@@ -3,9 +3,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import { ChannelType } from "~/constants/newApi"
 import { SITE_TYPES } from "~/constants/siteType"
 import type { ManagedSiteRuntimeConfig } from "~/services/managedSites/runtimeConfig"
-import { matchesProbeFilterRule } from "~/services/models/modelSync/channelModelFilterEvaluator"
+import {
+  applyChannelModelFilters,
+  matchesProbeFilterRule,
+} from "~/services/models/modelSync/channelModelFilterEvaluator"
 import { ModelSyncService } from "~/services/models/modelSync/modelSyncService"
-import type { ChannelConfigMap } from "~/types/channelConfig"
+import type { ChannelResourceConfigMap } from "~/types/channelConfig"
 import type {
   ChannelModelFilterRule,
   ChannelModelPatternFilterRule,
@@ -15,6 +18,7 @@ import type { ChannelFormData, ManagedSiteChannel } from "~/types/managedSite"
 import type { ExecutionItemResult } from "~/types/managedSiteModelSync"
 import {
   createManagedUpstreamResourceRef,
+  getManagedUpstreamResourceRefKey,
   MANAGED_UPSTREAM_RESOURCE_NATIVE_KINDS,
   MANAGED_UPSTREAM_RESOURCE_SECRET_STATES,
   MANAGED_UPSTREAM_RESOURCE_STATUSES,
@@ -352,13 +356,20 @@ const makeResourceCapabilities = () => ({
 
 const makeChannelConfigs = (
   rulesByChannelId: Record<number, ChannelModelFilterRule[]>,
-): ChannelConfigMap =>
+  scopeKey = "https://example.com",
+): ChannelResourceConfigMap =>
   Object.fromEntries(
     Object.entries(rulesByChannelId).map(([channelId, rules]) => {
       const numericChannelId = Number(channelId)
+      const resourceRef = createManagedUpstreamResourceRef({
+        managedSiteType: SITE_TYPES.NEW_API,
+        scopeKey,
+        resourceId: numericChannelId,
+      })
       return [
-        numericChannelId,
+        getManagedUpstreamResourceRefKey(resourceRef),
         {
+          resourceRef,
           channelId: numericChannelId,
           modelFilterSettings: {
             rules,
@@ -870,15 +881,7 @@ describe("ModelSyncService - global and channel filters", () => {
   const callApplyFilters = (
     rules: ChannelModelFilterRule[] | null | undefined,
     models: string[],
-  ): Promise<string[]> => {
-    const service = new ModelSyncService(
-      makeNewApiRuntimeConfig({
-        baseUrl: "https://example.com",
-        adminToken: "token",
-      }),
-    )
-    return (service as any).applyFilters(rules, models)
-  }
+  ): Promise<string[]> => applyChannelModelFilters(rules, models)
 
   it("returns normalized models when no filters are provided", async () => {
     const result = await callApplyFilters(undefined, [" gpt-4o ", "gpt-4o", ""])
@@ -1809,9 +1812,12 @@ describe("ModelSyncService - probe-backed filters", () => {
       [duplicateRule],
     )
     service.setChannelConfigs(
-      makeChannelConfigs({
-        79: [makeProbeRule({ id: "channel-duplicate" })],
-      }),
+      makeChannelConfigs(
+        {
+          79: [makeProbeRule({ id: "channel-duplicate" })],
+        },
+        "https://managed.example.com",
+      ),
     )
 
     const channel = makeChannel({

--- a/tests/services/modelSync/modelSyncService.test.ts
+++ b/tests/services/modelSync/modelSyncService.test.ts
@@ -975,7 +975,7 @@ describe("ModelSyncService - global and channel filters", () => {
 
   it("treats an unknown imported rule kind as non-matching", async () => {
     const unknownRule = {
-      ...makeFilterRule({ id: "unknown" }),
+      ...makeFilterRule({ id: "unknown", pattern: "gpt-4o" }),
       kind: "future-kind",
     } as unknown as ChannelModelFilterRule
 

--- a/tests/services/modelSync/modelSyncService.test.ts
+++ b/tests/services/modelSync/modelSyncService.test.ts
@@ -938,6 +938,50 @@ describe("ModelSyncService - global and channel filters", () => {
     const result = await callApplyFilters(rules, baseModels)
     expect(result).toEqual([])
   })
+
+  it("rejects unsafe regex filters from legacy or imported storage at runtime", async () => {
+    const rules: ChannelModelFilterRule[] = [
+      makeFilterRule({
+        id: "unsafe",
+        pattern: "(a+)+$",
+        isRegex: true,
+        action: "include",
+      }),
+    ]
+
+    await expect(
+      callApplyFilters(rules, ["a".repeat(40) + "z"]),
+    ).resolves.toEqual([])
+  })
+
+  it("fails closed when a probe rule is evaluated without channel context", async () => {
+    const probeRule = {
+      id: "probe",
+      kind: "probe",
+      name: "Probe",
+      probeIds: ["text-generation"],
+      match: "all",
+      action: "include",
+      enabled: true,
+      createdAt: 100,
+      updatedAt: 100,
+    } as ChannelModelFilterRule
+
+    await expect(
+      callApplyFilters([probeRule], ["gpt-4o"]),
+    ).rejects.toMatchObject({ reason: "provider-unsupported" })
+  })
+
+  it("treats an unknown imported rule kind as non-matching", async () => {
+    const unknownRule = {
+      ...makeFilterRule({ id: "unknown" }),
+      kind: "future-kind",
+    } as unknown as ChannelModelFilterRule
+
+    await expect(callApplyFilters([unknownRule], ["gpt-4o"])).resolves.toEqual(
+      [],
+    )
+  })
 })
 
 describe("ModelSyncService - channel execution", () => {

--- a/tests/services/modelSync/octopusModelSync.test.ts
+++ b/tests/services/modelSync/octopusModelSync.test.ts
@@ -3,6 +3,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { ApiError } from "~/services/apiTransport/errors"
 import { runOctopusBatch } from "~/services/models/modelSync/octopusModelSync"
 import type { OctopusChannelWithData } from "~/types/managedSite"
+import {
+  createManagedUpstreamResourceRef,
+  getManagedUpstreamResourceRefKey,
+} from "~/types/managedUpstreamResource"
 
 const {
   fetchRemoteModelsMock,
@@ -23,12 +27,18 @@ vi.mock("~/services/apiService/octopus", () => ({
   updateChannel: vi.fn((...args) => updateChannelMock(...args)),
 }))
 
-vi.mock("~/services/apiAdapters/managedSites/octopus", () => ({
-  octopusManagedSiteChannels: {
+vi.mock("~/services/apiAdapters/managedSites/octopus", () => {
+  const octopusManagedSiteChannels = {
     updateModels: (...args: unknown[]) => updateModelsMock(...args),
     list: (...args: unknown[]) => listChannelsMock(...args),
-  },
-}))
+  }
+  return {
+    octopusManagedSiteChannels,
+    octopusManagedSiteCapabilities: {
+      channels: octopusManagedSiteChannels,
+    },
+  }
+})
 
 vi.mock("~/utils/core/logger", () => ({
   createLogger: vi.fn(() => ({
@@ -154,6 +164,60 @@ describe("runOctopusBatch", () => {
         ok: true,
         newModels: ["beta", "gamma"],
       }),
+    })
+  })
+
+  it("applies the scoped resource filters before updating an Octopus channel", async () => {
+    fetchRemoteModelsMock.mockResolvedValueOnce(["model-a", "model-b"])
+    const resourceRef = createManagedUpstreamResourceRef({
+      managedSiteType: "octopus",
+      scopeKey: config.baseUrl,
+      resourceId: 1,
+    })
+    const channelConfigs = {
+      [getManagedUpstreamResourceRefKey(resourceRef)]: {
+        resourceRef,
+        channelId: 1,
+        modelFilterSettings: {
+          rules: [
+            {
+              id: "exclude-model-b",
+              kind: "pattern" as const,
+              name: "Exclude model-b",
+              pattern: "model-b",
+              isRegex: false,
+              action: "exclude" as const,
+              enabled: true,
+              createdAt: 10,
+              updatedAt: 10,
+            },
+          ],
+          updatedAt: 10,
+        },
+        createdAt: 10,
+        updatedAt: 10,
+      },
+    }
+
+    const result = await runOctopusBatch(
+      config as any,
+      [createChannel({ models: "legacy-model" })],
+      {
+        concurrency: 1,
+        maxRetries: 0,
+        channelConfigs,
+      },
+    )
+
+    expect(updateModelsMock).toHaveBeenCalledWith(
+      config,
+      1,
+      ["model-a"],
+      undefined,
+    )
+    expect(result.items[0]).toMatchObject({
+      ok: true,
+      newModels: ["model-a"],
     })
   })
 

--- a/tests/services/modelSync/octopusModelSync.test.ts
+++ b/tests/services/modelSync/octopusModelSync.test.ts
@@ -221,6 +221,55 @@ describe("runOctopusBatch", () => {
     })
   })
 
+  it("returns a channel failure when a probe filter cannot resolve a channel key", async () => {
+    fetchRemoteModelsMock.mockResolvedValueOnce(["model-a"])
+    const resourceRef = createManagedUpstreamResourceRef({
+      managedSiteType: "octopus",
+      scopeKey: config.baseUrl,
+      resourceId: 1,
+    })
+    const channelConfigs = {
+      [getManagedUpstreamResourceRefKey(resourceRef)]: {
+        resourceRef,
+        channelId: 1,
+        modelFilterSettings: {
+          rules: [
+            {
+              id: "probe-rule",
+              kind: "probe" as const,
+              name: "Probe model",
+              probeIds: ["text-generation" as const],
+              match: "all" as const,
+              action: "include" as const,
+              enabled: true,
+              createdAt: 100,
+              updatedAt: 100,
+            },
+          ],
+          updatedAt: 100,
+        },
+        createdAt: 100,
+        updatedAt: 100,
+      },
+    }
+
+    const result = await runOctopusBatch(
+      config as any,
+      [createChannel({ models: "legacy-model" })],
+      { concurrency: 1, maxRetries: 0, channelConfigs },
+    )
+
+    expect(updateModelsMock).not.toHaveBeenCalled()
+    expect(result.items).toEqual([
+      expect.objectContaining({
+        channelId: 1,
+        ok: false,
+        attempts: 1,
+        message: "Probe filtering is unsupported for this channel type.",
+      }),
+    ])
+  })
+
   it("skips updates when the normalized model set is unchanged", async () => {
     fetchRemoteModelsMock.mockResolvedValueOnce([" model-b ", "model-a", " "])
 

--- a/tests/services/modelSync/scheduler.lifecycle.test.ts
+++ b/tests/services/modelSync/scheduler.lifecycle.test.ts
@@ -13,6 +13,10 @@ import {
   PRODUCT_ANALYTICS_SOURCE_KINDS,
 } from "~/services/productAnalytics/contracts"
 
+vi.mock("~/services/managedSites/legacyChannelConfigMigration", () => ({
+  ensureLegacyChannelConfigMigrationReady: vi.fn().mockResolvedValue(undefined),
+}))
+
 const mocks = vi.hoisted(() => ({
   clearAlarm: vi.fn(),
   createAlarm: vi.fn(),

--- a/tests/services/modelSync/scheduler.lifecycle.test.ts
+++ b/tests/services/modelSync/scheduler.lifecycle.test.ts
@@ -22,7 +22,7 @@ const mocks = vi.hoisted(() => ({
   sendRuntimeMessage: vi.fn(),
   getPreferences: vi.fn(),
   savePreferences: vi.fn(),
-  getAllConfigs: vi.fn(),
+  getConfigsForScope: vi.fn(),
   listChannels: vi.fn(),
   runBatch: vi.fn(),
   octopusListChannels: vi.fn(),
@@ -80,7 +80,7 @@ vi.mock("~/services/preferences/userPreferences", () => ({
 
 vi.mock("~/services/managedSites/channelConfigStorage", () => ({
   channelConfigStorage: {
-    getAllConfigs: mocks.getAllConfigs,
+    getConfigsForScope: mocks.getConfigsForScope,
   },
 }))
 
@@ -152,7 +152,7 @@ describe("modelSyncScheduler lifecycle and edge flows", () => {
 
     mocks.hasAlarmsAPI.mockReturnValue(true)
     mocks.onAlarm.mockReturnValue(undefined)
-    mocks.getAllConfigs.mockResolvedValue({})
+    mocks.getConfigsForScope.mockResolvedValue({})
     mocks.saveLastExecution.mockResolvedValue(undefined)
     mocks.saveChannelUpstreamModelOptions.mockResolvedValue(undefined)
     mocks.getLastExecution.mockResolvedValue(null)
@@ -399,7 +399,10 @@ describe("modelSyncScheduler lifecycle and edge flows", () => {
       type_counts: { shared: 1 },
     })
 
-    expect(mocks.getAllConfigs).toHaveBeenCalledTimes(1)
+    expect(mocks.getConfigsForScope).toHaveBeenCalledWith({
+      managedSiteType: SITE_TYPES.NEW_API,
+      scopeKey: "https://example.com",
+    })
     expect(mocks.listChannels).toHaveBeenCalledTimes(1)
   })
 

--- a/tests/services/modelSync/scheduler.modelRedirectPrune.test.ts
+++ b/tests/services/modelSync/scheduler.modelRedirectPrune.test.ts
@@ -11,13 +11,13 @@ const realGenerateModelMappingForChannel =
   ModelRedirectService.generateModelMappingForChannel
 
 const {
-  mockGetAllChannelConfigs,
+  mockGetChannelConfigsForScope,
   mockGetPreferences,
   mockListChannels,
   mockRunBatch,
   mockSaveLastExecution,
 } = vi.hoisted(() => ({
-  mockGetAllChannelConfigs: vi.fn(),
+  mockGetChannelConfigsForScope: vi.fn(),
   mockGetPreferences: vi.fn(),
   mockListChannels: vi.fn(),
   mockRunBatch: vi.fn(),
@@ -26,7 +26,7 @@ const {
 
 vi.mock("~/services/managedSites/channelConfigStorage", () => ({
   channelConfigStorage: {
-    getAllConfigs: mockGetAllChannelConfigs,
+    getConfigsForScope: mockGetChannelConfigsForScope,
   },
 }))
 
@@ -81,7 +81,7 @@ describe("modelSyncScheduler.executeSync - model redirect pruning", () => {
   beforeEach(() => {
     vi.clearAllMocks()
 
-    mockGetAllChannelConfigs.mockResolvedValue({})
+    mockGetChannelConfigsForScope.mockResolvedValue({})
     mockSaveLastExecution.mockResolvedValue(undefined)
 
     mockedModelRedirectService.generateModelMappingForChannel = vi.fn(

--- a/tests/services/modelSync/scheduler.modelRedirectPrune.test.ts
+++ b/tests/services/modelSync/scheduler.modelRedirectPrune.test.ts
@@ -7,6 +7,10 @@ import { userPreferences } from "~/services/preferences/userPreferences"
 import { DEFAULT_MODEL_REDIRECT_PREFERENCES } from "~/types/managedSiteModelRedirect"
 import { buildManagedSiteChannel } from "~~/tests/test-utils/factories"
 
+vi.mock("~/services/managedSites/legacyChannelConfigMigration", () => ({
+  ensureLegacyChannelConfigMigrationReady: vi.fn().mockResolvedValue(undefined),
+}))
+
 const realGenerateModelMappingForChannel =
   ModelRedirectService.generateModelMappingForChannel
 

--- a/tests/services/modelSync/scheduler.more.test.ts
+++ b/tests/services/modelSync/scheduler.more.test.ts
@@ -2,6 +2,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { DEFAULT_PREFERENCES } from "~/services/preferences/userPreferences"
 
+vi.mock("~/services/managedSites/legacyChannelConfigMigration", () => ({
+  ensureLegacyChannelConfigMigrationReady: vi.fn().mockResolvedValue(undefined),
+}))
+
 const mocks = vi.hoisted(() => ({
   clearAlarm: vi.fn(),
   createAlarm: vi.fn(),

--- a/tests/services/modelSync/scheduler.more.test.ts
+++ b/tests/services/modelSync/scheduler.more.test.ts
@@ -11,7 +11,7 @@ const mocks = vi.hoisted(() => ({
   sendRuntimeMessage: vi.fn(),
   savePreferences: vi.fn(),
   getPreferences: vi.fn(),
-  channelConfigGetAllConfigs: vi.fn(),
+  channelConfigGetConfigsForScope: vi.fn(),
   listChannels: vi.fn(),
   runBatch: vi.fn(),
   octopusListChannels: vi.fn(),
@@ -61,7 +61,7 @@ vi.mock("~/services/preferences/userPreferences", () => ({
 
 vi.mock("~/services/managedSites/channelConfigStorage", () => ({
   channelConfigStorage: {
-    getAllConfigs: mocks.channelConfigGetAllConfigs,
+    getConfigsForScope: mocks.channelConfigGetConfigsForScope,
   },
 }))
 
@@ -120,7 +120,7 @@ describe("modelSyncScheduler additional scheduler flows", () => {
         ...(DEFAULT_PREFERENCES as any).managedSiteModelSync,
       },
     })
-    mocks.channelConfigGetAllConfigs.mockResolvedValue({})
+    mocks.channelConfigGetConfigsForScope.mockResolvedValue({})
     mocks.getStoredPreferences.mockResolvedValue({ enabled: true })
     mocks.getChannelUpstreamModelOptions.mockResolvedValue(["gpt-4o"])
     mocks.getLastExecution.mockResolvedValue({

--- a/tests/services/modelSync/scheduler.test.ts
+++ b/tests/services/modelSync/scheduler.test.ts
@@ -18,11 +18,24 @@ import {
   hasAlarmsAPI,
 } from "~/utils/browser/browserApi"
 
-const { modelSyncListChannelsMock, modelSyncServiceConstructorMock } =
-  vi.hoisted(() => ({
-    modelSyncListChannelsMock: vi.fn(),
-    modelSyncServiceConstructorMock: vi.fn(),
-  }))
+const {
+  ensureLegacyChannelConfigMigrationReadyMock,
+  getConfigsForScopeMock,
+  modelSyncListChannelsMock,
+  modelSyncServiceConstructorMock,
+} = vi.hoisted(() => ({
+  ensureLegacyChannelConfigMigrationReadyMock: vi
+    .fn()
+    .mockResolvedValue(undefined),
+  getConfigsForScopeMock: vi.fn().mockResolvedValue({}),
+  modelSyncListChannelsMock: vi.fn(),
+  modelSyncServiceConstructorMock: vi.fn(),
+}))
+
+vi.mock("~/services/managedSites/legacyChannelConfigMigration", () => ({
+  ensureLegacyChannelConfigMigrationReady:
+    ensureLegacyChannelConfigMigrationReadyMock,
+}))
 
 vi.mock("~/services/preferences/userPreferences", () => ({
   DEFAULT_PREFERENCES: {
@@ -76,7 +89,7 @@ vi.mock("~/services/models/modelSync/modelSyncService", () => ({
 
 vi.mock("~/services/managedSites/channelConfigStorage", () => ({
   channelConfigStorage: {
-    getConfigsForScope: vi.fn().mockResolvedValue({}),
+    getConfigsForScope: getConfigsForScopeMock,
   },
 }))
 
@@ -346,5 +359,9 @@ describe("model sync operation helpers", () => {
       },
     )
     expect(modelSyncListChannelsMock).toHaveBeenCalled()
+    expect(ensureLegacyChannelConfigMigrationReadyMock).toHaveBeenCalledTimes(1)
+    expect(
+      ensureLegacyChannelConfigMigrationReadyMock.mock.invocationCallOrder[0],
+    ).toBeLessThan(getConfigsForScopeMock.mock.invocationCallOrder[0])
   })
 })

--- a/tests/services/modelSync/scheduler.test.ts
+++ b/tests/services/modelSync/scheduler.test.ts
@@ -76,7 +76,7 @@ vi.mock("~/services/models/modelSync/modelSyncService", () => ({
 
 vi.mock("~/services/managedSites/channelConfigStorage", () => ({
   channelConfigStorage: {
-    getAllConfigs: vi.fn().mockResolvedValue({}),
+    getConfigsForScope: vi.fn().mockResolvedValue({}),
   },
 }))
 

--- a/tests/services/webdavAutoSyncService.test.ts
+++ b/tests/services/webdavAutoSyncService.test.ts
@@ -14,12 +14,8 @@ import { createDefaultTagStore } from "~/services/tags/tagStoreUtils"
 import { webdavAutoSyncService } from "~/services/webdav/webdavAutoSyncService"
 import { normalizeWebdavOrderedEntryIds } from "~/services/webdav/webdavSelectiveSync"
 import { DEFAULT_ACCOUNT_AUTO_REFRESH } from "~/types/accountAutoRefresh"
-import type { ChannelConfigSnapshot } from "~/types/channelConfig"
-import {
-  createManagedUpstreamResourceRef,
-  getManagedUpstreamResourceRefKey,
-} from "~/types/managedUpstreamResource"
 import { DEFAULT_WEBDAV_SETTINGS } from "~/types/webdav"
+import { channelConfigSnapshot } from "~~/tests/test-utils/channelConfigSnapshot"
 import { createDeferred } from "~~/tests/test-utils/deferred"
 
 vi.mock("~/services/managedSites/legacyChannelConfigMigration", () => ({
@@ -66,44 +62,6 @@ const preferenceWriteFailure = () => ({
     error: new Error("Failed to import WebDAV preferences"),
   },
 })
-
-function channelConfigSnapshot(
-  entries: Array<{
-    resourceId: string
-    scopeKey?: string
-    channelId?: number
-    updatedAt: number
-  }>,
-): ChannelConfigSnapshot {
-  const configs = Object.fromEntries(
-    entries.map(
-      ({
-        resourceId,
-        scopeKey = "https://admin.example.invalid",
-        channelId,
-        updatedAt,
-      }) => {
-        const resourceRef = createManagedUpstreamResourceRef({
-          managedSiteType: "new-api",
-          scopeKey,
-          resourceId,
-        })
-        return [
-          getManagedUpstreamResourceRefKey(resourceRef),
-          {
-            resourceRef,
-            ...(channelId !== undefined ? { channelId } : {}),
-            modelFilterSettings: { rules: [], updatedAt },
-            createdAt: updatedAt,
-            updatedAt,
-          },
-        ]
-      },
-    ),
-  )
-
-  return { schemaVersion: 1, configs }
-}
 
 vi.mock(
   import("~/services/preferences/userPreferences"),

--- a/tests/services/webdavAutoSyncService.test.ts
+++ b/tests/services/webdavAutoSyncService.test.ts
@@ -22,6 +22,10 @@ import {
 import { DEFAULT_WEBDAV_SETTINGS } from "~/types/webdav"
 import { createDeferred } from "~~/tests/test-utils/deferred"
 
+vi.mock("~/services/managedSites/legacyChannelConfigMigration", () => ({
+  ensureLegacyChannelConfigMigrationReady: vi.fn().mockResolvedValue(undefined),
+}))
+
 // Basic getErrorMessage passthrough to avoid noisy output
 vi.mock("~/utils/core/error", () => ({
   getErrorMessage: (e: unknown) => String(e),

--- a/tests/services/webdavAutoSyncService.test.ts
+++ b/tests/services/webdavAutoSyncService.test.ts
@@ -14,6 +14,11 @@ import { createDefaultTagStore } from "~/services/tags/tagStoreUtils"
 import { webdavAutoSyncService } from "~/services/webdav/webdavAutoSyncService"
 import { normalizeWebdavOrderedEntryIds } from "~/services/webdav/webdavSelectiveSync"
 import { DEFAULT_ACCOUNT_AUTO_REFRESH } from "~/types/accountAutoRefresh"
+import type { ChannelConfigSnapshot } from "~/types/channelConfig"
+import {
+  createManagedUpstreamResourceRef,
+  getManagedUpstreamResourceRefKey,
+} from "~/types/managedUpstreamResource"
 import { DEFAULT_WEBDAV_SETTINGS } from "~/types/webdav"
 import { createDeferred } from "~~/tests/test-utils/deferred"
 
@@ -58,6 +63,44 @@ const preferenceWriteFailure = () => ({
   },
 })
 
+function channelConfigSnapshot(
+  entries: Array<{
+    resourceId: string
+    scopeKey?: string
+    channelId?: number
+    updatedAt: number
+  }>,
+): ChannelConfigSnapshot {
+  const configs = Object.fromEntries(
+    entries.map(
+      ({
+        resourceId,
+        scopeKey = "https://admin.example.invalid",
+        channelId,
+        updatedAt,
+      }) => {
+        const resourceRef = createManagedUpstreamResourceRef({
+          managedSiteType: "new-api",
+          scopeKey,
+          resourceId,
+        })
+        return [
+          getManagedUpstreamResourceRefKey(resourceRef),
+          {
+            resourceRef,
+            ...(channelId !== undefined ? { channelId } : {}),
+            modelFilterSettings: { rules: [], updatedAt },
+            createdAt: updatedAt,
+            updatedAt,
+          },
+        ]
+      },
+    ),
+  )
+
+  return { schemaVersion: 1, configs }
+}
+
 vi.mock(
   import("~/services/preferences/userPreferences"),
   async (importOriginal) => {
@@ -86,12 +129,21 @@ vi.mock("~/services/accounts/accountStorage", () => ({
 
 const mockChannelConfigExport = vi.fn()
 const mockChannelConfigImport = vi.fn()
-vi.mock("~/services/managedSites/channelConfigStorage", () => ({
-  channelConfigStorage: {
-    exportConfigs: (...args: any[]) => mockChannelConfigExport(...args),
-    importConfigs: (...args: any[]) => mockChannelConfigImport(...args),
+const mockChannelConfigMerge = vi.fn()
+vi.mock(
+  import("~/services/managedSites/channelConfigStorage"),
+  async (importOriginal) => {
+    const actual = await importOriginal()
+    return {
+      ...actual,
+      channelConfigStorage: {
+        exportConfigs: (...args: any[]) => mockChannelConfigExport(...args),
+        importConfigs: (...args: any[]) => mockChannelConfigImport(...args),
+        mergeConfigs: (...args: any[]) => mockChannelConfigMerge(...args),
+      } as unknown as typeof actual.channelConfigStorage,
+    }
   },
-}))
+)
 
 const mockApiCredentialProfilesExport = vi.fn()
 const mockApiCredentialProfilesImport = vi.fn()
@@ -165,13 +217,6 @@ describe("WebdavAutoSyncService.mergeData", () => {
     themeMode: "dark",
     preferencesVersion: 2,
   } as any
-
-  const mkChannelConfig = (id: number, updatedAt: number) => ({
-    channelId: id,
-    modelFilterSettings: {},
-    createdAt: 0,
-    updatedAt,
-  })
 
   beforeEach(() => {
     vi.clearAllMocks()
@@ -744,52 +789,7 @@ describe("WebdavAutoSyncService.mergeData", () => {
     expect(result.preferences.themeMode).toBe("remote")
   })
 
-  it("merges channel configs by numeric id using latest updatedAt", () => {
-    const localChannels = {
-      1: mkChannelConfig(1, 10),
-      2: mkChannelConfig(2, 5),
-    }
-
-    const remoteChannels = {
-      2: mkChannelConfig(2, 20),
-      3: mkChannelConfig(3, 1),
-    }
-
-    const local: any = {
-      accounts: [],
-      bookmarks: [],
-      accountsTimestamp: 0,
-      tagStore: { version: 1, tagsById: {} },
-      preferences: basePrefsLocal,
-      preferencesTimestamp: 0,
-      channelConfigs: localChannels,
-      apiCredentialProfiles: emptyApiCredentialProfiles,
-    }
-
-    const remote: any = {
-      accounts: [],
-      bookmarks: [],
-      accountsTimestamp: 0,
-      tagStore: { version: 1, tagsById: {} },
-      preferences: basePrefsRemote,
-      preferencesTimestamp: 0,
-      channelConfigs: remoteChannels,
-      apiCredentialProfiles: emptyApiCredentialProfiles,
-    }
-
-    const result = callMerge(local, remote)
-
-    expect(
-      Object.keys(result.channelConfigs)
-        .map((k: any) => Number(k))
-        .sort(),
-    ).toEqual([1, 2, 3])
-
-    // id 2 should come from remote because of newer updatedAt
-    expect(result.channelConfigs[2].updatedAt).toBe(20)
-  })
-
-  it("keeps local-only selections and ignores invalid remote channel config ids", () => {
+  it("keeps local-only selections for the data domains owned by mergeData", () => {
     const local: any = {
       accounts: [{ id: "a1", site_name: "local-1" }],
       bookmarks: [
@@ -803,9 +803,6 @@ describe("WebdavAutoSyncService.mergeData", () => {
       tagStore: undefined,
       preferences: { ...basePrefsLocal, themeMode: "local-only" },
       preferencesTimestamp: 10,
-      channelConfigs: {
-        2: { ...mkChannelConfig(2, 30), label: "local-channel" },
-      },
       apiCredentialProfiles: {
         version: 2,
         profiles: [{ id: "local-profile" }],
@@ -836,12 +833,6 @@ describe("WebdavAutoSyncService.mergeData", () => {
       tagStore: undefined,
       preferences: { ...basePrefsRemote, themeMode: "remote-should-not-win" },
       preferencesTimestamp: 20,
-      channelConfigs: {
-        0: mkChannelConfig(0, 100),
-        "-1": mkChannelConfig(-1, 100),
-        abc: mkChannelConfig(5, 100),
-        2: { ...mkChannelConfig(2, 1), label: "remote-older" },
-      },
       apiCredentialProfiles: {
         version: 2,
         profiles: [{ id: "remote-profile" }],
@@ -861,9 +852,6 @@ describe("WebdavAutoSyncService.mergeData", () => {
     expect(result.preferences).toEqual(local.preferences)
     expect(result.tagStore).toEqual(createDefaultTagStore())
     expect(result.apiCredentialProfiles).toEqual(local.apiCredentialProfiles)
-    expect(result.channelConfigs).toEqual({
-      2: { ...mkChannelConfig(2, 30), label: "local-channel" },
-    })
   })
 })
 
@@ -905,13 +893,14 @@ describe("WebdavAutoSyncService.syncWithWebdav (selective sync)", () => {
 
     mockAccountStorageImportData.mockResolvedValue({ migratedCount: 0 })
     mockChannelConfigImport.mockResolvedValue(undefined)
+    mockChannelConfigMerge.mockImplementation(async (snapshot) => snapshot)
     mockApiCredentialProfilesImport.mockResolvedValue(undefined)
     mockTagStoreImport.mockResolvedValue(undefined)
     mockImportPreferences.mockResolvedValue(preferenceWriteSuccess())
 
     mockTagStoreExport.mockResolvedValue({ version: 1, tagsById: {} })
     mockExportPreferences.mockResolvedValue({ lastUpdated: 1 } as any)
-    mockChannelConfigExport.mockResolvedValue({})
+    mockChannelConfigExport.mockResolvedValue({ schemaVersion: 1, configs: {} })
     mockApiCredentialProfilesExport.mockResolvedValue({
       version: 2,
       profiles: [],
@@ -2036,6 +2025,12 @@ describe("WebdavAutoSyncService best-effort upload helpers", () => {
 
 describe("WebdavAutoSyncService local apply phase", () => {
   const createService = () => new (webdavAutoSyncService as any).constructor()
+  const localChannelConfigs = channelConfigSnapshot([
+    { resourceId: "1", channelId: 1, updatedAt: 100 },
+  ])
+  const remoteChannelConfigs = channelConfigSnapshot([
+    { resourceId: "2", channelId: 2, updatedAt: 200 },
+  ])
 
   beforeEach(() => {
     vi.clearAllMocks()
@@ -2046,7 +2041,9 @@ describe("WebdavAutoSyncService local apply phase", () => {
       JSON.parse(content),
     )
 
+    mockAccountStorageImportData.mockResolvedValue({ migratedCount: 0 })
     mockChannelConfigImport.mockResolvedValue(undefined)
+    mockChannelConfigMerge.mockImplementation(async (snapshot) => snapshot)
     mockApiCredentialProfilesImport.mockResolvedValue(undefined)
     mockTagStoreImport.mockResolvedValue(undefined)
     mockImportPreferences.mockResolvedValue(preferenceWriteSuccess())
@@ -2078,7 +2075,7 @@ describe("WebdavAutoSyncService local apply phase", () => {
         },
       },
     } as any)
-    mockChannelConfigExport.mockResolvedValue({ 1: { enabled: true } })
+    mockChannelConfigExport.mockResolvedValue(localChannelConfigs)
     mockApiCredentialProfilesExport.mockResolvedValue({
       version: 2,
       profiles: [
@@ -2111,7 +2108,7 @@ describe("WebdavAutoSyncService local apply phase", () => {
 
     mockDownloadBackup.mockResolvedValue(
       JSON.stringify({
-        version: "2.0",
+        version: "3.0",
         timestamp: 200,
         accounts: {
           accounts: [{ id: "remote-account", created_at: 3, updated_at: 30 }],
@@ -2122,7 +2119,7 @@ describe("WebdavAutoSyncService local apply phase", () => {
         },
         tagStore: { version: 1, tagsById: { remote: { id: "remote-tag" } } },
         preferences: { lastUpdated: 200, themeMode: "light" },
-        channelConfigs: { 2: { enabled: false } },
+        channelConfigs: remoteChannelConfigs,
         apiCredentialProfiles: {
           version: 2,
           profiles: [
@@ -2142,6 +2139,68 @@ describe("WebdavAutoSyncService local apply phase", () => {
         },
       }),
     )
+  })
+
+  it("atomically merges channel configs and returns the applied snapshot", async () => {
+    const service = createService() as any
+    const applied = channelConfigSnapshot([
+      { resourceId: "1", channelId: 1, updatedAt: 100 },
+      { resourceId: "2", channelId: 2, updatedAt: 200 },
+    ])
+    mockChannelConfigMerge.mockResolvedValueOnce(applied)
+
+    const result = await service.applyLocalSyncResult({
+      syncDataSelection: {
+        accounts: false,
+        bookmarks: false,
+        apiCredentialProfiles: false,
+        preferences: false,
+      },
+      accountsToSave: [],
+      bookmarksToSave: [],
+      pinnedAccountIdsToSave: [],
+      orderedAccountIdsToSave: [],
+      tagStoreToSave: createDefaultTagStore(),
+      preferencesToSave: {} as any,
+      channelConfigsToSave: remoteChannelConfigs,
+      mergeChannelConfigsOnApply: true,
+      apiCredentialProfilesToSave: {
+        version: 2,
+        profiles: [],
+        lastUpdated: 0,
+      },
+      localAccountsConfig: { accounts: [] },
+      localTagStore: createDefaultTagStore(),
+      localPreferences: {} as any,
+      localApiCredentialProfiles: {
+        version: 2,
+        profiles: [],
+        lastUpdated: 0,
+      },
+    })
+
+    expect(mockChannelConfigMerge).toHaveBeenCalledWith(remoteChannelConfigs)
+    expect(mockChannelConfigImport).not.toHaveBeenCalled()
+    expect(result).toEqual(applied)
+  })
+
+  it("passes only the remote channel snapshot into atomic merge", async () => {
+    const service = createService()
+    mockGetPreferences.mockResolvedValue({
+      webdav: {
+        syncStrategy: "merge",
+        syncData: {
+          accounts: true,
+          bookmarks: true,
+          apiCredentialProfiles: true,
+          preferences: true,
+        },
+      },
+    } as any)
+
+    await service.syncWithWebdav()
+
+    expect(mockChannelConfigMerge).toHaveBeenCalledWith(remoteChannelConfigs)
   })
 
   it("starts each local import only after the previous one completes", async () => {
@@ -2190,8 +2249,8 @@ describe("WebdavAutoSyncService local apply phase", () => {
       "account:done",
       "tag",
       "preferences",
-      "channel",
       "api",
+      "channel",
     ])
   })
 
@@ -2219,11 +2278,11 @@ describe("WebdavAutoSyncService local apply phase", () => {
       pinnedAccountIds: ["local-account"],
       orderedAccountIds: ["local-account", "local-bookmark"],
     })
-    expect(mockApiCredentialProfilesImport).not.toHaveBeenCalled()
+    expect(mockApiCredentialProfilesImport).toHaveBeenCalledTimes(2)
     expect(mockUploadBackup).not.toHaveBeenCalled()
   })
 
-  it("rolls back channel configs when api credential profile import fails", async () => {
+  it("does not write channel configs when api credential profile import fails", async () => {
     const service = createService()
 
     mockAccountStorageImportData.mockResolvedValue({ migratedCount: 0 })
@@ -2238,12 +2297,8 @@ describe("WebdavAutoSyncService local apply phase", () => {
       "profile import failed",
     )
 
-    expect(mockChannelConfigImport).toHaveBeenNthCalledWith(1, {
-      2: { enabled: false },
-    })
-    expect(mockChannelConfigImport).toHaveBeenNthCalledWith(2, {
-      1: { enabled: true },
-    })
+    expect(mockChannelConfigImport).not.toHaveBeenCalled()
+    expect(mockChannelConfigMerge).not.toHaveBeenCalled()
     expect(mockImportPreferences).toHaveBeenCalledTimes(2)
     expect(mockUploadBackup).not.toHaveBeenCalled()
   })

--- a/tests/services/webdavSelectiveSync.test.ts
+++ b/tests/services/webdavSelectiveSync.test.ts
@@ -2,12 +2,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { Storage } from "@plasmohq/storage"
 
+import { accountStorage } from "~/services/accounts/accountStorage"
 import { USER_PREFERENCES_STORAGE_KEYS } from "~/services/core/storageKeys"
+import { ensureLegacyChannelConfigMigrationReady } from "~/services/managedSites/legacyChannelConfigMigration"
 import {
   DEFAULT_PREFERENCES,
   userPreferences,
 } from "~/services/preferences/userPreferences"
 import {
+  buildWebdavImportPayloadBySelection,
   createWebdavImportPayloadBySelection,
   filterWebdavBackupPayloadBySelection,
   mergeWebdavBackupPayloadBySelection,
@@ -18,6 +21,9 @@ import { DEFAULT_WEBDAV_SETTINGS } from "~/types/webdav"
 vi.mock("~/services/managedSites/legacyChannelConfigMigration", () => ({
   ensureLegacyChannelConfigMigrationReady: vi.fn().mockResolvedValue(undefined),
 }))
+
+const ensureLegacyChannelConfigMigrationReadyMock =
+  ensureLegacyChannelConfigMigrationReady as unknown as ReturnType<typeof vi.fn>
 
 describe("filterWebdavBackupPayloadBySelection", () => {
   const baseBackup: any = {
@@ -991,6 +997,29 @@ describe("createWebdavImportPayloadBySelection", () => {
 
     expect(payload.version).toBe("3.0")
     expect(payload.apiCredentialProfiles).toBeUndefined()
+  })
+})
+
+describe("buildWebdavImportPayloadBySelection", () => {
+  it("propagates migration deferral before reading local backup state", async () => {
+    const exportAccounts = vi.spyOn(accountStorage, "exportData")
+    ensureLegacyChannelConfigMigrationReadyMock.mockRejectedValueOnce(
+      new Error("migration deferred"),
+    )
+
+    await expect(
+      buildWebdavImportPayloadBySelection({
+        rawBackup: { version: "3.0", timestamp: 200 },
+        selection: {
+          accounts: true,
+          bookmarks: true,
+          apiCredentialProfiles: true,
+          preferences: true,
+        },
+      }),
+    ).rejects.toThrow("migration deferred")
+    expect(exportAccounts).not.toHaveBeenCalled()
+    exportAccounts.mockRestore()
   })
 })
 

--- a/tests/services/webdavSelectiveSync.test.ts
+++ b/tests/services/webdavSelectiveSync.test.ts
@@ -840,7 +840,7 @@ describe("createWebdavImportPayloadBySelection", () => {
             },
           },
         },
-        channelConfigs: {},
+        channelConfigs: { schemaVersion: 1, configs: {} },
       } as any,
       selection: {
         accounts: true,
@@ -891,7 +891,7 @@ describe("createWebdavImportPayloadBySelection", () => {
           ],
           lastUpdated: 20,
         },
-        channelConfigs: {},
+        channelConfigs: { schemaVersion: 1, configs: {} },
       } as any,
       selection: {
         accounts: false,
@@ -931,7 +931,7 @@ describe("createWebdavImportPayloadBySelection", () => {
             },
           },
         },
-        channelConfigs: {},
+        channelConfigs: { schemaVersion: 1, configs: {} },
       } as any,
       selection: {
         accounts: false,
@@ -951,7 +951,7 @@ describe("createWebdavImportPayloadBySelection", () => {
     })
   })
 
-  it("always emits a canonical V2 payload even for legacy WebDAV backups", () => {
+  it("always emits a canonical V3 payload even for legacy WebDAV backups", () => {
     const payload = createWebdavImportPayloadBySelection({
       rawBackup: {
         timestamp: 200,
@@ -974,7 +974,7 @@ describe("createWebdavImportPayloadBySelection", () => {
             lastUpdated: 20,
           },
         },
-        channelConfigs: {},
+        channelConfigs: { schemaVersion: 1, configs: {} },
       } as any,
       selection: {
         accounts: false,
@@ -985,7 +985,7 @@ describe("createWebdavImportPayloadBySelection", () => {
       localState: baseLocalState,
     })
 
-    expect(payload.version).toBe("2.0")
+    expect(payload.version).toBe("3.0")
     expect(payload.apiCredentialProfiles).toBeUndefined()
   })
 })
@@ -1022,7 +1022,7 @@ describe("WebDAV preference convergence", () => {
             tempContextMode: "composite",
           },
         },
-        channelConfigs: {},
+        channelConfigs: { schemaVersion: 1, configs: {} },
       } as any,
       selection: {
         accounts: false,
@@ -1040,7 +1040,7 @@ describe("WebDAV preference convergence", () => {
         },
         tagStore: { version: 1, tagsById: {} },
         preferences: DEFAULT_PREFERENCES,
-        channelConfigs: {},
+        channelConfigs: { schemaVersion: 1, configs: {} },
         apiCredentialProfiles: { version: 2, profiles: [], lastUpdated: 0 },
       },
     })
@@ -1133,7 +1133,7 @@ describe("WebDAV preference convergence", () => {
         },
         tagStore: { version: 1, tagsById: {} },
         preferences: DEFAULT_PREFERENCES,
-        channelConfigs: {},
+        channelConfigs: { schemaVersion: 1, configs: {} },
         apiCredentialProfiles: { version: 2, profiles: [], lastUpdated: 0 },
       },
     })

--- a/tests/services/webdavSelectiveSync.test.ts
+++ b/tests/services/webdavSelectiveSync.test.ts
@@ -15,6 +15,10 @@ import {
 import { DEFAULT_ACCOUNT_AUTO_REFRESH } from "~/types/accountAutoRefresh"
 import { DEFAULT_WEBDAV_SETTINGS } from "~/types/webdav"
 
+vi.mock("~/services/managedSites/legacyChannelConfigMigration", () => ({
+  ensureLegacyChannelConfigMigrationReady: vi.fn().mockResolvedValue(undefined),
+}))
+
 describe("filterWebdavBackupPayloadBySelection", () => {
   const baseBackup: any = {
     version: "2.0",

--- a/tests/test-utils/channelConfigSnapshot.ts
+++ b/tests/test-utils/channelConfigSnapshot.ts
@@ -1,0 +1,47 @@
+import {
+  CHANNEL_CONFIG_SNAPSHOT_VERSION,
+  type ChannelConfigSnapshot,
+} from "~/types/channelConfig"
+import {
+  createManagedUpstreamResourceRef,
+  getManagedUpstreamResourceRefKey,
+} from "~/types/managedUpstreamResource"
+
+/** Builds a canonical scoped channel-config snapshot for backup tests. */
+export function channelConfigSnapshot(
+  entries: Array<{
+    resourceId: string | number
+    scopeKey?: string
+    channelId?: number
+    updatedAt: number
+  }>,
+): ChannelConfigSnapshot {
+  const configs = Object.fromEntries(
+    entries.map(
+      ({
+        resourceId,
+        scopeKey = "https://admin.example.invalid",
+        channelId,
+        updatedAt,
+      }) => {
+        const resourceRef = createManagedUpstreamResourceRef({
+          managedSiteType: "new-api",
+          scopeKey,
+          resourceId,
+        })
+        return [
+          getManagedUpstreamResourceRefKey(resourceRef),
+          {
+            resourceRef,
+            ...(channelId !== undefined ? { channelId } : {}),
+            modelFilterSettings: { rules: [], updatedAt },
+            createdAt: updatedAt,
+            updatedAt,
+          },
+        ]
+      },
+    ),
+  )
+
+  return { schemaVersion: CHANNEL_CONFIG_SNAPSHOT_VERSION, configs }
+}

--- a/tests/utils/importExportUtils.test.ts
+++ b/tests/utils/importExportUtils.test.ts
@@ -13,21 +13,31 @@ import {
 import { accountStorage } from "~/services/accounts/accountStorage"
 import { apiCredentialProfilesStorage } from "~/services/apiCredentialProfiles/apiCredentialProfilesStorage"
 import { channelConfigStorage } from "~/services/managedSites/channelConfigStorage"
-import { ensureLegacyChannelConfigMigrationReady } from "~/services/managedSites/legacyChannelConfigMigration"
+import {
+  ensureLegacyChannelConfigMigrationReady,
+  LegacyChannelConfigMigrationDeferredError,
+} from "~/services/managedSites/legacyChannelConfigMigration"
 import { userPreferences } from "~/services/preferences/userPreferences"
 import { tagStorage } from "~/services/tags/tagStorage"
 import { API_TYPES } from "~/services/verification/aiApiVerification"
 import { DEFAULT_ACCOUNT_AUTO_REFRESH } from "~/types/accountAutoRefresh"
-import type { ChannelConfigSnapshot } from "~/types/channelConfig"
-import {
-  createManagedUpstreamResourceRef,
-  getManagedUpstreamResourceRefKey,
-} from "~/types/managedUpstreamResource"
 import { DEFAULT_WEBDAV_SETTINGS } from "~/types/webdav"
+import { channelConfigSnapshot } from "~~/tests/test-utils/channelConfigSnapshot"
 
-vi.mock("~/services/managedSites/legacyChannelConfigMigration", () => ({
-  ensureLegacyChannelConfigMigrationReady: vi.fn().mockResolvedValue(undefined),
-}))
+vi.mock("~/services/managedSites/legacyChannelConfigMigration", () => {
+  class LegacyChannelConfigMigrationDeferredError extends Error {
+    constructor(readonly reason: string) {
+      super(`Legacy channel config migration deferred: ${reason}`)
+    }
+  }
+
+  return {
+    ensureLegacyChannelConfigMigrationReady: vi
+      .fn()
+      .mockResolvedValue(undefined),
+    LegacyChannelConfigMigrationDeferredError,
+  }
+})
 
 vi.mock("~/services/accounts/accountStorage", () => ({
   accountStorage: {
@@ -143,43 +153,6 @@ const preferenceWriteFailure = () => ({
   reason: { type: "storage-error", error: new Error("import failed") },
 })
 
-function channelConfigSnapshot(
-  entries: Array<{
-    resourceId: string
-    scopeKey?: string
-    channelId?: number
-    updatedAt: number
-  }>,
-): ChannelConfigSnapshot {
-  const configs = Object.fromEntries(
-    entries.map(
-      ({
-        resourceId,
-        scopeKey = "https://admin.example.invalid",
-        channelId,
-        updatedAt,
-      }) => {
-        const resourceRef = createManagedUpstreamResourceRef({
-          managedSiteType: "new-api",
-          scopeKey,
-          resourceId,
-        })
-        return [
-          getManagedUpstreamResourceRefKey(resourceRef),
-          {
-            resourceRef,
-            ...(channelId !== undefined ? { channelId } : {}),
-            modelFilterSettings: { rules: [], updatedAt },
-            createdAt: updatedAt,
-            updatedAt,
-          },
-        ]
-      },
-    ),
-  )
-
-  return { schemaVersion: 1, configs }
-}
 const mockApiCredentialProfilesExportConfig =
   apiCredentialProfilesStorage.exportConfig as unknown as ReturnType<
     typeof vi.fn
@@ -345,6 +318,21 @@ describe("importFromBackupObject", () => {
       channelConfigs: false,
       apiCredentialProfiles: false,
     })
+  })
+
+  it("restores a scoped channel snapshot carried by a legacy V1 envelope", async () => {
+    const channelConfigs = channelConfigSnapshot([
+      { resourceId: "9", channelId: 9, updatedAt: 200 },
+    ])
+
+    const result = await importFromBackupObject({
+      version: "1.0",
+      timestamp: Date.now(),
+      channelConfigs,
+    })
+
+    expect(mockChannelConfigImport).toHaveBeenCalledWith(channelConfigs)
+    expect(result.sections.channelConfigs).toBe(true)
   })
 
   it("imports a full scoped backup including bookmarks + pinned/ordered ids", async () => {
@@ -1218,6 +1206,30 @@ describe("importFromBackupObject", () => {
       "importExport:import.versionNotSupported",
     )
     expect(mockAccountStorageImportData).not.toHaveBeenCalled()
+  })
+
+  it("maps deferred channel-config migration failures to localized copy", async () => {
+    const channelConfigs = channelConfigSnapshot([
+      {
+        scopeKey: "https://admin.example.invalid",
+        resourceId: "9",
+        updatedAt: 200,
+      },
+    ])
+    mockEnsureLegacyChannelConfigMigrationReady.mockRejectedValueOnce(
+      new LegacyChannelConfigMigrationDeferredError("inventory-failed" as any),
+    )
+
+    await expect(
+      importFromBackupObject(
+        {
+          version: BACKUP_VERSION,
+          timestamp: Date.now(),
+          channelConfigs,
+        },
+        { plan: { channelConfigs: "merge" } },
+      ),
+    ).rejects.toThrow("importExport:import.channelConfigMigrationDeferred")
   })
 
   it("respects section plan skips for legacy V1 backups", async () => {

--- a/tests/utils/importExportUtils.test.ts
+++ b/tests/utils/importExportUtils.test.ts
@@ -1307,7 +1307,7 @@ describe("importFromBackupObject", () => {
     }
 
     await expect(importFromBackupObject(payload)).rejects.toThrow(
-      "importExport:import.importFailed",
+      "importExport:import.importOperationFailed",
     )
   })
 

--- a/tests/utils/importExportUtils.test.ts
+++ b/tests/utils/importExportUtils.test.ts
@@ -17,6 +17,11 @@ import { userPreferences } from "~/services/preferences/userPreferences"
 import { tagStorage } from "~/services/tags/tagStorage"
 import { API_TYPES } from "~/services/verification/aiApiVerification"
 import { DEFAULT_ACCOUNT_AUTO_REFRESH } from "~/types/accountAutoRefresh"
+import type { ChannelConfigSnapshot } from "~/types/channelConfig"
+import {
+  createManagedUpstreamResourceRef,
+  getManagedUpstreamResourceRefKey,
+} from "~/types/managedUpstreamResource"
 import { DEFAULT_WEBDAV_SETTINGS } from "~/types/webdav"
 
 vi.mock("~/services/accounts/accountStorage", () => ({
@@ -33,12 +38,20 @@ vi.mock("~/services/preferences/userPreferences", () => ({
   },
 }))
 
-vi.mock("~/services/managedSites/channelConfigStorage", () => ({
-  channelConfigStorage: {
-    importConfigs: vi.fn(),
-    exportConfigs: vi.fn(),
+vi.mock(
+  import("~/services/managedSites/channelConfigStorage"),
+  async (importOriginal) => {
+    const actual = await importOriginal()
+    return {
+      ...actual,
+      channelConfigStorage: {
+        importConfigs: vi.fn(),
+        mergeConfigs: vi.fn(),
+        exportConfigs: vi.fn(),
+      } as unknown as typeof actual.channelConfigStorage,
+    }
   },
-}))
+)
 
 vi.mock("~/services/tags/tagStorage", () => ({
   tagStorage: {
@@ -88,6 +101,8 @@ const mockUserPreferencesExport =
 
 const mockChannelConfigImport =
   channelConfigStorage.importConfigs as unknown as ReturnType<typeof vi.fn>
+const mockChannelConfigMerge =
+  channelConfigStorage.mergeConfigs as unknown as ReturnType<typeof vi.fn>
 const mockChannelConfigExport =
   channelConfigStorage.exportConfigs as unknown as ReturnType<typeof vi.fn>
 
@@ -120,6 +135,44 @@ const preferenceWriteFailure = () => ({
   ok: false,
   reason: { type: "storage-error", error: new Error("import failed") },
 })
+
+function channelConfigSnapshot(
+  entries: Array<{
+    resourceId: string
+    scopeKey?: string
+    channelId?: number
+    updatedAt: number
+  }>,
+): ChannelConfigSnapshot {
+  const configs = Object.fromEntries(
+    entries.map(
+      ({
+        resourceId,
+        scopeKey = "https://admin.example.invalid",
+        channelId,
+        updatedAt,
+      }) => {
+        const resourceRef = createManagedUpstreamResourceRef({
+          managedSiteType: "new-api",
+          scopeKey,
+          resourceId,
+        })
+        return [
+          getManagedUpstreamResourceRefKey(resourceRef),
+          {
+            resourceRef,
+            ...(channelId !== undefined ? { channelId } : {}),
+            modelFilterSettings: { rules: [], updatedAt },
+            createdAt: updatedAt,
+            updatedAt,
+          },
+        ]
+      },
+    ),
+  )
+
+  return { schemaVersion: 1, configs }
+}
 const mockApiCredentialProfilesExportConfig =
   apiCredentialProfilesStorage.exportConfig as unknown as ReturnType<
     typeof vi.fn
@@ -139,13 +192,22 @@ describe("parseBackupSummary", () => {
     expect(result).toEqual({ valid: false })
   })
 
-  it("parses full V2-like backup and marks all sections as present", () => {
+  it("rejects unsupported explicit versions during preview", () => {
+    const result = parseBackupSummary(
+      JSON.stringify({ version: "4.0", timestamp: Date.now() }),
+      "unknown",
+    )
+
+    expect(result).toEqual({ valid: false })
+  })
+
+  it("parses a full current backup and marks all sections as present", () => {
     const payload: RawBackupData = {
       version: BACKUP_VERSION,
       timestamp: Date.now(),
       accounts: {},
       preferences: {},
-      channelConfigs: {},
+      channelConfigs: { schemaVersion: 1, configs: {} },
     }
 
     const json = JSON.stringify(payload)
@@ -226,6 +288,7 @@ describe("importFromBackupObject", () => {
       createdTagCount: 0,
     })
     mockTagStoreImport.mockResolvedValue(undefined)
+    mockChannelConfigMerge.mockResolvedValue({ schemaVersion: 1, configs: {} })
     mockApiCredentialProfilesMergeConfig.mockResolvedValue({
       version: 1,
       profiles: [],
@@ -277,7 +340,10 @@ describe("importFromBackupObject", () => {
     })
   })
 
-  it("imports full V2 backup including bookmarks + pinned/ordered ids", async () => {
+  it("imports a full scoped backup including bookmarks + pinned/ordered ids", async () => {
+    const channelConfigs = channelConfigSnapshot([
+      { resourceId: "1", channelId: 1, updatedAt: 10 },
+    ])
     const backup: BackupFullV2 = {
       version: BACKUP_VERSION,
       timestamp: Date.now(),
@@ -290,7 +356,7 @@ describe("importFromBackupObject", () => {
       } as any,
       tagStore: { version: 1, tagsById: {} },
       preferences: { themeMode: "dark" } as any,
-      channelConfigs: { 1: { enabled: true } } as any,
+      channelConfigs,
     }
 
     const result = await importFromBackupObject(backup as BackupV2)
@@ -306,9 +372,7 @@ describe("importFromBackupObject", () => {
     expect(mockUserPreferencesImport).toHaveBeenCalledWith({
       themeMode: "dark",
     })
-    expect(mockChannelConfigImport).toHaveBeenCalledWith({
-      1: { enabled: true },
-    })
+    expect(mockChannelConfigImport).toHaveBeenCalledWith(channelConfigs)
 
     expect(result.allImported).toBe(true)
     expect(result.sections).toEqual({
@@ -319,7 +383,61 @@ describe("importFromBackupObject", () => {
     })
   })
 
-  it("merges V2 account backups without importing preferences when merge mode is selected", async () => {
+  it("ignores legacy numeric channel configs without replacing scoped storage", async () => {
+    const backup: RawBackupData = {
+      version: "2.0",
+      timestamp: Date.now(),
+      accounts: { accounts: [{ id: "legacy-account" }] },
+      channelConfigs: {
+        9: {
+          channelId: 9,
+          modelFilterSettings: { rules: [], updatedAt: 20 },
+          createdAt: 10,
+          updatedAt: 20,
+        },
+      },
+    }
+
+    const result = await importFromBackupObject(backup, {
+      plan: { accounts: "replace", channelConfigs: "replace" },
+    })
+
+    expect(mockAccountStorageImportData).toHaveBeenCalled()
+    expect(mockChannelConfigImport).not.toHaveBeenCalled()
+    expect(result.sections.channelConfigs).toBe(false)
+  })
+
+  it("rejects malformed V3 channel configs before importing other sections", async () => {
+    const payload: RawBackupData = {
+      version: BACKUP_VERSION,
+      timestamp: Date.now(),
+      accounts: { accounts: [{ id: "untouched-account" }] },
+      channelConfigs: {
+        schemaVersion: 1,
+        configs: {
+          malformed: {
+            createdAt: 1,
+            updatedAt: 2,
+            modelFilterSettings: { rules: [], updatedAt: 2 },
+          },
+        },
+      },
+    }
+
+    await expect(importFromBackupObject(payload)).rejects.toThrow(
+      "importExport:import.formatNotCorrect",
+    )
+    expect(mockAccountStorageImportData).not.toHaveBeenCalled()
+    expect(mockChannelConfigImport).not.toHaveBeenCalled()
+  })
+
+  it("merges scoped channel configs without importing preferences", async () => {
+    const localChannelConfigs = channelConfigSnapshot([
+      { resourceId: "1", channelId: 1, updatedAt: 10 },
+    ])
+    const remoteChannelConfigs = channelConfigSnapshot([
+      { resourceId: "2", channelId: 2, updatedAt: 20 },
+    ])
     mockAccountStorageExportData.mockResolvedValue({
       accounts: [
         {
@@ -341,9 +459,7 @@ describe("importFromBackupObject", () => {
       last_updated: 10,
     })
     mockTagStoreExport.mockResolvedValue({ version: 1, tagsById: {} })
-    mockChannelConfigExport.mockResolvedValue({
-      1: { channelId: 1, updatedAt: 10 },
-    })
+    mockChannelConfigExport.mockResolvedValue(localChannelConfigs)
     mockMergeTagStoresForSync.mockReturnValue({
       tagStore: { version: 1, tagsById: {} },
       localAccounts: [
@@ -402,9 +518,7 @@ describe("importFromBackupObject", () => {
       } as any,
       tagStore: { version: 1, tagsById: {} },
       preferences: { themeMode: "dark" } as any,
-      channelConfigs: {
-        2: { channelId: 2, updatedAt: 20 },
-      } as any,
+      channelConfigs: remoteChannelConfigs,
       apiCredentialProfiles: {
         version: 1,
         profiles: [],
@@ -439,10 +553,7 @@ describe("importFromBackupObject", () => {
       tagsById: {},
     })
     expect(mockUserPreferencesImport).not.toHaveBeenCalled()
-    expect(mockChannelConfigImport).toHaveBeenCalledWith({
-      1: { channelId: 1, updatedAt: 10 },
-      2: { channelId: 2, updatedAt: 20 },
-    })
+    expect(mockChannelConfigMerge).toHaveBeenCalledWith(remoteChannelConfigs)
     expect(mockApiCredentialProfilesMergeConfig).toHaveBeenCalledWith(
       backup.apiCredentialProfiles,
     )
@@ -458,6 +569,9 @@ describe("importFromBackupObject", () => {
   })
 
   it("applies a section import plan with mixed merge, replace, and skip actions", async () => {
+    const channelConfigs = channelConfigSnapshot([
+      { resourceId: "5", channelId: 5, updatedAt: 20 },
+    ])
     mockAccountStorageExportData.mockResolvedValue({
       accounts: [
         {
@@ -511,9 +625,7 @@ describe("importFromBackupObject", () => {
         last_updated: 20,
       } as any,
       preferences: { themeMode: "dark" } as any,
-      channelConfigs: {
-        5: { channelId: 5, updatedAt: 20 },
-      } as any,
+      channelConfigs,
       apiCredentialProfiles: {
         version: 1,
         profiles: [{ id: "backup-profile" }],
@@ -764,10 +876,15 @@ describe("importFromBackupObject", () => {
   })
 
   it("applies replace accounts with merged channel configs and profile merge fallback", async () => {
-    mockChannelConfigExport.mockResolvedValue({
-      1: { channelId: 1, updatedAt: 10 },
-      2: { channelId: 2, updatedAt: 30 },
-    })
+    const localChannelConfigs = channelConfigSnapshot([
+      { resourceId: "1", channelId: 1, updatedAt: 10 },
+      { resourceId: "2", channelId: 2, updatedAt: 30 },
+    ])
+    const remoteChannelConfigs = channelConfigSnapshot([
+      { resourceId: "2", channelId: 2, updatedAt: 20 },
+      { resourceId: "3", channelId: 3, updatedAt: 40 },
+    ])
+    mockChannelConfigExport.mockResolvedValue(localChannelConfigs)
 
     const backup = {
       version: BACKUP_VERSION,
@@ -786,10 +903,7 @@ describe("importFromBackupObject", () => {
         },
         last_updated: 20,
       } as any,
-      channelConfigs: {
-        2: { channelId: 2, updatedAt: 20 },
-        3: { channelId: 3, updatedAt: 40 },
-      } as any,
+      channelConfigs: remoteChannelConfigs,
       apiCredentialProfiles: {
         version: 1,
         profiles: [{ id: "backup-profile" }],
@@ -812,11 +926,7 @@ describe("importFromBackupObject", () => {
       orderedAccountIds: ["backup-account", "backup-bookmark"],
       deletedEntryRecords: backup.accounts.deletedEntryRecords,
     })
-    expect(mockChannelConfigImport).toHaveBeenCalledWith({
-      1: { channelId: 1, updatedAt: 10 },
-      2: { channelId: 2, updatedAt: 30 },
-      3: { channelId: 3, updatedAt: 40 },
-    })
+    expect(mockChannelConfigMerge).toHaveBeenCalledWith(remoteChannelConfigs)
     expect(mockApiCredentialProfilesMergeConfig).toHaveBeenCalledWith(
       backup.apiCredentialProfiles,
     )
@@ -837,7 +947,7 @@ describe("importFromBackupObject", () => {
       timestamp: Date.now(),
       accounts: { accounts: [] } as any,
       preferences: { themeMode: "dark" } as any,
-      channelConfigs: { 1: { channelId: 1 } } as any,
+      channelConfigs: { schemaVersion: 1, configs: {} },
       apiCredentialProfiles: {
         version: 1,
         profiles: [],
@@ -865,7 +975,7 @@ describe("importFromBackupObject", () => {
 
   it("imports legacy V2 account arrays without deletion marker metadata", async () => {
     const backup: RawBackupData = {
-      version: BACKUP_VERSION,
+      version: "2.0",
       timestamp: Date.now(),
       accounts: [{ id: "legacy-a" } as any] as any,
     }
@@ -892,7 +1002,7 @@ describe("importFromBackupObject", () => {
         last_updated: Date.now(),
       } as any,
       preferences: { themeMode: "dark" } as any,
-      channelConfigs: {},
+      channelConfigs: { schemaVersion: 1, configs: {} },
       apiCredentialProfiles: {
         version: 1,
         profiles: [],
@@ -1059,19 +1169,17 @@ describe("importFromBackupObject", () => {
     })
   })
 
-  it("falls back to V1 import when version is unknown", async () => {
+  it("rejects backups created by a newer unsupported version", async () => {
     const payload: RawBackupData = {
-      version: "3.0",
+      version: "4.0",
       timestamp: Date.now(),
       accounts: { accounts: [{ id: "x" }] },
     }
 
-    const result = await importFromBackupObject(payload)
-
-    expect(mockAccountStorageImportData).toHaveBeenCalledWith({
-      accounts: [{ id: "x" }],
-    })
-    expect(result.allImported).toBe(true)
+    await expect(importFromBackupObject(payload)).rejects.toThrow(
+      "importExport:import.versionNotSupported",
+    )
+    expect(mockAccountStorageImportData).not.toHaveBeenCalled()
   })
 
   it("respects section plan skips for legacy V1 backups", async () => {
@@ -1109,9 +1217,9 @@ describe("importFromBackupObject", () => {
     })
   })
 
-  it("respects section plan skips for unknown-version fallback imports", async () => {
+  it("respects section plan skips for legacy V1 imports", async () => {
     const payload: RawBackupData = {
-      version: "3.0",
+      version: "1.0",
       timestamp: Date.now(),
       accounts: { accounts: [{ id: "future-account" }] },
       preferences: { themeMode: "dark" },
@@ -1141,7 +1249,7 @@ describe("importFromBackupObject", () => {
   it("throws when legacy preference import cannot be persisted", async () => {
     mockUserPreferencesImport.mockResolvedValue(preferenceWriteFailure())
     const payload: RawBackupData = {
-      version: "3.0",
+      version: "1.0",
       timestamp: Date.now(),
       preferences: {
         themeMode: "dark",
@@ -1208,7 +1316,7 @@ describe("importFromBackupObject", () => {
         last_updated: Date.now(),
       } as any,
       preferences: { themeMode: "dark" } as any,
-      channelConfigs: {},
+      channelConfigs: { schemaVersion: 1, configs: {} },
     }
 
     const result = await importFromBackupObject(backup as BackupV2)
@@ -1239,6 +1347,41 @@ describe("importFromBackupObject", () => {
 })
 
 describe("normalizeBackupForMerge", () => {
+  it("rejects future backup versions instead of normalizing them as V1", () => {
+    expect(() =>
+      normalizeBackupForMerge(
+        {
+          version: "4.0",
+          timestamp: 123,
+          accounts: { accounts: [{ id: "future-account" }] },
+        },
+        null,
+      ),
+    ).toThrow("VERSION_NOT_SUPPORTED")
+  })
+
+  it("rejects malformed scoped channel configs instead of treating them as absent", () => {
+    expect(() =>
+      normalizeBackupForMerge(
+        {
+          version: BACKUP_VERSION,
+          timestamp: 123,
+          channelConfigs: {
+            schemaVersion: 1,
+            configs: {
+              malformed: {
+                createdAt: 1,
+                updatedAt: 2,
+                modelFilterSettings: { rules: [], updatedAt: 2 },
+              },
+            },
+          },
+        },
+        null,
+      ),
+    ).toThrow("FORMAT_NOT_CORRECT")
+  })
+
   beforeEach(() => {
     vi.clearAllMocks()
   })
@@ -1262,8 +1405,11 @@ describe("normalizeBackupForMerge", () => {
     })
   })
 
-  it("normalizes V2 full backup", () => {
+  it("normalizes a full scoped backup", () => {
     const localPrefs = { themeMode: "system" }
+    const channelConfigs = channelConfigSnapshot([
+      { resourceId: "1", channelId: 1, updatedAt: 10 },
+    ])
     const backup: BackupFullV2 = {
       version: BACKUP_VERSION,
       timestamp: 123,
@@ -1283,7 +1429,7 @@ describe("normalizeBackupForMerge", () => {
       } as any,
       tagStore: { version: 1, tagsById: {} },
       preferences: { themeMode: "dark" } as any,
-      channelConfigs: { 1: { enabled: true } } as any,
+      channelConfigs,
     }
 
     const result = normalizeBackupForMerge(backup, localPrefs)
@@ -1301,7 +1447,7 @@ describe("normalizeBackupForMerge", () => {
     })
     expect(result.accountsTimestamp).toBe(456)
     expect(result.preferences).toEqual({ themeMode: "dark" })
-    expect(result.channelConfigs).toEqual({ 1: { enabled: true } })
+    expect(result.channelConfigs).toEqual(channelConfigs)
     expect(result.tagStore).toEqual({ version: 1, tagsById: {} })
   })
 
@@ -1322,7 +1468,9 @@ describe("normalizeBackupForMerge", () => {
       } as any,
       tagStore: { version: 1, tagsById: {} },
       preferences: { themeMode: "dark" } as any,
-      channelConfigs: { 1: { enabled: true } } as any,
+      channelConfigs: channelConfigSnapshot([
+        { resourceId: "1", channelId: 1, updatedAt: 10 },
+      ]),
       apiCredentialProfiles: apiCredentialProfiles as any,
     }
 
@@ -1334,7 +1482,7 @@ describe("normalizeBackupForMerge", () => {
   it("normalizes V2 array-based account backups and falls back to local preferences when needed", () => {
     const localPrefs = { themeMode: "system" }
     const backup: RawBackupData = {
-      version: BACKUP_VERSION,
+      version: "2.0",
       timestamp: 321,
       accounts: [{ id: "array-account" }],
       channelConfigs: "invalid" as any,
@@ -1349,7 +1497,7 @@ describe("normalizeBackupForMerge", () => {
     expect(result.channelConfigs).toBeNull()
   })
 
-  it("normalizes V1-style backup falling back to legacy shapes", () => {
+  it("ignores numeric channel configs while normalizing a V1-style backup", () => {
     const localPrefs = { themeMode: "system" }
     const payload: RawBackupData = {
       version: "1.0",
@@ -1385,7 +1533,7 @@ describe("normalizeBackupForMerge", () => {
     })
     expect(result.accountsTimestamp).toBe(999)
     expect(result.preferences).toEqual({ themeMode: "dark" })
-    expect(result.channelConfigs).toEqual({ 2: { enabled: false } })
+    expect(result.channelConfigs).toBeNull()
     expect(result.tagStore).toBeNull()
   })
 

--- a/tests/utils/importExportUtils.test.ts
+++ b/tests/utils/importExportUtils.test.ts
@@ -13,6 +13,7 @@ import {
 import { accountStorage } from "~/services/accounts/accountStorage"
 import { apiCredentialProfilesStorage } from "~/services/apiCredentialProfiles/apiCredentialProfilesStorage"
 import { channelConfigStorage } from "~/services/managedSites/channelConfigStorage"
+import { ensureLegacyChannelConfigMigrationReady } from "~/services/managedSites/legacyChannelConfigMigration"
 import { userPreferences } from "~/services/preferences/userPreferences"
 import { tagStorage } from "~/services/tags/tagStorage"
 import { API_TYPES } from "~/services/verification/aiApiVerification"
@@ -23,6 +24,10 @@ import {
   getManagedUpstreamResourceRefKey,
 } from "~/types/managedUpstreamResource"
 import { DEFAULT_WEBDAV_SETTINGS } from "~/types/webdav"
+
+vi.mock("~/services/managedSites/legacyChannelConfigMigration", () => ({
+  ensureLegacyChannelConfigMigrationReady: vi.fn().mockResolvedValue(undefined),
+}))
 
 vi.mock("~/services/accounts/accountStorage", () => ({
   accountStorage: {
@@ -105,6 +110,8 @@ const mockChannelConfigMerge =
   channelConfigStorage.mergeConfigs as unknown as ReturnType<typeof vi.fn>
 const mockChannelConfigExport =
   channelConfigStorage.exportConfigs as unknown as ReturnType<typeof vi.fn>
+const mockEnsureLegacyChannelConfigMigrationReady =
+  ensureLegacyChannelConfigMigrationReady as unknown as ReturnType<typeof vi.fn>
 
 const mockEnsureLegacyMigration =
   tagStorage.ensureLegacyMigration as unknown as ReturnType<typeof vi.fn>
@@ -566,6 +573,37 @@ describe("importFromBackupObject", () => {
         apiCredentialProfiles: true,
       },
     })
+  })
+
+  it("waits for legacy migration before a merge import changes preferences", async () => {
+    const backup = {
+      version: BACKUP_VERSION,
+      timestamp: Date.now(),
+      preferences: { themeMode: "dark" },
+      channelConfigs: channelConfigSnapshot([
+        { resourceId: "5", channelId: 5, updatedAt: 20 },
+      ]),
+    } as BackupFullV2
+    mockEnsureLegacyChannelConfigMigrationReady.mockRejectedValueOnce(
+      new Error("migration deferred"),
+    )
+
+    await expect(
+      importFromBackupObject(backup, {
+        plan: {
+          accounts: "skip",
+          preferences: "replace",
+          channelConfigs: "merge",
+          apiCredentialProfiles: "skip",
+        },
+      }),
+    ).rejects.toThrow("migration deferred")
+
+    expect(mockEnsureLegacyChannelConfigMigrationReady).toHaveBeenCalledWith({
+      bypassBackoff: true,
+    })
+    expect(mockUserPreferencesImport).not.toHaveBeenCalled()
+    expect(mockChannelConfigMerge).not.toHaveBeenCalled()
   })
 
   it("applies a section import plan with mixed merge, replace, and skip actions", async () => {


### PR DESCRIPTION
## Summary

Channel configuration previously had competing numeric and resource-scoped storage paths. Numeric channel IDs are not globally unique across managed-site types and deployments, so flattening configuration by `channelId` could overwrite another scope's settings.

This change makes the complete managed-resource identity the only runtime authority and safely reconciles existing numeric configuration without guessing.

## What changed

- Store and resolve channel configuration by `managedSiteType + scopeKey + resourceId`.
- Route Managed Site Channels, generic model sync, Octopus model sync, backup/import, WebDAV merge/replace, and rollback through the scoped configuration contract.
- Use strict, versioned channel-config snapshots in backups and reject unsupported or malformed snapshots instead of treating them as missing data.
- Make scoped merges atomic and preserve concurrent edits across deployment scopes.
- Require complete pagination when enumerating channels for migration.

## Legacy migration and recovery

- Legacy `channel_configs` data is used only as a migration source and is never consulted by normal runtime reads.
- Network discovery runs only when recognizable legacy configuration exists.
- Every configured managed-site deployment must be enumerated successfully before migration proceeds.
- A numeric entry is migrated only when it maps to exactly one stable resource identity.
- Unmatched or ambiguous entries remain preserved and retryable; AxonHub numeric projections are never treated as migration evidence.
- Conflicts are resolved by `updatedAt`, with existing scoped data winning ties.
- Scoped data is written before migrated numeric entries are removed.
- Replace operations use a durable prepared/committed transaction envelope so interrupted writes can be replayed or finalized after an extension restart.
- Background retries use persisted exponential backoff, while explicit export/import/WebDAV actions may retry immediately.

## Validation

- Focused Vitest suites: 335 tests passed.
- `pnpm run validate:push`
- `pnpm lint`
- `pnpm run i18n:extract:ci`
- `pnpm run i18n:status` - all 8 secondary locales complete.
- `pnpm exec playwright test e2e/importExportCommonFlows.spec.ts --project=chromium --workers=1 --grep "round-trips a full backup|uploads a WebDAV backup|runs WebDAV auto-sync"` - build plus 3 browser flows passed.
- Independent specification and architecture reviews: Ready.
- Full sharded tests and coverage are left to PR CI according to repository policy.

## Scope

This does not attempt a full native-resource migration, remove the structured `resourceRef` from stored values, or broadly refactor the legacy Managed Site Channels routing layer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Backups and WebDAV synchronization now use version 3.0 with improved channel-configuration handling.
  * Legacy channel configurations are migrated automatically where possible.
  * Channel filters and model synchronization support resource-scoped configurations.
  * Channel inventory retrieval can require complete results.
* **Bug Fixes**
  * Unsupported backup versions now display localized, actionable messages.
  * Improved backup validation, migration recovery, and synchronization consistency.
  * Unsafe model-filter patterns are rejected to improve stability and security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->