### PR TITLE
fix(managed-sites): use native editors for channel imports

### DIFF
--- a/src/components/dialogs/ChannelDialog/components/ChannelDialogContainer.tsx
+++ b/src/components/dialogs/ChannelDialog/components/ChannelDialogContainer.tsx
@@ -1,4 +1,5 @@
 import { useChannelDialogContext } from "~/components/dialogs/ChannelDialog/context/ChannelDialogContext"
+import { ManagedResourceCreateDialog } from "~/features/ManagedSiteChannels/components/ManagedResourceCreateDialog"
 import AddTokenDialog from "~/features/TokenProvisioning/components/AddTokenDialog"
 import { buildDefaultTokenCreatePrefill } from "~/features/TokenProvisioning/components/AddTokenDialog/defaultTokenCreatePrefill"
 
@@ -26,7 +27,7 @@ export function ChannelDialogContainer() {
   return (
     <>
       <ChannelDialog
-        isOpen={state.isOpen}
+        isOpen={state.isOpen && !state.nativeCreate}
         onClose={closeDialog}
         mode={state.mode}
         channel={state.channel ?? null}
@@ -40,6 +41,18 @@ export function ChannelDialogContainer() {
         onMutationOutcome={state.onMutationOutcome ?? undefined}
         resourceEdit={state.resourceEdit ?? null}
       />
+      {state.nativeCreate ? (
+        <ManagedResourceCreateDialog
+          isOpen={state.isOpen}
+          siteType={state.nativeCreate.siteType}
+          kind={state.nativeCreate.kind}
+          editor={state.nativeCreate.editor}
+          showModelPrefillWarning={state.nativeCreate.showModelPrefillWarning}
+          advisoryWarning={state.nativeCreate.advisoryWarning}
+          onClose={closeDialog}
+          onSuccess={handleSuccess}
+        />
+      ) : null}
       {defaultTokenQuickCreateDialog.account &&
       defaultTokenQuickCreatePrefill ? (
         <AddTokenDialog

--- a/src/components/dialogs/ChannelDialog/components/ChannelDialogContainer.tsx
+++ b/src/components/dialogs/ChannelDialog/components/ChannelDialogContainer.tsx
@@ -13,6 +13,7 @@ export function ChannelDialogContainer() {
     state,
     defaultTokenQuickCreateDialog,
     closeDialog,
+    completeNativeDialogClose,
     closeDefaultTokenQuickCreateDialog,
     handleSuccess,
     handleDefaultTokenQuickCreateSuccess,
@@ -23,11 +24,12 @@ export function ChannelDialogContainer() {
         defaultTokenQuickCreateDialog.allowedGroups,
       )
     : undefined
+  const nativeCreate = state.nativeCreate
 
   return (
     <>
       <ChannelDialog
-        isOpen={state.isOpen && !state.nativeCreate}
+        isOpen={state.isOpen && !nativeCreate}
         onClose={closeDialog}
         mode={state.mode}
         channel={state.channel ?? null}
@@ -41,15 +43,19 @@ export function ChannelDialogContainer() {
         onMutationOutcome={state.onMutationOutcome ?? undefined}
         resourceEdit={state.resourceEdit ?? null}
       />
-      {state.nativeCreate ? (
+      {nativeCreate ? (
         <ManagedResourceCreateDialog
+          key={nativeCreate.sessionId}
           isOpen={state.isOpen}
-          siteType={state.nativeCreate.siteType}
-          kind={state.nativeCreate.kind}
-          editor={state.nativeCreate.editor}
-          showModelPrefillWarning={state.nativeCreate.showModelPrefillWarning}
-          advisoryWarning={state.nativeCreate.advisoryWarning}
+          siteType={nativeCreate.siteType}
+          kind={nativeCreate.kind}
+          editor={nativeCreate.editor}
+          showModelPrefillWarning={nativeCreate.showModelPrefillWarning}
+          advisoryWarning={nativeCreate.advisoryWarning}
           onClose={closeDialog}
+          onCloseComplete={() =>
+            completeNativeDialogClose(nativeCreate.sessionId)
+          }
           onSuccess={handleSuccess}
         />
       ) : null}

--- a/src/components/dialogs/ChannelDialog/components/ChannelEditorShell.tsx
+++ b/src/components/dialogs/ChannelDialog/components/ChannelEditorShell.tsx
@@ -10,6 +10,7 @@ export function ChannelEditorShell({
   description,
   children,
   onClose,
+  onCloseComplete,
   onSubmit,
   submitLabel,
   closeLabel,
@@ -24,6 +25,7 @@ export function ChannelEditorShell({
   description?: string
   children: ReactNode
   onClose: () => void
+  onCloseComplete?: () => void
   onSubmit: (event: FormEvent<HTMLFormElement>) => void
   submitLabel?: string
   closeLabel: string
@@ -77,6 +79,7 @@ export function ChannelEditorShell({
       isOpen={isOpen}
       title={title}
       onClose={handleClose}
+      onCloseComplete={onCloseComplete}
       closeOnBackdropClick={!isSubmitting}
       closeOnEsc={!isSubmitting}
       showCloseButton={!isSubmitting}

--- a/src/components/dialogs/ChannelDialog/context/ChannelDialogContext.tsx
+++ b/src/components/dialogs/ChannelDialog/context/ChannelDialogContext.tsx
@@ -9,6 +9,9 @@ import React, {
 
 import type { ChannelResourceEditContext } from "~/components/dialogs/ChannelDialog/hooks/useChannelForm"
 import { DIALOG_MODES, type DialogMode } from "~/constants/dialogModes"
+import type { ManagedSiteType } from "~/constants/siteType"
+import type { ManagedResourceKind } from "~/services/accountSiteDefinitions/contracts"
+import type { ResourceEditor } from "~/services/apiAdapters/contracts/managedResourceNative"
 import type { ManagedSiteChannelAssessmentSignals } from "~/services/managedSites/channelAssessmentSignals"
 import type { ApiToken, DisplaySiteData } from "~/types"
 import type { ChannelFormData, ManagedSiteChannel } from "~/types/managedSite"
@@ -34,6 +37,14 @@ export interface ChannelDialogAdvisoryWarning {
   assessment?: ManagedSiteChannelAssessmentSignals | null
 }
 
+export interface NativeChannelCreateDialogState {
+  siteType: ManagedSiteType
+  kind: ManagedResourceKind
+  editor: ResourceEditor
+  showModelPrefillWarning: boolean
+  advisoryWarning: ChannelDialogAdvisoryWarning | null
+}
+
 interface ChannelDialogState {
   isOpen: boolean
   mode: DialogMode
@@ -49,6 +60,7 @@ interface ChannelDialogState {
   onSuccessCallback?: (result: any) => void
   onMutationOutcome?: ChannelDialogMutationOutcomeHandler | null
   resourceEdit?: ChannelResourceEditContext | null
+  nativeCreate?: NativeChannelCreateDialogState | null
 }
 
 interface DuplicateChannelWarningState {
@@ -83,6 +95,10 @@ interface ChannelDialogContextValue {
     onSuccess?: (result: any) => void
     onMutationOutcome?: ChannelDialogMutationOutcomeHandler
     resourceEdit?: ChannelResourceEditContext | null
+  }) => void
+  openNativeCreateDialog: (config: {
+    nativeCreate: NativeChannelCreateDialogState
+    onSuccess?: (result: any) => void
   }) => void
   closeDialog: () => void
   handleSuccess: (result: any) => void
@@ -170,16 +186,39 @@ export function ChannelDialogProvider({
         onSuccessCallback: config.onSuccess,
         onMutationOutcome: config.onMutationOutcome ?? null,
         resourceEdit: config.resourceEdit ?? null,
+        nativeCreate: null,
+      })
+    },
+    [],
+  )
+
+  const openNativeCreateDialog = useCallback(
+    (config: {
+      nativeCreate: NativeChannelCreateDialogState
+      onSuccess?: (result: any) => void
+    }) => {
+      setState({
+        isOpen: true,
+        mode: DIALOG_MODES.ADD,
+        channel: null,
+        onSuccessCallback: config.onSuccess,
+        nativeCreate: config.nativeCreate,
       })
     },
     [],
   )
 
   const closeDialog = useCallback(() => {
-    setState((prev) => ({
-      ...prev,
-      isOpen: false,
-    }))
+    setState((prev) =>
+      prev.nativeCreate
+        ? {
+            isOpen: false,
+            mode: DIALOG_MODES.ADD,
+            channel: null,
+            nativeCreate: null,
+          }
+        : { ...prev, isOpen: false },
+    )
   }, [])
 
   const onSuccessRef = useRef(state.onSuccessCallback)
@@ -308,6 +347,7 @@ export function ChannelDialogProvider({
         duplicateChannelWarning,
         defaultTokenQuickCreateDialog,
         openDialog,
+        openNativeCreateDialog,
         closeDialog,
         handleSuccess,
         openDefaultTokenQuickCreateDialog,

--- a/src/components/dialogs/ChannelDialog/context/ChannelDialogContext.tsx
+++ b/src/components/dialogs/ChannelDialog/context/ChannelDialogContext.tsx
@@ -37,12 +37,17 @@ export interface ChannelDialogAdvisoryWarning {
   assessment?: ManagedSiteChannelAssessmentSignals | null
 }
 
-export interface NativeChannelCreateDialogState {
+export interface NativeChannelCreateDialogConfig {
   siteType: ManagedSiteType
   kind: ManagedResourceKind
   editor: ResourceEditor
   showModelPrefillWarning: boolean
   advisoryWarning: ChannelDialogAdvisoryWarning | null
+}
+
+export interface NativeChannelCreateDialogState
+  extends NativeChannelCreateDialogConfig {
+  sessionId: number
 }
 
 interface ChannelDialogState {
@@ -97,10 +102,11 @@ interface ChannelDialogContextValue {
     resourceEdit?: ChannelResourceEditContext | null
   }) => void
   openNativeCreateDialog: (config: {
-    nativeCreate: NativeChannelCreateDialogState
+    nativeCreate: NativeChannelCreateDialogConfig
     onSuccess?: (result: any) => void
   }) => void
   closeDialog: () => void
+  completeNativeDialogClose: (sessionId: number) => void
   handleSuccess: (result: any) => void
   openDefaultTokenQuickCreateDialog: (config: {
     account: DisplaySiteData
@@ -156,6 +162,7 @@ export function ChannelDialogProvider({
   const defaultTokenQuickCreateOnSuccessRef = useRef(
     defaultTokenQuickCreateDialog.onSuccessCallback,
   )
+  const nativeCreateSessionIdRef = useRef(0)
 
   const openDialog = useCallback(
     (config: {
@@ -194,31 +201,41 @@ export function ChannelDialogProvider({
 
   const openNativeCreateDialog = useCallback(
     (config: {
-      nativeCreate: NativeChannelCreateDialogState
+      nativeCreate: NativeChannelCreateDialogConfig
       onSuccess?: (result: any) => void
     }) => {
+      const sessionId = nativeCreateSessionIdRef.current + 1
+      nativeCreateSessionIdRef.current = sessionId
       setState({
         isOpen: true,
         mode: DIALOG_MODES.ADD,
         channel: null,
         onSuccessCallback: config.onSuccess,
-        nativeCreate: config.nativeCreate,
+        nativeCreate: { ...config.nativeCreate, sessionId },
       })
     },
     [],
   )
 
   const closeDialog = useCallback(() => {
-    setState((prev) =>
-      prev.nativeCreate
-        ? {
-            isOpen: false,
-            mode: DIALOG_MODES.ADD,
-            channel: null,
-            nativeCreate: null,
-          }
-        : { ...prev, isOpen: false },
-    )
+    setState((prev) => ({ ...prev, isOpen: false }))
+  }, [])
+
+  const completeNativeDialogClose = useCallback((sessionId: number) => {
+    setState((prev) => {
+      if (
+        prev.isOpen ||
+        !prev.nativeCreate ||
+        prev.nativeCreate.sessionId !== sessionId
+      )
+        return prev
+      return {
+        isOpen: false,
+        mode: DIALOG_MODES.ADD,
+        channel: null,
+        nativeCreate: null,
+      }
+    })
   }, [])
 
   const onSuccessRef = useRef(state.onSuccessCallback)
@@ -349,6 +366,7 @@ export function ChannelDialogProvider({
         openDialog,
         openNativeCreateDialog,
         closeDialog,
+        completeNativeDialogClose,
         handleSuccess,
         openDefaultTokenQuickCreateDialog,
         closeDefaultTokenQuickCreateDialog,

--- a/src/components/dialogs/ChannelDialog/hooks/useChannelDialog.ts
+++ b/src/components/dialogs/ChannelDialog/hooks/useChannelDialog.ts
@@ -121,11 +121,13 @@ export function useChannelDialog() {
     formData: Awaited<ReturnType<ManagedSiteService["prepareChannelFormData"]>>
     advisoryWarning: ChannelDialogAdvisoryWarning | null
     onSuccess?: (result: any) => void
-  }) => {
+    shouldContinue?: () => boolean
+  }): Promise<boolean> => {
     const nativeCreate = await openNativeManagedChannelImportEditor(
       params.service.siteType,
       params.formData,
     )
+    if (params.shouldContinue && !params.shouldContinue()) return false
 
     if (nativeCreate) {
       openNativeCreateDialog({
@@ -137,7 +139,7 @@ export function useChannelDialog() {
         },
         onSuccess: params.onSuccess,
       })
-      return
+      return true
     }
 
     openDialog({
@@ -149,6 +151,7 @@ export function useChannelDialog() {
       advisoryWarning: params.advisoryWarning,
       onSuccess: params.onSuccess,
     })
+    return true
   }
 
   const openDefaultTokenQuickCreateDialogForAccount = async (
@@ -597,12 +600,14 @@ export function useChannelDialog() {
         return cancelOpen()
       }
 
-      await openPreparedChannelCreateDialog({
+      const opened = await openPreparedChannelCreateDialog({
         service,
         formData,
         advisoryWarning: duplicateState.advisoryWarning,
         onSuccess,
+        shouldContinue,
       })
+      if (!opened) return cancelOpen()
       return { opened: true }
     } catch (error) {
       const diagnostic = toSanitizedErrorSummary(error, secretsToRedact)
@@ -686,13 +691,13 @@ export function useChannelDialog() {
         toast.dismiss(toastId)
       }
 
-      await openPreparedChannelCreateDialog({
+      const opened = await openPreparedChannelCreateDialog({
         service,
         formData,
         advisoryWarning: duplicateState.advisoryWarning,
         onSuccess,
       })
-      return { opened: true }
+      return { opened }
     } catch (error) {
       const diagnostic = toSanitizedErrorSummary(error, secretsToRedact)
       toast.error(

--- a/src/components/dialogs/ChannelDialog/hooks/useChannelDialog.ts
+++ b/src/components/dialogs/ChannelDialog/hooks/useChannelDialog.ts
@@ -23,6 +23,7 @@ import {
   requireDisplayAccountKeyManagement,
   resolveDisplayAccountTokenForSecret,
 } from "~/services/accounts/utils/apiServiceRequest"
+import { openNativeManagedChannelImportEditor } from "~/services/apiAdapters/managedResources/channelImport"
 import {
   API_CREDENTIAL_PROFILE_SYNTHETIC_ACCOUNT_ID_PREFIX,
   buildApiCredentialProfileSyntheticAccountId,
@@ -110,9 +111,45 @@ export function useChannelDialog() {
   const { t } = useTranslation(["messages", "channelDialog"])
   const {
     openDialog,
+    openNativeCreateDialog,
     openDefaultTokenQuickCreateDialog,
     requestDuplicateChannelWarning,
   } = useChannelDialogContext()
+
+  const openPreparedChannelCreateDialog = async (params: {
+    service: ManagedSiteService
+    formData: Awaited<ReturnType<ManagedSiteService["prepareChannelFormData"]>>
+    advisoryWarning: ChannelDialogAdvisoryWarning | null
+    onSuccess?: (result: any) => void
+  }) => {
+    const nativeCreate = await openNativeManagedChannelImportEditor(
+      params.service.siteType,
+      params.formData,
+    )
+
+    if (nativeCreate) {
+      openNativeCreateDialog({
+        nativeCreate: {
+          ...nativeCreate,
+          showModelPrefillWarning:
+            params.formData.modelPrefillFetchFailed === true,
+          advisoryWarning: params.advisoryWarning,
+        },
+        onSuccess: params.onSuccess,
+      })
+      return
+    }
+
+    openDialog({
+      mode: DIALOG_MODES.ADD,
+      initialValues: params.formData,
+      initialModels: params.formData.models,
+      initialGroups: params.formData.groups,
+      showModelPrefillWarning: params.formData.modelPrefillFetchFailed === true,
+      advisoryWarning: params.advisoryWarning,
+      onSuccess: params.onSuccess,
+    })
+  }
 
   const openDefaultTokenQuickCreateDialogForAccount = async (
     account: DisplaySiteData,
@@ -560,19 +597,11 @@ export function useChannelDialog() {
         return cancelOpen()
       }
 
-      // Open dialog
-      openDialog({
-        mode: DIALOG_MODES.ADD,
-        initialValues: formData,
-        initialModels: formData.models,
-        initialGroups: formData.groups,
-        showModelPrefillWarning: formData.modelPrefillFetchFailed === true,
+      await openPreparedChannelCreateDialog({
+        service,
+        formData,
         advisoryWarning: duplicateState.advisoryWarning,
-        onSuccess: (result) => {
-          if (onSuccess) {
-            onSuccess(result)
-          }
-        },
+        onSuccess,
       })
       return { opened: true }
     } catch (error) {
@@ -657,16 +686,11 @@ export function useChannelDialog() {
         toast.dismiss(toastId)
       }
 
-      openDialog({
-        mode: DIALOG_MODES.ADD,
-        initialValues: formData,
-        initialModels: formData.models,
-        initialGroups: formData.groups,
-        showModelPrefillWarning: formData.modelPrefillFetchFailed === true,
+      await openPreparedChannelCreateDialog({
+        service,
+        formData,
         advisoryWarning: duplicateState.advisoryWarning,
-        onSuccess: (result) => {
-          onSuccess?.(result)
-        },
+        onSuccess,
       })
       return { opened: true }
     } catch (error) {

--- a/src/components/ui/Dialog/Modal.tsx
+++ b/src/components/ui/Dialog/Modal.tsx
@@ -159,27 +159,29 @@ const removeFocusLease = (session: FocusSession) => {
 }
 
 const settleDeferredFocusLease = (session: FocusSession) => {
-  if (!focusLeaseStack.includes(session)) return
-  if (!session.active) {
-    removeFocusLease(session)
-    return
+  try {
+    if (!focusLeaseStack.includes(session)) return
+    if (!session.active) {
+      removeFocusLease(session)
+      return
+    }
+    if (
+      focusLeaseStack.at(-1) !== session &&
+      !focusLeaseStack.some(
+        (candidate) => candidate.active && candidate.parentSession === session,
+      )
+    ) {
+      removeFocusLease(session)
+      return
+    }
+    session.settled = true
+    if (focusLeaseStack.at(-1) !== session) return
+    const restoreSession = settleFocusLease(session)
+    const restoreFocusElement = restoreSession?.restoreElement
+    if (restoreFocusElement?.isConnected) restoreFocusElement.focus()
+  } finally {
+    notifyCloseComplete(session)
   }
-  if (
-    focusLeaseStack.at(-1) !== session &&
-    !focusLeaseStack.some(
-      (candidate) => candidate.active && candidate.parentSession === session,
-    )
-  ) {
-    removeFocusLease(session)
-    return
-  }
-  session.settled = true
-  if (focusLeaseStack.at(-1) !== session) {
-    return
-  }
-  const restoreSession = settleFocusLease(session)
-  const restoreFocusElement = restoreSession?.restoreElement
-  if (restoreFocusElement?.isConnected) restoreFocusElement.focus()
 }
 
 const scheduleDeferredFocusLeaseSettlement = (session: FocusSession) => {
@@ -267,10 +269,7 @@ export function Modal({
 
   useLayoutEffect(() => {
     const activeSession = activeFocusSessionRef.current
-    if (!isOpen && activeSession) {
-      activeSession.closeRequested = true
-      scheduleDeferredFocusLeaseSettlement(activeSession)
-    }
+    if (!isOpen && activeSession) activeSession.closeRequested = true
   }, [isOpen])
 
   useLayoutEffect(

--- a/src/components/ui/Dialog/Modal.tsx
+++ b/src/components/ui/Dialog/Modal.tsx
@@ -40,6 +40,8 @@ interface ModalProps {
   terminalCloseKey?: string | number | null
   /** Shares the original opener across an explicit terminal-dialog successor. */
   focusWorkflowId?: string | number
+  /** Runs after Radix finishes close-autofocus handling for this open session. */
+  onCloseComplete?: () => void
 }
 
 const sizeMap: Record<Size, string> = {
@@ -61,9 +63,17 @@ type FocusSession = {
   active: boolean
   settled: boolean
   closeRequested: boolean
+  completionNotified: boolean
+  onCloseComplete?: () => void
   focusWorkflowId?: string | number
   contentElement?: HTMLElement
   parentSession?: FocusSession
+}
+
+const notifyCloseComplete = (session: FocusSession) => {
+  if (!session.closeRequested || session.completionNotified) return
+  session.completionNotified = true
+  session.onCloseComplete?.()
 }
 
 // Radix may deliver close autofocus after a keyed Modal instance has unmounted.
@@ -212,6 +222,7 @@ export function Modal({
   focusFallbackKey,
   terminalCloseKey,
   focusWorkflowId,
+  onCloseComplete,
 }: ModalProps) {
   const contentRef = useRef<HTMLDivElement>(null)
   const backdropPointerDownTargetRef = useRef<HTMLDivElement | null>(null)
@@ -239,6 +250,8 @@ export function Modal({
         active: true,
         settled: false,
         closeRequested: false,
+        completionNotified: false,
+        onCloseComplete,
         focusWorkflowId,
       }
       if (activeFocusSessionRef.current)
@@ -250,12 +263,14 @@ export function Modal({
       }
     }
     wasOpenRef.current = true
-  }, [focusWorkflowId, isOpen])
+  }, [focusWorkflowId, isOpen, onCloseComplete])
 
   useLayoutEffect(() => {
     const activeSession = activeFocusSessionRef.current
-    if (!isOpen && activeSession?.closeRequested)
+    if (!isOpen && activeSession) {
+      activeSession.closeRequested = true
       scheduleDeferredFocusLeaseSettlement(activeSession)
+    }
   }, [isOpen])
 
   useLayoutEffect(
@@ -390,16 +405,22 @@ export function Modal({
               // unmounts. The shared lease prevents a replaced instance from
               // restoring focus over the currently opened dialog.
               event.preventDefault()
-              if (!(event.currentTarget instanceof HTMLElement)) return
               const focusSession =
-                focusSessionsByContentRef.current.get(event.currentTarget) ??
-                activeFocusSessionRef.current
-              const restoreSession =
-                focusSession && settleFocusLease(focusSession)
-              if (!restoreSession) return
-              const restoreFocusElement = restoreSession.restoreElement
-              if (!restoreFocusElement?.isConnected) return
-              restoreFocusElement.focus()
+                event.currentTarget instanceof HTMLElement
+                  ? focusSessionsByContentRef.current.get(
+                      event.currentTarget,
+                    ) ?? activeFocusSessionRef.current
+                  : null
+              if (!focusSession) return
+              try {
+                const restoreSession = settleFocusLease(focusSession)
+                if (!restoreSession) return
+                const restoreFocusElement = restoreSession.restoreElement
+                if (!restoreFocusElement?.isConnected) return
+                restoreFocusElement.focus()
+              } finally {
+                notifyCloseComplete(focusSession)
+              }
             }}
             onPointerDownOutside={(event) => {
               event.preventDefault()

--- a/src/features/KeyManagement/components/ManagedSiteTokenBatchExportDialog.tsx
+++ b/src/features/KeyManagement/components/ManagedSiteTokenBatchExportDialog.tsx
@@ -91,9 +91,7 @@ export function ManagedSiteTokenBatchExportDialog({
               dialog.executionResult?.items.some(
                 (item) =>
                   item.result ===
-                    MANAGED_SITE_TOKEN_BATCH_EXPORT_EXECUTION_RESULTS.FAILED ||
-                  item.result ===
-                    MANAGED_SITE_TOKEN_BATCH_EXPORT_EXECUTION_RESULTS.UNCERTAIN,
+                  MANAGED_SITE_TOKEN_BATCH_EXPORT_EXECUTION_RESULTS.FAILED,
               ),
             )}
             onClose={dialog.actions.close}

--- a/src/features/KeyManagement/components/ManagedSiteTokenBatchExportDialog/managedSiteTokenBatchExportSession.ts
+++ b/src/features/KeyManagement/components/ManagedSiteTokenBatchExportDialog/managedSiteTokenBatchExportSession.ts
@@ -27,9 +27,7 @@ export const getManagedSiteTokenBatchExportRetryItemIds = (
     .filter(
       (item) =>
         item.result ===
-          MANAGED_SITE_TOKEN_BATCH_EXPORT_EXECUTION_RESULTS.FAILED ||
-        item.result ===
-          MANAGED_SITE_TOKEN_BATCH_EXPORT_EXECUTION_RESULTS.UNCERTAIN,
+        MANAGED_SITE_TOKEN_BATCH_EXPORT_EXECUTION_RESULTS.FAILED,
     )
     .map((item) => item.id)
 

--- a/src/features/ManagedSiteChannels/components/ManagedResourceCreateDialog.tsx
+++ b/src/features/ManagedSiteChannels/components/ManagedResourceCreateDialog.tsx
@@ -7,6 +7,11 @@ import { CHANNEL_DIALOG_TEST_IDS } from "~/components/dialogs/ChannelDialog/test
 import { ManagedSiteChannelAssessmentSignalsRow } from "~/components/ManagedSiteChannelAssessmentSignals"
 import { Alert } from "~/components/ui"
 import type { ManagedSiteType } from "~/constants/siteType"
+import { ManagedResourceEditorBody } from "~/features/ManagedSiteChannels/presentation/ManagedResourceEditorBody"
+import {
+  getManagedResourceFieldPolicy,
+  MANAGED_RESOURCE_EDITOR_MODES,
+} from "~/features/ManagedSiteChannels/presentation/managedResourceFieldPolicy"
 import type { ManagedResourceKind } from "~/services/accountSiteDefinitions/contracts"
 import {
   MANAGED_RESOURCE_FAILURE_CODES,
@@ -19,12 +24,6 @@ import {
   assertManagedSiteMutationResult,
   MANAGED_SITE_MUTATION_OUTCOMES,
 } from "~/services/managedSites/mutations"
-
-import { ManagedResourceEditorBody } from "../presentation/ManagedResourceEditorBody"
-import {
-  getManagedResourceFieldPolicy,
-  MANAGED_RESOURCE_EDITOR_MODES,
-} from "../presentation/managedResourceFieldPolicy"
 
 type SaveFeedback =
   | { kind: "failed"; fieldIssues?: readonly ResourceFieldIssue[] }
@@ -39,6 +38,7 @@ export interface ManagedResourceCreateDialogProps {
   showModelPrefillWarning?: boolean
   advisoryWarning?: ChannelDialogAdvisoryWarning | null
   onClose: () => void
+  onCloseComplete: () => void
   onSuccess: (result: {
     success: true
     data: unknown
@@ -55,6 +55,7 @@ export function ManagedResourceCreateDialog({
   showModelPrefillWarning = false,
   advisoryWarning,
   onClose,
+  onCloseComplete,
   onSuccess,
 }: ManagedResourceCreateDialogProps) {
   const { t } = useTranslation([
@@ -154,6 +155,7 @@ export function ManagedResourceCreateDialog({
       title={t("channelDialog:title.add")}
       description={t("channelDialog:description.add")}
       onClose={onClose}
+      onCloseComplete={onCloseComplete}
       onSubmit={(event) => {
         event.preventDefault()
         void submit()

--- a/src/features/ManagedSiteChannels/components/ManagedResourceCreateDialog.tsx
+++ b/src/features/ManagedSiteChannels/components/ManagedResourceCreateDialog.tsx
@@ -1,0 +1,230 @@
+import { useEffect, useMemo, useRef, useState } from "react"
+import { useTranslation } from "react-i18next"
+
+import { ChannelEditorShell } from "~/components/dialogs/ChannelDialog/components/ChannelEditorShell"
+import type { ChannelDialogAdvisoryWarning } from "~/components/dialogs/ChannelDialog/context/ChannelDialogContext"
+import { CHANNEL_DIALOG_TEST_IDS } from "~/components/dialogs/ChannelDialog/testIds"
+import { ManagedSiteChannelAssessmentSignalsRow } from "~/components/ManagedSiteChannelAssessmentSignals"
+import { Alert } from "~/components/ui"
+import type { ManagedSiteType } from "~/constants/siteType"
+import type { ManagedResourceKind } from "~/services/accountSiteDefinitions/contracts"
+import {
+  MANAGED_RESOURCE_FAILURE_CODES,
+  ManagedResourceError,
+  type ResourceEditor,
+  type ResourceFieldIssue,
+  type ResourceFieldValue,
+} from "~/services/apiAdapters/contracts/managedResourceNative"
+import {
+  assertManagedSiteMutationResult,
+  MANAGED_SITE_MUTATION_OUTCOMES,
+} from "~/services/managedSites/mutations"
+
+import { ManagedResourceEditorBody } from "../presentation/ManagedResourceEditorBody"
+import {
+  getManagedResourceFieldPolicy,
+  MANAGED_RESOURCE_EDITOR_MODES,
+} from "../presentation/managedResourceFieldPolicy"
+
+type SaveFeedback =
+  | { kind: "failed"; fieldIssues?: readonly ResourceFieldIssue[] }
+  | { kind: "uncertain" }
+  | null
+
+export interface ManagedResourceCreateDialogProps {
+  isOpen: boolean
+  siteType: ManagedSiteType
+  kind: ManagedResourceKind
+  editor: ResourceEditor
+  showModelPrefillWarning?: boolean
+  advisoryWarning?: ChannelDialogAdvisoryWarning | null
+  onClose: () => void
+  onSuccess: (result: {
+    success: true
+    data: unknown
+    message?: string
+  }) => void
+}
+
+/** Presents a provider-native managed-resource create editor outside its list page. */
+export function ManagedResourceCreateDialog({
+  isOpen,
+  siteType,
+  kind,
+  editor,
+  showModelPrefillWarning = false,
+  advisoryWarning,
+  onClose,
+  onSuccess,
+}: ManagedResourceCreateDialogProps) {
+  const { t } = useTranslation([
+    "managedSiteChannels",
+    "channelDialog",
+    "common",
+  ])
+  const [values, setValues] = useState(editor.initialValues)
+  const [isSaving, setIsSaving] = useState(false)
+  const [feedback, setFeedback] = useState<SaveFeedback>(null)
+  const activeSubmit = useRef<AbortController | null>(null)
+  const policy = getManagedResourceFieldPolicy(
+    siteType,
+    kind,
+    MANAGED_RESOURCE_EDITOR_MODES.Create,
+  )
+  const validation = useMemo(() => editor.validate(values), [editor, values])
+  const fieldIssues =
+    feedback?.kind === "failed" && feedback.fieldIssues
+      ? feedback.fieldIssues
+      : []
+
+  useEffect(() => {
+    setValues(editor.initialValues)
+    setFeedback(null)
+    setIsSaving(false)
+  }, [editor])
+
+  useEffect(
+    () => () => {
+      activeSubmit.current?.abort()
+    },
+    [],
+  )
+
+  const updateValue = (fieldId: string, value: ResourceFieldValue) => {
+    setFeedback((current) => (current?.kind === "failed" ? null : current))
+    setValues((current) => ({ ...current, [fieldId]: value }))
+  }
+
+  const submit = async () => {
+    if (!policy || isSaving || feedback?.kind === "uncertain") return
+    if (!validation.valid) {
+      setFeedback({ kind: "failed", fieldIssues: validation.issues })
+      return
+    }
+
+    const controller = new AbortController()
+    activeSubmit.current = controller
+    setIsSaving(true)
+    setFeedback(null)
+    try {
+      const result = await editor.submit(values, {
+        signal: controller.signal,
+      })
+      assertManagedSiteMutationResult(result, { idempotent: false })
+      switch (result.outcome) {
+        case MANAGED_SITE_MUTATION_OUTCOMES.Succeeded:
+          onSuccess({
+            success: true,
+            data: result.data,
+            ...(result.message ? { message: result.message } : {}),
+          })
+          return
+        case MANAGED_SITE_MUTATION_OUTCOMES.Rejected:
+          setFeedback({ kind: "failed" })
+          return
+        case MANAGED_SITE_MUTATION_OUTCOMES.Partial:
+        case MANAGED_SITE_MUTATION_OUTCOMES.Uncertain:
+          setFeedback({ kind: "uncertain" })
+          return
+      }
+    } catch (error) {
+      if (controller.signal.aborted) return
+      if (
+        error instanceof ManagedResourceError &&
+        error.failure.code === MANAGED_RESOURCE_FAILURE_CODES.ValidationFailed
+      ) {
+        setFeedback({
+          kind: "failed",
+          fieldIssues: error.failure.fieldIssues,
+        })
+        return
+      }
+      setFeedback({ kind: "failed" })
+    } finally {
+      if (activeSubmit.current === controller) {
+        activeSubmit.current = null
+        setIsSaving(false)
+      }
+    }
+  }
+
+  return (
+    <ChannelEditorShell
+      isOpen={isOpen}
+      title={t("channelDialog:title.add")}
+      description={t("channelDialog:description.add")}
+      onClose={onClose}
+      onSubmit={(event) => {
+        event.preventDefault()
+        void submit()
+      }}
+      submitLabel={t("channelDialog:actions.create")}
+      closeLabel={t("common:actions.cancel")}
+      submitTestId={CHANNEL_DIALOG_TEST_IDS.submitButton}
+      isSubmitting={isSaving}
+      isSubmitDisabled={
+        !policy || validation.valid === false || feedback?.kind === "uncertain"
+      }
+      noValidate
+    >
+      {advisoryWarning ? (
+        <Alert
+          variant="warning"
+          title={advisoryWarning.title}
+          description={advisoryWarning.description}
+          className="mb-4"
+        >
+          {advisoryWarning.assessment ? (
+            <ManagedSiteChannelAssessmentSignalsRow
+              assessment={advisoryWarning.assessment}
+              managedSiteType={siteType}
+              className="mt-3 min-w-0"
+            />
+          ) : null}
+        </Alert>
+      ) : null}
+      {!policy ? (
+        <Alert
+          variant="destructive"
+          title={t("managedSiteChannels:alerts.editorLoadError.title")}
+          description={t(
+            "managedSiteChannels:alerts.editorLoadError.description",
+          )}
+        />
+      ) : null}
+      {feedback?.kind === "failed" && fieldIssues.length === 0 ? (
+        <Alert
+          variant="destructive"
+          title={t("managedSiteChannels:alerts.editorSaveError.title")}
+          description={t(
+            "managedSiteChannels:alerts.editorSaveError.description",
+          )}
+          className="mb-4"
+        />
+      ) : null}
+      {feedback?.kind === "uncertain" ? (
+        <Alert
+          variant="warning"
+          title={t("managedSiteChannels:alerts.partialMutation.title")}
+          description={t(
+            "managedSiteChannels:alerts.partialMutation.description",
+          )}
+          className="mb-4"
+        />
+      ) : null}
+      {policy ? (
+        <ManagedResourceEditorBody
+          t={t}
+          mode="create"
+          descriptors={editor.fields}
+          policy={policy}
+          values={values}
+          fieldIssues={fieldIssues}
+          disabled={isSaving || feedback?.kind === "uncertain"}
+          showModelPrefillWarning={showModelPrefillWarning}
+          onValueChange={updateValue}
+        />
+      ) : null}
+    </ChannelEditorShell>
+  )
+}

--- a/src/features/ManagedSiteChannels/presentation/ManagedResourceEditorBody.tsx
+++ b/src/features/ManagedSiteChannels/presentation/ManagedResourceEditorBody.tsx
@@ -40,6 +40,7 @@ type ManagedResourceEditorBodyProps = {
   values: EditableResourceProjection
   fieldIssues?: readonly ResourceFieldIssue[]
   disabled?: boolean
+  showModelPrefillWarning?: boolean
   onValueChange: (fieldId: string, value: ResourceFieldValue) => void
   onLoadSecret?: (
     fieldId: string,
@@ -140,6 +141,7 @@ export function ManagedResourceEditorBody({
   values,
   fieldIssues = [],
   disabled = false,
+  showModelPrefillWarning = false,
   onValueChange,
   onLoadSecret,
 }: ManagedResourceEditorBodyProps) {
@@ -350,6 +352,7 @@ export function ManagedResourceEditorBody({
               }}
               disabled={disabled}
               required={descriptor.required}
+              showPrefillWarning={showModelPrefillWarning}
               description={presentation.resolveHelp?.(t)}
               errorMessage={errorMessage}
             />

--- a/src/locales/de/keyManagement.json
+++ b/src/locales/de/keyManagement.json
@@ -61,7 +61,7 @@
       "clearSelection": "Auswahl löschen",
       "open": "Batch-Import in {{site}} ({{selectedCount}})",
       "refreshPreview": "Vorschau aktualisieren",
-      "retry": "Fehlgeschlagene oder unklare Schlüssel erneut versuchen",
+      "retry": "Fehlgeschlagene Schlüssel erneut versuchen",
       "running": "Importieren...",
       "selectAll": "{{selected}}/{{total}} ausgewählt",
       "start": "Import starten",

--- a/src/locales/en/keyManagement.json
+++ b/src/locales/en/keyManagement.json
@@ -61,7 +61,7 @@
       "clearSelection": "Clear selection",
       "open": "Batch import to {{site}} ({{selectedCount}})",
       "refreshPreview": "Refresh preview",
-      "retry": "Retry failed or uncertain keys",
+      "retry": "Retry failed keys",
       "running": "Importing...",
       "selectAll": "{{selected}}/{{total}} selected",
       "start": "Start import",

--- a/src/locales/es-419/keyManagement.json
+++ b/src/locales/es-419/keyManagement.json
@@ -64,7 +64,7 @@
       "clearSelection": "Limpiar selección",
       "open": "Importar por lote a {{site}} ({{selectedCount}})",
       "refreshPreview": "Actualizar vista previa",
-      "retry": "Reintentar claves fallidas o que requieren revisión",
+      "retry": "Reintentar claves fallidas",
       "running": "Importando...",
       "selectAll": "{{selected}}/{{total}} seleccionadas",
       "start": "Iniciar importación",

--- a/src/locales/ja/keyManagement.json
+++ b/src/locales/ja/keyManagement.json
@@ -58,7 +58,7 @@
       "clearSelection": "選択をクリア",
       "open": "{{site}} に一括インポート（{{selectedCount}}）",
       "refreshPreview": "プレビューを更新",
-      "retry": "失敗または要確認のキーを再試行",
+      "retry": "失敗したキーを再試行",
       "running": "インポート中...",
       "selectAll": "{{selected}}/{{total}} 選択中",
       "start": "インポート開始",

--- a/src/locales/pt-BR/keyManagement.json
+++ b/src/locales/pt-BR/keyManagement.json
@@ -64,7 +64,7 @@
       "clearSelection": "Limpar seleção",
       "open": "Importar em lote para {{site}} ({{selectedCount}})",
       "refreshPreview": "Atualizar prévia",
-      "retry": "Tentar novamente as chaves com falha ou que precisam de revisão",
+      "retry": "Tentar novamente as chaves com falha",
       "running": "Importando...",
       "selectAll": "Seleção: {{selected}}/{{total}}",
       "start": "Iniciar importação",

--- a/src/locales/vi/keyManagement.json
+++ b/src/locales/vi/keyManagement.json
@@ -58,7 +58,7 @@
       "clearSelection": "Xóa lựa chọn",
       "open": "Nhập hàng loạt vào {{site}} ({{selectedCount}})",
       "refreshPreview": "Làm mới bản xem trước",
-      "retry": "Thử lại các khóa thất bại hoặc cần xem lại",
+      "retry": "Thử lại các khóa thất bại",
       "running": "Đang nhập...",
       "selectAll": "Đã chọn {{selected}}/{{total}}",
       "start": "Bắt đầu nhập",

--- a/src/locales/zh-CN/keyManagement.json
+++ b/src/locales/zh-CN/keyManagement.json
@@ -58,7 +58,7 @@
       "clearSelection": "清空选择",
       "open": "批量导入到 {{site}}（{{selectedCount}}）",
       "refreshPreview": "刷新预览",
-      "retry": "重试失败或需检查的 Key",
+      "retry": "重试失败的 Key",
       "running": "正在导入...",
       "selectAll": "已选 {{selected}}/{{total}}",
       "start": "开始导入",

--- a/src/locales/zh-TW/keyManagement.json
+++ b/src/locales/zh-TW/keyManagement.json
@@ -58,7 +58,7 @@
       "clearSelection": "清除選取",
       "open": "批次匯入到 {{site}}（{{selectedCount}}）",
       "refreshPreview": "重新整理預覽",
-      "retry": "重試失敗或需要檢查的金鑰",
+      "retry": "重試失敗的金鑰",
       "running": "正在匯入...",
       "selectAll": "已選 {{selected}}/{{total}}",
       "start": "開始匯入",

--- a/src/services/apiAdapters/contracts/managedResourceNative.ts
+++ b/src/services/apiAdapters/contracts/managedResourceNative.ts
@@ -87,6 +87,31 @@ export type ResourcePage = {
   nextCursor?: string
 }
 
+export const MANAGED_RESOURCE_CREATE_SEED_KINDS = {
+  ManagedChannelImport: "managed-channel-import",
+} as const
+
+export type ManagedResourceCreateSeedKind =
+  (typeof MANAGED_RESOURCE_CREATE_SEED_KINDS)[keyof typeof MANAGED_RESOURCE_CREATE_SEED_KINDS]
+
+/** Provider-neutral source data for creating a managed channel from an import. */
+export type ManagedChannelImportCreateSeed = {
+  kind: typeof MANAGED_RESOURCE_CREATE_SEED_KINDS.ManagedChannelImport
+  name: string
+  channelType: string
+  credential: string
+  baseUrl: string
+  enabled: boolean
+  models: readonly string[]
+  orderingWeight: number
+}
+
+export type ManagedResourceCreateSeed = ManagedChannelImportCreateSeed
+
+export type ResourceCreateEditorOptions = ResourceOperationOptions & {
+  seed?: ManagedResourceCreateSeed
+}
+
 export class ManagedResourceError extends Error {
   constructor(
     readonly failure: ResourceFailure,
@@ -127,7 +152,9 @@ export interface ManagedResourceWorkspace {
     ref: ManagedResourceRef,
     options?: ResourceOperationOptions,
   ): Promise<ResourceDisplayFacts>
-  openCreateEditor(options?: ResourceOperationOptions): Promise<ResourceEditor>
+  openCreateEditor(
+    options?: ResourceCreateEditorOptions,
+  ): Promise<ResourceEditor>
   openEditEditor(
     ref: ManagedResourceRef,
     options?: ResourceOperationOptions,
@@ -141,5 +168,6 @@ export interface ManagedResourceWorkspace {
 export interface ManagedResourceRegistration {
   readonly siteType: ManagedSiteType
   readonly kind: ManagedResourceKind
+  readonly createSeedKinds?: readonly ManagedResourceCreateSeedKind[]
   open(options?: ResourceOperationOptions): Promise<ManagedResourceWorkspace>
 }

--- a/src/services/apiAdapters/managedResources/axonHub.ts
+++ b/src/services/apiAdapters/managedResources/axonHub.ts
@@ -11,12 +11,14 @@ import { MANAGED_RESOURCE_KINDS } from "~/services/accountSiteDefinitions/contra
 import { getAccountSiteDefinition } from "~/services/accountSiteDefinitions/registry"
 import { hasUsableApiTokenKey } from "~/services/accountTokens/apiTokenKey"
 import {
+  MANAGED_RESOURCE_CREATE_SEED_KINDS,
   MANAGED_RESOURCE_FAILURE_CODES,
   MANAGED_RESOURCE_FIELD_ISSUE_CODES,
   MANAGED_RESOURCE_FIELD_TYPES,
   MANAGED_RESOURCE_SECRET_REPLACEMENT_BLOCK_REASONS,
   ManagedResourceError,
   type EditableResourceProjection,
+  type ManagedChannelImportCreateSeed,
   type ManagedResourceRef,
   type ResourceDisplayFact,
   type ResourceDisplayFacts,
@@ -1341,6 +1343,30 @@ const createInitialValues = (): EditableResourceProjection => ({
   [AXON_HUB_CHANNEL_FIELD_IDS.EXTRA_MODEL_PREFIX]: "",
 })
 
+const createAxonHubChannelImportProjection = (
+  seed: ManagedChannelImportCreateSeed,
+): EditableResourceProjection => {
+  const models = normalizeList(seed.models)
+
+  return {
+    ...createInitialValues(),
+    [AXON_HUB_CHANNEL_FIELD_IDS.NAME]: seed.name,
+    [AXON_HUB_CHANNEL_FIELD_IDS.TYPE]: seed.channelType,
+    [AXON_HUB_CHANNEL_FIELD_IDS.BASE_URL]: seed.baseUrl,
+    [AXON_HUB_CHANNEL_FIELD_IDS.STATUS]: seed.enabled
+      ? AXON_HUB_CHANNEL_STATUS.ENABLED
+      : AXON_HUB_CHANNEL_STATUS.DISABLED,
+    [AXON_HUB_CHANNEL_FIELD_IDS.KEY]: {
+      kind: "replace",
+      value: seed.credential,
+    },
+    [AXON_HUB_CHANNEL_FIELD_IDS.SUPPORTED_MODELS]: models,
+    [AXON_HUB_CHANNEL_FIELD_IDS.MANUAL_MODELS]: models,
+    [AXON_HUB_CHANNEL_FIELD_IDS.DEFAULT_TEST_MODEL]: models[0] ?? "",
+    [AXON_HUB_CHANNEL_FIELD_IDS.ORDERING_WEIGHT]: seed.orderingWeight,
+  }
+}
+
 const editInitialValues = (
   detail: AxonHubChannel,
 ): EditableResourceProjection => ({
@@ -1612,6 +1638,12 @@ const mapFailure = (error: unknown): ResourceFailure => {
 const axonHubNativeDefinition = {
   siteType: SITE_TYPES.AXON_HUB,
   kind: MANAGED_RESOURCE_KINDS.Channel,
+  createSeedBindings: [
+    {
+      kind: MANAGED_RESOURCE_CREATE_SEED_KINDS.ManagedChannelImport,
+      project: createAxonHubChannelImportProjection,
+    },
+  ],
   capabilities: {
     canSearch: true,
     canCreate: true,

--- a/src/services/apiAdapters/managedResources/channelImport.ts
+++ b/src/services/apiAdapters/managedResources/channelImport.ts
@@ -1,0 +1,118 @@
+import type { ManagedSiteType } from "~/constants/siteType"
+import {
+  MANAGED_RESOURCE_KINDS,
+  MANAGED_RESOURCE_MODES,
+  type ManagedResourceKind,
+} from "~/services/accountSiteDefinitions/contracts"
+import { getAccountSiteDefinition } from "~/services/accountSiteDefinitions/registry"
+import type {
+  ManagedChannelImportCreateSeed,
+  ResourceDisplayFacts,
+  ResourceEditor,
+  ResourceOperationOptions,
+} from "~/services/apiAdapters/contracts/managedResourceNative"
+import { MANAGED_RESOURCE_CREATE_SEED_KINDS } from "~/services/apiAdapters/contracts/managedResourceNative"
+import { getManagedResourceRegistration } from "~/services/apiAdapters/managedResources/registry"
+import type { ManagedSiteMutationResult } from "~/services/managedSites/mutations"
+import { CHANNEL_STATUS, type ChannelFormData } from "~/types/managedSite"
+
+interface NativeManagedChannelImportEditor {
+  siteType: ManagedSiteType
+  kind: ManagedResourceKind
+  editor: ResourceEditor
+}
+
+interface NativeManagedChannelImportSession {
+  siteType: ManagedSiteType
+  kind: ManagedResourceKind
+  openEditor(
+    draft: ChannelFormData,
+    options?: ResourceOperationOptions,
+  ): Promise<NativeManagedChannelImportEditor>
+  submit(
+    draft: ChannelFormData,
+    options?: ResourceOperationOptions,
+  ): Promise<ManagedSiteMutationResult<ResourceDisplayFacts>>
+}
+
+const createManagedChannelImportSeed = (
+  draft: ChannelFormData,
+): ManagedChannelImportCreateSeed => ({
+  kind: MANAGED_RESOURCE_CREATE_SEED_KINDS.ManagedChannelImport,
+  name: draft.name,
+  channelType: String(draft.type),
+  credential: draft.key,
+  baseUrl: draft.base_url,
+  enabled: draft.status === CHANNEL_STATUS.Enable,
+  models: [...draft.models],
+  orderingWeight: draft.weight,
+})
+
+/** Opens a provider-native create editor when that provider owns import binding. */
+export async function openNativeManagedChannelImportEditor(
+  siteType: ManagedSiteType,
+  draft: ChannelFormData,
+  options?: ResourceOperationOptions,
+): Promise<NativeManagedChannelImportEditor | null> {
+  const session = await openNativeManagedChannelImportSession(siteType, options)
+  return session ? await session.openEditor(draft, options) : null
+}
+
+/** Opens one reusable native import session for interactive or batch creates. */
+export async function openNativeManagedChannelImportSession(
+  siteType: ManagedSiteType,
+  options?: ResourceOperationOptions,
+): Promise<NativeManagedChannelImportSession | null> {
+  const kind = MANAGED_RESOURCE_KINDS.Channel
+  const registration = getManagedResourceRegistration(siteType, kind)
+  const rejectMissingNativeCapability = () => {
+    const policy = getAccountSiteDefinition(siteType)?.managedResource
+    if (
+      policy?.mode === MANAGED_RESOURCE_MODES.NativeResource &&
+      policy.primaryKind === kind
+    ) {
+      throw new Error("native managed channel import capability missing")
+    }
+  }
+  if (!registration) {
+    rejectMissingNativeCapability()
+    return null
+  }
+  if (
+    !registration.createSeedKinds?.includes(
+      MANAGED_RESOURCE_CREATE_SEED_KINDS.ManagedChannelImport,
+    )
+  ) {
+    rejectMissingNativeCapability()
+    return null
+  }
+
+  const workspace = await registration.open(options)
+  const openEditor = async (
+    draft: ChannelFormData,
+    editorOptions?: ResourceOperationOptions,
+  ) => {
+    const editor = await workspace.openCreateEditor({
+      ...editorOptions,
+      seed: createManagedChannelImportSeed(draft),
+    })
+    return {
+      siteType,
+      kind,
+      editor,
+    }
+  }
+
+  return {
+    siteType,
+    kind,
+    openEditor,
+    submit: async (draft, submitOptions) => {
+      const prepared = await openEditor(draft, submitOptions)
+      return await prepared.editor.submit(
+        prepared.editor.initialValues,
+        submitOptions,
+      )
+    },
+  }
+}

--- a/src/services/apiAdapters/managedResources/factory.ts
+++ b/src/services/apiAdapters/managedResources/factory.ts
@@ -5,6 +5,8 @@ import {
   MANAGED_RESOURCE_FAILURE_CODES,
   ManagedResourceError,
   type EditableResourceProjection,
+  type ManagedResourceCreateSeed,
+  type ManagedResourceCreateSeedKind,
   type ManagedResourceRef,
   type ManagedResourceRegistration,
   type ManagedResourceWorkspace,
@@ -45,6 +47,15 @@ export type NativeResourceEditorDefinition<TCommand> = {
   ) => Promise<string>
 }
 
+export type NativeResourceCreateSeedBinding = {
+  [TKind in ManagedResourceCreateSeedKind]: {
+    kind: TKind
+    project(
+      seed: Extract<ManagedResourceCreateSeed, { kind: TKind }>,
+    ): EditableResourceProjection
+  }
+}[ManagedResourceCreateSeedKind]
+
 export type NativeResourceKindDefinition<
   TConfig,
   TLocator,
@@ -56,6 +67,7 @@ export type NativeResourceKindDefinition<
   siteType: ManagedSiteType
   kind: ManagedResourceKind
   capabilities?: Partial<ManagedResourceWorkspace["capabilities"]>
+  createSeedBindings?: readonly NativeResourceCreateSeedBinding[]
   openConfig(options?: ResourceOperationOptions): Promise<TConfig>
   scopeKey(config: TConfig): string
   encodeLocator(locator: TLocator): string
@@ -185,10 +197,13 @@ export function defineNativeResourceKind<
   >,
 ): ManagedResourceRegistration {
   const mapFailure = (error: unknown) => definition.mapFailure(error)
+  const createSeedKinds =
+    definition.createSeedBindings?.map((binding) => binding.kind) ?? []
 
   return {
     siteType: definition.siteType,
     kind: definition.kind,
+    createSeedKinds,
     open: (options) =>
       mapOperationFailure(async () => {
         const config = await definition.openConfig(options)
@@ -522,12 +537,35 @@ export function defineNativeResourceKind<
             !capabilities.canCreate
               ? rejectUnsupported()
               : mapOperationFailure(async () => {
+                  const createSeed = editorOptions?.seed
+                  const createSeedBinding = createSeed
+                    ? definition.createSeedBindings?.find(
+                        (binding) => binding.kind === createSeed.kind,
+                      )
+                    : undefined
+                  if (createSeed && !createSeedBinding) {
+                    throw invalidPublicInput()
+                  }
+                  const seedProjection =
+                    createSeed && createSeedBinding
+                      ? createSeedBinding.project(createSeed)
+                      : undefined
                   const editorDefinition = await definition.createEditor(
                     config,
-                    editorOptions,
+                    editorOptions?.signal
+                      ? { signal: editorOptions.signal }
+                      : undefined,
                   )
                   return createEditor(
-                    editorDefinition,
+                    seedProjection
+                      ? {
+                          ...editorDefinition,
+                          initialValues: {
+                            ...editorDefinition.initialValues,
+                            ...seedProjection,
+                          },
+                        }
+                      : editorDefinition,
                     async (command, submitOptions) => {
                       return definition.create(config, command, submitOptions)
                     },

--- a/src/services/managedSites/tokenBatchExport.ts
+++ b/src/services/managedSites/tokenBatchExport.ts
@@ -6,6 +6,8 @@ import {
   type AccountRuntimeKey,
 } from "~/services/accounts/accountRuntimeKeys"
 import { resolveDisplayAccountRuntimeKeySecret } from "~/services/accounts/utils/apiServiceRequest"
+import { ManagedResourceError } from "~/services/apiAdapters/contracts/managedResourceNative"
+import { openNativeManagedChannelImportSession } from "~/services/apiAdapters/managedResources/channelImport"
 import {
   getManagedSiteChannelExactMatch,
   getRecoverableManagedSiteChannelCandidate,
@@ -27,6 +29,7 @@ import {
   MANAGED_SITE_MUTATION_OUTCOMES,
   toPrivateManagedSiteMutationOutput,
   toPrivateManagedSiteThrownErrorMessage,
+  type ManagedSiteMutationResult,
 } from "~/services/managedSites/mutations"
 import {
   createManagedSiteOperationContext,
@@ -681,6 +684,12 @@ export async function executeManagedSiteTokenBatchExport(params: {
   const executableItems = params.preview.items.filter(
     isSelectedExecutablePreviewItem,
   )
+  const nativeImportSessionResult = executableItems.length
+    ? await openNativeManagedChannelImportSession(target.service.siteType).then(
+        (session) => ({ session, error: null }),
+        (error: unknown) => ({ session: null, error }),
+      )
+    : { session: null, error: null }
   let executedItems: ManagedSiteTokenBatchExportExecutionItem[]
   try {
     executedItems = await mapWithConcurrency(
@@ -691,14 +700,12 @@ export async function executeManagedSiteTokenBatchExport(params: {
           target.config,
           item.draft,
         )
-        let payload: ReturnType<typeof target.service.buildChannelPayload>
-        try {
-          payload = target.service.buildChannelPayload(item.draft)
-        } catch (error) {
+        if (nativeImportSessionResult.error) {
           const message = preDispatchSecretCollection.complete
-            ? toPrivateManagedSiteThrownErrorMessage(error, {
-                knownSecrets: preDispatchSecretCollection.knownSecrets,
-              })
+            ? toPrivateManagedSiteThrownErrorMessage(
+                nativeImportSessionResult.error,
+                { knownSecrets: preDispatchSecretCollection.knownSecrets },
+              )
             : undefined
           return {
             id: item.id,
@@ -712,29 +719,83 @@ export async function executeManagedSiteTokenBatchExport(params: {
               : FALLBACK_EXECUTION_ERROR,
           }
         }
-        const secretCollection = mergeManagedResourceSecretCollections(
-          preDispatchSecretCollection,
-          collectManagedResourceSecrets(payload),
-        )
-        let mutation: Awaited<ReturnType<typeof target.service.createChannel>>
-        try {
-          mutation = await target.service.createChannel(target.config, payload)
-        } catch (error) {
-          const message = secretCollection.complete
-            ? toPrivateManagedSiteThrownErrorMessage(error, {
-                knownSecrets: secretCollection.knownSecrets,
-              })
-            : undefined
-          return {
-            id: item.id,
-            accountName: item.accountName,
-            runtimeKeyName: item.runtimeKeyName,
-            result: MANAGED_SITE_TOKEN_BATCH_EXPORT_EXECUTION_RESULTS.UNCERTAIN,
-            success: false,
-            skipped: false,
-            error: message
-              ? `${FALLBACK_EXECUTION_ERROR}: ${message}`
-              : FALLBACK_EXECUTION_ERROR,
+        let secretCollection = preDispatchSecretCollection
+        let mutation: ManagedSiteMutationResult<unknown>
+        if (nativeImportSessionResult.session) {
+          try {
+            mutation = await nativeImportSessionResult.session.submit(
+              item.draft,
+            )
+          } catch (error) {
+            const message = secretCollection.complete
+              ? toPrivateManagedSiteThrownErrorMessage(error, {
+                  knownSecrets: secretCollection.knownSecrets,
+                })
+              : undefined
+            return {
+              id: item.id,
+              accountName: item.accountName,
+              runtimeKeyName: item.runtimeKeyName,
+              result:
+                error instanceof ManagedResourceError
+                  ? MANAGED_SITE_TOKEN_BATCH_EXPORT_EXECUTION_RESULTS.FAILED
+                  : MANAGED_SITE_TOKEN_BATCH_EXPORT_EXECUTION_RESULTS.UNCERTAIN,
+              success: false,
+              skipped: false,
+              error: message
+                ? `${FALLBACK_EXECUTION_ERROR}: ${message}`
+                : FALLBACK_EXECUTION_ERROR,
+            }
+          }
+        } else {
+          let payload: ReturnType<typeof target.service.buildChannelPayload>
+          try {
+            payload = target.service.buildChannelPayload(item.draft)
+          } catch (error) {
+            const message = preDispatchSecretCollection.complete
+              ? toPrivateManagedSiteThrownErrorMessage(error, {
+                  knownSecrets: preDispatchSecretCollection.knownSecrets,
+                })
+              : undefined
+            return {
+              id: item.id,
+              accountName: item.accountName,
+              runtimeKeyName: item.runtimeKeyName,
+              result: MANAGED_SITE_TOKEN_BATCH_EXPORT_EXECUTION_RESULTS.FAILED,
+              success: false,
+              skipped: false,
+              error: message
+                ? `${FALLBACK_EXECUTION_ERROR}: ${message}`
+                : FALLBACK_EXECUTION_ERROR,
+            }
+          }
+          secretCollection = mergeManagedResourceSecretCollections(
+            preDispatchSecretCollection,
+            collectManagedResourceSecrets(payload),
+          )
+          try {
+            mutation = await target.service.createChannel(
+              target.config,
+              payload,
+            )
+          } catch (error) {
+            const message = secretCollection.complete
+              ? toPrivateManagedSiteThrownErrorMessage(error, {
+                  knownSecrets: secretCollection.knownSecrets,
+                })
+              : undefined
+            return {
+              id: item.id,
+              accountName: item.accountName,
+              runtimeKeyName: item.runtimeKeyName,
+              result:
+                MANAGED_SITE_TOKEN_BATCH_EXPORT_EXECUTION_RESULTS.UNCERTAIN,
+              success: false,
+              skipped: false,
+              error: message
+                ? `${FALLBACK_EXECUTION_ERROR}: ${message}`
+                : FALLBACK_EXECUTION_ERROR,
+            }
           }
         }
         assertManagedSiteMutationResult(mutation, { idempotent: false })

--- a/src/services/managedSites/tokenBatchExport.ts
+++ b/src/services/managedSites/tokenBatchExport.ts
@@ -6,7 +6,11 @@ import {
   type AccountRuntimeKey,
 } from "~/services/accounts/accountRuntimeKeys"
 import { resolveDisplayAccountRuntimeKeySecret } from "~/services/accounts/utils/apiServiceRequest"
-import { ManagedResourceError } from "~/services/apiAdapters/contracts/managedResourceNative"
+import {
+  MANAGED_RESOURCE_FAILURE_CODES,
+  ManagedResourceError,
+  type ResourceFailure,
+} from "~/services/apiAdapters/contracts/managedResourceNative"
 import { openNativeManagedChannelImportSession } from "~/services/apiAdapters/managedResources/channelImport"
 import {
   getManagedSiteChannelExactMatch,
@@ -85,6 +89,21 @@ const logger = createLogger("ManagedSiteTokenBatchExport")
 const TOKEN_BATCH_EXPORT_CONCURRENCY = 4
 const FALLBACK_BLOCKING_MESSAGE = "Failed to prepare this key for batch import"
 const FALLBACK_EXECUTION_ERROR = "Failed to create channel"
+const DEFINITE_NATIVE_IMPORT_FAILURE_CODES: ReadonlySet<
+  ResourceFailure["code"]
+> = new Set([
+  MANAGED_RESOURCE_FAILURE_CODES.ConfigurationRequired,
+  MANAGED_RESOURCE_FAILURE_CODES.InvalidConfiguration,
+  MANAGED_RESOURCE_FAILURE_CODES.AuthenticationFailed,
+  MANAGED_RESOURCE_FAILURE_CODES.PermissionDenied,
+  MANAGED_RESOURCE_FAILURE_CODES.ValidationFailed,
+  MANAGED_RESOURCE_FAILURE_CODES.NotFound,
+  MANAGED_RESOURCE_FAILURE_CODES.UpstreamRejected,
+])
+
+const isDefiniteNativeImportFailure = (error: unknown) =>
+  error instanceof ManagedResourceError &&
+  DEFINITE_NATIVE_IMPORT_FAILURE_CODES.has(error.failure.code)
 export const MANAGED_SITE_TOKEN_BATCH_IMPORT_TARGET_CHANGED_ERROR_CODE =
   "managed-site-token-import-target-changed" as const
 
@@ -736,10 +755,9 @@ export async function executeManagedSiteTokenBatchExport(params: {
               id: item.id,
               accountName: item.accountName,
               runtimeKeyName: item.runtimeKeyName,
-              result:
-                error instanceof ManagedResourceError
-                  ? MANAGED_SITE_TOKEN_BATCH_EXPORT_EXECUTION_RESULTS.FAILED
-                  : MANAGED_SITE_TOKEN_BATCH_EXPORT_EXECUTION_RESULTS.UNCERTAIN,
+              result: isDefiniteNativeImportFailure(error)
+                ? MANAGED_SITE_TOKEN_BATCH_EXPORT_EXECUTION_RESULTS.FAILED
+                : MANAGED_SITE_TOKEN_BATCH_EXPORT_EXECUTION_RESULTS.UNCERTAIN,
               success: false,
               skipped: false,
               error: message

--- a/tests/components/UseChannelDialog.duplicateChannelWarning.test.tsx
+++ b/tests/components/UseChannelDialog.duplicateChannelWarning.test.tsx
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import {
   useChannelDialog,
@@ -39,6 +39,7 @@ import {
 } from "~/types/accountTodayStats"
 import type { ChannelFormData, ManagedSiteChannel } from "~/types/managedSite"
 import { buildCompleteTodayStatsAvailability } from "~~/tests/test-utils/accountTodayStats"
+import { createDeferred } from "~~/tests/test-utils/deferred"
 import { act, renderHook, waitFor } from "~~/tests/test-utils/render"
 
 const { mockToastLoading, mockToastDismiss, mockToastError } = vi.hoisted(
@@ -271,6 +272,8 @@ vi.mock("~/services/apiAdapters/registry", () => ({
 }))
 
 describe("useChannelDialog", () => {
+  let registrationSpy: { mockRestore: () => void } | undefined
+
   beforeEach(() => {
     vi.clearAllMocks()
 
@@ -286,6 +289,11 @@ describe("useChannelDialog", () => {
     mockResolveApiTokenKey.mockImplementation(
       async (_request: unknown, token: { key: string }) => token.key,
     )
+  })
+
+  afterEach(() => {
+    registrationSpy?.mockRestore()
+    registrationSpy = undefined
   })
 
   it("shows warning and cancels when user does not continue", async () => {
@@ -385,7 +393,7 @@ describe("useChannelDialog", () => {
       openEditEditor: vi.fn(),
       delete: vi.fn(),
     }))
-    const registrationSpy = vi
+    registrationSpy = vi
       .spyOn(nativeResourceRegistry, "getManagedResourceRegistration")
       .mockReturnValue({
         siteType: SITE_TYPES.AXON_HUB,
@@ -435,17 +443,76 @@ describe("useChannelDialog", () => {
         orderingWeight: 7,
       },
     })
-    expect((result.current.context.state as any).nativeCreate).toMatchObject({
+    expect(result.current.context.state.nativeCreate).toMatchObject({
       siteType: SITE_TYPES.AXON_HUB,
       kind: MANAGED_RESOURCE_KINDS.Channel,
       editor,
     })
+  })
 
-    registrationSpy.mockRestore()
+  it("does not open a native editor after its caller cancels while the editor loads", async () => {
+    const editor = {
+      fields: [],
+      initialValues: { name: "Imported channel" },
+      validate: vi.fn(() => ({ valid: true as const })),
+      submit: vi.fn(),
+    }
+    const pendingEditor = createDeferred<typeof editor>()
+    const openCreateEditor = vi.fn(() => pendingEditor.promise)
+    registrationSpy = vi
+      .spyOn(nativeResourceRegistry, "getManagedResourceRegistration")
+      .mockReturnValue({
+        siteType: SITE_TYPES.AXON_HUB,
+        kind: MANAGED_RESOURCE_KINDS.Channel,
+        createSeedKinds: [
+          MANAGED_RESOURCE_CREATE_SEED_KINDS.ManagedChannelImport,
+        ],
+        open: vi.fn(async () => ({
+          capabilities: {
+            canSearch: true,
+            canCreate: true,
+            canUpdate: true,
+            canDelete: true,
+          },
+          list: vi.fn(),
+          get: vi.fn(),
+          openCreateEditor,
+          openEditEditor: vi.fn(),
+          delete: vi.fn(),
+        })),
+      })
+    getManagedSiteServiceSpy.mockResolvedValue(
+      buildManagedSiteServiceMock({
+        siteType: SITE_TYPES.AXON_HUB,
+        messagesKey: "axonhub",
+      }) as ManagedSiteService,
+    )
+    let shouldContinue = true
+    const { result } = await renderChannelDialogHook()
+
+    const openPromise = result.current.dialog.openWithAccount(
+      buildDisplaySiteData(),
+      buildApiToken(),
+      undefined,
+      { shouldContinue: () => shouldContinue },
+    )
+    await waitFor(() => expect(openCreateEditor).toHaveBeenCalledOnce())
+
+    shouldContinue = false
+    let openResult: Awaited<typeof openPromise> | undefined
+    await act(async () => {
+      pendingEditor.resolve(editor)
+      openResult = await openPromise
+    })
+
+    expect(openResult).toEqual({ opened: false })
+    expect(result.current.context.state.isOpen).toBe(false)
+    expect(result.current.context.state.nativeCreate).toBeUndefined()
+    expect(mockToastError).not.toHaveBeenCalled()
   })
 
   it("does not downgrade a native provider when its import registration is missing", async () => {
-    const registrationSpy = vi
+    registrationSpy = vi
       .spyOn(nativeResourceRegistry, "getManagedResourceRegistration")
       .mockReturnValue(null)
     getManagedSiteServiceSpy.mockResolvedValue(
@@ -470,8 +537,6 @@ describe("useChannelDialog", () => {
     expect(result.current.context.state.isOpen).toBe(false)
     expect(result.current.context.state.nativeCreate).toBeUndefined()
     expect(mockToastError).toHaveBeenCalled()
-
-    registrationSpy.mockRestore()
   })
 
   it("shows duplicate channel warning from migrated resource candidates", async () => {

--- a/tests/components/UseChannelDialog.duplicateChannelWarning.test.tsx
+++ b/tests/components/UseChannelDialog.duplicateChannelWarning.test.tsx
@@ -10,7 +10,10 @@ import { SITE_TYPES } from "~/constants/siteType"
 import * as accountOperations from "~/services/accounts/accountOperations"
 import { accountStorage } from "~/services/accounts/accountStorage"
 import { TOKEN_QUICK_CREATE_RESOLUTION_KINDS } from "~/services/accounts/tokenQuickCreateResolution"
+import { MANAGED_RESOURCE_KINDS } from "~/services/accountSiteDefinitions/contracts"
+import { MANAGED_RESOURCE_CREATE_SEED_KINDS } from "~/services/apiAdapters/contracts/managedResourceNative"
 import { TOKEN_PROVISIONING_BLOCK_REASONS } from "~/services/apiAdapters/contracts/tokenProvisioning"
+import * as nativeResourceRegistry from "~/services/apiAdapters/managedResources/registry"
 import {
   MANAGED_SITE_CHANNEL_MATCH_UNRESOLVED_REASONS,
   MatchResolutionUnresolvedError,
@@ -349,6 +352,126 @@ describe("useChannelDialog", () => {
     expect(result.current.context.state.isOpen).toBe(false)
     expect(mockToastError).not.toHaveBeenCalled()
     expect(mockToastDismiss).toHaveBeenCalledWith("toast-id")
+  })
+
+  it("opens AxonHub account imports with the native create editor projection", async () => {
+    const editor = {
+      fields: [],
+      initialValues: {
+        name: "Auto channel",
+        type: "openai",
+        baseURL: "https://upstream.example.com",
+        status: "enabled",
+        key: { kind: "replace" as const, value: "sk-test" },
+        supportedModels: ["gpt-4"],
+        manualModels: ["gpt-4"],
+        defaultTestModel: "gpt-4",
+        orderingWeight: 7,
+      },
+      validate: vi.fn(() => ({ valid: true as const })),
+      submit: vi.fn(),
+    }
+    const openCreateEditor = vi.fn(async () => editor)
+    const openRegistration = vi.fn(async () => ({
+      capabilities: {
+        canSearch: true,
+        canCreate: true,
+        canUpdate: true,
+        canDelete: true,
+      },
+      list: vi.fn(),
+      get: vi.fn(),
+      openCreateEditor,
+      openEditEditor: vi.fn(),
+      delete: vi.fn(),
+    }))
+    const registrationSpy = vi
+      .spyOn(nativeResourceRegistry, "getManagedResourceRegistration")
+      .mockReturnValue({
+        siteType: SITE_TYPES.AXON_HUB,
+        kind: MANAGED_RESOURCE_KINDS.Channel,
+        createSeedKinds: [
+          MANAGED_RESOURCE_CREATE_SEED_KINDS.ManagedChannelImport,
+        ],
+        open: openRegistration,
+      })
+    getManagedSiteServiceSpy.mockResolvedValue(
+      buildManagedSiteServiceMock({
+        siteType: SITE_TYPES.AXON_HUB,
+        messagesKey: "axonhub",
+        prepareChannelFormData: vi.fn(async () =>
+          buildPreparedFormData({
+            type: "openai",
+            weight: 7,
+            status: 1,
+          }),
+        ),
+      }) as ManagedSiteService,
+    )
+
+    const { result } = await renderChannelDialogHook()
+
+    await act(async () => {
+      await result.current.dialog.openWithAccount(
+        buildDisplaySiteData(),
+        buildApiToken(),
+      )
+    })
+
+    expect(registrationSpy).toHaveBeenCalledWith(
+      SITE_TYPES.AXON_HUB,
+      MANAGED_RESOURCE_KINDS.Channel,
+    )
+    expect(openRegistration).toHaveBeenCalledOnce()
+    expect(openCreateEditor).toHaveBeenCalledWith({
+      seed: {
+        kind: MANAGED_RESOURCE_CREATE_SEED_KINDS.ManagedChannelImport,
+        name: "Auto channel",
+        channelType: "openai",
+        credential: "sk-test",
+        baseUrl: "https://upstream.example.com",
+        enabled: true,
+        models: ["gpt-4"],
+        orderingWeight: 7,
+      },
+    })
+    expect((result.current.context.state as any).nativeCreate).toMatchObject({
+      siteType: SITE_TYPES.AXON_HUB,
+      kind: MANAGED_RESOURCE_KINDS.Channel,
+      editor,
+    })
+
+    registrationSpy.mockRestore()
+  })
+
+  it("does not downgrade a native provider when its import registration is missing", async () => {
+    const registrationSpy = vi
+      .spyOn(nativeResourceRegistry, "getManagedResourceRegistration")
+      .mockReturnValue(null)
+    getManagedSiteServiceSpy.mockResolvedValue(
+      buildManagedSiteServiceMock({
+        siteType: SITE_TYPES.AXON_HUB,
+        messagesKey: "axonhub",
+      }) as ManagedSiteService,
+    )
+    const { result } = await renderChannelDialogHook()
+
+    let openResult: Awaited<
+      ReturnType<typeof result.current.dialog.openWithAccount>
+    >
+    await act(async () => {
+      openResult = await result.current.dialog.openWithAccount(
+        buildDisplaySiteData(),
+        buildApiToken(),
+      )
+    })
+
+    expect(openResult!).toEqual({ opened: false })
+    expect(result.current.context.state.isOpen).toBe(false)
+    expect(result.current.context.state.nativeCreate).toBeUndefined()
+    expect(mockToastError).toHaveBeenCalled()
+
+    registrationSpy.mockRestore()
   })
 
   it("shows duplicate channel warning from migrated resource candidates", async () => {

--- a/tests/components/dialogs/ChannelDialog/ChannelDialogContainer.test.tsx
+++ b/tests/components/dialogs/ChannelDialog/ChannelDialogContainer.test.tsx
@@ -1,3 +1,4 @@
+import userEvent from "@testing-library/user-event"
 import { useEffect } from "react"
 import { describe, expect, it, vi } from "vitest"
 
@@ -10,7 +11,7 @@ import { SITE_TYPES } from "~/constants/siteType"
 import { MANAGED_RESOURCE_KINDS } from "~/services/accountSiteDefinitions/contracts"
 import { AuthTypeEnum, SiteHealthStatus, type DisplaySiteData } from "~/types"
 import { buildCompleteTodayStatsAvailability } from "~~/tests/test-utils/accountTodayStats"
-import { render, screen, waitFor } from "~~/tests/test-utils/render"
+import { act, render, screen, waitFor } from "~~/tests/test-utils/render"
 
 const {
   addTokenDialogPropsMock,
@@ -32,7 +33,10 @@ vi.mock("~/components/dialogs/ChannelDialog/components/ChannelDialog", () => ({
 vi.mock(
   "~/features/ManagedSiteChannels/components/ManagedResourceCreateDialog",
   () => ({
-    ManagedResourceCreateDialog: (props: { isOpen: boolean }) => {
+    ManagedResourceCreateDialog: (props: {
+      isOpen: boolean
+      onCloseComplete: () => void
+    }) => {
       nativeDialogPropsMock(props)
       return props.isOpen ? <div data-testid="mock-native-dialog" /> : null
     },
@@ -116,6 +120,45 @@ function OpenNativeCreateDialog() {
   return null
 }
 
+function NativeDialogLifecycleProbe() {
+  const { state, closeDialog, openNativeCreateDialog } =
+    useChannelDialogContext()
+
+  const openReplacementNativeDialog = () => {
+    openNativeCreateDialog({
+      nativeCreate: {
+        siteType: SITE_TYPES.AXON_HUB,
+        kind: MANAGED_RESOURCE_KINDS.Channel,
+        editor: {
+          fields: [],
+          initialValues: { name: "Replacement channel" },
+          validate: () => ({ valid: true }),
+          submit: vi.fn(),
+        },
+        showModelPrefillWarning: false,
+        advisoryWarning: null,
+      },
+    })
+  }
+
+  return (
+    <>
+      <button type="button" onClick={closeDialog}>
+        Close native dialog
+      </button>
+      <button type="button" onClick={openReplacementNativeDialog}>
+        Open replacement native dialog
+      </button>
+      <span data-testid="native-dialog-state">
+        {state.nativeCreate ? "retained" : "cleared"}
+      </span>
+      <span data-testid="native-dialog-name">
+        {String(state.nativeCreate?.editor.initialValues.name ?? "")}
+      </span>
+    </>
+  )
+}
+
 describe("ChannelDialogContainer", () => {
   it("renders AddTokenDialog with default-token prefill for non-empty allowed groups", async () => {
     addTokenDialogPropsMock.mockReset()
@@ -190,6 +233,112 @@ describe("ChannelDialogContainer", () => {
           }),
           showModelPrefillWarning: true,
         }),
+      )
+    })
+  })
+
+  it("clears native editor state only after its close lifecycle completes", async () => {
+    const user = userEvent.setup()
+    nativeDialogPropsMock.mockReset()
+
+    render(
+      <ChannelDialogProvider>
+        <OpenNativeCreateDialog />
+        <NativeDialogLifecycleProbe />
+        <ChannelDialogContainer />
+      </ChannelDialogProvider>,
+    )
+
+    expect(await screen.findByTestId("mock-native-dialog")).toBeVisible()
+    expect(screen.getByTestId("native-dialog-state")).toHaveTextContent(
+      "retained",
+    )
+
+    await user.click(
+      screen.getByRole("button", { name: "Close native dialog" }),
+    )
+    await waitFor(() => {
+      expect(nativeDialogPropsMock).toHaveBeenLastCalledWith(
+        expect.objectContaining({ isOpen: false }),
+      )
+    })
+    expect(screen.queryByTestId("mock-native-dialog")).toBeNull()
+    expect(screen.getByTestId("native-dialog-state")).toHaveTextContent(
+      "retained",
+    )
+
+    const closedDialogProps = nativeDialogPropsMock.mock.lastCall?.[0] as {
+      onCloseComplete: () => void
+    }
+    act(() => closedDialogProps.onCloseComplete())
+
+    await waitFor(() => {
+      expect(screen.getByTestId("native-dialog-state")).toHaveTextContent(
+        "cleared",
+      )
+    })
+  })
+
+  it("does not let an older close completion clear a newer native editor", async () => {
+    const user = userEvent.setup()
+    nativeDialogPropsMock.mockReset()
+
+    render(
+      <ChannelDialogProvider>
+        <OpenNativeCreateDialog />
+        <NativeDialogLifecycleProbe />
+        <ChannelDialogContainer />
+      </ChannelDialogProvider>,
+    )
+
+    expect(await screen.findByTestId("mock-native-dialog")).toBeVisible()
+    await user.click(
+      screen.getByRole("button", { name: "Close native dialog" }),
+    )
+    await waitFor(() => {
+      expect(nativeDialogPropsMock).toHaveBeenLastCalledWith(
+        expect.objectContaining({ isOpen: false }),
+      )
+    })
+    const firstClosedDialogProps = nativeDialogPropsMock.mock.lastCall?.[0] as {
+      onCloseComplete: () => void
+    }
+
+    await user.click(
+      screen.getByRole("button", { name: "Open replacement native dialog" }),
+    )
+    expect(await screen.findByTestId("mock-native-dialog")).toBeVisible()
+    expect(screen.getByTestId("native-dialog-name")).toHaveTextContent(
+      "Replacement channel",
+    )
+    await user.click(
+      screen.getByRole("button", { name: "Close native dialog" }),
+    )
+    await waitFor(() => {
+      expect(nativeDialogPropsMock).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          isOpen: false,
+          editor: expect.objectContaining({
+            initialValues: { name: "Replacement channel" },
+          }),
+        }),
+      )
+    })
+    const replacementClosedDialogProps = nativeDialogPropsMock.mock
+      .lastCall?.[0] as { onCloseComplete: () => void }
+
+    act(() => firstClosedDialogProps.onCloseComplete())
+    expect(screen.getByTestId("native-dialog-state")).toHaveTextContent(
+      "retained",
+    )
+    expect(screen.getByTestId("native-dialog-name")).toHaveTextContent(
+      "Replacement channel",
+    )
+
+    act(() => replacementClosedDialogProps.onCloseComplete())
+    await waitFor(() => {
+      expect(screen.getByTestId("native-dialog-state")).toHaveTextContent(
+        "cleared",
       )
     })
   })

--- a/tests/components/dialogs/ChannelDialog/ChannelDialogContainer.test.tsx
+++ b/tests/components/dialogs/ChannelDialog/ChannelDialogContainer.test.tsx
@@ -6,15 +6,38 @@ import {
   ChannelDialogProvider,
   useChannelDialogContext,
 } from "~/components/dialogs/ChannelDialog"
+import { SITE_TYPES } from "~/constants/siteType"
+import { MANAGED_RESOURCE_KINDS } from "~/services/accountSiteDefinitions/contracts"
 import { AuthTypeEnum, SiteHealthStatus, type DisplaySiteData } from "~/types"
 import { buildCompleteTodayStatsAvailability } from "~~/tests/test-utils/accountTodayStats"
 import { render, screen, waitFor } from "~~/tests/test-utils/render"
 
-const addTokenDialogPropsMock = vi.hoisted(() => vi.fn())
+const {
+  addTokenDialogPropsMock,
+  channelDialogPropsMock,
+  nativeDialogPropsMock,
+} = vi.hoisted(() => ({
+  addTokenDialogPropsMock: vi.fn(),
+  channelDialogPropsMock: vi.fn(),
+  nativeDialogPropsMock: vi.fn(),
+}))
 
 vi.mock("~/components/dialogs/ChannelDialog/components/ChannelDialog", () => ({
-  ChannelDialog: () => <div data-testid="mock-channel-dialog" />,
+  ChannelDialog: (props: { isOpen: boolean }) => {
+    channelDialogPropsMock(props)
+    return <div data-testid="mock-channel-dialog" />
+  },
 }))
+
+vi.mock(
+  "~/features/ManagedSiteChannels/components/ManagedResourceCreateDialog",
+  () => ({
+    ManagedResourceCreateDialog: (props: { isOpen: boolean }) => {
+      nativeDialogPropsMock(props)
+      return props.isOpen ? <div data-testid="mock-native-dialog" /> : null
+    },
+  }),
+)
 
 vi.mock("~/features/TokenProvisioning/components/AddTokenDialog", () => ({
   default: (props: {
@@ -70,6 +93,29 @@ function OpenDefaultTokenQuickCreateDialog({
   return null
 }
 
+function OpenNativeCreateDialog() {
+  const { openNativeCreateDialog } = useChannelDialogContext()
+
+  useEffect(() => {
+    openNativeCreateDialog({
+      nativeCreate: {
+        siteType: SITE_TYPES.AXON_HUB,
+        kind: MANAGED_RESOURCE_KINDS.Channel,
+        editor: {
+          fields: [],
+          initialValues: { name: "Imported channel" },
+          validate: () => ({ valid: true }),
+          submit: vi.fn(),
+        },
+        showModelPrefillWarning: true,
+        advisoryWarning: null,
+      },
+    })
+  }, [openNativeCreateDialog])
+
+  return null
+}
+
 describe("ChannelDialogContainer", () => {
   it("renders AddTokenDialog with default-token prefill for non-empty allowed groups", async () => {
     addTokenDialogPropsMock.mockReset()
@@ -116,5 +162,35 @@ describe("ChannelDialogContainer", () => {
     expect(
       screen.queryByTestId("mock-add-token-dialog"),
     ).not.toBeInTheDocument()
+  })
+
+  it("renders a native create dialog instead of opening the legacy channel dialog", async () => {
+    channelDialogPropsMock.mockReset()
+    nativeDialogPropsMock.mockReset()
+
+    render(
+      <ChannelDialogProvider>
+        <OpenNativeCreateDialog />
+        <ChannelDialogContainer />
+      </ChannelDialogProvider>,
+    )
+
+    expect(await screen.findByTestId("mock-native-dialog")).toBeVisible()
+    await waitFor(() => {
+      expect(channelDialogPropsMock).toHaveBeenLastCalledWith(
+        expect.objectContaining({ isOpen: false }),
+      )
+      expect(nativeDialogPropsMock).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          isOpen: true,
+          siteType: SITE_TYPES.AXON_HUB,
+          kind: MANAGED_RESOURCE_KINDS.Channel,
+          editor: expect.objectContaining({
+            initialValues: { name: "Imported channel" },
+          }),
+          showModelPrefillWarning: true,
+        }),
+      )
+    })
   })
 })

--- a/tests/components/ui/Modal.test.tsx
+++ b/tests/components/ui/Modal.test.tsx
@@ -95,6 +95,91 @@ describe("Modal", () => {
     expect(secondTrigger).toHaveFocus()
   })
 
+  it("notifies after a controlled close restores focus", async () => {
+    const user = userEvent.setup()
+    const onCloseComplete = vi.fn()
+    const ModalHarness = () => {
+      const [isOpen, setIsOpen] = useState(false)
+      return (
+        <>
+          <button type="button" onClick={() => setIsOpen(true)}>
+            Open controlled modal
+          </button>
+          <Modal
+            isOpen={isOpen}
+            onClose={() => setIsOpen(false)}
+            onCloseComplete={onCloseComplete}
+            title="Controlled modal"
+          >
+            <button type="button" onClick={() => setIsOpen(false)}>
+              Close controlled modal
+            </button>
+          </Modal>
+        </>
+      )
+    }
+    render(<ModalHarness />, {
+      withUserPreferencesProvider: false,
+      withThemeProvider: false,
+    })
+
+    const trigger = screen.getByRole("button", {
+      name: "Open controlled modal",
+    })
+    await user.click(trigger)
+    await user.click(
+      await screen.findByRole("button", { name: "Close controlled modal" }),
+    )
+
+    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull())
+    expect(trigger).toHaveFocus()
+    expect(onCloseComplete).toHaveBeenCalledOnce()
+  })
+
+  it("notifies only for the real close lifecycle under StrictMode", async () => {
+    const user = userEvent.setup()
+    const onCloseComplete = vi.fn()
+    const ModalHarness = () => {
+      const [isOpen, setIsOpen] = useState(false)
+      return (
+        <>
+          <button type="button" onClick={() => setIsOpen(true)}>
+            Open strict modal
+          </button>
+          <Modal
+            isOpen={isOpen}
+            onClose={() => setIsOpen(false)}
+            onCloseComplete={onCloseComplete}
+            title="Strict modal"
+          >
+            <button type="button">Strict modal content</button>
+          </Modal>
+        </>
+      )
+    }
+
+    render(
+      <StrictMode>
+        <ModalHarness />
+      </StrictMode>,
+      {
+        withUserPreferencesProvider: false,
+        withThemeProvider: false,
+      },
+    )
+
+    const trigger = screen.getByRole("button", { name: "Open strict modal" })
+    await user.click(trigger)
+    expect(await screen.findByRole("dialog")).toBeVisible()
+    await act(async () => undefined)
+    expect(onCloseComplete).not.toHaveBeenCalled()
+
+    await user.keyboard("{Escape}")
+    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull())
+    expect(trigger).toHaveFocus()
+    expect(onCloseComplete).toHaveBeenCalledOnce()
+  })
+
   it("restores the correct trigger through StrictMode and rapid reopen cycles", async () => {
     const user = userEvent.setup()
     const ModalHarness = () => {

--- a/tests/components/ui/Modal.test.tsx
+++ b/tests/components/ui/Modal.test.tsx
@@ -136,6 +136,52 @@ describe("Modal", () => {
     expect(onCloseComplete).toHaveBeenCalledOnce()
   })
 
+  it("notifies once when a requested close unmounts the Modal shell", async () => {
+    vi.useFakeTimers()
+    const onCloseComplete = vi.fn()
+    const ModalHarness = () => {
+      const [isMounted, setIsMounted] = useState(false)
+      return (
+        <>
+          <button type="button" onClick={() => setIsMounted(true)}>
+            Open unmounting modal
+          </button>
+          {isMounted ? (
+            <Modal
+              isOpen
+              onClose={() => setIsMounted(false)}
+              onCloseComplete={onCloseComplete}
+              title="Unmounting modal"
+            >
+              <button type="button">Unmounting modal content</button>
+            </Modal>
+          ) : null}
+        </>
+      )
+    }
+    try {
+      render(<ModalHarness />, {
+        withUserPreferencesProvider: false,
+        withThemeProvider: false,
+      })
+
+      const trigger = screen.getByRole("button", {
+        name: "Open unmounting modal",
+      })
+      fireEvent.click(trigger)
+      await act(async () => undefined)
+      fireEvent.click(
+        screen.getByRole("button", { name: "common:actions.close" }),
+      )
+      await act(async () => undefined)
+
+      expect(screen.queryByRole("dialog")).toBeNull()
+      expect(onCloseComplete).toHaveBeenCalledOnce()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it("notifies only for the real close lifecycle under StrictMode", async () => {
     const user = userEvent.setup()
     const onCloseComplete = vi.fn()

--- a/tests/features/KeyManagement/components/ManagedSiteTokenBatchExportDialog.test.tsx
+++ b/tests/features/KeyManagement/components/ManagedSiteTokenBatchExportDialog.test.tsx
@@ -3087,6 +3087,108 @@ describe("ManagedSiteTokenBatchExportDialog", () => {
     ).toBeNull()
   })
 
+  it("does not offer blind retry for uncertain rows", async () => {
+    const user = userEvent.setup()
+    const uncertainResult: ManagedSiteTokenBatchExportExecutionResult = {
+      totalSelected: 1,
+      attemptedCount: 1,
+      createdCount: 0,
+      failedCount: 0,
+      uncertainCount: 1,
+      skippedCount: 0,
+      items: [
+        {
+          id: "account_token:account-1:1",
+          accountName: "Account 1",
+          runtimeKeyName: "Token 1",
+          result: "uncertain",
+          success: false,
+          skipped: false,
+        },
+      ],
+    }
+    mockPreparePreview.mockResolvedValueOnce(preview)
+    mockExecuteBatchExport.mockResolvedValueOnce(uncertainResult)
+
+    renderDialog()
+
+    expect(await screen.findByText("Account 1 / Token 1")).toBeInTheDocument()
+    await user.click(
+      screen.getByRole("button", {
+        name: "keyManagement:batchManagedSiteExport.actions.start",
+      }),
+    )
+    await user.click(getBatchImportConfirmButton())
+
+    await screen.findByText(
+      "keyManagement:batchManagedSiteExport.results.status.uncertain",
+    )
+    expect(
+      screen.queryByTestId(
+        "key-management-managed-site-batch-export-retry-button",
+      ),
+    ).toBeNull()
+  })
+
+  it("selects only failed rows when failed and uncertain results are mixed", async () => {
+    const user = userEvent.setup()
+    const mixedResult: ManagedSiteTokenBatchExportExecutionResult = {
+      totalSelected: 2,
+      attemptedCount: 2,
+      createdCount: 0,
+      failedCount: 1,
+      uncertainCount: 1,
+      skippedCount: 0,
+      items: [
+        {
+          id: "account_token:account-1:1",
+          accountName: "Account 1",
+          runtimeKeyName: "Token 1",
+          result: "failed",
+          success: false,
+          skipped: false,
+        },
+        {
+          id: "account_token:account-1:2",
+          accountName: "Account 1",
+          runtimeKeyName: "Token 2",
+          result: "uncertain",
+          success: false,
+          skipped: false,
+        },
+      ],
+    }
+    mockPreparePreview
+      .mockResolvedValueOnce(preview)
+      .mockResolvedValueOnce(preview)
+    mockExecuteBatchExport.mockResolvedValueOnce(mixedResult)
+
+    renderDialog()
+
+    expect(await screen.findByText("Account 1 / Token 1")).toBeInTheDocument()
+    await user.click(
+      screen.getByRole("button", {
+        name: "keyManagement:batchManagedSiteExport.actions.start",
+      }),
+    )
+    await user.click(getBatchImportConfirmButton())
+    await user.click(
+      await screen.findByTestId(
+        "key-management-managed-site-batch-export-retry-button",
+      ),
+    )
+
+    await waitFor(() => {
+      expect(mockPreparePreview).toHaveBeenCalledTimes(2)
+    })
+    expect(
+      screen.getByRole("checkbox", { name: "Account 1 / Token 1" }),
+    ).toHaveAttribute("aria-checked", "true")
+    expect(
+      screen.getByRole("checkbox", { name: "Account 1 / Token 2" }),
+    ).toHaveAttribute("aria-checked", "false")
+  })
+
   it.each(["verification-dialog", "item-verification"] as const)(
     "ignores retry while %s is active",
     async (verificationState) => {

--- a/tests/features/KeyManagement/components/managedSiteTokenBatchExportSession.test.ts
+++ b/tests/features/KeyManagement/components/managedSiteTokenBatchExportSession.test.ts
@@ -108,7 +108,7 @@ describe("managed-site token batch export session", () => {
     expect(reconciled.preview.items[1].draft?.models).toEqual(["refreshed-b"])
   })
 
-  it("selects only failed and uncertain execution rows for retry", () => {
+  it("selects only definitely failed execution rows for retry", () => {
     const result: ManagedSiteTokenBatchExportExecutionResult = {
       totalSelected: 3,
       attemptedCount: 3,
@@ -146,7 +146,6 @@ describe("managed-site token batch export session", () => {
 
     expect(getManagedSiteTokenBatchExportRetryItemIds(result)).toEqual([
       "failed-key",
-      "uncertain-key",
     ])
   })
 

--- a/tests/features/ManagedSiteChannels/components/ManagedResourceCreateDialog.test.tsx
+++ b/tests/features/ManagedSiteChannels/components/ManagedResourceCreateDialog.test.tsx
@@ -146,6 +146,48 @@ describe("ManagedResourceCreateDialog", () => {
     })
   })
 
+  it("shows an import advisory and forwards success without an optional message", async () => {
+    const submit = vi.fn().mockResolvedValue({
+      outcome: "succeeded",
+      data: { displayName: "Imported channel" },
+      confirmedEffects: [
+        {
+          kind: "resource-created",
+          resourceKind: MANAGED_RESOURCE_KINDS.Channel,
+          resourceId: "channel-id",
+        },
+      ],
+    })
+    const onSuccess = vi.fn()
+
+    render(
+      <ManagedResourceCreateDialog
+        isOpen
+        siteType={SITE_TYPES.AXON_HUB}
+        kind={MANAGED_RESOURCE_KINDS.Channel}
+        editor={createEditor(submit)}
+        advisoryWarning={{
+          kind: "review-required",
+          title: "Review imported models",
+          description: "Confirm the provider-owned defaults before creating.",
+        }}
+        onClose={vi.fn()}
+        onCloseComplete={vi.fn()}
+        onSuccess={onSuccess}
+      />,
+    )
+
+    expect(screen.getByText("Review imported models")).toBeVisible()
+    fireEvent.click(screen.getByTestId(CHANNEL_DIALOG_TEST_IDS.submitButton))
+
+    await waitFor(() => {
+      expect(onSuccess).toHaveBeenCalledWith({
+        success: true,
+        data: { displayName: "Imported channel" },
+      })
+    })
+  })
+
   it.each([
     {
       label: "partial",

--- a/tests/features/ManagedSiteChannels/components/ManagedResourceCreateDialog.test.tsx
+++ b/tests/features/ManagedSiteChannels/components/ManagedResourceCreateDialog.test.tsx
@@ -146,33 +146,56 @@ describe("ManagedResourceCreateDialog", () => {
     })
   })
 
-  it("keeps an uncertain non-idempotent create from being submitted again", async () => {
-    const submit = vi.fn().mockResolvedValue({
-      outcome: "uncertain",
-      diagnostic: { message: "unknown" },
-    })
+  it.each([
+    {
+      label: "partial",
+      result: {
+        outcome: "partial",
+        confirmedEffects: [
+          {
+            kind: "resource-created",
+            resourceKind: MANAGED_RESOURCE_KINDS.Channel,
+            resourceId: "channel-id",
+          },
+        ],
+        completion: "rejected",
+        diagnostic: { message: "partially applied" },
+      },
+    },
+    {
+      label: "uncertain",
+      result: {
+        outcome: "uncertain",
+        diagnostic: { message: "unknown" },
+      },
+    },
+  ] as const)(
+    "keeps a $label non-idempotent create from being submitted again",
+    async ({ result }) => {
+      const submit = vi.fn().mockResolvedValue(result)
 
-    render(
-      <ManagedResourceCreateDialog
-        isOpen
-        siteType={SITE_TYPES.AXON_HUB}
-        kind={MANAGED_RESOURCE_KINDS.Channel}
-        editor={createEditor(submit)}
-        onClose={vi.fn()}
-        onCloseComplete={vi.fn()}
-        onSuccess={vi.fn()}
-      />,
-    )
+      render(
+        <ManagedResourceCreateDialog
+          isOpen
+          siteType={SITE_TYPES.AXON_HUB}
+          kind={MANAGED_RESOURCE_KINDS.Channel}
+          editor={createEditor(submit)}
+          onClose={vi.fn()}
+          onCloseComplete={vi.fn()}
+          onSuccess={vi.fn()}
+        />,
+      )
 
-    const submitButton = screen.getByTestId(
-      CHANNEL_DIALOG_TEST_IDS.submitButton,
-    )
-    fireEvent.click(submitButton)
+      const submitButton = screen.getByTestId(
+        CHANNEL_DIALOG_TEST_IDS.submitButton,
+      )
+      fireEvent.click(submitButton)
 
-    await waitFor(() => expect(submitButton).toBeDisabled())
-    fireEvent.click(submitButton)
-    expect(submit).toHaveBeenCalledOnce()
-  })
+      await waitFor(() => expect(submitButton).toBeDisabled())
+      fireEvent.click(submitButton)
+      expect(submit).toHaveBeenCalledOnce()
+    },
+  )
 
   it("shows local validation issues without dispatching a create", async () => {
     const submit = vi.fn()
@@ -236,6 +259,7 @@ describe("ManagedResourceCreateDialog", () => {
         screen.queryByText("managedSiteChannels:alerts.editorSaveError.title"),
       ).toBeNull()
     })
+    fireEvent.click(screen.getByRole("button", { name: "Edit native name" }))
     expect(
       screen.getByTestId("native-resource-editor-values"),
     ).toHaveTextContent("Updated channel")
@@ -334,13 +358,14 @@ describe("ManagedResourceCreateDialog", () => {
 
   it("fails closed when the provider editor policy is unavailable", () => {
     getManagedResourceFieldPolicyMock.mockReturnValue(null)
+    const submit = vi.fn()
 
     render(
       <ManagedResourceCreateDialog
         isOpen
         siteType={SITE_TYPES.AXON_HUB}
         kind={MANAGED_RESOURCE_KINDS.Channel}
-        editor={createEditor(vi.fn())}
+        editor={createEditor(submit)}
         onClose={vi.fn()}
         onCloseComplete={vi.fn()}
         onSuccess={vi.fn()}
@@ -354,5 +379,11 @@ describe("ManagedResourceCreateDialog", () => {
     expect(
       screen.getByTestId(CHANNEL_DIALOG_TEST_IDS.submitButton),
     ).toBeDisabled()
+    const formId = screen
+      .getByTestId(CHANNEL_DIALOG_TEST_IDS.submitButton)
+      .getAttribute("form")
+    expect(formId).not.toBeNull()
+    fireEvent.submit(document.getElementById(formId!)!)
+    expect(submit).not.toHaveBeenCalled()
   })
 })

--- a/tests/features/ManagedSiteChannels/components/ManagedResourceCreateDialog.test.tsx
+++ b/tests/features/ManagedSiteChannels/components/ManagedResourceCreateDialog.test.tsx
@@ -73,6 +73,7 @@ describe("ManagedResourceCreateDialog", () => {
         kind={MANAGED_RESOURCE_KINDS.Channel}
         editor={createEditor(submit)}
         onClose={vi.fn()}
+        onCloseComplete={vi.fn()}
         onSuccess={onSuccess}
       />,
     )
@@ -110,6 +111,7 @@ describe("ManagedResourceCreateDialog", () => {
         kind={MANAGED_RESOURCE_KINDS.Channel}
         editor={createEditor(submit)}
         onClose={vi.fn()}
+        onCloseComplete={vi.fn()}
         onSuccess={vi.fn()}
       />,
     )

--- a/tests/features/ManagedSiteChannels/components/ManagedResourceCreateDialog.test.tsx
+++ b/tests/features/ManagedSiteChannels/components/ManagedResourceCreateDialog.test.tsx
@@ -1,0 +1,126 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import { CHANNEL_DIALOG_TEST_IDS } from "~/components/dialogs/ChannelDialog/testIds"
+import { SITE_TYPES } from "~/constants/siteType"
+import { ManagedResourceCreateDialog } from "~/features/ManagedSiteChannels/components/ManagedResourceCreateDialog"
+import { MANAGED_RESOURCE_KINDS } from "~/services/accountSiteDefinitions/contracts"
+import type { ResourceEditor } from "~/services/apiAdapters/contracts/managedResourceNative"
+
+vi.mock(
+  "~/features/ManagedSiteChannels/presentation/ManagedResourceEditorBody",
+  () => ({
+    ManagedResourceEditorBody: () => (
+      <div data-testid="native-resource-editor-body" />
+    ),
+  }),
+)
+
+vi.mock(
+  "~/features/ManagedSiteChannels/presentation/managedResourceFieldPolicy",
+  () => ({
+    MANAGED_RESOURCE_EDITOR_MODES: { Create: "create", Edit: "edit" },
+    getManagedResourceFieldPolicy: () => ({
+      fields: [],
+      hiddenFields: [],
+    }),
+  }),
+)
+
+const createEditor = (submit: ResourceEditor["submit"]): ResourceEditor => ({
+  fields: [],
+  initialValues: { name: "Imported channel" },
+  validate: () => ({ valid: true }),
+  submit,
+})
+
+describe("ManagedResourceCreateDialog", () => {
+  it("submits the native editor and forwards a legacy-compatible success result", async () => {
+    let resolveSubmit: ((result: unknown) => void) | undefined
+    const submission = new Promise((resolve) => {
+      resolveSubmit = resolve
+    })
+    const submit = vi.fn().mockReturnValue(submission)
+    const successResult = {
+      outcome: "succeeded",
+      data: {
+        ref: {
+          siteType: SITE_TYPES.AXON_HUB,
+          kind: MANAGED_RESOURCE_KINDS.Channel,
+          scopeKey: "https://managed.example.com",
+          resourceId: "channel-id",
+        },
+        displayName: "Imported channel",
+        status: "enabled",
+        fields: [],
+        actions: { canUpdate: true, canDelete: true },
+      },
+      confirmedEffects: [
+        {
+          kind: "resource-created",
+          resourceKind: MANAGED_RESOURCE_KINDS.Channel,
+          resourceId: "channel-id",
+        },
+      ],
+      message: "created",
+    }
+    const onSuccess = vi.fn()
+
+    render(
+      <ManagedResourceCreateDialog
+        isOpen
+        siteType={SITE_TYPES.AXON_HUB}
+        kind={MANAGED_RESOURCE_KINDS.Channel}
+        editor={createEditor(submit)}
+        onClose={vi.fn()}
+        onSuccess={onSuccess}
+      />,
+    )
+
+    expect(screen.getByTestId("native-resource-editor-body")).toBeVisible()
+    fireEvent.click(screen.getByTestId(CHANNEL_DIALOG_TEST_IDS.submitButton))
+
+    await waitFor(() => {
+      expect(submit).toHaveBeenCalledWith(
+        { name: "Imported channel" },
+        { signal: expect.any(AbortSignal) },
+      )
+    })
+    expect(submit.mock.calls[0]?.[1]?.signal.aborted).toBe(false)
+    resolveSubmit?.(successResult)
+    await waitFor(() => {
+      expect(onSuccess).toHaveBeenCalledWith({
+        success: true,
+        data: expect.objectContaining({ displayName: "Imported channel" }),
+        message: "created",
+      })
+    })
+  })
+
+  it("keeps an uncertain non-idempotent create from being submitted again", async () => {
+    const submit = vi.fn().mockResolvedValue({
+      outcome: "uncertain",
+      diagnostic: { message: "unknown" },
+    })
+
+    render(
+      <ManagedResourceCreateDialog
+        isOpen
+        siteType={SITE_TYPES.AXON_HUB}
+        kind={MANAGED_RESOURCE_KINDS.Channel}
+        editor={createEditor(submit)}
+        onClose={vi.fn()}
+        onSuccess={vi.fn()}
+      />,
+    )
+
+    const submitButton = screen.getByTestId(
+      CHANNEL_DIALOG_TEST_IDS.submitButton,
+    )
+    fireEvent.click(submitButton)
+
+    await waitFor(() => expect(submitButton).toBeDisabled())
+    fireEvent.click(submitButton)
+    expect(submit).toHaveBeenCalledOnce()
+  })
+})

--- a/tests/features/ManagedSiteChannels/components/ManagedResourceCreateDialog.test.tsx
+++ b/tests/features/ManagedSiteChannels/components/ManagedResourceCreateDialog.test.tsx
@@ -1,17 +1,56 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react"
-import { describe, expect, it, vi } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { CHANNEL_DIALOG_TEST_IDS } from "~/components/dialogs/ChannelDialog/testIds"
 import { SITE_TYPES } from "~/constants/siteType"
 import { ManagedResourceCreateDialog } from "~/features/ManagedSiteChannels/components/ManagedResourceCreateDialog"
 import { MANAGED_RESOURCE_KINDS } from "~/services/accountSiteDefinitions/contracts"
-import type { ResourceEditor } from "~/services/apiAdapters/contracts/managedResourceNative"
+import {
+  MANAGED_RESOURCE_FAILURE_CODES,
+  MANAGED_RESOURCE_FIELD_ISSUE_CODES,
+  ManagedResourceError,
+  type ResourceEditor,
+  type ResourceFieldIssue,
+  type ResourceFieldValue,
+} from "~/services/apiAdapters/contracts/managedResourceNative"
+
+const { getManagedResourceFieldPolicyMock } = vi.hoisted(() => ({
+  getManagedResourceFieldPolicyMock: vi.fn(),
+}))
+
+interface EditorBodyHarnessProps {
+  values: ResourceEditor["initialValues"]
+  fieldIssues: readonly ResourceFieldIssue[]
+  disabled: boolean
+  onValueChange: (fieldId: string, value: ResourceFieldValue) => void
+}
 
 vi.mock(
   "~/features/ManagedSiteChannels/presentation/ManagedResourceEditorBody",
   () => ({
-    ManagedResourceEditorBody: () => (
-      <div data-testid="native-resource-editor-body" />
+    ManagedResourceEditorBody: ({
+      values,
+      fieldIssues,
+      disabled,
+      onValueChange,
+    }: EditorBodyHarnessProps) => (
+      <div data-testid="native-resource-editor-body">
+        <span data-testid="native-resource-editor-values">
+          {String(values.name)}
+        </span>
+        <span data-testid="native-resource-editor-issues">
+          {fieldIssues
+            .map(({ fieldId, code }) => `${fieldId}:${code}`)
+            .join(",")}
+        </span>
+        <button
+          type="button"
+          disabled={disabled}
+          onClick={() => onValueChange("name", "Updated channel")}
+        >
+          Edit native name
+        </button>
+      </div>
     ),
   }),
 )
@@ -20,21 +59,30 @@ vi.mock(
   "~/features/ManagedSiteChannels/presentation/managedResourceFieldPolicy",
   () => ({
     MANAGED_RESOURCE_EDITOR_MODES: { Create: "create", Edit: "edit" },
-    getManagedResourceFieldPolicy: () => ({
-      fields: [],
-      hiddenFields: [],
-    }),
+    getManagedResourceFieldPolicy: getManagedResourceFieldPolicyMock,
   }),
 )
 
-const createEditor = (submit: ResourceEditor["submit"]): ResourceEditor => ({
+const createEditor = (
+  submit: ResourceEditor["submit"],
+  overrides: Partial<ResourceEditor> = {},
+): ResourceEditor => ({
   fields: [],
   initialValues: { name: "Imported channel" },
   validate: () => ({ valid: true }),
   submit,
+  ...overrides,
 })
 
 describe("ManagedResourceCreateDialog", () => {
+  beforeEach(() => {
+    getManagedResourceFieldPolicyMock.mockReset()
+    getManagedResourceFieldPolicyMock.mockReturnValue({
+      fields: [],
+      hiddenFields: [],
+    })
+  })
+
   it("submits the native editor and forwards a legacy-compatible success result", async () => {
     let resolveSubmit: ((result: unknown) => void) | undefined
     const submission = new Promise((resolve) => {
@@ -124,5 +172,187 @@ describe("ManagedResourceCreateDialog", () => {
     await waitFor(() => expect(submitButton).toBeDisabled())
     fireEvent.click(submitButton)
     expect(submit).toHaveBeenCalledOnce()
+  })
+
+  it("shows local validation issues without dispatching a create", async () => {
+    const submit = vi.fn()
+    const issue = {
+      fieldId: "name",
+      code: MANAGED_RESOURCE_FIELD_ISSUE_CODES.Required,
+    } as const
+
+    render(
+      <ManagedResourceCreateDialog
+        isOpen
+        siteType={SITE_TYPES.AXON_HUB}
+        kind={MANAGED_RESOURCE_KINDS.Channel}
+        editor={createEditor(submit, {
+          validate: () => ({ valid: false, issues: [issue] }),
+        })}
+        onClose={vi.fn()}
+        onCloseComplete={vi.fn()}
+        onSuccess={vi.fn()}
+      />,
+    )
+
+    const form = screen
+      .getByTestId("native-resource-editor-body")
+      .closest("form")
+    expect(form).not.toBeNull()
+    fireEvent.submit(form!)
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("native-resource-editor-issues"),
+      ).toHaveTextContent("name:required")
+    })
+    expect(submit).not.toHaveBeenCalled()
+  })
+
+  it("shows a definite rejection and clears it after the user edits a field", async () => {
+    const submit = vi.fn().mockResolvedValue({
+      outcome: "rejected",
+      diagnostic: { message: "not applied" },
+    })
+
+    render(
+      <ManagedResourceCreateDialog
+        isOpen
+        siteType={SITE_TYPES.AXON_HUB}
+        kind={MANAGED_RESOURCE_KINDS.Channel}
+        editor={createEditor(submit)}
+        onClose={vi.fn()}
+        onCloseComplete={vi.fn()}
+        onSuccess={vi.fn()}
+      />,
+    )
+
+    fireEvent.click(screen.getByTestId(CHANNEL_DIALOG_TEST_IDS.submitButton))
+    await screen.findByText("managedSiteChannels:alerts.editorSaveError.title")
+
+    fireEvent.click(screen.getByRole("button", { name: "Edit native name" }))
+    await waitFor(() => {
+      expect(
+        screen.queryByText("managedSiteChannels:alerts.editorSaveError.title"),
+      ).toBeNull()
+    })
+    expect(
+      screen.getByTestId("native-resource-editor-values"),
+    ).toHaveTextContent("Updated channel")
+  })
+
+  it("maps provider validation failures back to the native fields", async () => {
+    const submit = vi.fn().mockRejectedValue(
+      new ManagedResourceError({
+        code: MANAGED_RESOURCE_FAILURE_CODES.ValidationFailed,
+        fieldIssues: [
+          {
+            fieldId: "name",
+            code: MANAGED_RESOURCE_FIELD_ISSUE_CODES.InvalidValue,
+          },
+        ],
+      }),
+    )
+
+    render(
+      <ManagedResourceCreateDialog
+        isOpen
+        siteType={SITE_TYPES.AXON_HUB}
+        kind={MANAGED_RESOURCE_KINDS.Channel}
+        editor={createEditor(submit)}
+        onClose={vi.fn()}
+        onCloseComplete={vi.fn()}
+        onSuccess={vi.fn()}
+      />,
+    )
+
+    fireEvent.click(screen.getByTestId(CHANNEL_DIALOG_TEST_IDS.submitButton))
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("native-resource-editor-issues"),
+      ).toHaveTextContent("name:invalid_value")
+    })
+    expect(
+      screen.queryByText("managedSiteChannels:alerts.editorSaveError.title"),
+    ).toBeNull()
+  })
+
+  it("shows a local save failure when the provider throws an unknown error", async () => {
+    const submit = vi.fn().mockRejectedValue(new Error("provider unavailable"))
+
+    render(
+      <ManagedResourceCreateDialog
+        isOpen
+        siteType={SITE_TYPES.AXON_HUB}
+        kind={MANAGED_RESOURCE_KINDS.Channel}
+        editor={createEditor(submit)}
+        onClose={vi.fn()}
+        onCloseComplete={vi.fn()}
+        onSuccess={vi.fn()}
+      />,
+    )
+
+    fireEvent.click(screen.getByTestId(CHANNEL_DIALOG_TEST_IDS.submitButton))
+
+    expect(
+      await screen.findByText(
+        "managedSiteChannels:alerts.editorSaveError.title",
+      ),
+    ).toBeVisible()
+  })
+
+  it("aborts an in-flight provider create when its dialog is removed", async () => {
+    let submittedSignal: AbortSignal | undefined
+    const submit = vi.fn<ResourceEditor["submit"]>((_values, options) => {
+      submittedSignal = options?.signal
+      return new Promise((_resolve, reject) => {
+        options?.signal?.addEventListener("abort", () => {
+          reject(new DOMException("aborted", "AbortError"))
+        })
+      })
+    })
+    const { unmount } = render(
+      <ManagedResourceCreateDialog
+        isOpen
+        siteType={SITE_TYPES.AXON_HUB}
+        kind={MANAGED_RESOURCE_KINDS.Channel}
+        editor={createEditor(submit)}
+        onClose={vi.fn()}
+        onCloseComplete={vi.fn()}
+        onSuccess={vi.fn()}
+      />,
+    )
+
+    fireEvent.click(screen.getByTestId(CHANNEL_DIALOG_TEST_IDS.submitButton))
+    await waitFor(() => expect(submittedSignal).toBeDefined())
+
+    unmount()
+
+    expect(submittedSignal?.aborted).toBe(true)
+  })
+
+  it("fails closed when the provider editor policy is unavailable", () => {
+    getManagedResourceFieldPolicyMock.mockReturnValue(null)
+
+    render(
+      <ManagedResourceCreateDialog
+        isOpen
+        siteType={SITE_TYPES.AXON_HUB}
+        kind={MANAGED_RESOURCE_KINDS.Channel}
+        editor={createEditor(vi.fn())}
+        onClose={vi.fn()}
+        onCloseComplete={vi.fn()}
+        onSuccess={vi.fn()}
+      />,
+    )
+
+    expect(
+      screen.getByText("managedSiteChannels:alerts.editorLoadError.title"),
+    ).toBeVisible()
+    expect(screen.queryByTestId("native-resource-editor-body")).toBeNull()
+    expect(
+      screen.getByTestId(CHANNEL_DIALOG_TEST_IDS.submitButton),
+    ).toBeDisabled()
   })
 })

--- a/tests/services/apiAdapters/managedResources/axonHub.test.ts
+++ b/tests/services/apiAdapters/managedResources/axonHub.test.ts
@@ -21,6 +21,7 @@ import {
 } from "~/services/accountSiteDefinitions/contracts"
 import * as accountSiteDefinitionRegistry from "~/services/accountSiteDefinitions/registry"
 import {
+  MANAGED_RESOURCE_CREATE_SEED_KINDS,
   MANAGED_RESOURCE_FAILURE_CODES,
   ManagedResourceError,
   type EditableResourceProjection,
@@ -437,6 +438,37 @@ describe("AxonHub native managed-resource Adapter", () => {
         Object.values(RESOURCE_FIELD_TYPES).includes(field.type),
       ),
     ).toBe(true)
+  })
+
+  it("owns the managed-channel import seed projection at the registration seam", async () => {
+    const workspace = await axonHubManagedResourceRegistration.open()
+    const editor = await workspace.openCreateEditor({
+      seed: {
+        kind: MANAGED_RESOURCE_CREATE_SEED_KINDS.ManagedChannelImport,
+        name: "Imported channel",
+        channelType: "openai",
+        credential: "credential-placeholder",
+        baseUrl: "https://upstream.example.invalid",
+        enabled: true,
+        models: [" model-a ", "model-a", "model-b"],
+        orderingWeight: 7,
+      },
+    })
+
+    expect(axonHubManagedResourceRegistration.createSeedKinds).toContain(
+      MANAGED_RESOURCE_CREATE_SEED_KINDS.ManagedChannelImport,
+    )
+    expect(editor.initialValues).toMatchObject({
+      name: "Imported channel",
+      type: "openai",
+      baseURL: "https://upstream.example.invalid",
+      status: AXON_HUB_CHANNEL_STATUS.ENABLED,
+      key: { kind: "replace", value: "credential-placeholder" },
+      supportedModels: ["model-a", "model-a", "model-b"],
+      manualModels: ["model-a", "model-a", "model-b"],
+      defaultTestModel: "model-a",
+      orderingWeight: 7,
+    })
   })
 
   beforeEach(() => {

--- a/tests/services/apiAdapters/managedResources/channelImport.test.ts
+++ b/tests/services/apiAdapters/managedResources/channelImport.test.ts
@@ -144,4 +144,46 @@ describe("native managed-channel import", () => {
       seed: expect.objectContaining({ enabled: false }),
     })
   })
+
+  it("submits the provider-owned normalized projection through the same session", async () => {
+    const submit = vi.fn().mockResolvedValue({
+      outcome: "succeeded",
+      data: { displayName: "Imported channel" },
+      confirmedEffects: [],
+    })
+    const initialValues = { providerOwned: "normalized" }
+    const openCreateEditor = vi.fn(async () => ({
+      fields: [],
+      initialValues,
+      validate: vi.fn(() => ({ valid: true as const })),
+      submit,
+    }))
+    vi.spyOn(
+      managedResourceRegistry,
+      "getManagedResourceRegistration",
+    ).mockReturnValue({
+      siteType: SITE_TYPES.NEW_API,
+      kind: MANAGED_RESOURCE_KINDS.Channel,
+      createSeedKinds: [
+        MANAGED_RESOURCE_CREATE_SEED_KINDS.ManagedChannelImport,
+      ],
+      open: vi.fn(async () => ({ openCreateEditor })),
+    } as unknown as ManagedResourceRegistration)
+    const controller = new AbortController()
+
+    const session = await openNativeManagedChannelImportSession(
+      SITE_TYPES.NEW_API,
+    )
+    await session?.submit(draft, { signal: controller.signal })
+
+    expect(openCreateEditor).toHaveBeenCalledWith({
+      signal: controller.signal,
+      seed: expect.objectContaining({
+        kind: MANAGED_RESOURCE_CREATE_SEED_KINDS.ManagedChannelImport,
+      }),
+    })
+    expect(submit).toHaveBeenCalledWith(initialValues, {
+      signal: controller.signal,
+    })
+  })
 })

--- a/tests/services/apiAdapters/managedResources/channelImport.test.ts
+++ b/tests/services/apiAdapters/managedResources/channelImport.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { SITE_TYPES } from "~/constants/siteType"
+import { MANAGED_RESOURCE_KINDS } from "~/services/accountSiteDefinitions/contracts"
+import {
+  MANAGED_RESOURCE_CREATE_SEED_KINDS,
+  type ManagedResourceRegistration,
+} from "~/services/apiAdapters/contracts/managedResourceNative"
+import {
+  openNativeManagedChannelImportEditor,
+  openNativeManagedChannelImportSession,
+} from "~/services/apiAdapters/managedResources/channelImport"
+import * as managedResourceRegistry from "~/services/apiAdapters/managedResources/registry"
+import { CHANNEL_STATUS, type ChannelFormData } from "~/types/managedSite"
+
+const draft: ChannelFormData = {
+  name: "Imported channel",
+  type: "openai",
+  key: "sk-placeholder",
+  base_url: "https://upstream.example.invalid",
+  models: ["model-a"],
+  groups: [],
+  priority: 0,
+  weight: 7,
+  status: 1,
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe("native managed-channel import", () => {
+  it("discovers import support from the exact registration without provider branching", async () => {
+    const editor = {
+      fields: [],
+      initialValues: { providerOwned: "seeded" },
+      validate: vi.fn(() => ({ valid: true as const })),
+      submit: vi.fn(),
+    }
+    const openCreateEditor = vi.fn(async () => editor)
+    const registration = {
+      siteType: SITE_TYPES.NEW_API,
+      kind: MANAGED_RESOURCE_KINDS.Channel,
+      createSeedKinds: [
+        MANAGED_RESOURCE_CREATE_SEED_KINDS.ManagedChannelImport,
+      ],
+      open: vi.fn(async () => ({ openCreateEditor })),
+    } as unknown as ManagedResourceRegistration
+    vi.spyOn(
+      managedResourceRegistry,
+      "getManagedResourceRegistration",
+    ).mockReturnValue(registration)
+
+    const prepared = await openNativeManagedChannelImportEditor(
+      SITE_TYPES.NEW_API,
+      draft,
+    )
+
+    expect(prepared).toMatchObject({
+      siteType: SITE_TYPES.NEW_API,
+      kind: MANAGED_RESOURCE_KINDS.Channel,
+      editor,
+    })
+    expect(openCreateEditor).toHaveBeenCalledWith({
+      seed: {
+        kind: MANAGED_RESOURCE_CREATE_SEED_KINDS.ManagedChannelImport,
+        name: "Imported channel",
+        channelType: "openai",
+        credential: "sk-placeholder",
+        baseUrl: "https://upstream.example.invalid",
+        enabled: true,
+        models: ["model-a"],
+        orderingWeight: 7,
+      },
+    })
+  })
+
+  it("keeps registrations without the import capability on the legacy path", async () => {
+    vi.spyOn(
+      managedResourceRegistry,
+      "getManagedResourceRegistration",
+    ).mockReturnValue({
+      siteType: SITE_TYPES.NEW_API,
+      kind: MANAGED_RESOURCE_KINDS.Channel,
+      open: vi.fn(),
+    } as unknown as ManagedResourceRegistration)
+
+    await expect(
+      openNativeManagedChannelImportSession(SITE_TYPES.NEW_API),
+    ).resolves.toBeNull()
+  })
+
+  it("fails closed when a native provider loses its import capability", async () => {
+    vi.spyOn(
+      managedResourceRegistry,
+      "getManagedResourceRegistration",
+    ).mockReturnValue({
+      siteType: SITE_TYPES.AXON_HUB,
+      kind: MANAGED_RESOURCE_KINDS.Channel,
+      open: vi.fn(),
+    } as unknown as ManagedResourceRegistration)
+
+    await expect(
+      openNativeManagedChannelImportSession(SITE_TYPES.AXON_HUB),
+    ).rejects.toThrow("native managed channel import capability missing")
+  })
+
+  it("fails closed when a native provider loses its exact registration", async () => {
+    vi.spyOn(
+      managedResourceRegistry,
+      "getManagedResourceRegistration",
+    ).mockReturnValue(null)
+
+    await expect(
+      openNativeManagedChannelImportSession(SITE_TYPES.AXON_HUB),
+    ).rejects.toThrow("native managed channel import capability missing")
+  })
+
+  it("normalizes a disabled draft into a disabled provider-neutral seed", async () => {
+    const openCreateEditor = vi.fn(async () => ({
+      fields: [],
+      initialValues: {},
+      validate: vi.fn(() => ({ valid: true as const })),
+      submit: vi.fn(),
+    }))
+    vi.spyOn(
+      managedResourceRegistry,
+      "getManagedResourceRegistration",
+    ).mockReturnValue({
+      siteType: SITE_TYPES.NEW_API,
+      kind: MANAGED_RESOURCE_KINDS.Channel,
+      createSeedKinds: [
+        MANAGED_RESOURCE_CREATE_SEED_KINDS.ManagedChannelImport,
+      ],
+      open: vi.fn(async () => ({ openCreateEditor })),
+    } as unknown as ManagedResourceRegistration)
+
+    await openNativeManagedChannelImportEditor(SITE_TYPES.NEW_API, {
+      ...draft,
+      status: CHANNEL_STATUS.ManuallyDisabled,
+    })
+
+    expect(openCreateEditor).toHaveBeenCalledWith({
+      seed: expect.objectContaining({ enabled: false }),
+    })
+  })
+})

--- a/tests/services/apiAdapters/managedResources/factory.test.ts
+++ b/tests/services/apiAdapters/managedResources/factory.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, expectTypeOf, it, vi } from "vitest"
 import { SITE_TYPES } from "~/constants/siteType"
 import { MANAGED_RESOURCE_KINDS } from "~/services/accountSiteDefinitions/contracts"
 import {
+  MANAGED_RESOURCE_CREATE_SEED_KINDS,
   MANAGED_RESOURCE_FAILURE_CODES,
   MANAGED_RESOURCE_FIELD_ISSUE_CODES,
   ManagedResourceError,
@@ -286,6 +287,109 @@ describe("defineNativeResourceKind", () => {
     expect(editor.fields).toEqual([
       { fieldId: "name", type: RESOURCE_FIELD_TYPES.Text, required: true },
     ])
+  })
+
+  it("projects provider-neutral create seeds through the registration-owned binding", async () => {
+    const project = vi.fn((seed) => ({ name: `${seed.name} (seeded)` }))
+    const { definition, registration } = createHarness({
+      createSeedBindings: [
+        {
+          kind: MANAGED_RESOURCE_CREATE_SEED_KINDS.ManagedChannelImport,
+          project,
+        },
+      ],
+    })
+
+    expect(registration.createSeedKinds).toEqual([
+      MANAGED_RESOURCE_CREATE_SEED_KINDS.ManagedChannelImport,
+    ])
+
+    const editor = await (
+      await registration.open()
+    ).openCreateEditor({
+      seed: {
+        kind: MANAGED_RESOURCE_CREATE_SEED_KINDS.ManagedChannelImport,
+        name: "Imported channel",
+        channelType: "example",
+        credential: "credential-placeholder",
+        baseUrl: "https://upstream.example.invalid",
+        enabled: true,
+        models: ["model-a"],
+        orderingWeight: 7,
+      },
+    })
+
+    expect(project).toHaveBeenCalledOnce()
+    expect(editor.initialValues).toEqual({ name: "Imported channel (seeded)" })
+    expect(definition.createEditor).toHaveBeenCalledWith(
+      { scope: "scope-a" },
+      undefined,
+    )
+  })
+
+  it("rejects undeclared create seeds before opening the provider editor", async () => {
+    const { definition, registration } = createHarness()
+    const workspace = await registration.open()
+
+    const error = await captureManagedError(
+      workspace.openCreateEditor({
+        seed: {
+          kind: MANAGED_RESOURCE_CREATE_SEED_KINDS.ManagedChannelImport,
+          name: "Imported channel",
+          channelType: "example",
+          credential: "credential-placeholder",
+          baseUrl: "https://upstream.example.invalid",
+          enabled: true,
+          models: [],
+          orderingWeight: 0,
+        },
+      }),
+    )
+
+    expect(error.failure.code).toBe(
+      MANAGED_RESOURCE_FAILURE_CODES.ValidationFailed,
+    )
+    expect(definition.createEditor).not.toHaveBeenCalled()
+  })
+
+  it("forwards only the abort signal beside a credential-bearing create seed", async () => {
+    const project = vi.fn(() => ({ name: "Imported channel" }))
+    const { definition, registration } = createHarness({
+      createSeedBindings: [
+        {
+          kind: MANAGED_RESOURCE_CREATE_SEED_KINDS.ManagedChannelImport,
+          project,
+        },
+      ],
+    })
+    const controller = new AbortController()
+
+    await (
+      await registration.open()
+    ).openCreateEditor({
+      signal: controller.signal,
+      seed: {
+        kind: MANAGED_RESOURCE_CREATE_SEED_KINDS.ManagedChannelImport,
+        name: "Imported channel",
+        channelType: "example",
+        credential: "credential-placeholder",
+        baseUrl: "https://upstream.example.invalid",
+        enabled: true,
+        models: [],
+        orderingWeight: 0,
+      },
+    })
+
+    expect(project).toHaveBeenCalledWith(
+      expect.objectContaining({ credential: "credential-placeholder" }),
+    )
+    expect(definition.createEditor).toHaveBeenCalledWith(
+      { scope: "scope-a" },
+      { signal: controller.signal },
+    )
+    expect(
+      vi.mocked(definition.createEditor).mock.calls[0]?.[1],
+    ).not.toHaveProperty("seed")
   })
 
   it("exposes provider-neutral mutation results from the public workspace contract", async () => {

--- a/tests/services/managedSites/tokenBatchExport.test.ts
+++ b/tests/services/managedSites/tokenBatchExport.test.ts
@@ -35,6 +35,7 @@ const {
   mockGetCurrentManagedSiteRuntimeConfig,
   mockResolveManagedSiteChannelMatch,
   mockResolveManagedUpstreamResourceFeatureCapabilities,
+  mockOpenNativeManagedChannelImportSession,
   buildChannelMatchRequestCache,
 } = vi.hoisted(() => ({
   mockResolveDisplayAccountRuntimeKeySecret: vi.fn(),
@@ -43,6 +44,7 @@ const {
   mockGetCurrentManagedSiteRuntimeConfig: vi.fn(),
   mockResolveManagedSiteChannelMatch: vi.fn(),
   mockResolveManagedUpstreamResourceFeatureCapabilities: vi.fn(),
+  mockOpenNativeManagedChannelImportSession: vi.fn(),
   buildChannelMatchRequestCache: () => ({
     searchResultsByBaseUrl: new Map(),
     channelSecretKeysById: new Map(),
@@ -73,6 +75,11 @@ vi.mock("~/services/managedSites/channelMatchResolver", () => ({
 vi.mock("~/services/managedSites/managedUpstreamResourceService", () => ({
   resolveManagedUpstreamResourceFeatureCapabilities:
     mockResolveManagedUpstreamResourceFeatureCapabilities,
+}))
+
+vi.mock("~/services/apiAdapters/managedResources/channelImport", () => ({
+  openNativeManagedChannelImportSession:
+    mockOpenNativeManagedChannelImportSession,
 }))
 
 const buildAccountToken = (
@@ -265,6 +272,7 @@ describe("managed-site token batch export", () => {
         reason: "feature-slice-disabled",
       }),
     )
+    mockOpenNativeManagedChannelImportSession.mockResolvedValue(null)
   })
 
   it("returns an empty preview when there are no selected tokens", async () => {
@@ -350,6 +358,67 @@ describe("managed-site token batch export", () => {
         }),
       }),
     )
+  })
+
+  it("executes AxonHub batch imports through the native import session", async () => {
+    const service = buildService({
+      siteType: SITE_TYPES.AXON_HUB,
+      messagesKey: "axonhub",
+      prepareChannelFormData: vi.fn(async (account, token) => ({
+        name: `${account.name} - ${token.name}`,
+        type: "openai",
+        key: token.key,
+        base_url: account.baseUrl,
+        models: ["model-example"],
+        groups: [],
+        priority: 0,
+        weight: 3,
+        status: 1 as const,
+      })),
+    })
+    useManagedSiteService(service)
+    const submit = vi.fn().mockResolvedValue({
+      outcome: "succeeded",
+      data: { displayName: "Imported channel" },
+      confirmedEffects: [
+        {
+          kind: "resource-created",
+          resourceKind: "channel",
+          resourceId: "native-channel-id",
+        },
+      ],
+    })
+    mockOpenNativeManagedChannelImportSession.mockResolvedValue({ submit })
+
+    const {
+      prepareManagedSiteTokenBatchExportPreview,
+      executeManagedSiteTokenBatchExport,
+    } = await import("~/services/managedSites/tokenBatchExport")
+    const input = buildAccountTokenInput()
+    const preview = await prepareManagedSiteTokenBatchExportPreview({
+      items: [input],
+    })
+
+    const result = await executeManagedSiteTokenBatchExport({
+      preview,
+      selectedItemIds: [preview.items[0].id],
+    })
+
+    expect(mockOpenNativeManagedChannelImportSession).toHaveBeenCalledWith(
+      SITE_TYPES.AXON_HUB,
+    )
+    expect(submit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "Test Account - Token 11",
+        type: "openai",
+        key: "token-secret",
+        models: ["model-example"],
+        weight: 3,
+      }),
+    )
+    expect(service.buildChannelPayload).not.toHaveBeenCalled()
+    expect(service.createChannel).not.toHaveBeenCalled()
+    expect(result).toMatchObject({ createdCount: 1, failedCount: 0 })
   })
 
   it("passes previously resolved channel keys into duplicate matching", async () => {

--- a/tests/services/managedSites/tokenBatchExport.test.ts
+++ b/tests/services/managedSites/tokenBatchExport.test.ts
@@ -5,6 +5,10 @@ import {
   buildAccountTokenRuntimeKey,
   buildServiceCredentialRuntimeKey,
 } from "~/services/accounts/accountRuntimeKeys"
+import {
+  MANAGED_RESOURCE_FAILURE_CODES,
+  ManagedResourceError,
+} from "~/services/apiAdapters/contracts/managedResourceNative"
 import { API_ERROR_CODES } from "~/services/apiTransport/errors"
 import type { ManagedSiteService } from "~/services/managedSites/managedSiteService"
 import { MANAGED_UPSTREAM_RESOURCE_FEATURES } from "~/services/managedSites/managedUpstreamResourceMigration"
@@ -16,6 +20,7 @@ import type { AccountToken } from "~/types"
 import {
   MANAGED_SITE_TOKEN_BATCH_EXPORT_BLOCKED_DETAIL_CODES,
   MANAGED_SITE_TOKEN_BATCH_EXPORT_BLOCKED_REASON_CODES,
+  MANAGED_SITE_TOKEN_BATCH_EXPORT_EXECUTION_RESULTS,
   MANAGED_SITE_TOKEN_BATCH_EXPORT_INPUT_KINDS,
   MANAGED_SITE_TOKEN_BATCH_EXPORT_PREVIEW_STATUSES,
   MANAGED_SITE_TOKEN_BATCH_EXPORT_WARNING_CODES,
@@ -224,7 +229,7 @@ const buildRuntimeConfigForService = async (service: ManagedSiteService) => {
   return { siteType: service.siteType, config }
 }
 
-const useManagedSiteService = (service: ManagedSiteService) => {
+const configureManagedSiteService = (service: ManagedSiteService) => {
   mockGetManagedSiteService.mockResolvedValue(service)
   mockGetManagedSiteServiceForType.mockReturnValue(service)
   mockGetCurrentManagedSiteRuntimeConfig.mockImplementation(() =>
@@ -236,6 +241,43 @@ const expectBatchDraftOptions = () =>
   expect.objectContaining({
     operationContext: expect.any(Object),
   })
+
+const buildAxonHubImportService = () =>
+  buildService({
+    siteType: SITE_TYPES.AXON_HUB,
+    messagesKey: "axonhub",
+    prepareChannelFormData: vi.fn(async (account, token) => ({
+      name: `${account.name} - ${token.name}`,
+      type: "openai",
+      key: token.key,
+      base_url: account.baseUrl,
+      models: ["model-example"],
+      groups: [],
+      priority: 0,
+      weight: 3,
+      status: 1 as const,
+    })),
+  })
+
+const executeSingleNativeBatchImport = async (
+  service = buildAxonHubImportService(),
+) => {
+  configureManagedSiteService(service)
+  const {
+    prepareManagedSiteTokenBatchExportPreview,
+    executeManagedSiteTokenBatchExport,
+  } = await import("~/services/managedSites/tokenBatchExport")
+  const input = buildAccountTokenInput()
+  const preview = await prepareManagedSiteTokenBatchExportPreview({
+    items: [input],
+  })
+  const result = await executeManagedSiteTokenBatchExport({
+    preview,
+    selectedItemIds: [preview.items[0].id],
+  })
+
+  return { result, service }
+}
 
 const manualCompleteIntent = {
   source: "manual-selection",
@@ -361,22 +403,6 @@ describe("managed-site token batch export", () => {
   })
 
   it("executes AxonHub batch imports through the native import session", async () => {
-    const service = buildService({
-      siteType: SITE_TYPES.AXON_HUB,
-      messagesKey: "axonhub",
-      prepareChannelFormData: vi.fn(async (account, token) => ({
-        name: `${account.name} - ${token.name}`,
-        type: "openai",
-        key: token.key,
-        base_url: account.baseUrl,
-        models: ["model-example"],
-        groups: [],
-        priority: 0,
-        weight: 3,
-        status: 1 as const,
-      })),
-    })
-    useManagedSiteService(service)
     const submit = vi.fn().mockResolvedValue({
       outcome: "succeeded",
       data: { displayName: "Imported channel" },
@@ -390,19 +416,7 @@ describe("managed-site token batch export", () => {
     })
     mockOpenNativeManagedChannelImportSession.mockResolvedValue({ submit })
 
-    const {
-      prepareManagedSiteTokenBatchExportPreview,
-      executeManagedSiteTokenBatchExport,
-    } = await import("~/services/managedSites/tokenBatchExport")
-    const input = buildAccountTokenInput()
-    const preview = await prepareManagedSiteTokenBatchExportPreview({
-      items: [input],
-    })
-
-    const result = await executeManagedSiteTokenBatchExport({
-      preview,
-      selectedItemIds: [preview.items[0].id],
-    })
+    const { result, service } = await executeSingleNativeBatchImport()
 
     expect(mockOpenNativeManagedChannelImportSession).toHaveBeenCalledWith(
       SITE_TYPES.AXON_HUB,
@@ -419,6 +433,72 @@ describe("managed-site token batch export", () => {
     expect(service.buildChannelPayload).not.toHaveBeenCalled()
     expect(service.createChannel).not.toHaveBeenCalled()
     expect(result).toMatchObject({ createdCount: 1, failedCount: 0 })
+  })
+
+  it("marks native batch items failed when the import session cannot open", async () => {
+    mockOpenNativeManagedChannelImportSession.mockRejectedValue(
+      new Error("native import unavailable"),
+    )
+
+    const { result, service } = await executeSingleNativeBatchImport()
+
+    expect(service.buildChannelPayload).not.toHaveBeenCalled()
+    expect(service.createChannel).not.toHaveBeenCalled()
+    expect(result).toMatchObject({ createdCount: 0, failedCount: 1 })
+    expect(result.items[0]).toMatchObject({
+      result: MANAGED_SITE_TOKEN_BATCH_EXPORT_EXECUTION_RESULTS.FAILED,
+      success: false,
+      skipped: false,
+    })
+  })
+
+  it.each([
+    {
+      label: "known native errors as failed",
+      error: new ManagedResourceError({
+        code: MANAGED_RESOURCE_FAILURE_CODES.UpstreamRejected,
+      }),
+      expected: MANAGED_SITE_TOKEN_BATCH_EXPORT_EXECUTION_RESULTS.FAILED,
+      expectedCounts: { failedCount: 1, uncertainCount: 0 },
+    },
+    {
+      label: "unknown native errors as uncertain",
+      error: new Error("connection interrupted"),
+      expected: MANAGED_SITE_TOKEN_BATCH_EXPORT_EXECUTION_RESULTS.UNCERTAIN,
+      expectedCounts: { failedCount: 0, uncertainCount: 1 },
+    },
+    {
+      label: "explicit uncertain native errors as uncertain",
+      error: new ManagedResourceError({
+        code: MANAGED_RESOURCE_FAILURE_CODES.MutationStateUncertain,
+      }),
+      expected: MANAGED_SITE_TOKEN_BATCH_EXPORT_EXECUTION_RESULTS.UNCERTAIN,
+      expectedCounts: { failedCount: 0, uncertainCount: 1 },
+    },
+    ...[
+      MANAGED_RESOURCE_FAILURE_CODES.Unavailable,
+      MANAGED_RESOURCE_FAILURE_CODES.Aborted,
+      MANAGED_RESOURCE_FAILURE_CODES.Unexpected,
+    ].map((code) => ({
+      label: `${code} native errors as uncertain`,
+      error: new ManagedResourceError({ code }),
+      expected: MANAGED_SITE_TOKEN_BATCH_EXPORT_EXECUTION_RESULTS.UNCERTAIN,
+      expectedCounts: { failedCount: 0, uncertainCount: 1 },
+    })),
+  ])("classifies $label", async ({ error, expected, expectedCounts }) => {
+    const submit = vi.fn().mockRejectedValue(error)
+    mockOpenNativeManagedChannelImportSession.mockResolvedValue({ submit })
+
+    const { result, service } = await executeSingleNativeBatchImport()
+
+    expect(service.buildChannelPayload).not.toHaveBeenCalled()
+    expect(service.createChannel).not.toHaveBeenCalled()
+    expect(result).toMatchObject({ createdCount: 0, ...expectedCounts })
+    expect(result.items[0]).toMatchObject({
+      result: expected,
+      success: false,
+      skipped: false,
+    })
   })
 
   it("passes previously resolved channel keys into duplicate matching", async () => {
@@ -853,7 +933,7 @@ describe("managed-site token batch export", () => {
       })),
       createChannel,
     })
-    useManagedSiteService(service)
+    configureManagedSiteService(service)
 
     const {
       prepareManagedSiteTokenBatchExportPreview,
@@ -1080,7 +1160,7 @@ describe("managed-site token batch export", () => {
         throw new Error(providerMessage)
       }),
     })
-    useManagedSiteService(service)
+    configureManagedSiteService(service)
 
     const {
       prepareManagedSiteTokenBatchExportPreview,
@@ -2117,7 +2197,7 @@ describe("managed-site token batch export", () => {
     "runs complete duplicate and hidden-key verification for %s",
     async (_, intent) => {
       const service = buildService()
-      useManagedSiteService(service)
+      configureManagedSiteService(service)
 
       const { prepareManagedSiteTokenBatchExportPreview } = await import(
         "~/services/managedSites/tokenBatchExport"
@@ -2155,7 +2235,7 @@ describe("managed-site token batch export", () => {
         status: 1 as const,
       })),
     })
-    useManagedSiteService(service)
+    configureManagedSiteService(service)
 
     const { prepareManagedSiteTokenBatchExportPreview } = await import(
       "~/services/managedSites/tokenBatchExport"
@@ -2185,7 +2265,7 @@ describe("managed-site token batch export", () => {
 
   it("keeps an explicitly unresolved repair input as a blocked preview row", async () => {
     const service = buildService()
-    useManagedSiteService(service)
+    configureManagedSiteService(service)
 
     const { prepareManagedSiteTokenBatchExportPreview } = await import(
       "~/services/managedSites/tokenBatchExport"
@@ -2225,7 +2305,7 @@ describe("managed-site token batch export", () => {
     "prevents writes when the target fingerprint changes for $source/$verification",
     async (intent) => {
       const service = buildService()
-      useManagedSiteService(service)
+      configureManagedSiteService(service)
       const {
         prepareManagedSiteTokenBatchExportPreview,
         executeManagedSiteTokenBatchExport,
@@ -2256,7 +2336,7 @@ describe("managed-site token batch export", () => {
 
   it("returns execution items and counts only for selected attempted rows", async () => {
     const service = buildService()
-    useManagedSiteService(service)
+    configureManagedSiteService(service)
     const {
       prepareManagedSiteTokenBatchExportPreview,
       executeManagedSiteTokenBatchExport,
@@ -2318,7 +2398,7 @@ describe("managed-site token batch export", () => {
       }
     })
     const service = buildService({ createChannel })
-    useManagedSiteService(service)
+    configureManagedSiteService(service)
     const {
       prepareManagedSiteTokenBatchExportPreview,
       executeManagedSiteTokenBatchExport,
@@ -2376,7 +2456,7 @@ describe("managed-site token batch export", () => {
           },
         }),
       })
-      useManagedSiteService(service)
+      configureManagedSiteService(service)
       const {
         prepareManagedSiteTokenBatchExportPreview,
         executeManagedSiteTokenBatchExport,
@@ -2398,7 +2478,7 @@ describe("managed-site token batch export", () => {
 
   it("throws a target-changed failure when the managed-site config disappears before execution", async () => {
     const service = buildService()
-    useManagedSiteService(service)
+    configureManagedSiteService(service)
 
     const {
       prepareManagedSiteTokenBatchExportPreview,

--- a/tests/services/managedSites/tokenBatchExport.test.ts
+++ b/tests/services/managedSites/tokenBatchExport.test.ts
@@ -453,14 +453,20 @@ describe("managed-site token batch export", () => {
   })
 
   it.each([
-    {
-      label: "known native errors as failed",
-      error: new ManagedResourceError({
-        code: MANAGED_RESOURCE_FAILURE_CODES.UpstreamRejected,
-      }),
+    ...[
+      MANAGED_RESOURCE_FAILURE_CODES.ConfigurationRequired,
+      MANAGED_RESOURCE_FAILURE_CODES.InvalidConfiguration,
+      MANAGED_RESOURCE_FAILURE_CODES.AuthenticationFailed,
+      MANAGED_RESOURCE_FAILURE_CODES.PermissionDenied,
+      MANAGED_RESOURCE_FAILURE_CODES.ValidationFailed,
+      MANAGED_RESOURCE_FAILURE_CODES.NotFound,
+      MANAGED_RESOURCE_FAILURE_CODES.UpstreamRejected,
+    ].map((code) => ({
+      label: `${code} native errors as failed`,
+      error: new ManagedResourceError({ code }),
       expected: MANAGED_SITE_TOKEN_BATCH_EXPORT_EXECUTION_RESULTS.FAILED,
       expectedCounts: { failedCount: 1, uncertainCount: 0 },
-    },
+    })),
     {
       label: "unknown native errors as uncertain",
       error: new Error("connection interrupted"),


### PR DESCRIPTION
## Summary

- Route AxonHub single-channel imports through its native managed-resource editor instead of the legacy common channel form.
- Reuse the same adapter-owned native create contract for batch imports.
- Add a provider-neutral channel-import seed capability so future native managed-site providers can opt in without provider checks in shared orchestration.

## Architecture

- Keep provider-specific field mapping and defaults inside the provider registration.
- Derive native import capability from the registered seed binding.
- Fail closed when a native provider is missing its registration or binding, while retaining the existing fallback for legacy providers.
- Use `editor.initialValues` as the single normalized projection for rendering and submission.
- Preserve partial/uncertain mutation handling and prevent blind replay.

## Validation

- Lifecycle/import surface: 9 focused Vitest files, 221 tests passed.
- Coverage-focused Vitest: native create dialog 10 tests with 100% lines/functions and 95.74% branches; channel-import adapter 6 tests with 100% lines/functions.
- `pnpm compile`, per-commit staged validation, and pre-push `compile + knip` passed.
- Exact-head PR CI: all 10 checks passed on `b3c66819af497919f8970ec23c26746d0a4fb5fd`; Codecov patch coverage is 96.32% (target 95.60%).
- Playwright: default 166 passed / 44 skipped; DNR-required 2 passed / 1 skipped.
- Independent final architecture and lifecycle review reported no blockers.

## Additional notes

- No visual interaction redesign, so screenshots are not required.
- Existing telemetry is reused; no event schema changes were needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native managed-channel creation with provider-specific editors and prefilled details.
  * Added advisory warnings, validation, loading states, and handling for uncertain submissions.
  * Added native AxonHub channel imports, including batch creation.
* **Bug Fixes**
  * Preserved the standard creation flow when native support is unavailable.
  * Improved handling of failed, unsupported, and partially completed imports.
  * Retry actions now include only definitively failed batch items.
  * Improved dialog closing to prevent stale state.
  * Updated retry labels across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->