### PR TITLE
test(e2e): decouple profile saves from model probes

### DIFF
--- a/e2e/realSite/doneHubAccountAdd.spec.ts
+++ b/e2e/realSite/doneHubAccountAdd.spec.ts
@@ -32,12 +32,7 @@ test.describe("real-site E2E: DoneHub account add flow", () => {
 
   const usageChecks = [
     realSiteAccountUsageChecks.keyLifecycle(),
-    realSiteAccountUsageChecks.keyToApiProfileAndPopupModels({
-      popupModelsProbe: {
-        expectedStatus: "fail",
-        expectedSummaryText: "No models returned",
-      },
-    }),
+    realSiteAccountUsageChecks.keyToApiProfile(),
     realSiteAccountUsageChecks.providerDestinations({
       validateDestinationPages: true,
     }),

--- a/e2e/realSite/newApiAccountAdd.spec.ts
+++ b/e2e/realSite/newApiAccountAdd.spec.ts
@@ -39,7 +39,7 @@ test.describe("real-site E2E: New API account add flow", () => {
 
   const usageChecks = [
     realSiteAccountUsageChecks.keyLifecycle(),
-    realSiteAccountUsageChecks.keyToApiProfileAndPopupModels(),
+    realSiteAccountUsageChecks.keyToApiProfile(),
     realSiteAccountUsageChecks.providerDestinations({
       validateDestinationPages: true,
     }),

--- a/e2e/realSite/oneHubAccountAdd.spec.ts
+++ b/e2e/realSite/oneHubAccountAdd.spec.ts
@@ -32,7 +32,7 @@ test.describe("real-site E2E: OneHub account add flow", () => {
 
   const usageChecks = [
     realSiteAccountUsageChecks.keyLifecycle(),
-    realSiteAccountUsageChecks.keyToApiProfileAndPopupModels(),
+    realSiteAccountUsageChecks.keyToApiProfile(),
     realSiteAccountUsageChecks.providerDestinations({
       validateDestinationPages: true,
     }),

--- a/e2e/realSite/sub2apiAccountAdd.spec.ts
+++ b/e2e/realSite/sub2apiAccountAdd.spec.ts
@@ -35,7 +35,7 @@ test.describe("real-site E2E: Sub2API auto-detect account add flow", () => {
 
   const usageChecks = [
     realSiteAccountUsageChecks.keyLifecycle(),
-    realSiteAccountUsageChecks.keyToApiProfileAndPopupModels(),
+    realSiteAccountUsageChecks.keyToApiProfile(),
     realSiteAccountUsageChecks.providerDestinations({
       validateDestinationPages: true,
     }),

--- a/e2e/realSite/veloeraAccountAdd.spec.ts
+++ b/e2e/realSite/veloeraAccountAdd.spec.ts
@@ -32,7 +32,7 @@ test.describe("real-site E2E: Veloera account add flow", () => {
 
   const usageChecks = [
     realSiteAccountUsageChecks.keyLifecycle(),
-    realSiteAccountUsageChecks.keyToApiProfileAndPopupModels(),
+    realSiteAccountUsageChecks.keyToApiProfile(),
     realSiteAccountUsageChecks.providerDestinations({
       validateDestinationPages: {
         usage: true,

--- a/e2e/utils/realSite/accountUsage.ts
+++ b/e2e/utils/realSite/accountUsage.ts
@@ -14,10 +14,6 @@ import {
   runAccountFixtureUsagePlan,
   type AccountUsagePlanCheck,
 } from "~~/e2e/scenarios/accountUsagePlan"
-import {
-  openApiCredentialProfilesPopupScenario,
-  verifyApiCredentialProfileModelsProbeScenario,
-} from "~~/e2e/scenarios/apiCredentialProfileVerification"
 import type { ModelListCatalogExpectations } from "~~/e2e/scenarios/modelListCatalog"
 import type { SavedApiCredentialProfileExpectation } from "~~/e2e/utils/accountLifecycle"
 import type { getServiceWorker } from "~~/e2e/utils/extensionState"
@@ -50,9 +46,9 @@ type RealSiteAccountUsageCheck =
 
 const REAL_SITE_ACCOUNT_REMOTE_WRITE_TIMEOUT_MS = 120_000
 
-type ApiProfilePopupModelsProbeExpectation = {
-  expectedStatus?: "pass" | "fail" | "handled"
-  expectedSummaryText?: string
+type RealSiteKeyToApiProfileOptions = {
+  profileLabel?: string
+  expectedProfile?: SavedApiCredentialProfileExpectation
 }
 
 function buildUsageTokenName(label: string) {
@@ -78,13 +74,12 @@ export async function verifyRealSiteAccountKeyLifecycleUsage(
 }
 
 export async function verifyRealSiteAccountKeyToApiProfileUsage(
-  context: RealSiteAccountUsageContext & {
-    profileLabel?: string
-    expectedProfile?: SavedApiCredentialProfileExpectation
-    cleanupCreatedProfile?: boolean
-    cleanupCreatedToken?: boolean
-    afterProfileSaved?: (profile: ApiCredentialProfile) => Promise<void>
-  },
+  context: RealSiteAccountUsageContext &
+    RealSiteKeyToApiProfileOptions & {
+      cleanupCreatedProfile?: boolean
+      cleanupCreatedToken?: boolean
+      afterProfileSaved?: (profile: ApiCredentialProfile) => Promise<void>
+    },
 ) {
   return await verifyAccountKeyToApiProfileUsage({
     page: context.page,
@@ -157,55 +152,6 @@ export async function maybeVerifyRealSiteModelToKeyUsage(
   })
 }
 
-async function withApiCredentialProfilesPopupPage(
-  context: Pick<RealSiteAccountUsageContext, "page" | "extensionId">,
-  verify: (popupPage: Page) => Promise<void>,
-) {
-  const popupPage = await context.page.context().newPage()
-
-  try {
-    await openApiCredentialProfilesPopupScenario({
-      page: popupPage,
-      extensionId: context.extensionId,
-    })
-    await verify(popupPage)
-  } finally {
-    await popupPage.close()
-  }
-}
-
-async function verifyRealSiteApiProfilePopupModelsUsage(
-  context: RealSiteAccountUsageContext & {
-    profileLabel?: string
-    expectedProfile?: SavedApiCredentialProfileExpectation
-    popupModelsProbe?: ApiProfilePopupModelsProbeExpectation
-  },
-) {
-  let verifiedProfile: ApiCredentialProfile | null = null
-
-  await verifyRealSiteAccountKeyToApiProfileUsage({
-    ...context,
-    profileLabel: context.profileLabel,
-    expectedProfile: context.expectedProfile,
-    afterProfileSaved: async (profile) => {
-      await withApiCredentialProfilesPopupPage(context, async (popupPage) => {
-        await verifyApiCredentialProfileModelsProbeScenario({
-          page: popupPage,
-          profileName: profile.name,
-          ...context.popupModelsProbe,
-        })
-        verifiedProfile = profile
-      })
-    },
-  })
-
-  if (!verifiedProfile) {
-    throw new Error("Real-site API profile popup verification did not run")
-  }
-
-  return verifiedProfile
-}
-
 export const realSiteAccountUsageChecks = {
   keyLifecycle(): RealSiteAccountUsageCheck {
     return {
@@ -217,18 +163,14 @@ export const realSiteAccountUsageChecks = {
     }
   },
 
-  keyToApiProfileAndPopupModels(
-    options: {
-      profileLabel?: string
-      expectedProfile?: SavedApiCredentialProfileExpectation
-      popupModelsProbe?: ApiProfilePopupModelsProbeExpectation
-    } = {},
+  keyToApiProfile(
+    options: RealSiteKeyToApiProfileOptions = {},
   ): RealSiteAccountUsageCheck {
     return {
-      name: "create an account key, save it to API profiles, and verify it from the popup",
+      name: "create an account key and save it to API profiles",
       timeoutMs: REAL_SITE_ACCOUNT_REMOTE_WRITE_TIMEOUT_MS,
       run: async (context) => {
-        await verifyRealSiteApiProfilePopupModelsUsage({
+        await verifyRealSiteAccountKeyToApiProfileUsage({
           ...context,
           ...options,
         })

--- a/tests/utils/realSiteAccountUsage.test.ts
+++ b/tests/utils/realSiteAccountUsage.test.ts
@@ -9,10 +9,6 @@ import {
   verifyAccountProviderDestinationUsage,
 } from "~~/e2e/scenarios/accountUsage"
 import {
-  openApiCredentialProfilesPopupScenario,
-  verifyApiCredentialProfileModelsProbeScenario,
-} from "~~/e2e/scenarios/apiCredentialProfileVerification"
-import {
   maybeVerifyRealSiteModelToKeyUsage,
   realSiteAccountUsageChecks,
   runRealSiteAccountFixtureUsageChecks,
@@ -35,8 +31,6 @@ const mocks = vi.hoisted(() => ({
   buildRealSiteRunId: vi.fn(),
   buildRealSiteTestTokenName: vi.fn(),
   maybeRunRealSiteModelToKeyScenario: vi.fn(),
-  openApiCredentialProfilesPopupScenario: vi.fn(),
-  verifyApiCredentialProfileModelsProbeScenario: vi.fn(),
   testStep: vi.fn(),
 }))
 
@@ -58,13 +52,6 @@ vi.mock("~~/e2e/utils/realSite/keyManagement", async (importOriginal) => ({
 
 vi.mock("~~/e2e/utils/realSite/modelToKey", () => ({
   maybeRunRealSiteModelToKeyScenario: mocks.maybeRunRealSiteModelToKeyScenario,
-}))
-
-vi.mock("~~/e2e/scenarios/apiCredentialProfileVerification", () => ({
-  openApiCredentialProfilesPopupScenario:
-    mocks.openApiCredentialProfilesPopupScenario,
-  verifyApiCredentialProfileModelsProbeScenario:
-    mocks.verifyApiCredentialProfileModelsProbeScenario,
 }))
 
 vi.mock("~~/e2e/fixtures/extensionTest", () => ({
@@ -147,6 +134,37 @@ describe("real-site account usage adapters", () => {
       },
     })
     expect(call.buildTokenName()).toBe("New API Profile:run-id")
+  })
+
+  it("saves a real-site key to API profiles without probing models", async () => {
+    vi.mocked(verifyAccountKeyToApiProfileUsage).mockResolvedValue({
+      id: "profile-id",
+    } as any)
+
+    await realSiteAccountUsageChecks
+      .keyToApiProfile({
+        expectedProfile: { name: "Expected profile" },
+      })
+      .run({
+        testInfo: { annotations: [] } as any,
+        page,
+        extensionId: "extension-id",
+        serviceWorker,
+        account,
+        label: "DoneHub",
+      })
+
+    expect(verifyAccountKeyToApiProfileUsage).toHaveBeenCalledOnce()
+    expect(verifyAccountKeyToApiProfileUsage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        expectedProfile: {
+          baseUrl: "https://new-api.test",
+          name: "Expected profile",
+        },
+      }),
+    )
+    const call = vi.mocked(verifyAccountKeyToApiProfileUsage).mock.calls[0][0]
+    expect(call.afterProfileSaved).toBeUndefined()
   })
 
   it("forwards provider destinations and model catalog as separate scenarios", async () => {
@@ -314,161 +332,5 @@ describe("real-site account usage adapters", () => {
 
     expect(testInfo.setTimeout).toHaveBeenCalledOnce()
     expect(testInfo.setTimeout).toHaveBeenCalledWith(240_000)
-  })
-
-  it("verifies key-to-profile usage from the popup and closes the popup page", async () => {
-    const popupPage = {
-      close: vi.fn().mockResolvedValue(undefined),
-    }
-    const pageWithContext = {
-      context: () => ({
-        newPage: vi.fn().mockResolvedValue(popupPage),
-      }),
-    } as any
-    vi.mocked(openApiCredentialProfilesPopupScenario).mockResolvedValue(
-      popupPage as any,
-    )
-    vi.mocked(verifyApiCredentialProfileModelsProbeScenario).mockResolvedValue(
-      undefined,
-    )
-    vi.mocked(verifyAccountKeyToApiProfileUsage).mockImplementation(
-      async (params) => {
-        await params.afterProfileSaved?.({
-          id: "profile-id",
-          name: "Saved profile",
-        } as any)
-        return { id: "profile-id", name: "Saved profile" } as any
-      },
-    )
-
-    await realSiteAccountUsageChecks
-      .keyToApiProfileAndPopupModels({
-        expectedProfile: { name: "Expected profile" },
-        popupModelsProbe: {
-          expectedStatus: "fail",
-          expectedSummaryText: "No models returned",
-        },
-      })
-      .run({
-        testInfo: { annotations: [] } as any,
-        page: pageWithContext,
-        extensionId: "extension-id",
-        serviceWorker,
-        account,
-        label: "New API",
-      })
-
-    expect(openApiCredentialProfilesPopupScenario).toHaveBeenCalledWith({
-      page: popupPage,
-      extensionId: "extension-id",
-    })
-    expect(verifyApiCredentialProfileModelsProbeScenario).toHaveBeenCalledWith({
-      page: popupPage,
-      profileName: "Saved profile",
-      expectedStatus: "fail",
-      expectedSummaryText: "No models returned",
-    })
-    expect(popupPage.close).toHaveBeenCalledOnce()
-  })
-
-  it("closes the popup page when popup model verification fails", async () => {
-    const error = new Error("models probe failed")
-    const popupPage = {
-      close: vi.fn().mockResolvedValue(undefined),
-    }
-    const pageWithContext = {
-      context: () => ({
-        newPage: vi.fn().mockResolvedValue(popupPage),
-      }),
-    } as any
-    vi.mocked(openApiCredentialProfilesPopupScenario).mockResolvedValue(
-      popupPage as any,
-    )
-    vi.mocked(verifyApiCredentialProfileModelsProbeScenario).mockRejectedValue(
-      error,
-    )
-    vi.mocked(verifyAccountKeyToApiProfileUsage).mockImplementation(
-      async (params) => {
-        await params.afterProfileSaved?.({
-          id: "profile-id",
-          name: "Saved profile",
-        } as any)
-        return { id: "profile-id", name: "Saved profile" } as any
-      },
-    )
-
-    await expect(
-      realSiteAccountUsageChecks.keyToApiProfileAndPopupModels().run({
-        testInfo: { annotations: [] } as any,
-        page: pageWithContext,
-        extensionId: "extension-id",
-        serviceWorker,
-        account,
-        label: "New API",
-      }),
-    ).rejects.toThrow(error)
-
-    expect(popupPage.close).toHaveBeenCalledOnce()
-  })
-
-  it("closes the popup page when popup model opening fails after page creation", async () => {
-    const error = new Error("popup open failed")
-    const popupPage = {
-      close: vi.fn().mockResolvedValue(undefined),
-    }
-    const pageWithContext = {
-      context: () => ({
-        newPage: vi.fn().mockResolvedValue(popupPage),
-      }),
-    } as any
-    vi.mocked(openApiCredentialProfilesPopupScenario).mockRejectedValue(error)
-    vi.mocked(verifyAccountKeyToApiProfileUsage).mockImplementation(
-      async (params) => {
-        await params.afterProfileSaved?.({
-          id: "profile-id",
-          name: "Saved profile",
-        } as any)
-        return { id: "profile-id", name: "Saved profile" } as any
-      },
-    )
-
-    await expect(
-      realSiteAccountUsageChecks.keyToApiProfileAndPopupModels().run({
-        testInfo: { annotations: [] } as any,
-        page: pageWithContext,
-        extensionId: "extension-id",
-        serviceWorker,
-        account,
-        label: "New API",
-      }),
-    ).rejects.toThrow(error)
-
-    expect(openApiCredentialProfilesPopupScenario).toHaveBeenCalledWith({
-      page: popupPage,
-      extensionId: "extension-id",
-    })
-    expect(verifyApiCredentialProfileModelsProbeScenario).not.toHaveBeenCalled()
-    expect(popupPage.close).toHaveBeenCalledOnce()
-  })
-
-  it("fails when key-to-profile usage does not run popup verification", async () => {
-    vi.mocked(verifyAccountKeyToApiProfileUsage).mockResolvedValue({
-      id: "profile-id",
-      name: "Saved profile",
-    } as any)
-
-    await expect(
-      realSiteAccountUsageChecks.keyToApiProfileAndPopupModels().run({
-        testInfo: { annotations: [] } as any,
-        page,
-        extensionId: "extension-id",
-        serviceWorker,
-        account,
-        label: "New API",
-      }),
-    ).rejects.toThrow("Real-site API profile popup verification did not run")
-
-    expect(openApiCredentialProfilesPopupScenario).not.toHaveBeenCalled()
-    expect(verifyApiCredentialProfileModelsProbeScenario).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary

- separate real-site API profile persistence checks from popup model probes
- apply the independent profile-save check to New API, OneHub, DoneHub, Veloera, and Sub2API
- remove the obsolete combined profile-save-and-model-probe helper and its implementation-specific tests

## Why

Saving an account key as an API credential profile does not require the provider to expose models successfully. Model availability can vary by deployment, permissions, and current catalog state, so it should not determine whether profile persistence passes.

Model catalog behavior remains covered by its independent scenarios.

## Validation

- pre-commit `validate:staged`
- `pnpm exec vitest run tests/utils/realSiteAccountUsage.test.ts tests/utils/accountScenarios.test.ts tests/scripts/realSiteE2eMatrix.test.ts` - 30 tests passed
- `pnpm compile`
- pre-push `validate:push` (`pnpm compile` and `pnpm knip`)
- Playwright collection for all five real-site account specifications - 26 tests collected

## Not run

The credential-backed real-site workflow was not executed locally because it creates and deletes API keys on external deployments. It should be verified through the authorized real-site workflow after publication.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account-add usage checks across supported real-site integrations.
  * Profile validation now focuses on successfully creating and saving API profiles without relying on popup-model verification.
* **Tests**
  * Updated automated coverage to confirm profile saving behavior and prevent unnecessary popup-model probing.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->