### PR TITLE
test(e2e): harden real-site key cleanup

### DIFF
--- a/e2e/keyManagementCommonFlow.spec.ts
+++ b/e2e/keyManagementCommonFlow.spec.ts
@@ -5,6 +5,7 @@ import {
   getManagedSiteBatchExportRowSelectTestId,
   KEY_MANAGEMENT_TEST_IDS,
 } from "~/features/KeyManagement/testIds"
+import { TOKEN_PROVISIONING_TEST_IDS } from "~/features/TokenProvisioning/testIds"
 import { buildAccountTokenRuntimeKeyId } from "~/services/accounts/accountRuntimeKeys"
 import { ACCOUNT_KEY_AUTO_PROVISIONING_STORAGE_KEYS } from "~/services/core/storageKeys"
 import { AuthTypeEnum, type ApiToken } from "~/types"
@@ -16,7 +17,11 @@ import {
   verifyAccountTokenCcSwitchModelPickerUsage,
 } from "~~/e2e/scenarios/accountUsage"
 import { verifyCcSwitchModelExportDeepLink } from "~~/e2e/scenarios/ccSwitchExport"
-import { saveTokenToApiCredentialProfilesFromKeyManagementPage } from "~~/e2e/utils/accountLifecycle"
+import {
+  deleteTokenFromKeyManagementPage,
+  openKeyManagementForAccount,
+  saveTokenToApiCredentialProfilesFromKeyManagementPage,
+} from "~~/e2e/utils/accountLifecycle"
 import {
   createStoredAccount,
   forceExtensionLanguage,
@@ -389,6 +394,62 @@ test("reports the delete response instead of timing out on a retained token row"
       exact: true,
     }),
   ).toBeVisible()
+})
+
+test("ignores an unrelated success notification while deleting a token", async ({
+  context,
+  extensionId,
+  page,
+}) => {
+  const baseUrl = "https://unrelated-delete-status.example.invalid"
+  const token = createStubApiToken({
+    id: 81,
+    name: "E2E Deletion Target",
+  })
+  const serviceWorker = await getServiceWorker(context)
+  const accountFixture = await seedMockAccountFixture({
+    serviceWorker,
+    account: createStoredAccount({
+      id: "e2e-unrelated-delete-status-account",
+      site_url: baseUrl,
+    }),
+  })
+  await stubNewApiSiteRoutes(context, {
+    baseUrl,
+    initialTokens: [token],
+  })
+  await page.route(`${baseUrl}/api/token/${token.id}`, async (route) => {
+    if (route.request().method() === "DELETE") {
+      await page.evaluate((openProfilesButtonTestId) => {
+        const status = document.createElement("div")
+        status.setAttribute("role", "status")
+        status.textContent = "Saved fixture key to API credential library"
+        const action = document.createElement("button")
+        action.dataset.testid = openProfilesButtonTestId
+        action.textContent = "Open API credential library"
+        status.append(action)
+        document.body.append(status)
+      }, TOKEN_PROVISIONING_TEST_IDS.openApiProfilesToastButton)
+    }
+    await route.fallback()
+  })
+
+  const keyManagementPage = await openKeyManagementForAccount({
+    page,
+    extensionId,
+    accountId: accountFixture.accountId,
+    siteType: accountFixture.siteType,
+    baseUrl: accountFixture.baseUrl,
+    openFromAccountRow: false,
+  })
+  await deleteTokenFromKeyManagementPage({
+    page: keyManagementPage,
+    token: { id: token.id, name: token.name },
+  })
+
+  await expect(
+    keyManagementPage.getByTestId(getKeyManagementTokenRowTestId(token.id)),
+  ).toHaveCount(0)
 })
 
 test("opens the CC Switch model picker for an account API key", async ({

--- a/e2e/keyManagementCommonFlow.spec.ts
+++ b/e2e/keyManagementCommonFlow.spec.ts
@@ -350,6 +350,47 @@ test("reports the create response instead of timing out on a missing token row",
   ).rejects.toThrow("API key creation failed: Fixture token quota reached")
 })
 
+test("reports the delete response instead of timing out on a retained token row", async ({
+  context,
+  extensionId,
+  page,
+}) => {
+  const serviceWorker = await getServiceWorker(context)
+  const accountFixture = await seedMockAccountFixture({
+    serviceWorker,
+    account: createStoredAccount({
+      id: "e2e-key-delete-error-account",
+      site_url: "https://key-delete-error.example.invalid",
+    }),
+  })
+  await stubNewApiSiteRoutes(context, {
+    baseUrl: "https://key-delete-error.example.invalid",
+    deleteTokenError: {
+      status: 200,
+      message: "Fixture delete temporarily unavailable",
+    },
+  })
+
+  await expect(
+    verifyAccountKeyLifecycleUsage({
+      extensionId,
+      page,
+      serviceWorker,
+      account: accountFixture,
+      openFromAccountRow: false,
+      buildTokenName: () => "E2E Rejected Token",
+    }),
+  ).rejects.toThrow(
+    "API key deletion failed: Fixture delete temporarily unavailable",
+  )
+  await expect(
+    page.getByRole("heading", {
+      name: "E2E Rejected Token",
+      exact: true,
+    }),
+  ).toBeVisible()
+})
+
 test("opens the CC Switch model picker for an account API key", async ({
   context,
   extensionId,

--- a/e2e/scenarios/accountKeyToApiProfile.ts
+++ b/e2e/scenarios/accountKeyToApiProfile.ts
@@ -5,6 +5,7 @@ import type { AccountFixture } from "~~/e2e/scenarios/accountFixtures"
 import {
   deleteApiCredentialProfileFromStorage,
   deleteTokenFromKeyManagementPage,
+  deleteTokensMatchingNameFromKeyManagementPage,
   expectTokenCreatedInKeyManagementPage,
   openKeyManagementForAccount,
   saveTokenToApiCredentialProfilesFromKeyManagementPage,
@@ -26,6 +27,7 @@ type AccountKeyToApiProfileEnvironment = {
   ) => Promise<AccountFixture>
   openFromAccountRow?: boolean
   buildTokenName: () => string
+  cleanupTokenNameMatcher?: (tokenName: string) => boolean
   expectedProfile?: SavedApiCredentialProfileExpectation
   openProfilesPage?: boolean
   cleanupAccountFixture?: boolean
@@ -118,6 +120,12 @@ export async function runAccountKeyToApiProfileScenario(
       baseUrl: account.baseUrl,
       openFromAccountRow: env.openFromAccountRow ?? true,
     })
+    if (env.cleanupTokenNameMatcher) {
+      await deleteTokensMatchingNameFromKeyManagementPage({
+        page: keyManagementPage,
+        nameMatcher: env.cleanupTokenNameMatcher,
+      })
+    }
     await submitTokenCreationFromKeyManagementPage({
       page: keyManagementPage,
       tokenName,

--- a/e2e/scenarios/accountUsage.ts
+++ b/e2e/scenarios/accountUsage.ts
@@ -165,6 +165,7 @@ export async function verifyAccountKeyLifecycleUsage(
 export async function verifyAccountKeyToApiProfileUsage(
   context: AccountUsageScenarioContext & {
     buildTokenName: () => string
+    cleanupTokenNameMatcher?: (tokenName: string) => boolean
     expectedProfile?: SavedApiCredentialProfileExpectation
     openProfilesPage?: boolean
     openFromAccountRow?: boolean
@@ -181,6 +182,7 @@ export async function verifyAccountKeyToApiProfileUsage(
     resolveAccountFixture: async () => context.account,
     openFromAccountRow: context.openFromAccountRow,
     buildTokenName: context.buildTokenName,
+    cleanupTokenNameMatcher: context.cleanupTokenNameMatcher,
     expectedProfile: context.expectedProfile,
     openProfilesPage: context.openProfilesPage,
     cleanupAccountFixture: context.cleanupAccountFixture,

--- a/e2e/utils/accountLifecycle.ts
+++ b/e2e/utils/accountLifecycle.ts
@@ -42,6 +42,12 @@ type TokenCreationOutcome =
   | { status: "created" }
   | { status: "failed"; message: string }
 
+type TokenDeletionOutcome =
+  | { status: "deleted" }
+  | { status: "failed"; message: string }
+
+const PREEXISTING_STATUS_ATTRIBUTE = "data-aah-e2e-preexisting-status"
+
 export type SavedApiCredentialProfileExpectation = Partial<
   Pick<ApiCredentialProfile, "name" | "baseUrl" | "apiKey" | "tagIds">
 >
@@ -243,11 +249,7 @@ async function submitCreateTokenForm(params: {
   page: Page
   tokenName: string
 }) {
-  await params.page.getByRole("status").evaluateAll((elements) => {
-    for (const element of elements) {
-      element.setAttribute("data-aah-e2e-preexisting-status", "true")
-    }
-  })
+  await markExistingStatusMessages(params.page)
   await params.page.getByRole("button", { name: "Add API Key" }).click()
   await expect(params.page.locator("#tokenName")).toBeVisible({
     timeout: 30_000,
@@ -262,6 +264,7 @@ async function submitCreateTokenForm(params: {
       addTokenDialogTestId,
       addTokenSubmitButtonTestId,
       oneTimeCloseTestId,
+      preexistingStatusAttribute,
     }) => {
       const addTokenDialog = document.querySelector(
         `[data-testid="${addTokenDialogTestId}"]`,
@@ -286,7 +289,7 @@ async function submitCreateTokenForm(params: {
 
       const visibleStatusMessages = Array.from(
         document.querySelectorAll<HTMLElement>(
-          '[role="status"]:not([data-aah-e2e-preexisting-status])',
+          `[role="status"]:not([${preexistingStatusAttribute}])`,
         ),
       ).filter((element) => element.getClientRects().length > 0)
       const message = visibleStatusMessages.at(-1)?.textContent?.trim()
@@ -300,6 +303,7 @@ async function submitCreateTokenForm(params: {
       addTokenSubmitButtonTestId:
         TOKEN_PROVISIONING_TEST_IDS.addTokenSubmitButton,
       oneTimeCloseTestId: TOKEN_PROVISIONING_TEST_IDS.oneTimeKeyCloseButton,
+      preexistingStatusAttribute: PREEXISTING_STATUS_ATTRIBUTE,
     },
     { timeout: 30_000 },
   )
@@ -308,6 +312,47 @@ async function submitCreateTokenForm(params: {
   if (outcome.status === "failed") {
     throw new Error(`API key creation failed: ${outcome.message}`)
   }
+}
+
+async function markExistingStatusMessages(page: Page) {
+  await page.getByRole("status").evaluateAll((elements, attribute) => {
+    for (const element of elements) {
+      element.setAttribute(attribute, "true")
+    }
+  }, PREEXISTING_STATUS_ATTRIBUTE)
+}
+
+async function waitForTokenDeletionOutcome(params: {
+  page: Page
+  rowTestId: string
+}) {
+  const outcomeHandle = await params.page.waitForFunction(
+    ({ rowTestId, preexistingStatusAttribute }) => {
+      const row = document.querySelector(
+        `[data-testid="${CSS.escape(rowTestId)}"]`,
+      )
+      if (!row) {
+        return { status: "deleted" } satisfies TokenDeletionOutcome
+      }
+
+      const visibleStatusMessages = Array.from(
+        document.querySelectorAll<HTMLElement>(
+          `[role="status"]:not([${preexistingStatusAttribute}])`,
+        ),
+      ).filter((element) => element.getClientRects().length > 0)
+      const message = visibleStatusMessages.at(-1)?.textContent?.trim()
+
+      return message
+        ? ({ status: "failed", message } satisfies TokenDeletionOutcome)
+        : null
+    },
+    {
+      rowTestId: params.rowTestId,
+      preexistingStatusAttribute: PREEXISTING_STATUS_ATTRIBUTE,
+    },
+    { timeout: 30_000 },
+  )
+  return (await outcomeHandle.jsonValue()) as TokenDeletionOutcome
 }
 
 async function closeOneTimeKeyDialogIfPresent(page: Page) {
@@ -400,11 +445,26 @@ async function deleteTokenRowFromKeyManagementPage(params: {
   row: Locator
 }) {
   await expect(params.row).toBeVisible({ timeout: 30_000 })
-  await params.row.getByRole("button", { name: "Delete Key" }).click()
+  const rowTestId = await params.row.getAttribute("data-testid")
+  if (!rowTestId) {
+    throw new Error("Unable to identify a token row for deletion.")
+  }
+
+  await markExistingStatusMessages(params.page)
+  await params.row
+    .getByRole("button", { name: "Delete Key", exact: true })
+    .click()
   await params.page
     .getByTestId(KEY_MANAGEMENT_TEST_IDS.deleteTokenConfirmButton)
     .click()
-  await expect(params.row).toHaveCount(0, { timeout: 30_000 })
+  const outcome = await waitForTokenDeletionOutcome({
+    page: params.page,
+    rowTestId,
+  })
+
+  if (outcome.status === "failed") {
+    throw new Error(`API key deletion failed: ${outcome.message}`)
+  }
 }
 
 export async function deleteTokenFromKeyManagementPage(params: {

--- a/e2e/utils/accountLifecycle.ts
+++ b/e2e/utils/accountLifecycle.ts
@@ -327,7 +327,11 @@ async function waitForTokenDeletionOutcome(params: {
   rowTestId: string
 }) {
   const outcomeHandle = await params.page.waitForFunction(
-    ({ rowTestId, preexistingStatusAttribute }) => {
+    ({
+      rowTestId,
+      preexistingStatusAttribute,
+      deleteTokenErrorToastTestId,
+    }) => {
       const row = document.querySelector(
         `[data-testid="${CSS.escape(rowTestId)}"]`,
       )
@@ -339,7 +343,13 @@ async function waitForTokenDeletionOutcome(params: {
         document.querySelectorAll<HTMLElement>(
           `[role="status"]:not([${preexistingStatusAttribute}])`,
         ),
-      ).filter((element) => element.getClientRects().length > 0)
+      ).filter(
+        (element) =>
+          element.getClientRects().length > 0 &&
+          element.querySelector(
+            `[data-testid="${deleteTokenErrorToastTestId}"]`,
+          ),
+      )
       const message = visibleStatusMessages.at(-1)?.textContent?.trim()
 
       return message
@@ -349,6 +359,8 @@ async function waitForTokenDeletionOutcome(params: {
     {
       rowTestId: params.rowTestId,
       preexistingStatusAttribute: PREEXISTING_STATUS_ATTRIBUTE,
+      deleteTokenErrorToastTestId:
+        KEY_MANAGEMENT_TEST_IDS.deleteTokenErrorToast,
     },
     { timeout: 30_000 },
   )

--- a/e2e/utils/commonUserFlows.ts
+++ b/e2e/utils/commonUserFlows.ts
@@ -82,6 +82,10 @@ type StubNewApiSiteRoutesOptions = {
     status?: number
     message: string
   }
+  deleteTokenError?: {
+    status?: number
+    message: string
+  }
   groups?: Record<string, { desc: string; ratio: number }>
   dashboardAuthMode?: "legacy" | "auth-bundle"
 }
@@ -1027,6 +1031,18 @@ export async function stubNewApiSiteRoutes(
     }
 
     if (method === "DELETE" && /^\/api\/token\/\d+$/.test(url.pathname)) {
+      if (options.deleteTokenError) {
+        await route.fulfill({
+          status: options.deleteTokenError.status ?? 400,
+          contentType: "application/json",
+          body: JSON.stringify({
+            success: false,
+            message: options.deleteTokenError.message,
+          }),
+        })
+        return
+      }
+
       const tokenId = Number(url.pathname.split("/").pop())
       const tokenIndex = tokens.findIndex((token) => token.id === tokenId)
 

--- a/e2e/utils/realSite/accountUsage.ts
+++ b/e2e/utils/realSite/accountUsage.ts
@@ -81,6 +81,8 @@ export async function verifyRealSiteAccountKeyToApiProfileUsage(
       afterProfileSaved?: (profile: ApiCredentialProfile) => Promise<void>
     },
 ) {
+  const profileLabel = context.profileLabel ?? `${context.label} Profile`
+
   return await verifyAccountKeyToApiProfileUsage({
     page: context.page,
     extensionId: context.extensionId,
@@ -89,13 +91,14 @@ export async function verifyRealSiteAccountKeyToApiProfileUsage(
     cleanupAccountFixture: false,
     cleanupCreatedProfile: context.cleanupCreatedProfile,
     cleanupCreatedToken: context.cleanupCreatedToken,
+    cleanupTokenNameMatcher: (tokenName) =>
+      isRealSiteTestTokenName({ tokenName, label: profileLabel }),
     afterProfileSaved: context.afterProfileSaved,
     expectedProfile: {
       baseUrl: context.account.baseUrl,
       ...context.expectedProfile,
     },
-    buildTokenName: () =>
-      buildUsageTokenName(context.profileLabel ?? `${context.label} Profile`),
+    buildTokenName: () => buildUsageTokenName(profileLabel),
   })
 }
 

--- a/src/features/KeyManagement/hooks/useKeyManagement.ts
+++ b/src/features/KeyManagement/hooks/useKeyManagement.ts
@@ -11,6 +11,7 @@ import { useTranslation } from "react-i18next"
 
 import { SITE_TYPES } from "~/constants/siteType"
 import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
+import { KEY_MANAGEMENT_TEST_IDS } from "~/features/KeyManagement/testIds"
 import { useAccountData } from "~/hooks/useAccountData"
 import {
   buildDisplayAccountTokenRuntimeKey,
@@ -65,7 +66,6 @@ import { normalizeUrlForOriginKey } from "~/utils/core/urlParsing"
 
 import { KEY_MANAGEMENT_ALL_ACCOUNTS_VALUE } from "../constants"
 import { isKeyResourceExportable } from "../presentation/legacyKeyResourceCard"
-import { KEY_MANAGEMENT_TEST_IDS } from "../testIds"
 import { type KeyManagementEntry, type ServiceCredentialState } from "../types"
 import {
   buildAccountRuntimeKeyEntryIdentityKey,

--- a/src/features/KeyManagement/hooks/useKeyManagement.ts
+++ b/src/features/KeyManagement/hooks/useKeyManagement.ts
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import {
+  createElement,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react"
 import toast from "react-hot-toast"
 import { useTranslation } from "react-i18next"
 
@@ -58,6 +65,7 @@ import { normalizeUrlForOriginKey } from "~/utils/core/urlParsing"
 
 import { KEY_MANAGEMENT_ALL_ACCOUNTS_VALUE } from "../constants"
 import { isKeyResourceExportable } from "../presentation/legacyKeyResourceCard"
+import { KEY_MANAGEMENT_TEST_IDS } from "../testIds"
 import { type KeyManagementEntry, type ServiceCredentialState } from "../types"
 import {
   buildAccountRuntimeKeyEntryIdentityKey,
@@ -74,6 +82,16 @@ import {
  * Unified logger scoped to the Key Management options page hooks.
  */
 const logger = createLogger("KeyManagementHook")
+
+const showDeleteTokenError = (message: string) => {
+  toast.error(
+    createElement(
+      "span",
+      { "data-testid": KEY_MANAGEMENT_TEST_IDS.deleteTokenErrorToast },
+      message,
+    ),
+  )
+}
 
 const keyManagementAnalyticsContext = (
   actionId:
@@ -2141,7 +2159,7 @@ export function useKeyManagement(routeParams?: Record<string, string>) {
             (acc) => acc.id === token.accountId,
           )
           if (!account) {
-            toast.error(t("keyManagement:messages.accountNotFound"))
+            showDeleteTokenError(t("keyManagement:messages.accountNotFound"))
             tracker.complete(PRODUCT_ANALYTICS_RESULTS.Failure, {
               errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
             })
@@ -2191,7 +2209,7 @@ export function useKeyManagement(routeParams?: Record<string, string>) {
     } catch (error) {
       const errorMessage = getErrorMessage(error) || String(error)
       logger.error("删除密钥失败", errorMessage)
-      toast.error(errorMessage)
+      showDeleteTokenError(errorMessage)
       tracker.complete(PRODUCT_ANALYTICS_RESULTS.Failure, {
         errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
       })

--- a/src/features/KeyManagement/testIds.ts
+++ b/src/features/KeyManagement/testIds.ts
@@ -45,6 +45,7 @@ export const KEY_MANAGEMENT_TEST_IDS = {
   serviceCredentialCard: "key-management-service-credential-card",
   titleActions: "key-management-title-actions",
   deleteTokenConfirmButton: "key-management-delete-token-confirm-button",
+  deleteTokenErrorToast: "key-management-delete-token-error-toast",
   accountScopeSelect: "key-management-account-scope-select",
   accountScopeAllOption: "key-management-account-scope-all-option",
   expandAllButton: "key-management-expand-all-button",

--- a/tests/entrypoints/options/pages/KeyManagement/useKeyManagement.test.tsx
+++ b/tests/entrypoints/options/pages/KeyManagement/useKeyManagement.test.tsx
@@ -7,6 +7,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import { SITE_TYPES } from "~/constants/siteType"
 import { KEY_MANAGEMENT_ALL_ACCOUNTS_VALUE } from "~/features/KeyManagement/constants"
 import { useKeyManagement } from "~/features/KeyManagement/hooks/useKeyManagement"
+import { KEY_MANAGEMENT_TEST_IDS } from "~/features/KeyManagement/testIds"
 import { buildTokenIdentityKey } from "~/features/KeyManagement/utils"
 import { useAccountData } from "~/hooks/useAccountData"
 import {
@@ -4952,7 +4953,13 @@ describe("useKeyManagement enabled account filtering", () => {
     })
 
     expect(vi.mocked(toast.error)).toHaveBeenCalledWith(
-      "keyManagement:messages.accountNotFound",
+      expect.objectContaining({
+        type: "span",
+        props: expect.objectContaining({
+          "data-testid": KEY_MANAGEMENT_TEST_IDS.deleteTokenErrorToast,
+          children: "keyManagement:messages.accountNotFound",
+        }),
+      }),
     )
 
     confirmSpy.mockRestore()
@@ -5168,7 +5175,15 @@ describe("useKeyManagement enabled account filtering", () => {
       await result.current.handleDeleteToken(token)
     })
 
-    expect(vi.mocked(toast.error)).toHaveBeenCalledWith("delete boom")
+    expect(vi.mocked(toast.error)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "span",
+        props: expect.objectContaining({
+          "data-testid": KEY_MANAGEMENT_TEST_IDS.deleteTokenErrorToast,
+          children: "delete boom",
+        }),
+      }),
+    )
     expect(startProductAnalyticsActionMock).toHaveBeenCalledWith({
       featureId: PRODUCT_ANALYTICS_FEATURE_IDS.KeyManagement,
       actionId: PRODUCT_ANALYTICS_ACTION_IDS.DeleteAccountToken,

--- a/tests/utils/accountScenarios.test.ts
+++ b/tests/utils/accountScenarios.test.ts
@@ -604,6 +604,8 @@ describe("account E2E scenarios", () => {
     vi.mocked(deleteApiCredentialProfileFromStorage).mockResolvedValue(
       undefined,
     )
+    const cleanupTokenNameMatcher = (tokenName: string) =>
+      tokenName.startsWith("AAH E2E NewAPIPr ")
 
     const profile = await runAccountKeyToApiProfileScenario({
       extensionId: "extension-id",
@@ -616,6 +618,7 @@ describe("account E2E scenarios", () => {
         baseUrl: "https://seeded.example.com",
         apiKey: "sk-created-profile",
       },
+      cleanupTokenNameMatcher,
       cleanup: environmentCleanup,
     })
 
@@ -631,6 +634,17 @@ describe("account E2E scenarios", () => {
       baseUrl: "https://seeded.example.com",
       openFromAccountRow: true,
     })
+    expect(deleteTokensMatchingNameFromKeyManagementPage).toHaveBeenCalledWith({
+      page: keyPage,
+      nameMatcher: cleanupTokenNameMatcher,
+    })
+    expect(
+      vi.mocked(deleteTokensMatchingNameFromKeyManagementPage).mock
+        .invocationCallOrder[0],
+    ).toBeLessThan(
+      vi.mocked(submitTokenCreationFromKeyManagementPage).mock
+        .invocationCallOrder[0],
+    )
     expect(submitTokenCreationFromKeyManagementPage).toHaveBeenCalledWith({
       page: keyPage,
       tokenName: "E2E Profile Key",

--- a/tests/utils/realSiteAccountUsage.test.ts
+++ b/tests/utils/realSiteAccountUsage.test.ts
@@ -128,11 +128,18 @@ describe("real-site account usage adapters", () => {
     const call = vi.mocked(verifyAccountKeyToApiProfileUsage).mock.calls[0][0]
     expect(call).toMatchObject({
       cleanupAccountFixture: false,
+      cleanupTokenNameMatcher: expect.any(Function),
       expectedProfile: {
         baseUrl: "https://new-api.test",
         name: "Custom profile",
       },
     })
+    expect(call.cleanupTokenNameMatcher?.("AAH E2E NewAPIPr abc123def4")).toBe(
+      true,
+    )
+    expect(call.cleanupTokenNameMatcher?.("AAH E2E NewAPI abc123def4")).toBe(
+      false,
+    )
     expect(call.buildTokenName()).toBe("New API Profile:run-id")
   })
 


### PR DESCRIPTION
## Why

The scheduled Account / New API journey could leave a test-owned API-profile key behind and then time out on a later run. While hardening that cleanup, a targeted real-site run also showed that deletion diagnostics treated any new status toast as a deletion failure, including a late success toast from saving the profile.

## What changed

- Clean test-owned keys for both the account lifecycle and API-profile labels before creating the next real-site key.
- Wait for the target key row to disappear or for a Key Management-owned deletion error, without retrying uncertain mutations.
- Add deterministic Playwright coverage for stale cleanup, backend deletion errors, and unrelated-notification races, plus focused hook coverage for the deletion-error marker.

This does not change API deletion protocols or add automatic deletion retries. The user-visible error content remains unchanged; the marker only gives the E2E harness a stable ownership signal.

## Validation

- Pre-commit `validate:staged`: passed (Prettier, ESLint, affected Vitest, i18n checks).
- Pre-push `validate:push`: passed (`pnpm compile`, `pnpm knip`).
- `pnpm exec vitest run tests/entrypoints/options/pages/KeyManagement/useKeyManagement.test.tsx`: 85 passed.
- `pnpm e2e e2e/keyManagementCommonFlow.spec.ts --grep "reports the delete response|ignores an unrelated success notification" --project=chromium --no-deps --repeat-each=5`: 10 passed.
- `pnpm e2e e2e/accountToApiProfileJourney.spec.ts --project=chromium --no-deps`: 1 passed.
- [Real-Site E2E run 31469565567](https://github.com/qixing-jk/all-api-hub/actions/runs/31469565567), exact head `f573b04a143d696905fc105755ca13db8e636ae6`: Account / New API, 5 passed.

The full repository test suite and coverage were not run locally; pull-request CI remains authoritative for those checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token deletion error handling with clear, dedicated error notifications.
  * Preserved token visibility when deletion fails.
  * Prevented unrelated success notifications from masking deletion results.
  * Ensured matching existing tokens are cleaned up before creating new ones.

* **Tests**
  * Expanded coverage for token deletion failures, lifecycle flows, and token cleanup matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->