### PR TITLE
fix(options): keep page header actions reachable

### DIFF
--- a/e2e/accountManagementCommonFlows.spec.ts
+++ b/e2e/accountManagementCommonFlows.spec.ts
@@ -188,10 +188,7 @@ test("keeps every account header action reachable across constrained widths", as
       name: "Refresh disabled accounts",
       exact: true,
     }),
-    page.getByRole("button", {
-      name: "Open all external check-ins",
-      exact: true,
-    }),
+    page.getByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.externalCheckInButton),
     page.getByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.bookmarkImportButton),
     page.getByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.dedupeScanButton),
     page.getByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.addAccountButton),
@@ -278,10 +275,9 @@ test("keeps every account header action reachable across constrained widths", as
     await expectHeaderActionsContained(viewportSize)
   }
 
-  const externalCheckInAction = page.getByRole("button", {
-    name: "Open all external check-ins",
-    exact: true,
-  })
+  const externalCheckInAction = page.getByTestId(
+    ACCOUNT_MANAGEMENT_TEST_IDS.externalCheckInButton,
+  )
   const constrainedWidthStressLabel =
     "Open every available external check-in action in a separate page"
   await externalCheckInAction.evaluate((action, label) => {

--- a/e2e/accountManagementCommonFlows.spec.ts
+++ b/e2e/accountManagementCommonFlows.spec.ts
@@ -1,6 +1,7 @@
 import type { Page } from "@playwright/test"
 
 import { OPTIONS_PAGE_PATH } from "~/constants/extensionPages"
+import { OPTIONS_TEST_IDS } from "~/entrypoints/options/testIds"
 import {
   ACCOUNT_MANAGEMENT_TEST_IDS,
   getAccountManagementListItemTestId,
@@ -145,6 +146,160 @@ test.beforeEach(async ({ context, page }) => {
   installExtensionPageGuards(page)
   await forceExtensionLanguage(page, "en")
   await stubLlmMetadataIndex(context)
+})
+
+test("keeps every account header action reachable across constrained widths", async ({
+  context,
+  extensionId,
+  page,
+}) => {
+  const viewportSizes = [
+    { width: 1280, height: 720 },
+    { width: 320, height: 720 },
+  ]
+  await page.setViewportSize(viewportSizes[0])
+
+  const serviceWorker = await getServiceWorker(context)
+  await seedStoredAccounts(serviceWorker, [
+    createStoredAccount({
+      id: "responsive-header-account",
+      site_name: "Responsive Header Account",
+      site_url: "https://account.example.invalid",
+      disabled: true,
+      checkIn: {
+        enableDetection: true,
+        customCheckIn: { url: "https://check-in.example.invalid" },
+      },
+    }),
+  ])
+
+  await page.goto(
+    `chrome-extension://${extensionId}/${OPTIONS_PAGE_PATH}#account`,
+  )
+  await waitForExtensionRoot(page)
+  await expectPermissionOnboardingHidden(page)
+
+  const headerActionGroup = page.getByTestId(
+    ACCOUNT_MANAGEMENT_TEST_IDS.headerActions,
+  )
+  const requiredHeaderActions = [
+    page.getByRole("button", { name: "Refresh", exact: true }),
+    page.getByRole("button", {
+      name: "Refresh disabled accounts",
+      exact: true,
+    }),
+    page.getByRole("button", {
+      name: "Open all external check-ins",
+      exact: true,
+    }),
+    page.getByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.bookmarkImportButton),
+    page.getByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.dedupeScanButton),
+    page.getByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.addAccountButton),
+  ]
+  for (const action of requiredHeaderActions) {
+    await expect(action.first()).toBeVisible()
+  }
+
+  const headerActions = headerActionGroup.getByRole("button")
+  const contentCard = page.getByTestId(OPTIONS_TEST_IDS.contentCard)
+  await expect(contentCard).toBeVisible()
+
+  async function expectHeaderActionsContained(viewportSize: {
+    width: number
+    height: number
+  }) {
+    await page.setViewportSize(viewportSize)
+
+    await expect
+      .poll(async () => {
+        const contentCardBox = await contentCard.boundingBox()
+        const headerActionGroupBox = await headerActionGroup.boundingBox()
+        const boxes = await headerActions.evaluateAll((actions) => {
+          return actions.map((action) => {
+            const box = action.getBoundingClientRect()
+            return {
+              x: box.x,
+              y: box.y,
+              height: box.height,
+              right: box.right,
+              width: box.width,
+            }
+          })
+        })
+
+        const rowRightEdges = new Map<number, number>()
+        for (const box of boxes) {
+          const rowCenter = Math.round(box.y + box.height / 2)
+          rowRightEdges.set(
+            rowCenter,
+            Math.max(rowRightEdges.get(rowCenter) ?? 0, box.right),
+          )
+        }
+        const actionGroupRight = headerActionGroupBox
+          ? headerActionGroupBox.x + headerActionGroupBox.width
+          : 0
+        const rowAlignmentError = Math.max(
+          ...Array.from(rowRightEdges.values()).map((rightEdge) =>
+            Math.abs(rightEdge - actionGroupRight),
+          ),
+        )
+
+        return {
+          hasLayout: Boolean(contentCardBox && headerActionGroupBox),
+          actionsContained: Boolean(
+            contentCardBox &&
+              boxes.every(
+                (box) =>
+                  box.x >= contentCardBox.x &&
+                  box.x + box.width <= contentCardBox.x + contentCardBox.width,
+              ),
+          ),
+          actionsWrapped: rowRightEdges.size > 1,
+          rowsRightAligned: rowAlignmentError <= 1,
+        }
+      })
+      .toEqual({
+        hasLayout: true,
+        actionsContained: true,
+        actionsWrapped: true,
+        rowsRightAligned: true,
+      })
+
+    expect(
+      await page.evaluate(
+        () =>
+          document.documentElement.scrollWidth ===
+          document.documentElement.clientWidth,
+      ),
+    ).toBe(true)
+  }
+
+  for (const viewportSize of viewportSizes) {
+    await expectHeaderActionsContained(viewportSize)
+  }
+
+  const externalCheckInAction = page.getByRole("button", {
+    name: "Open all external check-ins",
+    exact: true,
+  })
+  const constrainedWidthStressLabel =
+    "Open every available external check-in action in a separate page"
+  await externalCheckInAction.evaluate((action, label) => {
+    const textNode = Array.from(action.childNodes).find(
+      (node) => node.nodeType === Node.TEXT_NODE && node.textContent?.trim(),
+    )
+    if (!textNode) {
+      throw new Error("Could not resolve the external check-in action label")
+    }
+    textNode.textContent = label
+  }, constrainedWidthStressLabel)
+  await expect(
+    page.getByRole("button", {
+      name: constrainedWidthStressLabel,
+      exact: true,
+    }),
+  ).toBeVisible()
+  await expectHeaderActionsContained(viewportSizes[1])
 })
 
 test("keeps the add account dialog open when text selection ends over its backdrop", async ({

--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -40,12 +40,18 @@ export function PageHeader({
   iconClassName,
 }: PageHeaderProps) {
   return (
-    <div className={cn(spacing === "compact" ? "mb-6" : "mb-8", className)}>
-      <div className="flex flex-col gap-2 md:flex-row md:items-start md:justify-between md:gap-4">
-        <div className="flex items-center gap-3">
+    <div
+      className={cn(
+        "[container-type:inline-size]",
+        spacing === "compact" ? "mb-6" : "mb-8",
+        className,
+      )}
+    >
+      <div className="flex flex-col gap-2 [@container(min-width:42rem)]:flex-row [@container(min-width:42rem)]:items-start [@container(min-width:42rem)]:justify-between [@container(min-width:42rem)]:gap-4">
+        <div className="flex min-w-0 items-center gap-3">
           <Icon
             className={cn(
-              "h-6 w-6 text-blue-600 dark:text-blue-400",
+              "h-6 w-6 shrink-0 text-blue-600 dark:text-blue-400",
               iconClassName,
             )}
           />
@@ -60,7 +66,7 @@ export function PageHeader({
           </div>
         </div>
         {actions && (
-          <div className="flex shrink-0 flex-wrap items-center gap-3">
+          <div className="flex w-full min-w-0 flex-wrap items-center gap-3 [&_[data-slot=button]]:h-auto [&_[data-slot=button]]:min-h-9 [&_[data-slot=button]]:max-w-full [&_[data-slot=button]]:whitespace-normal [&_[data-slot=button][data-size=default]]:min-h-9 [&_[data-slot=button][data-size=icon-lg]]:min-h-10 [&_[data-slot=button][data-size=icon-sm]]:min-h-8 [&_[data-slot=button][data-size=icon-xs]]:min-h-6 [&_[data-slot=button][data-size=icon]]:min-h-9 [&_[data-slot=button][data-size=lg]]:min-h-10 [&_[data-slot=button][data-size=sm]]:min-h-8 [@container(min-width:42rem)]:w-auto [@container(min-width:42rem)]:flex-1 [@container(min-width:42rem)]:justify-end">
             {actions}
           </div>
         )}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -88,6 +88,7 @@ function Button({
   }) {
   const Comp = asChild ? Slot.Root : "button"
   const isDisabled = Boolean(disabled || loading)
+  const resolvedSize = size ?? "default"
   const analytics = useProductAnalyticsActionTracking({
     analyticsAction,
     disabled: isDisabled,
@@ -147,6 +148,7 @@ function Button({
       disabled={asChild ? undefined : isDisabled}
       onClick={handleClick}
       {...props}
+      data-size={resolvedSize}
       aria-busy={loading ? true : ariaBusy}
     >
       {resolvedLeftIcon && <span>{resolvedLeftIcon}</span>}

--- a/src/entrypoints/options/App.tsx
+++ b/src/entrypoints/options/App.tsx
@@ -146,10 +146,13 @@ function OptionsPage() {
         />
 
         {/* 右侧内容区域 */}
-        <main className="flex-1">
+        <main className="min-w-0 flex-1">
           <div className="mx-auto w-full max-w-7xl px-2 py-3 sm:px-4 sm:py-5 md:px-6 md:py-6">
             <PopupInterruptionHintBanner className="mb-3 sm:mb-4" />
-            <div className="dark:border-dark-bg-tertiary dark:bg-dark-bg-secondary min-h-[400px] overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm md:min-h-[600px]">
+            <div
+              className="dark:border-dark-bg-tertiary dark:bg-dark-bg-secondary min-h-[400px] overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-sm md:min-h-[600px]"
+              data-testid={OPTIONS_TEST_IDS.contentCard}
+            >
               <Suspense fallback={<OptionsPageContentFallback />}>
                 <ActiveComponent
                   routeParams={routeParams}

--- a/src/entrypoints/options/testIds.ts
+++ b/src/entrypoints/options/testIds.ts
@@ -1,3 +1,4 @@
 export const OPTIONS_TEST_IDS = {
   app: "options-app",
+  contentCard: "options-content-card",
 } as const

--- a/src/features/AccountManagement/AccountManagement.tsx
+++ b/src/features/AccountManagement/AccountManagement.tsx
@@ -402,6 +402,9 @@ function AccountManagementContent({
                     onClick={handleOpenExternalCheckInsClick}
                     leftIcon={<CalendarCheck2 className="h-4 w-4" />}
                     title={t("account:actions.openAllExternalCheckInHint")}
+                    data-testid={
+                      ACCOUNT_MANAGEMENT_TEST_IDS.externalCheckInButton
+                    }
                   >
                     {t("account:actions.openAllExternalCheckIn")}
                   </Button>

--- a/src/features/AccountManagement/AccountManagement.tsx
+++ b/src/features/AccountManagement/AccountManagement.tsx
@@ -366,7 +366,10 @@ function AccountManagementContent({
             featureId={PRODUCT_ANALYTICS_FEATURE_IDS.AccountManagement}
             surfaceId={headerSurface}
           >
-            <div className="flex flex-wrap items-center gap-2">
+            <div
+              className="flex w-full flex-wrap items-center justify-end gap-2"
+              data-testid={ACCOUNT_MANAGEMENT_TEST_IDS.headerActions}
+            >
               <Button
                 onClick={() => void handleGlobalRefresh()}
                 variant="secondary"

--- a/src/features/AccountManagement/testIds.ts
+++ b/src/features/AccountManagement/testIds.ts
@@ -1,5 +1,6 @@
 export const ACCOUNT_MANAGEMENT_TEST_IDS = {
   addAccountButton: "account-management-add-account-button",
+  externalCheckInButton: "account-management-external-check-in-button",
   headerActions: "account-management-header-actions",
   accountDialog: "account-management-account-dialog",
   accountForm: "account-management-account-form",

--- a/src/features/AccountManagement/testIds.ts
+++ b/src/features/AccountManagement/testIds.ts
@@ -1,5 +1,6 @@
 export const ACCOUNT_MANAGEMENT_TEST_IDS = {
   addAccountButton: "account-management-add-account-button",
+  headerActions: "account-management-header-actions",
   accountDialog: "account-management-account-dialog",
   accountForm: "account-management-account-form",
   accountListView: "account-list-view",

--- a/tests/components/Button.test.tsx
+++ b/tests/components/Button.test.tsx
@@ -36,6 +36,40 @@ describe("Button", () => {
     ).not.toBeInTheDocument()
   })
 
+  it("exposes the resolved visual size for responsive layout containers", async () => {
+    render(
+      <>
+        <Button>Default</Button>
+        <Button size="sm">Small</Button>
+        <Button size="lg">Large</Button>
+      </>,
+    )
+
+    expect(
+      await screen.findByRole("button", { name: "Default" }),
+    ).toHaveAttribute("data-size", "default")
+    expect(screen.getByRole("button", { name: "Small" })).toHaveAttribute(
+      "data-size",
+      "sm",
+    )
+    expect(screen.getByRole("button", { name: "Large" })).toHaveAttribute(
+      "data-size",
+      "lg",
+    )
+  })
+
+  it("forwards the resolved visual size through asChild", async () => {
+    render(
+      <Button asChild size="sm" data-size="lg">
+        <a href="/settings">Settings</a>
+      </Button>,
+    )
+
+    expect(
+      await screen.findByRole("link", { name: "Settings" }),
+    ).toHaveAttribute("data-size", "sm")
+  })
+
   it("keeps caller pending content and exposes the loading state", async () => {
     const { container } = render(
       <Button


### PR DESCRIPTION
## Summary

Prevent options-page header actions from overflowing or becoming unreachable when the available content width is constrained.

Wrapped Account Management actions are also aligned to the right so multi-row toolbars retain a consistent visual edge.

## What changed

- Make the shared page header respond to its actual container width and allow title and action regions to shrink and wrap safely.
- Preserve each button size's intended minimum height while allowing long labels to wrap.
- Remove options-layout min-content constraints that could force the content card wider than the viewport.
- Right-align every wrapped Account Management action row.
- Add browser coverage for dynamic action counts, constrained widths, long labels, horizontal containment, and row alignment.

## Validation

- `pnpm run validate:staged`
- `pnpm run validate:push`
- `pnpm run build:e2e`
- `pnpm exec playwright test e2e/accountManagementCommonFlows.spec.ts --project=chromium --no-deps --workers=1 --grep "keeps every account header action reachable" --reporter=list`

All listed checks passed. The full test suite and coverage are delegated to PR CI.

## Risk

This changes shared page-header and button layout behavior, but does not alter persistence, protocols, permissions, or telemetry. Focused component and real-browser layout checks cover the affected behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved account header layouts across wide and narrow screens.
  - Actions now wrap, remain right-aligned, and stay within the content card without horizontal overflow.
  - Long action labels are handled more gracefully on small screens.

- **Bug Fixes**
  - Improved responsive sizing and alignment for options pages and account management controls.

- **Tests**
  - Added coverage for responsive layouts and button size behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->