### PR TITLE
feat(api-credentials): group profiles by endpoint

### DIFF
--- a/e2e/apiCredentialProfilesGrouping.spec.ts
+++ b/e2e/apiCredentialProfilesGrouping.spec.ts
@@ -1,0 +1,112 @@
+import { OPTIONS_PAGE_PATH, POPUP_PAGE_PATH } from "~/constants/extensionPages"
+import { MENU_ITEM_IDS } from "~/constants/optionsMenuIds"
+import { POPUP_TEST_IDS } from "~/entrypoints/popup/testIds"
+import { API_CREDENTIAL_PROFILES_TEST_IDS } from "~/features/ApiCredentialProfiles/testIds"
+import { expect, test } from "~~/e2e/fixtures/extensionTest"
+import {
+  createStoredApiCredentialProfile,
+  forceExtensionLanguage,
+  installExtensionPageGuards,
+  seedApiCredentialProfiles,
+} from "~~/e2e/utils/commonUserFlows"
+import {
+  expectPermissionOnboardingHidden,
+  getServiceWorker,
+} from "~~/e2e/utils/extensionState"
+import { waitForExtensionRoot } from "~~/e2e/utils/lazyLoading"
+
+test.beforeEach(async ({ page }) => {
+  installExtensionPageGuards(page)
+  await forceExtensionLanguage(page, "en")
+})
+
+test("groups credentials by Base URL while preserving each credential card", async ({
+  context,
+  extensionId,
+  page,
+}) => {
+  const firstBaseUrl = "https://team-gateway.example.invalid"
+  const secondBaseUrl = "https://backup-gateway.example.invalid"
+  const serviceWorker = await getServiceWorker(context)
+  await seedApiCredentialProfiles(serviceWorker, [
+    createStoredApiCredentialProfile({
+      id: "team-primary",
+      name: "Team primary",
+      baseUrl: firstBaseUrl,
+      apiKey: "sk-team-primary",
+    }),
+    createStoredApiCredentialProfile({
+      id: "team-fallback",
+      name: "Team fallback",
+      baseUrl: firstBaseUrl,
+      apiKey: "sk-team-fallback",
+    }),
+    createStoredApiCredentialProfile({
+      id: "backup-key",
+      name: "Backup endpoint key",
+      baseUrl: secondBaseUrl,
+      apiKey: "sk-backup-key",
+    }),
+  ])
+
+  await page.goto(
+    `chrome-extension://${extensionId}/${OPTIONS_PAGE_PATH}#${MENU_ITEM_IDS.API_CREDENTIAL_PROFILES}`,
+  )
+  await waitForExtensionRoot(page)
+  await expectPermissionOnboardingHidden(page)
+
+  const endpointNavigation = page.getByTestId(
+    API_CREDENTIAL_PROFILES_TEST_IDS.endpointNavigation,
+  )
+  await expect(endpointNavigation).toBeVisible()
+  await endpointNavigation
+    .getByRole("button", { name: /team-gateway\.example\.invalid/ })
+    .click()
+  await expect(page.getByText("Team primary", { exact: true })).toBeVisible()
+  await expect(page.getByText("Team fallback", { exact: true })).toBeVisible()
+  await expect(page.getByText(firstBaseUrl, { exact: true })).toHaveCount(1)
+  await expect(
+    page.getByTestId(
+      API_CREDENTIAL_PROFILES_TEST_IDS.endpointCopyBaseUrlButton,
+    ),
+  ).toHaveCount(1)
+  await expect(
+    page.getByText("Backup endpoint key", { exact: true }),
+  ).toHaveCount(0)
+
+  await endpointNavigation
+    .getByRole("button", { name: /backup-gateway\.example\.invalid/ })
+    .click()
+
+  await expect(
+    page.getByText("Backup endpoint key", { exact: true }),
+  ).toBeVisible()
+  await expect(page.getByText(secondBaseUrl, { exact: true })).toHaveCount(1)
+  await expect(
+    page.getByTestId(API_CREDENTIAL_PROFILES_TEST_IDS.editButton),
+  ).toBeVisible()
+
+  await page.setViewportSize({ width: 420, height: 900 })
+  await page.goto(`chrome-extension://${extensionId}/${POPUP_PAGE_PATH}`)
+  await waitForExtensionRoot(page)
+  await page.getByTestId(POPUP_TEST_IDS.apiCredentialProfilesTab).click()
+
+  const endpointSelector = page.getByTestId(
+    API_CREDENTIAL_PROFILES_TEST_IDS.endpointSelector,
+  )
+  await expect(endpointSelector).toBeVisible()
+  await endpointSelector.click()
+  await page
+    .getByRole("option", { name: /backup-gateway\.example\.invalid/ })
+    .click()
+  await expect(
+    page.getByText("Backup endpoint key", { exact: true }),
+  ).toBeVisible()
+  expect(
+    await page.evaluate(
+      () =>
+        document.documentElement.scrollWidth <=
+        document.documentElement.clientWidth,
+    ),
+  ).toBe(true)
+})

--- a/e2e/apiCredentialProfilesGrouping.spec.ts
+++ b/e2e/apiCredentialProfilesGrouping.spec.ts
@@ -60,7 +60,10 @@ test("groups credentials by Base URL while preserving each credential card", asy
   )
   await expect(endpointNavigation).toBeVisible()
   await endpointNavigation
-    .getByRole("button", { name: /team-gateway\.example\.invalid/ })
+    .getByRole("button", {
+      name: "https://team-gateway.example.invalid",
+      exact: true,
+    })
     .click()
   await expect(page.getByText("Team primary", { exact: true })).toBeVisible()
   await expect(page.getByText("Team fallback", { exact: true })).toBeVisible()
@@ -75,7 +78,10 @@ test("groups credentials by Base URL while preserving each credential card", asy
   ).toHaveCount(0)
 
   await endpointNavigation
-    .getByRole("button", { name: /backup-gateway\.example\.invalid/ })
+    .getByRole("button", {
+      name: "https://backup-gateway.example.invalid",
+      exact: true,
+    })
     .click()
 
   await expect(

--- a/e2e/apiCredentialProfilesOptionsActions.spec.ts
+++ b/e2e/apiCredentialProfilesOptionsActions.spec.ts
@@ -20,6 +20,7 @@ import {
   expectPermissionOnboardingHidden,
   getPlasmoStorageRawValue,
   getServiceWorker,
+  setPlasmoStorageValue,
 } from "~~/e2e/utils/extensionState"
 import { waitForExtensionRoot } from "~~/e2e/utils/lazyLoading"
 
@@ -190,8 +191,86 @@ test("filters options-page profiles and copies reusable credentials", async ({
       notes: "rarely used",
     }),
   ])
+  await setPlasmoStorageValue(
+    serviceWorker,
+    STORAGE_KEYS.VERIFICATION_RESULT_HISTORY,
+    {
+      version: 1,
+      lastUpdated: Date.now(),
+      summaries: [
+        {
+          target: {
+            kind: "profile-model",
+            profileId: "profile-primary",
+            modelId: "example-model",
+          },
+          targetKey: "profile:profile-primary:model:example-model",
+          status: "pass",
+          verifiedAt: Date.now(),
+          apiType: "openai-compatible",
+          resolvedModelId: "example-model",
+          probes: [
+            {
+              id: "text-generation",
+              status: "pass",
+              latencyMs: 12,
+              summary: "Generated text",
+            },
+          ],
+        },
+      ],
+    },
+  )
 
   await openProfilesPage(page, extensionId)
+  await page
+    .getByTestId(API_CREDENTIAL_PROFILES_TEST_IDS.endpointNavigation)
+    .getByRole("button", { name: /reusable\.example\.com/i })
+    .click()
+
+  await expect(page.getByText("Pass", { exact: true })).toBeVisible()
+  await expect(page.getByText("Unverified", { exact: true })).toHaveCount(0)
+
+  const endpointBaseUrl = page.getByTestId(
+    API_CREDENTIAL_PROFILES_TEST_IDS.endpointBaseUrl,
+  )
+  const endpointCredentialCount = page.getByTestId(
+    API_CREDENTIAL_PROFILES_TEST_IDS.endpointCredentialCount,
+  )
+  await expect
+    .poll(async () => {
+      const [baseUrlBox, countBox] = await Promise.all([
+        endpointBaseUrl.boundingBox(),
+        endpointCredentialCount.boundingBox(),
+      ])
+      return Boolean(
+        baseUrlBox &&
+          countBox &&
+          Math.abs(
+            baseUrlBox.y +
+              baseUrlBox.height / 2 -
+              (countBox.y + countBox.height / 2),
+          ) < 1 &&
+          countBox.x - (baseUrlBox.x + baseUrlBox.width) <= 12,
+      )
+    })
+    .toBe(true)
+
+  await page
+    .getByRole("region", {
+      name: "Credentials for https://reusable.example.com",
+    })
+    .getByTestId(API_CREDENTIAL_PROFILES_TEST_IDS.endpointAddCredentialButton)
+    .click()
+  const addToEndpointDialog = page.getByTestId(
+    API_CREDENTIAL_PROFILES_TEST_IDS.dialog,
+  )
+  await expect(addToEndpointDialog).toBeVisible()
+  await expect(page.locator("#api-credential-profile-baseUrl")).toHaveValue(
+    "https://reusable.example.com",
+  )
+  await addToEndpointDialog.getByRole("button", { name: "Close" }).click()
+  await expect(addToEndpointDialog).toHaveCount(0)
 
   const searchInput = page.getByPlaceholder(
     "Search by name, base URL, tag, or notes",
@@ -205,11 +284,57 @@ test("filters options-page profiles and copies reusable credentials", async ({
     page.getByRole("heading", { name: "Archive Profile" }),
   ).toHaveCount(0)
 
+  const toolbar = page.getByTestId(API_CREDENTIAL_PROFILES_TEST_IDS.toolbar)
+  const copyBundleButton = page.getByTestId(
+    API_CREDENTIAL_PROFILES_TEST_IDS.copyBundleButton,
+  )
+  const deleteButton = page.getByTestId(
+    API_CREDENTIAL_PROFILES_TEST_IDS.deleteTriggerButton,
+  )
+  await expect
+    .poll(async () => {
+      const [toolbarBox, firstButtonBox, lastButtonBox] = await Promise.all([
+        toolbar.boundingBox(),
+        copyBundleButton.boundingBox(),
+        deleteButton.boundingBox(),
+      ])
+      return Boolean(
+        toolbarBox &&
+          firstButtonBox &&
+          lastButtonBox &&
+          toolbarBox.width > 200 &&
+          Math.abs(firstButtonBox.y - lastButtonBox.y) < 1,
+      )
+    })
+    .toBe(true)
+
+  const telemetryToggle = page.getByTestId(
+    API_CREDENTIAL_PROFILES_TEST_IDS.telemetryToggle,
+  )
+  const telemetryPanel = page.getByTestId(
+    API_CREDENTIAL_PROFILES_TEST_IDS.telemetryPanel,
+  )
+  await expect(telemetryToggle).toHaveAttribute("aria-expanded", "false")
+  await expect(
+    page.getByTestId(API_CREDENTIAL_PROFILES_TEST_IDS.telemetryBalance),
+  ).toHaveCount(0)
+  await expect
+    .poll(async () => (await telemetryPanel.boundingBox())?.height)
+    .toBeLessThanOrEqual(64)
+  await telemetryToggle.click()
+  await expect(telemetryToggle).toHaveAttribute("aria-expanded", "true")
+  await expect(
+    page.getByTestId(API_CREDENTIAL_PROFILES_TEST_IDS.telemetryBalance),
+  ).toBeVisible()
+  await expect
+    .poll(async () => (await telemetryPanel.boundingBox())?.height)
+    .toBeGreaterThan(64)
+
   await page.getByTestId(API_CREDENTIAL_PROFILES_TEST_IDS.showKeyButton).click()
   await expect(page.getByText("sk-reusable-profile")).toBeVisible()
 
   await page
-    .getByTestId(API_CREDENTIAL_PROFILES_TEST_IDS.copyBaseUrlButton)
+    .getByTestId(API_CREDENTIAL_PROFILES_TEST_IDS.endpointCopyBaseUrlButton)
     .click()
   await page
     .getByTestId(API_CREDENTIAL_PROFILES_TEST_IDS.copyApiKeyButton)

--- a/e2e/apiCredentialProfilesOptionsActions.spec.ts
+++ b/e2e/apiCredentialProfilesOptionsActions.spec.ts
@@ -6,6 +6,15 @@ import { OPTIONS_PAGE_PATH } from "~/constants/extensionPages"
 import { MENU_ITEM_IDS } from "~/constants/optionsMenuIds"
 import { API_CREDENTIAL_PROFILES_TEST_IDS } from "~/features/ApiCredentialProfiles/testIds"
 import { STORAGE_KEYS } from "~/services/core/storageKeys"
+import {
+  API_TYPES,
+  API_VERIFICATION_PROBE_STATUSES,
+} from "~/services/verification/aiApiVerification/types"
+import { API_VERIFICATION_RESULT_HISTORY_CONFIG_VERSION } from "~/services/verification/verificationResultHistory/types"
+import {
+  createProfileModelVerificationHistoryTarget,
+  createVerificationHistorySummary,
+} from "~/services/verification/verificationResultHistory/utils"
 import { expect, test } from "~~/e2e/fixtures/extensionTest"
 import { verifyApiCredentialProfileCcSwitchModelPickerScenario } from "~~/e2e/scenarios/apiCredentialProfileVerification"
 import {
@@ -191,41 +200,44 @@ test("filters options-page profiles and copies reusable credentials", async ({
       notes: "rarely used",
     }),
   ])
+  const verifiedAt = Date.now()
+  const historyTarget = createProfileModelVerificationHistoryTarget(
+    "profile-primary",
+    "example-model",
+  )
+  if (!historyTarget) throw new Error("Expected a valid verification target")
+  const historySummary = createVerificationHistorySummary({
+    target: historyTarget,
+    apiType: API_TYPES.OPENAI_COMPATIBLE,
+    preferredModelId: "example-model",
+    verifiedAt,
+    results: [
+      {
+        id: "text-generation",
+        status: API_VERIFICATION_PROBE_STATUSES.Pass,
+        latencyMs: 12,
+        summary: "Generated text",
+      },
+    ],
+  })
+  if (!historySummary) throw new Error("Expected a verification summary")
   await setPlasmoStorageValue(
     serviceWorker,
     STORAGE_KEYS.VERIFICATION_RESULT_HISTORY,
     {
-      version: 1,
-      lastUpdated: Date.now(),
-      summaries: [
-        {
-          target: {
-            kind: "profile-model",
-            profileId: "profile-primary",
-            modelId: "example-model",
-          },
-          targetKey: "profile:profile-primary:model:example-model",
-          status: "pass",
-          verifiedAt: Date.now(),
-          apiType: "openai-compatible",
-          resolvedModelId: "example-model",
-          probes: [
-            {
-              id: "text-generation",
-              status: "pass",
-              latencyMs: 12,
-              summary: "Generated text",
-            },
-          ],
-        },
-      ],
+      version: API_VERIFICATION_RESULT_HISTORY_CONFIG_VERSION,
+      lastUpdated: verifiedAt,
+      summaries: [historySummary],
     },
   )
 
   await openProfilesPage(page, extensionId)
   await page
     .getByTestId(API_CREDENTIAL_PROFILES_TEST_IDS.endpointNavigation)
-    .getByRole("button", { name: /reusable\.example\.com/i })
+    .getByRole("button", {
+      name: "https://reusable.example.com",
+      exact: true,
+    })
     .click()
 
   await expect(page.getByText("Pass", { exact: true })).toBeVisible()
@@ -246,12 +258,9 @@ test("filters options-page profiles and copies reusable credentials", async ({
       return Boolean(
         baseUrlBox &&
           countBox &&
-          Math.abs(
-            baseUrlBox.y +
-              baseUrlBox.height / 2 -
-              (countBox.y + countBox.height / 2),
-          ) < 1 &&
-          countBox.x - (baseUrlBox.x + baseUrlBox.width) <= 12,
+          baseUrlBox.x < countBox.x &&
+          baseUrlBox.y < countBox.y + countBox.height &&
+          countBox.y < baseUrlBox.y + baseUrlBox.height,
       )
     })
     .toBe(true)
@@ -284,7 +293,6 @@ test("filters options-page profiles and copies reusable credentials", async ({
     page.getByRole("heading", { name: "Archive Profile" }),
   ).toHaveCount(0)
 
-  const toolbar = page.getByTestId(API_CREDENTIAL_PROFILES_TEST_IDS.toolbar)
   const copyBundleButton = page.getByTestId(
     API_CREDENTIAL_PROFILES_TEST_IDS.copyBundleButton,
   )
@@ -293,17 +301,16 @@ test("filters options-page profiles and copies reusable credentials", async ({
   )
   await expect
     .poll(async () => {
-      const [toolbarBox, firstButtonBox, lastButtonBox] = await Promise.all([
-        toolbar.boundingBox(),
+      const [firstButtonBox, lastButtonBox] = await Promise.all([
         copyBundleButton.boundingBox(),
         deleteButton.boundingBox(),
       ])
       return Boolean(
-        toolbarBox &&
-          firstButtonBox &&
+        firstButtonBox &&
           lastButtonBox &&
-          toolbarBox.width > 200 &&
-          Math.abs(firstButtonBox.y - lastButtonBox.y) < 1,
+          firstButtonBox.x < lastButtonBox.x &&
+          firstButtonBox.y < lastButtonBox.y + lastButtonBox.height &&
+          lastButtonBox.y < firstButtonBox.y + firstButtonBox.height,
       )
     })
     .toBe(true)
@@ -311,24 +318,15 @@ test("filters options-page profiles and copies reusable credentials", async ({
   const telemetryToggle = page.getByTestId(
     API_CREDENTIAL_PROFILES_TEST_IDS.telemetryToggle,
   )
-  const telemetryPanel = page.getByTestId(
-    API_CREDENTIAL_PROFILES_TEST_IDS.telemetryPanel,
-  )
   await expect(telemetryToggle).toHaveAttribute("aria-expanded", "false")
   await expect(
     page.getByTestId(API_CREDENTIAL_PROFILES_TEST_IDS.telemetryBalance),
   ).toHaveCount(0)
-  await expect
-    .poll(async () => (await telemetryPanel.boundingBox())?.height)
-    .toBeLessThanOrEqual(64)
   await telemetryToggle.click()
   await expect(telemetryToggle).toHaveAttribute("aria-expanded", "true")
   await expect(
     page.getByTestId(API_CREDENTIAL_PROFILES_TEST_IDS.telemetryBalance),
   ).toBeVisible()
-  await expect
-    .poll(async () => (await telemetryPanel.boundingBox())?.height)
-    .toBeGreaterThan(64)
 
   await page.getByTestId(API_CREDENTIAL_PROFILES_TEST_IDS.showKeyButton).click()
   await expect(page.getByText("sk-reusable-profile")).toBeVisible()

--- a/e2e/importExportCommonFlows.spec.ts
+++ b/e2e/importExportCommonFlows.spec.ts
@@ -9,7 +9,10 @@ import {
 import { BACKUP_VERSION } from "~/constants/importExport"
 import { MENU_ITEM_IDS } from "~/constants/optionsMenuIds"
 import { getPopupViewTestId, POPUP_TEST_IDS } from "~/entrypoints/popup/testIds"
-import { API_CREDENTIAL_PROFILES_TEST_IDS } from "~/features/ApiCredentialProfiles/testIds"
+import {
+  API_CREDENTIAL_PROFILES_TEST_IDS,
+  getApiCredentialEndpointOptionTestId,
+} from "~/features/ApiCredentialProfiles/testIds"
 import { WEBDAV_AUTO_SYNC_TARGET_IDS } from "~/features/ImportExport/searchTargets"
 import { IMPORT_EXPORT_TEST_IDS } from "~/features/ImportExport/testIds"
 import { SITE_BOOKMARKS_TEST_IDS } from "~/features/SiteBookmarks/testIds"
@@ -1482,7 +1485,7 @@ test("uploads a WebDAV backup and restores it through the WebDAV download flow",
   await expect(endpointSelector).toBeVisible()
   await endpointSelector.click()
   await restorePage
-    .getByRole("option", { name: /webdav-profile\.example\.com/i })
+    .getByTestId(getApiCredentialEndpointOptionTestId("webdav-profile"))
     .click()
   await expect(
     restorePage.getByRole("heading", { name: "WebDAV Profile" }),

--- a/e2e/importExportCommonFlows.spec.ts
+++ b/e2e/importExportCommonFlows.spec.ts
@@ -1476,6 +1476,14 @@ test("uploads a WebDAV backup and restores it through the WebDAV download flow",
   ).toBeVisible()
 
   await restorePage.getByTestId(POPUP_TEST_IDS.apiCredentialProfilesTab).click()
+  const endpointSelector = restorePage.getByTestId(
+    API_CREDENTIAL_PROFILES_TEST_IDS.endpointSelector,
+  )
+  await expect(endpointSelector).toBeVisible()
+  await endpointSelector.click()
+  await restorePage
+    .getByRole("option", { name: /webdav-profile\.example\.com/i })
+    .click()
   await expect(
     restorePage.getByRole("heading", { name: "WebDAV Profile" }),
   ).toBeVisible()

--- a/src/components/dialogs/VerifyApiDialog/VerificationHistorySummary.tsx
+++ b/src/components/dialogs/VerifyApiDialog/VerificationHistorySummary.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from "react-i18next"
 
 import {
+  API_VERIFICATION_HISTORY_STATUSES,
   getVerificationSummaryLatencyMs,
   type ApiVerificationHistorySummary,
 } from "~/services/verification/verificationResultHistory"
@@ -38,7 +39,9 @@ export function VerificationHistorySummary({
       }
     >
       <span className="sr-only">{t("verifyDialog.history.lastVerified")}</span>
-      <VerificationStatusBadge status={summary?.status ?? "unverified"} />
+      <VerificationStatusBadge
+        status={summary?.status ?? API_VERIFICATION_HISTORY_STATUSES.Unverified}
+      />
       {latencyMs !== null ? (
         <span className="dark:text-dark-text-tertiary truncate text-[11px] text-gray-500 sm:text-xs">
           {formatLatency(latencyMs)}

--- a/src/components/dialogs/VerifyApiDialog/VerificationStatusBadge.tsx
+++ b/src/components/dialogs/VerifyApiDialog/VerificationStatusBadge.tsx
@@ -2,8 +2,14 @@ import { CheckCircleIcon, XCircleIcon } from "@heroicons/react/24/outline"
 import { useTranslation } from "react-i18next"
 
 import { Badge } from "~/components/ui"
-import type { ApiVerificationProbeStatus } from "~/services/verification/aiApiVerification"
-import type { ApiVerificationHistoryDisplayStatus } from "~/services/verification/verificationResultHistory"
+import {
+  API_VERIFICATION_PROBE_STATUSES,
+  type ApiVerificationProbeStatus,
+} from "~/services/verification/aiApiVerification"
+import {
+  API_VERIFICATION_HISTORY_STATUSES,
+  type ApiVerificationHistoryDisplayStatus,
+} from "~/services/verification/verificationResultHistory"
 
 type VerificationStatusBadgeProps = {
   status: ApiVerificationProbeStatus | ApiVerificationHistoryDisplayStatus
@@ -18,7 +24,7 @@ export function VerificationStatusBadge({
 }: VerificationStatusBadgeProps) {
   const { t } = useTranslation("aiApiVerification")
 
-  if (status === "pass") {
+  if (status === API_VERIFICATION_PROBE_STATUSES.Pass) {
     return (
       <Badge variant="success" size="sm">
         <span className="flex items-center gap-1">
@@ -29,7 +35,7 @@ export function VerificationStatusBadge({
     )
   }
 
-  if (status === "unsupported") {
+  if (status === API_VERIFICATION_PROBE_STATUSES.Unsupported) {
     return (
       <Badge variant="outline" size="sm">
         {t("verifyDialog.status.unsupported")}
@@ -37,7 +43,7 @@ export function VerificationStatusBadge({
     )
   }
 
-  if (status === "unverified") {
+  if (status === API_VERIFICATION_HISTORY_STATUSES.Unverified) {
     return (
       <Badge variant="outline" size="sm">
         {t("verifyDialog.status.unverified")}

--- a/src/components/dialogs/VerifyApiDialog/index.tsx
+++ b/src/components/dialogs/VerifyApiDialog/index.tsx
@@ -42,6 +42,7 @@ import {
 import { resolveProductAnalyticsErrorCategoryFromProbeResult } from "~/services/productAnalytics/verification"
 import {
   API_TYPES,
+  API_VERIFICATION_PROBE_STATUSES,
   getApiVerificationProbeDefinitions,
   guessModelIdFromToken,
   runApiVerificationProbe,
@@ -102,7 +103,7 @@ function buildStoppedProbeResult(
 ): ApiVerificationProbeResult {
   return {
     id: probeId,
-    status: "unsupported",
+    status: API_VERIFICATION_PROBE_STATUSES.Unsupported,
     latencyMs: 0,
     summary: "Stopped",
     summaryKey: "verifyDialog.summaries.stopped",
@@ -396,7 +397,7 @@ export function VerifyApiDialog(props: VerifyApiDialogProps) {
 
       const fallback: ApiVerificationProbeResult = {
         id: probeId,
-        status: "fail",
+        status: API_VERIFICATION_PROBE_STATUSES.Fail,
         latencyMs: 0,
         summary: t("verifyDialog.errors.unexpected"),
         ...buildSafeProbeFailureDiagnostics(error, sanitizedMessage),
@@ -453,10 +454,10 @@ export function VerifyApiDialog(props: VerifyApiDialogProps) {
 
         const result = await runProbe(probe.id, abortController.signal)
         if (!result) continue
-        if (result.status === "pass") {
+        if (result.status === API_VERIFICATION_PROBE_STATUSES.Pass) {
           hasExecutedProbe = true
           successCount += 1
-        } else if (result.status === "fail") {
+        } else if (result.status === API_VERIFICATION_PROBE_STATUSES.Fail) {
           hasExecutedProbe = true
           failureCount += 1
           failedProbeResult ??= result
@@ -782,7 +783,7 @@ export function VerifyApiDialog(props: VerifyApiDialogProps) {
                     result.summaryKey,
                     result.summaryParams,
                   ) ?? result.summary
-                : result?.status === "unsupported"
+                : result?.status === API_VERIFICATION_PROBE_STATUSES.Unsupported
                   ? t("verifyDialog.unsupportedProbeForApiType", {
                       probe: getApiVerificationProbeLabel(
                         t,

--- a/src/components/dialogs/VerifyCliSupportDialog/ToolStatusBadge.tsx
+++ b/src/components/dialogs/VerifyCliSupportDialog/ToolStatusBadge.tsx
@@ -2,6 +2,7 @@ import { CheckCircleIcon, XCircleIcon } from "@heroicons/react/24/outline"
 import { useTranslation } from "react-i18next"
 
 import { Badge } from "~/components/ui"
+import { API_VERIFICATION_PROBE_STATUSES } from "~/services/verification/aiApiVerification"
 import type { CliSupportResult } from "~/services/verification/cliSupportVerification"
 
 /**
@@ -10,7 +11,7 @@ import type { CliSupportResult } from "~/services/verification/cliSupportVerific
 export function ToolStatusBadge({ result }: { result: CliSupportResult }) {
   const { t } = useTranslation("cliSupportVerification")
 
-  if (result.status === "pass") {
+  if (result.status === API_VERIFICATION_PROBE_STATUSES.Pass) {
     return (
       <Badge variant="success" size="sm">
         <span className="flex items-center gap-1">
@@ -21,7 +22,7 @@ export function ToolStatusBadge({ result }: { result: CliSupportResult }) {
     )
   }
 
-  if (result.status === "unsupported") {
+  if (result.status === API_VERIFICATION_PROBE_STATUSES.Unsupported) {
     return (
       <Badge variant="outline" size="sm">
         {t("verifyDialog.status.unsupported")}

--- a/src/components/dialogs/VerifyCliSupportDialog/index.tsx
+++ b/src/components/dialogs/VerifyCliSupportDialog/index.tsx
@@ -41,7 +41,10 @@ import {
   PRODUCT_ANALYTICS_SURFACE_IDS,
 } from "~/services/productAnalytics/contracts"
 import { resolveProductAnalyticsErrorCategoryFromProbeResult } from "~/services/productAnalytics/verification"
-import { guessModelIdFromToken } from "~/services/verification/aiApiVerification"
+import {
+  API_VERIFICATION_PROBE_STATUSES,
+  guessModelIdFromToken,
+} from "~/services/verification/aiApiVerification"
 import {
   inferHttpStatus,
   inferStructuredHttpStatus,
@@ -105,7 +108,7 @@ function buildStoppedToolResult(toolId: (typeof CLI_TOOL_IDS)[number]) {
   return {
     id: toolId,
     probeId: "tool-calling" as const,
-    status: "unsupported" as const,
+    status: API_VERIFICATION_PROBE_STATUSES.Unsupported,
     latencyMs: 0,
     summary: "Stopped",
     summaryKey: "verifyDialog.summaries.stopped",
@@ -397,7 +400,7 @@ export function VerifyCliSupportDialog(props: VerifyCliSupportDialogProps) {
                   result: {
                     id: toolId,
                     probeId: "tool-calling",
-                    status: "fail",
+                    status: API_VERIFICATION_PROBE_STATUSES.Fail,
                     latencyMs: Math.max(0, finishedAt - startedAt),
                     summary: "No API key is available for this runtime key.",
                     summaryKey: "verifyDialog.summaries.noRuntimeKeySecret",
@@ -489,7 +492,7 @@ export function VerifyCliSupportDialog(props: VerifyCliSupportDialogProps) {
       const failureResult: CliSupportResult = {
         id: toolId,
         probeId: "tool-calling",
-        status: "fail",
+        status: API_VERIFICATION_PROBE_STATUSES.Fail,
         latencyMs: Math.max(0, finishedAt - startedAt),
         summary: sanitizedMessage || "Unknown error",
         summaryKey,
@@ -556,10 +559,10 @@ export function VerifyCliSupportDialog(props: VerifyCliSupportDialogProps) {
         if (shouldStopRef.current || abortController.signal.aborted) break
         const result = await runTool(toolId, abortController.signal)
         if (!result) continue
-        if (result.status === "pass") {
+        if (result.status === API_VERIFICATION_PROBE_STATUSES.Pass) {
           hasExecutedTool = true
           successCount += 1
-        } else if (result.status === "fail") {
+        } else if (result.status === API_VERIFICATION_PROBE_STATUSES.Fail) {
           hasExecutedTool = true
           failureCount += 1
           failedToolResult ??= result

--- a/src/components/ui/IconButton.tsx
+++ b/src/components/ui/IconButton.tsx
@@ -13,6 +13,8 @@ const iconButtonVariants = cva(
         default: "bg-blue-600 text-white hover:bg-blue-700 focus:ring-blue-500",
         destructive:
           "bg-red-600 text-white hover:bg-red-700 focus:ring-red-500",
+        destructiveGhost:
+          "bg-transparent text-destructive hover:bg-destructive/10 focus:ring-destructive/30 dark:hover:bg-destructive/20",
         outline:
           "border border-gray-300 dark:border-dark-bg-tertiary bg-transparent hover:bg-gray-50 dark:hover:bg-dark-bg-secondary text-gray-700 dark:text-dark-text-secondary focus:ring-gray-500",
         secondary:

--- a/src/entrypoints/content/webAiApiCheck/components/ApiCheckBaseUrlHistoryPicker.tsx
+++ b/src/entrypoints/content/webAiApiCheck/components/ApiCheckBaseUrlHistoryPicker.tsx
@@ -95,9 +95,9 @@ export function ApiCheckBaseUrlHistoryPicker({
                 title={`${t("webAiApiCheck:modal.history.remove")}: ${
                   suggestion.baseUrl
                 }`}
-                variant="ghost"
+                variant="destructiveGhost"
                 size="xs"
-                className="text-muted-foreground hover:text-destructive shrink-0 opacity-70 group-hover:opacity-100"
+                className="shrink-0 opacity-70 group-hover:opacity-100"
                 onClick={() => onRemove(suggestion.baseUrl)}
               >
                 <TrashIcon className="h-3.5 w-3.5" />

--- a/src/entrypoints/content/webAiApiCheck/components/apiCheckModalAnalytics.ts
+++ b/src/entrypoints/content/webAiApiCheck/components/apiCheckModalAnalytics.ts
@@ -8,9 +8,10 @@ import {
   type ProductAnalyticsResult,
   type ProductAnalyticsSourceKind,
 } from "~/services/productAnalytics/contracts"
-import type {
-  ApiVerificationApiType,
-  ApiVerificationProbeResult,
+import {
+  API_VERIFICATION_PROBE_STATUSES,
+  type ApiVerificationApiType,
+  type ApiVerificationProbeResult,
 } from "~/services/verification/aiApiVerification"
 
 import type { ApiCheckOpenModalDetail } from "../events"
@@ -64,7 +65,11 @@ export function getProbeAnalyticsResult(
   result: ApiVerificationProbeResult | undefined,
 ): ProductAnalyticsResult {
   if (!result) return PRODUCT_ANALYTICS_RESULTS.Failure
-  if (result.status === "pass") return PRODUCT_ANALYTICS_RESULTS.Success
-  if (result.status === "unsupported") return PRODUCT_ANALYTICS_RESULTS.Skipped
+  if (result.status === API_VERIFICATION_PROBE_STATUSES.Pass) {
+    return PRODUCT_ANALYTICS_RESULTS.Success
+  }
+  if (result.status === API_VERIFICATION_PROBE_STATUSES.Unsupported) {
+    return PRODUCT_ANALYTICS_RESULTS.Skipped
+  }
   return PRODUCT_ANALYTICS_RESULTS.Failure
 }

--- a/src/entrypoints/content/webAiApiCheck/components/useApiCheckProbeRunner.ts
+++ b/src/entrypoints/content/webAiApiCheck/components/useApiCheckProbeRunner.ts
@@ -15,6 +15,7 @@ import {
 } from "~/services/productAnalytics/contracts"
 import { resolveProductAnalyticsErrorCategoryFromProbeResult } from "~/services/productAnalytics/verification"
 import {
+  API_VERIFICATION_PROBE_STATUSES,
   getApiVerificationProbeDefinitions,
   type ApiVerificationApiType,
   type ApiVerificationProbeId,
@@ -132,7 +133,7 @@ function buildMissingModelResult(
 ): ApiCheckProbeResultWithAnalyticsCategory {
   return {
     id: probeId,
-    status: "fail",
+    status: API_VERIFICATION_PROBE_STATUSES.Fail,
     latencyMs: 0,
     summary: "No model id provided",
     summaryKey: "verifyDialog.requiresModelId",
@@ -373,7 +374,7 @@ export function useApiCheckProbeRunner({
 
         const fallback: ApiCheckProbeResultWithAnalyticsCategory = {
           id: probeId,
-          status: "fail",
+          status: API_VERIFICATION_PROBE_STATUSES.Fail,
           latencyMs: 0,
           summary: message,
           analyticsErrorCategory: failedResponse?.errorCategory,
@@ -410,7 +411,7 @@ export function useApiCheckProbeRunner({
           resolveProductAnalyticsErrorCategoryFromError(error)
         const fallback: ApiCheckProbeResultWithAnalyticsCategory = {
           id: probeId,
-          status: "fail",
+          status: API_VERIFICATION_PROBE_STATUSES.Fail,
           latencyMs: 0,
           summary: t("webAiApiCheck:modal.errors.runProbeFailed"),
           analyticsErrorCategory: errorCategory,
@@ -574,10 +575,10 @@ export function useApiCheckProbeRunner({
 
       if (shouldStopRunAllRef.current) {
         const successCount = results.filter(
-          (result) => result.status === "pass",
+          (result) => result.status === API_VERIFICATION_PROBE_STATUSES.Pass,
         ).length
         const failureCount = results.filter(
-          (result) => result.status === "fail",
+          (result) => result.status === API_VERIFICATION_PROBE_STATUSES.Fail,
         ).length
         const skippedCount = Math.max(
           probeDefinitions.length - successCount - failureCount,
@@ -604,13 +605,14 @@ export function useApiCheckProbeRunner({
       }
 
       const successCount = results.filter(
-        (result) => result.status === "pass",
+        (result) => result.status === API_VERIFICATION_PROBE_STATUSES.Pass,
       ).length
       const failureCount = results.filter(
-        (result) => result.status === "fail",
+        (result) => result.status === API_VERIFICATION_PROBE_STATUSES.Fail,
       ).length
       const skippedCount = results.filter(
-        (result) => result.status === "unsupported",
+        (result) =>
+          result.status === API_VERIFICATION_PROBE_STATUSES.Unsupported,
       ).length
       const analyticsResult =
         failureCount > 0
@@ -623,10 +625,15 @@ export function useApiCheckProbeRunner({
         ...(analyticsResult === PRODUCT_ANALYTICS_RESULTS.Failure
           ? {
               errorCategory:
-                results.find((result) => result.status === "fail")
-                  ?.analyticsErrorCategory ??
+                results.find(
+                  (result) =>
+                    result.status === API_VERIFICATION_PROBE_STATUSES.Fail,
+                )?.analyticsErrorCategory ??
                 resolveProductAnalyticsErrorCategoryFromProbeResult(
-                  results.find((result) => result.status === "fail"),
+                  results.find(
+                    (result) =>
+                      result.status === API_VERIFICATION_PROBE_STATUSES.Fail,
+                  ),
                 ),
             }
           : {}),

--- a/src/features/AccountManagement/components/TagPicker/TagPicker.tsx
+++ b/src/features/AccountManagement/components/TagPicker/TagPicker.tsx
@@ -516,7 +516,7 @@ export function TagPicker({
                           {allowDelete && onDeleteTag ? (
                             <IconButton
                               type="button"
-                              variant="ghost"
+                              variant="destructiveGhost"
                               size="sm"
                               onClick={() => {
                                 setIsOpen(false)

--- a/src/features/ApiCredentialProfiles/components/ApiCredentialProfileDialog.tsx
+++ b/src/features/ApiCredentialProfiles/components/ApiCredentialProfileDialog.tsx
@@ -49,7 +49,10 @@ import type {
   ApiCredentialTelemetryConfig,
   ApiCredentialTelemetryJsonPathMap,
 } from "~/types/apiCredentialProfiles"
-import { DEFAULT_API_CREDENTIAL_TELEMETRY_CONFIG } from "~/types/apiCredentialProfiles"
+import {
+  API_CREDENTIAL_TELEMETRY_MODES,
+  DEFAULT_API_CREDENTIAL_TELEMETRY_CONFIG,
+} from "~/types/apiCredentialProfiles"
 import { createLogger } from "~/utils/core/logger"
 
 import { API_CREDENTIAL_PROFILES_TEST_IDS } from "../testIds"
@@ -304,7 +307,9 @@ export function ApiCredentialProfileDialog({
       )
     }
 
-    if (telemetryMode === "customReadOnlyEndpoint") {
+    if (
+      telemetryMode === API_CREDENTIAL_TELEMETRY_MODES.CustomReadOnlyEndpoint
+    ) {
       const trimmedEndpoint = customEndpoint.trim()
 
       if (!trimmedEndpoint) {
@@ -343,12 +348,14 @@ export function ApiCredentialProfileDialog({
   }
 
   const buildTelemetryConfig = (): ApiCredentialTelemetryConfig => {
-    if (telemetryMode !== "customReadOnlyEndpoint") {
+    if (
+      telemetryMode !== API_CREDENTIAL_TELEMETRY_MODES.CustomReadOnlyEndpoint
+    ) {
       return { mode: telemetryMode }
     }
 
     return {
-      mode: "customReadOnlyEndpoint",
+      mode: API_CREDENTIAL_TELEMETRY_MODES.CustomReadOnlyEndpoint,
       customEndpoint: {
         endpoint: customEndpoint.trim(),
         ...(customBearerToken.trim()
@@ -656,35 +663,35 @@ export function ApiCredentialProfileDialog({
               )}
               options={[
                 {
-                  value: "auto",
+                  value: API_CREDENTIAL_TELEMETRY_MODES.Auto,
                   label: t("apiCredentialProfiles:dialog.telemetryModes.auto"),
                 },
                 {
-                  value: "disabled",
+                  value: API_CREDENTIAL_TELEMETRY_MODES.Disabled,
                   label: t(
                     "apiCredentialProfiles:dialog.telemetryModes.disabled",
                   ),
                 },
                 {
-                  value: "newApiTokenUsage",
+                  value: API_CREDENTIAL_TELEMETRY_MODES.NewApiTokenUsage,
                   label: t(
                     "apiCredentialProfiles:dialog.telemetryModes.newApiTokenUsage",
                   ),
                 },
                 {
-                  value: "sub2apiUsage",
+                  value: API_CREDENTIAL_TELEMETRY_MODES.Sub2ApiUsage,
                   label: t(
                     "apiCredentialProfiles:dialog.telemetryModes.sub2apiUsage",
                   ),
                 },
                 {
-                  value: "openaiBilling",
+                  value: API_CREDENTIAL_TELEMETRY_MODES.OpenAiBilling,
                   label: t(
                     "apiCredentialProfiles:dialog.telemetryModes.openaiBilling",
                   ),
                 },
                 {
-                  value: "customReadOnlyEndpoint",
+                  value: API_CREDENTIAL_TELEMETRY_MODES.CustomReadOnlyEndpoint,
                   label: t(
                     "apiCredentialProfiles:dialog.telemetryModes.customReadOnlyEndpoint",
                   ),
@@ -701,7 +708,8 @@ export function ApiCredentialProfileDialog({
             />
           </FormField>
 
-          {telemetryMode === "customReadOnlyEndpoint" && (
+          {telemetryMode ===
+            API_CREDENTIAL_TELEMETRY_MODES.CustomReadOnlyEndpoint && (
             <details
               open
               className="dark:border-dark-bg-tertiary rounded-lg border border-gray-200 p-3"

--- a/src/features/ApiCredentialProfiles/components/ApiCredentialProfileListItem.tsx
+++ b/src/features/ApiCredentialProfiles/components/ApiCredentialProfileListItem.tsx
@@ -221,7 +221,8 @@ function hasTelemetryDetailData(
         snapshot.todayRequests !== undefined ||
         snapshot.todayTokens !== undefined ||
         snapshot.unlimitedQuota === true ||
-        snapshot.models !== undefined),
+        snapshot.models !== undefined ||
+        Boolean(snapshot.lastError)),
   )
 }
 

--- a/src/features/ApiCredentialProfiles/components/ApiCredentialProfileListItem.tsx
+++ b/src/features/ApiCredentialProfiles/components/ApiCredentialProfileListItem.tsx
@@ -1,6 +1,7 @@
 import {
   ArrowPathIcon,
   ArrowUpTrayIcon,
+  ChevronDownIcon,
   CommandLineIcon,
   CpuChipIcon,
   EyeIcon,
@@ -10,8 +11,8 @@ import {
   WrenchScrewdriverIcon,
 } from "@heroicons/react/24/outline"
 import type { TFunction } from "i18next"
-import { Copy } from "lucide-react"
-import { useEffect, useRef, useState } from "react"
+import { CalendarPlus, Copy, History, type LucideIcon } from "lucide-react"
+import { useEffect, useId, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 
 import { VerificationHistorySummary } from "~/components/dialogs/VerifyApiDialog/VerificationHistorySummary"
@@ -29,6 +30,11 @@ import {
   Heading6,
   IconButton,
 } from "~/components/ui"
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "~/components/ui/collapsible"
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -73,7 +79,6 @@ interface ApiCredentialProfileListItemProps {
   tagNames: string[]
   visibleKeys: Set<string>
   toggleKeyVisibility: (id: string) => void
-  onCopyBaseUrl: (profile: ApiCredentialProfile) => void
   onCopyApiKey: (profile: ApiCredentialProfile) => void
   onCopyBundle: (profile: ApiCredentialProfile) => void
   onOpenModelManagement: (profile: ApiCredentialProfile) => void
@@ -100,6 +105,47 @@ function getHealthIndicatorColor(status: SiteHealthStatus | undefined): string {
   if (status === SiteHealthStatus.Warning) return "bg-yellow-500"
   if (status === SiteHealthStatus.Error) return "bg-red-500"
   return "bg-gray-400"
+}
+
+const COMPACT_AUDIT_TIME_FORMAT: Intl.DateTimeFormatOptions = {
+  year: "numeric",
+  month: "numeric",
+  day: "numeric",
+  hour: "2-digit",
+  minute: "2-digit",
+}
+
+interface AuditTimeBadgeProps {
+  Icon: LucideIcon
+  label: string
+  timestamp: number | string | Date | null | undefined
+  fallback: string
+}
+
+/** Renders one quiet, responsive audit timestamp with full hover details. */
+function AuditTimeBadge({
+  Icon,
+  label,
+  timestamp,
+  fallback,
+}: AuditTimeBadgeProps) {
+  const fullLabel = formatLocaleDateTime(timestamp, fallback)
+
+  return (
+    <Badge
+      variant="outline"
+      size="sm"
+      className="dark:bg-dark-bg-tertiary/50 dark:text-dark-text-tertiary max-w-full bg-gray-50 font-normal text-gray-500 tabular-nums"
+      title={fullLabel}
+      aria-label={`${label}: ${fullLabel}`}
+    >
+      <Icon aria-hidden="true" />
+      <span className="truncate">
+        {label}{" "}
+        {formatLocaleDateTime(timestamp, fallback, COMPACT_AUDIT_TIME_FORMAT)}
+      </span>
+    </Badge>
+  )
 }
 
 /**
@@ -161,6 +207,24 @@ function formatProfileExpiration(
 }
 
 /**
+ * Checks whether the card has a concrete metric to show in telemetry details.
+ * Explicit zero values are data and must keep the section expanded.
+ */
+function hasTelemetryDetailData(
+  snapshot: ApiCredentialProfile["telemetrySnapshot"],
+): boolean {
+  return Boolean(
+    snapshot &&
+      (snapshot.balanceUsd !== undefined ||
+        snapshot.todayCostUsd !== undefined ||
+        snapshot.todayRequests !== undefined ||
+        snapshot.todayTokens !== undefined ||
+        snapshot.unlimitedQuota === true ||
+        snapshot.models !== undefined),
+  )
+}
+
+/**
  * Converts a timestamp to the start of its local calendar day for expiry checks.
  */
 function getStartOfLocalDay(timestamp: number): number {
@@ -181,7 +245,6 @@ export function ApiCredentialProfileListItem({
   tagNames,
   visibleKeys,
   toggleKeyVisibility,
-  onCopyBaseUrl,
   onCopyApiKey,
   onCopyBundle,
   onOpenModelManagement,
@@ -205,6 +268,10 @@ export function ApiCredentialProfileListItem({
   ])
   const { currencyType } = useUserPreferencesContext()
   const telemetry = profile.telemetrySnapshot
+  const hasTelemetryDetails = hasTelemetryDetailData(telemetry)
+  const [isTelemetryOpen, setIsTelemetryOpen] = useState(hasTelemetryDetails)
+  const previousHasTelemetryDetailsRef = useRef(hasTelemetryDetails)
+  const telemetryContentId = useId()
   const [isExportMenuOpen, setIsExportMenuOpen] = useState(false)
   const [isImportEntryHighlighted, setIsImportEntryHighlighted] =
     useState(false)
@@ -263,6 +330,14 @@ export function ApiCredentialProfileListItem({
     return () => window.clearTimeout(timeoutId)
   }, [guidedImportEntryRequest])
 
+  useEffect(() => {
+    const previouslyHadData = previousHasTelemetryDetailsRef.current
+    if (previouslyHadData !== hasTelemetryDetails) {
+      setIsTelemetryOpen(hasTelemetryDetails)
+      previousHasTelemetryDetailsRef.current = hasTelemetryDetails
+    }
+  }, [hasTelemetryDetails])
+
   return (
     <ProductAnalyticsScope
       entrypoint={optionsEntrypoint}
@@ -271,7 +346,7 @@ export function ApiCredentialProfileListItem({
     >
       <Card>
         <CardContent padding="md" spacing="sm">
-          <div className="flex min-w-0 flex-col gap-5 sm:flex-row sm:items-stretch sm:justify-between">
+          <div className="flex min-w-0 flex-col gap-5">
             <div className="flex min-w-0 flex-1 flex-col gap-2">
               <div className="flex min-w-0 flex-wrap items-center gap-2">
                 <Heading6 className="max-w-full min-w-0 truncate">
@@ -304,32 +379,6 @@ export function ApiCredentialProfileListItem({
               </div>
 
               <div className="flex flex-1 flex-col gap-2 text-xs">
-                <div className="flex min-w-0 flex-col gap-1 sm:flex-row sm:items-center sm:gap-2">
-                  <span className="dark:text-dark-text-tertiary shrink-0 whitespace-nowrap text-gray-500">
-                    {t("apiCredentialProfiles:list.baseUrl")}
-                  </span>
-                  <div className="flex w-full min-w-0 items-center gap-0.5 sm:flex-1">
-                    <code className="dark:bg-dark-bg-tertiary dark:text-dark-text-secondary min-w-0 flex-1 truncate rounded bg-gray-100 px-2 py-1 font-mono text-[10px] text-gray-800 sm:text-xs">
-                      {profile.baseUrl}
-                    </code>
-                    <IconButton
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => onCopyBaseUrl(profile)}
-                      data-testid={
-                        API_CREDENTIAL_PROFILES_TEST_IDS.copyBaseUrlButton
-                      }
-                      aria-label={t(
-                        "apiCredentialProfiles:actions.copyBaseUrl",
-                      )}
-                      className="shrink-0"
-                      analyticsAction={PRODUCT_ANALYTICS_ACTION_IDS.CopyBaseUrl}
-                    >
-                      <Copy className="h-4 w-4" />
-                    </IconButton>
-                  </div>
-                </div>
-
                 <div className="flex min-w-0 flex-col gap-1 sm:flex-row sm:items-center sm:gap-2">
                   <span className="dark:text-dark-text-tertiary shrink-0 whitespace-nowrap text-gray-500">
                     {t("apiCredentialProfiles:list.apiKey")}
@@ -379,51 +428,64 @@ export function ApiCredentialProfileListItem({
                   </div>
                 </div>
 
-                <div className="flex min-w-0 flex-col gap-1 sm:flex-row sm:items-center sm:gap-2">
+                <div className="flex min-w-0 flex-wrap items-center gap-1.5 sm:gap-2">
                   <span className="dark:text-dark-text-tertiary shrink-0 whitespace-nowrap text-gray-500">
                     {t("aiApiVerification:verifyDialog.history.lastVerified")}
                   </span>
                   <VerificationHistorySummary
                     summary={verificationSummary}
-                    className="flex min-w-0 flex-1 flex-wrap items-center gap-1.5 sm:gap-2"
+                    className="flex min-w-0 flex-wrap items-center gap-1.5 sm:gap-2"
                   />
                 </div>
 
-                <div className="dark:text-dark-text-tertiary flex flex-wrap gap-x-3 gap-y-1 text-xs text-gray-500">
-                  <span>
-                    {t("apiCredentialProfiles:list.createdAt")}:{" "}
-                    {formatLocaleDateTime(profile.createdAt, notAvailableLabel)}
-                  </span>
-                  <span>
-                    {t("apiCredentialProfiles:list.updatedAt")}:{" "}
-                    {formatLocaleDateTime(profile.updatedAt, notAvailableLabel)}
-                  </span>
-                </div>
-
-                <div className="dark:bg-dark-bg-tertiary/60 flex flex-1 flex-col rounded-lg border border-gray-100 bg-gray-50 p-2 sm:p-3 dark:border-gray-800">
-                  <div className="mb-2 flex min-w-0 flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-                    <div className="flex min-w-0 flex-wrap items-center gap-2">
-                      <span
-                        className={`h-2 w-2 shrink-0 rounded-full ${getHealthIndicatorColor(
-                          health?.status,
-                        )}`}
-                        title={healthTitle}
-                        aria-label={healthTitle}
-                        role="img"
-                      />
-                      <span className="dark:text-dark-text-secondary text-xs font-medium text-gray-700">
-                        {t("apiCredentialProfiles:telemetry.title")}
-                      </span>
-                      {telemetry?.source ? (
-                        <Badge
-                          variant="outline"
-                          size="sm"
-                          className="max-w-full truncate"
-                        >
-                          {getTelemetrySourceLabel(t, telemetry.source)}
-                        </Badge>
-                      ) : null}
-                    </div>
+                <Collapsible
+                  open={isTelemetryOpen}
+                  onOpenChange={setIsTelemetryOpen}
+                  className="dark:bg-dark-bg-tertiary/60 flex flex-col rounded-lg border border-gray-100 bg-gray-50 p-2 sm:p-3 dark:border-gray-800"
+                  data-testid={API_CREDENTIAL_PROFILES_TEST_IDS.telemetryPanel}
+                >
+                  <div className="flex min-w-0 items-center justify-between gap-2">
+                    <CollapsibleTrigger asChild>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        className="group h-auto min-w-0 flex-1 justify-start gap-2 px-1.5 py-1 text-left"
+                        aria-label={t("apiCredentialProfiles:telemetry.title")}
+                        aria-expanded={isTelemetryOpen}
+                        aria-controls={telemetryContentId}
+                        data-testid={
+                          API_CREDENTIAL_PROFILES_TEST_IDS.telemetryToggle
+                        }
+                      >
+                        <span
+                          className={`h-2 w-2 shrink-0 rounded-full ${getHealthIndicatorColor(
+                            health?.status,
+                          )}`}
+                          title={healthTitle}
+                          aria-label={healthTitle}
+                          role="img"
+                        />
+                        <span className="dark:text-dark-text-secondary min-w-0 truncate text-xs font-medium text-gray-700">
+                          {t("apiCredentialProfiles:telemetry.title")}
+                        </span>
+                        {telemetry?.source ? (
+                          <Badge
+                            variant="outline"
+                            size="sm"
+                            className="max-w-full truncate"
+                          >
+                            {getTelemetrySourceLabel(t, telemetry.source)}
+                          </Badge>
+                        ) : null}
+                        <ChevronDownIcon
+                          className={cn(
+                            "dark:text-dark-text-tertiary ml-auto h-3.5 w-3.5 shrink-0 text-gray-500 transition-transform",
+                            isTelemetryOpen ? "rotate-180" : "rotate-0",
+                          )}
+                          aria-hidden="true"
+                        />
+                      </Button>
+                    </CollapsibleTrigger>
                     <Button
                       type="button"
                       variant="ghost"
@@ -439,104 +501,106 @@ export function ApiCredentialProfileListItem({
                     </Button>
                   </div>
 
-                  <div className="grid flex-1 auto-rows-max grid-cols-[repeat(auto-fit,minmax(7rem,1fr))] content-evenly gap-2 text-xs sm:grid-cols-4">
-                    <div className="flex min-w-0 flex-col gap-1">
-                      <div className="dark:text-dark-text-tertiary text-gray-500">
-                        {t("apiCredentialProfiles:telemetry.balance")}
+                  <CollapsibleContent id={telemetryContentId}>
+                    <div className="grid flex-1 auto-rows-max grid-cols-[repeat(auto-fit,minmax(7rem,1fr))] content-evenly gap-2 pt-2 text-xs sm:grid-cols-4">
+                      <div className="flex min-w-0 flex-col gap-1">
+                        <div className="dark:text-dark-text-tertiary text-gray-500">
+                          {t("apiCredentialProfiles:telemetry.balance")}
+                        </div>
+                        <div
+                          className="dark:text-dark-text-primary font-semibold text-gray-900"
+                          data-testid={
+                            API_CREDENTIAL_PROFILES_TEST_IDS.telemetryBalance
+                          }
+                        >
+                          {telemetry?.unlimitedQuota
+                            ? t("common:quota.unlimited")
+                            : telemetry?.balanceUsd !== undefined
+                              ? formatTelemetryMoney(
+                                  telemetry.balanceUsd,
+                                  currencyType,
+                                )
+                              : missingTelemetryValue}
+                        </div>
                       </div>
-                      <div
-                        className="dark:text-dark-text-primary font-semibold text-gray-900"
-                        data-testid={
-                          API_CREDENTIAL_PROFILES_TEST_IDS.telemetryBalance
-                        }
-                      >
-                        {telemetry?.unlimitedQuota
-                          ? t("common:quota.unlimited")
-                          : telemetry?.balanceUsd !== undefined
+                      <div className="flex min-w-0 flex-col gap-1">
+                        <div className="dark:text-dark-text-tertiary text-gray-500">
+                          {t("apiCredentialProfiles:telemetry.todayUsage")}
+                        </div>
+                        <div
+                          className="font-semibold text-emerald-600 dark:text-emerald-400"
+                          data-testid={
+                            API_CREDENTIAL_PROFILES_TEST_IDS.telemetryTodayUsage
+                          }
+                        >
+                          {telemetry?.todayCostUsd !== undefined
                             ? formatTelemetryMoney(
-                                telemetry.balanceUsd,
+                                telemetry.todayCostUsd,
                                 currencyType,
                               )
                             : missingTelemetryValue}
+                        </div>
+                      </div>
+                      <div className="flex min-w-0 flex-col gap-1">
+                        <div className="dark:text-dark-text-tertiary text-gray-500">
+                          {t("apiCredentialProfiles:telemetry.todayRequests")}
+                        </div>
+                        <div
+                          className="dark:text-dark-text-primary font-semibold text-gray-900"
+                          data-testid={
+                            API_CREDENTIAL_PROFILES_TEST_IDS.telemetryTodayRequests
+                          }
+                        >
+                          {typeof telemetry?.todayRequests === "number"
+                            ? telemetry.todayRequests.toLocaleString()
+                            : missingTelemetryValue}
+                        </div>
+                      </div>
+                      <div className="flex min-w-0 flex-col gap-1">
+                        <div className="dark:text-dark-text-tertiary text-gray-500">
+                          {t("apiCredentialProfiles:telemetry.models")}
+                        </div>
+                        <div
+                          className="dark:text-dark-text-primary truncate font-semibold text-gray-900"
+                          data-testid={
+                            API_CREDENTIAL_PROFILES_TEST_IDS.telemetryModels
+                          }
+                          title={telemetry?.models?.preview.join(", ")}
+                        >
+                          {telemetry?.models
+                            ? t("apiCredentialProfiles:telemetry.modelCount", {
+                                count: telemetry.models.count,
+                              })
+                            : missingTelemetryValue}
+                        </div>
                       </div>
                     </div>
-                    <div className="flex min-w-0 flex-col gap-1">
-                      <div className="dark:text-dark-text-tertiary text-gray-500">
-                        {t("apiCredentialProfiles:telemetry.todayUsage")}
-                      </div>
-                      <div
-                        className="font-semibold text-emerald-600 dark:text-emerald-400"
-                        data-testid={
-                          API_CREDENTIAL_PROFILES_TEST_IDS.telemetryTodayUsage
-                        }
-                      >
-                        {telemetry?.todayCostUsd !== undefined
-                          ? formatTelemetryMoney(
-                              telemetry.todayCostUsd,
-                              currencyType,
-                            )
-                          : missingTelemetryValue}
-                      </div>
-                    </div>
-                    <div className="flex min-w-0 flex-col gap-1">
-                      <div className="dark:text-dark-text-tertiary text-gray-500">
-                        {t("apiCredentialProfiles:telemetry.todayRequests")}
-                      </div>
-                      <div
-                        className="dark:text-dark-text-primary font-semibold text-gray-900"
-                        data-testid={
-                          API_CREDENTIAL_PROFILES_TEST_IDS.telemetryTodayRequests
-                        }
-                      >
-                        {typeof telemetry?.todayRequests === "number"
-                          ? telemetry.todayRequests.toLocaleString()
-                          : missingTelemetryValue}
-                      </div>
-                    </div>
-                    <div className="flex min-w-0 flex-col gap-1">
-                      <div className="dark:text-dark-text-tertiary text-gray-500">
-                        {t("apiCredentialProfiles:telemetry.models")}
-                      </div>
-                      <div
-                        className="dark:text-dark-text-primary truncate font-semibold text-gray-900"
-                        data-testid={
-                          API_CREDENTIAL_PROFILES_TEST_IDS.telemetryModels
-                        }
-                        title={telemetry?.models?.preview.join(", ")}
-                      >
-                        {telemetry?.models
-                          ? t("apiCredentialProfiles:telemetry.modelCount", {
-                              count: telemetry.models.count,
-                            })
-                          : missingTelemetryValue}
-                      </div>
-                    </div>
-                  </div>
 
-                  <div className="dark:text-dark-text-tertiary mt-auto flex flex-wrap gap-x-3 gap-y-1 pt-2 text-xs text-gray-500">
-                    <span>
-                      {t("apiCredentialProfiles:telemetry.lastSync")}:{" "}
-                      {formatLocaleDateTime(
-                        telemetry?.lastSyncTime,
-                        t("common:labels.notAvailable"),
-                      )}
-                    </span>
-                    {telemetry?.todayTokens ? (
+                    <div className="dark:text-dark-text-tertiary mt-auto flex flex-wrap gap-x-3 gap-y-1 pt-2 text-xs text-gray-500">
                       <span>
-                        {t("apiCredentialProfiles:telemetry.todayTokens")}:{" "}
-                        {formatTokenCount(
-                          telemetry.todayTokens.upload +
-                            telemetry.todayTokens.download,
+                        {t("apiCredentialProfiles:telemetry.lastSync")}:{" "}
+                        {formatLocaleDateTime(
+                          telemetry?.lastSyncTime,
+                          t("common:labels.notAvailable"),
                         )}
                       </span>
-                    ) : null}
-                    {telemetry?.lastError ? (
-                      <span className="text-amber-600 dark:text-amber-300">
-                        {telemetry.lastError}
-                      </span>
-                    ) : null}
-                  </div>
-                </div>
+                      {telemetry?.todayTokens ? (
+                        <span>
+                          {t("apiCredentialProfiles:telemetry.todayTokens")}:{" "}
+                          {formatTokenCount(
+                            telemetry.todayTokens.upload +
+                              telemetry.todayTokens.download,
+                          )}
+                        </span>
+                      ) : null}
+                      {telemetry?.lastError ? (
+                        <span className="text-amber-600 dark:text-amber-300">
+                          {telemetry.lastError}
+                        </span>
+                      ) : null}
+                    </div>
+                  </CollapsibleContent>
+                </Collapsible>
               </div>
 
               {profile.notes?.trim() ? (
@@ -551,189 +615,213 @@ export function ApiCredentialProfileListItem({
               ) : null}
             </div>
 
-            <div className="flex w-full flex-wrap items-center justify-end gap-2 sm:w-auto sm:shrink-0 sm:flex-col sm:items-end sm:justify-start">
-              <IconButton
-                aria-label={t("apiCredentialProfiles:actions.copyBundle")}
-                size="sm"
-                variant="ghost"
-                onClick={() => onCopyBundle(profile)}
-                data-testid={API_CREDENTIAL_PROFILES_TEST_IDS.copyBundleButton}
-                analyticsAction={
-                  PRODUCT_ANALYTICS_ACTION_IDS.CopyApiCredentialBundle
-                }
+            <div className="flex w-full min-w-0 flex-wrap items-center justify-between gap-x-4 gap-y-2">
+              <div className="flex min-w-0 flex-wrap items-center gap-1.5 sm:gap-2">
+                <AuditTimeBadge
+                  Icon={CalendarPlus}
+                  label={t("apiCredentialProfiles:list.createdAt")}
+                  timestamp={profile.createdAt}
+                  fallback={notAvailableLabel}
+                />
+                <AuditTimeBadge
+                  Icon={History}
+                  label={t("apiCredentialProfiles:list.updatedAt")}
+                  timestamp={profile.updatedAt}
+                  fallback={notAvailableLabel}
+                />
+              </div>
+
+              <div
+                className="ml-auto flex flex-wrap items-center justify-end gap-2"
+                data-testid={API_CREDENTIAL_PROFILES_TEST_IDS.toolbar}
               >
-                <Copy className="h-4 w-4" />
-              </IconButton>
-              <IconButton
-                aria-label={t("common:actions.edit")}
-                size="sm"
-                variant="ghost"
-                onClick={() => onEdit(profile)}
-                data-testid={API_CREDENTIAL_PROFILES_TEST_IDS.editButton}
-                analyticsAction={
-                  PRODUCT_ANALYTICS_ACTION_IDS.OpenUpdateApiCredentialProfileDialog
-                }
-              >
-                <PencilIcon className="h-4 w-4 text-blue-500 dark:text-blue-400" />
-              </IconButton>
-              <IconButton
-                aria-label={t("apiCredentialProfiles:actions.verifyApi")}
-                size="sm"
-                variant="ghost"
-                onClick={() => onVerify(profile)}
-                data-testid={API_CREDENTIAL_PROFILES_TEST_IDS.verifyButton}
-                analyticsAction={
-                  PRODUCT_ANALYTICS_ACTION_IDS.VerifyApiCredential
-                }
-              >
-                <WrenchScrewdriverIcon className="h-4 w-4 text-emerald-600 dark:text-emerald-400" />
-              </IconButton>
-              <IconButton
-                aria-label={t("apiCredentialProfiles:actions.verifyCliSupport")}
-                size="sm"
-                variant="ghost"
-                onClick={() => onVerifyCliSupport(profile)}
-                analyticsAction={
-                  PRODUCT_ANALYTICS_ACTION_IDS.VerifyApiCredentialCliSupport
-                }
-              >
-                <CommandLineIcon className="h-4 w-4 text-sky-600 dark:text-sky-400" />
-              </IconButton>
-              <IconButton
-                aria-label={t(
-                  "apiCredentialProfiles:actions.openModelManagement",
-                )}
-                size="sm"
-                variant="ghost"
-                onClick={() => onOpenModelManagement(profile)}
-                data-testid={
-                  API_CREDENTIAL_PROFILES_TEST_IDS.openModelManagementButton
-                }
-                analyticsAction={{
-                  featureId: PRODUCT_ANALYTICS_FEATURE_IDS.ModelList,
-                  actionId:
-                    PRODUCT_ANALYTICS_ACTION_IDS.OpenApiCredentialModelManagement,
-                  surfaceId: rowActionsSurface,
-                  entrypoint: optionsEntrypoint,
-                }}
-              >
-                <CpuChipIcon className="h-4 w-4" />
-              </IconButton>
-              <DropdownMenu
-                open={isExportMenuOpen}
-                onOpenChange={setIsExportMenuOpen}
-              >
-                <DropdownMenuTrigger asChild>
-                  <IconButton
-                    ref={exportMenuButtonRef}
-                    aria-label={t("common:actions.export")}
-                    size="sm"
-                    variant="ghost"
-                    className={cn(
-                      isImportEntryHighlighted &&
-                        "ring-2 ring-emerald-500 ring-offset-2 dark:ring-emerald-400",
-                    )}
-                    data-guidance-highlight={
-                      isImportEntryHighlighted ? "true" : undefined
-                    }
-                    data-testid={
-                      API_CREDENTIAL_PROFILES_TEST_IDS.exportMenuButton
-                    }
-                    analyticsAction={
-                      PRODUCT_ANALYTICS_ACTION_IDS.OpenApiCredentialExportMenu
-                    }
-                  >
-                    <ArrowUpTrayIcon className="h-4 w-4" />
-                  </IconButton>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="end">
-                  <DropdownMenuItem
-                    onSelect={() => onExport(profile, "cherryStudio")}
-                  >
-                    <span aria-hidden="true">
-                      <CherryIcon className="h-4 w-4" />
-                    </span>
-                    {t("keyManagement:actions.useInCherry")}
-                  </DropdownMenuItem>
-                  <DropdownMenuItem
-                    data-testid={
-                      API_CREDENTIAL_PROFILES_TEST_IDS.exportToCCSwitchMenuItem
-                    }
-                    onSelect={() => onExport(profile, "ccSwitch")}
-                  >
-                    <span aria-hidden="true">
-                      <CCSwitchIcon size="sm" />
-                    </span>
-                    {t("keyManagement:actions.exportToCCSwitch")}
-                  </DropdownMenuItem>
-                  <DropdownMenuItem
-                    data-testid={
-                      API_CREDENTIAL_PROFILES_TEST_IDS.exportToKiloCodeMenuItem
-                    }
-                    onSelect={() => onExport(profile, "kiloCode")}
-                  >
-                    <span aria-hidden="true">
-                      <KiloCodeIcon size="sm" />
-                    </span>
-                    {t("keyManagement:actions.exportToKiloCode")}
-                  </DropdownMenuItem>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuItem
-                    data-testid={
-                      API_CREDENTIAL_PROFILES_TEST_IDS.exportToCliProxyMenuItem
-                    }
-                    onSelect={() => onExport(profile, "cliProxy")}
-                  >
-                    <span aria-hidden="true">
-                      <CliProxyIcon size="sm" />
-                    </span>
-                    {t("keyManagement:actions.importToCliProxy")}
-                  </DropdownMenuItem>
-                  <DropdownMenuItem
-                    data-testid={
-                      API_CREDENTIAL_PROFILES_TEST_IDS.exportToClaudeCodeRouterMenuItem
-                    }
-                    onSelect={() => onExport(profile, "claudeCodeRouter")}
-                  >
-                    <span aria-hidden="true">
-                      <ClaudeCodeRouterIcon size="sm" />
-                    </span>
-                    {t("keyManagement:actions.importToClaudeCodeRouter")}
-                  </DropdownMenuItem>
-                  <DropdownMenuSeparator />
-                  <DropdownMenuItem
-                    className={cn(
-                      isImportEntryHighlighted &&
-                        "bg-emerald-50 text-emerald-800 ring-1 ring-emerald-500 ring-inset dark:bg-emerald-950/40 dark:text-emerald-100 dark:ring-emerald-400",
-                    )}
-                    data-guidance-highlight={
-                      isImportEntryHighlighted ? "true" : undefined
-                    }
-                    onSelect={() => onExport(profile, "managedSite")}
-                  >
-                    <span aria-hidden="true">
-                      <ManagedSiteIcon siteType={managedSiteType} size="sm" />
-                    </span>
-                    {t("keyManagement:actions.importToManagedSite", {
-                      site: managedSiteLabel,
-                    })}
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
-              <IconButton
-                aria-label={t("common:actions.delete")}
-                size="sm"
-                variant="destructive"
-                onClick={() => onDelete(profile)}
-                data-testid={
-                  API_CREDENTIAL_PROFILES_TEST_IDS.deleteTriggerButton
-                }
-                analyticsAction={
-                  PRODUCT_ANALYTICS_ACTION_IDS.DeleteApiCredentialProfile
-                }
-              >
-                <TrashIcon className="h-4 w-4" />
-              </IconButton>
+                <IconButton
+                  aria-label={t("apiCredentialProfiles:actions.copyBundle")}
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => onCopyBundle(profile)}
+                  data-testid={
+                    API_CREDENTIAL_PROFILES_TEST_IDS.copyBundleButton
+                  }
+                  analyticsAction={
+                    PRODUCT_ANALYTICS_ACTION_IDS.CopyApiCredentialBundle
+                  }
+                >
+                  <Copy className="h-4 w-4" />
+                </IconButton>
+                <IconButton
+                  aria-label={t("common:actions.edit")}
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => onEdit(profile)}
+                  data-testid={API_CREDENTIAL_PROFILES_TEST_IDS.editButton}
+                  analyticsAction={
+                    PRODUCT_ANALYTICS_ACTION_IDS.OpenUpdateApiCredentialProfileDialog
+                  }
+                >
+                  <PencilIcon className="h-4 w-4 text-blue-500 dark:text-blue-400" />
+                </IconButton>
+                <IconButton
+                  aria-label={t("apiCredentialProfiles:actions.verifyApi")}
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => onVerify(profile)}
+                  data-testid={API_CREDENTIAL_PROFILES_TEST_IDS.verifyButton}
+                  analyticsAction={
+                    PRODUCT_ANALYTICS_ACTION_IDS.VerifyApiCredential
+                  }
+                >
+                  <WrenchScrewdriverIcon className="h-4 w-4 text-emerald-600 dark:text-emerald-400" />
+                </IconButton>
+                <IconButton
+                  aria-label={t(
+                    "apiCredentialProfiles:actions.verifyCliSupport",
+                  )}
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => onVerifyCliSupport(profile)}
+                  analyticsAction={
+                    PRODUCT_ANALYTICS_ACTION_IDS.VerifyApiCredentialCliSupport
+                  }
+                >
+                  <CommandLineIcon className="h-4 w-4 text-sky-600 dark:text-sky-400" />
+                </IconButton>
+                <IconButton
+                  aria-label={t(
+                    "apiCredentialProfiles:actions.openModelManagement",
+                  )}
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => onOpenModelManagement(profile)}
+                  data-testid={
+                    API_CREDENTIAL_PROFILES_TEST_IDS.openModelManagementButton
+                  }
+                  analyticsAction={{
+                    featureId: PRODUCT_ANALYTICS_FEATURE_IDS.ModelList,
+                    actionId:
+                      PRODUCT_ANALYTICS_ACTION_IDS.OpenApiCredentialModelManagement,
+                    surfaceId: rowActionsSurface,
+                    entrypoint: optionsEntrypoint,
+                  }}
+                >
+                  <CpuChipIcon className="h-4 w-4" />
+                </IconButton>
+                <DropdownMenu
+                  open={isExportMenuOpen}
+                  onOpenChange={setIsExportMenuOpen}
+                >
+                  <DropdownMenuTrigger asChild>
+                    <IconButton
+                      ref={exportMenuButtonRef}
+                      aria-label={t("common:actions.export")}
+                      size="sm"
+                      variant="ghost"
+                      className={cn(
+                        isImportEntryHighlighted &&
+                          "ring-2 ring-emerald-500 ring-offset-2 dark:ring-emerald-400",
+                      )}
+                      data-guidance-highlight={
+                        isImportEntryHighlighted ? "true" : undefined
+                      }
+                      data-testid={
+                        API_CREDENTIAL_PROFILES_TEST_IDS.exportMenuButton
+                      }
+                      analyticsAction={
+                        PRODUCT_ANALYTICS_ACTION_IDS.OpenApiCredentialExportMenu
+                      }
+                    >
+                      <ArrowUpTrayIcon className="h-4 w-4" />
+                    </IconButton>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    <DropdownMenuItem
+                      onSelect={() => onExport(profile, "cherryStudio")}
+                    >
+                      <span aria-hidden="true">
+                        <CherryIcon className="h-4 w-4" />
+                      </span>
+                      {t("keyManagement:actions.useInCherry")}
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      data-testid={
+                        API_CREDENTIAL_PROFILES_TEST_IDS.exportToCCSwitchMenuItem
+                      }
+                      onSelect={() => onExport(profile, "ccSwitch")}
+                    >
+                      <span aria-hidden="true">
+                        <CCSwitchIcon size="sm" />
+                      </span>
+                      {t("keyManagement:actions.exportToCCSwitch")}
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      data-testid={
+                        API_CREDENTIAL_PROFILES_TEST_IDS.exportToKiloCodeMenuItem
+                      }
+                      onSelect={() => onExport(profile, "kiloCode")}
+                    >
+                      <span aria-hidden="true">
+                        <KiloCodeIcon size="sm" />
+                      </span>
+                      {t("keyManagement:actions.exportToKiloCode")}
+                    </DropdownMenuItem>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem
+                      data-testid={
+                        API_CREDENTIAL_PROFILES_TEST_IDS.exportToCliProxyMenuItem
+                      }
+                      onSelect={() => onExport(profile, "cliProxy")}
+                    >
+                      <span aria-hidden="true">
+                        <CliProxyIcon size="sm" />
+                      </span>
+                      {t("keyManagement:actions.importToCliProxy")}
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      data-testid={
+                        API_CREDENTIAL_PROFILES_TEST_IDS.exportToClaudeCodeRouterMenuItem
+                      }
+                      onSelect={() => onExport(profile, "claudeCodeRouter")}
+                    >
+                      <span aria-hidden="true">
+                        <ClaudeCodeRouterIcon size="sm" />
+                      </span>
+                      {t("keyManagement:actions.importToClaudeCodeRouter")}
+                    </DropdownMenuItem>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem
+                      className={cn(
+                        isImportEntryHighlighted &&
+                          "bg-emerald-50 text-emerald-800 ring-1 ring-emerald-500 ring-inset dark:bg-emerald-950/40 dark:text-emerald-100 dark:ring-emerald-400",
+                      )}
+                      data-guidance-highlight={
+                        isImportEntryHighlighted ? "true" : undefined
+                      }
+                      onSelect={() => onExport(profile, "managedSite")}
+                    >
+                      <span aria-hidden="true">
+                        <ManagedSiteIcon siteType={managedSiteType} size="sm" />
+                      </span>
+                      {t("keyManagement:actions.importToManagedSite", {
+                        site: managedSiteLabel,
+                      })}
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+                <IconButton
+                  aria-label={t("common:actions.delete")}
+                  size="sm"
+                  variant="destructive"
+                  onClick={() => onDelete(profile)}
+                  data-testid={
+                    API_CREDENTIAL_PROFILES_TEST_IDS.deleteTriggerButton
+                  }
+                  analyticsAction={
+                    PRODUCT_ANALYTICS_ACTION_IDS.DeleteApiCredentialProfile
+                  }
+                >
+                  <TrashIcon className="h-4 w-4" />
+                </IconButton>
+              </div>
             </div>
           </div>
         </CardContent>

--- a/src/features/ApiCredentialProfiles/components/ApiCredentialProfileListItem.tsx
+++ b/src/features/ApiCredentialProfiles/components/ApiCredentialProfileListItem.tsx
@@ -841,7 +841,7 @@ export function ApiCredentialProfileListItem({
                 <IconButton
                   aria-label={t("common:actions.delete")}
                   size="sm"
-                  variant="destructive"
+                  variant="destructiveGhost"
                   onClick={() => onDelete(profile)}
                   data-testid={
                     API_CREDENTIAL_PROFILES_TEST_IDS.deleteTriggerButton

--- a/src/features/ApiCredentialProfiles/components/ApiCredentialProfileListItem.tsx
+++ b/src/features/ApiCredentialProfiles/components/ApiCredentialProfileListItem.tsx
@@ -55,7 +55,11 @@ import {
 import { getApiVerificationApiTypeLabel } from "~/services/verification/aiApiVerification/i18n"
 import type { ApiVerificationHistorySummary } from "~/services/verification/verificationResultHistory"
 import { SiteHealthStatus } from "~/types"
-import type { ApiCredentialProfile } from "~/types/apiCredentialProfiles"
+import {
+  API_CREDENTIAL_TELEMETRY_SOURCES,
+  type ApiCredentialProfile,
+  type ApiCredentialTelemetrySource,
+} from "~/types/apiCredentialProfiles"
 import {
   formatLocaleDateTime,
   formatTokenCount,
@@ -63,15 +67,11 @@ import {
 } from "~/utils/core/formatters"
 import { formatTelemetryMoney } from "~/utils/core/money"
 
+import {
+  API_CREDENTIAL_PROFILE_EXPORT_ACTIONS,
+  type ApiCredentialProfileExportAction,
+} from "../contracts"
 import { API_CREDENTIAL_PROFILES_TEST_IDS } from "../testIds"
-
-export type ApiCredentialProfileExportAction =
-  | "cherryStudio"
-  | "ccSwitch"
-  | "kiloCode"
-  | "cliProxy"
-  | "claudeCodeRouter"
-  | "managedSite"
 
 interface ApiCredentialProfileListItemProps {
   profile: ApiCredentialProfile
@@ -114,6 +114,7 @@ const COMPACT_AUDIT_TIME_FORMAT: Intl.DateTimeFormatOptions = {
   hour: "2-digit",
   minute: "2-digit",
 }
+const GUIDED_IMPORT_HIGHLIGHT_DURATION_MS = 5_000
 
 interface AuditTimeBadgeProps {
   Icon: LucideIcon
@@ -153,21 +154,21 @@ function AuditTimeBadge({
  */
 function getTelemetrySourceLabel(
   t: TFunction,
-  source: string | undefined,
+  source: ApiCredentialTelemetrySource | undefined,
 ): string {
   if (!source) return t("apiCredentialProfiles:telemetry.source.notAvailable")
-  if (source === "models")
+  if (source === API_CREDENTIAL_TELEMETRY_SOURCES.Models)
     return t("apiCredentialProfiles:telemetry.source.models")
-  if (source === "openaiBilling") {
+  if (source === API_CREDENTIAL_TELEMETRY_SOURCES.OpenAiBilling) {
     return t("apiCredentialProfiles:telemetry.source.openaiBilling")
   }
-  if (source === "newApiTokenUsage") {
+  if (source === API_CREDENTIAL_TELEMETRY_SOURCES.NewApiTokenUsage) {
     return t("apiCredentialProfiles:telemetry.source.newApiTokenUsage")
   }
-  if (source === "sub2apiUsage") {
+  if (source === API_CREDENTIAL_TELEMETRY_SOURCES.Sub2ApiUsage) {
     return t("apiCredentialProfiles:telemetry.source.sub2apiUsage")
   }
-  if (source === "customReadOnlyEndpoint") {
+  if (source === API_CREDENTIAL_TELEMETRY_SOURCES.CustomReadOnlyEndpoint) {
     return t("apiCredentialProfiles:telemetry.source.customReadOnlyEndpoint")
   }
   return source
@@ -325,7 +326,7 @@ export function ApiCredentialProfileListItem({
 
     const timeoutId = window.setTimeout(() => {
       setIsImportEntryHighlighted(false)
-    }, 5000)
+    }, GUIDED_IMPORT_HIGHLIGHT_DURATION_MS)
 
     return () => window.clearTimeout(timeoutId)
   }, [guidedImportEntryRequest])
@@ -735,7 +736,12 @@ export function ApiCredentialProfileListItem({
                   </DropdownMenuTrigger>
                   <DropdownMenuContent align="end">
                     <DropdownMenuItem
-                      onSelect={() => onExport(profile, "cherryStudio")}
+                      onSelect={() =>
+                        onExport(
+                          profile,
+                          API_CREDENTIAL_PROFILE_EXPORT_ACTIONS.CherryStudio,
+                        )
+                      }
                     >
                       <span aria-hidden="true">
                         <CherryIcon className="h-4 w-4" />
@@ -746,7 +752,12 @@ export function ApiCredentialProfileListItem({
                       data-testid={
                         API_CREDENTIAL_PROFILES_TEST_IDS.exportToCCSwitchMenuItem
                       }
-                      onSelect={() => onExport(profile, "ccSwitch")}
+                      onSelect={() =>
+                        onExport(
+                          profile,
+                          API_CREDENTIAL_PROFILE_EXPORT_ACTIONS.CCSwitch,
+                        )
+                      }
                     >
                       <span aria-hidden="true">
                         <CCSwitchIcon size="sm" />
@@ -757,7 +768,12 @@ export function ApiCredentialProfileListItem({
                       data-testid={
                         API_CREDENTIAL_PROFILES_TEST_IDS.exportToKiloCodeMenuItem
                       }
-                      onSelect={() => onExport(profile, "kiloCode")}
+                      onSelect={() =>
+                        onExport(
+                          profile,
+                          API_CREDENTIAL_PROFILE_EXPORT_ACTIONS.KiloCode,
+                        )
+                      }
                     >
                       <span aria-hidden="true">
                         <KiloCodeIcon size="sm" />
@@ -769,7 +785,12 @@ export function ApiCredentialProfileListItem({
                       data-testid={
                         API_CREDENTIAL_PROFILES_TEST_IDS.exportToCliProxyMenuItem
                       }
-                      onSelect={() => onExport(profile, "cliProxy")}
+                      onSelect={() =>
+                        onExport(
+                          profile,
+                          API_CREDENTIAL_PROFILE_EXPORT_ACTIONS.CliProxy,
+                        )
+                      }
                     >
                       <span aria-hidden="true">
                         <CliProxyIcon size="sm" />
@@ -780,7 +801,12 @@ export function ApiCredentialProfileListItem({
                       data-testid={
                         API_CREDENTIAL_PROFILES_TEST_IDS.exportToClaudeCodeRouterMenuItem
                       }
-                      onSelect={() => onExport(profile, "claudeCodeRouter")}
+                      onSelect={() =>
+                        onExport(
+                          profile,
+                          API_CREDENTIAL_PROFILE_EXPORT_ACTIONS.ClaudeCodeRouter,
+                        )
+                      }
                     >
                       <span aria-hidden="true">
                         <ClaudeCodeRouterIcon size="sm" />
@@ -796,7 +822,12 @@ export function ApiCredentialProfileListItem({
                       data-guidance-highlight={
                         isImportEntryHighlighted ? "true" : undefined
                       }
-                      onSelect={() => onExport(profile, "managedSite")}
+                      onSelect={() =>
+                        onExport(
+                          profile,
+                          API_CREDENTIAL_PROFILE_EXPORT_ACTIONS.ManagedSite,
+                        )
+                      }
                     >
                       <span aria-hidden="true">
                         <ManagedSiteIcon siteType={managedSiteType} size="sm" />

--- a/src/features/ApiCredentialProfiles/components/ApiCredentialProfilesList.tsx
+++ b/src/features/ApiCredentialProfiles/components/ApiCredentialProfilesList.tsx
@@ -1,5 +1,5 @@
 import { Copy, Plus } from "lucide-react"
-import { useEffect, useMemo, useState } from "react"
+import { useEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 
 import {
@@ -14,12 +14,7 @@ import {
 } from "~/components/ui"
 import { useIsDesktop } from "~/hooks/useMediaQuery"
 import { cn } from "~/lib/utils"
-import {
-  PRODUCT_ANALYTICS_ACTION_IDS,
-  PRODUCT_ANALYTICS_ENTRYPOINTS,
-  PRODUCT_ANALYTICS_FEATURE_IDS,
-  PRODUCT_ANALYTICS_SURFACE_IDS,
-} from "~/services/productAnalytics/contracts"
+import { PRODUCT_ANALYTICS_ACTION_IDS } from "~/services/productAnalytics/contracts"
 import type { ApiCredentialProfile } from "~/types/apiCredentialProfiles"
 
 import {
@@ -170,13 +165,7 @@ function EndpointHeader({
           }
           aria-label={t("apiCredentialProfiles:actions.copyBaseUrl")}
           className="shrink-0"
-          analyticsAction={{
-            featureId: PRODUCT_ANALYTICS_FEATURE_IDS.ApiCredentialProfiles,
-            actionId: PRODUCT_ANALYTICS_ACTION_IDS.CopyBaseUrl,
-            surfaceId:
-              PRODUCT_ANALYTICS_SURFACE_IDS.OptionsApiCredentialProfilesRowActions,
-            entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Options,
-          }}
+          analyticsAction={PRODUCT_ANALYTICS_ACTION_IDS.CopyBaseUrl}
         >
           <Copy className="h-4 w-4" />
         </IconButton>
@@ -219,6 +208,7 @@ function DesktopEndpointNavigation({
               <button
                 type="button"
                 aria-current={selected ? "true" : undefined}
+                aria-label={group.baseUrl}
                 className="min-w-0 flex-1 rounded-lg px-3 py-2.5 text-left outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-inset"
                 onClick={() => onSelectBaseUrl(group.baseUrl)}
               >
@@ -239,9 +229,9 @@ function DesktopEndpointNavigation({
                 size="sm"
                 onClick={() => onAddCredential(group.baseUrl)}
                 data-testid={
-                  API_CREDENTIAL_PROFILES_TEST_IDS.endpointAddCredentialButton
+                  API_CREDENTIAL_PROFILES_TEST_IDS.endpointNavigationAddCredentialButton
                 }
-                aria-label={t("apiCredentialProfiles:grouping.addCredential")}
+                aria-label={`${t("apiCredentialProfiles:grouping.addCredential")}: ${group.baseUrl}`}
                 className="mr-1 shrink-0"
                 analyticsAction={
                   PRODUCT_ANALYTICS_ACTION_IDS.OpenCreateApiCredentialProfileDialog
@@ -360,6 +350,7 @@ export function ApiCredentialProfilesList({
   const [selectedBaseUrl, setSelectedBaseUrl] = useState(
     () => groups[0]?.baseUrl ?? "",
   )
+  const handledGuidedImportRequestRef = useRef<number | null>(null)
   const selectedGroup =
     groups.find((group) => group.baseUrl === selectedBaseUrl) ?? groups[0]
   const guidedGroup = guidedImportEntry
@@ -374,15 +365,22 @@ export function ApiCredentialProfilesList({
   }
 
   useEffect(() => {
-    if (guidedGroup && guidedGroup.baseUrl !== selectedBaseUrl) {
-      setSelectedBaseUrl(guidedGroup.baseUrl)
+    if (
+      guidedImportEntry &&
+      guidedGroup &&
+      handledGuidedImportRequestRef.current !== guidedImportEntry.request
+    ) {
+      handledGuidedImportRequestRef.current = guidedImportEntry.request
+      if (guidedGroup.baseUrl !== selectedBaseUrl) {
+        setSelectedBaseUrl(guidedGroup.baseUrl)
+      }
       return
     }
 
     if (selectedGroup && selectedGroup.baseUrl !== selectedBaseUrl) {
       setSelectedBaseUrl(selectedGroup.baseUrl)
     }
-  }, [guidedGroup, selectedBaseUrl, selectedGroup])
+  }, [guidedGroup, guidedImportEntry, selectedBaseUrl, selectedGroup])
 
   if (!selectedGroup) {
     return null

--- a/src/features/ApiCredentialProfiles/components/ApiCredentialProfilesList.tsx
+++ b/src/features/ApiCredentialProfiles/components/ApiCredentialProfilesList.tsx
@@ -22,7 +22,10 @@ import {
   type ApiCredentialProfilesViewVariant,
 } from "../contracts"
 import type { ApiCredentialProfilesController } from "../hooks/useApiCredentialProfilesController"
-import { API_CREDENTIAL_PROFILES_TEST_IDS } from "../testIds"
+import {
+  API_CREDENTIAL_PROFILES_TEST_IDS,
+  getApiCredentialEndpointOptionTestId,
+} from "../testIds"
 import { ApiCredentialProfileListItem } from "./ApiCredentialProfileListItem"
 
 interface ApiCredentialProfilesListProps {
@@ -273,7 +276,13 @@ function CompactEndpointSelector({
         </SelectTrigger>
         <SelectContent align="start">
           {groups.map((group) => (
-            <SelectItem key={group.baseUrl} value={group.baseUrl}>
+            <SelectItem
+              key={group.baseUrl}
+              value={group.baseUrl}
+              data-testid={getApiCredentialEndpointOptionTestId(
+                group.profiles[0]!.id,
+              )}
+            >
               <span className="min-w-0 truncate">
                 {getEndpointLabel(group.baseUrl)}
               </span>

--- a/src/features/ApiCredentialProfiles/components/ApiCredentialProfilesList.tsx
+++ b/src/features/ApiCredentialProfiles/components/ApiCredentialProfilesList.tsx
@@ -1,15 +1,343 @@
+import { Copy, Plus } from "lucide-react"
+import { useEffect, useMemo, useState } from "react"
+import { useTranslation } from "react-i18next"
+
+import {
+  Badge,
+  Button,
+  IconButton,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "~/components/ui"
+import { useIsDesktop } from "~/hooks/useMediaQuery"
+import { cn } from "~/lib/utils"
+import {
+  PRODUCT_ANALYTICS_ACTION_IDS,
+  PRODUCT_ANALYTICS_ENTRYPOINTS,
+  PRODUCT_ANALYTICS_FEATURE_IDS,
+  PRODUCT_ANALYTICS_SURFACE_IDS,
+} from "~/services/productAnalytics/contracts"
 import type { ApiCredentialProfile } from "~/types/apiCredentialProfiles"
 
 import type { ApiCredentialProfilesController } from "../hooks/useApiCredentialProfilesController"
+import { API_CREDENTIAL_PROFILES_TEST_IDS } from "../testIds"
 import { ApiCredentialProfileListItem } from "./ApiCredentialProfileListItem"
 
 interface ApiCredentialProfilesListProps {
   profiles: ApiCredentialProfile[]
   controller: ApiCredentialProfilesController
+  variant?: "options" | "popup"
+  isFiltering?: boolean
   guidedImportEntry?: {
     profileId: string
     request: number
   }
+}
+
+type ApiCredentialEndpointGroup = {
+  baseUrl: string
+  profiles: ApiCredentialProfile[]
+}
+
+interface EndpointHeaderProps {
+  baseUrl: string
+  credentialCount: number
+  onAddCredential?: (baseUrl: string) => void
+  onCopyBaseUrl: (baseUrl: string) => void
+  className?: string
+}
+
+interface EndpointSelectionProps {
+  groups: ApiCredentialEndpointGroup[]
+  selectedBaseUrl: string
+  onSelectBaseUrl: (baseUrl: string) => void
+  onAddCredential: (baseUrl: string) => void
+}
+
+interface EndpointProfileListProps {
+  profiles: ApiCredentialProfile[]
+  controller: ApiCredentialProfilesController
+  guidedImportEntry?: ApiCredentialProfilesListProps["guidedImportEntry"]
+}
+
+const API_CREDENTIAL_ENDPOINT_SELECT_ID = "api-credential-endpoint-select"
+
+/**
+ * Groups the already-normalized persisted profiles by their canonical Base URL.
+ */
+function groupProfilesByBaseUrl(
+  profiles: ApiCredentialProfile[],
+): ApiCredentialEndpointGroup[] {
+  const groups = new Map<string, ApiCredentialEndpointGroup>()
+
+  for (const profile of profiles) {
+    const existing = groups.get(profile.baseUrl)
+    if (existing) {
+      existing.profiles.push(profile)
+    } else {
+      groups.set(profile.baseUrl, {
+        baseUrl: profile.baseUrl,
+        profiles: [profile],
+      })
+    }
+  }
+
+  return Array.from(groups.values())
+}
+
+/**
+ * Renders a compact endpoint label without hiding path-level distinctions.
+ */
+function getEndpointLabel(baseUrl: string): string {
+  try {
+    const parsed = new URL(baseUrl)
+    const pathname = parsed.pathname === "/" ? "" : parsed.pathname
+    return `${parsed.host}${pathname}`
+  } catch {
+    return baseUrl
+  }
+}
+
+/**
+ * Shows the shared endpoint once per group and owns its copy action.
+ */
+function EndpointHeader({
+  baseUrl,
+  credentialCount,
+  onAddCredential,
+  onCopyBaseUrl,
+  className,
+}: EndpointHeaderProps) {
+  const { t } = useTranslation(["apiCredentialProfiles"])
+
+  return (
+    <div className={cn("min-w-0", className)}>
+      <div className="flex min-w-0 items-center gap-1">
+        <div className="flex min-w-0 flex-1 items-center gap-2">
+          <code
+            className="min-w-0 truncate font-mono text-xs font-semibold text-gray-950 sm:text-sm dark:text-gray-50"
+            title={baseUrl}
+            data-testid={API_CREDENTIAL_PROFILES_TEST_IDS.endpointBaseUrl}
+          >
+            {baseUrl}
+          </code>
+          <Badge
+            variant="secondary"
+            size="sm"
+            className="shrink-0"
+            data-testid={
+              API_CREDENTIAL_PROFILES_TEST_IDS.endpointCredentialCount
+            }
+          >
+            {t("apiCredentialProfiles:grouping.credentialCount", {
+              count: credentialCount,
+            })}
+          </Badge>
+        </div>
+        {onAddCredential ? (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => onAddCredential(baseUrl)}
+            data-testid={
+              API_CREDENTIAL_PROFILES_TEST_IDS.endpointAddCredentialButton
+            }
+            aria-label={t("apiCredentialProfiles:grouping.addCredential")}
+            className="h-8 shrink-0 gap-1.5 px-2 text-xs"
+            leftIcon={<Plus className="h-4 w-4" />}
+            analyticsAction={
+              PRODUCT_ANALYTICS_ACTION_IDS.OpenCreateApiCredentialProfileDialog
+            }
+          >
+            <span className="hidden sm:inline">
+              {t("apiCredentialProfiles:grouping.addCredential")}
+            </span>
+          </Button>
+        ) : null}
+        <IconButton
+          variant="ghost"
+          size="sm"
+          onClick={() => onCopyBaseUrl(baseUrl)}
+          data-testid={
+            API_CREDENTIAL_PROFILES_TEST_IDS.endpointCopyBaseUrlButton
+          }
+          aria-label={t("apiCredentialProfiles:actions.copyBaseUrl")}
+          className="shrink-0"
+          analyticsAction={{
+            featureId: PRODUCT_ANALYTICS_FEATURE_IDS.ApiCredentialProfiles,
+            actionId: PRODUCT_ANALYTICS_ACTION_IDS.CopyBaseUrl,
+            surfaceId:
+              PRODUCT_ANALYTICS_SURFACE_IDS.OptionsApiCredentialProfilesRowActions,
+            entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Options,
+          }}
+        >
+          <Copy className="h-4 w-4" />
+        </IconButton>
+      </div>
+    </div>
+  )
+}
+
+/** Renders the endpoint switcher used by the full options-page layout. */
+function DesktopEndpointNavigation({
+  groups,
+  selectedBaseUrl,
+  onSelectBaseUrl,
+  onAddCredential,
+}: EndpointSelectionProps) {
+  const { t } = useTranslation(["apiCredentialProfiles"])
+
+  return (
+    <nav
+      aria-label={t("apiCredentialProfiles:grouping.navigationLabel")}
+      data-testid={API_CREDENTIAL_PROFILES_TEST_IDS.endpointNavigation}
+      className="border-r border-gray-200 bg-gray-50/70 p-2 dark:border-gray-800 dark:bg-gray-900/50"
+    >
+      <div className="px-2 pt-1 pb-2 text-xs font-semibold tracking-wide text-gray-500 uppercase dark:text-gray-400">
+        {t("apiCredentialProfiles:grouping.baseUrls")}
+      </div>
+      <div className="space-y-1">
+        {groups.map((group) => {
+          const selected = group.baseUrl === selectedBaseUrl
+          return (
+            <div
+              key={group.baseUrl}
+              className={cn(
+                "flex min-w-0 items-center rounded-lg border transition-colors",
+                selected
+                  ? "border-blue-300 bg-blue-50 text-blue-950 dark:border-blue-700 dark:bg-blue-950/40 dark:text-blue-100"
+                  : "border-transparent text-gray-700 hover:bg-white dark:text-gray-300 dark:hover:bg-gray-900",
+              )}
+            >
+              <button
+                type="button"
+                aria-current={selected ? "true" : undefined}
+                className="min-w-0 flex-1 rounded-lg px-3 py-2.5 text-left outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-inset"
+                onClick={() => onSelectBaseUrl(group.baseUrl)}
+              >
+                <span
+                  className="block truncate text-sm font-medium"
+                  title={group.baseUrl}
+                >
+                  {getEndpointLabel(group.baseUrl)}
+                </span>
+                <span className="mt-1 block text-xs text-gray-500 dark:text-gray-400">
+                  {t("apiCredentialProfiles:grouping.credentialCount", {
+                    count: group.profiles.length,
+                  })}
+                </span>
+              </button>
+              <IconButton
+                variant="ghost"
+                size="sm"
+                onClick={() => onAddCredential(group.baseUrl)}
+                data-testid={
+                  API_CREDENTIAL_PROFILES_TEST_IDS.endpointAddCredentialButton
+                }
+                aria-label={t("apiCredentialProfiles:grouping.addCredential")}
+                className="mr-1 shrink-0"
+                analyticsAction={
+                  PRODUCT_ANALYTICS_ACTION_IDS.OpenCreateApiCredentialProfileDialog
+                }
+              >
+                <Plus className="h-4 w-4" />
+              </IconButton>
+            </div>
+          )
+        })}
+      </div>
+    </nav>
+  )
+}
+
+/** Renders the endpoint switcher used by popup and narrow layouts. */
+function CompactEndpointSelector({
+  groups,
+  selectedBaseUrl,
+  onSelectBaseUrl,
+}: Omit<EndpointSelectionProps, "onAddCredential">) {
+  const { t } = useTranslation(["apiCredentialProfiles"])
+
+  return (
+    <div className="border-b border-gray-200 bg-gray-50/70 p-3 dark:border-gray-800 dark:bg-gray-900/50">
+      <label
+        htmlFor={API_CREDENTIAL_ENDPOINT_SELECT_ID}
+        className="mb-1.5 block text-xs font-medium text-gray-500 dark:text-gray-400"
+      >
+        {t("apiCredentialProfiles:grouping.baseUrlSelector")}
+      </label>
+      <Select value={selectedBaseUrl} onValueChange={onSelectBaseUrl}>
+        <SelectTrigger
+          id={API_CREDENTIAL_ENDPOINT_SELECT_ID}
+          size="sm"
+          data-testid={API_CREDENTIAL_PROFILES_TEST_IDS.endpointSelector}
+        >
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent align="start">
+          {groups.map((group) => (
+            <SelectItem key={group.baseUrl} value={group.baseUrl}>
+              <span className="min-w-0 truncate">
+                {getEndpointLabel(group.baseUrl)}
+              </span>
+              <span className="shrink-0 text-xs text-gray-500 dark:text-gray-400">
+                {t("apiCredentialProfiles:grouping.credentialCount", {
+                  count: group.profiles.length,
+                })}
+              </span>
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  )
+}
+
+/** Narrows configured tag lookups while preserving the existing empty filter. */
+function isTagName(value: string | undefined): value is string {
+  return Boolean(value)
+}
+
+/** Connects endpoint-group profiles to their row actions and display metadata. */
+function EndpointProfileList({
+  profiles,
+  controller,
+  guidedImportEntry,
+}: EndpointProfileListProps) {
+  return profiles.map((profile) => (
+    <ApiCredentialProfileListItem
+      key={profile.id}
+      profile={profile}
+      verificationSummary={controller.getProfileVerificationSummary(profile.id)}
+      tagNames={(profile.tagIds ?? [])
+        .map((id) => controller.tagNameById.get(id))
+        .filter(isTagName)}
+      visibleKeys={controller.visibleKeys}
+      toggleKeyVisibility={controller.toggleKeyVisibility}
+      onCopyApiKey={controller.handleCopyApiKey}
+      onCopyBundle={controller.handleCopyBundle}
+      onOpenModelManagement={controller.handleOpenModelManagement}
+      onRefreshTelemetry={controller.handleRefreshTelemetry}
+      onExport={controller.handleExport}
+      isTelemetryRefreshing={controller.refreshingTelemetryProfileIds.includes(
+        profile.id,
+      )}
+      managedSiteType={controller.managedSiteType}
+      managedSiteLabel={controller.managedSiteLabel}
+      guidedImportEntryRequest={
+        guidedImportEntry?.profileId === profile.id
+          ? guidedImportEntry.request
+          : undefined
+      }
+      onVerify={controller.setVerifyingProfile}
+      onVerifyCliSupport={controller.setCliVerifyingProfile}
+      onEdit={controller.openEditDialog}
+      onDelete={controller.handleRequestDelete}
+    />
+  ))
 }
 
 /**
@@ -18,46 +346,120 @@ interface ApiCredentialProfilesListProps {
 export function ApiCredentialProfilesList({
   profiles,
   controller,
+  variant = "options",
+  isFiltering = false,
   guidedImportEntry,
 }: ApiCredentialProfilesListProps) {
+  const { t } = useTranslation(["apiCredentialProfiles"])
+  const isDesktop = useIsDesktop()
+  const groups = useMemo(() => groupProfilesByBaseUrl(profiles), [profiles])
+  const [selectedBaseUrl, setSelectedBaseUrl] = useState(
+    () => groups[0]?.baseUrl ?? "",
+  )
+  const selectedGroup =
+    groups.find((group) => group.baseUrl === selectedBaseUrl) ?? groups[0]
+  const guidedGroup = guidedImportEntry
+    ? groups.find((group) =>
+        group.profiles.some(
+          (profile) => profile.id === guidedImportEntry.profileId,
+        ),
+      )
+    : undefined
+  const handleAddCredential = (baseUrl: string) => {
+    controller.openAddDialog({ baseUrl })
+  }
+
+  useEffect(() => {
+    if (guidedGroup && guidedGroup.baseUrl !== selectedBaseUrl) {
+      setSelectedBaseUrl(guidedGroup.baseUrl)
+      return
+    }
+
+    if (selectedGroup && selectedGroup.baseUrl !== selectedBaseUrl) {
+      setSelectedBaseUrl(selectedGroup.baseUrl)
+    }
+  }, [guidedGroup, selectedBaseUrl, selectedGroup])
+
+  if (!selectedGroup) {
+    return null
+  }
+
+  if (isFiltering) {
+    return (
+      <div className="space-y-4">
+        {groups.map((group) => (
+          <section
+            key={group.baseUrl}
+            aria-label={t("apiCredentialProfiles:grouping.selectedEndpoint", {
+              baseUrl: group.baseUrl,
+            })}
+            className="overflow-hidden rounded-xl border border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-950"
+          >
+            <EndpointHeader
+              baseUrl={group.baseUrl}
+              credentialCount={group.profiles.length}
+              onCopyBaseUrl={controller.handleCopyBaseUrl}
+              className="border-b border-gray-200 bg-gray-50/70 px-3 py-2.5 dark:border-gray-800 dark:bg-gray-900/50"
+            />
+            <div className="space-y-3 p-3 sm:p-4">
+              <EndpointProfileList
+                profiles={group.profiles}
+                controller={controller}
+                guidedImportEntry={guidedImportEntry}
+              />
+            </div>
+          </section>
+        ))}
+      </div>
+    )
+  }
+
+  const hasMultipleGroups = groups.length > 1
+  const useSidebar = hasMultipleGroups && variant === "options" && isDesktop
+
   return (
-    <div className="space-y-3">
-      {profiles.map((profile) => (
-        <ApiCredentialProfileListItem
-          key={profile.id}
-          profile={profile}
-          verificationSummary={controller.getProfileVerificationSummary(
-            profile.id,
-          )}
-          tagNames={
-            (profile.tagIds ?? [])
-              .map((id) => controller.tagNameById.get(id))
-              .filter(Boolean) as string[]
-          }
-          visibleKeys={controller.visibleKeys}
-          toggleKeyVisibility={controller.toggleKeyVisibility}
-          onCopyBaseUrl={controller.handleCopyBaseUrl}
-          onCopyApiKey={controller.handleCopyApiKey}
-          onCopyBundle={controller.handleCopyBundle}
-          onOpenModelManagement={controller.handleOpenModelManagement}
-          onRefreshTelemetry={controller.handleRefreshTelemetry}
-          onExport={controller.handleExport}
-          isTelemetryRefreshing={controller.refreshingTelemetryProfileIds.includes(
-            profile.id,
-          )}
-          managedSiteType={controller.managedSiteType}
-          managedSiteLabel={controller.managedSiteLabel}
-          guidedImportEntryRequest={
-            guidedImportEntry?.profileId === profile.id
-              ? guidedImportEntry.request
-              : undefined
-          }
-          onVerify={(p) => controller.setVerifyingProfile(p)}
-          onVerifyCliSupport={(p) => controller.setCliVerifyingProfile(p)}
-          onEdit={controller.openEditDialog}
-          onDelete={controller.handleRequestDelete}
+    <div
+      className={cn(
+        "overflow-hidden rounded-xl border border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-950",
+        useSidebar && "grid grid-cols-[15rem_minmax(0,1fr)]",
+      )}
+    >
+      {useSidebar ? (
+        <DesktopEndpointNavigation
+          groups={groups}
+          selectedBaseUrl={selectedGroup.baseUrl}
+          onSelectBaseUrl={setSelectedBaseUrl}
+          onAddCredential={handleAddCredential}
         />
-      ))}
+      ) : hasMultipleGroups ? (
+        <CompactEndpointSelector
+          groups={groups}
+          selectedBaseUrl={selectedGroup.baseUrl}
+          onSelectBaseUrl={setSelectedBaseUrl}
+        />
+      ) : null}
+
+      <section
+        aria-label={t("apiCredentialProfiles:grouping.selectedEndpoint", {
+          baseUrl: selectedGroup.baseUrl,
+        })}
+        className="min-w-0 p-3 sm:p-4"
+      >
+        <EndpointHeader
+          baseUrl={selectedGroup.baseUrl}
+          credentialCount={selectedGroup.profiles.length}
+          onAddCredential={handleAddCredential}
+          onCopyBaseUrl={controller.handleCopyBaseUrl}
+          className="mb-3"
+        />
+        <div className="space-y-3">
+          <EndpointProfileList
+            profiles={selectedGroup.profiles}
+            controller={controller}
+            guidedImportEntry={guidedImportEntry}
+          />
+        </div>
+      </section>
     </div>
   )
 }

--- a/src/features/ApiCredentialProfiles/components/ApiCredentialProfilesList.tsx
+++ b/src/features/ApiCredentialProfiles/components/ApiCredentialProfilesList.tsx
@@ -22,6 +22,10 @@ import {
 } from "~/services/productAnalytics/contracts"
 import type { ApiCredentialProfile } from "~/types/apiCredentialProfiles"
 
+import {
+  API_CREDENTIAL_PROFILES_VIEW_VARIANTS,
+  type ApiCredentialProfilesViewVariant,
+} from "../contracts"
 import type { ApiCredentialProfilesController } from "../hooks/useApiCredentialProfilesController"
 import { API_CREDENTIAL_PROFILES_TEST_IDS } from "../testIds"
 import { ApiCredentialProfileListItem } from "./ApiCredentialProfileListItem"
@@ -29,7 +33,7 @@ import { ApiCredentialProfileListItem } from "./ApiCredentialProfileListItem"
 interface ApiCredentialProfilesListProps {
   profiles: ApiCredentialProfile[]
   controller: ApiCredentialProfilesController
-  variant?: "options" | "popup"
+  variant?: ApiCredentialProfilesViewVariant
   isFiltering?: boolean
   guidedImportEntry?: {
     profileId: string
@@ -346,7 +350,7 @@ function EndpointProfileList({
 export function ApiCredentialProfilesList({
   profiles,
   controller,
-  variant = "options",
+  variant = API_CREDENTIAL_PROFILES_VIEW_VARIANTS.Options,
   isFiltering = false,
   guidedImportEntry,
 }: ApiCredentialProfilesListProps) {
@@ -415,7 +419,10 @@ export function ApiCredentialProfilesList({
   }
 
   const hasMultipleGroups = groups.length > 1
-  const useSidebar = hasMultipleGroups && variant === "options" && isDesktop
+  const useSidebar =
+    hasMultipleGroups &&
+    variant === API_CREDENTIAL_PROFILES_VIEW_VARIANTS.Options &&
+    isDesktop
 
   return (
     <div

--- a/src/features/ApiCredentialProfiles/components/ApiCredentialProfilesListView.tsx
+++ b/src/features/ApiCredentialProfiles/components/ApiCredentialProfilesListView.tsx
@@ -30,6 +30,10 @@ import {
 } from "~/services/verification/aiApiVerification"
 import { openKeysPage } from "~/utils/navigation"
 
+import {
+  API_CREDENTIAL_PROFILES_VIEW_VARIANTS,
+  type ApiCredentialProfilesViewVariant,
+} from "../contracts"
 import type { ApiCredentialProfilesController } from "../hooks/useApiCredentialProfilesController"
 import {
   buildApiCredentialProfileListModel,
@@ -40,7 +44,7 @@ import { ApiCredentialProfilesList } from "./ApiCredentialProfilesList"
 
 export interface ApiCredentialProfilesListViewProps {
   controller: ApiCredentialProfilesController
-  variant?: "options" | "popup"
+  variant?: ApiCredentialProfilesViewVariant
   autoFocusSearch?: boolean
   guidedImportEntryRequest?: number
   className?: string
@@ -57,13 +61,14 @@ const analyticsApiTypeByVerificationApiType: Partial<
   [API_TYPES.ANTHROPIC]: PRODUCT_ANALYTICS_API_TYPES.Anthropic,
   [API_TYPES.GOOGLE]: PRODUCT_ANALYTICS_API_TYPES.Google,
 }
+const FILTER_ANALYTICS_DEBOUNCE_MS = 400
 
 /**
  * Search/filterable API credential profiles view used in Options and Popup variants.
  */
 export function ApiCredentialProfilesListView({
   controller,
-  variant = "options",
+  variant = API_CREDENTIAL_PROFILES_VIEW_VARIANTS.Options,
   autoFocusSearch = false,
   guidedImportEntryRequest = 0,
   className,
@@ -82,7 +87,8 @@ export function ApiCredentialProfilesListView({
   const [lastFilterMode, setLastFilterMode] =
     useState<ApiCredentialProfileFilterMode | null>(null)
 
-  const searchInputSize = variant === "popup" ? "sm" : "default"
+  const searchInputSize =
+    variant === API_CREDENTIAL_PROFILES_VIEW_VARIANTS.Popup ? "sm" : "default"
 
   const clearSearch = useCallback(() => {
     setSearchTerm("")
@@ -168,11 +174,11 @@ export function ApiCredentialProfilesListView({
         featureId: PRODUCT_ANALYTICS_FEATURE_IDS.ApiCredentialProfiles,
         actionId: PRODUCT_ANALYTICS_ACTION_IDS.FilterApiCredentialProfiles,
         surfaceId:
-          variant === "popup"
+          variant === API_CREDENTIAL_PROFILES_VIEW_VARIANTS.Popup
             ? PRODUCT_ANALYTICS_SURFACE_IDS.PopupViewTabs
             : PRODUCT_ANALYTICS_SURFACE_IDS.OptionsApiCredentialProfilesPage,
         entrypoint:
-          variant === "popup"
+          variant === API_CREDENTIAL_PROFILES_VIEW_VARIANTS.Popup
             ? PRODUCT_ANALYTICS_ENTRYPOINTS.Popup
             : PRODUCT_ANALYTICS_ENTRYPOINTS.Options,
         result: PRODUCT_ANALYTICS_RESULTS.Success,
@@ -191,7 +197,7 @@ export function ApiCredentialProfilesListView({
           usageDataPresent: filteredProfiles.length > 0,
         },
       })
-    }, 400)
+    }, FILTER_ANALYTICS_DEBOUNCE_MS)
 
     return () => window.clearTimeout(timeoutId)
   }, [
@@ -203,7 +209,7 @@ export function ApiCredentialProfilesListView({
   ])
 
   const emptyStateAddAnalyticsAction =
-    variant === "popup"
+    variant === API_CREDENTIAL_PROFILES_VIEW_VARIANTS.Popup
       ? {
           featureId: PRODUCT_ANALYTICS_FEATURE_IDS.ApiCredentialProfiles,
           actionId:
@@ -272,7 +278,10 @@ export function ApiCredentialProfilesListView({
           value={apiTypeFilter}
           onChange={handleApiTypeFilterChange}
           placeholder={t("apiCredentialProfiles:controls.apiTypePlaceholder")}
-          className={cn(variant === "popup" && "h-8 px-2 text-xs")}
+          className={cn(
+            variant === API_CREDENTIAL_PROFILES_VIEW_VARIANTS.Popup &&
+              "h-8 px-2 text-xs",
+          )}
         />
       </div>
 

--- a/src/features/ApiCredentialProfiles/components/ApiCredentialProfilesListView.tsx
+++ b/src/features/ApiCredentialProfiles/components/ApiCredentialProfilesListView.tsx
@@ -278,6 +278,7 @@ export function ApiCredentialProfilesListView({
           value={apiTypeFilter}
           onChange={handleApiTypeFilterChange}
           placeholder={t("apiCredentialProfiles:controls.apiTypePlaceholder")}
+          aria-label={t("apiCredentialProfiles:controls.apiTypePlaceholder")}
           className={cn(
             variant === API_CREDENTIAL_PROFILES_VIEW_VARIANTS.Popup &&
               "h-8 px-2 text-xs",

--- a/src/features/ApiCredentialProfiles/components/ApiCredentialProfilesListView.tsx
+++ b/src/features/ApiCredentialProfiles/components/ApiCredentialProfilesListView.tsx
@@ -31,6 +31,10 @@ import {
 import { openKeysPage } from "~/utils/navigation"
 
 import type { ApiCredentialProfilesController } from "../hooks/useApiCredentialProfilesController"
+import {
+  buildApiCredentialProfileListModel,
+  type ApiCredentialProfileFilterMode,
+} from "../utils/apiCredentialProfileListModel"
 import { ApiCredentialProfilesDialogs } from "./ApiCredentialProfilesDialogs"
 import { ApiCredentialProfilesList } from "./ApiCredentialProfilesList"
 
@@ -40,21 +44,6 @@ export interface ApiCredentialProfilesListViewProps {
   autoFocusSearch?: boolean
   guidedImportEntryRequest?: number
   className?: string
-}
-
-/**
- * Normalize user-provided input for case/space-insensitive searching.
- */
-function normalizeForSearch(value: string): string {
-  if (!value) return ""
-
-  let normalized = value.toLowerCase().trim()
-  normalized = normalized.replace(/[\uff01-\uff5e]/g, (ch) =>
-    String.fromCharCode(ch.charCodeAt(0) - 0xfee0),
-  )
-  normalized = normalized.replace(/\s+/g, " ").trim()
-
-  return normalized
 }
 
 const analyticsApiTypeByVerificationApiType: Partial<
@@ -90,12 +79,8 @@ export function ApiCredentialProfilesListView({
   const [searchTerm, setSearchTerm] = useState("")
   const [apiTypeFilter, setApiTypeFilter] = useState<string>("")
   const [selectedTagIds, setSelectedTagIds] = useState<string[]>([])
-  const [lastFilterMode, setLastFilterMode] = useState<
-    | typeof PRODUCT_ANALYTICS_MODE_IDS.SearchFilter
-    | typeof PRODUCT_ANALYTICS_MODE_IDS.ProviderFilter
-    | typeof PRODUCT_ANALYTICS_MODE_IDS.GroupFilter
-    | null
-  >(null)
+  const [lastFilterMode, setLastFilterMode] =
+    useState<ApiCredentialProfileFilterMode | null>(null)
 
   const searchInputSize = variant === "popup" ? "sm" : "default"
 
@@ -132,32 +117,6 @@ export function ApiCredentialProfilesListView({
     [clearSearch],
   )
 
-  const tagCountsById = useMemo(() => {
-    const counts: Record<string, number> = {}
-
-    for (const profile of controller.profiles) {
-      const ids = profile.tagIds ?? []
-      for (const id of ids) {
-        if (!id) continue
-        counts[id] = (counts[id] ?? 0) + 1
-      }
-    }
-
-    return counts
-  }, [controller.profiles])
-
-  const tagFilterOptions = useMemo(() => {
-    if (controller.tags.length === 0) {
-      return []
-    }
-
-    return controller.tags.map((tag) => ({
-      value: tag.id,
-      label: tag.name,
-      count: tagCountsById[tag.id] ?? 0,
-    }))
-  }, [controller.tags, tagCountsById])
-
   const maxTagFilterLines = isSmallScreen ? 2 : isDesktop ? 3 : 2
 
   useEffect(() => {
@@ -171,74 +130,35 @@ export function ApiCredentialProfilesListView({
     setLastFilterMode(null)
   }, [controller.profiles.length, guidedImportEntryRequest])
 
-  const filteredProfiles = useMemo(() => {
-    const query = normalizeForSearch(searchTerm)
-    const typeFilter = apiTypeFilter.trim()
-
-    return controller.profiles.filter((profile) => {
-      if (typeFilter && profile.apiType !== typeFilter) {
-        return false
-      }
-
-      if (selectedTagIds.length > 0) {
-        const ids = profile.tagIds ?? []
-        if (!selectedTagIds.some((tagId) => ids.includes(tagId))) {
-          return false
-        }
-      }
-
-      if (!query) return true
-
-      const resolvedTagNames = (profile.tagIds ?? [])
-        .map((id) => controller.tagNameById.get(id))
-        .filter(Boolean) as string[]
-
-      const haystack = normalizeForSearch(
-        [
-          profile.name,
-          profile.baseUrl,
-          ...resolvedTagNames,
-          profile.notes ?? "",
-        ]
-          .filter(Boolean)
-          .join(" "),
-      )
-
-      return haystack.includes(query)
-    })
-  }, [
-    apiTypeFilter,
-    controller.profiles,
-    controller.tagNameById,
-    searchTerm,
-    selectedTagIds,
-  ])
+  const {
+    filteredProfiles,
+    tagFilterOptions,
+    activeFilterCount,
+    analyticsMode,
+  } = useMemo(
+    () =>
+      buildApiCredentialProfileListModel({
+        profiles: controller.profiles,
+        tags: controller.tags,
+        tagNameById: controller.tagNameById,
+        searchTerm,
+        apiTypeFilter,
+        selectedTagIds,
+        lastFilterMode,
+      }),
+    [
+      apiTypeFilter,
+      controller.profiles,
+      controller.tagNameById,
+      controller.tags,
+      lastFilterMode,
+      searchTerm,
+      selectedTagIds,
+    ],
+  )
 
   const isInitialLoading =
     controller.isLoading && controller.profiles.length === 0
-
-  const activeFilterCount = useMemo(() => {
-    let count = 0
-    if (searchTerm.trim()) count += 1
-    if (apiTypeFilter.trim()) count += 1
-    if (selectedTagIds.length > 0) count += 1
-    return count
-  }, [apiTypeFilter, searchTerm, selectedTagIds.length])
-
-  const analyticsMode = useMemo(() => {
-    if (activeFilterCount === 0) return null
-    if (lastFilterMode) return lastFilterMode
-    if (searchTerm.trim()) return PRODUCT_ANALYTICS_MODE_IDS.SearchFilter
-    if (apiTypeFilter.trim()) return PRODUCT_ANALYTICS_MODE_IDS.ProviderFilter
-    if (selectedTagIds.length > 0) return PRODUCT_ANALYTICS_MODE_IDS.GroupFilter
-    return null
-  }, [
-    activeFilterCount,
-    apiTypeFilter,
-    lastFilterMode,
-    searchTerm,
-    selectedTagIds.length,
-  ])
 
   useEffect(() => {
     if (!analyticsMode || activeFilterCount === 0) return
@@ -425,6 +345,8 @@ export function ApiCredentialProfilesListView({
         <ApiCredentialProfilesList
           profiles={filteredProfiles}
           controller={controller}
+          variant={variant}
+          isFiltering={activeFilterCount > 0}
           guidedImportEntry={
             guidedImportEntryRequest && controller.profiles[0]
               ? {

--- a/src/features/ApiCredentialProfiles/components/ApiCredentialProfilesPopupView.tsx
+++ b/src/features/ApiCredentialProfiles/components/ApiCredentialProfilesPopupView.tsx
@@ -1,5 +1,6 @@
 import { forwardRef, useImperativeHandle } from "react"
 
+import { API_CREDENTIAL_PROFILES_VIEW_VARIANTS } from "../contracts"
 import { useApiCredentialProfilesController } from "../hooks/useApiCredentialProfilesController"
 import { API_CREDENTIAL_PROFILES_TEST_IDS } from "../testIds"
 import { ApiCredentialProfilesListView } from "./ApiCredentialProfilesListView"
@@ -33,7 +34,7 @@ const ApiCredentialProfilesPopupView = forwardRef<
     >
       <ApiCredentialProfilesListView
         controller={controller}
-        variant="popup"
+        variant={API_CREDENTIAL_PROFILES_VIEW_VARIANTS.Popup}
         autoFocusSearch={true}
       />
     </div>

--- a/src/features/ApiCredentialProfiles/components/VerifyApiCredentialProfileDialog.tsx
+++ b/src/features/ApiCredentialProfiles/components/VerifyApiCredentialProfileDialog.tsx
@@ -541,6 +541,10 @@ export function VerifyApiCredentialProfileDialog({
       await persistProbeResults(nextProbes, modelIdOverride)
       if (result.status === API_VERIFICATION_PROBE_STATUSES.Pass) {
         tracker?.complete(PRODUCT_ANALYTICS_RESULTS.Success)
+      } else if (
+        result.status === API_VERIFICATION_PROBE_STATUSES.Unsupported
+      ) {
+        tracker?.complete(PRODUCT_ANALYTICS_RESULTS.Skipped)
       } else {
         tracker?.complete(PRODUCT_ANALYTICS_RESULTS.Failure, {
           errorCategory:
@@ -654,7 +658,9 @@ export function VerifyApiCredentialProfileDialog({
       const successCount = results.filter(
         (result) => result.status === API_VERIFICATION_PROBE_STATUSES.Pass,
       ).length
-      const failureCount = results.length - successCount
+      const failureCount = results.filter(
+        (result) => result.status === API_VERIFICATION_PROBE_STATUSES.Fail,
+      ).length
       const insights = {
         itemCount: results.length,
         successCount,
@@ -679,6 +685,11 @@ export function VerifyApiCredentialProfileDialog({
             errorCategory ?? PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
           insights,
         })
+        return
+      }
+
+      if (successCount === 0) {
+        tracker.complete(PRODUCT_ANALYTICS_RESULTS.Skipped, { insights })
         return
       }
 

--- a/src/features/ApiCredentialProfiles/components/VerifyApiCredentialProfileDialog.tsx
+++ b/src/features/ApiCredentialProfiles/components/VerifyApiCredentialProfileDialog.tsx
@@ -38,6 +38,7 @@ import {
 import { resolveProductAnalyticsErrorCategoryFromProbeResult } from "~/services/productAnalytics/verification"
 import {
   API_TYPES,
+  API_VERIFICATION_PROBE_STATUSES,
   getApiVerificationProbeDefinitions,
   runApiVerificationProbe,
   type ApiVerificationApiType,
@@ -538,7 +539,7 @@ export function VerifyApiCredentialProfileDialog({
       }
 
       await persistProbeResults(nextProbes, modelIdOverride)
-      if (result.status === "pass") {
+      if (result.status === API_VERIFICATION_PROBE_STATUSES.Pass) {
         tracker?.complete(PRODUCT_ANALYTICS_RESULTS.Success)
       } else {
         tracker?.complete(PRODUCT_ANALYTICS_RESULTS.Failure, {
@@ -559,7 +560,7 @@ export function VerifyApiCredentialProfileDialog({
 
       const fallback: ApiVerificationProbeResult = {
         id: probeId,
-        status: "fail",
+        status: API_VERIFICATION_PROBE_STATUSES.Fail,
         latencyMs: 0,
         summary: t("aiApiVerification:verifyDialog.errors.unexpected"),
         ...buildSafeProbeFailureDiagnostics(error, sanitizedMessage),
@@ -651,7 +652,7 @@ export function VerifyApiCredentialProfileDialog({
       }
 
       const successCount = results.filter(
-        (result) => result.status === "pass",
+        (result) => result.status === API_VERIFICATION_PROBE_STATUSES.Pass,
       ).length
       const failureCount = results.length - successCount
       const insights = {
@@ -663,7 +664,9 @@ export function VerifyApiCredentialProfileDialog({
       const hasFailedProbe = failureCount > 0
       if (hasFailedProbe) {
         const errorCategory = results
-          .filter((result) => result.status === "fail")
+          .filter(
+            (result) => result.status === API_VERIFICATION_PROBE_STATUSES.Fail,
+          )
           .map((result) =>
             resolveProductAnalyticsErrorCategoryFromProbeResult(result),
           )
@@ -868,7 +871,8 @@ export function VerifyApiCredentialProfileDialog({
                       result.summaryKey,
                       result.summaryParams,
                     ) ?? result.summary
-                  : result?.status === "unsupported"
+                  : result?.status ===
+                      API_VERIFICATION_PROBE_STATUSES.Unsupported
                     ? t(
                         "aiApiVerification:verifyDialog.unsupportedProbeForApiType",
                         {

--- a/src/features/ApiCredentialProfiles/contracts.ts
+++ b/src/features/ApiCredentialProfiles/contracts.ts
@@ -1,0 +1,19 @@
+export const API_CREDENTIAL_PROFILE_EXPORT_ACTIONS = {
+  CherryStudio: "cherryStudio",
+  CCSwitch: "ccSwitch",
+  KiloCode: "kiloCode",
+  CliProxy: "cliProxy",
+  ClaudeCodeRouter: "claudeCodeRouter",
+  ManagedSite: "managedSite",
+} as const
+
+export type ApiCredentialProfileExportAction =
+  (typeof API_CREDENTIAL_PROFILE_EXPORT_ACTIONS)[keyof typeof API_CREDENTIAL_PROFILE_EXPORT_ACTIONS]
+
+export const API_CREDENTIAL_PROFILES_VIEW_VARIANTS = {
+  Options: "options",
+  Popup: "popup",
+} as const
+
+export type ApiCredentialProfilesViewVariant =
+  (typeof API_CREDENTIAL_PROFILES_VIEW_VARIANTS)[keyof typeof API_CREDENTIAL_PROFILES_VIEW_VARIANTS]

--- a/src/features/ApiCredentialProfiles/hooks/useApiCredentialProfilesController.ts
+++ b/src/features/ApiCredentialProfiles/hooks/useApiCredentialProfilesController.ts
@@ -6,6 +6,10 @@ import { useChannelDialog } from "~/components/dialogs/ChannelDialog"
 import { RuntimeMessageTypes } from "~/constants/runtimeActions"
 import { useProductAnalyticsScope } from "~/contexts/ProductAnalyticsScopeContext"
 import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
+import {
+  API_CREDENTIAL_PROFILE_EXPORT_ACTIONS,
+  type ApiCredentialProfileExportAction,
+} from "~/features/ApiCredentialProfiles/contracts"
 import { refreshApiCredentialProfileTelemetry } from "~/services/apiCredentialProfiles/telemetry"
 import { OpenInCherryStudio } from "~/services/integrations/cherryStudio"
 import { getManagedSiteLabel } from "~/services/managedSites/utils/managedSite"
@@ -61,10 +65,6 @@ import { createLogger } from "~/utils/core/logger"
 import { showResultToast } from "~/utils/core/toastHelpers"
 import { openModelsPage } from "~/utils/navigation"
 
-import {
-  API_CREDENTIAL_PROFILE_EXPORT_ACTIONS,
-  type ApiCredentialProfileExportAction,
-} from "../contracts"
 import { createExportAccount, createExportToken } from "../utils/exportShims"
 import { useApiCredentialProfiles } from "./useApiCredentialProfiles"
 

--- a/src/features/ApiCredentialProfiles/hooks/useApiCredentialProfilesController.ts
+++ b/src/features/ApiCredentialProfiles/hooks/useApiCredentialProfilesController.ts
@@ -49,13 +49,22 @@ import type {
   ApiCredentialTelemetryConfig,
   ApiCredentialTelemetrySnapshot,
 } from "~/types/apiCredentialProfiles"
+import {
+  API_CREDENTIAL_TELEMETRY_ATTEMPT_STATUSES,
+  API_CREDENTIAL_TELEMETRY_MODES,
+  API_CREDENTIAL_TELEMETRY_SOURCES,
+} from "~/types/apiCredentialProfiles"
 import { onRuntimeMessage } from "~/utils/browser/browserApi"
+import { assertNever } from "~/utils/core/assert"
 import { getErrorMessage } from "~/utils/core/error"
 import { createLogger } from "~/utils/core/logger"
 import { showResultToast } from "~/utils/core/toastHelpers"
 import { openModelsPage } from "~/utils/navigation"
 
-import type { ApiCredentialProfileExportAction } from "../components/ApiCredentialProfileListItem"
+import {
+  API_CREDENTIAL_PROFILE_EXPORT_ACTIONS,
+  type ApiCredentialProfileExportAction,
+} from "../contracts"
 import { createExportAccount, createExportToken } from "../utils/exportShims"
 import { useApiCredentialProfiles } from "./useApiCredentialProfiles"
 
@@ -156,12 +165,17 @@ const telemetryModeByConfigMode: Record<
   ApiCredentialTelemetryConfig["mode"],
   ProductAnalyticsModeId
 > = {
-  auto: PRODUCT_ANALYTICS_MODE_IDS.TelemetryAuto,
-  disabled: PRODUCT_ANALYTICS_MODE_IDS.TelemetryDisabled,
-  newApiTokenUsage: PRODUCT_ANALYTICS_MODE_IDS.TelemetryNewApiTokenUsage,
-  sub2apiUsage: PRODUCT_ANALYTICS_MODE_IDS.TelemetrySub2ApiUsage,
-  openaiBilling: PRODUCT_ANALYTICS_MODE_IDS.TelemetryOpenAiBilling,
-  customReadOnlyEndpoint:
+  [API_CREDENTIAL_TELEMETRY_MODES.Auto]:
+    PRODUCT_ANALYTICS_MODE_IDS.TelemetryAuto,
+  [API_CREDENTIAL_TELEMETRY_MODES.Disabled]:
+    PRODUCT_ANALYTICS_MODE_IDS.TelemetryDisabled,
+  [API_CREDENTIAL_TELEMETRY_MODES.NewApiTokenUsage]:
+    PRODUCT_ANALYTICS_MODE_IDS.TelemetryNewApiTokenUsage,
+  [API_CREDENTIAL_TELEMETRY_MODES.Sub2ApiUsage]:
+    PRODUCT_ANALYTICS_MODE_IDS.TelemetrySub2ApiUsage,
+  [API_CREDENTIAL_TELEMETRY_MODES.OpenAiBilling]:
+    PRODUCT_ANALYTICS_MODE_IDS.TelemetryOpenAiBilling,
+  [API_CREDENTIAL_TELEMETRY_MODES.CustomReadOnlyEndpoint]:
     PRODUCT_ANALYTICS_MODE_IDS.TelemetryCustomReadOnlyEndpoint,
 }
 
@@ -171,11 +185,15 @@ const telemetrySourceBySnapshotSource: Partial<
     ProductAnalyticsTelemetrySource
   >
 > = {
-  models: PRODUCT_ANALYTICS_TELEMETRY_SOURCES.Models,
-  openaiBilling: PRODUCT_ANALYTICS_TELEMETRY_SOURCES.OpenAiBilling,
-  newApiTokenUsage: PRODUCT_ANALYTICS_TELEMETRY_SOURCES.NewApiTokenUsage,
-  sub2apiUsage: PRODUCT_ANALYTICS_TELEMETRY_SOURCES.Sub2ApiUsage,
-  customReadOnlyEndpoint:
+  [API_CREDENTIAL_TELEMETRY_SOURCES.Models]:
+    PRODUCT_ANALYTICS_TELEMETRY_SOURCES.Models,
+  [API_CREDENTIAL_TELEMETRY_SOURCES.OpenAiBilling]:
+    PRODUCT_ANALYTICS_TELEMETRY_SOURCES.OpenAiBilling,
+  [API_CREDENTIAL_TELEMETRY_SOURCES.NewApiTokenUsage]:
+    PRODUCT_ANALYTICS_TELEMETRY_SOURCES.NewApiTokenUsage,
+  [API_CREDENTIAL_TELEMETRY_SOURCES.Sub2ApiUsage]:
+    PRODUCT_ANALYTICS_TELEMETRY_SOURCES.Sub2ApiUsage,
+  [API_CREDENTIAL_TELEMETRY_SOURCES.CustomReadOnlyEndpoint]:
     PRODUCT_ANALYTICS_TELEMETRY_SOURCES.CustomReadOnlyEndpoint,
 }
 
@@ -228,9 +246,13 @@ function getApiCredentialProfileSaveAnalyticsInsights(
   return {
     apiType: analyticsApiTypeByVerificationApiType[input.apiType],
     sourceKind,
-    mode: telemetryModeByConfigMode[input.telemetryConfig?.mode ?? "auto"],
+    mode: telemetryModeByConfigMode[
+      input.telemetryConfig?.mode ?? API_CREDENTIAL_TELEMETRY_MODES.Auto
+    ],
     selectedCount: input.tagIds.length,
-    usageDataPresent: input.telemetryConfig?.mode === "customReadOnlyEndpoint",
+    usageDataPresent:
+      input.telemetryConfig?.mode ===
+      API_CREDENTIAL_TELEMETRY_MODES.CustomReadOnlyEndpoint,
   }
 }
 
@@ -242,7 +264,10 @@ function getApiCredentialTelemetryAnalyticsInsights(
   telemetryConfig?: ApiCredentialTelemetryConfig,
 ): ProductAnalyticsActionInsights {
   const successCount = Array.isArray(snapshot.attempts)
-    ? snapshot.attempts.filter((attempt) => attempt.status === "success").length
+    ? snapshot.attempts.filter(
+        (attempt) =>
+          attempt.status === API_CREDENTIAL_TELEMETRY_ATTEMPT_STATUSES.Success,
+      ).length
     : undefined
   const failureCount = Array.isArray(snapshot.attempts)
     ? snapshot.attempts.length - (successCount ?? 0)
@@ -252,7 +277,9 @@ function getApiCredentialTelemetryAnalyticsInsights(
     ...(snapshot.source && telemetrySourceBySnapshotSource[snapshot.source]
       ? { telemetrySource: telemetrySourceBySnapshotSource[snapshot.source] }
       : {}),
-    mode: telemetryModeByConfigMode[telemetryConfig?.mode ?? "auto"],
+    mode: telemetryModeByConfigMode[
+      telemetryConfig?.mode ?? API_CREDENTIAL_TELEMETRY_MODES.Auto
+    ],
     statusKind:
       analyticsStatusByHealthStatus[snapshot.health.status] ??
       PRODUCT_ANALYTICS_STATUS_KINDS.Unknown,
@@ -532,7 +559,7 @@ export function useApiCredentialProfilesController() {
       profile: ApiCredentialProfile,
       action: ApiCredentialProfileExportAction,
     ) => {
-      if (action === "cherryStudio") {
+      if (action === API_CREDENTIAL_PROFILE_EXPORT_ACTIONS.CherryStudio) {
         const tracker = startProductAnalyticsAction({
           featureId: apiCredentialProfilesFeature,
           actionId:
@@ -556,17 +583,17 @@ export function useApiCredentialProfilesController() {
         return
       }
 
-      if (action === "ccSwitch") {
+      if (action === API_CREDENTIAL_PROFILE_EXPORT_ACTIONS.CCSwitch) {
         setCCSwitchProfile(profile)
         return
       }
 
-      if (action === "kiloCode") {
+      if (action === API_CREDENTIAL_PROFILE_EXPORT_ACTIONS.KiloCode) {
         setKiloCodeProfile(profile)
         return
       }
 
-      if (action === "cliProxy") {
+      if (action === API_CREDENTIAL_PROFILE_EXPORT_ACTIONS.CliProxy) {
         if (!cliProxyBaseUrl?.trim() || !cliProxyManagementKey?.trim()) {
           showResultToast({
             success: false,
@@ -578,7 +605,7 @@ export function useApiCredentialProfilesController() {
         return
       }
 
-      if (action === "claudeCodeRouter") {
+      if (action === API_CREDENTIAL_PROFILE_EXPORT_ACTIONS.ClaudeCodeRouter) {
         if (!claudeCodeRouterBaseUrl?.trim()) {
           showResultToast({
             success: false,
@@ -590,7 +617,7 @@ export function useApiCredentialProfilesController() {
         return
       }
 
-      if (action === "managedSite") {
+      if (action === API_CREDENTIAL_PROFILE_EXPORT_ACTIONS.ManagedSite) {
         const tracker = startProductAnalyticsAction({
           featureId: PRODUCT_ANALYTICS_FEATURE_IDS.ManagedSiteChannels,
           actionId: PRODUCT_ANALYTICS_ACTION_IDS.ImportManagedSiteSingleToken,
@@ -640,7 +667,10 @@ export function useApiCredentialProfilesController() {
               error,
             )
           })
+        return
       }
+
+      return assertNever(action, `Unexpected export action: ${action}`)
     },
     [
       claudeCodeRouterBaseUrl,

--- a/src/features/ApiCredentialProfiles/hooks/useApiCredentialProfilesController.ts
+++ b/src/features/ApiCredentialProfiles/hooks/useApiCredentialProfilesController.ts
@@ -40,7 +40,7 @@ import {
 import {
   createProfileVerificationHistoryTarget,
   serializeVerificationHistoryTarget,
-  useVerificationResultHistorySummaries,
+  useLatestProfileVerificationSummaries,
 } from "~/services/verification/verificationResultHistory"
 import type { Tag } from "~/types"
 import { SiteHealthStatus } from "~/types"
@@ -294,16 +294,8 @@ export function useApiCredentialProfilesController() {
 
   const { profiles, isLoading, createProfile, updateProfile, deleteProfile } =
     useApiCredentialProfiles()
-  const profileVerificationTargets = useMemo(
-    () =>
-      profiles.flatMap((profile) => {
-        const target = createProfileVerificationHistoryTarget(profile.id)
-        return target ? [target] : []
-      }),
-    [profiles],
-  )
   const { summariesByKey: verificationSummariesByKey } =
-    useVerificationResultHistorySummaries(profileVerificationTargets)
+    useLatestProfileVerificationSummaries(profiles.map((profile) => profile.id))
 
   const [tags, setTags] = useState<Tag[]>([])
 
@@ -469,9 +461,9 @@ export function useApiCredentialProfilesController() {
   )
 
   const handleCopyBaseUrl = useCallback(
-    (profile: ApiCredentialProfile) => {
+    (baseUrl: string) => {
       void copyToClipboard(
-        profile.baseUrl,
+        baseUrl,
         t("apiCredentialProfiles:messages.baseUrlCopied"),
       )
     },

--- a/src/features/ApiCredentialProfiles/testIds.ts
+++ b/src/features/ApiCredentialProfiles/testIds.ts
@@ -45,6 +45,14 @@ export const API_CREDENTIAL_PROFILES_TEST_IDS = {
   toolbar: "api-credential-profile-toolbar",
 } as const
 
+const API_CREDENTIAL_ENDPOINT_OPTION_TEST_ID_PREFIX =
+  "api-credential-profile-endpoint-option-"
+
+/** Returns the stable test id for the endpoint option containing a profile. */
+export function getApiCredentialEndpointOptionTestId(profileId: string) {
+  return `${API_CREDENTIAL_ENDPOINT_OPTION_TEST_ID_PREFIX}${profileId}`
+}
+
 const API_CREDENTIAL_PROFILE_VERIFY_PROBE_TEST_ID_PREFIX =
   "profile-verify-probe-"
 

--- a/src/features/ApiCredentialProfiles/testIds.ts
+++ b/src/features/ApiCredentialProfiles/testIds.ts
@@ -7,6 +7,14 @@ export const API_CREDENTIAL_PROFILES_TEST_IDS = {
   deleteConfirmButton: "api-credential-profile-delete-confirm-button",
   deleteTriggerButton: "api-credential-profile-delete-trigger-button",
   editButton: "api-credential-profile-edit-button",
+  endpointNavigation: "api-credential-profile-endpoint-navigation",
+  endpointSelector: "api-credential-profile-endpoint-selector",
+  endpointCopyBaseUrlButton:
+    "api-credential-profile-endpoint-copy-base-url-button",
+  endpointAddCredentialButton:
+    "api-credential-profile-endpoint-add-credential-button",
+  endpointBaseUrl: "api-credential-profile-endpoint-base-url",
+  endpointCredentialCount: "api-credential-profile-endpoint-credential-count",
   exportMenuButton: "api-credential-profile-export-menu-button",
   exportToCCSwitchMenuItem:
     "api-credential-profile-export-to-cc-switch-menu-item",
@@ -20,7 +28,6 @@ export const API_CREDENTIAL_PROFILES_TEST_IDS = {
     "api-credential-profile-open-model-management-button",
   popupView: "api-credential-profiles-popup-view",
   showKeyButton: "api-credential-profile-show-key-button",
-  copyBaseUrlButton: "api-credential-profile-copy-base-url-button",
   copyApiKeyButton: "api-credential-profile-copy-api-key-button",
   copyBundleButton: "api-credential-profile-copy-bundle-button",
   verifyButton: "api-credential-profile-verify-button",
@@ -28,9 +35,12 @@ export const API_CREDENTIAL_PROFILES_TEST_IDS = {
   verifyProbeRunButton: "api-credential-profile-verify-probe-run-button",
   verifyModelId: "profile-verify-model-id",
   telemetryBalance: "api-credential-telemetry-balance",
+  telemetryPanel: "api-credential-telemetry-panel",
+  telemetryToggle: "api-credential-telemetry-toggle",
   telemetryTodayUsage: "api-credential-telemetry-today-usage",
   telemetryTodayRequests: "api-credential-telemetry-today-requests",
   telemetryModels: "api-credential-telemetry-models",
+  toolbar: "api-credential-profile-toolbar",
 } as const
 
 const API_CREDENTIAL_PROFILE_VERIFY_PROBE_TEST_ID_PREFIX =

--- a/src/features/ApiCredentialProfiles/testIds.ts
+++ b/src/features/ApiCredentialProfiles/testIds.ts
@@ -13,6 +13,8 @@ export const API_CREDENTIAL_PROFILES_TEST_IDS = {
     "api-credential-profile-endpoint-copy-base-url-button",
   endpointAddCredentialButton:
     "api-credential-profile-endpoint-add-credential-button",
+  endpointNavigationAddCredentialButton:
+    "api-credential-profile-endpoint-navigation-add-credential-button",
   endpointBaseUrl: "api-credential-profile-endpoint-base-url",
   endpointCredentialCount: "api-credential-profile-endpoint-credential-count",
   exportMenuButton: "api-credential-profile-export-menu-button",

--- a/src/features/ApiCredentialProfiles/utils/apiCredentialProfileListModel.ts
+++ b/src/features/ApiCredentialProfiles/utils/apiCredentialProfileListModel.ts
@@ -1,0 +1,144 @@
+import { PRODUCT_ANALYTICS_MODE_IDS } from "~/services/productAnalytics/contracts"
+import type { Tag } from "~/types"
+import type { ApiCredentialProfile } from "~/types/apiCredentialProfiles"
+
+export type ApiCredentialProfileFilterMode =
+  | typeof PRODUCT_ANALYTICS_MODE_IDS.SearchFilter
+  | typeof PRODUCT_ANALYTICS_MODE_IDS.ProviderFilter
+  | typeof PRODUCT_ANALYTICS_MODE_IDS.GroupFilter
+
+interface BuildApiCredentialProfileListModelInput {
+  profiles: ApiCredentialProfile[]
+  tags: Tag[]
+  tagNameById: Map<string, string>
+  searchTerm: string
+  apiTypeFilter: string
+  selectedTagIds: string[]
+  lastFilterMode: ApiCredentialProfileFilterMode | null
+}
+
+interface ApiCredentialProfileTagFilterOption {
+  value: string
+  label: string
+  count: number
+}
+
+interface ApiCredentialProfileListModel {
+  filteredProfiles: ApiCredentialProfile[]
+  tagFilterOptions: ApiCredentialProfileTagFilterOption[]
+  activeFilterCount: number
+  analyticsMode: ApiCredentialProfileFilterMode | null
+}
+
+/** Normalizes user input for case-, width-, and whitespace-insensitive search. */
+function normalizeForSearch(value: string): string {
+  if (!value) return ""
+
+  let normalized = value.toLowerCase().trim()
+  normalized = normalized.replace(/[\uff01-\uff5e]/g, (character) =>
+    String.fromCharCode(character.charCodeAt(0) - 0xfee0),
+  )
+  return normalized.replace(/\s+/g, " ").trim()
+}
+
+/** Resolves configured tag names while omitting missing and empty lookups. */
+function getProfileTagNames(
+  profile: ApiCredentialProfile,
+  tagNameById: Map<string, string>,
+): string[] {
+  return (profile.tagIds ?? []).flatMap((tagId) => {
+    const tagName = tagNameById.get(tagId)
+    return tagName ? [tagName] : []
+  })
+}
+
+/** Counts configured tag IDs across the full unfiltered profile collection. */
+function countProfilesByTagId(
+  profiles: ApiCredentialProfile[],
+): Record<string, number> {
+  const counts: Record<string, number> = {}
+
+  for (const profile of profiles) {
+    for (const tagId of profile.tagIds ?? []) {
+      if (!tagId) continue
+      counts[tagId] = (counts[tagId] ?? 0) + 1
+    }
+  }
+
+  return counts
+}
+
+/**
+ * Builds the derived profile-list state consumed by both options and popup views.
+ */
+export function buildApiCredentialProfileListModel({
+  profiles,
+  tags,
+  tagNameById,
+  searchTerm,
+  apiTypeFilter,
+  selectedTagIds,
+  lastFilterMode,
+}: BuildApiCredentialProfileListModelInput): ApiCredentialProfileListModel {
+  const query = normalizeForSearch(searchTerm)
+  const normalizedApiTypeFilter = apiTypeFilter.trim()
+  const filteredProfiles = profiles.filter((profile) => {
+    if (
+      normalizedApiTypeFilter &&
+      profile.apiType !== normalizedApiTypeFilter
+    ) {
+      return false
+    }
+
+    if (
+      selectedTagIds.length > 0 &&
+      !selectedTagIds.some((tagId) => (profile.tagIds ?? []).includes(tagId))
+    ) {
+      return false
+    }
+
+    if (!query) return true
+
+    const searchableText = normalizeForSearch(
+      [
+        profile.name,
+        profile.baseUrl,
+        ...getProfileTagNames(profile, tagNameById),
+        profile.notes ?? "",
+      ]
+        .filter(Boolean)
+        .join(" "),
+    )
+
+    return searchableText.includes(query)
+  })
+
+  const tagCountsById = countProfilesByTagId(profiles)
+  const tagFilterOptions = tags.map((tag) => ({
+    value: tag.id,
+    label: tag.name,
+    count: tagCountsById[tag.id] ?? 0,
+  }))
+
+  let activeFilterCount = 0
+  if (searchTerm.trim()) activeFilterCount += 1
+  if (normalizedApiTypeFilter) activeFilterCount += 1
+  if (selectedTagIds.length > 0) activeFilterCount += 1
+
+  const analyticsMode =
+    activeFilterCount === 0
+      ? null
+      : lastFilterMode ??
+        (searchTerm.trim()
+          ? PRODUCT_ANALYTICS_MODE_IDS.SearchFilter
+          : normalizedApiTypeFilter
+            ? PRODUCT_ANALYTICS_MODE_IDS.ProviderFilter
+            : PRODUCT_ANALYTICS_MODE_IDS.GroupFilter)
+
+  return {
+    filteredProfiles,
+    tagFilterOptions,
+    activeFilterCount,
+    analyticsMode,
+  }
+}

--- a/src/features/KeyManagement/components/AccountKeyResource/AccountKeyResourceListItem.tsx
+++ b/src/features/KeyManagement/components/AccountKeyResource/AccountKeyResourceListItem.tsx
@@ -67,7 +67,7 @@ export function AccountKeyResourceListItem({
           <IconButton
             type="button"
             size="sm"
-            variant="outline"
+            variant="ghost"
             aria-label={t("openRouter.list.actions.edit")}
             onClick={() => onEdit(row.facts.ref)}
           >
@@ -81,7 +81,7 @@ export function AccountKeyResourceListItem({
           <IconButton
             type="button"
             size="sm"
-            variant="destructive"
+            variant="destructiveGhost"
             aria-label={t("openRouter.list.actions.delete")}
             onClick={() => onDelete(row.facts.ref)}
           >

--- a/src/features/KeyManagement/components/TokenListItem/TokenHeader.tsx
+++ b/src/features/KeyManagement/components/TokenListItem/TokenHeader.tsx
@@ -909,7 +909,7 @@ function TokenActionButtons({
         <IconButton
           aria-label={t("actions.editKey")}
           size="sm"
-          variant="outline"
+          variant="ghost"
           onClick={() => handleEditToken(token)}
         >
           <PencilIcon className="h-4 w-4 text-blue-500 dark:text-blue-400" />
@@ -919,7 +919,7 @@ function TokenActionButtons({
         <IconButton
           aria-label={t("actions.deleteKey")}
           size="sm"
-          variant="destructive"
+          variant="destructiveGhost"
           onClick={() => handleDeleteToken(token)}
         >
           <TrashIcon className="h-4 w-4" />

--- a/src/features/ModelList/components/BatchVerifyModelsDialog.tsx
+++ b/src/features/ModelList/components/BatchVerifyModelsDialog.tsx
@@ -61,6 +61,7 @@ import {
 import { resolveProductAnalyticsErrorCategoryFromProbeResult } from "~/services/productAnalytics/verification"
 import {
   API_TYPES,
+  API_VERIFICATION_PROBE_STATUSES,
   getApiVerificationProbeDefinitions,
   runApiVerificationProbe,
   type ApiVerificationApiType,
@@ -176,10 +177,18 @@ export function deriveBatchVerifyRowStatus(
   results: ApiVerificationProbeResult[],
 ): BatchVerifyRowStatus {
   if (results.length === 0) return BATCH_VERIFY_ROW_STATUSES.SKIPPED
-  if (results.some((result) => result.status === "fail")) {
+  if (
+    results.some(
+      (result) => result.status === API_VERIFICATION_PROBE_STATUSES.Fail,
+    )
+  ) {
     return BATCH_VERIFY_ROW_STATUSES.FAIL
   }
-  if (results.some((result) => result.status === "pass")) {
+  if (
+    results.some(
+      (result) => result.status === API_VERIFICATION_PROBE_STATUSES.Pass,
+    )
+  ) {
     return BATCH_VERIFY_ROW_STATUSES.PASS
   }
   return BATCH_VERIFY_ROW_STATUSES.SKIPPED
@@ -693,7 +702,7 @@ export function BatchVerifyModelsDialog({
             const sanitizedMessage = toSanitizedErrorSummary(error, redactions)
             results.push({
               id: probe.id,
-              status: "fail",
+              status: API_VERIFICATION_PROBE_STATUSES.Fail,
               latencyMs: 0,
               summary:
                 sanitizedMessage ||
@@ -712,17 +721,25 @@ export function BatchVerifyModelsDialog({
           })
         })
 
-        const pass = results.filter((result) => result.status === "pass").length
-        const fail = results.filter((result) => result.status === "fail").length
+        const pass = results.filter(
+          (result) => result.status === API_VERIFICATION_PROBE_STATUSES.Pass,
+        ).length
+        const fail = results.filter(
+          (result) => result.status === API_VERIFICATION_PROBE_STATUSES.Fail,
+        ).length
         const unsupported = results.filter(
-          (result) => result.status === "unsupported",
+          (result) =>
+            result.status === API_VERIFICATION_PROBE_STATUSES.Unsupported,
         ).length
 
         const status = deriveBatchVerifyRowStatus(results)
         const errorCategory =
           status === BATCH_VERIFY_ROW_STATUSES.FAIL
             ? results
-                .filter((result) => result.status === "fail")
+                .filter(
+                  (result) =>
+                    result.status === API_VERIFICATION_PROBE_STATUSES.Fail,
+                )
                 .map((result) =>
                   resolveProductAnalyticsErrorCategoryFromProbeResult(result),
                 )
@@ -1024,7 +1041,8 @@ export function BatchVerifyModelsDialog({
                     <Badge
                       key={result.id}
                       variant={statusVariant(
-                        result.status === "unsupported"
+                        result.status ===
+                          API_VERIFICATION_PROBE_STATUSES.Unsupported
                           ? BATCH_VERIFY_ROW_STATUSES.SKIPPED
                           : result.status,
                       )}
@@ -1032,9 +1050,9 @@ export function BatchVerifyModelsDialog({
                     >
                       {getApiVerificationProbeLabel(t, result.id)}
                       {" · "}
-                      {result.status === "pass"
+                      {result.status === API_VERIFICATION_PROBE_STATUSES.Pass
                         ? t("modelList:batchVerify.status.pass")
-                        : result.status === "fail"
+                        : result.status === API_VERIFICATION_PROBE_STATUSES.Fail
                           ? t("modelList:batchVerify.status.fail")
                           : t(
                               "aiApiVerification:verifyDialog.status.unsupported",
@@ -1045,7 +1063,10 @@ export function BatchVerifyModelsDialog({
                   ))}
                 </div>
                 {row.results
-                  .filter((result) => result.status === "fail")
+                  .filter(
+                    (result) =>
+                      result.status === API_VERIFICATION_PROBE_STATUSES.Fail,
+                  )
                   .map((result) => (
                     <div
                       key={`${result.id}-summary`}

--- a/src/locales/de/apiCredentialProfiles.json
+++ b/src/locales/de/apiCredentialProfiles.json
@@ -104,9 +104,17 @@
   "filter": {
     "tagsAllLabel": "Alle Tags"
   },
+  "grouping": {
+    "addCredential": "Zugangsdaten für diesen Endpunkt hinzufügen",
+    "baseUrls": "Base URLs",
+    "baseUrlSelector": "Base URL auswählen",
+    "credentialCount_one": "{{count}} Zugangsdaten",
+    "credentialCount_other": "{{count}} Zugangsdaten",
+    "navigationLabel": "Zugangsdaten nach Base URL durchsuchen",
+    "selectedEndpoint": "Zugangsdaten für {{baseUrl}}"
+  },
   "list": {
     "apiKey": "API-Schlüssel",
-    "baseUrl": "Basis-URL",
     "createdAt": "Hinzugefügt",
     "expirationStatus": {
       "active": "Läuft am {{date}} ab",

--- a/src/locales/en/apiCredentialProfiles.json
+++ b/src/locales/en/apiCredentialProfiles.json
@@ -104,9 +104,17 @@
   "filter": {
     "tagsAllLabel": "All tags"
   },
+  "grouping": {
+    "addCredential": "Add credential to this endpoint",
+    "baseUrls": "Base URLs",
+    "baseUrlSelector": "Select Base URL",
+    "credentialCount_one": "{{count}} credential",
+    "credentialCount_other": "{{count}} credentials",
+    "navigationLabel": "Browse credentials by Base URL",
+    "selectedEndpoint": "Credentials for {{baseUrl}}"
+  },
   "list": {
     "apiKey": "API key",
-    "baseUrl": "Base URL",
     "createdAt": "Added",
     "expirationStatus": {
       "active": "Expires {{date}}",

--- a/src/locales/es-419/apiCredentialProfiles.json
+++ b/src/locales/es-419/apiCredentialProfiles.json
@@ -104,9 +104,18 @@
   "filter": {
     "tagsAllLabel": "Todas las etiquetas"
   },
+  "grouping": {
+    "addCredential": "Agregar credencial a este endpoint",
+    "baseUrls": "Base URLs",
+    "baseUrlSelector": "Seleccionar Base URL",
+    "credentialCount_one": "{{count}} credencial",
+    "credentialCount_many": "{{count}} credenciales",
+    "credentialCount_other": "{{count}} credenciales",
+    "navigationLabel": "Explorar credenciales por Base URL",
+    "selectedEndpoint": "Credenciales para {{baseUrl}}"
+  },
   "list": {
     "apiKey": "Clave de API",
-    "baseUrl": "URL base",
     "createdAt": "Agregada",
     "expirationStatus": {
       "active": "Vence {{date}}",

--- a/src/locales/ja/apiCredentialProfiles.json
+++ b/src/locales/ja/apiCredentialProfiles.json
@@ -104,9 +104,16 @@
   "filter": {
     "tagsAllLabel": "すべてのタグ"
   },
+  "grouping": {
+    "addCredential": "このエンドポイントに認証情報を追加",
+    "baseUrls": "Base URL",
+    "baseUrlSelector": "Base URL を選択",
+    "credentialCount_other": "{{count}} 件の認証情報",
+    "navigationLabel": "Base URL ごとに認証情報を表示",
+    "selectedEndpoint": "{{baseUrl}} の認証情報"
+  },
   "list": {
     "apiKey": "API キー",
-    "baseUrl": "Base URL",
     "createdAt": "追加日時",
     "expirationStatus": {
       "active": "{{date}} まで有効",

--- a/src/locales/pt-BR/apiCredentialProfiles.json
+++ b/src/locales/pt-BR/apiCredentialProfiles.json
@@ -104,9 +104,18 @@
   "filter": {
     "tagsAllLabel": "Todas as tags"
   },
+  "grouping": {
+    "addCredential": "Adicionar credencial a este endpoint",
+    "baseUrls": "Base URLs",
+    "baseUrlSelector": "Selecionar Base URL",
+    "credentialCount_one": "{{count}} credencial",
+    "credentialCount_many": "{{count}} credenciais",
+    "credentialCount_other": "{{count}} credenciais",
+    "navigationLabel": "Navegar pelas credenciais por Base URL",
+    "selectedEndpoint": "Credenciais de {{baseUrl}}"
+  },
   "list": {
     "apiKey": "Chave de API",
-    "baseUrl": "URL base",
     "createdAt": "Adicionada em",
     "expirationStatus": {
       "active": "Expira em {{date}}",

--- a/src/locales/vi/apiCredentialProfiles.json
+++ b/src/locales/vi/apiCredentialProfiles.json
@@ -104,9 +104,16 @@
   "filter": {
     "tagsAllLabel": "Tất cả thẻ"
   },
+  "grouping": {
+    "addCredential": "Thêm thông tin xác thực cho điểm cuối này",
+    "baseUrls": "Base URL",
+    "baseUrlSelector": "Chọn Base URL",
+    "credentialCount_other": "{{count}} thông tin xác thực",
+    "navigationLabel": "Duyệt thông tin xác thực theo Base URL",
+    "selectedEndpoint": "Thông tin xác thực cho {{baseUrl}}"
+  },
   "list": {
     "apiKey": "Mã khóa",
-    "baseUrl": "Base URL",
     "createdAt": "Đã thêm",
     "expirationStatus": {
       "active": "Hết hạn {{date}}",

--- a/src/locales/zh-CN/apiCredentialProfiles.json
+++ b/src/locales/zh-CN/apiCredentialProfiles.json
@@ -104,16 +104,23 @@
   "filter": {
     "tagsAllLabel": "全部标签"
   },
+  "grouping": {
+    "addCredential": "添加此端点凭据",
+    "baseUrls": "Base URL",
+    "baseUrlSelector": "选择 Base URL",
+    "credentialCount": "{{count}} 个凭据",
+    "navigationLabel": "按 Base URL 浏览凭据",
+    "selectedEndpoint": "{{baseUrl}} 的凭据"
+  },
   "list": {
     "apiKey": "密钥",
-    "baseUrl": "Base URL",
     "createdAt": "添加时间",
     "expirationStatus": {
       "active": "{{date}} 到期",
       "expired": "已过期 {{date}}",
       "none": "未设置到期"
     },
-    "updatedAt": "修改时间"
+    "updatedAt": "更新时间"
   },
   "messages": {
     "apiKeyCopied": "已复制密钥",

--- a/src/locales/zh-TW/apiCredentialProfiles.json
+++ b/src/locales/zh-TW/apiCredentialProfiles.json
@@ -104,16 +104,23 @@
   "filter": {
     "tagsAllLabel": "全部標籤"
   },
+  "grouping": {
+    "addCredential": "為此端點新增憑證",
+    "baseUrls": "Base URL",
+    "baseUrlSelector": "選擇 Base URL",
+    "credentialCount_other": "{{count}} 個憑證",
+    "navigationLabel": "按 Base URL 瀏覽憑證",
+    "selectedEndpoint": "{{baseUrl}} 的憑證"
+  },
   "list": {
     "apiKey": "金鑰",
-    "baseUrl": "Base URL",
     "createdAt": "新增時間",
     "expirationStatus": {
       "active": "{{date}} 到期",
       "expired": "已過期 {{date}}",
       "none": "未設定到期"
     },
-    "updatedAt": "修改時間"
+    "updatedAt": "更新時間"
   },
   "messages": {
     "apiKeyCopied": "已複製金鑰",

--- a/src/services/apiCredentialProfiles/apiCredentialProfilesStorage.ts
+++ b/src/services/apiCredentialProfiles/apiCredentialProfilesStorage.ts
@@ -24,7 +24,9 @@ import type {
 } from "~/types/apiCredentialProfiles"
 import {
   API_CREDENTIAL_PROFILES_CONFIG_VERSION,
+  API_CREDENTIAL_TELEMETRY_ATTEMPT_STATUSES,
   API_CREDENTIAL_TELEMETRY_CAPABILITY_MODES,
+  API_CREDENTIAL_TELEMETRY_SOURCES,
   DEFAULT_API_CREDENTIAL_TELEMETRY_CONFIG,
 } from "~/types/apiCredentialProfiles"
 import { onStorageChanged } from "~/utils/browser/browserApi"
@@ -172,7 +174,7 @@ function coerceTelemetryAttempts(
       const rawSource = candidate.source
       const source =
         typeof rawSource === "string" &&
-        (rawSource === "models" ||
+        (rawSource === API_CREDENTIAL_TELEMETRY_SOURCES.Models ||
           API_CREDENTIAL_TELEMETRY_CAPABILITY_MODES.includes(
             rawSource as ApiCredentialTelemetryCapabilityMode,
           ))
@@ -182,9 +184,9 @@ function coerceTelemetryAttempts(
         typeof candidate.endpoint === "string" ? candidate.endpoint.trim() : ""
       const rawStatus = candidate.status
       const status =
-        rawStatus === "success" ||
-        rawStatus === "unsupported" ||
-        rawStatus === "error"
+        rawStatus === API_CREDENTIAL_TELEMETRY_ATTEMPT_STATUSES.Success ||
+        rawStatus === API_CREDENTIAL_TELEMETRY_ATTEMPT_STATUSES.Unsupported ||
+        rawStatus === API_CREDENTIAL_TELEMETRY_ATTEMPT_STATUSES.Error
           ? rawStatus
           : null
 
@@ -235,7 +237,7 @@ function coerceTelemetrySnapshot(
   const rawSource = obj.source
   const source =
     typeof rawSource === "string" &&
-    (rawSource === "models" ||
+    (rawSource === API_CREDENTIAL_TELEMETRY_SOURCES.Models ||
       API_CREDENTIAL_TELEMETRY_CAPABILITY_MODES.includes(
         rawSource as ApiCredentialTelemetryCapabilityMode,
       ))

--- a/src/services/apiCredentialProfiles/telemetry.ts
+++ b/src/services/apiCredentialProfiles/telemetry.ts
@@ -17,6 +17,11 @@ import type {
   ApiCredentialTelemetryJsonPathMap,
   ApiCredentialTelemetrySnapshot,
 } from "~/types/apiCredentialProfiles"
+import {
+  API_CREDENTIAL_TELEMETRY_ATTEMPT_STATUSES,
+  API_CREDENTIAL_TELEMETRY_MODES,
+  API_CREDENTIAL_TELEMETRY_SOURCES,
+} from "~/types/apiCredentialProfiles"
 import { getErrorMessage } from "~/utils/core/error"
 
 type TelemetryPatch = Partial<
@@ -277,7 +282,9 @@ function attemptFromError(
     return createAttempt(
       source,
       error.endpoint || endpoint,
-      error.unsupported ? "unsupported" : "error",
+      error.unsupported
+        ? API_CREDENTIAL_TELEMETRY_ATTEMPT_STATUSES.Unsupported
+        : API_CREDENTIAL_TELEMETRY_ATTEMPT_STATUSES.Error,
       toSanitizedErrorSummary(error, secrets),
       secrets,
     )
@@ -286,7 +293,7 @@ function attemptFromError(
   return createAttempt(
     source,
     endpoint,
-    "error",
+    API_CREDENTIAL_TELEMETRY_ATTEMPT_STATUSES.Error,
     toSanitizedErrorSummary(error, secrets),
     secrets,
   )
@@ -346,7 +353,7 @@ async function queryOpenAiBilling(
   const directBalance = readNumber(subscriptionData.balance)
   if (directBalance !== undefined) {
     return {
-      source: "openaiBilling",
+      source: API_CREDENTIAL_TELEMETRY_SOURCES.OpenAiBilling,
       endpoint: subscription.endpoint,
       data: { balanceUsd: directBalance },
     }
@@ -363,7 +370,7 @@ async function queryOpenAiBilling(
   })
 
   return {
-    source: "openaiBilling",
+    source: API_CREDENTIAL_TELEMETRY_SOURCES.OpenAiBilling,
     endpoint: subscription.endpoint,
     data: parseOpenAiBillingUsage(subscription.json, usage.json),
   }
@@ -399,7 +406,7 @@ async function queryNewApiTokenUsage(
     : nonNegativeQuotaToUsd(totalAvailable)
 
   return {
-    source: "newApiTokenUsage",
+    source: API_CREDENTIAL_TELEMETRY_SOURCES.NewApiTokenUsage,
     endpoint: result.endpoint,
     data: {
       ...(unlimitedQuota ? { unlimitedQuota: true } : {}),
@@ -436,7 +443,7 @@ async function querySub2ApiUsage(
     readNumber(today.tokens) ?? readNumber(today.total_tokens)
 
   return {
-    source: "sub2apiUsage",
+    source: API_CREDENTIAL_TELEMETRY_SOURCES.Sub2ApiUsage,
     endpoint: result.endpoint,
     data: {
       ...(balance !== undefined ? { balanceUsd: balance } : {}),
@@ -547,7 +554,7 @@ async function queryCustomReadOnlyEndpoint(
   })
 
   return {
-    source: "customReadOnlyEndpoint",
+    source: API_CREDENTIAL_TELEMETRY_SOURCES.CustomReadOnlyEndpoint,
     endpoint: result.endpoint,
     data: mapCustomJson(result.json, config.customEndpoint.jsonPaths),
   }
@@ -568,9 +575,11 @@ async function queryModels(
     })
     attempts.push(
       createAttempt(
-        "models",
+        API_CREDENTIAL_TELEMETRY_SOURCES.Models,
         getModelsEndpoint(profile),
-        modelIds.length > 0 ? "success" : "unsupported",
+        modelIds.length > 0
+          ? API_CREDENTIAL_TELEMETRY_ATTEMPT_STATUSES.Success
+          : API_CREDENTIAL_TELEMETRY_ATTEMPT_STATUSES.Unsupported,
         modelIds.length > 0
           ? `Fetched ${modelIds.length} models`
           : "No models returned",
@@ -583,9 +592,12 @@ async function queryModels(
     }
   } catch (error) {
     attempts.push(
-      attemptFromError("models", getModelsEndpoint(profile), error, [
-        profile.apiKey,
-      ]),
+      attemptFromError(
+        API_CREDENTIAL_TELEMETRY_SOURCES.Models,
+        getModelsEndpoint(profile),
+        error,
+        [profile.apiKey],
+      ),
     )
     return undefined
   }
@@ -599,10 +611,16 @@ async function runUsageAdapter(
   mode: ApiCredentialTelemetryCapabilityMode,
   config: ApiCredentialTelemetryConfig,
 ): Promise<AdapterSuccess> {
-  if (mode === "openaiBilling") return await queryOpenAiBilling(profile)
-  if (mode === "newApiTokenUsage") return await queryNewApiTokenUsage(profile)
-  if (mode === "sub2apiUsage") return await querySub2ApiUsage(profile)
-  if (mode === "customReadOnlyEndpoint") {
+  if (mode === API_CREDENTIAL_TELEMETRY_MODES.OpenAiBilling) {
+    return await queryOpenAiBilling(profile)
+  }
+  if (mode === API_CREDENTIAL_TELEMETRY_MODES.NewApiTokenUsage) {
+    return await queryNewApiTokenUsage(profile)
+  }
+  if (mode === API_CREDENTIAL_TELEMETRY_MODES.Sub2ApiUsage) {
+    return await querySub2ApiUsage(profile)
+  }
+  if (mode === API_CREDENTIAL_TELEMETRY_MODES.CustomReadOnlyEndpoint) {
     return await queryCustomReadOnlyEndpoint(profile, config)
   }
 
@@ -615,11 +633,15 @@ async function runUsageAdapter(
 function resolveModes(
   config: ApiCredentialTelemetryConfig,
 ): ApiCredentialTelemetryCapabilityMode[] {
-  if (config.mode === "disabled") return []
-  if (config.mode === "auto") {
+  if (config.mode === API_CREDENTIAL_TELEMETRY_MODES.Disabled) return []
+  if (config.mode === API_CREDENTIAL_TELEMETRY_MODES.Auto) {
     // Prefer provider-specific key telemetry. OpenAI billing endpoints often
     // expose compatibility limits, not spendable gateway balance.
-    return ["newApiTokenUsage", "sub2apiUsage", "openaiBilling"]
+    return [
+      API_CREDENTIAL_TELEMETRY_MODES.NewApiTokenUsage,
+      API_CREDENTIAL_TELEMETRY_MODES.Sub2ApiUsage,
+      API_CREDENTIAL_TELEMETRY_MODES.OpenAiBilling,
+    ]
   }
   return [config.mode]
 }
@@ -675,7 +697,7 @@ export async function refreshApiCredentialProfileTelemetry(
           createAttempt(
             result.source,
             result.endpoint,
-            "success",
+            API_CREDENTIAL_TELEMETRY_ATTEMPT_STATUSES.Success,
             "Fetched usage",
             secrets,
           ),
@@ -687,18 +709,18 @@ export async function refreshApiCredentialProfileTelemetry(
         createAttempt(
           result.source,
           result.endpoint,
-          "unsupported",
+          API_CREDENTIAL_TELEMETRY_ATTEMPT_STATUSES.Unsupported,
           "No usage fields returned",
           secrets,
         ),
       )
     } catch (error) {
       const endpoint =
-        mode === "openaiBilling"
+        mode === API_CREDENTIAL_TELEMETRY_MODES.OpenAiBilling
           ? TELEMETRY_ENDPOINTS.openAiBilling.subscription
-          : mode === "newApiTokenUsage"
+          : mode === API_CREDENTIAL_TELEMETRY_MODES.NewApiTokenUsage
             ? TELEMETRY_ENDPOINTS.newApiTokenUsage
-            : mode === "sub2apiUsage"
+            : mode === API_CREDENTIAL_TELEMETRY_MODES.Sub2ApiUsage
               ? TELEMETRY_ENDPOINTS.sub2ApiUsage
               : config.customEndpoint?.endpoint || "custom"
       attempts.push(attemptFromError(mode, endpoint, error, secrets))
@@ -709,13 +731,18 @@ export async function refreshApiCredentialProfileTelemetry(
   const usageSucceeded = Boolean(usageResult)
   const customEndpointError = attempts.find(
     (attempt) =>
-      attempt.status === "error" && attempt.source === "customReadOnlyEndpoint",
+      attempt.status === API_CREDENTIAL_TELEMETRY_ATTEMPT_STATUSES.Error &&
+      attempt.source ===
+        API_CREDENTIAL_TELEMETRY_SOURCES.CustomReadOnlyEndpoint,
   )?.message
   const lastError =
     usageSucceeded || modelSucceeded
       ? undefined
       : customEndpointError ||
-        attempts.find((attempt) => attempt.status === "error")?.message ||
+        attempts.find(
+          (attempt) =>
+            attempt.status === API_CREDENTIAL_TELEMETRY_ATTEMPT_STATUSES.Error,
+        )?.message ||
         "No supported telemetry endpoint returned data"
 
   const snapshot: ApiCredentialTelemetrySnapshot = {

--- a/src/services/models/modelSync/channelModelFilterEvaluator.ts
+++ b/src/services/models/modelSync/channelModelFilterEvaluator.ts
@@ -9,6 +9,7 @@ import { hasUsableManagedSiteChannelKey } from "~/services/managedSites/utils/ma
 import type { ProtectionBypassExecution } from "~/services/protectionBypass/contracts"
 import {
   API_TYPES,
+  API_VERIFICATION_PROBE_STATUSES,
   runApiVerificationProbe,
   toSanitizedErrorSummary,
   type ApiVerificationApiType,
@@ -327,7 +328,7 @@ export async function matchesProbeFilterRule(
           probeId,
           abortSignal: context.abortSignal,
         })
-        const matched = result.status === "pass"
+        const matched = result.status === API_VERIFICATION_PROBE_STATUSES.Pass
         context.cache.set(cacheKey, matched)
         return matched
       } catch (error) {

--- a/src/services/productAnalytics/verification.ts
+++ b/src/services/productAnalytics/verification.ts
@@ -1,4 +1,7 @@
-import type { ApiVerificationProbeResult } from "~/services/verification/aiApiVerification"
+import {
+  API_VERIFICATION_PROBE_STATUSES,
+  type ApiVerificationProbeResult,
+} from "~/services/verification/aiApiVerification"
 
 import { resolveProductAnalyticsErrorCategoryFromError } from "./actions"
 import {
@@ -14,7 +17,7 @@ export function resolveProductAnalyticsErrorCategoryFromProbeResult(
   fallbackCategory: ProductAnalyticsErrorCategory = PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
 ): ProductAnalyticsErrorCategory {
   if (!result) return fallbackCategory
-  if (result.status === "unsupported") {
+  if (result.status === API_VERIFICATION_PROBE_STATUSES.Unsupported) {
     return PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unsupported
   }
 

--- a/src/services/verification/aiApiVerification/apiVerificationService.ts
+++ b/src/services/verification/aiApiVerification/apiVerificationService.ts
@@ -3,6 +3,7 @@ import type { ApiToken } from "~/types"
 import { resolveRequestedModelId } from "./modelResolver"
 import { apiVerificationProbeRegistry } from "./probeRegistry"
 import { runApiVerificationSuite } from "./suiteRunner"
+import { API_VERIFICATION_PROBE_STATUSES } from "./types"
 import type {
   ApiVerificationApiType,
   ApiVerificationProbeId,
@@ -43,7 +44,7 @@ export async function runApiVerificationProbe(
   if (registryEntry.requiresModelId && !resolvedModelId?.trim()) {
     return {
       id: params.probeId,
-      status: "fail",
+      status: API_VERIFICATION_PROBE_STATUSES.Fail,
       latencyMs: 0,
       summary: "No model id provided",
       summaryKey: "verifyDialog.summaries.noModelIdProvided",

--- a/src/services/verification/aiApiVerification/probes/modelsProbe.ts
+++ b/src/services/verification/aiApiVerification/probes/modelsProbe.ts
@@ -7,7 +7,7 @@ import type {
   ApiVerificationApiType,
   ApiVerificationProbeResult,
 } from "../types"
-import { API_TYPES } from "../types"
+import { API_TYPES, API_VERIFICATION_PROBE_STATUSES } from "../types"
 import {
   buildSafeProbeFailureDiagnostics,
   isAbortError,
@@ -135,7 +135,10 @@ export async function runModelsProbe(
       modelId: suggestedModelId,
       result: {
         id: "models",
-        status: modelIds.length > 0 ? "pass" : "fail",
+        status:
+          modelIds.length > 0
+            ? API_VERIFICATION_PROBE_STATUSES.Pass
+            : API_VERIFICATION_PROBE_STATUSES.Fail,
         latencyMs: okLatency(startedAt),
         summary:
           modelIds.length > 0
@@ -171,7 +174,7 @@ export async function runModelsProbe(
     return {
       result: {
         id: "models",
-        status: "fail",
+        status: API_VERIFICATION_PROBE_STATUSES.Fail,
         latencyMs: okLatency(startedAt),
         summary,
         summaryKey: diagnostics.summaryKey,

--- a/src/services/verification/aiApiVerification/probes/structuredOutputProbe.ts
+++ b/src/services/verification/aiApiVerification/probes/structuredOutputProbe.ts
@@ -3,6 +3,7 @@ import { z } from "zod"
 
 import { nowMs, okLatency } from "../probeTiming"
 import { createModel } from "../providers"
+import { API_VERIFICATION_PROBE_STATUSES } from "../types"
 import type {
   ApiVerificationApiType,
   ApiVerificationProbeResult,
@@ -52,7 +53,10 @@ export async function runStructuredOutputProbe(
 
     return {
       id: "structured-output",
-      status: output?.ok === true ? "pass" : "fail",
+      status:
+        output?.ok === true
+          ? API_VERIFICATION_PROBE_STATUSES.Pass
+          : API_VERIFICATION_PROBE_STATUSES.Fail,
       latencyMs: okLatency(startedAt),
       summary:
         output?.ok === true ? "Structured output succeeded" : "Invalid output",
@@ -80,7 +84,7 @@ export async function runStructuredOutputProbe(
     const diagnostics = buildSafeProbeFailureDiagnostics(error, summary)
     return {
       id: "structured-output",
-      status: "fail",
+      status: API_VERIFICATION_PROBE_STATUSES.Fail,
       latencyMs: okLatency(startedAt),
       summary,
       summaryKey: diagnostics.summaryKey,

--- a/src/services/verification/aiApiVerification/probes/textGenerationProbe.ts
+++ b/src/services/verification/aiApiVerification/probes/textGenerationProbe.ts
@@ -2,6 +2,7 @@ import { generateText } from "ai"
 
 import { nowMs, okLatency } from "../probeTiming"
 import { createModel } from "../providers"
+import { API_VERIFICATION_PROBE_STATUSES } from "../types"
 import type {
   ApiVerificationApiType,
   ApiVerificationProbeResult,
@@ -49,7 +50,9 @@ export async function runTextGenerationProbe(
 
     return {
       id: "text-generation",
-      status: ok ? "pass" : "fail",
+      status: ok
+        ? API_VERIFICATION_PROBE_STATUSES.Pass
+        : API_VERIFICATION_PROBE_STATUSES.Fail,
       latencyMs: okLatency(startedAt),
       summary: ok ? "Text generation succeeded" : "Unexpected response text",
       summaryKey: ok
@@ -78,7 +81,7 @@ export async function runTextGenerationProbe(
 
     return {
       id: "text-generation",
-      status: "fail",
+      status: API_VERIFICATION_PROBE_STATUSES.Fail,
       latencyMs: okLatency(startedAt),
       summary,
       summaryKey: diagnostics.summaryKey,

--- a/src/services/verification/aiApiVerification/probes/toolCallingProbe.ts
+++ b/src/services/verification/aiApiVerification/probes/toolCallingProbe.ts
@@ -2,6 +2,7 @@ import { generateText, jsonSchema, tool } from "ai"
 
 import { nowMs, okLatency } from "../probeTiming"
 import { createModel } from "../providers"
+import { API_VERIFICATION_PROBE_STATUSES } from "../types"
 import type {
   ApiVerificationApiType,
   ApiVerificationProbeResult,
@@ -72,7 +73,7 @@ export async function runToolCallingProbe(
     if (!toolCalled(result)) {
       return {
         id: "tool-calling",
-        status: "fail",
+        status: API_VERIFICATION_PROBE_STATUSES.Fail,
         latencyMs: okLatency(startedAt),
         summary: "No tool call detected (model may not support tools)",
         summaryKey: "verifyDialog.summaries.noToolCallDetected",
@@ -98,7 +99,7 @@ export async function runToolCallingProbe(
 
     return {
       id: "tool-calling",
-      status: "pass",
+      status: API_VERIFICATION_PROBE_STATUSES.Pass,
       latencyMs: okLatency(startedAt),
       summary: "Tool call succeeded",
       summaryKey: "verifyDialog.summaries.toolCallSucceeded",
@@ -129,7 +130,7 @@ export async function runToolCallingProbe(
     const diagnostics = buildSafeProbeFailureDiagnostics(error, summary)
     return {
       id: "tool-calling",
-      status: "fail",
+      status: API_VERIFICATION_PROBE_STATUSES.Fail,
       latencyMs: okLatency(startedAt),
       summary: summary || "Request failed",
       summaryKey: diagnostics.summaryKey,

--- a/src/services/verification/aiApiVerification/probes/webSearchProbe.ts
+++ b/src/services/verification/aiApiVerification/probes/webSearchProbe.ts
@@ -2,6 +2,7 @@ import { generateText } from "ai"
 
 import { nowMs, okLatency } from "../probeTiming"
 import { createGoogleProvider, createOpenAIProvider } from "../providers"
+import { API_VERIFICATION_PROBE_STATUSES } from "../types"
 import type {
   ApiVerificationApiType,
   ApiVerificationProbeResult,
@@ -32,7 +33,7 @@ export async function runWebSearchProbe(
   if (params.apiType === "anthropic") {
     return {
       id: "web-search",
-      status: "unsupported",
+      status: API_VERIFICATION_PROBE_STATUSES.Unsupported,
       latencyMs: okLatency(startedAt),
       summary: "Web search probe is not supported for Anthropic endpoints",
       summaryKey: "verifyDialog.summaries.webSearchUnsupportedAnthropic",
@@ -72,7 +73,9 @@ export async function runWebSearchProbe(
 
       return {
         id: "web-search",
-        status: searched ? "pass" : "fail",
+        status: searched
+          ? API_VERIFICATION_PROBE_STATUSES.Pass
+          : API_VERIFICATION_PROBE_STATUSES.Fail,
         latencyMs: okLatency(startedAt),
         summary: searched ? "Web search succeeded" : "No web search results",
         summaryKey: searched
@@ -118,7 +121,9 @@ export async function runWebSearchProbe(
 
       return {
         id: "web-search",
-        status: searched ? "pass" : "fail",
+        status: searched
+          ? API_VERIFICATION_PROBE_STATUSES.Pass
+          : API_VERIFICATION_PROBE_STATUSES.Fail,
         latencyMs: okLatency(startedAt),
         summary: searched
           ? "Web search/grounding succeeded"
@@ -143,7 +148,7 @@ export async function runWebSearchProbe(
 
     return {
       id: "web-search",
-      status: "unsupported",
+      status: API_VERIFICATION_PROBE_STATUSES.Unsupported,
       latencyMs: okLatency(startedAt),
       summary: "Web search probe is not supported for this API type",
       summaryKey: "verifyDialog.summaries.webSearchUnsupportedForApiType",
@@ -163,7 +168,7 @@ export async function runWebSearchProbe(
 
     return {
       id: "web-search",
-      status: "fail",
+      status: API_VERIFICATION_PROBE_STATUSES.Fail,
       latencyMs: okLatency(startedAt),
       summary,
       summaryKey: diagnostics.summaryKey,

--- a/src/services/verification/aiApiVerification/suiteRunner.ts
+++ b/src/services/verification/aiApiVerification/suiteRunner.ts
@@ -1,6 +1,7 @@
 import { apiVerificationProbeRegistry } from "./probeRegistry"
 import { getApiVerificationProbeDefinitions } from "./probes"
 import { runModelsProbe } from "./probes/modelsProbe"
+import { API_VERIFICATION_PROBE_STATUSES } from "./types"
 import type {
   ApiVerificationApiType,
   ApiVerificationProbeResult,
@@ -43,7 +44,7 @@ export async function runApiVerificationSuite(
       if (definition.id === "web-search") {
         results.push({
           id: "web-search",
-          status: "unsupported",
+          status: API_VERIFICATION_PROBE_STATUSES.Unsupported,
           latencyMs: 0,
           summary: "Web search probe requires explicit API type support",
           summaryKey: "verifyDialog.summaries.webSearchRequiresExplicitSupport",
@@ -53,7 +54,7 @@ export async function runApiVerificationSuite(
 
       results.push({
         id: definition.id,
-        status: "fail",
+        status: API_VERIFICATION_PROBE_STATUSES.Fail,
         latencyMs: 0,
         summary: "No model available to run probes",
         summaryKey: "verifyDialog.summaries.noModelAvailableToRunProbes",

--- a/src/services/verification/aiApiVerification/types.ts
+++ b/src/services/verification/aiApiVerification/types.ts
@@ -17,7 +17,14 @@ export type ApiVerificationProbeId =
   | "structured-output"
   | "web-search"
 
-export type ApiVerificationProbeStatus = "pass" | "fail" | "unsupported"
+export const API_VERIFICATION_PROBE_STATUSES = {
+  Pass: "pass",
+  Fail: "fail",
+  Unsupported: "unsupported",
+} as const
+
+export type ApiVerificationProbeStatus =
+  (typeof API_VERIFICATION_PROBE_STATUSES)[keyof typeof API_VERIFICATION_PROBE_STATUSES]
 
 export type ApiVerificationProbeResult = {
   id: ApiVerificationProbeId

--- a/src/services/verification/cliSupportVerification/runners/toolCalling.ts
+++ b/src/services/verification/cliSupportVerification/runners/toolCalling.ts
@@ -1,5 +1,8 @@
-import type { ApiVerificationApiType } from "~/services/verification/aiApiVerification"
-import { runApiVerificationProbe } from "~/services/verification/aiApiVerification"
+import {
+  API_VERIFICATION_PROBE_STATUSES,
+  runApiVerificationProbe,
+  type ApiVerificationApiType,
+} from "~/services/verification/aiApiVerification"
 
 import type { CliSupportResult, CliSupportStatus, CliToolId } from "../types"
 
@@ -40,7 +43,7 @@ export async function runCliToolCallingSimulation(
   })
 
   const status: CliSupportStatus = probeResult.status
-  const isPassed = status === "pass"
+  const isPassed = status === API_VERIFICATION_PROBE_STATUSES.Pass
   const { id: probeId, ...rest } = probeResult
 
   return {

--- a/src/services/verification/verificationResultHistory/index.ts
+++ b/src/services/verification/verificationResultHistory/index.ts
@@ -11,7 +11,10 @@ export type {
   PersistedApiVerificationStatus,
 } from "./types"
 export { API_VERIFICATION_RESULT_HISTORY_CONFIG_VERSION } from "./types"
-export { useVerificationResultHistorySummaries } from "./useVerificationResultHistorySummaries"
+export {
+  useLatestProfileVerificationSummaries,
+  useVerificationResultHistorySummaries,
+} from "./useVerificationResultHistorySummaries"
 export {
   createAccountModelVerificationHistoryTarget,
   createProfileModelVerificationHistoryTarget,

--- a/src/services/verification/verificationResultHistory/index.ts
+++ b/src/services/verification/verificationResultHistory/index.ts
@@ -10,7 +10,11 @@ export type {
   PersistedApiVerificationProbeSummary,
   PersistedApiVerificationStatus,
 } from "./types"
-export { API_VERIFICATION_RESULT_HISTORY_CONFIG_VERSION } from "./types"
+export {
+  API_VERIFICATION_HISTORY_STATUSES,
+  API_VERIFICATION_HISTORY_TARGET_KINDS,
+  API_VERIFICATION_RESULT_HISTORY_CONFIG_VERSION,
+} from "./types"
 export {
   useLatestProfileVerificationSummaries,
   useVerificationResultHistorySummaries,

--- a/src/services/verification/verificationResultHistory/storage.ts
+++ b/src/services/verification/verificationResultHistory/storage.ts
@@ -318,6 +318,52 @@ class VerificationResultHistoryStorageService {
     )
   }
 
+  /**
+   * Returns the newest profile- or profile-model-scoped API verification for
+   * each requested profile, keyed by the profile target used by list views.
+   */
+  async getLatestProfileSummaries(
+    profileIds: string[],
+  ): Promise<Record<string, ApiVerificationHistorySummary>> {
+    const profileKeyById = new Map(
+      profileIds.flatMap((profileId) => {
+        const normalizedProfileId = profileId.trim()
+        return normalizedProfileId
+          ? [
+              [
+                normalizedProfileId,
+                serializeVerificationHistoryTarget({
+                  kind: "profile",
+                  profileId: normalizedProfileId,
+                }),
+              ],
+            ]
+          : []
+      }),
+    )
+    if (profileKeyById.size === 0) return {}
+
+    const latestByProfileKey: Record<string, ApiVerificationHistorySummary> = {}
+    for (const summary of await this.listSummaries()) {
+      if (
+        summary.target.kind !== "profile" &&
+        summary.target.kind !== "profile-model"
+      ) {
+        continue
+      }
+
+      const profileKey = profileKeyById.get(summary.target.profileId)
+      if (!profileKey) continue
+
+      const current = latestByProfileKey[profileKey]
+      if (!current || summary.verifiedAt > current.verifiedAt) {
+        latestByProfileKey[profileKey] = summary
+      }
+    }
+
+    return latestByProfileKey
+  }
+
   async upsertLatestSummary(
     summary: ApiVerificationHistorySummary,
   ): Promise<ApiVerificationHistorySummary> {

--- a/src/services/verification/verificationResultHistory/storage.ts
+++ b/src/services/verification/verificationResultHistory/storage.ts
@@ -9,10 +9,13 @@ import type {
   ApiVerificationProbeId,
   ApiVerificationProbeStatus,
 } from "~/services/verification/aiApiVerification"
+import { API_VERIFICATION_PROBE_STATUSES } from "~/services/verification/aiApiVerification"
 import { apiVerificationProbeRegistry } from "~/services/verification/aiApiVerification/probeRegistry"
 import { onStorageChanged } from "~/utils/browser/browserApi"
 
 import {
+  API_VERIFICATION_HISTORY_STATUSES,
+  API_VERIFICATION_HISTORY_TARGET_KINDS,
   API_VERIFICATION_RESULT_HISTORY_CONFIG_VERSION,
   type ApiVerificationHistoryConfig,
   type ApiVerificationHistorySummary,
@@ -94,15 +97,22 @@ function normalizeTimestamp(input: unknown) {
 /**
  * Narrow persisted aggregate status values to the supported stored variants.
  */
-function isPersistedStatus(value: unknown): value is "pass" | "fail" {
-  return value === "pass" || value === "fail"
+function isPersistedStatus(
+  value: unknown,
+): value is ApiVerificationHistorySummary["status"] {
+  return (
+    value === API_VERIFICATION_HISTORY_STATUSES.Pass ||
+    value === API_VERIFICATION_HISTORY_STATUSES.Fail
+  )
 }
 
 /**
  * Validate persisted probe status values before rehydrating summaries.
  */
 function isProbeStatus(value: unknown): value is ApiVerificationProbeStatus {
-  return value === "pass" || value === "fail" || value === "unsupported"
+  return Object.values(API_VERIFICATION_PROBE_STATUSES).includes(
+    value as ApiVerificationProbeStatus,
+  )
 }
 
 /**
@@ -140,24 +150,34 @@ function coerceTarget(raw: unknown): ApiVerificationHistoryTarget | null {
   if (!raw || typeof raw !== "object") return null
 
   const value = raw as Record<string, unknown>
-  if (value.kind === "profile") {
+  if (value.kind === API_VERIFICATION_HISTORY_TARGET_KINDS.Profile) {
     const profileId = sanitizeText(value.profileId)
-    return profileId ? { kind: "profile", profileId } : null
-  }
-
-  if (value.kind === "profile-model") {
-    const profileId = sanitizeText(value.profileId)
-    const modelId = sanitizeText(value.modelId)
-    return profileId && modelId
-      ? { kind: "profile-model", profileId, modelId }
+    return profileId
+      ? { kind: API_VERIFICATION_HISTORY_TARGET_KINDS.Profile, profileId }
       : null
   }
 
-  if (value.kind === "account-model") {
+  if (value.kind === API_VERIFICATION_HISTORY_TARGET_KINDS.ProfileModel) {
+    const profileId = sanitizeText(value.profileId)
+    const modelId = sanitizeText(value.modelId)
+    return profileId && modelId
+      ? {
+          kind: API_VERIFICATION_HISTORY_TARGET_KINDS.ProfileModel,
+          profileId,
+          modelId,
+        }
+      : null
+  }
+
+  if (value.kind === API_VERIFICATION_HISTORY_TARGET_KINDS.AccountModel) {
     const accountId = sanitizeText(value.accountId)
     const modelId = sanitizeText(value.modelId)
     return accountId && modelId
-      ? { kind: "account-model", accountId, modelId }
+      ? {
+          kind: API_VERIFICATION_HISTORY_TARGET_KINDS.AccountModel,
+          accountId,
+          modelId,
+        }
       : null
   }
 
@@ -333,7 +353,7 @@ class VerificationResultHistoryStorageService {
               [
                 normalizedProfileId,
                 serializeVerificationHistoryTarget({
-                  kind: "profile",
+                  kind: API_VERIFICATION_HISTORY_TARGET_KINDS.Profile,
                   profileId: normalizedProfileId,
                 }),
               ],
@@ -346,8 +366,9 @@ class VerificationResultHistoryStorageService {
     const latestByProfileKey: Record<string, ApiVerificationHistorySummary> = {}
     for (const summary of await this.listSummaries()) {
       if (
-        summary.target.kind !== "profile" &&
-        summary.target.kind !== "profile-model"
+        summary.target.kind !== API_VERIFICATION_HISTORY_TARGET_KINDS.Profile &&
+        summary.target.kind !==
+          API_VERIFICATION_HISTORY_TARGET_KINDS.ProfileModel
       ) {
         continue
       }

--- a/src/services/verification/verificationResultHistory/types.ts
+++ b/src/services/verification/verificationResultHistory/types.ts
@@ -2,8 +2,8 @@ import type {
   ApiVerificationApiType,
   ApiVerificationProbeId,
   ApiVerificationProbeStatus,
-} from "~/services/verification/aiApiVerification"
-import { API_VERIFICATION_PROBE_STATUSES } from "~/services/verification/aiApiVerification"
+} from "~/services/verification/aiApiVerification/types"
+import { API_VERIFICATION_PROBE_STATUSES } from "~/services/verification/aiApiVerification/types"
 
 export const API_VERIFICATION_RESULT_HISTORY_CONFIG_VERSION = 1
 

--- a/src/services/verification/verificationResultHistory/types.ts
+++ b/src/services/verification/verificationResultHistory/types.ts
@@ -3,28 +3,42 @@ import type {
   ApiVerificationProbeId,
   ApiVerificationProbeStatus,
 } from "~/services/verification/aiApiVerification"
+import { API_VERIFICATION_PROBE_STATUSES } from "~/services/verification/aiApiVerification"
 
 export const API_VERIFICATION_RESULT_HISTORY_CONFIG_VERSION = 1
 
-export type ApiVerificationHistoryDisplayStatus = "pass" | "fail" | "unverified"
+export const API_VERIFICATION_HISTORY_STATUSES = {
+  Pass: API_VERIFICATION_PROBE_STATUSES.Pass,
+  Fail: API_VERIFICATION_PROBE_STATUSES.Fail,
+  Unverified: "unverified",
+} as const
+
+export type ApiVerificationHistoryDisplayStatus =
+  (typeof API_VERIFICATION_HISTORY_STATUSES)[keyof typeof API_VERIFICATION_HISTORY_STATUSES]
 
 export type PersistedApiVerificationStatus = Exclude<
   ApiVerificationHistoryDisplayStatus,
-  "unverified"
+  typeof API_VERIFICATION_HISTORY_STATUSES.Unverified
 >
+
+export const API_VERIFICATION_HISTORY_TARGET_KINDS = {
+  Profile: "profile",
+  ProfileModel: "profile-model",
+  AccountModel: "account-model",
+} as const
 
 export type ApiVerificationHistoryTarget =
   | {
-      kind: "profile"
+      kind: typeof API_VERIFICATION_HISTORY_TARGET_KINDS.Profile
       profileId: string
     }
   | {
-      kind: "profile-model"
+      kind: typeof API_VERIFICATION_HISTORY_TARGET_KINDS.ProfileModel
       profileId: string
       modelId: string
     }
   | {
-      kind: "account-model"
+      kind: typeof API_VERIFICATION_HISTORY_TARGET_KINDS.AccountModel
       accountId: string
       modelId: string
     }

--- a/src/services/verification/verificationResultHistory/useVerificationResultHistorySummaries.ts
+++ b/src/services/verification/verificationResultHistory/useVerificationResultHistorySummaries.ts
@@ -14,6 +14,70 @@ import { serializeVerificationHistoryTarget } from "./utils"
 
 const logger = createLogger("VerificationResultHistoryHook")
 
+const loadTargetSummaries = (targets: ApiVerificationHistoryTarget[]) =>
+  verificationResultHistoryStorage.getLatestSummaries(targets)
+
+const loadProfileSummaries = (profileIds: string[]) =>
+  verificationResultHistoryStorage.getLatestProfileSummaries(profileIds)
+
+/** Shares storage subscription, stale-request protection, and error handling. */
+function useStoredVerificationSummaries<T>(
+  stableItems: T[],
+  stableItemSignature: string,
+  loadSummaries: (
+    items: T[],
+  ) => Promise<Record<string, ApiVerificationHistorySummary>>,
+) {
+  const [summariesByKey, setSummariesByKey] = useState<
+    Record<string, ApiVerificationHistorySummary>
+  >({})
+  const latestRequestIdRef = useRef(0)
+  const stableItemsRef = useRef(stableItems)
+
+  useEffect(() => {
+    stableItemsRef.current = stableItems
+  }, [stableItems, stableItemSignature])
+
+  const reload = useCallback(async () => {
+    const currentItems = stableItemsRef.current
+    const requestId = ++latestRequestIdRef.current
+
+    if (stableItemSignature === "[]" || currentItems.length === 0) {
+      if (requestId !== latestRequestIdRef.current) return
+
+      setSummariesByKey((prev) => (Object.keys(prev).length === 0 ? prev : {}))
+      return
+    }
+
+    try {
+      const nextSummaries = await loadSummaries(currentItems)
+      if (requestId !== latestRequestIdRef.current) return
+
+      setSummariesByKey(nextSummaries)
+    } catch (error) {
+      if (requestId !== latestRequestIdRef.current) return
+
+      logger.error("Failed to load verification result history", error)
+      setSummariesByKey((prev) => (Object.keys(prev).length === 0 ? prev : {}))
+    }
+  }, [loadSummaries, stableItemSignature])
+
+  useEffect(() => {
+    void reload()
+  }, [reload])
+
+  useEffect(() => {
+    return subscribeToVerificationResultHistoryChanges(() => {
+      void reload()
+    })
+  }, [reload])
+
+  return {
+    summariesByKey,
+    reload,
+  }
+}
+
 /**
  * Loads persisted verification summaries for a known set of UI targets and keeps
  * them fresh when extension storage changes.
@@ -21,11 +85,6 @@ const logger = createLogger("VerificationResultHistoryHook")
 export function useVerificationResultHistorySummaries(
   targets: ApiVerificationHistoryTarget[],
 ) {
-  const [summariesByKey, setSummariesByKey] = useState<
-    Record<string, ApiVerificationHistorySummary>
-  >({})
-  const latestRequestIdRef = useRef(0)
-
   const { stableTargets, stableTargetSignature } = useMemo(() => {
     const seen = new Set<string>()
     const next: Array<{ target: ApiVerificationHistoryTarget; key: string }> =
@@ -45,51 +104,30 @@ export function useVerificationResultHistorySummaries(
       stableTargetSignature: JSON.stringify(next.map(({ key }) => key)),
     }
   }, [targets])
-  const stableTargetsRef = useRef(stableTargets)
 
-  useEffect(() => {
-    stableTargetsRef.current = stableTargets
-  }, [stableTargets, stableTargetSignature])
+  return useStoredVerificationSummaries(
+    stableTargets,
+    stableTargetSignature,
+    loadTargetSummaries,
+  )
+}
 
-  const reload = useCallback(async () => {
-    const currentTargets = stableTargetsRef.current
-    const requestId = ++latestRequestIdRef.current
+/** Loads the newest profile- or model-scoped API verification per profile. */
+export function useLatestProfileVerificationSummaries(profileIds: string[]) {
+  const { stableProfileIds, stableProfileIdSignature } = useMemo(() => {
+    const normalizedProfileIds = Array.from(
+      new Set(profileIds.map((profileId) => profileId.trim()).filter(Boolean)),
+    ).sort((a, b) => a.localeCompare(b))
 
-    if (stableTargetSignature === "[]" || currentTargets.length === 0) {
-      if (requestId !== latestRequestIdRef.current) return
-
-      setSummariesByKey((prev) => (Object.keys(prev).length === 0 ? prev : {}))
-      return
+    return {
+      stableProfileIds: normalizedProfileIds,
+      stableProfileIdSignature: JSON.stringify(normalizedProfileIds),
     }
+  }, [profileIds])
 
-    try {
-      const nextSummaries =
-        await verificationResultHistoryStorage.getLatestSummaries(
-          currentTargets,
-        )
-      if (requestId !== latestRequestIdRef.current) return
-
-      setSummariesByKey(nextSummaries)
-    } catch (error) {
-      if (requestId !== latestRequestIdRef.current) return
-
-      logger.error("Failed to load verification result history", error)
-      setSummariesByKey((prev) => (Object.keys(prev).length === 0 ? prev : {}))
-    }
-  }, [stableTargetSignature])
-
-  useEffect(() => {
-    void reload()
-  }, [reload])
-
-  useEffect(() => {
-    return subscribeToVerificationResultHistoryChanges(() => {
-      void reload()
-    })
-  }, [reload])
-
-  return {
-    summariesByKey,
-    reload,
-  }
+  return useStoredVerificationSummaries(
+    stableProfileIds,
+    stableProfileIdSignature,
+    loadProfileSummaries,
+  )
 }

--- a/src/services/verification/verificationResultHistory/utils.ts
+++ b/src/services/verification/verificationResultHistory/utils.ts
@@ -2,7 +2,7 @@ import {
   API_TYPES,
   type ApiVerificationApiType,
   type ApiVerificationProbeResult,
-} from "~/services/verification/aiApiVerification"
+} from "~/services/verification/aiApiVerification/types"
 
 import type {
   ApiVerificationHistorySummary,

--- a/src/services/verification/verificationResultHistory/utils.ts
+++ b/src/services/verification/verificationResultHistory/utils.ts
@@ -11,6 +11,10 @@ import type {
   PersistedApiVerificationStatus,
   PersistedApiVerificationSummaryParams,
 } from "./types"
+import {
+  API_VERIFICATION_HISTORY_STATUSES,
+  API_VERIFICATION_HISTORY_TARGET_KINDS,
+} from "./types"
 
 const FALLBACK_SUMMARY_MAX_LENGTH = 240
 const FALLBACK_PARAM_STRING_MAX_LENGTH = 120
@@ -122,7 +126,7 @@ export function createProfileVerificationHistoryTarget(profileId: string) {
   if (!sanitizedProfileId) return null
 
   return {
-    kind: "profile",
+    kind: API_VERIFICATION_HISTORY_TARGET_KINDS.Profile,
     profileId: sanitizedProfileId,
   } satisfies ApiVerificationHistoryTarget
 }
@@ -142,7 +146,7 @@ export function createProfileModelVerificationHistoryTarget(
   if (!sanitizedProfileId || !sanitizedModelId) return null
 
   return {
-    kind: "profile-model",
+    kind: API_VERIFICATION_HISTORY_TARGET_KINDS.ProfileModel,
     profileId: sanitizedProfileId,
     modelId: sanitizedModelId,
   } satisfies ApiVerificationHistoryTarget
@@ -163,7 +167,7 @@ export function createAccountModelVerificationHistoryTarget(
   if (!sanitizedAccountId || !sanitizedModelId) return null
 
   return {
-    kind: "account-model",
+    kind: API_VERIFICATION_HISTORY_TARGET_KINDS.AccountModel,
     accountId: sanitizedAccountId,
     modelId: sanitizedModelId,
   } satisfies ApiVerificationHistoryTarget
@@ -177,11 +181,11 @@ export function createAccountModelVerificationHistoryTarget(
 export function serializeVerificationHistoryTarget(
   target: ApiVerificationHistoryTarget,
 ) {
-  if (target.kind === "profile") {
+  if (target.kind === API_VERIFICATION_HISTORY_TARGET_KINDS.Profile) {
     return `profile:${target.profileId}`
   }
 
-  if (target.kind === "profile-model") {
+  if (target.kind === API_VERIFICATION_HISTORY_TARGET_KINDS.ProfileModel) {
     return `profile:${target.profileId}:model:${target.modelId}`
   }
 
@@ -210,7 +214,11 @@ export function isApiVerificationApiType(
 export function deriveVerificationHistoryStatus(
   results: Pick<ApiVerificationProbeResult, "status">[],
 ): PersistedApiVerificationStatus {
-  return results.some((result) => result.status === "fail") ? "fail" : "pass"
+  return results.some(
+    (result) => result.status === API_VERIFICATION_HISTORY_STATUSES.Fail,
+  )
+    ? API_VERIFICATION_HISTORY_STATUSES.Fail
+    : API_VERIFICATION_HISTORY_STATUSES.Pass
 }
 
 /**

--- a/src/services/verification/webAiApiCheck/background.ts
+++ b/src/services/verification/webAiApiCheck/background.ts
@@ -12,6 +12,7 @@ import { PRODUCT_ANALYTICS_ERROR_CATEGORIES } from "~/services/productAnalytics/
 import { tagStorage } from "~/services/tags/tagStorage"
 import {
   API_TYPES,
+  API_VERIFICATION_PROBE_STATUSES,
   runApiVerificationProbe,
   type ApiVerificationApiType,
   type ApiVerificationProbeId,
@@ -456,7 +457,7 @@ export async function resolveWebAiApiCheckRunProbeMessage(
 
       const result: ApiVerificationProbeResult = {
         id: probeId as ApiVerificationProbeId,
-        status: "fail",
+        status: API_VERIFICATION_PROBE_STATUSES.Fail,
         latencyMs: 0,
         summary: message,
         ...diagnostics,

--- a/src/types/apiCredentialProfiles.ts
+++ b/src/types/apiCredentialProfiles.ts
@@ -6,13 +6,25 @@ import type { HealthStatus, TokenUsage } from "~/types"
  */
 export const API_CREDENTIAL_PROFILES_CONFIG_VERSION = 4
 
+export const API_CREDENTIAL_TELEMETRY_MODES = {
+  Disabled: "disabled",
+  Auto: "auto",
+  OpenAiBilling: "openaiBilling",
+  NewApiTokenUsage: "newApiTokenUsage",
+  Sub2ApiUsage: "sub2apiUsage",
+  CustomReadOnlyEndpoint: "customReadOnlyEndpoint",
+} as const
+
 export type ApiCredentialTelemetryCapabilityMode =
-  | "disabled"
-  | "auto"
-  | "openaiBilling"
-  | "newApiTokenUsage"
-  | "sub2apiUsage"
-  | "customReadOnlyEndpoint"
+  (typeof API_CREDENTIAL_TELEMETRY_MODES)[keyof typeof API_CREDENTIAL_TELEMETRY_MODES]
+
+export const API_CREDENTIAL_TELEMETRY_SOURCES = {
+  ...API_CREDENTIAL_TELEMETRY_MODES,
+  Models: "models",
+} as const
+
+export type ApiCredentialTelemetrySource =
+  (typeof API_CREDENTIAL_TELEMETRY_SOURCES)[keyof typeof API_CREDENTIAL_TELEMETRY_SOURCES]
 
 export type ApiCredentialTelemetryJsonPathMap = {
   balanceUsd?: string
@@ -46,28 +58,26 @@ export type ApiCredentialTelemetryConfig = {
   customEndpoint?: ApiCredentialTelemetryCustomEndpoint
 }
 
-export const API_CREDENTIAL_TELEMETRY_CAPABILITY_MODES: ApiCredentialTelemetryCapabilityMode[] =
-  [
-    "disabled",
-    "auto",
-    "openaiBilling",
-    "newApiTokenUsage",
-    "sub2apiUsage",
-    "customReadOnlyEndpoint",
-  ]
+export const API_CREDENTIAL_TELEMETRY_CAPABILITY_MODES = Object.values(
+  API_CREDENTIAL_TELEMETRY_MODES,
+)
 
 export const DEFAULT_API_CREDENTIAL_TELEMETRY_CONFIG: ApiCredentialTelemetryConfig =
   {
-    mode: "auto",
+    mode: API_CREDENTIAL_TELEMETRY_MODES.Auto,
   }
 
+export const API_CREDENTIAL_TELEMETRY_ATTEMPT_STATUSES = {
+  Success: "success",
+  Unsupported: "unsupported",
+  Error: "error",
+} as const
+
 export type ApiCredentialTelemetryAttemptStatus =
-  | "success"
-  | "unsupported"
-  | "error"
+  (typeof API_CREDENTIAL_TELEMETRY_ATTEMPT_STATUSES)[keyof typeof API_CREDENTIAL_TELEMETRY_ATTEMPT_STATUSES]
 
 export type ApiCredentialTelemetryAttempt = {
-  source: ApiCredentialTelemetryCapabilityMode | "models"
+  source: ApiCredentialTelemetrySource
   endpoint: string
   status: ApiCredentialTelemetryAttemptStatus
   message?: string
@@ -83,7 +93,7 @@ export type ApiCredentialTelemetrySnapshot = {
   lastSyncTime: number
   lastSuccessTime?: number
   lastError?: string
-  source?: ApiCredentialTelemetryCapabilityMode | "models"
+  source?: ApiCredentialTelemetrySource
   balanceUsd?: number
   todayCostUsd?: number
   todayRequests?: number

--- a/src/utils/core/formatters.ts
+++ b/src/utils/core/formatters.ts
@@ -141,6 +141,7 @@ export function normalizeToDate(
 export const formatLocaleDateTime = (
   input: number | string | Date | null | undefined,
   fallback: string = t("common:labels.notAvailable"),
+  options?: Intl.DateTimeFormatOptions,
 ): string => {
   const date = normalizeToDate(input)
   if (!date || Number.isNaN(date.getTime()) || date.getTime() <= 0) {
@@ -148,7 +149,7 @@ export const formatLocaleDateTime = (
   }
 
   try {
-    return date.toLocaleString()
+    return date.toLocaleString(undefined, options)
   } catch {
     return fallback
   }

--- a/tests/components/IconButton.test.tsx
+++ b/tests/components/IconButton.test.tsx
@@ -50,6 +50,20 @@ describe("IconButton", () => {
     )
   })
 
+  it("renders destructive row actions without a persistent filled background", () => {
+    render(
+      <IconButton aria-label="Delete item" variant="destructiveGhost">
+        <span />
+      </IconButton>,
+    )
+
+    expect(screen.getByRole("button", { name: "Delete item" })).toHaveClass(
+      "bg-transparent",
+      "text-destructive",
+      "hover:bg-destructive/10",
+    )
+  })
+
   it("uses aria-label as the fallback title for icon-only discovery", () => {
     render(
       <IconButton aria-label="Refresh profiles">

--- a/tests/entrypoints/options/pages/ApiCredentialProfiles/ApiCredentialProfiles.test.tsx
+++ b/tests/entrypoints/options/pages/ApiCredentialProfiles/ApiCredentialProfiles.test.tsx
@@ -782,7 +782,9 @@ describe("ApiCredentialProfiles page", () => {
 
     await user.clear(searchInput)
 
-    const filter = screen.getAllByRole("combobox")[0]!
+    const filter = screen.getByRole("combobox", {
+      name: "apiCredentialProfiles:controls.apiTypePlaceholder",
+    })
     await user.click(filter)
     await user.click(
       await screen.findByRole("option", {

--- a/tests/entrypoints/options/pages/ApiCredentialProfiles/ApiCredentialProfiles.test.tsx
+++ b/tests/entrypoints/options/pages/ApiCredentialProfiles/ApiCredentialProfiles.test.tsx
@@ -757,8 +757,13 @@ describe("ApiCredentialProfiles page", () => {
       await screen.findByRole("heading", { name: "OpenAI" }),
     ).toBeInTheDocument()
     expect(
-      await screen.findByRole("heading", { name: "Google" }),
+      await screen.findByRole("combobox", {
+        name: "apiCredentialProfiles:grouping.baseUrlSelector",
+      }),
     ).toBeInTheDocument()
+    expect(
+      screen.queryByRole("heading", { name: "Google" }),
+    ).not.toBeInTheDocument()
 
     const searchInput = screen.getByPlaceholderText(
       "apiCredentialProfiles:controls.searchPlaceholder",
@@ -980,8 +985,13 @@ describe("ApiCredentialProfiles page", () => {
       await screen.findByRole("heading", { name: "OpenAI" }),
     ).toBeInTheDocument()
     expect(
-      await screen.findByRole("heading", { name: "Google" }),
+      await screen.findByRole("combobox", {
+        name: "apiCredentialProfiles:grouping.baseUrlSelector",
+      }),
     ).toBeInTheDocument()
+    expect(
+      screen.queryByRole("heading", { name: "Google" }),
+    ).not.toBeInTheDocument()
 
     await user.click(await screen.findByRole("button", { name: /prod/i }))
 

--- a/tests/entrypoints/options/pages/ApiCredentialProfiles/VerifyApiCredentialProfileDialog.test.tsx
+++ b/tests/entrypoints/options/pages/ApiCredentialProfiles/VerifyApiCredentialProfileDialog.test.tsx
@@ -15,7 +15,10 @@ import {
   PRODUCT_ANALYTICS_RESULTS,
   PRODUCT_ANALYTICS_SURFACE_IDS,
 } from "~/services/productAnalytics/contracts"
-import { API_TYPES } from "~/services/verification/aiApiVerification"
+import {
+  API_TYPES,
+  API_VERIFICATION_PROBE_STATUSES,
+} from "~/services/verification/aiApiVerification"
 import {
   createProfileModelVerificationHistoryTarget,
   createProfileVerificationHistoryTarget,
@@ -710,6 +713,49 @@ describe("VerifyApiCredentialProfileDialog", () => {
     ).toBeInTheDocument()
   })
 
+  it("tracks an unsupported single probe as skipped", async () => {
+    const user = userEvent.setup()
+    mockRunApiVerificationProbe.mockResolvedValueOnce({
+      id: "models",
+      status: API_VERIFICATION_PROBE_STATUSES.Unsupported,
+      latencyMs: 1,
+      summary: "Not supported",
+    })
+
+    render(
+      <VerifyApiCredentialProfileDialog
+        isOpen={true}
+        onClose={() => {}}
+        profile={{
+          id: "p-1",
+          name: "Profile",
+          apiType: API_TYPES.OPENAI_COMPATIBLE,
+          baseUrl: "https://example.com",
+          apiKey: "sk-test",
+          tagIds: [],
+          notes: "",
+          createdAt: 1,
+          updatedAt: 1,
+        }}
+      />,
+    )
+
+    const probeCard = await screen.findByTestId(
+      getApiCredentialProfileVerifyProbeTestId("models"),
+    )
+    await user.click(
+      within(probeCard).getByRole("button", {
+        name: "aiApiVerification:verifyDialog.actions.runOne",
+      }),
+    )
+
+    await waitFor(() =>
+      expect(mockCompleteProductAnalyticsAction).toHaveBeenCalledWith(
+        PRODUCT_ANALYTICS_RESULTS.Skipped,
+      ),
+    )
+  })
+
   it("redacts baseUrl and apiKey when a probe throws", async () => {
     const user = userEvent.setup()
 
@@ -1080,6 +1126,67 @@ describe("VerifyApiCredentialProfileDialog", () => {
         PRODUCT_ANALYTICS_SURFACE_IDS.OptionsApiCredentialProfilesDialog,
       entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Options,
     })
+  })
+
+  it("tracks an all-unsupported verification suite as skipped", async () => {
+    const user = userEvent.setup()
+    mockRunApiVerificationProbe.mockImplementation(async (params: any) => ({
+      id: params.probeId,
+      status: API_VERIFICATION_PROBE_STATUSES.Unsupported,
+      latencyMs: 1,
+      summary: "Not supported",
+      output:
+        params.probeId === "models"
+          ? {
+              suggestedModelId: "m1",
+              modelIdsPreview: ["m1"],
+            }
+          : undefined,
+    }))
+
+    render(
+      <VerifyApiCredentialProfileDialog
+        isOpen={true}
+        onClose={() => {}}
+        profile={{
+          id: "p-1",
+          name: "Profile",
+          apiType: API_TYPES.OPENAI_COMPATIBLE,
+          baseUrl: "https://example.com",
+          apiKey: "sk-test",
+          tagIds: [],
+          notes: "",
+          createdAt: 1,
+          updatedAt: 1,
+        }}
+      />,
+    )
+
+    const closeButton = await screen.findByText(
+      "aiApiVerification:verifyDialog.actions.close",
+      { selector: "button" },
+    )
+    const footer = closeButton.parentElement
+    if (!footer) throw new Error("Missing modal footer")
+
+    await user.click(
+      within(footer).getByRole("button", {
+        name: "aiApiVerification:verifyDialog.actions.run",
+      }),
+    )
+
+    await waitFor(() =>
+      expect(mockCompleteProductAnalyticsAction).toHaveBeenCalledWith(
+        PRODUCT_ANALYTICS_RESULTS.Skipped,
+        {
+          insights: {
+            itemCount: 5,
+            successCount: 0,
+            failureCount: 0,
+          },
+        },
+      ),
+    )
   })
 
   it("tracks API credential verification suite failures with an error category", async () => {

--- a/tests/entrypoints/popup/ApiCredentialProfilesPopupView.test.tsx
+++ b/tests/entrypoints/popup/ApiCredentialProfilesPopupView.test.tsx
@@ -119,8 +119,13 @@ describe("ApiCredentialProfiles popup view", () => {
       await screen.findByRole("heading", { name: "OpenAI" }),
     ).toBeInTheDocument()
     expect(
-      await screen.findByRole("heading", { name: "Google" }),
+      await screen.findByRole("combobox", {
+        name: "apiCredentialProfiles:grouping.baseUrlSelector",
+      }),
     ).toBeInTheDocument()
+    expect(
+      screen.queryByRole("heading", { name: "Google" }),
+    ).not.toBeInTheDocument()
 
     await user.type(
       screen.getByPlaceholderText(

--- a/tests/features/ApiCredentialProfiles/ApiCredentialProfilesList.test.tsx
+++ b/tests/features/ApiCredentialProfiles/ApiCredentialProfilesList.test.tsx
@@ -319,4 +319,36 @@ describe("ApiCredentialProfilesList endpoint navigation", () => {
       }),
     ).not.toBeInTheDocument()
   })
+
+  it("returns no endpoint content for an empty profile collection", () => {
+    const { container } = render(
+      <ApiCredentialProfilesList
+        profiles={[]}
+        controller={createController()}
+      />,
+    )
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it("keeps an invalid Base URL selectable with its original label", async () => {
+    const invalidBaseUrl = "not a valid URL"
+    render(
+      <ApiCredentialProfilesList
+        profiles={[
+          createProfile("invalid", "Invalid endpoint", invalidBaseUrl),
+          createProfile(
+            "valid",
+            "Valid endpoint",
+            "https://valid.example.invalid",
+          ),
+        ]}
+        controller={createController()}
+      />,
+    )
+
+    expect(
+      await screen.findByRole("button", { name: invalidBaseUrl }),
+    ).toBeVisible()
+  })
 })

--- a/tests/features/ApiCredentialProfiles/ApiCredentialProfilesList.test.tsx
+++ b/tests/features/ApiCredentialProfiles/ApiCredentialProfilesList.test.tsx
@@ -2,6 +2,7 @@ import userEvent from "@testing-library/user-event"
 import { describe, expect, it, vi } from "vitest"
 
 import { ApiCredentialProfilesList } from "~/features/ApiCredentialProfiles/components/ApiCredentialProfilesList"
+import { API_CREDENTIAL_PROFILES_TEST_IDS } from "~/features/ApiCredentialProfiles/testIds"
 import { render, screen, within } from "~~/tests/test-utils/render"
 
 const { useIsDesktopMock } = vi.hoisted(() => ({
@@ -85,16 +86,16 @@ describe("ApiCredentialProfilesList endpoint navigation", () => {
       name: "apiCredentialProfiles:grouping.navigationLabel",
     })
     expect(
-      within(navigation).getByRole("button", { name: /gateway-a/ }),
+      within(navigation).getByRole("button", { name: firstBaseUrl }),
     ).toHaveAttribute("aria-current", "true")
     expect(screen.getByText("Team primary")).toBeVisible()
     expect(screen.getByText("Team fallback")).toBeVisible()
     expect(screen.queryByText("Other endpoint")).not.toBeInTheDocument()
-    const navigationAddButtons = within(navigation).getAllByRole("button", {
-      name: "apiCredentialProfiles:grouping.addCredential",
-    })
-    expect(navigationAddButtons).toHaveLength(2)
-    await user.click(navigationAddButtons[1])
+    await user.click(
+      within(navigation).getByRole("button", {
+        name: `apiCredentialProfiles:grouping.addCredential: ${secondBaseUrl}`,
+      }),
+    )
     expect(controller.openAddDialog).toHaveBeenLastCalledWith({
       baseUrl: secondBaseUrl,
     })
@@ -106,19 +107,17 @@ describe("ApiCredentialProfilesList endpoint navigation", () => {
       }),
     )
     expect(controller.handleCopyBaseUrl).toHaveBeenCalledWith(firstBaseUrl)
-    const detailAddButton = screen
-      .getAllByRole("button", {
-        name: "apiCredentialProfiles:grouping.addCredential",
-      })
-      .find((button) => !navigation.contains(button))
-    expect(detailAddButton).toBeDefined()
-    await user.click(detailAddButton as HTMLButtonElement)
+    await user.click(
+      screen.getByTestId(
+        API_CREDENTIAL_PROFILES_TEST_IDS.endpointAddCredentialButton,
+      ),
+    )
     expect(controller.openAddDialog).toHaveBeenLastCalledWith({
       baseUrl: firstBaseUrl,
     })
 
     await user.click(
-      within(navigation).getByRole("button", { name: /gateway-b/ }),
+      within(navigation).getByRole("button", { name: secondBaseUrl }),
     )
 
     expect(screen.getByText("Other endpoint")).toBeVisible()
@@ -129,13 +128,11 @@ describe("ApiCredentialProfilesList endpoint navigation", () => {
     expect(controller.openEditDialog).toHaveBeenCalledWith(
       expect.objectContaining({ id: "b-1" }),
     )
-    const nextDetailAddButton = screen
-      .getAllByRole("button", {
-        name: "apiCredentialProfiles:grouping.addCredential",
-      })
-      .find((button) => !navigation.contains(button))
-    expect(nextDetailAddButton).toBeDefined()
-    await user.click(nextDetailAddButton as HTMLButtonElement)
+    await user.click(
+      screen.getByTestId(
+        API_CREDENTIAL_PROFILES_TEST_IDS.endpointAddCredentialButton,
+      ),
+    )
     expect(controller.openAddDialog).toHaveBeenLastCalledWith({
       baseUrl: secondBaseUrl,
     })
@@ -236,7 +233,7 @@ describe("ApiCredentialProfilesList endpoint navigation", () => {
     )
 
     await user.click(
-      await screen.findByRole("button", { name: /second\.example/ }),
+      await screen.findByRole("button", { name: second.baseUrl }),
     )
     expect(screen.getByText("Second endpoint")).toBeVisible()
 
@@ -246,6 +243,51 @@ describe("ApiCredentialProfilesList endpoint navigation", () => {
 
     expect(screen.getByText("First endpoint")).toBeVisible()
     expect(screen.queryByText("Second endpoint")).not.toBeInTheDocument()
+  })
+
+  it("applies each guided import request once without overriding later user selection", async () => {
+    const user = userEvent.setup()
+    const controller = createController()
+    const first = createProfile(
+      "first",
+      "First endpoint",
+      "https://first.example.invalid",
+    )
+    const second = createProfile(
+      "second",
+      "Second endpoint",
+      "https://second.example.invalid",
+    )
+    const { rerender } = render(
+      <ApiCredentialProfilesList
+        profiles={[first, second]}
+        controller={controller}
+        guidedImportEntry={{ profileId: second.id, request: 1 }}
+      />,
+    )
+
+    expect(await screen.findByText("Second endpoint")).toBeVisible()
+
+    await user.click(screen.getByRole("button", { name: first.baseUrl }))
+    expect(await screen.findByText("First endpoint")).toBeVisible()
+
+    rerender(
+      <ApiCredentialProfilesList
+        profiles={[first, second]}
+        controller={controller}
+        guidedImportEntry={{ profileId: second.id, request: 1 }}
+      />,
+    )
+    expect(screen.getByText("First endpoint")).toBeVisible()
+
+    rerender(
+      <ApiCredentialProfilesList
+        profiles={[first, second]}
+        controller={controller}
+        guidedImportEntry={{ profileId: second.id, request: 2 }}
+      />,
+    )
+    expect(await screen.findByText("Second endpoint")).toBeVisible()
   })
 
   it("keeps every matching endpoint visible while filters are active", async () => {

--- a/tests/features/ApiCredentialProfiles/ApiCredentialProfilesList.test.tsx
+++ b/tests/features/ApiCredentialProfiles/ApiCredentialProfilesList.test.tsx
@@ -1,0 +1,280 @@
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import { ApiCredentialProfilesList } from "~/features/ApiCredentialProfiles/components/ApiCredentialProfilesList"
+import { render, screen, within } from "~~/tests/test-utils/render"
+
+const { useIsDesktopMock } = vi.hoisted(() => ({
+  useIsDesktopMock: vi.fn(() => true),
+}))
+
+vi.mock("~/hooks/useMediaQuery", () => ({
+  useIsDesktop: () => useIsDesktopMock(),
+}))
+
+vi.mock(
+  "~/features/ApiCredentialProfiles/components/ApiCredentialProfileListItem",
+  () => ({
+    ApiCredentialProfileListItem: ({ profile, onEdit }: any) => (
+      <article aria-label={profile.name}>
+        <span>{profile.name}</span>
+        <button type="button" onClick={() => onEdit(profile)}>
+          Edit {profile.name}
+        </button>
+      </article>
+    ),
+  }),
+)
+
+function createProfile(id: string, name: string, baseUrl: string) {
+  return {
+    id,
+    name,
+    apiType: "openai",
+    baseUrl,
+    apiKey: `sk-${id}`,
+    tagIds: [],
+    notes: "",
+    createdAt: 1,
+    updatedAt: 1,
+  } as any
+}
+
+function createController() {
+  return {
+    getProfileVerificationSummary: vi.fn(() => null),
+    tagNameById: new Map<string, string>(),
+    visibleKeys: new Set<string>(),
+    toggleKeyVisibility: vi.fn(),
+    handleCopyBaseUrl: vi.fn(),
+    openAddDialog: vi.fn(),
+    handleCopyApiKey: vi.fn(),
+    handleCopyBundle: vi.fn(),
+    handleOpenModelManagement: vi.fn(),
+    handleRefreshTelemetry: vi.fn(),
+    handleExport: vi.fn(),
+    refreshingTelemetryProfileIds: [],
+    managedSiteType: "new-api",
+    managedSiteLabel: "New API",
+    setVerifyingProfile: vi.fn(),
+    setCliVerifyingProfile: vi.fn(),
+    openEditDialog: vi.fn(),
+    handleRequestDelete: vi.fn(),
+  } as any
+}
+
+describe("ApiCredentialProfilesList endpoint navigation", () => {
+  it("switches between Base URLs while keeping every credential action independent", async () => {
+    const user = userEvent.setup()
+    const controller = createController()
+    const firstBaseUrl = "https://gateway-a.example.invalid"
+    const secondBaseUrl = "https://gateway-b.example.invalid"
+
+    render(
+      <ApiCredentialProfilesList
+        profiles={[
+          createProfile("a-1", "Team primary", firstBaseUrl),
+          createProfile("a-2", "Team fallback", firstBaseUrl),
+          createProfile("b-1", "Other endpoint", secondBaseUrl),
+        ]}
+        controller={controller}
+      />,
+    )
+
+    const navigation = await screen.findByRole("navigation", {
+      name: "apiCredentialProfiles:grouping.navigationLabel",
+    })
+    expect(
+      within(navigation).getByRole("button", { name: /gateway-a/ }),
+    ).toHaveAttribute("aria-current", "true")
+    expect(screen.getByText("Team primary")).toBeVisible()
+    expect(screen.getByText("Team fallback")).toBeVisible()
+    expect(screen.queryByText("Other endpoint")).not.toBeInTheDocument()
+    const navigationAddButtons = within(navigation).getAllByRole("button", {
+      name: "apiCredentialProfiles:grouping.addCredential",
+    })
+    expect(navigationAddButtons).toHaveLength(2)
+    await user.click(navigationAddButtons[1])
+    expect(controller.openAddDialog).toHaveBeenLastCalledWith({
+      baseUrl: secondBaseUrl,
+    })
+    expect(screen.getByText("Team primary")).toBeVisible()
+    expect(screen.queryByText("Other endpoint")).not.toBeInTheDocument()
+    await user.click(
+      screen.getByRole("button", {
+        name: "apiCredentialProfiles:actions.copyBaseUrl",
+      }),
+    )
+    expect(controller.handleCopyBaseUrl).toHaveBeenCalledWith(firstBaseUrl)
+    const detailAddButton = screen
+      .getAllByRole("button", {
+        name: "apiCredentialProfiles:grouping.addCredential",
+      })
+      .find((button) => !navigation.contains(button))
+    expect(detailAddButton).toBeDefined()
+    await user.click(detailAddButton as HTMLButtonElement)
+    expect(controller.openAddDialog).toHaveBeenLastCalledWith({
+      baseUrl: firstBaseUrl,
+    })
+
+    await user.click(
+      within(navigation).getByRole("button", { name: /gateway-b/ }),
+    )
+
+    expect(screen.getByText("Other endpoint")).toBeVisible()
+    expect(screen.queryByText("Team primary")).not.toBeInTheDocument()
+    await user.click(
+      screen.getByRole("button", { name: "Edit Other endpoint" }),
+    )
+    expect(controller.openEditDialog).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "b-1" }),
+    )
+    const nextDetailAddButton = screen
+      .getAllByRole("button", {
+        name: "apiCredentialProfiles:grouping.addCredential",
+      })
+      .find((button) => !navigation.contains(button))
+    expect(nextDetailAddButton).toBeDefined()
+    await user.click(nextDetailAddButton as HTMLButtonElement)
+    expect(controller.openAddDialog).toHaveBeenLastCalledWith({
+      baseUrl: secondBaseUrl,
+    })
+  })
+
+  it("shows one shared Base URL header without endpoint navigation", async () => {
+    const user = userEvent.setup()
+    const baseUrl = "https://gateway.example.invalid"
+    const controller = createController()
+
+    render(
+      <ApiCredentialProfilesList
+        profiles={[
+          createProfile("first", "First key", baseUrl),
+          createProfile("second", "Second key", baseUrl),
+        ]}
+        controller={controller}
+      />,
+    )
+
+    expect(await screen.findByText("First key")).toBeVisible()
+    expect(screen.queryByRole("navigation")).not.toBeInTheDocument()
+    expect(screen.getByText("Second key")).toBeVisible()
+    expect(screen.getByText(baseUrl)).toBeVisible()
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "apiCredentialProfiles:actions.copyBaseUrl",
+      }),
+    )
+    expect(controller.handleCopyBaseUrl).toHaveBeenCalledWith(baseUrl)
+  })
+
+  it("uses a compact Base URL selector in the popup and switches endpoints", async () => {
+    const user = userEvent.setup()
+    const controller = createController()
+    const first = createProfile(
+      "first",
+      "Popup first",
+      "https://first.example.invalid",
+    )
+    const second = createProfile(
+      "second",
+      "Popup second",
+      "https://second.example.invalid",
+    )
+
+    render(
+      <ApiCredentialProfilesList
+        profiles={[first, second]}
+        controller={controller}
+        variant="popup"
+      />,
+    )
+
+    const selector = await screen.findByRole("combobox", {
+      name: "apiCredentialProfiles:grouping.baseUrlSelector",
+    })
+    expect(screen.queryByRole("navigation")).not.toBeInTheDocument()
+    expect(screen.getByText("Popup first")).toBeVisible()
+    expect(screen.queryByText("Popup second")).not.toBeInTheDocument()
+    await user.click(
+      screen.getByRole("button", {
+        name: "apiCredentialProfiles:grouping.addCredential",
+      }),
+    )
+    expect(controller.openAddDialog).toHaveBeenLastCalledWith({
+      baseUrl: first.baseUrl,
+    })
+
+    await user.click(selector)
+    await user.click(
+      await screen.findByRole("option", { name: /second\.example/ }),
+    )
+
+    expect(screen.getByText("Popup second")).toBeVisible()
+    expect(screen.queryByText("Popup first")).not.toBeInTheDocument()
+  })
+
+  it("falls back to an available Base URL after filtering removes the selection", async () => {
+    const user = userEvent.setup()
+    const controller = createController()
+    const first = createProfile(
+      "first",
+      "First endpoint",
+      "https://first.example.invalid",
+    )
+    const second = createProfile(
+      "second",
+      "Second endpoint",
+      "https://second.example.invalid",
+    )
+    const { rerender } = render(
+      <ApiCredentialProfilesList
+        profiles={[first, second]}
+        controller={controller}
+      />,
+    )
+
+    await user.click(
+      await screen.findByRole("button", { name: /second\.example/ }),
+    )
+    expect(screen.getByText("Second endpoint")).toBeVisible()
+
+    rerender(
+      <ApiCredentialProfilesList profiles={[first]} controller={controller} />,
+    )
+
+    expect(screen.getByText("First endpoint")).toBeVisible()
+    expect(screen.queryByText("Second endpoint")).not.toBeInTheDocument()
+  })
+
+  it("keeps every matching endpoint visible while filters are active", async () => {
+    render(
+      <ApiCredentialProfilesList
+        profiles={[
+          createProfile(
+            "first",
+            "First matching key",
+            "https://first.example.invalid",
+          ),
+          createProfile(
+            "second",
+            "Second matching key",
+            "https://second.example.invalid",
+          ),
+        ]}
+        controller={createController()}
+        isFiltering
+      />,
+    )
+
+    expect(await screen.findByText("First matching key")).toBeVisible()
+    expect(screen.getByText("Second matching key")).toBeVisible()
+    expect(screen.queryByRole("navigation")).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", {
+        name: "apiCredentialProfiles:grouping.addCredential",
+      }),
+    ).not.toBeInTheDocument()
+  })
+})

--- a/tests/features/ApiCredentialProfiles/apiCredentialProfileListModel.test.ts
+++ b/tests/features/ApiCredentialProfiles/apiCredentialProfileListModel.test.ts
@@ -51,7 +51,7 @@ describe("buildApiCredentialProfileListModel", () => {
         lastFilterMode: null,
       })
 
-      expect(model.filteredProfiles).toEqual([profile])
+      expect(model.filteredProfiles.map(({ id }) => id)).toEqual([profile.id])
     }
   })
 
@@ -85,7 +85,10 @@ describe("buildApiCredentialProfileListModel", () => {
       lastFilterMode: PRODUCT_ANALYTICS_MODE_IDS.GroupFilter,
     })
 
-    expect(model.filteredProfiles).toEqual([first, second])
+    expect(model.filteredProfiles.map(({ id }) => id)).toEqual([
+      first.id,
+      second.id,
+    ])
   })
 
   it("builds tag options with profile counts while preserving configured order", () => {

--- a/tests/features/ApiCredentialProfiles/apiCredentialProfileListModel.test.ts
+++ b/tests/features/ApiCredentialProfiles/apiCredentialProfileListModel.test.ts
@@ -145,6 +145,20 @@ describe("buildApiCredentialProfileListModel", () => {
     expect(
       buildApiCredentialProfileListModel({
         ...baseInput,
+        apiTypeFilter: "openai",
+        searchTerm: "",
+      }).analyticsMode,
+    ).toBe(PRODUCT_ANALYTICS_MODE_IDS.ProviderFilter)
+    expect(
+      buildApiCredentialProfileListModel({
+        ...baseInput,
+        selectedTagIds: ["team"],
+        searchTerm: "",
+      }).analyticsMode,
+    ).toBe(PRODUCT_ANALYTICS_MODE_IDS.GroupFilter)
+    expect(
+      buildApiCredentialProfileListModel({
+        ...baseInput,
         searchTerm: "",
       }).analyticsMode,
     ).toBeNull()

--- a/tests/features/ApiCredentialProfiles/apiCredentialProfileListModel.test.ts
+++ b/tests/features/ApiCredentialProfiles/apiCredentialProfileListModel.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest"
+
+import { buildApiCredentialProfileListModel } from "~/features/ApiCredentialProfiles/utils/apiCredentialProfileListModel"
+import { PRODUCT_ANALYTICS_MODE_IDS } from "~/services/productAnalytics/contracts"
+import type { Tag } from "~/types"
+import type { ApiCredentialProfile } from "~/types/apiCredentialProfiles"
+
+function buildProfile(
+  overrides: Partial<ApiCredentialProfile> = {},
+): ApiCredentialProfile {
+  return {
+    id: "profile-1",
+    name: "Primary credential",
+    apiType: "openai",
+    baseUrl: "https://gateway.example.invalid",
+    apiKey: "sk-example",
+    tagIds: [],
+    notes: "",
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides,
+  }
+}
+
+const tags: Tag[] = [
+  { id: "team", name: "Platform Team", createdAt: 1, updatedAt: 1 },
+  { id: "unused", name: "Unused Group", createdAt: 1, updatedAt: 1 },
+]
+
+describe("buildApiCredentialProfileListModel", () => {
+  it("normalizes case, whitespace, and full-width search text across profile fields", () => {
+    const profile = buildProfile({
+      name: "Production Gateway",
+      notes: "Shared credential",
+      tagIds: ["team"],
+    })
+
+    for (const searchTerm of [
+      "  PRODUCTION   gateway ",
+      "ｇａｔｅｗａｙ．ｅｘａｍｐｌｅ．ｉｎｖａｌｉｄ",
+      "platform team",
+      "shared credential",
+    ]) {
+      const model = buildApiCredentialProfileListModel({
+        profiles: [profile],
+        tags,
+        tagNameById: new Map([["team", "Platform Team"]]),
+        searchTerm,
+        apiTypeFilter: "",
+        selectedTagIds: [],
+        lastFilterMode: null,
+      })
+
+      expect(model.filteredProfiles).toEqual([profile])
+    }
+  })
+
+  it("combines query, API type, and any selected tag without changing profile order", () => {
+    const first = buildProfile({
+      id: "first",
+      name: "First matching credential",
+      apiType: "openai",
+      tagIds: ["team"],
+    })
+    const second = buildProfile({
+      id: "second",
+      name: "Second matching credential",
+      apiType: "openai",
+      tagIds: ["secondary"],
+    })
+    const wrongType = buildProfile({
+      id: "wrong-type",
+      name: "Matching credential",
+      apiType: "anthropic",
+      tagIds: ["team"],
+    })
+
+    const model = buildApiCredentialProfileListModel({
+      profiles: [first, second, wrongType],
+      tags,
+      tagNameById: new Map([["team", "Platform Team"]]),
+      searchTerm: "matching credential",
+      apiTypeFilter: " openai ",
+      selectedTagIds: ["team", "secondary"],
+      lastFilterMode: PRODUCT_ANALYTICS_MODE_IDS.GroupFilter,
+    })
+
+    expect(model.filteredProfiles).toEqual([first, second])
+  })
+
+  it("builds tag options with profile counts while preserving configured order", () => {
+    const model = buildApiCredentialProfileListModel({
+      profiles: [
+        buildProfile({ id: "first", tagIds: ["team", "team", ""] }),
+        buildProfile({ id: "second", tagIds: ["team"] }),
+      ],
+      tags,
+      tagNameById: new Map([["team", "Platform Team"]]),
+      searchTerm: "",
+      apiTypeFilter: "",
+      selectedTagIds: [],
+      lastFilterMode: null,
+    })
+
+    expect(model.tagFilterOptions).toEqual([
+      { value: "team", label: "Platform Team", count: 3 },
+      { value: "unused", label: "Unused Group", count: 0 },
+    ])
+  })
+
+  it("reports active filter count and preserves the latest filter mode", () => {
+    const model = buildApiCredentialProfileListModel({
+      profiles: [],
+      tags: [],
+      tagNameById: new Map(),
+      searchTerm: " query ",
+      apiTypeFilter: " openai ",
+      selectedTagIds: ["team"],
+      lastFilterMode: PRODUCT_ANALYTICS_MODE_IDS.GroupFilter,
+    })
+
+    expect(model.activeFilterCount).toBe(3)
+    expect(model.analyticsMode).toBe(PRODUCT_ANALYTICS_MODE_IDS.GroupFilter)
+  })
+
+  it("derives a stable fallback mode only when filters are active", () => {
+    const baseInput = {
+      profiles: [],
+      tags: [],
+      tagNameById: new Map<string, string>(),
+      apiTypeFilter: "",
+      selectedTagIds: [] as string[],
+      lastFilterMode: null,
+    }
+
+    expect(
+      buildApiCredentialProfileListModel({
+        ...baseInput,
+        searchTerm: "query",
+      }).analyticsMode,
+    ).toBe(PRODUCT_ANALYTICS_MODE_IDS.SearchFilter)
+    expect(
+      buildApiCredentialProfileListModel({
+        ...baseInput,
+        searchTerm: "",
+      }).analyticsMode,
+    ).toBeNull()
+  })
+})

--- a/tests/features/ApiCredentialProfiles/components/ApiCredentialProfileListItem.test.tsx
+++ b/tests/features/ApiCredentialProfiles/components/ApiCredentialProfileListItem.test.tsx
@@ -487,6 +487,26 @@ describe("ApiCredentialProfileListItem", () => {
     ).toHaveTextContent("0")
   })
 
+  it("keeps a telemetry error visible when no metrics were collected", () => {
+    renderListItem(
+      buildProfile({
+        telemetrySnapshot: {
+          attempts: [],
+          health: { status: SiteHealthStatus.Error },
+          lastSyncTime: 1,
+          lastError: "Usage endpoint unavailable",
+        },
+      }),
+    )
+
+    expect(
+      screen.getByRole("button", {
+        name: "apiCredentialProfiles:telemetry.title",
+      }),
+    ).toHaveAttribute("aria-expanded", "true")
+    expect(screen.getByText("Usage endpoint unavailable")).toBeVisible()
+  })
+
   it("uses not provided fallbacks for model-only refreshed snapshots", () => {
     renderListItem(
       buildProfile({

--- a/tests/features/ApiCredentialProfiles/components/ApiCredentialProfileListItem.test.tsx
+++ b/tests/features/ApiCredentialProfiles/components/ApiCredentialProfileListItem.test.tsx
@@ -1,3 +1,4 @@
+import userEvent from "@testing-library/user-event"
 import {
   afterAll,
   afterEach,
@@ -67,7 +68,9 @@ vi.mock("~/components/ui", async (importOriginal) => {
 
   return {
     ...actual,
-    Badge: ({ children }: any) => <span>{children}</span>,
+    Badge: ({ children, variant: _variant, size: _size, ...props }: any) => (
+      <span {...props}>{children}</span>
+    ),
     Card: ({ children }: any) => <div>{children}</div>,
     CardContent: ({ children }: any) => <div>{children}</div>,
     Heading6: ({ children }: any) => <h6>{children}</h6>,
@@ -154,7 +157,6 @@ function renderListItem(
       tagNames={[]}
       visibleKeys={overrides.visibleKeys ?? new Set()}
       toggleKeyVisibility={overrides.toggleKeyVisibility ?? vi.fn()}
-      onCopyBaseUrl={vi.fn()}
       onCopyApiKey={vi.fn()}
       onCopyBundle={vi.fn()}
       onOpenModelManagement={vi.fn()}
@@ -216,6 +218,19 @@ describe("ApiCredentialProfileListItem", () => {
     vi.clearAllMocks()
   })
 
+  it("leaves the shared Base URL to the endpoint group header", () => {
+    const profile = buildProfile()
+
+    renderListItem(profile)
+
+    expect(screen.queryByText(profile.baseUrl)).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", {
+        name: "apiCredentialProfiles:actions.copyBaseUrl",
+      }),
+    ).not.toBeInTheDocument()
+  })
+
   it("shows a full API key only when its visibility is enabled", () => {
     const profile = buildProfile()
     const toggleKeyVisibility = vi.fn()
@@ -238,14 +253,6 @@ describe("ApiCredentialProfileListItem", () => {
     const profileAction = (actionId: string) =>
       `${PRODUCT_ANALYTICS_FEATURE_IDS.ApiCredentialProfiles}:${actionId}:${PRODUCT_ANALYTICS_SURFACE_IDS.OptionsApiCredentialProfilesRowActions}:${PRODUCT_ANALYTICS_ENTRYPOINTS.Options}`
 
-    expect(
-      screen.getByRole("button", {
-        name: "apiCredentialProfiles:actions.copyBaseUrl",
-      }),
-    ).toHaveAttribute(
-      "data-analytics-action",
-      profileAction(PRODUCT_ANALYTICS_ACTION_IDS.CopyBaseUrl),
-    )
     expect(
       screen.getByRole("button", {
         name: "apiCredentialProfiles:actions.copyApiKey",
@@ -319,7 +326,7 @@ describe("ApiCredentialProfileListItem", () => {
     ).toHaveTextContent("apiCredentialProfiles:telemetry.notProvided")
   })
 
-  it("shows expiration as a status badge and keeps audit timestamps separate", () => {
+  it("shows expiration as a status badge and presents compact audit timestamps with full details", () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date(2026, 6, 30, 12).getTime())
 
@@ -345,12 +352,53 @@ describe("ApiCredentialProfileListItem", () => {
     expect(
       screen.queryByText(/apiCredentialProfiles:list.expiresAt:/),
     ).not.toBeInTheDocument()
+    const createdAtFull = new Date(createdAt).toLocaleString()
+    const updatedAtFull = new Date(updatedAt).toLocaleString()
+    const createdAtBadge = screen.getByTitle(createdAtFull)
+    const updatedAtBadge = screen.getByTitle(updatedAtFull)
+    const verificationSummary = screen.getByTestId("verification-summary")
+    const toolbar = screen.getByTestId(API_CREDENTIAL_PROFILES_TEST_IDS.toolbar)
+
     expect(
-      screen.getByText(/apiCredentialProfiles:list.createdAt:/),
-    ).toHaveTextContent(new Date(createdAt).toLocaleDateString())
+      screen.getByLabelText(
+        `apiCredentialProfiles:list.createdAt: ${createdAtFull}`,
+      ),
+    ).toBe(createdAtBadge)
     expect(
-      screen.getByText(/apiCredentialProfiles:list.updatedAt:/),
-    ).toHaveTextContent(new Date(updatedAt).toLocaleDateString())
+      screen.getByLabelText(
+        `apiCredentialProfiles:list.updatedAt: ${updatedAtFull}`,
+      ),
+    ).toBe(updatedAtBadge)
+    expect(createdAtBadge.parentElement).not.toBe(
+      verificationSummary.parentElement,
+    )
+    expect(createdAtBadge.parentElement?.parentElement).toBe(
+      toolbar.parentElement,
+    )
+    expect(updatedAtBadge.parentElement?.parentElement).toBe(
+      toolbar.parentElement,
+    )
+
+    expect(createdAtBadge).toHaveTextContent(
+      new Date(createdAt).toLocaleString(undefined, {
+        year: "numeric",
+        month: "numeric",
+        day: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+      }),
+    )
+    expect(updatedAtBadge).toHaveTextContent(
+      new Date(updatedAt).toLocaleString(undefined, {
+        year: "numeric",
+        month: "numeric",
+        day: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+      }),
+    )
+    expect(createdAtBadge).not.toHaveTextContent(createdAtFull)
+    expect(updatedAtBadge).not.toHaveTextContent(updatedAtFull)
   })
 
   it("distinguishes expired credentials from credentials without an expiration date", () => {
@@ -376,7 +424,6 @@ describe("ApiCredentialProfileListItem", () => {
         tagNames={[]}
         visibleKeys={new Set()}
         toggleKeyVisibility={vi.fn()}
-        onCopyBaseUrl={vi.fn()}
         onCopyApiKey={vi.fn()}
         onCopyBundle={vi.fn()}
         onOpenModelManagement={vi.fn()}
@@ -416,6 +463,30 @@ describe("ApiCredentialProfileListItem", () => {
     ).toHaveTextContent("apiCredentialProfiles:telemetry.notProvided")
   })
 
+  it("keeps explicit zero telemetry expanded", () => {
+    renderListItem(
+      buildProfile({
+        telemetrySnapshot: {
+          attempts: [],
+          health: { status: SiteHealthStatus.Healthy },
+          lastSyncTime: 1,
+          todayRequests: 0,
+        },
+      }),
+    )
+
+    expect(
+      screen.getByRole("button", {
+        name: "apiCredentialProfiles:telemetry.title",
+      }),
+    ).toHaveAttribute("aria-expanded", "true")
+    expect(
+      screen.getByTestId(
+        API_CREDENTIAL_PROFILES_TEST_IDS.telemetryTodayRequests,
+      ),
+    ).toHaveTextContent("0")
+  })
+
   it("uses not provided fallbacks for model-only refreshed snapshots", () => {
     renderListItem(
       buildProfile({
@@ -447,9 +518,26 @@ describe("ApiCredentialProfileListItem", () => {
     )
   })
 
-  it("renders dash fallbacks when telemetry has never been refreshed", () => {
+  it("collapses missing telemetry by default and lets the user reveal fallbacks", async () => {
+    const user = userEvent.setup()
     renderListItem(buildProfile({ telemetrySnapshot: undefined }))
 
+    const telemetryToggle = screen.getByRole("button", {
+      name: "apiCredentialProfiles:telemetry.title",
+    })
+    expect(telemetryToggle).toHaveAttribute("aria-expanded", "false")
+    expect(
+      screen.getByRole("button", {
+        name: "apiCredentialProfiles:telemetry.actions.refresh",
+      }),
+    ).toBeVisible()
+    expect(
+      screen.queryByTestId(API_CREDENTIAL_PROFILES_TEST_IDS.telemetryBalance),
+    ).not.toBeInTheDocument()
+
+    await user.click(telemetryToggle)
+
+    expect(telemetryToggle).toHaveAttribute("aria-expanded", "true")
     expect(
       screen.getByTestId(API_CREDENTIAL_PROFILES_TEST_IDS.telemetryBalance),
     ).toHaveTextContent("-")
@@ -464,6 +552,56 @@ describe("ApiCredentialProfileListItem", () => {
     expect(
       screen.getByTestId(API_CREDENTIAL_PROFILES_TEST_IDS.telemetryModels),
     ).toHaveTextContent("-")
+  })
+
+  it("opens telemetry when a refresh adds the first detail value", () => {
+    const { rerender } = renderListItem(
+      buildProfile({ telemetrySnapshot: undefined }),
+    )
+
+    expect(
+      screen.getByRole("button", {
+        name: "apiCredentialProfiles:telemetry.title",
+      }),
+    ).toHaveAttribute("aria-expanded", "false")
+
+    rerender(
+      <ApiCredentialProfileListItem
+        profile={buildProfile({
+          telemetrySnapshot: {
+            attempts: [],
+            health: { status: SiteHealthStatus.Healthy },
+            lastSyncTime: 2,
+            balanceUsd: 7.5,
+          },
+        })}
+        verificationSummary={null}
+        tagNames={[]}
+        visibleKeys={new Set()}
+        toggleKeyVisibility={vi.fn()}
+        onCopyApiKey={vi.fn()}
+        onCopyBundle={vi.fn()}
+        onOpenModelManagement={vi.fn()}
+        onVerify={vi.fn()}
+        onVerifyCliSupport={vi.fn()}
+        onRefreshTelemetry={vi.fn()}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+        onExport={vi.fn()}
+        isTelemetryRefreshing={false}
+        managedSiteType="new-api"
+        managedSiteLabel="New API"
+      />,
+    )
+
+    expect(
+      screen.getByRole("button", {
+        name: "apiCredentialProfiles:telemetry.title",
+      }),
+    ).toHaveAttribute("aria-expanded", "true")
+    expect(
+      screen.getByTestId(API_CREDENTIAL_PROFILES_TEST_IDS.telemetryBalance),
+    ).toBeVisible()
   })
 
   it("exposes localized health status text accessibly", () => {
@@ -509,7 +647,6 @@ describe("ApiCredentialProfileListItem", () => {
         tagNames={[]}
         visibleKeys={new Set()}
         toggleKeyVisibility={vi.fn()}
-        onCopyBaseUrl={vi.fn()}
         onCopyApiKey={vi.fn()}
         onCopyBundle={vi.fn()}
         onOpenModelManagement={vi.fn()}
@@ -563,7 +700,6 @@ describe("ApiCredentialProfileListItem", () => {
         tagNames={[]}
         visibleKeys={new Set()}
         toggleKeyVisibility={vi.fn()}
-        onCopyBaseUrl={vi.fn()}
         onCopyApiKey={vi.fn()}
         onCopyBundle={vi.fn()}
         onOpenModelManagement={vi.fn()}

--- a/tests/features/ApiCredentialProfiles/hooks/useApiCredentialProfilesController.test.tsx
+++ b/tests/features/ApiCredentialProfiles/hooks/useApiCredentialProfilesController.test.tsx
@@ -107,7 +107,7 @@ vi.mock("~/services/verification/verificationResultHistory", async () => {
 
   return {
     ...actual,
-    useVerificationResultHistorySummaries: () => ({ summariesByKey: {} }),
+    useLatestProfileVerificationSummaries: () => ({ summariesByKey: {} }),
   }
 })
 

--- a/tests/services/apiCredentialProfilesTelemetry.test.ts
+++ b/tests/services/apiCredentialProfilesTelemetry.test.ts
@@ -660,4 +660,38 @@ describe("api credential profile telemetry", () => {
     )
     expect(snapshot.lastError).toBe(customAttempt?.message)
   })
+
+  it("records empty model discovery as unsupported", async () => {
+    const profile = await apiCredentialProfilesStorage.createProfile({
+      name: "Empty Model Catalog",
+      apiType: API_TYPES.OPENAI_COMPATIBLE,
+      baseUrl: "https://empty-models.example.invalid",
+      apiKey: "sk-empty-models",
+      telemetryConfig: { mode: "newApiTokenUsage" },
+    })
+    fetchApiCredentialModelIdsMock.mockResolvedValueOnce([])
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        jsonResponse({
+          data: {
+            total_granted: 10,
+            total_used: 4,
+            total_available: 6,
+          },
+        }),
+      ),
+    )
+
+    const snapshot = await refreshApiCredentialProfileTelemetry(profile.id)
+
+    expect(snapshot.models).toEqual({ count: 0, preview: [] })
+    expect(snapshot.attempts).toContainEqual(
+      expect.objectContaining({
+        source: "models",
+        status: "unsupported",
+        message: "No models returned",
+      }),
+    )
+  })
 })

--- a/tests/services/cliSupportToolCallingRunner.test.ts
+++ b/tests/services/cliSupportToolCallingRunner.test.ts
@@ -4,9 +4,13 @@ const mocks = vi.hoisted(() => ({
   runApiVerificationProbe: vi.fn(),
 }))
 
-vi.mock("~/services/verification/aiApiVerification", () => ({
-  runApiVerificationProbe: mocks.runApiVerificationProbe,
-}))
+vi.mock(
+  "~/services/verification/aiApiVerification",
+  async (importOriginal) => ({
+    ...(await importOriginal()),
+    runApiVerificationProbe: mocks.runApiVerificationProbe,
+  }),
+)
 
 describe("cliSupport tool-calling runner", () => {
   beforeEach(() => {

--- a/tests/services/verificationResultHistoryStorage.test.ts
+++ b/tests/services/verificationResultHistoryStorage.test.ts
@@ -406,6 +406,55 @@ describe("verificationResultHistoryStorage", () => {
     ).resolves.toBe(false)
   })
 
+  it("returns the newest API verification summary for each profile", async () => {
+    const profileTarget = createProfileVerificationHistoryTarget("profile-1")
+    const olderModelTarget = createProfileModelVerificationHistoryTarget(
+      "profile-1",
+      "older-model",
+    )
+    const newerModelTarget = createProfileModelVerificationHistoryTarget(
+      "profile-1",
+      "newer-model",
+    )
+    if (!profileTarget || !olderModelTarget || !newerModelTarget) {
+      throw new Error("Expected history targets")
+    }
+
+    for (const [target, verifiedAt] of [
+      [profileTarget, 50],
+      [olderModelTarget, 100],
+      [newerModelTarget, 200],
+    ] as const) {
+      const summary = createVerificationHistorySummary({
+        target,
+        apiType: API_TYPES.OPENAI_COMPATIBLE,
+        verifiedAt,
+        results: [
+          {
+            id: "text-generation",
+            status: "pass",
+            latencyMs: 1,
+            summary: "Generated text",
+          },
+        ],
+      })
+      if (!summary) throw new Error("Expected verification summary")
+      await verificationResultHistoryStorage.upsertLatestSummary(summary)
+    }
+
+    await expect(
+      verificationResultHistoryStorage.getLatestProfileSummaries([
+        "profile-1",
+        "missing-profile",
+      ]),
+    ).resolves.toEqual({
+      "profile:profile-1": expect.objectContaining({
+        targetKey: "profile:profile-1:model:newer-model",
+        verifiedAt: 200,
+      }),
+    })
+  })
+
   it("rejects invalid summaries before writing to storage", async () => {
     await expect(
       verificationResultHistoryStorage.upsertLatestSummary({

--- a/tests/services/verificationResultHistoryStorage.test.ts
+++ b/tests/services/verificationResultHistoryStorage.test.ts
@@ -243,6 +243,20 @@ describe("verificationResultHistoryStorage", () => {
           {
             target: {
               kind: "profile",
+              profileId: "   ",
+            },
+            apiType: API_TYPES.OPENAI_COMPATIBLE,
+            probes: [
+              {
+                id: "models",
+                status: "pass",
+                summary: "invalid blank profile target",
+              },
+            ],
+          },
+          {
+            target: {
+              kind: "profile",
               profileId: "profile-invalid-api",
             },
             apiType: "invalid-api-type",

--- a/tests/services/verificationResultHistoryStorage.test.ts
+++ b/tests/services/verificationResultHistoryStorage.test.ts
@@ -442,8 +442,30 @@ describe("verificationResultHistoryStorage", () => {
       await verificationResultHistoryStorage.upsertLatestSummary(summary)
     }
 
+    const accountTarget = createAccountModelVerificationHistoryTarget(
+      "account-1",
+      "account-model",
+    )
+    if (!accountTarget) throw new Error("Expected account history target")
+    const accountSummary = createVerificationHistorySummary({
+      target: accountTarget,
+      apiType: API_TYPES.OPENAI_COMPATIBLE,
+      verifiedAt: 300,
+      results: [
+        {
+          id: "models",
+          status: "pass",
+          latencyMs: 1,
+          summary: "Account model",
+        },
+      ],
+    })
+    if (!accountSummary) throw new Error("Expected account summary")
+    await verificationResultHistoryStorage.upsertLatestSummary(accountSummary)
+
     await expect(
       verificationResultHistoryStorage.getLatestProfileSummaries([
+        "   ",
         "profile-1",
         "missing-profile",
       ]),
@@ -453,6 +475,12 @@ describe("verificationResultHistoryStorage", () => {
         verifiedAt: 200,
       }),
     })
+  })
+
+  it("returns no latest profile summaries for empty identifiers", async () => {
+    await expect(
+      verificationResultHistoryStorage.getLatestProfileSummaries(["", "   "]),
+    ).resolves.toEqual({})
   })
 
   it("rejects invalid summaries before writing to storage", async () => {

--- a/tests/services/verificationResultHistorySummaries.test.tsx
+++ b/tests/services/verificationResultHistorySummaries.test.tsx
@@ -8,15 +8,20 @@ import {
   type ApiVerificationHistorySummary,
   type ApiVerificationHistoryTarget,
 } from "~/services/verification/verificationResultHistory"
-import { useVerificationResultHistorySummaries } from "~/services/verification/verificationResultHistory/useVerificationResultHistorySummaries"
+import {
+  useLatestProfileVerificationSummaries,
+  useVerificationResultHistorySummaries,
+} from "~/services/verification/verificationResultHistory/useVerificationResultHistorySummaries"
 import { requireHistoryTarget } from "~~/tests/test-utils/history"
 
 const {
+  getLatestProfileSummariesMock,
   getLatestSummariesMock,
   subscribeMock,
   unsubscribeMock,
   loggerErrorMock,
 } = vi.hoisted(() => ({
+  getLatestProfileSummariesMock: vi.fn(),
   getLatestSummariesMock: vi.fn(),
   subscribeMock: vi.fn(),
   unsubscribeMock: vi.fn(),
@@ -25,6 +30,8 @@ const {
 
 vi.mock("~/services/verification/verificationResultHistory/storage", () => ({
   verificationResultHistoryStorage: {
+    getLatestProfileSummaries: (...args: unknown[]) =>
+      getLatestProfileSummariesMock(...args),
     getLatestSummaries: (...args: unknown[]) => getLatestSummariesMock(...args),
   },
   subscribeToVerificationResultHistoryChanges: (callback: () => void) => {
@@ -86,10 +93,47 @@ function buildSummary(
 
 describe("useVerificationResultHistorySummaries", () => {
   beforeEach(() => {
+    getLatestProfileSummariesMock.mockReset()
     getLatestSummariesMock.mockReset()
     subscribeMock.mockReset()
     unsubscribeMock.mockReset()
     loggerErrorMock.mockReset()
+  })
+
+  it("deduplicates profile ids and reloads latest profile summaries on storage changes", async () => {
+    const profileTarget = requireHistoryTarget(
+      createProfileVerificationHistoryTarget("profile-a"),
+    )
+    const profileKey = serializeVerificationHistoryTarget(profileTarget)
+    const firstSummary = buildSummary(profileTarget, 1)
+    const secondSummary = buildSummary(profileTarget, 2)
+    getLatestProfileSummariesMock
+      .mockResolvedValueOnce({ [profileKey]: firstSummary })
+      .mockResolvedValueOnce({ [profileKey]: secondSummary })
+
+    const { result } = renderHook(() =>
+      useLatestProfileVerificationSummaries([" profile-a ", "profile-a", ""]),
+    )
+
+    await waitFor(() => {
+      expect(result.current.summariesByKey).toEqual({
+        [profileKey]: firstSummary,
+      })
+    })
+    expect(getLatestProfileSummariesMock).toHaveBeenCalledWith(["profile-a"])
+
+    const callback = subscribeMock.mock.calls[0]?.[0] as
+      | (() => void)
+      | undefined
+    if (!callback) throw new Error("Expected storage listener callback")
+
+    act(() => callback())
+
+    await waitFor(() => {
+      expect(result.current.summariesByKey).toEqual({
+        [profileKey]: secondSummary,
+      })
+    })
   })
 
   it("clears summaries without reloading when targets become empty", async () => {

--- a/tests/utils/formatters.test.ts
+++ b/tests/utils/formatters.test.ts
@@ -12,6 +12,7 @@ import {
   createSortComparator,
   formatFullTime,
   formatKeyTime,
+  formatLocaleDateTime,
   formatQuota,
   formatRelativeTime,
   formatTimestamp,
@@ -31,6 +32,24 @@ import { buildCompleteTodayStatsAvailability } from "~~/tests/test-utils/account
 import { buildDisplaySiteData } from "~~/tests/test-utils/factories"
 
 describe("formatters utilities", () => {
+  describe("formatLocaleDateTime", () => {
+    it("accepts locale date-time options without changing invalid-input fallback behavior", () => {
+      const date = new Date(2026, 5, 1, 8, 30, 45)
+      const options: Intl.DateTimeFormatOptions = {
+        year: "numeric",
+        month: "numeric",
+        day: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+      }
+
+      expect(formatLocaleDateTime(date, "-", options)).toBe(
+        date.toLocaleString(undefined, options),
+      )
+      expect(formatLocaleDateTime(null, "-", options)).toBe("-")
+    })
+  })
+
   describe("maskSecretForDisplay", () => {
     it("fully masks short secrets", () => {
       expect(maskSecretForDisplay("short-key")).toBe("******")


### PR DESCRIPTION
## Summary

- group API credential profiles that share a normalized Base URL
- preserve independent profile details, editing, verification, and endpoint actions
- add responsive endpoint navigation and shortcuts for copying URLs or adding credentials
- centralize related runtime value contracts and align inline row actions

## Testing

- `pnpm compile`
- changed Vitest files: 138 tests passed
- `pnpm run i18n:extract:ci`
- `pnpm knip`
- API credential grouping/options Playwright flows: 9 tests passed

Fixes #1256

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API credential profiles are now grouped by Base URL, with endpoint navigation, credential counts, and endpoint-level copy/add actions.
  * Credential cards include responsive audit timestamps and expandable telemetry details.
  * Verification history displays the latest profile status more consistently.
* **Bug Fixes**
  * Improved profile filtering, endpoint selection, and verification status handling across options and popup views.
* **Style**
  * Added clearer, transparent destructive controls for deleting credentials, tags, keys, and tokens.
* **Localization**
  * Added endpoint-grouping translations across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->