### PR TITLE
fix(api): restore provider key compatibility

### DIFF
--- a/src/services/apiAdapters/newApi/tokenTransport.ts
+++ b/src/services/apiAdapters/newApi/tokenTransport.ts
@@ -25,9 +25,16 @@ const oneHubOverrides: Partial<NewApiFamilyTokenTransport> = {
   fetchAccountAvailableModels: oneHub.fetchAccountAvailableModels,
 }
 
+const zeroBasedTokenInventoryOverrides: Partial<NewApiFamilyTokenTransport> = {
+  fetchAccountTokens: (request) =>
+    defaultTransport.fetchAccountTokens(request, 0),
+}
+
 const overrides: Partial<
   Record<AccountSiteType, Partial<NewApiFamilyTokenTransport>>
 > = {
+  [SITE_TYPES.ONE_API]: zeroBasedTokenInventoryOverrides,
+  [SITE_TYPES.VELOERA]: zeroBasedTokenInventoryOverrides,
   [SITE_TYPES.ONE_HUB]: oneHubOverrides,
   [SITE_TYPES.DONE_HUB]: oneHubOverrides,
   [SITE_TYPES.WONG_GONGYI]: {

--- a/src/services/apiService/newApiFamily/default/keyManagement.ts
+++ b/src/services/apiService/newApiFamily/default/keyManagement.ts
@@ -50,12 +50,14 @@ interface KeyManagementImplementation {
  * Fetch the complete New API-family token list behind provider pagination.
  * New API uses one-based page numbers:
  * https://github.com/QuantumNous/new-api/blob/9c97e78aced572d540f227007a675d7d007666ac/common/page_info.go
- * One API and Veloera return bare paged arrays, which terminate on an empty page:
+ * One API and Veloera use zero-based pages and return bare arrays, which
+ * terminate on an empty page:
  * https://github.com/songquanpeng/one-api/blob/main/controller/token.go
  * https://github.com/Veloera/Veloera/blob/main/controller/token.go
  */
 export async function fetchAccountTokens(
   request: ApiServiceRequest,
+  startPage = 1,
 ): Promise<ApiToken[]> {
   const tokens = await fetchAllItems<ApiToken>(
     async (page) => {
@@ -84,7 +86,7 @@ export async function fetchAccountTokens(
     },
     {
       pageSize: REQUEST_CONFIG.DEFAULT_PAGE_SIZE,
-      startPage: 1,
+      startPage,
       requireComplete: true,
     },
   )

--- a/src/services/apiService/sub2api/parsing.ts
+++ b/src/services/apiService/sub2api/parsing.ts
@@ -546,19 +546,23 @@ export const translateSub2ApiCreateTokenRequest = (
   groupId?: number,
   nowMs?: number,
 ): Sub2ApiCreateKeyPayload => {
+  const expiresInDays =
+    tokenData.expired_time > 0
+      ? convertExpirySecondsToSub2ApiDays(tokenData.expired_time, nowMs)
+      : undefined
+
+  if (expiresInDays === 0) {
+    throw new RangeError("Sub2API token expiration must be in the future")
+  }
+
   return withOptionalGroupId(
     {
       ...buildSub2ApiKeyWritePayloadBase(tokenData),
       // Sub2API models never-expiring keys by omitting this optional field;
       // explicit zero is rejected. https://github.com/Wei-Shaw/sub2api/blob/main/frontend/src/api/keys.ts
-      ...(tokenData.expired_time > 0
-        ? {
-            expires_in_days: convertExpirySecondsToSub2ApiDays(
-              tokenData.expired_time,
-              nowMs,
-            ),
-          }
-        : {}),
+      ...(expiresInDays === undefined
+        ? {}
+        : { expires_in_days: expiresInDays }),
     },
     groupId,
   )

--- a/src/services/apiService/sub2api/parsing.ts
+++ b/src/services/apiService/sub2api/parsing.ts
@@ -549,10 +549,16 @@ export const translateSub2ApiCreateTokenRequest = (
   return withOptionalGroupId(
     {
       ...buildSub2ApiKeyWritePayloadBase(tokenData),
-      expires_in_days:
-        tokenData.expired_time > 0
-          ? convertExpirySecondsToSub2ApiDays(tokenData.expired_time, nowMs)
-          : 0,
+      // Sub2API models never-expiring keys by omitting this optional field;
+      // explicit zero is rejected. https://github.com/Wei-Shaw/sub2api/blob/main/frontend/src/api/keys.ts
+      ...(tokenData.expired_time > 0
+        ? {
+            expires_in_days: convertExpirySecondsToSub2ApiDays(
+              tokenData.expired_time,
+              nowMs,
+            ),
+          }
+        : {}),
     },
     groupId,
   )

--- a/tests/services/apiAdapters/keyManagement.test.ts
+++ b/tests/services/apiAdapters/keyManagement.test.ts
@@ -308,6 +308,17 @@ describe("apiAdapter keyManagement", () => {
     expect(mockFetchAccountAvailableModels).toHaveBeenCalledWith(request)
   })
 
+  it.each([SITE_TYPES.ONE_API, SITE_TYPES.VELOERA])(
+    "uses zero-based token inventory pagination for %s",
+    async (siteType) => {
+      mockFetchAccountTokens.mockResolvedValueOnce([])
+
+      await createNewApiKeyManagement(siteType).fetchTokens(request)
+
+      expect(mockFetchAccountTokens).toHaveBeenCalledWith(request, 0)
+    },
+  )
+
   it("uses OneHub-family key inventory overrides at the adapter layer", async () => {
     const expectedTokens = [token]
     mockOneHubFetchAccountTokens.mockResolvedValueOnce(expectedTokens)

--- a/tests/services/apiService/newApiFamily/keyManagement.test.ts
+++ b/tests/services/apiService/newApiFamily/keyManagement.test.ts
@@ -140,24 +140,24 @@ describe("newApiFamily keyManagement", () => {
     })
   })
 
-  it("fetchAccountTokens reads legacy array pages until the empty sentinel", async () => {
+  it("fetchAccountTokens reads zero-based legacy array pages until the empty sentinel", async () => {
     mockFetchApiData
       .mockResolvedValueOnce([{ id: 1, key: " first " }])
       .mockResolvedValueOnce([{ id: 2, key: " second " }])
       .mockResolvedValueOnce([])
 
-    await expect(fetchAccountTokens(request)).resolves.toEqual([
+    await expect(fetchAccountTokens(request, 0)).resolves.toEqual([
       { id: 1, key: "first" },
       { id: 2, key: "second" },
     ])
     expect(mockFetchApiData).toHaveBeenNthCalledWith(1, request, {
-      endpoint: "/api/token/?p=1&size=100",
+      endpoint: "/api/token/?p=0&size=100",
     })
     expect(mockFetchApiData).toHaveBeenNthCalledWith(2, request, {
-      endpoint: "/api/token/?p=2&size=100",
+      endpoint: "/api/token/?p=1&size=100",
     })
     expect(mockFetchApiData).toHaveBeenNthCalledWith(3, request, {
-      endpoint: "/api/token/?p=3&size=100",
+      endpoint: "/api/token/?p=2&size=100",
     })
   })
 

--- a/tests/services/apiService/sub2api/index.test.ts
+++ b/tests/services/apiService/sub2api/index.test.ts
@@ -595,7 +595,6 @@ describe("apiService sub2api parsing", () => {
       name: "Test Token",
       quota: 0,
       ip_whitelist: [],
-      expires_in_days: 0,
     })
   })
 
@@ -2633,7 +2632,6 @@ describe("apiService sub2api exported operations", () => {
       name: "Test Token",
       quota: 1,
       ip_whitelist: [],
-      expires_in_days: 0,
     })
   })
 

--- a/tests/services/apiService/sub2api/index.test.ts
+++ b/tests/services/apiService/sub2api/index.test.ts
@@ -598,6 +598,25 @@ describe("apiService sub2api parsing", () => {
     })
   })
 
+  it("rejects an already-expired positive timestamp when creating a token", () => {
+    expect(() =>
+      translateSub2ApiCreateTokenRequest(
+        {
+          name: "Expired Token",
+          unlimited_quota: true,
+          remain_quota: 0,
+          expired_time: 1_700_000_000,
+          model_limits_enabled: false,
+          model_limits: "",
+          allow_ips: "",
+          group: "default",
+        },
+        undefined,
+        1_700_000_000_000,
+      ),
+    ).toThrow("Sub2API token expiration must be in the future")
+  })
+
   it("extracts key items from array and object payloads", () => {
     expect(
       extractSub2ApiKeyItems([

--- a/tests/services/apiService/sub2api/keyManagement.test.ts
+++ b/tests/services/apiService/sub2api/keyManagement.test.ts
@@ -662,7 +662,6 @@ describe("apiService sub2api key management service", () => {
       name: "demo key",
       group_id: 10,
       quota: 1.5,
-      expires_in_days: 0,
       ip_whitelist: ["1.1.1.1", "2.2.2.2"],
     })
   })


### PR DESCRIPTION
## Summary

Restore provider-native API key compatibility after two upstream/adapter contract changes:

- keep New API token inventory pagination one-based while using zero-based pagination for One API and Veloera
- omit Sub2API's optional `expires_in_days` field for never-expiring keys

## Root cause

The shared New API-family token inventory path started all providers at `p=1`. Veloera interprets `p` as a zero-based page offset, so a newly created first-page key was skipped during reconciliation.

Sub2API now rejects non-positive `expires_in_days` values. Its create contract treats the omitted optional field as never expiring, while the adapter was sending `0`.

## Validation

- focused Vitest: 180 tests passed across the affected adapter/service suites
- isolated follow-up for broad-run resource-sensitive timeouts: 23 tests passed
- `pnpm compile`
- pre-commit `validate:staged`
- pre-push `validate:push` (`compile` and `knip`)
- Real-Site E2E: Account / Veloera passed
- Real-Site E2E: Account / Sub2API passed
- Real-Site E2E: Account / New API passed

The original New API `AUTH_SESSION_LIMIT` failure was external session capacity; the new-head real-site run passed without a product workaround.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token inventory retrieval for One API and Veloera by using the correct zero-based pagination.
  * Corrected token creation for never-expiring Sub2API tokens by omitting unsupported expiration values.
  * Preserved expiration settings for tokens configured with an expiry period.
  * Added validation to reject expiration dates that have already passed.

* **Tests**
  * Added and updated coverage for pagination and token expiration request behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->