### PR TITLE
test(e2e): stabilize provider-isolated real-site flows

### DIFF
--- a/.github/workflows/e2e-real-site.yml
+++ b/.github/workflows/e2e-real-site.yml
@@ -33,7 +33,12 @@ jobs:
     name: Prepare real-site E2E matrix
     runs-on: ubuntu-latest
     outputs:
-      matrix: ${{ steps.matrix.outputs.matrix }}
+      parallel_matrix: ${{ steps.matrix.outputs.parallel_matrix }}
+      new_api_matrix: ${{ steps.matrix.outputs.new_api_matrix }}
+      sub2api_matrix: ${{ steps.matrix.outputs.sub2api_matrix }}
+      has_parallel: ${{ steps.matrix.outputs.has_parallel }}
+      has_new_api: ${{ steps.matrix.outputs.has_new_api }}
+      has_sub2api: ${{ steps.matrix.outputs.has_sub2api }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -50,14 +55,15 @@ jobs:
   real-site-e2e:
     name: ${{ matrix.label }}
     needs: real-site-matrix
+    if: needs.real-site-matrix.outputs.has_parallel == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
     strategy:
       fail-fast: false
-      matrix: ${{ fromJson(needs.real-site-matrix.outputs.matrix) }}
+      matrix: ${{ fromJson(needs.real-site-matrix.outputs.parallel_matrix) }}
 
-    steps:
+    steps: &real-site-e2e-steps
       - name: Checkout code
         uses: actions/checkout@v5
         with:
@@ -118,17 +124,6 @@ jobs:
           MANAGED_SITE_ADMIN_TOKEN: ${{ secrets[format('AAH_E2E_{0}_ADMIN_TOKEN', matrix.env_prefix)] }}
           MANAGED_SITE_ADMIN_USER_ID: ${{ secrets[format('AAH_E2E_{0}_ADMIN_USER_ID', matrix.env_prefix)] }}
           MANAGED_SITE_EMAIL: ${{ secrets[format('AAH_E2E_{0}_EMAIL', matrix.env_prefix)] }}
-          NEW_API_SOURCE_BASE_URL: ${{ secrets.AAH_E2E_NEW_API_BASE_URL }}
-          NEW_API_SOURCE_USERNAME: ${{ secrets.AAH_E2E_NEW_API_USERNAME }}
-          NEW_API_SOURCE_PASSWORD: ${{ secrets.AAH_E2E_NEW_API_PASSWORD }}
-          NEW_API_SOURCE_TOTP_SECRET: ${{ secrets.AAH_E2E_NEW_API_TOTP_SECRET }}
-          NEW_API_SOURCE_LOGIN_PATH: ${{ secrets.AAH_E2E_NEW_API_LOGIN_PATH }}
-          NEW_API_SOURCE_LOGIN_API_PATH: ${{ secrets.AAH_E2E_NEW_API_LOGIN_API_PATH }}
-          NEW_API_SOURCE_LOGIN_2FA_API_PATH: ${{ secrets.AAH_E2E_NEW_API_LOGIN_2FA_API_PATH }}
-          NEW_API_SOURCE_USERNAME_SELECTOR: ${{ secrets.AAH_E2E_NEW_API_USERNAME_SELECTOR }}
-          NEW_API_SOURCE_PASSWORD_SELECTOR: ${{ secrets.AAH_E2E_NEW_API_PASSWORD_SELECTOR }}
-          NEW_API_SOURCE_SUBMIT_SELECTOR: ${{ secrets.AAH_E2E_NEW_API_SUBMIT_SELECTOR }}
-          NEW_API_SOURCE_AGREE_SELECTOR: ${{ secrets.AAH_E2E_NEW_API_AGREE_SELECTOR }}
           WEBDAV_PROVIDER_NAME: ${{ matrix.provider_name }}
           WEBDAV_PROVIDER_ACCOUNT_PREFIX: ${{ matrix.provider_account_prefix }}
           WEBDAV_URL: ${{ secrets[format('AAH_E2E_{0}_URL', matrix.env_prefix)] }}
@@ -175,18 +170,6 @@ jobs:
             write_env "AAH_E2E_${prefix}_ADMIN_TOKEN" "$MANAGED_SITE_ADMIN_TOKEN"
             write_env "AAH_E2E_${prefix}_ADMIN_USER_ID" "$MANAGED_SITE_ADMIN_USER_ID"
             write_env "AAH_E2E_${prefix}_EMAIL" "$MANAGED_SITE_EMAIL"
-            write_env "AAH_E2E_NEW_API_BASE_URL" "$NEW_API_SOURCE_BASE_URL"
-            write_env "AAH_E2E_NEW_API_USERNAME" "$NEW_API_SOURCE_USERNAME"
-            write_env "AAH_E2E_NEW_API_PASSWORD" "$NEW_API_SOURCE_PASSWORD"
-            write_env "AAH_E2E_NEW_API_TOTP_SECRET" "$NEW_API_SOURCE_TOTP_SECRET"
-            write_env "AAH_E2E_NEW_API_LOGIN_PATH" "$NEW_API_SOURCE_LOGIN_PATH"
-            write_env "AAH_E2E_NEW_API_LOGIN_API_PATH" "$NEW_API_SOURCE_LOGIN_API_PATH"
-            write_env "AAH_E2E_NEW_API_LOGIN_2FA_API_PATH" "$NEW_API_SOURCE_LOGIN_2FA_API_PATH"
-            write_env "AAH_E2E_NEW_API_USERNAME_SELECTOR" "$NEW_API_SOURCE_USERNAME_SELECTOR"
-            write_env "AAH_E2E_NEW_API_PASSWORD_SELECTOR" "$NEW_API_SOURCE_PASSWORD_SELECTOR"
-            write_env "AAH_E2E_NEW_API_SUBMIT_SELECTOR" "$NEW_API_SOURCE_SUBMIT_SELECTOR"
-            write_env "AAH_E2E_NEW_API_AGREE_SELECTOR" "$NEW_API_SOURCE_AGREE_SELECTOR"
-
             [ -z "$REAL_SITE_BASE_URL" ] && missing+=("AAH_E2E_${prefix}_BASE_URL")
             case "$prefix" in
               NEW_API|VELOERA|DONE_HUB)
@@ -246,3 +229,31 @@ jobs:
             playwright-report/
             test-results/
           retention-days: 7
+
+  real-site-e2e-new-api:
+    name: ${{ matrix.label }}
+    needs: real-site-matrix
+    if: needs.real-site-matrix.outputs.has_new_api == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix: ${{ fromJson(needs.real-site-matrix.outputs.new_api_matrix) }}
+
+    steps: *real-site-e2e-steps
+
+  real-site-e2e-sub2api:
+    name: ${{ matrix.label }}
+    needs: real-site-matrix
+    if: needs.real-site-matrix.outputs.has_sub2api == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix: ${{ fromJson(needs.real-site-matrix.outputs.sub2api_matrix) }}
+
+    steps: *real-site-e2e-steps

--- a/e2e/realSite/managedSiteChannels.spec.ts
+++ b/e2e/realSite/managedSiteChannels.spec.ts
@@ -304,13 +304,6 @@ async function maybePrepareStatusSourceAccount(params: {
     if (!sourceAccountResult.sourceAccount) return sourceAccountResult
 
     return { sourceAccount: sourceAccountResult.sourceAccount }
-  } catch (error) {
-    return {
-      sourceAccount: null,
-      skipReason: `Failed to prepare ${sourceAccountType} source account for ${params.managedSiteLabel} managed-site status checks: ${
-        error instanceof Error ? error.message : String(error)
-      }`,
-    }
   } finally {
     if (!sitePage.isClosed()) {
       await sitePage.close()

--- a/e2e/realSite/managedSiteChannels.spec.ts
+++ b/e2e/realSite/managedSiteChannels.spec.ts
@@ -5,6 +5,7 @@ import type { UserPreferences } from "~/services/preferences/userPreferences"
 import { test } from "~~/e2e/fixtures/extensionTest"
 import {
   buildManagedSiteE2ePrefix,
+  getManagedSiteStatusSourceAccountType,
   runManagedSiteChannelsCrudScenario,
   runManagedSiteTokenChannelStatusScenario,
 } from "~~/e2e/scenarios/managedSiteChannels"
@@ -34,6 +35,11 @@ import {
   resolveNewApiRealSiteConfig,
 } from "~~/e2e/utils/realSite/newApi"
 import { readEnv } from "~~/e2e/utils/realSite/shared"
+import {
+  getSub2ApiRealSiteSkipReason,
+  resolveSub2ApiRealSiteConfig,
+} from "~~/e2e/utils/realSite/sub2api"
+import { runSub2ApiRealSiteAccountSaveFlow } from "~~/e2e/utils/realSite/sub2apiAccountSaveFlow"
 
 type ServiceWorker = Awaited<ReturnType<typeof getServiceWorker>>
 
@@ -270,28 +276,13 @@ async function maybePrepareStatusSourceAccount(params: {
   > | null
   skipReason?: string
 }> {
-  if (
-    params.managedSiteType !== SITE_TYPES.NEW_API &&
-    params.managedSiteType !== SITE_TYPES.SUB2API
-  ) {
+  const sourceAccountType = getManagedSiteStatusSourceAccountType(
+    params.managedSiteType,
+  )
+  if (!sourceAccountType) {
     return {
       sourceAccount: null,
       skipReason: `${params.managedSiteLabel} token channel status is not covered by this real-site E2E`,
-    }
-  }
-
-  const realSite = {
-    ...resolveNewApiRealSiteConfig(),
-    siteType: SITE_TYPES.NEW_API,
-    expectedDetectedSiteType: undefined,
-    login: loginToRealNewApiSite,
-    label: "New API",
-  }
-
-  if (!realSite.config) {
-    return {
-      sourceAccount: null,
-      skipReason: `${realSite.label} source account E2E env is missing`,
     }
   }
 
@@ -305,27 +296,18 @@ async function maybePrepareStatusSourceAccount(params: {
 
   const sitePage = await params.context.newPage()
   try {
-    const sourceAccount = await runCompatibleRealSiteAccountSaveFlow({
-      page: params.page,
-      extensionId: params.extensionId,
-      serviceWorker: params.serviceWorker,
-      sitePage,
-      config: realSite.config,
-      siteType: realSite.siteType,
-      expectedDetectedSiteType: realSite.expectedDetectedSiteType,
-      extensionPageGuardOptions: {
-        ignoreConsoleErrorPatterns: [
-          /Failed to load resource: .*status of (401|429|500)/u,
-        ],
-      },
-      login: realSite.login,
-    })
+    const sourceAccountResult =
+      sourceAccountType === SITE_TYPES.SUB2API
+        ? await prepareSub2ApiStatusSourceAccount({ ...params, sitePage })
+        : await prepareNewApiStatusSourceAccount({ ...params, sitePage })
 
-    return { sourceAccount }
+    if (!sourceAccountResult.sourceAccount) return sourceAccountResult
+
+    return { sourceAccount: sourceAccountResult.sourceAccount }
   } catch (error) {
     return {
       sourceAccount: null,
-      skipReason: `Failed to prepare ${realSite.label} source account for ${params.managedSiteLabel} managed-site status checks: ${
+      skipReason: `Failed to prepare ${sourceAccountType} source account for ${params.managedSiteLabel} managed-site status checks: ${
         error instanceof Error ? error.message : String(error)
       }`,
     }
@@ -333,5 +315,60 @@ async function maybePrepareStatusSourceAccount(params: {
     if (!sitePage.isClosed()) {
       await sitePage.close()
     }
+  }
+}
+
+type StatusSourceAccountParams = Parameters<
+  typeof maybePrepareStatusSourceAccount
+>[0] & { sitePage: Page }
+
+async function prepareNewApiStatusSourceAccount(
+  params: StatusSourceAccountParams,
+) {
+  const realSite = resolveNewApiRealSiteConfig()
+  if (!realSite.config) {
+    return {
+      sourceAccount: null,
+      skipReason: "New API source account E2E env is missing",
+    }
+  }
+
+  return {
+    sourceAccount: await runCompatibleRealSiteAccountSaveFlow({
+      page: params.page,
+      extensionId: params.extensionId,
+      serviceWorker: params.serviceWorker,
+      sitePage: params.sitePage,
+      config: realSite.config,
+      siteType: SITE_TYPES.NEW_API,
+      extensionPageGuardOptions: {
+        ignoreConsoleErrorPatterns: [
+          /Failed to load resource: .*status of (401|429|500)/u,
+        ],
+      },
+      login: loginToRealNewApiSite,
+    }),
+  }
+}
+
+async function prepareSub2ApiStatusSourceAccount(
+  params: StatusSourceAccountParams,
+) {
+  const realSite = resolveSub2ApiRealSiteConfig()
+  if (!realSite.config) {
+    return {
+      sourceAccount: null,
+      skipReason: getSub2ApiRealSiteSkipReason(realSite.missingEnvKeys),
+    }
+  }
+
+  return {
+    sourceAccount: await runSub2ApiRealSiteAccountSaveFlow({
+      page: params.page,
+      extensionId: params.extensionId,
+      serviceWorker: params.serviceWorker,
+      sitePage: params.sitePage,
+      config: realSite.config,
+    }),
   }
 }

--- a/e2e/realSite/sub2apiAccountAdd.spec.ts
+++ b/e2e/realSite/sub2apiAccountAdd.spec.ts
@@ -1,12 +1,10 @@
-import { SITE_TYPES } from "~/constants/siteType"
-import { expect, test } from "~~/e2e/fixtures/extensionTest"
+import { test } from "~~/e2e/fixtures/extensionTest"
 import {
   forceExtensionLanguage,
   seedUserPreferences,
   stubLlmMetadataIndex,
 } from "~~/e2e/utils/commonUserFlows"
 import { getServiceWorker } from "~~/e2e/utils/extensionState"
-import { runRealSiteAccountSaveFlow } from "~~/e2e/utils/realSite/accountSaveFlow"
 import {
   realSiteAccountUsageChecks,
   runRealSiteAccountFixtureUsageChecks,
@@ -18,9 +16,9 @@ import {
 } from "~~/e2e/utils/realSite/sharedAccountFixture"
 import {
   getSub2ApiRealSiteSkipReason,
-  loginToRealSub2ApiSite,
   resolveSub2ApiRealSiteConfig,
 } from "~~/e2e/utils/realSite/sub2api"
+import { runSub2ApiRealSiteAccountSaveFlow } from "~~/e2e/utils/realSite/sub2apiAccountSaveFlow"
 
 const ACCOUNT_BACKED_MODEL_CATALOG_UNAVAILABLE_REASON =
   "Sub2API account model catalog skipped because this site type does not expose an account-backed model catalog."
@@ -90,76 +88,12 @@ test.describe("real-site E2E: Sub2API auto-detect account add flow", () => {
             prepareAccountFixture: async () => {
               const sitePage = await context.newPage()
               try {
-                return await runRealSiteAccountSaveFlow({
+                return await runSub2ApiRealSiteAccountSaveFlow({
                   page,
                   extensionId,
                   serviceWorker,
                   sitePage,
-                  baseUrl: config.baseUrl,
-                  siteType: SITE_TYPES.SUB2API,
-                  expectedDetectedSiteType: SITE_TYPES.SUB2API,
-                  login: async (realSitePage) => {
-                    const loginResult = await loginToRealSub2ApiSite(
-                      realSitePage,
-                      config,
-                    )
-                    expect(loginResult.authState.accessToken).not.toBe("")
-
-                    return {
-                      prepareDetectedDialog: async (dialog) => {
-                        await expect(dialog.siteNameInput).toHaveValue(/.+/, {
-                          timeout: 30_000,
-                        })
-
-                        await expect(dialog.userIdInput).toHaveValue(/.+/, {
-                          timeout: 30_000,
-                        })
-                        await expect
-                          .poll(
-                            async () =>
-                              (await dialog.accessTokenInput.inputValue()) ===
-                              loginResult.authState.accessToken,
-                            { timeout: 30_000 },
-                          )
-                          .toBe(true)
-                        await expect(
-                          dialog.sub2apiRefreshTokenSwitch,
-                        ).toHaveAttribute("aria-checked", "false")
-                        await expect(
-                          dialog.sub2apiImportSessionButton,
-                        ).toHaveCount(0)
-
-                        if (!loginResult.authState.refreshToken) {
-                          return
-                        }
-
-                        await dialog.sub2apiRefreshTokenSwitch.click()
-                        await expect(
-                          dialog.sub2apiRefreshTokenSwitch,
-                        ).toHaveAttribute("aria-checked", "true")
-
-                        const importSessionButtonVisible =
-                          await dialog.sub2apiImportSessionButton
-                            .waitFor({ state: "visible", timeout: 5_000 })
-                            .then(() => true)
-                            .catch(() => false)
-
-                        if (!importSessionButtonVisible) {
-                          return
-                        }
-
-                        await dialog.sub2apiImportSessionButton.click()
-                        await expect
-                          .poll(
-                            async () =>
-                              (await dialog.sub2apiRefreshTokenInput.inputValue()) ===
-                              loginResult.authState.refreshToken,
-                            { timeout: 30_000 },
-                          )
-                          .toBe(true)
-                      },
-                    }
-                  },
+                  config,
                 })
               } finally {
                 if (!sitePage.isClosed()) {

--- a/e2e/scenarios/accountAutoDetect.ts
+++ b/e2e/scenarios/accountAutoDetect.ts
@@ -9,33 +9,16 @@ import {
 import { saveAutoDetectedAccountFromApp } from "~~/e2e/utils/accountLifecycle"
 import type { getServiceWorker } from "~~/e2e/utils/extensionState"
 import type { AccountAddDialog } from "~~/e2e/utils/realSite/accountAdd"
-import { throwScenarioError } from "~~/e2e/utils/scenarioErrors"
+import {
+  collectCleanupError,
+  throwScenarioError,
+} from "~~/e2e/utils/scenarioErrors"
 
 type ServiceWorker = Awaited<ReturnType<typeof getServiceWorker>>
 
 type AccountDetectionContext = void | {
   prepareDetectedDialog?: (dialog: AccountAddDialog) => Promise<void>
   cleanupDetectableSite?: () => Promise<void>
-}
-
-async function runFinalizers(finalizers: Array<() => Promise<void>>) {
-  const errors: unknown[] = []
-
-  for (const finalizer of finalizers) {
-    try {
-      await finalizer()
-    } catch (error) {
-      errors.push(error)
-    }
-  }
-
-  if (errors.length === 1) {
-    throw errors[0]
-  }
-
-  if (errors.length > 1) {
-    throw new AggregateError(errors, "Account auto-detect cleanup failed")
-  }
 }
 
 type AccountAutoDetectEnvironment = {
@@ -84,9 +67,8 @@ export async function runAccountAutoDetectScenario(
     primaryError = error
   }
 
-  let cleanupError: unknown
-  try {
-    await runFinalizers([
+  const cleanupError = await collectCleanupError(
+    [
       async () => {
         await detectionContext?.cleanupDetectableSite?.()
       },
@@ -96,10 +78,9 @@ export async function runAccountAutoDetectScenario(
       async () => {
         await sitePage.close()
       },
-    ])
-  } catch (error) {
-    cleanupError = error
-  }
+    ],
+    "Account auto-detect cleanup failed",
+  )
 
   throwScenarioError({
     primaryError,

--- a/e2e/scenarios/accountAutoDetect.ts
+++ b/e2e/scenarios/accountAutoDetect.ts
@@ -9,6 +9,7 @@ import {
 import { saveAutoDetectedAccountFromApp } from "~~/e2e/utils/accountLifecycle"
 import type { getServiceWorker } from "~~/e2e/utils/extensionState"
 import type { AccountAddDialog } from "~~/e2e/utils/realSite/accountAdd"
+import { throwScenarioError } from "~~/e2e/utils/scenarioErrors"
 
 type ServiceWorker = Awaited<ReturnType<typeof getServiceWorker>>
 
@@ -34,27 +35,6 @@ async function runFinalizers(finalizers: Array<() => Promise<void>>) {
 
   if (errors.length > 1) {
     throw new AggregateError(errors, "Account auto-detect cleanup failed")
-  }
-}
-
-function throwScenarioError(params: {
-  primaryError: unknown
-  cleanupError: unknown
-  message: string
-}) {
-  if (params.primaryError && params.cleanupError) {
-    throw new AggregateError(
-      [params.primaryError, params.cleanupError],
-      params.message,
-    )
-  }
-
-  if (params.primaryError) {
-    throw params.primaryError
-  }
-
-  if (params.cleanupError) {
-    throw params.cleanupError
   }
 }
 

--- a/e2e/scenarios/accountKeyLifecycle.ts
+++ b/e2e/scenarios/accountKeyLifecycle.ts
@@ -9,7 +9,7 @@ import {
   submitTokenCreationFromKeyManagementPage,
 } from "~~/e2e/utils/accountLifecycle"
 import type { getServiceWorker } from "~~/e2e/utils/extensionState"
-import { formatScenarioError } from "~~/e2e/utils/scenarioErrors"
+import { throwScenarioError } from "~~/e2e/utils/scenarioErrors"
 
 type ServiceWorker = Awaited<ReturnType<typeof getServiceWorker>>
 
@@ -30,27 +30,6 @@ async function runFinalizers(finalizers: Array<() => Promise<void>>) {
 
   if (errors.length > 1) {
     throw new AggregateError(errors, "Account key lifecycle cleanup failed")
-  }
-}
-
-function throwScenarioError(params: {
-  primaryError: unknown
-  cleanupError: unknown
-  message: string
-}) {
-  if (params.primaryError && params.cleanupError) {
-    throw new AggregateError(
-      [params.primaryError, params.cleanupError],
-      `${params.message}: primary=${formatScenarioError(params.primaryError)}; cleanup=${formatScenarioError(params.cleanupError)}`,
-    )
-  }
-
-  if (params.primaryError) {
-    throw params.primaryError
-  }
-
-  if (params.cleanupError) {
-    throw params.cleanupError
   }
 }
 

--- a/e2e/scenarios/accountKeyLifecycle.ts
+++ b/e2e/scenarios/accountKeyLifecycle.ts
@@ -9,29 +9,12 @@ import {
   submitTokenCreationFromKeyManagementPage,
 } from "~~/e2e/utils/accountLifecycle"
 import type { getServiceWorker } from "~~/e2e/utils/extensionState"
-import { throwScenarioError } from "~~/e2e/utils/scenarioErrors"
+import {
+  collectCleanupError,
+  throwScenarioError,
+} from "~~/e2e/utils/scenarioErrors"
 
 type ServiceWorker = Awaited<ReturnType<typeof getServiceWorker>>
-
-async function runFinalizers(finalizers: Array<() => Promise<void>>) {
-  const errors: unknown[] = []
-
-  for (const finalizer of finalizers) {
-    try {
-      await finalizer()
-    } catch (error) {
-      errors.push(error)
-    }
-  }
-
-  if (errors.length === 1) {
-    throw errors[0]
-  }
-
-  if (errors.length > 1) {
-    throw new AggregateError(errors, "Account key lifecycle cleanup failed")
-  }
-}
 
 type AccountKeyLifecycleEnvironment = {
   extensionId: string
@@ -89,9 +72,8 @@ export async function runAccountKeyLifecycleScenario(
     primaryError = error
   }
 
-  let cleanupError: unknown
-  try {
-    await runFinalizers([
+  const cleanupError = await collectCleanupError(
+    [
       async () => {
         if (submittedTokenName) {
           await deleteTokenFromKeyManagementPage({
@@ -108,10 +90,9 @@ export async function runAccountKeyLifecycleScenario(
       async () => {
         await env.cleanup?.()
       },
-    ])
-  } catch (error) {
-    cleanupError = error
-  }
+    ],
+    "Account key lifecycle cleanup failed",
+  )
 
   throwScenarioError({
     primaryError,

--- a/e2e/scenarios/accountKeyToApiProfile.ts
+++ b/e2e/scenarios/accountKeyToApiProfile.ts
@@ -13,7 +13,7 @@ import {
   type SavedApiCredentialProfileExpectation,
 } from "~~/e2e/utils/accountLifecycle"
 import type { getServiceWorker } from "~~/e2e/utils/extensionState"
-import { formatScenarioError } from "~~/e2e/utils/scenarioErrors"
+import { throwScenarioError } from "~~/e2e/utils/scenarioErrors"
 
 type ServiceWorker = Awaited<ReturnType<typeof getServiceWorker>>
 
@@ -75,27 +75,6 @@ async function runFinalizers(finalizers: Array<() => Promise<void>>) {
       errors,
       "Account key to API profile cleanup failed",
     )
-  }
-}
-
-function throwScenarioError(params: {
-  primaryError: unknown
-  cleanupError: unknown
-  message: string
-}) {
-  if (params.primaryError && params.cleanupError) {
-    throw new AggregateError(
-      [params.primaryError, params.cleanupError],
-      `${params.message}: primary=${formatScenarioError(params.primaryError)}; cleanup=${formatScenarioError(params.cleanupError)}`,
-    )
-  }
-
-  if (params.primaryError) {
-    throw params.primaryError
-  }
-
-  if (params.cleanupError) {
-    throw params.cleanupError
   }
 }
 

--- a/e2e/scenarios/accountKeyToApiProfile.ts
+++ b/e2e/scenarios/accountKeyToApiProfile.ts
@@ -13,7 +13,10 @@ import {
   type SavedApiCredentialProfileExpectation,
 } from "~~/e2e/utils/accountLifecycle"
 import type { getServiceWorker } from "~~/e2e/utils/extensionState"
-import { throwScenarioError } from "~~/e2e/utils/scenarioErrors"
+import {
+  collectCleanupError,
+  throwScenarioError,
+} from "~~/e2e/utils/scenarioErrors"
 
 type ServiceWorker = Awaited<ReturnType<typeof getServiceWorker>>
 
@@ -53,29 +56,6 @@ type ExistingAccountTokenToApiProfileEnvironment = {
   cleanupCreatedProfile?: boolean
   afterProfileSaved?: (profile: ApiCredentialProfile) => Promise<void>
   cleanup?: () => Promise<void>
-}
-
-async function runFinalizers(finalizers: Array<() => Promise<void>>) {
-  const errors: unknown[] = []
-
-  for (const finalizer of finalizers) {
-    try {
-      await finalizer()
-    } catch (error) {
-      errors.push(error)
-    }
-  }
-
-  if (errors.length === 1) {
-    throw errors[0]
-  }
-
-  if (errors.length > 1) {
-    throw new AggregateError(
-      errors,
-      "Account key to API profile cleanup failed",
-    )
-  }
 }
 
 export async function runAccountKeyToApiProfileScenario(
@@ -129,9 +109,8 @@ export async function runAccountKeyToApiProfileScenario(
     primaryError = error
   }
 
-  let cleanupError: unknown
-  try {
-    await runFinalizers([
+  const cleanupError = await collectCleanupError(
+    [
       async () => {
         if (env.cleanupCreatedProfile !== false && savedProfile) {
           await deleteApiCredentialProfileFromStorage({
@@ -156,10 +135,9 @@ export async function runAccountKeyToApiProfileScenario(
       async () => {
         await env.cleanup?.()
       },
-    ])
-  } catch (error) {
-    cleanupError = error
-  }
+    ],
+    "Account key to API profile cleanup failed",
+  )
 
   throwScenarioError({
     primaryError,
@@ -214,9 +192,8 @@ export async function saveExistingAccountTokenToApiProfileScenario(
     primaryError = error
   }
 
-  let cleanupError: unknown
-  try {
-    await runFinalizers([
+  const cleanupError = await collectCleanupError(
+    [
       async () => {
         if (env.cleanupCreatedProfile !== false && savedProfile) {
           await deleteApiCredentialProfileFromStorage({
@@ -233,10 +210,9 @@ export async function saveExistingAccountTokenToApiProfileScenario(
       async () => {
         await env.cleanup?.()
       },
-    ])
-  } catch (error) {
-    cleanupError = error
-  }
+    ],
+    "Account key to API profile cleanup failed",
+  )
 
   throwScenarioError({
     primaryError,

--- a/e2e/scenarios/managedSiteChannels.ts
+++ b/e2e/scenarios/managedSiteChannels.ts
@@ -3,7 +3,11 @@ import type { Locator, Page } from "@playwright/test"
 import { CHANNEL_DIALOG_TEST_IDS } from "~/components/dialogs/ChannelDialog/testIds"
 import { OPTIONS_PAGE_PATH } from "~/constants/extensionPages"
 import { MENU_ITEM_IDS } from "~/constants/optionsMenuIds"
-import { SITE_TYPES, type ManagedSiteType } from "~/constants/siteType"
+import {
+  SITE_TYPES,
+  type AccountSiteType,
+  type ManagedSiteType,
+} from "~/constants/siteType"
 import { KEY_MANAGEMENT_TEST_IDS } from "~/features/KeyManagement/testIds"
 import {
   getManagedSiteChannelRowActionsButtonTestId,
@@ -41,6 +45,16 @@ type ManagedSiteChannelScenarioContext<TSiteType extends ManagedSiteType> = {
 
 const CRUD_MODEL = "gpt-4o-mini"
 const CRUD_UPDATED_MODEL = "gpt-4.1-mini"
+
+export function getManagedSiteStatusSourceAccountType(
+  siteType: ManagedSiteType,
+): AccountSiteType | null {
+  if (siteType === SITE_TYPES.NEW_API || siteType === SITE_TYPES.SUB2API) {
+    return siteType
+  }
+
+  return null
+}
 
 export function shouldEditModelsInManagedSiteCrudScenario(
   siteType: ManagedSiteType,

--- a/e2e/scenarios/managedSiteChannels.ts
+++ b/e2e/scenarios/managedSiteChannels.ts
@@ -23,6 +23,7 @@ import {
   submitTokenCreationFromKeyManagementPage,
 } from "~~/e2e/utils/accountLifecycle"
 import { waitForExtensionRoot } from "~~/e2e/utils/lazyLoading"
+import { throwScenarioError } from "~~/e2e/utils/scenarioErrors"
 
 type ManagedSiteChannelScenarioContext<TSiteType extends ManagedSiteType> = {
   page: Page
@@ -211,10 +212,12 @@ export async function runManagedSiteTokenChannelStatusScenario<
     }
   }
 
+  const sourceAccount = context.sourceAccount
+  const tokenName = context.tokenName
   const channelName = `${context.runPrefix} status`
   let keyManagementPage = context.page
   let createdTokenName: string | null = null
-  const tokenCleanupPrefix = context.tokenCleanupPrefix ?? context.tokenName
+  const tokenCleanupPrefix = context.tokenCleanupPrefix ?? tokenName
   const sub2ApiInventoryRequests: string[] = []
   const sub2ApiKeyExportRequests: string[] = []
   const observeSub2ApiInventoryRequest = (request: {
@@ -243,6 +246,7 @@ export async function runManagedSiteTokenChannelStatusScenario<
     prefix: context.cleanupPrefix ?? context.runPrefix,
   })
 
+  let primaryError: unknown
   try {
     if (context.siteType === SITE_TYPES.SUB2API) {
       context.page.context().on("request", observeSub2ApiInventoryRequest)
@@ -250,7 +254,7 @@ export async function runManagedSiteTokenChannelStatusScenario<
     keyManagementPage = await openKeyManagementForAccount({
       page: context.page,
       extensionId: context.extensionId,
-      accountId: context.sourceAccount.accountId,
+      accountId: sourceAccount.accountId,
       openFromAccountRow: false,
     })
     await cleanupKeyManagementTokensByPrefix({
@@ -260,13 +264,13 @@ export async function runManagedSiteTokenChannelStatusScenario<
 
     await submitTokenCreationFromKeyManagementPage({
       page: keyManagementPage,
-      tokenName: context.tokenName,
+      tokenName,
     })
-    createdTokenName = context.tokenName
+    createdTokenName = tokenName
 
     const tokenResult = await expectTokenCreatedInKeyManagementPage({
       page: keyManagementPage,
-      tokenName: context.tokenName,
+      tokenName,
     })
     let row = tokenResult.row
 
@@ -291,18 +295,16 @@ export async function runManagedSiteTokenChannelStatusScenario<
     await submitChannelDialogAndWaitForClose(keyManagementPage)
 
     if (context.siteType === SITE_TYPES.SUB2API) {
-      sub2ApiInventoryRequests.length = 0
-      sub2ApiKeyExportRequests.length = 0
       keyManagementPage = await openKeyManagementForAccount({
         page: keyManagementPage,
         extensionId: context.extensionId,
-        accountId: context.sourceAccount.accountId,
+        accountId: sourceAccount.accountId,
         openFromAccountRow: false,
       })
       row = (
         await expectTokenCreatedInKeyManagementPage({
           page: keyManagementPage,
-          tokenName: context.tokenName,
+          tokenName,
         })
       ).row
       await expectManagedSiteImportStatusAfterChannelCreate(row)
@@ -325,33 +327,64 @@ export async function runManagedSiteTokenChannelStatusScenario<
       channelName,
     })
     await expectPaginationSummary(keyManagementPage, "1", "1", "1")
+  } catch (error) {
+    primaryError = error
+  }
 
-    return { skipped: false as const }
-  } finally {
-    context.page.context().off("request", observeSub2ApiInventoryRequest)
-    if (createdTokenName) {
+  context.page.context().off("request", observeSub2ApiInventoryRequest)
+  const cleanupErrors: unknown[] = []
+  const runCleanup = async (cleanup: () => Promise<void>) => {
+    try {
+      await cleanup()
+    } catch (error) {
+      cleanupErrors.push(error)
+    }
+  }
+
+  if (createdTokenName) {
+    await runCleanup(async () => {
       keyManagementPage = await openKeyManagementForAccount({
         page: keyManagementPage,
         extensionId: context.extensionId,
-        accountId: context.sourceAccount.accountId,
+        accountId: sourceAccount.accountId,
         openFromAccountRow: false,
       })
       await deleteTokenFromKeyManagementPage({
         page: keyManagementPage,
         token: createdTokenName,
       })
-    }
+    })
+  }
+  await runCleanup(async () => {
     await cleanupKeyManagementTokensByPrefix({
       page: keyManagementPage,
       prefix: tokenCleanupPrefix,
     })
+  })
+  await runCleanup(async () => {
     await cleanupManagedSiteChannelsByPrefix({
       page: keyManagementPage,
       extensionId: context.extensionId,
       siteType: context.siteType,
       prefix: context.cleanupPrefix ?? context.runPrefix,
     })
-  }
+  })
+
+  const cleanupError =
+    cleanupErrors.length > 1
+      ? new AggregateError(
+          cleanupErrors,
+          "Managed-site token channel status cleanup failed",
+        )
+      : cleanupErrors[0]
+
+  throwScenarioError({
+    primaryError,
+    cleanupError,
+    message: "Managed-site token channel status scenario failed",
+  })
+
+  return { skipped: false as const }
 }
 
 async function openManagedSiteImportDialogFromTokenRow(params: {

--- a/e2e/scenarios/managedSiteChannels.ts
+++ b/e2e/scenarios/managedSiteChannels.ts
@@ -27,7 +27,10 @@ import {
   submitTokenCreationFromKeyManagementPage,
 } from "~~/e2e/utils/accountLifecycle"
 import { waitForExtensionRoot } from "~~/e2e/utils/lazyLoading"
-import { throwScenarioError } from "~~/e2e/utils/scenarioErrors"
+import {
+  collectCleanupError,
+  throwScenarioError,
+} from "~~/e2e/utils/scenarioErrors"
 
 type ManagedSiteChannelScenarioContext<TSiteType extends ManagedSiteType> = {
   page: Page
@@ -328,7 +331,6 @@ export async function runManagedSiteTokenChannelStatusScenario<
       await expect
         .poll(() => sub2ApiKeyExportRequests.length, { timeout: 30_000 })
         .toBeGreaterThan(0)
-      context.page.context().off("request", observeSub2ApiInventoryRequest)
       for (const requestUrl of sub2ApiInventoryRequests) {
         expect(new URL(requestUrl).searchParams.get("search")).toBeNull()
       }
@@ -346,17 +348,10 @@ export async function runManagedSiteTokenChannelStatusScenario<
   }
 
   context.page.context().off("request", observeSub2ApiInventoryRequest)
-  const cleanupErrors: unknown[] = []
-  const runCleanup = async (cleanup: () => Promise<void>) => {
-    try {
-      await cleanup()
-    } catch (error) {
-      cleanupErrors.push(error)
-    }
-  }
+  const cleanupFinalizers: Array<() => Promise<void>> = []
 
   if (createdTokenName) {
-    await runCleanup(async () => {
+    cleanupFinalizers.push(async () => {
       keyManagementPage = await openKeyManagementForAccount({
         page: keyManagementPage,
         extensionId: context.extensionId,
@@ -369,13 +364,13 @@ export async function runManagedSiteTokenChannelStatusScenario<
       })
     })
   }
-  await runCleanup(async () => {
+  cleanupFinalizers.push(async () => {
     await cleanupKeyManagementTokensByPrefix({
       page: keyManagementPage,
       prefix: tokenCleanupPrefix,
     })
   })
-  await runCleanup(async () => {
+  cleanupFinalizers.push(async () => {
     await cleanupManagedSiteChannelsByPrefix({
       page: keyManagementPage,
       extensionId: context.extensionId,
@@ -384,13 +379,10 @@ export async function runManagedSiteTokenChannelStatusScenario<
     })
   })
 
-  const cleanupError =
-    cleanupErrors.length > 1
-      ? new AggregateError(
-          cleanupErrors,
-          "Managed-site token channel status cleanup failed",
-        )
-      : cleanupErrors[0]
+  const cleanupError = await collectCleanupError(
+    cleanupFinalizers,
+    "Managed-site token channel status cleanup failed",
+  )
 
   throwScenarioError({
     primaryError,

--- a/e2e/utils/realSite/sub2api.ts
+++ b/e2e/utils/realSite/sub2api.ts
@@ -30,7 +30,7 @@ type Sub2ApiRealSiteResolution = {
   missingEnvKeys: RequiredSub2ApiRealSiteEnvKey[]
 }
 
-interface Sub2ApiRealSiteConfig {
+export interface Sub2ApiRealSiteConfig {
   baseUrl: string
   loginUrl: string
   loginApiUrl: string

--- a/e2e/utils/realSite/sub2apiAccountSaveFlow.ts
+++ b/e2e/utils/realSite/sub2apiAccountSaveFlow.ts
@@ -1,0 +1,87 @@
+import type { Page } from "@playwright/test"
+
+import { SITE_TYPES } from "~/constants/siteType"
+import { expect } from "~~/e2e/fixtures/extensionTest"
+import type { getServiceWorker } from "~~/e2e/utils/extensionState"
+import { runRealSiteAccountSaveFlow } from "~~/e2e/utils/realSite/accountSaveFlow"
+import {
+  loginToRealSub2ApiSite,
+  type Sub2ApiRealSiteConfig,
+} from "~~/e2e/utils/realSite/sub2api"
+
+type ServiceWorker = Awaited<ReturnType<typeof getServiceWorker>>
+
+export async function runSub2ApiRealSiteAccountSaveFlow(params: {
+  page: Page
+  extensionId: string
+  serviceWorker: ServiceWorker
+  sitePage: Page
+  config: Sub2ApiRealSiteConfig
+}) {
+  return await runRealSiteAccountSaveFlow({
+    page: params.page,
+    extensionId: params.extensionId,
+    serviceWorker: params.serviceWorker,
+    sitePage: params.sitePage,
+    baseUrl: params.config.baseUrl,
+    siteType: SITE_TYPES.SUB2API,
+    expectedDetectedSiteType: SITE_TYPES.SUB2API,
+    login: async (realSitePage) => {
+      const loginResult = await loginToRealSub2ApiSite(
+        realSitePage,
+        params.config,
+      )
+      expect(loginResult.authState.accessToken).not.toBe("")
+
+      return {
+        prepareDetectedDialog: async (dialog) => {
+          await expect(dialog.siteNameInput).toHaveValue(/.+/, {
+            timeout: 30_000,
+          })
+          await expect(dialog.userIdInput).toHaveValue(/.+/, {
+            timeout: 30_000,
+          })
+          await expect
+            .poll(
+              async () =>
+                (await dialog.accessTokenInput.inputValue()) ===
+                loginResult.authState.accessToken,
+              { timeout: 30_000 },
+            )
+            .toBe(true)
+          await expect(dialog.sub2apiRefreshTokenSwitch).toHaveAttribute(
+            "aria-checked",
+            "false",
+          )
+          await expect(dialog.sub2apiImportSessionButton).toHaveCount(0)
+
+          if (!loginResult.authState.refreshToken) return
+
+          await dialog.sub2apiRefreshTokenSwitch.click()
+          await expect(dialog.sub2apiRefreshTokenSwitch).toHaveAttribute(
+            "aria-checked",
+            "true",
+          )
+
+          const importSessionButtonVisible =
+            await dialog.sub2apiImportSessionButton
+              .waitFor({ state: "visible", timeout: 5_000 })
+              .then(() => true)
+              .catch(() => false)
+
+          if (!importSessionButtonVisible) return
+
+          await dialog.sub2apiImportSessionButton.click()
+          await expect
+            .poll(
+              async () =>
+                (await dialog.sub2apiRefreshTokenInput.inputValue()) ===
+                loginResult.authState.refreshToken,
+              { timeout: 30_000 },
+            )
+            .toBe(true)
+        },
+      }
+    },
+  })
+}

--- a/e2e/utils/realSite/sub2apiAccountSaveFlow.ts
+++ b/e2e/utils/realSite/sub2apiAccountSaveFlow.ts
@@ -63,13 +63,9 @@ export async function runSub2ApiRealSiteAccountSaveFlow(params: {
             "true",
           )
 
-          const importSessionButtonVisible =
-            await dialog.sub2apiImportSessionButton
-              .waitFor({ state: "visible", timeout: 5_000 })
-              .then(() => true)
-              .catch(() => false)
-
-          if (!importSessionButtonVisible) return
+          await expect(dialog.sub2apiImportSessionButton).toBeVisible({
+            timeout: 30_000,
+          })
 
           await dialog.sub2apiImportSessionButton.click()
           await expect

--- a/e2e/utils/scenarioErrors.ts
+++ b/e2e/utils/scenarioErrors.ts
@@ -6,23 +6,47 @@ function formatScenarioError(error: unknown) {
   return String(error)
 }
 
+export async function collectCleanupError(
+  finalizers: Array<() => Promise<void>>,
+  message: string,
+): Promise<unknown> {
+  const errors: unknown[] = []
+
+  for (const finalizer of finalizers) {
+    try {
+      await finalizer()
+    } catch (error) {
+      errors.push(error)
+    }
+  }
+
+  if (errors.length > 1) {
+    return new AggregateError(errors, message)
+  }
+
+  return errors[0]
+}
+
 export function throwScenarioError(params: {
   primaryError: unknown
   cleanupError: unknown
   message: string
 }): void {
-  if (params.primaryError && params.cleanupError) {
+  const hasPrimaryError = params.primaryError !== undefined
+  const hasCleanupError = params.cleanupError !== undefined
+
+  if (hasPrimaryError && hasCleanupError) {
     throw new AggregateError(
       [params.primaryError, params.cleanupError],
       `${params.message}: primary=${formatScenarioError(params.primaryError)}; cleanup=${formatScenarioError(params.cleanupError)}`,
     )
   }
 
-  if (params.primaryError) {
+  if (hasPrimaryError) {
     throw params.primaryError
   }
 
-  if (params.cleanupError) {
+  if (hasCleanupError) {
     throw params.cleanupError
   }
 }

--- a/e2e/utils/scenarioErrors.ts
+++ b/e2e/utils/scenarioErrors.ts
@@ -1,7 +1,28 @@
-export function formatScenarioError(error: unknown) {
+function formatScenarioError(error: unknown) {
   if (error instanceof Error) {
     return error.message
   }
 
   return String(error)
+}
+
+export function throwScenarioError(params: {
+  primaryError: unknown
+  cleanupError: unknown
+  message: string
+}): void {
+  if (params.primaryError && params.cleanupError) {
+    throw new AggregateError(
+      [params.primaryError, params.cleanupError],
+      `${params.message}: primary=${formatScenarioError(params.primaryError)}; cleanup=${formatScenarioError(params.cleanupError)}`,
+    )
+  }
+
+  if (params.primaryError) {
+    throw params.primaryError
+  }
+
+  if (params.cleanupError) {
+    throw params.cleanupError
+  }
 }

--- a/scripts/github-real-site-e2e-matrix.mjs
+++ b/scripts/github-real-site-e2e-matrix.mjs
@@ -1,16 +1,50 @@
 #!/usr/bin/env node
 import { appendFileSync } from "node:fs"
 
-import { filterRealSiteE2eMatrix } from "./real-site-e2e-matrix.mjs"
+import {
+  filterRealSiteE2eMatrix,
+  partitionRealSiteE2eMatrix,
+} from "./real-site-e2e-matrix.mjs"
 
 const category = process.argv[2] ?? "all"
 const target = process.argv[3] ?? "all"
 const include = filterRealSiteE2eMatrix(category, target)
 const matrix = JSON.stringify({ include })
+const partitioned = partitionRealSiteE2eMatrix(include)
 const outputFile = process.env.GITHUB_OUTPUT
 
 if (outputFile) {
   appendFileSync(outputFile, `matrix=${matrix}\n`, "utf8")
+  appendFileSync(
+    outputFile,
+    `parallel_matrix=${JSON.stringify({ include: partitioned.parallel })}\n`,
+    "utf8",
+  )
+  appendFileSync(
+    outputFile,
+    `new_api_matrix=${JSON.stringify({ include: partitioned.newApi })}\n`,
+    "utf8",
+  )
+  appendFileSync(
+    outputFile,
+    `sub2api_matrix=${JSON.stringify({ include: partitioned.sub2api })}\n`,
+    "utf8",
+  )
+  appendFileSync(
+    outputFile,
+    `has_parallel=${partitioned.parallel.length > 0}\n`,
+    "utf8",
+  )
+  appendFileSync(
+    outputFile,
+    `has_new_api=${partitioned.newApi.length > 0}\n`,
+    "utf8",
+  )
+  appendFileSync(
+    outputFile,
+    `has_sub2api=${partitioned.sub2api.length > 0}\n`,
+    "utf8",
+  )
 } else {
   console.log(matrix)
 }

--- a/scripts/real-site-e2e-matrix.mjs
+++ b/scripts/real-site-e2e-matrix.mjs
@@ -4,6 +4,11 @@ const REAL_SITE_E2E_CATEGORIES = {
   webdav: "webdav",
 }
 
+const REAL_SITE_E2E_RESOURCE_GROUPS = {
+  newApiAccount: "new-api-account",
+  sub2ApiAccount: "sub2api-account",
+}
+
 const REAL_SITE_E2E_MATRIX = [
   {
     id: "new-api-account",
@@ -11,6 +16,7 @@ const REAL_SITE_E2E_MATRIX = [
     label: "Account / New API",
     env_prefix: "NEW_API",
     kind: "account",
+    resource_group: REAL_SITE_E2E_RESOURCE_GROUPS.newApiAccount,
     spec: "e2e/realSite/newApiAccountAdd.spec.ts",
   },
   {
@@ -43,6 +49,7 @@ const REAL_SITE_E2E_MATRIX = [
     label: "Account / Sub2API",
     env_prefix: "SUB2API",
     kind: "account",
+    resource_group: REAL_SITE_E2E_RESOURCE_GROUPS.sub2ApiAccount,
     spec: "e2e/realSite/sub2apiAccountAdd.spec.ts",
   },
   {
@@ -52,6 +59,7 @@ const REAL_SITE_E2E_MATRIX = [
     env_prefix: "NEW_API",
     kind: "managed-site",
     managed_site_target: "new-api",
+    resource_group: REAL_SITE_E2E_RESOURCE_GROUPS.newApiAccount,
     spec: "e2e/realSite/managedSiteChannels.spec.ts",
   },
   {
@@ -106,6 +114,7 @@ const REAL_SITE_E2E_MATRIX = [
     env_prefix: "SUB2API",
     kind: "managed-site",
     managed_site_target: "sub2api",
+    resource_group: REAL_SITE_E2E_RESOURCE_GROUPS.sub2ApiAccount,
     spec: "e2e/realSite/managedSiteChannels.spec.ts",
   },
   {
@@ -200,6 +209,20 @@ export function filterRealSiteE2eMatrix(category = "all", target = "all") {
   }
 
   return [targetEntry]
+}
+
+export function partitionRealSiteE2eMatrix(entries) {
+  return {
+    parallel: entries.filter((entry) => !entry.resource_group),
+    newApi: entries.filter(
+      (entry) =>
+        entry.resource_group === REAL_SITE_E2E_RESOURCE_GROUPS.newApiAccount,
+    ),
+    sub2api: entries.filter(
+      (entry) =>
+        entry.resource_group === REAL_SITE_E2E_RESOURCE_GROUPS.sub2ApiAccount,
+    ),
+  }
 }
 
 function throwUnknownTarget(target) {

--- a/tests/scripts/realSiteE2eMatrix.test.ts
+++ b/tests/scripts/realSiteE2eMatrix.test.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from "node:child_process"
+import { readFileSync, rmSync } from "node:fs"
 import path from "node:path"
 import { describe, expect, it } from "vitest"
 
@@ -21,6 +22,38 @@ function runMatrix(...args: string[]) {
       stdio: ["ignore", "pipe", "pipe"],
     }),
   ) as { include: Array<Record<string, unknown>> }
+}
+
+function runMatrixWithOutput(...args: string[]) {
+  const scriptPath = path.resolve(
+    process.cwd(),
+    "scripts",
+    "github-real-site-e2e-matrix.mjs",
+  )
+  const outputPath = path.resolve(
+    process.cwd(),
+    ".scratch",
+    `real-site-matrix-${process.pid}-${Date.now()}.txt`,
+  )
+
+  try {
+    execFileSync(process.execPath, [scriptPath, ...args], {
+      encoding: "utf8",
+      env: { ...process.env, GITHUB_OUTPUT: outputPath },
+      stdio: ["ignore", "pipe", "pipe"],
+    })
+    return Object.fromEntries(
+      readFileSync(outputPath, "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => {
+          const separatorIndex = line.indexOf("=")
+          return [line.slice(0, separatorIndex), line.slice(separatorIndex + 1)]
+        }),
+    )
+  } finally {
+    rmSync(outputPath, { force: true })
+  }
 }
 
 function selectedIds(matrix: ReturnType<typeof runMatrix>) {
@@ -76,8 +109,98 @@ describe("GitHub real-site E2E matrix selection", () => {
         category: "managed-site",
         env_prefix: "SUB2API",
         managed_site_target: "sub2api",
+        resource_group: "sub2api-account",
       }),
     ])
+  })
+
+  it("serializes account and managed-site targets within each provider", () => {
+    const matrix = runMatrix()
+    const idsForResourceGroup = (resourceGroup: string) =>
+      matrix.include
+        .filter((entry) => entry.resource_group === resourceGroup)
+        .map((entry) => entry.id)
+
+    expect(idsForResourceGroup("new-api-account")).toEqual([
+      "new-api-account",
+      "new-api-managed-site",
+    ])
+    expect(idsForResourceGroup("sub2api-account")).toEqual([
+      "sub2api-account",
+      "sub2api-managed-site",
+    ])
+    expect(
+      matrix.include.find((entry) => entry.id === "veloera-managed-site"),
+    ).not.toHaveProperty("resource_group")
+  })
+
+  it("emits disjoint parallel and provider-serialized matrices", () => {
+    const output = runMatrixWithOutput()
+    const fullMatrix = JSON.parse(output.matrix) as ReturnType<typeof runMatrix>
+    const parallelMatrix = JSON.parse(output.parallel_matrix) as ReturnType<
+      typeof runMatrix
+    >
+    const newApiMatrix = JSON.parse(output.new_api_matrix) as ReturnType<
+      typeof runMatrix
+    >
+    const sub2ApiMatrix = JSON.parse(output.sub2api_matrix) as ReturnType<
+      typeof runMatrix
+    >
+
+    expect(output.has_parallel).toBe("true")
+    expect(output.has_new_api).toBe("true")
+    expect(output.has_sub2api).toBe("true")
+    expect([
+      ...selectedIds(parallelMatrix),
+      ...selectedIds(newApiMatrix),
+      ...selectedIds(sub2ApiMatrix),
+    ]).toEqual(expect.arrayContaining(selectedIds(fullMatrix)))
+    expect(
+      new Set([
+        ...selectedIds(parallelMatrix),
+        ...selectedIds(newApiMatrix),
+        ...selectedIds(sub2ApiMatrix),
+      ]).size,
+    ).toBe(fullMatrix.include.length)
+  })
+
+  it("keeps a narrow New API target in its provider matrix only", () => {
+    const output = runMatrixWithOutput("all", "new-api-account")
+
+    expect(output.has_parallel).toBe("false")
+    expect(output.has_new_api).toBe("true")
+    expect(output.has_sub2api).toBe("false")
+    expect(JSON.parse(output.parallel_matrix)).toEqual({ include: [] })
+    expect(selectedIds(JSON.parse(output.new_api_matrix))).toEqual([
+      "new-api-account",
+    ])
+    expect(JSON.parse(output.sub2api_matrix)).toEqual({ include: [] })
+  })
+
+  it("keeps a narrow Sub2API target in its provider matrix only", () => {
+    const output = runMatrixWithOutput("all", "sub2api-managed-site")
+
+    expect(output.has_parallel).toBe("false")
+    expect(output.has_new_api).toBe("false")
+    expect(output.has_sub2api).toBe("true")
+    expect(JSON.parse(output.parallel_matrix)).toEqual({ include: [] })
+    expect(JSON.parse(output.new_api_matrix)).toEqual({ include: [] })
+    expect(selectedIds(JSON.parse(output.sub2api_matrix))).toEqual([
+      "sub2api-managed-site",
+    ])
+  })
+
+  it("keeps a narrow independent target in the parallel matrix only", () => {
+    const output = runMatrixWithOutput("all", "veloera-account")
+
+    expect(output.has_parallel).toBe("true")
+    expect(output.has_new_api).toBe("false")
+    expect(output.has_sub2api).toBe("false")
+    expect(selectedIds(JSON.parse(output.parallel_matrix))).toEqual([
+      "veloera-account",
+    ])
+    expect(JSON.parse(output.new_api_matrix)).toEqual({ include: [] })
+    expect(JSON.parse(output.sub2api_matrix)).toEqual({ include: [] })
   })
 
   it("keeps the default all-category matrix unchanged", () => {

--- a/tests/utils/managedSiteChannelsScenario.test.ts
+++ b/tests/utils/managedSiteChannelsScenario.test.ts
@@ -2,9 +2,22 @@ import { describe, expect, it } from "vitest"
 
 import { SITE_TYPES } from "~/constants/siteType"
 import {
+  getManagedSiteStatusSourceAccountType,
   shouldEditModelsInManagedSiteCrudScenario,
   shouldSeedModelsInManagedSiteCrudScenario,
 } from "~~/e2e/scenarios/managedSiteChannels"
+
+describe("getManagedSiteStatusSourceAccountType", () => {
+  it("uses each provider's own account for token channel status", () => {
+    expect(getManagedSiteStatusSourceAccountType(SITE_TYPES.NEW_API)).toBe(
+      SITE_TYPES.NEW_API,
+    )
+    expect(getManagedSiteStatusSourceAccountType(SITE_TYPES.SUB2API)).toBe(
+      SITE_TYPES.SUB2API,
+    )
+    expect(getManagedSiteStatusSourceAccountType(SITE_TYPES.VELOERA)).toBeNull()
+  })
+})
 
 describe("shouldEditModelsInManagedSiteCrudScenario", () => {
   it("skips generic model edits for the AxonHub resource editor", () => {

--- a/tests/utils/scenarioErrors.test.ts
+++ b/tests/utils/scenarioErrors.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest"
+
+import { throwScenarioError } from "~~/e2e/utils/scenarioErrors"
+
+describe("throwScenarioError", () => {
+  it("preserves both the primary failure and a later cleanup failure", () => {
+    const primaryError = new Error("request observation timed out")
+    const cleanupError = new Error("temporary key cleanup failed")
+
+    expect(() =>
+      throwScenarioError({
+        primaryError,
+        cleanupError,
+        message: "Managed-site token channel status scenario failed",
+      }),
+    ).toThrow(
+      expect.objectContaining({
+        errors: [primaryError, cleanupError],
+        message:
+          "Managed-site token channel status scenario failed: primary=request observation timed out; cleanup=temporary key cleanup failed",
+      }),
+    )
+  })
+})

--- a/tests/utils/scenarioErrors.test.ts
+++ b/tests/utils/scenarioErrors.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest"
 
-import { throwScenarioError } from "~~/e2e/utils/scenarioErrors"
+import {
+  collectCleanupError,
+  throwScenarioError,
+} from "~~/e2e/utils/scenarioErrors"
 
 describe("throwScenarioError", () => {
   it("preserves both the primary failure and a later cleanup failure", () => {
@@ -20,5 +23,99 @@ describe("throwScenarioError", () => {
           "Managed-site token channel status scenario failed: primary=request observation timed out; cleanup=temporary key cleanup failed",
       }),
     )
+  })
+
+  it("rethrows a single primary or cleanup failure unwrapped", () => {
+    const primaryError = new Error("request observation timed out")
+    const cleanupError = new Error("temporary key cleanup failed")
+
+    expect(() =>
+      throwScenarioError({
+        primaryError,
+        cleanupError: undefined,
+        message: "Managed-site token channel status scenario failed",
+      }),
+    ).toThrow(primaryError)
+    expect(() =>
+      throwScenarioError({
+        primaryError: undefined,
+        cleanupError,
+        message: "Managed-site token channel status scenario failed",
+      }),
+    ).toThrow(cleanupError)
+  })
+
+  it("preserves falsy thrown values", () => {
+    expect.assertions(1)
+
+    try {
+      throwScenarioError({
+        primaryError: 0,
+        cleanupError: undefined,
+        message: "Managed-site token channel status scenario failed",
+      })
+    } catch (error) {
+      expect(error).toBe(0)
+    }
+  })
+
+  it("does not throw when neither failure occurred", () => {
+    expect(() =>
+      throwScenarioError({
+        primaryError: undefined,
+        cleanupError: undefined,
+        message: "Managed-site token channel status scenario failed",
+      }),
+    ).not.toThrow()
+  })
+})
+
+describe("collectCleanupError", () => {
+  it("runs every finalizer and aggregates multiple failures", async () => {
+    const calls: string[] = []
+    const firstError = new Error("first cleanup failed")
+    const secondError = new Error("second cleanup failed")
+
+    const cleanupError = await collectCleanupError(
+      [
+        async () => {
+          calls.push("first")
+          throw firstError
+        },
+        async () => {
+          calls.push("middle")
+        },
+        async () => {
+          calls.push("last")
+          throw secondError
+        },
+      ],
+      "Scenario cleanup failed",
+    )
+
+    expect(calls).toEqual(["first", "middle", "last"])
+    expect(cleanupError).toEqual(
+      expect.objectContaining({
+        errors: [firstError, secondError],
+        message: "Scenario cleanup failed",
+      }),
+    )
+  })
+
+  it("returns a single failure unwrapped", async () => {
+    const cleanupFailure = new Error("cleanup failed")
+
+    await expect(
+      collectCleanupError(
+        [async () => Promise.reject(cleanupFailure)],
+        "Scenario cleanup failed",
+      ),
+    ).resolves.toBe(cleanupFailure)
+  })
+
+  it("returns undefined when every finalizer succeeds", async () => {
+    await expect(
+      collectCleanupError([async () => undefined], "Scenario cleanup failed"),
+    ).resolves.toBeUndefined()
   })
 })


### PR DESCRIPTION
## Summary

Real-site E2E account and managed-site scenarios were sharing account resources across provider boundaries. This made unrelated New API and Sub2API flows interfere with each other and allowed the Sub2API managed-site scenario to depend on a New API ordinary account.

## What changed

- Split New API and Sub2API account resources into independent serialized groups, while allowing the two provider groups to run in parallel.
- Prepare Sub2API managed-site scenarios with a Sub2API ordinary account and inject only the credentials owned by each provider.
- Reuse the Sub2API account-save flow across account and managed-site specs.
- Preserve the primary scenario failure when cleanup also fails.
- Register Sub2API request observation before triggering the corresponding UI action.

## Validation

- 42 focused Vitest tests passed.
- `pnpm compile` passed.
- `pnpm knip` passed through the pre-push gate.
- Pre-commit and pre-push validation hooks passed.
- Playwright successfully collected 19 affected tests.
- Targeted real-site runs passed:
  - New API account: https://github.com/qixing-jk/all-api-hub/actions/runs/31746819402
  - New API managed site: https://github.com/qixing-jk/all-api-hub/actions/runs/31747100922
  - Sub2API account: https://github.com/qixing-jk/all-api-hub/actions/runs/31747318656
  - Sub2API managed site: https://github.com/qixing-jk/all-api-hub/actions/runs/31747565446

The full `target=all` workflow was not run. Matrix tests cover the grouping topology, and each affected real-site path passed independently.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Expanded real-site testing for New API and Sub2API account and managed-site scenarios.
  * Improved test routing, allowing scenarios to run independently or in controlled sequence.
  * Added validation for provider-specific account details, access tokens, and refresh-token handling.

* **Bug Fixes**
  * Improved cleanup and error reporting so primary and cleanup failures are preserved.

* **Tests**
  * Added coverage for matrix routing, provider mappings, account flows, and combined error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->