### PR TITLE
feat(model-list): normalize identities for price comparison

### DIFF
--- a/src/features/ModelList/ModelList.tsx
+++ b/src/features/ModelList/ModelList.tsx
@@ -222,15 +222,19 @@ export default function ModelList(props: {
 
   const isAllAccountsScope =
     selectedSource?.kind === MODEL_MANAGEMENT_SOURCE_KINDS.ALL_ACCOUNTS
-  const shouldShowPriceComparisonAction = canEnableModelPriceComparison({
-    selectedSource,
-    sourceCapabilities,
-    isAllAccountsSource: isAllAccountsScope,
-    sortMode,
-    selectedBillingMode,
-    selectedGroups,
-    showRealPrice,
-  })
+  const canStartUnselectedPriceComparison =
+    !selectedSource && accounts.length > 0
+  const shouldShowPriceComparisonAction =
+    canStartUnselectedPriceComparison ||
+    canEnableModelPriceComparison({
+      selectedSource,
+      sourceCapabilities,
+      isAllAccountsSource: isAllAccountsScope,
+      sortMode,
+      selectedBillingMode,
+      selectedGroups,
+      showRealPrice,
+    })
   const handleEnablePriceComparison = useCallback(() => {
     enableModelPriceComparison({
       isAllAccountsSource: isAllAccountsScope,
@@ -274,6 +278,9 @@ export default function ModelList(props: {
     selectedSource?.kind === MODEL_MANAGEMENT_SOURCE_KINDS.ALL_ACCOUNTS
       ? pricingContexts && pricingContexts.length > 0
       : !!pricingData
+  const shouldShowRefreshAction = Boolean(selectedSource && hasModelData)
+  const shouldShowHeaderActions =
+    shouldShowRefreshAction || shouldShowPriceComparisonAction
   const isRuntimeKeyOnlyFallbackCatalog =
     isFallbackCatalogActive &&
     !!currentAccount &&
@@ -572,23 +579,25 @@ export default function ModelList(props: {
         }
         description={t("description")}
         actions={
-          selectedSource && hasModelData ? (
+          shouldShowHeaderActions ? (
             <ProductAnalyticsScope
               entrypoint={PRODUCT_ANALYTICS_ENTRYPOINTS.Options}
               featureId={PRODUCT_ANALYTICS_FEATURE_IDS.ModelList}
               surfaceId={PRODUCT_ANALYTICS_SURFACE_IDS.OptionsModelListPage}
             >
-              <Button
-                onClick={loadPricingData}
-                variant="secondary"
-                leftIcon={<ArrowPathIcon className="h-4 w-4" />}
-                loading={isLoading}
-                analyticsAction={
-                  PRODUCT_ANALYTICS_ACTION_IDS.RefreshModelPricingData
-                }
-              >
-                {isLoading ? t("common:status.refreshing") : t("refreshData")}
-              </Button>
+              {shouldShowRefreshAction && (
+                <Button
+                  onClick={loadPricingData}
+                  variant="secondary"
+                  leftIcon={<ArrowPathIcon className="h-4 w-4" />}
+                  loading={isLoading}
+                  analyticsAction={
+                    PRODUCT_ANALYTICS_ACTION_IDS.RefreshModelPricingData
+                  }
+                >
+                  {isLoading ? t("common:status.refreshing") : t("refreshData")}
+                </Button>
+              )}
               {shouldShowPriceComparisonAction && (
                 <Tooltip
                   content={t("comparison.tooltip")}

--- a/src/features/ModelList/components/ModelDisplay.tsx
+++ b/src/features/ModelList/components/ModelDisplay.tsx
@@ -300,10 +300,10 @@ export function ModelDisplay(props: ModelDisplayProps) {
               className="dark:border-dark-bg-tertiary dark:bg-dark-bg-secondary overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm"
             >
               <header className="dark:border-dark-bg-tertiary dark:bg-dark-bg-primary/45 flex min-w-0 flex-wrap items-center gap-x-3 gap-y-2 border-b border-gray-200 bg-gray-50/80 px-3 py-2.5 sm:px-4">
-                <div className="flex w-full min-w-0 items-center gap-2 lg:w-auto lg:flex-1">
+                <div className="flex w-full min-w-0 flex-wrap items-center gap-2 lg:w-auto lg:flex-1">
                   <h2
                     id={headingId}
-                    className="text-foreground min-w-0 flex-1 font-mono text-sm font-semibold break-all"
+                    className="text-foreground max-w-full min-w-0 font-mono text-sm font-semibold break-all"
                   >
                     {group.modelName}
                   </h2>

--- a/src/features/ModelList/components/ModelDisplay.tsx
+++ b/src/features/ModelList/components/ModelDisplay.tsx
@@ -80,7 +80,7 @@ type ModelDisplayEntry =
   | { kind: "model"; item: CalculatedModelItem }
   | { kind: "price-comparison-group"; group: PriceComparisonDisplayGroup }
 
-/** Groups exact model ids while keeping incompatible billing modes separate. */
+/** Groups comparable model identities while keeping billing modes separate. */
 function createPriceComparisonDisplayGroups(
   models: CalculatedModelItem[],
 ): PriceComparisonDisplayGroup[] {
@@ -90,10 +90,10 @@ function createPriceComparisonDisplayGroups(
     const billingMode = isTokenBillingType(item.model.quota_type)
       ? MODEL_LIST_BILLING_MODES.TOKEN_BASED
       : MODEL_LIST_BILLING_MODES.PER_CALL
-    const key = JSON.stringify([item.model.model_name, billingMode])
+    const key = JSON.stringify([item.comparableModelIdentity.key, billingMode])
     const group = groups.get(key) ?? {
       key,
-      modelName: item.model.model_name,
+      modelName: item.comparableModelIdentity.displayName,
       quotaType: item.model.quota_type,
       comparableItems: [],
       notComparedItems: [],

--- a/src/features/ModelList/hooks/useFilteredModels.ts
+++ b/src/features/ModelList/hooks/useFilteredModels.ts
@@ -38,7 +38,11 @@ import {
   MODEL_UNAVAILABLE_PRICE_REASONS,
   type PricingResponse,
 } from "~/services/modelList/pricingModel"
-import { resolveModelIdentity } from "~/services/models/modelMetadata/modelIdentityIndex"
+import {
+  resolveComparableModelIdentity,
+  resolveModelIdentity,
+  type ComparableModelIdentity,
+} from "~/services/models/modelMetadata/modelIdentityIndex"
 import type {
   ModelMetadata,
   ModelVendorCandidate,
@@ -103,6 +107,7 @@ interface RawModelItem {
   groupContext: ModelGroupContext
   exchangeRate: number
   modelMetadata?: ModelMetadata
+  comparableModelIdentity: ComparableModelIdentity
   resolvedVendor: ResolvedModelVendor
 }
 
@@ -129,6 +134,7 @@ export type CalculatedModelItem = {
   activeGroupContext: ActiveModelGroupContext
   effectiveGroup?: string
   modelMetadata?: ModelMetadata
+  comparableModelIdentity: ComparableModelIdentity
   resolvedVendor: ResolvedModelVendor
   hasAutoSelectedGroup?: boolean
   isLowestPrice?: boolean
@@ -527,6 +533,7 @@ function resolveBestCalculatedItem(
     activeGroupContext: params.activeGroupContext,
     effectiveGroup: params.effectiveGroup,
     modelMetadata: rawItem.modelMetadata,
+    comparableModelIdentity: rawItem.comparableModelIdentity,
     resolvedVendor: rawItem.resolvedVendor,
     hasAutoSelectedGroup: params.hasAutoSelectedGroup,
   })
@@ -743,7 +750,10 @@ export function useFilteredModels(params: UseFilteredModelsProps) {
     }
 
     const attachVendorCandidate = (
-      item: Omit<RawModelItem, "resolvedVendor" | "modelMetadata">,
+      item: Omit<
+        RawModelItem,
+        "resolvedVendor" | "modelMetadata" | "comparableModelIdentity"
+      >,
     ): CandidateRawModelItem => {
       const lookupResult = resolveModelIdentity(
         modelMetadataIndex,
@@ -754,6 +764,10 @@ export function useFilteredModels(params: UseFilteredModelsProps) {
         ...item,
         modelMetadata:
           lookupResult.state === "resolved" ? lookupResult.metadata : undefined,
+        comparableModelIdentity: resolveComparableModelIdentity(
+          modelMetadataIndex,
+          item.model.model_name,
+        ),
         vendorCandidate: resolveModelVendorCandidate(
           {
             id: item.model.model_name,
@@ -1396,7 +1410,10 @@ export function useFilteredModels(params: UseFilteredModelsProps) {
           return
         }
 
-        const groupKey = `${item.model.model_name}:${priceKey.billingMode}`
+        const groupKey = JSON.stringify([
+          item.comparableModelIdentity.key,
+          priceKey.billingMode,
+        ])
         const group = groups.get(groupKey) ?? []
         group.push(item)
         groups.set(groupKey, group)
@@ -1458,11 +1475,12 @@ export function useFilteredModels(params: UseFilteredModelsProps) {
       b: (typeof indexedItems)[number] & { priceKey: ComparablePriceKey },
     ) => {
       if (sortMode === MODEL_LIST_SORT_MODES.MODEL_CHEAPEST_FIRST) {
-        const modelNameComparison = a.item.model.model_name.localeCompare(
-          b.item.model.model_name,
+        const modelIdentityComparison = compareCodePoints(
+          a.item.comparableModelIdentity.key,
+          b.item.comparableModelIdentity.key,
         )
-        if (modelNameComparison !== 0) {
-          return modelNameComparison
+        if (modelIdentityComparison !== 0) {
+          return modelIdentityComparison
         }
       }
 

--- a/src/services/models/modelMetadata/modelIdentityIndex.ts
+++ b/src/services/models/modelMetadata/modelIdentityIndex.ts
@@ -53,6 +53,13 @@ function getBareIdentity(value: string): string {
   return lastSlashIndex === -1 ? value : value.slice(lastSlashIndex + 1)
 }
 
+/** Extracts an undecorated model id while retaining version/date suffixes. */
+export function extractCoreModelIdentity(modelName: string): string {
+  const bareIdentity = getBareIdentity(modelName)
+  const colonIndex = bareIdentity.indexOf(":")
+  return colonIndex === -1 ? bareIdentity : bareIdentity.slice(0, colonIndex)
+}
+
 /**
  * Builds an order-insensitive alias key while retaining the leading model token.
  */
@@ -204,6 +211,24 @@ class ModelIdentityIndexImpl {
 
 export type ModelIdentityIndex = ModelIdentityIndexImpl
 
+export interface ComparableModelIdentity {
+  key: string
+  displayName: string
+}
+
+/** Converts one resolved metadata match into a comparable identity. */
+function toCanonicalComparableIdentity(
+  result: ModelIdentityLookupResult,
+): ComparableModelIdentity | null {
+  if (result.state !== "resolved") return null
+
+  const canonicalId = normalizeIdentity(result.metadata.id)
+  return {
+    key: `canonical:${canonicalId}`,
+    displayName: result.metadata.id,
+  }
+}
+
 /**
  * Builds an ambiguity-aware identity index without exposing its lookup maps.
  */
@@ -239,4 +264,40 @@ export function resolveRedirectModelIdentity(
   }
 
   return index.resolveRedirectAlias(rawModelId)
+}
+
+/** Resolves the stable identity used to compare equivalent model offers. */
+export function resolveComparableModelIdentity(
+  index: ModelIdentityIndex,
+  rawModelId: string,
+): ComparableModelIdentity {
+  const trimmedId = rawModelId.trim()
+  const undecoratedId = extractCoreModelIdentity(trimmedId).trim()
+  const normalizedUndecoratedId = normalizeIdentity(undecoratedId)
+
+  if (removeDateSuffix(normalizedUndecoratedId) !== normalizedUndecoratedId) {
+    return { key: `exact:${trimmedId}`, displayName: trimmedId }
+  }
+
+  const directResolution = resolveRedirectModelIdentity(index, trimmedId)
+  const directIdentity = toCanonicalComparableIdentity(directResolution)
+  if (directIdentity) return directIdentity
+  if (directResolution.state === "ambiguous") {
+    return { key: `exact:${trimmedId}`, displayName: trimmedId }
+  }
+
+  const resolved = resolveRedirectModelIdentity(index, undecoratedId)
+  const canonicalIdentity = toCanonicalComparableIdentity(resolved)
+  if (canonicalIdentity) return canonicalIdentity
+
+  if (resolved.state === "ambiguous") {
+    return { key: `exact:${trimmedId}`, displayName: trimmedId }
+  }
+
+  const tokenKey = toModelTokenKey(undecoratedId)
+  if (tokenKey) {
+    return { key: `normalized:${tokenKey}`, displayName: undecoratedId }
+  }
+
+  return { key: `exact:${trimmedId}`, displayName: trimmedId }
 }

--- a/src/services/models/modelMetadata/modelIdentityIndex.ts
+++ b/src/services/models/modelMetadata/modelIdentityIndex.ts
@@ -216,6 +216,22 @@ export interface ComparableModelIdentity {
   displayName: string
 }
 
+const COMPARABLE_MODEL_IDENTITY_KEY_PREFIXES = {
+  CANONICAL: "canonical",
+  EXACT: "exact",
+  NORMALIZED: "normalized",
+} as const
+
+/** Preserves a raw model id when normalization cannot be proven safe. */
+function toExactComparableModelIdentity(
+  modelId: string,
+): ComparableModelIdentity {
+  return {
+    key: `${COMPARABLE_MODEL_IDENTITY_KEY_PREFIXES.EXACT}:${modelId}`,
+    displayName: modelId,
+  }
+}
+
 /** Converts one resolved metadata match into a comparable identity. */
 function toCanonicalComparableIdentity(
   result: ModelIdentityLookupResult,
@@ -224,7 +240,7 @@ function toCanonicalComparableIdentity(
 
   const canonicalId = normalizeIdentity(result.metadata.id)
   return {
-    key: `canonical:${canonicalId}`,
+    key: `${COMPARABLE_MODEL_IDENTITY_KEY_PREFIXES.CANONICAL}:${canonicalId}`,
     displayName: result.metadata.id,
   }
 }
@@ -276,14 +292,14 @@ export function resolveComparableModelIdentity(
   const normalizedUndecoratedId = normalizeIdentity(undecoratedId)
 
   if (removeDateSuffix(normalizedUndecoratedId) !== normalizedUndecoratedId) {
-    return { key: `exact:${trimmedId}`, displayName: trimmedId }
+    return toExactComparableModelIdentity(trimmedId)
   }
 
   const directResolution = resolveRedirectModelIdentity(index, trimmedId)
   const directIdentity = toCanonicalComparableIdentity(directResolution)
   if (directIdentity) return directIdentity
   if (directResolution.state === "ambiguous") {
-    return { key: `exact:${trimmedId}`, displayName: trimmedId }
+    return toExactComparableModelIdentity(trimmedId)
   }
 
   const resolved = resolveRedirectModelIdentity(index, undecoratedId)
@@ -291,13 +307,16 @@ export function resolveComparableModelIdentity(
   if (canonicalIdentity) return canonicalIdentity
 
   if (resolved.state === "ambiguous") {
-    return { key: `exact:${trimmedId}`, displayName: trimmedId }
+    return toExactComparableModelIdentity(trimmedId)
   }
 
   const tokenKey = toModelTokenKey(undecoratedId)
   if (tokenKey) {
-    return { key: `normalized:${tokenKey}`, displayName: undecoratedId }
+    return {
+      key: `${COMPARABLE_MODEL_IDENTITY_KEY_PREFIXES.NORMALIZED}:${tokenKey}`,
+      displayName: undecoratedId,
+    }
   }
 
-  return { key: `exact:${trimmedId}`, displayName: trimmedId }
+  return toExactComparableModelIdentity(trimmedId)
 }

--- a/src/services/models/modelRedirect/ModelRedirectService.ts
+++ b/src/services/models/modelRedirect/ModelRedirectService.ts
@@ -29,6 +29,7 @@ import {
   collectManagedResourceSecrets,
 } from "~/services/managedSites/utils/managedSite"
 import { modelMetadataService } from "~/services/models/modelMetadata"
+import { extractCoreModelIdentity } from "~/services/models/modelMetadata/modelIdentityIndex"
 import {
   removeDateSuffix,
   toModelTokenKey,
@@ -51,11 +52,7 @@ import {
   userPreferences,
   type UserPreferences,
 } from "../../preferences/userPreferences"
-import {
-  extractActualModel,
-  extractCoreModelIdentity,
-  renameModel,
-} from "./modelNormalization"
+import { extractActualModel, renameModel } from "./modelNormalization"
 import { isEmptyModelMapping } from "./utils"
 
 /**

--- a/src/services/models/modelRedirect/modelNormalization.ts
+++ b/src/services/models/modelRedirect/modelNormalization.ts
@@ -3,8 +3,6 @@ import { extractCoreModelIdentity } from "~/services/models/modelMetadata/modelI
 import { resolveCuratedModelVendor } from "~/services/models/modelVendor"
 import { removeDateSuffix } from "~/services/models/utils/modelName"
 
-export { extractCoreModelIdentity }
-
 /**
  * Normalizes a raw model identifier to its core name by stripping known
  * vendor prefixes, path segments, non-model suffixes and date components.

--- a/src/services/models/modelRedirect/modelNormalization.ts
+++ b/src/services/models/modelRedirect/modelNormalization.ts
@@ -1,27 +1,9 @@
 import { modelMetadataService } from "~/services/models/modelMetadata"
+import { extractCoreModelIdentity } from "~/services/models/modelMetadata/modelIdentityIndex"
 import { resolveCuratedModelVendor } from "~/services/models/modelVendor"
 import { removeDateSuffix } from "~/services/models/utils/modelName"
 
-/**
- * Extracts the undecorated model identity while retaining any date suffix.
- */
-export function extractCoreModelIdentity(modelName: string): string {
-  let coreIdentity = modelName
-
-  // 提取真实模型名，提取最后一个/到结尾的内容
-  const lastSlashIndex = coreIdentity.lastIndexOf("/")
-  if (lastSlashIndex !== -1) {
-    coreIdentity = coreIdentity.slice(lastSlashIndex + 1)
-  }
-
-  // 移除冒号后缀（常见的:free等非模型信息后缀）
-  const colonIndex = coreIdentity.indexOf(":")
-  if (colonIndex !== -1) {
-    coreIdentity = coreIdentity.slice(0, colonIndex)
-  }
-
-  return coreIdentity
-}
+export { extractCoreModelIdentity }
 
 /**
  * Normalizes a raw model identifier to its core name by stripping known

--- a/tests/entrypoints/options/pages/ModelList/ModelListPageFlows.test.tsx
+++ b/tests/entrypoints/options/pages/ModelList/ModelListPageFlows.test.tsx
@@ -10,6 +10,7 @@ import {
   createAccountSource,
   createAllAccountsSource,
   createProfileSource,
+  EMPTY_MODEL_MANAGEMENT_CAPABILITIES,
   MODEL_LIST_GROUP_SEMANTICS,
   toAihubmixCatalogFallbackCapabilities,
 } from "~/features/ModelList/modelManagementSources"
@@ -1025,6 +1026,59 @@ describe("ModelList page flows", () => {
         insights: expect.objectContaining({ filterCount: 1 }),
       }),
     )
+  })
+
+  it("offers one-click price comparison before a source is selected", async () => {
+    const user = userEvent.setup()
+    const setSelectedSourceValue = vi.fn()
+    const setSortMode = vi.fn()
+    const setSelectedBillingMode = vi.fn()
+    const setSelectedGroups = vi.fn()
+    const setShowRealPrice = vi.fn()
+
+    mockUseModelListData.mockReturnValue(
+      buildState({
+        selectedSource: null,
+        currentAccount: null,
+        sourceCapabilities: EMPTY_MODEL_MANAGEMENT_CAPABILITIES,
+        selectedSourceValue: "",
+        setSelectedSourceValue,
+        setSortMode,
+        setSelectedBillingMode,
+        setSelectedGroups,
+        setShowRealPrice,
+        pricingData: null,
+        filteredModels: [],
+        baseFilteredModels: [],
+      }),
+    )
+
+    render(<ModelList />, {
+      withUserPreferencesProvider: false,
+      withThemeProvider: false,
+    })
+
+    expect(
+      screen.queryByRole("button", { name: "modelList:refreshData" }),
+    ).not.toBeInTheDocument()
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "modelList:comparison.cta",
+      }),
+    )
+
+    expect(setSelectedSourceValue).toHaveBeenCalledWith(
+      ALL_ACCOUNTS_SOURCE.value,
+    )
+    expect(setSortMode).toHaveBeenCalledWith(
+      MODEL_LIST_SORT_MODES.MODEL_CHEAPEST_FIRST,
+    )
+    expect(setSelectedBillingMode).toHaveBeenCalledWith(
+      MODEL_LIST_BILLING_MODES.ALL,
+    )
+    expect(setSelectedGroups).toHaveBeenCalledWith([])
+    expect(setShowRealPrice).toHaveBeenCalledWith(true)
   })
 
   it("hides the page comparison shortcut when comparison is already active", async () => {

--- a/tests/entrypoints/options/pages/ModelList/useFilteredModels.test.ts
+++ b/tests/entrypoints/options/pages/ModelList/useFilteredModels.test.ts
@@ -2243,6 +2243,65 @@ describe("useFilteredModels", () => {
     ).toEqual([true, false])
   })
 
+  it("groups normalized model aliases and puts the cheapest offer first", async () => {
+    const expensiveAccount = createDisplayAccount({
+      id: "normalized-expensive",
+      name: "Normalized Expensive",
+      balance: { USD: 10, CNY: 70 },
+    })
+    const cheaperAccount = createDisplayAccount({
+      id: "normalized-cheaper",
+      name: "Normalized Cheaper",
+      balance: { USD: 10, CNY: 70 },
+    })
+
+    const { result } = renderUseFilteredModels({
+      pricingContexts: [
+        {
+          account: expensiveAccount,
+          pricing: createPricingResponse([
+            {
+              model_name: "claude-4.5-sonnet",
+              quota_type: 0,
+              model_ratio: 2,
+              completion_ratio: 1,
+              enable_groups: ["default"],
+            },
+          ]),
+        },
+        {
+          account: cheaperAccount,
+          pricing: createPricingResponse([
+            {
+              model_name: "gateway/claude_sonnet_4_5:free",
+              quota_type: 0,
+              model_ratio: 1,
+              completion_ratio: 1,
+              enable_groups: ["default"],
+            },
+          ]),
+        },
+      ],
+      selectedSource: createAllAccountsSource(),
+      sortMode: MODEL_LIST_SORT_MODES.MODEL_CHEAPEST_FIRST,
+    })
+
+    await waitFor(() => {
+      expect(
+        result.current.filteredModels.map((item) => ({
+          modelName: item.model.model_name,
+          isLowestPrice: item.isLowestPrice,
+        })),
+      ).toEqual([
+        {
+          modelName: "gateway/claude_sonnet_4_5:free",
+          isLowestPrice: true,
+        },
+        { modelName: "claude-4.5-sonnet", isLowestPrice: false },
+      ])
+    })
+  })
+
   it("uses the cheapest eligible group per row and updates when account-specific group filters narrow", async () => {
     const multiGroupAccount = createDisplayAccount({
       id: "account-multi-group",

--- a/tests/features/ModelList/batchVerification.test.ts
+++ b/tests/features/ModelList/batchVerification.test.ts
@@ -59,6 +59,7 @@ const createCalculatedModelItem = (
     model: modelOverrides,
     groupContext: groupContextOverrides,
     activeGroupContext: activeGroupContextOverrides,
+    comparableModelIdentity,
     ...itemOverrides
   } = overrides
   const model: ModelPricing = {
@@ -99,6 +100,10 @@ const createCalculatedModelItem = (
     },
     resolvedVendor: { state: "unknown" },
     ...itemOverrides,
+    comparableModelIdentity: comparableModelIdentity ?? {
+      key: `exact:${model.model_name}`,
+      displayName: model.model_name,
+    },
   }
 }
 

--- a/tests/features/ModelList/components/ModelDisplay.test.tsx
+++ b/tests/features/ModelList/components/ModelDisplay.test.tsx
@@ -206,6 +206,7 @@ type CalculatedModelOverrides = {
   source?: CalculatedModelItem["source"]
   effectiveGroup?: string
   resolvedVendor?: CalculatedModelItem["resolvedVendor"]
+  comparableModelIdentity?: CalculatedModelItem["comparableModelIdentity"]
   isLowestPrice?: boolean
   isPriceComparable?: boolean
 }
@@ -279,6 +280,10 @@ const createCalculatedModel = (
     activeGroupContext,
     effectiveGroup: overrides.effectiveGroup,
     resolvedVendor: overrides.resolvedVendor ?? { state: "unknown" },
+    comparableModelIdentity: overrides.comparableModelIdentity ?? {
+      key: `exact:${model.model_name}`,
+      displayName: model.model_name,
+    },
     isLowestPrice: overrides.isLowestPrice,
     isPriceComparable: overrides.isPriceComparable,
   }
@@ -513,6 +518,51 @@ describe("ModelDisplay", () => {
         name: "modelList:priceComparison.results.notCompared",
       }),
     ).not.toBeInTheDocument()
+  })
+
+  it("renders normalized model aliases in one comparison region", () => {
+    const secondAccountSource = createAccountSource({
+      ...ACCOUNT_FIXTURE,
+      id: "account-2",
+      name: "Account Two",
+    })
+    const comparableModelIdentity = {
+      key: "normalized:4-5-claude-sonnet",
+      displayName: "claude-4.5-sonnet",
+    }
+
+    render(
+      <ModelDisplay
+        models={[
+          createCalculatedModel({
+            model: { model_name: "claude-4.5-sonnet" },
+            comparableModelIdentity,
+            isLowestPrice: true,
+            isPriceComparable: true,
+          }),
+          createCalculatedModel({
+            model: { model_name: "gateway/claude_sonnet_4_5:free" },
+            source: secondAccountSource,
+            comparableModelIdentity,
+            isPriceComparable: true,
+          }),
+        ]}
+        verificationSummariesByKey={{}}
+        showRealPrice={true}
+        showRatioColumn={true}
+        showEndpointTypes={true}
+        showPriceComparisonGroups={true}
+        handleGroupClick={vi.fn()}
+      />,
+    )
+
+    const comparisonRegion = screen.getByRole("region", {
+      name: "claude-4.5-sonnet ui:billing.tokenBased",
+    })
+    expect(screen.getAllByRole("region")).toHaveLength(1)
+    expect(
+      within(comparisonRegion).getAllByTestId(TEST_IDS.modelItem),
+    ).toHaveLength(2)
   })
 
   it("derives account exchange rates, group mode, and account verification summaries for rendered model cards", async () => {

--- a/tests/services/modelMetadata/modelIdentityIndex.test.ts
+++ b/tests/services/modelMetadata/modelIdentityIndex.test.ts
@@ -115,6 +115,15 @@ describe("modelIdentityIndex", () => {
     expect(nextVersion.key).not.toBe(ordered.key)
   })
 
+  it("keeps unnormalizable model ids isolated", () => {
+    const index = createModelIdentityIndex([])
+
+    expect(resolveComparableModelIdentity(index, " gateway/:free ")).toEqual({
+      key: "exact:gateway/:free",
+      displayName: "gateway/:free",
+    })
+  })
+
   it("distinguishes exact full ids from unambiguous bare-id and name aliases", () => {
     const providerQualified = createMetadata({
       id: "openai/gpt-4o",

--- a/tests/services/modelMetadata/modelIdentityIndex.test.ts
+++ b/tests/services/modelMetadata/modelIdentityIndex.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest"
 
 import {
   createModelIdentityIndex,
+  extractCoreModelIdentity,
   resolveComparableModelIdentity,
   resolveModelIdentity,
   resolveRedirectModelIdentity,
@@ -19,6 +20,15 @@ function createMetadata(
 }
 
 describe("modelIdentityIndex", () => {
+  it("extracts the core model identity without discarding date suffixes", () => {
+    expect(extractCoreModelIdentity("vendor/model-a-2025-01-01:free")).toBe(
+      "model-a-2025-01-01",
+    )
+    expect(extractCoreModelIdentity("vendor/model-a-20250101:free")).toBe(
+      "model-a-20250101",
+    )
+  })
+
   it("resolves decorated aliases to one comparable model identity", () => {
     const metadata = createMetadata({
       id: "openai/gpt-4o",

--- a/tests/services/modelMetadata/modelIdentityIndex.test.ts
+++ b/tests/services/modelMetadata/modelIdentityIndex.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest"
 
 import {
   createModelIdentityIndex,
+  resolveComparableModelIdentity,
   resolveModelIdentity,
   resolveRedirectModelIdentity,
 } from "~/services/models/modelMetadata/modelIdentityIndex"
@@ -18,6 +19,92 @@ function createMetadata(
 }
 
 describe("modelIdentityIndex", () => {
+  it("resolves decorated aliases to one comparable model identity", () => {
+    const metadata = createMetadata({
+      id: "openai/gpt-4o",
+      name: "GPT-4o",
+      provider_id: "openai",
+    })
+    const index = createModelIdentityIndex([metadata])
+
+    expect(resolveComparableModelIdentity(index, "gpt-4o")).toEqual({
+      key: "canonical:openai/gpt-4o",
+      displayName: "openai/gpt-4o",
+    })
+    expect(
+      resolveComparableModelIdentity(index, "upstream/openai/gpt-4o:free"),
+    ).toEqual({
+      key: "canonical:openai/gpt-4o",
+      displayName: "openai/gpt-4o",
+    })
+  })
+
+  it("keeps dated model offers isolated from aliases and other snapshots", () => {
+    const index = createModelIdentityIndex([])
+    const baseIdentity = resolveComparableModelIdentity(
+      index,
+      "vendor/model-a:free",
+    )
+    const firstSnapshot = resolveComparableModelIdentity(
+      index,
+      "vendor/model-a-2025-01-01:free",
+    )
+    const secondSnapshot = resolveComparableModelIdentity(
+      index,
+      "vendor/model-a-2025-02-02:free",
+    )
+
+    expect(firstSnapshot).toEqual({
+      key: "exact:vendor/model-a-2025-01-01:free",
+      displayName: "vendor/model-a-2025-01-01:free",
+    })
+    expect(firstSnapshot.key).not.toBe(baseIdentity.key)
+    expect(firstSnapshot.key).not.toBe(secondSnapshot.key)
+  })
+
+  it("fails closed when a normalized model alias is ambiguous", () => {
+    const providerA = createMetadata({ id: "provider-a/shared-model" })
+    const index = createModelIdentityIndex([
+      providerA,
+      createMetadata({ id: "provider-b/shared-model" }),
+    ])
+
+    expect(
+      resolveComparableModelIdentity(index, "provider-a/shared-model"),
+    ).toEqual({
+      key: "canonical:provider-a/shared-model",
+      displayName: providerA.id,
+    })
+
+    expect(resolveComparableModelIdentity(index, "shared-model")).toEqual({
+      key: "exact:shared-model",
+      displayName: "shared-model",
+    })
+    expect(
+      resolveComparableModelIdentity(index, "gateway/shared-model:free"),
+    ).toEqual({
+      key: "exact:gateway/shared-model:free",
+      displayName: "gateway/shared-model:free",
+    })
+  })
+
+  it("normalizes unknown separator and token-order aliases without crossing versions", () => {
+    const index = createModelIdentityIndex([])
+    const ordered = resolveComparableModelIdentity(index, "claude-4.5-sonnet")
+    const reordered = resolveComparableModelIdentity(
+      index,
+      "gateway/claude_sonnet_4_5:free",
+    )
+    const nextVersion = resolveComparableModelIdentity(
+      index,
+      "claude-sonnet-4-6",
+    )
+
+    expect(ordered.key).toBe("normalized:4-5-claude-sonnet")
+    expect(reordered.key).toBe(ordered.key)
+    expect(nextVersion.key).not.toBe(ordered.key)
+  })
+
   it("distinguishes exact full ids from unambiguous bare-id and name aliases", () => {
     const providerQualified = createMetadata({
       id: "openai/gpt-4o",

--- a/tests/services/modelRedirect/modelNormalization.test.ts
+++ b/tests/services/modelRedirect/modelNormalization.test.ts
@@ -3,7 +3,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import { modelMetadataService } from "~/services/models/modelMetadata"
 import {
   extractActualModel,
-  extractCoreModelIdentity,
   renameModel,
 } from "~/services/models/modelRedirect/modelNormalization"
 
@@ -21,15 +20,6 @@ vi.mock("~/services/models/modelMetadata", () => ({
 }))
 
 describe("extractActualModel", () => {
-  it("can retain date identity after removing provider and colon decoration", () => {
-    expect(extractCoreModelIdentity("vendor/model-a-2025-01-01:free")).toBe(
-      "model-a-2025-01-01",
-    )
-    expect(extractCoreModelIdentity("vendor/model-a-20250101:free")).toBe(
-      "model-a-20250101",
-    )
-  })
-
   it("should handle basic model names with vendor and suffix", () => {
     expect(extractActualModel("openai/gpt-4o:free")).toBe("gpt-4o")
     expect(extractActualModel("anthropic/claude-3-5-sonnet:premium")).toBe(


### PR DESCRIPTION
## Summary

Price comparison previously grouped offers by their raw model names. Provider prefixes, separator differences, reordered identity tokens, and non-model suffixes could therefore prevent equivalent offers from being compared.

This PR introduces a shared, ambiguity-aware comparable model identity so equivalent offers can be grouped and sorted together. Dated snapshots and ambiguous aliases remain isolated to avoid unsafe comparisons.

## What changed

- Add shared comparable identity resolution based on the existing model metadata and redirect-matching rules.
- Use comparable identities when grouping offers, sorting by cheapest model, and marking the lowest-price offer.
- Keep different billing modes, dated model versions, and ambiguous aliases in separate comparison groups.
- Move core model identity extraction into the model identity module and remove the redirect-layer re-export.
- Place the billing-method badge directly beside the comparison group name, with responsive wrapping.
- Keep the one-click price comparison action visible when accounts exist but no source is selected. Activating it switches to the All Accounts comparison scope, while refresh remains hidden until a source with data is selected.
- Reuse the existing price-comparison analytics action; no new telemetry payload or persistence contract is introduced.

## Validation

- `pnpm compile` — passed.
- `pnpm exec vitest related --run src/features/ModelList/ModelList.tsx src/features/ModelList/components/ModelDisplay.tsx src/features/ModelList/hooks/useFilteredModels.ts src/services/models/modelMetadata/modelIdentityIndex.ts src/services/models/modelRedirect/ModelRedirectService.ts src/services/models/modelRedirect/modelNormalization.ts` — passed, 43 files / 693 tests.
- Chromium Playwright coverage for the narrow-width price-comparison flow — passed, 2/2 including its build dependency.
- Pre-push `pnpm run validate:push` — passed (`pnpm compile` and `pnpm knip`).
- Full CI, Codecov patch coverage, and CodeRabbit review — passed on `48ab298fd`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Price comparison can now be started without selecting a model source when accounts are available.
  * Comparison groups recognize equivalent model aliases and display clearer shared names.
  * Refresh and comparison actions now appear based on the relevant available data.

* **Bug Fixes**
  * Improved all-account pricing comparisons so equivalent model offers are grouped correctly.
  * Cheapest matching offers are now sorted and identified more reliably across aliases.

* **Tests**
  * Added coverage for source-free comparisons, alias grouping, pricing order, and model identity matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
