### PR TITLE
fix(docs): prevent artifact-only translation PRs

### DIFF
--- a/.github/workflows/translate-docs.yml
+++ b/.github/workflows/translate-docs.yml
@@ -204,15 +204,33 @@ jobs:
       - name: Check translation completeness
         run: python docs_assistant/find_missing.py --check
 
+      - name: Detect generated translation changes
+        id: generated-changes
+        shell: bash
+        run: |
+          set -euo pipefail
+          GENERATED_STATUS="${RUNNER_TEMP}/generated-translation-status.bin"
+          git status --porcelain=v1 -z --untracked-files=all -- \
+            docs/docs/en \
+            docs/docs/ja > "$GENERATED_STATUS"
+
+          if [ -s "$GENERATED_STATUS" ]; then
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            echo "📝 检测到生成的翻译变更"
+          else
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            echo "✅ 没有生成新的翻译变更"
+          fi
+
       - name: Setup pnpm for docs check
-        if: steps.changed-files.outputs.has_changes == 'true'
+        if: steps.generated-changes.outputs.has_changes == 'true'
         uses: pnpm/action-setup@v5
         with:
           version: 10
           run_install: false
 
       - name: Setup Node.js for docs check
-        if: steps.changed-files.outputs.has_changes == 'true'
+        if: steps.generated-changes.outputs.has_changes == 'true'
         uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
@@ -220,22 +238,25 @@ jobs:
           cache-dependency-path: docs/pnpm-lock.yaml
 
       - name: Install docs dependencies
-        if: steps.changed-files.outputs.has_changes == 'true'
+        if: steps.generated-changes.outputs.has_changes == 'true'
         working-directory: docs
         run: pnpm install --frozen-lockfile --prefer-offline
 
       - name: Check generated docs
-        if: steps.changed-files.outputs.has_changes == 'true'
+        if: steps.generated-changes.outputs.has_changes == 'true'
         working-directory: docs
         env:
           NODE_OPTIONS: --max_old_space_size=8192
         run: pnpm run docs:check
 
       - name: Create Pull Request
-        if: steps.changed-files.outputs.has_changes == 'true'
+        if: steps.generated-changes.outputs.has_changes == 'true'
         uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          add-paths: |
+            docs/docs/en/**
+            docs/docs/ja/**
           commit-message: |
             🌐 Auto-translate documentation
 

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,10 @@
 .DS_Store
 *.pem
 
+# Python caches
+__pycache__/
+*.py[cod]
+
 # local env files
 .env*.local
 

--- a/tests/docs_assistant/test_translate_workflow.py
+++ b/tests/docs_assistant/test_translate_workflow.py
@@ -5,6 +5,7 @@ import yaml
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+GITIGNORE_PATH = REPO_ROOT / ".gitignore"
 WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "translate-docs.yml"
 TEST_WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "test.yml"
 TOOLING_CHECK_WORKFLOW_PATH = (
@@ -41,6 +42,43 @@ class TranslationWorkflowSafetyTests(unittest.TestCase):
         self.assertIn("mapfile -d '' -t files", step["run"])
         self.assertIn('"${files[@]}"', step["run"])
         self.assertNotIn("steps.changed-files.outputs.files }}", step["run"])
+
+    def test_pull_request_requires_generated_translation_changes(self):
+        detection_step = self.get_step("Detect generated translation changes")
+        detection_script = detection_step["run"]
+
+        self.assertIn(
+            "git status --porcelain=v1 -z --untracked-files=all --",
+            detection_script,
+        )
+        self.assertIn("docs/docs/en", detection_script)
+        self.assertIn("docs/docs/ja", detection_script)
+
+        generated_change_condition = (
+            "steps.generated-changes.outputs.has_changes == 'true'"
+        )
+        for step_name in (
+            "Setup pnpm for docs check",
+            "Setup Node.js for docs check",
+            "Install docs dependencies",
+            "Check generated docs",
+            "Create Pull Request",
+        ):
+            self.assertEqual(
+                self.get_step(step_name)["if"],
+                generated_change_condition,
+            )
+
+        pull_request_step = self.get_step("Create Pull Request")
+        add_paths = pull_request_step["with"]["add-paths"].splitlines()
+        self.assertEqual(
+            [path.strip() for path in add_paths if path.strip()],
+            ["docs/docs/en/**", "docs/docs/ja/**"],
+        )
+
+        gitignore = GITIGNORE_PATH.read_text(encoding="utf-8")
+        self.assertIn("__pycache__/", gitignore.splitlines())
+        self.assertIn("*.py[cod]", gitignore.splitlines())
 
     def test_python_translation_tests_use_a_dedicated_pr_check(self):
         test_workflow = load_workflow(TEST_WORKFLOW_PATH)


### PR DESCRIPTION
## Summary

- create auto-translation pull requests only when English or Japanese output actually changes
- restrict automated commits to generated locale documentation paths
- ignore Python bytecode/cache artifacts and lock the workflow contract with tests

## Root cause

The translation workflow ran Python tests before PR creation. When source documents already had manual English/Japanese updates, translation produced no locale diff, but Python caches left the worktree dirty. The PR action then staged the whole worktree and created #1308 containing only `.pyc` files.

## Validation

- `python -B -m unittest discover -s tests/docs_assistant -p "test_*.py" -v`
- `python -B docs_assistant/find_missing.py --check`
- `git check-ignore -v docs_assistant/__pycache__/translate.cpython-311.pyc tests/docs_assistant/__pycache__/test_translate.cpython-311.pyc`
- pre-commit `pnpm run validate:staged`
- pre-push `pnpm run validate:push`

## Related

Supersedes the artifact-only auto-translation PR #1308.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Documentation translation workflows now run only when generated English or Japanese documentation changes are detected.
  * Pull requests created by the translation workflow are limited to generated documentation files.

* **Bug Fixes**
  * Prevented unnecessary documentation validation and pull requests when no generated translations changed.

* **Tests**
  * Added coverage for translation change detection, workflow gating, path restrictions, and ignore rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->