### PR TITLE
refactor(ui): replace Heroicons with Lucide

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -63,6 +63,11 @@ const optionsPageImportRestrictionPattern = {
   message:
     "Do not import from `~/entrypoints/options/pages/**` outside the options entrypoint. Extract shared code into `~/features/`, `~/services/`, `~/utils/`, or `~/types/` instead.",
 }
+const heroiconsImportRestrictionPattern = {
+  group: ["@heroicons/react", "@heroicons/react/**"],
+  message:
+    "Heroicons has been retired from application code. Use lucide-react or a shared semantic icon component instead.",
+}
 const apiServiceBackendImplementationImportPattern = {
   regex:
     "^(?:~/services/apiService|(?:\\.\\./)+(?:services/)?apiService)/(?:aihubmix|anyrouter|axonHub|claudeCodeHub|doneHub|octopus|oneHub|sub2api|veloera|wong)$",
@@ -88,12 +93,6 @@ const workflowTransitionIconRestrictedImports = [
     message:
       "Use `~/components/icons/WorkflowTransitionIcon` for arrow-up-right workflow/link affordances so the app keeps a single transition glyph.",
   },
-  {
-    name: "@heroicons/react/24/outline",
-    importNames: ["ArrowTopRightOnSquareIcon"],
-    message:
-      "Use `~/components/icons/WorkflowTransitionIcon` for arrow-up-right workflow/link affordances so the app keeps a single transition glyph.",
-  },
 ]
 
 function restrictedImports(...patterns) {
@@ -101,7 +100,7 @@ function restrictedImports(...patterns) {
     "error",
     {
       paths: workflowTransitionIconRestrictedImports,
-      ...(patterns.length > 0 ? { patterns } : {}),
+      patterns: [heroiconsImportRestrictionPattern, ...patterns],
     },
   ]
 }

--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "@dnd-kit/modifiers": "^9.0.0",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
-    "@heroicons/react": "^2.2.0",
     "@lobehub/fluent-emoji": "^4.1.0",
     "@lobehub/icons": "^5.13.0",
     "@lobehub/ui": "^5.20.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,9 +35,6 @@ importers:
       '@dnd-kit/utilities':
         specifier: ^3.2.2
         version: 3.2.2(react@19.2.0)
-      '@heroicons/react':
-        specifier: ^2.2.0
-        version: 2.2.0(react@19.2.0)
       '@lobehub/fluent-emoji':
         specifier: ^4.1.0
         version: 4.1.0(@types/react@19.1.12)(antd@6.5.1(date-fns@4.4.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -1150,11 +1147,6 @@ packages:
     peerDependencies:
       react: ^16 || ^17 || ^18 || ^19
       react-dom: ^16 || ^17 || ^18 || ^19
-
-  '@heroicons/react@2.2.0':
-    resolution: {integrity: sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==}
-    peerDependencies:
-      react: '>= 16 || ^19.0.0-rc'
 
   '@hono/node-server@1.19.7':
     resolution: {integrity: sha512-vUcD0uauS7EU2caukW8z5lJKtoGMokxNbJtBiwHgpqxEXokaHCBkQUmCHhjFB1VUTWdqj25QoMkMKzgjq+uhrw==}
@@ -9988,10 +9980,6 @@ snapshots:
       giscus: 1.6.0
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
-
-  '@heroicons/react@2.2.0(react@19.2.0)':
-    dependencies:
-      react: 19.2.0
 
   '@hono/node-server@1.19.7(hono@4.11.3)':
     dependencies:

--- a/src/components/DevDialogDebugMenu.tsx
+++ b/src/components/DevDialogDebugMenu.tsx
@@ -1,10 +1,4 @@
-import {
-  BugAntIcon,
-  DocumentTextIcon,
-  ExclamationTriangleIcon,
-  LanguageIcon,
-  SparklesIcon,
-} from "@heroicons/react/24/outline"
+import { Bug, FileText, Languages, Sparkles, TriangleAlert } from "lucide-react"
 import { useCallback, useState } from "react"
 import toast from "react-hot-toast"
 
@@ -100,29 +94,29 @@ function DevDialogDebugMenuContent() {
             aria-label="Dev: Dialog debug menu"
             className="touch-manipulation"
           >
-            <BugAntIcon className="h-4 w-4" />
+            <Bug className="h-4 w-4" />
           </IconButton>
         </DropdownMenuTrigger>
       </Tooltip>
       <DropdownMenuContent align="end" className="w-56">
         <DropdownMenuItem onClick={() => void handleTriggerUpdateLog()}>
-          <DocumentTextIcon className="h-4 w-4" />
+          <FileText className="h-4 w-4" />
           Dev: Trigger update log
         </DropdownMenuItem>
         <DropdownMenuItem onClick={() => void handleTriggerOnboarding()}>
-          <SparklesIcon className="h-4 w-4" />
+          <Sparkles className="h-4 w-4" />
           Dev: Trigger onboarding
         </DropdownMenuItem>
         <DropdownMenuItem
           onClick={() => void handleQueuePopupInterruptionHint()}
         >
-          <ExclamationTriangleIcon className="h-4 w-4" />
+          <TriangleAlert className="h-4 w-4" />
           Dev: Queue popup interruption hint
         </DropdownMenuItem>
         <DropdownMenuItem
           onClick={() => setShouldTriggerTranslationCrash(true)}
         >
-          <LanguageIcon className="h-4 w-4" />
+          <Languages className="h-4 w-4" />
           Dev: Trigger translation crash
         </DropdownMenuItem>
       </DropdownMenuContent>

--- a/src/components/FeedbackDropdownMenu.tsx
+++ b/src/components/FeedbackDropdownMenu.tsx
@@ -1,12 +1,12 @@
-import {
-  BugAntIcon,
-  ChatBubbleLeftEllipsisIcon,
-  LanguageIcon,
-  LightBulbIcon,
-  PuzzlePieceIcon,
-  UsersIcon,
-} from "@heroicons/react/24/outline"
 import type { TFunction } from "i18next"
+import {
+  Bug,
+  Languages,
+  Lightbulb,
+  MessageSquareMore,
+  Puzzle,
+  Users,
+} from "lucide-react"
 import type { ComponentType } from "react"
 import { useTranslation } from "react-i18next"
 
@@ -42,27 +42,27 @@ type FeedbackMenuItem = {
 export const FEEDBACK_MENU_ITEMS: readonly FeedbackMenuItem[] = [
   {
     labelKey: "feedback.bugReport",
-    Icon: BugAntIcon,
+    Icon: Bug,
     open: () => void openBugReportPage(),
   },
   {
     labelKey: "feedback.featureRequest",
-    Icon: LightBulbIcon,
+    Icon: Lightbulb,
     open: () => void openFeatureRequestPage(),
   },
   {
     labelKey: "feedback.siteSupportRequest",
-    Icon: PuzzlePieceIcon,
+    Icon: Puzzle,
     open: () => void openSiteSupportRequestPage(),
   },
   {
     labelKey: "feedback.languageRequest",
-    Icon: LanguageIcon,
+    Icon: Languages,
     open: () => void openLanguageRequestPage(),
   },
   {
     labelKey: "feedback.community",
-    Icon: UsersIcon,
+    Icon: Users,
     open: (language) => void openCommunityPage(language),
   },
 ]
@@ -113,7 +113,7 @@ export function FeedbackDropdownMenu({
             aria-label={t("feedback.trigger")}
             className="touch-manipulation"
           >
-            <ChatBubbleLeftEllipsisIcon className="h-4 w-4" />
+            <MessageSquareMore className="h-4 w-4" />
           </IconButton>
         </DropdownMenuTrigger>
       </Tooltip>

--- a/src/components/ManagedSiteConfigRequiredState.tsx
+++ b/src/components/ManagedSiteConfigRequiredState.tsx
@@ -1,4 +1,4 @@
-import { ExclamationTriangleIcon } from "@heroicons/react/24/outline"
+import { TriangleAlert } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import { WorkflowTransitionIcon } from "~/components/icons/WorkflowTransitionIcon"
@@ -32,7 +32,7 @@ export default function ManagedSiteConfigRequiredState({
   return (
     <EmptyState
       className={className}
-      icon={<ExclamationTriangleIcon className="h-12 w-12 text-yellow-500" />}
+      icon={<TriangleAlert className="h-12 w-12 text-yellow-500" />}
       title={t("status.configurationRequired")}
       description={description}
       actions={[

--- a/src/components/ReleaseUpdateStatusPanel.tsx
+++ b/src/components/ReleaseUpdateStatusPanel.tsx
@@ -1,9 +1,5 @@
-import {
-  ArrowDownTrayIcon,
-  ArrowPathIcon,
-  CloudArrowDownIcon,
-} from "@heroicons/react/24/outline"
 import type { TFunction } from "i18next"
+import { CloudDownload, Download, RefreshCw } from "lucide-react"
 import toast from "react-hot-toast"
 import { useTranslation } from "react-i18next"
 
@@ -213,9 +209,9 @@ export function ReleaseUpdateStatusPanel() {
     : t("settings:releaseUpdate.openLatest")
   const actionIcon = hasUpdate ? (
     isStoreUpdateReady ? (
-      <ArrowPathIcon className="h-4 w-4" />
+      <RefreshCw className="h-4 w-4" />
     ) : (
-      <ArrowDownTrayIcon className="h-4 w-4" />
+      <Download className="h-4 w-4" />
     )
   ) : (
     <WorkflowTransitionIcon className="h-4 w-4" />
@@ -257,7 +253,7 @@ export function ReleaseUpdateStatusPanel() {
       <CardList>
         <CardItem
           icon={
-            <CloudArrowDownIcon className="h-5 w-5 text-sky-600 dark:text-sky-400" />
+            <CloudDownload className="h-5 w-5 text-sky-600 dark:text-sky-400" />
           }
           title={statusTitle}
           description={statusDescription}
@@ -288,7 +284,7 @@ export function ReleaseUpdateStatusPanel() {
                 size="sm"
                 onClick={() => void handleCheckNow()}
                 loading={isChecking}
-                leftIcon={<ArrowPathIcon className="h-4 w-4" />}
+                leftIcon={<RefreshCw className="h-4 w-4" />}
                 data-testid={
                   RELEASE_UPDATE_STATUS_PANEL_TEST_IDS.checkNowButton
                 }

--- a/src/components/SettingSection.tsx
+++ b/src/components/SettingSection.tsx
@@ -1,4 +1,4 @@
-import { ArrowPathIcon } from "@heroicons/react/24/outline"
+import { RefreshCw } from "lucide-react"
 import { useState, type ReactNode } from "react"
 import toast from "react-hot-toast"
 import { useTranslation } from "react-i18next"
@@ -89,7 +89,7 @@ export function SettingSection({
               variant="outline"
               size="sm"
               className="shrink-0"
-              leftIcon={<ArrowPathIcon className="h-4 w-4" />}
+              leftIcon={<RefreshCw className="h-4 w-4" />}
             >
               {resetButtonLabel || t("common:actions.reset")}
             </Button>

--- a/src/components/ThemeAwareToaster.tsx
+++ b/src/components/ThemeAwareToaster.tsx
@@ -1,4 +1,4 @@
-import { XMarkIcon } from "@heroicons/react/24/outline"
+import { X } from "lucide-react"
 import type { CSSProperties } from "react"
 import { createPortal } from "react-dom"
 import toast, { ToastBar, Toaster } from "react-hot-toast"
@@ -77,7 +77,7 @@ export const ThemeAwareToaster = ({
                     aria-label={translate("actions.close")}
                     onClick={() => toast.dismiss(toastInstance.id)}
                   >
-                    <XMarkIcon className="h-4 w-4" />
+                    <X className="h-4 w-4" />
                   </button>
                 )}
               </>

--- a/src/components/VersionBadge.tsx
+++ b/src/components/VersionBadge.tsx
@@ -1,4 +1,4 @@
-import { ArrowUpCircleIcon } from "@heroicons/react/24/solid"
+import { CircleArrowUp } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import { Badge } from "~/components/ui"
@@ -60,7 +60,7 @@ export function VersionBadge({
       >
         <span>v{version}</span>
         {hasUpdate && (
-          <ArrowUpCircleIcon
+          <CircleArrowUp
             aria-hidden="true"
             className="h-5 w-5 text-amber-500"
           />

--- a/src/components/dialogs/ChannelDialog/components/DuplicateChannelWarningDialog.tsx
+++ b/src/components/dialogs/ChannelDialog/components/DuplicateChannelWarningDialog.tsx
@@ -1,4 +1,4 @@
-import { ExclamationTriangleIcon } from "@heroicons/react/24/outline"
+import { TriangleAlert } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import { Alert } from "~/components/ui/Alert"
@@ -33,7 +33,7 @@ export function DuplicateChannelWarningDialog({
       header={
         <div className="flex items-center justify-between">
           <div className="flex items-center space-x-3">
-            <ExclamationTriangleIcon className="h-5 w-5 text-yellow-600 dark:text-yellow-400" />
+            <TriangleAlert className="h-5 w-5 text-yellow-600 dark:text-yellow-400" />
             <h2 className="dark:text-dark-text-primary text-lg font-semibold text-gray-900">
               {t("channelDialog:warnings.channelExists.title")}
             </h2>

--- a/src/components/dialogs/VerifyApiDialog/VerificationStatusBadge.tsx
+++ b/src/components/dialogs/VerifyApiDialog/VerificationStatusBadge.tsx
@@ -1,4 +1,4 @@
-import { CheckCircleIcon, XCircleIcon } from "@heroicons/react/24/outline"
+import { CircleCheck, CircleX } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import { Badge } from "~/components/ui"
@@ -28,7 +28,7 @@ export function VerificationStatusBadge({
     return (
       <Badge variant="success" size="sm">
         <span className="flex items-center gap-1">
-          <CheckCircleIcon className="h-3.5 w-3.5" />
+          <CircleCheck className="h-3.5 w-3.5" />
           {t("verifyDialog.status.pass")}
         </span>
       </Badge>
@@ -54,7 +54,7 @@ export function VerificationStatusBadge({
   return (
     <Badge variant="destructive" size="sm">
       <span className="flex items-center gap-1">
-        <XCircleIcon className="h-3.5 w-3.5" />
+        <CircleX className="h-3.5 w-3.5" />
         {t("verifyDialog.status.fail")}
       </span>
     </Badge>

--- a/src/components/dialogs/VerifyCliSupportDialog/ToolStatusBadge.tsx
+++ b/src/components/dialogs/VerifyCliSupportDialog/ToolStatusBadge.tsx
@@ -1,4 +1,4 @@
-import { CheckCircleIcon, XCircleIcon } from "@heroicons/react/24/outline"
+import { CircleCheck, CircleX } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import { Badge } from "~/components/ui"
@@ -15,7 +15,7 @@ export function ToolStatusBadge({ result }: { result: CliSupportResult }) {
     return (
       <Badge variant="success" size="sm">
         <span className="flex items-center gap-1">
-          <CheckCircleIcon className="h-3.5 w-3.5" />
+          <CircleCheck className="h-3.5 w-3.5" />
           {t("verifyDialog.status.pass")}
         </span>
       </Badge>
@@ -33,7 +33,7 @@ export function ToolStatusBadge({ result }: { result: CliSupportResult }) {
   return (
     <Badge variant="destructive" size="sm">
       <span className="flex items-center gap-1">
-        <XCircleIcon className="h-3.5 w-3.5" />
+        <CircleX className="h-3.5 w-3.5" />
         {t("verifyDialog.status.fail")}
       </span>
     </Badge>

--- a/src/components/toast/WarningToast.tsx
+++ b/src/components/toast/WarningToast.tsx
@@ -1,4 +1,4 @@
-import { XMarkIcon } from "@heroicons/react/24/outline"
+import { X } from "lucide-react"
 import { useRef, useState } from "react"
 import toast, { ToastBar, type Toast } from "react-hot-toast"
 
@@ -84,7 +84,7 @@ export function WarningToast({
             aria-label="Close notification"
             onClick={() => toast.dismiss(toastInstance.id)}
           >
-            <XMarkIcon className="h-4 w-4" />
+            <X className="h-4 w-4" />
           </button>
         </>
       )}

--- a/src/components/toast/WarningToastIcon.tsx
+++ b/src/components/toast/WarningToastIcon.tsx
@@ -1,4 +1,4 @@
-import { ExclamationTriangleIcon } from "@heroicons/react/24/solid"
+import { TriangleAlert } from "lucide-react"
 
 interface WarningToastIconProps {
   resolvedTheme?: string
@@ -11,7 +11,7 @@ interface WarningToastIconProps {
 export function WarningToastIcon({ resolvedTheme }: WarningToastIconProps) {
   return (
     <div className="flex min-w-5 items-center justify-center">
-      <ExclamationTriangleIcon
+      <TriangleAlert
         className={
           resolvedTheme === "dark"
             ? "h-5 w-5 text-amber-400"

--- a/src/components/ui/CollapsibleSection.tsx
+++ b/src/components/ui/CollapsibleSection.tsx
@@ -1,4 +1,4 @@
-import { ChevronDownIcon } from "@heroicons/react/24/outline"
+import { ChevronDown } from "lucide-react"
 import { useState, type ReactNode } from "react"
 
 import { cn } from "~/lib/utils"
@@ -40,7 +40,7 @@ export function CollapsibleSection({
         )}
       >
         <span className="min-w-0 truncate">{title}</span>
-        <ChevronDownIcon
+        <ChevronDown
           className={cn(
             "dark:text-dark-text-tertiary h-4 w-4 shrink-0 text-gray-500 transition-transform",
             open ? "rotate-180" : "rotate-0",

--- a/src/components/ui/Dialog/DestructiveConfirmDialog.tsx
+++ b/src/components/ui/Dialog/DestructiveConfirmDialog.tsx
@@ -1,4 +1,4 @@
-import { TrashIcon } from "@heroicons/react/24/outline"
+import { Trash2 } from "lucide-react"
 import type { ComponentProps, ReactNode } from "react"
 
 import { Button } from "~/components/ui/button"
@@ -93,7 +93,7 @@ export function DestructiveConfirmDialog({
   size = "sm",
   confirmButtonTestId,
   cancelButtonTestId,
-  icon = <TrashIcon className="h-5 w-5 text-red-600 dark:text-red-400" />,
+  icon = <Trash2 className="h-5 w-5 text-red-600 dark:text-red-400" />,
   confirmVariant = "destructive",
 }: DestructiveConfirmDialogProps) {
   return (

--- a/src/components/ui/MultiSelect.tsx
+++ b/src/components/ui/MultiSelect.tsx
@@ -1,10 +1,4 @@
-import {
-  CheckIcon,
-  ChevronDownIcon,
-  ChevronUpDownIcon,
-  XMarkIcon,
-} from "@heroicons/react/20/solid"
-import { Copy } from "lucide-react"
+import { Check, ChevronDown, ChevronsUpDown, Copy, X } from "lucide-react"
 import React, { useEffect, useId, useMemo, useRef, useState } from "react"
 import toast from "react-hot-toast"
 import { useTranslation } from "react-i18next"
@@ -343,7 +337,7 @@ export function MultiSelect({
                 className="inline-flex items-center justify-center rounded-full text-gray-400 hover:bg-gray-100 hover:text-gray-600 focus:bg-gray-200 focus:text-gray-700 focus:outline-none"
                 aria-label={t("multiSelect.clearInput")}
               >
-                <XMarkIcon className="h-5 w-5" />
+                <X className="h-5 w-5" />
               </button>
             )}
             <button
@@ -358,7 +352,7 @@ export function MultiSelect({
                 setActiveOptionIndex(null)
               }}
             >
-              <ChevronUpDownIcon
+              <ChevronsUpDown
                 className="h-5 w-5 text-gray-400"
                 aria-hidden="true"
               />
@@ -423,7 +417,7 @@ export function MultiSelect({
                     </span>
                     {isSelected ? (
                       <span className="absolute inset-y-0 left-0 flex items-center pl-3 text-blue-600 group-hover:text-white">
-                        <CheckIcon className="h-5 w-5" aria-hidden="true" />
+                        <Check className="h-5 w-5" aria-hidden="true" />
                       </span>
                     ) : null}
                   </button>
@@ -444,7 +438,7 @@ export function MultiSelect({
               aria-controls={`${uid}-selected-items`}
             >
               <span className="flex min-w-0 items-center gap-2">
-                <ChevronDownIcon
+                <ChevronDown
                   className={cn(
                     "dark:text-dark-text-secondary h-4 w-4 shrink-0 text-gray-500 transition-transform",
                     isSelectedExpanded ? "rotate-180" : "",
@@ -483,7 +477,7 @@ export function MultiSelect({
                 title={t("multiSelect.clearSelected")}
                 aria-label={t("multiSelect.clearSelected")}
               >
-                <XMarkIcon className="h-4 w-4" />
+                <X className="h-4 w-4" />
               </button>
             )}
             <button
@@ -518,7 +512,7 @@ export function MultiSelect({
                         value: option.label,
                       })}
                     >
-                      <XMarkIcon className="h-3 w-3" />
+                      <X className="h-3 w-3" />
                     </button>
                   )}
                 </span>

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,5 +1,5 @@
-import { EyeIcon, EyeSlashIcon } from "@heroicons/react/24/outline"
 import { cva, type VariantProps } from "class-variance-authority"
+import { Eye, EyeOff } from "lucide-react"
 import React from "react"
 
 import {
@@ -202,9 +202,9 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
                   }
                 >
                   {isRevealed ? (
-                    <EyeSlashIcon className="h-4 w-4" />
+                    <EyeOff className="h-4 w-4" />
                   ) : (
-                    <EyeIcon className="h-4 w-4" />
+                    <Eye className="h-4 w-4" />
                   )}
                 </IconButton>
               </span>

--- a/src/entrypoints/content/webAiApiCheck/components/ApiCheckBaseUrlHistoryPicker.tsx
+++ b/src/entrypoints/content/webAiApiCheck/components/ApiCheckBaseUrlHistoryPicker.tsx
@@ -1,5 +1,5 @@
-import { ClockIcon, TrashIcon } from "@heroicons/react/24/outline"
 import type { TFunction } from "i18next"
+import { Clock, Trash2 } from "lucide-react"
 
 import { IconButton } from "~/components/ui"
 import {
@@ -51,7 +51,7 @@ export function ApiCheckBaseUrlHistoryPicker({
           onMouseDown={(event) => event.preventDefault()}
           disabled={!hasSuggestions}
         >
-          <ClockIcon className="h-4 w-4" />
+          <Clock className="h-4 w-4" />
         </IconButton>
       </PopoverTrigger>
       <PopoverContent
@@ -100,7 +100,7 @@ export function ApiCheckBaseUrlHistoryPicker({
                 className="shrink-0 opacity-70 group-hover:opacity-100"
                 onClick={() => onRemove(suggestion.baseUrl)}
               >
-                <TrashIcon className="h-3.5 w-3.5" />
+                <Trash2 className="h-3.5 w-3.5" />
               </IconButton>
             </div>
           ))}

--- a/src/entrypoints/content/webAiApiCheck/components/ApiCheckModal.tsx
+++ b/src/entrypoints/content/webAiApiCheck/components/ApiCheckModal.tsx
@@ -1,5 +1,5 @@
-import { ChevronDownIcon, XMarkIcon } from "@heroicons/react/24/outline"
 import type { TFunction } from "i18next"
+import { ChevronDown, X } from "lucide-react"
 import type {
   KeyboardEvent as ReactKeyboardEvent,
   RefCallback,
@@ -109,7 +109,7 @@ export function ApiCheckModal({ t, view, actions, refs }: ApiCheckModalProps) {
               onClick={actions.close}
               disabled={!view.canClose}
             >
-              <XMarkIcon className="h-4 w-4" />
+              <X className="h-4 w-4" />
             </IconButton>
           </div>
 
@@ -279,7 +279,7 @@ export function ApiCheckModal({ t, view, actions, refs }: ApiCheckModalProps) {
                       )}
                     </div>
                   </div>
-                  <ChevronDownIcon
+                  <ChevronDown
                     className={cn(
                       "text-muted-foreground h-4 w-4 shrink-0 transition-transform",
                       view.isProfileOptionsOpen ? "rotate-180" : "rotate-0",

--- a/src/entrypoints/options/components/Header.tsx
+++ b/src/entrypoints/options/components/Header.tsx
@@ -1,8 +1,4 @@
-import {
-  Bars3Icon,
-  MagnifyingGlassIcon,
-  XMarkIcon,
-} from "@heroicons/react/24/outline"
+import { Menu, Search, X } from "lucide-react"
 import { useEffect, useState } from "react"
 import { useTranslation } from "react-i18next"
 
@@ -58,7 +54,7 @@ function SearchTrigger({
       aria-label={ariaLabel}
     >
       <span className="flex min-w-0 items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
-        <MagnifyingGlassIcon className="h-4 w-4 shrink-0" />
+        <Search className="h-4 w-4 shrink-0" />
         <span className="truncate">{placeholder}</span>
       </span>
       {showShortcutHint ? (
@@ -137,9 +133,9 @@ function Header({
               aria-label={t("navigation.toggleMenu")}
             >
               {isMobileSidebarOpen ? (
-                <XMarkIcon className="h-6 w-6" />
+                <X className="h-6 w-6" />
               ) : (
-                <Bars3Icon className="h-6 w-6" />
+                <Menu className="h-6 w-6" />
               )}
             </IconButton>
 
@@ -219,7 +215,7 @@ function Header({
               className="md:hidden"
               aria-label={t("optionsSearch.open")}
             >
-              <MagnifyingGlassIcon className="h-5 w-5" />
+              <Search className="h-5 w-5" />
             </IconButton>
           </div>
         </div>

--- a/src/entrypoints/options/components/HeaderThemeSwitcher.tsx
+++ b/src/entrypoints/options/components/HeaderThemeSwitcher.tsx
@@ -1,9 +1,5 @@
-import {
-  ComputerDesktopIcon,
-  MoonIcon,
-  SunIcon,
-} from "@heroicons/react/24/outline"
 import type { TFunction } from "i18next"
+import { Monitor, Moon, Sun } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import { IconButton } from "~/components/ui"
@@ -34,17 +30,17 @@ const getThemeOptions = (t: TFunction) => {
     {
       mode: "light" as ThemeMode,
       label: getThemeLabel(t, "light"),
-      icon: SunIcon,
+      icon: Sun,
     },
     {
       mode: "dark" as ThemeMode,
       label: getThemeLabel(t, "dark"),
-      icon: MoonIcon,
+      icon: Moon,
     },
     {
       mode: "system" as ThemeMode,
       label: getThemeLabel(t, "system"),
-      icon: ComputerDesktopIcon,
+      icon: Monitor,
     },
   ]
 }

--- a/src/entrypoints/options/components/Sidebar.tsx
+++ b/src/entrypoints/options/components/Sidebar.tsx
@@ -1,8 +1,5 @@
-import {
-  ChevronDoubleLeftIcon,
-  ChevronDoubleRightIcon,
-} from "@heroicons/react/24/outline"
 import { motion } from "framer-motion"
+import { ChevronsLeft, ChevronsRight } from "lucide-react"
 import { useEffect } from "react"
 import { useTranslation } from "react-i18next"
 
@@ -158,9 +155,9 @@ function Sidebar({
                 onClick={handleCollapseButtonClick}
               >
                 {shouldShowCollapsedState ? (
-                  <ChevronDoubleRightIcon className="h-4 w-4" />
+                  <ChevronsRight className="h-4 w-4" />
                 ) : (
-                  <ChevronDoubleLeftIcon className="h-4 w-4" />
+                  <ChevronsLeft className="h-4 w-4" />
                 )}
               </Button>
             )}
@@ -254,9 +251,9 @@ function Sidebar({
                 onClick={handleCollapseButtonClick}
               >
                 {shouldShowCollapsedState ? (
-                  <ChevronDoubleRightIcon className="h-5 w-5" />
+                  <ChevronsRight className="h-5 w-5" />
                 ) : (
-                  <ChevronDoubleLeftIcon className="h-5 w-5" />
+                  <ChevronsLeft className="h-5 w-5" />
                 )}
               </IconButton>
             )}

--- a/src/entrypoints/options/components/ThemeToggle/index.tsx
+++ b/src/entrypoints/options/components/ThemeToggle/index.tsx
@@ -1,9 +1,5 @@
-import {
-  ComputerDesktopIcon,
-  MoonIcon,
-  SunIcon,
-} from "@heroicons/react/24/outline"
 import type { TFunction } from "i18next"
+import { Monitor, Moon, Sun } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import { ResponsiveToggleGroup } from "~/components/ResponsiveButtonGroup"
@@ -17,19 +13,19 @@ const getThemeOptions = (t: TFunction) => {
     {
       mode: "light" as ThemeMode,
       label: t("settings:theme.light"),
-      icon: SunIcon,
+      icon: Sun,
       description: t("settings:theme.useLightTheme"),
     },
     {
       mode: "dark" as ThemeMode,
       label: t("settings:theme.dark"),
-      icon: MoonIcon,
+      icon: Moon,
       description: t("settings:theme.useDarkTheme"),
     },
     {
       mode: "system" as ThemeMode,
       label: t("settings:theme.followSystem"),
-      icon: ComputerDesktopIcon,
+      icon: Monitor,
       description: t("settings:theme.followSystemTheme"),
     },
   ]
@@ -47,7 +43,7 @@ const ThemeToggle = () => {
   return (
     <CardItem
       id="appearance-theme-mode"
-      icon={<SunIcon className="h-5 w-5 text-amber-500 dark:text-amber-400" />}
+      icon={<Sun className="h-5 w-5 text-amber-500 dark:text-amber-400" />}
       title={t("theme.appearance")}
       description={t("theme.selectTheme")}
       rightContent={

--- a/src/entrypoints/popup/components/ActionButtons.tsx
+++ b/src/entrypoints/popup/components/ActionButtons.tsx
@@ -1,10 +1,4 @@
-import {
-  CalendarDaysIcon,
-  CpuChipIcon,
-  CurrencyYenIcon,
-  KeyIcon,
-  PlusIcon,
-} from "@heroicons/react/24/outline"
+import { CalendarDays, Cpu, JapaneseYen, KeyRound, Plus } from "lucide-react"
 import type { MouseEvent } from "react"
 import { useTranslation } from "react-i18next"
 
@@ -114,7 +108,7 @@ export default function ActionButtons({
             data-testid={primaryActionTestId}
             className="flex-1 touch-manipulation"
             size="default"
-            leftIcon={<PlusIcon className="h-4 w-4" />}
+            leftIcon={<Plus className="h-4 w-4" />}
             analyticsAction={primaryAnalyticsAction}
           >
             {primaryActionLabel}
@@ -134,7 +128,7 @@ export default function ActionButtons({
                   PRODUCT_ANALYTICS_ACTION_IDS.OpenPopupKeyManagement
                 }
               >
-                <KeyIcon className="h-4 w-4" />
+                <KeyRound className="h-4 w-4" />
               </IconButton>
             </ProductAnalyticsScope>
           </Tooltip>
@@ -153,7 +147,7 @@ export default function ActionButtons({
                   PRODUCT_ANALYTICS_ACTION_IDS.OpenPopupModelManagement
                 }
               >
-                <CpuChipIcon className="h-4 w-4" />
+                <Cpu className="h-4 w-4" />
               </IconButton>
             </ProductAnalyticsScope>
           </Tooltip>
@@ -172,7 +166,7 @@ export default function ActionButtons({
                   PRODUCT_ANALYTICS_ACTION_IDS.RunPopupQuickCheckin
                 }
               >
-                <CalendarDaysIcon className="h-4 w-4" />
+                <CalendarDays className="h-4 w-4" />
               </IconButton>
             </Tooltip>
 
@@ -186,7 +180,7 @@ export default function ActionButtons({
                   aria-label={t("navigation.externalCheckinAll")}
                 >
                   {/* Match per-account indicator colors: red when not checked in today, green when done. */}
-                  <CurrencyYenIcon
+                  <JapaneseYen
                     className={`h-4 w-4 ${
                       hasUncheckedExternalCheckIns
                         ? "text-red-500"

--- a/src/entrypoints/popup/components/BalanceSection/TokenStats.tsx
+++ b/src/entrypoints/popup/components/BalanceSection/TokenStats.tsx
@@ -1,4 +1,4 @@
-import { ArrowDownIcon, ArrowUpIcon } from "@heroicons/react/24/outline"
+import { ArrowDown, ArrowUp } from "lucide-react"
 import React from "react"
 import { useTranslation } from "react-i18next"
 
@@ -119,13 +119,13 @@ export const TokenStats = React.memo(() => {
         aria-label={completeBreakdownLabel}
       >
         <div className="flex items-center gap-1">
-          <ArrowUpIcon className="h-4 w-4 text-green-500" />
+          <ArrowUp className="h-4 w-4 text-green-500" />
           <BodySmall weight="medium">
             {formatTokenCount(todayTokens.today_total_prompt_tokens)}
           </BodySmall>
         </div>
         <div className="flex items-center gap-1">
-          <ArrowDownIcon className="h-4 w-4 text-blue-500" />
+          <ArrowDown className="h-4 w-4 text-blue-500" />
           <BodySmall weight="medium">
             {formatTokenCount(todayTokens.today_total_completion_tokens)}
           </BodySmall>

--- a/src/entrypoints/popup/components/FirefoxAddAccountWarningDialog/index.tsx
+++ b/src/entrypoints/popup/components/FirefoxAddAccountWarningDialog/index.tsx
@@ -1,4 +1,4 @@
-import { ExclamationTriangleIcon } from "@heroicons/react/24/outline"
+import { TriangleAlert } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import { Button } from "~/components/ui"
@@ -23,7 +23,7 @@ export default function FirefoxAddAccountWarningDialog({
 
   const header = (
     <div className="flex items-center space-x-3">
-      <ExclamationTriangleIcon className="h-5 w-5 text-orange-500 dark:text-orange-300" />
+      <TriangleAlert className="h-5 w-5 text-orange-500 dark:text-orange-300" />
       <div className="dark:text-dark-text-primary text-lg font-semibold text-gray-900">
         {t("dialog.firefox.warningTitle")}
       </div>
@@ -33,7 +33,7 @@ export default function FirefoxAddAccountWarningDialog({
   const footer = (
     <div className="space-y-4">
       <div className="text-center">
-        <ExclamationTriangleIcon className="mx-auto h-12 w-12 text-orange-500" />
+        <TriangleAlert className="mx-auto h-12 w-12 text-orange-500" />
         <div className="mt-3">
           <h3 className="dark:text-dark-text-primary text-base font-medium text-gray-900">
             {t("dialog.firefox.limitation")}
@@ -49,7 +49,7 @@ export default function FirefoxAddAccountWarningDialog({
       <div className="rounded-lg border border-orange-100 bg-orange-50 p-3 dark:border-orange-900/30 dark:bg-orange-900/20">
         <div className="flex">
           <div className="shrink-0">
-            <ExclamationTriangleIcon className="h-5 w-5 text-orange-400 dark:text-orange-300" />
+            <TriangleAlert className="h-5 w-5 text-orange-400 dark:text-orange-300" />
           </div>
           <div className="ml-3">
             <h3 className="text-xs font-medium text-orange-800 dark:text-orange-200">

--- a/src/entrypoints/popup/components/HeaderSection.tsx
+++ b/src/entrypoints/popup/components/HeaderSection.tsx
@@ -1,9 +1,4 @@
-import {
-  ArrowPathIcon,
-  ArrowsPointingOutIcon,
-  Cog6ToothIcon,
-} from "@heroicons/react/24/outline"
-import { PanelRightClose } from "lucide-react"
+import { Maximize2, PanelRightClose, RefreshCw, Settings } from "lucide-react"
 import { useCallback, useState } from "react"
 import toast from "react-hot-toast"
 import { useTranslation } from "react-i18next"
@@ -239,7 +234,7 @@ export default function HeaderSection({
                   aria-label={t("common:actions.refresh")}
                   className="touch-manipulation"
                 >
-                  <ArrowPathIcon className="h-4 w-4" />
+                  <RefreshCw className="h-4 w-4" />
                 </IconButton>
               </Tooltip>
             )}
@@ -255,7 +250,7 @@ export default function HeaderSection({
                   className="touch-manipulation"
                   analyticsAction={openFullPageActionId}
                 >
-                  <ArrowsPointingOutIcon className="h-4 w-4" />
+                  <Maximize2 className="h-4 w-4" />
                 </IconButton>
               </Tooltip>
             </ProductAnalyticsScope>
@@ -291,7 +286,7 @@ export default function HeaderSection({
                   PRODUCT_ANALYTICS_ACTION_IDS.OpenPopupSettingsPage
                 }
               >
-                <Cog6ToothIcon className="h-4 w-4" />
+                <Settings className="h-4 w-4" />
               </IconButton>
             </Tooltip>
           </ProductAnalyticsScope>

--- a/src/entrypoints/popup/components/ShareOverviewSnapshotButton.tsx
+++ b/src/entrypoints/popup/components/ShareOverviewSnapshotButton.tsx
@@ -1,4 +1,4 @@
-import { ArrowUpOnSquareIcon } from "@heroicons/react/24/outline"
+import { Share2 } from "lucide-react"
 import { useMemo } from "react"
 import toast from "react-hot-toast"
 import { useTranslation } from "react-i18next"
@@ -133,7 +133,7 @@ export default function ShareOverviewSnapshotButton() {
         disabled={enabledAccountCount <= 0}
         className="touch-manipulation"
       >
-        <ArrowUpOnSquareIcon className="h-4 w-4" />
+        <Share2 className="h-4 w-4" />
       </IconButton>
     </Tooltip>
   )

--- a/src/entrypoints/popup/components/ThemeToggle/index.tsx
+++ b/src/entrypoints/popup/components/ThemeToggle/index.tsx
@@ -1,9 +1,5 @@
-import {
-  ComputerDesktopIcon,
-  MoonIcon,
-  SunIcon,
-} from "@heroicons/react/24/outline"
 import type { TFunction } from "i18next"
+import { Monitor, Moon, Sun } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import { IconButton } from "~/components/ui"
@@ -26,19 +22,19 @@ const getThemeOptions = (t: TFunction) => {
     {
       mode: "light" as ThemeMode,
       label: getThemeLabel(t, "light"),
-      icon: SunIcon,
+      icon: Sun,
       description: t("settings:theme.useLightTheme"),
     },
     {
       mode: "dark" as ThemeMode,
       label: getThemeLabel(t, "dark"),
-      icon: MoonIcon,
+      icon: Moon,
       description: t("settings:theme.useDarkTheme"),
     },
     {
       mode: "system" as ThemeMode,
       label: getThemeLabel(t, "system"),
-      icon: ComputerDesktopIcon,
+      icon: Monitor,
       description: t("settings:theme.followSystemTheme"),
     },
   ]
@@ -55,7 +51,7 @@ const CompactThemeToggle = () => {
   const nextIndex = (currentIndex + 1) % themeOptions.length
   const nextTheme = themeOptions[nextIndex]
 
-  const CurrentIcon = themeOptions[currentIndex]?.icon || ComputerDesktopIcon
+  const CurrentIcon = themeOptions[currentIndex]?.icon || Monitor
   const currentTheme = themeOptions[currentIndex]
 
   const handleThemeToggle = () => {

--- a/src/features/About/About.tsx
+++ b/src/features/About/About.tsx
@@ -1,16 +1,16 @@
-import {
-  ArrowDownTrayIcon,
-  BugAntIcon,
-  ChatBubbleLeftEllipsisIcon,
-  CodeBracketIcon,
-  GlobeAltIcon,
-  LanguageIcon,
-  LightBulbIcon,
-  StarIcon,
-  UsersIcon,
-} from "@heroicons/react/24/outline"
 import type { TFunction } from "i18next"
-import { Info } from "lucide-react"
+import {
+  Bug,
+  Code2,
+  Download,
+  Globe2,
+  Info,
+  Languages,
+  Lightbulb,
+  MessageSquareMore,
+  Star,
+  Users,
+} from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import FeatureList from "~/components/FeatureList"
@@ -110,7 +110,7 @@ export default function About() {
           <Heading4 className="mb-4">{t("projectLinks")}</Heading4>
           <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
             <LinkCard
-              Icon={CodeBracketIcon}
+              Icon={Code2}
               title={t("githubRepo")}
               description={t("githubDesc")}
               href={feedbackDestinations.repository}
@@ -119,7 +119,7 @@ export default function About() {
               iconClass="text-gray-900 dark:text-gray-100"
             />
             <LinkCard
-              Icon={GlobeAltIcon}
+              Icon={Globe2}
               title={t("homepage")}
               description={t("homepageDesc")}
               href={homepage}
@@ -139,7 +139,7 @@ export default function About() {
           <Heading4 className="mb-4">{t("feedbackSection.title")}</Heading4>
           <div className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
             <LinkCard
-              Icon={BugAntIcon}
+              Icon={Bug}
               title={t("ui:feedback.bugReport")}
               description={t("feedbackSection.bugReport.description")}
               href={feedbackDestinations.bugReport}
@@ -148,7 +148,7 @@ export default function About() {
               iconClass="text-red-600 dark:text-red-400"
             />
             <LinkCard
-              Icon={LightBulbIcon}
+              Icon={Lightbulb}
               title={t("ui:feedback.featureRequest")}
               description={t("feedbackSection.featureRequest.description")}
               href={feedbackDestinations.featureRequest}
@@ -157,7 +157,7 @@ export default function About() {
               iconClass="text-amber-500 dark:text-amber-400"
             />
             <LinkCard
-              Icon={LanguageIcon}
+              Icon={Languages}
               title={t("ui:feedback.languageRequest")}
               description={t("feedbackSection.languageRequest.description")}
               href={feedbackDestinations.languageRequest}
@@ -166,7 +166,7 @@ export default function About() {
               iconClass="text-indigo-600 dark:text-indigo-400"
             />
             <LinkCard
-              Icon={UsersIcon}
+              Icon={Users}
               title={t("ui:feedback.community")}
               description={t("feedbackSection.community.description")}
               href={feedbackDestinations.community}
@@ -175,7 +175,7 @@ export default function About() {
               iconClass="text-emerald-600 dark:text-emerald-400"
             />
             <LinkCard
-              Icon={ChatBubbleLeftEllipsisIcon}
+              Icon={MessageSquareMore}
               title={t("ui:feedback.discussion")}
               description={t("feedbackSection.discussion.description")}
               href={feedbackDestinations.discussions}
@@ -191,7 +191,7 @@ export default function About() {
           <Heading4 className="mb-4">{t("storesSection.title")}</Heading4>
           <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
             <LinkCard
-              Icon={StarIcon}
+              Icon={Star}
               title={t("storesSection.review.title")}
               description={t("storesSection.review.description", {
                 store: currentStoreName,
@@ -209,7 +209,7 @@ export default function About() {
               return (
                 <LinkCard
                   key={storeId}
-                  Icon={ArrowDownTrayIcon}
+                  Icon={Download}
                   title={storeLabel}
                   description={t("storesSection.download.description", {
                     store: storeLabel,

--- a/src/features/About/components/CreditsCard.tsx
+++ b/src/features/About/components/CreditsCard.tsx
@@ -1,4 +1,4 @@
-import { HeartIcon } from "@heroicons/react/24/outline"
+import { Heart } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import { Badge, BodySmall, Card, CardContent, Heading6 } from "~/components/ui"
@@ -9,7 +9,7 @@ const CreditsCard = () => {
     <Card>
       <CardContent>
         <div className="flex items-start space-x-4">
-          <HeartIcon className="mt-1 h-6 w-6 shrink-0 text-red-500 dark:text-red-400" />
+          <Heart className="mt-1 h-6 w-6 shrink-0 text-red-500 dark:text-red-400" />
           <div className="flex-1">
             <Heading6 className="mb-2">{t("devMaintenance")}</Heading6>
             <BodySmall className="dark:text-dark-text-secondary mb-4 text-gray-600">

--- a/src/features/AccountManagement/AccountManagement.tsx
+++ b/src/features/AccountManagement/AccountManagement.tsx
@@ -1,5 +1,10 @@
-import { ArrowPathIcon } from "@heroicons/react/24/outline"
-import { BookmarkPlus, CalendarCheck2, Search, UserRound } from "lucide-react"
+import {
+  BookmarkPlus,
+  CalendarCheck2,
+  RefreshCw,
+  Search,
+  UserRound,
+} from "lucide-react"
 import {
   useCallback,
   useEffect,
@@ -373,7 +378,7 @@ function AccountManagementContent({
               <Button
                 onClick={() => void handleGlobalRefresh()}
                 variant="secondary"
-                leftIcon={<ArrowPathIcon className="h-4 w-4" />}
+                leftIcon={<RefreshCw className="h-4 w-4" />}
                 loading={isRefreshing}
                 disabled={isAnyRefreshRunning}
               >
@@ -385,7 +390,7 @@ function AccountManagementContent({
                 <Button
                   onClick={() => void handleDisabledRefresh()}
                   variant="secondary"
-                  leftIcon={<ArrowPathIcon className="h-4 w-4" />}
+                  leftIcon={<RefreshCw className="h-4 w-4" />}
                   loading={isRefreshingDisabledAccounts}
                   disabled={isAnyRefreshRunning}
                 >

--- a/src/features/AccountManagement/components/AccountActionButtons/index.tsx
+++ b/src/features/AccountManagement/components/AccountActionButtons/index.tsx
@@ -1,21 +1,24 @@
-import {
-  ArrowPathIcon,
-  ArrowUpOnSquareIcon,
-  BanknotesIcon,
-  CheckCircleIcon,
-  CpuChipIcon,
-  EllipsisHorizontalIcon,
-  KeyIcon,
-  LinkIcon,
-  ListBulletIcon,
-  MagnifyingGlassIcon,
-  NoSymbolIcon,
-  PencilIcon,
-  TrashIcon,
-} from "@heroicons/react/24/outline"
 import type { TFunction } from "i18next"
 import { isPlainObject } from "lodash-es"
-import { CalendarCheck2, ChartPieIcon, PinIcon, PinOffIcon } from "lucide-react"
+import {
+  Ban,
+  Banknote,
+  CalendarCheck2,
+  ChartPie,
+  CircleCheck,
+  Cpu,
+  Ellipsis,
+  KeyRound,
+  Link,
+  List,
+  Pencil,
+  Pin,
+  PinOff,
+  RefreshCw,
+  Search,
+  Share2,
+  Trash2,
+} from "lucide-react"
 import React, { useEffect, useRef, useState } from "react"
 import toast from "react-hot-toast"
 import { useTranslation } from "react-i18next"
@@ -328,7 +331,7 @@ export default function AccountActionButtons({
 
   const isPinned = isAccountPinned(site.id)
   const pinLabel = isPinned ? t("actions.unpin") : t("actions.pin")
-  const PinToggleIcon = isPinned ? PinOffIcon : PinIcon
+  const PinToggleIcon = isPinned ? PinOff : Pin
 
   useEffect(() => {
     return () => {
@@ -1003,7 +1006,7 @@ export default function AccountActionButtons({
           title={t("actions.copyUrl")}
           analyticsAction={PRODUCT_ANALYTICS_ACTION_IDS.CopyAccountSiteUrl}
         >
-          <LinkIcon className="h-4 w-4" />
+          <Link className="h-4 w-4" />
         </IconButton>
 
         <IconButton
@@ -1017,7 +1020,7 @@ export default function AccountActionButtons({
           data-testid={ACCOUNT_MANAGEMENT_TEST_IDS.rowCopyKeyButton}
           title={primaryKeyActionLabel}
         >
-          <KeyIcon className="h-4 w-4" />
+          <KeyRound className="h-4 w-4" />
         </IconButton>
 
         <IconButton
@@ -1034,7 +1037,7 @@ export default function AccountActionButtons({
           title={t("actions.edit")}
           analyticsAction={PRODUCT_ANALYTICS_ACTION_IDS.OpenUpdateAccountDialog}
         >
-          <PencilIcon className="h-4 w-4" />
+          <Pencil className="h-4 w-4" />
         </IconButton>
 
         {/* Secondary Level - Dropdown menu */}
@@ -1049,7 +1052,7 @@ export default function AccountActionButtons({
               aria-label={t("common:actions.more")}
               data-testid={ACCOUNT_MANAGEMENT_TEST_IDS.rowMoreActionsButton}
             >
-              <EllipsisHorizontalIcon className="h-4 w-4" />
+              <Ellipsis className="h-4 w-4" />
             </IconButton>
           </DropdownMenuTrigger>
 
@@ -1061,7 +1064,7 @@ export default function AccountActionButtons({
               <>
                 <AccountActionMenuItem
                   onClick={handleDisableToggle}
-                  icon={CheckCircleIcon}
+                  icon={CircleCheck}
                   label={t("actions.enableAccount")}
                   tone="success"
                   testId={ACCOUNT_MANAGEMENT_TEST_IDS.rowDisableToggleMenuItem}
@@ -1071,7 +1074,7 @@ export default function AccountActionButtons({
 
                 <AccountActionMenuItem
                   onClick={handleDeleteLocal}
-                  icon={TrashIcon}
+                  icon={Trash2}
                   label={t("actions.delete")}
                   isDestructive={true}
                   testId={ACCOUNT_MANAGEMENT_TEST_IDS.rowDeleteMenuItem}
@@ -1082,14 +1085,14 @@ export default function AccountActionButtons({
                 {/* Secondary Menu Items */}
                 <AccountActionMenuItem
                   onClick={handleOpenKeyList}
-                  icon={ListBulletIcon}
+                  icon={List}
                   label={t("actions.keyList")}
                   analyticsAction={PRODUCT_ANALYTICS_ACTION_IDS.OpenKeyList}
                 />
 
                 <AccountActionMenuItem
                   onClick={handleNavigateToKeyManagement}
-                  icon={KeyIcon}
+                  icon={KeyRound}
                   label={t("actions.keyManagement")}
                   testId={ACCOUNT_MANAGEMENT_TEST_IDS.rowKeyManagementMenuItem}
                   analyticsAction={
@@ -1102,7 +1105,7 @@ export default function AccountActionButtons({
                 >
                   <AccountActionMenuItem
                     onClick={handleNavigateToModelManagement}
-                    icon={CpuChipIcon}
+                    icon={Cpu}
                     label={t("actions.modelManagement")}
                     testId={
                       ACCOUNT_MANAGEMENT_TEST_IDS.rowModelManagementMenuItem
@@ -1121,7 +1124,7 @@ export default function AccountActionButtons({
                   >
                     <AccountActionMenuItem
                       onClick={handleLocateManagedSiteChannel}
-                      icon={MagnifyingGlassIcon}
+                      icon={Search}
                       label={t("actions.locateManagedSiteChannel")}
                       hint={
                         !isManagedSiteChannelLookupSupported
@@ -1148,7 +1151,7 @@ export default function AccountActionButtons({
                 >
                   <AccountActionMenuItem
                     onClick={handleNavigateToUsageManagement}
-                    icon={ChartPieIcon}
+                    icon={ChartPie}
                     label={t("actions.usageLog")}
                     testId={ACCOUNT_MANAGEMENT_TEST_IDS.rowUsageLogMenuItem}
                     analyticsAction={
@@ -1159,7 +1162,7 @@ export default function AccountActionButtons({
 
                 <AccountActionMenuItem
                   onClick={handleNavigateToRedeemPage}
-                  icon={BanknotesIcon}
+                  icon={Banknote}
                   label={t("actions.redeemPage")}
                   testId={ACCOUNT_MANAGEMENT_TEST_IDS.rowRedeemMenuItem}
                   analyticsAction={PRODUCT_ANALYTICS_ACTION_IDS.OpenRedeemPage}
@@ -1179,7 +1182,7 @@ export default function AccountActionButtons({
 
                 <AccountActionMenuItem
                   onClick={handleRefreshLocal}
-                  icon={ArrowPathIcon}
+                  icon={RefreshCw}
                   label={t("actions.refresh")}
                   loading={isRefreshMenuPending}
                   loadingLabel={t("common:status.refreshing")}
@@ -1204,7 +1207,7 @@ export default function AccountActionButtons({
 
                 <AccountActionMenuItem
                   onClick={handleCopyInviteLink}
-                  icon={LinkIcon}
+                  icon={Link}
                   label={t("actions.copyInviteLink")}
                   hint={
                     !canCopyInviteLink
@@ -1224,7 +1227,7 @@ export default function AccountActionButtons({
 
                 <AccountActionMenuItem
                   onClick={handleShareSnapshot}
-                  icon={ArrowUpOnSquareIcon}
+                  icon={Share2}
                   label={t("shareSnapshots:actions.shareAccountSnapshot")}
                 />
 
@@ -1233,7 +1236,7 @@ export default function AccountActionButtons({
                 {/* Place Disable immediately above Delete for clarity and consistency. */}
                 <AccountActionMenuItem
                   onClick={handleDisableToggle}
-                  icon={NoSymbolIcon}
+                  icon={Ban}
                   label={t("actions.disableAccount")}
                   tone="warning"
                   testId={ACCOUNT_MANAGEMENT_TEST_IDS.rowDisableToggleMenuItem}
@@ -1241,7 +1244,7 @@ export default function AccountActionButtons({
 
                 <AccountActionMenuItem
                   onClick={handleDeleteLocal}
-                  icon={TrashIcon}
+                  icon={Trash2}
                   label={t("actions.delete")}
                   isDestructive={true}
                   testId={ACCOUNT_MANAGEMENT_TEST_IDS.rowDeleteMenuItem}

--- a/src/features/AccountManagement/components/AccountDialog/AccountForm.tsx
+++ b/src/features/AccountManagement/components/AccountDialog/AccountForm.tsx
@@ -1,13 +1,13 @@
 import {
-  ArrowDownTrayIcon,
-  CalendarDaysIcon,
-  CurrencyDollarIcon,
-  GlobeAltIcon,
-  KeyIcon,
-  TicketIcon,
-  UserIcon,
-} from "@heroicons/react/24/outline"
-import { Cookie } from "lucide-react"
+  CalendarDays,
+  Cookie,
+  DollarSign,
+  Download,
+  Globe2,
+  KeyRound,
+  Ticket,
+  User,
+} from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import {
@@ -173,7 +173,7 @@ export default function AccountForm({
             value={siteName}
             onChange={(e) => onSiteNameChange(e.target.value)}
             placeholder="example.com"
-            leftIcon={<GlobeAltIcon className="h-5 w-5" />}
+            leftIcon={<Globe2 className="h-5 w-5" />}
             data-testid={ACCOUNT_MANAGEMENT_TEST_IDS.siteNameInput}
             required
           />
@@ -192,7 +192,7 @@ export default function AccountForm({
               data-site-type={siteType ?? SITE_TYPES.UNKNOWN}
             >
               <div className="flex items-center gap-2">
-                <GlobeAltIcon className="text-muted-foreground h-5 w-5" />
+                <Globe2 className="text-muted-foreground h-5 w-5" />
                 <SelectValue placeholder={t("form.siteType")} />
               </div>
             </SelectTrigger>
@@ -238,7 +238,7 @@ export default function AccountForm({
             <SelectContent align="end" className="min-w-48">
               <SelectItem value={AuthTypeEnum.AccessToken}>
                 <div className="flex items-center gap-2">
-                  <KeyIcon className="h-4 w-4" />
+                  <KeyRound className="h-4 w-4" />
                   <span>{t("siteInfo.authType.accessToken")}</span>
                 </div>
               </SelectItem>
@@ -263,7 +263,7 @@ export default function AccountForm({
             value={username}
             onChange={(e) => onUsernameChange(e.target.value)}
             placeholder={t("form.username")}
-            leftIcon={<UserIcon className="h-5 w-5" />}
+            leftIcon={<User className="h-5 w-5" />}
             data-testid={ACCOUNT_MANAGEMENT_TEST_IDS.usernameInput}
             required={sitePolicy.requireUsername}
           />
@@ -309,7 +309,7 @@ export default function AccountForm({
                     ? t("form.openrouterManagementKey")
                     : t("form.accessToken")
                 }
-                leftIcon={<KeyIcon className="h-5 w-5" />}
+                leftIcon={<KeyRound className="h-5 w-5" />}
                 data-testid={ACCOUNT_MANAGEMENT_TEST_IDS.accessTokenInput}
                 required
               />
@@ -372,7 +372,7 @@ export default function AccountForm({
                       data-testid={
                         ACCOUNT_MANAGEMENT_TEST_IDS.sub2apiImportSessionButton
                       }
-                      leftIcon={<ArrowDownTrayIcon className="h-4 w-4" />}
+                      leftIcon={<Download className="h-4 w-4" />}
                     >
                       {isImportingSub2apiSession
                         ? t("common:status.importing")
@@ -390,7 +390,7 @@ export default function AccountForm({
                         onSub2apiRefreshTokenChange(e.target.value)
                       }
                       placeholder={t("form.sub2apiRefreshTokenPlaceholder")}
-                      leftIcon={<KeyIcon className="h-5 w-5" />}
+                      leftIcon={<KeyRound className="h-5 w-5" />}
                       data-testid={
                         ACCOUNT_MANAGEMENT_TEST_IDS.sub2apiRefreshTokenInput
                       }
@@ -407,7 +407,7 @@ export default function AccountForm({
                         sub2apiTokenExpiresAt,
                         t("common:labels.notAvailable"),
                       )}
-                      leftIcon={<CalendarDaysIcon className="h-5 w-5" />}
+                      leftIcon={<CalendarDays className="h-5 w-5" />}
                       disabled
                     />
                   </FormField>
@@ -437,7 +437,7 @@ export default function AccountForm({
                 size="sm"
                 onClick={onImportCookieAuthSessionCookie}
                 loading={isImportingCookies}
-                leftIcon={<ArrowDownTrayIcon className="h-4 w-4" />}
+                leftIcon={<Download className="h-4 w-4" />}
                 className="w-full"
               >
                 {isImportingCookies
@@ -579,7 +579,7 @@ export default function AccountForm({
               })
             }
             placeholder="https://cdk.example.com/"
-            leftIcon={<CalendarDaysIcon className="h-5 w-5" />}
+            leftIcon={<CalendarDays className="h-5 w-5" />}
           />
         </FormField>
 
@@ -630,7 +630,7 @@ export default function AccountForm({
               })
             }
             placeholder="https://example.com/console/topup"
-            leftIcon={<TicketIcon className="h-5 w-5" />}
+            leftIcon={<Ticket className="h-5 w-5" />}
           />
         </FormField>
       </AccountFormSection>
@@ -657,7 +657,7 @@ export default function AccountForm({
             value={exchangeRate}
             onChange={(e) => onExchangeRateChange(e.target.value)}
             placeholder={t("form.exchangeRatePlaceholder")}
-            leftIcon={<CurrencyDollarIcon className="h-5 w-5" />}
+            leftIcon={<DollarSign className="h-5 w-5" />}
             rightIcon={
               <span className="dark:text-dark-text-secondary text-sm text-gray-500">
                 CNY
@@ -688,7 +688,7 @@ export default function AccountForm({
             value={manualBalanceUsd}
             onChange={(e) => onManualBalanceUsdChange(e.target.value)}
             placeholder={t("form.manualBalanceUsdPlaceholder")}
-            leftIcon={<CurrencyDollarIcon className="h-5 w-5" />}
+            leftIcon={<DollarSign className="h-5 w-5" />}
             rightIcon={
               <span className="dark:text-dark-text-secondary text-sm text-gray-500">
                 USD

--- a/src/features/AccountManagement/components/AccountDialog/ActionButtons.tsx
+++ b/src/features/AccountManagement/components/AccountDialog/ActionButtons.tsx
@@ -1,9 +1,4 @@
-import {
-  BoltIcon,
-  CheckIcon,
-  PencilIcon,
-  SparklesIcon,
-} from "@heroicons/react/24/outline"
+import { Check, Pencil, Sparkles, Zap } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import { Button } from "~/components/ui"
@@ -129,9 +124,7 @@ export default function ActionButtons({
           }
           variant="default"
           data-testid={ACCOUNT_MANAGEMENT_TEST_IDS.autoDetectButton}
-          leftIcon={
-            !isDetecting ? <SparklesIcon className="h-4 w-4" /> : undefined
-          }
+          leftIcon={!isDetecting ? <Sparkles className="h-4 w-4" /> : undefined}
         >
           {autoDetectLabel}
         </Button>
@@ -143,7 +136,7 @@ export default function ActionButtons({
           className="flex-1"
           variant="outline"
           data-testid={ACCOUNT_MANAGEMENT_TEST_IDS.manualAddButton}
-          leftIcon={<PencilIcon className="h-4 w-4" />}
+          leftIcon={<Pencil className="h-4 w-4" />}
         >
           {t("accountDialog:mode.manualAdd")}
         </Button>
@@ -170,9 +163,7 @@ export default function ActionButtons({
               : "flex-1"
           }
           variant="warning"
-          leftIcon={
-            !isDetecting ? <SparklesIcon className="h-4 w-4" /> : undefined
-          }
+          leftIcon={!isDetecting ? <Sparkles className="h-4 w-4" /> : undefined}
         >
           {isDetecting
             ? autoDetectLabel
@@ -196,7 +187,7 @@ export default function ActionButtons({
           title={autoConfigTitle}
           variant="default"
           leftIcon={
-            !isAutoConfiguring ? <BoltIcon className="h-4 w-4" /> : undefined
+            !isAutoConfiguring ? <Zap className="h-4 w-4" /> : undefined
           }
         >
           {isAutoConfiguring
@@ -216,7 +207,7 @@ export default function ActionButtons({
         className="flex-1"
         variant={isAddMode ? "success" : "default"}
         data-testid={ACCOUNT_MANAGEMENT_TEST_IDS.confirmAddButton}
-        leftIcon={!isSaving ? <CheckIcon className="h-4 w-4" /> : undefined}
+        leftIcon={!isSaving ? <Check className="h-4 w-4" /> : undefined}
       >
         {isSaving
           ? t("common:status.saving")

--- a/src/features/AccountManagement/components/AccountDialog/AihubmixDefaultKeyPromptDialog.tsx
+++ b/src/features/AccountManagement/components/AccountDialog/AihubmixDefaultKeyPromptDialog.tsx
@@ -1,4 +1,4 @@
-import { KeyIcon } from "@heroicons/react/24/outline"
+import { KeyRound } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import { Alert } from "~/components/ui/Alert"
@@ -36,7 +36,7 @@ export function AihubmixDefaultKeyPromptDialog({
       header={
         <div className="flex items-center justify-between">
           <div className="flex items-center space-x-3">
-            <KeyIcon className="h-5 w-5 text-yellow-600 dark:text-yellow-400" />
+            <KeyRound className="h-5 w-5 text-yellow-600 dark:text-yellow-400" />
             <h2 className="dark:text-dark-text-primary text-lg font-semibold text-gray-900">
               {t("accountDialog:aihubmixDefaultKeyPrompt.title")}
             </h2>

--- a/src/features/AccountManagement/components/AccountDialog/AutoDetectErrorAlert.tsx
+++ b/src/features/AccountManagement/components/AccountDialog/AutoDetectErrorAlert.tsx
@@ -1,4 +1,4 @@
-import { BookOpenIcon } from "@heroicons/react/24/outline"
+import { BookOpen } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import { WorkflowTransitionIcon } from "~/components/icons/WorkflowTransitionIcon"
@@ -146,7 +146,7 @@ export default function AutoDetectErrorAlert({
                   onClick={handleHelpClick}
                   variant="secondary"
                   size="sm"
-                  leftIcon={<BookOpenIcon className="h-3.5 w-3.5" />}
+                  leftIcon={<BookOpen className="h-3.5 w-3.5" />}
                 >
                   {t("actions.helpDocument")}
                 </Button>

--- a/src/features/AccountManagement/components/AccountDialog/AutoDetectSlowHintAlert.tsx
+++ b/src/features/AccountManagement/components/AccountDialog/AutoDetectSlowHintAlert.tsx
@@ -1,7 +1,4 @@
-import {
-  ArrowPathIcon,
-  QuestionMarkCircleIcon,
-} from "@heroicons/react/24/outline"
+import { CircleHelp, RefreshCw } from "lucide-react"
 import { useState } from "react"
 import { useTranslation } from "react-i18next"
 
@@ -59,7 +56,7 @@ export default function AutoDetectSlowHintAlert({
               onClick={handleHelpClick}
               variant="secondary"
               size="sm"
-              leftIcon={<QuestionMarkCircleIcon className="h-3 w-3" />}
+              leftIcon={<CircleHelp className="h-3 w-3" />}
             >
               {t("accountDialog:actions.helpDocument")}
             </Button>
@@ -68,7 +65,7 @@ export default function AutoDetectSlowHintAlert({
               onClick={handleReloadExtension}
               variant="outline"
               size="sm"
-              leftIcon={<ArrowPathIcon className="h-3 w-3" />}
+              leftIcon={<RefreshCw className="h-3 w-3" />}
             >
               {t("accountDialog:actions.reloadExtensionAndRetry")}
             </Button>

--- a/src/features/AccountManagement/components/AccountDialog/DialogHeader.tsx
+++ b/src/features/AccountManagement/components/AccountDialog/DialogHeader.tsx
@@ -1,4 +1,4 @@
-import { PencilIcon, SparklesIcon } from "@heroicons/react/24/outline"
+import { Pencil, Sparkles } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import { DIALOG_MODES, type DialogMode } from "~/constants/dialogModes"
@@ -16,7 +16,7 @@ export default function DialogHeader({ mode }: DialogHeaderProps) {
   const { t } = useTranslation("accountDialog")
   const isAddMode = mode === DIALOG_MODES.ADD
   const title = isAddMode ? t("title.add") : t("title.edit")
-  const Icon = isAddMode ? SparklesIcon : PencilIcon
+  const Icon = isAddMode ? Sparkles : Pencil
   const iconClass = isAddMode
     ? "text-blue-600 dark:text-blue-400"
     : "text-emerald-600 dark:text-emerald-400"

--- a/src/features/AccountManagement/components/AccountDialog/DuplicateAccountWarningDialog.tsx
+++ b/src/features/AccountManagement/components/AccountDialog/DuplicateAccountWarningDialog.tsx
@@ -1,4 +1,4 @@
-import { ExclamationTriangleIcon } from "@heroicons/react/24/outline"
+import { TriangleAlert } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import { Alert } from "~/components/ui/Alert"
@@ -46,7 +46,7 @@ export function DuplicateAccountWarningDialog({
       header={
         <div className="flex items-center justify-between">
           <div className="flex items-center space-x-3">
-            <ExclamationTriangleIcon className="h-5 w-5 text-yellow-600 dark:text-yellow-400" />
+            <TriangleAlert className="h-5 w-5 text-yellow-600 dark:text-yellow-400" />
             <h2 className="dark:text-dark-text-primary text-lg font-semibold text-gray-900">
               {t("accountDialog:warnings.duplicateAccount.title")}
             </h2>

--- a/src/features/AccountManagement/components/AccountDialog/InfoPanel.tsx
+++ b/src/features/AccountManagement/components/AccountDialog/InfoPanel.tsx
@@ -1,4 +1,4 @@
-import { SparklesIcon, UsersIcon } from "@heroicons/react/24/outline"
+import { Sparkles, Users } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import { LdohIcon } from "~/components/icons/LdohIcon"
@@ -76,7 +76,7 @@ export default function InfoPanel({
     )
   }
 
-  const Icon = isAddMode ? SparklesIcon : UsersIcon
+  const Icon = isAddMode ? Sparkles : Users
   const iconColor = isAddMode ? "text-blue-400" : "text-green-400"
   const bgColor = isAddMode
     ? "bg-blue-50 dark:bg-blue-900/20"

--- a/src/features/AccountManagement/components/AccountDialog/ManagedSiteConfigPromptDialog.tsx
+++ b/src/features/AccountManagement/components/AccountDialog/ManagedSiteConfigPromptDialog.tsx
@@ -1,4 +1,4 @@
-import { ExclamationTriangleIcon } from "@heroicons/react/24/outline"
+import { TriangleAlert } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import { Alert } from "~/components/ui/Alert"
@@ -37,7 +37,7 @@ export function ManagedSiteConfigPromptDialog({
       header={
         <div className="flex items-center justify-between">
           <div className="flex items-center space-x-3">
-            <ExclamationTriangleIcon className="h-5 w-5 text-yellow-600 dark:text-yellow-400" />
+            <TriangleAlert className="h-5 w-5 text-yellow-600 dark:text-yellow-400" />
             <h2 className="dark:text-dark-text-primary text-lg font-semibold text-gray-900">
               {t("accountDialog:warnings.managedSiteConfig.title", {
                 managedSite: managedSiteLabel,

--- a/src/features/AccountManagement/components/AccountDialog/SiteInfoInput.tsx
+++ b/src/features/AccountManagement/components/AccountDialog/SiteInfoInput.tsx
@@ -1,11 +1,12 @@
 import {
-  ExclamationTriangleIcon,
-  GlobeAltIcon,
-  InformationCircleIcon,
-  KeyIcon,
-  PencilIcon,
-} from "@heroicons/react/24/outline"
-import { CircleHelp, Cookie } from "lucide-react"
+  CircleHelp,
+  Cookie,
+  Globe2,
+  Info,
+  KeyRound,
+  Pencil,
+  TriangleAlert,
+} from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import Tooltip from "~/components/Tooltip"
@@ -170,7 +171,7 @@ export default function SiteInfoInput(props: SiteInfoInputProps) {
                 <SelectContent align="end" className="min-w-48">
                   <SelectItem value={AuthTypeEnum.AccessToken}>
                     <div className="flex items-center gap-2">
-                      <KeyIcon className="h-4 w-4" />
+                      <KeyRound className="h-4 w-4" />
                       <span>{t("siteInfo.authType.accessToken")}</span>
                     </div>
                   </SelectItem>
@@ -250,14 +251,14 @@ export default function SiteInfoInput(props: SiteInfoInputProps) {
         )}
         {canUseSub2ApiRefreshToken && (
           <div className="flex w-full items-start gap-2 rounded-md bg-blue-50 p-2 text-xs text-blue-700 dark:bg-blue-900/20 dark:text-blue-300">
-            <InformationCircleIcon className="mt-0.5 h-4 w-4 shrink-0" />
+            <Info className="mt-0.5 h-4 w-4 shrink-0" />
             <span>{t("siteInfo.sub2apiHint")}</span>
           </div>
         )}
         {isCurrentSiteAdded && (
           <div className="flex w-full items-center justify-between rounded-md bg-yellow-50 p-2 text-xs text-yellow-700 dark:bg-yellow-900/20 dark:text-yellow-300">
             <div className="flex items-center">
-              <ExclamationTriangleIcon className="mr-1.5 h-4 w-4 shrink-0" />
+              <TriangleAlert className="mr-1.5 h-4 w-4 shrink-0" />
               {/* Distinguish "site exists" vs "current login matches an existing account" for multi-account sites. */}
               <span>
                 {detectedAccount
@@ -271,7 +272,7 @@ export default function SiteInfoInput(props: SiteInfoInputProps) {
                 onClick={handleEditClick}
                 variant="warning"
                 size="sm"
-                leftIcon={<PencilIcon className="h-3 w-3" />}
+                leftIcon={<Pencil className="h-3 w-3" />}
               >
                 {t("siteInfo.editNow")}
               </Button>
@@ -281,7 +282,7 @@ export default function SiteInfoInput(props: SiteInfoInputProps) {
         {!isDetected && onUseCurrentTab && (
           <div className="flex w-full items-center justify-between rounded-md bg-blue-50 p-2 text-xs text-blue-700 dark:bg-blue-900/20 dark:text-blue-300">
             <div className="flex items-center">
-              <InformationCircleIcon className="h-4 w-4" />
+              <Info className="h-4 w-4" />
               <span className="ml-1">{t("siteInfo.currentSite")}:</span>
               <Tooltip content={currentTabUrl}>
                 <span className="ml-1 max-w-[150px] truncate font-medium">
@@ -296,7 +297,7 @@ export default function SiteInfoInput(props: SiteInfoInputProps) {
               className="flex items-center font-medium text-blue-800 disabled:cursor-not-allowed disabled:text-gray-400 dark:text-blue-200 dark:disabled:text-gray-600"
               disabled={!currentTabUrl}
             >
-              <GlobeAltIcon className="mr-1 h-3 w-3" />
+              <Globe2 className="mr-1 h-3 w-3" />
               <span>{t("siteInfo.useCurrent")}</span>
             </button>
           </div>

--- a/src/features/AccountManagement/components/AccountDialog/index.tsx
+++ b/src/features/AccountManagement/components/AccountDialog/index.tsx
@@ -1,4 +1,4 @@
-import { InformationCircleIcon } from "@heroicons/react/24/outline"
+import { Info } from "lucide-react"
 import { useEffect, useState, type ComponentProps } from "react"
 import { useTranslation } from "react-i18next"
 
@@ -345,7 +345,7 @@ export default function AccountDialog({
                   className="flex items-start gap-2 rounded-md bg-blue-50 p-2 text-xs leading-5 text-blue-700 dark:bg-blue-900/20 dark:text-blue-300"
                   data-testid={ACCOUNT_MANAGEMENT_TEST_IDS.sponsorPostClickNote}
                 >
-                  <InformationCircleIcon
+                  <Info
                     aria-hidden="true"
                     className="mt-0.5 h-4 w-4 shrink-0"
                   />

--- a/src/features/AccountManagement/components/AccountList/AccountFilterBar.tsx
+++ b/src/features/AccountManagement/components/AccountList/AccountFilterBar.tsx
@@ -1,9 +1,4 @@
-import {
-  ArrowPathIcon,
-  CheckBadgeIcon,
-  GlobeAltIcon,
-  PauseCircleIcon,
-} from "@heroicons/react/24/outline"
+import { BadgeCheck, CirclePause, Globe2, RefreshCw } from "lucide-react"
 import type { ComponentType, SVGProps } from "react"
 import { useTranslation } from "react-i18next"
 
@@ -111,7 +106,7 @@ export default function AccountFilterBar({
         siteTypeOptions,
         onSiteTypeChange,
         "account-filter-site-type",
-        GlobeAltIcon,
+        Globe2,
       )}
       {renderSelect(
         checkInValue,
@@ -119,7 +114,7 @@ export default function AccountFilterBar({
         checkInOptions,
         onCheckInChange,
         "account-filter-check-in",
-        CheckBadgeIcon,
+        BadgeCheck,
       )}
       {renderSelect(
         refreshValue,
@@ -127,7 +122,7 @@ export default function AccountFilterBar({
         refreshOptions,
         onRefreshChange,
         "account-filter-refresh",
-        ArrowPathIcon,
+        RefreshCw,
       )}
       {renderSelect(
         disabledValue,
@@ -135,7 +130,7 @@ export default function AccountFilterBar({
         disabledOptions,
         onDisabledChange,
         "account-filter-disabled",
-        PauseCircleIcon,
+        CirclePause,
       )}
     </div>
   )

--- a/src/features/AccountManagement/components/AccountList/AccountListBaseItem.tsx
+++ b/src/features/AccountManagement/components/AccountList/AccountListBaseItem.tsx
@@ -1,4 +1,4 @@
-import { Bars3Icon } from "@heroicons/react/24/outline"
+import { GripVertical } from "lucide-react"
 
 import { IconButton } from "~/components/ui"
 import type { SearchResultWithHighlight } from "~/features/AccountManagement/hooks/useAccountSearch"
@@ -117,7 +117,7 @@ export function NonSortableAccountListItem({
             onPointerDown={handleActivateDnd}
             onTouchStart={handleActivateDnd}
           >
-            <Bars3Icon className="h-4 w-4" />
+            <GripVertical className="h-4 w-4" />
           </IconButton>
         ) : null
       }

--- a/src/features/AccountManagement/components/AccountList/AccountSearchInput.tsx
+++ b/src/features/AccountManagement/components/AccountList/AccountSearchInput.tsx
@@ -1,4 +1,4 @@
-import { MagnifyingGlassIcon } from "@heroicons/react/24/outline"
+import { Search } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import { Input } from "~/components/ui"
@@ -41,7 +41,7 @@ export default function AccountSearchInput({
         onChange={(e) => onChange(e.target.value)}
         onKeyDown={handleKeyDown}
         placeholder={t("search.placeholder")}
-        leftIcon={<MagnifyingGlassIcon className="h-4 w-4" />}
+        leftIcon={<Search className="h-4 w-4" />}
         onClear={onClear}
         clearButtonLabel={t("common:actions.clear")}
       />

--- a/src/features/AccountManagement/components/AccountList/SiteInfo.tsx
+++ b/src/features/AccountManagement/components/AccountList/SiteInfo.tsx
@@ -1,17 +1,17 @@
 import {
-  ArrowPathIcon,
-  CalendarDaysIcon,
-  CheckCircleIcon,
-  CurrencyYenIcon,
-  ExclamationTriangleIcon,
-  GiftIcon,
-  LinkIcon,
-  PencilSquareIcon,
-  TagIcon,
-  UserIcon,
-  XCircleIcon,
-} from "@heroicons/react/24/outline"
-import { PinIcon } from "lucide-react"
+  CalendarDays,
+  CircleCheck,
+  CircleX,
+  Gift,
+  JapaneseYen,
+  Link,
+  Pin,
+  RefreshCw,
+  SquarePen,
+  Tag,
+  TriangleAlert,
+  User,
+} from "lucide-react"
 import { useMemo, useState } from "react"
 import toast from "react-hot-toast"
 import { useTranslation } from "react-i18next"
@@ -300,7 +300,7 @@ export default function SiteInfo({
             position="top"
             wrapperClassName="flex items-center"
           >
-            <ExclamationTriangleIcon className="h-4 w-4 text-yellow-500" />
+            <TriangleAlert className="h-4 w-4 text-yellow-500" />
           </Tooltip>,
         )
       } else if (
@@ -332,7 +332,7 @@ export default function SiteInfo({
               disabled={isRefreshLocked}
               aria-label={staleStatusLabel}
             >
-              <ExclamationTriangleIcon className="h-4 w-4 text-orange-500" />
+              <TriangleAlert className="h-4 w-4 text-orange-500" />
             </IconButton>
           </Tooltip>,
         )
@@ -350,7 +350,7 @@ export default function SiteInfo({
               size="xs"
               aria-label={t("list.site.checkedInToday")}
             >
-              <CheckCircleIcon className="h-4 w-4 text-green-500" />
+              <CircleCheck className="h-4 w-4 text-green-500" />
             </IconButton>
           </Tooltip>,
         )
@@ -368,7 +368,7 @@ export default function SiteInfo({
               size="xs"
               aria-label={t("list.site.notCheckedInToday")}
             >
-              <XCircleIcon className="h-4 w-4 text-red-500" />
+              <CircleX className="h-4 w-4 text-red-500" />
             </IconButton>
           </Tooltip>,
         )
@@ -391,7 +391,7 @@ export default function SiteInfo({
               size="xs"
               aria-label={t("list.site.checkedInToday")}
             >
-              <CurrencyYenIcon className="h-4 w-4 text-green-500" />
+              <JapaneseYen className="h-4 w-4 text-green-500" />
             </IconButton>
           </Tooltip>
         ) : (
@@ -407,7 +407,7 @@ export default function SiteInfo({
               size="xs"
               aria-label={t("list.site.notCheckedInToday")}
             >
-              <CurrencyYenIcon className="h-4 w-4 text-red-500" />
+              <JapaneseYen className="h-4 w-4 text-red-500" />
             </IconButton>
           </Tooltip>
         ),
@@ -520,7 +520,7 @@ export default function SiteInfo({
               size="none"
               aria-label={pinTooltipLabel}
             >
-              <PinIcon
+              <Pin
                 className="dark:text-dark-text-tertiary h-3 w-3 -rotate-12 text-gray-400 transition-colors"
                 aria-hidden="true"
               />
@@ -615,7 +615,7 @@ export default function SiteInfo({
         </div>
 
         <div className="mt-0.5 flex min-w-0 items-start gap-1">
-          <UserIcon className="dark:text-dark-text-tertiary mt-0.5 h-3 w-3 shrink-0 text-gray-400" />
+          <User className="dark:text-dark-text-tertiary mt-0.5 h-3 w-3 shrink-0 text-gray-400" />
           <Caption className="truncate" title={site.username}>
             {highlights?.username && site.username
               ? renderHighlightedFragments(highlights.username, site.username)
@@ -625,7 +625,7 @@ export default function SiteInfo({
 
         {showCreatedAt && (
           <div className="mt-0.5 flex min-w-0 items-start gap-1">
-            <CalendarDaysIcon className="dark:text-dark-text-tertiary mt-0.5 h-3 w-3 shrink-0 text-gray-400" />
+            <CalendarDays className="dark:text-dark-text-tertiary mt-0.5 h-3 w-3 shrink-0 text-gray-400" />
             <Caption
               className="truncate"
               title={`${createdAtLabel}: ${createdAtText}`}
@@ -637,7 +637,7 @@ export default function SiteInfo({
 
         {highlights?.baseUrl && (
           <div className="mt-0.5 flex min-w-0 items-start gap-1">
-            <LinkIcon className="dark:text-dark-text-tertiary mt-0.5 h-3 w-3 shrink-0 text-gray-400" />
+            <Link className="dark:text-dark-text-tertiary mt-0.5 h-3 w-3 shrink-0 text-gray-400" />
             <Caption className="truncate" title={site.baseUrl}>
               {renderHighlightedFragments(highlights.baseUrl, site.baseUrl)}
             </Caption>
@@ -646,7 +646,7 @@ export default function SiteInfo({
 
         {highlights?.customCheckInUrl && customCheckInUrl && (
           <div className="mt-0.5 flex min-w-0 items-start gap-1">
-            <ArrowPathIcon className="dark:text-dark-text-tertiary mt-0.5 h-3 w-3 shrink-0 text-gray-400" />
+            <RefreshCw className="dark:text-dark-text-tertiary mt-0.5 h-3 w-3 shrink-0 text-gray-400" />
             <Caption className="truncate" title={customCheckInUrl}>
               {renderHighlightedFragments(
                 highlights.customCheckInUrl,
@@ -658,7 +658,7 @@ export default function SiteInfo({
 
         {highlights?.customRedeemUrl && customRedeemUrl && (
           <div className="mt-0.5 flex min-w-0 items-start gap-1">
-            <GiftIcon className="dark:text-dark-text-tertiary mt-0.5 h-3 w-3 shrink-0 text-gray-400" />
+            <Gift className="dark:text-dark-text-tertiary mt-0.5 h-3 w-3 shrink-0 text-gray-400" />
             <Caption className="truncate" title={customRedeemUrl}>
               {renderHighlightedFragments(
                 highlights.customRedeemUrl,
@@ -670,7 +670,7 @@ export default function SiteInfo({
 
         {site.notes && (
           <div className="mt-0.5 flex min-w-0 items-start gap-1 sm:mt-1">
-            <PencilSquareIcon className="dark:text-dark-text-tertiary mt-0.5 h-3 w-3 shrink-0 text-gray-400" />
+            <SquarePen className="dark:text-dark-text-tertiary mt-0.5 h-3 w-3 shrink-0 text-gray-400" />
             <Caption className="truncate" title={site.notes}>
               {site.notes}
             </Caption>
@@ -679,7 +679,7 @@ export default function SiteInfo({
 
         {site.tags && site.tags.length > 0 && (
           <div className="mt-0.5 flex min-w-0 items-start gap-1 sm:mt-1">
-            <TagIcon className="dark:text-dark-text-tertiary mt-0.5 h-3 w-3 shrink-0 text-gray-400" />
+            <Tag className="dark:text-dark-text-tertiary mt-0.5 h-3 w-3 shrink-0 text-gray-400" />
             <Caption className="truncate" title={site.tags.join(", ")}>
               {highlights?.tags
                 ? renderHighlightedFragments(

--- a/src/features/AccountManagement/components/AccountList/SortableAccountListItem.tsx
+++ b/src/features/AccountManagement/components/AccountList/SortableAccountListItem.tsx
@@ -1,6 +1,6 @@
 import { useSortable } from "@dnd-kit/sortable"
 import { CSS } from "@dnd-kit/utilities"
-import { Bars3Icon } from "@heroicons/react/24/outline"
+import { GripVertical } from "lucide-react"
 
 import { IconButton } from "~/components/ui"
 
@@ -68,7 +68,7 @@ function SortableAccountListItem({
               {...listeners}
               {...attributes}
             >
-              <Bars3Icon className="h-4 w-4" />
+              <GripVertical className="h-4 w-4" />
             </IconButton>
           ) : null
         }

--- a/src/features/AccountManagement/components/AccountList/index.tsx
+++ b/src/features/AccountManagement/components/AccountList/index.tsx
@@ -1,11 +1,6 @@
 import type { DragEndEvent } from "@dnd-kit/core"
-import {
-  ChevronDownIcon,
-  ChevronUpIcon,
-  InboxIcon,
-  PlusIcon,
-} from "@heroicons/react/24/outline"
 import type { TFunction } from "i18next"
+import { ChevronDown, ChevronUp, Inbox, Plus } from "lucide-react"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import toast from "react-hot-toast"
 import { useTranslation } from "react-i18next"
@@ -1209,7 +1204,7 @@ export default function AccountList({ initialSearchQuery }: AccountListProps) {
         <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
           <div className="flex items-start gap-3">
             <div className="shrink-0 rounded-md bg-blue-50 p-2 text-blue-600 dark:bg-blue-900/40 dark:text-blue-300">
-              <InboxIcon className="h-5 w-5" />
+              <Inbox className="h-5 w-5" />
             </div>
             <div className="space-y-1">
               <h2 className="dark:text-dark-text-primary text-sm font-medium text-gray-900">
@@ -1222,7 +1217,7 @@ export default function AccountList({ initialSearchQuery }: AccountListProps) {
           </div>
           <Button
             className="w-full shrink-0 sm:w-auto"
-            leftIcon={<PlusIcon className="h-4 w-4" />}
+            leftIcon={<Plus className="h-4 w-4" />}
             onClick={handleEmptyStateAddAccountClick}
             size="sm"
           >
@@ -1246,9 +1241,9 @@ export default function AccountList({ initialSearchQuery }: AccountListProps) {
       <span>{label}</span>
       {sortField === field &&
         (sortOrder === "asc" ? (
-          <ChevronUpIcon className="h-2.5 w-2.5 sm:h-3 sm:w-3" />
+          <ChevronUp className="h-2.5 w-2.5 sm:h-3 sm:w-3" />
         ) : (
-          <ChevronDownIcon className="h-2.5 w-2.5 sm:h-3 sm:w-3" />
+          <ChevronDown className="h-2.5 w-2.5 sm:h-3 sm:w-3" />
         ))}
     </IconButton>
   )
@@ -1594,7 +1589,7 @@ export default function AccountList({ initialSearchQuery }: AccountListProps) {
         {/* Account List or No Results */}
         {showFilteredSummary && displayedResults.length === 0 ? (
           <EmptyState
-            icon={<InboxIcon className="h-12 w-12" />}
+            icon={<Inbox className="h-12 w-12" />}
             title={t("account:search.noResults")}
           />
         ) : shouldRenderSortableList && DndWrapper ? (

--- a/src/features/AccountManagement/components/CopyKeyDialog/DialogFooter.tsx
+++ b/src/features/AccountManagement/components/CopyKeyDialog/DialogFooter.tsx
@@ -1,4 +1,4 @@
-import { KeyIcon } from "@heroicons/react/24/outline"
+import { KeyRound } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import { Button } from "~/components/ui"
@@ -25,7 +25,7 @@ export function DialogFooter({
       <div className="flex items-center space-x-2">
         {keyCount > 0 && (
           <div className="dark:text-dark-text-secondary flex items-center space-x-1.5 text-xs text-gray-500">
-            <KeyIcon className="h-3 w-3" />
+            <KeyRound className="h-3 w-3" />
             <span>{t("ui:dialog.copyKey.totalKeys", { count: keyCount })}</span>
           </div>
         )}
@@ -39,7 +39,7 @@ export function DialogFooter({
             onClick={onOpenKeyManagement}
             analyticsAction={PRODUCT_ANALYTICS_ACTION_IDS.OpenKeyManagement}
           >
-            <KeyIcon aria-hidden="true" className="h-4 w-4" />
+            <KeyRound aria-hidden="true" className="h-4 w-4" />
             {t("account:actions.keyManagement")}
           </Button>
         ) : null}

--- a/src/features/AccountManagement/components/CopyKeyDialog/DialogHeader.tsx
+++ b/src/features/AccountManagement/components/CopyKeyDialog/DialogHeader.tsx
@@ -1,4 +1,4 @@
-import { KeyIcon } from "@heroicons/react/24/outline"
+import { KeyRound } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import type { DisplaySiteData } from "~/types"
@@ -16,7 +16,7 @@ export function DialogHeader({ account }: DialogHeaderProps) {
   return (
     <div className="flex items-center justify-between">
       <div className="flex items-center space-x-3">
-        <KeyIcon className="h-5 w-5 text-blue-600 dark:text-blue-400" />
+        <KeyRound className="h-5 w-5 text-blue-600 dark:text-blue-400" />
         <div>
           <h2 className="dark:text-dark-text-primary text-lg font-semibold text-gray-900">
             {t("dialog.copyKey.title")}

--- a/src/features/AccountManagement/components/CopyKeyDialog/KeyInventoryList.tsx
+++ b/src/features/AccountManagement/components/CopyKeyDialog/KeyInventoryList.tsx
@@ -1,8 +1,4 @@
-import {
-  KeyIcon,
-  PencilSquareIcon,
-  PlusIcon,
-} from "@heroicons/react/24/outline"
+import { KeyRound, Plus, SquarePen } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import { Alert, EmptyState } from "~/components/ui"
@@ -63,7 +59,7 @@ export function KeyInventoryList({
                   label: t("dialog.copyKey.createKey"),
                   loadingLabel: t("dialog.copyKey.creatingKey"),
                   onClick: onCreateDefaultKey,
-                  icon: <PlusIcon className="h-4 w-4" />,
+                  icon: <Plus className="h-4 w-4" />,
                   disabled: !canCreateDefaultKey || isCreating,
                   loading: isCreating,
                 },
@@ -74,7 +70,7 @@ export function KeyInventoryList({
                 {
                   label: t("dialog.copyKey.createCustomKey"),
                   onClick: onOpenAddTokenDialog,
-                  icon: <PencilSquareIcon className="h-4 w-4" />,
+                  icon: <SquarePen className="h-4 w-4" />,
                   variant: "outline" as const,
                   disabled: !canCreateDefaultKey || isCreating,
                 },
@@ -86,7 +82,7 @@ export function KeyInventoryList({
     return (
       <div className="space-y-4">
         <EmptyState
-          icon={<KeyIcon className="h-12 w-12" />}
+          icon={<KeyRound className="h-12 w-12" />}
           title={t("dialog.copyKey.noKeys")}
           description={t("dialog.copyKey.noKeysDescription")}
           actions={actions}

--- a/src/features/AccountManagement/components/CopyKeyDialog/QuickKeyResourceCard.tsx
+++ b/src/features/AccountManagement/components/CopyKeyDialog/QuickKeyResourceCard.tsx
@@ -1,4 +1,4 @@
-import { ChevronDownIcon, ChevronRightIcon } from "@heroicons/react/24/outline"
+import { ChevronDown, ChevronRight } from "lucide-react"
 import { useId, type ReactNode } from "react"
 import { useTranslation } from "react-i18next"
 
@@ -90,9 +90,9 @@ export function QuickKeyResourceCard({
             {presentation.statusLabel}
           </Badge>
           {isExpanded ? (
-            <ChevronDownIcon aria-hidden="true" className="h-4 w-4" />
+            <ChevronDown aria-hidden="true" className="h-4 w-4" />
           ) : (
-            <ChevronRightIcon aria-hidden="true" className="h-4 w-4" />
+            <ChevronRight aria-hidden="true" className="h-4 w-4" />
           )}
         </span>
       </button>

--- a/src/features/AccountManagement/components/CopyKeyDialog/RuntimeKeyActionControls.tsx
+++ b/src/features/AccountManagement/components/CopyKeyDialog/RuntimeKeyActionControls.tsx
@@ -1,5 +1,4 @@
-import { CheckIcon } from "@heroicons/react/24/outline"
-import { Copy } from "lucide-react"
+import { Check, Copy } from "lucide-react"
 import { useEffect, useMemo, useState, type MouseEvent } from "react"
 import { useTranslation } from "react-i18next"
 
@@ -456,7 +455,7 @@ export function RuntimeKeyActionControls({
             onClick={handleCopy}
           >
             {copiedRuntimeKeyId === runtimeKey.id ? (
-              <CheckIcon className="h-4 w-4 text-green-500" />
+              <Check className="h-4 w-4 text-green-500" />
             ) : (
               <Copy className="dark:text-dark-text-tertiary h-4 w-4 text-gray-500" />
             )}

--- a/src/features/AccountManagement/components/CopyKeyDialog/RuntimeKeyItem.tsx
+++ b/src/features/AccountManagement/components/CopyKeyDialog/RuntimeKeyItem.tsx
@@ -1,8 +1,4 @@
-import {
-  ChevronDownIcon,
-  ChevronRightIcon,
-  UserGroupIcon,
-} from "@heroicons/react/24/outline"
+import { ChevronDown, ChevronRight, UsersRound } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import { Badge, Card, CardContent, IconButton } from "~/components/ui"
@@ -82,7 +78,7 @@ export function RuntimeKeyItem({
               {runtimeKey.label}
             </h4>
             <div className="flex items-center space-x-1.5">
-              <UserGroupIcon className="h-3 w-3 text-gray-400 dark:text-gray-500" />
+              <UsersRound className="h-3 w-3 text-gray-400 dark:text-gray-500" />
               <Badge
                 variant="outline"
                 size="sm"
@@ -112,9 +108,9 @@ export function RuntimeKeyItem({
               }
             >
               {isExpanded ? (
-                <ChevronDownIcon className="h-4 w-4" />
+                <ChevronDown className="h-4 w-4" />
               ) : (
-                <ChevronRightIcon className="h-4 w-4" />
+                <ChevronRight className="h-4 w-4" />
               )}
             </IconButton>
           </div>

--- a/src/features/AccountManagement/components/TagPicker/TagPicker.tsx
+++ b/src/features/AccountManagement/components/TagPicker/TagPicker.tsx
@@ -1,11 +1,4 @@
-import {
-  CheckIcon,
-  ChevronDownIcon,
-  PencilSquareIcon,
-  PlusIcon,
-  TrashIcon,
-  XMarkIcon,
-} from "@heroicons/react/24/outline"
+import { Check, ChevronDown, Plus, SquarePen, Trash2, X } from "lucide-react"
 import { useCallback, useEffect, useId, useMemo, useState } from "react"
 import toast from "react-hot-toast"
 import { useTranslation } from "react-i18next"
@@ -354,7 +347,7 @@ export function TagPicker({
             disabled={disabled}
           >
             <span className="truncate">{triggerLabel}</span>
-            <ChevronDownIcon className="h-4 w-4 opacity-70" />
+            <ChevronDown className="h-4 w-4 opacity-70" />
           </Button>
         </PopoverTrigger>
         <PopoverContent
@@ -391,7 +384,7 @@ export function TagPicker({
                 onClick={handleCreate}
                 disabled={disabled || isWorking}
                 loading={activeTagAction?.kind === "create"}
-                leftIcon={<PlusIcon className="h-4 w-4" />}
+                leftIcon={<Plus className="h-4 w-4" />}
                 id={getOptionId("create")}
                 data-active={activeIndex === 0}
               >
@@ -436,7 +429,7 @@ export function TagPicker({
                       {isEditing ? (
                         <div className="flex min-w-0 flex-1 items-center gap-2 text-left">
                           <span className="flex h-4 w-4 items-center justify-center rounded-sm border">
-                            {isSelected && <CheckIcon className="h-3 w-3" />}
+                            {isSelected && <Check className="h-3 w-3" />}
                           </span>
                           <span className="flex min-w-0 flex-1 items-center gap-2">
                             <Input
@@ -463,7 +456,7 @@ export function TagPicker({
                               disabled={disabled || isWorking}
                               loading={isRenamingThisTag}
                             >
-                              <CheckIcon className="h-4 w-4" />
+                              <Check className="h-4 w-4" />
                             </IconButton>
                             <IconButton
                               type="button"
@@ -476,7 +469,7 @@ export function TagPicker({
                               aria-label={t("form.tagsRenameCancel")}
                               disabled={disabled || isWorking}
                             >
-                              <XMarkIcon className="h-4 w-4" />
+                              <X className="h-4 w-4" />
                             </IconButton>
                           </span>
                         </div>
@@ -488,7 +481,7 @@ export function TagPicker({
                           disabled={disabled || isWorking}
                         >
                           <span className="flex h-4 w-4 items-center justify-center rounded-sm border">
-                            {isSelected && <CheckIcon className="h-3 w-3" />}
+                            {isSelected && <Check className="h-3 w-3" />}
                           </span>
                           <span className="flex min-w-0 flex-1 items-center justify-between gap-2">
                             <span className="truncate">{tag.name}</span>
@@ -511,7 +504,7 @@ export function TagPicker({
                             aria-label={t("form.tagsRename")}
                             disabled={disabled || isWorking}
                           >
-                            <PencilSquareIcon className="h-4 w-4" />
+                            <SquarePen className="h-4 w-4" />
                           </IconButton>
                           {allowDelete && onDeleteTag ? (
                             <IconButton
@@ -525,7 +518,7 @@ export function TagPicker({
                               aria-label={t("form.tagsDelete")}
                               disabled={disabled || isWorking}
                             >
-                              <TrashIcon className="h-4 w-4" />
+                              <Trash2 className="h-4 w-4" />
                             </IconButton>
                           ) : null}
                         </span>
@@ -556,7 +549,7 @@ export function TagPicker({
                   aria-label={t("form.tagsRemove", { name: tag.name })}
                   disabled={isWorking}
                 >
-                  <XMarkIcon className="h-3 w-3" />
+                  <X className="h-3 w-3" />
                 </button>
               )}
             </Badge>

--- a/src/features/ApiCredentialProfiles/components/ApiCredentialProfileDialog.tsx
+++ b/src/features/ApiCredentialProfiles/components/ApiCredentialProfileDialog.tsx
@@ -1,4 +1,4 @@
-import { KeyIcon, PencilIcon, PlusIcon } from "@heroicons/react/24/outline"
+import { KeyRound, Pencil, Plus } from "lucide-react"
 import type { ChangeEvent } from "react"
 import { useEffect, useMemo, useState } from "react"
 import toast from "react-hot-toast"
@@ -439,9 +439,9 @@ export function ApiCredentialProfileDialog({
         header={
           <div className="flex min-w-0 items-center gap-3">
             {isEditMode ? (
-              <PencilIcon className="h-5 w-5 text-blue-600 dark:text-blue-400" />
+              <Pencil className="h-5 w-5 text-blue-600 dark:text-blue-400" />
             ) : (
-              <PlusIcon className="h-5 w-5 text-blue-600 dark:text-blue-400" />
+              <Plus className="h-5 w-5 text-blue-600 dark:text-blue-400" />
             )}
             <h2 className="dark:text-dark-text-primary truncate text-lg font-semibold text-gray-900">
               {dialogTitle}
@@ -557,7 +557,7 @@ export function ApiCredentialProfileDialog({
                 "apiCredentialProfiles:dialog.placeholders.apiKey",
               )}
               disabled={isSaving}
-              leftIcon={<KeyIcon className="h-5 w-5" />}
+              leftIcon={<KeyRound className="h-5 w-5" />}
             />
           </FormField>
 
@@ -765,7 +765,7 @@ export function ApiCredentialProfileDialog({
                       "apiCredentialProfiles:dialog.placeholders.telemetryBearerToken",
                     )}
                     disabled={isSaving}
-                    leftIcon={<KeyIcon className="h-5 w-5" />}
+                    leftIcon={<KeyRound className="h-5 w-5" />}
                   />
                 </FormField>
 

--- a/src/features/ApiCredentialProfiles/components/ApiCredentialProfileListItem.tsx
+++ b/src/features/ApiCredentialProfiles/components/ApiCredentialProfileListItem.tsx
@@ -1,17 +1,20 @@
-import {
-  ArrowPathIcon,
-  ArrowUpTrayIcon,
-  ChevronDownIcon,
-  CommandLineIcon,
-  CpuChipIcon,
-  EyeIcon,
-  EyeSlashIcon,
-  PencilIcon,
-  TrashIcon,
-  WrenchScrewdriverIcon,
-} from "@heroicons/react/24/outline"
 import type { TFunction } from "i18next"
-import { CalendarPlus, Copy, History, type LucideIcon } from "lucide-react"
+import {
+  CalendarPlus,
+  ChevronDown,
+  Copy,
+  Cpu,
+  Eye,
+  EyeOff,
+  History,
+  Pencil,
+  RefreshCw,
+  Terminal,
+  Trash2,
+  Upload,
+  Wrench,
+  type LucideIcon,
+} from "lucide-react"
 import { useEffect, useId, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 
@@ -410,9 +413,9 @@ export function ApiCredentialProfileListItem({
                       }
                     >
                       {visibleKeys.has(profile.id) ? (
-                        <EyeSlashIcon className="h-4 w-4" />
+                        <EyeOff className="h-4 w-4" />
                       ) : (
-                        <EyeIcon className="h-4 w-4" />
+                        <Eye className="h-4 w-4" />
                       )}
                     </IconButton>
                     <IconButton
@@ -480,7 +483,7 @@ export function ApiCredentialProfileListItem({
                             {getTelemetrySourceLabel(t, telemetry.source)}
                           </Badge>
                         ) : null}
-                        <ChevronDownIcon
+                        <ChevronDown
                           className={cn(
                             "dark:text-dark-text-tertiary ml-auto h-3.5 w-3.5 shrink-0 text-gray-500 transition-transform",
                             isTelemetryOpen ? "rotate-180" : "rotate-0",
@@ -496,7 +499,7 @@ export function ApiCredentialProfileListItem({
                       className="dark:text-dark-text-tertiary dark:hover:text-dark-text-primary h-auto shrink-0 gap-1 px-1.5 py-1 text-[11px] text-gray-500 hover:text-gray-800"
                       onClick={handleRefreshTelemetry}
                       loading={isTelemetryRefreshing}
-                      leftIcon={<ArrowPathIcon className="h-3.5 w-3.5" />}
+                      leftIcon={<RefreshCw className="h-3.5 w-3.5" />}
                     >
                       {isTelemetryRefreshing
                         ? t("apiCredentialProfiles:telemetry.refreshing")
@@ -662,7 +665,7 @@ export function ApiCredentialProfileListItem({
                     PRODUCT_ANALYTICS_ACTION_IDS.OpenUpdateApiCredentialProfileDialog
                   }
                 >
-                  <PencilIcon className="h-4 w-4 text-blue-500 dark:text-blue-400" />
+                  <Pencil className="h-4 w-4 text-blue-500 dark:text-blue-400" />
                 </IconButton>
                 <IconButton
                   aria-label={t("apiCredentialProfiles:actions.verifyApi")}
@@ -674,7 +677,7 @@ export function ApiCredentialProfileListItem({
                     PRODUCT_ANALYTICS_ACTION_IDS.VerifyApiCredential
                   }
                 >
-                  <WrenchScrewdriverIcon className="h-4 w-4 text-emerald-600 dark:text-emerald-400" />
+                  <Wrench className="h-4 w-4 text-emerald-600 dark:text-emerald-400" />
                 </IconButton>
                 <IconButton
                   aria-label={t(
@@ -687,7 +690,7 @@ export function ApiCredentialProfileListItem({
                     PRODUCT_ANALYTICS_ACTION_IDS.VerifyApiCredentialCliSupport
                   }
                 >
-                  <CommandLineIcon className="h-4 w-4 text-sky-600 dark:text-sky-400" />
+                  <Terminal className="h-4 w-4 text-sky-600 dark:text-sky-400" />
                 </IconButton>
                 <IconButton
                   aria-label={t(
@@ -707,7 +710,7 @@ export function ApiCredentialProfileListItem({
                     entrypoint: optionsEntrypoint,
                   }}
                 >
-                  <CpuChipIcon className="h-4 w-4" />
+                  <Cpu className="h-4 w-4" />
                 </IconButton>
                 <DropdownMenu
                   open={isExportMenuOpen}
@@ -733,7 +736,7 @@ export function ApiCredentialProfileListItem({
                         PRODUCT_ANALYTICS_ACTION_IDS.OpenApiCredentialExportMenu
                       }
                     >
-                      <ArrowUpTrayIcon className="h-4 w-4" />
+                      <Upload className="h-4 w-4" />
                     </IconButton>
                   </DropdownMenuTrigger>
                   <DropdownMenuContent align="end">
@@ -868,7 +871,7 @@ export function ApiCredentialProfileListItem({
                     PRODUCT_ANALYTICS_ACTION_IDS.DeleteApiCredentialProfile
                   }
                 >
-                  <TrashIcon className="h-4 w-4" />
+                  <Trash2 className="h-4 w-4" />
                 </IconButton>
               </div>
             </div>

--- a/src/features/ApiCredentialProfiles/components/ApiCredentialProfilesListView.tsx
+++ b/src/features/ApiCredentialProfiles/components/ApiCredentialProfilesListView.tsx
@@ -1,4 +1,4 @@
-import { MagnifyingGlassIcon } from "@heroicons/react/24/outline"
+import { Search } from "lucide-react"
 import { useCallback, useEffect, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 
@@ -244,7 +244,7 @@ export function ApiCredentialProfilesListView({
             onChange={handleSearchChange}
             onKeyDown={handleSearchKeyDown}
             placeholder={t("apiCredentialProfiles:controls.searchPlaceholder")}
-            leftIcon={<MagnifyingGlassIcon className="h-4 w-4" />}
+            leftIcon={<Search className="h-4 w-4" />}
             onClear={clearSearch}
             clearButtonLabel={t("common:actions.clear")}
           />

--- a/src/features/AutoCheckin/components/AccountSnapshotTable.tsx
+++ b/src/features/AutoCheckin/components/AccountSnapshotTable.tsx
@@ -1,9 +1,4 @@
-import {
-  CheckCircleIcon,
-  ClockIcon,
-  ExclamationTriangleIcon,
-  XCircleIcon,
-} from "@heroicons/react/24/outline"
+import { CircleCheck, CircleX, Clock, TriangleAlert } from "lucide-react"
 import { useMemo } from "react"
 import { useTranslation } from "react-i18next"
 
@@ -54,21 +49,21 @@ export default function AccountSnapshotTable({
         case CHECKIN_RESULT_STATUS.ALREADY_CHECKED:
           return (
             <span className="inline-flex items-center gap-1 rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-800 dark:bg-green-900 dark:text-green-200">
-              <CheckCircleIcon className="h-3.5 w-3.5" />
+              <CircleCheck className="h-3.5 w-3.5" />
               {t("execution.status.success")}
             </span>
           )
         case CHECKIN_RESULT_STATUS.FAILED:
           return (
             <span className="inline-flex items-center gap-1 rounded-full bg-red-100 px-2 py-0.5 text-xs font-medium text-red-800 dark:bg-red-900 dark:text-red-200">
-              <XCircleIcon className="h-3.5 w-3.5" />
+              <CircleX className="h-3.5 w-3.5" />
               {t("execution.status.failed")}
             </span>
           )
         case CHECKIN_RESULT_STATUS.SKIPPED:
           return (
             <span className="inline-flex items-center gap-1 rounded-full bg-yellow-100 px-2 py-0.5 text-xs font-medium text-yellow-800 dark:bg-yellow-900 dark:text-yellow-100">
-              <ExclamationTriangleIcon className="h-3.5 w-3.5" />
+              <TriangleAlert className="h-3.5 w-3.5" />
               {t("execution.status.skipped")}
             </span>
           )
@@ -80,7 +75,7 @@ export default function AccountSnapshotTable({
     if (snapshot.skipReason) {
       return (
         <span className="inline-flex items-center gap-1 rounded-full bg-yellow-100 px-2 py-0.5 text-xs font-medium text-yellow-800 dark:bg-yellow-900 dark:text-yellow-100">
-          <ExclamationTriangleIcon className="h-3.5 w-3.5" />
+          <TriangleAlert className="h-3.5 w-3.5" />
           {t("execution.status.skipped")}
         </span>
       )
@@ -88,7 +83,7 @@ export default function AccountSnapshotTable({
 
     return (
       <span className="inline-flex items-center gap-1 rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-700 dark:bg-gray-800 dark:text-gray-200">
-        <ClockIcon className="h-3.5 w-3.5" />
+        <Clock className="h-3.5 w-3.5" />
         {t("snapshot.badges.pending")}
       </span>
     )

--- a/src/features/AutoCheckin/components/ActionBar.tsx
+++ b/src/features/AutoCheckin/components/ActionBar.tsx
@@ -1,9 +1,4 @@
-import {
-  ArrowPathIcon,
-  BugAntIcon,
-  CalendarDaysIcon,
-  PlayIcon,
-} from "@heroicons/react/24/outline"
+import { Bug, CalendarDays, Play, RefreshCw } from "lucide-react"
 import type { MouseEventHandler } from "react"
 import { useTranslation } from "react-i18next"
 
@@ -110,7 +105,7 @@ export default function ActionBar({
             onClick={onRunNow}
             disabled={isBusy}
             loading={isRunning}
-            leftIcon={<PlayIcon className="h-4 w-4" />}
+            leftIcon={<Play className="h-4 w-4" />}
             data-testid={BASIC_SETTINGS_TEST_IDS.autoCheckinRunNowButton}
           >
             {isRunning ? t("messages.loading.running") : t("execution.runNow")}
@@ -120,7 +115,7 @@ export default function ActionBar({
             variant="secondary"
             disabled={isBusy || isRefreshLocked}
             loading={isRefreshing}
-            leftIcon={<ArrowPathIcon className="h-4 w-4" />}
+            leftIcon={<RefreshCw className="h-4 w-4" />}
           >
             {isRefreshing
               ? t("common:status.refreshing")
@@ -148,7 +143,7 @@ export default function ActionBar({
               variant="outline"
               disabled={isBusy}
               loading={isOpeningExternalCheckIns}
-              leftIcon={<CalendarDaysIcon className="h-4 w-4" />}
+              leftIcon={<CalendarDays className="h-4 w-4" />}
               title={externalCheckInHint}
             >
               {isOpeningExternalCheckIns
@@ -166,7 +161,7 @@ export default function ActionBar({
                   activeDebugAction ===
                   AUTO_CHECKIN_DEBUG_ACTIONS.TRIGGER_DAILY_ALARM
                 }
-                leftIcon={<BugAntIcon className="h-4 w-4" />}
+                leftIcon={<Bug className="h-4 w-4" />}
               >
                 {activeDebugAction ===
                 AUTO_CHECKIN_DEBUG_ACTIONS.TRIGGER_DAILY_ALARM
@@ -181,7 +176,7 @@ export default function ActionBar({
                   activeDebugAction ===
                   AUTO_CHECKIN_DEBUG_ACTIONS.TRIGGER_RETRY_ALARM
                 }
-                leftIcon={<BugAntIcon className="h-4 w-4" />}
+                leftIcon={<Bug className="h-4 w-4" />}
               >
                 {activeDebugAction ===
                 AUTO_CHECKIN_DEBUG_ACTIONS.TRIGGER_RETRY_ALARM
@@ -196,7 +191,7 @@ export default function ActionBar({
                   activeDebugAction ===
                   AUTO_CHECKIN_DEBUG_ACTIONS.SCHEDULE_DAILY_ALARM
                 }
-                leftIcon={<BugAntIcon className="h-4 w-4" />}
+                leftIcon={<Bug className="h-4 w-4" />}
               >
                 {activeDebugAction ===
                 AUTO_CHECKIN_DEBUG_ACTIONS.SCHEDULE_DAILY_ALARM
@@ -211,7 +206,7 @@ export default function ActionBar({
                   activeDebugAction ===
                   AUTO_CHECKIN_DEBUG_ACTIONS.EVALUATE_UI_OPEN_PRETRIGGER
                 }
-                leftIcon={<BugAntIcon className="h-4 w-4" />}
+                leftIcon={<Bug className="h-4 w-4" />}
               >
                 {activeDebugAction ===
                 AUTO_CHECKIN_DEBUG_ACTIONS.EVALUATE_UI_OPEN_PRETRIGGER
@@ -226,7 +221,7 @@ export default function ActionBar({
                   activeDebugAction ===
                   AUTO_CHECKIN_DEBUG_ACTIONS.TRIGGER_UI_OPEN_PRETRIGGER
                 }
-                leftIcon={<BugAntIcon className="h-4 w-4" />}
+                leftIcon={<Bug className="h-4 w-4" />}
               >
                 {activeDebugAction ===
                 AUTO_CHECKIN_DEBUG_ACTIONS.TRIGGER_UI_OPEN_PRETRIGGER
@@ -241,7 +236,7 @@ export default function ActionBar({
                   activeDebugAction ===
                   AUTO_CHECKIN_DEBUG_ACTIONS.RESET_LAST_DAILY_RUN_DAY
                 }
-                leftIcon={<BugAntIcon className="h-4 w-4" />}
+                leftIcon={<Bug className="h-4 w-4" />}
               >
                 {activeDebugAction ===
                 AUTO_CHECKIN_DEBUG_ACTIONS.RESET_LAST_DAILY_RUN_DAY

--- a/src/features/AutoCheckin/components/FilterBar.tsx
+++ b/src/features/AutoCheckin/components/FilterBar.tsx
@@ -1,9 +1,4 @@
-import {
-  CheckCircleIcon,
-  ListBulletIcon,
-  MagnifyingGlassIcon,
-  XCircleIcon,
-} from "@heroicons/react/24/outline"
+import { CircleCheck, CircleX, List, Search } from "lucide-react"
 import { type ReactNode } from "react"
 import { useTranslation } from "react-i18next"
 
@@ -183,28 +178,28 @@ export default function FilterBar({
           FILTER_STATUS.ALL,
           t("execution.filters.all"),
           "bg-blue-600",
-          <ListBulletIcon className="h-4 w-4" />,
+          <List className="h-4 w-4" />,
           totalCount,
         )}
         {renderFilterButton(
           FILTER_STATUS.SUCCESS,
           t("execution.filters.success"),
           "bg-green-600",
-          <CheckCircleIcon className="h-4 w-4" />,
+          <CircleCheck className="h-4 w-4" />,
           successCount,
         )}
         {renderFilterButton(
           FILTER_STATUS.FAILED,
           t("execution.filters.failed"),
           "bg-red-600",
-          <XCircleIcon className="h-4 w-4" />,
+          <CircleX className="h-4 w-4" />,
           failedCount,
         )}
         {renderFilterButton(
           FILTER_STATUS.SKIPPED,
           t("execution.filters.skipped"),
           "bg-yellow-600",
-          <ListBulletIcon className="h-4 w-4" />,
+          <List className="h-4 w-4" />,
           skippedCount,
         )}
       </div>
@@ -214,7 +209,7 @@ export default function FilterBar({
           placeholder={t("execution.filters.searchPlaceholder") as string}
           value={keyword}
           onChange={(e) => onKeywordChange(e.target.value)}
-          leftIcon={<MagnifyingGlassIcon className="h-4 w-4" />}
+          leftIcon={<Search className="h-4 w-4" />}
           onClear={() => {
             onKeywordChange("")
             trackFilterSelection(

--- a/src/features/AutoCheckin/components/ResultsTable.tsx
+++ b/src/features/AutoCheckin/components/ResultsTable.tsx
@@ -1,12 +1,12 @@
 import {
-  ArrowPathIcon,
-  CalendarDaysIcon,
-  CheckCircleIcon,
-  ExclamationTriangleIcon,
-  NoSymbolIcon,
-  TrashIcon,
-  XCircleIcon,
-} from "@heroicons/react/24/outline"
+  Ban,
+  CalendarDays,
+  CircleCheck,
+  CircleX,
+  RefreshCw,
+  Trash2,
+  TriangleAlert,
+} from "lucide-react"
 import { useMemo } from "react"
 import { useTranslation } from "react-i18next"
 
@@ -131,28 +131,28 @@ export default function ResultsTable({
       case CHECKIN_RESULT_STATUS.SUCCESS:
         return (
           <span className="inline-flex items-center gap-1 rounded-full bg-green-100 px-2 py-1 text-xs font-medium text-green-800 dark:bg-green-900 dark:text-green-200">
-            <CheckCircleIcon className="h-3 w-3" />
+            <CircleCheck className="h-3 w-3" />
             {t("execution.status.success")}
           </span>
         )
       case CHECKIN_RESULT_STATUS.ALREADY_CHECKED:
         return (
           <span className="inline-flex items-center gap-1 rounded-full bg-blue-100 px-2 py-1 text-xs font-medium text-blue-800 dark:bg-blue-900 dark:text-blue-200">
-            <CheckCircleIcon className="h-3 w-3" />
+            <CircleCheck className="h-3 w-3" />
             {t("execution.status.alreadyChecked")}
           </span>
         )
       case CHECKIN_RESULT_STATUS.FAILED:
         return (
           <span className="inline-flex items-center gap-1 rounded-full bg-red-100 px-2 py-1 text-xs font-medium text-red-800 dark:bg-red-900 dark:text-red-200">
-            <XCircleIcon className="h-3 w-3" />
+            <CircleX className="h-3 w-3" />
             {t("execution.status.failed")}
           </span>
         )
       case CHECKIN_RESULT_STATUS.SKIPPED:
         return (
           <span className="inline-flex items-center gap-1 rounded-full bg-yellow-100 px-2 py-0.5 text-xs font-medium text-yellow-800 dark:bg-yellow-900 dark:text-yellow-100">
-            <ExclamationTriangleIcon className="h-3 w-3" />
+            <TriangleAlert className="h-3 w-3" />
             {t("execution.status.skipped")}
           </span>
         )
@@ -256,9 +256,7 @@ export default function ResultsTable({
                                 variant="secondary"
                                 loading={retryingAccountId === result.accountId}
                                 onClick={() => onRetryAccount(result.accountId)}
-                                leftIcon={
-                                  <ArrowPathIcon className="h-3.5 w-3.5" />
-                                }
+                                leftIcon={<RefreshCw className="h-3.5 w-3.5" />}
                               >
                                 {retryingAccountId === result.accountId
                                   ? t("common:status.retrying")
@@ -297,7 +295,7 @@ export default function ResultsTable({
                                 onOpenExternalCheckIn(result.accountId)
                               }
                               leftIcon={
-                                <CalendarDaysIcon className="h-3.5 w-3.5" />
+                                <CalendarDays className="h-3.5 w-3.5" />
                               }
                             >
                               {openingExternalCheckInAccountId ===
@@ -318,9 +316,7 @@ export default function ResultsTable({
                               variant="warning"
                               loading={disablingAccountId === result.accountId}
                               onClick={() => onDisableAccount(result.accountId)}
-                              leftIcon={
-                                <NoSymbolIcon className="h-3.5 w-3.5" />
-                              }
+                              leftIcon={<Ban className="h-3.5 w-3.5" />}
                             >
                               {disablingAccountId === result.accountId
                                 ? t("common:status.disabling")
@@ -333,7 +329,7 @@ export default function ResultsTable({
                               variant="destructive"
                               loading={deletingAccountId === result.accountId}
                               onClick={() => onDeleteAccount(result.accountId)}
-                              leftIcon={<TrashIcon className="h-3.5 w-3.5" />}
+                              leftIcon={<Trash2 className="h-3.5 w-3.5" />}
                             >
                               {deletingAccountId === result.accountId
                                 ? t("common:status.deleting")

--- a/src/features/BasicSettings/components/tabs/AccountManagement/AccountManagementTab.tsx
+++ b/src/features/BasicSettings/components/tabs/AccountManagement/AccountManagementTab.tsx
@@ -1,4 +1,4 @@
-import { UsersIcon } from "@heroicons/react/24/outline"
+import { Users } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import {
@@ -30,7 +30,7 @@ export default function AccountManagementTab() {
     <div className="space-y-6">
       <section id="account-management">
         <Heading4 className="mb-2 flex items-center gap-2">
-          <UsersIcon className="h-5 w-5 text-blue-600 dark:text-blue-400" />
+          <Users className="h-5 w-5 text-blue-600 dark:text-blue-400" />
           <span>{t("accountManagement.title")}</span>
         </Heading4>
         <Card>
@@ -42,7 +42,7 @@ export default function AccountManagementTab() {
               onClick={handleNavigate}
               variant="default"
               className="flex items-center gap-2 self-start"
-              leftIcon={<UsersIcon className="h-5 w-5" />}
+              leftIcon={<Users className="h-5 w-5" />}
             >
               <span>{t("accountManagement.openPage")}</span>
             </WorkflowTransitionButton>

--- a/src/features/BasicSettings/components/tabs/AccountManagement/AutoFillCurrentSiteUrlOnAccountAddSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/AccountManagement/AutoFillCurrentSiteUrlOnAccountAddSettings.tsx
@@ -1,4 +1,4 @@
-import { GlobeAltIcon } from "@heroicons/react/24/outline"
+import { Globe2 } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import { SettingSection } from "~/components/SettingSection"
@@ -35,9 +35,7 @@ export default function AutoFillCurrentSiteUrlOnAccountAddSettings() {
         <CardList>
           <CardItem
             id="auto-fill-current-site-url-toggle"
-            icon={
-              <GlobeAltIcon className="h-5 w-5 text-sky-600 dark:text-sky-400" />
-            }
+            icon={<Globe2 className="h-5 w-5 text-sky-600 dark:text-sky-400" />}
             title={t("autoFillCurrentSiteUrlOnAccountAdd.toggleLabel")}
             description={t("autoFillCurrentSiteUrlOnAccountAdd.toggleDesc")}
             rightContent={

--- a/src/features/BasicSettings/components/tabs/AccountManagement/AutoProvisionKeyOnAccountAddSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/AccountManagement/AutoProvisionKeyOnAccountAddSettings.tsx
@@ -1,4 +1,4 @@
-import { KeyIcon } from "@heroicons/react/24/outline"
+import { KeyRound } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import { SettingSection } from "~/components/SettingSection"
@@ -31,7 +31,7 @@ export default function AutoProvisionKeyOnAccountAddSettings() {
           <CardItem
             id="auto-provision-key-toggle"
             icon={
-              <KeyIcon className="h-5 w-5 text-amber-600 dark:text-amber-400" />
+              <KeyRound className="h-5 w-5 text-amber-600 dark:text-amber-400" />
             }
             title={t("autoProvisionKeyOnAccountAdd.toggleLabel")}
             description={t("autoProvisionKeyOnAccountAdd.toggleDesc")}

--- a/src/features/BasicSettings/components/tabs/AccountManagement/DuplicateAccountWarningOnAddSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/AccountManagement/DuplicateAccountWarningOnAddSettings.tsx
@@ -1,4 +1,4 @@
-import { ExclamationTriangleIcon } from "@heroicons/react/24/outline"
+import { TriangleAlert } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import { SettingSection } from "~/components/SettingSection"
@@ -31,7 +31,7 @@ export default function DuplicateAccountWarningOnAddSettings() {
           <CardItem
             id="duplicate-account-warning-toggle"
             icon={
-              <ExclamationTriangleIcon className="h-5 w-5 text-yellow-600 dark:text-yellow-400" />
+              <TriangleAlert className="h-5 w-5 text-yellow-600 dark:text-yellow-400" />
             }
             title={t("duplicateAccountWarningOnAdd.toggleLabel")}
             description={t("duplicateAccountWarningOnAdd.toggleDesc")}

--- a/src/features/BasicSettings/components/tabs/AccountManagement/SortingPrioritySettings/SortingCriteriaItem.tsx
+++ b/src/features/BasicSettings/components/tabs/AccountManagement/SortingPrioritySettings/SortingCriteriaItem.tsx
@@ -1,6 +1,6 @@
 import { useSortable } from "@dnd-kit/sortable"
 import { CSS } from "@dnd-kit/utilities"
-import { Bars2Icon } from "@heroicons/react/24/outline"
+import { GripVertical } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import { Badge, Card, CardContent, Switch } from "~/components/ui"
@@ -56,7 +56,7 @@ export function SortingCriteriaItem({
               {...listeners}
               className="dark:text-dark-text-tertiary dark:hover:text-dark-text-secondary mt-0.5 flex shrink-0 cursor-move touch-none items-center text-gray-400 hover:text-gray-600 [@container(min-width:42rem)]:mt-0"
             >
-              <Bars2Icon className="h-5 w-5" />
+              <GripVertical className="h-5 w-5" />
             </div>
             <div className="min-w-0 grow">
               <div className="dark:text-dark-text-primary text-sm font-medium break-words text-gray-900">

--- a/src/features/BasicSettings/components/tabs/DataBackup/DataBackupTab.tsx
+++ b/src/features/BasicSettings/components/tabs/DataBackup/DataBackupTab.tsx
@@ -1,4 +1,4 @@
-import { ArrowsRightLeftIcon } from "@heroicons/react/24/outline"
+import { ArrowRightLeft } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import {
@@ -40,7 +40,7 @@ export default function DataBackupTab() {
                 onClick={handleNavigateToImportExport}
                 variant="default"
                 className="justify-center"
-                leftIcon={<ArrowsRightLeftIcon className="h-5 w-5" />}
+                leftIcon={<ArrowRightLeft className="h-5 w-5" />}
               >
                 {t("dataBackup.importExport.openPage")}
               </WorkflowTransitionButton>

--- a/src/features/BasicSettings/components/tabs/General/ActionClickBehaviorSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/General/ActionClickBehaviorSettings.tsx
@@ -1,4 +1,4 @@
-import { CursorArrowRaysIcon } from "@heroicons/react/24/outline"
+import { MousePointerClick } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import { ResponsiveToggleGroup } from "~/components/ResponsiveButtonGroup"
@@ -54,7 +54,7 @@ export default function ActionClickBehaviorSettings() {
           <CardItem
             id="action-click-behavior"
             icon={
-              <CursorArrowRaysIcon className="h-5 w-5 text-blue-600 dark:text-blue-400" />
+              <MousePointerClick className="h-5 w-5 text-blue-600 dark:text-blue-400" />
             }
             title={t("actionClick.actionIconClickTitle")}
             description={

--- a/src/features/BasicSettings/components/tabs/General/AppearanceSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/General/AppearanceSettings.tsx
@@ -1,4 +1,4 @@
-import { LanguageIcon } from "@heroicons/react/24/outline"
+import { Languages } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import { LanguageSwitcher } from "~/components/LanguageSwitcher"
@@ -24,7 +24,7 @@ export default function AppearanceSettings() {
           <CardItem
             id="appearance-language"
             icon={
-              <LanguageIcon className="h-5 w-5 text-purple-600 dark:text-purple-400" />
+              <Languages className="h-5 w-5 text-purple-600 dark:text-purple-400" />
             }
             title={t("appearanceLanguage.language")}
             description={t("appearanceLanguage.languageDesc")}

--- a/src/features/BasicSettings/components/tabs/General/ChangelogOnUpdateSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/General/ChangelogOnUpdateSettings.tsx
@@ -1,4 +1,4 @@
-import { DocumentTextIcon } from "@heroicons/react/24/outline"
+import { FileText } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import { SettingSection } from "~/components/SettingSection"
@@ -31,7 +31,7 @@ export default function ChangelogOnUpdateSettings() {
           <CardItem
             id="changelog-on-update-toggle"
             icon={
-              <DocumentTextIcon className="h-5 w-5 text-indigo-600 dark:text-indigo-400" />
+              <FileText className="h-5 w-5 text-indigo-600 dark:text-indigo-400" />
             }
             title={t("changelogOnUpdate.toggleLabel")}
             description={t("changelogOnUpdate.toggleDesc")}

--- a/src/features/BasicSettings/components/tabs/General/DisplaySettings.tsx
+++ b/src/features/BasicSettings/components/tabs/General/DisplaySettings.tsx
@@ -1,8 +1,4 @@
-import {
-  CalendarDaysIcon,
-  EyeIcon,
-  GlobeAltIcon,
-} from "@heroicons/react/24/outline"
+import { CalendarDays, Eye, Globe2 } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import { ResponsiveToggleGroup } from "~/components/ResponsiveButtonGroup"
@@ -58,7 +54,7 @@ export default function DisplaySettings() {
           <CardItem
             id="display-currency-unit"
             icon={
-              <GlobeAltIcon className="h-5 w-5 text-green-600 dark:text-green-400" />
+              <Globe2 className="h-5 w-5 text-green-600 dark:text-green-400" />
             }
             title={t("display.currencyUnit")}
             description={t("display.currencyDesc")}
@@ -86,7 +82,7 @@ export default function DisplaySettings() {
           <CardItem
             id="display-today-cashflow-enabled"
             icon={
-              <CalendarDaysIcon className="h-5 w-5 text-amber-600 dark:text-amber-400" />
+              <CalendarDays className="h-5 w-5 text-amber-600 dark:text-amber-400" />
             }
             title={t("display.todayCashflowEnabled")}
             description={t("display.todayCashflowEnabledDesc")}
@@ -100,9 +96,7 @@ export default function DisplaySettings() {
 
           <CardItem
             id="display-default-tab"
-            icon={
-              <EyeIcon className="h-5 w-5 text-blue-600 dark:text-blue-400" />
-            }
+            icon={<Eye className="h-5 w-5 text-blue-600 dark:text-blue-400" />}
             title={t("display.defaultTab")}
             description={t("display.defaultTabDesc")}
             rightContent={

--- a/src/features/BasicSettings/components/tabs/General/LoggingSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/General/LoggingSettings.tsx
@@ -1,8 +1,5 @@
-import {
-  AdjustmentsHorizontalIcon,
-  CommandLineIcon,
-} from "@heroicons/react/24/outline"
 import type { TFunction } from "i18next"
+import { SlidersHorizontal, Terminal } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import { SettingSection } from "~/components/SettingSection"
@@ -74,7 +71,7 @@ export default function LoggingSettings() {
           <CardItem
             id="logging-console-enabled"
             icon={
-              <CommandLineIcon className="h-5 w-5 text-slate-600 dark:text-slate-300" />
+              <Terminal className="h-5 w-5 text-slate-600 dark:text-slate-300" />
             }
             title={t("logging.consoleEnabled")}
             description={t("logging.consoleEnabledDesc")}
@@ -89,7 +86,7 @@ export default function LoggingSettings() {
           <CardItem
             id="logging-min-level"
             icon={
-              <AdjustmentsHorizontalIcon className="h-5 w-5 text-slate-600 dark:text-slate-300" />
+              <SlidersHorizontal className="h-5 w-5 text-slate-600 dark:text-slate-300" />
             }
             title={t("logging.minLevel")}
             description={t("logging.minLevelDesc")}

--- a/src/features/BasicSettings/components/tabs/General/ProductAnalyticsSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/General/ProductAnalyticsSettings.tsx
@@ -1,4 +1,4 @@
-import { ChartBarIcon } from "@heroicons/react/24/outline"
+import { BarChart3 } from "lucide-react"
 import { useEffect, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 
@@ -105,7 +105,7 @@ export default function ProductAnalyticsSettings() {
           <CardItem
             id={SETTINGS_ANCHORS.PRODUCT_ANALYTICS_ENABLED}
             icon={
-              <ChartBarIcon className="h-5 w-5 text-slate-600 dark:text-slate-300" />
+              <BarChart3 className="h-5 w-5 text-slate-600 dark:text-slate-300" />
             }
             title={t("productAnalytics.enableLabel")}
             description={t("productAnalytics.enableDescription")}

--- a/src/features/BasicSettings/components/tabs/General/SiteAnnouncementNotificationSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/General/SiteAnnouncementNotificationSettings.tsx
@@ -1,4 +1,4 @@
-import { ClockIcon, MegaphoneIcon } from "@heroicons/react/24/outline"
+import { Clock, Megaphone } from "lucide-react"
 import { useEffect, useState } from "react"
 import { useTranslation } from "react-i18next"
 
@@ -100,7 +100,7 @@ export default function SiteAnnouncementNotificationSettings() {
           <CardItem
             id={SETTINGS_ANCHORS.SITE_ANNOUNCEMENT_NOTIFICATIONS_ENABLED}
             icon={
-              <MegaphoneIcon className="h-5 w-5 text-sky-600 dark:text-sky-400" />
+              <Megaphone className="h-5 w-5 text-sky-600 dark:text-sky-400" />
             }
             title={t("siteAnnouncementNotifications.polling.enable")}
             description={t("siteAnnouncementNotifications.polling.enableDesc")}
@@ -113,9 +113,7 @@ export default function SiteAnnouncementNotificationSettings() {
           />
           <CardItem
             id={SETTINGS_ANCHORS.SITE_ANNOUNCEMENT_NOTIFICATIONS_INTERVAL}
-            icon={
-              <ClockIcon className="h-5 w-5 text-sky-600 dark:text-sky-400" />
-            }
+            icon={<Clock className="h-5 w-5 text-sky-600 dark:text-sky-400" />}
             title={t("siteAnnouncementNotifications.polling.interval")}
             description={t(
               "siteAnnouncementNotifications.polling.intervalDesc",

--- a/src/features/BasicSettings/components/tabs/Notifications/TaskNotificationSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/Notifications/TaskNotificationSettings.tsx
@@ -1,5 +1,5 @@
-import { BellIcon } from "@heroicons/react/24/outline"
 import type { TFunction } from "i18next"
+import { Bell } from "lucide-react"
 import { useCallback, useEffect, useState, type ReactNode } from "react"
 import { useTranslation } from "react-i18next"
 
@@ -675,7 +675,7 @@ export default function TaskNotificationSettings() {
             <CardItem
               id={SETTINGS_ANCHORS.TASK_NOTIFICATIONS_ENABLED}
               icon={
-                <BellIcon className="h-5 w-5 text-teal-600 dark:text-teal-400" />
+                <Bell className="h-5 w-5 text-teal-600 dark:text-teal-400" />
               }
               title={t("taskNotifications.enable")}
               description={t("taskNotifications.enableDesc")}

--- a/src/features/ImportExport/components/ExportSection.tsx
+++ b/src/features/ImportExport/components/ExportSection.tsx
@@ -1,4 +1,4 @@
-import { ArrowUpTrayIcon } from "@heroicons/react/24/outline"
+import { Upload } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import {
@@ -73,7 +73,7 @@ const ExportSection = ({ isExporting, setIsExporting }: ExportSectionProps) => {
       <Card padding="none" className="flex flex-1 flex-col">
         <CardHeader>
           <div className="flex items-center gap-2">
-            <ArrowUpTrayIcon className="h-5 w-5 text-green-600 dark:text-green-400" />
+            <Upload className="h-5 w-5 text-green-600 dark:text-green-400" />
             <CardTitle className="mb-0">{t("export.title")}</CardTitle>
           </div>
           <CardDescription>{t("export.description")}</CardDescription>

--- a/src/features/ImportExport/components/ImportSection.tsx
+++ b/src/features/ImportExport/components/ImportSection.tsx
@@ -1,4 +1,4 @@
-import { ArrowDownTrayIcon, DocumentIcon } from "@heroicons/react/24/outline"
+import { Download, File } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import {
@@ -189,7 +189,7 @@ const ImportSection = ({
       <Card padding="none" className="flex flex-1 flex-col">
         <CardHeader>
           <div className="flex items-center gap-2">
-            <ArrowDownTrayIcon className="h-5 w-5 text-blue-600 dark:text-blue-400" />
+            <Download className="h-5 w-5 text-blue-600 dark:text-blue-400" />
             <CardTitle className="mb-0">{t("import.title")}</CardTitle>
           </div>
           <CardDescription>{t("import.description")}</CardDescription>
@@ -209,7 +209,7 @@ const ImportSection = ({
                 onChange={handleFileImport}
                 className="block w-full text-sm text-gray-500 file:mr-4 file:rounded-md file:border-0 file:bg-blue-50 file:px-4 file:py-2 file:text-sm file:font-medium file:text-blue-700 hover:file:bg-blue-100 dark:text-gray-400 dark:file:bg-blue-900/30 dark:file:text-blue-300 dark:hover:file:bg-blue-900/50"
               />
-              <DocumentIcon className="h-5 w-5 text-gray-400 dark:text-gray-500" />
+              <File className="h-5 w-5 text-gray-400 dark:text-gray-500" />
             </div>
           </FormField>
 

--- a/src/features/ImportExport/components/WebDAVAutoSyncSettings.tsx
+++ b/src/features/ImportExport/components/WebDAVAutoSyncSettings.tsx
@@ -1,9 +1,4 @@
-import {
-  ArrowPathIcon,
-  CheckCircleIcon,
-  ClockIcon,
-  XCircleIcon,
-} from "@heroicons/react/24/outline"
+import { CircleCheck, CircleX, Clock, RefreshCw } from "lucide-react"
 import { useCallback, useEffect, useMemo, useState } from "react"
 import toast from "react-hot-toast"
 import { useTranslation } from "react-i18next"
@@ -252,7 +247,7 @@ export default function WebDAVAutoSyncSettings() {
     if (isSyncing) {
       return (
         <Badge variant="info">
-          <ArrowPathIcon className="mr-1 h-3 w-3 animate-spin" />
+          <RefreshCw className="mr-1 h-3 w-3 animate-spin" />
           {t("webdav.syncing")}
         </Badge>
       )
@@ -261,7 +256,7 @@ export default function WebDAVAutoSyncSettings() {
     if (lastSyncStatus === "success") {
       return (
         <Badge variant="success">
-          <CheckCircleIcon className="mr-1 h-3 w-3" />
+          <CircleCheck className="mr-1 h-3 w-3" />
           {t("webdav.syncSuccess")}
         </Badge>
       )
@@ -270,7 +265,7 @@ export default function WebDAVAutoSyncSettings() {
     if (lastSyncStatus === "error") {
       return (
         <Badge variant="danger">
-          <XCircleIcon className="mr-1 h-3 w-3" />
+          <CircleX className="mr-1 h-3 w-3" />
           {t("webdav.syncError")}
         </Badge>
       )
@@ -278,7 +273,7 @@ export default function WebDAVAutoSyncSettings() {
 
     return (
       <Badge variant="secondary">
-        <ClockIcon className="mr-1 h-3 w-3" />
+        <Clock className="mr-1 h-3 w-3" />
         {t("webdav.notSynced")}
       </Badge>
     )

--- a/src/features/KeyManagement/components/RepairMissingKeysDialog/RepairAccountCoverageList.tsx
+++ b/src/features/KeyManagement/components/RepairMissingKeysDialog/RepairAccountCoverageList.tsx
@@ -1,8 +1,5 @@
-import {
-  ChevronDownIcon,
-  MagnifyingGlassIcon,
-} from "@heroicons/react/24/outline"
 import type { TFunction } from "i18next"
+import { ChevronDown, Search } from "lucide-react"
 import { useEffect, useState } from "react"
 
 import { Badge, EmptyState } from "~/components/ui"
@@ -107,7 +104,7 @@ function RepairAccountSummary({
           {getRepairOutcomeLabel(t, result.outcome)}
         </Badge>
         {expandable ? (
-          <ChevronDownIcon
+          <ChevronDown
             aria-hidden="true"
             className={cn(
               "dark:text-dark-text-tertiary mt-0.5 h-4 w-4 shrink-0 text-gray-500 transition-transform sm:mt-0",
@@ -308,7 +305,7 @@ export function RepairAccountCoverageList({
   if (filteredResults.length === 0) {
     return (
       <EmptyState
-        icon={<MagnifyingGlassIcon className="h-12 w-12" />}
+        icon={<Search className="h-12 w-12" />}
         title={t("keyManagement:repairMissingKeys.noMatchingResults")}
         className="py-10"
       />

--- a/src/features/KeyManagement/components/RepairMissingKeysDialog/RepairInvalidKeysList.tsx
+++ b/src/features/KeyManagement/components/RepairMissingKeysDialog/RepairInvalidKeysList.tsx
@@ -1,5 +1,5 @@
-import { MagnifyingGlassIcon } from "@heroicons/react/24/outline"
 import type { TFunction } from "i18next"
+import { Search } from "lucide-react"
 
 import { Alert, Badge, Button, Checkbox, EmptyState } from "~/components/ui"
 import type { AccountKeyRepairInvalidResource } from "~/types/accountKeyAutoProvisioning"
@@ -44,7 +44,7 @@ export function RepairInvalidKeysList({
           </div>
         ) : null}
         <EmptyState
-          icon={<MagnifyingGlassIcon className="h-12 w-12" />}
+          icon={<Search className="h-12 w-12" />}
           title={t("keyManagement:repairMissingKeys.invalidKeys.emptyTitle")}
           description={t(
             "keyManagement:repairMissingKeys.invalidKeys.emptyDescription",
@@ -64,7 +64,7 @@ export function RepairInvalidKeysList({
           </div>
         ) : null}
         <EmptyState
-          icon={<MagnifyingGlassIcon className="h-12 w-12" />}
+          icon={<Search className="h-12 w-12" />}
           title={t("keyManagement:repairMissingKeys.noMatchingResults")}
           className="py-10"
         />

--- a/src/features/KeyManagement/components/RepairMissingKeysDialog/RepairMissingKeysResultsPanel.tsx
+++ b/src/features/KeyManagement/components/RepairMissingKeysDialog/RepairMissingKeysResultsPanel.tsx
@@ -1,6 +1,5 @@
-import { MagnifyingGlassIcon, XMarkIcon } from "@heroicons/react/24/outline"
 import type { TFunction } from "i18next"
-import { ShieldCheck, TriangleAlert } from "lucide-react"
+import { Search, ShieldCheck, TriangleAlert, X } from "lucide-react"
 import { useRef, type Dispatch, type SetStateAction } from "react"
 
 import {
@@ -171,7 +170,7 @@ export function RepairMissingKeysResultsPanel({
               aria-label={t("keyManagement:repairMissingKeys.searchLabel")}
               value={searchTerm}
               onChange={(event) => onSearchTermChange(event.target.value)}
-              leftIcon={<MagnifyingGlassIcon className="h-4 w-4" />}
+              leftIcon={<Search className="h-4 w-4" />}
               rightIcon={
                 searchTerm ? (
                   <button
@@ -183,7 +182,7 @@ export function RepairMissingKeysResultsPanel({
                     className="dark:hover:bg-dark-bg-tertiary rounded p-1 hover:bg-gray-100"
                     aria-label={t("common:actions.clear")}
                   >
-                    <XMarkIcon className="h-4 w-4" />
+                    <X className="h-4 w-4" />
                   </button>
                 ) : null
               }

--- a/src/features/KeyManagement/components/ServiceCredentialCard.tsx
+++ b/src/features/KeyManagement/components/ServiceCredentialCard.tsx
@@ -1,10 +1,11 @@
 import {
-  ArrowPathIcon,
-  CommandLineIcon,
-  KeyIcon,
-  WrenchScrewdriverIcon,
-} from "@heroicons/react/24/outline"
-import { Copy, Library } from "lucide-react"
+  Copy,
+  KeyRound,
+  Library,
+  RefreshCw,
+  Terminal,
+  Wrench,
+} from "lucide-react"
 import { useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 
@@ -414,7 +415,7 @@ export function ServiceCredentialCard({
                   onSelectionChange={onSelectionChange}
                   disabledReason={selectionDisabledReason}
                 />
-                <KeyIcon className="h-4 w-4 shrink-0 text-sky-600 dark:text-sky-400" />
+                <KeyRound className="h-4 w-4 shrink-0 text-sky-600 dark:text-sky-400" />
                 <Heading6 className="truncate text-sm sm:text-base">
                   {credential.label}
                 </Heading6>
@@ -455,7 +456,7 @@ export function ServiceCredentialCard({
                   variant="ghost"
                   onClick={() => setVerifyingProfile(transientProfile)}
                 >
-                  <WrenchScrewdriverIcon className="h-4 w-4 text-emerald-600 dark:text-emerald-400" />
+                  <Wrench className="h-4 w-4 text-emerald-600 dark:text-emerald-400" />
                 </IconButton>
                 <IconButton
                   aria-label={t("actions.verifyCliSupport")}
@@ -463,7 +464,7 @@ export function ServiceCredentialCard({
                   variant="ghost"
                   onClick={() => setCliVerifyingProfile(transientProfile)}
                 >
-                  <CommandLineIcon className="h-4 w-4 text-sky-600 dark:text-sky-400" />
+                  <Terminal className="h-4 w-4 text-sky-600 dark:text-sky-400" />
                 </IconButton>
                 <IconButton
                   aria-label={t("actions.useInCherry")}
@@ -541,7 +542,7 @@ export function ServiceCredentialCard({
                     variant="outline"
                     loading={isRotating}
                     onClick={() => void onRotate(account)}
-                    leftIcon={<ArrowPathIcon className="h-4 w-4" />}
+                    leftIcon={<RefreshCw className="h-4 w-4" />}
                   >
                     {isRotating
                       ? t("serviceCredential.rotating")
@@ -562,7 +563,7 @@ export function ServiceCredentialCard({
                     data-testid={KEY_MANAGEMENT_TEST_IDS.managedSiteStatusBadge}
                   >
                     {isManagedSiteStatusChecking ? (
-                      <ArrowPathIcon className="h-3 w-3 animate-spin" />
+                      <RefreshCw className="h-3 w-3 animate-spin" />
                     ) : null}
                     {getManagedSiteStatusLabel(t, {
                       isChecking: isManagedSiteStatusChecking,

--- a/src/features/KeyManagement/components/TokenList.tsx
+++ b/src/features/KeyManagement/components/TokenList.tsx
@@ -1,13 +1,15 @@
 import {
-  ArrowPathIcon,
-  ChevronDownIcon,
-  ChevronUpIcon,
-  ExclamationTriangleIcon,
-  GlobeAltIcon,
-  KeyIcon,
-  PlusIcon,
-} from "@heroicons/react/24/outline"
-import { Library, Network, SendToBack } from "lucide-react"
+  ChevronDown,
+  ChevronUp,
+  Globe2,
+  KeyRound,
+  Library,
+  Network,
+  Plus,
+  RefreshCw,
+  SendToBack,
+  TriangleAlert,
+} from "lucide-react"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 
@@ -258,7 +260,7 @@ function TokenEmptyState({
   if (displayData.length === 0) {
     return (
       <EmptyState
-        icon={<KeyIcon className="h-12 w-12" />}
+        icon={<KeyRound className="h-12 w-12" />}
         title={t("account:emptyState")}
         description={t("keyManagement:pleaseAddAccount")}
         action={
@@ -267,7 +269,7 @@ function TokenEmptyState({
                 label: t("account:addFirstAccount"),
                 onClick: onAddAccount,
                 variant: "default",
-                icon: <PlusIcon className="h-4 w-4" />,
+                icon: <Plus className="h-4 w-4" />,
               }
             : undefined
         }
@@ -278,7 +280,7 @@ function TokenEmptyState({
   if (!selectedAccount) {
     return (
       <EmptyState
-        icon={<KeyIcon className="h-12 w-12" />}
+        icon={<KeyRound className="h-12 w-12" />}
         title={t("keyManagement:pleaseSelectAccount")}
         description={t("keyManagement:selectAccountToContinue")}
         action={
@@ -298,7 +300,7 @@ function TokenEmptyState({
     return (
       <EmptyState
         variant="destructive"
-        icon={<ExclamationTriangleIcon className="h-12 w-12" />}
+        icon={<TriangleAlert className="h-12 w-12" />}
         title={t("loadError.title")}
         description={t("loadError.description", {
           error: currentAccountLoadError,
@@ -310,14 +312,14 @@ function TokenEmptyState({
             label: t("refreshTokenList"),
             onClick: () => onRetryCurrentAccount?.(),
             variant: "default",
-            icon: <ArrowPathIcon className="h-4 w-4" />,
+            icon: <RefreshCw className="h-4 w-4" />,
             disabled: !onRetryCurrentAccount,
           },
           {
             label: t("loadError.openSite"),
             onClick: handleOpenCurrentAccountSite,
             variant: "outline",
-            icon: <GlobeAltIcon className="h-4 w-4" />,
+            icon: <Globe2 className="h-4 w-4" />,
             disabled: !currentAccount?.baseUrl?.trim(),
           },
         ]}
@@ -328,7 +330,7 @@ function TokenEmptyState({
   if (currentAccountUnsupportedKeyManagement && currentAccount) {
     return (
       <EmptyState
-        icon={<KeyIcon className="h-12 w-12" />}
+        icon={<KeyRound className="h-12 w-12" />}
         title={t("keyManagement:unsupportedSource.title")}
         description={t("keyManagement:unsupportedSource.description")}
         action={{
@@ -344,13 +346,13 @@ function TokenEmptyState({
   if (tokens.length === 0) {
     return (
       <EmptyState
-        icon={<KeyIcon className="h-12 w-12" />}
+        icon={<KeyRound className="h-12 w-12" />}
         title={t("noKeys")}
         action={{
           label: t("createFirstKey"),
           onClick: handleAddToken,
           variant: "success",
-          icon: <PlusIcon className="h-4 w-4" />,
+          icon: <Plus className="h-4 w-4" />,
           testId: KEY_MANAGEMENT_TEST_IDS.emptyStateAddTokenButton,
           disabled: !canCreateTokens,
         }}
@@ -361,7 +363,7 @@ function TokenEmptyState({
   // 搜索无结果
   return (
     <EmptyState
-      icon={<KeyIcon className="h-12 w-12" />}
+      icon={<KeyRound className="h-12 w-12" />}
       title={t("noMatchingKeys")}
     />
   )
@@ -1162,7 +1164,7 @@ export function TokenList(props: TokenListProps) {
               type="button"
               data-testid={KEY_MANAGEMENT_TEST_IDS.expandAllButton}
               onClick={expandAll}
-              leftIcon={<ChevronDownIcon className="h-4 w-4" />}
+              leftIcon={<ChevronDown className="h-4 w-4" />}
             >
               {t("actions.expandAll")}
             </Button>
@@ -1171,7 +1173,7 @@ export function TokenList(props: TokenListProps) {
               variant="outline"
               type="button"
               onClick={collapseAll}
-              leftIcon={<ChevronUpIcon className="h-4 w-4" />}
+              leftIcon={<ChevronUp className="h-4 w-4" />}
             >
               {t("actions.collapseAll")}
             </Button>
@@ -1267,7 +1269,7 @@ export function TokenList(props: TokenListProps) {
                           </Badge>
                         ) : null}
                       </div>
-                      <ChevronDownIcon
+                      <ChevronDown
                         className={cn(
                           "dark:text-dark-text-tertiary h-4 w-4 shrink-0 text-gray-500 transition-transform",
                           isCollapsed ? "rotate-0" : "rotate-180",

--- a/src/features/KeyManagement/components/TokenListItem/KeyDisplay.tsx
+++ b/src/features/KeyManagement/components/TokenListItem/KeyDisplay.tsx
@@ -1,4 +1,4 @@
-import { EyeIcon, EyeSlashIcon } from "@heroicons/react/24/outline"
+import { Eye, EyeOff } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import { IconButton } from "~/components/ui"
@@ -64,9 +64,9 @@ export function KeyDisplay({
         className="shrink-0"
       >
         {visibleKeys.has(tokenIdentityKey) ? (
-          <EyeSlashIcon className="h-3.5 w-3.5 sm:h-4 sm:w-4" />
+          <EyeOff className="h-3.5 w-3.5 sm:h-4 sm:w-4" />
         ) : (
-          <EyeIcon className="h-3.5 w-3.5 sm:h-4 sm:w-4" />
+          <Eye className="h-3.5 w-3.5 sm:h-4 sm:w-4" />
         )}
       </IconButton>
     </div>

--- a/src/features/KeyManagement/components/TokenListItem/TokenHeader.tsx
+++ b/src/features/KeyManagement/components/TokenListItem/TokenHeader.tsx
@@ -1,12 +1,5 @@
-import {
-  ArrowPathIcon,
-  CommandLineIcon,
-  PencilIcon,
-  TrashIcon,
-  WrenchScrewdriverIcon,
-} from "@heroicons/react/24/outline"
 import type { TFunction } from "i18next"
-import { Copy } from "lucide-react"
+import { Copy, Pencil, RefreshCw, Terminal, Trash2, Wrench } from "lucide-react"
 import { useEffect, useLayoutEffect, useRef, useState } from "react"
 import toast from "react-hot-toast"
 import { useTranslation } from "react-i18next"
@@ -913,7 +906,7 @@ function TokenActionButtons({
             data-testid={KEY_MANAGEMENT_TEST_IDS.verifyTokenApiButton}
             onClick={() => void handleVerifyApi()}
           >
-            <WrenchScrewdriverIcon className="h-4 w-4 text-emerald-600 dark:text-emerald-400" />
+            <Wrench className="h-4 w-4 text-emerald-600 dark:text-emerald-400" />
           </IconButton>
           <IconButton
             aria-label={t("keyManagement:actions.verifyCliSupport")}
@@ -922,7 +915,7 @@ function TokenActionButtons({
             data-testid={KEY_MANAGEMENT_TEST_IDS.verifyTokenCliSupportButton}
             onClick={() => void handleVerifyCliSupport()}
           >
-            <CommandLineIcon className="h-4 w-4 text-sky-600 dark:text-sky-400" />
+            <Terminal className="h-4 w-4 text-sky-600 dark:text-sky-400" />
           </IconButton>
         </>
       ) : null}
@@ -1015,7 +1008,7 @@ function TokenActionButtons({
           variant="ghost"
           onClick={() => handleEditToken(token)}
         >
-          <PencilIcon className="h-4 w-4 text-blue-500 dark:text-blue-400" />
+          <Pencil className="h-4 w-4 text-blue-500 dark:text-blue-400" />
         </IconButton>
       ) : null}
       {actionPolicy.delete ? (
@@ -1025,7 +1018,7 @@ function TokenActionButtons({
           variant="destructiveGhost"
           onClick={() => handleDeleteToken(token)}
         >
-          <TrashIcon className="h-4 w-4" />
+          <Trash2 className="h-4 w-4" />
         </IconButton>
       ) : null}
     </div>
@@ -1173,7 +1166,7 @@ export function TokenHeader({
         data-testid={KEY_MANAGEMENT_TEST_IDS.managedSiteStatusBadge}
       >
         {isManagedSiteStatusChecking ? (
-          <ArrowPathIcon className="h-3 w-3 animate-spin" />
+          <RefreshCw className="h-3 w-3 animate-spin" />
         ) : null}
         {getManagedSiteStatusLabel(t, {
           isChecking: isManagedSiteStatusChecking,

--- a/src/features/KeyManagement/components/TokenSearchBar.tsx
+++ b/src/features/KeyManagement/components/TokenSearchBar.tsx
@@ -1,4 +1,4 @@
-import { MagnifyingGlassIcon } from "@heroicons/react/24/outline"
+import { Search } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import { Input } from "~/components/ui"
@@ -25,7 +25,7 @@ export function TokenSearchBar({
         placeholder={t("searchPlaceholder")}
         value={searchTerm}
         onChange={(e) => setSearchTerm(e.target.value)}
-        leftIcon={<MagnifyingGlassIcon className="h-4 w-4" />}
+        leftIcon={<Search className="h-4 w-4" />}
         onClear={() => setSearchTerm("")}
         clearButtonLabel={t("common:actions.clear")}
       />

--- a/src/features/ManagedSiteModelSync/ManagedSiteModelSync.tsx
+++ b/src/features/ManagedSiteModelSync/ManagedSiteModelSync.tsx
@@ -1,5 +1,4 @@
-import { MagnifyingGlassIcon } from "@heroicons/react/24/outline"
-import { RefreshCcw } from "lucide-react"
+import { RefreshCcw, Search } from "lucide-react"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import toast from "react-hot-toast"
 import { useTranslation } from "react-i18next"
@@ -1395,7 +1394,7 @@ export default function ManagedSiteModelSync({
                   }
                   value={manualSearchKeyword}
                   onChange={(e) => handleManualSearchChange(e.target.value)}
-                  leftIcon={<MagnifyingGlassIcon className="h-4 w-4" />}
+                  leftIcon={<Search className="h-4 w-4" />}
                 />
               </div>
               <Button
@@ -1458,7 +1457,7 @@ export default function ManagedSiteModelSync({
                   ? channelsError
                   : (t("execution.manual.empty.description") as string)
               }
-              icon={<MagnifyingGlassIcon className="h-12 w-12" />}
+              icon={<Search className="h-12 w-12" />}
               action={{
                 label: t("execution.manual.reload"),
                 onClick: () => void loadChannels(),

--- a/src/features/ManagedSiteModelSync/components/ActionBar.tsx
+++ b/src/features/ManagedSiteModelSync/components/ActionBar.tsx
@@ -1,4 +1,4 @@
-import { ArrowPathIcon } from "@heroicons/react/24/outline"
+import { RefreshCw } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import { Button } from "~/components/ui"
@@ -68,7 +68,7 @@ export default function ActionBar({
           variant="default"
           disabled={isBusy}
           loading={activeAction === MANAGED_SITE_MODEL_SYNC_ACTIONS.RUN_ALL}
-          leftIcon={<ArrowPathIcon className="h-4 w-4" />}
+          leftIcon={<RefreshCw className="h-4 w-4" />}
         >
           {activeAction === MANAGED_SITE_MODEL_SYNC_ACTIONS.RUN_ALL
             ? t("execution.actions.runningAll")
@@ -104,7 +104,7 @@ export default function ActionBar({
           variant="ghost"
           disabled={isBusy}
           loading={isRefreshing}
-          leftIcon={<ArrowPathIcon className="h-4 w-4" />}
+          leftIcon={<RefreshCw className="h-4 w-4" />}
         >
           {isRefreshing
             ? t("common:status.refreshing")

--- a/src/features/ManagedSiteModelSync/components/EmptyResults.tsx
+++ b/src/features/ManagedSiteModelSync/components/EmptyResults.tsx
@@ -1,4 +1,4 @@
-import { ArrowPathIcon, MagnifyingGlassIcon } from "@heroicons/react/24/outline"
+import { RefreshCw, Search } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import { EmptyState } from "~/components/ui"
@@ -21,7 +21,7 @@ export default function EmptyResults(props: EmptyResultsProps) {
       <EmptyState
         title={t("execution.empty.noData")}
         description={t("execution.empty.noDataDesc")}
-        icon={<ArrowPathIcon className="h-12 w-12" />}
+        icon={<RefreshCw className="h-12 w-12" />}
       />
     )
   }
@@ -30,7 +30,7 @@ export default function EmptyResults(props: EmptyResultsProps) {
     <EmptyState
       title={t("execution.empty.noResults")}
       description={t("execution.empty.noResultsDesc")}
-      icon={<MagnifyingGlassIcon className="h-12 w-12" />}
+      icon={<Search className="h-12 w-12" />}
     />
   )
 }

--- a/src/features/ManagedSiteModelSync/components/FilterBar.tsx
+++ b/src/features/ManagedSiteModelSync/components/FilterBar.tsx
@@ -1,9 +1,4 @@
-import {
-  CheckCircleIcon,
-  ListBulletIcon,
-  MagnifyingGlassIcon,
-  XCircleIcon,
-} from "@heroicons/react/24/outline"
+import { CircleCheck, CircleX, List, Search } from "lucide-react"
 import { type ReactNode } from "react"
 import { useTranslation } from "react-i18next"
 
@@ -79,21 +74,21 @@ export default function FilterBar({
           "all",
           t("execution.filters.all"),
           "bg-blue-600",
-          <ListBulletIcon className="h-4 w-4" />,
+          <List className="h-4 w-4" />,
           statistics.total,
         )}
         {renderFilterButton(
           "success",
           t("execution.filters.success"),
           "bg-green-600",
-          <CheckCircleIcon className="h-4 w-4" />,
+          <CircleCheck className="h-4 w-4" />,
           statistics.successCount,
         )}
         {renderFilterButton(
           "failed",
           t("execution.filters.failed"),
           "bg-red-600",
-          <XCircleIcon className="h-4 w-4" />,
+          <CircleX className="h-4 w-4" />,
           statistics.failureCount,
         )}
       </div>
@@ -103,7 +98,7 @@ export default function FilterBar({
           placeholder={t("execution.filters.searchPlaceholder") as string}
           value={keyword}
           onChange={(e) => onKeywordChange(e.target.value)}
-          leftIcon={<MagnifyingGlassIcon className="h-4 w-4" />}
+          leftIcon={<Search className="h-4 w-4" />}
           onClear={() => onKeywordChange("")}
           clearButtonLabel={t("common:actions.clear")}
         />

--- a/src/features/ManagedSiteModelSync/components/ProgressCard.tsx
+++ b/src/features/ManagedSiteModelSync/components/ProgressCard.tsx
@@ -1,4 +1,4 @@
-import { ArrowPathIcon } from "@heroicons/react/24/outline"
+import { RefreshCw } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import { Card, CardContent } from "~/components/ui"
@@ -28,7 +28,7 @@ export default function ProgressCard(props: ProgressCardProps) {
         spacing="none"
         className="flex flex-col items-center gap-3 text-center sm:flex-row sm:items-center sm:gap-4 sm:text-left"
       >
-        <ArrowPathIcon className="h-5 w-5 shrink-0 animate-spin text-blue-600 dark:text-blue-400" />
+        <RefreshCw className="h-5 w-5 shrink-0 animate-spin text-blue-600 dark:text-blue-400" />
         <div className="flex flex-col items-center sm:items-start">
           <p className="font-medium text-blue-900 dark:text-blue-100">
             {t("execution.status.running")}

--- a/src/features/ManagedSiteModelSync/components/ResultsTable.tsx
+++ b/src/features/ManagedSiteModelSync/components/ResultsTable.tsx
@@ -1,9 +1,5 @@
-import {
-  ArrowPathIcon,
-  CheckCircleIcon,
-  ExclamationCircleIcon,
-} from "@heroicons/react/24/outline"
 import dayjs from "dayjs"
+import { CircleAlert, CircleCheck, RefreshCw } from "lucide-react"
 import { useEffect, useRef } from "react"
 import { useTranslation } from "react-i18next"
 
@@ -141,9 +137,9 @@ export default function ResultsTable({
                   {columns.status && (
                     <td className="px-4 py-3">
                       {item.ok ? (
-                        <CheckCircleIcon className="h-5 w-5 text-green-600 dark:text-green-400" />
+                        <CircleCheck className="h-5 w-5 text-green-600 dark:text-green-400" />
                       ) : (
-                        <ExclamationCircleIcon className="h-5 w-5 text-red-600 dark:text-red-400" />
+                        <CircleAlert className="h-5 w-5 text-red-600 dark:text-red-400" />
                       )}
                     </td>
                   )}
@@ -203,7 +199,7 @@ export default function ResultsTable({
                       loading={isRunningThis}
                       aria-label={t("execution.table.syncChannel")}
                       title={t("execution.table.syncChannel")}
-                      leftIcon={<ArrowPathIcon className="h-4 w-4" />}
+                      leftIcon={<RefreshCw className="h-4 w-4" />}
                     />
                   </td>
                 </tr>

--- a/src/features/ModelList/ModelList.tsx
+++ b/src/features/ModelList/ModelList.tsx
@@ -1,5 +1,4 @@
-import { ArrowPathIcon } from "@heroicons/react/24/outline"
-import { Cpu, KeyRound, TrendingDown } from "lucide-react"
+import { Cpu, KeyRound, RefreshCw, TrendingDown } from "lucide-react"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 
@@ -589,7 +588,7 @@ export default function ModelList(props: {
                 <Button
                   onClick={loadPricingData}
                   variant="secondary"
-                  leftIcon={<ArrowPathIcon className="h-4 w-4" />}
+                  leftIcon={<RefreshCw className="h-4 w-4" />}
                   loading={isLoading}
                   analyticsAction={
                     PRODUCT_ANALYTICS_ACTION_IDS.RefreshModelPricingData

--- a/src/features/ModelList/components/AllAccountsGroupFilterMenu.tsx
+++ b/src/features/ModelList/components/AllAccountsGroupFilterMenu.tsx
@@ -1,4 +1,4 @@
-import { FunnelIcon } from "@heroicons/react/24/outline"
+import { Funnel } from "lucide-react"
 import { useMemo } from "react"
 import { useTranslation } from "react-i18next"
 
@@ -164,7 +164,7 @@ export function AllAccountsGroupFilterMenu({
           className={cn("w-full justify-between px-3 sm:w-56")}
         >
           <span className="flex items-center gap-2">
-            <FunnelIcon className="h-4 w-4" />
+            <Funnel className="h-4 w-4" />
             <span>{t("accountGroupFilterTrigger")}</span>
           </span>
           {activeFilteredAccountCount > 0 ? (

--- a/src/features/ModelList/components/ControlPanel.tsx
+++ b/src/features/ModelList/components/ControlPanel.tsx
@@ -1,9 +1,11 @@
 import {
-  BeakerIcon,
-  CpuChipIcon,
-  MagnifyingGlassIcon,
-} from "@heroicons/react/24/outline"
-import { CircleHelp, Copy, TrendingDown } from "lucide-react"
+  CircleHelp,
+  Copy,
+  Cpu,
+  FlaskConical,
+  Search,
+  TrendingDown,
+} from "lucide-react"
 import { useMemo } from "react"
 import toast from "react-hot-toast"
 import { useTranslation } from "react-i18next"
@@ -514,7 +516,7 @@ export function ControlPanel({
                   placeholder={t("searchPlaceholder")}
                   value={searchTerm}
                   onChange={(e) => setSearchTerm(e.target.value)}
-                  leftIcon={<MagnifyingGlassIcon className="h-4 w-4" />}
+                  leftIcon={<Search className="h-4 w-4" />}
                   onClear={handleClearSearch}
                   clearButtonLabel={t("common:actions.clear")}
                 />
@@ -533,7 +535,7 @@ export function ControlPanel({
 
               <div className="flex h-9 items-center gap-3 self-end text-xs [@container(min-width:32rem)]:col-span-2 [@container(min-width:32rem)]:justify-end [@container(min-width:48rem)]:col-span-1">
                 <span className="dark:text-dark-text-secondary flex items-center gap-1.5 text-gray-600">
-                  <CpuChipIcon className="h-4 w-4" />
+                  <Cpu className="h-4 w-4" />
                   {t("totalModels", { count: totalModels })}
                 </span>
                 <span className="dark:bg-dark-bg-tertiary h-3 w-px bg-gray-300" />
@@ -711,7 +713,7 @@ export function ControlPanel({
                     onClick={onBatchVerifyModels}
                     disabled={filteredModels.length === 0}
                     data-testid={MODEL_LIST_TEST_IDS.batchVerifyButton}
-                    leftIcon={<BeakerIcon className="h-4 w-4" />}
+                    leftIcon={<FlaskConical className="h-4 w-4" />}
                     analyticsAction={
                       PRODUCT_ANALYTICS_ACTION_IDS.OpenBatchModelVerifyDialog
                     }

--- a/src/features/ModelList/components/ModelDisplay.tsx
+++ b/src/features/ModelList/components/ModelDisplay.tsx
@@ -1,4 +1,4 @@
-import { CpuChipIcon, InformationCircleIcon } from "@heroicons/react/24/outline"
+import { Cpu, Info } from "lucide-react"
 import { forwardRef, useCallback, useEffect, useMemo, useState } from "react"
 import type { HTMLAttributes } from "react"
 import { useTranslation } from "react-i18next"
@@ -199,7 +199,7 @@ export function ModelDisplay(props: ModelDisplayProps) {
   if (models.length === 0) {
     return (
       <EmptyState
-        icon={<CpuChipIcon className="h-12 w-12" />}
+        icon={<Cpu className="h-12 w-12" />}
         title={t("noMatchingModels")}
       />
     )
@@ -356,7 +356,7 @@ export function ModelDisplay(props: ModelDisplayProps) {
                     role="note"
                     className="dark:border-dark-bg-tertiary flex min-w-0 gap-2 border-b border-gray-200/80 px-3 py-2.5 sm:px-4"
                   >
-                    <InformationCircleIcon
+                    <Info
                       aria-hidden="true"
                       className="dark:text-dark-text-tertiary mt-0.5 h-4 w-4 shrink-0 text-gray-500"
                     />

--- a/src/features/ModelList/components/ModelItem/ModelCapabilityBadges.tsx
+++ b/src/features/ModelList/components/ModelItem/ModelCapabilityBadges.tsx
@@ -3,7 +3,7 @@ import {
   Brain,
   Eye,
   FileText,
-  Image as ImageIcon,
+  Image,
   Paperclip,
   Video,
   Volume2,
@@ -29,7 +29,7 @@ interface ModelCapabilityBadgesProps {
 
 const CAPABILITY_ICONS: Record<ModelCapabilitySelectionValue, LucideIcon> = {
   [MODEL_CAPABILITY_FILTER_VALUES.IMAGE_INPUT]: Eye,
-  [MODEL_CAPABILITY_FILTER_VALUES.IMAGE_OUTPUT]: ImageIcon,
+  [MODEL_CAPABILITY_FILTER_VALUES.IMAGE_OUTPUT]: Image,
   [MODEL_CAPABILITY_FILTER_VALUES.AUDIO_INPUT]: Volume2,
   [MODEL_CAPABILITY_FILTER_VALUES.AUDIO_OUTPUT]: Volume2,
   [MODEL_CAPABILITY_FILTER_VALUES.VIDEO_INPUT]: Video,

--- a/src/features/ModelList/components/ModelItem/ModelItemDetails.tsx
+++ b/src/features/ModelList/components/ModelItem/ModelItemDetails.tsx
@@ -1,8 +1,4 @@
-import {
-  CurrencyDollarIcon,
-  ServerIcon,
-  TagIcon,
-} from "@heroicons/react/24/outline"
+import { DollarSign, Server, Tag } from "lucide-react"
 import React from "react"
 import { useTranslation } from "react-i18next"
 
@@ -114,7 +110,7 @@ export const ModelItemDetails: React.FC<ModelItemDetailsProps> = ({
         {shouldShowGroupDetails && groupContext.usableGroups.length > 0 && (
           <div>
             <div className="mb-2 flex items-center space-x-2">
-              <TagIcon className="dark:text-dark-text-tertiary h-4 w-4 text-gray-400" />
+              <Tag className="dark:text-dark-text-tertiary h-4 w-4 text-gray-400" />
               <span className="dark:text-dark-text-secondary font-medium text-gray-700">
                 {t("currentUsableGroups")}
               </span>
@@ -169,7 +165,7 @@ export const ModelItemDetails: React.FC<ModelItemDetailsProps> = ({
                         variant={isCurrentGroup ? "default" : "secondary"}
                         size="sm"
                       >
-                        {isCurrentGroup && <TagIcon className="h-3 w-3" />}
+                        {isCurrentGroup && <Tag className="h-3 w-3" />}
                         {groupLabel}
                       </Badge>
                     )}
@@ -183,7 +179,7 @@ export const ModelItemDetails: React.FC<ModelItemDetailsProps> = ({
         {shouldShowGroupDetails && supportedOnlyGroups.length > 0 && (
           <div>
             <div className="mb-2 flex items-center space-x-2">
-              <TagIcon className="dark:text-dark-text-tertiary h-4 w-4 text-gray-400" />
+              <Tag className="dark:text-dark-text-tertiary h-4 w-4 text-gray-400" />
               <span className="dark:text-dark-text-secondary font-medium text-gray-700">
                 {t("siteSupportedGroups")}
               </span>
@@ -202,7 +198,7 @@ export const ModelItemDetails: React.FC<ModelItemDetailsProps> = ({
         {showEndpointTypes && (
           <div>
             <div className="mb-2 flex items-center space-x-2">
-              <ServerIcon className="dark:text-dark-text-tertiary h-4 w-4 text-gray-400" />
+              <Server className="dark:text-dark-text-tertiary h-4 w-4 text-gray-400" />
               <span className="dark:text-dark-text-secondary font-medium text-gray-700">
                 {t("endpointType")}
               </span>
@@ -217,7 +213,7 @@ export const ModelItemDetails: React.FC<ModelItemDetailsProps> = ({
         {showPricingDetails && isTokenBillingType(model.quota_type) && (
           <div className="md:col-span-2">
             <div className="mb-2 flex items-center space-x-2">
-              <CurrencyDollarIcon className="dark:text-dark-text-tertiary h-4 w-4 text-gray-400" />
+              <DollarSign className="dark:text-dark-text-tertiary h-4 w-4 text-gray-400" />
               <span className="dark:text-dark-text-secondary font-medium text-gray-700">
                 {t("detailedPricing")}
               </span>

--- a/src/features/ModelList/components/ModelItem/ModelItemExpandButton.tsx
+++ b/src/features/ModelList/components/ModelItem/ModelItemExpandButton.tsx
@@ -1,4 +1,4 @@
-import { ChevronDownIcon, ChevronUpIcon } from "@heroicons/react/24/outline"
+import { ChevronDown, ChevronUp } from "lucide-react"
 import React from "react"
 import { useTranslation } from "react-i18next"
 
@@ -30,9 +30,9 @@ export const ModelItemExpandButton: React.FC<ModelItemExpandButtonProps> = ({
       analyticsAction={analyticsAction}
     >
       {isExpanded ? (
-        <ChevronUpIcon className="h-4 w-4" />
+        <ChevronUp className="h-4 w-4" />
       ) : (
-        <ChevronDownIcon className="h-4 w-4" />
+        <ChevronDown className="h-4 w-4" />
       )}
     </IconButton>
   )

--- a/src/features/ModelList/components/ModelItem/ModelItemHeader.tsx
+++ b/src/features/ModelList/components/ModelItem/ModelItemHeader.tsx
@@ -1,9 +1,4 @@
-import {
-  CommandLineIcon,
-  KeyIcon,
-  WrenchScrewdriverIcon,
-} from "@heroicons/react/24/outline"
-import { Copy } from "lucide-react"
+import { Copy, KeyRound, Terminal, Wrench } from "lucide-react"
 import React from "react"
 import { useTranslation } from "react-i18next"
 
@@ -126,7 +121,7 @@ export const ModelItemHeader: React.FC<ModelItemHeaderProps> = ({
                   PRODUCT_ANALYTICS_ACTION_IDS.OpenModelKeyDialog
                 }
               >
-                <KeyIcon className="h-3 w-3 text-violet-600 sm:h-3.5 sm:w-3.5 dark:text-violet-400" />
+                <KeyRound className="h-3 w-3 text-violet-600 sm:h-3.5 sm:w-3.5 dark:text-violet-400" />
               </IconButton>
             )}
 
@@ -141,7 +136,7 @@ export const ModelItemHeader: React.FC<ModelItemHeaderProps> = ({
                 className="shrink-0"
                 analyticsAction={PRODUCT_ANALYTICS_ACTION_IDS.VerifyModelApi}
               >
-                <WrenchScrewdriverIcon className="h-3 w-3 text-emerald-600 sm:h-3.5 sm:w-3.5 dark:text-emerald-400" />
+                <Wrench className="h-3 w-3 text-emerald-600 sm:h-3.5 sm:w-3.5 dark:text-emerald-400" />
               </IconButton>
             )}
 
@@ -158,7 +153,7 @@ export const ModelItemHeader: React.FC<ModelItemHeaderProps> = ({
                   PRODUCT_ANALYTICS_ACTION_IDS.VerifyModelCliSupport
                 }
               >
-                <CommandLineIcon className="h-3 w-3 text-sky-600 sm:h-3.5 sm:w-3.5 dark:text-sky-400" />
+                <Terminal className="h-3 w-3 text-sky-600 sm:h-3.5 sm:w-3.5 dark:text-sky-400" />
               </IconButton>
             )}
           </div>

--- a/src/features/ModelList/components/ModelKeyDialog/index.tsx
+++ b/src/features/ModelList/components/ModelKeyDialog/index.tsx
@@ -1,4 +1,4 @@
-import { KeyIcon, PlusIcon } from "@heroicons/react/24/outline"
+import { KeyRound, Plus } from "lucide-react"
 import { useEffect, useId, useMemo, useState } from "react"
 import { useTranslation } from "react-i18next"
 
@@ -361,7 +361,7 @@ export default function ModelKeyDialog(props: ModelKeyDialogProps) {
             ) : (
               <div className="space-y-4">
                 <EmptyState
-                  icon={<KeyIcon className="h-12 w-12" />}
+                  icon={<KeyRound className="h-12 w-12" />}
                   title={t("modelList:keyDialog.noCompatibleTitle", {
                     modelId,
                   })}
@@ -432,7 +432,7 @@ export default function ModelKeyDialog(props: ModelKeyDialogProps) {
                       }
                       loading={isCreating}
                       variant="default"
-                      leftIcon={<PlusIcon className="h-4 w-4" />}
+                      leftIcon={<Plus className="h-4 w-4" />}
                     >
                       {isCreating
                         ? t("common:status.creating")

--- a/src/features/ModelList/components/ModelVendorMark.tsx
+++ b/src/features/ModelList/components/ModelVendorMark.tsx
@@ -1,5 +1,4 @@
-import { CpuChipIcon } from "@heroicons/react/24/outline"
-import { CircleHelp } from "lucide-react"
+import { CircleHelp, Cpu } from "lucide-react"
 import type { ReactNode } from "react"
 
 import { InitialsIcon } from "~/components/icons/InitialsIcon"
@@ -106,8 +105,7 @@ export function ModelVendorMark({
     )
   }
 
-  const FallbackIcon =
-    presentation.kind === "unknown" ? CircleHelp : CpuChipIcon
+  const FallbackIcon = presentation.kind === "unknown" ? CircleHelp : Cpu
 
   if (variant === "compact") {
     return (

--- a/src/features/ModelList/components/PersonalizedCatalogFallbackNotice.tsx
+++ b/src/features/ModelList/components/PersonalizedCatalogFallbackNotice.tsx
@@ -1,4 +1,4 @@
-import { ArrowPathIcon } from "@heroicons/react/24/outline"
+import { RefreshCw } from "lucide-react"
 import { useState } from "react"
 import { useTranslation } from "react-i18next"
 
@@ -40,7 +40,7 @@ export function PersonalizedCatalogFallbackNotice({
           variant="secondary"
           onClick={handleRetry}
           loading={isRetrying}
-          leftIcon={<ArrowPathIcon className="h-4 w-4" />}
+          leftIcon={<RefreshCw className="h-4 w-4" />}
         >
           {isRetrying
             ? t("personalizedCatalogFallback.retrying")

--- a/src/features/ModelList/components/StatusIndicator.tsx
+++ b/src/features/ModelList/components/StatusIndicator.tsx
@@ -1,4 +1,4 @@
-import { ArrowPathIcon, CpuChipIcon } from "@heroicons/react/24/outline"
+import { Cpu, RefreshCw } from "lucide-react"
 import { useId } from "react"
 import { useTranslation } from "react-i18next"
 
@@ -65,7 +65,7 @@ export function StatusIndicator({
   if (!selectedSource) {
     return (
       <EmptyState
-        icon={<CpuChipIcon className="h-12 w-12" />}
+        icon={<Cpu className="h-12 w-12" />}
         title={t("pleaseSelectFirst")}
       />
     )
@@ -104,7 +104,7 @@ export function StatusIndicator({
 
     return (
       <EmptyState
-        icon={<CpuChipIcon className="h-12 w-12" />}
+        icon={<Cpu className="h-12 w-12" />}
         title={t("status.unsupportedSourceTitle")}
         description={t("status.unsupportedSourceDescription")}
         action={{
@@ -159,7 +159,7 @@ export function StatusIndicator({
               <Button
                 variant="secondary"
                 onClick={accountFallback.loadRuntimeKeys}
-                leftIcon={<ArrowPathIcon className="h-4 w-4" />}
+                leftIcon={<RefreshCw className="h-4 w-4" />}
               >
                 {t("status.fallback.reloadKeys")}
               </Button>
@@ -189,7 +189,7 @@ export function StatusIndicator({
                 variant="secondary"
                 onClick={accountFallback.loadRuntimeKeys}
                 loading={accountFallback.isLoadingRuntimeKeys}
-                leftIcon={<ArrowPathIcon className="h-4 w-4" />}
+                leftIcon={<RefreshCw className="h-4 w-4" />}
               >
                 {accountFallback.isLoadingRuntimeKeys
                   ? t("status.fallback.loadingKeys")
@@ -273,7 +273,7 @@ export function StatusIndicator({
                 onClick={accountFallback.loadRuntimeKeys}
                 loading={accountFallback.isLoadingRuntimeKeys}
                 disabled={accountFallback.isLoadingCatalog}
-                leftIcon={<ArrowPathIcon className="h-4 w-4" />}
+                leftIcon={<RefreshCw className="h-4 w-4" />}
               >
                 {accountFallback.isLoadingRuntimeKeys
                   ? t("status.fallback.loadingKeys")
@@ -316,7 +316,7 @@ export function StatusIndicator({
           <Button
             variant="secondary"
             onClick={loadPricingData}
-            leftIcon={<ArrowPathIcon className="h-4 w-4" />}
+            leftIcon={<RefreshCw className="h-4 w-4" />}
           >
             {t("status.retryLoad")}
           </Button>
@@ -348,7 +348,7 @@ export function StatusIndicator({
             <Button
               variant="secondary"
               onClick={loadPricingData}
-              leftIcon={<ArrowPathIcon className="h-4 w-4" />}
+              leftIcon={<RefreshCw className="h-4 w-4" />}
             >
               {t("status.retryLoad")}
             </Button>

--- a/src/features/ProductAnnouncements/ProductAnnouncementButton.tsx
+++ b/src/features/ProductAnnouncements/ProductAnnouncementButton.tsx
@@ -1,4 +1,4 @@
-import { MegaphoneIcon } from "@heroicons/react/24/outline"
+import { Megaphone } from "lucide-react"
 import { useCallback, useEffect, useRef, useState } from "react"
 import { useTranslation } from "react-i18next"
 
@@ -195,7 +195,7 @@ export function ProductAnnouncementButton({
       data-testid={PRODUCT_ANNOUNCEMENT_TEST_IDS.button}
       className={cn("relative", className)}
     >
-      <MegaphoneIcon className="h-4 w-4" />
+      <Megaphone className="h-4 w-4" />
       {activeRiskCount > 0 ? (
         <Badge
           variant="danger"

--- a/src/features/SiteBookmarks/components/BookmarkDialog.tsx
+++ b/src/features/SiteBookmarks/components/BookmarkDialog.tsx
@@ -1,7 +1,4 @@
-import {
-  GlobeAltIcon,
-  InformationCircleIcon,
-} from "@heroicons/react/24/outline"
+import { Globe2, Info } from "lucide-react"
 import { useEffect, useMemo, useState } from "react"
 import toast from "react-hot-toast"
 import { useTranslation } from "react-i18next"
@@ -312,7 +309,7 @@ export default function BookmarkDialog({
             <div className="flex items-start justify-between gap-3">
               <div className="min-w-0 flex-1">
                 <div className="flex items-center gap-1 font-medium">
-                  <InformationCircleIcon className="h-4 w-4 shrink-0" />
+                  <Info className="h-4 w-4 shrink-0" />
                   <span>{t("bookmark:dialog.currentPageLabel")}</span>
                 </div>
                 <div className="mt-1 truncate font-medium">
@@ -330,7 +327,7 @@ export default function BookmarkDialog({
                 type="button"
                 variant="link"
                 size="sm"
-                leftIcon={<GlobeAltIcon className="h-4 w-4" />}
+                leftIcon={<Globe2 className="h-4 w-4" />}
                 onClick={handleUseCurrentPage}
                 loading={isCurrentPageLoading}
                 disabled={!currentPage || isWorking || isCurrentPageLoading}

--- a/src/features/SiteBookmarks/components/BookmarkListItem.tsx
+++ b/src/features/SiteBookmarks/components/BookmarkListItem.tsx
@@ -1,10 +1,4 @@
-import {
-  EllipsisHorizontalIcon,
-  LinkIcon,
-  PencilIcon,
-  TrashIcon,
-} from "@heroicons/react/24/outline"
-import { PinIcon, PinOffIcon } from "lucide-react"
+import { Ellipsis, Link, Pencil, Pin, PinOff, Trash2 } from "lucide-react"
 import type { MouseEvent } from "react"
 import { useTranslation } from "react-i18next"
 
@@ -73,7 +67,7 @@ export default function BookmarkListItem({
   const pinLabel = isPinned
     ? t("bookmark:actions.unpin")
     : t("bookmark:actions.pin")
-  const PinToggleIcon = isPinned ? PinOffIcon : PinIcon
+  const PinToggleIcon = isPinned ? PinOff : Pin
   const rowActionsSurface =
     PRODUCT_ANALYTICS_SURFACE_IDS.OptionsBookmarkManagementRowActions
 
@@ -110,7 +104,7 @@ export default function BookmarkListItem({
                 </BodySmall>
               </Button>
               {isPinned && (
-                <PinIcon className="h-3.5 w-3.5 shrink-0 text-gray-500 dark:text-gray-300" />
+                <Pin className="h-3.5 w-3.5 shrink-0 text-gray-500 dark:text-gray-300" />
               )}
             </div>
             <Button
@@ -160,7 +154,7 @@ export default function BookmarkListItem({
                 data-testid={SITE_BOOKMARKS_TEST_IDS.rowCopyUrlButton}
                 analyticsAction={PRODUCT_ANALYTICS_ACTION_IDS.CopyBookmarkUrl}
               >
-                <LinkIcon className="h-4 w-4" />
+                <Link className="h-4 w-4" />
               </IconButton>
 
               <IconButton
@@ -172,7 +166,7 @@ export default function BookmarkListItem({
                 data-testid={SITE_BOOKMARKS_TEST_IDS.rowEditButton}
                 analyticsAction={PRODUCT_ANALYTICS_ACTION_IDS.UpdateBookmark}
               >
-                <PencilIcon className="h-4 w-4" />
+                <Pencil className="h-4 w-4" />
               </IconButton>
 
               <DropdownMenu>
@@ -183,7 +177,7 @@ export default function BookmarkListItem({
                     aria-label={t("common:actions.more")}
                     data-testid={SITE_BOOKMARKS_TEST_IDS.rowMoreActionsButton}
                   >
-                    <EllipsisHorizontalIcon className="h-4 w-4" />
+                    <Ellipsis className="h-4 w-4" />
                   </IconButton>
                 </DropdownMenuTrigger>
 
@@ -203,7 +197,7 @@ export default function BookmarkListItem({
                   <DropdownMenuSeparator className="dark:bg-dark-bg-tertiary my-1 bg-gray-200" />
                   <AccountActionMenuItem
                     onClick={() => onDelete()}
-                    icon={TrashIcon}
+                    icon={Trash2}
                     label={t("common:actions.delete")}
                     isDestructive={true}
                     testId={SITE_BOOKMARKS_TEST_IDS.rowDeleteMenuItem}

--- a/src/features/SiteBookmarks/components/BookmarkSearchInput.tsx
+++ b/src/features/SiteBookmarks/components/BookmarkSearchInput.tsx
@@ -1,4 +1,4 @@
-import { MagnifyingGlassIcon } from "@heroicons/react/24/outline"
+import { Search } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 import { Input } from "~/components/ui"
@@ -37,7 +37,7 @@ export default function BookmarkSearchInput({
         onChange={(e) => onChange(e.target.value)}
         onKeyDown={handleKeyDown}
         placeholder={t("bookmark:search.placeholder")}
-        leftIcon={<MagnifyingGlassIcon className="h-4 w-4" />}
+        leftIcon={<Search className="h-4 w-4" />}
         onClear={onClear}
         clearButtonLabel={t("common:actions.clear")}
       />

--- a/src/features/SiteBookmarks/components/BookmarksList.tsx
+++ b/src/features/SiteBookmarks/components/BookmarksList.tsx
@@ -12,7 +12,7 @@ import {
   SortableContext,
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable"
-import { InboxIcon, PlusIcon } from "@heroicons/react/24/outline"
+import { Inbox, Plus } from "lucide-react"
 import { useCallback, useEffect, useMemo, useState } from "react"
 import toast from "react-hot-toast"
 import { useTranslation } from "react-i18next"
@@ -386,13 +386,13 @@ export default function BookmarksList({
           }
         >
           <EmptyState
-            icon={<InboxIcon className="h-12 w-12" />}
+            icon={<Inbox className="h-12 w-12" />}
             title={t("bookmark:emptyState")}
             action={{
               label: t("bookmark:addFirstBookmark"),
               onClick: openAddBookmark,
               variant: "default",
-              icon: <PlusIcon className="h-4 w-4" />,
+              icon: <Plus className="h-4 w-4" />,
               testId: SITE_BOOKMARKS_TEST_IDS.emptyStateAddButton,
               analyticsAction: PRODUCT_ANALYTICS_ACTION_IDS.CreateBookmark,
             }}

--- a/src/features/SiteBookmarks/components/SortableBookmarkListItem.tsx
+++ b/src/features/SiteBookmarks/components/SortableBookmarkListItem.tsx
@@ -1,6 +1,6 @@
 import { useSortable } from "@dnd-kit/sortable"
 import { CSS } from "@dnd-kit/utilities"
-import { Bars3Icon } from "@heroicons/react/24/outline"
+import { GripVertical } from "lucide-react"
 
 import { IconButton } from "~/components/ui"
 import { cn } from "~/lib/utils"
@@ -75,7 +75,7 @@ export default function SortableBookmarkListItem({
               {...listeners}
               {...attributes}
             >
-              <Bars3Icon className="h-4 w-4" />
+              <GripVertical className="h-4 w-4" />
             </IconButton>
           </div>
         )}

--- a/src/features/TokenProvisioning/components/AddTokenDialog/DialogHeader.tsx
+++ b/src/features/TokenProvisioning/components/AddTokenDialog/DialogHeader.tsx
@@ -1,4 +1,4 @@
-import { KeyIcon } from "@heroicons/react/24/outline"
+import { KeyRound } from "lucide-react"
 import { useTranslation } from "react-i18next"
 
 interface DialogHeaderProps {
@@ -16,7 +16,7 @@ export function DialogHeader({ isEditMode }: DialogHeaderProps) {
   return (
     <div className="flex items-center justify-between">
       <div className="flex items-center space-x-2">
-        <KeyIcon className="h-6 w-6 text-blue-600 dark:text-blue-400" />
+        <KeyRound className="h-6 w-6 text-blue-600 dark:text-blue-400" />
         <h2 className="dark:text-dark-text-primary text-lg font-semibold text-gray-900">
           {isEditMode ? t("dialog.editToken") : t("dialog.addToken")}
         </h2>

--- a/src/features/TokenProvisioning/components/OneTimeSecretDialog.tsx
+++ b/src/features/TokenProvisioning/components/OneTimeSecretDialog.tsx
@@ -1,4 +1,4 @@
-import { CheckIcon, ClipboardDocumentIcon } from "@heroicons/react/24/outline"
+import { Check, Clipboard } from "lucide-react"
 import { useCallback, useId, useLayoutEffect, useRef, useState } from "react"
 import toast from "react-hot-toast"
 import { useTranslation } from "react-i18next"
@@ -274,9 +274,9 @@ export function OneTimeSecretDialog({
               data-testid={TOKEN_PROVISIONING_TEST_IDS.oneTimeKeyCopyButton}
               leftIcon={
                 copied ? (
-                  <CheckIcon className="h-4 w-4" />
+                  <Check className="h-4 w-4" />
                 ) : (
-                  <ClipboardDocumentIcon className="h-4 w-4" />
+                  <Clipboard className="h-4 w-4" />
                 )
               }
             >

--- a/tests/components/LinkCard.test.tsx
+++ b/tests/components/LinkCard.test.tsx
@@ -1,4 +1,4 @@
-import { ExclamationTriangleIcon } from "@heroicons/react/24/outline"
+import { TriangleAlert } from "lucide-react"
 import { describe, expect, it } from "vitest"
 
 import LinkCard from "~/components/LinkCard"
@@ -6,7 +6,7 @@ import { render, screen } from "~~/tests/test-utils/render"
 
 describe("LinkCard", () => {
   const defaultProps = {
-    Icon: ExclamationTriangleIcon,
+    Icon: TriangleAlert,
     title: "Test Title",
     description: "Test description text",
     href: "https://example.com",

--- a/tests/components/VerificationStatusBadge.test.tsx
+++ b/tests/components/VerificationStatusBadge.test.tsx
@@ -16,11 +16,11 @@ vi.mock("react-i18next", async (importOriginal) => {
   }
 })
 
-vi.mock("@heroicons/react/24/outline", () => ({
-  CheckCircleIcon: (props: React.SVGProps<SVGSVGElement>) => (
+vi.mock("lucide-react", () => ({
+  CircleCheck: (props: React.SVGProps<SVGSVGElement>) => (
     <svg data-testid="check-circle-icon" {...props} />
   ),
-  XCircleIcon: (props: React.SVGProps<SVGSVGElement>) => (
+  CircleX: (props: React.SVGProps<SVGSVGElement>) => (
     <svg data-testid="x-circle-icon" {...props} />
   ),
 }))

--- a/tests/entrypoints/options/Header.test.tsx
+++ b/tests/entrypoints/options/Header.test.tsx
@@ -2,7 +2,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { useUpdateLogDialogContext } from "~/components/dialogs/UpdateLogDialog"
 import Header from "~/entrypoints/options/components/Header"
-import { act, render, screen, waitFor } from "~~/tests/test-utils/render"
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "~~/tests/test-utils/render"
 
 vi.mock("~/contexts/ReleaseUpdateStatusContext", async (importOriginal) => {
   const actual =
@@ -114,6 +120,25 @@ describe("options Header", () => {
       container.textContent?.match(/ui:optionsSearch\.placeholder/g)?.length ??
         0,
     ).toBe(1)
+  })
+
+  it("keeps the mobile menu toggle operable while the sidebar is open", async () => {
+    const onMenuToggle = vi.fn()
+
+    render(
+      <Header
+        onSearchOpen={vi.fn()}
+        onTitleClick={vi.fn()}
+        onMenuToggle={onMenuToggle}
+        isMobileSidebarOpen={true}
+      />,
+    )
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "ui:navigation.toggleMenu" }),
+    )
+
+    expect(onMenuToggle).toHaveBeenCalledTimes(1)
   })
 
   it("switches to the expanded mobile search trigger after scrolling", async () => {

--- a/tests/entrypoints/options/pages/ModelList/ProviderTabs.test.tsx
+++ b/tests/entrypoints/options/pages/ModelList/ProviderTabs.test.tsx
@@ -37,16 +37,6 @@ vi.mock("~/services/productAnalytics/actions", () => ({
     trackProductAnalyticsActionCompletedMock(...args),
 }))
 
-vi.mock("@heroicons/react/24/outline", async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import("@heroicons/react/24/outline")>()
-  const CpuChipIcon = (props: React.SVGProps<SVGSVGElement>) => (
-    <svg role="img" data-publisher-icon="generic" {...props} />
-  )
-
-  return { ...actual, CpuChipIcon }
-})
-
 vi.mock("lucide-react", async (importOriginal) => {
   const actual = await importOriginal<typeof import("lucide-react")>()
   const createIcon = (name: string) =>
@@ -57,6 +47,9 @@ vi.mock("lucide-react", async (importOriginal) => {
   return {
     ...actual,
     CircleHelp: createIcon("unknown-vendor"),
+    Cpu: (props: React.SVGProps<SVGSVGElement>) => (
+      <svg role="img" data-publisher-icon="generic" {...props} />
+    ),
     LayoutGrid: createIcon("all-vendors"),
   }
 })

--- a/tests/features/AccountManagement/components/AccountList.test.tsx
+++ b/tests/features/AccountManagement/components/AccountList.test.tsx
@@ -712,6 +712,29 @@ describe("AccountList", () => {
     ).toBeInTheDocument()
   })
 
+  it("keeps the active descending sort control actionable", async () => {
+    const user = userEvent.setup()
+    const handleSort = vi.fn()
+
+    mockUseAccountDataContext.mockReturnValue(
+      createAccountDataContextValue({
+        handleSort,
+        sortField: "name",
+        sortOrder: "desc",
+      }),
+    )
+
+    render(<AccountList />)
+
+    await user.click(
+      screen.getByRole("button", {
+        name: "account:list.sort account:list.header.account",
+      }),
+    )
+
+    expect(handleSort).toHaveBeenCalledWith("name")
+  })
+
   it("shows a clear sort action when field sorting is active", async () => {
     const user = userEvent.setup()
     const clearSortConfig = vi.fn()

--- a/tests/features/ModelList/components/ModelItemExpandButton.test.tsx
+++ b/tests/features/ModelList/components/ModelItemExpandButton.test.tsx
@@ -1,0 +1,36 @@
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import { ModelItemExpandButton } from "~/features/ModelList/components/ModelItem/ModelItemExpandButton"
+import { render, screen } from "~~/tests/test-utils/render"
+
+describe("ModelItemExpandButton", () => {
+  it("exposes both collapsed and expanded states while remaining actionable", async () => {
+    const user = userEvent.setup()
+    const onToggleExpand = vi.fn()
+    const { rerender } = render(
+      <ModelItemExpandButton
+        isExpanded={false}
+        onToggleExpand={onToggleExpand}
+      />,
+    )
+
+    const button = await screen.findByRole("button")
+    expect(button).toHaveAttribute("aria-expanded", "false")
+
+    await user.click(button)
+    expect(onToggleExpand).toHaveBeenCalledTimes(1)
+
+    rerender(
+      <ModelItemExpandButton
+        isExpanded={true}
+        onToggleExpand={onToggleExpand}
+      />,
+    )
+
+    expect(await screen.findByRole("button")).toHaveAttribute(
+      "aria-expanded",
+      "true",
+    )
+  })
+})

--- a/tests/features/ModelList/components/ModelItemHeader.test.tsx
+++ b/tests/features/ModelList/components/ModelItemHeader.test.tsx
@@ -32,16 +32,6 @@ vi.mock(
   }),
 )
 
-vi.mock("@heroicons/react/24/outline", async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import("@heroicons/react/24/outline")>()
-  const CpuChipIcon = (props: React.SVGProps<SVGSVGElement>) => (
-    <svg role="img" data-publisher-icon="generic" {...props} />
-  )
-
-  return { ...actual, CpuChipIcon }
-})
-
 vi.mock("@lobehub/icons/es/Anthropic/components/Mono", () => ({
   default: ({
     size,

--- a/tests/features/ModelList/components/ModelVendorMark.test.tsx
+++ b/tests/features/ModelList/components/ModelVendorMark.test.tsx
@@ -5,19 +5,6 @@ import { describe, expect, it, vi } from "vitest"
 import { ModelVendorMark } from "~/features/ModelList/components/ModelVendorMark"
 import type { ModelVendorPresentationInput } from "~/features/ModelList/modelVendorPresentation"
 
-vi.mock("@heroicons/react/24/outline", async (importOriginal) => {
-  const actual =
-    await importOriginal<typeof import("@heroicons/react/24/outline")>()
-  const CpuChipIcon = ({
-    size,
-    ...props
-  }: React.SVGProps<SVGSVGElement> & { size?: string | number }) => (
-    <svg role="img" data-mark="generic" data-size={size} {...props} />
-  )
-
-  return { ...actual, CpuChipIcon }
-})
-
 vi.mock("lucide-react", async (importOriginal) => {
   const actual = await importOriginal<typeof import("lucide-react")>()
   const CircleHelp = ({
@@ -26,8 +13,14 @@ vi.mock("lucide-react", async (importOriginal) => {
   }: React.SVGProps<SVGSVGElement> & { size?: string | number }) => (
     <svg role="img" data-mark="unknown" data-size={size} {...props} />
   )
+  const Cpu = ({
+    size,
+    ...props
+  }: React.SVGProps<SVGSVGElement> & { size?: string | number }) => (
+    <svg role="img" data-mark="generic" data-size={size} {...props} />
+  )
 
-  return { ...actual, CircleHelp }
+  return { ...actual, CircleHelp, Cpu }
 })
 
 vi.mock("@lobehub/icons/es/Google/components/Color", () => ({

--- a/tests/features/SiteBookmarks/components/BookmarksList.test.tsx
+++ b/tests/features/SiteBookmarks/components/BookmarksList.test.tsx
@@ -533,6 +533,34 @@ describe("BookmarksList", () => {
     )
   })
 
+  it("offers the unpin action for a pinned bookmark", async () => {
+    const user = userEvent.setup()
+    const bookmark: SiteBookmark = {
+      id: "b1",
+      name: "Docs",
+      url: "https://example.com/docs",
+      tagIds: [],
+      notes: "",
+      created_at: 0,
+      updated_at: 0,
+    }
+
+    bookmarksMock = [bookmark]
+    pinnedAccountIdsMock = [bookmark.id]
+
+    render(<BookmarksList />)
+
+    await user.click(
+      await screen.findByRole("button", { name: "common:actions.more" }),
+    )
+
+    expect(
+      await screen.findByRole("menuitem", {
+        name: "bookmark:actions.unpin",
+      }),
+    ).toBeInTheDocument()
+  })
+
   it("does not start delete bookmark analytics when confirmation is cancelled", async () => {
     const user = userEvent.setup()
     const bookmark: SiteBookmark = {


### PR DESCRIPTION
## Summary

Replace the remaining Heroicons usage with Lucide so generic UI icons use one consistent bundled library and the legacy dependency can be removed.

## What changed

- Migrated Heroicons imports across 113 UI source files to the closest Lucide equivalents.
- Used canonical Lucide component names directly instead of retaining Heroicons-compatible aliases.
- Preserved project-level semantic icons such as account-key and API-credential-library icons.
- Removed `@heroicons/react` from the dependency graph.
- Added an ESLint restriction to prevent Heroicons from being reintroduced.
- Updated affected icon-related tests.

## Validation

- `pnpm build`
- Pre-commit `validate:staged`
  - Prettier
  - ESLint
  - affected Vitest suites
  - i18n extraction and status checks
- Pre-push `validate:push`
  - `pnpm compile`
  - `pnpm knip`

## Notes

- No runtime behavior or layout changes are intended.
- LobeHub model and provider icons are unchanged.
- Playwright E2E was not run because this is an icon-source refactor. Visual review should focus on warning/status icons, multi-select controls, drag handles, and popup actions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated interface icons throughout the app for a more consistent visual experience.
  * Improved consistency across navigation, dialogs, settings, account management, model lists, notifications, and status indicators.
  * Existing icon sizing, styling, accessibility, and interactions remain unchanged.

* **Chores**
  * Removed the legacy icon library from the application.
  * Added safeguards to prevent future use of the retired icon set.

* **Tests**
  * Added coverage for mobile navigation, sorting, expansion controls, and bookmark actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->