### PR TITLE
perf(icons): reduce Lobe icon bundle overhead

### DIFF
--- a/e2e/dnrRequired/accountCookieDnrRealBrowser.spec.ts
+++ b/e2e/dnrRequired/accountCookieDnrRealBrowser.spec.ts
@@ -74,7 +74,8 @@ test("grants the Chromium cookie/DNR optional permissions needed for cookie auth
     await expectPermissionOnboardingHidden(page)
     await grantCookieDnrPermissions(page, localSite.origin)
   } finally {
-    await closeOtherPages(context, page)
+    // Stop extension-page requests before tearing down their local HTTP target.
+    await closeOtherPages(context)
     await localSite.close()
   }
 })
@@ -395,7 +396,8 @@ test("isolates same-site cookie and access-token accounts through account refres
       )
     })
   } finally {
-    await closeOtherPages(context, page)
+    // Stop extension-page requests before tearing down their local HTTP target.
+    await closeOtherPages(context)
     await localSite.close()
   }
 })

--- a/src/components/icons/ManagedSiteIcon.tsx
+++ b/src/components/icons/ManagedSiteIcon.tsx
@@ -1,4 +1,4 @@
-import { NewAPI } from "@lobehub/icons"
+import NewAPIColor from "@lobehub/icons/es/NewAPI/components/Color"
 
 import { AxonHubIcon } from "~/components/icons/AxonHubIcon"
 import { ClaudeCodeHubIcon } from "~/components/icons/ClaudeCodeHubIcon"
@@ -49,5 +49,5 @@ export function ManagedSiteIcon({
     return <Sub2ApiIcon size={size} />
   }
 
-  return <NewAPI.Color className={cn(ICON_SIZE_CLASSNAME[size])} />
+  return <NewAPIColor className={cn(ICON_SIZE_CLASSNAME[size])} />
 }

--- a/src/features/ModelList/components/ModelVendorMark.tsx
+++ b/src/features/ModelList/components/ModelVendorMark.tsx
@@ -56,7 +56,7 @@ export function ModelVendorMark({
   const presentation = getModelVendorPresentation(vendor)
 
   if (presentation.kind === "brand") {
-    const BrandMark = presentation.Brand.Color ?? presentation.Brand.Mark
+    const BrandMark = presentation.Icon
 
     if (variant === "badge") {
       return (

--- a/src/features/ModelList/modelVendorPresentation.ts
+++ b/src/features/ModelList/modelVendorPresentation.ts
@@ -1,71 +1,44 @@
 import Ai2Color from "@lobehub/icons/es/Ai2/components/Color"
-import Ai2 from "@lobehub/icons/es/Ai2/components/Mono"
 import AlibabaColor from "@lobehub/icons/es/Alibaba/components/Color"
-import Alibaba from "@lobehub/icons/es/Alibaba/components/Mono"
 import Anthropic from "@lobehub/icons/es/Anthropic/components/Mono"
 import ArceeColor from "@lobehub/icons/es/Arcee/components/Color"
-import Arcee from "@lobehub/icons/es/Arcee/components/Mono"
 import AwsColor from "@lobehub/icons/es/Aws/components/Color"
-import Aws from "@lobehub/icons/es/Aws/components/Mono"
 import BAAI from "@lobehub/icons/es/BAAI/components/Mono"
 import BaichuanColor from "@lobehub/icons/es/Baichuan/components/Color"
-import Baichuan from "@lobehub/icons/es/Baichuan/components/Mono"
 import BaiduColor from "@lobehub/icons/es/Baidu/components/Color"
-import Baidu from "@lobehub/icons/es/Baidu/components/Mono"
 import ByteDanceColor from "@lobehub/icons/es/ByteDance/components/Color"
-import ByteDance from "@lobehub/icons/es/ByteDance/components/Mono"
 import CohereColor from "@lobehub/icons/es/Cohere/components/Color"
-import Cohere from "@lobehub/icons/es/Cohere/components/Mono"
 import DeepCogitoColor from "@lobehub/icons/es/DeepCogito/components/Color"
-import DeepCogito from "@lobehub/icons/es/DeepCogito/components/Mono"
 import DeepSeekColor from "@lobehub/icons/es/DeepSeek/components/Color"
-import DeepSeek from "@lobehub/icons/es/DeepSeek/components/Mono"
 import EssentialAIColor from "@lobehub/icons/es/EssentialAI/components/Color"
-import EssentialAI from "@lobehub/icons/es/EssentialAI/components/Mono"
 import GoogleColor from "@lobehub/icons/es/Google/components/Color"
-import Google from "@lobehub/icons/es/Google/components/Mono"
 import Groq from "@lobehub/icons/es/Groq/components/Mono"
 import Inception from "@lobehub/icons/es/Inception/components/Mono"
 import InternLMColor from "@lobehub/icons/es/InternLM/components/Color"
-import InternLM from "@lobehub/icons/es/InternLM/components/Mono"
 import Jina from "@lobehub/icons/es/Jina/components/Mono"
 import KiloCode from "@lobehub/icons/es/KiloCode/components/Mono"
 import KolorsColor from "@lobehub/icons/es/Kolors/components/Color"
-import Kolors from "@lobehub/icons/es/Kolors/components/Mono"
 import Liquid from "@lobehub/icons/es/Liquid/components/Mono"
 import LongCatColor from "@lobehub/icons/es/LongCat/components/Color"
-import LongCat from "@lobehub/icons/es/LongCat/components/Mono"
 import MetaColor from "@lobehub/icons/es/Meta/components/Color"
-import Meta from "@lobehub/icons/es/Meta/components/Mono"
 import MicrosoftColor from "@lobehub/icons/es/Microsoft/components/Color"
-import Microsoft from "@lobehub/icons/es/Microsoft/components/Mono"
 import MinimaxColor from "@lobehub/icons/es/Minimax/components/Color"
-import Minimax from "@lobehub/icons/es/Minimax/components/Mono"
 import MistralColor from "@lobehub/icons/es/Mistral/components/Color"
-import Mistral from "@lobehub/icons/es/Mistral/components/Mono"
 import Moonshot from "@lobehub/icons/es/Moonshot/components/Mono"
 import NvidiaColor from "@lobehub/icons/es/Nvidia/components/Color"
-import Nvidia from "@lobehub/icons/es/Nvidia/components/Mono"
 import OpenAI from "@lobehub/icons/es/OpenAI/components/Mono"
 import OpenCode from "@lobehub/icons/es/OpenCode/components/Mono"
 import OpenRouterColor from "@lobehub/icons/es/OpenRouter/components/Color"
-import OpenRouter from "@lobehub/icons/es/OpenRouter/components/Mono"
 import PerplexityColor from "@lobehub/icons/es/Perplexity/components/Color"
-import Perplexity from "@lobehub/icons/es/Perplexity/components/Mono"
 import SenseNovaColor from "@lobehub/icons/es/SenseNova/components/Color"
-import SenseNova from "@lobehub/icons/es/SenseNova/components/Mono"
 import Stepfun from "@lobehub/icons/es/Stepfun/components/Mono"
 import TencentColor from "@lobehub/icons/es/Tencent/components/Color"
-import Tencent from "@lobehub/icons/es/Tencent/components/Mono"
 import type { IconType } from "@lobehub/icons/es/types"
 import UpstageColor from "@lobehub/icons/es/Upstage/components/Color"
-import Upstage from "@lobehub/icons/es/Upstage/components/Mono"
 import XAI from "@lobehub/icons/es/XAI/components/Mono"
 import XiaomiMiMo from "@lobehub/icons/es/XiaomiMiMo/components/Mono"
 import YiColor from "@lobehub/icons/es/Yi/components/Color"
-import Yi from "@lobehub/icons/es/Yi/components/Mono"
 import ZhipuColor from "@lobehub/icons/es/Zhipu/components/Color"
-import Zhipu from "@lobehub/icons/es/Zhipu/components/Mono"
 
 import type {
   ModelVendorCatalogEntry,
@@ -73,20 +46,15 @@ import type {
 } from "~/services/models/modelMetadata/types"
 import type { KnownModelVendorId } from "~/services/models/modelVendor"
 
-interface ModelVendorBrand {
-  Mark: IconType
-  Color?: IconType
-}
-
 type ModelVendorPresentation =
-  | { kind: "brand"; Brand: ModelVendorBrand }
+  | { kind: "brand"; Icon: IconType }
   | { kind: "initials"; initials: string }
   | { kind: "generic" }
   | { kind: "unknown" }
 
-const brand = (Mark: IconType, Color?: IconType): ModelVendorPresentation => ({
+const brand = (Icon: IconType): ModelVendorPresentation => ({
   kind: "brand",
-  Brand: { Mark, Color },
+  Icon,
 })
 
 const initials = (value: string): ModelVendorPresentation => ({
@@ -105,49 +73,49 @@ const UNKNOWN_VENDOR_PRESENTATION = {
 const KNOWN_VENDOR_PRESENTATION = {
   openai: brand(OpenAI),
   anthropic: brand(Anthropic),
-  google: brand(Google, GoogleColor),
-  meta: brand(Meta, MetaColor),
-  alibaba: brand(Alibaba, AlibabaColor),
+  google: brand(GoogleColor),
+  meta: brand(MetaColor),
+  alibaba: brand(AlibabaColor),
   xai: brand(XAI),
-  deepseek: brand(DeepSeek, DeepSeekColor),
-  mistral: brand(Mistral, MistralColor),
+  deepseek: brand(DeepSeekColor),
+  mistral: brand(MistralColor),
   moonshot: brand(Moonshot),
-  zhipu: brand(Zhipu, ZhipuColor),
-  minimax: brand(Minimax, MinimaxColor),
-  cohere: brand(Cohere, CohereColor),
-  tencent: brand(Tencent, TencentColor),
-  baidu: brand(Baidu, BaiduColor),
-  baichuan: brand(Baichuan, BaichuanColor),
-  "01-ai": brand(Yi, YiColor),
-  bytedance: brand(ByteDance, ByteDanceColor),
-  nvidia: brand(Nvidia, NvidiaColor),
+  zhipu: brand(ZhipuColor),
+  minimax: brand(MinimaxColor),
+  cohere: brand(CohereColor),
+  tencent: brand(TencentColor),
+  baidu: brand(BaiduColor),
+  baichuan: brand(BaichuanColor),
+  "01-ai": brand(YiColor),
+  bytedance: brand(ByteDanceColor),
+  nvidia: brand(NvidiaColor),
   xiaomi: brand(XiaomiMiMo),
-  meituan: brand(LongCat, LongCatColor),
+  meituan: brand(LongCatColor),
   stepfun: brand(Stepfun),
-  perplexity: brand(Perplexity, PerplexityColor),
-  "essential-ai": brand(EssentialAI, EssentialAIColor),
-  ai2: brand(Ai2, Ai2Color),
-  microsoft: brand(Microsoft, MicrosoftColor),
-  arcee: brand(Arcee, ArceeColor),
+  perplexity: brand(PerplexityColor),
+  "essential-ai": brand(EssentialAIColor),
+  ai2: brand(Ai2Color),
+  microsoft: brand(MicrosoftColor),
+  arcee: brand(ArceeColor),
   "netease-youdao": initials("YD"),
   baai: brand(BAAI),
   "canopy-labs": initials("CL"),
-  "deep-cogito": brand(DeepCogito, DeepCogitoColor),
+  "deep-cogito": brand(DeepCogitoColor),
   "deep-reinforce": initials("DR"),
   groq: brand(Groq),
-  openrouter: brand(OpenRouter, OpenRouterColor),
+  openrouter: brand(OpenRouterColor),
   "kilo-code": brand(KiloCode),
   "inclusion-ai": initials("IA"),
   jina: brand(Jina),
   liquid: brand(Liquid),
   inception: brand(Inception),
   nomic: initials("N"),
-  amazon: brand(Aws, AwsColor),
+  amazon: brand(AwsColor),
   sarvam: initials("S"),
-  sensetime: brand(SenseNova, SenseNovaColor),
-  upstage: brand(Upstage, UpstageColor),
-  kuaishou: brand(Kolors, KolorsColor),
-  "shanghai-ai-lab": brand(InternLM, InternLMColor),
+  sensetime: brand(SenseNovaColor),
+  upstage: brand(UpstageColor),
+  kuaishou: brand(KolorsColor),
+  "shanghai-ai-lab": brand(InternLMColor),
   opencode: brand(OpenCode),
   "swiss-ai": initials("CH"),
   sdaia: initials("SA"),

--- a/tests/entrypoints/options/pages/ModelList/ProviderTabs.test.tsx
+++ b/tests/entrypoints/options/pages/ModelList/ProviderTabs.test.tsx
@@ -67,12 +67,6 @@ vi.mock("@lobehub/icons/es/Google/components/Color", () => ({
   ),
 }))
 
-vi.mock("@lobehub/icons/es/Google/components/Mono", () => ({
-  default: (props: React.SVGProps<SVGSVGElement>) => (
-    <svg role="img" data-publisher-icon="Google-mono" {...props} />
-  ),
-}))
-
 vi.mock("@lobehub/icons/es/OpenAI/components/Mono", () => ({
   default: (props: React.SVGProps<SVGSVGElement>) => (
     <svg role="img" data-publisher-icon="OpenAI-mono" {...props} />

--- a/tests/features/ModelList/components/ModelVendorMark.test.tsx
+++ b/tests/features/ModelList/components/ModelVendorMark.test.tsx
@@ -39,15 +39,6 @@ vi.mock("@lobehub/icons/es/Google/components/Color", () => ({
   ),
 }))
 
-vi.mock("@lobehub/icons/es/Google/components/Mono", () => ({
-  default: ({
-    size,
-    ...props
-  }: React.SVGProps<SVGSVGElement> & { size?: string | number }) => (
-    <svg role="img" data-mark="Google-mono" data-size={size} {...props} />
-  ),
-}))
-
 vi.mock("@lobehub/icons/es/Anthropic/components/Mono", () => ({
   default: ({
     size,

--- a/tests/features/ModelList/modelVendorPresentation.test.ts
+++ b/tests/features/ModelList/modelVendorPresentation.test.ts
@@ -61,7 +61,7 @@ describe("getModelVendorPresentation", () => {
   ] as const satisfies ReadonlyArray<KnownModelVendorId>
 
   it.each(knownVendorBrands)(
-    "stores the compounded icon for known vendor %s",
+    "stores one preferred icon for known vendor %s",
     (knownId) => {
       const presentation = getModelVendorPresentation(
         resolvedKnownVendor(knownId),
@@ -71,23 +71,10 @@ describe("getModelVendorPresentation", () => {
       if (presentation.kind !== "brand") {
         throw new Error(`Expected a brand presentation for ${knownId}`)
       }
-      expect(presentation.Brand.Mark).toBeDefined()
+      expect(presentation.Icon).toBeDefined()
+      expect(presentation).not.toHaveProperty("Brand")
     },
   )
-
-  it("records library Color availability without assigning local brand colors", () => {
-    const google = getModelVendorPresentation(resolvedKnownVendor("google"))
-    const anthropic = getModelVendorPresentation(
-      resolvedKnownVendor("anthropic"),
-    )
-
-    expect(google.kind).toBe("brand")
-    expect(anthropic.kind).toBe("brand")
-    if (google.kind !== "brand" || anthropic.kind !== "brand") return
-
-    expect(google.Brand.Color).toBeDefined()
-    expect(anthropic.Brand.Color).toBeUndefined()
-  })
 
   const knownVendorInitials = [
     ["netease-youdao", "YD"],


### PR DESCRIPTION
## Summary

`@lobehub/icons` brand exports compose multiple icon variants, which keeps unused variants reachable when the extension only renders one fixed icon.

This change imports the exact components used by the extension while preserving the existing rendered icons and fallback behavior.

## What changed

- Import the New API Color icon directly instead of through the package root.
- Store one preferred icon for each model vendor: use Color when available, otherwise retain the existing Mono icon.
- Remove 27 unused Mono imports from the model vendor registry.
- Simplify the internal vendor presentation contract from `{ Brand: { Mark, Color } }` to `{ Icon }`.
- Keep the existing `@lobehub/icons` version and synchronous rendering behavior.
- Close DNR E2E extension pages before their local HTTP server to prevent teardown requests from racing server shutdown.

## Bundle impact

Measured using the Chrome MV3 production build:

- Total raw output: `20,168,835 B -> 20,064,653 B` (`-104,182 B`)
- Sum of per-file gzip sizes: `5,548,686 B -> 5,541,469 B` (`-7,217 B`)
- Vendor icon chunk: `482,013 B -> 395,209 B` (`-86,804 B` raw, `-4,682 B` gzip)

## Validation

- `pnpm vitest related --run src/features/ModelList/modelVendorPresentation.ts src/features/ModelList/components/ModelVendorMark.tsx`
  - 17 test files, 215 tests passed
- `pnpm compile`
- `pnpm build`
- DNR real-browser spec repeated 5 times with retries disabled: 10 tests passed
- Pre-commit `validate:staged` and pre-push `validate:push` gates

No icon-specific E2E test was added because the rendered component selection, sizing, styling, accessibility attributes, and fallback behavior remain unchanged. The existing DNR real-browser E2E was stabilized after its first-attempt CI failure was identified during PR feedback reconciliation.

## Compatibility note

These imports use the package's published `es/<brand>/components/<variant>` layout. That layout should be revalidated when upgrading `@lobehub/icons`, because it is not protected by an explicit package `exports` map.

Related upstream context: https://github.com/lobehub/lobe-icons/issues/132


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved model vendor branding with a consistent unified icon presentation.
  * Vendor marks now prefer color icons, with monochrome fallbacks where needed.
  * Refined the NewAPI fallback icon while preserving existing sizing.

* **Tests**
  * Updated provider and vendor icon coverage for the unified branding presentation.
  * Improved browser test cleanup to ensure pages are closed reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->