### PR TITLE
fix(api): preserve compatible token pagination

### DIFF
--- a/src/services/apiAdapters/newApi/tokenTransport.ts
+++ b/src/services/apiAdapters/newApi/tokenTransport.ts
@@ -25,21 +25,48 @@ const oneHubOverrides: Partial<NewApiFamilyTokenTransport> = {
   fetchAccountAvailableModels: oneHub.fetchAccountAvailableModels,
 }
 
-const zeroBasedTokenInventoryOverrides: Partial<NewApiFamilyTokenTransport> = {
+const oneApiTokenInventoryOverrides: Partial<NewApiFamilyTokenTransport> = {
   fetchAccountTokens: (request) =>
-    defaultTransport.fetchAccountTokens(request, 0),
+    defaultTransport.fetchAccountTokens(request, {
+      startPage: 0,
+      trustsRequestedPageSize: false,
+    }),
+}
+
+const veloeraTokenInventoryOverrides: Partial<NewApiFamilyTokenTransport> = {
+  fetchAccountTokens: (request) =>
+    defaultTransport.fetchAccountTokens(request, {
+      startPage: 0,
+      trustsRequestedPageSize: true,
+    }),
+}
+
+const compatibleTokenInventoryOverrides: Partial<NewApiFamilyTokenTransport> = {
+  fetchAccountTokens: (request) =>
+    defaultTransport.fetchAccountTokens(request, {
+      startPage: 0,
+      detectsNormalizedFirstPage: true,
+    }),
 }
 
 const overrides: Partial<
   Record<AccountSiteType, Partial<NewApiFamilyTokenTransport>>
 > = {
-  [SITE_TYPES.ONE_API]: zeroBasedTokenInventoryOverrides,
-  [SITE_TYPES.VELOERA]: zeroBasedTokenInventoryOverrides,
+  [SITE_TYPES.ANYROUTER]: compatibleTokenInventoryOverrides,
+  [SITE_TYPES.ONE_API]: oneApiTokenInventoryOverrides,
+  [SITE_TYPES.VELOERA]: veloeraTokenInventoryOverrides,
   [SITE_TYPES.ONE_HUB]: oneHubOverrides,
   [SITE_TYPES.DONE_HUB]: oneHubOverrides,
+  [SITE_TYPES.V_API]: compatibleTokenInventoryOverrides,
+  [SITE_TYPES.VO_API]: compatibleTokenInventoryOverrides,
+  [SITE_TYPES.SUPER_API]: compatibleTokenInventoryOverrides,
+  [SITE_TYPES.RIX_API]: compatibleTokenInventoryOverrides,
+  [SITE_TYPES.NEO_API]: compatibleTokenInventoryOverrides,
   [SITE_TYPES.WONG_GONGYI]: {
+    ...compatibleTokenInventoryOverrides,
     resolveApiTokenKey: wong.resolveApiTokenKey,
   },
+  [SITE_TYPES.UNKNOWN]: compatibleTokenInventoryOverrides,
 }
 
 /** Resolves site-type-specific token transport without routing through product capabilities. */

--- a/src/services/apiService/newApiFamily/default/keyManagement.ts
+++ b/src/services/apiService/newApiFamily/default/keyManagement.ts
@@ -11,7 +11,10 @@ import type {
 } from "~/services/accountTokens/tokenProvisioningModel"
 import { REQUEST_CONFIG } from "~/services/apiTransport/constant"
 import { API_ERROR_CODES, ApiError } from "~/services/apiTransport/errors"
-import { fetchAllItems } from "~/services/apiTransport/pagination"
+import {
+  fetchAllItems,
+  inferHasMoreFromNumberedPage,
+} from "~/services/apiTransport/pagination"
 import { fetchApi, fetchApiData } from "~/services/apiTransport/request"
 import type { ApiServiceRequest } from "~/services/apiTransport/type"
 import type { ApiToken } from "~/types"
@@ -46,19 +49,34 @@ interface KeyManagementImplementation {
   fetchAccountAvailableModels: (request: ApiServiceRequest) => Promise<string[]>
 }
 
+interface AccountTokenPaginationOptions {
+  startPage?: number
+  detectsNormalizedFirstPage?: boolean
+  trustsRequestedPageSize?: boolean
+}
+
 /**
  * Fetch the complete New API-family token list behind provider pagination.
- * New API uses one-based page numbers:
+ * New API uses one-based page numbers and normalizes `p=0` to page one, which
+ * lets compatibility callers probe from zero before selecting their next page:
  * https://github.com/QuantumNous/new-api/blob/9c97e78aced572d540f227007a675d7d007666ac/common/page_info.go
- * One API and Veloera use zero-based pages and return bare arrays, which
- * terminate on an empty page:
+ * One API uses zero-based pages, ignores the requested size, and returns bare
+ * arrays, so only an empty page proves completion:
  * https://github.com/songquanpeng/one-api/blob/main/controller/token.go
+ * Veloera uses zero-based pages but honors the requested size, so a short
+ * array page proves completion:
  * https://github.com/Veloera/Veloera/blob/main/controller/token.go
  */
 export async function fetchAccountTokens(
   request: ApiServiceRequest,
-  startPage = 1,
+  options: number | AccountTokenPaginationOptions = {},
 ): Promise<ApiToken[]> {
+  const {
+    startPage = 1,
+    detectsNormalizedFirstPage = false,
+    trustsRequestedPageSize = false,
+  } = typeof options === "number" ? { startPage: options } : options
+
   const tokens = await fetchAllItems<ApiToken>(
     async (page) => {
       const searchParams = new URLSearchParams({
@@ -71,7 +89,13 @@ export async function fetchAccountTokens(
 
       if (Array.isArray(tokensData)) {
         const items = tokensData.map(normalizeApiTokenKey)
-        return { items, hasMore: items.length > 0 }
+        return {
+          items,
+          hasMore:
+            items.length > 0 &&
+            (!trustsRequestedPageSize ||
+              items.length >= REQUEST_CONFIG.DEFAULT_PAGE_SIZE),
+        }
       }
 
       if (!isRecord(tokensData) || !Array.isArray(tokensData.items)) {
@@ -79,9 +103,28 @@ export async function fetchAccountTokens(
       }
 
       const items = tokensData.items.map(normalizeApiTokenKey)
+      const normalizedFirstPage =
+        detectsNormalizedFirstPage && page === 0 && tokensData.page === 1
+      const responsePage = normalizedFirstPage ? 1 : page
+      const metadataHasMore = inferHasMoreFromNumberedPage({
+        requestedPage: responsePage,
+        responsePage: tokensData.page,
+        responsePageSize: tokensData.page_size,
+        total: tokensData.total,
+        itemCount: items.length,
+      })
+      const hasMore = metadataHasMore ?? items.length > 0
+
+      if (normalizedFirstPage) {
+        return {
+          items,
+          nextPage: hasMore ? 2 : null,
+        }
+      }
+
       return {
         items,
-        hasMore: items.length > 0,
+        hasMore,
       }
     },
     {

--- a/src/services/apiService/newApiFamily/variants/oneHub.ts
+++ b/src/services/apiService/newApiFamily/variants/oneHub.ts
@@ -11,7 +11,10 @@ import type {
   OneHubUserGroupsResponse,
 } from "~/services/apiService/oneHub/type"
 import { REQUEST_CONFIG } from "~/services/apiTransport/constant"
-import { fetchAllItems } from "~/services/apiTransport/pagination"
+import {
+  fetchAllItems,
+  inferHasMoreFromNumberedPage,
+} from "~/services/apiTransport/pagination"
 import { fetchApiData } from "~/services/apiTransport/request"
 import type { ApiServiceRequest } from "~/services/apiTransport/type"
 import type { PricingResponse } from "~/services/modelList/pricingModel"
@@ -57,9 +60,12 @@ export const fetchModelPricing = async (
 
 /**
  * Fetch the complete token list using OneHub's one-based pagination.
- * Source: https://github.com/MartialBE/one-hub/blob/387f8bf16ed0d601fdede7ade378adb10aa1a35a/model/common.go
- * Provider-selected sizes and stale metadata are tolerated; an empty page is
- * the provider-owned completion signal.
+ * OneHub and DoneHub return `page`, `size`, and `total_count` with their token
+ * data. Coherent metadata is authoritative; incompatible or stale deployments
+ * fall back to an empty-page completion signal.
+ * Sources:
+ * https://github.com/MartialBE/one-hub/blob/387f8bf16ed0d601fdede7ade378adb10aa1a35a/model/common.go
+ * https://github.com/deanxv/done-hub/blob/main/model/common.go
  */
 export const fetchAccountTokens = async (
   request: ApiServiceRequest,
@@ -84,9 +90,16 @@ export const fetchAccountTokens = async (
         throw new Error("invalid_token_page_payload")
       }
       const items = tokensData.data.map(normalizeApiTokenKey)
+      const metadataHasMore = inferHasMoreFromNumberedPage({
+        requestedPage: upstreamPage,
+        responsePage: tokensData.page,
+        responsePageSize: tokensData.size,
+        total: tokensData.total_count,
+        itemCount: items.length,
+      })
       return {
         items,
-        hasMore: items.length > 0,
+        hasMore: metadataHasMore ?? items.length > 0,
       }
     },
     {

--- a/src/services/apiTransport/pagination.ts
+++ b/src/services/apiTransport/pagination.ts
@@ -18,6 +18,15 @@ interface PageData<T> {
   items: T[]
   total?: number
   hasMore?: boolean
+  nextPage?: number | null
+}
+
+interface NumberedPageCompletionInput {
+  requestedPage: number
+  responsePage: unknown
+  responsePageSize: unknown
+  total: unknown
+  itemCount: number
 }
 
 /** Indicates that a caller-required complete inventory hit the page cap. */
@@ -26,6 +35,48 @@ export class PaginationLimitError extends Error {
     super("Pagination limit reached before the inventory completed")
     this.name = "PaginationLimitError"
   }
+}
+
+/**
+ * Infer whether a one-based numbered page has a successor when the provider
+ * returns coherent page metadata. Invalid or stale metadata is advisory only;
+ * callers can fall back to their provider-specific completion signal.
+ */
+export function inferHasMoreFromNumberedPage({
+  requestedPage,
+  responsePage,
+  responsePageSize,
+  total,
+  itemCount,
+}: NumberedPageCompletionInput): boolean | undefined {
+  if (
+    typeof responsePage !== "number" ||
+    !Number.isSafeInteger(responsePage) ||
+    responsePage < 1 ||
+    responsePage !== requestedPage ||
+    typeof responsePageSize !== "number" ||
+    !Number.isSafeInteger(responsePageSize) ||
+    responsePageSize <= 0 ||
+    typeof total !== "number" ||
+    !Number.isSafeInteger(total) ||
+    total < 0 ||
+    !Number.isSafeInteger(itemCount) ||
+    itemCount < 0
+  ) {
+    return undefined
+  }
+
+  const pageStart = (responsePage - 1) * responsePageSize
+  const loadedThrough = pageStart + itemCount
+  if (
+    !Number.isSafeInteger(pageStart) ||
+    !Number.isSafeInteger(loadedThrough) ||
+    total < loadedThrough
+  ) {
+    return undefined
+  }
+
+  return loadedThrough < total
 }
 
 type ArrayOrItemsPayload<T> = T[] | { items?: T[] | null } | null | undefined
@@ -79,21 +130,29 @@ async function fetchAllPaginated<T, R>(
 
     aggregatedData = aggregator(aggregatedData, items)
 
-    if (typeof pageData.hasMore === "boolean") {
-      if (!pageData.hasMore) {
-        break
-      }
-    } else if (typeof pageData.total === "number") {
-      const totalPages = Math.ceil((pageData.total || 0) / pageSize)
-      const pageIndex = currentPage - startPage + 1
-      if (pageIndex >= totalPages) {
-        break
-      }
-    } else if (items.length < pageSize) {
+    if (pageData.nextPage === null) {
       break
     }
 
-    currentPage++
+    if (typeof pageData.nextPage === "number") {
+      currentPage = pageData.nextPage
+    } else {
+      if (typeof pageData.hasMore === "boolean") {
+        if (!pageData.hasMore) {
+          break
+        }
+      } else if (typeof pageData.total === "number") {
+        const totalPages = Math.ceil((pageData.total || 0) / pageSize)
+        const pageIndex = currentPage - startPage + 1
+        if (pageIndex >= totalPages) {
+          break
+        }
+      } else if (items.length < pageSize) {
+        break
+      }
+
+      currentPage++
+    }
     pageCount++
 
     if (pageCount >= maxPages) {

--- a/tests/services/apiAdapters/keyManagement.test.ts
+++ b/tests/services/apiAdapters/keyManagement.test.ts
@@ -308,16 +308,47 @@ describe("apiAdapter keyManagement", () => {
     expect(mockFetchAccountAvailableModels).toHaveBeenCalledWith(request)
   })
 
-  it.each([SITE_TYPES.ONE_API, SITE_TYPES.VELOERA])(
-    "uses zero-based token inventory pagination for %s",
-    async (siteType) => {
-      mockFetchAccountTokens.mockResolvedValueOnce([])
+  it("uses conservative zero-based token pagination for One API", async () => {
+    mockFetchAccountTokens.mockResolvedValueOnce([])
 
-      await createNewApiKeyManagement(siteType).fetchTokens(request)
+    await createNewApiKeyManagement(SITE_TYPES.ONE_API).fetchTokens(request)
 
-      expect(mockFetchAccountTokens).toHaveBeenCalledWith(request, 0)
-    },
-  )
+    expect(mockFetchAccountTokens).toHaveBeenCalledWith(request, {
+      startPage: 0,
+      trustsRequestedPageSize: false,
+    })
+  })
+
+  it("uses short-page-aware zero-based token pagination for Veloera", async () => {
+    mockFetchAccountTokens.mockResolvedValueOnce([])
+
+    await createNewApiKeyManagement(SITE_TYPES.VELOERA).fetchTokens(request)
+
+    expect(mockFetchAccountTokens).toHaveBeenCalledWith(request, {
+      startPage: 0,
+      trustsRequestedPageSize: true,
+    })
+  })
+
+  it.each([
+    SITE_TYPES.ANYROUTER,
+    SITE_TYPES.V_API,
+    SITE_TYPES.VO_API,
+    SITE_TYPES.SUPER_API,
+    SITE_TYPES.RIX_API,
+    SITE_TYPES.NEO_API,
+    SITE_TYPES.WONG_GONGYI,
+    SITE_TYPES.UNKNOWN,
+  ])("negotiates token pagination from p=0 for %s", async (siteType) => {
+    mockFetchAccountTokens.mockResolvedValueOnce([])
+
+    await createNewApiKeyManagement(siteType).fetchTokens(request)
+
+    expect(mockFetchAccountTokens).toHaveBeenCalledWith(request, {
+      startPage: 0,
+      detectsNormalizedFirstPage: true,
+    })
+  })
 
   it("uses OneHub-family key inventory overrides at the adapter layer", async () => {
     const expectedTokens = [token]

--- a/tests/services/apiService/newApiFamily/keyManagement.test.ts
+++ b/tests/services/apiService/newApiFamily/keyManagement.test.ts
@@ -100,7 +100,7 @@ describe("newApiFamily keyManagement", () => {
     mockFetchApiData.mockReset()
   })
 
-  it("fetchAccountTokens reads every New API page until the empty sentinel", async () => {
+  it("fetchAccountTokens stops at the New API total without probing an empty page", async () => {
     mockFetchApiData
       .mockResolvedValueOnce({
         items: [
@@ -117,12 +117,6 @@ describe("newApiFamily keyManagement", () => {
         page_size: 2,
         total: 3,
       })
-      .mockResolvedValueOnce({
-        items: [],
-        page: 3,
-        page_size: 2,
-        total: 3,
-      })
 
     await expect(fetchAccountTokens(request)).resolves.toEqual([
       { id: 1, key: "plain-key" },
@@ -135,9 +129,78 @@ describe("newApiFamily keyManagement", () => {
     expect(mockFetchApiData).toHaveBeenNthCalledWith(2, request, {
       endpoint: "/api/token/?p=2&size=100",
     })
-    expect(mockFetchApiData).toHaveBeenNthCalledWith(3, request, {
-      endpoint: "/api/token/?p=3&size=100",
+    expect(mockFetchApiData).toHaveBeenCalledTimes(2)
+  })
+
+  it("fetchAccountTokens does not request page two for a complete New API first page", async () => {
+    mockFetchApiData.mockResolvedValueOnce({
+      items: [{ id: 1, key: "sk-only" }],
+      page: 1,
+      page_size: 100,
+      total: 1,
     })
+
+    await expect(fetchAccountTokens(request)).resolves.toEqual([
+      { id: 1, key: "sk-only" },
+    ])
+    expect(mockFetchApiData).toHaveBeenCalledTimes(1)
+  })
+
+  it("fetchAccountTokens negotiates a New API response from p=0 without repeating page one", async () => {
+    mockFetchApiData
+      .mockResolvedValueOnce({
+        items: [
+          { id: 1, key: " first " },
+          { id: 2, key: "second" },
+        ],
+        page: 1,
+        page_size: 2,
+        total: 3,
+      })
+      .mockResolvedValueOnce({
+        items: [{ id: 3, key: " final " }],
+        page: 2,
+        page_size: 2,
+        total: 3,
+      })
+
+    await expect(
+      fetchAccountTokens(request, {
+        startPage: 0,
+        detectsNormalizedFirstPage: true,
+      }),
+    ).resolves.toEqual([
+      { id: 1, key: "first" },
+      { id: 2, key: "second" },
+      { id: 3, key: "final" },
+    ])
+    expect(mockFetchApiData).toHaveBeenNthCalledWith(1, request, {
+      endpoint: "/api/token/?p=0&size=100",
+    })
+    expect(mockFetchApiData).toHaveBeenNthCalledWith(2, request, {
+      endpoint: "/api/token/?p=2&size=100",
+    })
+    expect(mockFetchApiData).toHaveBeenCalledTimes(2)
+  })
+
+  it("fetchAccountTokens stops after a complete New API page negotiated from p=0", async () => {
+    mockFetchApiData.mockResolvedValueOnce({
+      items: [{ id: 1, key: "sk-only" }],
+      page: 1,
+      page_size: 100,
+      total: 1,
+    })
+
+    await expect(
+      fetchAccountTokens(request, {
+        startPage: 0,
+        detectsNormalizedFirstPage: true,
+      }),
+    ).resolves.toEqual([{ id: 1, key: "sk-only" }])
+    expect(mockFetchApiData).toHaveBeenCalledWith(request, {
+      endpoint: "/api/token/?p=0&size=100",
+    })
+    expect(mockFetchApiData).toHaveBeenCalledTimes(1)
   })
 
   it("fetchAccountTokens reads zero-based legacy array pages until the empty sentinel", async () => {
@@ -158,6 +221,44 @@ describe("newApiFamily keyManagement", () => {
     })
     expect(mockFetchApiData).toHaveBeenNthCalledWith(3, request, {
       endpoint: "/api/token/?p=2&size=100",
+    })
+  })
+
+  it("fetchAccountTokens keeps zero-based array pagination during compatibility negotiation", async () => {
+    mockFetchApiData
+      .mockResolvedValueOnce([{ id: 1, key: " first " }])
+      .mockResolvedValueOnce([{ id: 2, key: " second " }])
+      .mockResolvedValueOnce([])
+
+    await expect(
+      fetchAccountTokens(request, {
+        startPage: 0,
+        detectsNormalizedFirstPage: true,
+      }),
+    ).resolves.toEqual([
+      { id: 1, key: "first" },
+      { id: 2, key: "second" },
+    ])
+    expect(mockFetchApiData).toHaveBeenNthCalledWith(1, request, {
+      endpoint: "/api/token/?p=0&size=100",
+    })
+    expect(mockFetchApiData).toHaveBeenNthCalledWith(2, request, {
+      endpoint: "/api/token/?p=1&size=100",
+    })
+  })
+
+  it("fetchAccountTokens stops on a short array page when the site honors the requested size", async () => {
+    mockFetchApiData.mockResolvedValueOnce([{ id: 1, key: " only " }])
+
+    await expect(
+      fetchAccountTokens(request, {
+        startPage: 0,
+        trustsRequestedPageSize: true,
+      }),
+    ).resolves.toEqual([{ id: 1, key: "only" }])
+    expect(mockFetchApiData).toHaveBeenCalledTimes(1)
+    expect(mockFetchApiData).toHaveBeenCalledWith(request, {
+      endpoint: "/api/token/?p=0&size=100",
     })
   })
 
@@ -249,14 +350,12 @@ describe("newApiFamily keyManagement", () => {
   })
 
   it("fetchAccountTokens syncs the complete normalized inventory", async () => {
-    mockFetchApiData
-      .mockResolvedValueOnce({
-        items: [{ id: 3, key: "  sk-trim  " }],
-        page: 1,
-        page_size: 50,
-        total: 1,
-      })
-      .mockResolvedValueOnce({ items: [], page: 2, total: 1 })
+    mockFetchApiData.mockResolvedValueOnce({
+      items: [{ id: 3, key: "  sk-trim  " }],
+      page: 1,
+      page_size: 50,
+      total: 1,
+    })
 
     const result = await fetchAccountTokens(request)
 

--- a/tests/services/apiService/oneHub/index.test.ts
+++ b/tests/services/apiService/oneHub/index.test.ts
@@ -154,6 +154,20 @@ describe("OneHub API service", () => {
     )
   })
 
+  it("fetchAccountTokens stops at the OneHub total without probing page two", async () => {
+    mockedFetchApiData.mockResolvedValueOnce({
+      data: [{ id: 1 }],
+      page: 1,
+      size: 100,
+      total_count: 1,
+    })
+
+    await expect(fetchAccountTokens(baseRequest as any)).resolves.toEqual([
+      { id: 1 },
+    ])
+    expect(mockedFetchApiData).toHaveBeenCalledTimes(1)
+  })
+
   it("fetchAccountTokens should reject an unexpected format", async () => {
     mockedFetchApiData.mockResolvedValueOnce({ foo: "bar" })
 
@@ -171,7 +185,7 @@ describe("OneHub API service", () => {
     )
   })
 
-  it("fetchAccountTokens collects OneHub pages without requiring size echo", async () => {
+  it("fetchAccountTokens collects OneHub pages using its pagination metadata", async () => {
     const firstPageTokens = [{ id: 1 }, { id: 2 }]
     mockedFetchApiData
       .mockResolvedValueOnce({
@@ -186,7 +200,6 @@ describe("OneHub API service", () => {
         size: 2,
         total_count: 3,
       })
-      .mockResolvedValueOnce({ data: [], page: 3, total_count: 3 })
 
     await expect(fetchAccountTokens(baseRequest as any)).resolves.toEqual([
       ...firstPageTokens,
@@ -198,9 +211,7 @@ describe("OneHub API service", () => {
     expect(mockedFetchApiData).toHaveBeenNthCalledWith(2, baseRequest, {
       endpoint: "/api/token/?page=2&size=100",
     })
-    expect(mockedFetchApiData).toHaveBeenNthCalledWith(3, baseRequest, {
-      endpoint: "/api/token/?page=3&size=100",
-    })
+    expect(mockedFetchApiData).toHaveBeenCalledTimes(2)
   })
 
   it("fetchAccountTokens tolerates stale OneHub page metadata", async () => {

--- a/tests/services/apiTransport/pagination.test.ts
+++ b/tests/services/apiTransport/pagination.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import {
   extractItemsFromArrayOrItemsPayload,
   fetchAllItems,
+  inferHasMoreFromNumberedPage,
   PaginationLimitError,
 } from "~/services/apiTransport/pagination"
 
@@ -33,6 +34,54 @@ describe("API transport pagination helpers", () => {
     expect(extractItemsFromArrayOrItemsPayload(undefined)).toEqual([])
   })
 
+  it("infers numbered-page completion only from coherent one-based metadata", () => {
+    expect(
+      inferHasMoreFromNumberedPage({
+        requestedPage: 1,
+        responsePage: 1,
+        responsePageSize: 2,
+        total: 3,
+        itemCount: 2,
+      }),
+    ).toBe(true)
+    expect(
+      inferHasMoreFromNumberedPage({
+        requestedPage: 2,
+        responsePage: 2,
+        responsePageSize: 2,
+        total: 3,
+        itemCount: 1,
+      }),
+    ).toBe(false)
+    expect(
+      inferHasMoreFromNumberedPage({
+        requestedPage: 2,
+        responsePage: 1,
+        responsePageSize: 2,
+        total: 3,
+        itemCount: 1,
+      }),
+    ).toBeUndefined()
+    expect(
+      inferHasMoreFromNumberedPage({
+        requestedPage: 0,
+        responsePage: 0,
+        responsePageSize: 2,
+        total: 1,
+        itemCount: 1,
+      }),
+    ).toBeUndefined()
+    expect(
+      inferHasMoreFromNumberedPage({
+        requestedPage: 2,
+        responsePage: 2,
+        responsePageSize: 2,
+        total: 2,
+        itemCount: 1,
+      }),
+    ).toBeUndefined()
+  })
+
   it("fetchAllItems stops when the upstream explicitly says there are no more pages", async () => {
     const fetchPage = vi
       .fn()
@@ -46,6 +95,21 @@ describe("API transport pagination helpers", () => {
     expect(fetchPage).toHaveBeenCalledTimes(2)
     expect(fetchPage).toHaveBeenNthCalledWith(1, 1)
     expect(fetchPage).toHaveBeenNthCalledWith(2, 2)
+  })
+
+  it("fetchAllItems follows an explicit provider-normalized next page", async () => {
+    const fetchPage = vi
+      .fn()
+      .mockResolvedValueOnce({ items: ["page-1"], nextPage: 2 })
+      .mockResolvedValueOnce({ items: ["page-2"], nextPage: null })
+
+    await expect(fetchAllItems(fetchPage, { startPage: 0 })).resolves.toEqual([
+      "page-1",
+      "page-2",
+    ])
+    expect(fetchPage).toHaveBeenNthCalledWith(1, 0)
+    expect(fetchPage).toHaveBeenNthCalledWith(2, 2)
+    expect(fetchPage).not.toHaveBeenCalledWith(1)
   })
 
   it("fetchAllItems stops when a short page implies the last page", async () => {


### PR DESCRIPTION
## Summary

- Preserve provider-native token inventory pagination for One API, Veloera, and OneHub/DoneHub.
- Let compatibility buckets probe from `p=0`, recognize New API's normalized `page=1` response, and continue directly at `p=2` without repeating the first page.
- Keep legacy zero-based array responses working until their provider-specific completion signal, with focused adapter and pagination coverage.

## Why

New API-compatible deployments do not share one pagination contract. New API normalizes `p=0` to page one, while older One API-family endpoints can use zero-based array pagination. A single default start page and termination rule can either issue unnecessary continuation requests for a one-page inventory or skip data on legacy deployments.

## Validation

- `pnpm exec vitest run tests/services/apiAdapters/keyManagement.test.ts tests/services/apiService/newApiFamily/keyManagement.test.ts tests/services/apiService/oneHub/index.test.ts tests/services/apiTransport/pagination.test.ts` — 4 files, 91 tests passed.
- Pre-commit `validate:staged` — Prettier, ESLint, related Vitest, and i18n checks passed.
- Actual pre-push `validate:push` — TypeScript compile and Knip passed.
- A real configured New API backend exercised through the compatibility adapter stopped each inventory after `p=0` for `page=1`, `page_size=100`, `total=4`.

## Scope and follow-up

The real-site probe also exposed two separate page-level inventory invocations, producing `p=0, p=0`. This comes from the existing `useAccountData` / Key Management lifecycle rather than one paginator continuing to another page, and is intentionally outside this protocol fix. A dedicated AnyRouter deployment was not available for live verification.

No user-facing workflow or telemetry contract changes are included; transport and adapter tests are the appropriate coverage layer for this fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved account-token retrieval across supported API providers with more reliable pagination handling.
  - Prevented unnecessary extra requests after all token results have been retrieved.
  - Improved support for providers using zero-based pages, normalized first pages, and provider-specific page sizes.
  - Added safeguards for inconsistent or incomplete pagination metadata.
  - Improved token synchronization behavior when results are returned in a single complete response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->