### PR TITLE
fix(account): detect modern New API white-label sessions

### DIFF
--- a/src/entrypoints/content/messageHandlers/handlers/storage.ts
+++ b/src/entrypoints/content/messageHandlers/handlers/storage.ts
@@ -53,6 +53,9 @@ export function handleGetUserFromLocalStorage(
         siteTypeHint: isAccountSiteType(request?.siteType)
           ? request.siteType
           : SITE_TYPES.UNKNOWN,
+        ...(request?.allowNewApiAuthProbe === true
+          ? { allowNewApiAuthProbe: true }
+          : {}),
       }
 
       for (const extractor of getContentSessionExtractors()) {

--- a/src/services/accountBrowserSession/sessionReader.ts
+++ b/src/services/accountBrowserSession/sessionReader.ts
@@ -167,11 +167,14 @@ export async function readAccountBrowserSessionFromTab(
   options: ReadAccountBrowserSessionFromTabOptions,
 ): Promise<AccountBrowserSession | null> {
   try {
+    const allowNewApiAuthProbe =
+      options.source === ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB &&
+      options.allowNewApiAuthProbe === true
     const response = await sendTabMessageWithRetry(options.tabId, {
       action: RuntimeActionIds.ContentGetUserFromLocalStorage,
       url: options.baseUrl,
       siteType: options.siteType,
-      ...(options.allowNewApiAuthProbe ? { allowNewApiAuthProbe: true } : {}),
+      ...(allowNewApiAuthProbe ? { allowNewApiAuthProbe: true } : {}),
     })
 
     if (!response?.success || !response.data) return null
@@ -180,7 +183,7 @@ export async function readAccountBrowserSessionFromTab(
       source: options.source,
       baseUrl: options.baseUrl,
       siteType: options.siteType,
-      allowNewApiAuthProbe: options.allowNewApiAuthProbe,
+      allowNewApiAuthProbe,
       fetchContext: options.fetchContext,
     })
   } catch (error) {

--- a/src/services/accountBrowserSession/sessionReader.ts
+++ b/src/services/accountBrowserSession/sessionReader.ts
@@ -1,5 +1,5 @@
 import { RuntimeActionIds } from "~/constants/runtimeActions"
-import { isAccountSiteType } from "~/constants/siteType"
+import { isAccountSiteType, SITE_TYPES } from "~/constants/siteType"
 import { normalizeAccountIdentity } from "~/services/accounts/accountIdentity"
 import { API_SERVICE_FETCH_CONTEXT_KINDS } from "~/services/apiTransport/type"
 import {
@@ -98,6 +98,7 @@ const normalizeSessionData = (
     source: AccountBrowserSession["source"]
     baseUrl: string
     siteType: AccountBrowserSession["siteType"]
+    allowNewApiAuthProbe?: boolean
     fetchContext?: AccountBrowserSessionFetchContext
   },
 ): AccountBrowserSession | null => {
@@ -130,11 +131,17 @@ const normalizeSessionData = (
       ? payload.siteType
       : undefined
   const sub2apiAuth = normalizeSub2ApiAuth(payload.sub2apiAuth)
+  const transientAuthSiteType =
+    options.allowNewApiAuthProbe === true &&
+    options.siteType === SITE_TYPES.UNKNOWN &&
+    siteTypeHint === SITE_TYPES.NEW_API
+      ? SITE_TYPES.NEW_API
+      : options.siteType
   const transientAuth = normalizeContentSessionTransientAuth(
     payload.transientAuth,
     {
       baseUrl: options.baseUrl,
-      siteType: options.siteType,
+      siteType: transientAuthSiteType,
     },
   )
   const fetchContext =
@@ -164,6 +171,7 @@ export async function readAccountBrowserSessionFromTab(
       action: RuntimeActionIds.ContentGetUserFromLocalStorage,
       url: options.baseUrl,
       siteType: options.siteType,
+      ...(options.allowNewApiAuthProbe ? { allowNewApiAuthProbe: true } : {}),
     })
 
     if (!response?.success || !response.data) return null
@@ -172,6 +180,7 @@ export async function readAccountBrowserSessionFromTab(
       source: options.source,
       baseUrl: options.baseUrl,
       siteType: options.siteType,
+      allowNewApiAuthProbe: options.allowNewApiAuthProbe,
       fetchContext: options.fetchContext,
     })
   } catch (error) {

--- a/src/services/accountBrowserSession/types.ts
+++ b/src/services/accountBrowserSession/types.ts
@@ -51,6 +51,8 @@ export type ReadAccountBrowserSessionFromTabOptions = {
     | typeof ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB
   >
   fetchContext?: AccountBrowserSessionFetchContext
+  /** Enables the one-shot modern New API refresh probe for explicit current-tab detection. */
+  allowNewApiAuthProbe?: boolean
   /** Carries caller intent for downstream temp-context workflows; tab reads do not consume it. */
   protectionBypassExecution?: ProtectionBypassExecution
   onError?: AccountBrowserSessionErrorHandler

--- a/src/services/accountSiteOnboarding/contentSession/newApiAuthBundle.ts
+++ b/src/services/accountSiteOnboarding/contentSession/newApiAuthBundle.ts
@@ -104,6 +104,8 @@ async function extractNewApiAuthBundle(): Promise<ContentSessionExtractionResult
 export const newApiAuthBundleContentSessionExtractor: ContentSessionExtractor =
   {
     id: "new-api-auth-bundle",
-    canExtract: (context) => context.siteTypeHint === SITE_TYPES.NEW_API,
+    canExtract: (context) =>
+      context.siteTypeHint === SITE_TYPES.NEW_API ||
+      context.allowNewApiAuthProbe === true,
     extract: extractNewApiAuthBundle,
   }

--- a/src/services/accountSiteOnboarding/contracts.ts
+++ b/src/services/accountSiteOnboarding/contracts.ts
@@ -8,6 +8,8 @@ import type {
 export type ContentSessionExtractionContext = {
   url?: string
   siteTypeHint?: AccountSiteType
+  /** Allows an explicit current-tab auto-detect to probe the modern New API session. */
+  allowNewApiAuthProbe?: boolean
 }
 
 export const NEW_API_DASHBOARD_TRANSIENT_AUTH_KIND = "new_api_dashboard_bearer"

--- a/src/services/siteDetection/autoDetectService.ts
+++ b/src/services/siteDetection/autoDetectService.ts
@@ -18,6 +18,7 @@ import {
   AIHUBMIX_API_ORIGIN,
   AIHUBMIX_HOSTNAMES,
   isAccountSiteType,
+  SITE_TYPES,
   type AccountSiteType,
 } from "~/constants/siteType"
 import {
@@ -581,6 +582,9 @@ async function getUserDataFromCurrentTab(
       siteType,
       source: ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB,
       fetchContext,
+      ...(siteType === SITE_TYPES.UNKNOWN
+        ? { allowNewApiAuthProbe: true }
+        : {}),
       protectionBypassExecution,
       onError(error) {
         contentScriptUnavailable = isMessageReceiverUnavailableError(error)

--- a/tests/entrypoints/content/messageHandlers/handlers/storage.test.ts
+++ b/tests/entrypoints/content/messageHandlers/handlers/storage.test.ts
@@ -798,6 +798,96 @@ describe("content storage handler", () => {
       },
     )
 
+    it("detects a modern white-label New API session when explicitly probed", async () => {
+      const nowSeconds = 1_800_000_000
+      vi.spyOn(Date, "now").mockReturnValue(nowSeconds * 1000)
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          new Response(
+            JSON.stringify({
+              success: true,
+              data: {
+                access_token: "dashboard-token-placeholder",
+                token_type: "Bearer",
+                access_expires_at: nowSeconds + 900,
+                user: { id: "white-label-user", username: "example-user" },
+                session: { sid: "session-placeholder", current: true },
+              },
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+        ),
+      )
+      mockGetContentSessionExtractors.mockReturnValue([
+        newApiAuthBundleContentSessionExtractor,
+        compatibleUserContentSessionExtractor,
+      ])
+
+      const response = await new Promise<any>((resolve) => {
+        handleGetUserFromLocalStorage(
+          {
+            url: "https://white-label.example.invalid",
+            siteType: "unknown",
+            allowNewApiAuthProbe: true,
+          },
+          resolve,
+        )
+      })
+
+      expect(response).toEqual({
+        success: true,
+        data: {
+          userId: "white-label-user",
+          user: { id: "white-label-user", username: "example-user" },
+          siteTypeHint: "new-api",
+          transientAuth: {
+            kind: "new_api_dashboard_bearer",
+            token: "dashboard-token-placeholder",
+            expiresAt: nowSeconds + 900,
+            sessionId: "session-placeholder",
+            origin: window.location.origin,
+          },
+        },
+      })
+    })
+
+    it("does not classify an unauthorized unknown-site refresh as New API", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          new Response(
+            JSON.stringify({
+              success: false,
+              code: "AUTH_UNAUTHORIZED",
+              message: "Unauthorized",
+            }),
+            { status: 401, headers: { "Content-Type": "application/json" } },
+          ),
+        ),
+      )
+      mockGetContentSessionExtractors.mockReturnValue([
+        newApiAuthBundleContentSessionExtractor,
+        compatibleUserContentSessionExtractor,
+      ])
+
+      const response = await new Promise<any>((resolve) => {
+        handleGetUserFromLocalStorage(
+          {
+            url: "https://unknown.example.invalid",
+            siteType: "unknown",
+            allowNewApiAuthProbe: true,
+          },
+          resolve,
+        )
+      })
+
+      expect(response).toEqual({
+        success: false,
+        error: "AUTH_UNAUTHORIZED: Unauthorized",
+      })
+    })
+
     it("returns userInfoNotFound when no extractor returns a result", async () => {
       mockGetContentSessionExtractors.mockReturnValue([
         {

--- a/tests/services/accountBrowserSession/sessionReader.test.ts
+++ b/tests/services/accountBrowserSession/sessionReader.test.ts
@@ -253,6 +253,38 @@ describe("account browser-session reader", () => {
     })
   })
 
+  it("rejects the modern New API probe intent for existing-tab reads", async () => {
+    mockSendTabMessage.mockResolvedValueOnce({
+      success: true,
+      data: {
+        userId: "user-42",
+        siteTypeHint: SITE_TYPES.NEW_API,
+        transientAuth: {
+          kind: NEW_API_DASHBOARD_TRANSIENT_AUTH_KIND,
+          token: "dashboard-token-placeholder",
+          expiresAt: 2_000_000_000,
+          sessionId: "session-placeholder",
+          origin: "https://white-label.example.invalid",
+        },
+      },
+    })
+
+    const session = await readAccountBrowserSessionFromTab({
+      tabId: 14,
+      baseUrl: "https://white-label.example.invalid",
+      siteType: SITE_TYPES.UNKNOWN,
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB,
+      allowNewApiAuthProbe: true,
+    })
+
+    expect(mockSendTabMessage).toHaveBeenCalledWith(14, {
+      action: RuntimeActionIds.ContentGetUserFromLocalStorage,
+      url: "https://white-label.example.invalid",
+      siteType: SITE_TYPES.UNKNOWN,
+    })
+    expect(session).not.toHaveProperty("transientAuth")
+  })
+
   it("retains modern New API auth discovered from an unknown white-label site", async () => {
     mockSendTabMessage.mockResolvedValueOnce({
       success: true,

--- a/tests/services/accountBrowserSession/sessionReader.test.ts
+++ b/tests/services/accountBrowserSession/sessionReader.test.ts
@@ -227,6 +227,101 @@ describe("account browser-session reader", () => {
     })
   })
 
+  it("passes the explicit modern New API probe intent to the current tab", async () => {
+    mockSendTabMessage.mockResolvedValueOnce({
+      success: true,
+      data: {
+        userId: "user-42",
+        user: { username: "example-user" },
+        siteTypeHint: SITE_TYPES.NEW_API,
+      },
+    })
+
+    await readAccountBrowserSessionFromTab({
+      tabId: 14,
+      baseUrl: "https://white-label.example.invalid",
+      siteType: SITE_TYPES.UNKNOWN,
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB,
+      allowNewApiAuthProbe: true,
+    })
+
+    expect(mockSendTabMessage).toHaveBeenCalledWith(14, {
+      action: RuntimeActionIds.ContentGetUserFromLocalStorage,
+      url: "https://white-label.example.invalid",
+      siteType: SITE_TYPES.UNKNOWN,
+      allowNewApiAuthProbe: true,
+    })
+  })
+
+  it("retains modern New API auth discovered from an unknown white-label site", async () => {
+    mockSendTabMessage.mockResolvedValueOnce({
+      success: true,
+      data: {
+        userId: "user-42",
+        user: { username: "example-user" },
+        siteTypeHint: SITE_TYPES.NEW_API,
+        transientAuth: {
+          kind: NEW_API_DASHBOARD_TRANSIENT_AUTH_KIND,
+          token: "dashboard-token-placeholder",
+          expiresAt: 2_000_000_000,
+          sessionId: "session-placeholder",
+          origin: "https://white-label.example.invalid",
+        },
+      },
+    })
+
+    const session = await readAccountBrowserSessionFromTab({
+      tabId: 14,
+      baseUrl: "https://white-label.example.invalid/dashboard",
+      siteType: SITE_TYPES.UNKNOWN,
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB,
+      allowNewApiAuthProbe: true,
+    })
+
+    expect(session).toEqual(
+      expect.objectContaining({
+        siteType: SITE_TYPES.UNKNOWN,
+        siteTypeHint: SITE_TYPES.NEW_API,
+        transientAuth: expect.objectContaining({
+          kind: NEW_API_DASHBOARD_TRANSIENT_AUTH_KIND,
+          token: "dashboard-token-placeholder",
+        }),
+      }),
+    )
+  })
+
+  it("drops a New API auth hint from an unknown site without explicit probing", async () => {
+    mockSendTabMessage.mockResolvedValueOnce({
+      success: true,
+      data: {
+        userId: "user-42",
+        siteTypeHint: SITE_TYPES.NEW_API,
+        transientAuth: {
+          kind: NEW_API_DASHBOARD_TRANSIENT_AUTH_KIND,
+          token: "dashboard-token-placeholder",
+          expiresAt: 2_000_000_000,
+          sessionId: "session-placeholder",
+          origin: "https://unknown.example.invalid",
+        },
+      },
+    })
+
+    const session = await readAccountBrowserSessionFromTab({
+      tabId: 14,
+      baseUrl: "https://unknown.example.invalid/dashboard",
+      siteType: SITE_TYPES.UNKNOWN,
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB,
+    })
+
+    expect(session).toEqual(
+      expect.objectContaining({
+        siteType: SITE_TYPES.UNKNOWN,
+        siteTypeHint: SITE_TYPES.NEW_API,
+      }),
+    )
+    expect(session).not.toHaveProperty("transientAuth")
+  })
+
   it("normalizes a valid transient dashboard auth payload", async () => {
     mockSendTabMessage.mockResolvedValueOnce({
       success: true,

--- a/tests/services/accountSiteOnboarding/contentSession/newApiAuthBundle.test.ts
+++ b/tests/services/accountSiteOnboarding/contentSession/newApiAuthBundle.test.ts
@@ -56,7 +56,7 @@ describe("newApiAuthBundleContentSessionExtractor", () => {
     vi.stubGlobal("localStorage", createLocalStorageMock())
   })
 
-  it("only extracts an exact New API site-type hint", () => {
+  it("extracts known New API sites or an explicitly enabled unknown-site probe", () => {
     expect(
       newApiAuthBundleContentSessionExtractor.canExtract({
         siteTypeHint: SITE_TYPES.NEW_API,
@@ -72,6 +72,11 @@ describe("newApiAuthBundleContentSessionExtractor", () => {
         siteTypeHint: SITE_TYPES.VELOERA,
       }),
     ).toBe(false)
+    expect(
+      newApiAuthBundleContentSessionExtractor.canExtract({
+        allowNewApiAuthProbe: true,
+      }),
+    ).toBe(true)
     expect(newApiAuthBundleContentSessionExtractor.canExtract({})).toBe(false)
   })
 

--- a/tests/services/autoDetectService.test.ts
+++ b/tests/services/autoDetectService.test.ts
@@ -585,6 +585,50 @@ describe("autoDetectSmart", () => {
     expect(mockFetchUserInfo).not.toHaveBeenCalled()
   })
 
+  it("enables the modern New API probe only for unknown current-tab sites", async () => {
+    mockGetAccountSiteType.mockResolvedValueOnce(SITE_TYPES.UNKNOWN)
+    mockGetActiveOrAllTabs.mockResolvedValue([
+      {
+        id: 301,
+        active: true,
+        url: "https://white-label.example.invalid/dashboard",
+      },
+    ])
+    mockReadAccountBrowserSessionFromTab.mockResolvedValueOnce({
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.CURRENT_TAB,
+      siteType: SITE_TYPES.NEW_API,
+      siteTypeHint: SITE_TYPES.NEW_API,
+      userId: "43",
+      user: { username: "modern-user" },
+      accessToken: "modern-jwt",
+      fetchContext: {
+        kind: API_SERVICE_FETCH_CONTEXT_KINDS.CURRENT_TAB,
+        tabId: 301,
+        origin: "https://white-label.example.invalid",
+      },
+    })
+
+    const result = await autoDetectSmart(
+      "https://white-label.example.invalid/console",
+    )
+
+    expect(result).toMatchObject({
+      success: true,
+      data: {
+        siteType: SITE_TYPES.NEW_API,
+        userId: "43",
+        accessToken: "modern-jwt",
+      },
+    })
+    expect(mockReadAccountBrowserSessionFromTab).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tabId: 301,
+        siteType: SITE_TYPES.UNKNOWN,
+        allowNewApiAuthProbe: true,
+      }),
+    )
+  })
+
   it("does not report Sub2API API fallback success from cookie-auth user-info calls", async () => {
     mockGetAccountSiteType.mockResolvedValueOnce(SITE_TYPES.SUB2API)
     mockGetActiveOrAllTabs.mockResolvedValue([


### PR DESCRIPTION
## Summary

- detect rebranded New API deployments that use the modern refresh-cookie/AuthBundle authentication flow
- retain the short-lived dashboard Bearer only through account completion, then exchange it for the existing management PAT contract
- keep legacy New API detection and known non-New API site paths unchanged

## Root cause

Modern New API dashboards keep the short-lived access JWT in page memory and refresh it through an HttpOnly cookie. White-label deployments therefore no longer expose the legacy storage or error markers used by automatic site detection.

The new unknown-site probe could obtain a valid AuthBundle, but browser-session normalization still validated it against the pre-detection `unknown` type and discarded the transient Bearer. Account completion then fell back to the legacy authentication path and received 401.

## Validation

- `pnpm exec vitest run tests/services/accountBrowserSession/sessionReader.test.ts tests/services/autoDetectService.test.ts tests/services/accountOperations.autoDetectAccount.test.ts tests/services/accountSiteOnboarding/contentSession/newApiAuthBundle.test.ts tests/entrypoints/content/messageHandlers/handlers/storage.test.ts` — 174 tests passed
- `pnpm compile`
- `pnpm build`
- pre-push `pnpm run validate:push` — compile and Knip passed
- reporter manually verified the current Edge login-state flow against the affected deployment

## Compatibility and safety

The refresh probe runs only for explicit current-tab detection when the site is still unknown. Transient dashboard credentials must match the detected New API type and target origin, are not persisted, and are not added to analytics or logs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved automatic account detection for previously unrecognized sites using modern authentication.
  * Preserves valid temporary authentication details when explicitly probing the current tab.
  * Restricts probing to intentional current-tab detection.
  * Handles unauthorized probe responses safely without misclassifying accounts.

* **Tests**
  * Added coverage for successful detection, authentication handling, probe restrictions, and unauthorized responses across supported scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->