### PR TITLE
fix(account-management): keep list controls reachable

### DIFF
--- a/e2e/accountManagementCommonFlows.spec.ts
+++ b/e2e/accountManagementCommonFlows.spec.ts
@@ -5,6 +5,7 @@ import { OPTIONS_TEST_IDS } from "~/entrypoints/options/testIds"
 import {
   ACCOUNT_MANAGEMENT_TEST_IDS,
   getAccountManagementListItemTestId,
+  getAccountManagementSortButtonTestId,
 } from "~/features/AccountManagement/testIds"
 import {
   createDefaultAccountStorageConfig,
@@ -324,23 +325,11 @@ test("keeps account management controls reachable across constrained widths", as
     ACCOUNT_MANAGEMENT_TEST_IDS.accountListClearSortButton,
   )
   const requiredAccountListHeaderActions = [
-    accountListHeader.getByRole("button", {
-      name: "Sort Account",
-      exact: true,
-    }),
-    accountListHeader.getByRole("button", {
-      name: "Sort Created At",
-      exact: true,
-    }),
-    accountListHeader.getByRole("button", {
-      name: "Sort Balance",
-      exact: true,
-    }),
+    page.getByTestId(getAccountManagementSortButtonTestId("name")),
+    page.getByTestId(getAccountManagementSortButtonTestId("created_at")),
+    page.getByTestId(getAccountManagementSortButtonTestId("balance")),
     clearSortAction,
-    accountListHeader.getByRole("button", {
-      name: "Bulk manage",
-      exact: true,
-    }),
+    page.getByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.accountListBulkManageButton),
   ]
   for (const action of requiredAccountListHeaderActions) {
     await expect(action).toBeVisible()

--- a/e2e/accountManagementCommonFlows.spec.ts
+++ b/e2e/accountManagementCommonFlows.spec.ts
@@ -1,4 +1,4 @@
-import type { Page } from "@playwright/test"
+import type { Locator, Page } from "@playwright/test"
 
 import { OPTIONS_PAGE_PATH } from "~/constants/extensionPages"
 import { OPTIONS_TEST_IDS } from "~/entrypoints/options/testIds"
@@ -31,6 +31,8 @@ import { waitForExtensionRoot } from "~~/e2e/utils/lazyLoading"
 
 const ACCOUNT_QUICK_CHECKIN_E2E_STATE_KEY =
   "__aah_account_quick_checkin_e2e_state__"
+const DESKTOP_VIEWPORT_SIZE = { width: 1280, height: 720 }
+const MOBILE_VIEWPORT_SIZE = { width: 320, height: 720 }
 
 type AccountQuickCheckinRuntimeState = {
   calls: Array<{
@@ -41,6 +43,57 @@ type AccountQuickCheckinRuntimeState = {
 
 type RuntimeLike = {
   sendMessage?: (message: unknown) => Promise<unknown>
+}
+
+type ElementBounds = {
+  bottom: number
+  height: number
+  right: number
+  width: number
+  x: number
+  y: number
+}
+
+async function readElementBounds(locator: Locator): Promise<ElementBounds[]> {
+  return locator.evaluateAll((elements) =>
+    elements.map((element) => {
+      const box = element.getBoundingClientRect()
+      return {
+        bottom: box.bottom,
+        height: box.height,
+        right: box.right,
+        width: box.width,
+        x: box.x,
+        y: box.y,
+      }
+    }),
+  )
+}
+
+function elementBoundsOverlap(left: ElementBounds, right: ElementBounds) {
+  return (
+    left.x < right.right &&
+    left.right > right.x &&
+    left.y < right.bottom &&
+    left.bottom > right.y
+  )
+}
+
+function isHorizontallyContained(
+  bounds: ElementBounds,
+  container: { width: number; x: number },
+) {
+  return (
+    bounds.x >= container.x && bounds.right <= container.x + container.width
+  )
+}
+
+async function openAccountManagement(page: Page, extensionId: string) {
+  await page.goto(
+    `chrome-extension://${extensionId}/${OPTIONS_PAGE_PATH}#account`,
+  )
+  await waitForExtensionRoot(page)
+  await expectPermissionOnboardingHidden(page)
 }
 
 async function readStoredAccountConfig(
@@ -148,15 +201,12 @@ test.beforeEach(async ({ context, page }) => {
   await stubLlmMetadataIndex(context)
 })
 
-test("keeps every account header action reachable across constrained widths", async ({
+test("keeps account management controls reachable across constrained widths", async ({
   context,
   extensionId,
   page,
 }) => {
-  const viewportSizes = [
-    { width: 1280, height: 720 },
-    { width: 320, height: 720 },
-  ]
+  const viewportSizes = [DESKTOP_VIEWPORT_SIZE, MOBILE_VIEWPORT_SIZE]
   await page.setViewportSize(viewportSizes[0])
 
   const serviceWorker = await getServiceWorker(context)
@@ -173,11 +223,7 @@ test("keeps every account header action reachable across constrained widths", as
     }),
   ])
 
-  await page.goto(
-    `chrome-extension://${extensionId}/${OPTIONS_PAGE_PATH}#account`,
-  )
-  await waitForExtensionRoot(page)
-  await expectPermissionOnboardingHidden(page)
+  await openAccountManagement(page, extensionId)
 
   const headerActionGroup = page.getByTestId(
     ACCOUNT_MANAGEMENT_TEST_IDS.headerActions,
@@ -211,18 +257,7 @@ test("keeps every account header action reachable across constrained widths", as
       .poll(async () => {
         const contentCardBox = await contentCard.boundingBox()
         const headerActionGroupBox = await headerActionGroup.boundingBox()
-        const boxes = await headerActions.evaluateAll((actions) => {
-          return actions.map((action) => {
-            const box = action.getBoundingClientRect()
-            return {
-              x: box.x,
-              y: box.y,
-              height: box.height,
-              right: box.right,
-              width: box.width,
-            }
-          })
-        })
+        const boxes = await readElementBounds(headerActions)
 
         const rowRightEdges = new Map<number, number>()
         for (const box of boxes) {
@@ -245,10 +280,8 @@ test("keeps every account header action reachable across constrained widths", as
           hasLayout: Boolean(contentCardBox && headerActionGroupBox),
           actionsContained: Boolean(
             contentCardBox &&
-              boxes.every(
-                (box) =>
-                  box.x >= contentCardBox.x &&
-                  box.x + box.width <= contentCardBox.x + contentCardBox.width,
+              boxes.every((box) =>
+                isHorizontallyContained(box, contentCardBox),
               ),
           ),
           actionsWrapped: rowRightEdges.size > 1,
@@ -275,6 +308,121 @@ test("keeps every account header action reachable across constrained widths", as
     await expectHeaderActionsContained(viewportSize)
   }
 
+  const accountList = page.getByTestId(
+    ACCOUNT_MANAGEMENT_TEST_IDS.accountListView,
+  )
+  const accountListHeader = page.getByTestId(
+    ACCOUNT_MANAGEMENT_TEST_IDS.accountListHeader,
+  )
+  const accountListSortControls = page.getByTestId(
+    ACCOUNT_MANAGEMENT_TEST_IDS.accountListSortControls,
+  )
+  const accountListUtilities = page.getByTestId(
+    ACCOUNT_MANAGEMENT_TEST_IDS.accountListUtilities,
+  )
+  const clearSortAction = page.getByTestId(
+    ACCOUNT_MANAGEMENT_TEST_IDS.accountListClearSortButton,
+  )
+  const requiredAccountListHeaderActions = [
+    accountListHeader.getByRole("button", {
+      name: "Sort Account",
+      exact: true,
+    }),
+    accountListHeader.getByRole("button", {
+      name: "Sort Created At",
+      exact: true,
+    }),
+    accountListHeader.getByRole("button", {
+      name: "Sort Balance",
+      exact: true,
+    }),
+    clearSortAction,
+    accountListHeader.getByRole("button", {
+      name: "Bulk manage",
+      exact: true,
+    }),
+  ]
+  for (const action of requiredAccountListHeaderActions) {
+    await expect(action).toBeVisible()
+  }
+
+  async function expectAccountListHeaderLayout(
+    viewportSize: { height: number; width: number },
+    layout: "inline" | "stacked",
+  ) {
+    await page.setViewportSize(viewportSize)
+
+    await expect
+      .poll(async () => {
+        const listBox = await accountList.boundingBox()
+        const sortControlsBox = await accountListSortControls.boundingBox()
+        const utilitiesBox = await accountListUtilities.boundingBox()
+        const clearSortActionBox = await clearSortAction.boundingBox()
+        const headerButtons = await readElementBounds(
+          accountListHeader.getByRole("button"),
+        )
+        const hasOverlappingButtons = headerButtons.some((box, index) =>
+          headerButtons
+            .slice(index + 1)
+            .some((other) => elementBoundsOverlap(box, other)),
+        )
+        const clearSortStaysWithinSortTier = Boolean(
+          sortControlsBox &&
+            clearSortActionBox &&
+            clearSortActionBox.y >= sortControlsBox.y &&
+            clearSortActionBox.y + clearSortActionBox.height <=
+              sortControlsBox.y + sortControlsBox.height,
+        )
+
+        return {
+          hasLayout: Boolean(
+            listBox && sortControlsBox && utilitiesBox && clearSortActionBox,
+          ),
+          utilitiesPlacementMatches: Boolean(
+            sortControlsBox &&
+              utilitiesBox &&
+              (layout === "stacked"
+                ? utilitiesBox.y + utilitiesBox.height <= sortControlsBox.y
+                : sortControlsBox.x + sortControlsBox.width <= utilitiesBox.x &&
+                  Math.abs(
+                    sortControlsBox.y +
+                      sortControlsBox.height / 2 -
+                      (utilitiesBox.y + utilitiesBox.height / 2),
+                  ) <= 1),
+          ),
+          clearSortPlacementMatches:
+            clearSortStaysWithinSortTier &&
+            (layout === "inline" ||
+              Boolean(
+                sortControlsBox &&
+                  clearSortActionBox &&
+                  Math.abs(
+                    clearSortActionBox.x +
+                      clearSortActionBox.width -
+                      (sortControlsBox.x + sortControlsBox.width),
+                  ) <= 1,
+              )),
+          buttonsContained: Boolean(
+            listBox &&
+              headerButtons.every((box) =>
+                isHorizontallyContained(box, listBox),
+              ),
+          ),
+          hasOverlappingButtons,
+        }
+      })
+      .toEqual({
+        hasLayout: true,
+        utilitiesPlacementMatches: true,
+        clearSortPlacementMatches: true,
+        buttonsContained: true,
+        hasOverlappingButtons: false,
+      })
+  }
+
+  await expectAccountListHeaderLayout(DESKTOP_VIEWPORT_SIZE, "inline")
+  await expectAccountListHeaderLayout(MOBILE_VIEWPORT_SIZE, "stacked")
+
   const externalCheckInAction = page.getByTestId(
     ACCOUNT_MANAGEMENT_TEST_IDS.externalCheckInButton,
   )
@@ -295,18 +443,14 @@ test("keeps every account header action reachable across constrained widths", as
       exact: true,
     }),
   ).toBeVisible()
-  await expectHeaderActionsContained(viewportSizes[1])
+  await expectHeaderActionsContained(MOBILE_VIEWPORT_SIZE)
 })
 
 test("keeps the add account dialog open when text selection ends over its backdrop", async ({
   extensionId,
   page,
 }) => {
-  await page.goto(
-    `chrome-extension://${extensionId}/${OPTIONS_PAGE_PATH}#account`,
-  )
-  await waitForExtensionRoot(page)
-  await expectPermissionOnboardingHidden(page)
+  await openAccountManagement(page, extensionId)
 
   await page.getByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.addAccountButton).click()
 
@@ -360,11 +504,7 @@ test("disables and re-enables a stored account from account management", async (
     }),
   ])
 
-  await page.goto(
-    `chrome-extension://${extensionId}/${OPTIONS_PAGE_PATH}#account`,
-  )
-  await waitForExtensionRoot(page)
-  await expectPermissionOnboardingHidden(page)
+  await openAccountManagement(page, extensionId)
 
   await expect(
     page.getByRole("button", { name: "Toggle Account" }),
@@ -429,11 +569,7 @@ test("deletes a stored account from account management and removes it from stora
     }),
   ])
 
-  await page.goto(
-    `chrome-extension://${extensionId}/${OPTIONS_PAGE_PATH}#account`,
-  )
-  await waitForExtensionRoot(page)
-  await expectPermissionOnboardingHidden(page)
+  await openAccountManagement(page, extensionId)
 
   await expect(
     page.getByRole("button", { name: "Delete Account" }),
@@ -486,6 +622,24 @@ test("runs quick check-in for the selected eligible account from account managem
         window.sessionStorage.setItem(stateKey, JSON.stringify(nextState))
       }
 
+      const readAccountIds = (message: unknown): string[] => {
+        if (typeof message !== "object" || message === null) {
+          return []
+        }
+
+        const data = (message as Record<string, unknown>).data
+        if (typeof data !== "object" || data === null) {
+          return []
+        }
+
+        const accountIds = (data as Record<string, unknown>).accountIds
+        return Array.isArray(accountIds)
+          ? accountIds.filter(
+              (accountId): accountId is string => typeof accountId === "string",
+            )
+          : []
+      }
+
       const patchRuntime = (runtime: RuntimeLike | undefined) => {
         if (!runtime || typeof runtime.sendMessage !== "function") {
           return
@@ -508,17 +662,7 @@ test("runs quick check-in for the selected eligible account from account managem
               return await originalSendMessage(message)
             }
 
-            const accountIds =
-              typeof message === "object" &&
-              message !== null &&
-              "data" in message &&
-              typeof (message as { data?: unknown }).data === "object" &&
-              (message as { data?: unknown }).data !== null &&
-              "accountIds" in (message as { data: any }).data &&
-              Array.isArray((message as { data: any }).data.accountIds)
-                ? (message as { data: { accountIds: string[] } }).data
-                    .accountIds
-                : []
+            const accountIds = readAccountIds(message)
 
             const nextState = {
               calls: [...readState().calls, { type, accountIds }],
@@ -585,11 +729,7 @@ test("runs quick check-in for the selected eligible account from account managem
     }),
   ])
 
-  await page.goto(
-    `chrome-extension://${extensionId}/${OPTIONS_PAGE_PATH}#account`,
-  )
-  await waitForExtensionRoot(page)
-  await expectPermissionOnboardingHidden(page)
+  await openAccountManagement(page, extensionId)
 
   await openAccountActionsMenu(page, "Quick Check-in Account")
   await page
@@ -648,11 +788,7 @@ test("pins and unpins an account from account management while persisting pinned
     orderedAccountIds: ["stored-account-1", "stored-account-2"],
   })
 
-  await page.goto(
-    `chrome-extension://${extensionId}/${OPTIONS_PAGE_PATH}#account`,
-  )
-  await waitForExtensionRoot(page)
-  await expectPermissionOnboardingHidden(page)
+  await openAccountManagement(page, extensionId)
 
   await expect(
     page.getByRole("button", { name: "Alpha Account" }),
@@ -733,11 +869,7 @@ test("shows the empty duplicate-cleanup state when no duplicate accounts are fou
     }),
   ])
 
-  await page.goto(
-    `chrome-extension://${extensionId}/${OPTIONS_PAGE_PATH}#account`,
-  )
-  await waitForExtensionRoot(page)
-  await expectPermissionOnboardingHidden(page)
+  await openAccountManagement(page, extensionId)
 
   await page.getByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.dedupeScanButton).click()
 
@@ -801,11 +933,7 @@ test("cleans duplicate accounts after preview confirmation and prunes stale refe
     orderedAccountIds: ["dup-keep", "dup-delete", "unique-account"],
   })
 
-  await page.goto(
-    `chrome-extension://${extensionId}/${OPTIONS_PAGE_PATH}#account`,
-  )
-  await waitForExtensionRoot(page)
-  await expectPermissionOnboardingHidden(page)
+  await openAccountManagement(page, extensionId)
 
   await page.getByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.dedupeScanButton).click()
 

--- a/src/features/AccountManagement/components/AccountList/AccountListHeader.tsx
+++ b/src/features/AccountManagement/components/AccountList/AccountListHeader.tsx
@@ -8,7 +8,10 @@ import {
   DATA_TYPE_CREATED_AT,
   DATA_TYPE_INCOME,
 } from "~/constants"
-import { ACCOUNT_MANAGEMENT_TEST_IDS } from "~/features/AccountManagement/testIds"
+import {
+  ACCOUNT_MANAGEMENT_TEST_IDS,
+  getAccountManagementSortButtonTestId,
+} from "~/features/AccountManagement/testIds"
 import { cn } from "~/lib/utils"
 import type { ActiveSortField, SortField, SortOrder } from "~/types"
 
@@ -55,6 +58,7 @@ function AccountListSortButton({
       size="none"
       disabled={disabled}
       aria-label={`${sortLabel} ${label}`}
+      data-testid={getAccountManagementSortButtonTestId(field)}
       className={cn(
         "min-h-6 space-x-0.5 rounded-md px-1.5 text-xs font-medium sm:space-x-1",
         isActive &&
@@ -172,6 +176,9 @@ export function AccountListHeader({
             className="h-7 shrink-0 px-2 text-xs"
             onClick={isBulkMode ? onBulkModeExit : onBulkModeEnter}
             disabled={isBulkBusy}
+            data-testid={
+              ACCOUNT_MANAGEMENT_TEST_IDS.accountListBulkManageButton
+            }
           >
             {isBulkMode ? t("account:bulk.exit") : t("account:bulk.manage")}
           </Button>

--- a/src/features/AccountManagement/components/AccountList/AccountListHeader.tsx
+++ b/src/features/AccountManagement/components/AccountList/AccountListHeader.tsx
@@ -1,0 +1,182 @@
+import { ChevronDown, ChevronUp, XIcon } from "lucide-react"
+import { useTranslation } from "react-i18next"
+
+import { Button, IconButton } from "~/components/ui"
+import {
+  DATA_TYPE_BALANCE,
+  DATA_TYPE_CONSUMPTION,
+  DATA_TYPE_CREATED_AT,
+  DATA_TYPE_INCOME,
+} from "~/constants"
+import { ACCOUNT_MANAGEMENT_TEST_IDS } from "~/features/AccountManagement/testIds"
+import { cn } from "~/lib/utils"
+import type { ActiveSortField, SortField, SortOrder } from "~/types"
+
+interface AccountListHeaderProps {
+  displayedResultCount: number
+  inSearchMode: boolean
+  isBulkBusy: boolean
+  isBulkMode: boolean
+  onBulkModeEnter: () => void
+  onBulkModeExit: () => void
+  onClearSort: () => void
+  onSort: (field: SortField) => void
+  showTodayCashflow: boolean
+  sortField: ActiveSortField
+  sortOrder: SortOrder
+}
+
+interface AccountListSortButtonProps {
+  activeSortField: ActiveSortField
+  disabled: boolean
+  field: SortField
+  label: string
+  onSort: (field: SortField) => void
+  sortLabel: string
+  sortOrder: SortOrder
+}
+
+/** Renders one sort field while preserving the active direction indicator. */
+function AccountListSortButton({
+  activeSortField,
+  disabled,
+  field,
+  label,
+  onSort,
+  sortLabel,
+  sortOrder,
+}: AccountListSortButtonProps) {
+  const isActive = activeSortField === field
+
+  return (
+    <IconButton
+      onClick={() => onSort(field)}
+      variant="ghost"
+      size="none"
+      disabled={disabled}
+      aria-label={`${sortLabel} ${label}`}
+      className={cn(
+        "min-h-6 space-x-0.5 rounded-md px-1.5 text-xs font-medium sm:space-x-1",
+        isActive &&
+          "bg-blue-100/80 font-semibold text-blue-700 hover:bg-blue-100 dark:bg-blue-950/60 dark:text-blue-300 dark:hover:bg-blue-950/80",
+      )}
+    >
+      <span>{label}</span>
+      {isActive &&
+        (sortOrder === "asc" ? (
+          <ChevronUp className="h-2.5 w-2.5 sm:h-3 sm:w-3" />
+        ) : (
+          <ChevronDown className="h-2.5 w-2.5 sm:h-3 sm:w-3" />
+        ))}
+    </IconButton>
+  )
+}
+
+/** Responsive account-list sorting and bulk-management controls. */
+export function AccountListHeader({
+  displayedResultCount,
+  inSearchMode,
+  isBulkBusy,
+  isBulkMode,
+  onBulkModeEnter,
+  onBulkModeExit,
+  onClearSort,
+  onSort,
+  showTodayCashflow,
+  sortField,
+  sortOrder,
+}: AccountListHeaderProps) {
+  const { t } = useTranslation(["account", "common"])
+  const renderSortButton = (field: SortField, label: string) => (
+    <AccountListSortButton
+      activeSortField={sortField}
+      disabled={inSearchMode}
+      field={field}
+      label={label}
+      onSort={onSort}
+      sortLabel={t("account:list.sort")}
+      sortOrder={sortOrder}
+    />
+  )
+
+  return (
+    <div
+      className="dark:border-dark-bg-tertiary dark:bg-dark-bg-secondary sticky top-0 z-10 border-b border-gray-200 bg-gray-50 px-3 py-2 sm:px-5"
+      data-testid={ACCOUNT_MANAGEMENT_TEST_IDS.accountListHeader}
+    >
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
+        <div
+          className="dark:border-dark-bg-tertiary order-2 grid w-full min-w-0 grid-cols-[minmax(0,1fr)_auto] items-start gap-2 border-t border-gray-200/70 pt-1.5 sm:order-1 sm:flex sm:w-auto sm:flex-1 sm:items-center sm:border-0 sm:pt-0"
+          data-testid={ACCOUNT_MANAGEMENT_TEST_IDS.accountListSortControls}
+        >
+          <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
+            <div className="flex min-w-0 flex-wrap items-center gap-x-2">
+              {renderSortButton("name", t("account:list.header.account"))}
+              {renderSortButton(
+                DATA_TYPE_CREATED_AT,
+                t("account:list.header.createdAt"),
+              )}
+            </div>
+            <span
+              aria-hidden="true"
+              className="dark:bg-dark-bg-tertiary hidden h-3.5 w-px shrink-0 bg-gray-300 sm:block"
+            />
+            <div className="flex min-w-0 flex-wrap items-center gap-x-2">
+              {renderSortButton(
+                DATA_TYPE_BALANCE,
+                t("account:list.header.balance"),
+              )}
+              {showTodayCashflow && (
+                <>
+                  {renderSortButton(
+                    DATA_TYPE_CONSUMPTION,
+                    t("account:list.header.todayConsumption"),
+                  )}
+                  {renderSortButton(
+                    DATA_TYPE_INCOME,
+                    t("account:list.header.todayIncome"),
+                  )}
+                </>
+              )}
+            </div>
+          </div>
+          {sortField !== null && !inSearchMode ? (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              className="h-7 shrink-0 px-2 text-xs font-normal text-gray-500 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-200"
+              leftIcon={<XIcon aria-hidden="true" className="size-3" />}
+              onClick={onClearSort}
+              aria-label={t("account:list.clearSort")}
+              data-testid={
+                ACCOUNT_MANAGEMENT_TEST_IDS.accountListClearSortButton
+              }
+            >
+              {t("account:list.clearSort")}
+            </Button>
+          ) : null}
+        </div>
+
+        <div
+          className="order-1 flex w-full shrink-0 items-center justify-between gap-2 sm:order-2 sm:w-auto sm:justify-end"
+          data-testid={ACCOUNT_MANAGEMENT_TEST_IDS.accountListUtilities}
+        >
+          <span className="dark:text-dark-text-tertiary text-xs font-medium whitespace-nowrap text-gray-500">
+            {t("common:total") + ": " + displayedResultCount}
+          </span>
+          <Button
+            type="button"
+            variant={isBulkMode ? "secondary" : "outline"}
+            size="sm"
+            className="h-7 shrink-0 px-2 text-xs"
+            onClick={isBulkMode ? onBulkModeExit : onBulkModeEnter}
+            disabled={isBulkBusy}
+          >
+            {isBulkMode ? t("account:bulk.exit") : t("account:bulk.manage")}
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/features/AccountManagement/components/AccountList/SiteInfo.tsx
+++ b/src/features/AccountManagement/components/AccountList/SiteInfo.tsx
@@ -1,9 +1,9 @@
 import {
   CalendarDays,
   CircleCheck,
+  CircleDollarSign,
   CircleX,
   Gift,
-  JapaneseYen,
   Link,
   Pin,
   RefreshCw,
@@ -11,8 +11,9 @@ import {
   Tag,
   TriangleAlert,
   User,
+  type LucideIcon,
 } from "lucide-react"
-import { useMemo, useState } from "react"
+import { useState } from "react"
 import toast from "react-hot-toast"
 import { useTranslation } from "react-i18next"
 
@@ -42,7 +43,7 @@ import {
   getTempWindowFallbackSettingsTab,
 } from "~/features/AccountManagement/utils/tempWindowFallbackReminder"
 import { useLdohSiteLookupContext } from "~/features/LdohSiteLookup/hooks/LdohSiteLookupContext"
-import { getDayKeyFromUnixSeconds } from "~/services/history/usageHistory/core"
+import { cn } from "~/lib/utils"
 import {
   SiteHealthStatus,
   TEMP_WINDOW_HEALTH_STATUS_CODES,
@@ -59,6 +60,8 @@ import {
   openCustomCheckInPage,
   openSettingsTab,
 } from "~/utils/navigation"
+
+import { isCheckInStatusDetectedToday } from "./checkInStatus"
 
 interface SiteInfoProps {
   site: DisplaySiteData
@@ -78,6 +81,43 @@ type SiteInfoRefreshTarget =
  * Logger scoped to account list rows so navigation failures can be diagnosed without leaking account secrets.
  */
 const logger = createLogger("AccountList.SiteInfo")
+
+interface CheckInStatusButtonProps {
+  checkedIn: boolean
+  icon: LucideIcon
+  label: string
+  onClick: () => void
+}
+
+/** Renders a check-in action with its source-specific icon and shared status color. */
+function CheckInStatusButton({
+  checkedIn,
+  icon: Icon,
+  label,
+  onClick,
+}: CheckInStatusButtonProps) {
+  return (
+    <Tooltip
+      content={label}
+      position="top"
+      wrapperClassName="flex items-center"
+    >
+      <IconButton
+        onClick={onClick}
+        variant="ghost"
+        size="xs"
+        aria-label={label}
+      >
+        <Icon
+          className={cn(
+            "h-4 w-4",
+            checkedIn ? "text-green-500" : "text-red-500",
+          )}
+        />
+      </IconButton>
+    </Tooltip>
+  )
+}
 
 /**
  * Renders highlighted fragments (such as search matches) with mark elements while preserving non-highlighted text.
@@ -128,9 +168,8 @@ export default function SiteInfo({
   const { getLdohSearchUrlForAccountUrl } = useLdohSiteLookupContext()
   const [activeRefreshTarget, setActiveRefreshTarget] =
     useState<SiteInfoRefreshTarget | null>(null)
-  const detectedAccountIdSet = useMemo(
-    () => new Set(detectedSiteAccounts.map((account) => account.id)),
-    [detectedSiteAccounts],
+  const isDetectedAccount = detectedSiteAccounts.some(
+    (account) => account.id === site.id,
   )
 
   const isPinned = isAccountPinned(site.id)
@@ -141,6 +180,8 @@ export default function SiteInfo({
   const ldohSearchUrl = getLdohSearchUrlForAccountUrl(site.baseUrl)
   const customCheckInUrl = site.checkIn?.customCheckIn?.url
   const customRedeemUrl = site.checkIn?.customCheckIn?.redeemUrl
+  const hasTags = Boolean(site.tags && site.tags.length > 0)
+  const tagLabel = hasTags ? site.tags?.join(", ") || "" : ""
   const createdAtLabel = t("account:list.header.createdAt")
   const siteTypeLabel = t("list.site.siteType")
   const createdAtText = formatLocaleDateTime(
@@ -267,23 +308,6 @@ export default function SiteInfo({
       return null
     }
 
-    /**
-     * Check-in status is fetched and persisted during refresh operations.
-     * When the last detection date isn't today, we show a warning state to avoid
-     * misleading users with stale "checked in" / "not checked in" indicators.
-     */
-    const isCheckInStatusDetectedToday = (detectedAt?: number): boolean => {
-      if (typeof detectedAt !== "number" || !Number.isFinite(detectedAt)) {
-        return false
-      }
-
-      const todayKey = getDayKeyFromUnixSeconds(Math.floor(Date.now() / 1000))
-      const detectedKey = getDayKeyFromUnixSeconds(
-        Math.floor(detectedAt / 1000),
-      )
-      return detectedKey === todayKey
-    }
-
     const indicators: React.ReactNode[] = []
 
     const customUrl = site.checkIn?.customCheckIn?.url
@@ -338,79 +362,40 @@ export default function SiteInfo({
         )
       } else if (siteCheckedIn) {
         indicators.push(
-          <Tooltip
+          <CheckInStatusButton
             key="site-checkin"
-            content={t("list.site.checkedInToday")}
-            position="top"
-            wrapperClassName="flex items-center"
-          >
-            <IconButton
-              onClick={handleSiteCheckIn}
-              variant="ghost"
-              size="xs"
-              aria-label={t("list.site.checkedInToday")}
-            >
-              <CircleCheck className="h-4 w-4 text-green-500" />
-            </IconButton>
-          </Tooltip>,
+            checkedIn
+            icon={CircleCheck}
+            label={t("list.site.checkedInToday")}
+            onClick={handleSiteCheckIn}
+          />,
         )
       } else {
         indicators.push(
-          <Tooltip
+          <CheckInStatusButton
             key="site-checkin"
-            content={t("list.site.notCheckedInToday")}
-            position="top"
-            wrapperClassName="flex items-center"
-          >
-            <IconButton
-              onClick={handleSiteCheckIn}
-              variant="ghost"
-              size="xs"
-              aria-label={t("list.site.notCheckedInToday")}
-            >
-              <CircleX className="h-4 w-4 text-red-500" />
-            </IconButton>
-          </Tooltip>,
+            checkedIn={false}
+            icon={CircleX}
+            label={t("list.site.notCheckedInToday")}
+            onClick={handleSiteCheckIn}
+          />,
         )
       }
     }
 
     if (hasCustomUrl) {
       const isCustomCheckedIn = site.checkIn.customCheckIn?.isCheckedInToday
+      const customCheckInLabel = isCustomCheckedIn
+        ? t("list.site.checkedInToday")
+        : t("list.site.notCheckedInToday")
       indicators.push(
-        isCustomCheckedIn ? (
-          <Tooltip
-            key="custom-checkin"
-            content={t("list.site.checkedInToday")}
-            position="top"
-            wrapperClassName="flex items-center"
-          >
-            <IconButton
-              onClick={handleCustomCheckIn}
-              variant="ghost"
-              size="xs"
-              aria-label={t("list.site.checkedInToday")}
-            >
-              <JapaneseYen className="h-4 w-4 text-green-500" />
-            </IconButton>
-          </Tooltip>
-        ) : (
-          <Tooltip
-            key="custom-checkin"
-            content={t("list.site.notCheckedInToday")}
-            position="top"
-            wrapperClassName="flex items-center"
-          >
-            <IconButton
-              onClick={handleCustomCheckIn}
-              variant="ghost"
-              size="xs"
-              aria-label={t("list.site.notCheckedInToday")}
-            >
-              <JapaneseYen className="h-4 w-4 text-red-500" />
-            </IconButton>
-          </Tooltip>
-        ),
+        <CheckInStatusButton
+          key="custom-checkin"
+          checkedIn={Boolean(isCustomCheckedIn)}
+          icon={CircleDollarSign}
+          label={customCheckInLabel}
+          onClick={handleCustomCheckIn}
+        />,
       )
     }
 
@@ -422,6 +407,7 @@ export default function SiteInfo({
   }
 
   const checkInIndicator = renderCheckInIndicators()
+  const healthStatusDisplay = getHealthStatusDisplay(site.health?.status, t)
 
   return (
     <div className="flex w-full min-w-0 items-center gap-2">
@@ -431,14 +417,8 @@ export default function SiteInfo({
             <div className="space-y-1">
               <p>
                 {t("list.site.status")}:{" "}
-                <span
-                  className={
-                    getHealthStatusDisplay(site.health?.status, t).color ||
-                    "text-gray-400"
-                  }
-                >
-                  {getHealthStatusDisplay(site.health?.status, t).text ||
-                    t("list.site.unknown")}
+                <span className={healthStatusDisplay.color || "text-gray-400"}>
+                  {healthStatusDisplay.text || t("list.site.unknown")}
                 </span>
               </p>
               {site.health?.reason && (
@@ -532,7 +512,7 @@ export default function SiteInfo({
       <div className="min-w-0 flex-1">
         <div className="flex flex-wrap items-center gap-x-1 gap-y-1">
           <div className="flex min-w-0 flex-wrap items-center gap-1.5">
-            {detectedAccountIdSet.has(site.id) && (
+            {isDetectedAccount && (
               <Tooltip
                 content={t("list.site.currentSiteExists")}
                 position="top"
@@ -569,7 +549,7 @@ export default function SiteInfo({
             </Tooltip>
           </div>
 
-          <div className="flex min-w-0 items-center gap-1.5 sm:gap-2">
+          <div className="flex min-w-0 items-center gap-1 sm:gap-1.5">
             {/* Keep the site URL clickable even when the account is disabled so users can still open the provider site. */}
             {/* Avoid `bleed`/non-shrinking button layout that can overflow into the action buttons column. */}
             <Button
@@ -677,16 +657,13 @@ export default function SiteInfo({
           </div>
         )}
 
-        {site.tags && site.tags.length > 0 && (
+        {hasTags && (
           <div className="mt-0.5 flex min-w-0 items-start gap-1 sm:mt-1">
             <Tag className="dark:text-dark-text-tertiary mt-0.5 h-3 w-3 shrink-0 text-gray-400" />
-            <Caption className="truncate" title={site.tags.join(", ")}>
+            <Caption className="truncate" title={tagLabel}>
               {highlights?.tags
-                ? renderHighlightedFragments(
-                    highlights.tags,
-                    site.tags.join(", "),
-                  )
-                : site.tags.join(", ")}
+                ? renderHighlightedFragments(highlights.tags, tagLabel)
+                : tagLabel}
             </Caption>
           </div>
         )}

--- a/src/features/AccountManagement/components/AccountList/SiteInfo.tsx
+++ b/src/features/AccountManagement/components/AccountList/SiteInfo.tsx
@@ -87,6 +87,7 @@ interface CheckInStatusButtonProps {
   icon: LucideIcon
   label: string
   onClick: () => void
+  testId: string
 }
 
 /** Renders a check-in action with its source-specific icon and shared status color. */
@@ -95,6 +96,7 @@ function CheckInStatusButton({
   icon: Icon,
   label,
   onClick,
+  testId,
 }: CheckInStatusButtonProps) {
   return (
     <Tooltip
@@ -107,6 +109,7 @@ function CheckInStatusButton({
         variant="ghost"
         size="xs"
         aria-label={label}
+        data-testid={testId}
       >
         <Icon
           className={cn(
@@ -368,6 +371,7 @@ export default function SiteInfo({
             icon={CircleCheck}
             label={t("list.site.checkedInToday")}
             onClick={handleSiteCheckIn}
+            testId={ACCOUNT_MANAGEMENT_TEST_IDS.siteCheckInStatusButton}
           />,
         )
       } else {
@@ -378,6 +382,7 @@ export default function SiteInfo({
             icon={CircleX}
             label={t("list.site.notCheckedInToday")}
             onClick={handleSiteCheckIn}
+            testId={ACCOUNT_MANAGEMENT_TEST_IDS.siteCheckInStatusButton}
           />,
         )
       }
@@ -395,6 +400,7 @@ export default function SiteInfo({
           icon={CircleDollarSign}
           label={customCheckInLabel}
           onClick={handleCustomCheckIn}
+          testId={ACCOUNT_MANAGEMENT_TEST_IDS.customCheckInStatusButton}
         />,
       )
     }

--- a/src/features/AccountManagement/components/AccountList/checkInFilter.ts
+++ b/src/features/AccountManagement/components/AccountList/checkInFilter.ts
@@ -1,5 +1,6 @@
-import { getDayKeyFromUnixSeconds } from "~/services/history/usageHistory/core"
 import type { DisplaySiteData } from "~/types"
+
+import { isCheckInStatusDetectedToday } from "./checkInStatus"
 
 export type AccountCheckInFilterValue =
   | "checked-in"
@@ -9,19 +10,6 @@ export type AccountCheckInFilterValue =
 
 export const ACCOUNT_CHECK_IN_FILTER_OPTION_ORDER: AccountCheckInFilterValue[] =
   ["checked-in", "not-checked-in", "outdated", "unsupported"]
-
-/**
- * Checks whether a persisted site check-in detection timestamp belongs to today.
- */
-function isCheckInStatusDetectedToday(detectedAt?: number): boolean {
-  if (typeof detectedAt !== "number" || !Number.isFinite(detectedAt)) {
-    return false
-  }
-
-  const todayKey = getDayKeyFromUnixSeconds(Math.floor(Date.now() / 1000))
-  const detectedKey = getDayKeyFromUnixSeconds(Math.floor(detectedAt / 1000))
-  return detectedKey === todayKey
-}
 
 /**
  * Maps combined site/custom check-in state into one stable filter bucket.

--- a/src/features/AccountManagement/components/AccountList/checkInStatus.ts
+++ b/src/features/AccountManagement/components/AccountList/checkInStatus.ts
@@ -1,0 +1,12 @@
+import { getDayKeyFromUnixSeconds } from "~/services/history/usageHistory/core"
+
+/** Returns whether a persisted check-in detection belongs to the current local day. */
+export function isCheckInStatusDetectedToday(detectedAt?: number): boolean {
+  if (typeof detectedAt !== "number" || !Number.isFinite(detectedAt)) {
+    return false
+  }
+
+  const todayKey = getDayKeyFromUnixSeconds(Math.floor(Date.now() / 1000))
+  const detectedKey = getDayKeyFromUnixSeconds(Math.floor(detectedAt / 1000))
+  return detectedKey === todayKey
+}

--- a/src/features/AccountManagement/components/AccountList/index.tsx
+++ b/src/features/AccountManagement/components/AccountList/index.tsx
@@ -1,6 +1,6 @@
 import type { DragEndEvent } from "@dnd-kit/core"
 import type { TFunction } from "i18next"
-import { ChevronDown, ChevronUp, Inbox, Plus } from "lucide-react"
+import { Inbox, Plus } from "lucide-react"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import toast from "react-hot-toast"
 import { useTranslation } from "react-i18next"
@@ -14,15 +14,9 @@ import {
   Checkbox,
   DestructiveConfirmDialog,
   EmptyState,
-  IconButton,
   TagFilter,
 } from "~/components/ui"
-import {
-  DATA_TYPE_BALANCE,
-  DATA_TYPE_CONSUMPTION,
-  DATA_TYPE_CREATED_AT,
-  DATA_TYPE_INCOME,
-} from "~/constants"
+import { DATA_TYPE_CREATED_AT } from "~/constants"
 import { ACCOUNT_SITE_TITLE_RULES } from "~/constants/siteType"
 import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
 import { NewcomerSponsorRecommendationsSection } from "~/features/AccountManagement/components/NewcomerSponsorRecommendationsSection"
@@ -64,7 +58,7 @@ import {
   PRODUCT_ANALYTICS_SOURCE_KINDS,
   PRODUCT_ANALYTICS_SURFACE_IDS,
 } from "~/services/productAnalytics/contracts"
-import type { CurrencyMetricTotal, DisplaySiteData, SortField } from "~/types"
+import type { CurrencyMetricTotal, DisplaySiteData } from "~/types"
 import { ACCOUNT_TODAY_METRIC_STATUSES } from "~/types/accountTodayStats"
 import {
   calculateTotalBalanceForSites,
@@ -79,6 +73,7 @@ import DelAccountDialog from "../DelAccountDialog"
 import { InviteLinkManualCopyDialog } from "../InviteLinkManualCopyDialog"
 import AccountFilterBar from "./AccountFilterBar"
 import { NonSortableAccountListItem } from "./AccountListBaseItem"
+import { AccountListHeader } from "./AccountListHeader"
 import { AccountListInitialLoadingState } from "./AccountListLoadingState"
 import AccountSearchInput from "./AccountSearchInput"
 import {
@@ -1229,25 +1224,6 @@ export default function AccountList({ initialSearchQuery }: AccountListProps) {
     )
   }
 
-  const renderSortButton = (field: SortField, label: string) => (
-    <IconButton
-      onClick={() => handleSort(field)}
-      variant="ghost"
-      size="none"
-      disabled={inSearchMode}
-      aria-label={`${t("account:list.sort")} ${label}`}
-      className="space-x-0.5 text-[10px] font-medium sm:space-x-1 sm:text-xs"
-    >
-      <span>{label}</span>
-      {sortField === field &&
-        (sortOrder === "asc" ? (
-          <ChevronUp className="h-2.5 w-2.5 sm:h-3 sm:w-3" />
-        ) : (
-          <ChevronDown className="h-2.5 w-2.5 sm:h-3 sm:w-3" />
-        ))}
-    </IconButton>
-  )
-
   const listContent = (
     <CardList>
       {displayedResults.map((item) => {
@@ -1508,83 +1484,19 @@ export default function AccountList({ initialSearchQuery }: AccountListProps) {
           </div>
         </div>
 
-        {/* Header */}
-        <div className="dark:border-dark-bg-tertiary dark:bg-dark-bg-secondary sticky top-0 z-10 border-b border-gray-200 bg-gray-50 px-3 py-2 sm:px-5">
-          <div className="flex items-center justify-between gap-2 sm:gap-4">
-            {/* Account Name Column */}
-            <div className="flex min-w-0 flex-1 items-center gap-2">
-              <div className="flex min-w-0 items-center gap-0.5">
-                {renderSortButton("name", t("account:list.header.account"))}
-                <div className="dark:text-dark-text-tertiary text-[10px] text-gray-400 sm:text-xs">
-                  /
-                </div>
-                <div className="dark:text-dark-text-tertiary flex items-center text-[9px] text-gray-400 sm:text-[10px]">
-                  {renderSortButton(
-                    DATA_TYPE_CREATED_AT,
-                    t("account:list.header.createdAt"),
-                  )}
-                </div>
-              </div>
-              <span className="text-[10px] font-medium sm:text-xs">
-                {t("common:total") + ": " + displayedResults.length}
-              </span>
-              {sortField !== null && !inSearchMode ? (
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  className="h-7 shrink-0 px-2 text-xs"
-                  onClick={clearSortConfig}
-                  aria-label={t("account:list.clearSort")}
-                >
-                  {t("account:list.clearSort")}
-                </Button>
-              ) : null}
-              <Button
-                type="button"
-                variant={isBulkMode ? "secondary" : "outline"}
-                size="sm"
-                className="h-7 shrink-0 px-2 text-xs"
-                onClick={isBulkMode ? handleBulkModeExit : handleBulkModeEnter}
-                disabled={isBulkBusy}
-              >
-                {isBulkMode ? t("account:bulk.exit") : t("account:bulk.manage")}
-              </Button>
-            </div>
-
-            {/* Balance & Consumption Column */}
-            <div className="flex shrink-0 items-end gap-0.5">
-              <div className="flex items-center">
-                {renderSortButton(
-                  DATA_TYPE_BALANCE,
-                  t("account:list.header.balance"),
-                )}
-              </div>
-              {showTodayCashflow && (
-                <>
-                  <div className="dark:text-dark-text-tertiary text-[10px] text-gray-400 sm:text-xs">
-                    /
-                  </div>
-                  <div className="dark:text-dark-text-tertiary flex items-center text-[9px] text-gray-400 sm:text-[10px]">
-                    {renderSortButton(
-                      DATA_TYPE_CONSUMPTION,
-                      t("account:list.header.todayConsumption"),
-                    )}
-                  </div>
-                  <div className="dark:text-dark-text-tertiary text-[10px] text-gray-400 sm:text-xs">
-                    /
-                  </div>
-                  <div className="dark:text-dark-text-tertiary flex items-center text-[9px] text-gray-400 sm:text-[10px]">
-                    {renderSortButton(
-                      DATA_TYPE_INCOME,
-                      t("account:list.header.todayIncome"),
-                    )}
-                  </div>
-                </>
-              )}
-            </div>
-          </div>
-        </div>
+        <AccountListHeader
+          displayedResultCount={displayedResults.length}
+          inSearchMode={inSearchMode}
+          isBulkBusy={isBulkBusy}
+          isBulkMode={isBulkMode}
+          onBulkModeEnter={handleBulkModeEnter}
+          onBulkModeExit={handleBulkModeExit}
+          onClearSort={clearSortConfig}
+          onSort={handleSort}
+          showTodayCashflow={showTodayCashflow}
+          sortField={sortField}
+          sortOrder={sortOrder}
+        />
 
         {/* Account List or No Results */}
         {showFilteredSummary && displayedResults.length === 0 ? (

--- a/src/features/AccountManagement/testIds.ts
+++ b/src/features/AccountManagement/testIds.ts
@@ -1,3 +1,5 @@
+import type { SortField } from "~/types"
+
 export const ACCOUNT_MANAGEMENT_TEST_IDS = {
   addAccountButton: "account-management-add-account-button",
   externalCheckInButton: "account-management-external-check-in-button",
@@ -7,6 +9,10 @@ export const ACCOUNT_MANAGEMENT_TEST_IDS = {
   accountListUtilities: "account-management-account-list-utilities",
   accountListClearSortButton:
     "account-management-account-list-clear-sort-button",
+  accountListBulkManageButton:
+    "account-management-account-list-bulk-manage-button",
+  siteCheckInStatusButton: "account-management-site-check-in-status-button",
+  customCheckInStatusButton: "account-management-custom-check-in-status-button",
   accountDialog: "account-management-account-dialog",
   accountForm: "account-management-account-form",
   accountListView: "account-list-view",
@@ -114,6 +120,11 @@ export const ACCOUNT_MANAGEMENT_TEST_IDS = {
   sponsorFallbackApiCredentialProfilesAction:
     "account-management-sponsor-fallback-api-credential-profiles-action",
 } as const
+
+/** Returns a stable test id for an account-list sort control. */
+export function getAccountManagementSortButtonTestId(field: SortField) {
+  return `account-management-account-list-sort-${field}-button`
+}
 
 /**
  * Returns a stable test id for a rendered account row.

--- a/src/features/AccountManagement/testIds.ts
+++ b/src/features/AccountManagement/testIds.ts
@@ -2,6 +2,11 @@ export const ACCOUNT_MANAGEMENT_TEST_IDS = {
   addAccountButton: "account-management-add-account-button",
   externalCheckInButton: "account-management-external-check-in-button",
   headerActions: "account-management-header-actions",
+  accountListHeader: "account-management-account-list-header",
+  accountListSortControls: "account-management-account-list-sort-controls",
+  accountListUtilities: "account-management-account-list-utilities",
+  accountListClearSortButton:
+    "account-management-account-list-clear-sort-button",
   accountDialog: "account-management-account-dialog",
   accountForm: "account-management-account-form",
   accountListView: "account-list-view",

--- a/tests/features/AccountManagement/components/AccountList.checkInFilter.test.ts
+++ b/tests/features/AccountManagement/components/AccountList.checkInFilter.test.ts
@@ -56,6 +56,19 @@ describe("getAccountCheckInFilterValue", () => {
         getAccountCheckInFilterValue(
           buildDisplaySiteData({
             checkIn: {
+              enableDetection: true,
+              siteStatus: {
+                isCheckedInToday: true,
+              },
+            },
+          }),
+        ),
+      ).toBe("outdated")
+
+      expect(
+        getAccountCheckInFilterValue(
+          buildDisplaySiteData({
+            checkIn: {
               enableDetection: false,
             },
           }),

--- a/tests/features/AccountManagement/components/AccountList.test.tsx
+++ b/tests/features/AccountManagement/components/AccountList.test.tsx
@@ -157,18 +157,33 @@ vi.mock("@dnd-kit/sortable", () => ({
 }))
 
 vi.mock("~/components/ui", () => {
-  const MockInput = React.forwardRef<HTMLInputElement, any>(function MockInput(
-    { leftIcon, rightIcon, ...props },
-    ref,
-  ) {
-    return (
-      <div>
-        {leftIcon}
-        <input ref={ref} {...props} />
-        {rightIcon}
-      </div>
-    )
-  })
+  interface MockInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+    clearButtonLabel?: string
+    leftIcon?: React.ReactNode
+    onClear?: () => void
+    rightIcon?: React.ReactNode
+  }
+
+  const MockInput = React.forwardRef<HTMLInputElement, MockInputProps>(
+    function MockInput(
+      {
+        clearButtonLabel: _clearButtonLabel,
+        leftIcon,
+        onClear: _onClear,
+        rightIcon,
+        ...props
+      },
+      ref,
+    ) {
+      return (
+        <div>
+          {leftIcon}
+          <input ref={ref} {...props} />
+          {rightIcon}
+        </div>
+      )
+    },
+  )
 
   const MockTagFilter = ({ mode, options, value, onChange, allLabel }: any) => {
     const isSingleMode = mode === "single"

--- a/tests/features/AccountManagement/components/SiteInfo.test.tsx
+++ b/tests/features/AccountManagement/components/SiteInfo.test.tsx
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { SITE_TYPES } from "~/constants/siteType"
 import SiteInfo from "~/features/AccountManagement/components/AccountList/SiteInfo"
+import { ACCOUNT_MANAGEMENT_TEST_IDS } from "~/features/AccountManagement/testIds"
 import type { DisplaySiteData } from "~/types"
 import {
   AuthTypeEnum,
@@ -376,18 +377,20 @@ describe("SiteInfo", () => {
         />,
       )
 
-      const checkInActions = await screen.findAllByRole("button", {
-        name: "account:list.site.checkedInToday",
-      })
-      expect(checkInActions).toHaveLength(2)
+      const siteCheckInAction = await screen.findByTestId(
+        ACCOUNT_MANAGEMENT_TEST_IDS.siteCheckInStatusButton,
+      )
+      const customCheckInAction = await screen.findByTestId(
+        ACCOUNT_MANAGEMENT_TEST_IDS.customCheckInStatusButton,
+      )
 
-      await user.click(checkInActions[0])
+      await user.click(siteCheckInAction)
       expect(mockOpenCheckInPage).toHaveBeenCalledWith(
         expect.objectContaining({ id: "acc-1" }),
       )
       expect(mockHandleMarkCustomCheckInAsCheckedIn).not.toHaveBeenCalled()
 
-      await user.click(checkInActions[1])
+      await user.click(customCheckInAction)
       expect(mockHandleMarkCustomCheckInAsCheckedIn).toHaveBeenCalledWith(
         expect.objectContaining({ id: "acc-1" }),
       )

--- a/tests/features/AccountManagement/components/SiteInfo.test.tsx
+++ b/tests/features/AccountManagement/components/SiteInfo.test.tsx
@@ -4,8 +4,14 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { SITE_TYPES } from "~/constants/siteType"
 import SiteInfo from "~/features/AccountManagement/components/AccountList/SiteInfo"
-import { TEMP_WINDOW_HEALTH_STATUS_CODES } from "~/types"
+import type { DisplaySiteData } from "~/types"
+import {
+  AuthTypeEnum,
+  SiteHealthStatus,
+  TEMP_WINDOW_HEALTH_STATUS_CODES,
+} from "~/types"
 import { formatLocaleDateTime } from "~/utils/core/formatters"
+import { buildDisplaySiteData } from "~~/tests/test-utils/factories"
 import { render, screen, waitFor } from "~~/tests/test-utils/render"
 
 const createDeferred = <T,>() => {
@@ -140,8 +146,8 @@ vi.mock("~/utils/navigation", () => ({
   openSettingsTab: mockOpenSettingsTab,
 }))
 
-const buildSite = (overrides: Record<string, unknown> = {}) =>
-  ({
+const buildSite = (overrides: Partial<DisplaySiteData> = {}) =>
+  buildDisplaySiteData({
     id: "acc-1",
     disabled: false,
     name: "Site",
@@ -150,15 +156,15 @@ const buildSite = (overrides: Record<string, unknown> = {}) =>
     siteType: SITE_TYPES.UNKNOWN,
     token: "token",
     userId: "1",
-    authType: "access_token",
+    authType: AuthTypeEnum.AccessToken,
     balance: { USD: 0, CNY: 0 },
     todayConsumption: { USD: 0, CNY: 0 },
     todayIncome: { USD: 0, CNY: 0 },
     todayTokens: { upload: 0, download: 0 },
-    health: { status: "healthy" },
+    health: { status: SiteHealthStatus.Healthy },
     checkIn: { enableDetection: false },
     ...overrides,
-  }) as any
+  })
 
 describe("SiteInfo", () => {
   beforeEach(() => {
@@ -212,7 +218,9 @@ describe("SiteInfo", () => {
   it("renders the neutral health indicator for an unknown health status", () => {
     render(
       <SiteInfo
-        site={buildSite({ health: { status: "unexpected-status" } })}
+        site={buildSite({
+          health: { status: "unexpected-status" as SiteHealthStatus },
+        })}
       />,
     )
 
@@ -342,6 +350,55 @@ describe("SiteInfo", () => {
     }
   })
 
+  it("keeps provider and custom check-in actions independently actionable", async () => {
+    const user = userEvent.setup()
+    const dateNowSpy = vi
+      .spyOn(Date, "now")
+      .mockReturnValue(new Date(2026, 0, 2, 10, 0, 0).getTime())
+
+    try {
+      render(
+        <SiteInfo
+          site={buildSite({
+            checkIn: {
+              enableDetection: true,
+              siteStatus: {
+                isCheckedInToday: true,
+                lastDetectedAt: new Date(2026, 0, 2, 9, 0, 0).getTime(),
+              },
+              customCheckIn: {
+                url: "https://check-in.example.invalid",
+                isCheckedInToday: true,
+                openRedeemWithCheckIn: false,
+              },
+            },
+          })}
+        />,
+      )
+
+      const checkInActions = await screen.findAllByRole("button", {
+        name: "account:list.site.checkedInToday",
+      })
+      expect(checkInActions).toHaveLength(2)
+
+      await user.click(checkInActions[0])
+      expect(mockOpenCheckInPage).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "acc-1" }),
+      )
+      expect(mockHandleMarkCustomCheckInAsCheckedIn).not.toHaveBeenCalled()
+
+      await user.click(checkInActions[1])
+      expect(mockHandleMarkCustomCheckInAsCheckedIn).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "acc-1" }),
+      )
+      expect(mockOpenCustomCheckInPage).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "acc-1" }),
+      )
+    } finally {
+      dateNowSpy.mockRestore()
+    }
+  })
+
   it("hides View on LDOH when no match is available", async () => {
     getLdohSearchUrlForAccountUrlMock.mockReturnValue(null)
 
@@ -374,7 +431,7 @@ describe("SiteInfo", () => {
       <SiteInfo
         site={buildSite({
           health: {
-            status: "warning",
+            status: SiteHealthStatus.Warning,
             code: TEMP_WINDOW_HEALTH_STATUS_CODES.PERMISSION_REQUIRED,
             reason: "Permission required",
           },
@@ -406,7 +463,7 @@ describe("SiteInfo", () => {
       <SiteInfo
         site={buildSite({
           health: {
-            status: "warning",
+            status: SiteHealthStatus.Warning,
             code: TEMP_WINDOW_HEALTH_STATUS_CODES.DISABLED,
             reason: "Temp window fallback disabled",
           },
@@ -440,7 +497,7 @@ describe("SiteInfo", () => {
       <SiteInfo
         site={buildSite({
           health: {
-            status: "warning",
+            status: SiteHealthStatus.Warning,
             code: TEMP_WINDOW_HEALTH_STATUS_CODES.PERMISSION_REQUIRED,
             reason: "Permission required",
           },

--- a/tests/features/AccountManagement/components/SiteInfo.test.tsx
+++ b/tests/features/AccountManagement/components/SiteInfo.test.tsx
@@ -216,6 +216,13 @@ describe("SiteInfo", () => {
     )
   })
 
+  it("renders plain tags without search highlights", () => {
+    render(<SiteInfo site={buildSite({ tags: ["team", "backup"] })} />)
+
+    expect(screen.getByTitle("team, backup")).toHaveTextContent("team, backup")
+    expect(document.querySelector("mark")).toBeNull()
+  })
+
   it("renders the neutral health indicator for an unknown health status", () => {
     render(
       <SiteInfo

--- a/tests/features/AccountManagement/components/SiteInfo.test.tsx
+++ b/tests/features/AccountManagement/components/SiteInfo.test.tsx
@@ -219,8 +219,10 @@ describe("SiteInfo", () => {
   it("renders plain tags without search highlights", () => {
     render(<SiteInfo site={buildSite({ tags: ["team", "backup"] })} />)
 
-    expect(screen.getByTitle("team, backup")).toHaveTextContent("team, backup")
-    expect(document.querySelector("mark")).toBeNull()
+    const tags = screen.getByTitle("team, backup")
+
+    expect(tags).toHaveTextContent("team, backup")
+    expect(tags.querySelector("mark")).toBeNull()
   })
 
   it("renders the neutral health indicator for an unknown health status", () => {


### PR DESCRIPTION
## Summary

- Keep account-list sorting, clear-sort, result-count, and bulk-management controls reachable without overlap at constrained desktop and mobile widths.
- Extract the responsive list header while preserving existing sorting, search, and bulk-action behavior.
- Clarify provider and custom check-in indicators and share their current-day status detection logic.

## Validation

- `pnpm compile`
- `pnpm exec vitest --run tests/features/AccountManagement/components/AccountList.test.tsx tests/features/AccountManagement/components/SiteInfo.test.tsx tests/features/AccountManagement/components/AccountList.checkInFilter.test.ts` — 72 tests passed
- `pnpm exec playwright test e2e/accountManagementCommonFlows.spec.ts --grep "keeps account management controls reachable"` — build and Chromium checks passed
- Pre-commit staged validation passed for both commits
- Pre-push `pnpm run validate:push` passed (`compile` and `knip`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a responsive account-list header with sorting, result counts, clear-sort controls, and bulk-management actions.
  - Added sortable account fields, including today’s cashflow, with visual sort indicators.
  - Improved check-in status and custom status displays with clearer indicators and independently actionable controls.

- **Bug Fixes**
  - Improved responsive layout behavior across desktop and mobile screen sizes.
  - Refined same-day check-in detection and account-list status presentation.

- **Tests**
  - Expanded coverage for responsive layouts, sorting controls, bulk actions, check-in actions, and health-status displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->