### PR TITLE
fix(sub2api): detect deployment site name

### DIFF
--- a/src/services/apiService/sub2api/index.ts
+++ b/src/services/apiService/sub2api/index.ts
@@ -611,17 +611,14 @@ const fetchSub2ApiData = async <T>(
 }
 
 /**
- * Fetch an opt-in Sub2API affiliate link from the deployment that owns the account.
- * The settings route is public, while the affiliate detail route uses the saved
- * dashboard JWT; the frontend builds a same-origin `/register?aff=` URL.
- * https://github.com/Wei-Shaw/sub2api/blob/main/backend/internal/handler/setting_handler.go
- * https://github.com/Wei-Shaw/sub2api/blob/main/backend/internal/handler/user_handler.go
- * https://github.com/Wei-Shaw/sub2api/blob/main/frontend/src/views/user/AffiliateView.vue
+ * Fetch deployment-owned settings that Sub2API exposes without authentication.
+ * Source: https://github.com/Wei-Shaw/sub2api/blob/2bc139ab527b4a687546d145dc7bb9063cf14510/backend/internal/handler/dto/settings.go
+ * `PublicSettings.site_name` is the canonical public deployment name.
  */
-export async function fetchInviteLink(
+const fetchSub2ApiPublicSettings = async (
   request: ApiServiceRequest,
-): Promise<string> {
-  const publicSettingsBody = await fetchApi<unknown>(
+): Promise<Sub2ApiPublicSettingsData | undefined> => {
+  const body = await fetchApi<unknown>(
     {
       ...request,
       auth: { authType: AuthTypeEnum.None },
@@ -632,11 +629,26 @@ export async function fetchInviteLink(
     },
     true,
   )
-  const publicSettings = parseSub2ApiEnvelope<Sub2ApiPublicSettingsData>(
-    publicSettingsBody,
+
+  return parseSub2ApiEnvelope<Sub2ApiPublicSettingsData>(
+    body,
     SUB2API_PUBLIC_SETTINGS_ENDPOINT,
     { allowMissingData: true },
   )
+}
+
+/**
+ * Fetch an opt-in Sub2API affiliate link from the deployment that owns the account.
+ * The settings route is public, while the affiliate detail route uses the saved
+ * dashboard JWT; the frontend builds a same-origin `/register?aff=` URL.
+ * https://github.com/Wei-Shaw/sub2api/blob/main/backend/internal/handler/setting_handler.go
+ * https://github.com/Wei-Shaw/sub2api/blob/main/backend/internal/handler/user_handler.go
+ * https://github.com/Wei-Shaw/sub2api/blob/main/frontend/src/views/user/AffiliateView.vue
+ */
+export async function fetchInviteLink(
+  request: ApiServiceRequest,
+): Promise<string> {
+  const publicSettings = await fetchSub2ApiPublicSettings(request)
 
   if (
     !publicSettings ||
@@ -1198,15 +1210,33 @@ export async function getOrCreateAccessToken(
 }
 
 /**
- * Sub2API does not expose the One-API-style public `/api/status` endpoint.
- * Return a synthetic status payload so shared callers can skip that request and
- * still treat built-in check-in as unsupported.
+ * Sub2API does not expose the One-API-style public `/api/status` endpoint, so
+ * adapt its native public settings into the shared status contract. Name lookup
+ * remains optional so a transient settings failure cannot block account setup.
  */
 export async function fetchSiteStatus(
-  _request: ApiServiceRequest,
+  request: ApiServiceRequest,
 ): Promise<SiteStatusInfo> {
-  return {
-    checkin_enabled: false,
+  try {
+    const publicSettings = await fetchSub2ApiPublicSettings(request)
+    const siteName =
+      typeof publicSettings?.site_name === "string"
+        ? publicSettings.site_name.trim()
+        : ""
+
+    return {
+      ...(siteName ? { system_name: siteName } : {}),
+      checkin_enabled: false,
+    }
+  } catch (error) {
+    logger.warn("Failed to fetch optional Sub2API site name", {
+      endpoint: SUB2API_PUBLIC_SETTINGS_ENDPOINT,
+      error: getSafeErrorMessage(error),
+    })
+
+    return {
+      checkin_enabled: false,
+    }
   }
 }
 

--- a/src/services/apiService/sub2api/type.ts
+++ b/src/services/apiService/sub2api/type.ts
@@ -51,6 +51,7 @@ export type Sub2ApiAuthMeResponse = Sub2ApiEnvelope<Sub2ApiAuthMeData>
 
 export type Sub2ApiPublicSettingsData = {
   affiliate_enabled?: boolean | null
+  site_name?: string | null
 }
 
 export type Sub2ApiAffiliateData = {

--- a/tests/services/accountOperations.autoDetectAccount.test.ts
+++ b/tests/services/accountOperations.autoDetectAccount.test.ts
@@ -436,7 +436,10 @@ describe("accountOperations autoDetectAccount", () => {
       },
     })
 
-    mockFetchSiteStatus.mockResolvedValueOnce(null)
+    mockFetchSiteStatus.mockResolvedValueOnce({
+      system_name: "Example Portal",
+      checkin_enabled: false,
+    })
     mockExtractDefaultExchangeRate.mockReturnValueOnce(null)
 
     const result = await autoDetectAccount(
@@ -448,6 +451,7 @@ describe("accountOperations autoDetectAccount", () => {
     expect(result.success).toBe(true)
     expect(result.data?.siteType).toBe(SITE_TYPES.SUB2API)
     expect(result.data?.username).toBe("")
+    expect(result.data?.siteName).toBe("Example Portal")
     expect(result.data?.accessToken).toBe("jwt-token")
     expect(result.data?.exchangeRate).toBe(UI_CONSTANTS.EXCHANGE_RATE.DEFAULT)
     expect(mockFetchSiteStatus).toHaveBeenCalledTimes(1)

--- a/tests/services/apiService/sub2api/index.test.ts
+++ b/tests/services/apiService/sub2api/index.test.ts
@@ -2158,6 +2158,18 @@ describe("apiService sub2api exported operations", () => {
     )
   })
 
+  it("keeps synthetic status when public settings have no site name", async () => {
+    vi.mocked(fetchApi).mockResolvedValueOnce({
+      code: 0,
+      message: "ok",
+      data: { site_name: null },
+    } as any)
+
+    await expect(fetchSiteStatus(baseRequest as any)).resolves.toEqual({
+      checkin_enabled: false,
+    })
+  })
+
   it("keeps synthetic Sub2API status when the optional public name lookup fails", async () => {
     vi.mocked(fetchApi).mockRejectedValueOnce(
       new Error("public settings unavailable"),

--- a/tests/services/apiService/sub2api/index.test.ts
+++ b/tests/services/apiService/sub2api/index.test.ts
@@ -2133,12 +2133,39 @@ describe("apiService sub2api exported operations", () => {
     })
   })
 
-  it("provides an explicit synthetic site status instead of calling /api/status", async () => {
+  it("maps the public Sub2API site name into the account status contract", async () => {
+    vi.mocked(fetchApi).mockResolvedValueOnce({
+      code: 0,
+      message: "ok",
+      data: { site_name: "  Example Portal  " },
+    } as any)
+
     await expect(fetchSiteStatus(baseRequest as any)).resolves.toEqual({
+      system_name: "Example Portal",
       checkin_enabled: false,
     })
 
-    expect(vi.mocked(fetchApi)).not.toHaveBeenCalled()
+    expect(vi.mocked(fetchApi)).toHaveBeenCalledWith(
+      {
+        ...baseRequest,
+        auth: { authType: AuthTypeEnum.None },
+      },
+      {
+        endpoint: "/api/v1/settings/public",
+        options: { method: "GET", cache: "no-store" },
+      },
+      true,
+    )
+  })
+
+  it("keeps synthetic Sub2API status when the optional public name lookup fails", async () => {
+    vi.mocked(fetchApi).mockRejectedValueOnce(
+      new Error("public settings unavailable"),
+    )
+
+    await expect(fetchSiteStatus(baseRequest as any)).resolves.toEqual({
+      checkin_enabled: false,
+    })
   })
 
   it("reuses the common exchange-rate extraction contract for status payloads", () => {


### PR DESCRIPTION
## Summary

- load Sub2API's deployment name from its public settings endpoint during account bootstrap
- map the provider-native `site_name` field into the shared site-name contract
- reuse the existing public-settings request used by affiliate-link discovery
- preserve domain fallback when the optional name request fails or returns no usable name

## Root cause

Sub2API does not expose the One API-style `/api/status` endpoint. Its bootstrap adapter therefore returned only a synthetic check-in status, so auto-detection never received a site name and fell back to the domain whenever the page title was unavailable or matched a default product title.

Sub2API exposes the configured deployment name through `GET /api/v1/settings/public` as `site_name`.

## Validation

- `pnpm exec vitest run tests/services/accountOperations.autoDetectAccount.test.ts tests/services/apiService/sub2api/index.test.ts tests/services/apiAdapters/sub2api/accountCompletion.test.ts` — 141 tests passed
- `pnpm compile` — passed
- `pnpm run validate:push` — passed via the pre-push hook

Full-suite coverage and browser E2E are left to CI. The changed behavior is confined to the Sub2API protocol mapping and account auto-detection data path; there are no UI, persistence, locale, or schema changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Site status now displays the configured Sub2API site name when available.
  * Account auto-detection includes the detected site name.
  * Invite-link and site-status checks can retrieve public deployment settings without authentication.

* **Bug Fixes**
  * Site status remains available with check-in disabled when public settings cannot be retrieved.
  * Missing or blank site names no longer prevent status information from being returned.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->