### PR TITLE
fix(cc-switch): resolve Codex endpoint from model discovery

### DIFF
--- a/src/components/CCSwitchExportDialog.tsx
+++ b/src/components/CCSwitchExportDialog.tsx
@@ -17,7 +17,7 @@ import {
   SelectValue,
 } from "~/components/ui"
 import { resolveExportTokenForSecret } from "~/services/accounts/utils/exportTokenSecret"
-import { fetchOpenAICompatibleModelIds } from "~/services/aiApi/openaiCompatible"
+import { discoverOpenAICompatibleModels } from "~/services/aiApi/openaiCompatible"
 import {
   CCSWITCH_APPS,
   openInCCSwitch,
@@ -65,6 +65,16 @@ const APP_LIMITATION_NOTICE_ID = "ccswitch-app-limitation"
 // Preserve the real debounce in dev/prod so endpoint edits do not spam model-list
 // requests, but skip the wall-clock delay in Vitest.
 const UPSTREAM_MODEL_FETCH_DEBOUNCE_MS = isTestMode() ? 0 : 300
+
+const getConservativeCodexEndpoint = (baseUrl: string) => {
+  const normalizedBaseUrl = normalizeHttpUrl(baseUrl)
+  if (!normalizedBaseUrl) return baseUrl
+
+  const path = new URL(normalizedBaseUrl).pathname.replace(/\/+$/, "")
+  return path
+    ? normalizedBaseUrl
+    : coerceBaseUrlToPathSuffix(normalizedBaseUrl, "/v1")
+}
 
 const getCCSwitchAppLabel = (t: TFunction, app: CCSwitchApp) => {
   switch (app) {
@@ -115,14 +125,26 @@ export function CCSwitchExportDialog(props: CCSwitchExportDialogProps) {
   const [notes, setNotes] = useState("")
   const [providerName, setProviderName] = useState(account.name)
   const [homepage, setHomepage] = useState(account.baseUrl)
+  // CC Switch writes this directly to Codex's provider base_url. Model discovery
+  // confirms whether the compatible route uses `/v1`; provider paths remain intact.
+  // https://github.com/farion1231/cc-switch/blob/0b5da510168914b251481654a568c3ffacd62cf4/src-tauri/src/deeplink/provider.rs
+  // https://developers.openai.com/api/reference/cli/resources/responses/methods/create
   const [endpoint, setEndpoint] = useState(account.baseUrl)
   const [isEndpointCustomized, setIsEndpointCustomized] = useState(false)
+  const [codexEndpointDiscovery, setCodexEndpointDiscovery] = useState<{
+    sourceBaseUrl: string
+    resolvedBaseUrl: string
+  } | null>(null)
   const [upstreamModelOptions, setUpstreamModelOptions] = useState<
     { value: string; label: string }[]
   >([])
   const [isLoadingModels, setIsLoadingModels] = useState(false)
   const formId = useMemo(() => `ccswitch-export-form-${token.id}`, [token.id])
   const limitationNotice = getCCSwitchLimitationNotice(t, app)
+  const upstreamBaseUrl = useMemo(() => {
+    const normalizedEndpoint = normalizeHttpUrl(endpoint)
+    return normalizedEndpoint ? stripTrailingOpenAIV1(normalizedEndpoint) : ""
+  }, [endpoint])
 
   useEffect(() => {
     if (isOpen) {
@@ -133,6 +155,7 @@ export function CCSwitchExportDialog(props: CCSwitchExportDialogProps) {
       setHomepage(account.baseUrl)
       setEndpoint(account.baseUrl)
       setIsEndpointCustomized(false)
+      setCodexEndpointDiscovery(null)
       setUpstreamModelOptions([])
       setIsLoadingModels(false)
     }
@@ -140,24 +163,7 @@ export function CCSwitchExportDialog(props: CCSwitchExportDialogProps) {
 
   useEffect(() => {
     if (!isOpen) return
-    if (isEndpointCustomized) return
 
-    // CC Switch expects Codex exports to default to an OpenAI-style /v1 endpoint,
-    // while OpenCode/OpenClaw should keep the stored base URL unless the user overrides it.
-    const defaultEndpoint =
-      app === "codex"
-        ? coerceBaseUrlToPathSuffix(account.baseUrl, "/v1")
-        : account.baseUrl
-    setEndpoint(defaultEndpoint)
-  }, [account.baseUrl, app, isEndpointCustomized, isOpen])
-
-  useEffect(() => {
-    if (!isOpen) return
-
-    const normalizedEndpoint = normalizeHttpUrl(endpoint)
-    const upstreamBaseUrl = normalizedEndpoint
-      ? stripTrailingOpenAIV1(normalizedEndpoint)
-      : ""
     if (!upstreamBaseUrl) {
       setUpstreamModelOptions([])
       setIsLoadingModels(false)
@@ -173,23 +179,28 @@ export function CCSwitchExportDialog(props: CCSwitchExportDialogProps) {
             account,
             token,
           )
-          const modelIds = await fetchOpenAICompatibleModelIds({
+          const discovery = await discoverOpenAICompatibleModels({
             baseUrl: upstreamBaseUrl,
             apiKey: resolvedToken.key,
           })
-          const normalized = modelIds
-            .map((item) => (typeof item === "string" ? item.trim() : ""))
+          const normalized = discovery.models
+            .map((item) => item.id.trim())
             .filter(Boolean)
             .sort((a, b) => a.localeCompare(b))
             .map((id) => ({ value: id, label: id }))
 
           if (isMounted) {
             setUpstreamModelOptions(normalized)
+            setCodexEndpointDiscovery({
+              sourceBaseUrl: upstreamBaseUrl,
+              resolvedBaseUrl: discovery.resolvedBaseUrl,
+            })
           }
         } catch (error) {
           logger.warn("Failed to fetch upstream model list", error)
           if (isMounted) {
             setUpstreamModelOptions([])
+            setCodexEndpointDiscovery(null)
           }
         } finally {
           if (isMounted) {
@@ -203,7 +214,29 @@ export function CCSwitchExportDialog(props: CCSwitchExportDialogProps) {
       isMounted = false
       clearTimeout(handle)
     }
-  }, [account, endpoint, isOpen, token])
+  }, [account, isOpen, token, upstreamBaseUrl])
+
+  useEffect(() => {
+    if (!isOpen || isEndpointCustomized) return
+
+    if (app !== "codex") {
+      setEndpoint(account.baseUrl)
+      return
+    }
+
+    const resolvedEndpoint =
+      codexEndpointDiscovery?.sourceBaseUrl === upstreamBaseUrl
+        ? codexEndpointDiscovery.resolvedBaseUrl
+        : getConservativeCodexEndpoint(account.baseUrl)
+    setEndpoint(resolvedEndpoint)
+  }, [
+    account.baseUrl,
+    app,
+    codexEndpointDiscovery,
+    isEndpointCustomized,
+    isOpen,
+    upstreamBaseUrl,
+  ])
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()

--- a/src/services/aiApi/openaiCompatible/index.ts
+++ b/src/services/aiApi/openaiCompatible/index.ts
@@ -1,3 +1,4 @@
+import { ApiError } from "~/services/apiTransport/errors"
 import { fetchApiData } from "~/services/apiTransport/request"
 import type {
   OpenAIAuthParams,
@@ -6,6 +7,7 @@ import type {
 } from "~/services/apiTransport/type"
 import { AuthTypeEnum } from "~/types"
 import { createLogger } from "~/utils/core/logger"
+import { coerceBaseUrlToPathSuffix, normalizeHttpUrl } from "~/utils/core/url"
 
 /**
  * Unified logger scoped to OpenAI-compatible upstream model fetch helpers.
@@ -17,7 +19,43 @@ const logger = createLogger("AiApi.OpenAICompatible")
 // Volcengine Ark Coding Plan: https://docs.volcengine.com/docs/82379/2160841
 const OPENAI_COMPATIBLE_MODELS_ENDPOINTS = ["/v1/models", "/models"] as const
 
-export const fetchOpenAICompatibleModels = async (params: OpenAIAuthParams) => {
+interface OpenAICompatibleModelDiscovery {
+  models: UpstreamModelList
+  resolvedBaseUrl: string
+}
+
+const isModelList = (value: unknown): value is UpstreamModelList =>
+  Array.isArray(value) &&
+  value.every(
+    (item) =>
+      typeof item === "object" &&
+      item !== null &&
+      typeof (item as { id?: unknown }).id === "string",
+  )
+
+const isMissingModelRoute = (error: unknown) =>
+  error instanceof ApiError &&
+  (error.statusCode === 404 || error.statusCode === 405)
+
+const resolveBaseUrlForModelEndpoint = (
+  baseUrl: string,
+  endpoint: (typeof OPENAI_COMPATIBLE_MODELS_ENDPOINTS)[number],
+) => {
+  const normalizedBaseUrl =
+    normalizeHttpUrl(baseUrl) ?? baseUrl.trim().replace(/\/+$/, "")
+  return endpoint === "/v1/models"
+    ? coerceBaseUrlToPathSuffix(normalizedBaseUrl, "/v1")
+    : normalizedBaseUrl
+}
+
+/**
+ * Discovers models and retains the API base URL confirmed by that same request.
+ * Only route-level 404/405 responses justify trying the path-preserving fallback;
+ * authentication, throttling, server, and network failures are inconclusive.
+ */
+export const discoverOpenAICompatibleModels = async (
+  params: OpenAIAuthParams,
+): Promise<OpenAICompatibleModelDiscovery> => {
   const request = {
     baseUrl: params.baseUrl,
     auth: {
@@ -26,14 +64,28 @@ export const fetchOpenAICompatibleModels = async (params: OpenAIAuthParams) => {
     },
   }
   let lastError: unknown
-  for (const endpoint of OPENAI_COMPATIBLE_MODELS_ENDPOINTS) {
+  for (const [
+    index,
+    endpoint,
+  ] of OPENAI_COMPATIBLE_MODELS_ENDPOINTS.entries()) {
     try {
-      return await fetchApiData<UpstreamModelList>(request, {
+      const models = await fetchApiData<unknown>(request, {
         endpoint,
         ...(params.abortSignal
           ? { options: { signal: params.abortSignal } }
           : {}),
       })
+      if (!isModelList(models)) {
+        throw new TypeError("Upstream returned an invalid model list")
+      }
+
+      return {
+        models,
+        resolvedBaseUrl: resolveBaseUrlForModelEndpoint(
+          params.baseUrl,
+          endpoint,
+        ),
+      }
     } catch (error) {
       if (
         params.abortSignal?.aborted ||
@@ -42,12 +94,22 @@ export const fetchOpenAICompatibleModels = async (params: OpenAIAuthParams) => {
         throw error
       }
       lastError = error
+      const hasFallback = index < OPENAI_COMPATIBLE_MODELS_ENDPOINTS.length - 1
+      if (hasFallback && isMissingModelRoute(error)) {
+        continue
+      }
+
+      logger.error("Failed to fetch upstream model list", error)
+      throw error
     }
   }
 
   logger.error("Failed to fetch upstream model list", lastError)
   throw lastError
 }
+
+export const fetchOpenAICompatibleModels = async (params: OpenAIAuthParams) =>
+  (await discoverOpenAICompatibleModels(params)).models
 
 export const fetchOpenAICompatibleModelIds = async (
   params: OpenAIAuthParams,

--- a/tests/components/CCSwitchExportDialog.test.tsx
+++ b/tests/components/CCSwitchExportDialog.test.tsx
@@ -18,9 +18,13 @@ import {
 import type { ApiCredentialProfile } from "~/types/apiCredentialProfiles"
 import { render, screen, waitFor } from "~~/tests/test-utils/render"
 
-const mockFetchOpenAICompatibleModelIds = vi.fn()
+const mockDiscoverOpenAICompatibleModels = vi.fn()
 const mockOpenInCCSwitch = vi.fn()
 const mockResolveDisplayAccountTokenForSecret = vi.fn()
+const createModelDiscovery = (
+  models: { id: string }[] = [],
+  resolvedBaseUrl = "https://x.test/v1",
+) => ({ models, resolvedBaseUrl })
 const { startProductAnalyticsActionMock, completeProductAnalyticsActionMock } =
   vi.hoisted(() => ({
     startProductAnalyticsActionMock: vi.fn(),
@@ -43,8 +47,8 @@ vi.mock(
 )
 
 vi.mock("~/services/aiApi/openaiCompatible", () => ({
-  fetchOpenAICompatibleModelIds: (...args: any[]) =>
-    mockFetchOpenAICompatibleModelIds(...args),
+  discoverOpenAICompatibleModels: (...args: any[]) =>
+    mockDiscoverOpenAICompatibleModels(...args),
 }))
 
 vi.mock("~/services/integrations/ccSwitch", async (importOriginal) => {
@@ -62,7 +66,7 @@ vi.mock("~/services/productAnalytics/actions", () => ({
 
 describe("CCSwitchExportDialog", () => {
   beforeEach(() => {
-    mockFetchOpenAICompatibleModelIds.mockReset()
+    mockDiscoverOpenAICompatibleModels.mockReset()
     mockOpenInCCSwitch.mockReset()
     mockResolveDisplayAccountTokenForSecret.mockReset()
     startProductAnalyticsActionMock.mockReset()
@@ -78,7 +82,9 @@ describe("CCSwitchExportDialog", () => {
 
   it("exposes stable test ids for E2E flows", async () => {
     const user = userEvent.setup()
-    mockFetchOpenAICompatibleModelIds.mockResolvedValueOnce([])
+    mockDiscoverOpenAICompatibleModels.mockResolvedValueOnce(
+      createModelDiscovery(),
+    )
 
     render(
       <CCSwitchExportDialog
@@ -111,7 +117,9 @@ describe("CCSwitchExportDialog", () => {
   })
 
   it("places the app selector before provider details", async () => {
-    mockFetchOpenAICompatibleModelIds.mockResolvedValueOnce([])
+    mockDiscoverOpenAICompatibleModels.mockResolvedValueOnce(
+      createModelDiscovery(),
+    )
 
     render(
       <CCSwitchExportDialog
@@ -139,7 +147,9 @@ describe("CCSwitchExportDialog", () => {
 
   it("loads upstream model ids and exposes them as a selectable default model", async () => {
     const user = userEvent.setup()
-    mockFetchOpenAICompatibleModelIds.mockResolvedValueOnce(["gpt-4", "claude"])
+    mockDiscoverOpenAICompatibleModels.mockResolvedValueOnce(
+      createModelDiscovery([{ id: "gpt-4" }, { id: "claude" }]),
+    )
 
     render(
       <CCSwitchExportDialog
@@ -153,7 +163,7 @@ describe("CCSwitchExportDialog", () => {
     )
 
     await waitFor(() => {
-      expect(mockFetchOpenAICompatibleModelIds).toHaveBeenCalledWith({
+      expect(mockDiscoverOpenAICompatibleModels).toHaveBeenCalledWith({
         baseUrl: "https://x.test",
         apiKey: "sk-test",
       })
@@ -166,16 +176,22 @@ describe("CCSwitchExportDialog", () => {
     expect(await screen.findByText("gpt-4")).toBeInTheDocument()
   })
 
-  it("appends /v1 to the default endpoint when switching to Codex", async () => {
+  it("uses the endpoint confirmed by model discovery for Codex", async () => {
     const user = userEvent.setup()
-    mockFetchOpenAICompatibleModelIds.mockResolvedValue([])
+    mockDiscoverOpenAICompatibleModels.mockResolvedValue(
+      createModelDiscovery([], "https://ark.example.invalid/api/v3"),
+    )
 
     render(
       <CCSwitchExportDialog
         isOpen={true}
         onClose={() => {}}
         account={
-          { id: "acc", name: "Example", baseUrl: "https://x.test" } as any
+          {
+            id: "acc",
+            name: "Example",
+            baseUrl: "https://ark.example.invalid/api/v3",
+          } as any
         }
         token={{ id: "tok", key: "sk-test" } as any}
       />,
@@ -184,7 +200,14 @@ describe("CCSwitchExportDialog", () => {
     const endpointInput = await screen.findByLabelText(
       "ui:dialog.ccswitch.fields.endpoint",
     )
-    expect(endpointInput).toHaveValue("https://x.test")
+    expect(endpointInput).toHaveValue("https://ark.example.invalid/api/v3")
+
+    await waitFor(() => {
+      expect(mockDiscoverOpenAICompatibleModels).toHaveBeenCalledWith({
+        baseUrl: "https://ark.example.invalid/api/v3",
+        apiKey: "sk-test",
+      })
+    })
 
     const appSelect = await screen.findByLabelText(
       "ui:dialog.ccswitch.fields.app",
@@ -197,9 +220,96 @@ describe("CCSwitchExportDialog", () => {
     )
 
     await waitFor(() => {
-      expect(endpointInput).toHaveValue("https://x.test/v1")
+      expect(endpointInput).toHaveValue("https://ark.example.invalid/api/v3")
     })
   })
+
+  it("uses a discovered /v1 endpoint for Codex without another model request", async () => {
+    const user = userEvent.setup()
+    mockDiscoverOpenAICompatibleModels.mockResolvedValue(
+      createModelDiscovery([], "https://x.test/v1"),
+    )
+
+    render(
+      <CCSwitchExportDialog
+        isOpen={true}
+        onClose={() => {}}
+        account={
+          { id: "acc", name: "Example", baseUrl: "https://x.test" } as any
+        }
+        token={{ id: "tok", key: "sk-test" } as any}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(mockDiscoverOpenAICompatibleModels).toHaveBeenCalledTimes(1)
+    })
+
+    const endpointInput = screen.getByLabelText(
+      "ui:dialog.ccswitch.fields.endpoint",
+    )
+    const appSelect = screen.getByLabelText("ui:dialog.ccswitch.fields.app")
+    await user.click(appSelect)
+    await user.click(
+      await screen.findByRole("option", {
+        name: "ui:dialog.ccswitch.appOptions.codex",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(endpointInput).toHaveValue("https://x.test/v1")
+    })
+    expect(mockDiscoverOpenAICompatibleModels).toHaveBeenCalledTimes(1)
+  })
+
+  it.each([
+    {
+      baseUrl: "https://x.test",
+      expectedEndpoint: "https://x.test/v1",
+    },
+    {
+      baseUrl: "https://ark.example.invalid/api/v3",
+      expectedEndpoint: "https://ark.example.invalid/api/v3",
+    },
+  ])(
+    "uses the conservative Codex fallback for $baseUrl when discovery is inconclusive",
+    async ({ baseUrl, expectedEndpoint }) => {
+      const user = userEvent.setup()
+      mockDiscoverOpenAICompatibleModels.mockRejectedValue(
+        new Error("network error"),
+      )
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {})
+
+      render(
+        <CCSwitchExportDialog
+          isOpen={true}
+          onClose={() => {}}
+          account={{ id: "acc", name: "Example", baseUrl } as any}
+          token={{ id: "tok", key: "sk-test" } as any}
+        />,
+      )
+
+      await waitFor(() => {
+        expect(mockDiscoverOpenAICompatibleModels).toHaveBeenCalled()
+      })
+
+      const endpointInput = screen.getByLabelText(
+        "ui:dialog.ccswitch.fields.endpoint",
+      )
+      const appSelect = screen.getByLabelText("ui:dialog.ccswitch.fields.app")
+      await user.click(appSelect)
+      await user.click(
+        await screen.findByRole("option", {
+          name: "ui:dialog.ccswitch.appOptions.codex",
+        }),
+      )
+
+      await waitFor(() => {
+        expect(endpointInput).toHaveValue(expectedEndpoint)
+      })
+      warnSpy.mockRestore()
+    },
+  )
 
   it.each([
     "ui:dialog.ccswitch.appOptions.opencode",
@@ -208,7 +318,9 @@ describe("CCSwitchExportDialog", () => {
     "keeps the stored base URL as the default endpoint for %s",
     async (appLabel) => {
       const user = userEvent.setup()
-      mockFetchOpenAICompatibleModelIds.mockResolvedValue([])
+      mockDiscoverOpenAICompatibleModels.mockResolvedValue(
+        createModelDiscovery(),
+      )
 
       render(
         <CCSwitchExportDialog
@@ -258,7 +370,9 @@ describe("CCSwitchExportDialog", () => {
     "shows the protocol limitation notice for $appLabel",
     async ({ appLabel, notice }) => {
       const user = userEvent.setup()
-      mockFetchOpenAICompatibleModelIds.mockResolvedValue([])
+      mockDiscoverOpenAICompatibleModels.mockResolvedValue(
+        createModelDiscovery(),
+      )
 
       render(
         <CCSwitchExportDialog
@@ -307,7 +421,9 @@ describe("CCSwitchExportDialog", () => {
     "submits the selected $app CC Switch app",
     async ({ app, appLabel }) => {
       const user = userEvent.setup()
-      mockFetchOpenAICompatibleModelIds.mockResolvedValue([])
+      mockDiscoverOpenAICompatibleModels.mockResolvedValue(
+        createModelDiscovery(),
+      )
 
       render(
         <CCSwitchExportDialog
@@ -341,7 +457,7 @@ describe("CCSwitchExportDialog", () => {
 
   it("does not show the limitation notice for Codex", async () => {
     const user = userEvent.setup()
-    mockFetchOpenAICompatibleModelIds.mockResolvedValue([])
+    mockDiscoverOpenAICompatibleModels.mockResolvedValue(createModelDiscovery())
 
     render(
       <CCSwitchExportDialog
@@ -371,7 +487,7 @@ describe("CCSwitchExportDialog", () => {
 
   it("preserves a custom endpoint when switching between CC Switch apps", async () => {
     const user = userEvent.setup()
-    mockFetchOpenAICompatibleModelIds.mockResolvedValue([])
+    mockDiscoverOpenAICompatibleModels.mockResolvedValue(createModelDiscovery())
 
     render(
       <CCSwitchExportDialog
@@ -419,7 +535,7 @@ describe("CCSwitchExportDialog", () => {
   })
 
   it("keeps the model picker usable when upstream model fetch fails", async () => {
-    mockFetchOpenAICompatibleModelIds.mockRejectedValueOnce(
+    mockDiscoverOpenAICompatibleModels.mockRejectedValueOnce(
       new Error("network error"),
     )
 
@@ -436,7 +552,7 @@ describe("CCSwitchExportDialog", () => {
     )
 
     await waitFor(() => {
-      expect(mockFetchOpenAICompatibleModelIds).toHaveBeenCalled()
+      expect(mockDiscoverOpenAICompatibleModels).toHaveBeenCalled()
     })
 
     const modelCombo = await screen.findByLabelText(
@@ -449,7 +565,9 @@ describe("CCSwitchExportDialog", () => {
   })
 
   it("prefills notes from the API token note field", async () => {
-    mockFetchOpenAICompatibleModelIds.mockResolvedValueOnce([])
+    mockDiscoverOpenAICompatibleModels.mockResolvedValueOnce(
+      createModelDiscovery(),
+    )
 
     render(
       <CCSwitchExportDialog
@@ -470,7 +588,7 @@ describe("CCSwitchExportDialog", () => {
   it("tracks successful CC Switch exports without sensitive metadata", async () => {
     const user = userEvent.setup()
     const onClose = vi.fn()
-    mockFetchOpenAICompatibleModelIds.mockResolvedValue([])
+    mockDiscoverOpenAICompatibleModels.mockResolvedValue(createModelDiscovery())
 
     render(
       <CCSwitchExportDialog
@@ -520,7 +638,7 @@ describe("CCSwitchExportDialog", () => {
 
   it("tracks false CC Switch export results as failures", async () => {
     const user = userEvent.setup()
-    mockFetchOpenAICompatibleModelIds.mockResolvedValue([])
+    mockDiscoverOpenAICompatibleModels.mockResolvedValue(createModelDiscovery())
     mockOpenInCCSwitch.mockReturnValueOnce(false)
 
     render(
@@ -549,7 +667,7 @@ describe("CCSwitchExportDialog", () => {
 
   it("uses an explicit analytics context for profile-origin exports", async () => {
     const user = userEvent.setup()
-    mockFetchOpenAICompatibleModelIds.mockResolvedValue([])
+    mockDiscoverOpenAICompatibleModels.mockResolvedValue(createModelDiscovery())
 
     render(
       <CCSwitchExportDialog
@@ -604,7 +722,9 @@ describe("CCSwitchExportDialog", () => {
     mockResolveDisplayAccountTokenForSecret.mockRejectedValue(
       new Error("account_api_context_missing_user_id"),
     )
-    mockFetchOpenAICompatibleModelIds.mockResolvedValueOnce(["gpt-4o"])
+    mockDiscoverOpenAICompatibleModels.mockResolvedValueOnce(
+      createModelDiscovery([{ id: "gpt-4o" }]),
+    )
 
     render(
       <CCSwitchExportDialog
@@ -616,7 +736,7 @@ describe("CCSwitchExportDialog", () => {
     )
 
     await waitFor(() => {
-      expect(mockFetchOpenAICompatibleModelIds).toHaveBeenCalledWith({
+      expect(mockDiscoverOpenAICompatibleModels).toHaveBeenCalledWith({
         baseUrl: "https://profile.example.com",
         apiKey: "sk-profile",
       })
@@ -644,7 +764,7 @@ describe("CCSwitchExportDialog", () => {
 
   it("tracks thrown CC Switch submissions as unknown failures", async () => {
     const user = userEvent.setup()
-    mockFetchOpenAICompatibleModelIds.mockResolvedValue([])
+    mockDiscoverOpenAICompatibleModels.mockResolvedValue(createModelDiscovery())
     mockResolveDisplayAccountTokenForSecret.mockRejectedValue(
       new Error("secret unavailable"),
     )

--- a/tests/services/aiApi/openaiCompatible.index.test.ts
+++ b/tests/services/aiApi/openaiCompatible.index.test.ts
@@ -28,6 +28,13 @@ describe("OpenAI-compatible model fetchers", () => {
     baseUrl: "https://openai-compatible.example.com",
     apiKey: "synthetic-openai-compatible-key",
   }
+  const expectedRequest = {
+    baseUrl: params.baseUrl,
+    auth: {
+      authType: AuthTypeEnum.AccessToken,
+      accessToken: params.apiKey,
+    },
+  }
 
   beforeEach(() => {
     vi.clearAllMocks()
@@ -109,22 +116,38 @@ describe("OpenAI-compatible model fetchers", () => {
         resolvedBaseUrl: "https://openai-compatible.example.com",
       })
 
-      expect(mockFetchApiData).toHaveBeenNthCalledWith(1, expect.any(Object), {
+      expect(mockFetchApiData).toHaveBeenNthCalledWith(1, expectedRequest, {
         endpoint: "/v1/models",
       })
-      expect(mockFetchApiData).toHaveBeenNthCalledWith(2, expect.any(Object), {
+      expect(mockFetchApiData).toHaveBeenNthCalledWith(2, expectedRequest, {
         endpoint: "/models",
       })
     },
   )
 
-  it("does not infer another route from an authentication failure", async () => {
-    const authenticationError = new ApiError("unauthorized", 401)
-    mockFetchApiData.mockRejectedValueOnce(authenticationError)
+  it("normalizes a path-fragment Base URL after fallback discovery", async () => {
+    const pathParams = { ...params, baseUrl: "  /api/v3/  " }
+    const canonicalError = new ApiError("canonical route unavailable", 404)
+    const models = [{ id: "custom-model" }]
+    mockFetchApiData
+      .mockRejectedValueOnce(canonicalError)
+      .mockResolvedValueOnce(models)
 
-    await expect(discoverOpenAICompatibleModels(params)).rejects.toBe(
-      authenticationError,
-    )
+    await expect(discoverOpenAICompatibleModels(pathParams)).resolves.toEqual({
+      models,
+      resolvedBaseUrl: "/api/v3",
+    })
+  })
+
+  it.each([
+    ["authentication", new ApiError("unauthorized", 401)],
+    ["throttling", new ApiError("rate limited", 429)],
+    ["server", new ApiError("upstream unavailable", 500)],
+    ["network", new TypeError("network request failed")],
+  ])("does not infer another route from a %s failure", async (_kind, error) => {
+    mockFetchApiData.mockRejectedValueOnce(error)
+
+    await expect(discoverOpenAICompatibleModels(params)).rejects.toBe(error)
 
     expect(mockFetchApiData).toHaveBeenCalledTimes(1)
   })

--- a/tests/services/aiApi/openaiCompatible.index.test.ts
+++ b/tests/services/aiApi/openaiCompatible.index.test.ts
@@ -1,9 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import {
+  discoverOpenAICompatibleModels,
   fetchOpenAICompatibleModelIds,
   fetchOpenAICompatibleModels,
 } from "~/services/aiApi/openaiCompatible"
+import { ApiError } from "~/services/apiTransport/errors"
 import { AuthTypeEnum } from "~/types"
 
 const { mockFetchApiData, mockLoggerError } = vi.hoisted(() => ({
@@ -52,6 +54,16 @@ describe("OpenAI-compatible model fetchers", () => {
     )
   })
 
+  it("returns the API base URL confirmed by the canonical model endpoint", async () => {
+    const models = [{ id: "gpt-4.1" }]
+    mockFetchApiData.mockResolvedValueOnce(models)
+
+    await expect(discoverOpenAICompatibleModels(params)).resolves.toEqual({
+      models,
+      resolvedBaseUrl: "https://openai-compatible.example.com/v1",
+    })
+  })
+
   it("accepts an empty canonical model list without trying another endpoint", async () => {
     mockFetchApiData.mockResolvedValueOnce([])
 
@@ -60,8 +72,55 @@ describe("OpenAI-compatible model fetchers", () => {
     expect(mockFetchApiData).toHaveBeenCalledTimes(1)
   })
 
-  it("falls back to /models when the canonical model endpoint fails", async () => {
-    const canonicalError = new Error("canonical endpoint unavailable")
+  it.each([404, 405])(
+    "falls back to /models when the canonical route returns %s",
+    async (statusCode) => {
+      const canonicalError = new ApiError(
+        "canonical route unavailable",
+        statusCode,
+      )
+      const models = [{ id: "custom-model" }]
+      mockFetchApiData
+        .mockRejectedValueOnce(canonicalError)
+        .mockResolvedValueOnce(models)
+
+      await expect(discoverOpenAICompatibleModels(params)).resolves.toEqual({
+        models,
+        resolvedBaseUrl: "https://openai-compatible.example.com",
+      })
+
+      expect(mockFetchApiData).toHaveBeenNthCalledWith(1, expect.any(Object), {
+        endpoint: "/v1/models",
+      })
+      expect(mockFetchApiData).toHaveBeenNthCalledWith(2, expect.any(Object), {
+        endpoint: "/models",
+      })
+    },
+  )
+
+  it("does not infer another route from an authentication failure", async () => {
+    const authenticationError = new ApiError("unauthorized", 401)
+    mockFetchApiData.mockRejectedValueOnce(authenticationError)
+
+    await expect(discoverOpenAICompatibleModels(params)).rejects.toBe(
+      authenticationError,
+    )
+
+    expect(mockFetchApiData).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not accept an invalid successful payload as route confirmation", async () => {
+    mockFetchApiData.mockResolvedValueOnce({ message: "not a model list" })
+
+    await expect(discoverOpenAICompatibleModels(params)).rejects.toThrow(
+      "invalid model list",
+    )
+
+    expect(mockFetchApiData).toHaveBeenCalledTimes(1)
+  })
+
+  it("keeps the model-only wrapper compatible with /models fallback", async () => {
+    const canonicalError = new ApiError("canonical route unavailable", 404)
     const models = [{ id: "custom-model" }]
     mockFetchApiData
       .mockRejectedValueOnce(canonicalError)
@@ -140,7 +199,7 @@ describe("OpenAI-compatible model fetchers", () => {
   })
 
   it("logs and rethrows after both model endpoints fail", async () => {
-    const canonicalError = new Error("canonical endpoint unavailable")
+    const canonicalError = new ApiError("canonical route unavailable", 404)
     const fallbackError = new Error("fallback endpoint unavailable")
     mockFetchApiData
       .mockRejectedValueOnce(canonicalError)

--- a/tests/services/aiApi/openaiCompatible.index.test.ts
+++ b/tests/services/aiApi/openaiCompatible.index.test.ts
@@ -54,15 +54,35 @@ describe("OpenAI-compatible model fetchers", () => {
     )
   })
 
-  it("returns the API base URL confirmed by the canonical model endpoint", async () => {
-    const models = [{ id: "gpt-4.1" }]
-    mockFetchApiData.mockResolvedValueOnce(models)
-
-    await expect(discoverOpenAICompatibleModels(params)).resolves.toEqual({
-      models,
+  it.each([
+    {
+      baseUrl: "https://openai-compatible.example.com",
       resolvedBaseUrl: "https://openai-compatible.example.com/v1",
-    })
-  })
+    },
+    {
+      baseUrl: "https://x.test/v1",
+      resolvedBaseUrl: "https://x.test/v1",
+    },
+    {
+      baseUrl: "https://ark.example.invalid/api/v3",
+      resolvedBaseUrl: "https://ark.example.invalid/api/v3/v1",
+    },
+  ])(
+    "returns $resolvedBaseUrl when the canonical route succeeds for $baseUrl",
+    async ({ baseUrl, resolvedBaseUrl }) => {
+      const models = [{ id: "gpt-4.1" }]
+      mockFetchApiData.mockResolvedValueOnce(models)
+
+      await expect(
+        discoverOpenAICompatibleModels({ ...params, baseUrl }),
+      ).resolves.toEqual({ models, resolvedBaseUrl })
+
+      expect(mockFetchApiData).toHaveBeenCalledWith(
+        expect.objectContaining({ baseUrl }),
+        { endpoint: "/v1/models" },
+      )
+    },
+  )
 
   it("accepts an empty canonical model list without trying another endpoint", async () => {
     mockFetchApiData.mockResolvedValueOnce([])


### PR DESCRIPTION
## Summary

CCSwitch previously appended `/v1` to every untouched Codex endpoint. This fixed standard OpenAI-compatible origins but corrupted provider-owned paths such as `/api/v3` into `/api/v3/v1`.

This change derives the Codex Base URL from the model discovery request that the export dialog already performs, without adding another network probe.

## What changed

- Return the confirmed API Base URL alongside OpenAI-compatible model discovery results.
- Try the path-preserving `/models` fallback only when `/v1/models` returns a route-level 404 or 405.
- Treat authentication, throttling, server, network, and invalid-payload failures as inconclusive instead of using them to infer a route.
- Reuse the confirmed endpoint for Codex exports while preserving user-edited endpoints.
- When discovery is inconclusive, keep the compatibility default:
  - pure origins use `/v1`
  - existing provider paths remain unchanged
- Add service and component regression coverage for `/v1`, `/api/v3`, error fallback, and manual endpoint edits.

## Validation

- `pnpm exec vitest run tests/services/aiApi/openaiCompatible.index.test.ts tests/components/CCSwitchExportDialog.test.tsx` — 35 tests passed
- `pnpm run validate:staged` — Prettier, ESLint, affected Vitest tests, and i18n checks passed
- `pnpm run validate:push` — TypeScript compilation and Knip passed

Full CI and coverage are pending on this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved OpenAI-compatible model discovery and endpoint detection.
  * Codex connections now select compatible endpoints more reliably.
  * Previously discovered endpoints are reused to avoid unnecessary requests.

* **Bug Fixes**
  * Added safer fallback handling for unavailable model routes.
  * Improved handling of discovery failures, authentication errors, and invalid responses.
  * Discovery state now resets correctly when model loading fails or the dialog is reopened.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->