### PR TITLE
fix(content): keep API check dialog close action clickable

### DIFF
--- a/e2e/contentWebAiApiCheck.spec.ts
+++ b/e2e/contentWebAiApiCheck.spec.ts
@@ -400,6 +400,23 @@ test("opens the API check modal from the background context-menu message path", 
   )
 })
 
+test("closes the API check modal with detected credentials in one click", async ({
+  context,
+  page,
+}) => {
+  const serviceWorker = await getServiceWorker(context)
+  await seedAutoDetectApiCheckPreferences(serviceWorker)
+
+  const { modal } = await openApiCheckModalFromCopiedCredentials(page)
+  await expect(modal.getByRole("textbox", { name: "API key" })).toHaveValue(
+    API_KEY,
+  )
+
+  await modal.getByRole("button", { name: "Close" }).click()
+
+  await expect(modal).toHaveCount(0)
+})
+
 test("reads copied web API credentials from the clipboard after clicking a copy-like control", async ({
   context,
   page,

--- a/e2e/contentWebAiApiCheck.spec.ts
+++ b/e2e/contentWebAiApiCheck.spec.ts
@@ -412,7 +412,7 @@ test("closes the API check modal with detected credentials in one click", async 
     API_KEY,
   )
 
-  await modal.getByRole("button", { name: "Close" }).click()
+  await modal.getByTestId(WEB_AI_API_CHECK_TEST_IDS.closeButton).click()
 
   await expect(modal).toHaveCount(0)
 })

--- a/src/entrypoints/content/webAiApiCheck/components/ApiCheckModal.tsx
+++ b/src/entrypoints/content/webAiApiCheck/components/ApiCheckModal.tsx
@@ -103,12 +103,14 @@ export function ApiCheckModal({ t, view, actions, refs }: ApiCheckModalProps) {
                 {t("webAiApiCheck:modal.privacyHint")}
               </div>
             </div>
+            {/* Focus-opened react-tooltip can consume the first dismiss click in Edge's content ShadowRoot. */}
             <IconButton
               aria-label={t("common:actions.close")}
               variant="ghost"
               size="sm"
               onClick={actions.close}
               disabled={!view.canClose}
+              disableAutoTooltip
             >
               <X className="h-4 w-4" />
             </IconButton>

--- a/src/entrypoints/content/webAiApiCheck/components/ApiCheckModal.tsx
+++ b/src/entrypoints/content/webAiApiCheck/components/ApiCheckModal.tsx
@@ -105,6 +105,7 @@ export function ApiCheckModal({ t, view, actions, refs }: ApiCheckModalProps) {
             </div>
             {/* Focus-opened react-tooltip can consume the first dismiss click in Edge's content ShadowRoot. */}
             <IconButton
+              data-testid={WEB_AI_API_CHECK_TEST_IDS.closeButton}
               aria-label={t("common:actions.close")}
               variant="ghost"
               size="sm"

--- a/src/entrypoints/content/webAiApiCheck/testIds.ts
+++ b/src/entrypoints/content/webAiApiCheck/testIds.ts
@@ -3,6 +3,7 @@ import type { ApiVerificationProbeId } from "~/services/verification/aiApiVerifi
 export const WEB_AI_API_CHECK_TEST_IDS = {
   backdrop: "api-check-backdrop",
   modal: "api-check-modal",
+  closeButton: "api-check-close-button",
   modelId: "api-check-model-id",
   baseUrlCandidatePrefix: "web-ai-api-check-base-url-candidate",
   apiKeyCandidatePrefix: "web-ai-api-check-api-key-candidate",

--- a/tests/components/ApiCheckModalHost.test.tsx
+++ b/tests/components/ApiCheckModalHost.test.tsx
@@ -1192,10 +1192,11 @@ describe("ApiCheckModalHost", () => {
       trigger: "autoDetect",
     })
 
-    const closeButton = screen.getByRole("button", {
-      name: "common:actions.close",
-    })
+    const closeButton = screen.getByTestId(
+      WEB_AI_API_CHECK_TEST_IDS.closeButton,
+    )
 
+    expect(closeButton).toHaveAccessibleName("common:actions.close")
     expect(closeButton).not.toHaveAttribute("aria-describedby")
     expect(closeButton).toHaveAttribute("title", "common:actions.close")
   })

--- a/tests/components/ApiCheckModalHost.test.tsx
+++ b/tests/components/ApiCheckModalHost.test.tsx
@@ -1185,6 +1185,21 @@ describe("ApiCheckModalHost", () => {
     ])
   })
 
+  it("does not attach a focus tooltip to the close control when credentials are detected", async () => {
+    await openModal({
+      sourceText:
+        "Base URL: https://proxy.example.com/api\nAPI Key: sk-test-close-fixture",
+      trigger: "autoDetect",
+    })
+
+    const closeButton = screen.getByRole("button", {
+      name: "common:actions.close",
+    })
+
+    expect(closeButton).not.toHaveAttribute("aria-describedby")
+    expect(closeButton).toHaveAttribute("title", "common:actions.close")
+  })
+
   it("auto-extract fills baseUrl + apiKey from pasted text", async () => {
     const user = userEvent.setup()
     await openModal()


### PR DESCRIPTION
## Summary

- Keep the Web AI API check dialog's close action responsive on the first click in Edge content-script pages.
- Opt the close icon out of the focus-opened automatic tooltip while preserving its accessible name and native title.
- Add component and real-extension regression coverage for detected credentials.

## Validation

- `pnpm exec vitest run tests/components/ApiCheckModalHost.test.tsx` - 84 passed
- `pnpm exec playwright test e2e/contentWebAiApiCheck.spec.ts --project=chromium --grep "closes the API check modal with detected credentials in one click" --workers=1` - 2 passed
- `pnpm run validate:push` - passed (`compile` and `knip`)
- Manually verified in the affected Edge flow that the dialog closes on the first click.

## Scope

This is a localized content-script Shadow DOM fix. Other `IconButton` tooltip behavior remains unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where the API check modal’s close button could require multiple clicks in Edge.
  - Disabled an interfering focus tooltip while preserving the close button’s standard title.
  - Improved the close control’s accessibility and reliable dismissal behavior.

- **Tests**
  - Added coverage confirming the modal closes with one click after credentials are detected.
  - Added regression coverage for the close button’s accessible name and tooltip behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->