### PR TITLE
fix(sub2api): harden auth credential durability

### DIFF
--- a/src/locales/de/messages.json
+++ b/src/locales/de/messages.json
@@ -162,6 +162,7 @@
     "updateFailed": "Konto konnte nicht aktualisiert werden"
   },
   "sub2api": {
+    "authPersistenceFailed": "Die aktualisierte Sub2API-Anmeldung konnte nicht sicher in diesem Konto gespeichert werden. Aktualisieren oder importieren Sie das Konto erneut und versuchen Sie es dann noch einmal.",
     "configMissing": "Bitte konfigurieren Sie zuerst die Sub2API-Basis-URL und den Admin API Key in den Grundeinstellungen.",
     "groupMissing": "Die Sub2API-Gruppe „{{group}}“ ist nicht mehr verfügbar. Aktualisieren Sie die Gruppenliste und versuchen Sie es erneut.",
     "loginRequired": "Bitte melden Sie sich zuerst beim Sub2API-Dashboard an (damit die Erweiterung auth_token/auth_user aus localStorage lesen kann) und versuchen Sie es erneut.",

--- a/src/locales/en/messages.json
+++ b/src/locales/en/messages.json
@@ -162,6 +162,7 @@
     "updateFailed": "Failed to update account"
   },
   "sub2api": {
+    "authPersistenceFailed": "The refreshed Sub2API sign-in could not be saved to this account. Refresh or re-import the account, then try again.",
     "configMissing": "Please configure the Sub2API Base URL and Admin API Key in basic settings first.",
     "groupMissing": "Sub2API group '{{group}}' is no longer available. Refresh the group list and try again.",
     "loginRequired": "Please log in to the Sub2API dashboard first (so the extension can read auth_token/auth_user from localStorage) and try again.",

--- a/src/locales/es-419/messages.json
+++ b/src/locales/es-419/messages.json
@@ -162,6 +162,7 @@
     "updateFailed": "No se pudo actualizar la cuenta"
   },
   "sub2api": {
+    "authPersistenceFailed": "No se pudo guardar de forma segura el inicio de sesión actualizado de Sub2API en esta cuenta. Actualiza o vuelve a importar la cuenta y vuelve a intentarlo.",
     "configMissing": "Configura primero la URL base y la Admin API Key de Sub2API en la configuración básica.",
     "groupMissing": "El grupo de Sub2API '{{group}}' ya no está disponible. Actualiza la lista de grupos y vuelve a intentarlo.",
     "loginRequired": "Primero inicia sesión en el panel de Sub2API (para que la extensión pueda leer auth_token/auth_user desde localStorage) y vuelve a intentarlo.",

--- a/src/locales/ja/messages.json
+++ b/src/locales/ja/messages.json
@@ -162,6 +162,7 @@
     "updateFailed": "アカウントの更新に失敗しました"
   },
   "sub2api": {
+    "authPersistenceFailed": "更新された Sub2API のログイン情報をこのアカウントに安全に保存できませんでした。アカウントを更新または再インポートしてから、もう一度お試しください。",
     "configMissing": "先に基本設定で Sub2API のベース URL と管理者 API Key を設定してください。",
     "groupMissing": "Sub2API グループ '{{group}}' は現在利用できません。グループ一覧を更新して再試行してください。",
     "loginRequired": "先に Sub2API ダッシュボードへログインして（拡張機能が localStorage から auth_token / auth_user を読めるようにして）、再試行してください。",

--- a/src/locales/pt-BR/messages.json
+++ b/src/locales/pt-BR/messages.json
@@ -162,6 +162,7 @@
     "updateFailed": "Falha ao atualizar conta"
   },
   "sub2api": {
+    "authPersistenceFailed": "Não foi possível salvar com segurança o login atualizado do Sub2API nesta conta. Atualize ou importe a conta novamente e tente outra vez.",
     "configMissing": "Configure primeiro a URL base e a Admin API Key do Sub2API nas configurações básicas.",
     "groupMissing": "O grupo '{{group}}' do Sub2API não está mais disponível. Atualize a lista de grupos e tente novamente.",
     "loginRequired": "Faça login no painel do Sub2API primeiro (para que a extensão possa ler auth_token/auth_user do localStorage) e tente novamente.",

--- a/src/locales/vi/messages.json
+++ b/src/locales/vi/messages.json
@@ -162,6 +162,7 @@
     "updateFailed": "Cập nhật tài khoản thất bại"
   },
   "sub2api": {
+    "authPersistenceFailed": "Không thể lưu thông tin đăng nhập Sub2API đã làm mới vào tài khoản này một cách an toàn. Hãy làm mới hoặc nhập lại tài khoản rồi thử lại.",
     "configMissing": "Hãy cấu hình URL gốc và Admin API Key của Sub2API trong phần Cài đặt cơ bản trước.",
     "groupMissing": "Nhóm Sub2API \"{{group}}\" không còn khả dụng. Vui lòng làm mới danh sách nhóm rồi thử lại.",
     "loginRequired": "Vui lòng đăng nhập vào bảng điều khiển Sub2API (tiện ích sẽ đọc auth_token/auth_user để nhập phiên) rồi thử lại.",

--- a/src/locales/zh-CN/messages.json
+++ b/src/locales/zh-CN/messages.json
@@ -162,6 +162,7 @@
     "updateFailed": "更新账号失败"
   },
   "sub2api": {
+    "authPersistenceFailed": "无法将刷新的 Sub2API 登录信息安全地保存到此账号。请刷新或重新导入该账号，然后重试。",
     "configMissing": "请先在基础设置中配置 Sub2API 基础 URL 和管理员 API Key。",
     "groupMissing": "Sub2API 分组“{{group}}”已不可用。请刷新分组列表后重试。",
     "loginRequired": "请先登录 Sub2API 控制台（插件会读取 auth_token/auth_user 用于导入会话）后再重试。",

--- a/src/locales/zh-TW/messages.json
+++ b/src/locales/zh-TW/messages.json
@@ -162,6 +162,7 @@
     "updateFailed": "更新帳號失敗"
   },
   "sub2api": {
+    "authPersistenceFailed": "無法將重新整理的 Sub2API 登入資訊安全地儲存到此帳號。請重新整理或重新匯入該帳號，然後再試一次。",
     "configMissing": "請先在基礎設定中配置 Sub2API 基礎 URL 和管理員 API Key。",
     "groupMissing": "Sub2API 分組“{{group}}”已不可用。請重新整理分組列表後重試。",
     "loginRequired": "請先登入 Sub2API 控制台（外掛會讀取 auth_token/auth_user 用於匯入會話）後再重試。",

--- a/src/services/accounts/accountStorage.ts
+++ b/src/services/accounts/accountStorage.ts
@@ -15,6 +15,11 @@ import {
   resolveAccountDisplayName,
 } from "~/services/accounts/utils/accountDisplayName"
 import { getSiteTypeCapabilities } from "~/services/apiAdapters/registry"
+import type {
+  Sub2ApiAuthPersistenceResult,
+  Sub2ApiPersistAuthUpdate,
+} from "~/services/apiService/sub2api/authSession"
+import { SUB2API_AUTH_PERSISTENCE_STATUSES } from "~/services/apiService/sub2api/authSession"
 import { isCheckInMethodId } from "~/services/checkin/autoCheckin/providers/registry"
 import {
   markCheckInMethodExecuted,
@@ -502,6 +507,90 @@ class AccountStorageService {
     } catch (error) {
       logger.error(t("messages:storage.updateFailed", { error: "" }), error)
       return false
+    }
+  }
+
+  /**
+   * Atomically replaces Sub2API credentials after re-reading the account under
+   * the storage lock and confirming its origin and user identity still match.
+   */
+  async updateSub2ApiAuth(
+    id: string,
+    update: Sub2ApiPersistAuthUpdate,
+    options: UpdateAccountOptions,
+  ): Promise<Sub2ApiAuthPersistenceResult> {
+    try {
+      const expectedOrigin = normalizeAccountSiteProfileUrlForOriginKey({
+        siteType: SITE_TYPES.SUB2API,
+        url: update.expectedOrigin,
+      })
+      const expectedUserId = normalizeAccountIdentity(update.expectedUserId)
+      const result =
+        await this.mutateStorageConfig<Sub2ApiAuthPersistenceResult>(
+          (config) => {
+            const account = config.accounts.find((item) => item.id === id)
+            if (!account) {
+              return {
+                result: {
+                  status: SUB2API_AUTH_PERSISTENCE_STATUSES.ACCOUNT_MISSING,
+                },
+                changed: false,
+              }
+            }
+
+            const actualOrigin = normalizeAccountSiteProfileUrlForOriginKey({
+              siteType: account.site_type,
+              url: account.site_url,
+            })
+            const actualUserId = normalizeAccountIdentity(
+              account.account_info.id,
+            )
+            if (
+              account.site_type !== SITE_TYPES.SUB2API ||
+              !expectedUserId ||
+              !actualUserId ||
+              actualOrigin !== expectedOrigin ||
+              actualUserId !== expectedUserId
+            ) {
+              return {
+                result: {
+                  status: SUB2API_AUTH_PERSISTENCE_STATUSES.IDENTITY_MISMATCH,
+                },
+                changed: false,
+              }
+            }
+
+            const index = config.accounts.indexOf(account)
+            const authUpdates: DeepPartial<SiteAccount> = {
+              account_info: {
+                access_token: update.accessToken,
+              },
+            }
+            const refreshToken = update.refreshToken?.trim()
+            if (refreshToken) {
+              authUpdates.sub2apiAuth = {
+                refreshToken,
+                ...(typeof update.tokenExpiresAt === "number" &&
+                Number.isFinite(update.tokenExpiresAt)
+                  ? { tokenExpiresAt: update.tokenExpiresAt }
+                  : {}),
+              }
+            }
+            config.accounts[index] = applySiteAccountUpdates({
+              account,
+              updates: authUpdates,
+              now: Date.now(),
+              userTimestampMode: options.userTimestampMode,
+            })
+            return {
+              result: { status: SUB2API_AUTH_PERSISTENCE_STATUSES.PERSISTED },
+              changed: true,
+            }
+          },
+        )
+      return result
+    } catch {
+      return { status: SUB2API_AUTH_PERSISTENCE_STATUSES.WRITE_FAILED }
     }
   }
 

--- a/src/services/accounts/accountStorage.ts
+++ b/src/services/accounts/accountStorage.ts
@@ -525,6 +525,7 @@ class AccountStorageService {
         url: update.expectedOrigin,
       })
       const expectedUserId = normalizeAccountIdentity(update.expectedUserId)
+      const updateUserId = normalizeAccountIdentity(update.userId)
       const result =
         await this.mutateStorageConfig<Sub2ApiAuthPersistenceResult>(
           (config) => {
@@ -550,7 +551,8 @@ class AccountStorageService {
               !expectedUserId ||
               !actualUserId ||
               actualOrigin !== expectedOrigin ||
-              actualUserId !== expectedUserId
+              actualUserId !== expectedUserId ||
+              (update.userId !== undefined && updateUserId !== expectedUserId)
             ) {
               return {
                 result: {
@@ -564,6 +566,7 @@ class AccountStorageService {
             const authUpdates: DeepPartial<SiteAccount> = {
               account_info: {
                 access_token: update.accessToken,
+                ...(updateUserId ? { id: updateUserId } : {}),
               },
             }
             const refreshToken = update.refreshToken?.trim()
@@ -589,7 +592,11 @@ class AccountStorageService {
           },
         )
       return result
-    } catch {
+    } catch (error) {
+      logger.error("Failed to persist Sub2API credentials", {
+        accountId: id,
+        error: getErrorMessage(error),
+      })
       return { status: SUB2API_AUTH_PERSISTENCE_STATUSES.WRITE_FAILED }
     }
   }

--- a/src/services/accounts/sub2apiAuthSession.ts
+++ b/src/services/accounts/sub2apiAuthSession.ts
@@ -1,12 +1,11 @@
 import { AccountUpdateUserTimestampMode } from "~/services/accounts/accountDefaults"
+import { normalizeAccountSiteProfileUrlForOriginKey } from "~/services/accounts/accountSiteProfile"
 import { accountStorage } from "~/services/accounts/accountStorage"
 import type {
   Sub2ApiAuthSession,
-  Sub2ApiPersistAuthUpdate,
   Sub2ApiStoredAuthSnapshot,
 } from "~/services/apiService/sub2api/authSession"
 import type { SiteAccount } from "~/types"
-import type { DeepPartial } from "~/types/utils"
 
 const normalizeString = (value: unknown): string | undefined => {
   if (typeof value !== "string") return undefined
@@ -18,9 +17,19 @@ const normalizeTokenExpiresAt = (value: unknown): number | undefined =>
   typeof value === "number" && Number.isFinite(value) ? value : undefined
 
 const buildStoredAuthSnapshot = (
-  account: Pick<SiteAccount, "account_info" | "sub2apiAuth">,
+  account: Pick<
+    SiteAccount,
+    "account_info" | "site_type" | "site_url" | "sub2apiAuth"
+  >,
 ): Sub2ApiStoredAuthSnapshot => {
   const accessToken = normalizeString(account.account_info?.access_token)
+  const siteUrl = normalizeString(account.site_url)
+  const origin = siteUrl
+    ? normalizeAccountSiteProfileUrlForOriginKey({
+        siteType: account.site_type,
+        url: siteUrl,
+      })
+    : undefined
   const userId = normalizeString(account.account_info?.id)
   const refreshToken = normalizeString(account.sub2apiAuth?.refreshToken)
   const tokenExpiresAt = normalizeTokenExpiresAt(
@@ -29,6 +38,7 @@ const buildStoredAuthSnapshot = (
 
   return {
     ...(accessToken ? { accessToken } : {}),
+    ...(origin ? { origin } : {}),
     ...(userId ? { userId } : {}),
     ...(refreshToken
       ? {
@@ -41,41 +51,14 @@ const buildStoredAuthSnapshot = (
   }
 }
 
-const buildPersistedAuthUpdate = (
-  update: Sub2ApiPersistAuthUpdate,
-): DeepPartial<SiteAccount> => {
-  const refreshToken = normalizeString(update.refreshToken)
-  const persisted: DeepPartial<SiteAccount> = {
-    account_info: {
-      access_token: update.accessToken,
-    },
-  }
-
-  if (refreshToken) {
-    persisted.sub2apiAuth = {
-      refreshToken,
-      ...(typeof update.tokenExpiresAt === "number" &&
-      Number.isFinite(update.tokenExpiresAt)
-        ? { tokenExpiresAt: update.tokenExpiresAt }
-        : {}),
-    }
-  }
-
-  return persisted
-}
-
 export const accountSub2ApiAuthSession: Sub2ApiAuthSession = {
   async getLatestAuth(accountId) {
     const account = await accountStorage.getAccountById(accountId)
     return account ? buildStoredAuthSnapshot(account) : null
   },
   async persistAuthUpdate(accountId, update) {
-    return accountStorage.updateAccount(
-      accountId,
-      buildPersistedAuthUpdate(update),
-      {
-        userTimestampMode: AccountUpdateUserTimestampMode.Preserve,
-      },
-    )
+    return accountStorage.updateSub2ApiAuth(accountId, update, {
+      userTimestampMode: AccountUpdateUserTimestampMode.Preserve,
+    })
   },
 }

--- a/src/services/apiService/sub2api/authSession.ts
+++ b/src/services/apiService/sub2api/authSession.ts
@@ -3,14 +3,29 @@ import type { AccountIdentity, Sub2ApiAuthConfig } from "~/types"
 
 export type Sub2ApiStoredAuthSnapshot = {
   accessToken?: string
+  origin?: string
   userId?: AccountIdentity
   sub2apiAuth?: Sub2ApiAuthConfig
 }
 
 export type Sub2ApiPersistAuthUpdate = {
   accessToken: string
+  userId?: AccountIdentity
   refreshToken?: string
   tokenExpiresAt?: number
+  expectedOrigin: string
+  expectedUserId: AccountIdentity
+}
+
+export const SUB2API_AUTH_PERSISTENCE_STATUSES = {
+  PERSISTED: "persisted",
+  ACCOUNT_MISSING: "account_missing",
+  IDENTITY_MISMATCH: "identity_mismatch",
+  WRITE_FAILED: "write_failed",
+} as const
+
+export type Sub2ApiAuthPersistenceResult = {
+  status: (typeof SUB2API_AUTH_PERSISTENCE_STATUSES)[keyof typeof SUB2API_AUTH_PERSISTENCE_STATUSES]
 }
 
 export type Sub2ApiAuthSession = {
@@ -18,7 +33,7 @@ export type Sub2ApiAuthSession = {
   persistAuthUpdate(
     accountId: string,
     update: Sub2ApiPersistAuthUpdate,
-  ): Promise<boolean>
+  ): Promise<Sub2ApiAuthPersistenceResult>
 }
 
 export type Sub2ApiAuthSessionRequest<

--- a/src/services/apiService/sub2api/index.ts
+++ b/src/services/apiService/sub2api/index.ts
@@ -423,7 +423,14 @@ const verifySub2ApiAuthIdentity = async <TRequest extends ApiServiceRequest>(
   }
 
   const verificationRequest = applySub2ApiAuthUpdate(request, authUpdate)
-  const verified = await fetchUserInfo(verificationRequest)
+  let verified: Awaited<ReturnType<typeof fetchUserInfo>>
+  try {
+    verified = await fetchUserInfo(verificationRequest)
+  } catch {
+    throw new Sub2ApiTokenRefreshError(
+      SUB2API_TOKEN_REFRESH_FAILURE_REASONS.UNCERTAIN_ROTATION,
+    )
+  }
   const verifiedUserId = normalizeAccountIdentity(verified.id)
   if (verifiedUserId !== expectedUserId) {
     throw new Sub2ApiAuthPersistenceError({
@@ -511,18 +518,12 @@ const resyncSub2ApiRequestAuth = async <
     const expectedUserId = normalizeAccountIdentity(latestRequest.auth?.userId)
     let resynced
     try {
-      resynced = expectedUserId
-        ? await resyncSub2ApiAuthToken(
-            latestRequest.baseUrl,
-            latestRequest.tempWindowRequestSource,
-            latestRequest.protectionBypassExecution,
-            expectedUserId,
-          )
-        : await resyncSub2ApiAuthToken(
-            latestRequest.baseUrl,
-            latestRequest.tempWindowRequestSource,
-            latestRequest.protectionBypassExecution,
-          )
+      resynced = await resyncSub2ApiAuthToken(
+        latestRequest.baseUrl,
+        latestRequest.tempWindowRequestSource,
+        latestRequest.protectionBypassExecution,
+        expectedUserId ?? undefined,
+      )
     } catch (error) {
       if (error instanceof Sub2ApiAuthIdentityMismatchError) {
         throw new Sub2ApiAuthPersistenceError({
@@ -540,29 +541,24 @@ const resyncSub2ApiRequestAuth = async <
       source: resynced.source,
     })
 
-    const resyncedRequest = applySub2ApiAuthUpdate(latestRequest, {
+    const resyncedUpdate: PersistableSub2ApiAuthUpdate = {
       accessToken: resynced.accessToken,
-      userId: resynced.userId,
+      ...(resynced.userId ? { userId: resynced.userId } : {}),
       ...(resynced.sub2apiAuth?.refreshToken
         ? { refreshToken: resynced.sub2apiAuth.refreshToken }
         : {}),
       ...(typeof resynced.sub2apiAuth?.tokenExpiresAt === "number"
         ? { tokenExpiresAt: resynced.sub2apiAuth.tokenExpiresAt }
         : {}),
-    })
+    }
+    const resyncedRequest = applySub2ApiAuthUpdate(
+      latestRequest,
+      resyncedUpdate,
+    )
 
     await persistSub2ApiAuthUpdate(
       resyncedRequest,
-      {
-        accessToken: resynced.accessToken,
-        userId: resynced.userId,
-        ...(resyncedRequest.auth?.refreshToken
-          ? { refreshToken: resyncedRequest.auth.refreshToken }
-          : {}),
-        ...(typeof resyncedRequest.auth?.tokenExpiresAt === "number"
-          ? { tokenExpiresAt: resyncedRequest.auth.tokenExpiresAt }
-          : {}),
-      },
+      resyncedUpdate,
       latestAuthSession,
     )
 
@@ -1085,6 +1081,11 @@ const createRefreshTokenRestoreRequiredHealthStatus = () => ({
   message: t("messages:sub2api.refreshTokenInvalid"),
 })
 
+const createAuthPersistenceFailureHealthStatus = () => ({
+  status: SiteHealthStatus.Warning,
+  message: t("messages:sub2api.authPersistenceFailed"),
+})
+
 const createHealthyHealthStatus = () => ({
   status: SiteHealthStatus.Healthy,
   message: t("account:healthStatus.normal"),
@@ -1546,6 +1547,12 @@ export async function refreshAccountData(
         : {}),
     })
   } catch (error) {
+    if (error instanceof Sub2ApiAuthPersistenceError) {
+      return {
+        success: false,
+        healthStatus: createAuthPersistenceFailureHealthStatus(),
+      }
+    }
     if (error instanceof ApiError && error.statusCode === 401) {
       hydratedRequest ??= await hydrateSub2ApiAuthRequest(request)
       effectiveRequest = didSub2ApiAuthChange(request, effectiveRequest)
@@ -1586,10 +1593,13 @@ export async function refreshAccountData(
               authSession: hydratedRequest.authSession,
               checkIn,
             })
-          } catch {
+          } catch (resyncError) {
             return {
               success: false,
-              healthStatus: createRefreshTokenRestoreRequiredHealthStatus(),
+              healthStatus:
+                resyncError instanceof Sub2ApiAuthPersistenceError
+                  ? createAuthPersistenceFailureHealthStatus()
+                  : createRefreshTokenRestoreRequiredHealthStatus(),
             }
           }
         }
@@ -1602,6 +1612,12 @@ export async function refreshAccountData(
           checkIn,
         })
       } catch (retryError) {
+        if (retryError instanceof Sub2ApiAuthPersistenceError) {
+          return {
+            success: false,
+            healthStatus: createAuthPersistenceFailureHealthStatus(),
+          }
+        }
         if (retryError instanceof ApiError && retryError.statusCode === 401) {
           return {
             success: false,

--- a/src/services/apiService/sub2api/index.ts
+++ b/src/services/apiService/sub2api/index.ts
@@ -4,6 +4,7 @@
  * Sub2API differs from One-API/New-API backends in that authenticated endpoints
  * live under `/api/v1/*` and require a dashboard JWT.
  */
+import { SITE_TYPES } from "~/constants/siteType"
 import type {
   AccountData,
   ApiServiceAccountRequest,
@@ -13,6 +14,8 @@ import type {
   TodayUsageDataWithAvailability,
 } from "~/services/accounts/accountDataModel"
 import { determineHealthStatus } from "~/services/accounts/accountHealth"
+import { normalizeAccountIdentity } from "~/services/accounts/accountIdentity"
+import { normalizeAccountSiteProfileUrlForOriginKey } from "~/services/accounts/accountSiteProfile"
 import { hasUsableApiTokenKey } from "~/services/accountTokens/apiTokenKey"
 import { resolveApiTokenKeyWithFetcher } from "~/services/accountTokens/tokenKeyResolver"
 import type {
@@ -45,7 +48,12 @@ import {
 import { createLogger } from "~/utils/core/logger"
 import { t } from "~/utils/i18n/core"
 
-import { getSub2ApiAuthSession, type Sub2ApiAuthSession } from "./authSession"
+import {
+  getSub2ApiAuthSession,
+  SUB2API_AUTH_PERSISTENCE_STATUSES,
+  type Sub2ApiAuthPersistenceResult,
+  type Sub2ApiAuthSession,
+} from "./authSession"
 import {
   buildSub2ApiGroupDescriptors,
   buildSub2ApiUserGroups,
@@ -63,8 +71,13 @@ import { getSafeErrorMessage } from "./redaction"
 import {
   refreshSub2ApiTokens,
   SUB2API_TOKEN_REFRESH_BUFFER_MS,
+  SUB2API_TOKEN_REFRESH_FAILURE_REASONS,
+  Sub2ApiTokenRefreshError,
 } from "./tokenRefresh"
-import { resyncSub2ApiAuthToken } from "./tokenResync"
+import {
+  resyncSub2ApiAuthToken,
+  Sub2ApiAuthIdentityMismatchError,
+} from "./tokenResync"
 import {
   SUB2API_AFFILIATE_ENDPOINT,
   SUB2API_ANNOUNCEMENTS_ENDPOINT,
@@ -163,15 +176,34 @@ const createRefreshTokenInvalidError = (endpoint: string) =>
   )
 
 const isSub2ApiRefreshTokenContractError = (error: unknown): boolean =>
-  error instanceof Error && error.message === "Sub2API token refresh failed"
+  error instanceof Sub2ApiTokenRefreshError &&
+  error.reason === SUB2API_TOKEN_REFRESH_FAILURE_REASONS.INVALID_REFRESH_TOKEN
+
+const isUncertainSub2ApiRefreshRotation = (error: unknown): boolean =>
+  error instanceof Sub2ApiTokenRefreshError &&
+  error.reason === SUB2API_TOKEN_REFRESH_FAILURE_REASONS.UNCERTAIN_ROTATION
 
 const isUnauthorizedError = (error: unknown): error is ApiError =>
   error instanceof ApiError && error.statusCode === 401
 
 type PersistableSub2ApiAuthUpdate = {
   accessToken: string
+  userId?: string
   refreshToken?: string
   tokenExpiresAt?: number
+}
+
+class Sub2ApiAuthPersistenceError extends Error {
+  constructor(public readonly result: Sub2ApiAuthPersistenceResult) {
+    super(t("messages:sub2api.authPersistenceFailed"))
+    this.name = "Sub2ApiAuthPersistenceError"
+  }
+}
+
+const throwIfSub2ApiAuthPersistenceFailed = (error: unknown): void => {
+  if (error instanceof Sub2ApiAuthPersistenceError) {
+    throw error
+  }
 }
 
 type RefreshedSub2ApiRequest<
@@ -201,6 +233,21 @@ const hydrateSub2ApiAuthRequest = async <TRequest extends ApiServiceRequest>(
   if (request.accountId && authSession) {
     const storedAuth = await authSession.getLatestAuth(request.accountId)
     if (storedAuth) {
+      const expectedUserId = normalizeAccountIdentity(userId)
+      const storedUserId = normalizeAccountIdentity(storedAuth.userId)
+      const expectedOrigin = normalizeAccountSiteProfileUrlForOriginKey({
+        siteType: SITE_TYPES.SUB2API,
+        url: request.baseUrl,
+      })
+      if (
+        (storedUserId && expectedUserId && storedUserId !== expectedUserId) ||
+        (storedAuth.origin && storedAuth.origin !== expectedOrigin)
+      ) {
+        throw new Sub2ApiAuthPersistenceError({
+          status: SUB2API_AUTH_PERSISTENCE_STATUSES.IDENTITY_MISMATCH,
+        })
+      }
+
       const storedAccessToken = normalizeAccessToken(storedAuth.accessToken)
       const storedRefreshToken = normalizeRefreshToken(
         storedAuth.sub2apiAuth?.refreshToken,
@@ -221,7 +268,7 @@ const hydrateSub2ApiAuthRequest = async <TRequest extends ApiServiceRequest>(
         tokenExpiresAt = storedTokenExpiresAt
       }
       if (userId === undefined) {
-        userId = storedAuth.userId
+        userId = storedUserId ?? undefined
       }
     }
   }
@@ -250,29 +297,41 @@ const persistSub2ApiAuthUpdate = async (
   authSession: Sub2ApiAuthSession | undefined,
 ) => {
   if (!request.accountId) {
-    return
+    return { status: SUB2API_AUTH_PERSISTENCE_STATUSES.PERSISTED } as const
   }
 
   if (!authSession) {
-    return
+    return { status: SUB2API_AUTH_PERSISTENCE_STATUSES.PERSISTED } as const
   }
 
+  const expectedUserId = normalizeAccountIdentity(request.auth?.userId)
+  if (!expectedUserId) {
+    throw new Sub2ApiAuthPersistenceError({
+      status: SUB2API_AUTH_PERSISTENCE_STATUSES.IDENTITY_MISMATCH,
+    })
+  }
+
+  let result: Sub2ApiAuthPersistenceResult
   try {
-    const updated = await authSession.persistAuthUpdate(
-      request.accountId,
-      authUpdate,
-    )
-    if (!updated) {
-      logger.warn("Failed to persist Sub2API auth update after key request", {
-        accountId: request.accountId,
-      })
-    }
+    result = await authSession.persistAuthUpdate(request.accountId, {
+      ...authUpdate,
+      expectedOrigin: request.baseUrl,
+      expectedUserId,
+    })
   } catch (error) {
     logger.warn("Failed to persist Sub2API auth update", {
       accountId: request.accountId,
       error: getSafeErrorMessage(error),
     })
+    throw new Sub2ApiAuthPersistenceError({
+      status: SUB2API_AUTH_PERSISTENCE_STATUSES.WRITE_FAILED,
+    })
   }
+
+  if (result.status !== SUB2API_AUTH_PERSISTENCE_STATUSES.PERSISTED) {
+    throw new Sub2ApiAuthPersistenceError(result)
+  }
+  return result
 }
 
 const applySub2ApiAuthUpdate = <TRequest extends ApiServiceRequest>(
@@ -291,6 +350,7 @@ const applySub2ApiAuthUpdate = <TRequest extends ApiServiceRequest>(
       ...(typeof authUpdate.tokenExpiresAt === "number"
         ? { tokenExpiresAt: authUpdate.tokenExpiresAt }
         : {}),
+      ...(authUpdate.userId ? { userId: authUpdate.userId } : {}),
     },
   }) as TRequest
 
@@ -348,6 +408,32 @@ const didSub2ApiAuthChange = (
   )
 }
 
+const verifySub2ApiAuthIdentity = async <TRequest extends ApiServiceRequest>(
+  request: TRequest,
+  authUpdate: PersistableSub2ApiAuthUpdate,
+): Promise<PersistableSub2ApiAuthUpdate> => {
+  const expectedUserId = normalizeAccountIdentity(request.auth?.userId)
+  if (!request.accountId || !getSub2ApiAuthSession(request)) {
+    return authUpdate
+  }
+  if (!expectedUserId) {
+    throw new Sub2ApiAuthPersistenceError({
+      status: SUB2API_AUTH_PERSISTENCE_STATUSES.IDENTITY_MISMATCH,
+    })
+  }
+
+  const verificationRequest = applySub2ApiAuthUpdate(request, authUpdate)
+  const verified = await fetchUserInfo(verificationRequest)
+  const verifiedUserId = normalizeAccountIdentity(verified.id)
+  if (verifiedUserId !== expectedUserId) {
+    throw new Sub2ApiAuthPersistenceError({
+      status: SUB2API_AUTH_PERSISTENCE_STATUSES.IDENTITY_MISMATCH,
+    })
+  }
+
+  return { ...authUpdate, userId: verifiedUserId }
+}
+
 const refreshSub2ApiRequestAuth = async <
   TRequest extends ApiServiceRequest,
 >(params: {
@@ -384,10 +470,17 @@ const refreshSub2ApiRequestAuth = async <
       refreshToken: latestRefreshToken,
     })
 
-    const refreshedRequest = applySub2ApiAuthUpdate(latestRequest, refreshed)
+    const verifiedRefresh = await verifySub2ApiAuthIdentity(
+      latestRequest,
+      refreshed,
+    )
+    const refreshedRequest = applySub2ApiAuthUpdate(
+      latestRequest,
+      verifiedRefresh,
+    )
     await persistSub2ApiAuthUpdate(
       refreshedRequest,
-      refreshed,
+      verifiedRefresh,
       latestAuthSession,
     )
 
@@ -415,11 +508,29 @@ const resyncSub2ApiRequestAuth = async <
       return latestRequest
     }
 
-    const resynced = await resyncSub2ApiAuthToken(
-      latestRequest.baseUrl,
-      latestRequest.tempWindowRequestSource,
-      latestRequest.protectionBypassExecution,
-    )
+    const expectedUserId = normalizeAccountIdentity(latestRequest.auth?.userId)
+    let resynced
+    try {
+      resynced = expectedUserId
+        ? await resyncSub2ApiAuthToken(
+            latestRequest.baseUrl,
+            latestRequest.tempWindowRequestSource,
+            latestRequest.protectionBypassExecution,
+            expectedUserId,
+          )
+        : await resyncSub2ApiAuthToken(
+            latestRequest.baseUrl,
+            latestRequest.tempWindowRequestSource,
+            latestRequest.protectionBypassExecution,
+          )
+    } catch (error) {
+      if (error instanceof Sub2ApiAuthIdentityMismatchError) {
+        throw new Sub2ApiAuthPersistenceError({
+          status: SUB2API_AUTH_PERSISTENCE_STATUSES.IDENTITY_MISMATCH,
+        })
+      }
+      throw error
+    }
     if (!resynced) {
       throw createLoginRequiredError(params.endpoint)
     }
@@ -431,11 +542,27 @@ const resyncSub2ApiRequestAuth = async <
 
     const resyncedRequest = applySub2ApiAuthUpdate(latestRequest, {
       accessToken: resynced.accessToken,
+      userId: resynced.userId,
+      ...(resynced.sub2apiAuth?.refreshToken
+        ? { refreshToken: resynced.sub2apiAuth.refreshToken }
+        : {}),
+      ...(typeof resynced.sub2apiAuth?.tokenExpiresAt === "number"
+        ? { tokenExpiresAt: resynced.sub2apiAuth.tokenExpiresAt }
+        : {}),
     })
 
     await persistSub2ApiAuthUpdate(
       resyncedRequest,
-      { accessToken: resynced.accessToken },
+      {
+        accessToken: resynced.accessToken,
+        userId: resynced.userId,
+        ...(resyncedRequest.auth?.refreshToken
+          ? { refreshToken: resyncedRequest.auth.refreshToken }
+          : {}),
+        ...(typeof resyncedRequest.auth?.tokenExpiresAt === "number"
+          ? { tokenExpiresAt: resyncedRequest.auth.tokenExpiresAt }
+          : {}),
+      },
       latestAuthSession,
     )
 
@@ -501,10 +628,22 @@ const executeAuthenticatedSub2ApiRequest = async <T>(
       effectiveRequest = refreshed.request
       refreshToken = refreshed.refreshToken
     } catch (refreshError) {
-      logger.warn("Sub2API proactive key auth refresh failed", {
-        endpoint,
-        error: getSafeErrorMessage(refreshError),
-      })
+      throwIfSub2ApiAuthPersistenceFailed(refreshError)
+      if (isUncertainSub2ApiRefreshRotation(refreshError)) {
+        effectiveRequest = await resyncSub2ApiRequestAuth({
+          request: effectiveRequest,
+          endpoint,
+          authSession: hydrated.authSession,
+        })
+        refreshToken = normalizeRefreshToken(
+          effectiveRequest.auth?.refreshToken,
+        )
+      } else {
+        logger.warn("Sub2API proactive key auth refresh failed", {
+          endpoint,
+          error: getSafeErrorMessage(refreshError),
+        })
+      }
     }
   }
 
@@ -516,17 +655,15 @@ const executeAuthenticatedSub2ApiRequest = async <T>(
     }
 
     if (refreshToken) {
+      let refreshed: RefreshedSub2ApiRequest
       try {
-        const refreshed = await refreshSub2ApiRequestAuth({
+        refreshed = await refreshSub2ApiRequestAuth({
           request: effectiveRequest,
           refreshToken,
           authSession: hydrated.authSession,
         })
-
-        effectiveRequest = refreshed.request
-
-        return await runner(effectiveRequest)
       } catch (refreshError) {
+        throwIfSub2ApiAuthPersistenceFailed(refreshError)
         logger.warn("Failed to restore Sub2API key request via refresh token", {
           endpoint,
           error: getSafeErrorMessage(refreshError),
@@ -542,7 +679,8 @@ const executeAuthenticatedSub2ApiRequest = async <T>(
             endpoint,
             authSession: hydrated.authSession,
           })
-        } catch {
+        } catch (resyncError) {
+          throwIfSub2ApiAuthPersistenceFailed(resyncError)
           throw refreshError
         }
 
@@ -555,6 +693,17 @@ const executeAuthenticatedSub2ApiRequest = async <T>(
 
           throw retryError
         }
+      }
+
+      effectiveRequest = refreshed.request
+      try {
+        return await runner(effectiveRequest)
+      } catch (retryError) {
+        if (isUnauthorizedError(retryError)) {
+          throw createLoginRequiredError(endpoint)
+        }
+
+        throw retryError
       }
     }
 
@@ -1135,6 +1284,7 @@ const fetchSub2ApiAccessTokenInfoWithAuthRecovery = async (params: {
 
         return await fetchSub2ApiAccessTokenInfo(refreshed.request)
       } catch (refreshError) {
+        throwIfSub2ApiAuthPersistenceFailed(refreshError)
         logger.warn("Failed to restore Sub2API user info via refresh token", {
           endpoint: SUB2API_AUTH_ME_ENDPOINT,
           error: getSafeErrorMessage(refreshError),
@@ -1189,6 +1339,7 @@ export async function getOrCreateAccessToken(
         access_token: accessToken,
       }
     } catch (refreshError) {
+      throwIfSub2ApiAuthPersistenceFailed(refreshError)
       logger.warn("Failed to restore Sub2API user info via refresh token", {
         endpoint: SUB2API_AUTH_ME_ENDPOINT,
         error: getSafeErrorMessage(refreshError),
@@ -1357,9 +1508,25 @@ export async function refreshAccountData(
           tokenExpiresAt = refreshed.tokenExpiresAt
           hasProactiveRefreshUpdate = true
         } catch (refreshError) {
-          logger.warn("Sub2API proactive token refresh failed", {
-            error: getSafeErrorMessage(refreshError),
-          })
+          throwIfSub2ApiAuthPersistenceFailed(refreshError)
+          if (isUncertainSub2ApiRefreshRotation(refreshError)) {
+            effectiveRequest = await resyncSub2ApiRequestAuth({
+              request: effectiveRequest,
+              endpoint: SUB2API_AUTH_ME_ENDPOINT,
+              authSession: hydratedRequest.authSession,
+            })
+            refreshToken = normalizeRefreshToken(
+              effectiveRequest.auth?.refreshToken,
+            )
+            tokenExpiresAt = normalizeTokenExpiresAt(
+              effectiveRequest.auth?.tokenExpiresAt,
+            )
+            hasProactiveRefreshUpdate = true
+          } else {
+            logger.warn("Sub2API proactive token refresh failed", {
+              error: getSafeErrorMessage(refreshError),
+            })
+          }
         }
       }
     }
@@ -1408,6 +1575,7 @@ export async function refreshAccountData(
             },
           })
         } catch (refreshError) {
+          throwIfSub2ApiAuthPersistenceFailed(refreshError)
           logger.warn("Failed to restore Sub2API session via refresh token", {
             error: getSafeErrorMessage(refreshError),
           })

--- a/src/services/apiService/sub2api/tokenRefresh.ts
+++ b/src/services/apiService/sub2api/tokenRefresh.ts
@@ -64,6 +64,7 @@ export async function refreshSub2ApiTokens(params: {
 
   const endpoint = new URL("/api/v1/auth/refresh", baseUrl).toString()
   let payload: Sub2ApiEnvelope<Sub2ApiRefreshTokenData> | null
+  let responseStatus: number | undefined
 
   try {
     const response = await fetch(endpoint, {
@@ -74,6 +75,7 @@ export async function refreshSub2ApiTokens(params: {
       },
       body: JSON.stringify({ refresh_token: normalizedRefreshToken }),
     })
+    responseStatus = response.status
 
     payload =
       (await response.json()) as Sub2ApiEnvelope<Sub2ApiRefreshTokenData>
@@ -90,8 +92,13 @@ export async function refreshSub2ApiTokens(params: {
   }
 
   if (payload.code !== 0) {
+    // Upstream maps rejected refresh tokens to HTTP 401. Other failures may
+    // occur after rotation and cannot safely authorize replay of the old token.
+    // Source: https://github.com/Wei-Shaw/sub2api/blob/67380eafd5ae2eaa8db910ae738199c3dac62e37/backend/internal/handler/auth_handler.go#L692-L704
     throw new Sub2ApiTokenRefreshError(
-      SUB2API_TOKEN_REFRESH_FAILURE_REASONS.INVALID_REFRESH_TOKEN,
+      responseStatus === 401
+        ? SUB2API_TOKEN_REFRESH_FAILURE_REASONS.INVALID_REFRESH_TOKEN
+        : SUB2API_TOKEN_REFRESH_FAILURE_REASONS.UNCERTAIN_ROTATION,
     )
   }
 

--- a/src/services/apiService/sub2api/tokenRefresh.ts
+++ b/src/services/apiService/sub2api/tokenRefresh.ts
@@ -1,5 +1,3 @@
-import { getSafeErrorMessage } from "./redaction"
-
 /**
  * Match upstream buffer: refresh ~2 minutes before expiry.
  */
@@ -24,6 +22,20 @@ type Sub2ApiRefreshedCredentials = {
   tokenExpiresAt: number
 }
 
+export const SUB2API_TOKEN_REFRESH_FAILURE_REASONS = {
+  INVALID_REFRESH_TOKEN: "invalid_refresh_token",
+  UNCERTAIN_ROTATION: "uncertain_rotation",
+} as const
+
+export class Sub2ApiTokenRefreshError extends Error {
+  constructor(
+    public readonly reason: (typeof SUB2API_TOKEN_REFRESH_FAILURE_REASONS)[keyof typeof SUB2API_TOKEN_REFRESH_FAILURE_REASONS],
+  ) {
+    super("Sub2API token refresh failed")
+    this.name = "Sub2ApiTokenRefreshError"
+  }
+}
+
 const normalizeString = (value: unknown): string =>
   typeof value === "string" ? value.trim() : ""
 
@@ -32,6 +44,11 @@ const normalizeExpiresInSeconds = (value: unknown): number =>
 
 /**
  * Refreshes Sub2API tokens.
+ *
+ * Source: https://github.com/Wei-Shaw/sub2api/blob/67380eafd5ae2eaa8db910ae738199c3dac62e37/backend/internal/service/auth_service.go#L1777-L1861
+ * Each refresh immediately invalidates the submitted refresh token and returns
+ * a complete replacement pair. An incomplete success response is therefore an
+ * uncertain credential mutation and must not replay the submitted token.
  */
 export async function refreshSub2ApiTokens(params: {
   baseUrl: string
@@ -46,7 +63,7 @@ export async function refreshSub2ApiTokens(params: {
   }
 
   const endpoint = new URL("/api/v1/auth/refresh", baseUrl).toString()
-  let payload: Sub2ApiEnvelope<Sub2ApiRefreshTokenData> | null = null
+  let payload: Sub2ApiEnvelope<Sub2ApiRefreshTokenData> | null
 
   try {
     const response = await fetch(endpoint, {
@@ -58,27 +75,40 @@ export async function refreshSub2ApiTokens(params: {
       body: JSON.stringify({ refresh_token: normalizedRefreshToken }),
     })
 
-    payload = (await response
-      .json()
-      .catch(() => null)) as Sub2ApiEnvelope<Sub2ApiRefreshTokenData> | null
-  } catch (error) {
-    throw new Error(getSafeErrorMessage(error))
+    payload =
+      (await response.json()) as Sub2ApiEnvelope<Sub2ApiRefreshTokenData>
+  } catch {
+    throw new Sub2ApiTokenRefreshError(
+      SUB2API_TOKEN_REFRESH_FAILURE_REASONS.UNCERTAIN_ROTATION,
+    )
   }
 
-  if (!payload || typeof payload !== "object" || payload.code !== 0) {
-    throw new Error("Sub2API token refresh failed")
+  if (!payload || typeof payload !== "object") {
+    throw new Sub2ApiTokenRefreshError(
+      SUB2API_TOKEN_REFRESH_FAILURE_REASONS.UNCERTAIN_ROTATION,
+    )
+  }
+
+  if (payload.code !== 0) {
+    throw new Sub2ApiTokenRefreshError(
+      SUB2API_TOKEN_REFRESH_FAILURE_REASONS.INVALID_REFRESH_TOKEN,
+    )
   }
 
   const data = payload.data
   if (!data || typeof data !== "object") {
-    throw new Error("Sub2API token refresh failed")
+    throw new Sub2ApiTokenRefreshError(
+      SUB2API_TOKEN_REFRESH_FAILURE_REASONS.UNCERTAIN_ROTATION,
+    )
   }
 
   const nextAccessToken = normalizeString(data.access_token)
   const nextRefreshToken = normalizeString(data.refresh_token)
   const expiresInSeconds = normalizeExpiresInSeconds(data.expires_in)
   if (!nextAccessToken || !nextRefreshToken || expiresInSeconds <= 0) {
-    throw new Error("Sub2API token refresh failed")
+    throw new Sub2ApiTokenRefreshError(
+      SUB2API_TOKEN_REFRESH_FAILURE_REASONS.UNCERTAIN_ROTATION,
+    )
   }
 
   const now = Date.now()

--- a/src/services/apiService/sub2api/tokenResync.ts
+++ b/src/services/apiService/sub2api/tokenResync.ts
@@ -4,11 +4,14 @@ import {
   resolveAccountBrowserSession,
   type AccountBrowserSession,
 } from "~/services/accountBrowserSession"
+import { normalizeAccountIdentity } from "~/services/accounts/accountIdentity"
 import type { ProtectionBypassExecution } from "~/services/protectionBypass/contracts"
 import type { TempWindowRequestSource } from "~/types/tempWindowFetch"
 
-type Sub2ApiResyncedToken = {
+type Sub2ApiResyncedAuth = {
   accessToken: string
+  userId?: string
+  sub2apiAuth?: AccountBrowserSession["sub2apiAuth"]
   source:
     | typeof ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB
     | typeof ACCOUNT_BROWSER_SESSION_SOURCES.TEMP_WINDOW
@@ -27,13 +30,20 @@ const SUB2API_RESYNC_SOURCE_BY_BROWSER_SESSION_SOURCE = {
     ACCOUNT_BROWSER_SESSION_SOURCES.TEMP_WINDOW,
 } as const satisfies Record<
   AccountBrowserSession["source"],
-  Sub2ApiResyncedToken["source"]
+  Sub2ApiResyncedAuth["source"]
 >
 
 const mapResyncSource = (
   source: AccountBrowserSession["source"],
-): Sub2ApiResyncedToken["source"] =>
+): Sub2ApiResyncedAuth["source"] =>
   SUB2API_RESYNC_SOURCE_BY_BROWSER_SESSION_SOURCE[source]
+
+export class Sub2ApiAuthIdentityMismatchError extends Error {
+  constructor() {
+    super("Sub2API browser session identity mismatch")
+    this.name = "Sub2ApiAuthIdentityMismatchError"
+  }
+}
 
 /**
  * Re-sync Sub2API JWT from browser-session state.
@@ -46,7 +56,10 @@ export async function resyncSub2ApiAuthToken(
   baseUrl: string,
   tempWindowRequestSource?: TempWindowRequestSource,
   protectionBypassExecution?: ProtectionBypassExecution,
-): Promise<Sub2ApiResyncedToken | null> {
+  expectedUserId?: string,
+): Promise<Sub2ApiResyncedAuth | null> {
+  const normalizedExpectedUserId = normalizeAccountIdentity(expectedUserId)
+  let foundMismatchedCredential = false
   const session = await resolveAccountBrowserSession({
     baseUrl,
     siteType: SITE_TYPES.SUB2API,
@@ -55,14 +68,40 @@ export async function resyncSub2ApiAuthToken(
     requestIdPrefix: "sub2api-token-resync",
     ...(tempWindowRequestSource ? { tempWindowRequestSource } : {}),
     ...(protectionBypassExecution ? { protectionBypassExecution } : {}),
-    isUsableSession: hasUsableAccessToken,
+    isUsableSession: (candidate) => {
+      if (!hasUsableAccessToken(candidate)) {
+        return false
+      }
+
+      const identityMatches =
+        !normalizedExpectedUserId ||
+        normalizeAccountIdentity(candidate.userId) === normalizedExpectedUserId
+      if (!identityMatches) {
+        foundMismatchedCredential = true
+      }
+      return identityMatches
+    },
   })
 
   const accessToken = session?.accessToken?.trim()
-  if (!session || !accessToken) return null
+  const returnedIdentityMismatch = Boolean(
+    session &&
+      normalizedExpectedUserId &&
+      normalizeAccountIdentity(session.userId) !== normalizedExpectedUserId,
+  )
+  if ((foundMismatchedCredential && !session) || returnedIdentityMismatch) {
+    throw new Sub2ApiAuthIdentityMismatchError()
+  }
 
+  if (!session || !accessToken) {
+    return null
+  }
+
+  const userId = normalizeAccountIdentity(session.userId)
   return {
     accessToken,
+    ...(userId ? { userId } : {}),
+    ...(session.sub2apiAuth ? { sub2apiAuth: session.sub2apiAuth } : {}),
     source: mapResyncSource(session.source),
   }
 }

--- a/tests/services/accountStorage.test.ts
+++ b/tests/services/accountStorage.test.ts
@@ -264,6 +264,180 @@ describe("accountStorage core behaviors", () => {
     })
   })
 
+  describe("updateSub2ApiAuth", () => {
+    const authUpdate = {
+      accessToken: "rotated-access-token",
+      refreshToken: "rotated-refresh-token",
+      tokenExpiresAt: 1_800_000_000_000,
+      expectedOrigin: "https://auth.example.invalid/dashboard",
+      expectedUserId: "user-1",
+    }
+
+    it("persists a complete rotation only when the locked account identity still matches", async () => {
+      seedStorage([
+        createAccount({
+          id: "sub2-account",
+          site_type: SITE_TYPES.SUB2API,
+          site_url: "https://auth.example.invalid",
+          account_info: { id: "user-1" } as SiteAccount["account_info"],
+          sub2apiAuth: {
+            refreshToken: "stored-refresh-token",
+            tokenExpiresAt: 1_700_000_000_000,
+          },
+        }),
+      ])
+
+      await expect(
+        accountStorage.updateSub2ApiAuth("sub2-account", authUpdate, {
+          userTimestampMode: AccountUpdateUserTimestampMode.Preserve,
+        }),
+      ).resolves.toEqual({ status: "persisted" })
+
+      await expect(
+        accountStorage.getAccountById("sub2-account"),
+      ).resolves.toMatchObject({
+        account_info: {
+          id: "user-1",
+          access_token: "rotated-access-token",
+        },
+        sub2apiAuth: {
+          refreshToken: "rotated-refresh-token",
+          tokenExpiresAt: 1_800_000_000_000,
+        },
+      })
+    })
+
+    it("returns typed non-success outcomes for deletion, identity drift, and write failure", async () => {
+      await expect(
+        accountStorage.updateSub2ApiAuth("missing", authUpdate, {
+          userTimestampMode: AccountUpdateUserTimestampMode.Preserve,
+        }),
+      ).resolves.toEqual({ status: "account_missing" })
+
+      seedStorage([
+        createAccount({
+          id: "sub2-account",
+          site_type: SITE_TYPES.SUB2API,
+          site_url: "https://other.example.invalid",
+          account_info: { id: "user-1" } as SiteAccount["account_info"],
+        }),
+      ])
+      await expect(
+        accountStorage.updateSub2ApiAuth("sub2-account", authUpdate, {
+          userTimestampMode: AccountUpdateUserTimestampMode.Preserve,
+        }),
+      ).resolves.toEqual({ status: "identity_mismatch" })
+
+      seedStorage([
+        createAccount({
+          id: "sub2-account",
+          site_type: SITE_TYPES.SUB2API,
+          site_url: "https://auth.example.invalid",
+          account_info: { id: "other-user" } as SiteAccount["account_info"],
+        }),
+      ])
+      await expect(
+        accountStorage.updateSub2ApiAuth("sub2-account", authUpdate, {
+          userTimestampMode: AccountUpdateUserTimestampMode.Preserve,
+        }),
+      ).resolves.toEqual({ status: "identity_mismatch" })
+
+      seedStorage([
+        createAccount({
+          id: "sub2-account",
+          site_type: SITE_TYPES.SUB2API,
+          site_url: "https://auth.example.invalid",
+          account_info: { id: "user-1" } as SiteAccount["account_info"],
+        }),
+      ])
+      storageHooks.beforeSet = async () => {
+        throw new Error("storage unavailable")
+      }
+      await expect(
+        accountStorage.updateSub2ApiAuth("sub2-account", authUpdate, {
+          userTimestampMode: AccountUpdateUserTimestampMode.Preserve,
+        }),
+      ).resolves.toEqual({ status: "write_failed" })
+    })
+
+    it("requires a non-empty expected identity before writing credentials", async () => {
+      seedStorage([
+        createAccount({
+          id: "sub2-account",
+          site_type: SITE_TYPES.SUB2API,
+          site_url: "https://auth.example.invalid",
+          account_info: { id: "" } as SiteAccount["account_info"],
+        }),
+      ])
+
+      await expect(
+        accountStorage.updateSub2ApiAuth(
+          "sub2-account",
+          { ...authUpdate, expectedUserId: "   " },
+          { userTimestampMode: AccountUpdateUserTimestampMode.Preserve },
+        ),
+      ).resolves.toEqual({ status: "identity_mismatch" })
+    })
+
+    it("does not recreate credentials when deletion wins the storage lock race", async () => {
+      seedStorage([
+        createAccount({
+          id: "sub2-account",
+          site_type: SITE_TYPES.SUB2API,
+          site_url: "https://auth.example.invalid",
+          account_info: { id: "user-1" } as SiteAccount["account_info"],
+        }),
+      ])
+
+      const deletion = accountStorage.deleteAccount("sub2-account")
+      const persistence = accountStorage.updateSub2ApiAuth(
+        "sub2-account",
+        authUpdate,
+        { userTimestampMode: AccountUpdateUserTimestampMode.Preserve },
+      )
+
+      await expect(deletion).resolves.toBe(true)
+      await expect(persistence).resolves.toEqual({ status: "account_missing" })
+      await expect(
+        accountStorage.getAccountById("sub2-account"),
+      ).resolves.toBeNull()
+    })
+
+    it("preserves stored refresh metadata when a verified resync supplies only an access token", async () => {
+      seedStorage([
+        createAccount({
+          id: "sub2-account",
+          site_type: SITE_TYPES.SUB2API,
+          site_url: "https://auth.example.invalid",
+          account_info: { id: "user-1" } as SiteAccount["account_info"],
+          sub2apiAuth: {
+            refreshToken: "stored-refresh-token",
+            tokenExpiresAt: 1_700_000_000_000,
+          },
+        }),
+      ])
+
+      await accountStorage.updateSub2ApiAuth(
+        "sub2-account",
+        {
+          accessToken: "resynced-access-token",
+          expectedOrigin: "https://auth.example.invalid",
+          expectedUserId: "user-1",
+        },
+        { userTimestampMode: AccountUpdateUserTimestampMode.Preserve },
+      )
+
+      await expect(
+        accountStorage.getAccountById("sub2-account"),
+      ).resolves.toMatchObject({
+        sub2apiAuth: {
+          refreshToken: "stored-refresh-token",
+          tokenExpiresAt: 1_700_000_000_000,
+        },
+      })
+    })
+  })
+
   it("migrates legacy string tags on reads (account.tags -> tagIds + global tag store)", async () => {
     const account = createAccount({
       id: "with-legacy-tags",

--- a/tests/services/accountStorage.test.ts
+++ b/tests/services/accountStorage.test.ts
@@ -379,6 +379,33 @@ describe("accountStorage core behaviors", () => {
       ).resolves.toEqual({ status: "identity_mismatch" })
     })
 
+    it("rejects a credential update whose returned identity differs from the expected account", async () => {
+      seedStorage([
+        createAccount({
+          id: "sub2-account",
+          site_type: SITE_TYPES.SUB2API,
+          site_url: "https://auth.example.invalid",
+          account_info: { id: "user-1" } as SiteAccount["account_info"],
+        }),
+      ])
+
+      await expect(
+        accountStorage.updateSub2ApiAuth(
+          "sub2-account",
+          { ...authUpdate, userId: "user-2" },
+          { userTimestampMode: AccountUpdateUserTimestampMode.Preserve },
+        ),
+      ).resolves.toEqual({ status: "identity_mismatch" })
+
+      await expect(
+        accountStorage.getAccountById("sub2-account"),
+      ).resolves.toMatchObject({
+        account_info: {
+          id: "user-1",
+        },
+      })
+    })
+
     it("does not recreate credentials when deletion wins the storage lock race", async () => {
       seedStorage([
         createAccount({
@@ -432,6 +459,46 @@ describe("accountStorage core behaviors", () => {
       ).resolves.toMatchObject({
         sub2apiAuth: {
           refreshToken: "stored-refresh-token",
+          tokenExpiresAt: 1_700_000_000_000,
+        },
+      })
+    })
+
+    it("preserves the latest valid expiry when resync supplies a new refresh token without one", async () => {
+      seedStorage([
+        createAccount({
+          id: "sub2-account",
+          site_type: SITE_TYPES.SUB2API,
+          site_url: "https://auth.example.invalid",
+          account_info: { id: "user-1" } as SiteAccount["account_info"],
+          sub2apiAuth: {
+            refreshToken: "stored-refresh-token",
+            tokenExpiresAt: 1_700_000_000_000,
+          },
+        }),
+      ])
+
+      await accountStorage.updateSub2ApiAuth(
+        "sub2-account",
+        {
+          accessToken: "resynced-access-token",
+          refreshToken: "resynced-refresh-token",
+          expectedOrigin: "https://auth.example.invalid",
+          expectedUserId: "user-1",
+          userId: " user-1 ",
+        },
+        { userTimestampMode: AccountUpdateUserTimestampMode.Preserve },
+      )
+
+      await expect(
+        accountStorage.getAccountById("sub2-account"),
+      ).resolves.toMatchObject({
+        account_info: {
+          id: "user-1",
+          access_token: "resynced-access-token",
+        },
+        sub2apiAuth: {
+          refreshToken: "resynced-refresh-token",
           tokenExpiresAt: 1_700_000_000_000,
         },
       })

--- a/tests/services/accounts/sub2apiAuthSession.test.ts
+++ b/tests/services/accounts/sub2apiAuthSession.test.ts
@@ -3,15 +3,15 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import { AccountUpdateUserTimestampMode } from "~/services/accounts/accountDefaults"
 import { accountSub2ApiAuthSession } from "~/services/accounts/sub2apiAuthSession"
 
-const { getAccountByIdMock, updateAccountMock } = vi.hoisted(() => ({
+const { getAccountByIdMock, updateSub2ApiAuthMock } = vi.hoisted(() => ({
   getAccountByIdMock: vi.fn(),
-  updateAccountMock: vi.fn(),
+  updateSub2ApiAuthMock: vi.fn(),
 }))
 
 vi.mock("~/services/accounts/accountStorage", () => ({
   accountStorage: {
     getAccountById: (...args: unknown[]) => getAccountByIdMock(...args),
-    updateAccount: (...args: unknown[]) => updateAccountMock(...args),
+    updateSub2ApiAuth: (...args: unknown[]) => updateSub2ApiAuthMock(...args),
   },
 }))
 
@@ -19,11 +19,13 @@ describe("accountSub2ApiAuthSession", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     getAccountByIdMock.mockResolvedValue(null)
-    updateAccountMock.mockResolvedValue(true)
+    updateSub2ApiAuthMock.mockResolvedValue({ status: "persisted" })
   })
 
   it("returns a narrow stored auth snapshot for an existing Sub2API account", async () => {
     getAccountByIdMock.mockResolvedValueOnce({
+      site_type: "sub2api",
+      site_url: "https://auth.example.invalid/dashboard",
       account_info: {
         id: "9",
         access_token: " stored-jwt ",
@@ -38,6 +40,7 @@ describe("accountSub2ApiAuthSession", () => {
       accountSub2ApiAuthSession.getLatestAuth("account-1"),
     ).resolves.toEqual({
       accessToken: "stored-jwt",
+      origin: "https://auth.example.invalid",
       userId: "9",
       sub2apiAuth: {
         refreshToken: "stored-refresh",
@@ -111,60 +114,54 @@ describe("accountSub2ApiAuthSession", () => {
     await expect(
       accountSub2ApiAuthSession.persistAuthUpdate("account-1", {
         accessToken: "resynced-jwt",
+        expectedOrigin: "https://sub2.example.com",
+        expectedUserId: "9",
       }),
-    ).resolves.toBe(true)
+    ).resolves.toEqual({ status: "persisted" })
 
-    expect(updateAccountMock).toHaveBeenCalledWith(
+    expect(updateSub2ApiAuthMock).toHaveBeenCalledWith(
       "account-1",
-      {
-        account_info: {
-          access_token: "resynced-jwt",
-        },
-      },
+      expect.objectContaining({
+        accessToken: "resynced-jwt",
+        expectedOrigin: "https://sub2.example.com",
+        expectedUserId: "9",
+      }),
       { userTimestampMode: AccountUpdateUserTimestampMode.Preserve },
     )
   })
 
-  it("normalizes refresh-token updates before persisting", async () => {
+  it("delegates refresh-token updates to storage normalization", async () => {
     await expect(
       accountSub2ApiAuthSession.persistAuthUpdate("account-1", {
         accessToken: "new-jwt",
         refreshToken: "  trimmed-refresh  ",
         tokenExpiresAt: 1_700_000_060_000,
+        expectedOrigin: "https://sub2.example.com",
+        expectedUserId: "9",
       }),
-    ).resolves.toBe(true)
+    ).resolves.toEqual({ status: "persisted" })
 
-    expect(updateAccountMock).toHaveBeenCalledWith(
+    expect(updateSub2ApiAuthMock).toHaveBeenCalledWith(
       "account-1",
-      {
-        account_info: {
-          access_token: "new-jwt",
-        },
-        sub2apiAuth: {
-          refreshToken: "trimmed-refresh",
-          tokenExpiresAt: 1_700_000_060_000,
-        },
-      },
+      expect.objectContaining({ refreshToken: "  trimmed-refresh  " }),
       { userTimestampMode: AccountUpdateUserTimestampMode.Preserve },
     )
 
-    updateAccountMock.mockClear()
+    updateSub2ApiAuthMock.mockClear()
 
     await expect(
       accountSub2ApiAuthSession.persistAuthUpdate("account-1", {
         accessToken: "new-jwt",
         refreshToken: "   ",
         tokenExpiresAt: 1_700_000_060_000,
+        expectedOrigin: "https://sub2.example.com",
+        expectedUserId: "9",
       }),
-    ).resolves.toBe(true)
+    ).resolves.toEqual({ status: "persisted" })
 
-    expect(updateAccountMock).toHaveBeenCalledWith(
+    expect(updateSub2ApiAuthMock).toHaveBeenCalledWith(
       "account-1",
-      {
-        account_info: {
-          access_token: "new-jwt",
-        },
-      },
+      expect.objectContaining({ refreshToken: "   " }),
       { userTimestampMode: AccountUpdateUserTimestampMode.Preserve },
     )
   })
@@ -175,20 +172,14 @@ describe("accountSub2ApiAuthSession", () => {
         accessToken: "new-jwt",
         refreshToken: "new-refresh",
         tokenExpiresAt: 1_700_000_060_000,
+        expectedOrigin: "https://sub2.example.com",
+        expectedUserId: "9",
       }),
-    ).resolves.toBe(true)
+    ).resolves.toEqual({ status: "persisted" })
 
-    expect(updateAccountMock).toHaveBeenCalledWith(
+    expect(updateSub2ApiAuthMock).toHaveBeenCalledWith(
       "account-1",
-      {
-        account_info: {
-          access_token: "new-jwt",
-        },
-        sub2apiAuth: {
-          refreshToken: "new-refresh",
-          tokenExpiresAt: 1_700_000_060_000,
-        },
-      },
+      expect.objectContaining({ refreshToken: "new-refresh" }),
       { userTimestampMode: AccountUpdateUserTimestampMode.Preserve },
     )
   })

--- a/tests/services/apiService/sub2api/index.test.ts
+++ b/tests/services/apiService/sub2api/index.test.ts
@@ -645,7 +645,7 @@ describe("apiService sub2api refreshAccountData", () => {
     mockGetLatestAuth.mockReset()
     mockPersistAuthUpdate.mockReset()
     mockGetLatestAuth.mockResolvedValue(null)
-    mockPersistAuthUpdate.mockResolvedValue(true)
+    mockPersistAuthUpdate.mockResolvedValue({ status: "persisted" })
   })
 
   const createRequest = (
@@ -819,6 +819,7 @@ describe("apiService sub2api refreshAccountData", () => {
       request.baseUrl,
       TEMP_WINDOW_REQUEST_SOURCES.Popup,
       undefined,
+      "1",
     )
     const retryRequest = vi.mocked(fetchApi).mock.calls[1]?.[0] as any
     expect(retryRequest?.auth?.accessToken).toBe("new-jwt")
@@ -967,6 +968,145 @@ describe("apiService sub2api refreshAccountData", () => {
     expect(mockPersistAuthUpdate).not.toHaveBeenCalled()
 
     nowSpy.mockRestore()
+  })
+
+  it("does not invoke a business mutation after rotated credentials fail to persist", async () => {
+    const now = 1_700_000_000_000
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(now)
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            code: 0,
+            message: "ok",
+            data: {
+              access_token: "rotated-access-token",
+              refresh_token: "rotated-refresh-token",
+              expires_in: 3600,
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      ),
+    )
+    vi.mocked(fetchApi).mockResolvedValueOnce({
+      code: 0,
+      message: "ok",
+      data: { id: 1, username: "example-user", balance: 1 },
+    } as any)
+    mockPersistAuthUpdate.mockResolvedValueOnce({ status: "write_failed" })
+
+    const request = createRequest({
+      accountId: "account-1",
+      sub2apiAuthSession: {
+        getLatestAuth: (...args: any[]) => mockGetLatestAuth(...args),
+        persistAuthUpdate: (...args: any[]) => mockPersistAuthUpdate(...args),
+      },
+      auth: {
+        authType: AuthTypeEnum.AccessToken,
+        userId: "1",
+        accessToken: "old-access-token",
+        refreshToken: "single-use-refresh-token",
+        tokenExpiresAt: now + 60_000,
+      },
+    })
+
+    await expect(
+      createApiToken(request, createTokenRequest({ group: "" })),
+    ).rejects.toThrow("messages:sub2api.authPersistenceFailed")
+
+    expect(fetchApi).toHaveBeenCalledTimes(1)
+    expect(vi.mocked(fetchApi).mock.calls[0]?.[1]).toMatchObject({
+      endpoint: "/api/v1/auth/me",
+    })
+    expect(mockPersistAuthUpdate).toHaveBeenCalledTimes(1)
+    nowSpy.mockRestore()
+  })
+
+  it("rejects refreshed credentials that resolve to another account identity", async () => {
+    const now = 1_700_000_000_000
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(now)
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            code: 0,
+            message: "ok",
+            data: {
+              access_token: "other-user-access-token",
+              refresh_token: "other-user-refresh-token",
+              expires_in: 3600,
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      ),
+    )
+    vi.mocked(fetchApi).mockResolvedValueOnce({
+      code: 0,
+      message: "ok",
+      data: { id: 2, username: "other-user", balance: 1 },
+    } as any)
+
+    const request = createRequest({
+      accountId: "account-1",
+      sub2apiAuthSession: {
+        getLatestAuth: (...args: any[]) => mockGetLatestAuth(...args),
+        persistAuthUpdate: (...args: any[]) => mockPersistAuthUpdate(...args),
+      },
+      auth: {
+        authType: AuthTypeEnum.AccessToken,
+        userId: "1",
+        accessToken: "old-access-token",
+        refreshToken: "single-use-refresh-token",
+        tokenExpiresAt: now + 60_000,
+      },
+    })
+
+    await expect(
+      createApiToken(request, createTokenRequest({ group: "" })),
+    ).rejects.toThrow("messages:sub2api.authPersistenceFailed")
+
+    expect(fetchApi).toHaveBeenCalledTimes(1)
+    expect(mockPersistAuthUpdate).not.toHaveBeenCalled()
+    nowSpy.mockRestore()
+  })
+
+  it.each([
+    {
+      label: "identity",
+      stored: {
+        accessToken: "other-user-access-token",
+        origin: "https://sub2.example.com",
+        userId: "2",
+      },
+    },
+    {
+      label: "origin",
+      stored: {
+        accessToken: "other-origin-access-token",
+        origin: "https://other.example.invalid",
+        userId: "1",
+      },
+    },
+  ])("rejects stored auth after account $label drift", async ({ stored }) => {
+    mockGetLatestAuth.mockResolvedValueOnce(stored)
+    const request = createRequest({
+      accountId: "account-1",
+      sub2apiAuthSession: {
+        getLatestAuth: (...args: any[]) => mockGetLatestAuth(...args),
+        persistAuthUpdate: (...args: any[]) => mockPersistAuthUpdate(...args),
+      },
+    })
+
+    await expect(
+      createApiToken(request, createTokenRequest({ group: "" })),
+    ).rejects.toThrow("messages:sub2api.authPersistenceFailed")
+
+    expect(fetchApi).not.toHaveBeenCalled()
+    expect(mockPersistAuthUpdate).not.toHaveBeenCalled()
   })
 
   it("uses rotated refresh token for 401 retry after proactive refresh", async () => {
@@ -1154,6 +1294,7 @@ describe("apiService sub2api refreshAccountData", () => {
       request.baseUrl,
       undefined,
       undefined,
+      "1",
     )
     expect(
       (vi.mocked(fetchApi).mock.calls[1]?.[0] as any)?.auth?.accessToken,
@@ -1163,6 +1304,152 @@ describe("apiService sub2api refreshAccountData", () => {
       key: "sub2api-token",
       group: "default",
     })
+  })
+
+  it("recovers a lost refresh-token response only through identity-checked resync", async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          code: 0,
+          message: "ok",
+          data: {
+            access_token: "rotated-access-without-pair",
+            expires_in: 3600,
+          },
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    )
+    vi.stubGlobal("fetch", fetchMock as any)
+    vi.mocked(fetchApi)
+      .mockRejectedValueOnce(new ApiError("Unauthorized", 401, "/api/v1/keys"))
+      .mockResolvedValueOnce({
+        code: 0,
+        message: "ok",
+        data: {
+          items: [
+            {
+              id: 1,
+              name: "Recovered key",
+              key: "recovered-key",
+              enabled: true,
+              quota: 0,
+              used_quota: 0,
+              group: { name: "default" },
+            },
+          ],
+        },
+      } as any)
+    vi.mocked(resyncSub2ApiAuthToken).mockResolvedValueOnce({
+      accessToken: "identity-checked-access-token",
+      userId: "1",
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB,
+    })
+
+    const tokens = await fetchAccountTokens(
+      createRequest({
+        auth: {
+          authType: AuthTypeEnum.AccessToken,
+          userId: "1",
+          accessToken: "old-access-token",
+          refreshToken: "single-use-refresh-token",
+        },
+      }),
+    )
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(resyncSub2ApiAuthToken).toHaveBeenCalledWith(
+      "https://sub2.example.com",
+      undefined,
+      undefined,
+      "1",
+    )
+    expect(tokens).toHaveLength(1)
+  })
+
+  it("does not use stale auth after a proactive refresh response is lost", async () => {
+    const now = 1_700_000_000_000
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(now)
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValueOnce(new Error("network down")),
+    )
+    vi.mocked(resyncSub2ApiAuthToken).mockResolvedValueOnce({
+      accessToken: "identity-checked-access-token",
+      userId: "1",
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB,
+    })
+    vi.mocked(fetchApi).mockResolvedValueOnce({
+      code: 0,
+      message: "ok",
+      data: { items: [] },
+    } as any)
+
+    await fetchAccountTokens(
+      createRequest({
+        auth: {
+          authType: AuthTypeEnum.AccessToken,
+          userId: "1",
+          accessToken: "old-access-token",
+          refreshToken: "single-use-refresh-token",
+          tokenExpiresAt: now + 60_000,
+        },
+      }),
+    )
+
+    expect(resyncSub2ApiAuthToken).toHaveBeenCalledWith(
+      "https://sub2.example.com",
+      undefined,
+      undefined,
+      "1",
+    )
+    expect(fetchApi).toHaveBeenCalledTimes(1)
+    expect(
+      (vi.mocked(fetchApi).mock.calls[0]?.[0] as any).auth.accessToken,
+    ).toBe("identity-checked-access-token")
+    nowSpy.mockRestore()
+  })
+
+  it("does not replay a business request after its refreshed retry fails", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            code: 0,
+            message: "ok",
+            data: {
+              access_token: "refreshed-access-token",
+              refresh_token: "rotated-refresh-token",
+              expires_in: 3600,
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      ),
+    )
+    vi.mocked(fetchApi)
+      .mockRejectedValueOnce(new ApiError("Unauthorized", 401, "/api/v1/keys"))
+      .mockRejectedValueOnce(new ApiError("Unauthorized", 401, "/api/v1/keys"))
+
+    await expect(
+      fetchAccountTokens(
+        createRequest({
+          auth: {
+            authType: AuthTypeEnum.AccessToken,
+            userId: "1",
+            accessToken: "old-access-token",
+            refreshToken: "single-use-refresh-token",
+          },
+        }),
+      ),
+    ).rejects.toMatchObject({
+      message: "messages:sub2api.loginRequired",
+      code: API_ERROR_CODES.HTTP_401,
+    })
+
+    expect(fetchApi).toHaveBeenCalledTimes(2)
+    expect(resyncSub2ApiAuthToken).not.toHaveBeenCalled()
   })
 
   it("does not re-sync key requests when refresh token restore fails with a contract error", async () => {
@@ -1260,6 +1547,7 @@ describe("apiService sub2api refreshAccountData", () => {
       request.baseUrl,
       undefined,
       undefined,
+      "1",
     )
     expect(
       (vi.mocked(fetchApi).mock.calls[1]?.[0] as any)?.auth?.accessToken,
@@ -1304,6 +1592,7 @@ describe("apiService sub2api refreshAccountData", () => {
       request.baseUrl,
       undefined,
       undefined,
+      "1",
     )
     expect(fetchApi).toHaveBeenCalledTimes(1)
     expect(result.success).toBe(false)
@@ -1342,11 +1631,17 @@ describe("apiService sub2api refreshAccountData", () => {
     )
     vi.stubGlobal("fetch", fetchMock as any)
 
-    vi.mocked(fetchApi).mockResolvedValueOnce({
-      code: 0,
-      message: "ok",
-      data: { id: 9, username: "stored-user", balance: 3 },
-    } as any)
+    vi.mocked(fetchApi)
+      .mockResolvedValueOnce({
+        code: 0,
+        message: "ok",
+        data: { id: 9, username: "stored-user", balance: 3 },
+      } as any)
+      .mockResolvedValueOnce({
+        code: 0,
+        message: "ok",
+        data: { id: 9, username: "stored-user", balance: 3 },
+      } as any)
 
     const result = await refreshAccountData(
       createRequest({
@@ -1375,6 +1670,9 @@ describe("apiService sub2api refreshAccountData", () => {
       accessToken: "new-jwt",
       refreshToken: "new-refresh",
       tokenExpiresAt: now + 3600 * 1000,
+      expectedOrigin: "https://sub2.example.com",
+      expectedUserId: "9",
+      userId: "9",
     })
     expect(result.success).toBe(true)
     expect(result.authUpdate?.userId).toBe("9")
@@ -1394,7 +1692,7 @@ describe("apiService sub2api exported operations", () => {
     mockGetLatestAuth.mockReset()
     mockPersistAuthUpdate.mockReset()
     mockGetLatestAuth.mockResolvedValue(null)
-    mockPersistAuthUpdate.mockResolvedValue(true)
+    mockPersistAuthUpdate.mockResolvedValue({ status: "persisted" })
   })
 
   const baseRequest = {

--- a/tests/services/apiService/sub2api/index.test.ts
+++ b/tests/services/apiService/sub2api/index.test.ts
@@ -42,7 +42,14 @@ import {
   translateSub2ApiCreateTokenRequest,
   translateSub2ApiUpdateTokenRequest,
 } from "~/services/apiService/sub2api/parsing"
-import { resyncSub2ApiAuthToken } from "~/services/apiService/sub2api/tokenResync"
+import {
+  SUB2API_TOKEN_REFRESH_FAILURE_REASONS,
+  Sub2ApiTokenRefreshError,
+} from "~/services/apiService/sub2api/tokenRefresh"
+import {
+  resyncSub2ApiAuthToken,
+  Sub2ApiAuthIdentityMismatchError,
+} from "~/services/apiService/sub2api/tokenResync"
 import type {
   Sub2ApiAnnouncementListData,
   Sub2ApiEnvelope,
@@ -80,9 +87,16 @@ vi.mock("~/services/apiTransport/request", () => ({
   fetchApi: vi.fn(),
 }))
 
-vi.mock("~/services/apiService/sub2api/tokenResync", () => ({
-  resyncSub2ApiAuthToken: vi.fn(),
-}))
+vi.mock("~/services/apiService/sub2api/tokenResync", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("~/services/apiService/sub2api/tokenResync")
+    >()
+  return {
+    ...actual,
+    resyncSub2ApiAuthToken: vi.fn(),
+  }
+})
 
 describe("apiService sub2api parsing", () => {
   it("convertUsdBalanceToQuota rounds using conversion factor", () => {
@@ -924,6 +938,216 @@ describe("apiService sub2api refreshAccountData", () => {
     nowSpy.mockRestore()
   })
 
+  it("resynchronizes instead of using stale auth when post-rotation identity verification is unavailable", async () => {
+    const now = 1_700_000_000_000
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(now)
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            code: 0,
+            message: "ok",
+            data: {
+              access_token: "rotated-access-token",
+              refresh_token: "rotated-refresh-token",
+              expires_in: 3600,
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      ),
+    )
+    vi.mocked(fetchApi)
+      .mockRejectedValueOnce(new Error("identity verification unavailable"))
+      .mockResolvedValueOnce({
+        code: 0,
+        message: "ok",
+        data: { id: 1, username: "alice", balance: 2 },
+      } as any)
+    vi.mocked(resyncSub2ApiAuthToken).mockResolvedValueOnce({
+      accessToken: "identity-checked-access-token",
+      userId: "1",
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB,
+    })
+
+    const result = await refreshAccountData(
+      createRequest({
+        accountId: "account-1",
+        includeTodayCashflow: false,
+        sub2apiAuthSession: {
+          getLatestAuth: (...args: any[]) => mockGetLatestAuth(...args),
+          persistAuthUpdate: (...args: any[]) => mockPersistAuthUpdate(...args),
+        },
+        auth: {
+          authType: AuthTypeEnum.AccessToken,
+          userId: "1",
+          accessToken: "old-access-token",
+          refreshToken: "single-use-refresh-token",
+          tokenExpiresAt: now + 60_000,
+        },
+      }),
+    )
+
+    expect(resyncSub2ApiAuthToken).toHaveBeenCalledWith(
+      "https://sub2.example.com",
+      undefined,
+      undefined,
+      "1",
+    )
+    expect(
+      (vi.mocked(fetchApi).mock.calls[1]?.[0] as any)?.auth.accessToken,
+    ).toBe("identity-checked-access-token")
+    expect(result.success).toBe(true)
+    expect(result.authUpdate?.accessToken).toBe("identity-checked-access-token")
+    nowSpy.mockRestore()
+  })
+
+  it("continues with the current access token after a conclusive proactive refresh rejection", async () => {
+    const now = 1_700_000_000_000
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(now)
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({ code: 401, message: "invalid refresh token" }),
+            { status: 401, headers: { "Content-Type": "application/json" } },
+          ),
+        ),
+    )
+    vi.mocked(fetchApi).mockResolvedValueOnce({
+      code: 0,
+      message: "ok",
+      data: { id: 1, username: "alice", balance: 2 },
+    } as any)
+
+    const result = await refreshAccountData(
+      createRequest({
+        includeTodayCashflow: false,
+        auth: {
+          authType: AuthTypeEnum.AccessToken,
+          userId: "1",
+          accessToken: "old-access-token",
+          refreshToken: "invalid-refresh-token",
+          tokenExpiresAt: now + 60_000,
+        },
+      }),
+    )
+
+    expect(resyncSub2ApiAuthToken).not.toHaveBeenCalled()
+    expect(
+      (vi.mocked(fetchApi).mock.calls[0]?.[0] as any)?.auth.accessToken,
+    ).toBe("old-access-token")
+    expect(result.success).toBe(true)
+    expect(result.authUpdate).not.toHaveProperty("accessToken")
+    nowSpy.mockRestore()
+  })
+
+  it("returns the credential persistence warning when the auth store throws", async () => {
+    const now = 1_700_000_000_000
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(now)
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            code: 0,
+            message: "ok",
+            data: {
+              access_token: "rotated-access-token",
+              refresh_token: "rotated-refresh-token",
+              expires_in: 3600,
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      ),
+    )
+    vi.mocked(fetchApi).mockResolvedValueOnce({
+      code: 0,
+      message: "ok",
+      data: { id: 1, username: "alice", balance: 2 },
+    } as any)
+    mockPersistAuthUpdate.mockRejectedValueOnce(
+      new Error("storage unavailable"),
+    )
+
+    const result = await refreshAccountData(
+      createRequest({
+        accountId: "account-1",
+        includeTodayCashflow: false,
+        sub2apiAuthSession: {
+          getLatestAuth: (...args: any[]) => mockGetLatestAuth(...args),
+          persistAuthUpdate: (...args: any[]) => mockPersistAuthUpdate(...args),
+        },
+        auth: {
+          authType: AuthTypeEnum.AccessToken,
+          userId: "1",
+          accessToken: "old-access-token",
+          refreshToken: "single-use-refresh-token",
+          tokenExpiresAt: now + 60_000,
+        },
+      }),
+    )
+
+    expect(result.success).toBe(false)
+    expect(result.healthStatus).toEqual({
+      status: SiteHealthStatus.Warning,
+      message: "messages:sub2api.authPersistenceFailed",
+    })
+    nowSpy.mockRestore()
+  })
+
+  it("returns the credential persistence warning when a stored account has no expected identity", async () => {
+    const now = 1_700_000_000_000
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(now)
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            code: 0,
+            message: "ok",
+            data: {
+              access_token: "rotated-access-token",
+              refresh_token: "rotated-refresh-token",
+              expires_in: 3600,
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      ),
+    )
+
+    const result = await refreshAccountData(
+      createRequest({
+        accountId: "account-1",
+        includeTodayCashflow: false,
+        sub2apiAuthSession: {
+          getLatestAuth: (...args: any[]) => mockGetLatestAuth(...args),
+          persistAuthUpdate: (...args: any[]) => mockPersistAuthUpdate(...args),
+        },
+        auth: {
+          authType: AuthTypeEnum.AccessToken,
+          accessToken: "old-access-token",
+          refreshToken: "single-use-refresh-token",
+          tokenExpiresAt: now + 60_000,
+        },
+      }),
+    )
+
+    expect(fetchApi).not.toHaveBeenCalled()
+    expect(mockPersistAuthUpdate).not.toHaveBeenCalled()
+    expect(result.success).toBe(false)
+    expect(result.healthStatus).toEqual({
+      status: SiteHealthStatus.Warning,
+      message: "messages:sub2api.authPersistenceFailed",
+    })
+    nowSpy.mockRestore()
+  })
+
   it("skips persistence when refreshed credentials have no auth store", async () => {
     const now = 1_700_000_000_000
     const nowSpy = vi.spyOn(Date, "now").mockReturnValue(now)
@@ -1107,6 +1331,159 @@ describe("apiService sub2api refreshAccountData", () => {
 
     expect(fetchApi).not.toHaveBeenCalled()
     expect(mockPersistAuthUpdate).not.toHaveBeenCalled()
+  })
+
+  it("reports stored identity drift with the credential persistence warning", async () => {
+    mockGetLatestAuth.mockResolvedValueOnce({
+      accessToken: "other-user-access-token",
+      origin: "https://sub2.example.com",
+      userId: "2",
+    })
+
+    const result = await refreshAccountData(
+      createRequest({
+        accountId: "account-1",
+        sub2apiAuthSession: {
+          getLatestAuth: (...args: any[]) => mockGetLatestAuth(...args),
+          persistAuthUpdate: (...args: any[]) => mockPersistAuthUpdate(...args),
+        },
+      }),
+    )
+
+    expect(fetchApi).not.toHaveBeenCalled()
+    expect(result).toEqual({
+      success: false,
+      healthStatus: {
+        status: SiteHealthStatus.Warning,
+        message: "messages:sub2api.authPersistenceFailed",
+      },
+    })
+  })
+
+  it("reports browser-session identity drift with the credential persistence warning", async () => {
+    vi.mocked(fetchApi).mockRejectedValueOnce(
+      new ApiError("Unauthorized", 401, "/api/v1/auth/me"),
+    )
+    vi.mocked(resyncSub2ApiAuthToken).mockRejectedValueOnce(
+      new Sub2ApiAuthIdentityMismatchError(),
+    )
+
+    const result = await refreshAccountData(createRequest())
+
+    expect(result).toEqual({
+      success: false,
+      healthStatus: {
+        status: SiteHealthStatus.Warning,
+        message: "messages:sub2api.authPersistenceFailed",
+      },
+    })
+  })
+
+  it("reports a resynced browser session with no account identity as non-persistable", async () => {
+    vi.mocked(fetchApi).mockRejectedValueOnce(
+      new ApiError("Unauthorized", 401, "/api/v1/auth/me"),
+    )
+    vi.mocked(resyncSub2ApiAuthToken).mockResolvedValueOnce({
+      accessToken: "identity-missing-access-token",
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB,
+    })
+
+    const result = await refreshAccountData(
+      createRequest({
+        accountId: "account-1",
+        sub2apiAuthSession: {
+          getLatestAuth: (...args: any[]) => mockGetLatestAuth(...args),
+          persistAuthUpdate: (...args: any[]) => mockPersistAuthUpdate(...args),
+        },
+        auth: {
+          authType: AuthTypeEnum.AccessToken,
+          accessToken: "old-access-token",
+        },
+      }),
+    )
+
+    expect(mockPersistAuthUpdate).not.toHaveBeenCalled()
+    expect(result).toEqual({
+      success: false,
+      healthStatus: {
+        status: SiteHealthStatus.Warning,
+        message: "messages:sub2api.authPersistenceFailed",
+      },
+    })
+  })
+
+  it("reports identity drift found while resyncing after refresh-token rejection", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({ code: 401, message: "invalid refresh token" }),
+            { status: 401, headers: { "Content-Type": "application/json" } },
+          ),
+        ),
+    )
+    vi.mocked(fetchApi).mockRejectedValueOnce(
+      new ApiError("Unauthorized", 401, "/api/v1/auth/me"),
+    )
+    vi.mocked(resyncSub2ApiAuthToken).mockRejectedValueOnce(
+      new Sub2ApiAuthIdentityMismatchError(),
+    )
+
+    const result = await refreshAccountData(
+      createRequest({
+        auth: {
+          authType: AuthTypeEnum.AccessToken,
+          userId: "1",
+          accessToken: "old-access-token",
+          refreshToken: "invalid-refresh-token",
+        },
+      }),
+    )
+
+    expect(result).toEqual({
+      success: false,
+      healthStatus: {
+        status: SiteHealthStatus.Warning,
+        message: "messages:sub2api.authPersistenceFailed",
+      },
+    })
+  })
+
+  it("hydrates an account whose stored auth has not yet learned an identity", async () => {
+    mockGetLatestAuth.mockResolvedValueOnce({
+      accessToken: "stored-access-token",
+      origin: "https://sub2.example.com",
+    })
+    vi.mocked(fetchApi).mockResolvedValueOnce({
+      code: 0,
+      message: "ok",
+      data: { id: 1, username: "alice", balance: 2 },
+    } as any)
+
+    const result = await refreshAccountData(
+      createRequest({
+        accountId: "account-1",
+        includeTodayCashflow: false,
+        sub2apiAuthSession: {
+          getLatestAuth: (...args: any[]) => mockGetLatestAuth(...args),
+          persistAuthUpdate: (...args: any[]) => mockPersistAuthUpdate(...args),
+        },
+        auth: {
+          authType: AuthTypeEnum.AccessToken,
+          accessToken: "request-access-token",
+        },
+      }),
+    )
+
+    expect((vi.mocked(fetchApi).mock.calls[0]?.[0] as any)?.auth).toMatchObject(
+      {
+        accessToken: "stored-access-token",
+      },
+    )
+    expect(result.success).toBe(true)
+    expect(result.authUpdate?.userId).toBe("1")
   })
 
   it("uses rotated refresh token for 401 retry after proactive refresh", async () => {
@@ -1306,6 +1683,37 @@ describe("apiService sub2api refreshAccountData", () => {
     })
   })
 
+  it("preserves the original refresh failure when browser-session resync also fails", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValueOnce(new Error("refresh response unavailable")),
+    )
+    vi.mocked(fetchApi).mockRejectedValueOnce(
+      new ApiError("Unauthorized", 401, "/api/v1/keys"),
+    )
+    vi.mocked(resyncSub2ApiAuthToken).mockRejectedValueOnce(
+      new Error("browser session unavailable"),
+    )
+
+    const failure = await fetchAccountTokens(
+      createRequest({
+        auth: {
+          authType: AuthTypeEnum.AccessToken,
+          userId: "1",
+          accessToken: "old-access-token",
+          refreshToken: "single-use-refresh-token",
+        },
+      }),
+    ).catch((error) => error)
+
+    expect(failure).toBeInstanceOf(Sub2ApiTokenRefreshError)
+    expect(failure).toMatchObject({
+      reason: SUB2API_TOKEN_REFRESH_FAILURE_REASONS.UNCERTAIN_ROTATION,
+    })
+    expect(fetchApi).toHaveBeenCalledTimes(1)
+    expect(resyncSub2ApiAuthToken).toHaveBeenCalledTimes(1)
+  })
+
   it("recovers a lost refresh-token response only through identity-checked resync", async () => {
     const fetchMock = vi.fn().mockResolvedValueOnce(
       new Response(
@@ -1410,6 +1818,90 @@ describe("apiService sub2api refreshAccountData", () => {
     nowSpy.mockRestore()
   })
 
+  it("uses the current access token after a conclusive proactive key refresh rejection", async () => {
+    const now = 1_700_000_000_000
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(now)
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({ code: 401, message: "invalid refresh token" }),
+            { status: 401, headers: { "Content-Type": "application/json" } },
+          ),
+        ),
+    )
+    vi.mocked(fetchApi).mockResolvedValueOnce({
+      code: 0,
+      message: "ok",
+      data: { items: [] },
+    } as any)
+
+    await fetchAccountTokens(
+      createRequest({
+        auth: {
+          authType: AuthTypeEnum.AccessToken,
+          userId: "1",
+          accessToken: "current-access-token",
+          refreshToken: "invalid-refresh-token",
+          tokenExpiresAt: now + 60_000,
+        },
+      }),
+    )
+
+    expect(resyncSub2ApiAuthToken).not.toHaveBeenCalled()
+    expect(
+      (vi.mocked(fetchApi).mock.calls[0]?.[0] as any).auth.accessToken,
+    ).toBe("current-access-token")
+    nowSpy.mockRestore()
+  })
+
+  it("persists supplemental credentials returned by browser-session re-sync", async () => {
+    const tokenExpiresAt = 1_700_003_600_000
+    vi.mocked(fetchApi)
+      .mockRejectedValueOnce(new ApiError("Unauthorized", 401, "/api/v1/keys"))
+      .mockResolvedValueOnce({
+        code: 0,
+        message: "ok",
+        data: { items: [] },
+      } as any)
+    vi.mocked(resyncSub2ApiAuthToken).mockResolvedValueOnce({
+      accessToken: "resynced-access-token",
+      userId: "1",
+      sub2apiAuth: {
+        refreshToken: "resynced-refresh-token",
+        tokenExpiresAt,
+      },
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB,
+    })
+
+    await fetchAccountTokens(
+      createRequest({
+        accountId: "account-1",
+        sub2apiAuthSession: {
+          getLatestAuth: (...args: any[]) => mockGetLatestAuth(...args),
+          persistAuthUpdate: (...args: any[]) => mockPersistAuthUpdate(...args),
+        },
+      }),
+    )
+
+    expect(mockPersistAuthUpdate).toHaveBeenCalledWith("account-1", {
+      accessToken: "resynced-access-token",
+      refreshToken: "resynced-refresh-token",
+      tokenExpiresAt,
+      expectedOrigin: "https://sub2.example.com",
+      expectedUserId: "1",
+      userId: "1",
+    })
+    expect((vi.mocked(fetchApi).mock.calls[1]?.[0] as any).auth).toMatchObject({
+      accessToken: "resynced-access-token",
+      refreshToken: "resynced-refresh-token",
+      tokenExpiresAt,
+      userId: "1",
+    })
+  })
+
   it("does not replay a business request after its refreshed retry fails", async () => {
     vi.stubGlobal(
       "fetch",
@@ -1447,6 +1939,50 @@ describe("apiService sub2api refreshAccountData", () => {
       message: "messages:sub2api.loginRequired",
       code: API_ERROR_CODES.HTTP_401,
     })
+
+    expect(fetchApi).toHaveBeenCalledTimes(2)
+    expect(resyncSub2ApiAuthToken).not.toHaveBeenCalled()
+  })
+
+  it("preserves a non-auth business failure from the single refreshed retry", async () => {
+    const businessFailure = new ApiError(
+      "upstream unavailable",
+      503,
+      "/api/v1/keys",
+    )
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            code: 0,
+            message: "ok",
+            data: {
+              access_token: "refreshed-access-token",
+              refresh_token: "rotated-refresh-token",
+              expires_in: 3600,
+            },
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      ),
+    )
+    vi.mocked(fetchApi)
+      .mockRejectedValueOnce(new ApiError("Unauthorized", 401, "/api/v1/keys"))
+      .mockRejectedValueOnce(businessFailure)
+
+    await expect(
+      fetchAccountTokens(
+        createRequest({
+          auth: {
+            authType: AuthTypeEnum.AccessToken,
+            userId: "1",
+            accessToken: "old-access-token",
+            refreshToken: "single-use-refresh-token",
+          },
+        }),
+      ),
+    ).rejects.toBe(businessFailure)
 
     expect(fetchApi).toHaveBeenCalledTimes(2)
     expect(resyncSub2ApiAuthToken).not.toHaveBeenCalled()
@@ -2187,6 +2723,7 @@ describe("apiService sub2api exported operations", () => {
       "https://sub2.example.com",
       undefined,
       undefined,
+      undefined,
     )
     expect((vi.mocked(fetchApi).mock.calls[0]?.[0] as any)?.auth).toMatchObject(
       {
@@ -2297,6 +2834,7 @@ describe("apiService sub2api exported operations", () => {
       "https://sub2.example.com",
       undefined,
       undefined,
+      undefined,
     )
     expect(fetchApi).toHaveBeenCalledTimes(2)
     expect(
@@ -2338,6 +2876,7 @@ describe("apiService sub2api exported operations", () => {
       "https://sub2.example.com",
       undefined,
       undefined,
+      undefined,
     )
   })
 
@@ -2359,6 +2898,7 @@ describe("apiService sub2api exported operations", () => {
 
     expect(resyncSub2ApiAuthToken).toHaveBeenCalledWith(
       "https://sub2.example.com",
+      undefined,
       undefined,
       undefined,
     )

--- a/tests/services/apiService/sub2api/keyManagement.test.ts
+++ b/tests/services/apiService/sub2api/keyManagement.test.ts
@@ -201,7 +201,7 @@ describe("apiService sub2api key management service", () => {
     getLatestAuthMock.mockReset()
     persistAuthUpdateMock.mockReset()
     getLatestAuthMock.mockResolvedValue(null)
-    persistAuthUpdateMock.mockResolvedValue(true)
+    persistAuthUpdateMock.mockResolvedValue({ status: "persisted" })
   })
 
   it("combines available groups with rate data for shared forms", async () => {
@@ -908,7 +908,7 @@ describe("apiService sub2api key management service", () => {
           : currentAccount.sub2apiAuth,
       }
 
-      return true
+      return { status: "persisted" }
     })
 
     const fetchMock = vi.fn().mockResolvedValue(
@@ -928,6 +928,14 @@ describe("apiService sub2api key management service", () => {
     vi.stubGlobal("fetch", fetchMock as any)
 
     fetchApiMock.mockImplementation(async (_request, options) => {
+      if (options?.endpoint === "/api/v1/auth/me") {
+        return {
+          code: 0,
+          message: "ok",
+          data: { id: 1, username: "example-user", balance: 1 },
+        }
+      }
+
       if (options?.endpoint === "/api/v1/groups/available") {
         return {
           code: 0,
@@ -991,6 +999,11 @@ describe("apiService sub2api key management service", () => {
       .mockResolvedValueOnce({
         code: 0,
         message: "ok",
+        data: { id: 1, username: "example-user", balance: 1 },
+      })
+      .mockResolvedValueOnce({
+        code: 0,
+        message: "ok",
         data: {
           items: [
             {
@@ -1024,6 +1037,9 @@ describe("apiService sub2api key management service", () => {
       accessToken: "new-jwt",
       refreshToken: "rotated-refresh",
       tokenExpiresAt: now + 3600 * 1000,
+      userId: "1",
+      expectedOrigin: "https://sub2.example.com",
+      expectedUserId: "1",
     })
   })
 
@@ -1031,6 +1047,7 @@ describe("apiService sub2api key management service", () => {
     getLatestAuthMock.mockResolvedValue(null)
     resyncSub2ApiAuthTokenMock.mockResolvedValue({
       accessToken: "resynced-jwt",
+      userId: "1",
       source: ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB,
     })
 
@@ -1070,9 +1087,13 @@ describe("apiService sub2api key management service", () => {
       "https://sub2.example.com",
       undefined,
       undefined,
+      "1",
     )
     expect(persistAuthUpdateMock).toHaveBeenCalledWith("acc-1", {
       accessToken: "resynced-jwt",
+      userId: "1",
+      expectedOrigin: "https://sub2.example.com",
+      expectedUserId: "1",
     })
   })
 

--- a/tests/services/apiService/sub2api/tokenRefresh.test.ts
+++ b/tests/services/apiService/sub2api/tokenRefresh.test.ts
@@ -7,6 +7,18 @@ import {
   Sub2ApiTokenRefreshError,
 } from "~/services/apiService/sub2api/tokenRefresh"
 
+const captureRefreshError = async (
+  params: Parameters<typeof refreshSub2ApiTokens>[0],
+): Promise<unknown> => {
+  try {
+    await refreshSub2ApiTokens(params)
+  } catch (error) {
+    return error
+  }
+
+  throw new Error("Expected Sub2API token refresh to fail")
+}
+
 describe("Sub2API token refresh", () => {
   beforeEach(() => {
     vi.clearAllMocks()
@@ -102,13 +114,13 @@ describe("Sub2API token refresh", () => {
       vi.fn().mockRejectedValueOnce(new Error("raw upstream failure")),
     )
 
-    await expect(
-      refreshSub2ApiTokens({
-        baseUrl: "https://sub2.example.com",
-        refreshToken: "refresh-token",
-      }),
-    ).rejects.toMatchObject({
-      name: Sub2ApiTokenRefreshError.name,
+    const error = await captureRefreshError({
+      baseUrl: "https://sub2.example.com",
+      refreshToken: "refresh-token",
+    })
+
+    expect(error).toBeInstanceOf(Sub2ApiTokenRefreshError)
+    expect(error).toMatchObject({
       reason: SUB2API_TOKEN_REFRESH_FAILURE_REASONS.UNCERTAIN_ROTATION,
     })
   })
@@ -116,20 +128,48 @@ describe("Sub2API token refresh", () => {
   it("rejects envelopes whose code is not successful", async () => {
     vi.stubGlobal(
       "fetch",
-      vi.fn().mockResolvedValueOnce({
-        json: vi.fn().mockResolvedValue({
-          code: 401,
-          message: "expired",
+      vi.fn().mockResolvedValueOnce(
+        new Response(JSON.stringify({ code: 401, message: "expired" }), {
+          status: 401,
+          headers: { "Content-Type": "application/json" },
         }),
-      }),
+      ),
     )
 
-    await expect(
-      refreshSub2ApiTokens({
-        baseUrl: "https://sub2.example.com",
-        refreshToken: "refresh-token",
-      }),
-    ).rejects.toThrow("Sub2API token refresh failed")
+    const error = await captureRefreshError({
+      baseUrl: "https://sub2.example.com",
+      refreshToken: "refresh-token",
+    })
+
+    expect(error).toBeInstanceOf(Sub2ApiTokenRefreshError)
+    expect(error).toMatchObject({
+      reason: SUB2API_TOKEN_REFRESH_FAILURE_REASONS.INVALID_REFRESH_TOKEN,
+    })
+  })
+
+  it("treats a server-side refresh failure as an uncertain rotation", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ code: 503, message: "service unavailable" }),
+          {
+            status: 503,
+            headers: { "Content-Type": "application/json" },
+          },
+        ),
+      ),
+    )
+
+    const error = await captureRefreshError({
+      baseUrl: "https://sub2.example.com",
+      refreshToken: "refresh-token",
+    })
+
+    expect(error).toBeInstanceOf(Sub2ApiTokenRefreshError)
+    expect(error).toMatchObject({
+      reason: SUB2API_TOKEN_REFRESH_FAILURE_REASONS.UNCERTAIN_ROTATION,
+    })
   })
 
   it("treats an unreadable refresh response as an uncertain rotation", async () => {
@@ -140,13 +180,33 @@ describe("Sub2API token refresh", () => {
       }),
     )
 
-    await expect(
-      refreshSub2ApiTokens({
-        baseUrl: "https://sub2.example.com",
-        refreshToken: "refresh-token",
+    const error = await captureRefreshError({
+      baseUrl: "https://sub2.example.com",
+      refreshToken: "refresh-token",
+    })
+
+    expect(error).toBeInstanceOf(Sub2ApiTokenRefreshError)
+    expect(error).toMatchObject({
+      reason: SUB2API_TOKEN_REFRESH_FAILURE_REASONS.UNCERTAIN_ROTATION,
+    })
+  })
+
+  it("treats a non-object refresh envelope as an uncertain rotation", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValueOnce({
+        status: 200,
+        json: vi.fn().mockResolvedValue(null),
       }),
-    ).rejects.toMatchObject({
-      name: Sub2ApiTokenRefreshError.name,
+    )
+
+    const error = await captureRefreshError({
+      baseUrl: "https://sub2.example.com",
+      refreshToken: "refresh-token",
+    })
+
+    expect(error).toBeInstanceOf(Sub2ApiTokenRefreshError)
+    expect(error).toMatchObject({
       reason: SUB2API_TOKEN_REFRESH_FAILURE_REASONS.UNCERTAIN_ROTATION,
     })
   })
@@ -174,21 +234,21 @@ describe("Sub2API token refresh", () => {
         }),
     )
 
-    await expect(
-      refreshSub2ApiTokens({
-        baseUrl: "https://sub2.example.com",
-        refreshToken: "refresh-token",
-      }),
-    ).rejects.toMatchObject({
+    const missingDataError = await captureRefreshError({
+      baseUrl: "https://sub2.example.com",
+      refreshToken: "refresh-token",
+    })
+    expect(missingDataError).toBeInstanceOf(Sub2ApiTokenRefreshError)
+    expect(missingDataError).toMatchObject({
       reason: SUB2API_TOKEN_REFRESH_FAILURE_REASONS.UNCERTAIN_ROTATION,
     })
 
-    await expect(
-      refreshSub2ApiTokens({
-        baseUrl: "https://sub2.example.com",
-        refreshToken: "refresh-token",
-      }),
-    ).rejects.toMatchObject({
+    const invalidExpiryError = await captureRefreshError({
+      baseUrl: "https://sub2.example.com",
+      refreshToken: "refresh-token",
+    })
+    expect(invalidExpiryError).toBeInstanceOf(Sub2ApiTokenRefreshError)
+    expect(invalidExpiryError).toMatchObject({
       reason: SUB2API_TOKEN_REFRESH_FAILURE_REASONS.UNCERTAIN_ROTATION,
     })
   })
@@ -207,13 +267,13 @@ describe("Sub2API token refresh", () => {
       }),
     )
 
-    await expect(
-      refreshSub2ApiTokens({
-        baseUrl: "https://auth.example.invalid",
-        refreshToken: "single-use-refresh-token",
-      }),
-    ).rejects.toMatchObject({
-      name: Sub2ApiTokenRefreshError.name,
+    const error = await captureRefreshError({
+      baseUrl: "https://auth.example.invalid",
+      refreshToken: "single-use-refresh-token",
+    })
+
+    expect(error).toBeInstanceOf(Sub2ApiTokenRefreshError)
+    expect(error).toMatchObject({
       reason: SUB2API_TOKEN_REFRESH_FAILURE_REASONS.UNCERTAIN_ROTATION,
     })
   })

--- a/tests/services/apiService/sub2api/tokenRefresh.test.ts
+++ b/tests/services/apiService/sub2api/tokenRefresh.test.ts
@@ -3,15 +3,9 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import {
   refreshSub2ApiTokens,
   SUB2API_TOKEN_REFRESH_BUFFER_MS,
+  SUB2API_TOKEN_REFRESH_FAILURE_REASONS,
+  Sub2ApiTokenRefreshError,
 } from "~/services/apiService/sub2api/tokenRefresh"
-
-const { mockGetSafeErrorMessage } = vi.hoisted(() => ({
-  mockGetSafeErrorMessage: vi.fn(),
-}))
-
-vi.mock("~/services/apiService/sub2api/redaction", () => ({
-  getSafeErrorMessage: mockGetSafeErrorMessage,
-}))
 
 describe("Sub2API token refresh", () => {
   beforeEach(() => {
@@ -102,8 +96,7 @@ describe("Sub2API token refresh", () => {
     )
   })
 
-  it("sanitizes network failures through getSafeErrorMessage", async () => {
-    mockGetSafeErrorMessage.mockReturnValueOnce("redacted network error")
+  it("treats a lost refresh response as an uncertain rotation", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn().mockRejectedValueOnce(new Error("raw upstream failure")),
@@ -114,9 +107,10 @@ describe("Sub2API token refresh", () => {
         baseUrl: "https://sub2.example.com",
         refreshToken: "refresh-token",
       }),
-    ).rejects.toThrow("redacted network error")
-
-    expect(mockGetSafeErrorMessage).toHaveBeenCalled()
+    ).rejects.toMatchObject({
+      name: Sub2ApiTokenRefreshError.name,
+      reason: SUB2API_TOKEN_REFRESH_FAILURE_REASONS.UNCERTAIN_ROTATION,
+    })
   })
 
   it("rejects envelopes whose code is not successful", async () => {
@@ -138,7 +132,7 @@ describe("Sub2API token refresh", () => {
     ).rejects.toThrow("Sub2API token refresh failed")
   })
 
-  it("falls back to a generic refresh failure when the response body is not valid JSON", async () => {
+  it("treats an unreadable refresh response as an uncertain rotation", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn().mockResolvedValueOnce({
@@ -151,7 +145,10 @@ describe("Sub2API token refresh", () => {
         baseUrl: "https://sub2.example.com",
         refreshToken: "refresh-token",
       }),
-    ).rejects.toThrow("Sub2API token refresh failed")
+    ).rejects.toMatchObject({
+      name: Sub2ApiTokenRefreshError.name,
+      reason: SUB2API_TOKEN_REFRESH_FAILURE_REASONS.UNCERTAIN_ROTATION,
+    })
   })
 
   it("rejects payloads with missing token fields or non-positive expiry", async () => {
@@ -182,13 +179,42 @@ describe("Sub2API token refresh", () => {
         baseUrl: "https://sub2.example.com",
         refreshToken: "refresh-token",
       }),
-    ).rejects.toThrow("Sub2API token refresh failed")
+    ).rejects.toMatchObject({
+      reason: SUB2API_TOKEN_REFRESH_FAILURE_REASONS.UNCERTAIN_ROTATION,
+    })
 
     await expect(
       refreshSub2ApiTokens({
         baseUrl: "https://sub2.example.com",
         refreshToken: "refresh-token",
       }),
-    ).rejects.toThrow("Sub2API token refresh failed")
+    ).rejects.toMatchObject({
+      reason: SUB2API_TOKEN_REFRESH_FAILURE_REASONS.UNCERTAIN_ROTATION,
+    })
+  })
+
+  it("classifies a response that loses the rotated refresh token as uncertain", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValueOnce({
+        json: vi.fn().mockResolvedValue({
+          code: 0,
+          data: {
+            access_token: "rotated-access-token",
+            expires_in: 3600,
+          },
+        }),
+      }),
+    )
+
+    await expect(
+      refreshSub2ApiTokens({
+        baseUrl: "https://auth.example.invalid",
+        refreshToken: "single-use-refresh-token",
+      }),
+    ).rejects.toMatchObject({
+      name: Sub2ApiTokenRefreshError.name,
+      reason: SUB2API_TOKEN_REFRESH_FAILURE_REASONS.UNCERTAIN_ROTATION,
+    })
   })
 })

--- a/tests/services/apiService/sub2api/tokenResync.test.ts
+++ b/tests/services/apiService/sub2api/tokenResync.test.ts
@@ -1,7 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { ACCOUNT_BROWSER_SESSION_SOURCES } from "~/services/accountBrowserSession"
-import { resyncSub2ApiAuthToken } from "~/services/apiService/sub2api/tokenResync"
+import {
+  resyncSub2ApiAuthToken,
+  Sub2ApiAuthIdentityMismatchError,
+} from "~/services/apiService/sub2api/tokenResync"
 import { PROTECTION_BYPASS_USER_COMMANDS } from "~/services/protectionBypass/contracts"
 import { TEMP_WINDOW_REQUEST_SOURCES } from "~/types/tempWindowFetch"
 import { userCommandExecution } from "~~/tests/services/protectionBypass/fixtures"
@@ -38,6 +41,7 @@ describe("Sub2API token re-sync", () => {
 
     expect(result).toEqual({
       accessToken: "token-from-tab",
+      userId: "42",
       source: ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB,
     })
     expect(mockResolveAccountBrowserSession).toHaveBeenCalledWith(
@@ -91,6 +95,7 @@ describe("Sub2API token re-sync", () => {
       resyncSub2ApiAuthToken("https://sub2.example.com"),
     ).resolves.toEqual({
       accessToken: "current-tab-token",
+      userId: "42",
       source: ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB,
     })
   })
@@ -108,6 +113,7 @@ describe("Sub2API token re-sync", () => {
       resyncSub2ApiAuthToken("https://sub2.example.com"),
     ).resolves.toEqual({
       accessToken: "temp-window-token",
+      userId: "42",
       source: ACCOUNT_BROWSER_SESSION_SOURCES.TEMP_WINDOW,
     })
   })
@@ -156,7 +162,97 @@ describe("Sub2API token re-sync", () => {
       resyncSub2ApiAuthToken("https://sub2.example.com"),
     ).resolves.toEqual({
       accessToken: "usable-token",
+      userId: "42",
       source: ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB,
     })
+  })
+
+  it("rejects another same-origin user and returns the complete matching session", async () => {
+    mockResolveAccountBrowserSession.mockImplementationOnce(async (options) => {
+      const wrongUser = {
+        source: ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB,
+        siteType: "sub2api" as const,
+        userId: "user-2",
+        user: { id: "user-2" },
+        accessToken: "wrong-user-token",
+      }
+      const matchingUser = {
+        source: ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB,
+        siteType: "sub2api" as const,
+        userId: "user-1",
+        user: { id: "user-1" },
+        accessToken: "matching-token",
+        sub2apiAuth: {
+          refreshToken: "matching-refresh",
+          tokenExpiresAt: 1_800_000_000_000,
+        },
+      }
+
+      expect(options.isUsableSession?.(wrongUser)).toBe(false)
+      expect(options.isUsableSession?.(matchingUser)).toBe(true)
+      return matchingUser
+    })
+
+    await expect(
+      resyncSub2ApiAuthToken(
+        "https://auth.example.invalid",
+        undefined,
+        undefined,
+        " user-1 ",
+      ),
+    ).resolves.toEqual({
+      accessToken: "matching-token",
+      userId: "user-1",
+      sub2apiAuth: {
+        refreshToken: "matching-refresh",
+        tokenExpiresAt: 1_800_000_000_000,
+      },
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB,
+    })
+  })
+
+  it("reports an identity mismatch when the session resolver returns another user", async () => {
+    mockResolveAccountBrowserSession.mockResolvedValueOnce({
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB,
+      siteType: "sub2api",
+      userId: "user-2",
+      user: { id: "user-2" },
+      accessToken: "wrong-user-token",
+    })
+
+    await expect(
+      resyncSub2ApiAuthToken(
+        "https://auth.example.invalid",
+        undefined,
+        undefined,
+        "user-1",
+      ),
+    ).rejects.toBeInstanceOf(Sub2ApiAuthIdentityMismatchError)
+  })
+
+  it("reports an identity mismatch when only another user is usable", async () => {
+    mockResolveAccountBrowserSession.mockImplementationOnce(
+      async ({ isUsableSession }) => {
+        expect(
+          isUsableSession({
+            source: ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB,
+            siteType: "sub2api",
+            userId: "user-2",
+            user: { id: "user-2" },
+            accessToken: "wrong-user-token",
+          }),
+        ).toBe(false)
+        return null
+      },
+    )
+
+    await expect(
+      resyncSub2ApiAuthToken(
+        "https://auth.example.invalid",
+        undefined,
+        undefined,
+        "user-1",
+      ),
+    ).rejects.toBeInstanceOf(Sub2ApiAuthIdentityMismatchError)
   })
 })


### PR DESCRIPTION
## Summary

- Guard Sub2API credential updates with the expected normalized origin and user identity while holding the account-storage lock.
- Return and persist complete refreshed or resynced credential state, preserving valid supplemental refresh and expiry data when browser resync omits it.
- Classify account deletion, identity mismatch, and persistence failure explicitly instead of treating them as durable success.
- Require rotated credentials to be persisted before downstream business callbacks can run.
- Treat a lost refresh-token response as an uncertain mutation and recover only through identity-checked resync.
- Preserve the existing per-account serialization and bounded 401 recovery behavior.

This does not enable Sub2API check-in by itself. It hardens the authentication foundation required by the later check-in execution work.

## Validation

- Focused Sub2API authentication and account-storage Vitest coverage: 282 tests passed.
- `pnpm compile`
- `pnpm lint`
- `pnpm run i18n:extract:ci`
- Full Vitest suite with `--maxWorkers=4`: 1,015 files and 15,040 tests passed.
- Pre-commit `pnpm run validate:staged` completed successfully.

Browser E2E coverage was not added because the changed behavior is contained in service-layer credential validation, persistence, and recovery paths and is covered directly by Vitest.

No new telemetry was added, and no identities, origins, tokens, cookies, or backend payloads are recorded.

Part of #1270


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Sub2API authentication refresh and recovery with account, identity, and origin validation.
  * Added clearer handling for invalid tokens, uncertain refresh outcomes, and authentication persistence failures.
  * Prevented stale or mismatched credentials from being reused.
* **Bug Fixes**
  * Improved recovery after failed refreshes while preventing unsafe request retries.
* **Localization**
  * Added authentication persistence failure messages in English, German, Spanish, Japanese, Portuguese, Vietnamese, Simplified Chinese, and Traditional Chinese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->