### PR TITLE
fix(popup): stabilize selects across page zoom

### DIFF
--- a/e2e/popupSelectResize.spec.ts
+++ b/e2e/popupSelectResize.spec.ts
@@ -1,0 +1,386 @@
+import type { CDPSession, ChromiumBrowser } from "@playwright/test"
+
+import { POPUP_PAGE_PATH } from "~/constants/extensionPages"
+import { ACCOUNT_MANAGEMENT_TEST_IDS } from "~/features/AccountManagement/testIds"
+import { expect, test } from "~~/e2e/fixtures/extensionTest"
+import { stubLlmMetadataIndex } from "~~/e2e/utils/commonUserFlows"
+import { getExtensionServiceWorker } from "~~/e2e/utils/extension"
+
+type CdpTargetInfo = {
+  targetId: string
+  url: string
+}
+
+type CdpCommandResult = Record<string, unknown>
+
+async function attachToActionPopup(
+  session: CDPSession,
+  popupUrl: string,
+): Promise<string> {
+  const deadline = Date.now() + 10_000
+
+  while (Date.now() <= deadline) {
+    const { targetInfos } = await session.send("Target.getTargets")
+    const popupTarget = (targetInfos as CdpTargetInfo[]).find(
+      (target) => target.url === popupUrl,
+    )
+
+    if (popupTarget) {
+      const { sessionId } = await session.send("Target.attachToTarget", {
+        flatten: false,
+        targetId: popupTarget.targetId,
+      })
+      return sessionId as string
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 50))
+  }
+
+  throw new Error(`Timed out waiting for action popup target '${popupUrl}'`)
+}
+
+function createTargetCommandSender(
+  session: CDPSession,
+  sessionId: string,
+): (
+  method: string,
+  params?: Record<string, unknown>,
+) => Promise<CdpCommandResult> {
+  let nextId = 0
+
+  return async (method, params = {}) => {
+    nextId += 1
+    const commandId = nextId
+    const response = new Promise<CdpCommandResult>((resolve, reject) => {
+      const handleMessage = (event: { message: string; sessionId: string }) => {
+        if (event.sessionId !== sessionId) return
+
+        const message = JSON.parse(event.message) as {
+          id?: number
+          error?: { message: string }
+          result?: CdpCommandResult
+        }
+        if (message.id !== commandId) return
+
+        session.off("Target.receivedMessageFromTarget", handleMessage)
+        if (message.error) {
+          reject(new Error(message.error.message))
+        } else {
+          resolve(message.result ?? {})
+        }
+      }
+
+      session.on("Target.receivedMessageFromTarget", handleMessage)
+    })
+
+    await session.send("Target.sendMessageToTarget", {
+      message: JSON.stringify({ id: commandId, method, params }),
+      sessionId,
+    })
+
+    return await response
+  }
+}
+
+async function evaluateInTarget<T>(
+  send: ReturnType<typeof createTargetCommandSender>,
+  expression: string,
+): Promise<T> {
+  const response = await send("Runtime.evaluate", {
+    awaitPromise: true,
+    expression,
+    returnByValue: true,
+  })
+  const exceptionDetails = response["exceptionDetails"] as
+    | { text?: string }
+    | undefined
+  if (exceptionDetails) {
+    throw new Error(exceptionDetails.text ?? "Action popup evaluation failed")
+  }
+
+  const result = response["result"] as { value?: T } | undefined
+  return result?.value as T
+}
+
+async function waitForTargetCondition(
+  send: ReturnType<typeof createTargetCommandSender>,
+  expression: string,
+): Promise<void> {
+  const deadline = Date.now() + 10_000
+
+  while (Date.now() <= deadline) {
+    if (await evaluateInTarget<boolean>(send, expression)) return
+    await new Promise((resolve) => setTimeout(resolve, 50))
+  }
+
+  throw new Error(`Timed out waiting for action popup condition: ${expression}`)
+}
+
+async function clickTargetElement(
+  send: ReturnType<typeof createTargetCommandSender>,
+  elementExpression: string,
+): Promise<void> {
+  await evaluateInTarget(
+    send,
+    `(() => {
+      const element = ${elementExpression}
+      if (!(element instanceof HTMLElement)) {
+        throw new Error('Target element is not available for pointer input')
+      }
+
+      const pointerDefaults = {
+        bubbles: true,
+        button: 0,
+        cancelable: true,
+        composed: true,
+        isPrimary: true,
+        pointerId: 1,
+        pointerType: 'mouse',
+      }
+      element.dispatchEvent(new PointerEvent('pointerdown', {
+        ...pointerDefaults,
+        buttons: 1,
+      }))
+      element.dispatchEvent(new MouseEvent('mousedown', {
+        bubbles: true,
+        button: 0,
+        buttons: 1,
+        cancelable: true,
+        composed: true,
+      }))
+      element.dispatchEvent(new PointerEvent('pointerup', pointerDefaults))
+      element.dispatchEvent(new MouseEvent('mouseup', {
+        bubbles: true,
+        button: 0,
+        cancelable: true,
+        composed: true,
+      }))
+      element.dispatchEvent(new MouseEvent('click', {
+        bubbles: true,
+        button: 0,
+        cancelable: true,
+        composed: true,
+        detail: 1,
+      }))
+    })()`,
+  )
+}
+
+const POPUP_ZOOM_PERCENTAGES = [80, 90, 100, 110, 125, 150, 175, 200]
+
+test.beforeEach(async ({ context }) => {
+  await stubLlmMetadataIndex(context)
+})
+
+for (const zoomPercentage of POPUP_ZOOM_PERCENTAGES) {
+  test(`keeps the action popup select stable at ${zoomPercentage}% zoom`, async ({
+    context,
+    extensionId,
+  }) => {
+    const zoomFactor = zoomPercentage / 100
+    const serviceWorker = await getExtensionServiceWorker(context)
+    const browser = context.browser() as ChromiumBrowser
+    const browserSession = await browser.newBrowserCDPSession()
+    const popupUrl = `chrome-extension://${extensionId}/${POPUP_PAGE_PATH}`
+
+    const appliedZoom = await serviceWorker.evaluate(async (factor) => {
+      const [activeTab] = await chrome.tabs.query({
+        active: true,
+        currentWindow: true,
+      })
+      if (activeTab?.id === undefined) {
+        throw new Error("No active tab is available for popup zoom testing")
+      }
+
+      await chrome.tabs.setZoom(activeTab.id, factor)
+      await chrome.action.openPopup({ windowId: activeTab.windowId })
+      return await chrome.tabs.getZoom(activeTab.id)
+    }, zoomFactor)
+    expect(appliedZoom).toBeCloseTo(zoomFactor)
+
+    const popupSessionId = await attachToActionPopup(browserSession, popupUrl)
+    const send = createTargetCommandSender(browserSession, popupSessionId)
+    await send("Runtime.enable")
+    await waitForTargetCondition(
+      send,
+      `Boolean(document.querySelector('[data-testid="${ACCOUNT_MANAGEMENT_TEST_IDS.addAccountButton}"]'))`,
+    )
+
+    await clickTargetElement(
+      send,
+      `document.querySelector('[data-testid="${ACCOUNT_MANAGEMENT_TEST_IDS.addAccountButton}"]')`,
+    )
+    await waitForTargetCondition(
+      send,
+      `Boolean(document.querySelector('[data-testid="${ACCOUNT_MANAGEMENT_TEST_IDS.siteUrlInput}"]'))`,
+    )
+    await evaluateInTarget(
+      send,
+      `(() => {
+        const input = document.querySelector('[data-testid="${ACCOUNT_MANAGEMENT_TEST_IDS.siteUrlInput}"]')
+        const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set
+        setter.call(input, 'https://account.example.invalid')
+        input.dispatchEvent(new Event('input', { bubbles: true }))
+      })()`,
+    )
+    await waitForTargetCondition(
+      send,
+      `!document.querySelector('[data-testid="${ACCOUNT_MANAGEMENT_TEST_IDS.manualAddButton}"]').disabled`,
+    )
+    await clickTargetElement(
+      send,
+      `document.querySelector('[data-testid="${ACCOUNT_MANAGEMENT_TEST_IDS.manualAddButton}"]')`,
+    )
+    await waitForTargetCondition(
+      send,
+      `Boolean(document.querySelector('[data-testid="${ACCOUNT_MANAGEMENT_TEST_IDS.siteTypeTrigger}"]'))`,
+    )
+
+    await evaluateInTarget(
+      send,
+      `(() => {
+        const formSection = document.querySelector('[data-testid="${ACCOUNT_MANAGEMENT_TEST_IDS.accountFormSectionSiteInfo}"]')
+        window.__aahActionPopupFormSection = formSection
+        window.__aahActionPopupFormLayout = formSection?.getAttribute('data-layout')
+        window.__aahActionPopupResizeCount = 0
+        window.__aahActionPopupSizes = [window.innerWidth + 'x' + window.innerHeight]
+        window.addEventListener('resize', () => {
+          window.__aahActionPopupResizeCount += 1
+          window.__aahActionPopupSizes.push(window.innerWidth + 'x' + window.innerHeight)
+        }, { capture: true })
+      })()`,
+    )
+    await clickTargetElement(
+      send,
+      `document.querySelector('[data-testid="${ACCOUNT_MANAGEMENT_TEST_IDS.siteTypeTrigger}"]')`,
+    )
+    await waitForTargetCondition(
+      send,
+      `Boolean(document.querySelector('[role="listbox"]'))`,
+    )
+
+    const observedNativeResize = await evaluateInTarget<boolean>(
+      send,
+      `new Promise(resolve => {
+        if ((window.__aahActionPopupResizeCount ?? 0) > 0) {
+          resolve(true)
+          return
+        }
+
+        const handleResize = () => {
+          clearTimeout(timeoutId)
+          resolve(true)
+        }
+        const timeoutId = setTimeout(() => {
+          window.removeEventListener('resize', handleResize, true)
+          resolve(false)
+        }, 750)
+        window.addEventListener('resize', handleResize, {
+          capture: true,
+          once: true,
+        })
+      })`,
+    )
+    if (!observedNativeResize) {
+      await evaluateInTarget(send, "window.dispatchEvent(new Event('resize'))")
+    }
+    await evaluateInTarget(
+      send,
+      `new Promise(resolve => {
+        let quietTimeoutId
+        const hardTimeoutId = setTimeout(finish, 1500)
+
+        function finish() {
+          clearTimeout(quietTimeoutId)
+          clearTimeout(hardTimeoutId)
+          window.removeEventListener('resize', scheduleFinish, true)
+          resolve()
+        }
+
+        function scheduleFinish() {
+          clearTimeout(quietTimeoutId)
+          quietTimeoutId = setTimeout(finish, 250)
+        }
+
+        window.addEventListener('resize', scheduleFinish, true)
+        scheduleFinish()
+      })`,
+    )
+
+    const popupState = await evaluateInTarget<{
+      bodyOverflowing: boolean
+      contentHeight: number
+      contentWidth: number
+      documentOverflowing: boolean
+      formLayout: string | null
+      formLayoutStable: boolean
+      formSectionPreserved: boolean
+      innerHeight: number
+      innerWidth: number
+      listboxPresent: boolean
+      sizes: string[]
+    }>(
+      send,
+      `({
+        bodyOverflowing:
+          document.body.scrollWidth > document.body.clientWidth ||
+          document.body.scrollHeight > document.body.clientHeight,
+        contentHeight: document.querySelector('#root')?.firstElementChild?.getBoundingClientRect().height,
+        contentWidth: document.querySelector('#root')?.firstElementChild?.getBoundingClientRect().width,
+        documentOverflowing:
+          document.documentElement.scrollWidth > document.documentElement.clientWidth ||
+          document.documentElement.scrollHeight > document.documentElement.clientHeight,
+        formLayout:
+          document.querySelector('[data-testid="${ACCOUNT_MANAGEMENT_TEST_IDS.accountFormSectionSiteInfo}"]')?.getAttribute('data-layout') ?? null,
+        formLayoutStable:
+          window.__aahActionPopupFormLayout ===
+          document.querySelector('[data-testid="${ACCOUNT_MANAGEMENT_TEST_IDS.accountFormSectionSiteInfo}"]')?.getAttribute('data-layout'),
+        formSectionPreserved:
+          window.__aahActionPopupFormSection ===
+          document.querySelector('[data-testid="${ACCOUNT_MANAGEMENT_TEST_IDS.accountFormSectionSiteInfo}"]'),
+        innerHeight: window.innerHeight,
+        innerWidth: window.innerWidth,
+        listboxPresent: Boolean(document.querySelector('[role="listbox"]')),
+        sizes: [...new Set(window.__aahActionPopupSizes)],
+      })`,
+    )
+    expect(popupState.listboxPresent).toBe(true)
+    expect(popupState.sizes).toHaveLength(1)
+    expect(popupState.documentOverflowing).toBe(false)
+    expect(popupState.bodyOverflowing).toBe(false)
+    expect(popupState.formLayout).toBe("mobile-collapsible")
+    expect(popupState.formLayoutStable).toBe(true)
+    expect(popupState.formSectionPreserved).toBe(true)
+    expect(popupState.innerWidth).toBeGreaterThanOrEqual(200)
+    expect(popupState.innerHeight).toBeGreaterThanOrEqual(200)
+    expect(popupState.contentWidth).toBe(popupState.innerWidth)
+    expect(popupState.contentHeight).toBe(popupState.innerHeight)
+
+    await evaluateInTarget(
+      send,
+      `(() => {
+        const option = Array.from(document.querySelectorAll('[role="option"]'))
+          .find(option => option.textContent?.trim() === 'new-api')
+        option.dispatchEvent(new PointerEvent('pointerdown', {
+          bubbles: true,
+          button: 0,
+          pointerType: 'mouse',
+        }))
+        option.dispatchEvent(new PointerEvent('pointerup', {
+          bubbles: true,
+          button: 0,
+          pointerType: 'mouse',
+        }))
+      })()`,
+    )
+    await waitForTargetCondition(
+      send,
+      `document.querySelector('[data-testid="${ACCOUNT_MANAGEMENT_TEST_IDS.siteTypeTrigger}"]')
+        ?.getAttribute('data-site-type') === 'new-api'`,
+    )
+    await waitForTargetCondition(
+      send,
+      `!document.querySelector('[role="listbox"]')`,
+    )
+  })
+}

--- a/e2e/popupSelectResize.spec.ts
+++ b/e2e/popupSelectResize.spec.ts
@@ -51,8 +51,15 @@ function createTargetCommandSender(
   return async (method, params = {}) => {
     nextId += 1
     const commandId = nextId
+    let handleMessage:
+      | ((event: { message: string; sessionId: string }) => void)
+      | undefined
+    let handleDetach: ((event: { sessionId: string }) => void) | undefined
+    let rejectResponse: ((reason?: unknown) => void) | undefined
+    let timeoutId: ReturnType<typeof setTimeout> | undefined
     const response = new Promise<CdpCommandResult>((resolve, reject) => {
-      const handleMessage = (event: { message: string; sessionId: string }) => {
+      rejectResponse = reject
+      handleMessage = (event) => {
         if (event.sessionId !== sessionId) return
 
         const message = JSON.parse(event.message) as {
@@ -62,23 +69,42 @@ function createTargetCommandSender(
         }
         if (message.id !== commandId) return
 
-        session.off("Target.receivedMessageFromTarget", handleMessage)
         if (message.error) {
           reject(new Error(message.error.message))
         } else {
           resolve(message.result ?? {})
         }
       }
+      handleDetach = (event) => {
+        if (event.sessionId !== sessionId) return
+        reject(new Error(`Action popup target detached during CDP '${method}'`))
+      }
+      timeoutId = setTimeout(() => {
+        reject(new Error(`Timed out waiting for CDP '${method}'`))
+      }, 10_000)
 
       session.on("Target.receivedMessageFromTarget", handleMessage)
+      session.on("Target.detachedFromTarget", handleDetach)
     })
 
-    await session.send("Target.sendMessageToTarget", {
-      message: JSON.stringify({ id: commandId, method, params }),
-      sessionId,
-    })
+    void session
+      .send("Target.sendMessageToTarget", {
+        message: JSON.stringify({ id: commandId, method, params }),
+        sessionId,
+      })
+      .catch((error) => rejectResponse?.(error))
 
-    return await response
+    try {
+      return await response
+    } finally {
+      if (timeoutId !== undefined) clearTimeout(timeoutId)
+      if (handleMessage) {
+        session.off("Target.receivedMessageFromTarget", handleMessage)
+      }
+      if (handleDetach) {
+        session.off("Target.detachedFromTarget", handleDetach)
+      }
+    }
   }
 }
 
@@ -353,14 +379,16 @@ for (const zoomPercentage of POPUP_ZOOM_PERCENTAGES) {
     expect(popupState.formSectionPreserved).toBe(true)
     expect(popupState.innerWidth).toBeGreaterThanOrEqual(200)
     expect(popupState.innerHeight).toBeGreaterThanOrEqual(200)
-    expect(popupState.contentWidth).toBe(popupState.innerWidth)
-    expect(popupState.contentHeight).toBe(popupState.innerHeight)
+    expect(popupState.contentWidth).toBeCloseTo(popupState.innerWidth, 0)
+    expect(popupState.contentHeight).toBeCloseTo(popupState.innerHeight, 0)
 
     await evaluateInTarget(
       send,
       `(() => {
-        const option = Array.from(document.querySelectorAll('[role="option"]'))
-          .find(option => option.textContent?.trim() === 'new-api')
+        const option = document.querySelector(
+          '[role="option"][data-site-type="new-api"]',
+        )
+        if (!option) throw new Error('new-api option was not rendered')
         option.dispatchEvent(new PointerEvent('pointerdown', {
           bubbles: true,
           button: 0,

--- a/e2e/popupSelectResize.spec.ts
+++ b/e2e/popupSelectResize.spec.ts
@@ -1,7 +1,10 @@
 import type { CDPSession, ChromiumBrowser } from "@playwright/test"
 
 import { POPUP_PAGE_PATH } from "~/constants/extensionPages"
-import { ACCOUNT_MANAGEMENT_TEST_IDS } from "~/features/AccountManagement/testIds"
+import {
+  ACCOUNT_MANAGEMENT_TEST_IDS,
+  getAccountManagementSiteTypeOptionTestId,
+} from "~/features/AccountManagement/testIds"
 import { expect, test } from "~~/e2e/fixtures/extensionTest"
 import { stubLlmMetadataIndex } from "~~/e2e/utils/commonUserFlows"
 import { getExtensionServiceWorker } from "~~/e2e/utils/extension"
@@ -385,9 +388,7 @@ for (const zoomPercentage of POPUP_ZOOM_PERCENTAGES) {
     await evaluateInTarget(
       send,
       `(() => {
-        const option = document.querySelector(
-          '[role="option"][data-site-type="new-api"]',
-        )
+        const option = document.querySelector('[data-testid="${getAccountManagementSiteTypeOptionTestId("new-api")}"]')
         if (!option) throw new Error('new-api option was not rendered')
         option.dispatchEvent(new PointerEvent('pointerdown', {
           bubbles: true,

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -53,7 +53,10 @@ function ResizeStableSelect({
   const isControlled = controlledOpen !== undefined
   const open = isControlled ? controlledOpen : uncontrolledOpen
   const openRef = React.useRef(open)
-  openRef.current = open
+
+  React.useEffect(() => {
+    openRef.current = open
+  }, [open])
 
   React.useEffect(() => {
     const handleResize = () => {

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -6,12 +6,174 @@ import { cn } from "~/lib/utils"
 
 import { useFloatingLayerClass } from "./floating-layer"
 
+const SelectViewportResizeContext = React.createContext(false)
+
+interface SelectViewportResizeProviderProps {
+  children: React.ReactNode
+  preserveOpen: boolean
+}
+
+/**
+ * Configures whether descendant selects stay open during a viewport resize.
+ * Action popups need this because opening a floating layer can resize the
+ * browser-owned popup viewport synchronously.
+ */
+function SelectViewportResizeProvider({
+  children,
+  preserveOpen,
+}: SelectViewportResizeProviderProps) {
+  return (
+    <SelectViewportResizeContext.Provider value={preserveOpen}>
+      {children}
+    </SelectViewportResizeContext.Provider>
+  )
+}
+
+type SelectRootProps = React.ComponentProps<typeof SelectPrimitive.Root>
+
+/** Keeps a controlled or uncontrolled Select open for the active resize event. */
+function ResizeStableSelect({
+  open: controlledOpen,
+  defaultOpen,
+  onOpenChange,
+  ...props
+}: SelectRootProps) {
+  const [uncontrolledOpen, setUncontrolledOpen] = React.useState(
+    defaultOpen ?? false,
+  )
+  const resizeEventActiveRef = React.useRef(false)
+  const resizeResetTimeoutRef = React.useRef<ReturnType<
+    typeof setTimeout
+  > | null>(null)
+  const interactionResetTimeoutRef = React.useRef<ReturnType<
+    typeof setTimeout
+  > | null>(null)
+  const pointerStartedWhileOpenRef = React.useRef(false)
+  const userCloseIntentRef = React.useRef(false)
+  const isControlled = controlledOpen !== undefined
+  const open = isControlled ? controlledOpen : uncontrolledOpen
+  const openRef = React.useRef(open)
+  openRef.current = open
+
+  React.useEffect(() => {
+    const handleResize = () => {
+      resizeEventActiveRef.current = true
+      if (resizeResetTimeoutRef.current !== null) {
+        clearTimeout(resizeResetTimeoutRef.current)
+      }
+      // Radix forwards its controlled close after the native listener returns.
+      // Keep the marker through those microtasks, then clear it before the next
+      // user interaction task.
+      resizeResetTimeoutRef.current = setTimeout(() => {
+        resizeEventActiveRef.current = false
+        resizeResetTimeoutRef.current = null
+      }, 0)
+    }
+
+    // Capture runs before Radix's window resize listener, which synchronously
+    // requests that the Select close during the same event dispatch.
+    window.addEventListener("resize", handleResize, true)
+    return () => {
+      window.removeEventListener("resize", handleResize, true)
+      if (resizeResetTimeoutRef.current !== null) {
+        clearTimeout(resizeResetTimeoutRef.current)
+      }
+    }
+  }, [])
+
+  React.useEffect(() => {
+    const scheduleIntentReset = () => {
+      if (interactionResetTimeoutRef.current !== null) {
+        clearTimeout(interactionResetTimeoutRef.current)
+      }
+      interactionResetTimeoutRef.current = setTimeout(() => {
+        userCloseIntentRef.current = false
+        interactionResetTimeoutRef.current = null
+      }, 0)
+    }
+    const handlePointerDown = () => {
+      pointerStartedWhileOpenRef.current = openRef.current
+      if (pointerStartedWhileOpenRef.current) {
+        userCloseIntentRef.current = true
+      }
+    }
+    const handlePointerEnd = () => {
+      const startedWhileOpen = pointerStartedWhileOpenRef.current
+      pointerStartedWhileOpenRef.current = false
+      if (!startedWhileOpen) return
+      userCloseIntentRef.current = true
+      scheduleIntentReset()
+    }
+    const handleClick = (event: MouseEvent) => {
+      // Pointer interactions are classified from their pointerdown state.
+      // detail=0 covers keyboard and assistive-technology click activation.
+      if (event.detail !== 0 || !openRef.current) return
+      userCloseIntentRef.current = true
+      scheduleIntentReset()
+    }
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (!openRef.current || ![" ", "Enter", "Escape"].includes(event.key)) {
+        return
+      }
+      userCloseIntentRef.current = true
+      scheduleIntentReset()
+    }
+
+    document.addEventListener("click", handleClick, true)
+    document.addEventListener("keydown", handleKeyDown, true)
+    document.addEventListener("pointercancel", handlePointerEnd, true)
+    document.addEventListener("pointerdown", handlePointerDown, true)
+    document.addEventListener("pointerup", handlePointerEnd, true)
+    return () => {
+      document.removeEventListener("click", handleClick, true)
+      document.removeEventListener("keydown", handleKeyDown, true)
+      document.removeEventListener("pointercancel", handlePointerEnd, true)
+      document.removeEventListener("pointerdown", handlePointerDown, true)
+      document.removeEventListener("pointerup", handlePointerEnd, true)
+      if (interactionResetTimeoutRef.current !== null) {
+        clearTimeout(interactionResetTimeoutRef.current)
+      }
+    }
+  }, [])
+
+  const handleOpenChange = React.useCallback(
+    (nextOpen: boolean) => {
+      if (
+        !nextOpen &&
+        resizeEventActiveRef.current &&
+        !userCloseIntentRef.current
+      ) {
+        return
+      }
+
+      if (!isControlled) {
+        setUncontrolledOpen(nextOpen)
+      }
+      onOpenChange?.(nextOpen)
+    },
+    [isControlled, onOpenChange],
+  )
+
+  return (
+    <SelectPrimitive.Root
+      data-slot="select"
+      {...props}
+      open={open}
+      onOpenChange={handleOpenChange}
+    />
+  )
+}
+
 /**
  * Select provides a Radix-based select root for controlled value and open state.
  */
-function Select({
-  ...props
-}: React.ComponentProps<typeof SelectPrimitive.Root>) {
+function Select({ ...props }: SelectRootProps) {
+  const preserveOpenOnResize = React.useContext(SelectViewportResizeContext)
+
+  if (preserveOpenOnResize) {
+    return <ResizeStableSelect {...props} />
+  }
+
   return <SelectPrimitive.Root data-slot="select" {...props} />
 }
 
@@ -207,4 +369,5 @@ export {
   SelectSeparator,
   SelectTrigger,
   SelectValue,
+  SelectViewportResizeProvider,
 }

--- a/src/constants/ui.ts
+++ b/src/constants/ui.ts
@@ -6,8 +6,10 @@ import { DATA_TYPE_BALANCE } from "~/constants/index"
 export const UI_CONSTANTS = {
   // 弹窗尺寸
   POPUP: {
-    WIDTH: "w-[410px]",
-    HEIGHT: "h-[600px]",
+    WIDTH_PX: 410,
+    HEIGHT_PX: 600,
+    WIDTH: "w-full",
+    HEIGHT: "h-full",
     MAX_HEIGHT: "max-h-[90vh]",
   },
 

--- a/src/entrypoints/popup/App.tsx
+++ b/src/entrypoints/popup/App.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next"
 
 import { AppLayout } from "~/components/AppLayout"
 import PopupInterruptionHintBanner from "~/components/PopupInterruptionHintBanner"
+import { SelectViewportResizeProvider } from "~/components/ui/select"
 import { UI_CONSTANTS } from "~/constants/ui"
 import { ProductAnalyticsScope } from "~/contexts/ProductAnalyticsScopeContext"
 import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
@@ -201,9 +202,11 @@ function PopupContent() {
 function App() {
   return (
     <AppLayout>
-      <AccountManagementProvider>
-        <PopupContent />
-      </AccountManagementProvider>
+      <SelectViewportResizeProvider preserveOpen={isExtensionPopup()}>
+        <AccountManagementProvider>
+          <PopupContent />
+        </AccountManagementProvider>
+      </SelectViewportResizeProvider>
     </AppLayout>
   )
 }

--- a/src/entrypoints/popup/main.tsx
+++ b/src/entrypoints/popup/main.tsx
@@ -4,13 +4,44 @@ import ReactDOM from "react-dom/client"
 import "~/utils/i18n" // Import the i18n configuration
 
 import { RootErrorBoundary } from "~/components/RootErrorBoundary"
+import { UI_CONSTANTS } from "~/constants/ui"
+import { isMobileDevice } from "~/utils/browser"
 import { t } from "~/utils/i18n/core"
 import { setDocumentTitle } from "~/utils/navigation/documentTitle"
 
 import App from "./App"
 
+import "./style.css"
+
 // Set the document title immediately
 setDocumentTitle("popup")
+
+if (!isMobileDevice()) {
+  const popupDocument = document.documentElement
+  const { HEIGHT_PX, WIDTH_PX } = UI_CONSTANTS.POPUP
+  const syncPopupDocumentSize = () => {
+    // Ignore the transient tiny viewport Edge exposes before it measures the
+    // seeded popup content. The following resize will carry the usable size.
+    if (window.innerWidth >= 200) {
+      popupDocument.style.setProperty(
+        "--extension-popup-width",
+        `${Math.min(WIDTH_PX, window.innerWidth)}px`,
+      )
+    }
+    if (window.innerHeight >= 200) {
+      popupDocument.style.setProperty(
+        "--extension-popup-height",
+        `${Math.min(HEIGHT_PX, window.innerHeight)}px`,
+      )
+    }
+  }
+
+  popupDocument.classList.add("desktop-extension-popup")
+  popupDocument.style.setProperty("--extension-popup-width", `${WIDTH_PX}px`)
+  popupDocument.style.setProperty("--extension-popup-height", `${HEIGHT_PX}px`)
+  requestAnimationFrame(syncPopupDocumentSize)
+  window.addEventListener("resize", syncPopupDocumentSize)
+}
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>

--- a/src/entrypoints/popup/style.css
+++ b/src/entrypoints/popup/style.css
@@ -1,0 +1,14 @@
+html.desktop-extension-popup {
+  width: var(--extension-popup-width);
+  height: var(--extension-popup-height);
+  overflow: hidden;
+}
+
+html.desktop-extension-popup body,
+html.desktop-extension-popup #root {
+  width: 100%;
+  max-width: 100%;
+  height: 100%;
+  max-height: 100%;
+  overflow: hidden;
+}

--- a/src/entrypoints/popup/viewRegistry.tsx
+++ b/src/entrypoints/popup/viewRegistry.tsx
@@ -9,6 +9,7 @@ import {
 import { useTranslation } from "react-i18next"
 
 import AccountList from "~/features/AccountManagement/components/AccountList"
+import { ACCOUNT_MANAGEMENT_TEST_IDS } from "~/features/AccountManagement/testIds"
 import type { ApiCredentialProfilesPopupViewHandle } from "~/features/ApiCredentialProfiles/components/ApiCredentialProfilesPopupView"
 import { useBookmarkDialogContext } from "~/features/SiteBookmarks/hooks/BookmarkDialogStateContext"
 import { useAddAccountHandler } from "~/hooks/useAddAccountHandler"
@@ -121,6 +122,7 @@ export function usePopupViewRegistry(): Record<PopupViewType, PopupViewConfig> {
         featureId: PRODUCT_ANALYTICS_FEATURE_IDS.AccountManagement,
         actionId: PRODUCT_ANALYTICS_ACTION_IDS.OpenCreateAccountDialog,
       },
+      primaryActionTestId: ACCOUNT_MANAGEMENT_TEST_IDS.addAccountButton,
       content: <AccountList />,
     },
     bookmarks: {

--- a/src/features/AccountManagement/components/AccountDialog/AccountForm.tsx
+++ b/src/features/AccountManagement/components/AccountDialog/AccountForm.tsx
@@ -207,7 +207,11 @@ export default function AccountForm({
             </SelectTrigger>
             <SelectContent>
               {ACCOUNT_FORM_SITE_TYPE_OPTIONS.map((siteType) => (
-                <SelectItem key={siteType} value={siteType}>
+                <SelectItem
+                  key={siteType}
+                  value={siteType}
+                  data-site-type={siteType}
+                >
                   {siteType}
                 </SelectItem>
               ))}

--- a/src/features/AccountManagement/components/AccountDialog/AccountForm.tsx
+++ b/src/features/AccountManagement/components/AccountDialog/AccountForm.tsx
@@ -34,7 +34,10 @@ import {
 import type { AccountDialogDraft } from "~/features/AccountManagement/components/AccountDialog/models"
 import type { AccountDialogSitePolicy } from "~/features/AccountManagement/components/AccountDialog/sitePolicy"
 import { TagPicker } from "~/features/AccountManagement/components/TagPicker"
-import { ACCOUNT_MANAGEMENT_TEST_IDS } from "~/features/AccountManagement/testIds"
+import {
+  ACCOUNT_MANAGEMENT_TEST_IDS,
+  getAccountManagementSiteTypeOptionTestId,
+} from "~/features/AccountManagement/testIds"
 import { isValidExchangeRate } from "~/services/accounts/accountOperations"
 import { inspectAccountCheckIn } from "~/services/checkin/autoCheckin/inspection"
 import { AuthTypeEnum, type CheckInConfig, type Tag } from "~/types"
@@ -210,7 +213,9 @@ export default function AccountForm({
                 <SelectItem
                   key={siteType}
                   value={siteType}
-                  data-site-type={siteType}
+                  data-testid={getAccountManagementSiteTypeOptionTestId(
+                    siteType,
+                  )}
                 >
                   {siteType}
                 </SelectItem>

--- a/src/features/AccountManagement/testIds.ts
+++ b/src/features/AccountManagement/testIds.ts
@@ -1,3 +1,4 @@
+import type { AccountSiteType } from "~/constants/siteType"
 import type { SortField } from "~/types"
 
 export const ACCOUNT_MANAGEMENT_TEST_IDS = {
@@ -124,6 +125,13 @@ export const ACCOUNT_MANAGEMENT_TEST_IDS = {
 /** Returns a stable test id for an account-list sort control. */
 export function getAccountManagementSortButtonTestId(field: SortField) {
   return `account-management-account-list-sort-${field}-button`
+}
+
+/** Returns a stable test id for a site-type option in the account form. */
+export function getAccountManagementSiteTypeOptionTestId(
+  siteType: AccountSiteType,
+) {
+  return `account-management-site-type-option-${siteType}`
 }
 
 /**

--- a/tests/components/ui/select.test.tsx
+++ b/tests/components/ui/select.test.tsx
@@ -1,0 +1,169 @@
+import { act, fireEvent, render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  SelectViewportResizeProvider,
+} from "~/components/ui/select"
+
+function SelectFixture({ preserveOpen }: { preserveOpen: boolean }) {
+  return (
+    <SelectViewportResizeProvider preserveOpen={preserveOpen}>
+      <Select defaultValue="first">
+        <SelectTrigger aria-label="Example selection">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="first">First</SelectItem>
+          <SelectItem value="second">Second</SelectItem>
+        </SelectContent>
+      </Select>
+    </SelectViewportResizeProvider>
+  )
+}
+
+describe("Select viewport resize behavior", () => {
+  it("keeps an action-popup select open during its resize event", async () => {
+    const user = userEvent.setup()
+    render(<SelectFixture preserveOpen />)
+
+    await user.click(
+      screen.getByRole("combobox", { name: "Example selection" }),
+    )
+    expect(screen.getByRole("listbox")).toBeInTheDocument()
+
+    act(() => {
+      window.dispatchEvent(new Event("resize"))
+    })
+
+    expect(screen.getByRole("listbox")).toBeInTheDocument()
+  })
+
+  it("does not treat the pointer gesture that opens the select as close intent", () => {
+    render(<SelectFixture preserveOpen />)
+
+    const trigger = screen.getByRole("combobox", {
+      name: "Example selection",
+    })
+    fireEvent.pointerDown(trigger, {
+      button: 0,
+      ctrlKey: false,
+      pointerType: "mouse",
+    })
+    fireEvent.pointerUp(trigger, { pointerType: "mouse" })
+    expect(screen.getByRole("listbox")).toBeInTheDocument()
+
+    act(() => {
+      window.dispatchEvent(new Event("resize"))
+    })
+
+    expect(screen.getByRole("listbox")).toBeInTheDocument()
+  })
+
+  it("retains Radix resize closing outside the action popup", async () => {
+    const user = userEvent.setup()
+    render(<SelectFixture preserveOpen={false} />)
+
+    await user.click(
+      screen.getByRole("combobox", { name: "Example selection" }),
+    )
+
+    act(() => {
+      window.dispatchEvent(new Event("resize"))
+    })
+
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument()
+  })
+
+  it("does not report a resize close to a controlled parent", () => {
+    const onOpenChange = vi.fn()
+
+    render(
+      <SelectViewportResizeProvider preserveOpen>
+        <Select open onOpenChange={onOpenChange} value="first">
+          <SelectTrigger aria-label="Controlled selection">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="first">First</SelectItem>
+          </SelectContent>
+        </Select>
+      </SelectViewportResizeProvider>,
+    )
+
+    act(() => {
+      window.dispatchEvent(new Event("resize"))
+    })
+
+    expect(screen.getByRole("listbox")).toBeInTheDocument()
+    expect(onOpenChange).not.toHaveBeenCalled()
+  })
+
+  it("still closes with Escape when resize closing is suppressed", async () => {
+    const user = userEvent.setup()
+    render(<SelectFixture preserveOpen />)
+
+    const trigger = screen.getByRole("combobox", {
+      name: "Example selection",
+    })
+    await user.click(trigger)
+    await user.keyboard("{Escape}")
+
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument()
+    expect(trigger).toHaveFocus()
+  })
+
+  it("still closes when the popup window loses focus", async () => {
+    const user = userEvent.setup()
+    render(<SelectFixture preserveOpen />)
+
+    await user.click(
+      screen.getByRole("combobox", { name: "Example selection" }),
+    )
+
+    act(() => {
+      window.dispatchEvent(new Event("blur"))
+    })
+
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument()
+  })
+
+  it("still selects an option and closes normally", async () => {
+    const user = userEvent.setup()
+    render(<SelectFixture preserveOpen />)
+
+    const trigger = screen.getByRole("combobox", {
+      name: "Example selection",
+    })
+    await user.click(trigger)
+    await user.click(screen.getByRole("option", { name: "Second" }))
+
+    expect(trigger).toHaveTextContent("Second")
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument()
+  })
+
+  it("lets a pointer selection close during the popup resize task", async () => {
+    const user = userEvent.setup()
+    render(<SelectFixture preserveOpen />)
+
+    const trigger = screen.getByRole("combobox", {
+      name: "Example selection",
+    })
+    await user.click(trigger)
+    const secondOption = screen.getByRole("option", { name: "Second" })
+
+    act(() => {
+      window.dispatchEvent(new Event("resize"))
+      fireEvent.pointerDown(secondOption, { pointerType: "mouse" })
+      fireEvent.pointerUp(secondOption, { pointerType: "mouse" })
+    })
+
+    expect(trigger).toHaveTextContent("Second")
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument()
+  })
+})

--- a/tests/components/ui/select.test.tsx
+++ b/tests/components/ui/select.test.tsx
@@ -27,6 +27,25 @@ function SelectFixture({ preserveOpen }: { preserveOpen: boolean }) {
   )
 }
 
+function ControlledSelectFixture({
+  onOpenChange,
+}: {
+  onOpenChange: (open: boolean) => void
+}) {
+  return (
+    <SelectViewportResizeProvider preserveOpen>
+      <Select open onOpenChange={onOpenChange} value="first">
+        <SelectTrigger aria-label="Controlled selection">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="first">First</SelectItem>
+        </SelectContent>
+      </Select>
+    </SelectViewportResizeProvider>
+  )
+}
+
 describe("Select viewport resize behavior", () => {
   it("keeps an action-popup select open during its resize event", async () => {
     const user = userEvent.setup()
@@ -39,6 +58,25 @@ describe("Select viewport resize behavior", () => {
 
     act(() => {
       window.dispatchEvent(new Event("resize"))
+    })
+
+    expect(screen.getByRole("listbox")).toBeInTheDocument()
+  })
+
+  it("keeps the select open across consecutive resize events", async () => {
+    const user = userEvent.setup()
+    render(<SelectFixture preserveOpen />)
+
+    await user.click(
+      screen.getByRole("combobox", { name: "Example selection" }),
+    )
+
+    act(() => {
+      window.dispatchEvent(new Event("resize"))
+      window.dispatchEvent(new Event("resize"))
+    })
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0))
     })
 
     expect(screen.getByRole("listbox")).toBeInTheDocument()
@@ -83,24 +121,45 @@ describe("Select viewport resize behavior", () => {
   it("does not report a resize close to a controlled parent", () => {
     const onOpenChange = vi.fn()
 
-    render(
-      <SelectViewportResizeProvider preserveOpen>
-        <Select open onOpenChange={onOpenChange} value="first">
-          <SelectTrigger aria-label="Controlled selection">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem value="first">First</SelectItem>
-          </SelectContent>
-        </Select>
-      </SelectViewportResizeProvider>,
-    )
+    render(<ControlledSelectFixture onOpenChange={onOpenChange} />)
 
     act(() => {
       window.dispatchEvent(new Event("resize"))
     })
 
     expect(screen.getByRole("listbox")).toBeInTheDocument()
+    expect(onOpenChange).not.toHaveBeenCalled()
+  })
+
+  it("preserves assistive-technology click close intent during resize", async () => {
+    const onOpenChange = vi.fn()
+
+    render(<ControlledSelectFixture onOpenChange={onOpenChange} />)
+
+    fireEvent.click(document, { detail: 0 })
+    onOpenChange.mockClear()
+    fireEvent.click(document, { detail: 0 })
+    onOpenChange.mockClear()
+    act(() => {
+      window.dispatchEvent(new Event("resize"))
+    })
+
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+  })
+
+  it("does not treat unrelated keys as close intent", () => {
+    const onOpenChange = vi.fn()
+
+    render(<ControlledSelectFixture onOpenChange={onOpenChange} />)
+
+    fireEvent.keyDown(document, { key: "Tab" })
+    act(() => {
+      window.dispatchEvent(new Event("resize"))
+    })
+
     expect(onOpenChange).not.toHaveBeenCalled()
   })
 

--- a/tests/entrypoints/popup/main.test.tsx
+++ b/tests/entrypoints/popup/main.test.tsx
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const { createRootMock, isMobileDeviceMock, renderMock, setDocumentTitleMock } =
+  vi.hoisted(() => {
+    const renderMock = vi.fn()
+    return {
+      createRootMock: vi.fn(() => ({ render: renderMock })),
+      isMobileDeviceMock: vi.fn(),
+      renderMock,
+      setDocumentTitleMock: vi.fn(),
+    }
+  })
+
+vi.mock("react-dom/client", () => ({
+  default: { createRoot: createRootMock },
+}))
+vi.mock("~/components/RootErrorBoundary", () => ({
+  RootErrorBoundary: ({ children }: { children: React.ReactNode }) => children,
+}))
+vi.mock("~/entrypoints/popup/App", () => ({ default: () => null }))
+vi.mock("~/utils/browser", () => ({ isMobileDevice: isMobileDeviceMock }))
+vi.mock("~/utils/i18n", () => ({}))
+vi.mock("~/utils/i18n/core", () => ({ t: vi.fn(() => "Loading") }))
+vi.mock("~/utils/navigation/documentTitle", () => ({
+  setDocumentTitle: setDocumentTitleMock,
+}))
+
+const POPUP_WIDTH_PROPERTY = "--extension-popup-width"
+const POPUP_HEIGHT_PROPERTY = "--extension-popup-height"
+const originalViewport = {
+  height: window.innerHeight,
+  width: window.innerWidth,
+}
+let resizeListener: EventListener | undefined
+
+function setViewportSize(width: number, height: number) {
+  Object.defineProperty(window, "innerWidth", {
+    configurable: true,
+    value: width,
+  })
+  Object.defineProperty(window, "innerHeight", {
+    configurable: true,
+    value: height,
+  })
+}
+
+describe("popup entrypoint sizing", () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    document.body.innerHTML = '<div id="root"></div>'
+    document.documentElement.classList.remove("desktop-extension-popup")
+    document.documentElement.style.removeProperty(POPUP_WIDTH_PROPERTY)
+    document.documentElement.style.removeProperty(POPUP_HEIGHT_PROPERTY)
+    setViewportSize(500, 700)
+  })
+
+  afterEach(() => {
+    if (resizeListener) {
+      window.removeEventListener("resize", resizeListener)
+      resizeListener = undefined
+    }
+    document.documentElement.classList.remove("desktop-extension-popup")
+    document.documentElement.style.removeProperty(POPUP_WIDTH_PROPERTY)
+    document.documentElement.style.removeProperty(POPUP_HEIGHT_PROPERTY)
+    setViewportSize(originalViewport.width, originalViewport.height)
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  it("seeds and clamps the desktop action popup to the usable viewport", async () => {
+    let animationFrameCallback: FrameRequestCallback | undefined
+    isMobileDeviceMock.mockReturnValue(false)
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      vi.fn((callback: FrameRequestCallback) => {
+        animationFrameCallback = callback
+        return 1
+      }),
+    )
+    const addEventListenerSpy = vi.spyOn(window, "addEventListener")
+
+    await import("~/entrypoints/popup/main")
+
+    expect(setDocumentTitleMock).toHaveBeenCalledWith("popup")
+    expect(document.documentElement).toHaveClass("desktop-extension-popup")
+    expect(
+      document.documentElement.style.getPropertyValue(POPUP_WIDTH_PROPERTY),
+    ).toBe("410px")
+    expect(
+      document.documentElement.style.getPropertyValue(POPUP_HEIGHT_PROPERTY),
+    ).toBe("600px")
+
+    setViewportSize(320, 480)
+    animationFrameCallback?.(0)
+    expect(
+      document.documentElement.style.getPropertyValue(POPUP_WIDTH_PROPERTY),
+    ).toBe("320px")
+    expect(
+      document.documentElement.style.getPropertyValue(POPUP_HEIGHT_PROPERTY),
+    ).toBe("480px")
+
+    resizeListener = addEventListenerSpy.mock.calls.find(
+      ([eventName]) => eventName === "resize",
+    )?.[1] as EventListener | undefined
+    expect(resizeListener).toBeDefined()
+    setViewportSize(350, 550)
+    resizeListener?.(new Event("resize"))
+    expect(
+      document.documentElement.style.getPropertyValue(POPUP_WIDTH_PROPERTY),
+    ).toBe("350px")
+    expect(
+      document.documentElement.style.getPropertyValue(POPUP_HEIGHT_PROPERTY),
+    ).toBe("550px")
+
+    setViewportSize(100, 100)
+    resizeListener?.(new Event("resize"))
+    expect(
+      document.documentElement.style.getPropertyValue(POPUP_WIDTH_PROPERTY),
+    ).toBe("350px")
+    expect(
+      document.documentElement.style.getPropertyValue(POPUP_HEIGHT_PROPERTY),
+    ).toBe("550px")
+    expect(createRootMock).toHaveBeenCalledWith(document.getElementById("root"))
+    expect(renderMock).toHaveBeenCalledOnce()
+  })
+
+  it("does not apply desktop popup sizing on mobile", async () => {
+    isMobileDeviceMock.mockReturnValue(true)
+    const requestAnimationFrameMock = vi.fn()
+    vi.stubGlobal("requestAnimationFrame", requestAnimationFrameMock)
+
+    await import("~/entrypoints/popup/main")
+
+    expect(document.documentElement).not.toHaveClass("desktop-extension-popup")
+    expect(
+      document.documentElement.style.getPropertyValue(POPUP_WIDTH_PROPERTY),
+    ).toBe("")
+    expect(
+      document.documentElement.style.getPropertyValue(POPUP_HEIGHT_PROPERTY),
+    ).toBe("")
+    expect(requestAnimationFrameMock).not.toHaveBeenCalled()
+    expect(renderMock).toHaveBeenCalledOnce()
+  })
+})


### PR DESCRIPTION
## Summary

- Stabilize the desktop action popup document size before React renders, then clamp it to the browser-provided usable viewport.
- Prevent resize-only events from closing Radix Select components while preserving option selection, outside interactions, Escape, and keyboard activation.
- Add real action-popup E2E coverage across 80%–200% page zoom in Edge and Chromium.

## Root cause

The toolbar popup was sizing only its React content while the browser measured the complete document. Opening a portaled Select changed the measured document bounds and could introduce extra scrollbars, causing Edge to repeatedly resize the browser-owned popup.

Radix responds to these window resize events by requesting that the Select close. Depending on pointer and resize timing, the dropdown could therefore appear briefly and immediately disappear.

The popup now establishes one document-level size boundary, owns scrolling inside the application, and ignores only resize-originated Select close requests.

## Scope

- The behavior is limited to the desktop browser action popup.
- Options pages, side panels, and mobile layouts retain their existing behavior.
- No dependency upgrade or data migration is required.

## Validation

- `pnpm exec vitest run tests/features/AccountManagement/components/AccountDialogForm.test.tsx tests/components/ui/select.test.tsx` — 29 tests passed
- `pnpm compile`
- `pnpm build:e2e`
- Changed-file ESLint checks
- Edge action popup at 80%, 90%, 100%, 110%, 125%, 150%, 175%, and 200% — 8/8 passed
- Edge at 125% repeated 10 times — 10/10 passed
- Chromium action popup zoom matrix — 8/8 passed
- Pre-commit `validate:staged`, pre-push `validate:push`, and i18n checks passed

Full repository CI and coverage remain for the pull request.

Fixes #477


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved desktop popup sizing to adapt to available screen space while maintaining consistent dimensions.
  - Preserved open dropdown menus when the popup is resized or zoom level changes.
  - Maintained proper popup layout and overflow behavior across different viewport sizes.

- **Bug Fixes**
  - Improved select-menu behavior during resizing while retaining expected dismissal through Escape, blur, or option selection.
  - Improved account site-type option handling for more reliable selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->