### PR TITLE
perf(i18n): lazy-load locale resources

### DIFF
--- a/knip.ts
+++ b/knip.ts
@@ -17,6 +17,8 @@ const config: KnipConfig = {
     "src/entrypoints/options/main.tsx",
     "src/entrypoints/popup/main.tsx",
     "src/entrypoints/sidepanel/main.tsx",
+    // WXT discovers this local build module from the configured modulesDir.
+    "src/locales/runtime-assets.ts",
     "tests/**/*.test.{ts,tsx}",
     "tests/setup.ts",
     "tests/setup.node.ts",

--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -18,14 +18,21 @@ import {
   DropdownMenuRadioItem,
   DropdownMenuTrigger,
 } from "~/components/ui/dropdown-menu"
-import { DEFAULT_LANG, GERMAN_LANG, PORTUGUESE_BRAZIL_LANG } from "~/constants"
+import {
+  DEFAULT_LANG,
+  ENGLISH_LANG,
+  GERMAN_LANG,
+  JAPANESE_LANG,
+  PORTUGUESE_BRAZIL_LANG,
+  SPANISH_LATIN_AMERICA_LANG,
+  SUPPORTED_UI_LANGUAGES,
+  TRADITIONAL_CHINESE_LANG,
+  VIETNAMESE_LANG,
+} from "~/constants"
 import type { SupportedUiLanguage } from "~/constants"
 import { cn } from "~/lib/utils"
 import { userPreferences } from "~/services/preferences/userPreferences"
-import {
-  normalizeAppLanguage,
-  UI_LANGUAGE_OPTIONS,
-} from "~/utils/i18n/language"
+import { normalizeAppLanguage } from "~/utils/i18n/language"
 import { changePageLanguage } from "~/utils/i18n/pageLanguage"
 
 interface LanguageSwitcherProps {
@@ -40,21 +47,21 @@ interface LanguageSwitcherProps {
  */
 function getLanguageOptionLabel(t: TFunction, language: SupportedUiLanguage) {
   switch (language) {
-    case "en":
+    case ENGLISH_LANG:
       return t("settings:appearanceLanguage.switcher.options.en.label")
     case GERMAN_LANG:
       return t("settings:appearanceLanguage.switcher.options.de.label")
-    case "es-419":
+    case SPANISH_LATIN_AMERICA_LANG:
       return t("settings:appearanceLanguage.switcher.options.es-419.label")
     case PORTUGUESE_BRAZIL_LANG:
       return t("settings:appearanceLanguage.switcher.options.pt-BR.label")
-    case "ja":
+    case JAPANESE_LANG:
       return t("settings:appearanceLanguage.switcher.options.ja.label")
-    case "vi":
+    case VIETNAMESE_LANG:
       return t("settings:appearanceLanguage.switcher.options.vi.label")
-    case "zh-CN":
+    case DEFAULT_LANG:
       return t("settings:appearanceLanguage.switcher.options.zh-CN.label")
-    case "zh-TW":
+    case TRADITIONAL_CHINESE_LANG:
       return t("settings:appearanceLanguage.switcher.options.zh-TW.label")
   }
 }
@@ -64,23 +71,28 @@ function getLanguageOptionLabel(t: TFunction, language: SupportedUiLanguage) {
  */
 function getLanguageOptionName(t: TFunction, language: SupportedUiLanguage) {
   switch (language) {
-    case "en":
+    case ENGLISH_LANG:
       return t("settings:appearanceLanguage.switcher.options.en.name")
     case GERMAN_LANG:
       return t("settings:appearanceLanguage.switcher.options.de.name")
-    case "es-419":
+    case SPANISH_LATIN_AMERICA_LANG:
       return t("settings:appearanceLanguage.switcher.options.es-419.name")
     case PORTUGUESE_BRAZIL_LANG:
       return t("settings:appearanceLanguage.switcher.options.pt-BR.name")
-    case "ja":
+    case JAPANESE_LANG:
       return t("settings:appearanceLanguage.switcher.options.ja.name")
-    case "vi":
+    case VIETNAMESE_LANG:
       return t("settings:appearanceLanguage.switcher.options.vi.name")
-    case "zh-CN":
+    case DEFAULT_LANG:
       return t("settings:appearanceLanguage.switcher.options.zh-CN.name")
-    case "zh-TW":
+    case TRADITIONAL_CHINESE_LANG:
       return t("settings:appearanceLanguage.switcher.options.zh-TW.name")
   }
+}
+
+/** Resolve only exact option values emitted by the language controls. */
+function findSupportedUiLanguage(value: string) {
+  return SUPPORTED_UI_LANGUAGES.find((language) => language === value)
 }
 
 /**
@@ -110,6 +122,10 @@ export function LanguageSwitcher({
     }
     await userPreferences.setLanguage(language)
   }
+  const handleSupportedLanguageChange = (value: string) => {
+    const nextLanguage = findSupportedUiLanguage(value)
+    if (nextLanguage) void handleLanguageChange(nextLanguage)
+  }
 
   if (variant === "icon-dropdown") {
     const triggerLabel = `${t("appearanceLanguage.switcher.groupLabel")}: ${currentLanguageLabel}`
@@ -130,17 +146,9 @@ export function LanguageSwitcher({
         <DropdownMenuContent align="end" className="w-36">
           <DropdownMenuRadioGroup
             value={activeLanguage}
-            onValueChange={(value: string) => {
-              const nextLanguage = UI_LANGUAGE_OPTIONS.find(
-                ({ code }) => code === value,
-              )?.code
-
-              if (nextLanguage) {
-                void handleLanguageChange(nextLanguage)
-              }
-            }}
+            onValueChange={handleSupportedLanguageChange}
           >
-            {UI_LANGUAGE_OPTIONS.map(({ code }) => {
+            {SUPPORTED_UI_LANGUAGES.map((code) => {
               const languageName = getLanguageOptionName(t, code)
 
               return (
@@ -173,15 +181,7 @@ export function LanguageSwitcher({
         )}
         <Select
           value={activeLanguage}
-          onValueChange={(value: string) => {
-            const nextLanguage = UI_LANGUAGE_OPTIONS.find(
-              ({ code }) => code === value,
-            )?.code
-
-            if (nextLanguage) {
-              void handleLanguageChange(nextLanguage)
-            }
-          }}
+          onValueChange={handleSupportedLanguageChange}
         >
           <SelectTrigger
             size={compact ? "sm" : "default"}
@@ -192,7 +192,7 @@ export function LanguageSwitcher({
             <SelectValue />
           </SelectTrigger>
           <SelectContent align="end">
-            {UI_LANGUAGE_OPTIONS.map(({ code }) => {
+            {SUPPORTED_UI_LANGUAGES.map((code) => {
               const languageName = getLanguageOptionName(t, code)
 
               return (
@@ -238,7 +238,7 @@ export function LanguageSwitcher({
         buttonSize="sm"
         showActiveIndicator
         className={cn("p-0.5", !compact && "sm:p-1")}
-        options={UI_LANGUAGE_OPTIONS.map(({ code }) => {
+        options={SUPPORTED_UI_LANGUAGES.map((code) => {
           const label = getLanguageOptionLabel(t, code)
           const languageName = getLanguageOptionName(t, code)
           const accessibleLabel =

--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -122,9 +122,12 @@ export function LanguageSwitcher({
     }
     await userPreferences.setLanguage(language)
   }
+  const queueLanguageChange = (language: SupportedUiLanguage) => {
+    void handleLanguageChange(language).catch(() => undefined)
+  }
   const handleSupportedLanguageChange = (value: string) => {
     const nextLanguage = findSupportedUiLanguage(value)
-    if (nextLanguage) void handleLanguageChange(nextLanguage)
+    if (nextLanguage) queueLanguageChange(nextLanguage)
   }
 
   if (variant === "icon-dropdown") {
@@ -201,7 +204,7 @@ export function LanguageSwitcher({
                   value={code}
                   onPointerUp={() => {
                     if (code === activeLanguage) {
-                      void handleLanguageChange(code)
+                      queueLanguageChange(code)
                     }
                   }}
                 >
@@ -234,7 +237,7 @@ export function LanguageSwitcher({
       <ResponsiveToggleGroup
         aria-label={t("appearanceLanguage.switcher.groupLabel")}
         value={activeLanguage}
-        onValueChange={(code) => void handleLanguageChange(code)}
+        onValueChange={queueLanguageChange}
         buttonSize="sm"
         showActiveIndicator
         className={cn("p-0.5", !compact && "sm:p-1")}

--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -26,7 +26,7 @@ import {
   normalizeAppLanguage,
   UI_LANGUAGE_OPTIONS,
 } from "~/utils/i18n/language"
-import { changeAppLanguage } from "~/utils/i18n/resources"
+import { changePageLanguage } from "~/utils/i18n/pageLanguage"
 
 interface LanguageSwitcherProps {
   className?: string
@@ -105,7 +105,8 @@ export function LanguageSwitcher({
 
   const handleLanguageChange = async (language: SupportedUiLanguage) => {
     if (language !== activeLanguage) {
-      await changeAppLanguage(i18n, language)
+      const applied = await changePageLanguage(i18n, language)
+      if (!applied) return
     }
     await userPreferences.setLanguage(language)
   }

--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -26,6 +26,7 @@ import {
   normalizeAppLanguage,
   UI_LANGUAGE_OPTIONS,
 } from "~/utils/i18n/language"
+import { changeAppLanguage } from "~/utils/i18n/resources"
 
 interface LanguageSwitcherProps {
   className?: string
@@ -104,7 +105,7 @@ export function LanguageSwitcher({
 
   const handleLanguageChange = async (language: SupportedUiLanguage) => {
     if (language !== activeLanguage) {
-      await i18n.changeLanguage(language)
+      await changeAppLanguage(i18n, language)
     }
     await userPreferences.setLanguage(language)
   }

--- a/src/components/ui/DatePicker.tsx
+++ b/src/components/ui/DatePicker.tsx
@@ -7,7 +7,6 @@ import { cn } from "~/lib/utils"
 
 import { Button } from "./button"
 import { Calendar } from "./calendar"
-import { loadDatePickerLocale } from "./datePickerLocale"
 import {
   isNoExpirationNaturalInput,
   parseNaturalDatePickerValue,
@@ -20,6 +19,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "./popover"
+import { useDatePickerLocale } from "./useDatePickerLocale"
 
 export interface DatePickerNaturalInputLabels {
   invalid: string
@@ -70,7 +70,7 @@ export function DatePicker({
 }: DatePickerProps) {
   const [open, setOpen] = useState(false)
   const [naturalInputValue, setNaturalInputValue] = useState("")
-  const [loadedLocale, setLoadedLocale] = useState<Locale | undefined>(locale)
+  const calendarLocale = useDatePickerLocale(locale, language)
   const generatedFeedbackId = useId()
   const selectedDate = useMemo(() => parseDatePickerValue(value), [value])
   const triggerLabel = selectedDate ? value : labels.placeholder
@@ -106,31 +106,6 @@ export function DatePicker({
 
     setNaturalInputValue(selectedDate ? value : "")
   }, [naturalInput, selectedDate, value])
-
-  useEffect(() => {
-    if (locale) {
-      setLoadedLocale(locale)
-      return
-    }
-    if (!language) {
-      setLoadedLocale(undefined)
-      return
-    }
-
-    let acceptsResult = true
-    setLoadedLocale(undefined)
-    void loadDatePickerLocale(language)
-      .then((nextLocale) => {
-        if (acceptsResult) setLoadedLocale(nextLocale)
-      })
-      .catch(() => {
-        // Keep the calendar usable with React DayPicker's English fallback.
-      })
-
-    return () => {
-      acceptsResult = false
-    }
-  }, [language, locale])
 
   const selectDate = (date: Date | undefined) => {
     const nextValue = date ? formatDatePickerValue(date) : ""
@@ -196,7 +171,7 @@ export function DatePicker({
         selected={selectedDate ?? undefined}
         defaultMonth={calendarDefaultMonth}
         onSelect={selectDate}
-        locale={locale ?? loadedLocale}
+        locale={calendarLocale}
       />
       <div className="border-border grid grid-cols-2 gap-2 border-t p-2">
         <Button

--- a/src/components/ui/DatePicker.tsx
+++ b/src/components/ui/DatePicker.tsx
@@ -7,6 +7,7 @@ import { cn } from "~/lib/utils"
 
 import { Button } from "./button"
 import { Calendar } from "./calendar"
+import { loadDatePickerLocale } from "./datePickerLocale"
 import {
   isNoExpirationNaturalInput,
   parseNaturalDatePickerValue,
@@ -47,6 +48,7 @@ export interface DatePickerProps {
   disabled?: boolean
   className?: string
   locale?: Locale
+  language?: string
   portalContainer?: HTMLElement | null
   naturalInput?: boolean
 }
@@ -62,11 +64,13 @@ export function DatePicker({
   disabled,
   className,
   locale,
+  language,
   portalContainer,
   naturalInput = false,
 }: DatePickerProps) {
   const [open, setOpen] = useState(false)
   const [naturalInputValue, setNaturalInputValue] = useState("")
+  const [loadedLocale, setLoadedLocale] = useState<Locale | undefined>(locale)
   const generatedFeedbackId = useId()
   const selectedDate = useMemo(() => parseDatePickerValue(value), [value])
   const triggerLabel = selectedDate ? value : labels.placeholder
@@ -102,6 +106,31 @@ export function DatePicker({
 
     setNaturalInputValue(selectedDate ? value : "")
   }, [naturalInput, selectedDate, value])
+
+  useEffect(() => {
+    if (locale) {
+      setLoadedLocale(locale)
+      return
+    }
+    if (!language) {
+      setLoadedLocale(undefined)
+      return
+    }
+
+    let acceptsResult = true
+    setLoadedLocale(undefined)
+    void loadDatePickerLocale(language)
+      .then((nextLocale) => {
+        if (acceptsResult) setLoadedLocale(nextLocale)
+      })
+      .catch(() => {
+        // Keep the calendar usable with React DayPicker's English fallback.
+      })
+
+    return () => {
+      acceptsResult = false
+    }
+  }, [language, locale])
 
   const selectDate = (date: Date | undefined) => {
     const nextValue = date ? formatDatePickerValue(date) : ""
@@ -167,7 +196,7 @@ export function DatePicker({
         selected={selectedDate ?? undefined}
         defaultMonth={calendarDefaultMonth}
         onSelect={selectDate}
-        locale={locale}
+        locale={locale ?? loadedLocale}
       />
       <div className="border-border grid grid-cols-2 gap-2 border-t p-2">
         <Button

--- a/src/components/ui/datePickerLocale.ts
+++ b/src/components/ui/datePickerLocale.ts
@@ -1,0 +1,83 @@
+import type { Locale } from "date-fns"
+
+import {
+  DEFAULT_LANG,
+  GERMAN_LANG,
+  JAPANESE_LANG,
+  PORTUGUESE_BRAZIL_LANG,
+  SPANISH_LATIN_AMERICA_LANG,
+  TRADITIONAL_CHINESE_LANG,
+  VIETNAMESE_LANG,
+} from "~/constants"
+import { normalizeAppLanguage } from "~/utils/i18n/language"
+
+type DatePickerLocaleKey =
+  | "de"
+  | "en-US"
+  | "es"
+  | "ja"
+  | "pt-BR"
+  | "vi"
+  | "zh-CN"
+  | "zh-TW"
+
+const localeImportCache = new Map<
+  DatePickerLocaleKey,
+  Promise<Locale | undefined>
+>()
+const resolvedEnglishLocale = Promise.resolve(undefined)
+
+const localeImporters: Record<
+  Exclude<DatePickerLocaleKey, "en-US">,
+  () => Promise<Locale>
+> = {
+  de: () => import("date-fns/locale/de").then(({ de }) => de),
+  es: () => import("date-fns/locale/es").then(({ es }) => es),
+  ja: () => import("date-fns/locale/ja").then(({ ja }) => ja),
+  "pt-BR": () => import("date-fns/locale/pt-BR").then(({ ptBR }) => ptBR),
+  vi: () => import("date-fns/locale/vi").then(({ vi }) => vi),
+  "zh-CN": () => import("date-fns/locale/zh-CN").then(({ zhCN }) => zhCN),
+  "zh-TW": () => import("date-fns/locale/zh-TW").then(({ zhTW }) => zhTW),
+}
+
+/** Resolve a runtime language tag to the closest date-fns calendar locale. */
+export function resolveDatePickerLocaleKey(
+  language?: string | null,
+): DatePickerLocaleKey {
+  switch (normalizeAppLanguage(language)) {
+    case GERMAN_LANG:
+      return "de"
+    case SPANISH_LATIN_AMERICA_LANG:
+      return "es"
+    case PORTUGUESE_BRAZIL_LANG:
+      return "pt-BR"
+    case JAPANESE_LANG:
+      return "ja"
+    case VIETNAMESE_LANG:
+      return "vi"
+    case DEFAULT_LANG:
+      return "zh-CN"
+    case TRADITIONAL_CHINESE_LANG:
+      return "zh-TW"
+    default:
+      return "en-US"
+  }
+}
+
+/** Load one date-fns locale, sharing in-flight work and allowing retries. */
+export function loadDatePickerLocale(
+  language?: string | null,
+): Promise<Locale | undefined> {
+  const localeKey = resolveDatePickerLocaleKey(language)
+  if (localeKey === "en-US") return resolvedEnglishLocale
+
+  const cachedImport = localeImportCache.get(localeKey)
+  if (cachedImport) return cachedImport
+
+  const importPromise = localeImporters[localeKey]().catch((error) => {
+    localeImportCache.delete(localeKey)
+    throw error
+  })
+  localeImportCache.set(localeKey, importPromise)
+  return importPromise
+}

--- a/src/components/ui/datePickerLocale.ts
+++ b/src/components/ui/datePickerLocale.ts
@@ -9,6 +9,7 @@ import {
   TRADITIONAL_CHINESE_LANG,
   VIETNAMESE_LANG,
 } from "~/constants"
+import { createCachedLocaleLoader } from "~/utils/i18n/createCachedLocaleLoader"
 import { normalizeAppLanguage } from "~/utils/i18n/language"
 
 type DatePickerLocaleKey =
@@ -21,14 +22,11 @@ type DatePickerLocaleKey =
   | "zh-CN"
   | "zh-TW"
 
-const localeImportCache = new Map<
-  DatePickerLocaleKey,
-  Promise<Locale | undefined>
->()
 const resolvedEnglishLocale = Promise.resolve(undefined)
+type LocalizedDatePickerLocaleKey = Exclude<DatePickerLocaleKey, "en-US">
 
 const localeImporters: Record<
-  Exclude<DatePickerLocaleKey, "en-US">,
+  LocalizedDatePickerLocaleKey,
   () => Promise<Locale>
 > = {
   de: () => import("date-fns/locale/de").then(({ de }) => de),
@@ -39,6 +37,10 @@ const localeImporters: Record<
   "zh-CN": () => import("date-fns/locale/zh-CN").then(({ zhCN }) => zhCN),
   "zh-TW": () => import("date-fns/locale/zh-TW").then(({ zhTW }) => zhTW),
 }
+
+const loadDatePickerLocaleImport = createCachedLocaleLoader(
+  (localeKey: LocalizedDatePickerLocaleKey) => localeImporters[localeKey](),
+)
 
 /** Resolve a runtime language tag to the closest date-fns calendar locale. */
 export function resolveDatePickerLocaleKey(
@@ -70,14 +72,5 @@ export function loadDatePickerLocale(
 ): Promise<Locale | undefined> {
   const localeKey = resolveDatePickerLocaleKey(language)
   if (localeKey === "en-US") return resolvedEnglishLocale
-
-  const cachedImport = localeImportCache.get(localeKey)
-  if (cachedImport) return cachedImport
-
-  const importPromise = localeImporters[localeKey]().catch((error) => {
-    localeImportCache.delete(localeKey)
-    throw error
-  })
-  localeImportCache.set(localeKey, importPromise)
-  return importPromise
+  return loadDatePickerLocaleImport(localeKey)
 }

--- a/src/components/ui/datePickerLocale.ts
+++ b/src/components/ui/datePickerLocale.ts
@@ -2,33 +2,22 @@ import type { Locale } from "date-fns"
 
 import {
   DEFAULT_LANG,
+  ENGLISH_LANG,
   GERMAN_LANG,
   JAPANESE_LANG,
   PORTUGUESE_BRAZIL_LANG,
   SPANISH_LATIN_AMERICA_LANG,
   TRADITIONAL_CHINESE_LANG,
   VIETNAMESE_LANG,
+  type SupportedUiLanguage,
 } from "~/constants"
 import { createCachedLocaleLoader } from "~/utils/i18n/createCachedLocaleLoader"
 import { normalizeAppLanguage } from "~/utils/i18n/language"
 
-type DatePickerLocaleKey =
-  | "de"
-  | "en-US"
-  | "es"
-  | "ja"
-  | "pt-BR"
-  | "vi"
-  | "zh-CN"
-  | "zh-TW"
-
+const DEFAULT_DATE_PICKER_LOCALE_KEY = "en-US" as const
 const resolvedEnglishLocale = Promise.resolve(undefined)
-type LocalizedDatePickerLocaleKey = Exclude<DatePickerLocaleKey, "en-US">
 
-const localeImporters: Record<
-  LocalizedDatePickerLocaleKey,
-  () => Promise<Locale>
-> = {
+const localeImporters = {
   de: () => import("date-fns/locale/de").then(({ de }) => de),
   es: () => import("date-fns/locale/es").then(({ es }) => es),
   ja: () => import("date-fns/locale/ja").then(({ ja }) => ja),
@@ -36,7 +25,23 @@ const localeImporters: Record<
   vi: () => import("date-fns/locale/vi").then(({ vi }) => vi),
   "zh-CN": () => import("date-fns/locale/zh-CN").then(({ zhCN }) => zhCN),
   "zh-TW": () => import("date-fns/locale/zh-TW").then(({ zhTW }) => zhTW),
-}
+} as const satisfies Record<string, () => Promise<Locale>>
+
+type LocalizedDatePickerLocaleKey = keyof typeof localeImporters
+type DatePickerLocaleKey =
+  | typeof DEFAULT_DATE_PICKER_LOCALE_KEY
+  | LocalizedDatePickerLocaleKey
+
+const DATE_PICKER_LOCALE_BY_APP_LANGUAGE = {
+  [ENGLISH_LANG]: DEFAULT_DATE_PICKER_LOCALE_KEY,
+  [GERMAN_LANG]: "de",
+  [SPANISH_LATIN_AMERICA_LANG]: "es",
+  [PORTUGUESE_BRAZIL_LANG]: "pt-BR",
+  [JAPANESE_LANG]: "ja",
+  [VIETNAMESE_LANG]: "vi",
+  [DEFAULT_LANG]: "zh-CN",
+  [TRADITIONAL_CHINESE_LANG]: "zh-TW",
+} as const satisfies Record<SupportedUiLanguage, DatePickerLocaleKey>
 
 const loadDatePickerLocaleImport = createCachedLocaleLoader(
   (localeKey: LocalizedDatePickerLocaleKey) => localeImporters[localeKey](),
@@ -46,24 +51,8 @@ const loadDatePickerLocaleImport = createCachedLocaleLoader(
 export function resolveDatePickerLocaleKey(
   language?: string | null,
 ): DatePickerLocaleKey {
-  switch (normalizeAppLanguage(language)) {
-    case GERMAN_LANG:
-      return "de"
-    case SPANISH_LATIN_AMERICA_LANG:
-      return "es"
-    case PORTUGUESE_BRAZIL_LANG:
-      return "pt-BR"
-    case JAPANESE_LANG:
-      return "ja"
-    case VIETNAMESE_LANG:
-      return "vi"
-    case DEFAULT_LANG:
-      return "zh-CN"
-    case TRADITIONAL_CHINESE_LANG:
-      return "zh-TW"
-    default:
-      return "en-US"
-  }
+  const appLanguage = normalizeAppLanguage(language) ?? ENGLISH_LANG
+  return DATE_PICKER_LOCALE_BY_APP_LANGUAGE[appLanguage]
 }
 
 /** Load one date-fns locale, sharing in-flight work and allowing retries. */
@@ -71,6 +60,8 @@ export function loadDatePickerLocale(
   language?: string | null,
 ): Promise<Locale | undefined> {
   const localeKey = resolveDatePickerLocaleKey(language)
-  if (localeKey === "en-US") return resolvedEnglishLocale
+  if (localeKey === DEFAULT_DATE_PICKER_LOCALE_KEY) {
+    return resolvedEnglishLocale
+  }
   return loadDatePickerLocaleImport(localeKey)
 }

--- a/src/components/ui/datePickerValue.ts
+++ b/src/components/ui/datePickerValue.ts
@@ -1,8 +1,3 @@
-import type { Locale } from "date-fns"
-import { de, enUS, es, ja, ptBR, vi, zhCN, zhTW } from "date-fns/locale"
-
-import { GERMAN_LANG } from "~/constants"
-
 const DATE_PICKER_VALUE_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/
 const MIN_SUPPORTED_YEAR = 1000
 const MAX_SUPPORTED_YEAR = 9999
@@ -69,19 +64,4 @@ export function formatDatePickerTimestamp(
  */
 export function parseDatePickerTimestamp(value: string): number | null {
   return parseDatePickerValue(value)?.getTime() ?? null
-}
-
-/**
- * Maps the app language to the closest date-fns locale supported by the picker.
- */
-export function getDatePickerLocale(language?: string): Locale {
-  const normalizedLanguage = (language ?? "").toLowerCase()
-  if (normalizedLanguage.startsWith("zh-tw")) return zhTW
-  if (normalizedLanguage.startsWith("zh")) return zhCN
-  if (normalizedLanguage.startsWith(GERMAN_LANG)) return de
-  if (normalizedLanguage.startsWith("ja")) return ja
-  if (normalizedLanguage.startsWith("vi")) return vi
-  if (normalizedLanguage.startsWith("es")) return es
-  if (normalizedLanguage.startsWith("pt")) return ptBR
-  return enUS
 }

--- a/src/components/ui/useDatePickerLocale.ts
+++ b/src/components/ui/useDatePickerLocale.ts
@@ -1,0 +1,39 @@
+import type { Locale } from "date-fns"
+import { useEffect, useState } from "react"
+
+import { loadDatePickerLocale } from "./datePickerLocale"
+
+/** Resolve a controlled locale immediately or lazily load one by language. */
+export function useDatePickerLocale(
+  locale: Locale | undefined,
+  language: string | undefined,
+) {
+  const [loadedLocale, setLoadedLocale] = useState<Locale | undefined>(locale)
+
+  useEffect(() => {
+    if (locale) {
+      setLoadedLocale(locale)
+      return
+    }
+    if (!language) {
+      setLoadedLocale(undefined)
+      return
+    }
+
+    let acceptsResult = true
+    setLoadedLocale(undefined)
+    void loadDatePickerLocale(language)
+      .then((nextLocale) => {
+        if (acceptsResult) setLoadedLocale(nextLocale)
+      })
+      .catch(() => {
+        // Keep the calendar usable with React DayPicker's English fallback.
+      })
+
+    return () => {
+      acceptsResult = false
+    }
+  }, [language, locale])
+
+  return locale ?? loadedLocale
+}

--- a/src/constants/i18n.ts
+++ b/src/constants/i18n.ts
@@ -1,4 +1,5 @@
 export const DEFAULT_LANG = "zh-CN"
+export const DEFAULT_I18N_NAMESPACE = "common"
 export const ENGLISH_LANG = "en"
 export const GERMAN_LANG = "de"
 export const PORTUGUESE_BRAZIL_LANG = "pt-BR"
@@ -6,7 +7,10 @@ export const SPANISH_LATIN_AMERICA_LANG = "es-419"
 export const JAPANESE_LANG = "ja"
 export const TRADITIONAL_CHINESE_LANG = "zh-TW"
 export const VIETNAMESE_LANG = "vi"
-export const APP_LOCALE_ASSET_DIR = "app-locales"
+const APP_LOCALE_ASSET_DIR = "app-locales"
+const APP_LOCALE_ASSET_FILE_EXTENSION = ".json"
+export const APP_LOCALE_ASSET_GLOB =
+  `${APP_LOCALE_ASSET_DIR}/*${APP_LOCALE_ASSET_FILE_EXTENSION}` as const
 
 export const SUPPORTED_UI_LANGUAGES = [
   ENGLISH_LANG,
@@ -20,3 +24,8 @@ export const SUPPORTED_UI_LANGUAGES = [
 ] as const
 
 export type SupportedUiLanguage = (typeof SUPPORTED_UI_LANGUAGES)[number]
+
+/** Return the canonical packaged asset path for one application locale. */
+export function getAppLocaleAssetPath(language: SupportedUiLanguage) {
+  return `${APP_LOCALE_ASSET_DIR}/${language}${APP_LOCALE_ASSET_FILE_EXTENSION}` as const
+}

--- a/src/constants/i18n.ts
+++ b/src/constants/i18n.ts
@@ -5,6 +5,7 @@ export const SPANISH_LATIN_AMERICA_LANG = "es-419"
 export const JAPANESE_LANG = "ja"
 export const TRADITIONAL_CHINESE_LANG = "zh-TW"
 export const VIETNAMESE_LANG = "vi"
+export const APP_LOCALE_ASSET_DIR = "app-locales"
 
 export const SUPPORTED_UI_LANGUAGES = [
   "en",

--- a/src/constants/i18n.ts
+++ b/src/constants/i18n.ts
@@ -1,4 +1,5 @@
 export const DEFAULT_LANG = "zh-CN"
+export const ENGLISH_LANG = "en"
 export const GERMAN_LANG = "de"
 export const PORTUGUESE_BRAZIL_LANG = "pt-BR"
 export const SPANISH_LATIN_AMERICA_LANG = "es-419"
@@ -8,7 +9,7 @@ export const VIETNAMESE_LANG = "vi"
 export const APP_LOCALE_ASSET_DIR = "app-locales"
 
 export const SUPPORTED_UI_LANGUAGES = [
-  "en",
+  ENGLISH_LANG,
   GERMAN_LANG,
   SPANISH_LATIN_AMERICA_LANG,
   PORTUGUESE_BRAZIL_LANG,

--- a/src/entrypoints/content/webAiApiCheck/components/ApiCheckModal.tsx
+++ b/src/entrypoints/content/webAiApiCheck/components/ApiCheckModal.tsx
@@ -342,7 +342,7 @@ export function ApiCheckModal({ t, view, actions, refs }: ApiCheckModalProps) {
                             ),
                           },
                         }}
-                        locale={view.datePickerLocale}
+                        language={view.datePickerLanguage}
                         portalContainer={view.popoverPortalContainer}
                         disabled={view.isSavingProfile}
                         naturalInput

--- a/src/entrypoints/content/webAiApiCheck/components/useApiCheckModalViewModel.tsx
+++ b/src/entrypoints/content/webAiApiCheck/components/useApiCheckModalViewModel.tsx
@@ -2,10 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import toast from "react-hot-toast/headless"
 import { useTranslation } from "react-i18next"
 
-import {
-  getDatePickerLocale,
-  parseDatePickerTimestamp,
-} from "~/components/ui/datePickerValue"
+import { parseDatePickerTimestamp } from "~/components/ui/datePickerValue"
 import { RuntimeActionIds } from "~/constants/runtimeActions"
 import {
   resolveProductAnalyticsErrorCategoryFromError,
@@ -82,7 +79,7 @@ export interface ApiCheckModalViewModel {
   selectedTagIds: string[]
   notes: string
   expiresAtInput: string
-  datePickerLocale: ReturnType<typeof getDatePickerLocale>
+  datePickerLanguage: string
   isProfileOptionsOpen: boolean
   hasProfileMetadataInput: boolean
   isFetchingModels: boolean
@@ -601,11 +598,6 @@ export function useApiCheckModalViewModel() {
     ],
     [],
   )
-  const datePickerLocale = useMemo(
-    () => getDatePickerLocale(i18n.language),
-    [i18n.language],
-  )
-
   return {
     view: {
       isOpen,
@@ -623,7 +615,7 @@ export function useApiCheckModalViewModel() {
       selectedTagIds,
       notes,
       expiresAtInput,
-      datePickerLocale,
+      datePickerLanguage: i18n.language,
       isProfileOptionsOpen,
       hasProfileMetadataInput,
       isFetchingModels,

--- a/src/entrypoints/options/main.tsx
+++ b/src/entrypoints/options/main.tsx
@@ -1,32 +1,14 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
-import React, { Suspense } from "react"
-import ReactDOM from "react-dom/client"
 
-import { RootErrorBoundary } from "~/components/RootErrorBoundary"
-import { i18nReady } from "~/utils/i18n"
-import { t } from "~/utils/i18n/core"
-import { setDocumentTitle } from "~/utils/navigation/documentTitle"
+import { renderExtensionPage } from "~/entrypoints/shared/renderExtensionPage"
 
 import App from "./App"
 
 const queryClient = new QueryClient()
 
-/** Render only after the active and fallback locale assets are ready. */
-async function renderApp() {
-  await i18nReady
-  setDocumentTitle("options")
-
-  ReactDOM.createRoot(document.getElementById("root")!).render(
-    <React.StrictMode>
-      <RootErrorBoundary>
-        <QueryClientProvider client={queryClient}>
-          <Suspense fallback={<div>{t("common:status.loading")}</div>}>
-            <App />
-          </Suspense>
-        </QueryClientProvider>
-      </RootErrorBoundary>
-    </React.StrictMode>,
-  )
-}
-
-void renderApp()
+void renderExtensionPage(
+  "options",
+  <QueryClientProvider client={queryClient}>
+    <App />
+  </QueryClientProvider>,
+)

--- a/src/entrypoints/options/main.tsx
+++ b/src/entrypoints/options/main.tsx
@@ -2,26 +2,31 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import React, { Suspense } from "react"
 import ReactDOM from "react-dom/client"
 
-import "~/utils/i18n"
-
 import { RootErrorBoundary } from "~/components/RootErrorBoundary"
+import { i18nReady } from "~/utils/i18n"
 import { t } from "~/utils/i18n/core"
 import { setDocumentTitle } from "~/utils/navigation/documentTitle"
 
 import App from "./App"
 
-setDocumentTitle("options")
-
 const queryClient = new QueryClient()
 
-ReactDOM.createRoot(document.getElementById("root")!).render(
-  <React.StrictMode>
-    <RootErrorBoundary>
-      <QueryClientProvider client={queryClient}>
-        <Suspense fallback={<div>{t("common:status.loading")}</div>}>
-          <App />
-        </Suspense>
-      </QueryClientProvider>
-    </RootErrorBoundary>
-  </React.StrictMode>,
-)
+/** Render only after the active and fallback locale assets are ready. */
+async function renderApp() {
+  await i18nReady
+  setDocumentTitle("options")
+
+  ReactDOM.createRoot(document.getElementById("root")!).render(
+    <React.StrictMode>
+      <RootErrorBoundary>
+        <QueryClientProvider client={queryClient}>
+          <Suspense fallback={<div>{t("common:status.loading")}</div>}>
+            <App />
+          </Suspense>
+        </QueryClientProvider>
+      </RootErrorBoundary>
+    </React.StrictMode>,
+  )
+}
+
+void renderApp()

--- a/src/entrypoints/popup/main.tsx
+++ b/src/entrypoints/popup/main.tsx
@@ -1,12 +1,6 @@
-import React, { Suspense } from "react"
-import ReactDOM from "react-dom/client"
-
-import { RootErrorBoundary } from "~/components/RootErrorBoundary"
 import { UI_CONSTANTS } from "~/constants/ui"
+import { renderExtensionPage } from "~/entrypoints/shared/renderExtensionPage"
 import { isMobileDevice } from "~/utils/browser"
-import { i18nReady } from "~/utils/i18n"
-import { t } from "~/utils/i18n/core"
-import { setDocumentTitle } from "~/utils/navigation/documentTitle"
 
 import App from "./App"
 
@@ -39,20 +33,4 @@ if (!isMobileDevice()) {
   window.addEventListener("resize", syncPopupDocumentSize)
 }
 
-/** Render only after the active and fallback locale assets are ready. */
-async function renderApp() {
-  await i18nReady
-  setDocumentTitle("popup")
-
-  ReactDOM.createRoot(document.getElementById("root")!).render(
-    <React.StrictMode>
-      <RootErrorBoundary>
-        <Suspense fallback={<div>{t("common:status.loading")}</div>}>
-          <App />
-        </Suspense>
-      </RootErrorBoundary>
-    </React.StrictMode>,
-  )
-}
-
-void renderApp()
+void renderExtensionPage("popup", <App />)

--- a/src/entrypoints/popup/main.tsx
+++ b/src/entrypoints/popup/main.tsx
@@ -1,20 +1,16 @@
 import React, { Suspense } from "react"
 import ReactDOM from "react-dom/client"
 
-import "~/utils/i18n" // Import the i18n configuration
-
 import { RootErrorBoundary } from "~/components/RootErrorBoundary"
 import { UI_CONSTANTS } from "~/constants/ui"
 import { isMobileDevice } from "~/utils/browser"
+import { i18nReady } from "~/utils/i18n"
 import { t } from "~/utils/i18n/core"
 import { setDocumentTitle } from "~/utils/navigation/documentTitle"
 
 import App from "./App"
 
 import "./style.css"
-
-// Set the document title immediately
-setDocumentTitle("popup")
 
 if (!isMobileDevice()) {
   const popupDocument = document.documentElement
@@ -43,12 +39,20 @@ if (!isMobileDevice()) {
   window.addEventListener("resize", syncPopupDocumentSize)
 }
 
-ReactDOM.createRoot(document.getElementById("root")!).render(
-  <React.StrictMode>
-    <RootErrorBoundary>
-      <Suspense fallback={<div>{t("common:status.loading")}</div>}>
-        <App />
-      </Suspense>
-    </RootErrorBoundary>
-  </React.StrictMode>,
-)
+/** Render only after the active and fallback locale assets are ready. */
+async function renderApp() {
+  await i18nReady
+  setDocumentTitle("popup")
+
+  ReactDOM.createRoot(document.getElementById("root")!).render(
+    <React.StrictMode>
+      <RootErrorBoundary>
+        <Suspense fallback={<div>{t("common:status.loading")}</div>}>
+          <App />
+        </Suspense>
+      </RootErrorBoundary>
+    </React.StrictMode>,
+  )
+}
+
+void renderApp()

--- a/src/entrypoints/shared/renderExtensionPage.tsx
+++ b/src/entrypoints/shared/renderExtensionPage.tsx
@@ -1,0 +1,29 @@
+import type { ReactNode } from "react"
+import React, { Suspense } from "react"
+import ReactDOM from "react-dom/client"
+
+import { RootErrorBoundary } from "~/components/RootErrorBoundary"
+import { i18nReady } from "~/utils/i18n"
+import { t } from "~/utils/i18n/core"
+import { setDocumentTitle } from "~/utils/navigation/documentTitle"
+
+type ExtensionPageType = Parameters<typeof setDocumentTitle>[0]
+
+/** Mount a page only after its active and fallback locale assets are ready. */
+export async function renderExtensionPage(
+  pageType: ExtensionPageType,
+  app: ReactNode,
+) {
+  await i18nReady
+  setDocumentTitle(pageType)
+
+  ReactDOM.createRoot(document.getElementById("root")!).render(
+    <React.StrictMode>
+      <RootErrorBoundary>
+        <Suspense fallback={<div>{t("common:status.loading")}</div>}>
+          {app}
+        </Suspense>
+      </RootErrorBoundary>
+    </React.StrictMode>,
+  )
+}

--- a/src/entrypoints/sidepanel/main.tsx
+++ b/src/entrypoints/sidepanel/main.tsx
@@ -1,27 +1,5 @@
-import React, { Suspense } from "react"
-import ReactDOM from "react-dom/client"
-
-import { RootErrorBoundary } from "~/components/RootErrorBoundary"
-import { i18nReady } from "~/utils/i18n"
-import { t } from "~/utils/i18n/core"
-import { setDocumentTitle } from "~/utils/navigation/documentTitle"
+import { renderExtensionPage } from "~/entrypoints/shared/renderExtensionPage"
 
 import App from "./App"
 
-/** Render only after the active and fallback locale assets are ready. */
-async function renderApp() {
-  await i18nReady
-  setDocumentTitle("sidepanel")
-
-  ReactDOM.createRoot(document.getElementById("root")!).render(
-    <React.StrictMode>
-      <RootErrorBoundary>
-        <Suspense fallback={<div>{t("common:status.loading")}</div>}>
-          <App />
-        </Suspense>
-      </RootErrorBoundary>
-    </React.StrictMode>,
-  )
-}
-
-void renderApp()
+void renderExtensionPage("sidepanel", <App />)

--- a/src/entrypoints/sidepanel/main.tsx
+++ b/src/entrypoints/sidepanel/main.tsx
@@ -1,23 +1,27 @@
 import React, { Suspense } from "react"
 import ReactDOM from "react-dom/client"
 
-import "~/utils/i18n" // Import the i18n configuration
-
 import { RootErrorBoundary } from "~/components/RootErrorBoundary"
+import { i18nReady } from "~/utils/i18n"
 import { t } from "~/utils/i18n/core"
 import { setDocumentTitle } from "~/utils/navigation/documentTitle"
 
 import App from "./App"
 
-// Set the document title immediately
-setDocumentTitle("sidepanel")
+/** Render only after the active and fallback locale assets are ready. */
+async function renderApp() {
+  await i18nReady
+  setDocumentTitle("sidepanel")
 
-ReactDOM.createRoot(document.getElementById("root")!).render(
-  <React.StrictMode>
-    <RootErrorBoundary>
-      <Suspense fallback={<div>{t("common:status.loading")}</div>}>
-        <App />
-      </Suspense>
-    </RootErrorBoundary>
-  </React.StrictMode>,
-)
+  ReactDOM.createRoot(document.getElementById("root")!).render(
+    <React.StrictMode>
+      <RootErrorBoundary>
+        <Suspense fallback={<div>{t("common:status.loading")}</div>}>
+          <App />
+        </Suspense>
+      </RootErrorBoundary>
+    </React.StrictMode>,
+  )
+}
+
+void renderApp()

--- a/src/features/ApiCredentialProfiles/components/ApiCredentialProfileDialog.tsx
+++ b/src/features/ApiCredentialProfiles/components/ApiCredentialProfileDialog.tsx
@@ -15,7 +15,6 @@ import {
 } from "~/components/ui"
 import {
   formatDatePickerTimestamp,
-  getDatePickerLocale,
   parseDatePickerTimestamp,
 } from "~/components/ui/datePickerValue"
 import { Modal } from "~/components/ui/Dialog/Modal"
@@ -220,11 +219,6 @@ export function ApiCredentialProfileDialog({
     const normalized = normalizeBaseUrl(apiType, baseUrl)
     return normalized ?? ""
   }, [apiType, baseUrl])
-  const datePickerLocale = useMemo(
-    () => getDatePickerLocale(i18n.language),
-    [i18n.language],
-  )
-
   const telemetryJsonPathFields = useMemo(
     () => [
       {
@@ -643,7 +637,7 @@ export function ApiCredentialProfileDialog({
                   preview: t("common:datePicker.naturalInput.preview"),
                 },
               }}
-              locale={datePickerLocale}
+              language={i18n.language}
               disabled={isSaving}
               naturalInput
             />

--- a/src/features/ImportExport/components/WebDAVSettings.tsx
+++ b/src/features/ImportExport/components/WebDAVSettings.tsx
@@ -74,6 +74,7 @@ import { createLogger } from "~/utils/core/logger"
 import { getPreferenceWriteFailureMessage } from "~/utils/core/toastHelpers"
 import { applyPreferenceLanguage } from "~/utils/i18n/applyPreferenceLanguage"
 import { t as translate } from "~/utils/i18n/core"
+import { changePageLanguage } from "~/utils/i18n/pageLanguage"
 
 import { WEBDAV_TARGET_IDS } from "../searchTargets"
 import { IMPORT_EXPORT_TEST_IDS } from "../testIds"
@@ -635,7 +636,10 @@ export default function WebDAVSettings() {
       const result = await handleImportWithSelection(data)
       if (result.allImported || result.sections?.preferences) {
         await loadPreferences()
-        await applyPreferenceLanguage(await userPreferences.getLanguage())
+        await applyPreferenceLanguage(
+          await userPreferences.getLanguage(),
+          changePageLanguage,
+        )
       }
       if (result.allImported) {
         toast.success(t("importExport:import.importSuccess"))
@@ -738,7 +742,10 @@ export default function WebDAVSettings() {
         const refreshedPreferences = await userPreferences.getPreferences()
         importedPreferencesLastUpdated = refreshedPreferences.lastUpdated
         await loadPreferences()
-        await applyPreferenceLanguage(await userPreferences.getLanguage())
+        await applyPreferenceLanguage(
+          await userPreferences.getLanguage(),
+          changePageLanguage,
+        )
       }
 
       if (saveDecryptPassword) {

--- a/src/features/ImportExport/hooks/useImportExport.ts
+++ b/src/features/ImportExport/hooks/useImportExport.ts
@@ -21,6 +21,7 @@ import {
 import { getErrorMessage } from "~/utils/core/error"
 import { createLogger } from "~/utils/core/logger"
 import { applyPreferenceLanguage } from "~/utils/i18n/applyPreferenceLanguage"
+import { changePageLanguage } from "~/utils/i18n/pageLanguage"
 
 import { importFromBackupObject, parseBackupSummary } from "../utils"
 
@@ -139,7 +140,10 @@ export const useImportExport = () => {
       )
       if (result.sections?.preferences) {
         await loadPreferences()
-        await applyPreferenceLanguage(await userPreferences.getLanguage())
+        await applyPreferenceLanguage(
+          await userPreferences.getLanguage(),
+          changePageLanguage,
+        )
       }
       if (result.allImported) {
         toast.success(t("importExport:import.importSuccess"))

--- a/src/locales/README.md
+++ b/src/locales/README.md
@@ -31,8 +31,15 @@ locales/
 │   └── (同上结构)
 ├── zh-TW/                  # 繁体中文翻译
 │   └── (同上结构)
+├── runtime-assets.ts       # 构建期语言资源聚合模块
 └── README.md               # 本文件
 ```
+
+---
+
+## ⚙️ 运行时加载
+
+各 namespace JSON 仍是唯一翻译源。WXT 构建时由 `runtime-assets.ts` 为每种语言生成一个压缩后的 `app-locales/<language>.json`；扩展运行时只加载当前语言与 `zh-CN` 回退，不要直接编辑 `.output/**/app-locales/` 中的生成文件。
 
 ---
 

--- a/src/locales/runtime-assets.ts
+++ b/src/locales/runtime-assets.ts
@@ -1,0 +1,52 @@
+import { readdir, readFile } from "node:fs/promises"
+import path from "node:path"
+import { defineWxtModule } from "wxt/modules"
+
+import {
+  APP_LOCALE_ASSET_DIR,
+  SUPPORTED_UI_LANGUAGES,
+  type SupportedUiLanguage,
+} from "../constants/i18n"
+
+/**
+ * Combine a language's namespace files into one minified runtime asset.
+ */
+export async function createLocaleAssetContents(
+  localeRoot: string,
+  language: SupportedUiLanguage,
+) {
+  const languageDir = path.join(localeRoot, language)
+  const namespaceFiles = (await readdir(languageDir, { withFileTypes: true }))
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".json"))
+    .map((entry) => entry.name)
+    .sort()
+
+  if (namespaceFiles.length === 0) {
+    throw new Error(`No locale namespaces found for ${language}`)
+  }
+
+  const namespaceEntries = await Promise.all(
+    namespaceFiles.map(async (filename) => {
+      const namespace = filename.slice(0, -".json".length)
+      const contents = await readFile(path.join(languageDir, filename), "utf8")
+      return [namespace, JSON.parse(contents)] as const
+    }),
+  )
+
+  return JSON.stringify(Object.fromEntries(namespaceEntries))
+}
+
+export default defineWxtModule((wxt) => {
+  const localeRoot = path.resolve(wxt.config.root, "src/locales")
+
+  wxt.hooks.hook("build:publicAssets", async (_wxt, files) => {
+    const assets = await Promise.all(
+      SUPPORTED_UI_LANGUAGES.map(async (language) => ({
+        contents: await createLocaleAssetContents(localeRoot, language),
+        relativeDest: `${APP_LOCALE_ASSET_DIR}/${language}.json`,
+      })),
+    )
+
+    files.push(...assets)
+  })
+})

--- a/src/locales/runtime-assets.ts
+++ b/src/locales/runtime-assets.ts
@@ -3,7 +3,7 @@ import path from "node:path"
 import { defineWxtModule } from "wxt/modules"
 
 import {
-  APP_LOCALE_ASSET_DIR,
+  getAppLocaleAssetPath,
   SUPPORTED_UI_LANGUAGES,
   type SupportedUiLanguage,
 } from "../constants/i18n"
@@ -43,7 +43,7 @@ export default defineWxtModule((wxt) => {
     const assets = await Promise.all(
       SUPPORTED_UI_LANGUAGES.map(async (language) => ({
         contents: await createLocaleAssetContents(localeRoot, language),
-        relativeDest: `${APP_LOCALE_ASSET_DIR}/${language}.json`,
+        relativeDest: getAppLocaleAssetPath(language),
       })),
     )
 

--- a/src/utils/browser/extensionResourceUrl.ts
+++ b/src/utils/browser/extensionResourceUrl.ts
@@ -12,8 +12,10 @@ export function getExtensionResourceUrl(path: string) {
     browser?: ExtensionRuntimeBrowser
     chrome?: ExtensionRuntimeBrowser
   }
-  const runtime =
-    runtimeGlobal.browser?.runtime ?? runtimeGlobal.chrome?.runtime
+  const browserRuntime = runtimeGlobal.browser?.runtime
+  const runtime = browserRuntime?.getURL
+    ? browserRuntime
+    : runtimeGlobal.chrome?.runtime
 
   if (!runtime?.getURL) {
     throw new Error("Extension runtime.getURL is unavailable")

--- a/src/utils/browser/extensionResourceUrl.ts
+++ b/src/utils/browser/extensionResourceUrl.ts
@@ -1,0 +1,23 @@
+interface ExtensionRuntimeBrowser {
+  runtime?: {
+    getURL?: (path: string) => string
+  }
+}
+
+/**
+ * Resolve a packaged extension asset without assuming one browser global.
+ */
+export function getExtensionResourceUrl(path: string) {
+  const runtimeGlobal = globalThis as unknown as {
+    browser?: ExtensionRuntimeBrowser
+    chrome?: ExtensionRuntimeBrowser
+  }
+  const runtime =
+    runtimeGlobal.browser?.runtime ?? runtimeGlobal.chrome?.runtime
+
+  if (!runtime?.getURL) {
+    throw new Error("Extension runtime.getURL is unavailable")
+  }
+
+  return runtime.getURL(path)
+}

--- a/src/utils/i18n/applyPreferenceLanguage.ts
+++ b/src/utils/i18n/applyPreferenceLanguage.ts
@@ -1,5 +1,6 @@
 import i18n from "./core"
 import { normalizeAppLanguage } from "./language"
+import { changeAppLanguage } from "./resources"
 
 /**
  * Apply a persisted UI language preference to the active i18n instance when it
@@ -21,6 +22,6 @@ export async function applyPreferenceLanguage(
     return false
   }
 
-  await i18n.changeLanguage(nextLanguage)
+  await changeAppLanguage(i18n, nextLanguage)
   return true
 }

--- a/src/utils/i18n/applyPreferenceLanguage.ts
+++ b/src/utils/i18n/applyPreferenceLanguage.ts
@@ -1,6 +1,15 @@
+import type { i18n as I18nInstance } from "i18next"
+
+import type { SupportedUiLanguage } from "~/constants"
+
 import i18n from "./core"
 import { normalizeAppLanguage } from "./language"
 import { changeAppLanguage } from "./resources"
+
+type AppLanguageChanger = (
+  instance: I18nInstance,
+  language: SupportedUiLanguage,
+) => Promise<boolean | void>
 
 /**
  * Apply a persisted UI language preference to the active i18n instance when it
@@ -8,6 +17,7 @@ import { changeAppLanguage } from "./resources"
  */
 export async function applyPreferenceLanguage(
   language?: string | null,
+  changeLanguage: AppLanguageChanger = changeAppLanguage,
 ): Promise<boolean> {
   const nextLanguage = normalizeAppLanguage(language)
   if (!nextLanguage) {
@@ -22,6 +32,6 @@ export async function applyPreferenceLanguage(
     return false
   }
 
-  await changeAppLanguage(i18n, nextLanguage)
-  return true
+  const applied = await changeLanguage(i18n, nextLanguage)
+  return applied !== false
 }

--- a/src/utils/i18n/background.ts
+++ b/src/utils/i18n/background.ts
@@ -1,19 +1,9 @@
-import dayjs from "dayjs"
-
-import "dayjs/locale/de"
-import "dayjs/locale/es"
-import "dayjs/locale/ja"
-import "dayjs/locale/pt-br"
-import "dayjs/locale/vi"
-import "dayjs/locale/zh-cn"
-import "dayjs/locale/zh-tw"
-
 import { DEFAULT_LANG } from "~/constants"
 import { userPreferences } from "~/services/preferences/userPreferences"
 
 import i18n from "./core"
 import { resolveInitialAppLanguage } from "./language"
-import { loadAppLanguageResources, mapToDayjsLocale } from "./resources"
+import { loadAppLanguageResources } from "./resources"
 
 /**
  * 初始化 background i18n
@@ -36,12 +26,4 @@ export async function initBackgroundI18n() {
   })
 
   await i18n.changeLanguage(initialLanguage)
-
-  // 同步 dayjs locale
-  dayjs.locale(mapToDayjsLocale(initialLanguage))
 }
-
-// 监听语言变更，保持 dayjs 一致
-i18n.on("languageChanged", (lng) => {
-  dayjs.locale(mapToDayjsLocale(lng))
-})

--- a/src/utils/i18n/background.ts
+++ b/src/utils/i18n/background.ts
@@ -13,25 +13,26 @@ import { userPreferences } from "~/services/preferences/userPreferences"
 
 import i18n from "./core"
 import { resolveInitialAppLanguage } from "./language"
-import { mapToDayjsLocale, resources } from "./resources"
+import { loadAppLanguageResources, mapToDayjsLocale } from "./resources"
 
 /**
  * 初始化 background i18n
  */
 export async function initBackgroundI18n() {
+  const storedLanguage = await userPreferences.getLanguage()
+  const initialLanguage = resolveInitialAppLanguage({
+    userPreferenceLanguage: storedLanguage,
+    detectedLanguage:
+      typeof navigator !== "undefined" ? navigator.language : undefined,
+  })
+  const resources = await loadAppLanguageResources(initialLanguage)
+
   await i18n.init({
     resources,
     fallbackLng: DEFAULT_LANG,
     defaultNS: "common",
     interpolation: { escapeValue: false },
     returnEmptyString: false,
-  })
-
-  const storedLanguage = await userPreferences.getLanguage()
-  const initialLanguage = resolveInitialAppLanguage({
-    userPreferenceLanguage: storedLanguage,
-    detectedLanguage:
-      typeof navigator !== "undefined" ? navigator.language : undefined,
   })
 
   await i18n.changeLanguage(initialLanguage)

--- a/src/utils/i18n/background.ts
+++ b/src/utils/i18n/background.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_LANG } from "~/constants"
+import { DEFAULT_I18N_NAMESPACE, DEFAULT_LANG } from "~/constants"
 import { userPreferences } from "~/services/preferences/userPreferences"
 
 import i18n from "./core"
@@ -20,7 +20,7 @@ export async function initBackgroundI18n() {
   await i18n.init({
     resources,
     fallbackLng: DEFAULT_LANG,
-    defaultNS: "common",
+    defaultNS: DEFAULT_I18N_NAMESPACE,
     interpolation: { escapeValue: false },
     returnEmptyString: false,
   })

--- a/src/utils/i18n/content.ts
+++ b/src/utils/i18n/content.ts
@@ -16,7 +16,7 @@ import { userPreferences } from "~/services/preferences/userPreferences"
 import { applyPreferenceLanguage } from "./applyPreferenceLanguage"
 import i18n from "./core"
 import { resolveInitialAppLanguage } from "./language"
-import { mapToDayjsLocale, resources } from "./resources"
+import { loadAppLanguageResources, mapToDayjsLocale } from "./resources"
 
 let contentI18nReadyPromise: Promise<void> | null = null
 let contentI18nInitialized = false
@@ -25,6 +25,14 @@ let contentI18nInitialized = false
  * Initializes i18n for content scripts without reading host-page storage.
  */
 async function initContentI18n() {
+  const storedLanguage = await userPreferences.getLanguage()
+  const initialLanguage = resolveInitialAppLanguage({
+    userPreferenceLanguage: storedLanguage,
+    detectedLanguage:
+      typeof navigator !== "undefined" ? navigator.language : undefined,
+  })
+  const resources = await loadAppLanguageResources(initialLanguage)
+
   await i18n.use(initReactI18next).init({
     resources,
     fallbackLng: DEFAULT_LANG,
@@ -32,13 +40,6 @@ async function initContentI18n() {
     interpolation: { escapeValue: false },
     returnEmptyString: false,
     react: { useSuspense: false },
-  })
-
-  const storedLanguage = await userPreferences.getLanguage()
-  const initialLanguage = resolveInitialAppLanguage({
-    userPreferenceLanguage: storedLanguage,
-    detectedLanguage:
-      typeof navigator !== "undefined" ? navigator.language : undefined,
   })
 
   await i18n.changeLanguage(initialLanguage)

--- a/src/utils/i18n/content.ts
+++ b/src/utils/i18n/content.ts
@@ -1,6 +1,6 @@
 import { initReactI18next } from "react-i18next"
 
-import { DEFAULT_LANG } from "~/constants"
+import { DEFAULT_I18N_NAMESPACE, DEFAULT_LANG } from "~/constants"
 import { userPreferences } from "~/services/preferences/userPreferences"
 
 import { applyPreferenceLanguage } from "./applyPreferenceLanguage"
@@ -26,7 +26,7 @@ async function initContentI18n() {
   await i18n.use(initReactI18next).init({
     resources,
     fallbackLng: DEFAULT_LANG,
-    defaultNS: "common",
+    defaultNS: DEFAULT_I18N_NAMESPACE,
     interpolation: { escapeValue: false },
     returnEmptyString: false,
     react: { useSuspense: false },

--- a/src/utils/i18n/content.ts
+++ b/src/utils/i18n/content.ts
@@ -1,13 +1,3 @@
-import dayjs from "dayjs"
-
-import "dayjs/locale/de"
-import "dayjs/locale/es"
-import "dayjs/locale/ja"
-import "dayjs/locale/pt-br"
-import "dayjs/locale/vi"
-import "dayjs/locale/zh-cn"
-import "dayjs/locale/zh-tw"
-
 import { initReactI18next } from "react-i18next"
 
 import { DEFAULT_LANG } from "~/constants"
@@ -16,7 +6,7 @@ import { userPreferences } from "~/services/preferences/userPreferences"
 import { applyPreferenceLanguage } from "./applyPreferenceLanguage"
 import i18n from "./core"
 import { resolveInitialAppLanguage } from "./language"
-import { loadAppLanguageResources, mapToDayjsLocale } from "./resources"
+import { loadAppLanguageResources } from "./resources"
 
 let contentI18nReadyPromise: Promise<void> | null = null
 let contentI18nInitialized = false
@@ -43,7 +33,6 @@ async function initContentI18n() {
   })
 
   await i18n.changeLanguage(initialLanguage)
-  dayjs.locale(mapToDayjsLocale(initialLanguage))
   contentI18nInitialized = true
 }
 
@@ -65,7 +54,3 @@ export async function ensureContentI18nReady() {
     await applyPreferenceLanguage(await userPreferences.getLanguage())
   }
 }
-
-i18n.on("languageChanged", (lng) => {
-  dayjs.locale(mapToDayjsLocale(lng))
-})

--- a/src/utils/i18n/createCachedLocaleLoader.ts
+++ b/src/utils/i18n/createCachedLocaleLoader.ts
@@ -1,0 +1,21 @@
+/**
+ * Cache successful and in-flight locale loads while allowing failed loads to
+ * be retried.
+ */
+export function createCachedLocaleLoader<Key, Value>(
+  load: (key: Key) => Promise<Value>,
+) {
+  const cache = new Map<Key, Promise<Value>>()
+
+  return (key: Key): Promise<Value> => {
+    const cachedLoad = cache.get(key)
+    if (cachedLoad) return cachedLoad
+
+    const pendingLoad = load(key).catch((error) => {
+      cache.delete(key)
+      throw error
+    })
+    cache.set(key, pendingLoad)
+    return pendingLoad
+  }
+}

--- a/src/utils/i18n/dayjsLocale.ts
+++ b/src/utils/i18n/dayjsLocale.ts
@@ -1,0 +1,80 @@
+import {
+  DEFAULT_LANG,
+  GERMAN_LANG,
+  JAPANESE_LANG,
+  PORTUGUESE_BRAZIL_LANG,
+  SPANISH_LATIN_AMERICA_LANG,
+  TRADITIONAL_CHINESE_LANG,
+  VIETNAMESE_LANG,
+} from "~/constants"
+
+import { normalizeAppLanguage } from "./language"
+
+type DayjsLocale =
+  | "de"
+  | "en"
+  | "es"
+  | "ja"
+  | "pt-br"
+  | "vi"
+  | "zh-cn"
+  | "zh-tw"
+
+const ENGLISH_DAYJS_LOCALE: DayjsLocale = "en"
+const resolvedEnglishLocale = Promise.resolve(ENGLISH_DAYJS_LOCALE)
+const localeImportCache = new Map<DayjsLocale, Promise<DayjsLocale>>()
+
+const localeImporters: Partial<Record<DayjsLocale, () => Promise<unknown>>> = {
+  de: () => import("dayjs/locale/de"),
+  es: () => import("dayjs/locale/es"),
+  ja: () => import("dayjs/locale/ja"),
+  "pt-br": () => import("dayjs/locale/pt-br"),
+  vi: () => import("dayjs/locale/vi"),
+  "zh-cn": () => import("dayjs/locale/zh-cn"),
+  "zh-tw": () => import("dayjs/locale/zh-tw"),
+}
+
+/** Resolve a runtime language tag to the finite Day.js locale set we ship. */
+export function resolveDayjsLocale(language?: string | null): DayjsLocale {
+  switch (normalizeAppLanguage(language)) {
+    case GERMAN_LANG:
+      return "de"
+    case SPANISH_LATIN_AMERICA_LANG:
+      return "es"
+    case PORTUGUESE_BRAZIL_LANG:
+      return "pt-br"
+    case JAPANESE_LANG:
+      return "ja"
+    case VIETNAMESE_LANG:
+      return "vi"
+    case DEFAULT_LANG:
+      return "zh-cn"
+    case TRADITIONAL_CHINESE_LANG:
+      return "zh-tw"
+    default:
+      return ENGLISH_DAYJS_LOCALE
+  }
+}
+
+/** Load one Day.js locale module, sharing in-flight work and allowing retries. */
+export function loadDayjsLocale(
+  language?: string | null,
+): Promise<DayjsLocale> {
+  const locale = resolveDayjsLocale(language)
+  if (locale === ENGLISH_DAYJS_LOCALE) return resolvedEnglishLocale
+
+  const cachedImport = localeImportCache.get(locale)
+  if (cachedImport) return cachedImport
+
+  const importer = localeImporters[locale]
+  if (!importer) return resolvedEnglishLocale
+
+  const importPromise = importer()
+    .then(() => locale)
+    .catch((error) => {
+      localeImportCache.delete(locale)
+      throw error
+    })
+  localeImportCache.set(locale, importPromise)
+  return importPromise
+}

--- a/src/utils/i18n/dayjsLocale.ts
+++ b/src/utils/i18n/dayjsLocale.ts
@@ -1,31 +1,20 @@
 import {
   DEFAULT_LANG,
+  ENGLISH_LANG,
   GERMAN_LANG,
   JAPANESE_LANG,
   PORTUGUESE_BRAZIL_LANG,
   SPANISH_LATIN_AMERICA_LANG,
   TRADITIONAL_CHINESE_LANG,
   VIETNAMESE_LANG,
+  type SupportedUiLanguage,
 } from "~/constants"
 
 import { createCachedLocaleLoader } from "./createCachedLocaleLoader"
 import { normalizeAppLanguage } from "./language"
 
-type DayjsLocale =
-  | "de"
-  | "en"
-  | "es"
-  | "ja"
-  | "pt-br"
-  | "vi"
-  | "zh-cn"
-  | "zh-tw"
-
 const ENGLISH_DAYJS_LOCALE = "en" as const
-const resolvedEnglishLocale = Promise.resolve(ENGLISH_DAYJS_LOCALE)
-type NonEnglishDayjsLocale = Exclude<DayjsLocale, "en">
-
-const localeImporters: Record<NonEnglishDayjsLocale, () => Promise<unknown>> = {
+const localeImporters = {
   de: () => import("dayjs/locale/de"),
   es: () => import("dayjs/locale/es"),
   ja: () => import("dayjs/locale/ja"),
@@ -33,7 +22,22 @@ const localeImporters: Record<NonEnglishDayjsLocale, () => Promise<unknown>> = {
   vi: () => import("dayjs/locale/vi"),
   "zh-cn": () => import("dayjs/locale/zh-cn"),
   "zh-tw": () => import("dayjs/locale/zh-tw"),
-}
+} as const
+
+type NonEnglishDayjsLocale = keyof typeof localeImporters
+type DayjsLocale = typeof ENGLISH_DAYJS_LOCALE | NonEnglishDayjsLocale
+
+const resolvedEnglishLocale = Promise.resolve(ENGLISH_DAYJS_LOCALE)
+const DAYJS_LOCALE_BY_APP_LANGUAGE = {
+  [ENGLISH_LANG]: ENGLISH_DAYJS_LOCALE,
+  [GERMAN_LANG]: "de",
+  [SPANISH_LATIN_AMERICA_LANG]: "es",
+  [PORTUGUESE_BRAZIL_LANG]: "pt-br",
+  [JAPANESE_LANG]: "ja",
+  [VIETNAMESE_LANG]: "vi",
+  [DEFAULT_LANG]: "zh-cn",
+  [TRADITIONAL_CHINESE_LANG]: "zh-tw",
+} as const satisfies Record<SupportedUiLanguage, DayjsLocale>
 
 const loadDayjsLocaleImport = createCachedLocaleLoader(
   async (locale: NonEnglishDayjsLocale) => {
@@ -44,24 +48,8 @@ const loadDayjsLocaleImport = createCachedLocaleLoader(
 
 /** Resolve a runtime language tag to the finite Day.js locale set we ship. */
 export function resolveDayjsLocale(language?: string | null): DayjsLocale {
-  switch (normalizeAppLanguage(language)) {
-    case GERMAN_LANG:
-      return "de"
-    case SPANISH_LATIN_AMERICA_LANG:
-      return "es"
-    case PORTUGUESE_BRAZIL_LANG:
-      return "pt-br"
-    case JAPANESE_LANG:
-      return "ja"
-    case VIETNAMESE_LANG:
-      return "vi"
-    case DEFAULT_LANG:
-      return "zh-cn"
-    case TRADITIONAL_CHINESE_LANG:
-      return "zh-tw"
-    default:
-      return ENGLISH_DAYJS_LOCALE
-  }
+  const appLanguage = normalizeAppLanguage(language) ?? ENGLISH_LANG
+  return DAYJS_LOCALE_BY_APP_LANGUAGE[appLanguage]
 }
 
 /** Load one Day.js locale module, sharing in-flight work and allowing retries. */

--- a/src/utils/i18n/dayjsLocale.ts
+++ b/src/utils/i18n/dayjsLocale.ts
@@ -8,6 +8,7 @@ import {
   VIETNAMESE_LANG,
 } from "~/constants"
 
+import { createCachedLocaleLoader } from "./createCachedLocaleLoader"
 import { normalizeAppLanguage } from "./language"
 
 type DayjsLocale =
@@ -20,11 +21,11 @@ type DayjsLocale =
   | "zh-cn"
   | "zh-tw"
 
-const ENGLISH_DAYJS_LOCALE: DayjsLocale = "en"
+const ENGLISH_DAYJS_LOCALE = "en" as const
 const resolvedEnglishLocale = Promise.resolve(ENGLISH_DAYJS_LOCALE)
-const localeImportCache = new Map<DayjsLocale, Promise<DayjsLocale>>()
+type NonEnglishDayjsLocale = Exclude<DayjsLocale, "en">
 
-const localeImporters: Partial<Record<DayjsLocale, () => Promise<unknown>>> = {
+const localeImporters: Record<NonEnglishDayjsLocale, () => Promise<unknown>> = {
   de: () => import("dayjs/locale/de"),
   es: () => import("dayjs/locale/es"),
   ja: () => import("dayjs/locale/ja"),
@@ -33,6 +34,13 @@ const localeImporters: Partial<Record<DayjsLocale, () => Promise<unknown>>> = {
   "zh-cn": () => import("dayjs/locale/zh-cn"),
   "zh-tw": () => import("dayjs/locale/zh-tw"),
 }
+
+const loadDayjsLocaleImport = createCachedLocaleLoader(
+  async (locale: NonEnglishDayjsLocale) => {
+    await localeImporters[locale]()
+    return locale
+  },
+)
 
 /** Resolve a runtime language tag to the finite Day.js locale set we ship. */
 export function resolveDayjsLocale(language?: string | null): DayjsLocale {
@@ -62,19 +70,5 @@ export function loadDayjsLocale(
 ): Promise<DayjsLocale> {
   const locale = resolveDayjsLocale(language)
   if (locale === ENGLISH_DAYJS_LOCALE) return resolvedEnglishLocale
-
-  const cachedImport = localeImportCache.get(locale)
-  if (cachedImport) return cachedImport
-
-  const importer = localeImporters[locale]
-  if (!importer) return resolvedEnglishLocale
-
-  const importPromise = importer()
-    .then(() => locale)
-    .catch((error) => {
-      localeImportCache.delete(locale)
-      throw error
-    })
-  localeImportCache.set(locale, importPromise)
-  return importPromise
+  return loadDayjsLocaleImport(locale)
 }

--- a/src/utils/i18n/index.ts
+++ b/src/utils/i18n/index.ts
@@ -18,7 +18,11 @@ import { isDevBuild } from "~/utils/core/environment"
 
 import i18n from "./core"
 import { normalizeAppLanguage, resolveInitialAppLanguage } from "./language"
-import { mapToDayjsLocale, resources } from "./resources"
+import {
+  installAppLanguageResources,
+  loadAppLanguageResources,
+  mapToDayjsLocale,
+} from "./resources"
 
 /**
  * Keep the extension page root language aligned with the active UI locale.
@@ -31,7 +35,7 @@ function syncDocumentLanguage(language: string) {
   document.documentElement.lang = normalizeAppLanguage(language) ?? language
 }
 
-i18n
+export const i18nReady = i18n
   .use(LanguageDetector)
   .use(initReactI18next)
   .init({
@@ -42,7 +46,7 @@ i18n
     detection: {
       lookupLocalStorage: I18NEXT_LANGUAGE_STORAGE_KEY,
     },
-    resources,
+    resources: {},
     interpolation: {
       escapeValue: false, // react already escapes by default
     },
@@ -69,12 +73,13 @@ i18n
       detectedLanguage,
     })
 
-    if (
-      initialLanguage !== i18n.resolvedLanguage &&
-      initialLanguage !== i18n.language
-    ) {
-      await i18n.changeLanguage(initialLanguage)
-    }
+    installAppLanguageResources(
+      i18n,
+      await loadAppLanguageResources(initialLanguage),
+    )
+    // Re-resolve even when the detector selected the same language because
+    // resources are intentionally installed only after detection completes.
+    await i18n.changeLanguage(initialLanguage)
 
     dayjs.locale(mapToDayjsLocale(initialLanguage))
     syncDocumentLanguage(initialLanguage)

--- a/src/utils/i18n/index.ts
+++ b/src/utils/i18n/index.ts
@@ -1,13 +1,4 @@
 import dayjs from "dayjs"
-
-import "dayjs/locale/de"
-import "dayjs/locale/es"
-import "dayjs/locale/ja"
-import "dayjs/locale/pt-br"
-import "dayjs/locale/vi"
-import "dayjs/locale/zh-cn"
-import "dayjs/locale/zh-tw"
-
 import LanguageDetector from "i18next-browser-languagedetector"
 import { initReactI18next } from "react-i18next"
 
@@ -17,11 +8,11 @@ import { userPreferences } from "~/services/preferences/userPreferences"
 import { isDevBuild } from "~/utils/core/environment"
 
 import i18n from "./core"
+import { loadDayjsLocale } from "./dayjsLocale"
 import { normalizeAppLanguage, resolveInitialAppLanguage } from "./language"
 import {
   installAppLanguageResources,
   loadAppLanguageResources,
-  mapToDayjsLocale,
 } from "./resources"
 
 /**
@@ -73,21 +64,21 @@ export const i18nReady = i18n
       detectedLanguage,
     })
 
-    installAppLanguageResources(
-      i18n,
-      await loadAppLanguageResources(initialLanguage),
-    )
+    const [resources, dayjsLocale] = await Promise.all([
+      loadAppLanguageResources(initialLanguage),
+      loadDayjsLocale(initialLanguage),
+    ])
+    installAppLanguageResources(i18n, resources)
     // Re-resolve even when the detector selected the same language because
     // resources are intentionally installed only after detection completes.
     await i18n.changeLanguage(initialLanguage)
 
-    dayjs.locale(mapToDayjsLocale(initialLanguage))
+    dayjs.locale(dayjsLocale)
     syncDocumentLanguage(initialLanguage)
   })
 
 export default i18n
 
-i18n.on("languageChanged", async (lng) => {
-  dayjs.locale(mapToDayjsLocale(lng))
+i18n.on("languageChanged", (lng) => {
   syncDocumentLanguage(lng)
 })

--- a/src/utils/i18n/index.ts
+++ b/src/utils/i18n/index.ts
@@ -2,7 +2,7 @@ import dayjs from "dayjs"
 import LanguageDetector from "i18next-browser-languagedetector"
 import { initReactI18next } from "react-i18next"
 
-import { DEFAULT_LANG } from "~/constants"
+import { DEFAULT_I18N_NAMESPACE, DEFAULT_LANG } from "~/constants"
 import { I18NEXT_LANGUAGE_STORAGE_KEY } from "~/services/core/storageKeys"
 import { userPreferences } from "~/services/preferences/userPreferences"
 import { isDevBuild } from "~/utils/core/environment"
@@ -32,7 +32,7 @@ export const i18nReady = i18n
   .init({
     debug: isDevBuild(),
     fallbackLng: DEFAULT_LANG,
-    defaultNS: "common",
+    defaultNS: DEFAULT_I18N_NAMESPACE,
     // default config: https://github.com/i18next/i18next-browser-languageDetector#detector-options
     detection: {
       lookupLocalStorage: I18NEXT_LANGUAGE_STORAGE_KEY,

--- a/src/utils/i18n/language.ts
+++ b/src/utils/i18n/language.ts
@@ -1,5 +1,6 @@
 import {
   DEFAULT_LANG,
+  ENGLISH_LANG,
   GERMAN_LANG,
   JAPANESE_LANG,
   PORTUGUESE_BRAZIL_LANG,
@@ -9,8 +10,15 @@ import {
   type SupportedUiLanguage,
 } from "~/constants"
 
-const ENGLISH_LANG: SupportedUiLanguage = "en"
 const TRADITIONAL_CHINESE_REGIONS = new Set(["hk", "mo", "tw"])
+const APP_LANGUAGE_BY_FAMILY: Partial<Record<string, SupportedUiLanguage>> = {
+  en: ENGLISH_LANG,
+  [GERMAN_LANG]: GERMAN_LANG,
+  es: SPANISH_LATIN_AMERICA_LANG,
+  pt: PORTUGUESE_BRAZIL_LANG,
+  [JAPANESE_LANG]: JAPANESE_LANG,
+  [VIETNAMESE_LANG]: VIETNAMESE_LANG,
+}
 
 const isLanguageFamily = (
   language: string | undefined,
@@ -18,35 +26,6 @@ const isLanguageFamily = (
 ): boolean => {
   return language === family || language?.startsWith(`${family}-`) === true
 }
-
-export const UI_LANGUAGE_OPTIONS = [
-  {
-    code: ENGLISH_LANG,
-  },
-  {
-    code: GERMAN_LANG,
-  },
-  {
-    code: SPANISH_LATIN_AMERICA_LANG,
-  },
-  {
-    code: PORTUGUESE_BRAZIL_LANG,
-  },
-  {
-    code: JAPANESE_LANG,
-  },
-  {
-    code: VIETNAMESE_LANG,
-  },
-  {
-    code: DEFAULT_LANG,
-  },
-  {
-    code: TRADITIONAL_CHINESE_LANG,
-  },
-] as const satisfies ReadonlyArray<{
-  code: SupportedUiLanguage
-}>
 
 /**
  * Normalize a runtime language tag into a lowercase, hyphenated form.
@@ -68,11 +47,8 @@ export function isChineseLanguage(language?: string | null): boolean {
 /**
  * Return true when the language belongs to a Traditional Chinese variant.
  */
-function isTraditionalChineseLanguage(language?: string | null): boolean {
-  const normalized = normalizeLanguageTag(language)
-  if (!normalized || !isChineseLanguage(normalized)) return false
-
-  const subtags = normalized.split("-")
+function isTraditionalChineseLanguage(normalizedLanguage: string): boolean {
+  const subtags = normalizedLanguage.split("-")
   if (subtags.includes("hans")) return false
 
   return (
@@ -85,42 +61,14 @@ function isTraditionalChineseLanguage(language?: string | null): boolean {
  * Return true when the language belongs to the English locale family.
  */
 export function isEnglishLanguage(language?: string | null): boolean {
-  return isLanguageFamily(normalizeLanguageTag(language), "en")
-}
-
-/**
- * Return true when the language belongs to the German locale family.
- */
-function isGermanLanguage(language?: string | null): boolean {
-  return isLanguageFamily(normalizeLanguageTag(language), GERMAN_LANG)
+  return isLanguageFamily(normalizeLanguageTag(language), ENGLISH_LANG)
 }
 
 /**
  * Return true when the language belongs to the Japanese locale family.
  */
 export function isJapaneseLanguage(language?: string | null): boolean {
-  return isLanguageFamily(normalizeLanguageTag(language), "ja")
-}
-
-/**
- * Return true when the language belongs to the Vietnamese locale family.
- */
-function isVietnameseLanguage(language?: string | null): boolean {
-  return isLanguageFamily(normalizeLanguageTag(language), "vi")
-}
-
-/**
- * Return true when the language belongs to the Spanish locale family.
- */
-function isSpanishLanguage(language?: string | null): boolean {
-  return isLanguageFamily(normalizeLanguageTag(language), "es")
-}
-
-/**
- * Return true when the language belongs to the Portuguese locale family.
- */
-function isPortugueseLanguage(language?: string | null): boolean {
-  return isLanguageFamily(normalizeLanguageTag(language), "pt")
+  return isLanguageFamily(normalizeLanguageTag(language), JAPANESE_LANG)
 }
 
 /**
@@ -129,16 +77,17 @@ function isPortugueseLanguage(language?: string | null): boolean {
 export function normalizeAppLanguage(
   language?: string | null,
 ): SupportedUiLanguage | undefined {
-  if (isEnglishLanguage(language)) return ENGLISH_LANG
-  if (isGermanLanguage(language)) return GERMAN_LANG
-  if (isSpanishLanguage(language)) return SPANISH_LATIN_AMERICA_LANG
-  if (isPortugueseLanguage(language)) return PORTUGUESE_BRAZIL_LANG
-  if (isJapaneseLanguage(language)) return JAPANESE_LANG
-  if (isVietnameseLanguage(language)) return VIETNAMESE_LANG
-  if (isTraditionalChineseLanguage(language)) return TRADITIONAL_CHINESE_LANG
-  if (isChineseLanguage(language)) return DEFAULT_LANG
+  const normalizedLanguage = normalizeLanguageTag(language)
+  if (!normalizedLanguage) return undefined
 
-  return undefined
+  const languageFamily = normalizedLanguage.split("-")[0]
+  if (languageFamily !== "zh") {
+    return APP_LANGUAGE_BY_FAMILY[languageFamily]
+  }
+
+  return isTraditionalChineseLanguage(normalizedLanguage)
+    ? TRADITIONAL_CHINESE_LANG
+    : DEFAULT_LANG
 }
 
 /**

--- a/src/utils/i18n/pageLanguage.ts
+++ b/src/utils/i18n/pageLanguage.ts
@@ -1,0 +1,42 @@
+import dayjs from "dayjs"
+import type { i18n } from "i18next"
+
+import type { SupportedUiLanguage } from "~/constants"
+
+import { loadDayjsLocale } from "./dayjsLocale"
+import {
+  installAppLanguageResources,
+  loadAppLanguageResources,
+} from "./resources"
+
+let latestLanguageRequest = 0
+
+/**
+ * Prepare page-only locale dependencies, then commit only the latest request.
+ */
+export async function changePageLanguage(
+  instance: i18n,
+  language: SupportedUiLanguage,
+): Promise<boolean> {
+  const requestId = ++latestLanguageRequest
+  const [resources, dayjsLocale] = await Promise.all([
+    loadAppLanguageResources(language),
+    loadDayjsLocale(language),
+  ])
+
+  if (requestId !== latestLanguageRequest) return false
+
+  installAppLanguageResources(instance, resources)
+  const previousDayjsLocale = dayjs.locale()
+  dayjs.locale(dayjsLocale)
+  try {
+    await instance.changeLanguage(language)
+  } catch (error) {
+    dayjs.locale(previousDayjsLocale)
+    throw error
+  }
+
+  if (requestId !== latestLanguageRequest) return false
+
+  return true
+}

--- a/src/utils/i18n/pageLanguage.ts
+++ b/src/utils/i18n/pageLanguage.ts
@@ -33,6 +33,7 @@ export async function changePageLanguage(
     if (!isLatestRequest()) return false
 
     installAppLanguageResources(instance, resources)
+    const previousLanguage = instance.language
     const previousDayjsLocale = dayjs.locale()
     dayjs.locale(dayjsLocale)
     try {
@@ -42,7 +43,11 @@ export async function changePageLanguage(
       throw error
     }
 
-    return isLatestRequest()
+    if (isLatestRequest()) return true
+
+    dayjs.locale(previousDayjsLocale)
+    if (previousLanguage) await instance.changeLanguage(previousLanguage)
+    return false
   }
   const commitResult = languageCommitQueue.then(commit)
   languageCommitQueue = commitResult.then(

--- a/src/utils/i18n/pageLanguage.ts
+++ b/src/utils/i18n/pageLanguage.ts
@@ -10,6 +10,8 @@ import {
 } from "./resources"
 
 let latestLanguageRequest = 0
+// Locale assets can load concurrently, but i18next and Day.js commits must not.
+let languageCommitQueue = Promise.resolve()
 
 /**
  * Prepare page-only locale dependencies, then commit only the latest request.
@@ -19,24 +21,33 @@ export async function changePageLanguage(
   language: SupportedUiLanguage,
 ): Promise<boolean> {
   const requestId = ++latestLanguageRequest
+  const isLatestRequest = () => requestId === latestLanguageRequest
   const [resources, dayjsLocale] = await Promise.all([
     loadAppLanguageResources(language),
     loadDayjsLocale(language),
   ])
 
-  if (requestId !== latestLanguageRequest) return false
+  if (!isLatestRequest()) return false
 
-  installAppLanguageResources(instance, resources)
-  const previousDayjsLocale = dayjs.locale()
-  dayjs.locale(dayjsLocale)
-  try {
-    await instance.changeLanguage(language)
-  } catch (error) {
-    dayjs.locale(previousDayjsLocale)
-    throw error
+  const commit = async () => {
+    if (!isLatestRequest()) return false
+
+    installAppLanguageResources(instance, resources)
+    const previousDayjsLocale = dayjs.locale()
+    dayjs.locale(dayjsLocale)
+    try {
+      await instance.changeLanguage(language)
+    } catch (error) {
+      dayjs.locale(previousDayjsLocale)
+      throw error
+    }
+
+    return isLatestRequest()
   }
-
-  if (requestId !== latestLanguageRequest) return false
-
-  return true
+  const commitResult = languageCommitQueue.then(commit)
+  languageCommitQueue = commitResult.then(
+    () => undefined,
+    () => undefined,
+  )
+  return commitResult
 }

--- a/src/utils/i18n/resources.ts
+++ b/src/utils/i18n/resources.ts
@@ -7,10 +7,7 @@ import {
 } from "~/constants/i18n"
 import { getExtensionResourceUrl } from "~/utils/browser/extensionResourceUrl"
 
-const languageResourceCache = new Map<
-  SupportedUiLanguage,
-  Promise<ResourceLanguage>
->()
+import { createCachedLocaleLoader } from "./createCachedLocaleLoader"
 
 /** Return whether a fetched locale payload has a namespace map shape. */
 function isResourceLanguage(value: unknown): value is ResourceLanguage {
@@ -38,18 +35,7 @@ async function fetchLanguageResource(
   return resource
 }
 
-/** Return one cached language request, evicting failed attempts for retries. */
-function loadLanguageResource(language: SupportedUiLanguage) {
-  const cachedResource = languageResourceCache.get(language)
-  if (cachedResource) return cachedResource
-
-  const resourcePromise = fetchLanguageResource(language).catch((error) => {
-    languageResourceCache.delete(language)
-    throw error
-  })
-  languageResourceCache.set(language, resourcePromise)
-  return resourcePromise
-}
+const loadLanguageResource = createCachedLocaleLoader(fetchLanguageResource)
 
 /**
  * Load only the requested UI language and the default fallback language.

--- a/src/utils/i18n/resources.ts
+++ b/src/utils/i18n/resources.ts
@@ -1,8 +1,8 @@
 import type { i18n, Resource, ResourceLanguage } from "i18next"
 
 import {
-  APP_LOCALE_ASSET_DIR,
   DEFAULT_LANG,
+  getAppLocaleAssetPath,
   type SupportedUiLanguage,
 } from "~/constants/i18n"
 import { getExtensionResourceUrl } from "~/utils/browser/extensionResourceUrl"
@@ -18,8 +18,9 @@ function isResourceLanguage(value: unknown): value is ResourceLanguage {
 async function fetchLanguageResource(
   language: SupportedUiLanguage,
 ): Promise<ResourceLanguage> {
-  const assetPath = `${APP_LOCALE_ASSET_DIR}/${language}.json`
-  const response = await fetch(getExtensionResourceUrl(assetPath))
+  const response = await fetch(
+    getExtensionResourceUrl(getAppLocaleAssetPath(language)),
+  )
 
   if (!response.ok) {
     throw new Error(

--- a/src/utils/i18n/resources.ts
+++ b/src/utils/i18n/resources.ts
@@ -1,17 +1,102 @@
-import { GERMAN_LANG, SPANISH_LATIN_AMERICA_LANG } from "~/constants/i18n"
+import type { i18n, Resource, ResourceLanguage } from "i18next"
 
-// Automatically import all locale JSON files under `src/locales`.
-const modules = import.meta.glob("~/locales/*/*.json", { eager: true })
+import {
+  APP_LOCALE_ASSET_DIR,
+  DEFAULT_LANG,
+  GERMAN_LANG,
+  SPANISH_LATIN_AMERICA_LANG,
+  type SupportedUiLanguage,
+} from "~/constants/i18n"
+import { getExtensionResourceUrl } from "~/utils/browser/extensionResourceUrl"
 
-export const resources: Record<string, Record<string, any>> = {}
+const languageResourceCache = new Map<
+  SupportedUiLanguage,
+  Promise<ResourceLanguage>
+>()
 
-for (const path in modules) {
-  const match = path.match(/locales\/([^/]+)\/([^/]+)\.json$/)
-  if (!match) continue
+/** Return whether a fetched locale payload has a namespace map shape. */
+function isResourceLanguage(value: unknown): value is ResourceLanguage {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
 
-  const [, lang, ns] = match
-  resources[lang] ??= {}
-  resources[lang][ns] = (modules[path] as any).default
+/** Fetch and validate one generated language asset. */
+async function fetchLanguageResource(
+  language: SupportedUiLanguage,
+): Promise<ResourceLanguage> {
+  const assetPath = `${APP_LOCALE_ASSET_DIR}/${language}.json`
+  const response = await fetch(getExtensionResourceUrl(assetPath))
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to load locale asset for ${language} (${response.status})`,
+    )
+  }
+
+  const resource: unknown = await response.json()
+  if (!isResourceLanguage(resource)) {
+    throw new Error(`Locale asset for ${language} is not a JSON object`)
+  }
+
+  return resource
+}
+
+/** Return one cached language request, evicting failed attempts for retries. */
+function loadLanguageResource(language: SupportedUiLanguage) {
+  const cachedResource = languageResourceCache.get(language)
+  if (cachedResource) return cachedResource
+
+  const resourcePromise = fetchLanguageResource(language).catch((error) => {
+    languageResourceCache.delete(language)
+    throw error
+  })
+  languageResourceCache.set(language, resourcePromise)
+  return resourcePromise
+}
+
+/**
+ * Load only the requested UI language and the default fallback language.
+ */
+export async function loadAppLanguageResources(
+  language: SupportedUiLanguage,
+): Promise<Resource> {
+  const languages: SupportedUiLanguage[] =
+    language === DEFAULT_LANG ? [DEFAULT_LANG] : [language, DEFAULT_LANG]
+  const resourceEntries = await Promise.all(
+    languages.map(async (resourceLanguage) => [
+      resourceLanguage,
+      await loadLanguageResource(resourceLanguage),
+    ]),
+  )
+
+  return Object.fromEntries(resourceEntries)
+}
+
+/**
+ * Add lazily loaded language namespaces to an initialized i18next instance.
+ */
+export function installAppLanguageResources(
+  instance: i18n,
+  resources: Resource,
+) {
+  for (const [language, namespaces] of Object.entries(resources)) {
+    for (const [namespace, resource] of Object.entries(namespaces)) {
+      instance.addResourceBundle(language, namespace, resource, true, true)
+    }
+  }
+}
+
+/**
+ * Load and install a language before switching so no translation keys flash.
+ */
+export async function changeAppLanguage(
+  instance: i18n,
+  language: SupportedUiLanguage,
+) {
+  installAppLanguageResources(
+    instance,
+    await loadAppLanguageResources(language),
+  )
+  await instance.changeLanguage(language)
 }
 
 /**

--- a/src/utils/i18n/resources.ts
+++ b/src/utils/i18n/resources.ts
@@ -3,8 +3,6 @@ import type { i18n, Resource, ResourceLanguage } from "i18next"
 import {
   APP_LOCALE_ASSET_DIR,
   DEFAULT_LANG,
-  GERMAN_LANG,
-  SPANISH_LATIN_AMERICA_LANG,
   type SupportedUiLanguage,
 } from "~/constants/i18n"
 import { getExtensionResourceUrl } from "~/utils/browser/extensionResourceUrl"
@@ -97,15 +95,4 @@ export async function changeAppLanguage(
     await loadAppLanguageResources(language),
   )
   await instance.changeLanguage(language)
-}
-
-/**
- * Convert i18next language codes into dayjs-compatible locale names.
- */
-export function mapToDayjsLocale(lng: string): string {
-  const normalized = lng.toLowerCase().replace("_", "-")
-  if (normalized === GERMAN_LANG || normalized.startsWith(`${GERMAN_LANG}-`)) {
-    return GERMAN_LANG
-  }
-  return normalized === SPANISH_LATIN_AMERICA_LANG ? "es" : normalized
 }

--- a/tests/components/LanguageSwitcher.test.tsx
+++ b/tests/components/LanguageSwitcher.test.tsx
@@ -49,11 +49,14 @@ vi.mock("~/services/preferences/userPreferences", () => ({
   },
 }))
 
-vi.mock("~/utils/i18n/resources", () => ({
-  changeAppLanguage: (
+vi.mock("~/utils/i18n/pageLanguage", () => ({
+  changePageLanguage: async (
     instance: { changeLanguage: (language: string) => Promise<void> },
     language: string,
-  ) => instance.changeLanguage(language),
+  ) => {
+    await instance.changeLanguage(language)
+    return true
+  },
 }))
 
 const selectContext = createContext<{

--- a/tests/components/LanguageSwitcher.test.tsx
+++ b/tests/components/LanguageSwitcher.test.tsx
@@ -49,6 +49,13 @@ vi.mock("~/services/preferences/userPreferences", () => ({
   },
 }))
 
+vi.mock("~/utils/i18n/resources", () => ({
+  changeAppLanguage: (
+    instance: { changeLanguage: (language: string) => Promise<void> },
+    language: string,
+  ) => instance.changeLanguage(language),
+}))
+
 const selectContext = createContext<{
   onValueChange?: (value: string) => void
 } | null>(null)

--- a/tests/components/LanguageSwitcher.test.tsx
+++ b/tests/components/LanguageSwitcher.test.tsx
@@ -4,16 +4,20 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { LanguageSwitcher } from "~/components/LanguageSwitcher"
 
-const { changeLanguageMock, setLanguageMock, translationState } = vi.hoisted(
-  () => ({
-    changeLanguageMock: vi.fn().mockResolvedValue(undefined),
-    setLanguageMock: vi.fn().mockResolvedValue(undefined),
-    translationState: {
-      language: "en",
-      resolvedLanguage: "en",
-    },
-  }),
-)
+const {
+  changeLanguageMock,
+  changePageLanguageMock,
+  setLanguageMock,
+  translationState,
+} = vi.hoisted(() => ({
+  changeLanguageMock: vi.fn().mockResolvedValue(undefined),
+  changePageLanguageMock: vi.fn().mockResolvedValue(true),
+  setLanguageMock: vi.fn().mockResolvedValue(undefined),
+  translationState: {
+    language: "en",
+    resolvedLanguage: "en",
+  },
+}))
 
 vi.mock("react-i18next", async (importOriginal) => {
   const actual = await importOriginal<typeof import("react-i18next")>()
@@ -50,13 +54,7 @@ vi.mock("~/services/preferences/userPreferences", () => ({
 }))
 
 vi.mock("~/utils/i18n/pageLanguage", () => ({
-  changePageLanguage: async (
-    instance: { changeLanguage: (language: string) => Promise<void> },
-    language: string,
-  ) => {
-    await instance.changeLanguage(language)
-    return true
-  },
+  changePageLanguage: (...args: unknown[]) => changePageLanguageMock(...args),
 }))
 
 const selectContext = createContext<{
@@ -182,6 +180,7 @@ vi.mock("~/components/ui/dropdown-menu", () => ({
 describe("LanguageSwitcher", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    changePageLanguageMock.mockResolvedValue(true)
     translationState.language = "en"
     translationState.resolvedLanguage = "en"
   })
@@ -209,8 +208,13 @@ describe("LanguageSwitcher", () => {
 
     fireEvent.click(nextButton)
 
-    expect(changeLanguageMock).toHaveBeenCalledTimes(1)
-    expect(changeLanguageMock).toHaveBeenCalledWith("ja")
+    expect(changePageLanguageMock).toHaveBeenCalledTimes(1)
+    expect(changePageLanguageMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        changeLanguage: changeLanguageMock,
+      }),
+      "ja",
+    )
     await waitFor(() => {
       expect(setLanguageMock).toHaveBeenCalledTimes(2)
     })
@@ -255,7 +259,7 @@ describe("LanguageSwitcher", () => {
 
     fireEvent.pointerUp(activeSelectItem)
 
-    expect(changeLanguageMock).not.toHaveBeenCalled()
+    expect(changePageLanguageMock).not.toHaveBeenCalled()
     expect(setLanguageMock).toHaveBeenCalledWith("en")
   })
 
@@ -270,7 +274,10 @@ describe("LanguageSwitcher", () => {
         }),
       )
 
-      expect(changeLanguageMock).toHaveBeenCalledWith(language)
+      expect(changePageLanguageMock).toHaveBeenCalledWith(
+        expect.any(Object),
+        language,
+      )
       await waitFor(() => {
         expect(setLanguageMock).toHaveBeenCalledWith(language)
       })
@@ -292,9 +299,38 @@ describe("LanguageSwitcher", () => {
       }),
     )
 
-    expect(changeLanguageMock).toHaveBeenCalledWith("ja")
+    expect(changePageLanguageMock).toHaveBeenCalledWith(
+      expect.any(Object),
+      "ja",
+    )
     return waitFor(() => {
       expect(setLanguageMock).toHaveBeenCalledWith("ja")
     })
+  })
+
+  it.each([
+    ["returns false", false],
+    ["rejects", new Error("locale asset unavailable")],
+  ])("does not persist when changing language %s", async (_label, outcome) => {
+    if (outcome instanceof Error) {
+      changePageLanguageMock.mockRejectedValueOnce(outcome)
+    } else {
+      changePageLanguageMock.mockResolvedValueOnce(outcome)
+    }
+    render(<LanguageSwitcher />)
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Switch to settings:appearanceLanguage.switcher.options.ja.name",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(changePageLanguageMock).toHaveBeenCalledWith(
+        expect.any(Object),
+        "ja",
+      )
+    })
+    expect(setLanguageMock).not.toHaveBeenCalled()
   })
 })

--- a/tests/components/LanguageSwitcher.test.tsx
+++ b/tests/components/LanguageSwitcher.test.tsx
@@ -259,80 +259,23 @@ describe("LanguageSwitcher", () => {
     expect(setLanguageMock).toHaveBeenCalledWith("en")
   })
 
-  it("changes language from the select variant when a different option is chosen", async () => {
-    render(<LanguageSwitcher variant="select" />)
+  it.each(["ja", "vi", "es-419", "pt-BR", "de"] as const)(
+    "shows and persists %s from the select variant",
+    async (language) => {
+      render(<LanguageSwitcher variant="select" />)
 
-    fireEvent.click(
-      screen.getByRole("button", {
-        name: "settings:appearanceLanguage.switcher.options.ja.name",
-      }),
-    )
+      fireEvent.click(
+        screen.getByRole("button", {
+          name: `settings:appearanceLanguage.switcher.options.${language}.name`,
+        }),
+      )
 
-    expect(changeLanguageMock).toHaveBeenCalledWith("ja")
-    await waitFor(() => {
-      expect(setLanguageMock).toHaveBeenCalledWith("ja")
-    })
-  })
-
-  it("shows and persists Vietnamese from the select variant", async () => {
-    render(<LanguageSwitcher variant="select" />)
-
-    fireEvent.click(
-      screen.getByRole("button", {
-        name: "settings:appearanceLanguage.switcher.options.vi.name",
-      }),
-    )
-
-    expect(changeLanguageMock).toHaveBeenCalledWith("vi")
-    await waitFor(() => {
-      expect(setLanguageMock).toHaveBeenCalledWith("vi")
-    })
-  })
-
-  it("shows and persists latin american spanish from the select variant", async () => {
-    render(<LanguageSwitcher variant="select" />)
-
-    fireEvent.click(
-      screen.getByRole("button", {
-        name: "settings:appearanceLanguage.switcher.options.es-419.name",
-      }),
-    )
-
-    expect(changeLanguageMock).toHaveBeenCalledWith("es-419")
-    await waitFor(() => {
-      expect(setLanguageMock).toHaveBeenCalledWith("es-419")
-    })
-  })
-
-  it("shows and persists Brazilian Portuguese from the select variant", async () => {
-    render(<LanguageSwitcher variant="select" />)
-
-    fireEvent.click(
-      screen.getByRole("button", {
-        name: "settings:appearanceLanguage.switcher.options.pt-BR.name",
-      }),
-    )
-
-    expect(changeLanguageMock).toHaveBeenCalledWith("pt-BR")
-    await waitFor(() => {
-      expect(setLanguageMock).toHaveBeenCalledWith("pt-BR")
-    })
-  })
-
-  it("shows and persists German from the select variant", async () => {
-    render(<LanguageSwitcher variant="select" />)
-
-    fireEvent.click(
-      screen.getByRole("button", {
-        name: "settings:appearanceLanguage.switcher.options.de.name",
-      }),
-    )
-
-    expect(changeLanguageMock).toHaveBeenCalledWith("de")
-    await waitFor(() => {
-      expect(setLanguageMock).toHaveBeenCalledWith("de")
-    })
-  })
+      expect(changeLanguageMock).toHaveBeenCalledWith(language)
+      await waitFor(() => {
+        expect(setLanguageMock).toHaveBeenCalledWith(language)
+      })
+    },
+  )
 
   it("renders the icon-dropdown trigger label and changes language from the radio menu", () => {
     render(<LanguageSwitcher variant="icon-dropdown" />)

--- a/tests/components/ui/DatePicker.test.tsx
+++ b/tests/components/ui/DatePicker.test.tsx
@@ -1,14 +1,10 @@
 import userEvent from "@testing-library/user-event"
-import { de, ptBR } from "date-fns/locale"
 import dayjs from "dayjs"
 import { afterEach, describe, expect, it, vi } from "vitest"
 
 import { Calendar } from "~/components/ui/calendar"
 import { DatePicker } from "~/components/ui/DatePicker"
-import {
-  getDatePickerLocale,
-  parseDatePickerValue,
-} from "~/components/ui/datePickerValue"
+import { parseDatePickerValue } from "~/components/ui/datePickerValue"
 import { render, screen, within } from "~~/tests/test-utils/render"
 
 const labels = {
@@ -168,6 +164,31 @@ describe("DatePicker", () => {
     )
 
     expect(onChange).toHaveBeenCalledWith("2026-07-15")
+  })
+
+  it("loads calendar copy for the active app language", async () => {
+    const user = userEvent.setup()
+
+    render(
+      <DatePicker
+        value="2026-07-01"
+        onChange={vi.fn()}
+        labels={labels}
+        language="de-DE"
+      />,
+      {
+        withUserPreferencesProvider: false,
+        withThemeProvider: false,
+      },
+    )
+
+    await user.click(
+      screen.getByRole("button", {
+        name: `${labels.trigger}: 2026-07-01`,
+      }),
+    )
+
+    expect(await screen.findByText("Juli 2026")).toBeVisible()
   })
 
   it("includes the selected value in the trigger accessible name", () => {
@@ -451,16 +472,6 @@ describe("Calendar", () => {
 })
 
 describe("datePickerValue", () => {
-  it("uses Brazilian Portuguese calendar copy for Portuguese locales", () => {
-    expect(getDatePickerLocale("pt-BR")).toBe(ptBR)
-    expect(getDatePickerLocale("pt-PT")).toBe(ptBR)
-  })
-
-  it("uses German calendar copy for German locale variants", () => {
-    expect(getDatePickerLocale("de")).toBe(de)
-    expect(getDatePickerLocale("de-DE")).toBe(de)
-  })
-
   it("returns null for canonical dates with missing month or day parts", () => {
     expect(parseDatePickerValue("2026-00-01")).toBeNull()
     expect(parseDatePickerValue("2026-01-00")).toBeNull()

--- a/tests/components/ui/datePickerLocale.test.ts
+++ b/tests/components/ui/datePickerLocale.test.ts
@@ -20,12 +20,17 @@ describe("date picker locale loading", () => {
     expect(resolveDatePickerLocaleKey(language)).toBe(expected)
   })
 
-  it("loads only the requested date-fns locale contract", async () => {
-    await expect(loadDatePickerLocale("de-DE")).resolves.toMatchObject({
-      code: "de",
-    })
-    await expect(loadDatePickerLocale("pt-PT")).resolves.toMatchObject({
-      code: "pt-BR",
+  it.each([
+    ["de", "de"],
+    ["es-419", "es"],
+    ["ja", "ja"],
+    ["pt-BR", "pt-BR"],
+    ["vi", "vi"],
+    ["zh-CN", "zh-CN"],
+    ["zh-TW", "zh-TW"],
+  ])("loads only the requested %s locale contract", async (language, code) => {
+    await expect(loadDatePickerLocale(language)).resolves.toMatchObject({
+      code,
     })
   })
 

--- a/tests/components/ui/datePickerLocale.test.ts
+++ b/tests/components/ui/datePickerLocale.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  loadDatePickerLocale,
+  resolveDatePickerLocaleKey,
+} from "~/components/ui/datePickerLocale"
+
+describe("date picker locale loading", () => {
+  it.each([
+    ["en", "en-US"],
+    ["de-DE", "de"],
+    ["es-MX", "es"],
+    ["pt-PT", "pt-BR"],
+    ["ja-JP", "ja"],
+    ["vi_VN", "vi"],
+    ["zh-Hans", "zh-CN"],
+    ["zh-HK", "zh-TW"],
+    ["unsupported", "en-US"],
+  ])("maps %s to %s", (language, expected) => {
+    expect(resolveDatePickerLocaleKey(language)).toBe(expected)
+  })
+
+  it("loads only the requested date-fns locale contract", async () => {
+    await expect(loadDatePickerLocale("de-DE")).resolves.toMatchObject({
+      code: "de",
+    })
+    await expect(loadDatePickerLocale("pt-PT")).resolves.toMatchObject({
+      code: "pt-BR",
+    })
+  })
+
+  it("reuses an in-flight locale import", () => {
+    expect(loadDatePickerLocale("zh-HK")).toBe(loadDatePickerLocale("zh-TW"))
+  })
+})

--- a/tests/components/ui/useDatePickerLocale.test.tsx
+++ b/tests/components/ui/useDatePickerLocale.test.tsx
@@ -1,0 +1,57 @@
+import { act, renderHook, waitFor } from "@testing-library/react"
+import type { Locale } from "date-fns"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { useDatePickerLocale } from "~/components/ui/useDatePickerLocale"
+
+const { loadDatePickerLocaleMock } = vi.hoisted(() => ({
+  loadDatePickerLocaleMock: vi.fn(),
+}))
+
+vi.mock("~/components/ui/datePickerLocale", () => ({
+  loadDatePickerLocale: (...args: unknown[]) =>
+    loadDatePickerLocaleMock(...args),
+}))
+
+const ENGLISH_LOCALE = { code: "en-US" } as Locale
+const GERMAN_LOCALE = { code: "de" } as Locale
+
+describe("useDatePickerLocale", () => {
+  beforeEach(() => {
+    loadDatePickerLocaleMock.mockReset()
+  })
+
+  it("prefers a controlled locale without loading by language", () => {
+    const { result } = renderHook(() =>
+      useDatePickerLocale(ENGLISH_LOCALE, "de"),
+    )
+
+    expect(result.current).toBe(ENGLISH_LOCALE)
+    expect(loadDatePickerLocaleMock).not.toHaveBeenCalled()
+  })
+
+  it("loads a locale by language and clears it when the language is removed", async () => {
+    loadDatePickerLocaleMock.mockResolvedValue(GERMAN_LOCALE)
+    const initialProps: { language: string | undefined } = { language: "de" }
+    const { result, rerender } = renderHook(
+      ({ language }: { language?: string }) =>
+        useDatePickerLocale(undefined, language),
+      { initialProps },
+    )
+
+    await waitFor(() => expect(result.current).toBe(GERMAN_LOCALE))
+    rerender({ language: undefined })
+    await waitFor(() => expect(result.current).toBeUndefined())
+  })
+
+  it("keeps the English fallback when lazy locale loading fails", async () => {
+    loadDatePickerLocaleMock.mockRejectedValue(new Error("import failed"))
+    const { result } = renderHook(() => useDatePickerLocale(undefined, "de"))
+
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(loadDatePickerLocaleMock).toHaveBeenCalledWith("de")
+    expect(result.current).toBeUndefined()
+  })
+})

--- a/tests/entrypoints/pageEntrypoints.test.tsx
+++ b/tests/entrypoints/pageEntrypoints.test.tsx
@@ -1,0 +1,37 @@
+import { isValidElement } from "react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const { renderExtensionPageMock } = vi.hoisted(() => ({
+  renderExtensionPageMock: vi.fn().mockResolvedValue(undefined),
+}))
+
+vi.mock("~/entrypoints/shared/renderExtensionPage", () => ({
+  renderExtensionPage: (...args: unknown[]) => renderExtensionPageMock(...args),
+}))
+vi.mock("~/entrypoints/options/App", () => ({ default: () => null }))
+vi.mock("~/entrypoints/sidepanel/App", () => ({ default: () => null }))
+
+describe("page entrypoints", () => {
+  beforeEach(() => {
+    vi.resetModules()
+    renderExtensionPageMock.mockClear()
+  })
+
+  it("routes the options app through the shared locale-ready renderer", async () => {
+    await import("~/entrypoints/options/main")
+
+    expect(renderExtensionPageMock).toHaveBeenCalledOnce()
+    const [pageType, app] = renderExtensionPageMock.mock.calls[0]!
+    expect(pageType).toBe("options")
+    expect(isValidElement(app)).toBe(true)
+  })
+
+  it("routes the side panel app through the shared locale-ready renderer", async () => {
+    await import("~/entrypoints/sidepanel/main")
+
+    expect(renderExtensionPageMock).toHaveBeenCalledOnce()
+    const [pageType, app] = renderExtensionPageMock.mock.calls[0]!
+    expect(pageType).toBe("sidepanel")
+    expect(isValidElement(app)).toBe(true)
+  })
+})

--- a/tests/entrypoints/popup/main.test.tsx
+++ b/tests/entrypoints/popup/main.test.tsx
@@ -19,7 +19,7 @@ vi.mock("~/components/RootErrorBoundary", () => ({
 }))
 vi.mock("~/entrypoints/popup/App", () => ({ default: () => null }))
 vi.mock("~/utils/browser", () => ({ isMobileDevice: isMobileDeviceMock }))
-vi.mock("~/utils/i18n", () => ({}))
+vi.mock("~/utils/i18n", () => ({ i18nReady: Promise.resolve() }))
 vi.mock("~/utils/i18n/core", () => ({ t: vi.fn(() => "Loading") }))
 vi.mock("~/utils/navigation/documentTitle", () => ({
   setDocumentTitle: setDocumentTitleMock,

--- a/tests/entrypoints/shared/renderExtensionPage.test.tsx
+++ b/tests/entrypoints/shared/renderExtensionPage.test.tsx
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+
+import { act, screen } from "@testing-library/react"
+import { createElement } from "react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { renderExtensionPage } from "~/entrypoints/shared/renderExtensionPage"
+
+const { i18nReadyMock, resolveI18nReady, setDocumentTitleMock } = vi.hoisted(
+  () => {
+    let resolveI18nReady!: () => void
+    const i18nReadyMock = new Promise<void>((resolve) => {
+      resolveI18nReady = resolve
+    })
+
+    return {
+      i18nReadyMock,
+      resolveI18nReady,
+      setDocumentTitleMock: vi.fn(),
+    }
+  },
+)
+
+vi.mock("~/utils/i18n", () => ({
+  i18nReady: i18nReadyMock,
+}))
+
+vi.mock("~/utils/i18n/core", () => ({
+  t: (key: string) => key,
+}))
+
+vi.mock("~/utils/navigation/documentTitle", () => ({
+  setDocumentTitle: setDocumentTitleMock,
+}))
+
+describe("renderExtensionPage", () => {
+  afterEach(() => {
+    document.body.replaceChildren()
+    setDocumentTitleMock.mockReset()
+  })
+
+  it("sets the localized title and mounts the shared page shell", async () => {
+    const root = document.createElement("div")
+    root.id = "root"
+    document.body.appendChild(root)
+
+    const renderPromise = renderExtensionPage(
+      "popup",
+      createElement("div", null, "Popup content"),
+    )
+
+    expect(setDocumentTitleMock).not.toHaveBeenCalled()
+    expect(screen.queryByText("Popup content")).not.toBeInTheDocument()
+
+    resolveI18nReady()
+    await act(async () => {
+      await renderPromise
+    })
+
+    expect(setDocumentTitleMock).toHaveBeenCalledWith("popup")
+    expect(screen.getByText("Popup content")).toBeVisible()
+  })
+})

--- a/tests/features/ImportExport/components/WebDAVSettings.test.tsx
+++ b/tests/features/ImportExport/components/WebDAVSettings.test.tsx
@@ -1503,7 +1503,10 @@ describe("WebDAVSettings", () => {
         { preserveWebdav: true },
       )
       expect(mockUserPreferences.getLanguage).toHaveBeenCalledTimes(1)
-      expect(mockApplyPreferenceLanguage).toHaveBeenCalledWith("ja")
+      expect(mockApplyPreferenceLanguage).toHaveBeenCalledWith(
+        "ja",
+        expect.any(Function),
+      )
     })
     expect(
       mockUserPreferences.savePreferencesWithResult,
@@ -1908,7 +1911,10 @@ describe("WebDAVSettings", () => {
         { preserveWebdav: true },
       )
       expect(mockUserPreferences.getLanguage).toHaveBeenCalledTimes(1)
-      expect(mockApplyPreferenceLanguage).toHaveBeenCalledWith("ja")
+      expect(mockApplyPreferenceLanguage).toHaveBeenCalledWith(
+        "ja",
+        expect.any(Function),
+      )
       expect(mockUserPreferences.getPreferences).toHaveBeenCalledTimes(2)
       expect(toast.success).toHaveBeenCalledWith(
         "importExport:import.importSuccess",

--- a/tests/features/ImportExport/components/WebDAVSettings.test.tsx
+++ b/tests/features/ImportExport/components/WebDAVSettings.test.tsx
@@ -4,6 +4,7 @@ import {
   screen,
   waitFor,
 } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
 import type { ReactNode } from "react"
 import toast from "react-hot-toast"
 import { I18nextProvider } from "react-i18next"
@@ -2329,6 +2330,7 @@ describe("WebDAVSettings", () => {
   })
 
   it("updates the editable fields and toggles password visibility in both forms", async () => {
+    const user = userEvent.setup()
     mockDownloadBackupRaw.mockResolvedValueOnce("encrypted-payload")
     mockTryParseEncryptedWebdavBackupEnvelope.mockReturnValue(
       ENCRYPTED_BACKUP_ENVELOPE,
@@ -2361,12 +2363,12 @@ describe("WebDAVSettings", () => {
     expect(usernameInput.value).toBe("bob")
     expect(webdavPasswordInput.value).toBe("pw-2")
 
-    fireEvent.click(
+    await user.click(
       screen.getAllByRole("button", {
         name: /importExport:webdav\.(show|hide)Password/,
       })[0],
     )
-    fireEvent.click(
+    await user.click(
       screen.getAllByRole("button", {
         name: /importExport:webdav\.(show|hide)Password/,
       })[1],
@@ -2378,8 +2380,10 @@ describe("WebDAVSettings", () => {
     fireEvent.change(backupPasswordInput, {
       target: { value: "" },
     })
-    fireEvent.click(screen.getByRole("switch"))
-    clickWebdavAction("webdav-download-import")
+    await user.click(screen.getByRole("switch"))
+    await user.click(
+      document.getElementById("webdav-download-import") as HTMLButtonElement,
+    )
 
     expect(
       await screen.findByText(
@@ -2387,7 +2391,7 @@ describe("WebDAVSettings", () => {
       ),
     ).toBeInTheDocument()
 
-    fireEvent.click(
+    await user.click(
       screen.getAllByRole("button", {
         name: /importExport:webdav\.(show|hide)Password/,
       })[2],

--- a/tests/features/ImportExport/components/WebDAVSettings.test.tsx
+++ b/tests/features/ImportExport/components/WebDAVSettings.test.tsx
@@ -3,6 +3,7 @@ import {
   render as rtlRender,
   screen,
   waitFor,
+  within,
 } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import type { ReactNode } from "react"
@@ -2342,12 +2343,12 @@ describe("WebDAVSettings", () => {
       "https://dav.example.com/backup.json",
     )) as HTMLInputElement
     const usernameInput = screen.getByDisplayValue("alice") as HTMLInputElement
-    const webdavPasswordInput = screen.getByDisplayValue(
-      "pw",
+    const webdavPasswordInput = document.getElementById(
+      WEBDAV_TARGET_IDS.password,
     ) as HTMLInputElement
-    const backupPasswordInput = screen.getAllByDisplayValue(
-      "stored-secret",
-    )[0] as HTMLInputElement
+    const backupPasswordInput = document.getElementById(
+      WEBDAV_TARGET_IDS.encryptionPassword,
+    ) as HTMLInputElement
 
     fireEvent.change(urlInput, {
       target: { value: "https://dav.example.com/backup-2.json" },
@@ -2364,14 +2365,14 @@ describe("WebDAVSettings", () => {
     expect(webdavPasswordInput.value).toBe("pw-2")
 
     await user.click(
-      screen.getAllByRole("button", {
+      within(webdavPasswordInput.parentElement!).getByRole("button", {
         name: /importExport:webdav\.(show|hide)Password/,
-      })[0],
+      }),
     )
     await user.click(
-      screen.getAllByRole("button", {
+      within(backupPasswordInput.parentElement!).getByRole("button", {
         name: /importExport:webdav\.(show|hide)Password/,
-      })[1],
+      }),
     )
 
     expect(webdavPasswordInput).toHaveAttribute("type", "text")

--- a/tests/features/ImportExport/hooks/useImportExport.test.tsx
+++ b/tests/features/ImportExport/hooks/useImportExport.test.tsx
@@ -206,7 +206,10 @@ describe("useImportExport", () => {
     )
     expect(loadPreferencesMock).toHaveBeenCalledTimes(1)
     expect(getLanguageMock).toHaveBeenCalledTimes(1)
-    expect(applyPreferenceLanguageMock).toHaveBeenCalledWith("ja")
+    expect(applyPreferenceLanguageMock).toHaveBeenCalledWith(
+      "ja",
+      expect.any(Function),
+    )
     expect(result.current.isImporting).toBe(false)
     expect(startProductAnalyticsActionMock).toHaveBeenCalledWith({
       featureId: PRODUCT_ANALYTICS_FEATURE_IDS.ImportExport,
@@ -315,7 +318,10 @@ describe("useImportExport", () => {
 
     expect(loadPreferencesMock).toHaveBeenCalledTimes(1)
     expect(getLanguageMock).toHaveBeenCalledTimes(1)
-    expect(applyPreferenceLanguageMock).toHaveBeenCalledWith("ja")
+    expect(applyPreferenceLanguageMock).toHaveBeenCalledWith(
+      "ja",
+      expect.any(Function),
+    )
     expect(toastSuccessMock).toHaveBeenCalledWith(
       "importExport:import.importSelectedSuccess",
     )

--- a/tests/features/OptionsOverview/PermissionOnboardingDialog.languageSelection.test.tsx
+++ b/tests/features/OptionsOverview/PermissionOnboardingDialog.languageSelection.test.tsx
@@ -177,6 +177,18 @@ vi.mock("~/utils/core/toastHelpers", () => ({
   showResultToast: toastHelperMocks.showResultToast,
 }))
 
+vi.mock("~/utils/i18n/resources", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("~/utils/i18n/resources")>()
+
+  return {
+    ...actual,
+    changeAppLanguage: (
+      instance: { changeLanguage: (language: string) => Promise<unknown> },
+      language: string,
+    ) => instance.changeLanguage(language),
+  }
+})
+
 vi.mock("~/contexts/ReleaseUpdateStatusContext", () => ({
   useReleaseUpdateStatus: () => ({
     status: null,

--- a/tests/features/OptionsOverview/PermissionOnboardingDialog.languageSelection.test.tsx
+++ b/tests/features/OptionsOverview/PermissionOnboardingDialog.languageSelection.test.tsx
@@ -177,17 +177,15 @@ vi.mock("~/utils/core/toastHelpers", () => ({
   showResultToast: toastHelperMocks.showResultToast,
 }))
 
-vi.mock("~/utils/i18n/resources", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("~/utils/i18n/resources")>()
-
-  return {
-    ...actual,
-    changeAppLanguage: (
-      instance: { changeLanguage: (language: string) => Promise<unknown> },
-      language: string,
-    ) => instance.changeLanguage(language),
-  }
-})
+vi.mock("~/utils/i18n/pageLanguage", () => ({
+  changePageLanguage: async (
+    instance: { changeLanguage: (language: string) => Promise<unknown> },
+    language: string,
+  ) => {
+    await instance.changeLanguage(language)
+    return true
+  },
+}))
 
 vi.mock("~/contexts/ReleaseUpdateStatusContext", () => ({
   useReleaseUpdateStatus: () => ({

--- a/tests/utils/applyPreferenceLanguage.test.ts
+++ b/tests/utils/applyPreferenceLanguage.test.ts
@@ -15,6 +15,13 @@ vi.mock("~/utils/i18n/core", () => ({
   default: i18nCoreMock,
 }))
 
+vi.mock("~/utils/i18n/resources", () => ({
+  changeAppLanguage: (
+    instance: { changeLanguage: (language: string) => Promise<void> },
+    language: string,
+  ) => instance.changeLanguage(language),
+}))
+
 describe("applyPreferenceLanguage", () => {
   beforeEach(() => {
     vi.clearAllMocks()

--- a/tests/utils/createCachedLocaleLoader.test.ts
+++ b/tests/utils/createCachedLocaleLoader.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { createCachedLocaleLoader } from "~/utils/i18n/createCachedLocaleLoader"
+
+describe("createCachedLocaleLoader", () => {
+  it("shares successful and in-flight loads by key", async () => {
+    const load = vi.fn(async (key: string) => ({ key }))
+    const loadCached = createCachedLocaleLoader(load)
+
+    const firstLoad = loadCached("de")
+    const repeatedLoad = loadCached("de")
+
+    expect(repeatedLoad).toBe(firstLoad)
+    await expect(firstLoad).resolves.toEqual({ key: "de" })
+    expect(loadCached("de")).toBe(firstLoad)
+    expect(load).toHaveBeenCalledTimes(1)
+  })
+
+  it("evicts failed loads so the same key can retry", async () => {
+    const load = vi
+      .fn<(key: string) => Promise<string>>()
+      .mockRejectedValueOnce(new Error("locale unavailable"))
+      .mockResolvedValueOnce("ja")
+    const loadCached = createCachedLocaleLoader(load)
+
+    await expect(loadCached("ja")).rejects.toThrow("locale unavailable")
+    await expect(loadCached("ja")).resolves.toBe("ja")
+    expect(load).toHaveBeenCalledTimes(2)
+  })
+})

--- a/tests/utils/dayjsLocale.test.ts
+++ b/tests/utils/dayjsLocale.test.ts
@@ -18,7 +18,22 @@ describe("dayjs locale loading", () => {
     expect(resolveDayjsLocale(language)).toBe(expected)
   })
 
-  it("reuses an in-flight locale import", () => {
-    expect(loadDayjsLocale("de")).toBe(loadDayjsLocale("de-DE"))
+  it.each([
+    ["de", "de"],
+    ["es-419", "es"],
+    ["ja", "ja"],
+    ["pt-BR", "pt-br"],
+    ["vi", "vi"],
+    ["zh-CN", "zh-cn"],
+    ["zh-TW", "zh-tw"],
+  ])("loads the %s locale module", async (language, expected) => {
+    await expect(loadDayjsLocale(language)).resolves.toBe(expected)
+  })
+
+  it("reuses an in-flight locale import", async () => {
+    const firstLoad = loadDayjsLocale("de")
+
+    expect(firstLoad).toBe(loadDayjsLocale("de-DE"))
+    await expect(firstLoad).resolves.toBe("de")
   })
 })

--- a/tests/utils/dayjsLocale.test.ts
+++ b/tests/utils/dayjsLocale.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest"
+
+import { loadDayjsLocale, resolveDayjsLocale } from "~/utils/i18n/dayjsLocale"
+
+describe("dayjs locale loading", () => {
+  it.each([
+    ["en", "en"],
+    ["en-US", "en"],
+    ["de-DE", "de"],
+    ["es-MX", "es"],
+    ["pt-PT", "pt-br"],
+    ["ja-JP", "ja"],
+    ["vi_VN", "vi"],
+    ["zh-Hans", "zh-cn"],
+    ["zh-HK", "zh-tw"],
+    ["unsupported", "en"],
+  ])("maps %s to %s", (language, expected) => {
+    expect(resolveDayjsLocale(language)).toBe(expected)
+  })
+
+  it("reuses an in-flight locale import", () => {
+    expect(loadDayjsLocale("de")).toBe(loadDayjsLocale("de-DE"))
+  })
+})

--- a/tests/utils/extensionResourceUrl.test.ts
+++ b/tests/utils/extensionResourceUrl.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { getExtensionResourceUrl } from "~/utils/browser/extensionResourceUrl"
+
+describe("getExtensionResourceUrl", () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it("uses the browser runtime when it is available", () => {
+    const getURL = vi.fn((path: string) => `browser-extension://${path}`)
+    vi.stubGlobal("browser", { runtime: { getURL } })
+
+    expect(getExtensionResourceUrl("app-locales/en.json")).toBe(
+      "browser-extension://app-locales/en.json",
+    )
+    expect(getURL).toHaveBeenCalledWith("app-locales/en.json")
+  })
+
+  it("falls back to the chrome runtime when browser runtime is incomplete", () => {
+    const getURL = vi.fn((path: string) => `chrome-extension://${path}`)
+    vi.stubGlobal("browser", { runtime: {} })
+    vi.stubGlobal("chrome", { runtime: { getURL } })
+
+    expect(getExtensionResourceUrl("app-locales/zh-CN.json")).toBe(
+      "chrome-extension://app-locales/zh-CN.json",
+    )
+  })
+
+  it("rejects asset resolution when no extension runtime is available", () => {
+    vi.stubGlobal("browser", undefined)
+    vi.stubGlobal("chrome", undefined)
+
+    expect(() => getExtensionResourceUrl("app-locales/en.json")).toThrow(
+      "Extension runtime.getURL is unavailable",
+    )
+  })
+})

--- a/tests/utils/i18nBackground.test.ts
+++ b/tests/utils/i18nBackground.test.ts
@@ -1,4 +1,3 @@
-import dayjs from "dayjs"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 const {
@@ -6,7 +5,6 @@ const {
   getLanguageMock,
   loadAppLanguageResourcesMock,
   resolveInitialAppLanguageMock,
-  mapToDayjsLocaleMock,
 } = vi.hoisted(() => ({
   i18nCoreMock: {
     init: vi.fn(),
@@ -16,7 +14,6 @@ const {
   getLanguageMock: vi.fn(),
   loadAppLanguageResourcesMock: vi.fn(),
   resolveInitialAppLanguageMock: vi.fn(),
-  mapToDayjsLocaleMock: vi.fn(),
 }))
 
 vi.mock("~/utils/i18n/core", () => ({
@@ -35,7 +32,6 @@ vi.mock("~/utils/i18n/language", () => ({
 
 vi.mock("~/utils/i18n/resources", () => ({
   loadAppLanguageResources: loadAppLanguageResourcesMock,
-  mapToDayjsLocale: mapToDayjsLocaleMock,
 }))
 
 describe("initBackgroundI18n", () => {
@@ -49,24 +45,17 @@ describe("initBackgroundI18n", () => {
       en: { common: { hello: "Hello" } },
     })
     resolveInitialAppLanguageMock.mockReset()
-    mapToDayjsLocaleMock.mockReset()
     vi.resetModules()
   })
 
-  it("initializes i18n, resolves the initial language, and syncs dayjs", async () => {
-    const localeSpy = vi.spyOn(dayjs, "locale").mockReturnValue("en")
+  it("initializes i18n and resolves the initial language", async () => {
     getLanguageMock.mockResolvedValueOnce("ja")
     resolveInitialAppLanguageMock.mockReturnValueOnce("ja")
-    mapToDayjsLocaleMock.mockReturnValue("ja")
 
     const { initBackgroundI18n } = await import("~/utils/i18n/background")
 
     await initBackgroundI18n()
 
-    expect(i18nCoreMock.on).toHaveBeenCalledWith(
-      "languageChanged",
-      expect.any(Function),
-    )
     expect(i18nCoreMock.init).toHaveBeenCalledWith({
       resources: { en: { common: { hello: "Hello" } } },
       fallbackLng: "zh-CN",
@@ -81,39 +70,12 @@ describe("initBackgroundI18n", () => {
         typeof navigator !== "undefined" ? navigator.language : undefined,
     })
     expect(i18nCoreMock.changeLanguage).toHaveBeenCalledWith("ja")
-    expect(localeSpy).toHaveBeenCalledWith("ja")
-
-    localeSpy.mockRestore()
-  })
-
-  it("updates dayjs when the registered language-change listener fires", async () => {
-    const localeSpy = vi.spyOn(dayjs, "locale").mockReturnValue("en")
-    getLanguageMock.mockResolvedValueOnce("en")
-    resolveInitialAppLanguageMock.mockReturnValueOnce("en")
-    mapToDayjsLocaleMock.mockImplementation((language: string) =>
-      language === "zh-TW" ? "zh-tw" : language,
-    )
-
-    await import("~/utils/i18n/background")
-
-    const languageChangedHandler = i18nCoreMock.on.mock.calls.find(
-      ([eventName]) => eventName === "languageChanged",
-    )?.[1] as ((language: string) => void) | undefined
-
-    expect(languageChangedHandler).toBeTypeOf("function")
-    languageChangedHandler?.("zh-TW")
-
-    expect(localeSpy).toHaveBeenCalledWith("zh-tw")
-
-    localeSpy.mockRestore()
   })
 
   it("resolves the initial language without navigator when the background runtime has no browser language", async () => {
     const originalNavigator = globalThis.navigator
-    const localeSpy = vi.spyOn(dayjs, "locale").mockReturnValue("en")
     getLanguageMock.mockResolvedValueOnce(undefined)
     resolveInitialAppLanguageMock.mockReturnValueOnce("en")
-    mapToDayjsLocaleMock.mockReturnValue("en")
 
     Object.defineProperty(globalThis, "navigator", {
       value: undefined,
@@ -131,14 +93,12 @@ describe("initBackgroundI18n", () => {
         detectedLanguage: undefined,
       })
       expect(i18nCoreMock.changeLanguage).toHaveBeenCalledWith("en")
-      expect(localeSpy).toHaveBeenCalledWith("en")
     } finally {
       Object.defineProperty(globalThis, "navigator", {
         value: originalNavigator,
         configurable: true,
         writable: true,
       })
-      localeSpy.mockRestore()
     }
   })
 })

--- a/tests/utils/i18nBackground.test.ts
+++ b/tests/utils/i18nBackground.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 const {
   i18nCoreMock,
   getLanguageMock,
+  loadAppLanguageResourcesMock,
   resolveInitialAppLanguageMock,
   mapToDayjsLocaleMock,
 } = vi.hoisted(() => ({
@@ -13,6 +14,7 @@ const {
     on: vi.fn(),
   },
   getLanguageMock: vi.fn(),
+  loadAppLanguageResourcesMock: vi.fn(),
   resolveInitialAppLanguageMock: vi.fn(),
   mapToDayjsLocaleMock: vi.fn(),
 }))
@@ -32,8 +34,8 @@ vi.mock("~/utils/i18n/language", () => ({
 }))
 
 vi.mock("~/utils/i18n/resources", () => ({
+  loadAppLanguageResources: loadAppLanguageResourcesMock,
   mapToDayjsLocale: mapToDayjsLocaleMock,
-  resources: { en: { common: { hello: "Hello" } } },
 }))
 
 describe("initBackgroundI18n", () => {
@@ -42,6 +44,10 @@ describe("initBackgroundI18n", () => {
     i18nCoreMock.changeLanguage.mockReset()
     i18nCoreMock.on.mockReset()
     getLanguageMock.mockReset()
+    loadAppLanguageResourcesMock.mockReset()
+    loadAppLanguageResourcesMock.mockResolvedValue({
+      en: { common: { hello: "Hello" } },
+    })
     resolveInitialAppLanguageMock.mockReset()
     mapToDayjsLocaleMock.mockReset()
     vi.resetModules()
@@ -68,6 +74,7 @@ describe("initBackgroundI18n", () => {
       interpolation: { escapeValue: false },
       returnEmptyString: false,
     })
+    expect(loadAppLanguageResourcesMock).toHaveBeenCalledWith("ja")
     expect(resolveInitialAppLanguageMock).toHaveBeenCalledWith({
       userPreferenceLanguage: "ja",
       detectedLanguage:

--- a/tests/utils/i18nContent.test.ts
+++ b/tests/utils/i18nContent.test.ts
@@ -1,4 +1,3 @@
-import dayjs from "dayjs"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 const {
@@ -7,7 +6,6 @@ const {
   loadAppLanguageResourcesMock,
   reactI18nextPlugin,
   resolveInitialAppLanguageMock,
-  mapToDayjsLocaleMock,
 } = vi.hoisted(() => ({
   i18nCoreMock: {
     use: vi.fn(),
@@ -21,7 +19,6 @@ const {
   loadAppLanguageResourcesMock: vi.fn(),
   reactI18nextPlugin: { type: "3rdParty" },
   resolveInitialAppLanguageMock: vi.fn(),
-  mapToDayjsLocaleMock: vi.fn(),
 }))
 
 vi.mock("~/utils/i18n/core", () => ({
@@ -52,7 +49,6 @@ vi.mock("~/utils/i18n/resources", () => ({
     language: string,
   ) => instance.changeLanguage(language),
   loadAppLanguageResources: loadAppLanguageResourcesMock,
-  mapToDayjsLocale: mapToDayjsLocaleMock,
 }))
 
 vi.mock("react-i18next", () => ({
@@ -75,14 +71,9 @@ describe("content i18n initialization", () => {
       en: { common: { hello: "Hello" } },
     })
     resolveInitialAppLanguageMock.mockReset()
-    mapToDayjsLocaleMock.mockReset()
-    mapToDayjsLocaleMock.mockImplementation((language: string) =>
-      language.toLowerCase(),
-    )
   })
 
   it("initializes without app-page language detection and resolves from extension preferences", async () => {
-    const localeSpy = vi.spyOn(dayjs, "locale").mockReturnValue("en")
     getLanguageMock.mockResolvedValue("ja")
     resolveInitialAppLanguageMock.mockReturnValue("ja")
 
@@ -107,9 +98,6 @@ describe("content i18n initialization", () => {
     })
     expect(loadAppLanguageResourcesMock).toHaveBeenCalledWith("ja")
     expect(i18nCoreMock.changeLanguage).toHaveBeenCalledWith("ja")
-    expect(localeSpy).toHaveBeenCalledWith("ja")
-
-    localeSpy.mockRestore()
   })
 
   it("refreshes persisted language on later readiness calls for already-injected content scripts", async () => {
@@ -144,22 +132,5 @@ describe("content i18n initialization", () => {
 
     expect(i18nCoreMock.init).toHaveBeenCalledTimes(2)
     expect(i18nCoreMock.changeLanguage).toHaveBeenCalledWith("ja")
-  })
-
-  it("keeps dayjs locale aligned with later i18n language changes", async () => {
-    const localeSpy = vi.spyOn(dayjs, "locale").mockReturnValue("en")
-
-    await import("~/utils/i18n/content")
-
-    const languageChangedHandler = i18nCoreMock.on.mock.calls.find(
-      ([eventName]) => eventName === "languageChanged",
-    )?.[1]
-    expect(languageChangedHandler).toBeTypeOf("function")
-
-    languageChangedHandler("zh-TW")
-
-    expect(localeSpy).toHaveBeenCalledWith("zh-tw")
-
-    localeSpy.mockRestore()
   })
 })

--- a/tests/utils/i18nContent.test.ts
+++ b/tests/utils/i18nContent.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 const {
   i18nCoreMock,
   getLanguageMock,
+  loadAppLanguageResourcesMock,
   reactI18nextPlugin,
   resolveInitialAppLanguageMock,
   mapToDayjsLocaleMock,
@@ -17,6 +18,7 @@ const {
     language: "en",
   },
   getLanguageMock: vi.fn(),
+  loadAppLanguageResourcesMock: vi.fn(),
   reactI18nextPlugin: { type: "3rdParty" },
   resolveInitialAppLanguageMock: vi.fn(),
   mapToDayjsLocaleMock: vi.fn(),
@@ -45,8 +47,12 @@ vi.mock("~/utils/i18n/language", () => ({
 }))
 
 vi.mock("~/utils/i18n/resources", () => ({
+  changeAppLanguage: (
+    instance: { changeLanguage: (language: string) => Promise<void> },
+    language: string,
+  ) => instance.changeLanguage(language),
+  loadAppLanguageResources: loadAppLanguageResourcesMock,
   mapToDayjsLocale: mapToDayjsLocaleMock,
-  resources: { en: { common: { hello: "Hello" } } },
 }))
 
 vi.mock("react-i18next", () => ({
@@ -64,6 +70,10 @@ describe("content i18n initialization", () => {
     i18nCoreMock.resolvedLanguage = "en"
     i18nCoreMock.language = "en"
     getLanguageMock.mockReset()
+    loadAppLanguageResourcesMock.mockReset()
+    loadAppLanguageResourcesMock.mockResolvedValue({
+      en: { common: { hello: "Hello" } },
+    })
     resolveInitialAppLanguageMock.mockReset()
     mapToDayjsLocaleMock.mockReset()
     mapToDayjsLocaleMock.mockImplementation((language: string) =>
@@ -73,8 +83,8 @@ describe("content i18n initialization", () => {
 
   it("initializes without app-page language detection and resolves from extension preferences", async () => {
     const localeSpy = vi.spyOn(dayjs, "locale").mockReturnValue("en")
-    getLanguageMock.mockResolvedValueOnce("ja")
-    resolveInitialAppLanguageMock.mockReturnValueOnce("ja")
+    getLanguageMock.mockResolvedValue("ja")
+    resolveInitialAppLanguageMock.mockReturnValue("ja")
 
     const { ensureContentI18nReady } = await import("~/utils/i18n/content")
 
@@ -95,6 +105,7 @@ describe("content i18n initialization", () => {
       detectedLanguage:
         typeof navigator !== "undefined" ? navigator.language : undefined,
     })
+    expect(loadAppLanguageResourcesMock).toHaveBeenCalledWith("ja")
     expect(i18nCoreMock.changeLanguage).toHaveBeenCalledWith("ja")
     expect(localeSpy).toHaveBeenCalledWith("ja")
 
@@ -123,8 +134,8 @@ describe("content i18n initialization", () => {
     i18nCoreMock.init
       .mockRejectedValueOnce(initError)
       .mockResolvedValueOnce(undefined)
-    getLanguageMock.mockResolvedValueOnce("ja")
-    resolveInitialAppLanguageMock.mockReturnValueOnce("ja")
+    getLanguageMock.mockResolvedValue("ja")
+    resolveInitialAppLanguageMock.mockReturnValue("ja")
 
     const { ensureContentI18nReady } = await import("~/utils/i18n/content")
 

--- a/tests/utils/i18nIndex.node.test.ts
+++ b/tests/utils/i18nIndex.node.test.ts
@@ -7,7 +7,9 @@ import { I18NEXT_LANGUAGE_STORAGE_KEY } from "~/services/core/storageKeys"
 const {
   getLanguageMock,
   i18nCoreMock,
+  installAppLanguageResourcesMock,
   languageDetectorPlugin,
+  loadAppLanguageResourcesMock,
   mapToDayjsLocaleMock,
   reactI18nextPlugin,
   resolveInitialAppLanguageMock,
@@ -21,7 +23,9 @@ const {
     language: "en",
     resolvedLanguage: "en" as string | undefined,
   },
+  installAppLanguageResourcesMock: vi.fn(),
   languageDetectorPlugin: { type: "languageDetector" },
+  loadAppLanguageResourcesMock: vi.fn(),
   mapToDayjsLocaleMock: vi.fn(),
   reactI18nextPlugin: { type: "3rdParty" },
   resolveInitialAppLanguageMock: vi.fn(),
@@ -43,10 +47,9 @@ vi.mock("~/utils/i18n/language", () => ({
 }))
 
 vi.mock("~/utils/i18n/resources", () => ({
+  installAppLanguageResources: installAppLanguageResourcesMock,
+  loadAppLanguageResources: loadAppLanguageResourcesMock,
   mapToDayjsLocale: mapToDayjsLocaleMock,
-  resources: {
-    en: { common: { greeting: "Hello" } },
-  },
 }))
 
 vi.mock("i18next-browser-languagedetector", () => ({
@@ -71,6 +74,11 @@ describe("app i18n initialization without a document", () => {
     i18nCoreMock.on.mockReset()
 
     getLanguageMock.mockReset()
+    installAppLanguageResourcesMock.mockReset()
+    loadAppLanguageResourcesMock.mockReset()
+    loadAppLanguageResourcesMock.mockResolvedValue({
+      en: { common: { greeting: "Hello" } },
+    })
     resolveInitialAppLanguageMock.mockReset()
     mapToDayjsLocaleMock.mockReset()
     mapToDayjsLocaleMock.mockImplementation((language: string) => language)
@@ -85,7 +93,8 @@ describe("app i18n initialization without a document", () => {
     resolveInitialAppLanguageMock.mockReturnValueOnce("ja")
 
     try {
-      await import("~/utils/i18n/index")
+      const { i18nReady } = await import("~/utils/i18n/index")
+      await i18nReady
 
       await vi.waitFor(() => {
         expect(getLanguageMock).toHaveBeenCalledTimes(1)

--- a/tests/utils/i18nIndex.node.test.ts
+++ b/tests/utils/i18nIndex.node.test.ts
@@ -9,8 +9,8 @@ const {
   i18nCoreMock,
   installAppLanguageResourcesMock,
   languageDetectorPlugin,
+  loadDayjsLocaleMock,
   loadAppLanguageResourcesMock,
-  mapToDayjsLocaleMock,
   reactI18nextPlugin,
   resolveInitialAppLanguageMock,
 } = vi.hoisted(() => ({
@@ -25,8 +25,8 @@ const {
   },
   installAppLanguageResourcesMock: vi.fn(),
   languageDetectorPlugin: { type: "languageDetector" },
+  loadDayjsLocaleMock: vi.fn(),
   loadAppLanguageResourcesMock: vi.fn(),
-  mapToDayjsLocaleMock: vi.fn(),
   reactI18nextPlugin: { type: "3rdParty" },
   resolveInitialAppLanguageMock: vi.fn(),
 }))
@@ -49,7 +49,10 @@ vi.mock("~/utils/i18n/language", () => ({
 vi.mock("~/utils/i18n/resources", () => ({
   installAppLanguageResources: installAppLanguageResourcesMock,
   loadAppLanguageResources: loadAppLanguageResourcesMock,
-  mapToDayjsLocale: mapToDayjsLocaleMock,
+}))
+
+vi.mock("~/utils/i18n/dayjsLocale", () => ({
+  loadDayjsLocale: loadDayjsLocaleMock,
 }))
 
 vi.mock("i18next-browser-languagedetector", () => ({
@@ -80,8 +83,8 @@ describe("app i18n initialization without a document", () => {
       en: { common: { greeting: "Hello" } },
     })
     resolveInitialAppLanguageMock.mockReset()
-    mapToDayjsLocaleMock.mockReset()
-    mapToDayjsLocaleMock.mockImplementation((language: string) => language)
+    loadDayjsLocaleMock.mockReset()
+    loadDayjsLocaleMock.mockImplementation(async (language: string) => language)
 
     i18nCoreMock.language = "en"
     i18nCoreMock.resolvedLanguage = "en"

--- a/tests/utils/i18nIndex.test.ts
+++ b/tests/utils/i18nIndex.test.ts
@@ -10,6 +10,8 @@ const {
   getLanguageMock,
   i18nCoreMock,
   languageDetectorPlugin,
+  installAppLanguageResourcesMock,
+  loadAppLanguageResourcesMock,
   mapToDayjsLocaleMock,
   reactI18nextPlugin,
   resolveInitialAppLanguageMock,
@@ -24,6 +26,8 @@ const {
     resolvedLanguage: "en" as string | undefined,
   },
   languageDetectorPlugin: { type: "languageDetector" },
+  installAppLanguageResourcesMock: vi.fn(),
+  loadAppLanguageResourcesMock: vi.fn(),
   mapToDayjsLocaleMock: vi.fn(),
   reactI18nextPlugin: { type: "3rdParty" },
   resolveInitialAppLanguageMock: vi.fn(),
@@ -59,12 +63,9 @@ vi.mock("~/utils/i18n/language", () => ({
 }))
 
 vi.mock("~/utils/i18n/resources", () => ({
+  installAppLanguageResources: installAppLanguageResourcesMock,
+  loadAppLanguageResources: loadAppLanguageResourcesMock,
   mapToDayjsLocale: mapToDayjsLocaleMock,
-  resources: {
-    en: { common: { greeting: "Hello" } },
-    de: { common: { greeting: "Hallo" } },
-    ja: { common: { greeting: "こんにちは" } },
-  },
 }))
 
 vi.mock("i18next-browser-languagedetector", () => ({
@@ -90,6 +91,11 @@ describe("app i18n initialization", () => {
     i18nCoreMock.on.mockReset()
 
     getLanguageMock.mockReset()
+    installAppLanguageResourcesMock.mockReset()
+    loadAppLanguageResourcesMock.mockReset()
+    loadAppLanguageResourcesMock.mockResolvedValue({
+      en: { common: { greeting: "Hello" } },
+    })
     resolveInitialAppLanguageMock.mockReset()
     mapToDayjsLocaleMock.mockReset()
     mapToDayjsLocaleMock.mockImplementation((language: string) =>
@@ -109,7 +115,8 @@ describe("app i18n initialization", () => {
     resolveInitialAppLanguageMock.mockReturnValueOnce("ja")
 
     try {
-      await import("~/utils/i18n/index")
+      const { i18nReady } = await import("~/utils/i18n/index")
+      await i18nReady
 
       await vi.waitFor(() => {
         expect(getLanguageMock).toHaveBeenCalledTimes(1)
@@ -127,11 +134,7 @@ describe("app i18n initialization", () => {
         detection: {
           lookupLocalStorage: I18NEXT_LANGUAGE_STORAGE_KEY,
         },
-        resources: {
-          en: { common: { greeting: "Hello" } },
-          de: { common: { greeting: "Hallo" } },
-          ja: { common: { greeting: "こんにちは" } },
-        },
+        resources: {},
         interpolation: {
           escapeValue: false,
         },
@@ -148,6 +151,11 @@ describe("app i18n initialization", () => {
         userPreferenceLanguage: "ja",
         detectedLanguage: "en",
       })
+      expect(loadAppLanguageResourcesMock).toHaveBeenCalledWith("ja")
+      expect(installAppLanguageResourcesMock).toHaveBeenCalledWith(
+        i18nCoreMock,
+        { en: { common: { greeting: "Hello" } } },
+      )
       expect(i18nCoreMock.changeLanguage).toHaveBeenCalledWith("ja")
       expect(localeSpy).toHaveBeenCalledWith("ja")
       expect(document.documentElement.lang).toBe("ja")
@@ -172,7 +180,8 @@ describe("app i18n initialization", () => {
     getLanguageMock.mockResolvedValueOnce(undefined)
     resolveInitialAppLanguageMock.mockReturnValueOnce("en")
 
-    await import("~/utils/i18n/index")
+    const { i18nReady } = await import("~/utils/i18n/index")
+    await i18nReady
 
     await vi.waitFor(() => {
       expect(i18nCoreMock.init).toHaveBeenCalledWith(
@@ -183,7 +192,7 @@ describe("app i18n initialization", () => {
     })
   })
 
-  it("keeps the current resolved language without calling changeLanguage again", async () => {
+  it("re-resolves the detected language after installing its resources", async () => {
     vi.stubEnv("DEV", false)
     const localeSpy = vi.spyOn(dayjs, "locale").mockReturnValue("ja")
     i18nCoreMock.resolvedLanguage = "ja"
@@ -192,7 +201,8 @@ describe("app i18n initialization", () => {
     resolveInitialAppLanguageMock.mockReturnValueOnce("ja")
 
     try {
-      await import("~/utils/i18n/index")
+      const { i18nReady } = await import("~/utils/i18n/index")
+      await i18nReady
 
       await vi.waitFor(() => {
         expect(resolveInitialAppLanguageMock).toHaveBeenCalledWith({
@@ -206,7 +216,7 @@ describe("app i18n initialization", () => {
           debug: false,
         }),
       )
-      expect(i18nCoreMock.changeLanguage).not.toHaveBeenCalled()
+      expect(i18nCoreMock.changeLanguage).toHaveBeenCalledWith("ja")
       expect(localeSpy).toHaveBeenCalledWith("ja")
       expect(document.documentElement.lang).toBe("ja")
     } finally {
@@ -222,7 +232,8 @@ describe("app i18n initialization", () => {
     resolveInitialAppLanguageMock.mockReturnValueOnce("pt-BR")
 
     try {
-      await import("~/utils/i18n/index")
+      const { i18nReady } = await import("~/utils/i18n/index")
+      await i18nReady
 
       await vi.waitFor(() => {
         expect(resolveInitialAppLanguageMock).toHaveBeenCalledWith({
@@ -247,7 +258,8 @@ describe("app i18n initialization", () => {
     resolveInitialAppLanguageMock.mockReturnValueOnce("de")
 
     try {
-      await import("~/utils/i18n/index")
+      const { i18nReady } = await import("~/utils/i18n/index")
+      await i18nReady
 
       await vi.waitFor(() => {
         expect(resolveInitialAppLanguageMock).toHaveBeenCalledWith({
@@ -264,7 +276,7 @@ describe("app i18n initialization", () => {
     }
   })
 
-  it("falls back to i18n.language when resolvedLanguage is missing and skips a redundant change", async () => {
+  it("falls back to i18n.language when resolvedLanguage is missing", async () => {
     const localeSpy = vi.spyOn(dayjs, "locale").mockReturnValue("zh-tw")
     i18nCoreMock.resolvedLanguage = undefined
     i18nCoreMock.language = "zh-TW"
@@ -272,7 +284,8 @@ describe("app i18n initialization", () => {
     resolveInitialAppLanguageMock.mockReturnValueOnce("zh-TW")
 
     try {
-      await import("~/utils/i18n/index")
+      const { i18nReady } = await import("~/utils/i18n/index")
+      await i18nReady
 
       await vi.waitFor(() => {
         expect(resolveInitialAppLanguageMock).toHaveBeenCalledWith({
@@ -281,7 +294,7 @@ describe("app i18n initialization", () => {
         })
       })
 
-      expect(i18nCoreMock.changeLanguage).not.toHaveBeenCalled()
+      expect(i18nCoreMock.changeLanguage).toHaveBeenCalledWith("zh-TW")
       expect(localeSpy).toHaveBeenCalledWith("zh-tw")
     } finally {
       localeSpy.mockRestore()

--- a/tests/utils/i18nIndex.test.ts
+++ b/tests/utils/i18nIndex.test.ts
@@ -11,8 +11,8 @@ const {
   i18nCoreMock,
   languageDetectorPlugin,
   installAppLanguageResourcesMock,
+  loadDayjsLocaleMock,
   loadAppLanguageResourcesMock,
-  mapToDayjsLocaleMock,
   reactI18nextPlugin,
   resolveInitialAppLanguageMock,
 } = vi.hoisted(() => ({
@@ -27,8 +27,8 @@ const {
   },
   languageDetectorPlugin: { type: "languageDetector" },
   installAppLanguageResourcesMock: vi.fn(),
+  loadDayjsLocaleMock: vi.fn(),
   loadAppLanguageResourcesMock: vi.fn(),
-  mapToDayjsLocaleMock: vi.fn(),
   reactI18nextPlugin: { type: "3rdParty" },
   resolveInitialAppLanguageMock: vi.fn(),
 }))
@@ -65,7 +65,10 @@ vi.mock("~/utils/i18n/language", () => ({
 vi.mock("~/utils/i18n/resources", () => ({
   installAppLanguageResources: installAppLanguageResourcesMock,
   loadAppLanguageResources: loadAppLanguageResourcesMock,
-  mapToDayjsLocale: mapToDayjsLocaleMock,
+}))
+
+vi.mock("~/utils/i18n/dayjsLocale", () => ({
+  loadDayjsLocale: loadDayjsLocaleMock,
 }))
 
 vi.mock("i18next-browser-languagedetector", () => ({
@@ -97,10 +100,12 @@ describe("app i18n initialization", () => {
       en: { common: { greeting: "Hello" } },
     })
     resolveInitialAppLanguageMock.mockReset()
-    mapToDayjsLocaleMock.mockReset()
-    mapToDayjsLocaleMock.mockImplementation((language: string) =>
-      language.toLowerCase().replace("_", "-"),
-    )
+    loadDayjsLocaleMock.mockReset()
+    loadDayjsLocaleMock.mockImplementation(async (language: string) => {
+      if (language === "pt-BR") return "pt-br"
+      if (language === "zh-TW") return "zh-tw"
+      return language.toLowerCase().replace("_", "-")
+    })
 
     i18nCoreMock.language = "en"
     i18nCoreMock.resolvedLanguage = "en"
@@ -167,7 +172,7 @@ describe("app i18n initialization", () => {
       expect(languageChangedHandler).toBeTypeOf("function")
       languageChangedHandler?.("zh_TW")
 
-      expect(localeSpy).toHaveBeenLastCalledWith("zh-tw")
+      expect(localeSpy).toHaveBeenLastCalledWith("ja")
       expect(document.documentElement.lang).toBe("zh-TW")
     } finally {
       localeSpy.mockRestore()

--- a/tests/utils/i18nLocaleAssets.test.ts
+++ b/tests/utils/i18nLocaleAssets.test.ts
@@ -1,3 +1,5 @@
+import { readdir } from "node:fs/promises"
+import path from "node:path"
 import { fileURLToPath } from "node:url"
 import { describe, expect, it } from "vitest"
 
@@ -6,15 +8,25 @@ import { createLocaleAssetContents } from "~/locales/runtime-assets"
 
 const localeRoot = fileURLToPath(new URL("../../src/locales", import.meta.url))
 
+async function listSourceNamespaces(language: string) {
+  const entries = await readdir(path.join(localeRoot, language), {
+    withFileTypes: true,
+  })
+  return entries
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".json"))
+    .map((entry) => entry.name.slice(0, -".json".length))
+    .sort()
+}
+
 describe("locale asset generation", () => {
   it("emits one complete namespaced JSON asset per supported language", async () => {
     for (const language of SUPPORTED_UI_LANGUAGES) {
       const contents = await createLocaleAssetContents(localeRoot, language)
       const resources = JSON.parse(contents) as Record<string, unknown>
 
-      expect(Object.keys(resources)).toHaveLength(30)
-      expect(resources.common).toBeTypeOf("object")
-      expect(resources.settings).toBeTypeOf("object")
+      expect(Object.keys(resources).sort()).toEqual(
+        await listSourceNamespaces(language),
+      )
     }
   })
 

--- a/tests/utils/i18nLocaleAssets.test.ts
+++ b/tests/utils/i18nLocaleAssets.test.ts
@@ -1,0 +1,30 @@
+import { fileURLToPath } from "node:url"
+import { describe, expect, it } from "vitest"
+
+import { SUPPORTED_UI_LANGUAGES } from "~/constants/i18n"
+import { createLocaleAssetContents } from "~/locales/runtime-assets"
+
+const localeRoot = fileURLToPath(new URL("../../src/locales", import.meta.url))
+
+describe("locale asset generation", () => {
+  it("emits one complete namespaced JSON asset per supported language", async () => {
+    for (const language of SUPPORTED_UI_LANGUAGES) {
+      const contents = await createLocaleAssetContents(localeRoot, language)
+      const resources = JSON.parse(contents) as Record<string, unknown>
+
+      expect(Object.keys(resources)).toHaveLength(30)
+      expect(resources.common).toBeTypeOf("object")
+      expect(resources.settings).toBeTypeOf("object")
+    }
+  })
+
+  it("preserves namespace values while removing source indentation", async () => {
+    const contents = await createLocaleAssetContents(localeRoot, "en")
+    const resources = JSON.parse(contents) as {
+      common: { actions: { cancel: string } }
+    }
+
+    expect(resources.common.actions.cancel).toBe("Cancel")
+    expect(contents).not.toContain("\n")
+  })
+})

--- a/tests/utils/i18nLocaleAssets.test.ts
+++ b/tests/utils/i18nLocaleAssets.test.ts
@@ -1,16 +1,27 @@
-import { readdir } from "node:fs/promises"
+import { mkdir, mkdtemp, readdir, rm } from "node:fs/promises"
+import os from "node:os"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
-import { describe, expect, it } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
+import type { ResolvedPublicFile, Wxt } from "wxt"
 
 import {
   APP_LOCALE_ASSET_GLOB,
   getAppLocaleAssetPath,
   SUPPORTED_UI_LANGUAGES,
 } from "~/constants/i18n"
-import { createLocaleAssetContents } from "~/locales/runtime-assets"
+import runtimeAssetsModule, {
+  createLocaleAssetContents,
+} from "~/locales/runtime-assets"
 
 const localeRoot = fileURLToPath(new URL("../../src/locales", import.meta.url))
+const temporaryRoots: string[] = []
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots.splice(0).map((root) => rm(root, { recursive: true })),
+  )
+})
 
 async function listSourceNamespaces(language: string) {
   const entries = await readdir(path.join(localeRoot, language), {
@@ -47,5 +58,45 @@ describe("locale asset generation", () => {
 
     expect(resources.common.actions.cancel).toBe("Cancel")
     expect(contents).not.toContain("\n")
+  })
+
+  it("rejects a language directory without namespace files", async () => {
+    const emptyRoot = await mkdtemp(path.join(os.tmpdir(), "locale-assets-"))
+    temporaryRoots.push(emptyRoot)
+    await mkdir(path.join(emptyRoot, "en"))
+
+    await expect(createLocaleAssetContents(emptyRoot, "en")).rejects.toThrow(
+      "No locale namespaces found for en",
+    )
+  })
+
+  it("registers generated assets for every supported language", async () => {
+    let buildPublicAssets:
+      | ((wxt: Wxt, files: ResolvedPublicFile[]) => Promise<void>)
+      | undefined
+    const projectRoot = path.resolve(localeRoot, "../..")
+    const wxt = {
+      config: { root: projectRoot },
+      hooks: {
+        hook: vi.fn(
+          (
+            _name: string,
+            callback: (wxt: Wxt, files: ResolvedPublicFile[]) => Promise<void>,
+          ) => {
+            buildPublicAssets = callback
+          },
+        ),
+      },
+    } as unknown as Wxt
+
+    await runtimeAssetsModule.setup?.(wxt)
+    expect(buildPublicAssets).toBeDefined()
+    const files: ResolvedPublicFile[] = []
+    await buildPublicAssets!(wxt, files)
+
+    expect(files).toHaveLength(SUPPORTED_UI_LANGUAGES.length)
+    expect(files.map((file) => file.relativeDest)).toEqual(
+      SUPPORTED_UI_LANGUAGES.map(getAppLocaleAssetPath),
+    )
   })
 })

--- a/tests/utils/i18nLocaleAssets.test.ts
+++ b/tests/utils/i18nLocaleAssets.test.ts
@@ -3,7 +3,11 @@ import path from "node:path"
 import { fileURLToPath } from "node:url"
 import { describe, expect, it } from "vitest"
 
-import { SUPPORTED_UI_LANGUAGES } from "~/constants/i18n"
+import {
+  APP_LOCALE_ASSET_GLOB,
+  getAppLocaleAssetPath,
+  SUPPORTED_UI_LANGUAGES,
+} from "~/constants/i18n"
 import { createLocaleAssetContents } from "~/locales/runtime-assets"
 
 const localeRoot = fileURLToPath(new URL("../../src/locales", import.meta.url))
@@ -19,6 +23,11 @@ async function listSourceNamespaces(language: string) {
 }
 
 describe("locale asset generation", () => {
+  it("keeps generated asset paths aligned with the manifest glob", () => {
+    expect(getAppLocaleAssetPath("en")).toBe("app-locales/en.json")
+    expect(APP_LOCALE_ASSET_GLOB).toBe("app-locales/*.json")
+  })
+
   it("emits one complete namespaced JSON asset per supported language", async () => {
     for (const language of SUPPORTED_UI_LANGUAGES) {
       const contents = await createLocaleAssetContents(localeRoot, language)

--- a/tests/utils/i18nResources.test.ts
+++ b/tests/utils/i18nResources.test.ts
@@ -71,6 +71,15 @@ describe("i18n resources", () => {
     expect(fetchMock).toHaveBeenCalledTimes(3)
   })
 
+  it("rejects locale assets that are not namespace objects", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(createJsonResponse([])))
+    const { loadAppLanguageResources } = await import("~/utils/i18n/resources")
+
+    await expect(loadAppLanguageResources("zh-CN")).rejects.toThrow(
+      "Locale asset for zh-CN is not a JSON object",
+    )
+  })
+
   it("installs every loaded namespace before changing language", async () => {
     vi.stubGlobal(
       "fetch",

--- a/tests/utils/i18nResources.test.ts
+++ b/tests/utils/i18nResources.test.ts
@@ -102,17 +102,4 @@ describe("i18n resources", () => {
       changeLanguage.mock.invocationCallOrder[0]!,
     )
   })
-
-  it("normalizes i18next language tags to dayjs-compatible locale names", async () => {
-    const { mapToDayjsLocale } = await import("~/utils/i18n/resources")
-
-    expect(mapToDayjsLocale("EN")).toBe("en")
-    expect(mapToDayjsLocale("zh_TW")).toBe("zh-tw")
-    expect(mapToDayjsLocale("ja-JP")).toBe("ja-jp")
-    expect(mapToDayjsLocale("vi_VN")).toBe("vi-vn")
-    expect(mapToDayjsLocale("es-419")).toBe("es")
-    expect(mapToDayjsLocale("pt-BR")).toBe("pt-br")
-    expect(mapToDayjsLocale("de")).toBe("de")
-    expect(mapToDayjsLocale("de-DE")).toBe("de")
-  })
 })

--- a/tests/utils/i18nResources.test.ts
+++ b/tests/utils/i18nResources.test.ts
@@ -1,68 +1,111 @@
-import { describe, expect, it } from "vitest"
+import type { i18n } from "i18next"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 
-import { mapToDayjsLocale, resources } from "~/utils/i18n/resources"
+const EN_RESOURCES = {
+  common: { actions: { cancel: "Cancel" } },
+  ui: { title: "UI" },
+}
+const ZH_CN_RESOURCES = {
+  common: { actions: { cancel: "取消" } },
+  ui: { title: "界面" },
+}
+
+function createJsonResponse(body: unknown, ok = true): Response {
+  return {
+    ok,
+    status: ok ? 200 : 404,
+    json: vi.fn().mockResolvedValue(body),
+  } as unknown as Response
+}
 
 describe("i18n resources", () => {
-  it("loads locale namespaces under their language keys", () => {
-    expect(resources.en).toMatchObject({
-      common: expect.objectContaining({
-        actions: expect.objectContaining({
-          cancel: "Cancel",
-        }),
-      }),
-      ui: expect.any(Object),
-    })
-    expect(resources.de).toMatchObject({
-      common: expect.objectContaining({
-        actions: expect.objectContaining({
-          cancel: "Abbrechen",
-        }),
-      }),
-      settings: expect.any(Object),
-    })
-    expect(resources.ja).toMatchObject({
-      common: expect.objectContaining({
-        actions: expect.objectContaining({
-          cancel: "キャンセル",
-        }),
-      }),
-      settings: expect.any(Object),
-    })
-    expect(resources.vi).toMatchObject({
-      common: expect.objectContaining({
-        actions: expect.objectContaining({
-          cancel: "Hủy",
-        }),
-      }),
-      settings: expect.any(Object),
-    })
-    expect(resources["pt-BR"]).toMatchObject({
-      common: expect.objectContaining({
-        actions: expect.objectContaining({
-          cancel: "Cancelar",
-        }),
-      }),
-      settings: expect.any(Object),
-    })
-    expect(resources["zh-CN"]).toMatchObject({
-      common: expect.objectContaining({
-        actions: expect.objectContaining({
-          cancel: "取消",
-        }),
-      }),
-      modelList: expect.any(Object),
-    })
-    expect(resources["zh-TW"]).toMatchObject({
-      common: expect.objectContaining({
-        actions: expect.objectContaining({
-          cancel: "取消",
-        }),
-      }),
-      managedSiteChannels: expect.any(Object),
+  beforeEach(() => {
+    vi.resetModules()
+    vi.stubGlobal("browser", {
+      runtime: {
+        getURL: vi.fn((path: string) => `extension://${path}`),
+      },
     })
   })
 
-  it("normalizes i18next language tags to dayjs-compatible locale names", () => {
+  it("loads only the requested language and the configured fallback asset", async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.endsWith("/en.json")) return createJsonResponse(EN_RESOURCES)
+      if (url.endsWith("/zh-CN.json")) {
+        return createJsonResponse(ZH_CN_RESOURCES)
+      }
+      return createJsonResponse({}, false)
+    })
+    vi.stubGlobal("fetch", fetchMock)
+
+    const { loadAppLanguageResources } = await import("~/utils/i18n/resources")
+
+    await expect(loadAppLanguageResources("en")).resolves.toEqual({
+      en: EN_RESOURCES,
+      "zh-CN": ZH_CN_RESOURCES,
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(fetchMock).toHaveBeenCalledWith("extension://app-locales/en.json")
+    expect(fetchMock).toHaveBeenCalledWith("extension://app-locales/zh-CN.json")
+  })
+
+  it("deduplicates locale fetches and retries after a failed request", async () => {
+    let englishAttempts = 0
+    const fetchMock = vi.fn(async (url: string) => {
+      if (url.endsWith("/en.json") && englishAttempts++ === 0) {
+        return createJsonResponse({}, false)
+      }
+      return createJsonResponse(EN_RESOURCES)
+    })
+    vi.stubGlobal("fetch", fetchMock)
+
+    const { loadAppLanguageResources } = await import("~/utils/i18n/resources")
+
+    await expect(loadAppLanguageResources("en")).rejects.toThrow(
+      "Failed to load locale asset",
+    )
+    await expect(loadAppLanguageResources("en")).resolves.toEqual({
+      en: EN_RESOURCES,
+      "zh-CN": EN_RESOURCES,
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+  })
+
+  it("installs every loaded namespace before changing language", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(createJsonResponse(EN_RESOURCES)),
+    )
+    const addResourceBundle = vi.fn()
+    const changeLanguage = vi.fn().mockResolvedValue(undefined)
+    const instance = { addResourceBundle, changeLanguage } as unknown as i18n
+    const { changeAppLanguage } = await import("~/utils/i18n/resources")
+
+    await changeAppLanguage(instance, "en")
+
+    expect(addResourceBundle).toHaveBeenCalledWith(
+      "en",
+      "common",
+      EN_RESOURCES.common,
+      true,
+      true,
+    )
+    expect(addResourceBundle).toHaveBeenCalledWith(
+      "en",
+      "ui",
+      EN_RESOURCES.ui,
+      true,
+      true,
+    )
+    expect(changeLanguage).toHaveBeenCalledWith("en")
+    expect(addResourceBundle.mock.invocationCallOrder.at(-1)).toBeLessThan(
+      changeLanguage.mock.invocationCallOrder[0]!,
+    )
+  })
+
+  it("normalizes i18next language tags to dayjs-compatible locale names", async () => {
+    const { mapToDayjsLocale } = await import("~/utils/i18n/resources")
+
     expect(mapToDayjsLocale("EN")).toBe("en")
     expect(mapToDayjsLocale("zh_TW")).toBe("zh-tw")
     expect(mapToDayjsLocale("ja-JP")).toBe("ja-jp")

--- a/tests/utils/pageLanguage.test.ts
+++ b/tests/utils/pageLanguage.test.ts
@@ -92,4 +92,43 @@ describe("page language switching", () => {
 
     localeSpy.mockRestore()
   })
+
+  it("keeps the latest language when change commits overlap", async () => {
+    const japaneseCommit = deferred<void>()
+    loadAppLanguageResourcesMock.mockImplementation((language: string) =>
+      Promise.resolve({ [language]: { common: {} } }),
+    )
+    loadDayjsLocaleMock.mockImplementation((language: string) =>
+      Promise.resolve(language),
+    )
+    const localeSpy = vi.spyOn(dayjs, "locale").mockReturnValue("de")
+    let activeLanguage = "en"
+    const instance = {
+      changeLanguage: vi.fn(async (language: string) => {
+        if (language === "ja") await japaneseCommit.promise
+        activeLanguage = language
+      }),
+    }
+    const { changePageLanguage } = await import("~/utils/i18n/pageLanguage")
+
+    const japaneseRequest = changePageLanguage(
+      instance as unknown as i18n,
+      "ja",
+    )
+    await vi.waitFor(() => {
+      expect(instance.changeLanguage).toHaveBeenCalledWith("ja")
+    })
+
+    const germanRequest = changePageLanguage(instance as unknown as i18n, "de")
+    await vi.waitFor(() => {
+      expect(loadAppLanguageResourcesMock).toHaveBeenCalledWith("de")
+    })
+    japaneseCommit.resolve()
+
+    await expect(japaneseRequest).resolves.toBe(false)
+    await expect(germanRequest).resolves.toBe(true)
+    expect(activeLanguage).toBe("de")
+
+    localeSpy.mockRestore()
+  })
 })

--- a/tests/utils/pageLanguage.test.ts
+++ b/tests/utils/pageLanguage.test.ts
@@ -104,9 +104,11 @@ describe("page language switching", () => {
     const localeSpy = vi.spyOn(dayjs, "locale").mockReturnValue("de")
     let activeLanguage = "en"
     const instance = {
+      language: "en",
       changeLanguage: vi.fn(async (language: string) => {
         if (language === "ja") await japaneseCommit.promise
         activeLanguage = language
+        instance.language = language
       }),
     }
     const { changePageLanguage } = await import("~/utils/i18n/pageLanguage")
@@ -128,6 +130,80 @@ describe("page language switching", () => {
     await expect(japaneseRequest).resolves.toBe(false)
     await expect(germanRequest).resolves.toBe(true)
     expect(activeLanguage).toBe("de")
+
+    localeSpy.mockRestore()
+  })
+
+  it("restores the prior locales when a newer request fails during an older commit", async () => {
+    const japaneseCommit = deferred<void>()
+    loadAppLanguageResourcesMock.mockImplementation((language: string) => {
+      if (language === "de") {
+        return Promise.reject(new Error("German locale unavailable"))
+      }
+      return Promise.resolve({ ja: { common: {} } })
+    })
+    loadDayjsLocaleMock.mockImplementation((language: string) =>
+      Promise.resolve(language),
+    )
+    let activeDayjsLocale = "en"
+    const localeSpy = vi
+      .spyOn(dayjs, "locale")
+      .mockImplementation((locale?: Parameters<typeof dayjs.locale>[0]) => {
+        if (typeof locale === "string") activeDayjsLocale = locale
+        return activeDayjsLocale
+      })
+    let activeLanguage = "en"
+    const instance = {
+      language: "en",
+      changeLanguage: vi.fn(async (language: string) => {
+        if (language === "ja") await japaneseCommit.promise
+        activeLanguage = language
+        instance.language = language
+      }),
+    }
+    const { changePageLanguage } = await import("~/utils/i18n/pageLanguage")
+
+    const japaneseRequest = changePageLanguage(
+      instance as unknown as i18n,
+      "ja",
+    )
+    await vi.waitFor(() => {
+      expect(instance.changeLanguage).toHaveBeenCalledWith("ja")
+    })
+    const germanRequest = changePageLanguage(instance as unknown as i18n, "de")
+
+    await expect(germanRequest).rejects.toThrow("German locale unavailable")
+    japaneseCommit.resolve()
+    await expect(japaneseRequest).resolves.toBe(false)
+
+    expect(instance.changeLanguage).toHaveBeenNthCalledWith(1, "ja")
+    expect(instance.changeLanguage).toHaveBeenNthCalledWith(2, "en")
+    expect(activeLanguage).toBe("en")
+    expect(activeDayjsLocale).toBe("en")
+
+    localeSpy.mockRestore()
+  })
+
+  it("restores the prior Day.js locale when i18next rejects a change", async () => {
+    loadAppLanguageResourcesMock.mockResolvedValue({ ja: { common: {} } })
+    loadDayjsLocaleMock.mockResolvedValue("ja")
+    let activeDayjsLocale = "en"
+    const localeSpy = vi
+      .spyOn(dayjs, "locale")
+      .mockImplementation((locale?: Parameters<typeof dayjs.locale>[0]) => {
+        if (typeof locale === "string") activeDayjsLocale = locale
+        return activeDayjsLocale
+      })
+    const instance = {
+      language: "en",
+      changeLanguage: vi.fn().mockRejectedValue(new Error("change failed")),
+    }
+    const { changePageLanguage } = await import("~/utils/i18n/pageLanguage")
+
+    await expect(
+      changePageLanguage(instance as unknown as i18n, "ja"),
+    ).rejects.toThrow("change failed")
+    expect(activeDayjsLocale).toBe("en")
 
     localeSpy.mockRestore()
   })

--- a/tests/utils/pageLanguage.test.ts
+++ b/tests/utils/pageLanguage.test.ts
@@ -1,0 +1,95 @@
+import dayjs from "dayjs"
+import type { i18n, Resource } from "i18next"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const {
+  installAppLanguageResourcesMock,
+  loadAppLanguageResourcesMock,
+  loadDayjsLocaleMock,
+} = vi.hoisted(() => ({
+  installAppLanguageResourcesMock: vi.fn(),
+  loadAppLanguageResourcesMock: vi.fn(),
+  loadDayjsLocaleMock: vi.fn(),
+}))
+
+vi.mock("~/utils/i18n/resources", () => ({
+  installAppLanguageResources: installAppLanguageResourcesMock,
+  loadAppLanguageResources: loadAppLanguageResourcesMock,
+}))
+
+vi.mock("~/utils/i18n/dayjsLocale", () => ({
+  loadDayjsLocale: loadDayjsLocaleMock,
+}))
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((nextResolve) => {
+    resolve = nextResolve
+  })
+  return { promise, resolve }
+}
+
+describe("page language switching", () => {
+  beforeEach(() => {
+    vi.resetModules()
+    installAppLanguageResourcesMock.mockReset()
+    loadAppLanguageResourcesMock.mockReset()
+    loadDayjsLocaleMock.mockReset()
+  })
+
+  it("installs translations and the matching dayjs locale before resolving", async () => {
+    const resources = { ja: { common: { greeting: "こんにちは" } } }
+    loadAppLanguageResourcesMock.mockResolvedValue(resources)
+    loadDayjsLocaleMock.mockResolvedValue("ja")
+    const localeSpy = vi.spyOn(dayjs, "locale").mockReturnValue("ja")
+    const instance = { changeLanguage: vi.fn().mockResolvedValue(undefined) }
+
+    const { changePageLanguage } = await import("~/utils/i18n/pageLanguage")
+
+    await expect(
+      changePageLanguage(instance as unknown as i18n, "ja"),
+    ).resolves.toBe(true)
+    expect(installAppLanguageResourcesMock).toHaveBeenCalledWith(
+      instance,
+      resources,
+    )
+    expect(instance.changeLanguage).toHaveBeenCalledWith("ja")
+    expect(localeSpy).toHaveBeenCalledWith("ja")
+
+    localeSpy.mockRestore()
+  })
+
+  it("lets the latest request win when locale loads finish out of order", async () => {
+    const japaneseResources = deferred<Resource>()
+    loadAppLanguageResourcesMock.mockImplementation((language: string) =>
+      language === "ja"
+        ? japaneseResources.promise
+        : Promise.resolve({ de: { common: { greeting: "Hallo" } } }),
+    )
+    loadDayjsLocaleMock.mockImplementation((language: string) =>
+      Promise.resolve(language),
+    )
+    const localeSpy = vi.spyOn(dayjs, "locale").mockReturnValue("de")
+    const instance = { changeLanguage: vi.fn().mockResolvedValue(undefined) }
+    const { changePageLanguage } = await import("~/utils/i18n/pageLanguage")
+
+    const japaneseRequest = changePageLanguage(
+      instance as unknown as i18n,
+      "ja",
+    )
+    const germanRequest = changePageLanguage(instance as unknown as i18n, "de")
+
+    await expect(germanRequest).resolves.toBe(true)
+    japaneseResources.resolve({
+      ja: { common: { greeting: "こんにちは" } },
+    })
+    await expect(japaneseRequest).resolves.toBe(false)
+
+    expect(instance.changeLanguage).toHaveBeenCalledTimes(1)
+    expect(instance.changeLanguage).toHaveBeenCalledWith("de")
+    expect(localeSpy).toHaveBeenCalledWith("de")
+    expect(localeSpy).not.toHaveBeenCalledWith("ja")
+
+    localeSpy.mockRestore()
+  })
+})

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -8,6 +8,7 @@ import {
   readE2eBuildVariant,
 } from "./e2e/utils/e2eBuildVariants"
 import { reactDevToolsAuto } from "./plugins/react-devtools-auto"
+import { APP_LOCALE_ASSET_DIR } from "./src/constants/i18n"
 import { OPENROUTER_WEB_ORIGIN } from "./src/services/accountSiteDefinitions/identifiers"
 
 type BrowserTarget = "chrome" | "firefox" | "safari" | string
@@ -47,6 +48,8 @@ const e2eBuildVariant = readE2eBuildVariant()
 export default defineConfig({
   srcDir: "src",
   publicDir: "src/public",
+  // Locale changes restart dev so the local module can regenerate runtime assets.
+  modulesDir: "src/locales",
   outDirTemplate: getOutDirTemplate(),
   modules: ["@wxt-dev/auto-icons", "@wxt-dev/module-react"],
   manifest: (env) => {
@@ -72,6 +75,11 @@ export default defineConfig({
         {
           resources: ["openrouter-clerk-session.js"],
           matches: [`${OPENROUTER_WEB_ORIGIN}/*`],
+        },
+        {
+          resources: [`${APP_LOCALE_ASSET_DIR}/*.json`],
+          matches: ["<all_urls>"],
+          use_dynamic_url: true,
         },
       ],
       browser_specific_settings: {

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -8,7 +8,7 @@ import {
   readE2eBuildVariant,
 } from "./e2e/utils/e2eBuildVariants"
 import { reactDevToolsAuto } from "./plugins/react-devtools-auto"
-import { APP_LOCALE_ASSET_DIR } from "./src/constants/i18n"
+import { APP_LOCALE_ASSET_GLOB } from "./src/constants/i18n"
 import { OPENROUTER_WEB_ORIGIN } from "./src/services/accountSiteDefinitions/identifiers"
 
 type BrowserTarget = "chrome" | "firefox" | "safari" | string
@@ -77,7 +77,7 @@ export default defineConfig({
           matches: [`${OPENROUTER_WEB_ORIGIN}/*`],
         },
         {
-          resources: [`${APP_LOCALE_ASSET_DIR}/*.json`],
+          resources: [APP_LOCALE_ASSET_GLOB],
           matches: ["<all_urls>"],
           use_dynamic_url: true,
         },


### PR DESCRIPTION
## Summary

Reduce initial extension runtime and bundle overhead from eagerly loading every application locale while preserving runtime language switching.

## What changed

- Generate one runtime asset per supported application language under `app-locales/`.
- Load only the selected language and `zh-CN` fallback during startup.
- Load locale resources before language changes to avoid untranslated flashes.
- Add cached, retry-safe locale loading and extension resource URL handling.
- Gate options, popup, and sidepanel mounting on initial locale readiness.
- Lazy-load Day.js locale data used by date pickers.
- Preserve popup viewport sizing behavior introduced on `main`.
- Update locale, date-picker, onboarding, and entrypoint tests.

All eight supported UI languages remain switchable on demand.

## Validation

- Focused Vitest: 17 files, 101 tests passed.
- `tsc --noEmit`: passed.
- Chrome production build: passed.
- `knip`: passed.
- `i18next-cli extract --dry-run --ci --quiet`: passed with no file changes.
- `i18next-cli status`: all supported locales reported complete.
- `git diff --check`: passed.
- Pre-push validation (`compile` + `knip`): passed.

## Compatibility

- Locale source JSON remains authoritative.
- Existing language switching behavior is retained.
- Content-script locale assets are exposed through WXT web-accessible resources.
- No persistence migration or breaking public contract is introduced.

## Follow-up

No telemetry changes were added because this is an infrastructure/performance optimization without a new user action or funnel.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dynamic language resource loading for supported interface languages.
  * Language changes now update translations and date formatting together.
  * Date pickers automatically display localized calendars based on the selected language.
  * Restoring preferences from backups now applies the saved language to the current page.
* **Bug Fixes**
  * Improved language switching reliability, including fallback handling and recovery from failed loads.
  * Prevented outdated language requests from overriding newer selections.
* **Refactor**
  * Standardized language selection and startup behavior across extension pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->