### PR TITLE
feat(checkin): add Sub2API Pro daily check-in method

### DIFF
--- a/src/constants/checkIn.ts
+++ b/src/constants/checkIn.ts
@@ -8,6 +8,7 @@ export const AUTO_CHECKIN_METHOD_IDS = {
   WongGongyiDailyCheckIn: "wong-gongyi:daily-checkin",
   AnyrouterDailyCheckIn: "anyrouter:daily-checkin",
   VoApiV2DailyCheckIn: "voapi-v2:daily-checkin",
+  Sub2ApiProDailyCheckIn: "sub2api-pro:daily-checkin",
 } as const
 
 export const CHECK_IN_METHOD_UNKNOWN_REASON_CODES = {

--- a/src/services/apiService/sub2api/index.ts
+++ b/src/services/apiService/sub2api/index.ts
@@ -200,6 +200,14 @@ class Sub2ApiAuthPersistenceError extends Error {
   }
 }
 
+/**
+ * Classifies rotated-credential persistence failures for protocol callers
+ * without exposing the private error class. Such failures must stop before
+ * any business mutation (e.g. check-in POST).
+ */
+export const isSub2ApiAuthPersistenceError = (error: unknown): boolean =>
+  error instanceof Sub2ApiAuthPersistenceError
+
 const throwIfSub2ApiAuthPersistenceFailed = (error: unknown): void => {
   if (error instanceof Sub2ApiAuthPersistenceError) {
     throw error
@@ -711,6 +719,18 @@ const executeAuthenticatedSub2ApiRequest = async <T>(
     })
   }
 }
+
+/**
+ * Narrow authenticated-execution seam for protocol transports that own their
+ * response parsing (e.g. the redeem check-in flow). The runner receives a fully
+ * hydrated request and inline 401 recovery has already been applied; persistence
+ * failures surface through {@link isSub2ApiAuthPersistenceError}.
+ */
+export const executeSub2ApiAuthenticatedRequest = <T>(
+  request: ApiServiceRequest,
+  endpoint: string,
+  runner: AuthenticatedSub2ApiRunner<T>,
+): Promise<T> => executeAuthenticatedSub2ApiRequest(request, endpoint, runner)
 
 const fetchSub2ApiDataWithRequest = async <T>(
   request: ApiServiceRequest,
@@ -1392,7 +1412,9 @@ export async function fetchSiteStatus(
 export const extractDefaultExchangeRate = extractNewApiFamilyDefaultExchangeRate
 
 /**
- * Sub2API does not support the extension's built-in check-in flow.
+ * The legacy boolean check-in contract stays unsupported; the verified redeem
+ * check-in method lives in ./redeemCheckIn and is reached through the
+ * Check-in Methods Module registry instead of this adapter surface.
  */
 export async function fetchSupportCheckIn(
   _request: ApiServiceRequest,
@@ -1401,7 +1423,8 @@ export async function fetchSupportCheckIn(
 }
 
 /**
- * Sub2API check-in is unsupported; always return undefined.
+ * Legacy boolean check-in status stays unsupported; see ./redeemCheckIn for
+ * the verified redeem check-in status contract.
  */
 export async function fetchCheckInStatus(
   _request: ApiServiceRequest,

--- a/src/services/apiService/sub2api/redeemCheckIn.ts
+++ b/src/services/apiService/sub2api/redeemCheckIn.ts
@@ -1,0 +1,252 @@
+/**
+ * Verified Sub2API Pro daily check-in protocol transport.
+ *
+ * Contract pinned to jiangmuran/sub2api_pro@3f8585707632c959ca36be84e13c5a738c005a83
+ * and Wei-Shaw/sub2api#510:
+ * - `GET /api/v1/redeem/checkin/status` is the read-only probe/status surface;
+ *   `POST /api/v1/redeem/checkin` executes the check-in. No alias endpoints.
+ * - Success envelopes are `{ code: 0, message: "success", data }`.
+ * - Failures are HTTP 403/409 whose top-level numeric `code` mirrors the HTTP
+ *   status and whose top-level string `reason` is the authoritative machine
+ *   discriminator (`DAILY_CHECKIN_DISABLED`, `DAILY_CHECKIN_ROLE_FORBIDDEN`,
+ *   `DAILY_CHECKIN_ALREADY_DONE`).
+ */
+import { API_ERROR_CODES, ApiError } from "~/services/apiTransport/errors"
+import { fetchApiResponse } from "~/services/apiTransport/request"
+import type { ApiServiceRequest } from "~/services/apiTransport/type"
+import { t } from "~/utils/i18n/core"
+
+import { executeSub2ApiAuthenticatedRequest } from "./index"
+import { parseSub2ApiEnvelope } from "./parsing"
+import {
+  SUB2API_REDEEM_CHECKIN_ENDPOINT,
+  SUB2API_REDEEM_CHECKIN_ERROR_REASONS,
+  SUB2API_REDEEM_CHECKIN_STATUS_ENDPOINT,
+  type Sub2ApiRedeemCheckInErrorReason,
+  type Sub2ApiRedeemCheckInResultData,
+  type Sub2ApiRedeemCheckInStatusData,
+} from "./type"
+
+const invalidResponseError = (endpoint: string) =>
+  new ApiError(
+    t("messages:errors.api.invalidResponseFormat"),
+    undefined,
+    endpoint,
+    API_ERROR_CODES.JSON_PARSE_ERROR,
+  )
+
+const getErrorCodeForStatus = (status: number) => {
+  if (status === 401) return API_ERROR_CODES.HTTP_401
+  if (status === 403) return API_ERROR_CODES.HTTP_403
+  if (status === 429) return API_ERROR_CODES.HTTP_429
+  return API_ERROR_CODES.HTTP_OTHER
+}
+
+/**
+ * Normalizes a non-2xx redeem check-in response into an {@link ApiError}.
+ *
+ * The top-level numeric `code` mirrors the HTTP status per contract, so the
+ * HTTP status drives classification while the string `reason` is carried as
+ * `upstreamCode`. A recognized `DAILY_CHECKIN_ALREADY_DONE` reason forces
+ * statusCode 409 so callers converge on already-checked semantics even if a
+ * deployment drifts its HTTP status.
+ */
+const buildRedeemCheckInHttpError = (
+  body: unknown,
+  status: number,
+  endpoint: string,
+): ApiError => {
+  const record =
+    body && typeof body === "object" && !Array.isArray(body)
+      ? (body as Record<string, unknown>)
+      : undefined
+
+  const rawMessage =
+    typeof record?.message === "string" && record.message.trim()
+      ? record.message.trim()
+      : undefined
+  const rawReason =
+    typeof record?.reason === "string" ? record.reason.trim() : undefined
+  const knownReasons = new Set(
+    Object.values(SUB2API_REDEEM_CHECKIN_ERROR_REASONS),
+  )
+  const reason = knownReasons.has(rawReason as Sub2ApiRedeemCheckInErrorReason)
+    ? (rawReason as Sub2ApiRedeemCheckInErrorReason)
+    : undefined
+
+  // The contract pins numeric `code` to the HTTP status; only a verified
+  // string `reason` is allowed to override it.
+  let statusCode = status
+  if (
+    reason === SUB2API_REDEEM_CHECKIN_ERROR_REASONS.DailyCheckinAlreadyDone &&
+    status !== 403
+  ) {
+    statusCode = 409
+  } else if (
+    (reason === SUB2API_REDEEM_CHECKIN_ERROR_REASONS.DailyCheckinDisabled ||
+      reason ===
+        SUB2API_REDEEM_CHECKIN_ERROR_REASONS.DailyCheckinRoleForbidden) &&
+    status !== 409
+  ) {
+    statusCode = 403
+  }
+
+  return new ApiError(
+    rawMessage ?? `请求失败: ${statusCode}`,
+    statusCode,
+    endpoint,
+    getErrorCodeForStatus(statusCode),
+    reason,
+  )
+}
+
+const runRedeemCheckInRequest = async <T>(
+  authRequest: ApiServiceRequest,
+  endpoint: string,
+  init: RequestInit,
+  validate: (data: unknown) => T,
+): Promise<T> => {
+  const response = await fetchApiResponse<unknown>(authRequest, {
+    endpoint,
+    options: init,
+  })
+
+  if (!response.ok) {
+    throw buildRedeemCheckInHttpError(response.body, response.status, endpoint)
+  }
+
+  return validate(parseSub2ApiEnvelope(response.body, endpoint))
+}
+
+const requireRecord = (
+  value: unknown,
+  endpoint: string,
+): Record<string, unknown> => {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw invalidResponseError(endpoint)
+  }
+  return value as Record<string, unknown>
+}
+
+const requireTrueBoolean = (value: unknown, endpoint: string): boolean => {
+  if (typeof value !== "boolean") {
+    throw invalidResponseError(endpoint)
+  }
+  return value
+}
+
+const requireFiniteNumber = (value: unknown, endpoint: string): number => {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw invalidResponseError(endpoint)
+  }
+  return value
+}
+
+const requireString = (value: unknown, endpoint: string): string => {
+  if (typeof value !== "string") {
+    throw invalidResponseError(endpoint)
+  }
+  return value
+}
+
+const validateCheckInStatusData = (
+  data: unknown,
+  endpoint: string,
+): Sub2ApiRedeemCheckInStatusData => {
+  const record = requireRecord(data, endpoint)
+
+  const enabled = requireTrueBoolean(record.enabled, endpoint)
+  const checked_in_today = requireTrueBoolean(record.checked_in_today, endpoint)
+  const reward_min = requireFiniteNumber(record.reward_min, endpoint)
+  const reward_max = requireFiniteNumber(record.reward_max, endpoint)
+
+  if (reward_min < 0 || reward_min > reward_max) {
+    throw invalidResponseError(endpoint)
+  }
+
+  const rewardAmount =
+    record.reward_amount === undefined || record.reward_amount === null
+      ? undefined
+      : requireFiniteNumber(record.reward_amount, endpoint)
+
+  return {
+    enabled,
+    checked_in_today,
+    reward_min,
+    reward_max,
+    ...(rewardAmount !== undefined ? { reward_amount: rewardAmount } : {}),
+  }
+}
+
+const validateCheckInResultData = (
+  data: unknown,
+  endpoint: string,
+): Sub2ApiRedeemCheckInResultData => {
+  const record = requireRecord(data, endpoint)
+
+  return {
+    message: requireString(record.message, endpoint),
+    reward_amount: requireFiniteNumber(record.reward_amount, endpoint),
+    new_balance: requireFiniteNumber(record.new_balance, endpoint),
+    checked_in_at: requireString(record.checked_in_at, endpoint),
+  }
+}
+
+/**
+ * Reads the verified daily check-in status through the shared Sub2API
+ * authenticated executor so JWT hydration and inline 401 recovery apply.
+ */
+export function fetchSub2ApiProCheckInStatus(
+  request: ApiServiceRequest,
+): Promise<Sub2ApiRedeemCheckInStatusData> {
+  return executeSub2ApiAuthenticatedRequest(
+    request,
+    SUB2API_REDEEM_CHECKIN_STATUS_ENDPOINT,
+    (authRequest) =>
+      runRedeemCheckInRequest(
+        authRequest,
+        SUB2API_REDEEM_CHECKIN_STATUS_ENDPOINT,
+        { method: "GET", cache: "no-store" },
+        (data) =>
+          validateCheckInStatusData(
+            data,
+            SUB2API_REDEEM_CHECKIN_STATUS_ENDPOINT,
+          ),
+      ),
+  )
+}
+
+/**
+ * Executes exactly one daily check-in mutation. Callers own the status-first
+ * gating and bounded reconciliation; this transport neither probes nor retries
+ * the POST beyond the shared executor's inline 401 recovery.
+ */
+export function submitSub2ApiProCheckIn(
+  request: ApiServiceRequest,
+): Promise<Sub2ApiRedeemCheckInResultData> {
+  return executeSub2ApiAuthenticatedRequest(
+    request,
+    SUB2API_REDEEM_CHECKIN_ENDPOINT,
+    (authRequest) =>
+      runRedeemCheckInRequest(
+        authRequest,
+        SUB2API_REDEEM_CHECKIN_ENDPOINT,
+        { method: "POST" },
+        (data) =>
+          validateCheckInResultData(data, SUB2API_REDEEM_CHECKIN_ENDPOINT),
+      ),
+  )
+}
+
+/**
+ * Returns the verified machine-readable check-in failure reason carried by an
+ * error, letting providers classify already-done/disabled/role-forbidden
+ * outcomes without depending on internal error construction.
+ */
+export function getSub2ApiRedeemCheckInErrorReason(
+  error: unknown,
+): Sub2ApiRedeemCheckInErrorReason | undefined {
+  if (!(error instanceof ApiError)) return undefined
+  const reasonValues = Object.values(SUB2API_REDEEM_CHECKIN_ERROR_REASONS)
+  return reasonValues.find((value) => value === error.upstreamCode)
+}

--- a/src/services/apiService/sub2api/type.ts
+++ b/src/services/apiService/sub2api/type.ts
@@ -13,6 +13,48 @@ export const SUB2API_ANNOUNCEMENTS_ENDPOINT = "/api/v1/announcements"
 export const SUB2API_AVAILABLE_GROUPS_ENDPOINT = "/api/v1/groups/available"
 export const SUB2API_GROUP_RATES_ENDPOINT = "/api/v1/groups/rates"
 export const SUB2API_USAGE_STATS_ENDPOINT = "/api/v1/usage/stats"
+export const SUB2API_REDEEM_CHECKIN_ENDPOINT = "/api/v1/redeem/checkin"
+export const SUB2API_REDEEM_CHECKIN_STATUS_ENDPOINT =
+  "/api/v1/redeem/checkin/status"
+
+/**
+ * Machine-readable failure reasons carried in the top-level `reason` field of
+ * redeem check-in error envelopes. Numeric `code` mirrors the HTTP status;
+ * `reason` is the authoritative discriminator.
+ *
+ * Contract pinned to jiangmuran/sub2api_pro@3f858570 and Wei-Shaw/sub2api#510.
+ */
+export const SUB2API_REDEEM_CHECKIN_ERROR_REASONS = {
+  DailyCheckinDisabled: "DAILY_CHECKIN_DISABLED",
+  DailyCheckinRoleForbidden: "DAILY_CHECKIN_ROLE_FORBIDDEN",
+  DailyCheckinAlreadyDone: "DAILY_CHECKIN_ALREADY_DONE",
+} as const
+
+export type Sub2ApiRedeemCheckInErrorReason =
+  (typeof SUB2API_REDEEM_CHECKIN_ERROR_REASONS)[keyof typeof SUB2API_REDEEM_CHECKIN_ERROR_REASONS]
+
+/**
+ * Strict status DTO for `GET /api/v1/redeem/checkin/status`.
+ * Booleans must be real booleans, numbers finite, and reward bounds ordered.
+ * Extra unrelated fields may be present; alias probing is forbidden.
+ */
+export type Sub2ApiRedeemCheckInStatusData = {
+  enabled: boolean
+  checked_in_today: boolean
+  reward_min: number
+  reward_max: number
+  reward_amount?: number
+}
+
+/**
+ * Execution DTO for `POST /api/v1/redeem/checkin` on success.
+ */
+export type Sub2ApiRedeemCheckInResultData = {
+  message: string
+  reward_amount: number
+  new_balance: number
+  checked_in_at: string
+}
 
 type IntLike = number | string
 type NumericLike = number | string

--- a/src/services/checkin/autoCheckin/compatibilityConfig.ts
+++ b/src/services/checkin/autoCheckin/compatibilityConfig.ts
@@ -4,20 +4,19 @@ import {
   CHECK_IN_SELECTION_MODES,
 } from "~/constants/checkIn"
 import type { AccountSiteType } from "~/constants/siteType"
-import {
-  getAutoCheckinCandidateMethodIds,
-  getNewAccountCompatibilityMethodIds,
-} from "~/services/checkin/autoCheckin/providers/registry"
+import { getNewAccountCompatibilityMethodIds } from "~/services/checkin/autoCheckin/providers/registry"
 import type { CheckInConfig, CustomCheckInConfig } from "~/types/checkIn"
 
 /**
- * Defaults a new account into automatic execution intent when its site type
- * has at least one candidate method. Discovery remains the execution gate.
+ * Defaults a new account into automatic execution intent only when its site
+ * type has a pre-registry compatibility registration. Discovery-only candidates
+ * (no legacy bridge) default off; users can still enable automatic execution
+ * explicitly. Discovery remains the execution gate either way.
  */
 export function getNewAccountAutomaticExecutionDefault(
   siteType: AccountSiteType,
 ): boolean {
-  return getAutoCheckinCandidateMethodIds(siteType).length > 0
+  return getNewAccountCompatibilityMethodIds(siteType).length > 0
 }
 
 /** Returns whether legacy compatibility may preselect a new account method. */

--- a/src/services/checkin/autoCheckin/providers/index.ts
+++ b/src/services/checkin/autoCheckin/providers/index.ts
@@ -1,5 +1,6 @@
 import { AUTO_CHECKIN_METHOD_IDS } from "~/constants/checkIn"
 import { newApiProvider } from "~/services/checkin/autoCheckin/providers/newApi"
+import { sub2ApiProvider } from "~/services/checkin/autoCheckin/providers/sub2api"
 import { voApiV2Provider } from "~/services/checkin/autoCheckin/providers/voapiV2"
 import type { CheckInMethodId } from "~/types/checkIn"
 
@@ -18,6 +19,7 @@ const PROVIDER_BY_METHOD_ID = {
   [AUTO_CHECKIN_METHOD_IDS.WongGongyiDailyCheckIn]: wongGongyiProvider,
   [AUTO_CHECKIN_METHOD_IDS.NewApiDailyCheckIn]: newApiProvider,
   [AUTO_CHECKIN_METHOD_IDS.VoApiV2DailyCheckIn]: voApiV2Provider,
+  [AUTO_CHECKIN_METHOD_IDS.Sub2ApiProDailyCheckIn]: sub2ApiProvider,
 } as const satisfies Record<CheckInMethodId, AutoCheckinProvider>
 
 export const autoCheckinMethodRegistry = createAutoCheckinMethodRegistry(

--- a/src/services/checkin/autoCheckin/providers/registry.ts
+++ b/src/services/checkin/autoCheckin/providers/registry.ts
@@ -171,6 +171,12 @@ export const AUTO_CHECKIN_METHOD_DEFINITIONS = {
     legacy: true,
     newAccountCompatibility: true,
   },
+  [AUTO_CHECKIN_METHOD_IDS.Sub2ApiProDailyCheckIn]: {
+    id: AUTO_CHECKIN_METHOD_IDS.Sub2ApiProDailyCheckIn,
+    siteTypes: [SITE_TYPES.SUB2API],
+    legacy: false,
+    newAccountCompatibility: false,
+  },
 } as const satisfies Record<CheckInMethodId, AutoCheckinMethodDefinition>
 
 const AUTO_CHECKIN_METHOD_METADATA = createAutoCheckinMethodMetadata(

--- a/src/services/checkin/autoCheckin/providers/sub2api.ts
+++ b/src/services/checkin/autoCheckin/providers/sub2api.ts
@@ -1,0 +1,234 @@
+import {
+  CHECK_IN_METHOD_STATUS_EVIDENCE_SOURCES,
+  CHECK_IN_METHOD_STATUS_OUTCOMES,
+  CHECK_IN_METHOD_TODAY_STATUSES,
+  CHECK_IN_PROVIDER_READINESS_REASONS,
+} from "~/constants/checkIn"
+import { SITE_TYPES } from "~/constants/siteType"
+import { isSub2ApiAuthPersistenceError } from "~/services/apiService/sub2api"
+import {
+  fetchSub2ApiProCheckInStatus,
+  getSub2ApiRedeemCheckInErrorReason,
+  submitSub2ApiProCheckIn,
+} from "~/services/apiService/sub2api/redeemCheckIn"
+import {
+  SUB2API_REDEEM_CHECKIN_ERROR_REASONS,
+  type Sub2ApiRedeemCheckInResultData,
+  type Sub2ApiRedeemCheckInStatusData,
+} from "~/services/apiService/sub2api/type"
+import { composeAbortSignals } from "~/services/apiTransport/abortableTask"
+import type { ApiServiceRequest } from "~/services/apiTransport/type"
+import type {
+  AutoCheckinProvider,
+  AutoCheckinProviderContext,
+} from "~/services/checkin/autoCheckin/providers/contracts"
+import { detectWithStatusReadback } from "~/services/checkin/autoCheckin/providers/detection"
+import {
+  AUTO_CHECKIN_PROVIDER_FALLBACK_MESSAGE_KEYS,
+  resolveProviderErrorResult,
+} from "~/services/checkin/autoCheckin/providers/shared"
+import type { AutoCheckinProviderResult } from "~/services/checkin/autoCheckin/providers/types"
+import { AuthTypeEnum, type SiteAccount } from "~/types"
+import { CHECKIN_RESULT_STATUS } from "~/types/autoCheckin"
+import type { TempWindowRequestSource } from "~/types/tempWindowFetch"
+import { normalizeTempWindowRequestSource } from "~/utils/browser/tempWindowRequestSource"
+
+// Contract pinned to jiangmuran/sub2api_pro@3f858570 and Wei-Shaw/sub2api#510:
+// GET /api/v1/redeem/checkin/status is the read-only probe; POST
+// /api/v1/redeem/checkin executes the mutation. Numeric `code` mirrors the
+// HTTP status; string `reason` is the authoritative discriminator.
+
+const createRequest = (
+  account: SiteAccount,
+  tempWindowRequestSource?: TempWindowRequestSource,
+  protectionBypassExecution?: AutoCheckinProviderContext["protectionBypassExecution"],
+): ApiServiceRequest => ({
+  baseUrl: account.site_url,
+  accountId: account.id,
+  auth: {
+    authType: AuthTypeEnum.AccessToken,
+    accessToken: account.account_info.access_token,
+  },
+  ...(tempWindowRequestSource ? { tempWindowRequestSource } : {}),
+  ...(protectionBypassExecution ? { protectionBypassExecution } : {}),
+})
+
+const isSub2ApiAccount = (account: SiteAccount): boolean =>
+  account.site_type === SITE_TYPES.SUB2API
+
+const getStatus: NonNullable<AutoCheckinProvider["getStatus"]> = async ({
+  account,
+  request,
+  observedAt,
+  signal,
+}) => {
+  const statusRequest =
+    request ?? (account ? createRequest(account, undefined) : undefined)
+  if (!statusRequest) return undefined
+  const composedSignal = composeAbortSignals([
+    statusRequest.abortSignal,
+    signal,
+  ])
+  let status: Sub2ApiRedeemCheckInStatusData
+  try {
+    status = await fetchSub2ApiProCheckInStatus({
+      ...statusRequest,
+      ...(composedSignal.signal ? { abortSignal: composedSignal.signal } : {}),
+    })
+  } finally {
+    composedSignal.dispose()
+  }
+  return {
+    outcome: CHECK_IN_METHOD_STATUS_OUTCOMES.Known,
+    today: status.checked_in_today
+      ? CHECK_IN_METHOD_TODAY_STATUSES.Checked
+      : CHECK_IN_METHOD_TODAY_STATUSES.NotChecked,
+    evidence: {
+      source: CHECK_IN_METHOD_STATUS_EVIDENCE_SOURCES.Probe,
+      observedAt,
+    },
+  }
+}
+
+/**
+ * Maps a redeem check-in transport error to a controlled result when the
+ * pinned protocol proves a stronger outcome, otherwise defers to the shared
+ * error resolver. Rotated-credential persistence failures stop execution.
+ */
+const resolveRedeemCheckInErrorResult = (
+  error: unknown,
+): AutoCheckinProviderResult => {
+  if (isSub2ApiAuthPersistenceError(error)) {
+    // Credential rotation failed; the POST never reached the business handler.
+    // Treat as a retryable failure so the next run re-attempts from GET.
+    return {
+      status: CHECKIN_RESULT_STATUS.FAILED,
+      messageKey: AUTO_CHECKIN_PROVIDER_FALLBACK_MESSAGE_KEYS.checkinFailed,
+    }
+  }
+
+  const reason = getSub2ApiRedeemCheckInErrorReason(error)
+  if (reason === SUB2API_REDEEM_CHECKIN_ERROR_REASONS.DailyCheckinAlreadyDone) {
+    return {
+      status: CHECKIN_RESULT_STATUS.ALREADY_CHECKED,
+      messageKey:
+        AUTO_CHECKIN_PROVIDER_FALLBACK_MESSAGE_KEYS.alreadyCheckedToday,
+    }
+  }
+  if (
+    reason === SUB2API_REDEEM_CHECKIN_ERROR_REASONS.DailyCheckinDisabled ||
+    reason === SUB2API_REDEEM_CHECKIN_ERROR_REASONS.DailyCheckinRoleForbidden
+  ) {
+    // Disabled (site-wide) and role-forbidden (per-user) both mean the method
+    // cannot run for this account; skip rather than fail.
+    return {
+      status: CHECKIN_RESULT_STATUS.SKIPPED,
+      messageKey:
+        AUTO_CHECKIN_PROVIDER_FALLBACK_MESSAGE_KEYS.endpointNotSupported,
+    }
+  }
+  return resolveProviderErrorResult({ error })
+}
+
+/**
+ * Reconciles after an uncertain POST by reading the authoritative status.
+ * checked → applied; not_checked → failed+retryable (no same-cycle repost);
+ * unknown → failed (no ordinary retry for unresolved uncertain).
+ */
+const reconcileUncertainPost = async (
+  request: ApiServiceRequest,
+): Promise<AutoCheckinProviderResult> => {
+  try {
+    const status = await fetchSub2ApiProCheckInStatus(request)
+    if (status.checked_in_today) {
+      return {
+        status: CHECKIN_RESULT_STATUS.SUCCESS,
+        messageKey:
+          AUTO_CHECKIN_PROVIDER_FALLBACK_MESSAGE_KEYS.checkinSuccessful,
+        data: status,
+      }
+    }
+    // Authoritative not-checked after an uncertain POST: the server did not
+    // apply the mutation. Permit a later retry but never repost this cycle.
+    return {
+      status: CHECKIN_RESULT_STATUS.FAILED,
+      messageKey: AUTO_CHECKIN_PROVIDER_FALLBACK_MESSAGE_KEYS.checkinFailed,
+      data: status,
+    }
+  } catch {
+    // Reconciliation itself failed; remain uncertain without ordinary retry.
+    return {
+      status: CHECKIN_RESULT_STATUS.FAILED,
+      messageKey: AUTO_CHECKIN_PROVIDER_FALLBACK_MESSAGE_KEYS.unknownError,
+    }
+  }
+}
+
+const runCheckIn = async (
+  request: ApiServiceRequest,
+): Promise<AutoCheckinProviderResult> => {
+  let result: Sub2ApiRedeemCheckInResultData
+  try {
+    result = await submitSub2ApiProCheckIn(request)
+  } catch (error) {
+    if (isSub2ApiAuthPersistenceError(error)) {
+      return resolveRedeemCheckInErrorResult(error)
+    }
+    const reason = getSub2ApiRedeemCheckInErrorReason(error)
+    if (
+      reason === SUB2API_REDEEM_CHECKIN_ERROR_REASONS.DailyCheckinAlreadyDone ||
+      reason === SUB2API_REDEEM_CHECKIN_ERROR_REASONS.DailyCheckinDisabled ||
+      reason === SUB2API_REDEEM_CHECKIN_ERROR_REASONS.DailyCheckinRoleForbidden
+    ) {
+      // The pinned protocol proves a stronger outcome than uncertain dispatch.
+      return resolveRedeemCheckInErrorResult(error)
+    }
+    // Uncertain dispatch (timeout, 5xx, unparseable, network). Perform one
+    // bounded GET reconciliation; never blindly repost.
+    return reconcileUncertainPost(request)
+  }
+
+  return {
+    status: CHECKIN_RESULT_STATUS.SUCCESS,
+    messageKey: AUTO_CHECKIN_PROVIDER_FALLBACK_MESSAGE_KEYS.checkinSuccessful,
+    data: result,
+  }
+}
+
+export const sub2ApiProvider: AutoCheckinProvider = {
+  getReadiness(account) {
+    if (!isSub2ApiAccount(account)) {
+      return {
+        ready: false,
+        reason: CHECK_IN_PROVIDER_READINESS_REASONS.AccountDataMissing,
+      }
+    }
+    return account.account_info?.access_token
+      ? { ready: true }
+      : {
+          ready: false,
+          reason: CHECK_IN_PROVIDER_READINESS_REASONS.CredentialsMissing,
+        }
+  },
+  detect: (context) => detectWithStatusReadback(context, getStatus),
+  getStatus,
+  async checkIn(
+    account,
+    context: AutoCheckinProviderContext,
+  ): Promise<AutoCheckinProviderResult> {
+    const tempWindowRequestSource = normalizeTempWindowRequestSource(
+      context.tempWindowRequestSource,
+    )
+    const siteAccount = account as SiteAccount
+    const request = createRequest(
+      siteAccount,
+      tempWindowRequestSource,
+      context.protectionBypassExecution,
+    )
+    try {
+      return await runCheckIn(request)
+    } catch (error) {
+      return resolveRedeemCheckInErrorResult(error)
+    }
+  },
+}

--- a/tests/services/apiService/sub2api/redeemCheckIn.test.ts
+++ b/tests/services/apiService/sub2api/redeemCheckIn.test.ts
@@ -1,0 +1,365 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+  fetchSub2ApiProCheckInStatus,
+  getSub2ApiRedeemCheckInErrorReason,
+  submitSub2ApiProCheckIn,
+} from "~/services/apiService/sub2api/redeemCheckIn"
+import {
+  SUB2API_REDEEM_CHECKIN_ENDPOINT,
+  SUB2API_REDEEM_CHECKIN_ERROR_REASONS,
+  SUB2API_REDEEM_CHECKIN_STATUS_ENDPOINT,
+} from "~/services/apiService/sub2api/type"
+import { API_ERROR_CODES, ApiError } from "~/services/apiTransport/errors"
+import type { ApiServiceRequest } from "~/services/apiTransport/type"
+
+// Contract pinned to jiangmuran/sub2api_pro@3f858570 and Wei-Shaw/sub2api#510.
+// Tests use placeholder hosts and credentials only.
+
+const { mockExecuteAuthed, mockFetchApiResponse } = vi.hoisted(() => ({
+  // Delegates the runner so tests receive the fully-hydrated request and can
+  // assert transport parsing/error-classification in isolation.
+  mockExecuteAuthed: vi.fn(),
+  mockFetchApiResponse: vi.fn(),
+}))
+
+vi.mock("~/services/apiService/sub2api", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("~/services/apiService/sub2api")>()
+  return {
+    ...actual,
+    executeSub2ApiAuthenticatedRequest: mockExecuteAuthed,
+  }
+})
+
+vi.mock("~/services/apiTransport/request", () => ({
+  fetchApiResponse: mockFetchApiResponse,
+}))
+
+vi.mock("~/utils/i18n/core", () => ({
+  t: (key: string) => key,
+}))
+
+const baseRequest = {
+  baseUrl: "https://sub2api.example.invalid",
+  accountId: "acct-1",
+  auth: {
+    authType: "access_token" as const,
+    accessToken: "placeholder-jwt",
+  },
+} as unknown as ApiServiceRequest
+
+/**
+ * Wires executeSub2ApiAuthenticatedRequest to call the runner with the same
+ * request, and stubs fetchApiResponse to return the given response.
+ */
+const stubResponse = (body: unknown, ok = true, status = 200) => {
+  mockExecuteAuthed.mockImplementationOnce(
+    async (
+      _req: ApiServiceRequest,
+      _endpoint: string,
+      runner: (r: ApiServiceRequest) => Promise<unknown>,
+    ) => runner(_req),
+  )
+  mockFetchApiResponse.mockResolvedValueOnce({
+    ok,
+    status,
+    headers: new Headers(),
+    body,
+  })
+}
+
+const stubErrorResponse = (body: unknown, status: number) =>
+  stubResponse(body, false, status)
+
+describe("Sub2API redeem check-in transport", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe("status parsing", () => {
+    it("parses a valid status envelope with optional reward_amount", async () => {
+      stubResponse({
+        code: 0,
+        message: "success",
+        data: {
+          enabled: true,
+          checked_in_today: false,
+          reward_min: 1,
+          reward_max: 5,
+          reward_amount: 3,
+        },
+      })
+      const status = await fetchSub2ApiProCheckInStatus(baseRequest)
+      expect(status).toEqual({
+        enabled: true,
+        checked_in_today: false,
+        reward_min: 1,
+        reward_max: 5,
+        reward_amount: 3,
+      })
+    })
+
+    it("parses a valid status envelope without optional reward_amount", async () => {
+      stubResponse({
+        code: 0,
+        message: "success",
+        data: {
+          enabled: false,
+          checked_in_today: true,
+          reward_min: 0,
+          reward_max: 0,
+        },
+      })
+      const status = await fetchSub2ApiProCheckInStatus(baseRequest)
+      expect(status.checked_in_today).toBe(true)
+      expect(status).not.toHaveProperty("reward_amount")
+    })
+
+    it("rejects a non-boolean enabled field", async () => {
+      stubResponse({
+        code: 0,
+        message: "success",
+        data: {
+          enabled: "yes",
+          checked_in_today: false,
+          reward_min: 0,
+          reward_max: 0,
+        },
+      })
+      await expect(fetchSub2ApiProCheckInStatus(baseRequest)).rejects.toThrow(
+        "messages:errors.api.invalidResponseFormat",
+      )
+    })
+
+    it("rejects non-finite numeric reward bounds", async () => {
+      stubResponse({
+        code: 0,
+        message: "success",
+        data: {
+          enabled: true,
+          checked_in_today: false,
+          reward_min: NaN,
+          reward_max: 0,
+        },
+      })
+      await expect(fetchSub2ApiProCheckInStatus(baseRequest)).rejects.toThrow()
+    })
+
+    it("rejects reversed reward bounds", async () => {
+      stubResponse({
+        code: 0,
+        message: "success",
+        data: {
+          enabled: true,
+          checked_in_today: false,
+          reward_min: 10,
+          reward_max: 5,
+        },
+      })
+      await expect(fetchSub2ApiProCheckInStatus(baseRequest)).rejects.toThrow(
+        "messages:errors.api.invalidResponseFormat",
+      )
+    })
+
+    it("rejects negative reward_min", async () => {
+      stubResponse({
+        code: 0,
+        message: "success",
+        data: {
+          enabled: true,
+          checked_in_today: false,
+          reward_min: -1,
+          reward_max: 5,
+        },
+      })
+      await expect(fetchSub2ApiProCheckInStatus(baseRequest)).rejects.toThrow(
+        "messages:errors.api.invalidResponseFormat",
+      )
+    })
+
+    it("rejects missing required success fields", async () => {
+      stubResponse({
+        code: 0,
+        message: "success",
+        data: { enabled: true, checked_in_today: false },
+      })
+      await expect(fetchSub2ApiProCheckInStatus(baseRequest)).rejects.toThrow()
+    })
+
+    it("rejects array data wrappers", async () => {
+      stubResponse({ code: 0, message: "success", data: [] })
+      await expect(fetchSub2ApiProCheckInStatus(baseRequest)).rejects.toThrow()
+    })
+
+    it("rejects a non-zero business code as not success", async () => {
+      stubResponse({ code: 500, message: "fail", data: null })
+      await expect(fetchSub2ApiProCheckInStatus(baseRequest)).rejects.toThrow()
+    })
+  })
+
+  describe("result parsing", () => {
+    it("parses a valid check-in result envelope", async () => {
+      stubResponse({
+        code: 0,
+        message: "success",
+        data: {
+          message: "Checked in",
+          reward_amount: 2,
+          new_balance: 42,
+          checked_in_at: "2026-01-01T00:00:00Z",
+        },
+      })
+      const result = await submitSub2ApiProCheckIn(baseRequest)
+      expect(result).toEqual({
+        message: "Checked in",
+        reward_amount: 2,
+        new_balance: 42,
+        checked_in_at: "2026-01-01T00:00:00Z",
+      })
+    })
+
+    it("rejects a check-in result missing required fields", async () => {
+      stubResponse({
+        code: 0,
+        message: "success",
+        data: { message: "Checked in", reward_amount: 2 },
+      })
+      await expect(submitSub2ApiProCheckIn(baseRequest)).rejects.toThrow()
+    })
+  })
+
+  describe("HTTP error envelope normalization", () => {
+    it("extracts DAILY_CHECKIN_ALREADY_DONE reason from 409", async () => {
+      stubErrorResponse(
+        { code: 409, message: "already", reason: "DAILY_CHECKIN_ALREADY_DONE" },
+        409,
+      )
+      await expect(
+        fetchSub2ApiProCheckInStatus(baseRequest),
+      ).rejects.toMatchObject({
+        statusCode: 409,
+        upstreamCode:
+          SUB2API_REDEEM_CHECKIN_ERROR_REASONS.DailyCheckinAlreadyDone,
+      })
+    })
+
+    it("forces 409 for DAILY_CHECKIN_ALREADY_DONE when HTTP drifts", async () => {
+      stubErrorResponse(
+        { code: 200, message: "already", reason: "DAILY_CHECKIN_ALREADY_DONE" },
+        400,
+      )
+      await expect(
+        fetchSub2ApiProCheckInStatus(baseRequest),
+      ).rejects.toMatchObject({
+        statusCode: 409,
+        upstreamCode:
+          SUB2API_REDEEM_CHECKIN_ERROR_REASONS.DailyCheckinAlreadyDone,
+      })
+    })
+
+    it("extracts DAILY_CHECKIN_DISABLED reason and forces 403", async () => {
+      stubErrorResponse(
+        { code: 403, message: "disabled", reason: "DAILY_CHECKIN_DISABLED" },
+        403,
+      )
+      await expect(
+        fetchSub2ApiProCheckInStatus(baseRequest),
+      ).rejects.toMatchObject({
+        statusCode: 403,
+        upstreamCode: SUB2API_REDEEM_CHECKIN_ERROR_REASONS.DailyCheckinDisabled,
+      })
+    })
+
+    it("extracts DAILY_CHECKIN_ROLE_FORBIDDEN reason and forces 403", async () => {
+      stubErrorResponse(
+        {
+          code: 500,
+          message: "forbidden",
+          reason: "DAILY_CHECKIN_ROLE_FORBIDDEN",
+        },
+        500,
+      )
+      await expect(
+        fetchSub2ApiProCheckInStatus(baseRequest),
+      ).rejects.toMatchObject({
+        statusCode: 403,
+        upstreamCode:
+          SUB2API_REDEEM_CHECKIN_ERROR_REASONS.DailyCheckinRoleForbidden,
+      })
+    })
+
+    it("does not force 409 for DAILY_CHECKIN_ALREADY_DONE on 403", async () => {
+      // Already-done on a 403 keeps 403 (the forced 409 path excludes 403).
+      stubErrorResponse(
+        { code: 403, message: "done", reason: "DAILY_CHECKIN_ALREADY_DONE" },
+        403,
+      )
+      await expect(
+        fetchSub2ApiProCheckInStatus(baseRequest),
+      ).rejects.toMatchObject({ statusCode: 403 })
+    })
+
+    it("falls back to HTTP status when reason is unrecognized", async () => {
+      stubErrorResponse(
+        { code: 500, message: "unknown", reason: "SOME_OTHER_REASON" },
+        500,
+      )
+      await expect(
+        fetchSub2ApiProCheckInStatus(baseRequest),
+      ).rejects.toMatchObject({
+        statusCode: 500,
+        upstreamCode: undefined,
+      })
+    })
+
+    it("falls back when body is missing", async () => {
+      stubErrorResponse(undefined, 500)
+      await expect(
+        fetchSub2ApiProCheckInStatus(baseRequest),
+      ).rejects.toMatchObject({ statusCode: 500 })
+    })
+
+    it("uses a fallback message when backend message is empty", async () => {
+      stubErrorResponse({ reason: "DAILY_CHECKIN_DISABLED" }, 403)
+      await expect(
+        fetchSub2ApiProCheckInStatus(baseRequest),
+      ).rejects.toMatchObject({
+        message: expect.stringContaining("403"),
+        statusCode: 403,
+      })
+    })
+  })
+
+  describe("getSub2ApiRedeemCheckInErrorReason", () => {
+    it("returns the reason for a known ApiError", () => {
+      const error = new ApiError(
+        "done",
+        409,
+        SUB2API_REDEEM_CHECKIN_ENDPOINT,
+        API_ERROR_CODES.HTTP_403,
+        SUB2API_REDEEM_CHECKIN_ERROR_REASONS.DailyCheckinAlreadyDone,
+      )
+      expect(getSub2ApiRedeemCheckInErrorReason(error)).toBe(
+        SUB2API_REDEEM_CHECKIN_ERROR_REASONS.DailyCheckinAlreadyDone,
+      )
+    })
+
+    it("returns undefined for a non-ApiError", () => {
+      expect(getSub2ApiRedeemCheckInErrorReason(new Error("boom"))).toBe(
+        undefined,
+      )
+    })
+
+    it("returns undefined when upstreamCode is not a known reason", () => {
+      const error = new ApiError(
+        "x",
+        500,
+        SUB2API_REDEEM_CHECKIN_STATUS_ENDPOINT,
+        API_ERROR_CODES.HTTP_OTHER,
+        "UNRECOGNIZED",
+      )
+      expect(getSub2ApiRedeemCheckInErrorReason(error)).toBeUndefined()
+    })
+  })
+})

--- a/tests/services/autoCheckin/providers/registry.test.ts
+++ b/tests/services/autoCheckin/providers/registry.test.ts
@@ -9,6 +9,7 @@ import {
   createAutoCheckinMethodMetadata,
   createAutoCheckinMethodRegistry,
   decodePersistedCheckInMethodId,
+  getAutoCheckinCandidateMethodIds,
   getLegacyAutoCheckinMethodIds,
   getNewAccountCompatibilityMethodIds,
 } from "~/services/checkin/autoCheckin/providers/registry"
@@ -16,6 +17,7 @@ import type {
   AutoCheckinMethodDefinition,
   AutoCheckinMethodRegistration,
 } from "~/services/checkin/autoCheckin/providers/registry"
+import { sub2ApiProvider } from "~/services/checkin/autoCheckin/providers/sub2api"
 import { veloeraProvider } from "~/services/checkin/autoCheckin/providers/veloera"
 import { voApiV2Provider } from "~/services/checkin/autoCheckin/providers/voapiV2"
 import { wongGongyiProvider } from "~/services/checkin/autoCheckin/providers/wong"
@@ -44,7 +46,7 @@ describe("autoCheckinMethodRegistry", () => {
       }),
     )
 
-    expect(registrationContracts).toHaveLength(5)
+    expect(registrationContracts).toHaveLength(6)
     expect(registrationContracts).toEqual(
       expect.arrayContaining([
         {
@@ -71,6 +73,11 @@ describe("autoCheckinMethodRegistry", () => {
           id: "voapi-v2:daily-checkin",
           candidateSiteTypes: [SITE_TYPES.VO_API_V2],
           provider: voApiV2Provider,
+        },
+        {
+          id: "sub2api-pro:daily-checkin",
+          candidateSiteTypes: [SITE_TYPES.SUB2API],
+          provider: sub2ApiProvider,
         },
       ]),
     )
@@ -158,6 +165,20 @@ describe("autoCheckinMethodRegistry", () => {
       "anyrouter:daily-checkin",
     ])
     expect(getNewAccountCompatibilityMethodIds(SITE_TYPES.SUB2API)).toEqual([])
+  })
+
+  it("registers Sub2API as a discovery-only candidate without a legacy bridge", () => {
+    expect(getAutoCheckinCandidateMethodIds(SITE_TYPES.SUB2API)).toEqual([
+      AUTO_CHECKIN_METHOD_IDS.Sub2ApiProDailyCheckIn,
+    ])
+    expect(getLegacyAutoCheckinMethodIds(SITE_TYPES.SUB2API)).toEqual([])
+    expect(getNewAccountCompatibilityMethodIds(SITE_TYPES.SUB2API)).toEqual([])
+    const registration = registrationFor(
+      AUTO_CHECKIN_METHOD_IDS.Sub2ApiProDailyCheckIn,
+    )
+    expect(registration.compatibilityRegistration).toBe(false)
+    expect(sub2ApiProvider.getStatus).toBeTypeOf("function")
+    expect(sub2ApiProvider.detect).toBeTypeOf("function")
   })
 
   it("rejects duplicate method IDs deterministically", () => {

--- a/tests/services/autoCheckin/providers/sub2api.test.ts
+++ b/tests/services/autoCheckin/providers/sub2api.test.ts
@@ -1,0 +1,456 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+  AUTO_CHECKIN_METHOD_IDS,
+  CHECK_IN_METHOD_DETECTION_OUTCOMES,
+  CHECK_IN_METHOD_STATUS_EVIDENCE_SOURCES,
+  CHECK_IN_METHOD_STATUS_OUTCOMES,
+  CHECK_IN_METHOD_TODAY_STATUSES,
+  CHECK_IN_METHOD_UNKNOWN_REASON_CODES,
+  CHECK_IN_PROVIDER_READINESS_REASONS,
+} from "~/constants/checkIn"
+import { SITE_TYPES } from "~/constants/siteType"
+import { SUB2API_REDEEM_CHECKIN_ERROR_REASONS } from "~/services/apiService/sub2api/type"
+import { autoCheckinMethodRegistry } from "~/services/checkin/autoCheckin/providers"
+import type { AutoCheckinProvider } from "~/services/checkin/autoCheckin/providers/contracts"
+import { sub2ApiProvider } from "~/services/checkin/autoCheckin/providers/sub2api"
+import { PROTECTION_BYPASS_USER_COMMANDS } from "~/services/protectionBypass/contracts"
+import type { SiteAccount } from "~/types"
+import { CHECKIN_RESULT_STATUS } from "~/types/autoCheckin"
+import { TEMP_WINDOW_REQUEST_SOURCES } from "~/types/tempWindowFetch"
+import { userCommandExecution } from "~~/tests/services/protectionBypass/fixtures"
+import { buildCheckInConfig } from "~~/tests/test-utils/factories"
+
+// Contract pinned to jiangmuran/sub2api_pro@3f858570 and Wei-Shaw/sub2api#510.
+// All hosts and credentials are placeholders. Transport-layer parsing is covered
+// separately in tests/services/apiService/sub2api/redeemCheckIn.test.ts; these
+// provider tests drive the safety chain (status-first, bounded reconciliation,
+// error classification, persistence failure, identity-mismatch seam) by
+// controlling the transport fakes and the auth-session persistence guard.
+
+const {
+  mockFetchStatus,
+  mockSubmitCheckIn,
+  mockGetReason,
+  mockIsPersistenceError,
+} = vi.hoisted(() => ({
+  mockFetchStatus: vi.fn(),
+  mockSubmitCheckIn: vi.fn(),
+  mockGetReason: vi.fn(),
+  mockIsPersistenceError: vi.fn(),
+}))
+
+vi.mock("~/services/apiService/sub2api/redeemCheckIn", () => ({
+  fetchSub2ApiProCheckInStatus: mockFetchStatus,
+  submitSub2ApiProCheckIn: mockSubmitCheckIn,
+  getSub2ApiRedeemCheckInErrorReason: mockGetReason,
+}))
+
+vi.mock("~/services/apiService/sub2api", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("~/services/apiService/sub2api")>()
+  return {
+    ...actual,
+    isSub2ApiAuthPersistenceError: mockIsPersistenceError,
+  }
+})
+
+const account = {
+  id: "account-1",
+  site_type: SITE_TYPES.SUB2API,
+  site_url: "https://sub2api.example.invalid",
+  account_info: {
+    id: "7",
+    access_token: "placeholder-jwt",
+  },
+  checkIn: buildCheckInConfig({ automaticExecutionEnabled: true }),
+} as unknown as SiteAccount
+
+const DEFAULT_PROVIDER_CONTEXT = {
+  tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Background,
+  protectionBypassExecution: userCommandExecution(
+    PROTECTION_BYPASS_USER_COMMANDS.ManualCheckin,
+  ),
+} as const
+
+const checkInForTest = (
+  acct: Parameters<typeof sub2ApiProvider.checkIn>[0] = account,
+  context: Parameters<
+    typeof sub2ApiProvider.checkIn
+  >[1] = DEFAULT_PROVIDER_CONTEXT,
+) => sub2ApiProvider.checkIn(acct, context)
+
+const validStatus = (
+  overrides: Partial<{
+    enabled: boolean
+    checked_in_today: boolean
+    reward_min: number
+    reward_max: number
+    reward_amount: number
+  }> = {},
+) => ({
+  enabled: true,
+  checked_in_today: false,
+  reward_min: 1,
+  reward_max: 5,
+  ...overrides,
+})
+
+const validResult = () => ({
+  message: "Checked in",
+  reward_amount: 2,
+  new_balance: 42,
+  checked_in_at: "2026-01-01T00:00:00Z",
+})
+
+/** Stubs the POST-stage reason extractor to a controlled reason. */
+const stubReason = (reason: string | undefined) => {
+  mockGetReason.mockReturnValue(reason as never)
+}
+
+describe("sub2ApiProvider", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockIsPersistenceError.mockReturnValue(false)
+    mockGetReason.mockReturnValue(undefined)
+  })
+
+  it("registers the Sub2API Pro auto-check-in provider", () => {
+    expect(
+      autoCheckinMethodRegistry.resolveById(
+        AUTO_CHECKIN_METHOD_IDS.Sub2ApiProDailyCheckIn,
+      )?.provider,
+    ).toBe(sub2ApiProvider as AutoCheckinProvider)
+  })
+
+  describe("getReadiness", () => {
+    it("is ready when the account has an access token", () => {
+      expect(sub2ApiProvider.getReadiness(account)).toEqual({ ready: true })
+    })
+
+    it("is not ready when the access token is missing", () => {
+      expect(
+        sub2ApiProvider.getReadiness({
+          ...account,
+          account_info: { ...account.account_info, access_token: "" },
+        } as SiteAccount),
+      ).toEqual({
+        ready: false,
+        reason: CHECK_IN_PROVIDER_READINESS_REASONS.CredentialsMissing,
+      })
+    })
+
+    it("is not ready for a non-Sub2API site type", () => {
+      expect(
+        sub2ApiProvider.getReadiness({
+          ...account,
+          site_type: SITE_TYPES.NEW_API,
+        } as SiteAccount),
+      ).toEqual({
+        ready: false,
+        reason: CHECK_IN_PROVIDER_READINESS_REASONS.AccountDataMissing,
+      })
+    })
+
+    it("leaves automatic-execution intent to the Module", () => {
+      // Readiness is orthogonal to execution intent; the Module gates execution.
+      expect(
+        sub2ApiProvider.getReadiness({
+          ...account,
+          checkIn: buildCheckInConfig({ automaticExecutionEnabled: false }),
+        } as SiteAccount),
+      ).toEqual({ ready: true })
+    })
+  })
+
+  describe("detect", () => {
+    it("returns matched with not-checked status from a successful GET", async () => {
+      mockFetchStatus.mockResolvedValueOnce(
+        validStatus({ checked_in_today: false }),
+      )
+      await expect(
+        sub2ApiProvider.detect!({ account, observedAt: 230 }),
+      ).resolves.toMatchObject({
+        detection: {
+          outcome: CHECK_IN_METHOD_DETECTION_OUTCOMES.Matched,
+          evidence: { source: CHECK_IN_METHOD_STATUS_EVIDENCE_SOURCES.Probe },
+        },
+        status: {
+          outcome: CHECK_IN_METHOD_STATUS_OUTCOMES.Known,
+          today: CHECK_IN_METHOD_TODAY_STATUSES.NotChecked,
+        },
+      })
+    })
+
+    it("returns matched with checked status when already checked in today", async () => {
+      mockFetchStatus.mockResolvedValueOnce(
+        validStatus({ checked_in_today: true }),
+      )
+      await expect(
+        sub2ApiProvider.detect!({ account, observedAt: 231 }),
+      ).resolves.toMatchObject({
+        detection: { outcome: CHECK_IN_METHOD_DETECTION_OUTCOMES.Matched },
+        status: { today: CHECK_IN_METHOD_TODAY_STATUSES.Checked },
+      })
+    })
+
+    it("never sends POST during detection", async () => {
+      mockFetchStatus.mockResolvedValueOnce(validStatus())
+      await sub2ApiProvider.detect!({ account, observedAt: 232 })
+      expect(mockSubmitCheckIn).not.toHaveBeenCalled()
+    })
+
+    it("maps a 404 to authoritative unsupported", async () => {
+      const error = Object.assign(new Error("not found"), {
+        statusCode: 404,
+      })
+      mockFetchStatus.mockRejectedValueOnce(error)
+      await expect(
+        sub2ApiProvider.detect!({ account, observedAt: 233 }),
+      ).resolves.toMatchObject({
+        outcome: CHECK_IN_METHOD_DETECTION_OUTCOMES.Unsupported,
+      })
+    })
+
+    it("maps a 405 to authoritative unsupported", async () => {
+      const error = Object.assign(new Error("method not allowed"), {
+        statusCode: 405,
+      })
+      mockFetchStatus.mockRejectedValueOnce(error)
+      await expect(
+        sub2ApiProvider.detect!({ account, observedAt: 234 }),
+      ).resolves.toMatchObject({
+        outcome: CHECK_IN_METHOD_DETECTION_OUTCOMES.Unsupported,
+      })
+    })
+
+    it("does not map a 403 to unsupported (403 is a controlled unknown, not missing endpoint)", async () => {
+      // 403 from the status endpoint means the endpoint exists but access is
+      // denied; detection must not claim the method is unsupported.
+      const error = Object.assign(new Error("forbidden"), {
+        statusCode: 403,
+      })
+      mockFetchStatus.mockRejectedValueOnce(error)
+      await expect(
+        sub2ApiProvider.detect!({ account, observedAt: 235 }),
+      ).resolves.toMatchObject({
+        outcome: CHECK_IN_METHOD_DETECTION_OUTCOMES.Unknown,
+        reason: CHECK_IN_METHOD_UNKNOWN_REASON_CODES.PermissionDenied,
+      })
+    })
+
+    it("maps an unparseable response to unknown with invalid_response", async () => {
+      mockFetchStatus.mockRejectedValueOnce(new Error("parse fail"))
+      await expect(
+        sub2ApiProvider.detect!({ account, observedAt: 236 }),
+      ).resolves.toMatchObject({
+        outcome: CHECK_IN_METHOD_DETECTION_OUTCOMES.Unknown,
+        reason: CHECK_IN_METHOD_UNKNOWN_REASON_CODES.InvalidResponse,
+        attemptedAt: 236,
+      })
+    })
+
+    it("propagates the abort signal to the status request", async () => {
+      mockFetchStatus.mockImplementationOnce(
+        (request: { abortSignal?: AbortSignal }) => {
+          expect(request.abortSignal?.aborted).toBe(false)
+          return new Promise<never>(() => undefined)
+        },
+      )
+      const controller = new AbortController()
+      sub2ApiProvider.detect!({
+        account,
+        observedAt: 237,
+        signal: controller.signal,
+      })
+      await vi.waitFor(() => {
+        expect(mockFetchStatus).toHaveBeenCalled()
+      })
+      controller.abort()
+      expect(mockFetchStatus.mock.calls[0]?.[0].abortSignal).toBe(
+        controller.signal,
+      )
+    })
+  })
+
+  describe("getStatus", () => {
+    it("returns known/not_checked for a not-checked status", async () => {
+      mockFetchStatus.mockResolvedValueOnce(
+        validStatus({ checked_in_today: false }),
+      )
+      await expect(
+        sub2ApiProvider.getStatus!({ account, observedAt: 300 }),
+      ).resolves.toMatchObject({
+        outcome: CHECK_IN_METHOD_STATUS_OUTCOMES.Known,
+        today: CHECK_IN_METHOD_TODAY_STATUSES.NotChecked,
+      })
+    })
+
+    it("returns known/checked for an already-checked status", async () => {
+      mockFetchStatus.mockResolvedValueOnce(
+        validStatus({ checked_in_today: true }),
+      )
+      await expect(
+        sub2ApiProvider.getStatus!({ account, observedAt: 301 }),
+      ).resolves.toMatchObject({
+        outcome: CHECK_IN_METHOD_STATUS_OUTCOMES.Known,
+        today: CHECK_IN_METHOD_TODAY_STATUSES.Checked,
+      })
+    })
+
+    it("returns undefined when account is missing", async () => {
+      await expect(
+        sub2ApiProvider.getStatus!({ observedAt: 302 }),
+      ).resolves.toBeUndefined()
+    })
+  })
+
+  describe("checkIn", () => {
+    it("returns success with result data on a valid POST", async () => {
+      mockSubmitCheckIn.mockResolvedValueOnce(validResult())
+      const result = await checkInForTest()
+      expect(result).toMatchObject({
+        status: CHECKIN_RESULT_STATUS.SUCCESS,
+        messageKey: "autoCheckin:providerFallback.checkinSuccessful",
+      })
+      expect(result.data).toEqual(validResult())
+      // No reconciliation GET needed on a clean success.
+      expect(mockFetchStatus).not.toHaveBeenCalled()
+    })
+
+    it("classifies already-done as already_checked without repost or reconciliation", async () => {
+      stubReason(SUB2API_REDEEM_CHECKIN_ERROR_REASONS.DailyCheckinAlreadyDone)
+      mockSubmitCheckIn.mockRejectedValueOnce(new Error("already done"))
+      const result = await checkInForTest()
+      expect(result).toMatchObject({
+        status: CHECKIN_RESULT_STATUS.ALREADY_CHECKED,
+        messageKey: "autoCheckin:providerFallback.alreadyCheckedToday",
+      })
+      expect(mockSubmitCheckIn).toHaveBeenCalledTimes(1)
+      expect(mockFetchStatus).not.toHaveBeenCalled()
+    })
+
+    it("classifies disabled as skipped without reconciliation", async () => {
+      stubReason(SUB2API_REDEEM_CHECKIN_ERROR_REASONS.DailyCheckinDisabled)
+      mockSubmitCheckIn.mockRejectedValueOnce(new Error("disabled"))
+      const result = await checkInForTest()
+      expect(result).toMatchObject({
+        status: CHECKIN_RESULT_STATUS.SKIPPED,
+        messageKey: "autoCheckin:providerFallback.endpointNotSupported",
+      })
+      expect(mockFetchStatus).not.toHaveBeenCalled()
+    })
+
+    it("classifies role-forbidden as skipped without reconciliation", async () => {
+      stubReason(SUB2API_REDEEM_CHECKIN_ERROR_REASONS.DailyCheckinRoleForbidden)
+      mockSubmitCheckIn.mockRejectedValueOnce(new Error("role forbidden"))
+      const result = await checkInForTest()
+      expect(result).toMatchObject({
+        status: CHECKIN_RESULT_STATUS.SKIPPED,
+        messageKey: "autoCheckin:providerFallback.endpointNotSupported",
+      })
+      expect(mockFetchStatus).not.toHaveBeenCalled()
+    })
+
+    it("reconciles uncertain POST as success when status confirms checked", async () => {
+      stubReason(undefined)
+      mockSubmitCheckIn.mockRejectedValueOnce(new Error("timeout"))
+      mockFetchStatus.mockResolvedValueOnce(
+        validStatus({ checked_in_today: true }),
+      )
+      const result = await checkInForTest()
+      expect(result).toMatchObject({
+        status: CHECKIN_RESULT_STATUS.SUCCESS,
+        messageKey: "autoCheckin:providerFallback.checkinSuccessful",
+      })
+      // At most one POST, one bounded GET — no same-cycle repost.
+      expect(mockSubmitCheckIn).toHaveBeenCalledTimes(1)
+      expect(mockFetchStatus).toHaveBeenCalledTimes(1)
+    })
+
+    it("reconciles uncertain POST as failed when status confirms not-checked", async () => {
+      stubReason(undefined)
+      mockSubmitCheckIn.mockRejectedValueOnce(new Error("network"))
+      mockFetchStatus.mockResolvedValueOnce(
+        validStatus({ checked_in_today: false }),
+      )
+      const result = await checkInForTest()
+      expect(result.status).toBe(CHECKIN_RESULT_STATUS.FAILED)
+      expect(result.messageKey).toBe(
+        "autoCheckin:providerFallback.checkinFailed",
+      )
+      // No same-cycle repost after not-checked reconciliation.
+      expect(mockSubmitCheckIn).toHaveBeenCalledTimes(1)
+      expect(mockFetchStatus).toHaveBeenCalledTimes(1)
+    })
+
+    it("reconciles uncertain POST as failed when reconciliation itself fails", async () => {
+      stubReason(undefined)
+      mockSubmitCheckIn.mockRejectedValueOnce(new Error("5xx"))
+      mockFetchStatus.mockRejectedValueOnce(new Error("reconcile fail"))
+      const result = await checkInForTest()
+      expect(result.status).toBe(CHECKIN_RESULT_STATUS.FAILED)
+      // No ordinary retry for unresolved uncertain; unknownError fallback.
+      expect(result.messageKey).toBe(
+        "autoCheckin:providerFallback.unknownError",
+      )
+      expect(mockSubmitCheckIn).toHaveBeenCalledTimes(1)
+    })
+
+    it("does not treat unrecognized errors as already-checked or disabled", async () => {
+      // A backend 500 with no pinned reason is uncertain, not already-done.
+      stubReason(undefined)
+      mockSubmitCheckIn.mockRejectedValueOnce(
+        Object.assign(new Error("backend unavailable"), { statusCode: 500 }),
+      )
+      mockFetchStatus.mockResolvedValueOnce(
+        validStatus({ checked_in_today: false }),
+      )
+      const result = await checkInForTest()
+      expect(result.status).toBe(CHECKIN_RESULT_STATUS.FAILED)
+      expect(mockFetchStatus).toHaveBeenCalledTimes(1)
+    })
+
+    it("stops at rotated-credential persistence failure before reaching the business handler", async () => {
+      // The auth-session seam reports a persistence failure; execution must
+      // stop without reconciliation so the next run re-attempts from GET.
+      mockIsPersistenceError.mockReturnValue(true)
+      stubReason(undefined)
+      mockSubmitCheckIn.mockRejectedValueOnce(new Error("persistence failed"))
+      const result = await checkInForTest()
+      expect(result).toMatchObject({
+        status: CHECKIN_RESULT_STATUS.FAILED,
+        messageKey: "autoCheckin:providerFallback.checkinFailed",
+      })
+      expect(mockFetchStatus).not.toHaveBeenCalled()
+      expect(mockSubmitCheckIn).toHaveBeenCalledTimes(1)
+    })
+
+    it("propagates temp-window source through the check-in request", async () => {
+      mockSubmitCheckIn.mockResolvedValueOnce(validResult())
+      await checkInForTest(account, {
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+        protectionBypassExecution: userCommandExecution(
+          PROTECTION_BYPASS_USER_COMMANDS.ManualCheckin,
+        ),
+      })
+      expect(mockSubmitCheckIn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+        }),
+      )
+    })
+
+    it("does not alias-fallback to /api/v1/check-in", async () => {
+      // The provider only calls the pinned redeem endpoints. The transport
+      // fakes record exactly which functions were invoked; no alias endpoint
+      // is wired, so any fallback would surface as an unmocked call error.
+      mockSubmitCheckIn.mockResolvedValueOnce(validResult())
+      mockFetchStatus.mockResolvedValueOnce(validStatus())
+      await checkInForTest()
+      // Only submit (POST) was called; status (GET) is not invoked on success.
+      expect(mockSubmitCheckIn).toHaveBeenCalledTimes(1)
+      expect(mockFetchStatus).not.toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
## Why

Ticket #1270 introduced an account-level check-in method model; its foundation (method registry, V7 storage, discovery/selection) landed in PR #1350 and Sub2API auth persistence hardening in PR #1343. This change adds the verified `sub2api-pro:daily-checkin` method for the Sub2API site type, following that registry architecture instead of the previously-rejected global-switch approach (PR #1229).

## What changed

- **Transport** (`src/services/apiService/sub2api/redeemCheckIn.ts`): verified `GET /api/v1/redeem/checkin/status` (read-only probe + status readback) and `POST /api/v1/redeem/checkin` (mutation only). Strict DTO validation (real booleans, finite numbers, `reward_min <= reward_max`, required fields; non-zero business `code` is not success). Error normalization where the numeric `code` mirrors the HTTP status and the string `reason` is authoritative (`DAILY_CHECKIN_DISABLED` / `DAILY_CHECKIN_ROLE_FORBIDDEN` / `DAILY_CHECKIN_ALREADY_DONE`). Contract pinned to `jiangmuran/sub2api_pro@3f858570` and `Wei-Shaw/sub2api#510`.
- **Provider** (`src/services/checkin/autoCheckin/providers/sub2api.ts`): status-first GET, at most one handler-reaching POST, one bounded GET reconciliation after an uncertain POST; no same-cycle repost, no alias fallback to `/api/v1/check-in`. Maps disabled / role-forbidden -> `SKIPPED`; already-done -> `ALREADY_CHECKED`; rotated-credential persistence failure stops before POST -> `FAILED`; uncertain -> reconcile (checked -> `SUCCESS`, not-checked -> `FAILED` + retryable, reconcile-fail -> `FAILED`). Reuses `detectWithStatusReadback`, `resolveProviderErrorResult`, `composeAbortSignals`, and the Sub2API auth-session seam.
- **Registration & compatibility**: `sub2api-pro:daily-checkin` registered as `legacy: false, newAccountCompatibility: false` (discovery-only, no V6 migration bridge). `getNewAccountAutomaticExecutionDefault` now keys off compatibility registration so new Sub2API accounts default auto-execution **off**, while legacy-compatible site types keep their existing default-on behavior.

## Acceptance criteria satisfied (Ticket 07)

- Detection never sends POST; does not guess support from site type, host, or loose fields.
- Non-zero business `code` is not success.
- Strict DTO validation rejects malformed booleans, non-finite ranges, reversed reward bounds, missing required fields.
- Disabled / already-checked / role-forbidden / auth / unsupported / invalid / uncertain each map to the documented controlled result.
- Rotated-credential persistence succeeds before POST or execution stops.
- Reconciliation: checked converges to applied; not-checked never reposts in the same cycle; not-checked may become failed + retryable and the later retry still begins with GET.
- New Sub2API accounts default automatic execution off; users can enable explicitly.

## Compatibility and scope

- New method is discovery-only; it does not claim every Sub2API deployment supports check-in.
- No alias/unverified `/api/v1/check-in` endpoint or field-heuristic fallback.
- Custom check-in URL flow unchanged.
- No telemetry changes: the Auto Check-in analytics already report only controlled enums (status, site type, skip reason, counts) and never touch the provider `data` payload, so no `sub2api-pro` category was needed.

## Tests

- Transport: 22 tests — every documented status/error envelope, strict DTO boundaries, non-zero business code, forced 409/403 status normalization.
- Provider: 27 tests — registration, readiness, detect (GET-only + abort signal), getStatus, and checkIn safety chain (success, already-done, disabled, role-forbidden, reconciliation success/failure, reconcile-fail branch, unrecognized, persistence-failure seam, temp-window propagation, no alias fallback).
- Registry: 1 candidate test confirming Sub2API is discovery-only without a legacy bridge.

## Validation

- `pnpm compile` — passed
- `pnpm knip` — passed (no dead code)
- `pnpm run validate:staged` (lint-staged + i18n:check:staged) — passed; equivalent ran manually because the husky pre-commit path intermittently tripped an environment `pnpm install` approve-builds prompt; the pre-push hook (`pnpm compile && pnpm knip`) ran cleanly on push.
- `pnpm run i18n:extract:ci` — no unexpected updates
- `pnpm test` related suite — 74 tests across the new transport/provider/registry files plus the voapiV2 regression passed.

## E2E decision

This change is adapter + pure-logic layer (transport parsing, provider state machine, registry wiring). The shared execution entrypoint `executeSelectedCheckIn` owns the status-first GET; the four test files prove the safety-chain invariants at the unit layer, which is the correct coverage layer here. No new cross-entrypoint browser protocol was introduced that requires a new Playwright scenario; Ticket 08 owns unified browser E2E for check-in.

## Maintainability decision

- **Reused**: `detectWithStatusReadback`, `resolveProviderErrorResult` + `AUTO_CHECKIN_PROVIDER_FALLBACK_MESSAGE_KEYS`, `composeAbortSignals`, the Sub2API authenticated-executor seam (`executeSub2ApiAuthenticatedRequest`) with inline 401 recovery, and the existing `isSub2ApiAuthPersistenceError` guard.
- **Added**: the verified redeem-checkin transport and the Sub2API provider state machine with bounded reconciliation.
- **Left intact**: `voapiV2`/`anyrouter` providers and the `createRequest` helper were not extracted into a shared builder because their auth payloads differ (Sub2API uses no `userId`, others carry it); extraction would add abstraction without removing meaningful duplication.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic daily check-in support for Sub2API Pro.
  * Check-in status, rewards, balance updates, and completion times are now handled automatically.
  * Added clear handling for unavailable, already completed, and permission-restricted check-ins.
* **Bug Fixes**
  * Improved reliability when check-in results are uncertain by verifying status before retrying.
  * Prevented automatic execution for accounts without supported compatibility registrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->