### PR TITLE
fix(e2e): harden real-site compatibility, cleanup, and artifacts

### DIFF
--- a/.github/workflows/e2e-real-site.yml
+++ b/.github/workflows/e2e-real-site.yml
@@ -220,15 +220,14 @@ jobs:
           REAL_SITE_SPEC: ${{ matrix.spec }}
         run: pnpm exec playwright test "$REAL_SITE_SPEC" --project=chromium --reporter=list --no-deps
 
-      - name: Upload Playwright artifacts (failure)
+      - name: Upload failure screenshots
         if: failure()
         uses: actions/upload-artifact@v7
         with:
-          name: real-site-playwright-report-${{ matrix.category }}-${{ matrix.env_prefix }}-${{ github.run_attempt }}
-          path: |
-            playwright-report/
-            test-results/
-          retention-days: 7
+          name: real-site-failure-screenshots-${{ matrix.category }}-${{ matrix.env_prefix }}-${{ github.run_attempt }}
+          path: test-results/**/test-failed-*.png
+          if-no-files-found: ignore
+          retention-days: 3
 
   real-site-e2e-new-api:
     name: ${{ matrix.label }}

--- a/e2e/utils/realSite/compatibleApi.ts
+++ b/e2e/utils/realSite/compatibleApi.ts
@@ -788,6 +788,11 @@ function createOwnedAuthSessionCleanup(
         "cleanup",
       )
     }
+
+    // Some compatible deployments acknowledge logout while leaving the
+    // session row active. Revoke this run's exact SID as an idempotent
+    // backstop; never use revoke-others because the account may be shared.
+    await revokeOwnedAuthSession(page, config, options, authBundle)
   }
 }
 
@@ -822,6 +827,14 @@ async function revokeOwnedAuthSession(
   }
 
   if (!response.ok()) {
+    // Logout may already have revoked the session, which makes a follow-up
+    // exact revoke return an auth/not-found response. Those are safe,
+    // idempotent outcomes for cleanup. A missing endpoint also preserves
+    // compatibility with older deployments whose logout already worked.
+    if ([401, 403, 404, 405].includes(response.status())) {
+      return
+    }
+
     const responseText = await response.text()
     throw createAuthSessionStatusError(
       options,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,6 +5,7 @@ import { loadPlaywrightEnvFiles } from "./e2e/utils/playwrightEnv"
 loadPlaywrightEnvFiles()
 
 const isCI = !!process.env.CI
+const isRealSiteE2E = !!process.env.AAH_E2E_REAL_SITE_CATEGORY
 const configuredWorkerCount = Number(process.env.AAH_E2E_WORKERS)
 const workers =
   Number.isInteger(configuredWorkerCount) && configuredWorkerCount > 0
@@ -37,17 +38,20 @@ export default defineConfig({
   // Keeping local concurrency bounded avoids service-worker startup/teardown
   // timeouts on machines with many logical CPUs.
   workers,
-  reporter: isCI
-    ? [
-        ["github"],
-        ["html", { open: "never", outputFolder: "playwright-report" }],
-      ]
-    : [["list"]],
+  reporter:
+    isCI && !isRealSiteE2E
+      ? [
+          ["github"],
+          ["html", { open: "never", outputFolder: "playwright-report" }],
+        ]
+      : [["list"]],
   use: {
     headless: true,
     screenshot: "only-on-failure",
-    trace: "on-first-retry",
-    video: isCI ? "retain-on-failure" : "off",
+    // Real-site traces and videos can capture authenticated requests, cookies,
+    // response bodies, and credentials rendered by the extension.
+    trace: isRealSiteE2E ? "off" : "on-first-retry",
+    video: isCI && !isRealSiteE2E ? "retain-on-failure" : "off",
   },
   outputDir: "test-results",
 })

--- a/src/services/apiService/octopus/current.ts
+++ b/src/services/apiService/octopus/current.ts
@@ -184,6 +184,30 @@ const parseCurrentStats = (
   }
 }
 
+const normalizeCurrentModel = (value: Record<string, unknown>): string => {
+  if (typeof value.model === "string") {
+    return value.model
+  }
+
+  // Some Octopus deployments still return the legacy `models` array, while
+  // newly-created channels may omit both fields. Preserve those channels at
+  // the codec boundary instead of rejecting the complete channel list.
+  if (!Array.isArray(value.models)) {
+    return ""
+  }
+
+  return value.models
+    .map((model) => {
+      if (typeof model === "string") return model
+      if (isRecord(model) && typeof model.name === "string") {
+        return model.name
+      }
+      return null
+    })
+    .filter((model): model is string => Boolean(model?.trim()))
+    .join(",")
+}
+
 const toCurrentOctopusChannelType = (
   type: OctopusOutboundType,
 ): CurrentOctopusChannelType | null => {
@@ -245,7 +269,7 @@ const parseCurrentChannel = (value: unknown): CurrentOctopusChannelDto => {
     enabled: requireBoolean(value, "enabled"),
     base_url: requireString(value, "base_url"),
     key: requireString(value, "key"),
-    model: requireString(value, "model"),
+    model: normalizeCurrentModel(value),
     custom_model:
       typeof value.custom_model === "string" ? value.custom_model : undefined,
     proxy: requireBoolean(value, "proxy"),

--- a/tests/services/apiService/octopus.index.test.ts
+++ b/tests/services/apiService/octopus.index.test.ts
@@ -1057,11 +1057,13 @@ describe("Octopus API service", () => {
       },
     })
 
-    await expect(listChannels(config)).resolves.toEqual([
-      expect.objectContaining({ id: 5, model: "" }),
-      expect.objectContaining({ id: 2, model: "model-a,model-b" }),
-      expect.objectContaining({ id: 16, model: "" }),
-    ])
+    await expect(listChannels(config)).resolves.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 5, model: "" }),
+        expect.objectContaining({ id: 2, model: "model-a,model-b" }),
+        expect.objectContaining({ id: 16, model: "" }),
+      ]),
+    )
   })
 
   it("normalizes a current create response that omits model", async () => {

--- a/tests/services/apiService/octopus.index.test.ts
+++ b/tests/services/apiService/octopus.index.test.ts
@@ -1044,7 +1044,11 @@ describe("Octopus API service", () => {
           {
             ...currentChannelResponse({ id: 2 }),
             model: undefined,
-            models: [{ name: "model-a" }, { name: "model-b" }],
+            models: [
+              { name: "model-a" },
+              { name: "model-b" },
+              { unsupported: true },
+            ],
           },
           {
             ...currentChannelResponse({

--- a/tests/services/apiService/octopus.index.test.ts
+++ b/tests/services/apiService/octopus.index.test.ts
@@ -1026,6 +1026,78 @@ describe("Octopus API service", () => {
     })
   })
 
+  it("accepts current deployments that omit model or return legacy models", async () => {
+    mockGetValidSession.mockResolvedValueOnce({
+      mode: OCTOPUS_AUTH_MODES.Cookie,
+      expireAt: 1_700_000_900_000,
+    })
+    mockTempWindowOctopusApiFetch.mockResolvedValueOnce({
+      success: true,
+      status: 200,
+      data: {
+        code: 200,
+        data: [
+          {
+            ...currentChannelResponse({ id: 5 }),
+            model: undefined,
+          },
+          {
+            ...currentChannelResponse({ id: 2 }),
+            model: undefined,
+            models: [{ name: "model-a" }, { name: "model-b" }],
+          },
+          {
+            ...currentChannelResponse({
+              id: 16,
+              type: "openai_responses",
+            }),
+            model: undefined,
+          },
+        ],
+      },
+    })
+
+    await expect(listChannels(config)).resolves.toEqual([
+      expect.objectContaining({ id: 5, model: "" }),
+      expect.objectContaining({ id: 2, model: "model-a,model-b" }),
+      expect.objectContaining({ id: 16, model: "" }),
+    ])
+  })
+
+  it("normalizes a current create response that omits model", async () => {
+    mockGetValidSession.mockResolvedValueOnce({
+      mode: OCTOPUS_AUTH_MODES.Cookie,
+      expireAt: 1_700_000_900_000,
+    })
+    mockTempWindowOctopusApiFetch.mockResolvedValueOnce({
+      success: true,
+      status: 200,
+      data: {
+        code: 200,
+        data: {
+          ...currentChannelResponse({
+            id: 16,
+            type: "openai_responses",
+            model: undefined,
+          }),
+        },
+      },
+    })
+
+    await expect(
+      createChannel(config, {
+        name: "Created",
+        type: OctopusOutboundType.OpenAIResponse,
+        baseUrl: "https://upstream.example.invalid/v1",
+        key: "credential-placeholder",
+        model: "model-a",
+      }),
+    ).resolves.toMatchObject({
+      success: true,
+      data: { id: 16, model: "" },
+    })
+  })
+
   it.each([
     {
       name: "a non-object channel",

--- a/tests/utils/realSiteCompatibleApi.test.ts
+++ b/tests/utils/realSiteCompatibleApi.test.ts
@@ -83,7 +83,9 @@ function createPage(
       request: {
         post,
         get: options.getRequest ?? vi.fn(),
-        delete: options.deleteRequest ?? vi.fn(),
+        delete:
+          options.deleteRequest ??
+          vi.fn().mockResolvedValue(createResponse(404, {})),
       },
       close: vi.fn().mockResolvedValue(undefined),
     } as any,
@@ -262,6 +264,27 @@ describe("compatible real-site login", () => {
         Origin: ORIGIN,
         Authorization: "Bearer access-token-placeholder",
         "X-Auth-Session": "session-id-placeholder",
+      },
+    })
+  })
+
+  it("also revokes the exact fresh session after a successful logout", async () => {
+    const post = vi
+      .fn()
+      .mockResolvedValueOnce(createResponse(401, { code: "AUTH_UNAUTHORIZED" }))
+      .mockResolvedValueOnce(createResponse(200, createAuthBundle()))
+      .mockResolvedValueOnce(createResponse(200, { success: true }))
+    const deleteRequest = vi.fn().mockResolvedValue(createResponse(200, {}))
+    const { page } = createPage(post, { deleteRequest })
+
+    const result = await loginToRealNewApiSite(page, config)
+    await result.cleanupOwnedSession?.()
+
+    expect(deleteRequest).toHaveBeenCalledWith(AUTH_SESSION_DELETE_URL, {
+      failOnStatusCode: false,
+      headers: {
+        Origin: ORIGIN,
+        Authorization: "Bearer access-token-placeholder",
       },
     })
   })


### PR DESCRIPTION
## Summary

Harden the real-site E2E flows after failures observed in run 32769925595.

The run exposed three independent problems:

1. Octopus channel responses from the target deployment may omit \`model\`, causing the complete channel list to be rejected.
2. Some New API-compatible deployments acknowledge logout without removing the active auth-session row, eventually causing \`AUTH_SESSION_LIMIT\` errors.
3. Real-site Playwright traces included authenticated requests, cookies, response data, and credentials, and were uploaded as CI artifacts.

## What changed

### Octopus channel compatibility

- Normalize the current Octopus channel \`model\` field at the protocol boundary.
- Preserve a string \`model\` when present.
- Convert legacy \`models\` arrays containing strings or \`{ name }\` objects into the normalized model string.
- Accept channels where both fields are absent by using an empty model value instead of rejecting the entire response.
- Keep the remaining required channel fields strictly validated.
- Add focused coverage for legacy, incomplete, and malformed channel responses.

### New API auth-session cleanup

- After successful logout, revoke the exact auth session created by the current E2E run.
- Use the session's own SID and bearer token; never revoke other sessions.
- Treat \`401\`, \`403\`, \`404\`, and \`405\` responses from the follow-up revoke as safe idempotent outcomes because logout may already have removed the session or older deployments may not expose the endpoint.
- Preserve failures for unexpected cleanup responses.
- Add coverage for exact-session revocation and idempotent cleanup responses.

### Real-site CI artifact protection

- Detect real-site runs through the existing \`AAH_E2E_REAL_SITE_CATEGORY\` environment variable.
- Use the \`list\` reporter for real-site runs so an HTML report is not generated.
- Disable Playwright trace and video recording for real-site runs.
- Keep failure screenshots enabled.
- Change the GitHub Actions upload step to an explicit \`test-results/**/test-failed-*.png\` allow-list.
- Stop uploading the complete \`test-results/\` directory and Playwright HTML report.
- Reduce real-site artifact retention from 7 days to 3 days.
- Preserve HTML reports, retry traces, and failure videos for ordinary non-real-site CI E2E runs.

## Validation

- \`pnpm exec vitest run tests/services/apiService/octopus.index.test.ts tests/utils/realSiteCompatibleApi.test.ts\`
  - 2 files passed
  - 118 tests passed
- \`pnpm compile\`
- \`pnpm knip\`
- Playwright real-site configuration loading and test discovery
- \`pnpm exec prettier --check playwright.config.ts .github/workflows/e2e-real-site.yml\`
- Staged validation hook
- Real-Site E2E run 32817132740
  - head \`e21be53c91c211d62adcb06ec46067ae0ff33fab\`
  - all 16 jobs completed successfully

## Compatibility and risks

- Octopus channel parsing is more tolerant only for the optional/incomplete model representation; required protocol fields remain strict.
- Exact-session cleanup is scoped to the session created by the current run and does not affect other account sessions.
- Real-site failures no longer provide trace/video replay because those artifacts can contain credentials and authenticated network data. Failure screenshots and console/list output remain available.
- Existing artifacts from run 32769925595 are not removed by this code change. They still require manual deletion, and credentials exposed by those artifacts should be rotated separately.

## Scope

No changes were made to ordinary mocked/local E2E artifact behavior, unrelated providers, or production runtime authentication flows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility with deployment responses that omit model information or use legacy model formats.
  - Ensured sessions are fully revoked after logout, including when already removed.
  - Treated expected “already revoked” responses as successful cleanup.

- **Test Improvements**
  - Improved end-to-end diagnostics by retaining only failed-test screenshots.
  - Reduced failure artifact retention and streamlined test reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->