### PR TITLE
fix(account): avoid blocking on post-save refresh

### DIFF
--- a/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
+++ b/src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts
@@ -212,7 +212,7 @@ function createCurrentTabBrowserSessionContext(
 const logger = createLogger("AccountDialogHook")
 
 /**
- * Refreshes saved account data within the originating save command.
+ * Refreshes saved account data after the save command has persisted the account.
  */
 async function refreshPostSaveAccount(
   accountId: string,
@@ -2455,7 +2455,9 @@ export function useAccountDialog({
               : null
 
           if (savedAccountId) {
-            await refreshPostSaveAccount(
+            // The execution metadata is immutable and validated at each protected request,
+            // so the refresh can continue after this save command returns.
+            void refreshPostSaveAccount(
               savedAccountId,
               tempWindowRequestSource,
               protectionBypassExecution,

--- a/tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
+++ b/tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx
@@ -391,6 +391,65 @@ describe("useAccountDialog save and auto-config flows", () => {
     expect(mockGetCurrentTempWindowRequestSource).toHaveBeenCalledTimes(1)
   })
 
+  it("does not keep the save command pending while post-save refresh is running", async () => {
+    let resolveRefresh!: (value: {
+      account: SiteAccount
+      refreshed: boolean
+    }) => void
+    const refreshPromise = new Promise<{
+      account: SiteAccount
+      refreshed: boolean
+    }>((resolve) => {
+      resolveRefresh = resolve
+    })
+    vi.spyOn(accountStorage, "refreshAccount").mockReturnValueOnce(
+      refreshPromise as ReturnType<typeof accountStorage.refreshAccount>,
+    )
+    const onPostSaveAccountRefresh = vi.fn().mockResolvedValue(undefined)
+
+    const { result } = renderAddHook({ onPostSaveAccountRefresh })
+
+    await waitFor(() => {
+      expect(result.current.state).toBeTruthy()
+    })
+    await fillStandardAddAccountDraft(result)
+
+    let savePromise!: ReturnType<
+      typeof result.current.handlers.handleSaveAccount
+    >
+    await act(async () => {
+      savePromise = result.current.handlers.handleSaveAccount()
+      await Promise.resolve()
+    })
+    await waitFor(() => {
+      expect(accountStorage.refreshAccount).toHaveBeenCalled()
+    })
+
+    const saveCompletedBeforeRefresh = await Promise.race([
+      savePromise.then(() => true),
+      new Promise<boolean>((resolve) => {
+        setTimeout(() => resolve(false), 0)
+      }),
+    ])
+    expect(saveCompletedBeforeRefresh).toBe(true)
+
+    resolveRefresh({
+      account: buildSiteAccount({ id: "saved-account-id" }),
+      refreshed: true,
+    })
+    await act(async () => {
+      await savePromise
+    })
+    expect(onPostSaveAccountRefresh).toHaveBeenCalledWith(["saved-account-id"])
+    expect(mockSendRuntimeMessage).toHaveBeenCalledWith(
+      {
+        action: RuntimeActionIds.AccountRefreshCompleted,
+        updatedAccountIds: ["saved-account-id"],
+      },
+      { maxAttempts: 1 },
+    )
+  })
+
   it("captures the current surface again when the warning refresh action is clicked", async () => {
     const initialExecution = userCommandExecution("add_account", "options")
     const retryExecution = userCommandExecution("add_account", "popup")


### PR DESCRIPTION
## Summary

Fixes #1326

Saving a detected New API account currently waits for the post-save account refresh before completing, leaving the save button spinning for 10+ seconds.

This change lets the save command finish after the account is persisted while keeping the post-save refresh and targeted account-display update.

## What changed

- Schedule the post-save account refresh without awaiting it from the save command.
- Preserve the immutable protection-bypass execution metadata and temporary-window surface for protected requests.
- Keep the existing targeted account reload callback and runtime notification so refreshed balance, usage, health, and check-in data update in the account list after the refresh completes.
- Add a regression test covering save completion before refresh completion and the subsequent targeted update notification.

## Validation

- `pnpm vitest run tests/features/AccountManagement/hooks/useAccountDialog.saveAndAutoConfig.test.tsx` — 63 tests passed.
- `pnpm vitest related --run src/features/AccountManagement/components/AccountDialog/hooks/useAccountDialog.ts src/features/AccountManagement/hooks/AccountDataContext.tsx` — 47 files, 725 tests passed.
- `pnpm compile` — passed.
- Staged validation (`validate:staged`) — passed.
- Pre-push validation (`validate:push`) — passed.
- Prettier check — passed.

Full repository CI and coverage remain the PR checks.

## Scope

The save dialog no longer waits for the remote refresh. A separate row-level loading indicator is intentionally not added; the existing account data is updated when the background refresh completes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Account saves now complete without waiting for background account refreshes, improving responsiveness.
  - Post-save refreshes and notifications continue to run reliably after saving.

- **Tests**
  - Added regression coverage to verify save completion and subsequent refresh behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->