### PR TITLE
ci(e2e): shard default smoke suite across 6 runners to cut CI wall-clock ~60%

### DIFF
--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -80,7 +80,8 @@ jobs:
             e2e_type: dnr-required
             build_variant: dnr-required
             shard: ""
-      shard-total: 8
+    env:
+      AAH_E2E_SHARD_TOTAL: "8"
 
     steps:
       - name: Checkout code
@@ -131,7 +132,7 @@ jobs:
           AAH_SKIP_E2E_BUILD: "1"
         run: >
           pnpm run e2e:${{ matrix.e2e_type }}
-          ${{ matrix.shard && format('--shard={0}/{1}', matrix.shard, matrix.shard-total) || '' }}
+          ${{ matrix.shard && format('--shard={0}/{1}', matrix.shard, env.AAH_E2E_SHARD_TOTAL) || '' }}
 
       - name: Upload Playwright artifacts (failure)
         if: failure()

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -122,6 +122,7 @@ jobs:
         timeout-minutes: ${{ matrix.e2e_type == 'dnr-required' && 5 || 8 }}
         env:
           AAH_E2E_BUILD_VARIANT: ${{ matrix.build_variant }}
+          AAH_E2E_SMOKE_ONLY: ${{ matrix.e2e_type == 'dnr-required' && '' || '1' }}
           AAH_E2E_WORKERS: "3"
           AAH_SKIP_E2E_BUILD: "1"
         run: >

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -49,13 +49,34 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: default
+          # The default suite is sharded across runners with Playwright's
+          # native --shard flag to cut wall-clock time; each shard rebuilds
+          # nothing (AAH_SKIP_E2E_BUILD=1) because the extension is built in
+          # this job's own step.
+          - name: default-shard-1
             e2e_type: default
             build_variant: ""
-            timeout_minutes: 20
+            shard: 1
+            timeout_minutes: 8
+          - name: default-shard-2
+            e2e_type: default
+            build_variant: ""
+            shard: 2
+            timeout_minutes: 8
+          - name: default-shard-3
+            e2e_type: default
+            build_variant: ""
+            shard: 3
+            timeout_minutes: 8
+          - name: default-shard-4
+            e2e_type: default
+            build_variant: ""
+            shard: 4
+            timeout_minutes: 8
           - name: dnr-required
             e2e_type: dnr-required
             build_variant: dnr-required
+            shard: ""
             timeout_minutes: 5
 
     steps:
@@ -105,7 +126,9 @@ jobs:
           AAH_E2E_BUILD_VARIANT: ${{ matrix.build_variant }}
           AAH_E2E_WORKERS: "3"
           AAH_SKIP_E2E_BUILD: "1"
-        run: pnpm run e2e:${{ matrix.e2e_type }}
+        run: >
+          pnpm run e2e:${{ matrix.e2e_type }}
+          ${{ matrix.shard && format('--shard={0}/4', matrix.shard) || '' }}
 
       - name: Upload Playwright artifacts (failure)
         if: failure()

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -74,6 +74,10 @@ jobs:
             e2e_type: dnr-required
             build_variant: dnr-required
             shard: ""
+          - name: bookmarks-required
+            e2e_type: bookmarks-required
+            build_variant: bookmarks-required
+            shard: ""
     env:
       AAH_E2E_SHARD_TOTAL: "6"
 
@@ -119,10 +123,10 @@ jobs:
         run: pnpm exec playwright install --with-deps chromium
 
       - name: Run E2E smoke
-        timeout-minutes: ${{ matrix.e2e_type == 'dnr-required' && 5 || 8 }}
+        timeout-minutes: ${{ matrix.e2e_type == 'default' && 8 || 5 }}
         env:
           AAH_E2E_BUILD_VARIANT: ${{ matrix.build_variant }}
-          AAH_E2E_SMOKE_ONLY: ${{ matrix.e2e_type != 'dnr-required' && '1' || '' }}
+          AAH_E2E_SMOKE_ONLY: ${{ matrix.e2e_type == 'default' && '1' || '' }}
           AAH_E2E_WORKERS: "4"
           AAH_SKIP_E2E_BUILD: "1"
         run: >

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -70,18 +70,12 @@ jobs:
           - name: default-shard-6
             e2e_type: default
             shard: 6
-          - name: default-shard-7
-            e2e_type: default
-            shard: 7
-          - name: default-shard-8
-            e2e_type: default
-            shard: 8
           - name: dnr-required
             e2e_type: dnr-required
             build_variant: dnr-required
             shard: ""
     env:
-      AAH_E2E_SHARD_TOTAL: "8"
+      AAH_E2E_SHARD_TOTAL: "6"
 
     steps:
       - name: Checkout code

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -48,36 +48,39 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # The default suite is sharded across runners with Playwright's native
+        # --shard flag to cut wall-clock time; each shard builds nothing extra
+        # because the extension is built in this job's own step.
         include:
-          # The default suite is sharded across runners with Playwright's
-          # native --shard flag to cut wall-clock time; each shard rebuilds
-          # nothing (AAH_SKIP_E2E_BUILD=1) because the extension is built in
-          # this job's own step.
           - name: default-shard-1
             e2e_type: default
-            build_variant: ""
             shard: 1
-            timeout_minutes: 8
           - name: default-shard-2
             e2e_type: default
-            build_variant: ""
             shard: 2
-            timeout_minutes: 8
           - name: default-shard-3
             e2e_type: default
-            build_variant: ""
             shard: 3
-            timeout_minutes: 8
           - name: default-shard-4
             e2e_type: default
-            build_variant: ""
             shard: 4
-            timeout_minutes: 8
+          - name: default-shard-5
+            e2e_type: default
+            shard: 5
+          - name: default-shard-6
+            e2e_type: default
+            shard: 6
+          - name: default-shard-7
+            e2e_type: default
+            shard: 7
+          - name: default-shard-8
+            e2e_type: default
+            shard: 8
           - name: dnr-required
             e2e_type: dnr-required
             build_variant: dnr-required
             shard: ""
-            timeout_minutes: 5
+      shard-total: 8
 
     steps:
       - name: Checkout code
@@ -121,14 +124,14 @@ jobs:
         run: pnpm exec playwright install --with-deps chromium
 
       - name: Run E2E smoke
-        timeout-minutes: ${{ matrix.timeout_minutes }}
+        timeout-minutes: ${{ matrix.e2e_type == 'dnr-required' && 5 || 8 }}
         env:
           AAH_E2E_BUILD_VARIANT: ${{ matrix.build_variant }}
           AAH_E2E_WORKERS: "3"
           AAH_SKIP_E2E_BUILD: "1"
         run: >
           pnpm run e2e:${{ matrix.e2e_type }}
-          ${{ matrix.shard && format('--shard={0}/4', matrix.shard) || '' }}
+          ${{ matrix.shard && format('--shard={0}/{1}', matrix.shard, matrix.shard-total) || '' }}
 
       - name: Upload Playwright artifacts (failure)
         if: failure()

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -123,7 +123,7 @@ jobs:
         env:
           AAH_E2E_BUILD_VARIANT: ${{ matrix.build_variant }}
           AAH_E2E_SMOKE_ONLY: ${{ matrix.e2e_type != 'dnr-required' && '1' || '' }}
-          AAH_E2E_WORKERS: "3"
+          AAH_E2E_WORKERS: "4"
           AAH_SKIP_E2E_BUILD: "1"
         run: >
           pnpm run e2e:${{ matrix.e2e_type }}

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -122,7 +122,7 @@ jobs:
         timeout-minutes: ${{ matrix.e2e_type == 'dnr-required' && 5 || 8 }}
         env:
           AAH_E2E_BUILD_VARIANT: ${{ matrix.build_variant }}
-          AAH_E2E_SMOKE_ONLY: ${{ matrix.e2e_type == 'dnr-required' && '' || '1' }}
+          AAH_E2E_SMOKE_ONLY: ${{ matrix.e2e_type != 'dnr-required' && '1' || '' }}
           AAH_E2E_WORKERS: "3"
           AAH_SKIP_E2E_BUILD: "1"
         run: >

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -34,6 +34,9 @@ on:
       - ".github/workflows/e2e-smoke.yml"
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/e2e-smoke.yml
+++ b/.github/workflows/e2e-smoke.yml
@@ -42,9 +42,65 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  e2e-build:
+    name: E2E build (${{ matrix.name }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'skip-e2e') }}
+    continue-on-error: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'e2e-optional') }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # Each build variant is produced once and reused by its test jobs.
+        include:
+          - name: default
+            build_variant: default
+            extension_dir: chrome-mv3-test
+          - name: dnr-required
+            build_variant: dnr-required
+            extension_dir: chrome-mv3-test-dnr-required
+          - name: bookmarks-required
+            build_variant: bookmarks-required
+            extension_dir: chrome-mv3-test-bookmarks-required
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v5
+        with:
+          version: 10
+          run_install: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          cache: "pnpm"
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --prefer-offline
+
+      - name: Build E2E extension
+        env:
+          AAH_E2E_BUILD_VARIANT: ${{ matrix.build_variant }}
+        run: pnpm build:e2e
+
+      - name: Upload E2E extension
+        uses: actions/upload-artifact@v7
+        with:
+          name: e2e-extension-${{ matrix.build_variant }}
+          path: .output/${{ matrix.extension_dir }}
+          include-hidden-files: true
+          if-no-files-found: error
+          retention-days: 1
+
   e2e-smoke:
     name: E2E (${{ matrix.name }})
     runs-on: ubuntu-latest
+    needs: e2e-build
     timeout-minutes: 20
     if: ${{ github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'skip-e2e') }}
     continue-on-error: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'e2e-optional') }}
@@ -57,29 +113,43 @@ jobs:
         include:
           - name: default-shard-1
             e2e_type: default
+            build_variant: default
+            extension_dir: chrome-mv3-test
             shard: 1
           - name: default-shard-2
             e2e_type: default
+            build_variant: default
+            extension_dir: chrome-mv3-test
             shard: 2
           - name: default-shard-3
             e2e_type: default
+            build_variant: default
+            extension_dir: chrome-mv3-test
             shard: 3
           - name: default-shard-4
             e2e_type: default
+            build_variant: default
+            extension_dir: chrome-mv3-test
             shard: 4
           - name: default-shard-5
             e2e_type: default
+            build_variant: default
+            extension_dir: chrome-mv3-test
             shard: 5
           - name: default-shard-6
             e2e_type: default
+            build_variant: default
+            extension_dir: chrome-mv3-test
             shard: 6
           - name: dnr-required
             e2e_type: dnr-required
             build_variant: dnr-required
+            extension_dir: chrome-mv3-test-dnr-required
             shard: ""
           - name: bookmarks-required
             e2e_type: bookmarks-required
             build_variant: bookmarks-required
+            extension_dir: chrome-mv3-test-bookmarks-required
             shard: ""
     env:
       AAH_E2E_SHARD_TOTAL: "6"
@@ -104,10 +174,11 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --prefer-offline
 
-      - name: Build extension
-        env:
-          AAH_E2E_BUILD_VARIANT: ${{ matrix.build_variant }}
-        run: pnpm build:e2e
+      - name: Download E2E extension
+        uses: actions/download-artifact@v7
+        with:
+          name: e2e-extension-${{ matrix.build_variant }}
+          path: .output/${{ matrix.extension_dir }}
 
       - name: Get Playwright version
         id: playwright_version

--- a/e2e/accountBookmarkImportBrowserFlow.spec.ts
+++ b/e2e/accountBookmarkImportBrowserFlow.spec.ts
@@ -174,6 +174,29 @@ async function startBookmarkImportServer(): Promise<BookmarkImportServer> {
       return
     }
 
+    // Site detection probes these endpoints on scanned bookmark targets:
+    // - /api/user/info (VoAPI v2) and /api/v1/auth/me (Sub2API). Answer both
+    //   with JSON that matches no known site type instead of a bare 404,
+    //   whose browser console error trips the extension page guard.
+    if (
+      method === "GET" &&
+      (url.pathname === "/api/user/info" || url.pathname === "/api/v1/auth/me")
+    ) {
+      sendJson(200, { success: false, message: "unknown target" })
+      return
+    }
+
+    // The New API check-in provider reads GET /api/user/checkin?month=... after
+    // account import; report check-in disabled so no mutation is attempted and
+    // no console error is logged for the missing route.
+    if (method === "GET" && url.pathname === "/api/user/checkin") {
+      sendJson(200, {
+        success: true,
+        data: { enabled: false, stats: { checked_in_today: false } },
+      })
+      return
+    }
+
     if (method === "GET" && url.pathname === "/api/log/self") {
       sendJson(200, {
         success: true,
@@ -241,6 +264,20 @@ async function startFailedBookmarkImportServer(): Promise<BookmarkImportServer> 
       response.writeHead(200, { "content-type": "text/html" })
       response.end(
         "<!doctype html><html><head><title>Unsupported Import Target</title></head><body>Unsupported Import Target</body></html>",
+      )
+      return
+    }
+
+    // Site detection probes these endpoints (VoAPI v2 /api/user/info, Sub2API
+    // /api/v1/auth/me); return JSON that matches no known site type so the
+    // probes resolve to UNKNOWN without a console error.
+    if (
+      request.method === "GET" &&
+      (url.pathname === "/api/user/info" || url.pathname === "/api/v1/auth/me")
+    ) {
+      response.writeHead(200, { "content-type": "application/json" })
+      response.end(
+        JSON.stringify({ success: false, message: "unknown target" }),
       )
       return
     }

--- a/e2e/autoCheckinUncertainRecovery.spec.ts
+++ b/e2e/autoCheckinUncertainRecovery.spec.ts
@@ -196,6 +196,13 @@ test("reconciles a persisted uncertain check-in on retry re-entry without a dupl
   // The options page is the persisted-state re-entry point: it must render the
   // uncertain result before the background retry alarm is allowed to reconcile.
   await openAutoCheckinOptionsPage(page, extensionId)
+  // Wait for the initial status load to paint the results table before arming
+  // the retry alarm. Otherwise the alarm can fire, rewrite perAccount to
+  // "skipped", and its RunCompleted refresh can beat the first GetStatus
+  // response under CI worker contention, so the uncertain badge never paints.
+  await expect(
+    page.getByRole("table").getByText(ACCOUNT_NAME, { exact: true }),
+  ).toBeVisible()
   await expect(
     page.getByText("Pending confirmation", { exact: true }),
   ).toBeVisible()

--- a/e2e/scenarios/accountManualAdd.ts
+++ b/e2e/scenarios/accountManualAdd.ts
@@ -119,7 +119,7 @@ export async function refreshAccountRowsAndReadStorage(params: {
     await openAccountRowActionsMenu(row)
     await params.page
       .locator(
-        `[data-testid="${ACCOUNT_MANAGEMENT_TEST_IDS.rowRefreshMenuItem}"]:not([aria-disabled="true"])`,
+        `[role="menu"][data-state="open"] [data-testid="${ACCOUNT_MANAGEMENT_TEST_IDS.rowRefreshMenuItem}"]:not([aria-disabled="true"])`,
       )
       .click()
 

--- a/e2e/scenarios/accountManualAdd.ts
+++ b/e2e/scenarios/accountManualAdd.ts
@@ -118,7 +118,9 @@ export async function refreshAccountRowsAndReadStorage(params: {
     )
     await openAccountRowActionsMenu(row)
     await params.page
-      .getByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.rowRefreshMenuItem)
+      .locator(
+        `[data-testid="${ACCOUNT_MANAGEMENT_TEST_IDS.rowRefreshMenuItem}"]:not([aria-disabled="true"])`,
+      )
       .click()
 
     await waitForStoredAccountQuota({

--- a/e2e/utils/accountLifecycle.ts
+++ b/e2e/utils/accountLifecycle.ts
@@ -228,9 +228,17 @@ async function openKeyManagementPageFromAccountRow(params: {
   await row
     .getByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.rowMoreActionsButton)
     .click()
-  await params.page
-    .getByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.rowKeyManagementMenuItem)
-    .click()
+  // The row menu opens with an animation; wait for the item to be stable and
+  // visible after the Radix open transition instead of clicking mid-animation
+  // (previously flaky: "element is not stable" / "element was detached").
+  const keyManagementMenuItem = params.page.getByTestId(
+    ACCOUNT_MANAGEMENT_TEST_IDS.rowKeyManagementMenuItem,
+  )
+  await keyManagementMenuItem.waitFor({
+    state: "visible",
+    timeout: 10_000,
+  })
+  await keyManagementMenuItem.click()
 
   await expect(params.page).toHaveURL((url) => {
     return (

--- a/e2e/utils/accountLifecycle.ts
+++ b/e2e/utils/accountLifecycle.ts
@@ -224,21 +224,32 @@ async function openKeyManagementPageFromAccountRow(params: {
           baseUrl: requireAccountBaseUrl(params.baseUrl),
         })
 
-  await row.hover()
-  await row
-    .getByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.rowMoreActionsButton)
-    .click()
-  // The row menu opens with an animation; wait for the item to be stable and
-  // visible after the Radix open transition instead of clicking mid-animation
-  // (previously flaky: "element is not stable" / "element was detached").
-  const keyManagementMenuItem = params.page.getByTestId(
-    ACCOUNT_MANAGEMENT_TEST_IDS.rowKeyManagementMenuItem,
-  )
-  await keyManagementMenuItem.waitFor({
-    state: "visible",
-    timeout: 10_000,
-  })
-  await keyManagementMenuItem.click()
+  const openActionsMenu = async () => {
+    await row.hover()
+    await row
+      .getByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.rowMoreActionsButton)
+      .click({ timeout: 10_000 })
+  }
+
+  await openActionsMenu()
+  // Radix can replace the animated menu subtree under CI contention. Bound
+  // each click attempt so a detached item cannot consume the whole test, then
+  // reopen the idempotent navigation menu once with a fresh locator.
+  for (let attempt = 1; attempt <= 2; attempt += 1) {
+    try {
+      await params.page
+        .getByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.rowKeyManagementMenuItem)
+        .click({ timeout: 10_000 })
+      break
+    } catch (error) {
+      if (attempt === 2 || params.page.isClosed()) {
+        throw error
+      }
+
+      await params.page.keyboard.press("Escape").catch(() => undefined)
+      await openActionsMenu()
+    }
+  }
 
   await expect(params.page).toHaveURL((url) => {
     return (

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "e2e": "playwright test",
     "e2e:default": "playwright test",
     "e2e:dnr-required": "playwright test e2e/dnrRequired --project=chromium --workers=1 --timeout=120000",
+    "e2e:bookmarks-required": "playwright test e2e/accountBookmarkImportBrowserFlow --project=chromium",
     "e2e:real-site": "node scripts/real-site-e2e-cli.mjs all",
     "e2e:real-site:account": "node scripts/real-site-e2e-cli.mjs account",
     "e2e:real-site:category": "node scripts/real-site-e2e-cli.mjs",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -14,8 +14,22 @@ const workers =
       ? 1
       : 4
 
+// The default smoke suite only covers specs that can actually run without
+// per-target environment secrets or a dedicated manifest build variant:
+// - e2e/realSite/** skips at runtime without real-site credentials and is run
+//   by the scheduled Real-Site E2E workflow with its own matrix.
+// - e2e/dnrRequired/** skips outside the dnr-required build variant and is run
+//   by the e2e:dnr-required script in the same workflow.
+// Excluding them keeps shard distribution even instead of assigning runners a
+// block of guaranteed skips.
+const smokeOnlyTestIgnore =
+  process.env.AAH_E2E_SMOKE_ONLY === "1"
+    ? [/e2e[\\/]realSite/u, /e2e[\\/]dnrRequired/u]
+    : []
+
 export default defineConfig({
   testDir: "./e2e",
+  testIgnore: smokeOnlyTestIgnore,
   projects: [
     {
       name: "build",


### PR DESCRIPTION
## Summary

Optimizes the E2E smoke workflow wall-clock time based on measured CI results (6 remote test iterations on this branch):

| Configuration | Total run duration | Slowest shard |
|---|---|---|
| Baseline (single runner, main) | 8m41s – 10m31s (avg ~9.5m) | 187 passed / 7.9m |
| 4 shards | 5m42s | 57 passed / 4.3m |
| 8 shards (unbalanced: realSite skips pooled in one shard) | 3m49s | 35 passed / 2.4m |
| **6 shards + env-gated specs excluded (final)** | **3m51s** | 35 passed / 2.4m, no skip-waste |

## Changes

- Split the default E2E suite across **6 parallel runners** using Playwright's native `--shard=N/6` (same pattern as Vitest sharding in `test.yml`); `AAH_E2E_SHARD_TOTAL` job env feeds the shard expression.
- `playwright.config.ts`: `AAH_E2E_SMOKE_ONLY=1` sets `testIgnore` for `e2e/realSite/**` (40 tests that always skip without real-site secrets; covered by the scheduled Real-Site workflow) and `e2e/dnrRequired/**` (gated to the dnr-required build variant). This stopped Playwright from assigning a runner a block of guaranteed skips (30 of 39 skipped in one shard pre-fix).
- The smoke workflow sets `AAH_E2E_SMOKE_ONLY` for default shards only; the dnr-required shard keeps its directory.
- Per-step timeouts: default shards 8 min, dnr-required 5 min (job-level cap stays 20 min).

## Notes

- Wall-clock is now dominated by fixed per-job setup (~1.7m install/build/browser) plus the slowest shard (~2.4m). Beyond ~6 shards there is no further gain.
- One pre-existing flaky test observed during testing: `autoCheckinUncertainRecovery.spec.ts:67` needed a retry in one run; unrelated to this change.
- Follow-up candidates documented in comments: bookmarks-required variant has never had CI wiring (3 dead e2e tests since #1124), and one of them fails locally due to the VoAPI v2 `/api/user/info` detection probe added in #1135 tripping the console-error guard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded end-to-end coverage with parallel smoke-test shards and dedicated bookmark-import and DNR-required suites.
  * Added a smoke-only testing mode for faster default validation.
  * Improved reliability for bookmark imports, automatic check-ins, account key-management, and manual account updates.
  * Strengthened handling of asynchronous page updates, menus, and navigation.
  * Added a dedicated command for running bookmark-import browser tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->