### PR TITLE
fix(settings): improve responsive card layouts

### DIFF
--- a/e2e/basicSettingsCommonFlows.spec.ts
+++ b/e2e/basicSettingsCommonFlows.spec.ts
@@ -265,3 +265,90 @@ test("updates toolbar action behavior from settings into the live extension acti
     await expectNativeSidePanelActionClickState(serviceWorker, false)
   }
 })
+
+test("uses control-specific layouts at narrow card widths", async ({
+  extensionId,
+  page,
+}) => {
+  await page.setViewportSize({ width: 560, height: 900 })
+  await page.goto(
+    `chrome-extension://${extensionId}/${OPTIONS_PAGE_PATH}#${MENU_ITEM_IDS.BASIC}`,
+  )
+  await waitForExtensionRoot(page)
+
+  const card = page.locator("#appearance-theme-mode")
+  const content = card.locator('[data-slot="card-item-content"]')
+
+  await expect(card).toBeVisible()
+  await expect
+    .poll(async () =>
+      content.evaluate((element) => getComputedStyle(element).flexDirection),
+    )
+    .toBe("column")
+
+  const narrowLayout = await content.evaluate((element) => {
+    const control = element.querySelector<HTMLElement>(
+      '[data-slot="card-item-control"]',
+    )
+    if (!control) throw new Error("Card item control is missing")
+
+    const contentRect = element.getBoundingClientRect()
+    const controlRect = control.getBoundingClientRect()
+    const renderedControl = control.firstElementChild
+    if (!(renderedControl instanceof HTMLElement)) {
+      throw new Error("Rendered card item control is missing")
+    }
+    const renderedControlRect = renderedControl.getBoundingClientRect()
+
+    return {
+      renderedControlRightDifference: Math.abs(
+        renderedControlRect.right - contentRect.right,
+      ),
+      controlWidthDifference: Math.abs(controlRect.width - contentRect.width),
+    }
+  })
+
+  expect(narrowLayout.renderedControlRightDifference).toBeLessThanOrEqual(1)
+  expect(narrowLayout.controlWidthDifference).toBeLessThanOrEqual(1)
+
+  const switchCard = page.locator("#changelog-on-update-toggle")
+  const switchContent = switchCard.locator('[data-slot="card-item-content"]')
+
+  await expect(switchCard).toBeVisible()
+  await expect
+    .poll(async () =>
+      switchContent.evaluate(
+        (element) => getComputedStyle(element).flexDirection,
+      ),
+    )
+    .toBe("row")
+
+  const switchLayout = await switchContent.evaluate((element) => {
+    const control = element.querySelector<HTMLElement>(
+      '[data-slot="card-item-control"]',
+    )
+    if (!control) throw new Error("Switch control is missing")
+
+    const contentRect = element.getBoundingClientRect()
+    const controlRect = control.getBoundingClientRect()
+
+    return {
+      rightDifference: Math.abs(controlRect.right - contentRect.right),
+      verticalCenterDifference: Math.abs(
+        controlRect.top +
+          controlRect.height / 2 -
+          (contentRect.top + contentRect.height / 2),
+      ),
+    }
+  })
+
+  expect(switchLayout.rightDifference).toBeLessThanOrEqual(1)
+  expect(switchLayout.verticalCenterDifference).toBeLessThanOrEqual(1)
+
+  await page.setViewportSize({ width: 1400, height: 900 })
+  await expect
+    .poll(async () =>
+      content.evaluate((element) => getComputedStyle(element).flexDirection),
+    )
+    .toBe("row")
+})

--- a/src/components/ui/CardItem.tsx
+++ b/src/components/ui/CardItem.tsx
@@ -80,7 +80,10 @@ const CardItem = React.forwardRef<HTMLDivElement, CardSectionProps>(
         {...props}
       >
         {children || (
-          <>
+          <div
+            data-slot="card-item-content"
+            className="flex w-full flex-col items-start justify-between gap-4 text-left has-[>[data-slot=card-item-control]>[data-slot=switch]]:flex-row has-[>[data-slot=card-item-control]>[data-slot=switch]]:items-center [@container(min-width:42rem)]:flex-row [@container(min-width:42rem)]:items-center"
+          >
             <div className="flex w-full min-w-0 flex-1 items-center gap-3 [@container(min-width:42rem)]:w-auto">
               {icon && (
                 <div className="dark:bg-dark-bg-tertiary shrink-0 rounded-lg bg-gray-100 p-1 transition-colors sm:p-2">
@@ -113,15 +116,16 @@ const CardItem = React.forwardRef<HTMLDivElement, CardSectionProps>(
             </div>
             {rightContent && (
               <div
+                data-slot="card-item-control"
                 className={cn(
-                  "w-full min-w-0 flex-1 sm:ml-auto sm:w-auto sm:flex-none",
+                  "flex w-full min-w-0 flex-1 justify-end has-[>[data-slot=switch]]:ml-auto has-[>[data-slot=switch]]:w-auto has-[>[data-slot=switch]]:flex-none [@container(min-width:42rem)]:ml-auto [@container(min-width:42rem)]:block [@container(min-width:42rem)]:w-auto [@container(min-width:42rem)]:flex-none",
                   rightContentClassName,
                 )}
               >
                 {rightContent}
               </div>
             )}
-          </>
+          </div>
         )}
       </Component>
     )

--- a/src/features/BasicSettings/components/tabs/Notifications/TaskNotificationSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/Notifications/TaskNotificationSettings.tsx
@@ -92,7 +92,10 @@ function NotificationSettingItem({
   return (
     <CardItem id={id} className="items-stretch sm:items-stretch">
       <div className="w-full space-y-4">
-        <div className="flex flex-col gap-3 [@container(min-width:42rem)]:flex-row [@container(min-width:42rem)]:items-center [@container(min-width:42rem)]:justify-between">
+        <div
+          data-slot="notification-setting-content"
+          className="flex flex-col gap-3 has-[>[data-slot=notification-setting-actions]>[data-slot=switch]]:flex-row has-[>[data-slot=notification-setting-actions]>[data-slot=switch]]:items-center has-[>[data-slot=notification-setting-actions]>[data-slot=switch]]:justify-between [@container(min-width:42rem)]:flex-row [@container(min-width:42rem)]:items-center [@container(min-width:42rem)]:justify-between"
+        >
           <div className="min-w-0 flex-1 space-y-1">
             {title && (
               <Label className="text-base font-semibold tracking-tight">
@@ -106,7 +109,10 @@ function NotificationSettingItem({
             )}
           </div>
           {actions && (
-            <div className="flex w-full flex-wrap items-center gap-3 [@container(min-width:42rem)]:w-auto [@container(min-width:42rem)]:shrink-0">
+            <div
+              data-slot="notification-setting-actions"
+              className="flex w-full flex-wrap items-center justify-end gap-3 has-[>[data-slot=switch]]:w-auto has-[>[data-slot=switch]]:shrink-0 [@container(min-width:42rem)]:w-auto [@container(min-width:42rem)]:shrink-0"
+            >
               {actions}
             </div>
           )}

--- a/src/features/BasicSettings/components/tabs/Refresh/ProtectionBypassDevTrigger.tsx
+++ b/src/features/BasicSettings/components/tabs/Refresh/ProtectionBypassDevTrigger.tsx
@@ -292,7 +292,7 @@ export function ProtectionBypassDevTrigger() {
     <CardItem
       title={t("refresh.shieldDevTriggerTitle")}
       description={t("refresh.shieldDevTriggerDescription")}
-      rightContentClassName="sm:flex-1"
+      rightContentClassName="[@container(min-width:42rem)]:flex-1"
       rightContent={
         <div
           data-testid="shield-dev-trigger-form"

--- a/src/features/BasicSettings/components/tabs/Refresh/ShieldSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/Refresh/ShieldSettings.tsx
@@ -214,7 +214,7 @@ export default function ShieldSettings() {
             id={SHIELD_SETTINGS_TARGET_IDS.method}
             title={t("refresh.shieldMethodTitle")}
             description={t("refresh.shieldMethodDesc")}
-            rightContentClassName="sm:flex-1"
+            rightContentClassName="[@container(min-width:42rem)]:flex-1"
             rightContent={
               <div className="flex flex-col items-stretch space-y-2 text-left">
                 <ResponsiveButtonGroup

--- a/tests/components/CardItem.test.tsx
+++ b/tests/components/CardItem.test.tsx
@@ -2,9 +2,10 @@ import { render, screen } from "@testing-library/react"
 import { describe, expect, it } from "vitest"
 
 import { CardItem } from "~/components/ui/CardItem"
+import { Switch } from "~/components/ui/Switch"
 
 describe("CardItem", () => {
-  it("keeps settings rows horizontal on wider viewports while allowing child content to respond to container width", () => {
+  it("stacks non-switch settings content until the card container is wide enough", () => {
     const { container } = render(
       <CardItem
         title="Title"
@@ -13,16 +14,52 @@ describe("CardItem", () => {
       />,
     )
 
-    expect(container.firstElementChild).toHaveClass(
-      "[container-type:inline-size]",
+    const cardItem = container.firstElementChild
+    const contentLayout = container.querySelector(
+      '[data-slot="card-item-content"]',
+    )
+
+    expect(cardItem).toHaveClass("[container-type:inline-size]")
+    expect(contentLayout).toHaveClass(
       "flex-col",
-      "sm:flex-row",
+      "items-start",
+      "text-left",
+      "[@container(min-width:42rem)]:flex-row",
+      "[@container(min-width:42rem)]:items-center",
     )
     expect(screen.getByTestId("right-content").parentElement).toHaveClass(
+      "flex",
       "w-full",
-      "sm:ml-auto",
-      "sm:w-auto",
-      "sm:flex-none",
+      "justify-end",
+      "[@container(min-width:42rem)]:ml-auto",
+      "[@container(min-width:42rem)]:block",
+      "[@container(min-width:42rem)]:w-auto",
+      "[@container(min-width:42rem)]:flex-none",
+    )
+  })
+
+  it("keeps a direct switch on the right in an inline layout", () => {
+    const { container } = render(
+      <CardItem
+        title="Title"
+        description="Description"
+        rightContent={<Switch checked={false} onChange={() => undefined} />}
+      />,
+    )
+
+    const contentLayout = container.querySelector(
+      '[data-slot="card-item-content"]',
+    )
+    const control = container.querySelector('[data-slot="card-item-control"]')
+
+    expect(contentLayout).toHaveClass(
+      "has-[>[data-slot=card-item-control]>[data-slot=switch]]:flex-row",
+      "has-[>[data-slot=card-item-control]>[data-slot=switch]]:items-center",
+    )
+    expect(control).toHaveClass(
+      "has-[>[data-slot=switch]]:ml-auto",
+      "has-[>[data-slot=switch]]:w-auto",
+      "has-[>[data-slot=switch]]:flex-none",
     )
   })
 
@@ -31,12 +68,14 @@ describe("CardItem", () => {
       <CardItem
         title="Title"
         rightContent={<span data-testid="right-content">Right</span>}
-        rightContentClassName="sm:flex-1 [@container(min-width:42rem)]:flex-none"
+        rightContentClassName="[@container(min-width:42rem)]:flex-1"
       />,
     )
 
     expect(screen.getByTestId("right-content").parentElement).toHaveClass(
-      "sm:flex-1",
+      "[@container(min-width:42rem)]:flex-1",
+    )
+    expect(screen.getByTestId("right-content").parentElement).not.toHaveClass(
       "[@container(min-width:42rem)]:flex-none",
     )
   })

--- a/tests/entrypoints/options/ShieldSettings.test.tsx
+++ b/tests/entrypoints/options/ShieldSettings.test.tsx
@@ -298,7 +298,7 @@ describe("ShieldSettings", () => {
 
     // JSDOM cannot resolve container-query geometry, so protect the three
     // constraints that prevent max-content buttons from crushing the copy.
-    expect(rightPane).toHaveClass("sm:flex-1")
+    expect(rightPane).toHaveClass("[@container(min-width:42rem)]:flex-1")
     expect(rightPane).not.toHaveClass("[@container(min-width:42rem)]:flex-none")
     expect(methodLayout).toHaveClass("items-stretch")
     expect(methodLayout).not.toHaveClass(
@@ -852,7 +852,7 @@ describe("ShieldSettings", () => {
 
     // JSDOM cannot calculate container-query widths, so protect the
     // shrinkability constraints exercised by the headed browser smoke.
-    expect(rightPane).toHaveClass("sm:flex-1")
+    expect(rightPane).toHaveClass("[@container(min-width:42rem)]:flex-1")
     expect(form).toHaveClass("min-w-0")
     expect(form).not.toHaveClass("[@container(min-width:42rem)]:min-w-[32rem]")
   })

--- a/tests/features/BasicSettings/TaskNotificationSettings.test.tsx
+++ b/tests/features/BasicSettings/TaskNotificationSettings.test.tsx
@@ -181,7 +181,7 @@ describe("TaskNotificationSettings", () => {
   })
 
   it("uses container-width responsive layout for notification row actions", async () => {
-    render(<TaskNotificationSettings />, {
+    const { container } = render(<TaskNotificationSettings />, {
       withUserPreferencesProvider: false,
       withThemeProvider: false,
     })
@@ -201,8 +201,27 @@ describe("TaskNotificationSettings", () => {
     expect(actionBar).toHaveClass(
       "w-full",
       "flex-wrap",
+      "justify-end",
       "[@container(min-width:42rem)]:w-auto",
       "[@container(min-width:42rem)]:shrink-0",
+    )
+
+    const taskRow = container.querySelector("#task-notifications-autoCheckin")
+    const taskContent = taskRow?.querySelector(
+      '[data-slot="notification-setting-content"]',
+    )
+    const taskActions = taskRow?.querySelector(
+      '[data-slot="notification-setting-actions"]',
+    )
+
+    expect(taskContent).toHaveClass(
+      "has-[>[data-slot=notification-setting-actions]>[data-slot=switch]]:flex-row",
+      "has-[>[data-slot=notification-setting-actions]>[data-slot=switch]]:items-center",
+      "has-[>[data-slot=notification-setting-actions]>[data-slot=switch]]:justify-between",
+    )
+    expect(taskActions).toHaveClass(
+      "has-[>[data-slot=switch]]:w-auto",
+      "has-[>[data-slot=switch]]:shrink-0",
     )
   })
 


### PR DESCRIPTION
## Summary
- stack settings copy and non-switch controls according to the card container width, preventing narrow panes from squeezing text vertically
- keep Switch controls right-aligned and vertically centered while preserving the existing wide-screen layout
- apply the same responsive behavior to notification rows and wide Shield setting controls

## Testing
- 63 focused Vitest tests passed
- Chromium narrow/wide layout regression passed (2 Playwright checks including the build setup)
- production Chromium build passed
- TypeScript compile and Knip checks passed
- Prettier and git diff checks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved responsive layouts for settings cards and notification rows.
  - Theme controls now stack and expand appropriately on narrow screens, while switches remain horizontally aligned and right-aligned.
  - Updated settings panels to transition correctly between stacked and horizontal layouts at suitable container widths.

- **Tests**
  - Added end-to-end coverage for responsive card behavior.
  - Expanded component and settings tests to verify control alignment, sizing, and responsive layout changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->