### PR TITLE
perf(popup): add startup skeleton and defer heavy export/analytics assets

### DIFF
--- a/src/entrypoints/popup/index.html
+++ b/src/entrypoints/popup/index.html
@@ -14,7 +14,69 @@
     />
   </head>
   <body>
-    <div id="root"></div>
+    <div id="root">
+      <!-- Static first-paint skeleton; replaced when React mounts into #root.
+           Covers the i18n/storage startup window that renders a blank popup. -->
+      <style>
+        .popup-skeleton {
+          display: flex;
+          flex-direction: column;
+          gap: 12px;
+          box-sizing: border-box;
+          width: 100%;
+          height: 100vh;
+          padding: 16px;
+          background: #ffffff;
+        }
+        @media (prefers-color-scheme: dark) {
+          .popup-skeleton {
+            background: #111827;
+          }
+          .popup-skeleton__bar {
+            background: #1f2937;
+          }
+        }
+        .popup-skeleton__bar {
+          border-radius: 8px;
+          background: #f3f4f6;
+          animation: popup-skeleton-pulse 1.5s ease-in-out infinite;
+        }
+        .popup-skeleton__header {
+          height: 28px;
+          width: 60%;
+        }
+        .popup-skeleton__tabs {
+          height: 56px;
+          width: 100%;
+        }
+        .popup-skeleton__row {
+          height: 64px;
+          width: 100%;
+        }
+        @keyframes popup-skeleton-pulse {
+          0%,
+          100% {
+            opacity: 1;
+          }
+          50% {
+            opacity: 0.55;
+          }
+        }
+      </style>
+      <div class="popup-skeleton" aria-hidden="true">
+        <div class="popup-skeleton__bar popup-skeleton__header"></div>
+        <div class="popup-skeleton__bar popup-skeleton__tabs"></div>
+        <div class="popup-skeleton__bar popup-skeleton__row"></div>
+        <div
+          class="popup-skeleton__bar popup-skeleton__row"
+          style="animation-delay: 0.15s"
+        ></div>
+        <div
+          class="popup-skeleton__bar popup-skeleton__row"
+          style="animation-delay: 0.3s"
+        ></div>
+      </div>
+    </div>
     <script type="module" src="main.tsx"></script>
   </body>
 </html>

--- a/src/features/AccountManagement/components/CopyKeyDialog/RuntimeKeyActionControls.tsx
+++ b/src/features/AccountManagement/components/CopyKeyDialog/RuntimeKeyActionControls.tsx
@@ -1,5 +1,12 @@
 import { Check, Copy } from "lucide-react"
-import { useEffect, useMemo, useState, type MouseEvent } from "react"
+import {
+  lazy,
+  Suspense,
+  useEffect,
+  useMemo,
+  useState,
+  type MouseEvent,
+} from "react"
 import { useTranslation } from "react-i18next"
 
 import { ClaudeCodeRouterImportDialog } from "~/components/ClaudeCodeRouterImportDialog"
@@ -11,12 +18,10 @@ import {
   ExportActionsMenu,
 } from "~/components/ExportActionsMenu"
 import { KelivoExportDialog } from "~/components/KelivoExportDialog"
-import { KiloCodeExportDialog } from "~/components/KiloCodeExportDialog"
 import { ManagedSiteImportButton } from "~/components/ManagedSiteImportButton"
 import { IconButton } from "~/components/ui"
 import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
 import { ACCOUNT_MANAGEMENT_TEST_IDS } from "~/features/AccountManagement/testIds"
-import { KiloCodeProfileExportDialog } from "~/features/ApiCredentialProfiles/components/KiloCodeProfileExportDialog"
 import {
   createCliProxyExportPayload,
   createExportAccount,
@@ -33,7 +38,6 @@ import {
 } from "~/services/accounts/accountRuntimeKeys"
 import { resolveDisplayAccountRuntimeKeySecret } from "~/services/accounts/utils/apiServiceRequest"
 import { buildApiCredentialProfileName } from "~/services/apiCredentialProfiles/accountTokenProfileName"
-import { OpenInCherryStudio } from "~/services/integrations/cherryStudio"
 import type { KelivoProviderExportInput } from "~/services/integrations/kelivo"
 import { getManagedSiteLabel } from "~/services/managedSites/utils/managedSite"
 import { startProductAnalyticsAction } from "~/services/productAnalytics/actions"
@@ -60,6 +64,20 @@ interface RuntimeKeyActionControlsProps {
   account: DisplaySiteData
   onOpenCCSwitchDialog?: (token: ApiToken, account: DisplaySiteData) => void
 }
+
+// Kilo Code export dialogs and the Cherry Studio integration are only needed
+// after the user picks those export targets; keep their bundles out of the
+// popup's first-paint import graph.
+const LazyKiloCodeExportDialog = lazy(() =>
+  import("~/components/KiloCodeExportDialog").then((m) => ({
+    default: m.KiloCodeExportDialog,
+  })),
+)
+const LazyKiloCodeProfileExportDialog = lazy(() =>
+  import(
+    "~/features/ApiCredentialProfiles/components/KiloCodeProfileExportDialog"
+  ).then((m) => ({ default: m.KiloCodeProfileExportDialog })),
+)
 
 const buildServiceCredentialExportProfile = (
   account: DisplaySiteData,
@@ -147,6 +165,9 @@ export function RuntimeKeyActionControls({
     })
 
     try {
+      const { OpenInCherryStudio } = await import(
+        "~/services/integrations/cherryStudio"
+      )
       if (serviceCredentialProfile) {
         OpenInCherryStudio(
           createExportAccount(serviceCredentialProfile),
@@ -320,25 +341,29 @@ export function RuntimeKeyActionControls({
 
     if (serviceCredentialProfile) {
       return (
-        <KiloCodeProfileExportDialog
-          isOpen={true}
-          onClose={() => setIsKiloCodeDialogOpen(false)}
-          profile={serviceCredentialProfile}
-        />
+        <Suspense fallback={null}>
+          <LazyKiloCodeProfileExportDialog
+            isOpen={true}
+            onClose={() => setIsKiloCodeDialogOpen(false)}
+            profile={serviceCredentialProfile}
+          />
+        </Suspense>
       )
     }
 
     if (!accountToken) return null
 
     return (
-      <KiloCodeExportDialog
-        isOpen={true}
-        onClose={() => setIsKiloCodeDialogOpen(false)}
-        initialSelectedSiteIds={[account.id]}
-        initialSelectedTokenIdsBySite={{
-          [account.id]: [`${accountToken.id}`],
-        }}
-      />
+      <Suspense fallback={null}>
+        <LazyKiloCodeExportDialog
+          isOpen={true}
+          onClose={() => setIsKiloCodeDialogOpen(false)}
+          initialSelectedSiteIds={[account.id]}
+          initialSelectedTokenIdsBySite={{
+            [account.id]: [`${accountToken.id}`],
+          }}
+        />
+      </Suspense>
     )
   }
 

--- a/src/services/productAnalytics/client.ts
+++ b/src/services/productAnalytics/client.ts
@@ -1,4 +1,4 @@
-import posthog, { type Properties } from "posthog-js/dist/module.no-external"
+import type { Properties } from "posthog-js/dist/module.no-external"
 
 import { getExtensionVersion } from "~/utils/browser/browserApi"
 import { detectBrowserFamily } from "~/utils/browser/userAgent"
@@ -12,6 +12,12 @@ import {
 } from "./contracts"
 import { productAnalyticsPreferences } from "./preferences"
 import { sanitizeProductAnalyticsEvent } from "./privacy"
+
+/**
+ * Lazily loaded PostHog SDK instance type.
+ */
+type PostHogClient =
+  (typeof import("posthog-js/dist/module.no-external"))["default"]
 
 const logger = createLogger("ProductAnalyticsClient")
 const DEVELOPMENT_DISTINCT_ID = "analytics-development"
@@ -35,6 +41,19 @@ type ProductAnalyticsPolicyPayload = {
 
 let initialized = false
 
+let posthogClientPromise: Promise<PostHogClient> | null = null
+
+/**
+ * Loads the PostHog SDK on first capture instead of at UI startup so the
+ * analytics bundle stays out of every surface's first-paint import graph.
+ */
+function loadPostHogClient(): Promise<PostHogClient> {
+  posthogClientPromise ??= import("posthog-js/dist/module.no-external").then(
+    (module) => module.default,
+  )
+  return posthogClientPromise
+}
+
 /**
  * Reads build-time PostHog configuration and disables analytics when incomplete.
  */
@@ -48,10 +67,14 @@ function readConfig(): PostHogConfig | null {
 /**
  * Initializes the bundled PostHog client once with passive collection disabled.
  */
-function initializePostHog(config: PostHogConfig, distinctId: string) {
+function initializePostHog(
+  client: PostHogClient,
+  config: PostHogConfig,
+  distinctId: string,
+) {
   if (initialized) return
 
-  posthog.init(config.projectToken, {
+  client.init(config.projectToken, {
     api_host: config.host,
     autocapture: false,
     capture_pageview: false,
@@ -116,8 +139,10 @@ function normalizeStringList(value: unknown): string[] {
 /**
  * Reads the optional PostHog-hosted analytics policy payload.
  */
-function readAnalyticsPolicyPayload(): ProductAnalyticsPolicyPayload {
-  const payload = posthog.getFeatureFlagPayload(
+function readAnalyticsPolicyPayload(
+  client: PostHogClient,
+): ProductAnalyticsPolicyPayload {
+  const payload = client.getFeatureFlagPayload(
     PRODUCT_ANALYTICS_POLICY_FLAG_KEY,
   )
   if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
@@ -136,10 +161,11 @@ function readAnalyticsPolicyPayload(): ProductAnalyticsPolicyPayload {
  * Checks whether the sanitized event is suppressed by the remote policy.
  */
 function isDisabledByPolicy(
+  client: PostHogClient,
   eventName: ProductAnalyticsEventName,
   properties: Properties,
 ): boolean {
-  const policy = readAnalyticsPolicyPayload()
+  const policy = readAnalyticsPolicyPayload(client)
   if (policy.disabledEvents?.includes(eventName)) return true
 
   const featureId =
@@ -187,15 +213,16 @@ async function captureWithAnonymousId(
 ): Promise<boolean> {
   const captured = await productAnalyticsPreferences.withAnonymousIdIfEnabled(
     async (anonymousId) => {
+      const client = await loadPostHogClient()
       const distinctId = resolveDistinctId(anonymousId)
 
-      initializePostHog(capture.config, distinctId)
+      initializePostHog(client, capture.config, distinctId)
 
-      if (isDisabledByPolicy(eventName, capture.properties)) {
+      if (isDisabledByPolicy(client, eventName, capture.properties)) {
         return false
       }
 
-      posthog.capture(eventName, {
+      client.capture(eventName, {
         ...buildSharedContext(),
         ...capture.properties,
       })

--- a/tests/features/AccountManagement/components/RuntimeKeyActionControls.deferredModules.test.tsx
+++ b/tests/features/AccountManagement/components/RuntimeKeyActionControls.deferredModules.test.tsx
@@ -73,41 +73,37 @@ vi.mock("~/components/KelivoExportDialog", () => ({
   KelivoExportDialog: () => null,
 }))
 
-// Load counters prove each deferred module stays unloaded until its action
-// selects it; the mocked component factories prove the resolved module renders.
+// Module-factory counters prove each deferred import stays unresolved until its
+// action selects it; component spies prove the resolved exports still run.
 const kiloCodeModuleLoadMock = vi.hoisted(() => ({ count: 0 }))
 const kiloCodeProfileModuleLoadMock = vi.hoisted(() => ({ count: 0 }))
 const cherryStudioModuleLoadMock = vi.hoisted(() => ({ count: 0 }))
 
-vi.mock("~/components/KiloCodeExportDialog", () => ({
-  get KiloCodeExportDialog() {
-    return (props: unknown) => {
-      kiloCodeModuleLoadMock.count += 1
-      return kiloCodeExportDialogMock(props) ?? null
-    }
-  },
-}))
+vi.mock("~/components/KiloCodeExportDialog", () => {
+  kiloCodeModuleLoadMock.count += 1
+  return {
+    KiloCodeExportDialog: (props: unknown) =>
+      kiloCodeExportDialogMock(props) ?? null,
+  }
+})
 
 vi.mock(
   "~/features/ApiCredentialProfiles/components/KiloCodeProfileExportDialog",
-  () => ({
-    get KiloCodeProfileExportDialog() {
-      return (props: unknown) => {
-        kiloCodeProfileModuleLoadMock.count += 1
-        return kiloCodeProfileExportDialogMock(props) ?? null
-      }
-    },
-  }),
-)
-
-vi.mock("~/services/integrations/cherryStudio", () => ({
-  get OpenInCherryStudio() {
-    return (...args: unknown[]) => {
-      cherryStudioModuleLoadMock.count += 1
-      return openInCherryStudioMock(...args)
+  () => {
+    kiloCodeProfileModuleLoadMock.count += 1
+    return {
+      KiloCodeProfileExportDialog: (props: unknown) =>
+        kiloCodeProfileExportDialogMock(props) ?? null,
     }
   },
-}))
+)
+
+vi.mock("~/services/integrations/cherryStudio", () => {
+  cherryStudioModuleLoadMock.count += 1
+  return {
+    OpenInCherryStudio: (...args: unknown[]) => openInCherryStudioMock(...args),
+  }
+})
 
 vi.mock(
   "~/services/accounts/utils/apiServiceRequest",
@@ -225,6 +221,8 @@ describe("RuntimeKeyActionControls deferred module loading", () => {
   })
 
   it("renders the service-credential profile dialog from its deferred module", async () => {
+    expect(kiloCodeProfileModuleLoadMock.count).toBe(0)
+
     const sharedChatAccount = {
       ...ACCOUNT,
       id: "sharedchat-account",

--- a/tests/features/AccountManagement/components/RuntimeKeyActionControls.deferredModules.test.tsx
+++ b/tests/features/AccountManagement/components/RuntimeKeyActionControls.deferredModules.test.tsx
@@ -1,0 +1,293 @@
+import type { UserEvent } from "@testing-library/user-event"
+import type { ReactNode } from "react"
+import { Suspense } from "react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { RuntimeKeyActionControls } from "~/features/AccountManagement/components/CopyKeyDialog/RuntimeKeyActionControls"
+import {
+  buildDisplayAccountTokenRuntimeKey,
+  buildServiceCredentialRuntimeKey,
+} from "~/services/accounts/accountRuntimeKeys"
+import type { AccountRuntimeKey } from "~/services/accounts/accountRuntimeKeys"
+import { AuthTypeEnum } from "~/types"
+import { render, screen, waitFor } from "~~/tests/test-utils/render"
+
+const {
+  kiloCodeExportDialogMock,
+  kiloCodeProfileExportDialogMock,
+  openInCherryStudioMock,
+  userPreferencesContextMock,
+} = vi.hoisted(() => ({
+  kiloCodeExportDialogMock: vi.fn(),
+  kiloCodeProfileExportDialogMock: vi.fn(),
+  openInCherryStudioMock: vi.fn(),
+  userPreferencesContextMock: {
+    managedSiteType: "new-api",
+    claudeCodeRouterBaseUrl: "https://router.example.invalid",
+    claudeCodeRouterApiKey: "ccr-management-key",
+    cliProxyBaseUrl: "https://cliproxy.example.invalid",
+    cliProxyManagementKey: "cliproxy-management-key",
+    markGatewayGuidanceOnboardingCompleted: vi.fn(),
+  },
+}))
+
+vi.mock("~/contexts/UserPreferencesContext", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("~/contexts/UserPreferencesContext")>()
+  return {
+    ...actual,
+    UserPreferencesProvider: ({ children }: { children: ReactNode }) =>
+      children,
+    useUserPreferencesContext: () => userPreferencesContextMock,
+  }
+})
+
+vi.mock("~/components/dialogs/ChannelDialog", () => ({
+  ChannelDialogProvider: ({ children }: { children: ReactNode }) => children,
+  useChannelDialog: () => ({
+    openWithAccount: vi.fn(),
+    openWithCredentials: vi.fn(),
+  }),
+}))
+
+vi.mock("~/components/ManagedSiteImportButton", () => ({
+  ManagedSiteImportButton: () => null,
+}))
+
+vi.mock("~/components/ExportActionsMenu", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("~/components/ExportActionsMenu")>()
+  return actual
+})
+
+vi.mock("~/components/ClaudeCodeRouterImportDialog", () => ({
+  ClaudeCodeRouterImportDialog: () => null,
+}))
+vi.mock("~/components/CliProxyExportDialog", () => ({
+  CliProxyExportDialog: () => null,
+}))
+vi.mock("~/components/CursorPlusExportDialog", () => ({
+  CursorPlusExportDialog: () => null,
+}))
+vi.mock("~/components/KelivoExportDialog", () => ({
+  KelivoExportDialog: () => null,
+}))
+
+// Load counters prove each deferred module stays unloaded until its action
+// selects it; the mocked component factories prove the resolved module renders.
+const kiloCodeModuleLoadMock = vi.hoisted(() => ({ count: 0 }))
+const kiloCodeProfileModuleLoadMock = vi.hoisted(() => ({ count: 0 }))
+const cherryStudioModuleLoadMock = vi.hoisted(() => ({ count: 0 }))
+
+vi.mock("~/components/KiloCodeExportDialog", () => ({
+  get KiloCodeExportDialog() {
+    return (props: unknown) => {
+      kiloCodeModuleLoadMock.count += 1
+      return kiloCodeExportDialogMock(props) ?? null
+    }
+  },
+}))
+
+vi.mock(
+  "~/features/ApiCredentialProfiles/components/KiloCodeProfileExportDialog",
+  () => ({
+    get KiloCodeProfileExportDialog() {
+      return (props: unknown) => {
+        kiloCodeProfileModuleLoadMock.count += 1
+        return kiloCodeProfileExportDialogMock(props) ?? null
+      }
+    },
+  }),
+)
+
+vi.mock("~/services/integrations/cherryStudio", () => ({
+  get OpenInCherryStudio() {
+    return (...args: unknown[]) => {
+      cherryStudioModuleLoadMock.count += 1
+      return openInCherryStudioMock(...args)
+    }
+  },
+}))
+
+vi.mock(
+  "~/services/accounts/utils/apiServiceRequest",
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import("~/services/accounts/utils/apiServiceRequest")
+      >()
+    return {
+      ...actual,
+      resolveDisplayAccountRuntimeKeySecret: async (
+        _account: unknown,
+        runtimeKey: { token: { key: string } },
+      ) => ({ ...runtimeKey, secret: runtimeKey.token.key }),
+    }
+  },
+)
+
+const ACCOUNT = {
+  id: "acc-1",
+  name: "Example",
+  username: "tester",
+  siteType: "new-api",
+  baseUrl: "https://example.com",
+  token: "token",
+  userId: "1",
+  authType: AuthTypeEnum.AccessToken,
+} as any
+
+const TOKEN = {
+  id: 1,
+  user_id: 1,
+  key: "sk-test",
+  status: 1,
+  name: "default",
+  created_time: 0,
+  accessed_time: 0,
+  expired_time: -1,
+  remain_quota: 0,
+  unlimited_quota: true,
+  used_quota: 0,
+  allow_ips: "",
+  model_limits_enabled: false,
+  model_limits: "",
+  group: "",
+} as any
+
+function renderActionControls(overrides?: {
+  account?: typeof ACCOUNT
+  runtimeKey?: AccountRuntimeKey
+}) {
+  const account = overrides?.account ?? ACCOUNT
+  const runtimeKey =
+    overrides?.runtimeKey ?? buildDisplayAccountTokenRuntimeKey(account, TOKEN)
+  return render(
+    <Suspense fallback={null}>
+      <RuntimeKeyActionControls
+        runtimeKey={runtimeKey}
+        actionPolicy={{ copySecret: false, exportSecret: true }}
+        copiedRuntimeKeyId={null}
+        onCopyKey={() => {}}
+        account={account}
+      />
+    </Suspense>,
+  )
+}
+
+async function clickKiloCodeAction(user: UserEvent) {
+  const trigger = screen.getByRole("button", { name: "common:actions.export" })
+  await user.click(trigger)
+  await user.click(
+    screen.getByRole("menuitem", {
+      name: "keyManagement:actions.exportToKiloCode",
+    }),
+  )
+}
+
+describe("RuntimeKeyActionControls deferred module loading", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    kiloCodeModuleLoadMock.count = 0
+    kiloCodeProfileModuleLoadMock.count = 0
+    cherryStudioModuleLoadMock.count = 0
+  })
+
+  it("does not load Kilo Code dialog modules until the Kilo Code action runs", async () => {
+    expect(kiloCodeModuleLoadMock.count).toBe(0)
+    expect(kiloCodeProfileModuleLoadMock.count).toBe(0)
+
+    const { default: userEvent } = await import("@testing-library/user-event")
+    const user = userEvent.setup()
+    renderActionControls()
+
+    // Opening the export menu alone must not load any deferred module.
+    await user.click(
+      screen.getByRole("button", { name: "common:actions.export" }),
+    )
+    expect(kiloCodeModuleLoadMock.count).toBe(0)
+    expect(kiloCodeProfileModuleLoadMock.count).toBe(0)
+
+    await user.click(
+      screen.getByRole("menuitem", {
+        name: "keyManagement:actions.exportToKiloCode",
+      }),
+    )
+
+    // The account-token path resolves through the lazy dialog after load.
+    await waitFor(() => {
+      expect(kiloCodeExportDialogMock).toHaveBeenCalledWith(
+        expect.objectContaining({ isOpen: true }),
+      )
+    })
+    expect(kiloCodeModuleLoadMock.count).toBe(1)
+    expect(kiloCodeProfileModuleLoadMock.count).toBe(0)
+  })
+
+  it("renders the service-credential profile dialog from its deferred module", async () => {
+    const sharedChatAccount = {
+      ...ACCOUNT,
+      id: "sharedchat-account",
+      siteType: "sharedchat" as const,
+      authType: AuthTypeEnum.Cookie,
+      token: "",
+    } as any
+    const runtimeKey = buildServiceCredentialRuntimeKey(sharedChatAccount, {
+      kind: "singleton_service_key",
+      service: "codex",
+      label: "Codex service key",
+      key: "sk-service-credential-secret",
+      isAuthenticated: true,
+      baseUrl: "https://api.example.invalid/v1",
+    })
+
+    const { default: userEvent } = await import("@testing-library/user-event")
+    const user = userEvent.setup()
+    renderActionControls({ account: sharedChatAccount, runtimeKey })
+
+    await user.click(
+      screen.getByRole("button", { name: "common:actions.export" }),
+    )
+    await user.click(
+      screen.getByRole("menuitem", {
+        name: "keyManagement:actions.exportToKiloCode",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(kiloCodeProfileExportDialogMock).toHaveBeenCalledWith(
+        expect.objectContaining({ isOpen: true }),
+      )
+    })
+    expect(kiloCodeProfileModuleLoadMock.count).toBe(1)
+    expect(kiloCodeModuleLoadMock.count).toBe(0)
+  })
+
+  it("loads Cherry Studio only when its export action runs", async () => {
+    expect(cherryStudioModuleLoadMock.count).toBe(0)
+
+    const { default: userEvent } = await import("@testing-library/user-event")
+    const user = userEvent.setup()
+    renderActionControls()
+    await clickKiloCodeAction(user)
+
+    await user.click(
+      screen.getByRole("button", { name: "common:actions.export" }),
+    )
+    expect(cherryStudioModuleLoadMock.count).toBe(0)
+
+    await user.click(
+      screen.getByRole("menuitem", {
+        name: "keyManagement:actions.useInCherry",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(openInCherryStudioMock).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "acc-1" }),
+        expect.objectContaining({ key: "sk-test" }),
+      )
+    })
+    expect(cherryStudioModuleLoadMock.count).toBe(1)
+  })
+})

--- a/tests/services/productAnalytics/client.test.ts
+++ b/tests/services/productAnalytics/client.test.ts
@@ -11,6 +11,7 @@ import {
 
 const {
   posthogMocks,
+  posthogModuleLoadMock,
   preferenceMocks,
   getExtensionVersionMock,
   i18nCoreMock,
@@ -22,6 +23,7 @@ const {
     capture: vi.fn(),
     getFeatureFlagPayload: vi.fn(),
   },
+  posthogModuleLoadMock: vi.fn(),
   preferenceMocks: {
     isEnabled: vi.fn(),
     getOrCreateAnonymousId: vi.fn(),
@@ -37,9 +39,10 @@ const {
   mockLoggerDebug: vi.fn(),
 }))
 
-vi.mock("posthog-js/dist/module.no-external", () => ({
-  default: posthogMocks,
-}))
+vi.mock("posthog-js/dist/module.no-external", () => {
+  posthogModuleLoadMock()
+  return { default: posthogMocks }
+})
 
 vi.mock("~/services/productAnalytics/preferences", () => ({
   productAnalyticsPreferences: preferenceMocks,
@@ -103,6 +106,25 @@ describe("productAnalyticsClient", () => {
   afterEach(() => {
     vi.unstubAllEnvs()
     vi.unstubAllGlobals()
+  })
+
+  it("defers loading PostHog until the first eligible capture", async () => {
+    vi.stubEnv("VITE_PUBLIC_POSTHOG_PROJECT_TOKEN", "phc_test")
+    vi.stubEnv("VITE_PUBLIC_POSTHOG_HOST", "https://posthog.example")
+
+    const client = await importClient()
+
+    expect(posthogModuleLoadMock).not.toHaveBeenCalled()
+
+    await expect(
+      client.capture(PRODUCT_ANALYTICS_EVENTS.AppOpened, {
+        entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Options,
+      }),
+    ).resolves.toBe(true)
+
+    expect(posthogModuleLoadMock).toHaveBeenCalledTimes(1)
+    expect(posthogMocks.init).toHaveBeenCalledTimes(1)
+    expect(posthogMocks.capture).toHaveBeenCalledTimes(1)
   })
 
   it("no-ops when analytics is disabled", async () => {


### PR DESCRIPTION
## Why

Popup first paint showed a blank window for the i18n/storage startup phase, and the eager import graph pulled in the full PostHog SDK plus export-only integrations before any user interaction.

## What

- Static HTML/CSS skeleton in the popup entrypoint (theme-aware via `prefers-color-scheme`), replaced when React mounts.
- PostHog SDK now loads via dynamic import on first analytics capture; capture semantics unchanged (~236KB out of every surface's eager graph).
- KiloCode export dialogs use `React.lazy` and the Cherry Studio integration imports dynamically inside `RuntimeKeyActionControls`.

Popup eager graph: ~2.57MB → ~2.31MB across the same 36 files. Automated Playwright A/B benchmarking (12 hot samples per build) shows script evaluation unchanged at ~60–70ms median — the win is critical-path removal and perceived latency, not eval time.

## Validation

- vitest: 72/72 (`productAnalytics` client + `CopyKeyDialog` flows)
- `pnpm compile`, ESLint on touched files, and the pre-commit gate all green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a responsive loading skeleton to the popup for a smoother startup experience.
  * Improved light and dark theme support for loading states.
  * Loading placeholders are optimized for assistive technologies.

* **Performance**
  * Account export and integration dialogs now load only when needed.
  * Analytics services load on demand to improve initial application startup.
  * Deferred loading reduces unnecessary work until features are used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->