### PR TITLE
perf(account): virtualize account list outside reorder mode

### DIFF
--- a/e2e/accountManagementCommonFlows.spec.ts
+++ b/e2e/accountManagementCommonFlows.spec.ts
@@ -333,6 +333,7 @@ test("keeps account management controls reachable across constrained widths", as
     page.getByTestId(getAccountManagementSortButtonTestId("created_at")),
     page.getByTestId(getAccountManagementSortButtonTestId("balance")),
     clearSortAction,
+    page.getByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.accountListReorderButton),
     page.getByTestId(ACCOUNT_MANAGEMENT_TEST_IDS.accountListBulkManageButton),
   ]
   for (const action of requiredAccountListHeaderActions) {

--- a/e2e/popupSavedItems.spec.ts
+++ b/e2e/popupSavedItems.spec.ts
@@ -293,6 +293,13 @@ test("opens the account manager from the default popup accounts tab", async ({
   await waitForExtensionRoot(page)
 
   await expect(page.getByTestId(getPopupViewTestId("accounts"))).toBeVisible()
+  const reorderButton = page.getByTestId(
+    ACCOUNT_MANAGEMENT_TEST_IDS.accountListReorderButton,
+  )
+  await expect(reorderButton).toHaveAttribute("aria-disabled", "true")
+  await expect(reorderButton).toHaveAccessibleDescription(
+    "Reordering is unavailable in the popup. Open the side panel or account management page to reorder accounts.",
+  )
   await expect(
     page.getByRole("button", { name: "Popup Account" }),
   ).toBeVisible()
@@ -420,6 +427,43 @@ test("updates popup account totals after disabling an account from management", 
       getAccountManagementListItemTestId("popup-disable-account"),
     ),
   ).toContainText("Disabled")
+})
+
+test("virtualizes long popup account lists while keeping the final account reachable", async ({
+  context,
+  extensionId,
+  page,
+}) => {
+  const serviceWorker = await getServiceWorker(context)
+  const accountCount = 80
+  await seedStoredAccounts(
+    serviceWorker,
+    Array.from({ length: accountCount }, (_, index) =>
+      createStoredAccount({
+        id: `virtual-account-${index}`,
+        site_name: `Virtual Account ${String(index).padStart(2, "0")}`,
+        site_url: `https://account-${index}.example.invalid`,
+      }),
+    ),
+  )
+
+  await page.goto(`chrome-extension://${extensionId}/${POPUP_PAGE_PATH}`)
+  await waitForExtensionRoot(page)
+
+  const renderedRows = page.locator(
+    '[data-testid^="account-management-account-list-item-"]',
+  )
+  await expect.poll(() => renderedRows.count()).toBeLessThan(accountCount)
+
+  await page
+    .getByTestId(POPUP_TEST_IDS.scrollContainer)
+    .evaluate((element) => element.scrollTo({ top: element.scrollHeight }))
+
+  await expect(
+    page.getByTestId(
+      getAccountManagementListItemTestId(`virtual-account-${accountCount - 1}`),
+    ),
+  ).toBeVisible()
 })
 
 test("downloads an overview share snapshot from the popup and copies the fallback caption", async ({

--- a/e2e/popupSavedItems.spec.ts
+++ b/e2e/popupSavedItems.spec.ts
@@ -5,6 +5,7 @@ import { OPTIONS_PAGE_PATH, POPUP_PAGE_PATH } from "~/constants/extensionPages"
 import { MENU_ITEM_IDS } from "~/constants/optionsMenuIds"
 import { getPopupViewTestId, POPUP_TEST_IDS } from "~/entrypoints/popup/testIds"
 import {
+  ACCOUNT_MANAGEMENT_LIST_ITEM_TEST_ID_PREFIX,
   ACCOUNT_MANAGEMENT_TEST_IDS,
   getAccountManagementListItemTestId,
 } from "~/features/AccountManagement/testIds"
@@ -14,6 +15,7 @@ import {
   getSiteBookmarkListItemTestId,
   SITE_BOOKMARKS_TEST_IDS,
 } from "~/features/SiteBookmarks/testIds"
+import enAccount from "~/locales/en/account.json" with { type: "json" }
 import { STORAGE_KEYS } from "~/services/core/storageKeys"
 import type { SiteAccount, SiteBookmark } from "~/types"
 import { expect, test } from "~~/e2e/fixtures/extensionTest"
@@ -298,7 +300,7 @@ test("opens the account manager from the default popup accounts tab", async ({
   )
   await expect(reorderButton).toHaveAttribute("aria-disabled", "true")
   await expect(reorderButton).toHaveAccessibleDescription(
-    "Reordering is unavailable in the popup. Open the side panel or account management page to reorder accounts.",
+    enAccount.list.reorderUnavailableInPopup,
   )
   await expect(
     page.getByRole("button", { name: "Popup Account" }),
@@ -451,19 +453,22 @@ test("virtualizes long popup account lists while keeping the final account reach
   await waitForExtensionRoot(page)
 
   const renderedRows = page.locator(
-    '[data-testid^="account-management-account-list-item-"]',
+    `[data-testid^="${ACCOUNT_MANAGEMENT_LIST_ITEM_TEST_ID_PREFIX}"]`,
   )
-  await expect.poll(() => renderedRows.count()).toBeLessThan(accountCount)
+  await expect.poll(() => renderedRows.count()).toBeGreaterThan(0)
+  expect(await renderedRows.count()).toBeLessThan(accountCount)
 
-  await page
-    .getByTestId(POPUP_TEST_IDS.scrollContainer)
-    .evaluate((element) => element.scrollTo({ top: element.scrollHeight }))
-
-  await expect(
-    page.getByTestId(
-      getAccountManagementListItemTestId(`virtual-account-${accountCount - 1}`),
-    ),
-  ).toBeVisible()
+  const lastRow = page.getByTestId(
+    getAccountManagementListItemTestId(`virtual-account-${accountCount - 1}`),
+  )
+  await expect
+    .poll(async () => {
+      await page
+        .getByTestId(POPUP_TEST_IDS.scrollContainer)
+        .evaluate((element) => element.scrollTo({ top: element.scrollHeight }))
+      return lastRow.isVisible()
+    })
+    .toBe(true)
 })
 
 test("downloads an overview share snapshot from the popup and copies the fallback caption", async ({

--- a/e2e/sidepanelUserFlows.spec.ts
+++ b/e2e/sidepanelUserFlows.spec.ts
@@ -7,6 +7,7 @@ import { SITE_TYPES } from "~/constants/siteType"
 import { getPopupViewTestId, POPUP_TEST_IDS } from "~/entrypoints/popup/testIds"
 import { SPONSOR_ADD_ACCOUNT_PREFILL_SOURCE } from "~/features/AccountManagement/sponsors/types"
 import {
+  ACCOUNT_MANAGEMENT_LIST_ITEM_TEST_ID_PREFIX,
   ACCOUNT_MANAGEMENT_TEST_IDS,
   getAccountManagementListItemTestId,
 } from "~/features/AccountManagement/testIds"
@@ -198,20 +199,24 @@ test("sidepanel virtualizes long account lists and enables explicit reordering",
   await expectPermissionOnboardingHidden(page)
 
   const renderedRows = page.locator(
-    '[data-testid^="account-management-account-list-item-"]',
+    `[data-testid^="${ACCOUNT_MANAGEMENT_LIST_ITEM_TEST_ID_PREFIX}"]`,
   )
-  await expect.poll(() => renderedRows.count()).toBeLessThan(accountCount)
+  await expect.poll(() => renderedRows.count()).toBeGreaterThan(0)
+  expect(await renderedRows.count()).toBeLessThan(accountCount)
 
-  await page.evaluate(() =>
-    window.scrollTo({ top: document.body.scrollHeight }),
-  )
-  await expect(
-    page.getByTestId(
-      getAccountManagementListItemTestId(
-        `sidepanel-virtual-account-${accountCount - 1}`,
-      ),
+  const lastRow = page.getByTestId(
+    getAccountManagementListItemTestId(
+      `sidepanel-virtual-account-${accountCount - 1}`,
     ),
-  ).toBeVisible()
+  )
+  await expect
+    .poll(async () => {
+      await page.evaluate(() =>
+        window.scrollTo({ top: document.body.scrollHeight }),
+      )
+      return lastRow.isVisible()
+    })
+    .toBe(true)
 
   await page.evaluate(() => window.scrollTo({ top: 0 }))
   await page.getByRole("button", { name: "Reorder" }).click()

--- a/e2e/sidepanelUserFlows.spec.ts
+++ b/e2e/sidepanelUserFlows.spec.ts
@@ -6,7 +6,10 @@ import { MENU_ITEM_IDS } from "~/constants/optionsMenuIds"
 import { SITE_TYPES } from "~/constants/siteType"
 import { getPopupViewTestId, POPUP_TEST_IDS } from "~/entrypoints/popup/testIds"
 import { SPONSOR_ADD_ACCOUNT_PREFILL_SOURCE } from "~/features/AccountManagement/sponsors/types"
-import { ACCOUNT_MANAGEMENT_TEST_IDS } from "~/features/AccountManagement/testIds"
+import {
+  ACCOUNT_MANAGEMENT_TEST_IDS,
+  getAccountManagementListItemTestId,
+} from "~/features/AccountManagement/testIds"
 import { API_CREDENTIAL_PROFILES_TEST_IDS } from "~/features/ApiCredentialProfiles/testIds"
 import { SITE_BOOKMARKS_TEST_IDS } from "~/features/SiteBookmarks/testIds"
 import {
@@ -162,6 +165,62 @@ test("sidepanel switches common saved-item tabs and opens the matching managemen
   expect(new URL(profilesPage.url()).hash).toBe(
     `#${MENU_ITEM_IDS.API_CREDENTIAL_PROFILES}`,
   )
+})
+
+test("sidepanel virtualizes long account lists and enables explicit reordering", async ({
+  context,
+  extensionId,
+  page,
+}) => {
+  const serviceWorker = await getServiceWorker(context)
+  const now = Date.now()
+  const accountCount = 80
+  await setPlasmoStorageValue(
+    serviceWorker,
+    STORAGE_KEYS.ACCOUNTS,
+    normalizeAccountStorageConfigForWrite(
+      {
+        ...createDefaultAccountStorageConfig(now),
+        accounts: Array.from({ length: accountCount }, (_, index) =>
+          createStoredAccount({
+            id: `sidepanel-virtual-account-${index}`,
+            site_name: `Sidepanel Virtual Account ${String(index).padStart(2, "0")}`,
+            site_url: `https://sidepanel-account-${index}.example.invalid`,
+          }),
+        ),
+      },
+      now,
+    ),
+  )
+
+  await page.goto(SIDEPANEL_URL(extensionId))
+  await waitForExtensionRoot(page)
+  await expectPermissionOnboardingHidden(page)
+
+  const renderedRows = page.locator(
+    '[data-testid^="account-management-account-list-item-"]',
+  )
+  await expect.poll(() => renderedRows.count()).toBeLessThan(accountCount)
+
+  await page.evaluate(() =>
+    window.scrollTo({ top: document.body.scrollHeight }),
+  )
+  await expect(
+    page.getByTestId(
+      getAccountManagementListItemTestId(
+        `sidepanel-virtual-account-${accountCount - 1}`,
+      ),
+    ),
+  ).toBeVisible()
+
+  await page.evaluate(() => window.scrollTo({ top: 0 }))
+  await page.getByRole("button", { name: "Reorder" }).click()
+  await expect(
+    page.getByRole("button", { name: "Done reordering" }),
+  ).toBeVisible()
+  await expect(
+    page.getByRole("button", { name: "Drag to reorder" }),
+  ).toHaveCount(accountCount)
 })
 
 test("sidepanel opens saved account and bookmark targets in browser tabs", async ({

--- a/src/entrypoints/popup/App.tsx
+++ b/src/entrypoints/popup/App.tsx
@@ -32,7 +32,7 @@ import HeaderSection from "./components/HeaderSection"
 import PopupViewSwitchTabs, {
   type PopupViewType,
 } from "./components/PopupViewSwitchTabs"
-import { getPopupViewTestId } from "./testIds"
+import { getPopupViewTestId, POPUP_TEST_IDS } from "./testIds"
 import { usePopupViewRegistry } from "./viewRegistry"
 
 /**
@@ -87,8 +87,14 @@ function PopupContent() {
   const { t } = useTranslation(["bookmark", "apiCredentialProfiles"])
   const { isLoading } = useUserPreferencesContext()
   const inSidePanel = isExtensionSidePanel()
+  const inPopup = isExtensionPopup()
+  const onMobile = isMobileDevice()
   const [activeView, setActiveView] = useState<PopupViewType>("accounts")
-  const viewConfig = usePopupViewRegistry()
+  const [scrollParent, setScrollParent] = useState<HTMLDivElement | null>(null)
+  const viewConfig = usePopupViewRegistry({
+    isPopup: inPopup,
+    scrollParent: inPopup && !onMobile ? scrollParent : null,
+  })
 
   const activeViewConfig = viewConfig[activeView]
   const entrypoint = inSidePanel
@@ -118,13 +124,13 @@ function PopupContent() {
     }
   }, [])
 
-  const popupWidthClass = isMobileDevice()
+  const popupWidthClass = onMobile
     ? "w-full"
     : inSidePanel
       ? ""
       : UI_CONSTANTS.POPUP.WIDTH
 
-  const popupHeightClass = isMobileDevice()
+  const popupHeightClass = onMobile
     ? ""
     : inSidePanel
       ? ""
@@ -132,6 +138,8 @@ function PopupContent() {
 
   return (
     <div
+      ref={setScrollParent}
+      data-testid={POPUP_TEST_IDS.scrollContainer}
       className={cn(
         "dark:bg-dark-bg-primary flex flex-col overflow-y-auto bg-white",
         popupWidthClass,

--- a/src/entrypoints/popup/App.tsx
+++ b/src/entrypoints/popup/App.tsx
@@ -83,11 +83,10 @@ function mapPopupViewToAnalyticsAction(view: PopupViewType): {
  * Popup body content for the extension popup and side panel.
  * Handles device-aware layout sizing, header/actions, and account list rendering.
  */
-function PopupContent() {
+function PopupContent({ inPopup }: { inPopup: boolean }) {
   const { t } = useTranslation(["bookmark", "apiCredentialProfiles"])
   const { isLoading } = useUserPreferencesContext()
   const inSidePanel = isExtensionSidePanel()
-  const inPopup = isExtensionPopup()
   const onMobile = isMobileDevice()
   const [activeView, setActiveView] = useState<PopupViewType>("accounts")
   const [scrollParent, setScrollParent] = useState<HTMLDivElement | null>(null)
@@ -110,7 +109,7 @@ function PopupContent() {
   })
 
   useEffect(() => {
-    if (!isExtensionPopup()) {
+    if (!inPopup) {
       return
     }
 
@@ -122,7 +121,7 @@ function PopupContent() {
     return () => {
       window.removeEventListener("pagehide", handlePageHide)
     }
-  }, [])
+  }, [inPopup])
 
   const popupWidthClass = onMobile
     ? "w-full"
@@ -208,11 +207,13 @@ function PopupContent() {
  * @returns Popup component tree rendered inside AppLayout.
  */
 function App() {
+  const [inPopup] = useState(isExtensionPopup)
+
   return (
     <AppLayout>
-      <SelectViewportResizeProvider preserveOpen={isExtensionPopup()}>
+      <SelectViewportResizeProvider preserveOpen={inPopup}>
         <AccountManagementProvider>
-          <PopupContent />
+          <PopupContent inPopup={inPopup} />
         </AccountManagementProvider>
       </SelectViewportResizeProvider>
     </AppLayout>

--- a/src/entrypoints/popup/testIds.ts
+++ b/src/entrypoints/popup/testIds.ts
@@ -7,6 +7,7 @@ export const POPUP_TEST_IDS = {
   accountsTab: "popup-accounts-tab",
   apiCredentialProfilesTab: "popup-api-credential-profiles-tab",
   bookmarksTab: "popup-bookmarks-tab",
+  scrollContainer: "popup-scroll-container",
   openAccountManagementButton: "popup-open-account-management-button",
   openApiCredentialProfilesButton: "popup-open-api-credential-profiles-button",
   openBookmarkManagementButton: "popup-open-bookmark-management-button",

--- a/src/entrypoints/popup/viewRegistry.tsx
+++ b/src/entrypoints/popup/viewRegistry.tsx
@@ -59,6 +59,11 @@ interface PopupViewConfig {
   preload?: () => void
 }
 
+interface PopupViewRegistryOptions {
+  isPopup?: boolean
+  scrollParent?: HTMLElement | null
+}
+
 /**
  * Compact placeholder for lazily loaded popup stats cards.
  */
@@ -84,7 +89,10 @@ function PopupContentFallback() {
 /**
  * Builds popup view definitions, including lazy-loaded secondary tabs and their preload hooks.
  */
-export function usePopupViewRegistry(): Record<PopupViewType, PopupViewConfig> {
+export function usePopupViewRegistry({
+  isPopup = false,
+  scrollParent,
+}: PopupViewRegistryOptions = {}): Record<PopupViewType, PopupViewConfig> {
   const { t } = useTranslation([
     "account",
     "bookmark",
@@ -93,6 +101,11 @@ export function usePopupViewRegistry(): Record<PopupViewType, PopupViewConfig> {
   ])
   const { handleAddAccountClick } = useAddAccountHandler()
   const { openAddBookmark } = useBookmarkDialogContext()
+  // Native action-popup pointer lifecycles do not reliably deliver dnd-kit drag
+  // completion, so keep reordering discoverable there but direct users elsewhere.
+  const reorderUnavailableReason = isPopup
+    ? t("account:list.reorderUnavailableInPopup")
+    : undefined
 
   const apiCredentialProfilesViewRef =
     useRef<ApiCredentialProfilesPopupViewHandle>(null)
@@ -123,7 +136,12 @@ export function usePopupViewRegistry(): Record<PopupViewType, PopupViewConfig> {
         actionId: PRODUCT_ANALYTICS_ACTION_IDS.OpenCreateAccountDialog,
       },
       primaryActionTestId: ACCOUNT_MANAGEMENT_TEST_IDS.addAccountButton,
-      content: <AccountList />,
+      content: (
+        <AccountList
+          reorderUnavailableReason={reorderUnavailableReason}
+          virtualScrollParent={scrollParent}
+        />
+      ),
     },
     bookmarks: {
       showRefresh: false,

--- a/src/features/AccountManagement/components/AccountList/AccountListHeader.tsx
+++ b/src/features/AccountManagement/components/AccountList/AccountListHeader.tsx
@@ -1,6 +1,14 @@
-import { ChevronDown, ChevronUp, XIcon } from "lucide-react"
+import {
+  Check,
+  ChevronDown,
+  ChevronUp,
+  ListChecks,
+  ListOrdered,
+  XIcon,
+} from "lucide-react"
 import { useTranslation } from "react-i18next"
 
+import Tooltip from "~/components/Tooltip"
 import { Button, IconButton } from "~/components/ui"
 import {
   DATA_TYPE_BALANCE,
@@ -20,10 +28,15 @@ interface AccountListHeaderProps {
   inSearchMode: boolean
   isBulkBusy: boolean
   isBulkMode: boolean
+  isReorderLoading: boolean
+  isReorderMode: boolean
   onBulkModeEnter: () => void
   onBulkModeExit: () => void
   onClearSort: () => void
+  onReorderModeEnter: () => void
+  onReorderModeExit: () => void
   onSort: (field: SortField) => void
+  reorderDisabledReason: string | null
   showTodayCashflow: boolean
   sortField: ActiveSortField
   sortOrder: SortOrder
@@ -82,10 +95,15 @@ export function AccountListHeader({
   inSearchMode,
   isBulkBusy,
   isBulkMode,
+  isReorderLoading,
+  isReorderMode,
   onBulkModeEnter,
   onBulkModeExit,
   onClearSort,
+  onReorderModeEnter,
+  onReorderModeExit,
   onSort,
+  reorderDisabledReason,
   showTodayCashflow,
   sortField,
   sortOrder,
@@ -101,6 +119,41 @@ export function AccountListHeader({
       sortLabel={t("account:list.sort")}
       sortOrder={sortOrder}
     />
+  )
+  const reorderButton = (
+    <Button
+      type="button"
+      variant={isReorderMode ? "secondary" : "outline"}
+      size="sm"
+      className={cn(
+        "h-7 max-w-none shrink-0 px-2 text-xs whitespace-nowrap",
+        reorderDisabledReason !== null &&
+          "aria-disabled:pointer-events-auto aria-disabled:cursor-not-allowed",
+      )}
+      leftIcon={
+        isReorderMode ? (
+          <Check aria-hidden="true" className="size-3.5" />
+        ) : (
+          <ListOrdered aria-hidden="true" className="size-3.5" />
+        )
+      }
+      onClick={() => {
+        if (reorderDisabledReason !== null) return
+        if (isReorderMode) {
+          onReorderModeExit()
+          return
+        }
+        onReorderModeEnter()
+      }}
+      aria-disabled={reorderDisabledReason !== null}
+      aria-pressed={isReorderMode}
+      loading={isReorderLoading}
+      data-testid={ACCOUNT_MANAGEMENT_TEST_IDS.accountListReorderButton}
+    >
+      {isReorderMode
+        ? t("account:list.reorderDone")
+        : t("account:list.reorder")}
+    </Button>
   )
 
   return (
@@ -169,19 +222,40 @@ export function AccountListHeader({
           <span className="dark:text-dark-text-tertiary text-xs font-medium whitespace-nowrap text-gray-500">
             {t("common:total") + ": " + displayedResultCount}
           </span>
-          <Button
-            type="button"
-            variant={isBulkMode ? "secondary" : "outline"}
-            size="sm"
-            className="h-7 shrink-0 px-2 text-xs"
-            onClick={isBulkMode ? onBulkModeExit : onBulkModeEnter}
-            disabled={isBulkBusy}
-            data-testid={
-              ACCOUNT_MANAGEMENT_TEST_IDS.accountListBulkManageButton
-            }
-          >
-            {isBulkMode ? t("account:bulk.exit") : t("account:bulk.manage")}
-          </Button>
+          <div className="flex shrink-0 items-center gap-1.5">
+            {reorderDisabledReason === null ? (
+              reorderButton
+            ) : (
+              <Tooltip
+                anchorAsChild
+                content={reorderDisabledReason}
+                position="bottom-end"
+              >
+                {reorderButton}
+              </Tooltip>
+            )}
+            <Button
+              type="button"
+              variant={isBulkMode ? "secondary" : "outline"}
+              size="sm"
+              className="h-7 max-w-none shrink-0 px-2 text-xs whitespace-nowrap"
+              leftIcon={
+                isBulkMode ? (
+                  <Check aria-hidden="true" className="size-3.5" />
+                ) : (
+                  <ListChecks aria-hidden="true" className="size-3.5" />
+                )
+              }
+              onClick={isBulkMode ? onBulkModeExit : onBulkModeEnter}
+              disabled={isBulkBusy || isReorderMode}
+              aria-pressed={isBulkMode}
+              data-testid={
+                ACCOUNT_MANAGEMENT_TEST_IDS.accountListBulkManageButton
+              }
+            >
+              {isBulkMode ? t("account:bulk.exit") : t("account:bulk.manage")}
+            </Button>
+          </div>
         </div>
       </div>
     </div>

--- a/src/features/AccountManagement/components/AccountList/AccountListHeader.tsx
+++ b/src/features/AccountManagement/components/AccountList/AccountListHeader.tsx
@@ -109,6 +109,12 @@ export function AccountListHeader({
   sortOrder,
 }: AccountListHeaderProps) {
   const { t } = useTranslation(["account", "common"])
+  const reorderLabel = isReorderMode
+    ? t("account:list.reorderDone")
+    : t("account:list.reorder")
+  const bulkModeLabel = isBulkMode
+    ? t("account:bulk.exit")
+    : t("account:bulk.manage")
   const renderSortButton = (field: SortField, label: string) => (
     <AccountListSortButton
       activeSortField={sortField}
@@ -146,13 +152,12 @@ export function AccountListHeader({
         onReorderModeEnter()
       }}
       aria-disabled={reorderDisabledReason !== null}
+      aria-label={reorderLabel}
       aria-pressed={isReorderMode}
       loading={isReorderLoading}
       data-testid={ACCOUNT_MANAGEMENT_TEST_IDS.accountListReorderButton}
     >
-      {isReorderMode
-        ? t("account:list.reorderDone")
-        : t("account:list.reorder")}
+      <span className="hidden sm:inline">{reorderLabel}</span>
     </Button>
   )
 
@@ -248,12 +253,13 @@ export function AccountListHeader({
               }
               onClick={isBulkMode ? onBulkModeExit : onBulkModeEnter}
               disabled={isBulkBusy || isReorderMode}
+              aria-label={bulkModeLabel}
               aria-pressed={isBulkMode}
               data-testid={
                 ACCOUNT_MANAGEMENT_TEST_IDS.accountListBulkManageButton
               }
             >
-              {isBulkMode ? t("account:bulk.exit") : t("account:bulk.manage")}
+              <span className="hidden sm:inline">{bulkModeLabel}</span>
             </Button>
           </div>
         </div>

--- a/src/features/AccountManagement/components/AccountList/AccountSearchInput.tsx
+++ b/src/features/AccountManagement/components/AccountList/AccountSearchInput.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next"
 import { Input } from "~/components/ui"
 
 interface AccountSearchInputProps {
+  disabled?: boolean
   value: string
   onChange: (value: string) => void
   onClear: () => void
@@ -12,11 +13,13 @@ interface AccountSearchInputProps {
 /**
  * Compact search field used to filter account list entries.
  * @param props Component props containing search value and handlers.
+ * @param props.disabled Whether account reordering temporarily locks search.
  * @param props.value Current search string.
  * @param props.onChange Handler invoked when user types in the field.
  * @param props.onClear Handler clearing the current search string.
  */
 export default function AccountSearchInput({
+  disabled = false,
   value,
   onChange,
   onClear,
@@ -35,6 +38,7 @@ export default function AccountSearchInput({
     <div className="relative">
       <Input
         autoFocus={true}
+        disabled={disabled}
         type="text"
         size="sm"
         value={value}

--- a/src/features/AccountManagement/components/AccountList/VirtualizedAccountList.tsx
+++ b/src/features/AccountManagement/components/AccountList/VirtualizedAccountList.tsx
@@ -1,0 +1,42 @@
+import { forwardRef, type ReactNode } from "react"
+import { Virtuoso, type ListProps } from "react-virtuoso"
+
+import { CardList } from "~/components/ui"
+
+interface VirtualizedAccountListProps<Item> {
+  items: Item[]
+  renderItem: (item: Item) => ReactNode
+  scrollParent?: HTMLElement | null
+  getItemKey: (item: Item) => React.Key
+}
+
+const VirtualizedCardList = forwardRef<HTMLDivElement, ListProps>(
+  function VirtualizedCardList({ children, ...props }, ref) {
+    return (
+      <CardList ref={ref} {...props}>
+        {children}
+      </CardList>
+    )
+  },
+)
+
+/** Renders account rows against either the page or a supplied popup scroller. */
+export function VirtualizedAccountList<Item>({
+  getItemKey,
+  items,
+  renderItem,
+  scrollParent,
+}: VirtualizedAccountListProps<Item>) {
+  return (
+    <Virtuoso
+      components={{ List: VirtualizedCardList }}
+      computeItemKey={(_, item) => getItemKey(item)}
+      customScrollParent={scrollParent ?? undefined}
+      data={items}
+      defaultItemHeight={112}
+      increaseViewportBy={240}
+      itemContent={(_, item) => renderItem(item)}
+      useWindowScroll={scrollParent == null}
+    />
+  )
+}

--- a/src/features/AccountManagement/components/AccountList/index.tsx
+++ b/src/features/AccountManagement/components/AccountList/index.tsx
@@ -1,6 +1,6 @@
 import type { DragEndEvent } from "@dnd-kit/core"
 import type { TFunction } from "i18next"
-import { Inbox, Plus } from "lucide-react"
+import { Inbox, Info, Plus } from "lucide-react"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import toast from "react-hot-toast"
 import { useTranslation } from "react-i18next"
@@ -58,7 +58,7 @@ import {
   PRODUCT_ANALYTICS_SOURCE_KINDS,
   PRODUCT_ANALYTICS_SURFACE_IDS,
 } from "~/services/productAnalytics/contracts"
-import type { CurrencyMetricTotal, DisplaySiteData } from "~/types"
+import type { CurrencyMetricTotal, DisplaySiteData, SortField } from "~/types"
 import { ACCOUNT_TODAY_METRIC_STATUSES } from "~/types/accountTodayStats"
 import {
   calculateTotalBalanceForSites,
@@ -67,6 +67,7 @@ import {
   getTodayMetricPresentation,
 } from "~/utils/core/formatters"
 import { formatMoneyFixed } from "~/utils/core/money"
+import { showWarningToast } from "~/utils/core/toastHelpers"
 
 import CopyKeyDialog from "../CopyKeyDialog"
 import DelAccountDialog from "../DelAccountDialog"
@@ -81,9 +82,12 @@ import {
   getAccountCheckInFilterValue,
   type AccountCheckInFilterValue,
 } from "./checkInFilter"
+import { VirtualizedAccountList } from "./VirtualizedAccountList"
 
 interface AccountListProps {
   initialSearchQuery?: string
+  reorderUnavailableReason?: string
+  virtualScrollParent?: HTMLElement | null
 }
 
 type AccountListResultItem = {
@@ -130,15 +134,6 @@ interface AccountListFilterAggregation {
 }
 
 type DndLoadState = "inactive" | "loading" | "ready"
-type RequestIdleCallbackHandle = number
-type RequestIdleCallbackDeadline = {
-  didTimeout: boolean
-  timeRemaining: () => number
-}
-type RequestIdleCallbackFn = (
-  callback: (deadline: RequestIdleCallbackDeadline) => void,
-) => RequestIdleCallbackHandle
-type CancelIdleCallbackFn = (handle: RequestIdleCallbackHandle) => void
 
 /**
  * Lazily loads the account list drag-and-drop runtime for manual ordering mode.
@@ -150,6 +145,38 @@ function loadAccountListDndRuntime() {
 type AccountListDndRuntime = Awaited<
   ReturnType<typeof loadAccountListDndRuntime>
 >
+
+const ACCOUNT_REORDER_TOAST_ID = "account-reorder"
+const ACCOUNT_REORDER_BOUNDARY_TOAST_ID = "account-reorder-boundary"
+
+/** Projects current account records through a session-owned ID order. */
+function projectAccountsByIdOrder(
+  accounts: DisplaySiteData[],
+  orderedIds: string[],
+) {
+  const accountById = new Map(accounts.map((account) => [account.id, account]))
+  const projectedAccounts = orderedIds.flatMap((id) => {
+    const account = accountById.get(id)
+    if (!account) return []
+    accountById.delete(id)
+    return [account]
+  })
+
+  return [...projectedAccounts, ...accountById.values()]
+}
+
+/** Replaces only visible slots while retaining filtered-out account positions. */
+function replaceVisibleAccountOrder(
+  allIds: string[],
+  nextVisibleIds: string[],
+) {
+  const visibleIdSet = new Set(nextVisibleIds)
+  let visibleIndex = 0
+
+  return allIds.map((id) =>
+    visibleIdSet.has(id) ? nextVisibleIds[visibleIndex++] : id,
+  )
+}
 
 const ACCOUNT_REFRESH_FILTER_OPTION_ORDER: AccountRefreshFilterValue[] = [
   "never-synced",
@@ -403,7 +430,11 @@ function FilteredTodayMetric({
 /**
  * Master list view for user accounts, including search, tagging, sorting, filtering, and manual reordering controls.
  */
-export default function AccountList({ initialSearchQuery }: AccountListProps) {
+export default function AccountList({
+  initialSearchQuery,
+  reorderUnavailableReason,
+  virtualScrollParent,
+}: AccountListProps) {
   const { t } = useTranslation(["account", "common"])
   const isSmallScreen = useIsSmallScreen()
   const isDesktop = useIsDesktop()
@@ -417,6 +448,7 @@ export default function AccountList({ initialSearchQuery }: AccountListProps) {
     sortField,
     sortOrder,
     handleReorder,
+    pinnedAccountIds,
     tags,
     tagCountsById,
     isManualSortFeatureEnabled,
@@ -433,6 +465,11 @@ export default function AccountList({ initialSearchQuery }: AccountListProps) {
   const [copyKeyDialogAccount, setCopyKeyDialogAccount] =
     useState<DisplaySiteData | null>(null)
   const [isBulkMode, setIsBulkMode] = useState(false)
+  const [isReorderMode, setIsReorderMode] = useState(false)
+  const [isReorderSaving, setIsReorderSaving] = useState(false)
+  const [reorderAccountIds, setReorderAccountIds] = useState<string[] | null>(
+    null,
+  )
   const [selectedAccountIds, setSelectedAccountIds] = useState<string[]>([])
   const [isBulkDeleting, setIsBulkDeleting] = useState(false)
   const [isBulkDisabling, setIsBulkDisabling] = useState(false)
@@ -453,6 +490,7 @@ export default function AccountList({ initialSearchQuery }: AccountListProps) {
   const [dndLoadState, setDndLoadState] = useState<DndLoadState>("inactive")
   const dndLoadPromiseRef = useRef<Promise<AccountListDndRuntime> | null>(null)
   const dndRuntimeRef = useRef<AccountListDndRuntime | null>(null)
+  const isReorderSavingRef = useRef(false)
   const isMountedRef = useRef(true)
   const inviteLinkCopyAbortControllerRef = useRef<AbortController | null>(null)
 
@@ -460,6 +498,7 @@ export default function AccountList({ initialSearchQuery }: AccountListProps) {
     useAccountSearch(displayData, initialSearchQuery)
 
   useEffect(() => {
+    isMountedRef.current = true
     return () => {
       isMountedRef.current = false
       inviteLinkCopyAbortControllerRef.current?.abort()
@@ -474,6 +513,18 @@ export default function AccountList({ initialSearchQuery }: AccountListProps) {
     setCopyKeyDialogAccount(site)
   }
 
+  const accountsInDisplayOrder = useMemo(
+    () =>
+      reorderAccountIds === null
+        ? sortedData
+        : projectAccountsByIdOrder(displayData, reorderAccountIds),
+    [displayData, reorderAccountIds, sortedData],
+  )
+  const pinnedAccountIdSet = useMemo(
+    () => new Set(pinnedAccountIds),
+    [pinnedAccountIds],
+  )
+
   const baseResults = useMemo<AccountListResultItem[]>(() => {
     if (inSearchMode) {
       return searchResults.map((result) => ({
@@ -482,8 +533,11 @@ export default function AccountList({ initialSearchQuery }: AccountListProps) {
       }))
     }
 
-    return sortedData.map((account) => ({ account, highlights: undefined }))
-  }, [inSearchMode, searchResults, sortedData])
+    return accountsInDisplayOrder.map((account) => ({
+      account,
+      highlights: undefined,
+    }))
+  }, [accountsInDisplayOrder, inSearchMode, searchResults])
 
   const filterState = useMemo<AccountListFilterState>(
     () => ({
@@ -522,9 +576,18 @@ export default function AccountList({ initialSearchQuery }: AccountListProps) {
   useEffect(() => {
     if (displayData.length === 0) {
       setIsBulkMode(false)
+      setIsReorderMode(false)
+      setReorderAccountIds(null)
       setSelectedAccountIds([])
     }
   }, [displayData.length])
+
+  useEffect(() => {
+    if (inSearchMode || !isManualSortFeatureEnabled) {
+      setIsReorderMode(false)
+      setReorderAccountIds(null)
+    }
+  }, [inSearchMode, isManualSortFeatureEnabled])
 
   const tagFilterOptions = useMemo(() => {
     if (tags.length === 0) {
@@ -701,15 +764,35 @@ export default function AccountList({ initialSearchQuery }: AccountListProps) {
     siteTypeFilter !== null ||
     refreshStatusFilter !== null ||
     disabledFilter !== null
-  const dragDisabled = inSearchMode || !isManualSortFeatureEnabled || isBulkMode
+  const showPinnedReorderHint =
+    isReorderMode &&
+    filteredSites.some((account) => pinnedAccountIdSet.has(account.id)) &&
+    filteredSites.some((account) => !pinnedAccountIdSet.has(account.id))
+  const dragDisabled =
+    !isReorderMode ||
+    inSearchMode ||
+    !isManualSortFeatureEnabled ||
+    isBulkMode ||
+    isReorderSaving
   const handleLabel = t("account:list.dragHandle")
   const isBulkBusy =
     isBulkDeleting || isBulkDisabling || isBulkCopyingInviteLinks
   const shouldRenderSortableList =
+    isReorderMode &&
     isManualSortFeatureEnabled &&
-    !dragDisabled &&
     dndLoadState === "ready" &&
     dndRuntimeRef.current !== null
+
+  const resolvedReorderDisabledReason = isReorderMode
+    ? null
+    : reorderUnavailableReason ??
+      (isBulkMode
+        ? t("account:list.reorderUnavailableWhileBulk")
+        : inSearchMode
+          ? t("account:list.reorderUnavailableWhileSearch")
+          : !isManualSortFeatureEnabled
+            ? t("account:list.reorderUnavailableInSettings")
+            : null)
 
   const sortedIds = useMemo(
     () => displayedResults.map((item) => item.account.id),
@@ -741,6 +824,8 @@ export default function AccountList({ initialSearchQuery }: AccountListProps) {
       ...accountListAnalyticsBaseContext,
       actionId: PRODUCT_ANALYTICS_ACTION_IDS.EnterAccountBulkMode,
     })
+    setIsReorderMode(false)
+    setReorderAccountIds(null)
     setIsBulkMode(true)
   }
 
@@ -1052,7 +1137,13 @@ export default function AccountList({ initialSearchQuery }: AccountListProps) {
   }
 
   const onDragEnd = (event: DragEndEvent) => {
-    if (dragDisabled) return
+    if (
+      dragDisabled ||
+      reorderAccountIds === null ||
+      isReorderSavingRef.current
+    ) {
+      return
+    }
     const { active, over } = event
     if (!over || active.id === over.id) return
 
@@ -1060,15 +1151,53 @@ export default function AccountList({ initialSearchQuery }: AccountListProps) {
     const newIndex = sortedIds.indexOf(over.id as string)
     if (oldIndex === -1 || newIndex === -1) return
 
+    const activeIsPinned = pinnedAccountIdSet.has(active.id as string)
+    const crossedPinBoundary = sortedIds
+      .slice(Math.min(oldIndex, newIndex), Math.max(oldIndex, newIndex) + 1)
+      .some((id) => pinnedAccountIdSet.has(id) !== activeIsPinned)
+
+    if (crossedPinBoundary) {
+      showWarningToast(t("account:list.reorderPinnedBoundary"), {
+        id: ACCOUNT_REORDER_BOUNDARY_TOAST_ID,
+      })
+      return
+    }
+
     const itemCount = sortedIds.length
     const analyticsContext = {
       ...accountListAnalyticsBaseContext,
       actionId: PRODUCT_ANALYTICS_ACTION_IDS.ReorderAccounts,
     }
     const tracker = startProductAnalyticsAction(analyticsContext)
-    const newOrder = moveAccountId(sortedIds, oldIndex, newIndex)
-    void Promise.resolve(handleReorder(newOrder))
+    const previousAccountIds = accountsInDisplayOrder.map(
+      (account) => account.id,
+    )
+    const nextVisibleIds = moveAccountId(sortedIds, oldIndex, newIndex)
+    const nextAccountIds = replaceVisibleAccountOrder(
+      previousAccountIds,
+      nextVisibleIds,
+    )
+    const clearsFieldSort = sortField !== null
+
+    isReorderSavingRef.current = true
+    setIsReorderSaving(true)
+    setReorderAccountIds(nextAccountIds)
+
+    void Promise.resolve(handleReorder(nextVisibleIds))
       .then(() => {
+        if (clearsFieldSort) {
+          clearSortConfig()
+        }
+        toast.success(
+          t(
+            clearsFieldSort
+              ? "account:list.reorderSuccessFieldSortCleared"
+              : "account:list.reorderSuccess",
+          ),
+          {
+            id: ACCOUNT_REORDER_TOAST_ID,
+          },
+        )
         tracker.complete(PRODUCT_ANALYTICS_RESULTS.Success, {
           insights: {
             sourceKind: PRODUCT_ANALYTICS_SOURCE_KINDS.Manual,
@@ -1077,6 +1206,10 @@ export default function AccountList({ initialSearchQuery }: AccountListProps) {
         })
       })
       .catch(() => {
+        setReorderAccountIds(previousAccountIds)
+        toast.error(t("account:list.reorderFailed"), {
+          id: ACCOUNT_REORDER_TOAST_ID,
+        })
         tracker.complete(PRODUCT_ANALYTICS_RESULTS.Failure, {
           errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
           insights: {
@@ -1084,6 +1217,12 @@ export default function AccountList({ initialSearchQuery }: AccountListProps) {
             itemCount,
           },
         })
+      })
+      .finally(() => {
+        isReorderSavingRef.current = false
+        if (isMountedRef.current) {
+          setIsReorderSaving(false)
+        }
       })
   }
 
@@ -1129,59 +1268,35 @@ export default function AccountList({ initialSearchQuery }: AccountListProps) {
     return loadPromise
   }, [dndLoadState, isManualSortFeatureEnabled])
 
-  const handleActivateDnd = useCallback(() => {
-    if (dragDisabled || !isManualSortFeatureEnabled) {
-      return
-    }
+  const handleReorderModeEnter = useCallback(() => {
+    if (resolvedReorderDisabledReason !== null) return
 
-    void ensureDndReady()
-  }, [dragDisabled, ensureDndReady, isManualSortFeatureEnabled])
-
-  useEffect(() => {
-    if (
-      !isManualSortFeatureEnabled ||
-      dragDisabled ||
-      !hasAccounts ||
-      dndLoadState !== "inactive"
-    ) {
-      return
-    }
-
-    const requestIdleCallbackFn = (
-      globalThis as typeof globalThis & {
-        requestIdleCallback?: RequestIdleCallbackFn
+    setReorderAccountIds(sortedData.map((account) => account.id))
+    setIsReorderMode(true)
+    void ensureDndReady().catch(() => {
+      if (isMountedRef.current) {
+        setIsReorderMode(false)
+        setReorderAccountIds(null)
+        toast.error(t("account:list.reorderLoadFailed"))
       }
-    ).requestIdleCallback
-    const cancelIdleCallbackFn = (
-      globalThis as typeof globalThis & {
-        cancelIdleCallback?: CancelIdleCallbackFn
-      }
-    ).cancelIdleCallback
+    })
+  }, [ensureDndReady, resolvedReorderDisabledReason, sortedData, t])
 
-    if (typeof requestIdleCallbackFn === "function") {
-      const idleHandle = requestIdleCallbackFn(() => {
-        void ensureDndReady()
-      })
+  const handleReorderModeExit = useCallback(() => {
+    if (isReorderSavingRef.current) return
+    setIsReorderMode(false)
+    setReorderAccountIds(null)
+  }, [])
 
-      return () => {
-        cancelIdleCallbackFn?.(idleHandle)
-      }
-    }
-
-    const timeoutHandle = window.setTimeout(() => {
-      void ensureDndReady()
-    }, 0)
-
-    return () => {
-      window.clearTimeout(timeoutHandle)
-    }
-  }, [
-    dndLoadState,
-    dragDisabled,
-    ensureDndReady,
-    hasAccounts,
-    isManualSortFeatureEnabled,
-  ])
+  const handleListSort = useCallback(
+    (field: SortField) => {
+      if (isReorderSavingRef.current) return
+      setIsReorderMode(false)
+      setReorderAccountIds(null)
+      handleSort(field)
+    },
+    [handleSort],
+  )
 
   const maxTagFilterLines = isSmallScreen ? 2 : isDesktop ? 3 : 2
 
@@ -1226,69 +1341,67 @@ export default function AccountList({ initialSearchQuery }: AccountListProps) {
     )
   }
 
-  const listContent = (
-    <CardList>
-      {displayedResults.map((item) => {
-        const selectionControl = isBulkMode ? (
-          <Checkbox
-            data-testid={getAccountManagementSelectionCheckboxTestId(
-              item.account.id,
-            )}
-            checked={selectedIdSet.has(item.account.id)}
-            onCheckedChange={(checked) =>
-              handleToggleAccountSelection(item.account.id, Boolean(checked))
-            }
-            aria-label={t("account:bulk.selectAccount", {
-              accountName: item.account.name,
-            })}
-            disabled={isBulkBusy}
-          />
-        ) : undefined
-
-        if (shouldRenderSortableList && dndRuntimeRef.current !== null) {
-          const { SortableAccountListItem } = dndRuntimeRef.current
-
-          return (
-            <SortableAccountListItem
-              key={item.account.id}
-              site={item.account}
-              showCreatedAt={sortField === DATA_TYPE_CREATED_AT}
-              className={cn(
-                detectedAccount?.id === item.account.id &&
-                  "rounded-lg border-l-4 border-l-blue-500 bg-blue-50 dark:border-l-blue-400 dark:bg-blue-900/50",
-              )}
-              highlights={item.highlights}
-              onDeleteWithDialog={handleDeleteWithDialog}
-              onCopyKey={handleCopyKeyWithDialog}
-              isDragDisabled={dragDisabled}
-              handleLabel={handleLabel}
-              showHandle={isManualSortFeatureEnabled && !isBulkMode}
-              selectionControl={selectionControl}
-            />
-          )
+  const renderAccountListItem = (item: AccountListResultItem) => {
+    const selectionControl = isBulkMode ? (
+      <Checkbox
+        data-testid={getAccountManagementSelectionCheckboxTestId(
+          item.account.id,
+        )}
+        checked={selectedIdSet.has(item.account.id)}
+        onCheckedChange={(checked) =>
+          handleToggleAccountSelection(item.account.id, Boolean(checked))
         }
+        aria-label={t("account:bulk.selectAccount", {
+          accountName: item.account.name,
+        })}
+        disabled={isBulkBusy}
+      />
+    ) : undefined
 
-        return (
-          <NonSortableAccountListItem
-            key={item.account.id}
-            site={item.account}
-            showCreatedAt={sortField === DATA_TYPE_CREATED_AT}
-            className={cn(
-              detectedAccount?.id === item.account.id &&
-                "rounded-lg border-l-4 border-l-blue-500 bg-blue-50 dark:border-l-blue-400 dark:bg-blue-900/50",
-            )}
-            highlights={item.highlights}
-            onDeleteWithDialog={handleDeleteWithDialog}
-            onCopyKey={handleCopyKeyWithDialog}
-            isDragDisabled={dragDisabled}
-            handleLabel={handleLabel}
-            showHandle={isManualSortFeatureEnabled && !isBulkMode}
-            onActivateDnd={handleActivateDnd}
-            selectionControl={selectionControl}
-          />
-        )
-      })}
-    </CardList>
+    if (shouldRenderSortableList && dndRuntimeRef.current !== null) {
+      const { SortableAccountListItem } = dndRuntimeRef.current
+
+      return (
+        <SortableAccountListItem
+          key={item.account.id}
+          site={item.account}
+          showCreatedAt={sortField === DATA_TYPE_CREATED_AT}
+          className={cn(
+            detectedAccount?.id === item.account.id &&
+              "rounded-lg border-l-4 border-l-blue-500 bg-blue-50 dark:border-l-blue-400 dark:bg-blue-900/50",
+          )}
+          highlights={item.highlights}
+          onDeleteWithDialog={handleDeleteWithDialog}
+          onCopyKey={handleCopyKeyWithDialog}
+          isDragDisabled={dragDisabled}
+          handleLabel={handleLabel}
+          showHandle
+          selectionControl={selectionControl}
+        />
+      )
+    }
+
+    return (
+      <NonSortableAccountListItem
+        key={item.account.id}
+        site={item.account}
+        showCreatedAt={sortField === DATA_TYPE_CREATED_AT}
+        className={cn(
+          detectedAccount?.id === item.account.id &&
+            "rounded-lg border-l-4 border-l-blue-500 bg-blue-50 dark:border-l-blue-400 dark:bg-blue-900/50",
+        )}
+        highlights={item.highlights}
+        onDeleteWithDialog={handleDeleteWithDialog}
+        onCopyKey={handleCopyKeyWithDialog}
+        isDragDisabled
+        handleLabel={handleLabel}
+        showHandle={false}
+        selectionControl={selectionControl}
+      />
+    )
+  }
+  const renderUnvirtualizedList = () => (
+    <CardList>{displayedResults.map(renderAccountListItem)}</CardList>
   )
   const DndWrapper = dndRuntimeRef.current?.AccountListDndWrapper
 
@@ -1305,6 +1418,7 @@ export default function AccountList({ initialSearchQuery }: AccountListProps) {
             <div className="flex flex-col gap-1.5 sm:gap-2 lg:flex-row lg:items-center lg:gap-3">
               <div className="min-w-0 lg:w-72 lg:shrink-0 xl:w-80">
                 <AccountSearchInput
+                  disabled={isReorderMode}
                   value={query}
                   onChange={setQuery}
                   onClear={clearSearch}
@@ -1491,14 +1605,34 @@ export default function AccountList({ initialSearchQuery }: AccountListProps) {
           inSearchMode={inSearchMode}
           isBulkBusy={isBulkBusy}
           isBulkMode={isBulkMode}
+          isReorderLoading={
+            isReorderMode && (dndLoadState === "loading" || isReorderSaving)
+          }
+          isReorderMode={isReorderMode}
           onBulkModeEnter={handleBulkModeEnter}
           onBulkModeExit={handleBulkModeExit}
           onClearSort={clearSortConfig}
-          onSort={handleSort}
+          onReorderModeEnter={handleReorderModeEnter}
+          onReorderModeExit={handleReorderModeExit}
+          onSort={handleListSort}
+          reorderDisabledReason={resolvedReorderDisabledReason}
           showTodayCashflow={showTodayCashflow}
           sortField={sortField}
           sortOrder={sortOrder}
         />
+
+        {showPinnedReorderHint ? (
+          <div
+            className="dark:border-dark-bg-tertiary flex items-center gap-2 border-b border-blue-100 bg-blue-50/80 px-3 py-1.5 text-xs leading-5 text-blue-800 dark:bg-blue-950/40 dark:text-blue-200"
+            role="note"
+          >
+            <Info
+              aria-hidden="true"
+              className="size-3.5 shrink-0 text-blue-600 dark:text-blue-400"
+            />
+            <span>{t("account:list.reorderPinnedHint")}</span>
+          </div>
+        ) : null}
 
         {/* Account List or No Results */}
         {showFilteredSummary && displayedResults.length === 0 ? (
@@ -1508,10 +1642,17 @@ export default function AccountList({ initialSearchQuery }: AccountListProps) {
           />
         ) : shouldRenderSortableList && DndWrapper ? (
           <DndWrapper sortedIds={sortedIds} onDragEnd={onDragEnd}>
-            {listContent}
+            {renderUnvirtualizedList()}
           </DndWrapper>
+        ) : isReorderMode ? (
+          renderUnvirtualizedList()
         ) : (
-          listContent
+          <VirtualizedAccountList
+            getItemKey={(item) => item.account.id}
+            items={displayedResults}
+            renderItem={renderAccountListItem}
+            scrollParent={virtualScrollParent}
+          />
         )}
       </CardContent>
 

--- a/src/features/AccountManagement/components/AccountList/index.tsx
+++ b/src/features/AccountManagement/components/AccountList/index.tsx
@@ -82,6 +82,7 @@ import {
   getAccountCheckInFilterValue,
   type AccountCheckInFilterValue,
 } from "./checkInFilter"
+import * as accountListDndRuntimeLoader from "./loadAccountListDndRuntime"
 import { VirtualizedAccountList } from "./VirtualizedAccountList"
 
 interface AccountListProps {
@@ -135,15 +136,8 @@ interface AccountListFilterAggregation {
 
 type DndLoadState = "inactive" | "loading" | "ready"
 
-/**
- * Lazily loads the account list drag-and-drop runtime for manual ordering mode.
- */
-function loadAccountListDndRuntime() {
-  return import("./AccountListDndRuntime")
-}
-
 type AccountListDndRuntime = Awaited<
-  ReturnType<typeof loadAccountListDndRuntime>
+  ReturnType<typeof accountListDndRuntimeLoader.loadAccountListDndRuntime>
 >
 
 const ACCOUNT_REORDER_TOAST_ID = "account-reorder"
@@ -1247,7 +1241,8 @@ export default function AccountList({
 
     setDndLoadState("loading")
 
-    const loadPromise = loadAccountListDndRuntime()
+    const loadPromise = accountListDndRuntimeLoader
+      .loadAccountListDndRuntime()
       .then((runtime) => {
         dndRuntimeRef.current = runtime
         dndLoadPromiseRef.current = Promise.resolve(runtime)

--- a/src/features/AccountManagement/components/AccountList/loadAccountListDndRuntime.ts
+++ b/src/features/AccountManagement/components/AccountList/loadAccountListDndRuntime.ts
@@ -1,0 +1,4 @@
+/** Lazily loads the account-list drag-and-drop runtime. */
+export function loadAccountListDndRuntime() {
+  return import("./AccountListDndRuntime")
+}

--- a/src/features/AccountManagement/hooks/AccountDataContext.tsx
+++ b/src/features/AccountManagement/hooks/AccountDataContext.tsx
@@ -1177,26 +1177,26 @@ export const AccountDataProvider = ({
       setOrderedAccountIds(optimisticOrderedIds)
 
       try {
-        if (shouldUpdatePinnedOrder) {
-          const didPersistPinned = await accountStorage.setPinnedListSubset({
-            entryType: "account",
-            ids: optimisticPinnedIds.filter((id) => allAccountIdSet.has(id)),
-          })
-
-          if (!didPersistPinned) {
-            throw new Error("Failed to persist pinned account order")
-          }
-        }
-
-        const didPersistOrder = await accountStorage.setOrderedListSubset({
-          entryType: "account",
-          ids: optimisticOrderedIds.filter((id) => allAccountIdSet.has(id)),
+        const didPersistOrder = await accountStorage.setAccountListOrder({
+          pinnedIds: optimisticPinnedIds.filter((id) =>
+            allAccountIdSet.has(id),
+          ),
+          orderedIds: optimisticOrderedIds.filter((id) =>
+            allAccountIdSet.has(id),
+          ),
         })
 
         if (!didPersistOrder) {
           throw new Error("Failed to persist account order")
         }
+      } catch (error) {
+        logger.error("Failed to persist account reorder", { ids, error })
+        setPinnedAccountIds(previousPinnedIds)
+        setOrderedAccountIds(previousOrderedIds)
+        throw error
+      }
 
+      try {
         const [nextPinnedIds, nextOrderedIds] = await Promise.all([
           accountStorage.getPinnedList(),
           accountStorage.getOrderedList(),
@@ -1205,10 +1205,9 @@ export const AccountDataProvider = ({
         setPinnedAccountIds(nextPinnedIds)
         setOrderedAccountIds(nextOrderedIds)
       } catch (error) {
-        logger.error("Failed to persist account reorder", { ids, error })
-        setPinnedAccountIds(previousPinnedIds)
-        setOrderedAccountIds(previousOrderedIds)
-        throw error
+        logger.warn("Persisted account reorder but failed to refresh order", {
+          error,
+        })
       }
     },
     [displayData, orderedAccountIds, pinnedAccountIds],

--- a/src/features/AccountManagement/hooks/AccountDataContext.tsx
+++ b/src/features/AccountManagement/hooks/AccountDataContext.tsx
@@ -1208,6 +1208,7 @@ export const AccountDataProvider = ({
         logger.error("Failed to persist account reorder", { ids, error })
         setPinnedAccountIds(previousPinnedIds)
         setOrderedAccountIds(previousOrderedIds)
+        throw error
       }
     },
     [displayData, orderedAccountIds, pinnedAccountIds],

--- a/src/features/AccountManagement/testIds.ts
+++ b/src/features/AccountManagement/testIds.ts
@@ -12,6 +12,7 @@ export const ACCOUNT_MANAGEMENT_TEST_IDS = {
     "account-management-account-list-clear-sort-button",
   accountListBulkManageButton:
     "account-management-account-list-bulk-manage-button",
+  accountListReorderButton: "account-management-account-list-reorder-button",
   siteCheckInStatusButton: "account-management-site-check-in-status-button",
   customCheckInStatusButton: "account-management-custom-check-in-status-button",
   accountDialog: "account-management-account-dialog",

--- a/src/features/AccountManagement/testIds.ts
+++ b/src/features/AccountManagement/testIds.ts
@@ -123,6 +123,9 @@ export const ACCOUNT_MANAGEMENT_TEST_IDS = {
     "account-management-sponsor-fallback-api-credential-profiles-action",
 } as const
 
+export const ACCOUNT_MANAGEMENT_LIST_ITEM_TEST_ID_PREFIX =
+  "account-management-account-list-item-"
+
 /** Returns a stable test id for an account-list sort control. */
 export function getAccountManagementSortButtonTestId(field: SortField) {
   return `account-management-account-list-sort-${field}-button`
@@ -139,7 +142,7 @@ export function getAccountManagementSiteTypeOptionTestId(
  * Returns a stable test id for a rendered account row.
  */
 export function getAccountManagementListItemTestId(accountId: string) {
-  return `account-management-account-list-item-${accountId}`
+  return `${ACCOUNT_MANAGEMENT_LIST_ITEM_TEST_ID_PREFIX}${accountId}`
 }
 
 /**

--- a/src/locales/de/account.json
+++ b/src/locales/de/account.json
@@ -203,6 +203,18 @@
       "todayConsumption": "Heutiger Verbrauch",
       "todayIncome": "Heutiges Einkommen"
     },
+    "reorder": "Neu anordnen",
+    "reorderDone": "Anordnung abschließen",
+    "reorderFailed": "Die Kontoreihenfolge konnte nicht gespeichert werden. Die vorherige Reihenfolge wurde wiederhergestellt. Bitte erneut versuchen.",
+    "reorderLoadFailed": "Die Neuanordnung konnte nicht gestartet werden. Bitte erneut versuchen.",
+    "reorderPinnedBoundary": "Angeheftete und nicht angeheftete Konten werden getrennt sortiert. Ändern Sie zuerst den Anheftungsstatus, um das Konto zwischen den Gruppen zu verschieben.",
+    "reorderPinnedHint": "Angeheftete und nicht angeheftete Konten werden jeweils innerhalb ihrer eigenen Gruppe sortiert.",
+    "reorderSuccess": "Kontoreihenfolge gespeichert.",
+    "reorderSuccessFieldSortCleared": "Kontoreihenfolge gespeichert. Die aktive Feldsortierung wurde aufgehoben, damit die manuelle Reihenfolge wirksam wird.",
+    "reorderUnavailableInPopup": "Die Neuanordnung ist im Popup nicht verfügbar. Öffnen Sie die Seitenleiste oder die Kontoverwaltung.",
+    "reorderUnavailableInSettings": "Aktivieren Sie die manuelle Reihenfolge in den Sortierprioritäten.",
+    "reorderUnavailableWhileBulk": "Beenden Sie den Mehrfachmodus, bevor Sie Konten neu anordnen.",
+    "reorderUnavailableWhileSearch": "Löschen Sie die Suche, bevor Sie Konten neu anordnen.",
     "site": {
       "checkedInToday": "Heute eingecheckt, zum Ansehen klicken",
       "checkInStatusOutdated": "Der Check-in-Status wurde heute nicht erkannt (letzte Überprüfungszeit: {{time}}). Zum Aktualisieren klicken",

--- a/src/locales/en/account.json
+++ b/src/locales/en/account.json
@@ -203,6 +203,18 @@
       "todayConsumption": "Today's Consumption",
       "todayIncome": "Today's Income"
     },
+    "reorder": "Reorder",
+    "reorderDone": "Done reordering",
+    "reorderFailed": "Couldn't save the account order. The previous order was restored. Try again.",
+    "reorderLoadFailed": "Reordering could not be started. Please try again.",
+    "reorderPinnedBoundary": "Pinned and unpinned accounts are reordered separately. Change the account's pinned status before moving it between groups.",
+    "reorderPinnedHint": "Pinned and unpinned accounts reorder within their own groups.",
+    "reorderSuccess": "Account order saved.",
+    "reorderSuccessFieldSortCleared": "Account order saved. The active field sort was cleared so your manual order can take effect.",
+    "reorderUnavailableInPopup": "Reordering is unavailable in the popup. Open the side panel or account management page to reorder accounts.",
+    "reorderUnavailableInSettings": "Enable manual ordering in sorting priorities to reorder accounts.",
+    "reorderUnavailableWhileBulk": "Exit bulk mode before reordering accounts.",
+    "reorderUnavailableWhileSearch": "Clear the search before reordering accounts.",
     "site": {
       "checkedInToday": "Checked in today, click to view",
       "checkInStatusOutdated": "Check-in status wasn't detected today (last check time: {{time}}). Click to refresh",

--- a/src/locales/es-419/account.json
+++ b/src/locales/es-419/account.json
@@ -225,6 +225,18 @@
       "todayConsumption": "Consumo de hoy",
       "todayIncome": "Ingresos de hoy"
     },
+    "reorder": "Reordenar",
+    "reorderDone": "Terminar de reordenar",
+    "reorderFailed": "No se pudo guardar el orden de las cuentas. Se restauró el orden anterior. Inténtalo de nuevo.",
+    "reorderLoadFailed": "No se pudo iniciar el reordenamiento. Inténtalo de nuevo.",
+    "reorderPinnedBoundary": "Las cuentas fijadas y no fijadas se ordenan por separado. Cambia primero el estado de fijación para mover la cuenta entre grupos.",
+    "reorderPinnedHint": "Las cuentas fijadas y no fijadas se ordenan dentro de sus propios grupos.",
+    "reorderSuccess": "Orden de cuentas guardado.",
+    "reorderSuccessFieldSortCleared": "Orden de cuentas guardado. Se quitó el orden por campo activo para aplicar tu orden manual.",
+    "reorderUnavailableInPopup": "No se puede reordenar en la ventana emergente. Abre el panel lateral o la página de administración de cuentas.",
+    "reorderUnavailableInSettings": "Activa el orden manual en las prioridades de clasificación.",
+    "reorderUnavailableWhileBulk": "Sal del modo masivo antes de reordenar las cuentas.",
+    "reorderUnavailableWhileSearch": "Borra la búsqueda antes de reordenar las cuentas.",
     "site": {
       "checkedInToday": "Check-in realizado hoy, haz clic para ver",
       "checkInStatusOutdated": "El estado de check-in no se detectó hoy (última comprobación: {{time}}). Haz clic para actualizar",

--- a/src/locales/ja/account.json
+++ b/src/locales/ja/account.json
@@ -181,6 +181,18 @@
       "todayConsumption": "本日の消費",
       "todayIncome": "本日の収入"
     },
+    "reorder": "順序を変更",
+    "reorderDone": "並び替えを完了",
+    "reorderFailed": "アカウントの順序を保存できませんでした。以前の順序に戻しました。もう一度お試しください。",
+    "reorderLoadFailed": "並び替えを開始できませんでした。もう一度お試しください。",
+    "reorderPinnedBoundary": "ピン留めしたアカウントと通常のアカウントは別々に並び替えます。グループ間を移動するには、先にピン留め状態を変更してください。",
+    "reorderPinnedHint": "ピン留めしたアカウントと通常のアカウントは、それぞれのグループ内で並び替えます。",
+    "reorderSuccess": "アカウントの順序を保存しました。",
+    "reorderSuccessFieldSortCleared": "アカウントの順序を保存しました。手動の順序を反映するため、使用中の項目別並び替えを解除しました。",
+    "reorderUnavailableInPopup": "ポップアップでは並び替えを利用できません。サイドパネルまたはアカウント管理ページで操作してください。",
+    "reorderUnavailableInSettings": "並び替えの優先順位で手動順序を有効にしてください。",
+    "reorderUnavailableWhileBulk": "一括操作を終了してから並び替えてください。",
+    "reorderUnavailableWhileSearch": "検索をクリアしてから並び替えてください。",
     "site": {
       "checkedInToday": "本日はチェックイン済み、クリックして表示",
       "checkInStatusOutdated": "本日のチェックイン状態はまだ検出されていません（前回確認時刻: {{time}}）。クリックして更新",

--- a/src/locales/pt-BR/account.json
+++ b/src/locales/pt-BR/account.json
@@ -225,6 +225,18 @@
       "todayConsumption": "Consumo de hoje",
       "todayIncome": "Renda de hoje"
     },
+    "reorder": "Reordenar",
+    "reorderDone": "Concluir reordenação",
+    "reorderFailed": "Não foi possível salvar a ordem das contas. A ordem anterior foi restaurada. Tente novamente.",
+    "reorderLoadFailed": "Não foi possível iniciar a reordenação. Tente novamente.",
+    "reorderPinnedBoundary": "Contas fixadas e não fixadas são ordenadas separadamente. Altere primeiro o status de fixação para mover a conta entre os grupos.",
+    "reorderPinnedHint": "Contas fixadas e não fixadas são ordenadas dentro de seus próprios grupos.",
+    "reorderSuccess": "Ordem das contas salva.",
+    "reorderSuccessFieldSortCleared": "Ordem das contas salva. A ordenação por campo ativa foi removida para aplicar sua ordem manual.",
+    "reorderUnavailableInPopup": "A reordenação não está disponível no pop-up. Abra o painel lateral ou a página de gerenciamento de contas.",
+    "reorderUnavailableInSettings": "Ative a ordem manual nas prioridades de classificação.",
+    "reorderUnavailableWhileBulk": "Saia do modo em lote antes de reordenar as contas.",
+    "reorderUnavailableWhileSearch": "Limpe a pesquisa antes de reordenar as contas.",
     "site": {
       "checkedInToday": "Check-in hoje, clique para visualizar",
       "checkInStatusOutdated": "O status do check-in não foi detectado hoje (horário da última verificação: {{time}}). Clique para atualizar",

--- a/src/locales/vi/account.json
+++ b/src/locales/vi/account.json
@@ -181,6 +181,18 @@
       "todayConsumption": "Tiêu dùng hôm nay",
       "todayIncome": "Thu nhập hôm nay"
     },
+    "reorder": "Sắp xếp lại",
+    "reorderDone": "Hoàn tất sắp xếp",
+    "reorderFailed": "Không thể lưu thứ tự tài khoản. Thứ tự trước đó đã được khôi phục. Vui lòng thử lại.",
+    "reorderLoadFailed": "Không thể bắt đầu sắp xếp. Vui lòng thử lại.",
+    "reorderPinnedBoundary": "Tài khoản đã ghim và chưa ghim được sắp xếp riêng. Hãy đổi trạng thái ghim trước khi chuyển tài khoản giữa các nhóm.",
+    "reorderPinnedHint": "Tài khoản đã ghim và chưa ghim chỉ được sắp xếp trong nhóm tương ứng.",
+    "reorderSuccess": "Đã lưu thứ tự tài khoản.",
+    "reorderSuccessFieldSortCleared": "Đã lưu thứ tự tài khoản. Kiểu sắp xếp theo trường đang dùng đã được xóa để áp dụng thứ tự thủ công.",
+    "reorderUnavailableInPopup": "Không thể sắp xếp trong cửa sổ bật lên. Hãy mở bảng bên hoặc trang quản lý tài khoản.",
+    "reorderUnavailableInSettings": "Hãy bật thứ tự thủ công trong ưu tiên sắp xếp.",
+    "reorderUnavailableWhileBulk": "Hãy thoát chế độ hàng loạt trước khi sắp xếp tài khoản.",
+    "reorderUnavailableWhileSearch": "Hãy xóa tìm kiếm trước khi sắp xếp tài khoản.",
     "site": {
       "checkedInToday": "Hôm nay đã điểm danh, nhấp vào tôi để xem",
       "checkInStatusOutdated": "Trạng thái điểm danh không phải là kiểm tra hôm nay (lần kiểm tra cuối: {{time}}), nhấp vào tôi để làm mới",

--- a/src/locales/zh-CN/account.json
+++ b/src/locales/zh-CN/account.json
@@ -181,6 +181,18 @@
       "todayConsumption": "今日消费",
       "todayIncome": "今日收入"
     },
+    "reorder": "调整顺序",
+    "reorderDone": "完成排序",
+    "reorderFailed": "无法保存账号顺序，已恢复之前的顺序，请重试。",
+    "reorderLoadFailed": "无法启动排序，请重试。",
+    "reorderPinnedBoundary": "置顶账号和普通账号需分别排序。如需跨组移动，请先更改账号的置顶状态。",
+    "reorderPinnedHint": "置顶账号和普通账号仅在各自组内调整顺序。",
+    "reorderSuccess": "账号顺序已保存。",
+    "reorderSuccessFieldSortCleared": "账号顺序已保存。为使手动顺序生效，已清除当前字段排序。",
+    "reorderUnavailableInPopup": "弹出窗口暂不支持拖拽排序。请在侧边栏或账号管理页面中调整顺序。",
+    "reorderUnavailableInSettings": "请先在排序优先级中启用手动排序。",
+    "reorderUnavailableWhileBulk": "请先退出批量操作，再调整账号顺序。",
+    "reorderUnavailableWhileSearch": "请先清除搜索，再调整账号顺序。",
     "site": {
       "checkedInToday": "今日已签到，点我查看",
       "checkInStatusOutdated": "签到状态不是今日检测（上次检测时间：{{time}}），点我刷新",

--- a/src/locales/zh-TW/account.json
+++ b/src/locales/zh-TW/account.json
@@ -181,6 +181,18 @@
       "todayConsumption": "今日消費",
       "todayIncome": "今日收入"
     },
+    "reorder": "調整順序",
+    "reorderDone": "完成排序",
+    "reorderFailed": "無法儲存帳號順序，已還原先前的順序，請重試。",
+    "reorderLoadFailed": "無法啟動排序，請重試。",
+    "reorderPinnedBoundary": "置頂帳號和一般帳號需分別排序。如需跨組移動，請先變更帳號的置頂狀態。",
+    "reorderPinnedHint": "置頂帳號和一般帳號僅能在各自群組內調整順序。",
+    "reorderSuccess": "帳號順序已儲存。",
+    "reorderSuccessFieldSortCleared": "帳號順序已儲存。為使手動順序生效，已清除目前的欄位排序。",
+    "reorderUnavailableInPopup": "彈出視窗暫不支援拖曳排序。請在側邊欄或帳號管理頁面中調整順序。",
+    "reorderUnavailableInSettings": "請先在排序優先順序中啟用手動排序。",
+    "reorderUnavailableWhileBulk": "請先退出批次操作，再調整帳號順序。",
+    "reorderUnavailableWhileSearch": "請先清除搜尋，再調整帳號順序。",
     "site": {
       "checkedInToday": "今日已簽到，點我檢視",
       "checkInStatusOutdated": "簽到狀態不是今日檢測（上次檢測時間：{{time}}），點我重新整理",

--- a/src/services/accounts/accountStorage.ts
+++ b/src/services/accounts/accountStorage.ts
@@ -1115,6 +1115,38 @@ class AccountStorageService {
   }
 
   /**
+   * Atomically update account-only pinned and manual ordering while preserving bookmarks.
+   */
+  async setAccountListOrder(input: {
+    pinnedIds: string[]
+    orderedIds: string[]
+  }): Promise<boolean> {
+    try {
+      return await this.mutateStorageConfig((config) => {
+        const { accountIds, entryIds } =
+          AccountStorageService.buildEntryIdSets(config)
+        const pinnedIds = AccountStorageService.replaceIdListSubset({
+          existingIds: config.pinnedAccountIds,
+          subsetIdSet: accountIds,
+          nextSubsetIds: Array.from(new Set(input.pinnedIds)),
+        })
+        const orderedIds = AccountStorageService.replaceIdListSubset({
+          existingIds: config.orderedAccountIds,
+          subsetIdSet: accountIds,
+          nextSubsetIds: Array.from(new Set(input.orderedIds)),
+        })
+
+        config.pinnedAccountIds = pinnedIds.filter((id) => entryIds.has(id))
+        config.orderedAccountIds = orderedIds.filter((id) => entryIds.has(id))
+        return { result: true, changed: true }
+      })
+    } catch (error) {
+      logger.error("设置账号排序失败", error)
+      return false
+    }
+  }
+
+  /**
    * Pin account (moves to front).
    */
   async pinAccount(id: string): Promise<boolean> {

--- a/tests/entrypoints/popup/viewRegistry.test.tsx
+++ b/tests/entrypoints/popup/viewRegistry.test.tsx
@@ -192,9 +192,11 @@ describe("usePopupViewRegistry", () => {
       withThemeProvider: false,
     })
 
-    expect(accountListPropsMock).toHaveBeenLastCalledWith({
-      reorderUnavailableReason: "account:list.reorderUnavailableInPopup",
-      virtualScrollParent: scrollParent,
-    })
+    expect(accountListPropsMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        reorderUnavailableReason: "account:list.reorderUnavailableInPopup",
+        virtualScrollParent: scrollParent,
+      }),
+    )
   })
 })

--- a/tests/entrypoints/popup/viewRegistry.test.tsx
+++ b/tests/entrypoints/popup/viewRegistry.test.tsx
@@ -4,12 +4,17 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import { usePopupViewRegistry } from "~/entrypoints/popup/viewRegistry"
 import { fireEvent, render, screen } from "~~/tests/test-utils/render"
 
-const { handleAddAccountClickMock, openAddBookmarkMock, openAddDialogMock } =
-  vi.hoisted(() => ({
-    handleAddAccountClickMock: vi.fn(),
-    openAddBookmarkMock: vi.fn(),
-    openAddDialogMock: vi.fn(),
-  }))
+const {
+  accountListPropsMock,
+  handleAddAccountClickMock,
+  openAddBookmarkMock,
+  openAddDialogMock,
+} = vi.hoisted(() => ({
+  accountListPropsMock: vi.fn(),
+  handleAddAccountClickMock: vi.fn(),
+  openAddBookmarkMock: vi.fn(),
+  openAddDialogMock: vi.fn(),
+}))
 
 vi.mock("~/hooks/useAddAccountHandler", () => ({
   useAddAccountHandler: () => ({
@@ -24,7 +29,10 @@ vi.mock("~/features/SiteBookmarks/hooks/BookmarkDialogStateContext", () => ({
 }))
 
 vi.mock("~/features/AccountManagement/components/AccountList", () => ({
-  default: () => <div>AccountList</div>,
+  default: (props: Record<string, unknown>) => {
+    accountListPropsMock(props)
+    return <div>AccountList</div>
+  },
 }))
 
 vi.mock("~/entrypoints/popup/components/BalanceSection", () => ({
@@ -64,11 +72,15 @@ vi.mock(
 )
 
 function RegistryProbe({
+  isPopup = false,
   mountApiContent = true,
+  scrollParent,
 }: {
+  isPopup?: boolean
   mountApiContent?: boolean
+  scrollParent?: HTMLElement | null
 }) {
-  const registry = usePopupViewRegistry()
+  const registry = usePopupViewRegistry({ isPopup, scrollParent })
 
   return (
     <div>
@@ -170,5 +182,19 @@ describe("usePopupViewRegistry", () => {
       await screen.findByText("ApiCredentialProfilesPopupView"),
     ).toBeInTheDocument()
     expect(openAddDialogMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("disables popup reordering and forwards its shared scroll container", () => {
+    const scrollParent = document.createElement("div")
+
+    render(<RegistryProbe isPopup scrollParent={scrollParent} />, {
+      withUserPreferencesProvider: false,
+      withThemeProvider: false,
+    })
+
+    expect(accountListPropsMock).toHaveBeenLastCalledWith({
+      reorderUnavailableReason: "account:list.reorderUnavailableInPopup",
+      virtualScrollParent: scrollParent,
+    })
   })
 })

--- a/tests/features/AccountManagement/components/AccountList.test.tsx
+++ b/tests/features/AccountManagement/components/AccountList.test.tsx
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { DATA_TYPE_BALANCE } from "~/constants"
 import { AUTO_CHECKIN_METHOD_IDS } from "~/constants/checkIn"
 import AccountList from "~/features/AccountManagement/components/AccountList"
+import * as accountListDndRuntimeLoader from "~/features/AccountManagement/components/AccountList/loadAccountListDndRuntime"
 import * as inviteLinkCopyWorkflow from "~/features/AccountManagement/inviteLinkCopyWorkflow"
 import {
   ACCOUNT_MANAGEMENT_TEST_IDS,
@@ -883,8 +884,12 @@ describe("AccountList", () => {
 
   it("enters an explicit unvirtualized reorder mode next to bulk management", async () => {
     const user = userEvent.setup()
+    const handleReorder = vi.fn()
     mockUseAccountDataContext.mockReturnValue(
-      createAccountDataContextValue({ isManualSortFeatureEnabled: true }),
+      createAccountDataContextValue({
+        handleReorder,
+        isManualSortFeatureEnabled: true,
+      }),
     )
 
     render(<AccountList />)
@@ -904,6 +909,64 @@ describe("AccountList", () => {
     expect(
       screen.getByRole("button", { name: "account:bulk.manage" }),
     ).toBeDisabled()
+
+    await user.click(
+      screen.getByRole("button", { name: "account:list.reorderDone" }),
+    )
+
+    expect(screen.getByTestId(TEST_IDS.virtuoso)).toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: "account:list.dragHandle" }),
+    ).not.toBeInTheDocument()
+    expect(handleReorder).not.toHaveBeenCalled()
+  })
+
+  it("restores virtual browsing when the dnd runtime fails to load", async () => {
+    const user = userEvent.setup()
+    vi.spyOn(
+      accountListDndRuntimeLoader,
+      "loadAccountListDndRuntime",
+    ).mockRejectedValueOnce(new Error("dnd load failed"))
+    mockUseAccountDataContext.mockReturnValue(
+      createAccountDataContextValue({ isManualSortFeatureEnabled: true }),
+    )
+
+    render(<AccountList />)
+
+    await user.click(
+      screen.getByRole("button", { name: "account:list.reorder" }),
+    )
+
+    await waitFor(() => {
+      expect(toastErrorMock).toHaveBeenCalledWith(
+        "account:list.reorderLoadFailed",
+      )
+    })
+    expect(screen.getByTestId(TEST_IDS.virtuoso)).toBeInTheDocument()
+    expect(screen.queryByTestId(TEST_IDS.dndContext)).not.toBeInTheDocument()
+  })
+
+  it("keeps the detected account highlighted in browsing and reorder modes", async () => {
+    const user = userEvent.setup()
+    const contextValue = createAccountDataContextValue({
+      detectedAccount: { id: "enabled-alpha" },
+      isManualSortFeatureEnabled: true,
+    })
+    mockUseAccountDataContext.mockReturnValue(contextValue)
+
+    render(<AccountList />)
+
+    expect(
+      screen.getByText("Enabled Alpha").closest(".border-l-blue-500"),
+    ).toBeInTheDocument()
+
+    await user.click(
+      screen.getByRole("button", { name: "account:list.reorder" }),
+    )
+
+    expect(
+      (await screen.findByText("Enabled Alpha")).closest(".border-l-blue-500"),
+    ).toBeInTheDocument()
   })
 
   it("loads reorder controls after StrictMode replays mount effects", async () => {
@@ -1192,6 +1255,14 @@ describe("AccountList", () => {
     expect(
       screen.getAllByRole("button", { name: "account:list.dragHandle" })[0],
     ).toBeDisabled()
+
+    act(() => {
+      dndState.onDragEnd?.({
+        active: { id: "enabled-gamma" },
+        over: { id: "disabled-beta" },
+      })
+    })
+    expect(handleReorder).toHaveBeenCalledTimes(1)
 
     await act(async () => {
       rejectReorder?.(new Error("storage unavailable"))

--- a/tests/features/AccountManagement/components/AccountList.test.tsx
+++ b/tests/features/AccountManagement/components/AccountList.test.tsx
@@ -3,12 +3,14 @@ import userEvent from "@testing-library/user-event"
 import React from "react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
+import { DATA_TYPE_BALANCE } from "~/constants"
 import { AUTO_CHECKIN_METHOD_IDS } from "~/constants/checkIn"
 import AccountList from "~/features/AccountManagement/components/AccountList"
 import * as inviteLinkCopyWorkflow from "~/features/AccountManagement/inviteLinkCopyWorkflow"
 import {
   ACCOUNT_MANAGEMENT_TEST_IDS,
   getAccountManagementSelectionCheckboxTestId,
+  getAccountManagementSortButtonTestId,
 } from "~/features/AccountManagement/testIds"
 import enAccount from "~/locales/en/account.json"
 import { createCompatibilityCheckInConfig } from "~/services/checkin/autoCheckin/compatibilityConfig"
@@ -56,6 +58,7 @@ type SortableMockState = {
 const TEST_IDS = vi.hoisted(() => ({
   dndContext: "dnd-context",
   sortableContext: "sortable-context",
+  virtuoso: "virtuoso",
   singleTagFilter: "single-tag-filter",
   multiTagFilter: "multi-tag-filter",
   accountRow: "account-row",
@@ -72,6 +75,7 @@ const {
   handleSetAccountsDisabledMock,
   startProductAnalyticsActionMock,
   clipboardWriteTextMock,
+  toastDefaultMock,
   toastErrorMock,
   toastSuccessMock,
   trackProductAnalyticsActionStartedMock,
@@ -92,6 +96,7 @@ const {
   handleSetAccountsDisabledMock: vi.fn(),
   startProductAnalyticsActionMock: vi.fn(),
   clipboardWriteTextMock: vi.fn(),
+  toastDefaultMock: vi.fn(),
   toastErrorMock: vi.fn(),
   toastSuccessMock: vi.fn(),
   trackProductAnalyticsActionStartedMock: vi.fn(),
@@ -116,13 +121,6 @@ const {
   useSortableMock: vi.fn(),
 }))
 
-const idleCallbackState = {
-  callback: null as
-    | ((deadline: { didTimeout: boolean; timeRemaining: () => number }) => void)
-    | null,
-  handle: 0,
-}
-
 vi.mock("@dnd-kit/core", () => ({
   closestCenter: vi.fn(),
   DndContext: ({
@@ -139,6 +137,44 @@ vi.mock("@dnd-kit/core", () => ({
   PointerSensor: vi.fn(),
   useSensor: useSensorMock,
   useSensors: () => [],
+}))
+
+vi.mock("react-virtuoso", () => ({
+  Virtuoso: ({
+    components,
+    computeItemKey,
+    customScrollParent,
+    data,
+    itemContent,
+    useWindowScroll,
+  }: {
+    components?: { List?: React.ComponentType<any> }
+    computeItemKey?: (index: number, item: any) => React.Key
+    customScrollParent?: HTMLElement
+    data: any[]
+    itemContent: (index: number, item: any) => React.ReactNode
+    useWindowScroll?: boolean
+  }) => {
+    const List = components?.List ?? ((props: any) => <div {...props} />)
+
+    return (
+      <div
+        data-testid={TEST_IDS.virtuoso}
+        data-custom-scroll-parent={customScrollParent ? "true" : "false"}
+        data-window-scroll={String(Boolean(useWindowScroll))}
+      >
+        <List>
+          {data.map((item, index) => (
+            <React.Fragment
+              key={computeItemKey?.(index, item) ?? String(index)}
+            >
+              {itemContent(index, item)}
+            </React.Fragment>
+          ))}
+        </List>
+      </div>
+    )
+  },
 }))
 
 vi.mock("@dnd-kit/sortable", () => ({
@@ -332,10 +368,10 @@ vi.mock("~/services/productAnalytics/actions", async (importOriginal) => {
 })
 
 vi.mock("react-hot-toast", () => ({
-  default: {
+  default: Object.assign(toastDefaultMock, {
     success: toastSuccessMock,
     error: toastErrorMock,
-  },
+  }),
 }))
 
 vi.mock("~/hooks/useMediaQuery", () => ({
@@ -536,6 +572,9 @@ function createAccountDataContextValue(
     sortField: "name",
     sortOrder: "asc",
     handleReorder: vi.fn(),
+    orderedAccountIds: [],
+    pinnedAccountIds: [],
+    isPinFeatureEnabled: false,
     tags: [
       buildTag({ id: "team-a", name: "Team A" }),
       buildTag({ id: "team-b", name: "Team B" }),
@@ -597,8 +636,6 @@ describe("AccountList", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     dndState.onDragEnd = undefined
-    idleCallbackState.callback = null
-    idleCallbackState.handle = 0
     sortableReturnState.current = {
       attributes: {},
       listeners: {},
@@ -608,15 +645,6 @@ describe("AccountList", () => {
       transition: undefined,
       isDragging: false,
     }
-    vi.stubGlobal(
-      "requestIdleCallback",
-      vi.fn((callback: NonNullable<typeof idleCallbackState.callback>) => {
-        idleCallbackState.callback = callback
-        idleCallbackState.handle += 1
-        return idleCallbackState.handle
-      }),
-    )
-    vi.stubGlobal("cancelIdleCallback", vi.fn())
     handleDeleteAccountsMock.mockResolvedValue({
       deletedCount: 0,
       deletedIds: [],
@@ -825,7 +853,7 @@ describe("AccountList", () => {
     expect(clearSortConfig).not.toHaveBeenCalled()
   })
 
-  it("auto-loads dnd during idle time after the first render settles", async () => {
+  it("virtualizes normal browsing and keeps dnd inactive until reorder is requested", () => {
     mockUseAccountDataContext.mockReturnValue(
       createAccountDataContextValue({
         isManualSortFeatureEnabled: true,
@@ -834,96 +862,165 @@ describe("AccountList", () => {
 
     render(<AccountList />)
 
-    expect(screen.queryByTestId(TEST_IDS.dndContext)).not.toBeInTheDocument()
-    expect(
-      screen.queryByTestId(TEST_IDS.sortableContext),
-    ).not.toBeInTheDocument()
-    expect(useSortableMock).not.toHaveBeenCalled()
-
-    await act(async () => {
-      idleCallbackState.callback?.({
-        didTimeout: false,
-        timeRemaining: () => 50,
-      })
-    })
-
-    expect(await screen.findByTestId(TEST_IDS.dndContext)).toBeInTheDocument()
-    expect(screen.getByTestId(TEST_IDS.sortableContext)).toBeInTheDocument()
-    expect(useSensorMock).toHaveBeenCalledWith(expect.any(Function))
-    expect(useSensorMock).toHaveBeenCalledWith(expect.any(Function), {
-      coordinateGetter: sortableKeyboardCoordinatesMock,
-    })
-    expect(useSortableMock).toHaveBeenCalledTimes(4)
-  })
-
-  it("falls back to timeout-based dnd loading when requestIdleCallback is unavailable", async () => {
-    vi.stubGlobal("requestIdleCallback", undefined)
-    vi.useFakeTimers()
-    try {
-      mockUseAccountDataContext.mockReturnValue(
-        createAccountDataContextValue({
-          isManualSortFeatureEnabled: true,
-        }),
-      )
-
-      render(<AccountList />)
-
-      expect(screen.queryByTestId(TEST_IDS.dndContext)).not.toBeInTheDocument()
-
-      await act(async () => {
-        await vi.runOnlyPendingTimersAsync()
-      })
-
-      vi.useRealTimers()
-      expect(await screen.findByTestId(TEST_IDS.dndContext)).toBeInTheDocument()
-      expect(screen.getByTestId(TEST_IDS.sortableContext)).toBeInTheDocument()
-    } finally {
-      vi.useRealTimers()
-    }
-  })
-
-  it("cancels the pending idle callback when the list unmounts before dnd preload runs", () => {
-    mockUseAccountDataContext.mockReturnValue(
-      createAccountDataContextValue({
-        isManualSortFeatureEnabled: true,
-      }),
+    expect(screen.getByTestId(TEST_IDS.virtuoso)).toHaveAttribute(
+      "data-window-scroll",
+      "true",
     )
-
-    const { unmount } = render(<AccountList />)
-
-    unmount()
-
-    expect(globalThis.cancelIdleCallback).toHaveBeenCalledWith(1)
+    expect(screen.queryByTestId(TEST_IDS.dndContext)).not.toBeInTheDocument()
+    expect(useSortableMock).not.toHaveBeenCalled()
+    expect(
+      screen.queryByRole("button", { name: "account:list.dragHandle" }),
+    ).not.toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "account:list.reorder" }),
+    ).toBeEnabled()
+    expect(
+      screen.getByTestId(
+        ACCOUNT_MANAGEMENT_TEST_IDS.accountListBulkManageButton,
+      ),
+    ).toHaveAttribute("aria-pressed", "false")
   })
 
-  it("uses the drag handle as a manual fallback before idle loading finishes", async () => {
+  it("enters an explicit unvirtualized reorder mode next to bulk management", async () => {
     const user = userEvent.setup()
-
     mockUseAccountDataContext.mockReturnValue(
-      createAccountDataContextValue({
-        isManualSortFeatureEnabled: true,
-      }),
+      createAccountDataContextValue({ isManualSortFeatureEnabled: true }),
     )
 
     render(<AccountList />)
 
     await user.click(
-      screen.getAllByRole("button", {
-        name: "account:list.dragHandle",
-      })[0],
+      screen.getByRole("button", { name: "account:list.reorder" }),
     )
 
     expect(await screen.findByTestId(TEST_IDS.dndContext)).toBeInTheDocument()
-    expect(screen.getByTestId(TEST_IDS.sortableContext)).toBeInTheDocument()
-    expect(useSortableMock).toHaveBeenCalledTimes(4)
+    expect(screen.queryByTestId(TEST_IDS.virtuoso)).not.toBeInTheDocument()
+    expect(
+      screen.getAllByRole("button", { name: "account:list.dragHandle" }),
+    ).toHaveLength(4)
+    expect(
+      screen.getByRole("button", { name: "account:list.reorderDone" }),
+    ).toHaveAttribute("aria-pressed", "true")
+    expect(
+      screen.getByRole("button", { name: "account:bulk.manage" }),
+    ).toBeDisabled()
   })
 
-  it("keeps the existing reorder flow after dnd activation", async () => {
+  it("loads reorder controls after StrictMode replays mount effects", async () => {
     const user = userEvent.setup()
-    const handleReorder = vi.fn()
+    mockUseAccountDataContext.mockReturnValue(
+      createAccountDataContextValue({ isManualSortFeatureEnabled: true }),
+    )
+
+    render(
+      <React.StrictMode>
+        <AccountList />
+      </React.StrictMode>,
+    )
+
+    await user.click(
+      screen.getByRole("button", { name: "account:list.reorder" }),
+    )
+
+    expect(await screen.findByTestId(TEST_IDS.dndContext)).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "account:list.reorderDone" }),
+    ).not.toBeDisabled()
+  })
+
+  it("uses the supplied popup scroller for virtualized browsing", () => {
+    const scrollParent = document.createElement("div")
+
+    render(<AccountList virtualScrollParent={scrollParent} />)
+
+    expect(screen.getByTestId(TEST_IDS.virtuoso)).toHaveAttribute(
+      "data-custom-scroll-parent",
+      "true",
+    )
+    expect(screen.getByTestId(TEST_IDS.virtuoso)).toHaveAttribute(
+      "data-window-scroll",
+      "false",
+    )
+  })
+
+  it("preserves the visible order and lets field sorting replace reorder mode", async () => {
+    const user = userEvent.setup()
+    const clearSortConfig = vi.fn()
+    const handleSort = vi.fn()
+    const contextValue = createAccountDataContextValue({
+      clearSortConfig,
+      handleSort,
+      isManualSortFeatureEnabled: true,
+      isPinFeatureEnabled: true,
+      orderedAccountIds: ["enabled-gamma", "enabled-alpha"],
+      pinnedAccountIds: ["disabled-beta"],
+    })
+    contextValue.sortedData = [...contextValue.sortedData].reverse()
+    mockUseAccountDataContext.mockReturnValue(contextValue)
+
+    render(<AccountList />)
+    const orderBeforeReorder = screen
+      .getAllByTestId(TEST_IDS.accountRow)
+      .map((row) => row.textContent)
+
+    await user.click(
+      screen.getByRole("button", { name: "account:list.reorder" }),
+    )
+
+    const rows = await screen.findAllByTestId(TEST_IDS.accountRow)
+    expect(rows.map((row) => row.textContent)).toEqual(orderBeforeReorder)
+    expect(
+      screen.getByTestId(getAccountManagementSortButtonTestId("name")),
+    ).toBeEnabled()
+    expect(
+      screen.getByRole("button", { name: "account:list.clearSort" }),
+    ).toBeInTheDocument()
+
+    await user.click(
+      screen.getByTestId(
+        getAccountManagementSortButtonTestId(DATA_TYPE_BALANCE),
+      ),
+    )
+    expect(handleSort).toHaveBeenCalledWith(DATA_TYPE_BALANCE)
+    expect(clearSortConfig).not.toHaveBeenCalled()
+    expect(screen.queryByTestId(TEST_IDS.dndContext)).not.toBeInTheDocument()
+  })
+
+  it("keeps popup reorder discoverable with a hoverable disabled explanation", async () => {
+    const user = userEvent.setup()
+    mockUseAccountDataContext.mockReturnValue(
+      createAccountDataContextValue({ isManualSortFeatureEnabled: true }),
+    )
+
+    render(
+      <AccountList reorderUnavailableReason="account:list.reorderUnavailableInPopup" />,
+    )
+
+    const reorderButton = screen.getByRole("button", {
+      name: "account:list.reorder",
+    })
+    expect(reorderButton).toHaveAttribute("aria-disabled", "true")
+    expect(reorderButton).toHaveAccessibleDescription(
+      "account:list.reorderUnavailableInPopup",
+    )
+    expect(reorderButton).toHaveClass("aria-disabled:pointer-events-auto")
+
+    await user.hover(reorderButton)
+    expect(
+      await screen.findByRole("tooltip", {
+        name: "account:list.reorderUnavailableInPopup",
+      }),
+    ).toBeInTheDocument()
+  })
+
+  it("keeps a successful drag in place and activates manual ordering", async () => {
+    const user = userEvent.setup()
+    const clearSortConfig = vi.fn()
+    const handleReorder = vi.fn().mockResolvedValue(undefined)
 
     mockUseAccountDataContext.mockReturnValue(
       createAccountDataContextValue({
+        clearSortConfig,
         isManualSortFeatureEnabled: true,
         handleReorder,
       }),
@@ -932,17 +1029,17 @@ describe("AccountList", () => {
     render(<AccountList />)
 
     await user.click(
-      screen.getAllByRole("button", {
-        name: "account:list.dragHandle",
-      })[0],
+      screen.getByRole("button", { name: "account:list.reorder" }),
     )
 
     expect(await screen.findByTestId(TEST_IDS.dndContext)).toBeInTheDocument()
     expect(dndState.onDragEnd).toBeTypeOf("function")
 
-    dndState.onDragEnd?.({
-      active: { id: "enabled-alpha" },
-      over: { id: "enabled-gamma" },
+    act(() => {
+      dndState.onDragEnd?.({
+        active: { id: "enabled-alpha" },
+        over: { id: "enabled-gamma" },
+      })
     })
 
     expect(handleReorder).toHaveBeenCalledWith([
@@ -951,16 +1048,182 @@ describe("AccountList", () => {
       "enabled-alpha",
       "unsynced-delta",
     ])
+    expect(
+      screen.getAllByTestId(TEST_IDS.accountRow).map((row) => row.textContent),
+    ).toEqual([
+      "Disabled Beta",
+      "Enabled Gamma",
+      "Enabled Alpha",
+      "Unsynced Delta",
+    ])
+    await waitFor(() => {
+      expect(clearSortConfig).toHaveBeenCalledOnce()
+      expect(toastSuccessMock).toHaveBeenCalledWith(
+        "account:list.reorderSuccessFieldSortCleared",
+        { id: "account-reorder" },
+      )
+    })
+  })
+
+  it("keeps pinned and unpinned accounts in separate reorder groups", async () => {
+    const user = userEvent.setup()
+    const clearSortConfig = vi.fn()
+    const handleReorder = vi.fn().mockResolvedValue(undefined)
+
+    mockUseAccountDataContext.mockReturnValue(
+      createAccountDataContextValue({
+        clearSortConfig,
+        handleReorder,
+        isManualSortFeatureEnabled: true,
+        pinnedAccountIds: ["enabled-alpha", "enabled-gamma"],
+      }),
+    )
+
+    render(<AccountList />)
+    const previousOrder = screen
+      .getAllByTestId(TEST_IDS.accountRow)
+      .map((row) => row.textContent)
+
+    await user.click(
+      screen.getByRole("button", { name: "account:list.reorder" }),
+    )
+    expect(await screen.findByTestId(TEST_IDS.dndContext)).toBeInTheDocument()
+    expect(screen.getByRole("note")).toHaveTextContent(
+      "account:list.reorderPinnedHint",
+    )
+
+    act(() => {
+      dndState.onDragEnd?.({
+        active: { id: "enabled-alpha" },
+        over: { id: "enabled-gamma" },
+      })
+    })
+
+    expect(handleReorder).not.toHaveBeenCalled()
+    expect(clearSortConfig).not.toHaveBeenCalled()
+    expect(
+      screen.getAllByTestId(TEST_IDS.accountRow).map((row) => row.textContent),
+    ).toEqual(previousOrder)
+    expect(toastDefaultMock).toHaveBeenCalledWith(
+      "account:list.reorderPinnedBoundary",
+      {
+        duration: 5000,
+        icon: expect.any(Object),
+        id: "account-reorder-boundary",
+      },
+    )
+  })
+
+  it("reorders pinned accounts within one contiguous group", async () => {
+    const user = userEvent.setup()
+    const handleReorder = vi.fn().mockResolvedValue(undefined)
+    const contextValue = createAccountDataContextValue({
+      handleReorder,
+      isManualSortFeatureEnabled: true,
+      pinnedAccountIds: ["enabled-alpha", "enabled-gamma"],
+      sortField: null,
+    })
+    const [alpha, beta, gamma, delta] = contextValue.sortedData
+    contextValue.sortedData = [alpha, gamma, beta, delta]
+    mockUseAccountDataContext.mockReturnValue(contextValue)
+
+    render(<AccountList />)
+
+    await user.click(
+      screen.getByRole("button", { name: "account:list.reorder" }),
+    )
+    expect(await screen.findByTestId(TEST_IDS.dndContext)).toBeInTheDocument()
+
+    await act(async () => {
+      dndState.onDragEnd?.({
+        active: { id: "enabled-alpha" },
+        over: { id: "enabled-gamma" },
+      })
+      await Promise.resolve()
+    })
+
+    expect(handleReorder).toHaveBeenCalledWith([
+      "enabled-gamma",
+      "enabled-alpha",
+      "disabled-beta",
+      "unsynced-delta",
+    ])
+    expect(toastDefaultMock).not.toHaveBeenCalled()
+  })
+
+  it("restores the previous order and explains a failed reorder save", async () => {
+    const user = userEvent.setup()
+    const clearSortConfig = vi.fn()
+    let rejectReorder: ((reason?: unknown) => void) | undefined
+    const handleReorder = vi.fn(
+      () =>
+        new Promise<void>((_resolve, reject) => {
+          rejectReorder = reject
+        }),
+    )
+
+    mockUseAccountDataContext.mockReturnValue(
+      createAccountDataContextValue({
+        clearSortConfig,
+        handleReorder,
+        isManualSortFeatureEnabled: true,
+      }),
+    )
+
+    render(<AccountList />)
+    const previousOrder = screen
+      .getAllByTestId(TEST_IDS.accountRow)
+      .map((row) => row.textContent)
+
+    await user.click(
+      screen.getByRole("button", { name: "account:list.reorder" }),
+    )
+    expect(await screen.findByTestId(TEST_IDS.dndContext)).toBeInTheDocument()
+
+    act(() => {
+      dndState.onDragEnd?.({
+        active: { id: "enabled-alpha" },
+        over: { id: "enabled-gamma" },
+      })
+    })
+
+    expect(
+      screen.getAllByTestId(TEST_IDS.accountRow).map((row) => row.textContent),
+    ).not.toEqual(previousOrder)
+    expect(screen.getByTestId(TEST_IDS.dndContext)).toBeInTheDocument()
+    expect(
+      screen.getAllByRole("button", { name: "account:list.dragHandle" })[0],
+    ).toBeDisabled()
+
+    await act(async () => {
+      rejectReorder?.(new Error("storage unavailable"))
+    })
+
+    await waitFor(() => {
+      expect(
+        screen
+          .getAllByTestId(TEST_IDS.accountRow)
+          .map((row) => row.textContent),
+      ).toEqual(previousOrder)
+      expect(clearSortConfig).not.toHaveBeenCalled()
+      expect(toastErrorMock).toHaveBeenCalledWith(
+        "account:list.reorderFailed",
+        { id: "account-reorder" },
+      )
+    })
   })
 
   it("reorders only the visible subset after filters are applied", async () => {
     const user = userEvent.setup()
+    const clearSortConfig = vi.fn()
     const handleReorder = vi.fn()
 
     mockUseAccountDataContext.mockReturnValue(
       createAccountDataContextValue({
+        clearSortConfig,
         isManualSortFeatureEnabled: true,
         handleReorder,
+        sortField: null,
       }),
     )
 
@@ -973,17 +1236,18 @@ describe("AccountList", () => {
     expect(screen.getAllByTestId(TEST_IDS.accountRow)).toHaveLength(3)
 
     await user.click(
-      screen.getAllByRole("button", {
-        name: "account:list.dragHandle",
-      })[0],
+      screen.getByRole("button", { name: "account:list.reorder" }),
     )
 
     expect(await screen.findByTestId(TEST_IDS.dndContext)).toBeInTheDocument()
     expect(dndState.onDragEnd).toBeTypeOf("function")
 
-    dndState.onDragEnd?.({
-      active: { id: "enabled-alpha" },
-      over: { id: "enabled-gamma" },
+    await act(async () => {
+      dndState.onDragEnd?.({
+        active: { id: "enabled-alpha" },
+        over: { id: "enabled-gamma" },
+      })
+      await Promise.resolve()
     })
 
     expect(handleReorder).toHaveBeenCalledWith([
@@ -991,6 +1255,11 @@ describe("AccountList", () => {
       "enabled-alpha",
       "unsynced-delta",
     ])
+    expect(clearSortConfig).not.toHaveBeenCalled()
+    expect(toastSuccessMock).toHaveBeenCalledWith(
+      "account:list.reorderSuccess",
+      { id: "account-reorder" },
+    )
   })
 
   it("tracks completed manual reorder with aggregate metadata only", async () => {
@@ -1007,17 +1276,18 @@ describe("AccountList", () => {
     render(<AccountList />)
 
     await user.click(
-      screen.getAllByRole("button", {
-        name: "account:list.dragHandle",
-      })[0],
+      screen.getByRole("button", { name: "account:list.reorder" }),
     )
 
     expect(await screen.findByTestId(TEST_IDS.dndContext)).toBeInTheDocument()
     expect(dndState.onDragEnd).toBeTypeOf("function")
 
-    dndState.onDragEnd?.({
-      active: { id: "enabled-alpha" },
-      over: { id: "enabled-gamma" },
+    await act(async () => {
+      dndState.onDragEnd?.({
+        active: { id: "enabled-alpha" },
+        over: { id: "enabled-gamma" },
+      })
+      await Promise.resolve()
     })
 
     await waitFor(() => {
@@ -1040,7 +1310,7 @@ describe("AccountList", () => {
     expect(completionPayload).not.toHaveProperty("toAccountId")
   })
 
-  it("does not activate dnd from disabled search handles or bulk mode", async () => {
+  it("does not activate dnd while search or bulk mode disables reorder", async () => {
     const user = userEvent.setup()
 
     mockUseAccountDataContext.mockReturnValue(
@@ -1051,12 +1321,13 @@ describe("AccountList", () => {
 
     const { unmount } = render(<AccountList initialSearchQuery="Alpha" />)
 
-    const searchHandle = screen.getByRole("button", {
-      name: "account:list.dragHandle",
+    const searchReorderButton = screen.getByRole("button", {
+      name: "account:list.reorder",
     })
-    expect(searchHandle).toBeDisabled()
-
-    await user.click(searchHandle)
+    expect(searchReorderButton).toHaveAttribute("aria-disabled", "true")
+    expect(searchReorderButton).toHaveAccessibleDescription(
+      "account:list.reorderUnavailableWhileSearch",
+    )
 
     expect(screen.queryByTestId(TEST_IDS.dndContext)).not.toBeInTheDocument()
     expect(useSortableMock).not.toHaveBeenCalled()
@@ -1068,10 +1339,19 @@ describe("AccountList", () => {
     await user.click(
       screen.getByRole("button", { name: "account:bulk.manage" }),
     )
-
     expect(
-      screen.queryByRole("button", { name: "account:list.dragHandle" }),
-    ).not.toBeInTheDocument()
+      screen.getByTestId(
+        ACCOUNT_MANAGEMENT_TEST_IDS.accountListBulkManageButton,
+      ),
+    ).toHaveAttribute("aria-pressed", "true")
+
+    const bulkReorderButton = screen.getByRole("button", {
+      name: "account:list.reorder",
+    })
+    expect(bulkReorderButton).toHaveAttribute("aria-disabled", "true")
+    expect(bulkReorderButton).toHaveAccessibleDescription(
+      "account:list.reorderUnavailableWhileBulk",
+    )
     expect(screen.queryByTestId(TEST_IDS.dndContext)).not.toBeInTheDocument()
     expect(useSortableMock).not.toHaveBeenCalled()
   })
@@ -1088,9 +1368,7 @@ describe("AccountList", () => {
     const { rerender } = render(<AccountList />)
 
     await user.click(
-      screen.getAllByRole("button", {
-        name: "account:list.dragHandle",
-      })[0],
+      screen.getByRole("button", { name: "account:list.reorder" }),
     )
 
     expect(await screen.findByTestId(TEST_IDS.dndContext)).toBeInTheDocument()
@@ -1105,8 +1383,9 @@ describe("AccountList", () => {
         screen.queryByTestId(TEST_IDS.sortableContext),
       ).not.toBeInTheDocument()
       expect(
-        screen.getByRole("button", { name: "account:list.dragHandle" }),
-      ).toBeDisabled()
+        screen.getByRole("button", { name: "account:list.reorder" }),
+      ).toHaveAttribute("aria-disabled", "true")
+      expect(screen.getByTestId(TEST_IDS.virtuoso)).toBeInTheDocument()
     })
   })
 
@@ -1132,9 +1411,7 @@ describe("AccountList", () => {
     render(<AccountList />)
 
     await user.click(
-      screen.getAllByRole("button", {
-        name: "account:list.dragHandle",
-      })[0],
+      screen.getByRole("button", { name: "account:list.reorder" }),
     )
 
     expect(await screen.findByTestId(TEST_IDS.dndContext)).toBeInTheDocument()

--- a/tests/features/AccountManagement/components/AccountList.test.tsx
+++ b/tests/features/AccountManagement/components/AccountList.test.tsx
@@ -1003,8 +1003,6 @@ describe("AccountList", () => {
     expect(reorderButton).toHaveAccessibleDescription(
       "account:list.reorderUnavailableInPopup",
     )
-    expect(reorderButton).toHaveClass("aria-disabled:pointer-events-auto")
-
     await user.hover(reorderButton)
     expect(
       await screen.findByRole("tooltip", {

--- a/tests/features/AccountManagement/hooks/AccountDataContext.test.tsx
+++ b/tests/features/AccountManagement/hooks/AccountDataContext.test.tsx
@@ -729,7 +729,9 @@ describe("AccountDataContext handleReorder", () => {
     mockLogger.error.mockClear()
 
     await act(async () => {
-      await getLatestCtx().handleReorder(["acc-2", "acc-1"])
+      await expect(
+        getLatestCtx().handleReorder(["acc-2", "acc-1"]),
+      ).rejects.toThrow("Failed to persist account order")
     })
 
     await waitFor(() => {
@@ -773,7 +775,9 @@ describe("AccountDataContext handleReorder", () => {
     mockLogger.error.mockClear()
 
     await act(async () => {
-      await getLatestCtx().handleReorder(["p-2", "p-1", "u-1"])
+      await expect(
+        getLatestCtx().handleReorder(["p-2", "p-1", "u-1"]),
+      ).rejects.toThrow("Failed to persist pinned account order")
     })
 
     expect(mockSetPinnedListSubset).toHaveBeenCalledWith({
@@ -825,7 +829,9 @@ describe("AccountDataContext handleReorder", () => {
     mockLogger.error.mockClear()
 
     await act(async () => {
-      await getLatestCtx().handleReorder(["p-2", "p-1", "u-1"])
+      await expect(
+        getLatestCtx().handleReorder(["p-2", "p-1", "u-1"]),
+      ).rejects.toThrow("Failed to persist account order")
     })
 
     expect(mockSetPinnedListSubset).toHaveBeenCalledWith({

--- a/tests/features/AccountManagement/hooks/AccountDataContext.test.tsx
+++ b/tests/features/AccountManagement/hooks/AccountDataContext.test.tsx
@@ -92,6 +92,7 @@ const {
   mockResetExpiredCheckIns,
   mockSetPinnedList,
   mockSetOrderedList,
+  mockSetAccountListOrder,
   mockSetPinnedListSubset,
   mockSetOrderedListSubset,
   mockGetTagStore,
@@ -134,6 +135,7 @@ const {
   mockResetExpiredCheckIns: vi.fn(),
   mockSetPinnedList: vi.fn(),
   mockSetOrderedList: vi.fn(),
+  mockSetAccountListOrder: vi.fn(),
   mockSetPinnedListSubset: vi.fn(),
   mockSetOrderedListSubset: vi.fn(),
   mockGetTagStore: vi.fn(),
@@ -248,6 +250,7 @@ vi.mock("~/services/accounts/accountStorage", () => ({
     convertToDisplayData: mockConvertToDisplayData,
     setPinnedList: mockSetPinnedList,
     setOrderedList: mockSetOrderedList,
+    setAccountListOrder: mockSetAccountListOrder,
     setPinnedListSubset: mockSetPinnedListSubset,
     setOrderedListSubset: mockSetOrderedListSubset,
     pinAccount: mockPinAccount,
@@ -387,6 +390,7 @@ beforeEach(() => {
   mockGetOrderedList.mockResolvedValue([])
   mockGetPinnedList.mockResolvedValue([])
   mockGetAccountStats.mockResolvedValue(createEmptyStats())
+  mockSetAccountListOrder.mockResolvedValue(true)
   mockConvertToDisplayData.mockImplementation((input: any) => {
     const accounts = Array.isArray(input) ? input : [input]
     const display = accounts.map((account: any) => ({
@@ -536,9 +540,6 @@ describe("AccountDataContext handleReorder", () => {
       { id: "p-2" },
       { id: "u-1" },
     ])
-    mockSetPinnedListSubset.mockResolvedValue(true)
-    mockSetOrderedListSubset.mockResolvedValue(true)
-
     let latestCtx: ReturnType<typeof useAccountDataContext> | null = null
 
     render(
@@ -558,13 +559,9 @@ describe("AccountDataContext handleReorder", () => {
       await latestCtx!.handleReorder(["p-2", "p-1", "u-1"])
     })
 
-    expect(mockSetPinnedListSubset).toHaveBeenCalledWith({
-      entryType: "account",
-      ids: ["p-2", "p-1"],
-    })
-    expect(mockSetOrderedListSubset).toHaveBeenCalledWith({
-      entryType: "account",
-      ids: ["p-2", "p-1", "u-1"],
+    expect(mockSetAccountListOrder).toHaveBeenCalledWith({
+      pinnedIds: ["p-2", "p-1"],
+      orderedIds: ["p-2", "p-1", "u-1"],
     })
   })
 
@@ -588,9 +585,6 @@ describe("AccountDataContext handleReorder", () => {
       { id: "p-2" },
       { id: "u-1" },
     ])
-    mockSetPinnedListSubset.mockResolvedValue(true)
-    mockSetOrderedListSubset.mockResolvedValue(true)
-
     let latestCtx: ReturnType<typeof useAccountDataContext> | null = null
 
     render(
@@ -606,17 +600,15 @@ describe("AccountDataContext handleReorder", () => {
       expect(latestCtx?.pinnedAccountIds).toEqual(["p-1", "p-2"])
     })
 
-    mockSetPinnedListSubset.mockClear()
-    mockSetOrderedListSubset.mockClear()
+    mockSetAccountListOrder.mockClear()
 
     await act(async () => {
       await latestCtx!.handleReorder(["u-1", "p-1", "p-2"])
     })
 
-    expect(mockSetPinnedListSubset).not.toHaveBeenCalled()
-    expect(mockSetOrderedListSubset).toHaveBeenCalledWith({
-      entryType: "account",
-      ids: ["p-1", "p-2", "u-1"],
+    expect(mockSetAccountListOrder).toHaveBeenCalledWith({
+      pinnedIds: ["p-1", "p-2"],
+      orderedIds: ["p-1", "p-2", "u-1"],
     })
   })
 
@@ -630,7 +622,7 @@ describe("AccountDataContext handleReorder", () => {
     mockGetOrderedList.mockResolvedValue(["acc-1", "acc-2"])
     mockGetPinnedList.mockResolvedValue([])
     mockGetAccountStats.mockResolvedValue(createEmptyStats())
-    mockSetOrderedListSubset.mockImplementation(
+    mockSetAccountListOrder.mockImplementation(
       () =>
         new Promise<boolean>((resolve) => {
           resolveOrderedWrite = resolve
@@ -678,9 +670,6 @@ describe("AccountDataContext handleReorder", () => {
     mockGetOrderedList.mockResolvedValue(["a1", "a2", "a3", "a4"])
     mockGetPinnedList.mockResolvedValue(["a1", "a2", "a3"])
     mockGetAccountStats.mockResolvedValue(createEmptyStats())
-    mockSetPinnedListSubset.mockResolvedValue(true)
-    mockSetOrderedListSubset.mockResolvedValue(true)
-
     const getLatestCtx = await renderAccountDataProvider()
 
     await waitFor(() => {
@@ -695,13 +684,9 @@ describe("AccountDataContext handleReorder", () => {
       await getLatestCtx().handleReorder(["a3", "a1", "a4"])
     })
 
-    expect(mockSetPinnedListSubset).toHaveBeenCalledWith({
-      entryType: "account",
-      ids: ["a3", "a2", "a1"],
-    })
-    expect(mockSetOrderedListSubset).toHaveBeenCalledWith({
-      entryType: "account",
-      ids: ["a3", "a2", "a1", "a4"],
+    expect(mockSetAccountListOrder).toHaveBeenCalledWith({
+      pinnedIds: ["a3", "a2", "a1"],
+      orderedIds: ["a3", "a2", "a1", "a4"],
     })
 
     await waitFor(() => {
@@ -718,7 +703,7 @@ describe("AccountDataContext handleReorder", () => {
     mockGetOrderedList.mockResolvedValue(["acc-1", "acc-2"])
     mockGetPinnedList.mockResolvedValue([])
     mockGetAccountStats.mockResolvedValue(createEmptyStats())
-    mockSetOrderedListSubset.mockResolvedValue(false)
+    mockSetAccountListOrder.mockResolvedValue(false)
 
     const getLatestCtx = await renderAccountDataProvider()
 
@@ -751,7 +736,7 @@ describe("AccountDataContext handleReorder", () => {
     expect(details.error.message).toBe("Failed to persist account order")
   })
 
-  it("rolls back account reorder when pinned persistence fails before ordered writes", async () => {
+  it("keeps the persisted optimistic order when storage readback fails", async () => {
     mockResetExpiredCheckIns.mockResolvedValue(undefined)
     mockGetTagStore.mockResolvedValue({ version: 1, tagsById: {} })
     mockGetAllAccounts.mockResolvedValue([
@@ -763,7 +748,6 @@ describe("AccountDataContext handleReorder", () => {
     mockGetOrderedList.mockResolvedValue(["p-1", "p-2", "u-1"])
     mockGetPinnedList.mockResolvedValue(["p-1", "p-2"])
     mockGetAccountStats.mockResolvedValue(createEmptyStats())
-    mockSetPinnedListSubset.mockResolvedValueOnce(false)
 
     const getLatestCtx = await renderAccountDataProvider()
 
@@ -772,93 +756,32 @@ describe("AccountDataContext handleReorder", () => {
       expect(getLatestCtx().orderedAccountIds).toEqual(["p-1", "p-2", "u-1"])
     })
 
-    mockLogger.error.mockClear()
+    mockGetPinnedList.mockRejectedValueOnce(new Error("readback failed"))
+    mockGetOrderedList.mockResolvedValueOnce(["p-2", "p-1", "u-1"])
+    mockLogger.warn.mockClear()
 
     await act(async () => {
       await expect(
         getLatestCtx().handleReorder(["p-2", "p-1", "u-1"]),
-      ).rejects.toThrow("Failed to persist pinned account order")
+      ).resolves.toBeUndefined()
     })
 
-    expect(mockSetPinnedListSubset).toHaveBeenCalledWith({
-      entryType: "account",
-      ids: ["p-2", "p-1"],
+    expect(mockSetAccountListOrder).toHaveBeenCalledWith({
+      pinnedIds: ["p-2", "p-1"],
+      orderedIds: ["p-2", "p-1", "u-1"],
     })
-    expect(mockSetOrderedListSubset).not.toHaveBeenCalled()
 
     await waitFor(() => {
-      expect(getLatestCtx().pinnedAccountIds).toEqual(["p-1", "p-2"])
-      expect(getLatestCtx().orderedAccountIds).toEqual(["p-1", "p-2", "u-1"])
+      expect(getLatestCtx().pinnedAccountIds).toEqual(["p-2", "p-1"])
+      expect(getLatestCtx().orderedAccountIds).toEqual(["p-2", "p-1", "u-1"])
     })
 
-    expect(mockLogger.error).toHaveBeenCalledWith(
-      "Failed to persist account reorder",
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      "Persisted account reorder but failed to refresh order",
       expect.objectContaining({
-        ids: ["p-2", "p-1", "u-1"],
         error: expect.any(Error),
       }),
     )
-
-    const [, details] = mockLogger.error.mock.calls.at(-1)!
-    expect(details.error).toBeInstanceOf(Error)
-    expect(details.error.message).toBe("Failed to persist pinned account order")
-  })
-
-  it("rolls back account reorder when ordered persistence fails after pinned writes", async () => {
-    mockResetExpiredCheckIns.mockResolvedValue(undefined)
-    mockGetTagStore.mockResolvedValue({ version: 1, tagsById: {} })
-    mockGetAllAccounts.mockResolvedValue([
-      { id: "p-1" },
-      { id: "p-2" },
-      { id: "u-1" },
-    ])
-    mockGetAllBookmarks.mockResolvedValue([])
-    mockGetOrderedList.mockResolvedValue(["p-1", "p-2", "u-1"])
-    mockGetPinnedList.mockResolvedValue(["p-1", "p-2"])
-    mockGetAccountStats.mockResolvedValue(createEmptyStats())
-    mockSetPinnedListSubset.mockResolvedValueOnce(true)
-    mockSetOrderedListSubset.mockResolvedValueOnce(false)
-
-    const getLatestCtx = await renderAccountDataProvider()
-
-    await waitFor(() => {
-      expect(getLatestCtx().pinnedAccountIds).toEqual(["p-1", "p-2"])
-      expect(getLatestCtx().orderedAccountIds).toEqual(["p-1", "p-2", "u-1"])
-    })
-
-    mockLogger.error.mockClear()
-
-    await act(async () => {
-      await expect(
-        getLatestCtx().handleReorder(["p-2", "p-1", "u-1"]),
-      ).rejects.toThrow("Failed to persist account order")
-    })
-
-    expect(mockSetPinnedListSubset).toHaveBeenCalledWith({
-      entryType: "account",
-      ids: ["p-2", "p-1"],
-    })
-    expect(mockSetOrderedListSubset).toHaveBeenCalledWith({
-      entryType: "account",
-      ids: ["p-2", "p-1", "u-1"],
-    })
-
-    await waitFor(() => {
-      expect(getLatestCtx().pinnedAccountIds).toEqual(["p-1", "p-2"])
-      expect(getLatestCtx().orderedAccountIds).toEqual(["p-1", "p-2", "u-1"])
-    })
-
-    expect(mockLogger.error).toHaveBeenCalledWith(
-      "Failed to persist account reorder",
-      expect.objectContaining({
-        ids: ["p-2", "p-1", "u-1"],
-        error: expect.any(Error),
-      }),
-    )
-
-    const [, details] = mockLogger.error.mock.calls.at(-1)!
-    expect(details.error).toBeInstanceOf(Error)
-    expect(details.error.message).toBe("Failed to persist account order")
   })
 })
 

--- a/tests/services/accountStorage.test.ts
+++ b/tests/services/accountStorage.test.ts
@@ -3963,6 +3963,7 @@ describe("accountStorage bookmarks", () => {
   beforeEach(() => {
     storageData.clear()
     storageHooks.beforeGet = async () => {}
+    storageHooks.beforeSet = async () => {}
   })
 
   it("getAllBookmarks falls back to an empty list when bookmark reads fail", async () => {
@@ -4292,6 +4293,28 @@ describe("accountStorage bookmarks", () => {
       "a-1",
       "b-2",
     ])
+  })
+
+  it("setAccountListOrder reports a failed atomic storage write", async () => {
+    const writeError = new Error("storage unavailable")
+    storageData.set(ACCOUNT_STORAGE_KEYS.ACCOUNTS, {
+      accounts: [createAccount({ id: "a-1" }), createAccount({ id: "a-2" })],
+      bookmarks: [],
+      pinnedAccountIds: ["a-1"],
+      orderedAccountIds: ["a-1", "a-2"],
+      last_updated: Date.now(),
+    } satisfies AccountStorageConfig)
+    storageHooks.beforeSet = async () => {
+      throw writeError
+    }
+
+    await expect(
+      accountStorage.setAccountListOrder({
+        pinnedIds: ["a-2"],
+        orderedIds: ["a-2", "a-1"],
+      }),
+    ).resolves.toBe(false)
+    expect(mockLoggerError).toHaveBeenCalledWith("设置账号排序失败", writeError)
   })
 
   describe("replaceIdListSubset (via set*ListSubset APIs)", () => {

--- a/tests/services/accountStorage.test.ts
+++ b/tests/services/accountStorage.test.ts
@@ -4259,6 +4259,41 @@ describe("accountStorage bookmarks", () => {
     ])
   })
 
+  it("setAccountListOrder atomically updates account order while preserving bookmark slots", async () => {
+    storageData.set(ACCOUNT_STORAGE_KEYS.ACCOUNTS, {
+      accounts: [createAccount({ id: "a-1" }), createAccount({ id: "a-2" })],
+      bookmarks: [createBookmark({ id: "b-1" }), createBookmark({ id: "b-2" })],
+      pinnedAccountIds: ["a-1", "b-1", "a-2", "b-2"],
+      orderedAccountIds: ["a-1", "b-1", "a-2", "b-2"],
+      last_updated: Date.now(),
+    } satisfies AccountStorageConfig)
+
+    let writeCount = 0
+    storageHooks.beforeSet = async () => {
+      writeCount += 1
+    }
+
+    const success = await accountStorage.setAccountListOrder({
+      pinnedIds: ["a-2", "a-1"],
+      orderedIds: ["a-2", "a-1"],
+    })
+
+    expect(success).toBe(true)
+    expect(writeCount).toBe(1)
+    expect(await accountStorage.getPinnedList()).toEqual([
+      "a-2",
+      "b-1",
+      "a-1",
+      "b-2",
+    ])
+    expect(await accountStorage.getOrderedList()).toEqual([
+      "a-2",
+      "b-1",
+      "a-1",
+      "b-2",
+    ])
+  })
+
   describe("replaceIdListSubset (via set*ListSubset APIs)", () => {
     it("appends subset ids when existingIds is empty", async () => {
       storageData.set(ACCOUNT_STORAGE_KEYS.ACCOUNTS, {


### PR DESCRIPTION
## Summary

- Virtualize normal account browsing across popup, options, and sidepanel to reduce first-render work.
- Load drag-and-drop support only after users explicitly enter reorder mode.
- Preserve predictable manual ordering, clear conflicting field sorting after a successful reorder, and roll back with feedback when persistence fails.
- Restrict pinned-account dragging to compatible groups and warn when crossing a pinned boundary.
- Keep popup reordering disabled with actionable guidance, while aligning reorder and bulk-management controls.

## Validation

- Pre-commit staged validation passed: formatting, ESLint, related Vitest, and i18n checks.
- `pnpm compile`
- `pnpm exec playwright test e2e/popupSavedItems.spec.ts e2e/sidepanelUserFlows.spec.ts --project=chromium --workers=1 --grep "virtualizes long"` (3 passed, including the build setup)
- Pre-push validation passed: TypeScript compilation and `knip`.

## Notes

- Reorder mode intentionally renders the complete list because drag-and-drop requires stable item geometry; normal browsing remains virtualized.
- The existing persisted reorder action continues to record success and failure. Entering and exiting reorder mode are intentionally not recorded as separate low-signal actions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added manual drag-and-drop reordering for account lists, with dedicated controls, status feedback, and pinned-account boundaries.
  * Account lists now use virtualization for smoother browsing of long lists in the popup and side panel.
  * Reordering is unavailable during search, bulk actions, and in unsupported views, with clear guidance.

* **Bug Fixes**
  * Failed reorder operations now restore the previous order and provide an error notification.

* **Localization**
  * Added account-reordering translations for supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->