### PR TITLE
perf(test): reduce CI unit test wall time

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,7 +84,7 @@ jobs:
   unit-tests:
     runs-on: ubuntu-latest
     env:
-      UNIT_TEST_SHARD_TOTAL: 5
+      UNIT_TEST_SHARD_TOTAL: 6
     strategy:
       fail-fast: false
       matrix:
@@ -94,6 +94,7 @@ jobs:
           - 3
           - 4
           - 5
+          - 6
 
     steps:
       - name: Checkout code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,18 +83,17 @@ jobs:
 
   unit-tests:
     runs-on: ubuntu-latest
+    env:
+      UNIT_TEST_SHARD_TOTAL: 5
     strategy:
       fail-fast: false
       matrix:
         shard:
-          - index: 1
-            total: 4
-          - index: 2
-            total: 4
-          - index: 3
-            total: 4
-          - index: 4
-            total: 4
+          - 1
+          - 2
+          - 3
+          - 4
+          - 5
 
     steps:
       - name: Checkout code
@@ -125,13 +124,13 @@ jobs:
           --coverage.thresholds.lines=0
           --reporter=default
           --reporter=blob
-          --shard=${{ matrix.shard.index }}/${{ matrix.shard.total }}
+          --shard=${{ matrix.shard }}/${{ env.UNIT_TEST_SHARD_TOTAL }}
 
       - name: Upload Vitest blob report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ !cancelled() }}
         with:
-          name: vitest-blob-report-${{ matrix.shard.index }}
+          name: vitest-blob-report-${{ matrix.shard }}
           path: .vitest-reports/*.json
           include-hidden-files: true
           retention-days: 1

--- a/tests/entrypoints/options/pages/KeyManagement/KeyManagement.nativeIntegration.test.tsx
+++ b/tests/entrypoints/options/pages/KeyManagement/KeyManagement.nativeIntegration.test.tsx
@@ -1,4 +1,4 @@
-import { act, within } from "@testing-library/react"
+import { act, fireEvent, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { useState } from "react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
@@ -1912,9 +1912,11 @@ describe("KeyManagement native page integration", () => {
     expect(screen.getByText("keyManagement:details.empty")).toBeVisible()
     expect(successful.collection.get).not.toHaveBeenCalled()
 
-    await user.type(
+    fireEvent.change(
       screen.getByPlaceholderText("keyManagement:searchPlaceholder"),
-      "Native one",
+      {
+        target: { value: "Native one" },
+      },
     )
     await waitFor(() =>
       expect(accountSummaryBarPropsSpy.mock.lastCall?.[0]).toMatchObject({

--- a/tests/features/AccountManagement/components/CopyKeyDialog.exports.test.tsx
+++ b/tests/features/AccountManagement/components/CopyKeyDialog.exports.test.tsx
@@ -539,14 +539,12 @@ describe("CopyKeyDialog exports and service credentials", () => {
     const user = await renderExpandedDetails()
 
     await selectExportAction(user, "keyManagement:actions.exportToCCSwitch")
-    await waitFor(() => {
-      expect(ccSwitchDialogMock).toHaveBeenCalledWith(
-        expect.objectContaining({
-          account: expect.objectContaining({ id: "acc-1" }),
-          token: expect.objectContaining({ id: 1, key: "sk-test" }),
-        }),
-      )
-    })
+    expect(ccSwitchDialogMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        account: expect.objectContaining({ id: "acc-1" }),
+        token: expect.objectContaining({ id: 1, key: "sk-test" }),
+      }),
+    )
 
     await selectExportAction(user, "keyManagement:actions.exportToKiloCode")
     await waitFor(() => {
@@ -565,14 +563,12 @@ describe("CopyKeyDialog exports and service credentials", () => {
     })
 
     await selectExportAction(user, "keyManagement:actions.importToCliProxy")
-    await waitFor(() => {
-      expect(cliProxyDialogMock).toHaveBeenCalledWith(
-        expect.objectContaining({
-          account: expect.objectContaining({ id: "acc-1" }),
-          token: expect.objectContaining({ id: 1, key: "sk-test" }),
-        }),
-      )
-    })
+    expect(cliProxyDialogMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        account: expect.objectContaining({ id: "acc-1" }),
+        token: expect.objectContaining({ id: 1, key: "sk-test" }),
+      }),
+    )
     act(() => {
       cliProxyDialogMock.mock.calls[0]?.[0].onClose()
     })
@@ -581,16 +577,14 @@ describe("CopyKeyDialog exports and service credentials", () => {
       user,
       "keyManagement:actions.importToClaudeCodeRouter",
     )
-    await waitFor(() => {
-      expect(claudeCodeRouterDialogMock).toHaveBeenCalledWith(
-        expect.objectContaining({
-          account: expect.objectContaining({ id: "acc-1" }),
-          token: expect.objectContaining({ id: 1, key: "sk-test" }),
-          routerApiKey: "ccr-management-key",
-          routerBaseUrl: "https://router.example.invalid",
-        }),
-      )
-    })
+    expect(claudeCodeRouterDialogMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        account: expect.objectContaining({ id: "acc-1" }),
+        token: expect.objectContaining({ id: 1, key: "sk-test" }),
+        routerApiKey: "ccr-management-key",
+        routerBaseUrl: "https://router.example.invalid",
+      }),
+    )
     act(() => {
       claudeCodeRouterDialogMock.mock.calls[0]?.[0].onClose()
     })

--- a/tests/features/BasicSettings/TaskNotificationSettings.test.tsx
+++ b/tests/features/BasicSettings/TaskNotificationSettings.test.tsx
@@ -1,5 +1,4 @@
 import { act, fireEvent, within } from "@testing-library/react"
-import userEvent from "@testing-library/user-event"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { SETTINGS_ANCHORS } from "~/constants/settingsAnchors"
@@ -1211,7 +1210,6 @@ describe("TaskNotificationSettings", () => {
   })
 
   it("deduplicates blur and test-triggered saves for the same channel draft", async () => {
-    const user = userEvent.setup()
     const write = createDeferred<ReturnType<typeof preferenceWriteSuccess>>()
     updateTaskNotificationsMock.mockReturnValueOnce(write.promise)
     taskNotificationsMock.current = {
@@ -1242,9 +1240,11 @@ describe("TaskNotificationSettings", () => {
       name: "settings:taskNotifications.test.action",
     })
 
-    await user.type(webhookInput, "https://hooks.example.invalid/test")
+    fireEvent.change(webhookInput, {
+      target: { value: "https://hooks.example.invalid/test" },
+    })
     expect(testButton).toBeEnabled()
-    await user.click(testButton)
+    fireEvent.click(testButton)
 
     expect(updateTaskNotificationsMock).toHaveBeenCalledTimes(1)
     expect(updateTaskNotificationsMock).toHaveBeenCalledWith({

--- a/tests/features/KeyManagement/components/ServiceCredentialCard.test.tsx
+++ b/tests/features/KeyManagement/components/ServiceCredentialCard.test.tsx
@@ -678,30 +678,26 @@ describe("ServiceCredentialCard", () => {
     ).not.toBeInTheDocument()
 
     await selectExportAction(user, "keyManagement:actions.exportToCCSwitch")
-    await waitFor(() => {
-      expect(mockCCSwitchDialog).toHaveBeenCalledWith(
-        expect.objectContaining({
-          isOpen: true,
-          account: expect.objectContaining({
-            baseUrl: "https://sharedchat.example.invalid/v1",
-          }),
-          token: expect.objectContaining({ key: "sk-service-credential" }),
+    expect(mockCCSwitchDialog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isOpen: true,
+        account: expect.objectContaining({
+          baseUrl: "https://sharedchat.example.invalid/v1",
         }),
-      )
-    })
+        token: expect.objectContaining({ key: "sk-service-credential" }),
+      }),
+    )
 
     await selectExportAction(user, "keyManagement:actions.exportToKiloCode")
-    await waitFor(() => {
-      expect(mockKiloCodeDialog).toHaveBeenCalledWith(
-        expect.objectContaining({
-          isOpen: true,
-          profile: expect.objectContaining({
-            baseUrl: "https://sharedchat.example.invalid/v1",
-            apiKey: "sk-service-credential",
-          }),
+    expect(mockKiloCodeDialog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isOpen: true,
+        profile: expect.objectContaining({
+          baseUrl: "https://sharedchat.example.invalid/v1",
+          apiKey: "sk-service-credential",
         }),
-      )
-    })
+      }),
+    )
 
     await selectExportAction(user, "keyManagement:actions.exportToCursorPlus")
     expect(
@@ -726,35 +722,31 @@ describe("ServiceCredentialCard", () => {
     ).not.toBeInTheDocument()
 
     await selectExportAction(user, "keyManagement:actions.importToCliProxy")
-    await waitFor(() => {
-      expect(mockCliProxyDialog).toHaveBeenCalledWith(
-        expect.objectContaining({
-          isOpen: true,
-          account: expect.objectContaining({
-            baseUrl: "https://sharedchat.example.invalid/v1",
-          }),
-          token: expect.objectContaining({ key: "sk-service-credential" }),
+    expect(mockCliProxyDialog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isOpen: true,
+        account: expect.objectContaining({
+          baseUrl: "https://sharedchat.example.invalid/v1",
         }),
-      )
-    })
+        token: expect.objectContaining({ key: "sk-service-credential" }),
+      }),
+    )
 
     await selectExportAction(
       user,
       "keyManagement:actions.importToClaudeCodeRouter",
     )
-    await waitFor(() => {
-      expect(mockClaudeCodeRouterDialog).toHaveBeenCalledWith(
-        expect.objectContaining({
-          isOpen: true,
-          account: expect.objectContaining({
-            baseUrl: "https://sharedchat.example.invalid/v1",
-          }),
-          token: expect.objectContaining({ key: "sk-service-credential" }),
-          routerApiKey: "ccr-management-key",
-          routerBaseUrl: "https://router.example.invalid",
+    expect(mockClaudeCodeRouterDialog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isOpen: true,
+        account: expect.objectContaining({
+          baseUrl: "https://sharedchat.example.invalid/v1",
         }),
-      )
-    })
+        token: expect.objectContaining({ key: "sk-service-credential" }),
+        routerApiKey: "ccr-management-key",
+        routerBaseUrl: "https://router.example.invalid",
+      }),
+    )
 
     await selectExportAction(user, "keyManagement:actions.importToManagedSite")
     expect(mockOpenWithCredentials).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary

- Increase the native Vitest unit-test matrix from 4 to 6 shards.
- Reduce redundant rerenders and polling in the slowest unit tests.
- Preserve real asynchronous waits and leave the E2E matrix unchanged.

## Why

The unit-test workflow critical path is dominated by the slowest Vitest shard. Remote run [#4121](https://github.com/qixing-jk/all-api-hub/actions/runs/33048545449) showed unit-test steps of roughly 287–439 seconds, while dependency installation took only a few seconds.

This change reduces avoidable test work without introducing a manually maintained test-to-shard mapping.

## What changed

- Raised the native Vitest unit-test matrix from 4 to 6 shards.
- Replaced per-character input simulation with a single change event in tests that verify the resulting filter or draft-submission behavior, not individual keystrokes.
- Removed redundant `waitFor` polling around synchronous state-driven dialog assertions.
- Kept waits for genuinely asynchronous and lazy-loaded export paths.

## Validation

- Focused affected tests: 4 files, 66 tests passed.
- Pre-commit staged validation passed.
- Prettier check passed.
- `git diff --check` passed.
- Pre-push validation passed: `pnpm compile` and `pnpm knip`.
- Full repository unit, coverage, and E2E validation will run in PR CI.

## Risk and compatibility

- No production runtime behavior changed.
- Vitest keeps its native file-based shard assignment; no manual shard ownership list was added.
- E2E configuration is unchanged.
- An existing non-failing React `act(...)` warning remains in the lazy Kilo Code export test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved reliability of account management, credential export, notification, and key management test coverage.
  - Updated interaction checks to provide more deterministic validation of search, dialog, and webhook workflows.

- **Chores**
  - Expanded automated test execution across additional parallel partitions, helping CI validate changes more efficiently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->