### PR TITLE
fix(checkin): route AnyRouter sign-in through protected context

### DIFF
--- a/src/services/apiTransport/request.ts
+++ b/src/services/apiTransport/request.ts
@@ -892,6 +892,10 @@ const _fetchApiWithMapper = async <T, TResult>(
             )
           }
 
+          if (dispatchedContext.forceTempWindow) {
+            return await fallback()
+          }
+
           return await executeWithCurrentTabContentPreference<T, TResult>(
             {
               request,

--- a/src/services/apiTransport/request.ts
+++ b/src/services/apiTransport/request.ts
@@ -818,18 +818,16 @@ const _fetchApiWithMapper = async <T, TResult>(
     cookieStoreId: request.fetchContext?.cookieStoreId,
     forceTempWindow:
       request.fetchContext?.incognito === true ||
-      Boolean(request.fetchContext?.cookieStoreId),
+      Boolean(request.fetchContext?.cookieStoreId) ||
+      request.forceTempWindow === true,
   }
 
   if (context.forceTempWindow) {
-    logger.debug(
-      "Forcing temp-window fetch for browser-profile auto-detect context",
-      {
-        endpoint: options.endpoint,
-        url,
-        fetchContext: summarizeApiTransportFetchContext(request.fetchContext),
-      },
-    )
+    logger.debug("Forcing temp-window fetch for protected request context", {
+      endpoint: options.endpoint,
+      url,
+      fetchContext: summarizeApiTransportFetchContext(request.fetchContext),
+    })
   }
 
   const startRequest = () => {

--- a/src/services/apiTransport/type.ts
+++ b/src/services/apiTransport/type.ts
@@ -121,6 +121,8 @@ export interface ApiTransportRequest {
   tempWindowRequestSource?: TempWindowRequestSource
   /** Invocation intent for protected temporary-context work. */
   protectionBypassExecution?: ProtectionBypassExecution
+  /** Force the request through the protected temporary context from the start. */
+  forceTempWindow?: boolean
   /** Skip the generic per-site limiter when the caller already applies a narrower limiter. */
   bypassSiteRequestLimit?: boolean
   /** Process-local lifecycle evidence; callbacks must never cross extension messaging. */

--- a/src/services/checkin/autoCheckin/providers/anyrouter.ts
+++ b/src/services/checkin/autoCheckin/providers/anyrouter.ts
@@ -54,6 +54,10 @@ const checkinAnyRouter = async (
           userId: account_info.id,
         },
         tempWindowRequestSource,
+        // AnyRouter's sign-in POST relies on browser-established WAF cookies;
+        // see https://github.com/millylee/anyrouter-check-in.
+        // Keep it in one protected context instead of replaying a mutating request.
+        forceTempWindow: true,
         ...(protectionBypassExecution ? { protectionBypassExecution } : {}),
         ...(context.mutationLifecycle
           ? { observer: context.mutationLifecycle }

--- a/tests/services/apiTransport/request.test.ts
+++ b/tests/services/apiTransport/request.test.ts
@@ -2258,6 +2258,11 @@ describe("apiTransport request helpers", () => {
             authType: AuthTypeEnum.Cookie,
             cookie: "session=abc123",
           },
+          fetchContext: {
+            kind: API_TRANSPORT_FETCH_CONTEXT_KINDS.CURRENT_TAB,
+            tabId: 456,
+            origin: "https://example.com",
+          },
           forceTempWindow: true,
           protectionBypassExecution: backgroundProtectionBypassExecution,
         },
@@ -2266,6 +2271,7 @@ describe("apiTransport request helpers", () => {
     ).resolves.toEqual({ ok: true })
 
     expect(normalFetchCount).toBe(0)
+    expect(mockSendTabMessageWithRetry).not.toHaveBeenCalled()
     expect(mockSendRuntimeMessage).toHaveBeenCalledWith(
       expect.objectContaining({
         action: RuntimeActionIds.ProtectionBypassExecuteTask,

--- a/tests/services/apiTransport/request.test.ts
+++ b/tests/services/apiTransport/request.test.ts
@@ -2226,6 +2226,60 @@ describe("apiTransport request helpers", () => {
     onResponse: vi.fn(),
   })
 
+  it("uses the temp-window route for an explicitly forced request", async () => {
+    forceTempWindowRoute()
+    mockSendRuntimeMessage.mockResolvedValueOnce({
+      success: true,
+      status: 200,
+      data: {
+        success: true,
+        data: { ok: true },
+        message: "temp",
+      },
+    })
+
+    let normalFetchCount = 0
+    server.use(
+      http.post(API_URL, () => {
+        normalFetchCount += 1
+        return HttpResponse.json({
+          success: true,
+          data: { ok: false },
+          message: "normal",
+        })
+      }),
+    )
+
+    await expect(
+      fetchApiData<{ ok: boolean }>(
+        {
+          baseUrl: BASE_URL,
+          auth: {
+            authType: AuthTypeEnum.Cookie,
+            cookie: "session=abc123",
+          },
+          forceTempWindow: true,
+          protectionBypassExecution: backgroundProtectionBypassExecution,
+        },
+        { endpoint: ENDPOINT, options: { method: "POST", body: "{}" } },
+      ),
+    ).resolves.toEqual({ ok: true })
+
+    expect(normalFetchCount).toBe(0)
+    expect(mockSendRuntimeMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: RuntimeActionIds.ProtectionBypassExecuteTask,
+        task: {
+          kind: "profile_isolated_fetch",
+          params: expect.objectContaining({
+            originUrl: BASE_URL,
+            fetchUrl: API_URL,
+          }),
+        },
+      }),
+    )
+  })
+
   it("keeps the observer local when a forced temp-window route is selected", async () => {
     const lifecycle: string[] = []
     let responseObserved = false

--- a/tests/services/autoCheckin/providers/anyrouter.test.ts
+++ b/tests/services/autoCheckin/providers/anyrouter.test.ts
@@ -111,6 +111,7 @@ describe("anyrouterProvider", () => {
       expect(mockedFetchApi.mock.calls[0]?.[0]).toMatchObject({
         accountId: "test-id",
         tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
+        forceTempWindow: true,
         protectionBypassExecution,
       })
     })
@@ -146,6 +147,7 @@ describe("anyrouterProvider", () => {
         accountId: "stored-account-id",
         cookieAuthSessionCookie: "session=stored-cookie",
         tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Background,
+        forceTempWindow: true,
         auth: {
           authType: AuthTypeEnum.Cookie,
           userId: 12345,


### PR DESCRIPTION
#1372

## Summary

AnyRouter sign-in depends on browser-established WAF cookies. The existing flow first sent the mutating sign-in POST through the normal transport, but mutation safety rules correctly prevent retrying that POST through a temporary window after dispatch.

Route the AnyRouter sign-in request through the protected temporary context from the start, avoiding both missing WAF cookies and unsafe mutation replay.

## What changed

- Added a request-level `forceTempWindow` transport option for callers that must start in a protected browser context.
- Enabled that option specifically for AnyRouter `/api/user/sign_in`.
- Preserved the existing rule that generic POST, PUT, and DELETE requests are not automatically replayed after dispatch.
- Added transport and provider regression coverage confirming that the normal POST path is skipped.

## Validation

- `pnpm vitest run tests/services/autoCheckin/providers/anyrouter.test.ts tests/services/apiTransport/request.test.ts`
  - 2 files passed
  - 141 tests passed
- `pnpm compile`
- Pre-push `pnpm run validate:push` (`compile` + `knip`)
- Rebased onto the latest `origin/main`; the feature patch remained equivalent.

Full repository tests, coverage, and E2E are left to PR CI.

## Risk

Real-site behavior still depends on the target AnyRouter deployment's WAF and session state. The final implementation was not validated by triggering another real-account sign-in POST.

No generic mutation replay behavior was relaxed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to route specific requests through a protected temporary browser context.
  * AnyRouter sign-in requests now consistently use the protected temporary context.
  * Forced temporary-context requests bypass current-tab content retrieval.

* **Bug Fixes**
  * Improved protected request handling to prevent mutating requests from being replayed across browser contexts.

* **Tests**
  * Added coverage for protected request routing and updated sign-in request expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->