### PR TITLE
fix(octopus): support v0.13 channel management

### DIFF
--- a/e2e/scenarios/managedSiteChannels.ts
+++ b/e2e/scenarios/managedSiteChannels.ts
@@ -29,6 +29,7 @@ import {
 import { waitForExtensionRoot } from "~~/e2e/utils/lazyLoading"
 import {
   collectCleanupError,
+  runScenarioWithCleanup,
   throwScenarioError,
 } from "~~/e2e/utils/scenarioErrors"
 
@@ -131,83 +132,92 @@ async function cleanupManagedSiteChannelsByPrefix<
 export async function runManagedSiteChannelsCrudScenario<
   TSiteType extends ManagedSiteType,
 >(context: ManagedSiteChannelScenarioContext<TSiteType>) {
-  await cleanupManagedSiteChannelsByPrefix({
-    page: context.page,
-    extensionId: context.extensionId,
-    siteType: context.siteType,
-    prefix: context.cleanupPrefix ?? context.runPrefix,
+  await runScenarioWithCleanup({
+    run: async () => {
+      await cleanupManagedSiteChannelsByPrefix({
+        page: context.page,
+        extensionId: context.extensionId,
+        siteType: context.siteType,
+        prefix: context.cleanupPrefix ?? context.runPrefix,
+      })
+
+      const channelName = `${context.runPrefix} CRUD`
+      const editedChannelName = `${channelName} edited`
+
+      await context.page.goto(channelsUrl(context.extensionId))
+      await waitForExtensionRoot(context.page)
+      await expect(
+        context.page.getByTestId(
+          MANAGED_SITE_CHANNELS_TEST_IDS.addChannelButton,
+        ),
+      ).toBeVisible({ timeout: 30_000 })
+
+      await createManagedSiteChannelFromUi(context.page, {
+        name: channelName,
+        key: `sk-${slugify(context.runPrefix)}-crud`,
+        baseUrl: "https://upstream.example.invalid/v1",
+        model: shouldSeedModelsInManagedSiteCrudScenario(context.siteType)
+          ? CRUD_MODEL
+          : undefined,
+      })
+      await expectManagedSiteChannelVisibleAfterRefresh({
+        page: context.page,
+        channelName,
+      })
+
+      await context.page
+        .getByTestId(MANAGED_SITE_CHANNELS_TEST_IDS.searchInput)
+        .fill(channelName)
+      await expect(channelRowByName(context.page, channelName)).toBeVisible({
+        timeout: 30_000,
+      })
+      await expectPaginationSummary(context.page, "1", "1", "1")
+
+      await openSingleVisibleChannelEditDialog(context.page, channelName)
+      await context.page
+        .getByTestId(CHANNEL_DIALOG_TEST_IDS.nameInput)
+        .fill(editedChannelName)
+      if (shouldEditModelsInManagedSiteCrudScenario(context.siteType)) {
+        await fillModelInput(context.page, CRUD_UPDATED_MODEL)
+      }
+      await submitChannelDialogAndWaitForClose(context.page)
+
+      await expect(
+        channelRowByName(context.page, editedChannelName),
+      ).toBeVisible({
+        timeout: 30_000,
+      })
+
+      await context.page
+        .getByTestId(MANAGED_SITE_CHANNELS_TEST_IDS.searchInput)
+        .fill(editedChannelName)
+      await expect(
+        channelRowByName(context.page, editedChannelName),
+      ).toBeVisible({
+        timeout: 30_000,
+      })
+      await expect(channelRowByName(context.page, channelName)).toHaveCount(0)
+      await expectPaginationSummary(context.page, "1", "1", "1")
+
+      await deleteVisibleChannelByName(
+        context.page,
+        editedChannelName,
+        context.beforeDeleteConfirm,
+      )
+    },
+    finalizers: [
+      async () => {
+        await cleanupManagedSiteChannelsByPrefix({
+          page: context.page,
+          extensionId: context.extensionId,
+          siteType: context.siteType,
+          prefix: context.cleanupPrefix ?? context.runPrefix,
+        })
+      },
+    ],
+    cleanupMessage: "Managed-site channel CRUD cleanup failed",
+    failureMessage: "Managed-site channel CRUD scenario failed",
   })
-
-  const channelName = `${context.runPrefix} CRUD`
-  const editedChannelName = `${channelName} edited`
-
-  try {
-    await context.page.goto(channelsUrl(context.extensionId))
-    await waitForExtensionRoot(context.page)
-    await expect(
-      context.page.getByTestId(MANAGED_SITE_CHANNELS_TEST_IDS.addChannelButton),
-    ).toBeVisible({ timeout: 30_000 })
-
-    await createManagedSiteChannelFromUi(context.page, {
-      name: channelName,
-      key: `sk-${slugify(context.runPrefix)}-crud`,
-      baseUrl: "https://upstream.example.invalid/v1",
-      model: shouldSeedModelsInManagedSiteCrudScenario(context.siteType)
-        ? CRUD_MODEL
-        : undefined,
-    })
-    await expectManagedSiteChannelVisibleAfterRefresh({
-      page: context.page,
-      channelName,
-    })
-
-    await context.page
-      .getByTestId(MANAGED_SITE_CHANNELS_TEST_IDS.searchInput)
-      .fill(channelName)
-    await expect(channelRowByName(context.page, channelName)).toBeVisible({
-      timeout: 30_000,
-    })
-    await expectPaginationSummary(context.page, "1", "1", "1")
-
-    await openSingleVisibleChannelEditDialog(context.page, channelName)
-    await context.page
-      .getByTestId(CHANNEL_DIALOG_TEST_IDS.nameInput)
-      .fill(editedChannelName)
-    if (shouldEditModelsInManagedSiteCrudScenario(context.siteType)) {
-      await fillModelInput(context.page, CRUD_UPDATED_MODEL)
-    }
-    await submitChannelDialogAndWaitForClose(context.page)
-
-    await expect(channelRowByName(context.page, editedChannelName)).toBeVisible(
-      {
-        timeout: 30_000,
-      },
-    )
-
-    await context.page
-      .getByTestId(MANAGED_SITE_CHANNELS_TEST_IDS.searchInput)
-      .fill(editedChannelName)
-    await expect(channelRowByName(context.page, editedChannelName)).toBeVisible(
-      {
-        timeout: 30_000,
-      },
-    )
-    await expect(channelRowByName(context.page, channelName)).toHaveCount(0)
-    await expectPaginationSummary(context.page, "1", "1", "1")
-
-    await deleteVisibleChannelByName(
-      context.page,
-      editedChannelName,
-      context.beforeDeleteConfirm,
-    )
-  } finally {
-    await cleanupManagedSiteChannelsByPrefix({
-      page: context.page,
-      extensionId: context.extensionId,
-      siteType: context.siteType,
-      prefix: context.cleanupPrefix ?? context.runPrefix,
-    })
-  }
 }
 
 export async function runManagedSiteTokenChannelStatusScenario<

--- a/e2e/utils/scenarioErrors.ts
+++ b/e2e/utils/scenarioErrors.ts
@@ -50,3 +50,31 @@ export function throwScenarioError(params: {
     throw params.cleanupError
   }
 }
+
+export async function runScenarioWithCleanup<TResult>(params: {
+  run: () => Promise<TResult>
+  finalizers: Array<() => Promise<void>>
+  cleanupMessage: string
+  failureMessage: string
+}): Promise<TResult> {
+  let result: TResult | undefined
+  let primaryError: unknown
+
+  try {
+    result = await params.run()
+  } catch (error) {
+    primaryError = error
+  }
+
+  const cleanupError = await collectCleanupError(
+    params.finalizers,
+    params.cleanupMessage,
+  )
+  throwScenarioError({
+    primaryError,
+    cleanupError,
+    message: params.failureMessage,
+  })
+
+  return result as TResult
+}

--- a/e2e/utils/scenarioErrors.ts
+++ b/e2e/utils/scenarioErrors.ts
@@ -6,10 +6,10 @@ function formatScenarioError(error: unknown) {
   return String(error)
 }
 
-export async function collectCleanupError(
+async function collectCleanupFailure(
   finalizers: Array<() => Promise<void>>,
   message: string,
-): Promise<unknown> {
+): Promise<{ error: unknown; hasError: boolean }> {
   const errors: unknown[] = []
 
   for (const finalizer of finalizers) {
@@ -21,19 +21,33 @@ export async function collectCleanupError(
   }
 
   if (errors.length > 1) {
-    return new AggregateError(errors, message)
+    return {
+      error: new AggregateError(errors, message),
+      hasError: true,
+    }
   }
 
-  return errors[0]
+  return { error: errors[0], hasError: errors.length === 1 }
+}
+
+export async function collectCleanupError(
+  finalizers: Array<() => Promise<void>>,
+  message: string,
+): Promise<unknown> {
+  return (await collectCleanupFailure(finalizers, message)).error
 }
 
 export function throwScenarioError(params: {
   primaryError: unknown
   cleanupError: unknown
   message: string
+  hasPrimaryError?: boolean
+  hasCleanupError?: boolean
 }): void {
-  const hasPrimaryError = params.primaryError !== undefined
-  const hasCleanupError = params.cleanupError !== undefined
+  const hasPrimaryError =
+    params.hasPrimaryError ?? params.primaryError !== undefined
+  const hasCleanupError =
+    params.hasCleanupError ?? params.cleanupError !== undefined
 
   if (hasPrimaryError && hasCleanupError) {
     throw new AggregateError(
@@ -59,21 +73,25 @@ export async function runScenarioWithCleanup<TResult>(params: {
 }): Promise<TResult> {
   let result: TResult | undefined
   let primaryError: unknown
+  let hasPrimaryError = false
 
   try {
     result = await params.run()
   } catch (error) {
     primaryError = error
+    hasPrimaryError = true
   }
 
-  const cleanupError = await collectCleanupError(
+  const cleanupFailure = await collectCleanupFailure(
     params.finalizers,
     params.cleanupMessage,
   )
   throwScenarioError({
     primaryError,
-    cleanupError,
+    cleanupError: cleanupFailure.error,
     message: params.failureMessage,
+    hasPrimaryError,
+    hasCleanupError: cleanupFailure.hasError,
   })
 
   return result as TResult

--- a/src/services/apiAdapters/managedSites/octopus.ts
+++ b/src/services/apiAdapters/managedSites/octopus.ts
@@ -12,6 +12,7 @@ import {
   deleteChannel as deleteOctopusChannel,
   fetchGroups,
   fetchAvailableModels as fetchOctopusAvailableModels,
+  getChannel,
   listChannels,
   OctopusMutationApiError,
   searchChannels,
@@ -374,14 +375,7 @@ const findOctopusChannelByRef = async (
 ): Promise<OctopusChannel> => {
   assertOctopusResourceRef(config, ref)
 
-  const channels = await listChannels(config)
-  const channel = channels.find((item) => String(item.id) === ref.resourceId)
-
-  if (!channel) {
-    throw new Error(`Channel ${ref.resourceId} was not found`)
-  }
-
-  return channel
+  return await getChannel(config, Number(ref.resourceId))
 }
 
 const prepareOctopusEditDraft = (

--- a/src/services/apiService/octopus/auth.ts
+++ b/src/services/apiService/octopus/auth.ts
@@ -26,6 +26,14 @@ export const OCTOPUS_AUTH_MODES = {
   Cookie: "cookie",
 } as const
 
+export const OCTOPUS_COOKIE_API_VERSIONS = {
+  V012: "v0.12",
+  V013: "v0.13",
+} as const
+
+export type OctopusCookieApiVersion =
+  (typeof OCTOPUS_COOKIE_API_VERSIONS)[keyof typeof OCTOPUS_COOKIE_API_VERSIONS]
+
 export type OctopusAuthSession =
   | {
       mode: typeof OCTOPUS_AUTH_MODES.Bearer
@@ -37,6 +45,8 @@ export type OctopusAuthSession =
       expireAt: number
       /** Set after a harmless protected request proves the cookie is usable. */
       confirmed: boolean
+      /** Learned from the protected channel API without relying on version text. */
+      apiVersion?: OctopusCookieApiVersion
     }
 
 interface LegacyOctopusLoginResponse {

--- a/src/services/apiService/octopus/index.ts
+++ b/src/services/apiService/octopus/index.ts
@@ -411,7 +411,7 @@ async function fetchOctopusApi<T>(
 
     if (
       session.mode === OCTOPUS_AUTH_MODES.Cookie &&
-      session.confirmed === false &&
+      (session.confirmed === false || session.apiVersion === undefined) &&
       (isMutation ||
         operation.kind === OCTOPUS_API_OPERATIONS.FetchRemoteModels)
     ) {

--- a/src/services/apiService/octopus/index.ts
+++ b/src/services/apiService/octopus/index.ts
@@ -34,6 +34,7 @@ import { normalizeBaseUrl } from "~/utils/core/url"
 
 import {
   OCTOPUS_AUTH_MODES,
+  OCTOPUS_COOKIE_API_VERSIONS,
   octopusAuthManager,
   type OctopusAuthSession,
 } from "./auth"
@@ -42,6 +43,7 @@ import { legacyOctopusContract } from "./legacy"
 import { OCTOPUS_API_OPERATIONS, type OctopusApiOperation } from "./operations"
 import { tempWindowOctopusApiFetch } from "./tempContextClient"
 import { buildOctopusAuthHeaders } from "./utils"
+import { octopusV013Contract } from "./v013"
 
 const logger = createLogger("OctopusAPI")
 
@@ -203,6 +205,167 @@ const parseOctopusEnvelope = (
   return data as Record<string, unknown>
 }
 
+const getOctopusEnvelopeData = (endpoint: string, data: unknown): unknown => {
+  const envelope = parseOctopusEnvelope(endpoint, data)
+  if (
+    envelope.success === false ||
+    (envelope.code !== undefined && envelope.code !== 200)
+  ) {
+    throw new Error(
+      typeof envelope.message === "string"
+        ? envelope.message
+        : "API request failed",
+    )
+  }
+  return envelope.data
+}
+
+const fetchOctopusV013Channels = async (params: {
+  config: OctopusConfig
+  session: Extract<OctopusAuthSession, { mode: "cookie" }>
+  baseUrl: string
+  signal?: AbortSignal
+  protectionBypassExecution?: ProtectionBypassExecution
+  resourceBinding?: OctopusApiResourceBinding
+}): Promise<OctopusChannel[]> => {
+  const request = async (endpoint: string) => {
+    const remote = await fetchOctopusCookieApi({
+      config: params.config,
+      session: params.session,
+      baseUrl: params.baseUrl,
+      endpoint,
+      fetchOptions: params.signal ? { signal: params.signal } : {},
+      protectionBypassExecution: params.protectionBypassExecution,
+      resourceBinding: params.resourceBinding,
+    })
+    if (!remote.success) {
+      throw new Error(
+        remote.status
+          ? "HTTP " +
+            remote.status +
+            ": " +
+            (remote.error || "Octopus request failed")
+          : remote.error || "Octopus request failed",
+      )
+    }
+    return getOctopusEnvelopeData(endpoint, remote.data)
+  }
+
+  return octopusV013Contract
+    .parseStatsList(await request(octopusV013Contract.statsEndpoint))
+    .map(octopusV013Contract.normalizeStatsChannel)
+}
+
+const fetchOctopusV013ChannelDetail = async (params: {
+  config: OctopusConfig
+  session: Extract<OctopusAuthSession, { mode: "cookie" }>
+  baseUrl: string
+  channelId: number
+  signal?: AbortSignal
+  protectionBypassExecution?: ProtectionBypassExecution
+  resourceBinding?: OctopusApiResourceBinding
+}): Promise<OctopusChannel> => {
+  const endpoint = octopusV013Contract.detailEndpoint(params.channelId)
+  const remote = await fetchOctopusCookieApi({
+    config: params.config,
+    session: params.session,
+    baseUrl: params.baseUrl,
+    endpoint,
+    fetchOptions: params.signal ? { signal: params.signal } : {},
+    protectionBypassExecution: params.protectionBypassExecution,
+    resourceBinding: params.resourceBinding,
+  })
+  if (!remote.success) {
+    throw new Error(
+      remote.status
+        ? "HTTP " +
+          remote.status +
+          ": " +
+          (remote.error || "Octopus request failed")
+        : remote.error || "Octopus request failed",
+    )
+  }
+  return octopusV013Contract.normalizeChannel(
+    getOctopusEnvelopeData(endpoint, remote.data),
+  )
+}
+
+const resolveOctopusCookieApiVersion = async (params: {
+  config: OctopusConfig
+  session: Extract<OctopusAuthSession, { mode: "cookie" }>
+  baseUrl: string
+  signal?: AbortSignal
+  protectionBypassExecution?: ProtectionBypassExecution
+  resourceBinding?: OctopusApiResourceBinding
+}) => {
+  if (params.session.apiVersion) return params.session.apiVersion
+
+  const probeOperation: OctopusApiOperation = {
+    kind: OCTOPUS_API_OPERATIONS.ListChannels,
+  }
+  const probeRequest = currentOctopusContract.createRequest(
+    probeOperation,
+    params.signal ? { signal: params.signal } : {},
+  )
+  const probe = await fetchOctopusCookieApi({
+    config: params.config,
+    session: params.session,
+    baseUrl: params.baseUrl,
+    endpoint: probeRequest.endpoint,
+    fetchOptions: probeRequest.init,
+    protectionBypassExecution: params.protectionBypassExecution,
+    resourceBinding: params.resourceBinding,
+  })
+
+  if (probe.success) {
+    currentOctopusContract.normalizeResponse(
+      probeOperation,
+      getOctopusEnvelopeData(probeRequest.endpoint, probe.data),
+    )
+    params.session.apiVersion = OCTOPUS_COOKIE_API_VERSIONS.V012
+    params.session.confirmed = true
+    return params.session.apiVersion
+  }
+
+  if (probe.status !== 404) {
+    throw new Error(
+      probe.status
+        ? "HTTP " +
+          probe.status +
+          ": " +
+          (probe.error || "Octopus session confirmation failed")
+        : probe.error || "Octopus session confirmation failed",
+    )
+  }
+
+  const statsEndpoint = octopusV013Contract.statsEndpoint
+  const statsProbe = await fetchOctopusCookieApi({
+    config: params.config,
+    session: params.session,
+    baseUrl: params.baseUrl,
+    endpoint: statsEndpoint,
+    fetchOptions: params.signal ? { signal: params.signal } : {},
+    protectionBypassExecution: params.protectionBypassExecution,
+    resourceBinding: params.resourceBinding,
+  })
+  if (!statsProbe.success) {
+    throw new Error(
+      statsProbe.status
+        ? "HTTP " +
+          statsProbe.status +
+          ": " +
+          (statsProbe.error || "Octopus session confirmation failed")
+        : statsProbe.error || "Octopus session confirmation failed",
+    )
+  }
+  octopusV013Contract.parseStatsList(
+    getOctopusEnvelopeData(statsEndpoint, statsProbe.data),
+  )
+  params.session.apiVersion = OCTOPUS_COOKIE_API_VERSIONS.V013
+  params.session.confirmed = true
+  return params.session.apiVersion
+}
+
 /**
  * 执行 Octopus API 请求
  */
@@ -229,11 +392,85 @@ async function fetchOctopusApi<T>(
 
     const { protectionBypassExecution, resourceBinding, ...fetchOptions } =
       options
+    if (
+      session.mode === OCTOPUS_AUTH_MODES.Cookie &&
+      session.apiVersion === OCTOPUS_COOKIE_API_VERSIONS.V013 &&
+      operation.kind === OCTOPUS_API_OPERATIONS.ListChannels
+    ) {
+      const channels = await fetchOctopusV013Channels({
+        config,
+        session,
+        baseUrl,
+        signal,
+        protectionBypassExecution: options.protectionBypassExecution,
+        resourceBinding: options.resourceBinding,
+      })
+      session.confirmed = true
+      return { success: true, data: channels as T, message: "success" }
+    }
+
+    if (
+      session.mode === OCTOPUS_AUTH_MODES.Cookie &&
+      session.confirmed === false &&
+      (isMutation ||
+        operation.kind === OCTOPUS_API_OPERATIONS.FetchRemoteModels)
+    ) {
+      await resolveOctopusCookieApiVersion({
+        config,
+        session,
+        baseUrl,
+        signal,
+        protectionBypassExecution,
+        resourceBinding,
+      })
+    }
+
+    const usesV013Contract =
+      session.mode === OCTOPUS_AUTH_MODES.Cookie &&
+      session.apiVersion === OCTOPUS_COOKIE_API_VERSIONS.V013
+    let existingV013Detail
+    if (
+      usesV013Contract &&
+      operation.kind === OCTOPUS_API_OPERATIONS.UpdateChannel
+    ) {
+      const detailEndpoint = octopusV013Contract.detailEndpoint(
+        operation.input.id,
+      )
+      const detailResponse = await fetchOctopusCookieApi({
+        config,
+        session,
+        baseUrl,
+        endpoint: detailEndpoint,
+        fetchOptions: signal ? { signal } : {},
+        protectionBypassExecution,
+        resourceBinding,
+      })
+      if (!detailResponse.success) {
+        throw new Error(
+          detailResponse.status
+            ? "HTTP " +
+              detailResponse.status +
+              ": " +
+              (detailResponse.error || "Octopus request failed")
+            : detailResponse.error || "Octopus request failed",
+        )
+      }
+      existingV013Detail = octopusV013Contract.parseDetail(
+        getOctopusEnvelopeData(detailEndpoint, detailResponse.data),
+      )
+    }
+
     const contract =
-      session.mode === OCTOPUS_AUTH_MODES.Cookie
-        ? currentOctopusContract
-        : legacyOctopusContract
-    const nativeRequest = contract.createRequest(operation, fetchOptions)
+      session.mode === OCTOPUS_AUTH_MODES.Bearer
+        ? legacyOctopusContract
+        : currentOctopusContract
+    const nativeRequest = usesV013Contract
+      ? octopusV013Contract.createRequest(
+          operation,
+          fetchOptions,
+          existingV013Detail,
+        )
+      : contract.createRequest(operation, fetchOptions)
     const { endpoint } = nativeRequest
     let data: unknown
 
@@ -303,6 +540,22 @@ async function fetchOctopusApi<T>(
         remote.status !== undefined
       responseStatus = remote.status
       if (!remote.success) {
+        if (
+          operation.kind === OCTOPUS_API_OPERATIONS.ListChannels &&
+          remote.status === 404
+        ) {
+          const channels = await fetchOctopusV013Channels({
+            config,
+            session,
+            baseUrl,
+            signal,
+            protectionBypassExecution,
+            resourceBinding,
+          })
+          session.apiVersion = OCTOPUS_COOKIE_API_VERSIONS.V013
+          session.confirmed = true
+          return { success: true, data: channels as T, message: "success" }
+        }
         throw new Error(
           remote.status
             ? `HTTP ${remote.status}: ${remote.error || "Octopus request failed"}`
@@ -310,6 +563,9 @@ async function fetchOctopusApi<T>(
         )
       }
       data = remote.data
+      if (operation.kind === OCTOPUS_API_OPERATIONS.ListChannels) {
+        session.apiVersion = OCTOPUS_COOKIE_API_VERSIONS.V012
+      }
       session.confirmed = true
     } else {
       fetchStarted = true
@@ -399,10 +655,9 @@ async function fetchOctopusApi<T>(
       throw new Error(message)
     }
 
-    const normalizedData = contract.normalizeResponse(
-      operation,
-      responseData.data,
-    )
+    const normalizedData = usesV013Contract
+      ? octopusV013Contract.normalizeResponse(operation, responseData.data)
+      : contract.normalizeResponse(operation, responseData.data)
     return {
       success: true,
       data: (normalizedData as T | undefined) ?? null,
@@ -444,6 +699,50 @@ export async function listChannels(
     logger.error("Failed to list channels", error)
     throw error
   }
+}
+
+/** Loads one full channel configuration for editing. */
+export async function getChannel(
+  config: OctopusConfig,
+  channelId: number,
+  options?: Pick<
+    OctopusRequestInit,
+    "signal" | "protectionBypassExecution" | "resourceBinding"
+  >,
+): Promise<OctopusChannel> {
+  const signal = options?.signal ?? undefined
+  const session = await octopusAuthManager.getValidSession(config, { signal })
+  const loadV013Detail = (
+    cookieSession: Extract<OctopusAuthSession, { mode: "cookie" }>,
+  ) =>
+    fetchOctopusV013ChannelDetail({
+      config,
+      session: cookieSession,
+      baseUrl: normalizeBaseUrl(config.baseUrl),
+      channelId,
+      signal,
+      protectionBypassExecution: options?.protectionBypassExecution,
+      resourceBinding: options?.resourceBinding,
+    })
+
+  if (
+    session.mode === OCTOPUS_AUTH_MODES.Cookie &&
+    session.apiVersion === OCTOPUS_COOKIE_API_VERSIONS.V013
+  ) {
+    return await loadV013Detail(session)
+  }
+
+  const channels = await listChannels(config, options)
+  if (
+    session.mode === OCTOPUS_AUTH_MODES.Cookie &&
+    session.apiVersion === OCTOPUS_COOKIE_API_VERSIONS.V013
+  ) {
+    return await loadV013Detail(session)
+  }
+
+  const channel = channels.find((item) => item.id === channelId)
+  if (!channel) throw new Error(`Channel ${channelId} was not found`)
+  return channel
 }
 
 /** Validates both authentication and a harmless protected Octopus read. */

--- a/src/services/apiService/octopus/v013.ts
+++ b/src/services/apiService/octopus/v013.ts
@@ -1,0 +1,505 @@
+import {
+  OctopusAutoGroupType,
+  OctopusOutboundType,
+  type OctopusChannel,
+  type OctopusChannelStats,
+  type OctopusCreateChannelInput,
+  type OctopusCustomHeader,
+  type OctopusFetchModelInput,
+  type OctopusUpdateChannelInput,
+} from "~/types/octopus"
+
+import {
+  OCTOPUS_API_OPERATIONS,
+  type OctopusApiOperation,
+  type OctopusNativeRequest,
+} from "./operations"
+
+const OCTOPUS_V013_PROTOCOLS = {
+  OpenAIChatCompletion: 1 << 1,
+  OpenAIResponse: 1 << 2,
+  AnthropicMessage: 1 << 3,
+} as const
+
+interface OctopusV013ChannelModelStatsDto {
+  model_id: number
+  model_name: string
+}
+
+interface OctopusV013ChannelStatsDto extends OctopusChannelStats {
+  channel_name: string
+  enabled: boolean
+  models: OctopusV013ChannelModelStatsDto[]
+}
+
+interface OctopusV013ChannelKeyDto {
+  name: string
+  key: string
+  enabled: boolean
+}
+
+interface OctopusV013ChannelGrantDto {
+  model_name: string
+  key_name: string
+  protocols: number
+}
+
+interface OctopusV013ChannelDetailDto {
+  id: number
+  name: string
+  dialect: string
+  enabled: boolean
+  base_url: string
+  openai_chat_completion_path: string
+  openai_response_path: string
+  anthropic_message_path: string
+  keys: OctopusV013ChannelKeyDto[]
+  models: string[]
+  grants: OctopusV013ChannelGrantDto[]
+  proxy: boolean
+  custom_header: OctopusCustomHeader[]
+  param_override: string
+  channel_proxy: string
+  match_regex: string
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+const invalidV013Response = (field?: string) =>
+  new Error(
+    field
+      ? "Invalid Octopus v0.13 channel response: " + field
+      : "Invalid Octopus v0.13 channel response",
+  )
+
+const requireString = (value: Record<string, unknown>, field: string) => {
+  const candidate = value[field]
+  if (typeof candidate !== "string") throw invalidV013Response(field)
+  return candidate
+}
+
+const requireInteger = (value: Record<string, unknown>, field: string) => {
+  const candidate = value[field]
+  if (typeof candidate !== "number" || !Number.isSafeInteger(candidate)) {
+    throw invalidV013Response(field)
+  }
+  return candidate
+}
+
+const requireFiniteNumber = (value: Record<string, unknown>, field: string) => {
+  const candidate = value[field]
+  if (typeof candidate !== "number" || !Number.isFinite(candidate)) {
+    throw invalidV013Response(field)
+  }
+  return candidate
+}
+
+const requireBoolean = (value: Record<string, unknown>, field: string) => {
+  const candidate = value[field]
+  if (typeof candidate !== "boolean") throw invalidV013Response(field)
+  return candidate
+}
+
+const requireArray = (value: Record<string, unknown>, field: string) => {
+  const candidate = value[field]
+  if (!Array.isArray(candidate)) throw invalidV013Response(field)
+  return candidate
+}
+
+const parseCustomHeader = (value: unknown): OctopusCustomHeader => {
+  if (!isRecord(value)) throw invalidV013Response("custom_header")
+  return {
+    header_key: requireString(value, "header_key"),
+    header_value: requireString(value, "header_value"),
+  }
+}
+
+const parseChannelKey = (value: unknown): OctopusV013ChannelKeyDto => {
+  if (!isRecord(value)) throw invalidV013Response("keys")
+  return {
+    name: requireString(value, "name"),
+    key: requireString(value, "key"),
+    enabled: requireBoolean(value, "enabled"),
+  }
+}
+
+const parseChannelGrant = (value: unknown): OctopusV013ChannelGrantDto => {
+  if (!isRecord(value)) throw invalidV013Response("grants")
+  return {
+    model_name: requireString(value, "model_name"),
+    key_name: requireString(value, "key_name"),
+    protocols: requireInteger(value, "protocols"),
+  }
+}
+
+const parseChannelStats = (value: unknown): OctopusV013ChannelStatsDto => {
+  if (!isRecord(value)) throw invalidV013Response("stats")
+  return {
+    channel_id: requireInteger(value, "channel_id"),
+    channel_name: requireString(value, "channel_name"),
+    enabled: requireBoolean(value, "enabled"),
+    input_token: requireFiniteNumber(value, "input_token"),
+    output_token: requireFiniteNumber(value, "output_token"),
+    input_cost: requireFiniteNumber(value, "input_cost"),
+    output_cost: requireFiniteNumber(value, "output_cost"),
+    wait_time: requireFiniteNumber(value, "wait_time"),
+    request_success: requireFiniteNumber(value, "request_success"),
+    request_failed: requireFiniteNumber(value, "request_failed"),
+    models: requireArray(value, "models").map((model) => {
+      if (!isRecord(model)) throw invalidV013Response("models")
+      return {
+        model_id: requireInteger(model, "model_id"),
+        model_name: requireString(model, "model_name"),
+      }
+    }),
+  }
+}
+
+const parseChannelDetail = (value: unknown): OctopusV013ChannelDetailDto => {
+  if (!isRecord(value)) throw invalidV013Response()
+  return {
+    id: requireInteger(value, "id"),
+    name: requireString(value, "name"),
+    dialect: requireString(value, "dialect"),
+    enabled: requireBoolean(value, "enabled"),
+    base_url: requireString(value, "base_url"),
+    openai_chat_completion_path: requireString(
+      value,
+      "openai_chat_completion_path",
+    ),
+    openai_response_path: requireString(value, "openai_response_path"),
+    anthropic_message_path: requireString(value, "anthropic_message_path"),
+    keys: requireArray(value, "keys").map(parseChannelKey),
+    models: requireArray(value, "models").map((model) => {
+      if (typeof model !== "string") throw invalidV013Response("models")
+      return model
+    }),
+    grants: requireArray(value, "grants").map(parseChannelGrant),
+    proxy: requireBoolean(value, "proxy"),
+    custom_header: requireArray(value, "custom_header").map(parseCustomHeader),
+    param_override: requireString(value, "param_override"),
+    channel_proxy: requireString(value, "channel_proxy"),
+    match_regex: requireString(value, "match_regex"),
+  }
+}
+
+const inferOutboundType = (
+  grants: OctopusV013ChannelGrantDto[],
+): OctopusOutboundType => {
+  const protocols = grants.reduce((all, grant) => all | grant.protocols, 0)
+  if (protocols & OCTOPUS_V013_PROTOCOLS.OpenAIChatCompletion) {
+    return OctopusOutboundType.OpenAIChat
+  }
+  if (protocols & OCTOPUS_V013_PROTOCOLS.OpenAIResponse) {
+    return OctopusOutboundType.OpenAIResponse
+  }
+  if (protocols & OCTOPUS_V013_PROTOCOLS.AnthropicMessage) {
+    return OctopusOutboundType.Anthropic
+  }
+  return OctopusOutboundType.OpenAIChat
+}
+
+const protocolForOutboundType = (type: OctopusOutboundType): number => {
+  switch (type) {
+    case OctopusOutboundType.OpenAIChat:
+    case OctopusOutboundType.Gemini:
+    case OctopusOutboundType.Volcengine:
+      return OCTOPUS_V013_PROTOCOLS.OpenAIChatCompletion
+    case OctopusOutboundType.OpenAIResponse:
+      return OCTOPUS_V013_PROTOCOLS.OpenAIResponse
+    case OctopusOutboundType.Anthropic:
+      return OCTOPUS_V013_PROTOCOLS.AnthropicMessage
+    case OctopusOutboundType.OpenAIEmbedding:
+      break
+  }
+  throw new Error("Octopus v0.13 cannot represent this channel operation")
+}
+
+const protocolPathsForOutboundType = (type: OctopusOutboundType) =>
+  type === OctopusOutboundType.Volcengine
+    ? {
+        openai_chat_completion_path: "/chat/completions",
+        openai_response_path: "/responses",
+        anthropic_message_path: "/messages",
+      }
+    : {
+        openai_chat_completion_path: "/v1/chat/completions",
+        openai_response_path: "/v1/responses",
+        anthropic_message_path: "/v1/messages",
+      }
+
+const splitModels = (...values: Array<string | undefined>): string[] => {
+  const models = values.flatMap((value) => value?.split(",") ?? [])
+  return [...new Set(models.map((model) => model.trim()).filter(Boolean))]
+}
+
+const createGrants = (
+  models: string[],
+  keyName: string | undefined,
+  protocols: number,
+): OctopusV013ChannelGrantDto[] =>
+  keyName
+    ? models.map((model_name) => ({ model_name, key_name: keyName, protocols }))
+    : []
+
+const encodeCreate = (
+  input: OctopusCreateChannelInput,
+): OctopusV013ChannelDetailDto => {
+  const models = splitModels(input.model, input.customModel)
+  const keyName = "default"
+  const protocols = protocolForOutboundType(input.type)
+  return {
+    id: 0,
+    name: input.name,
+    dialect: "generic",
+    enabled: input.enabled ?? true,
+    base_url: input.baseUrl,
+    ...protocolPathsForOutboundType(input.type),
+    keys: [{ name: keyName, key: input.key, enabled: true }],
+    models,
+    grants: createGrants(models, keyName, protocols),
+    proxy: input.proxy ?? false,
+    custom_header: input.customHeaders ?? [],
+    param_override: input.paramOverride ?? "",
+    channel_proxy: input.channelProxy ?? "",
+    match_regex: input.matchRegex ?? "",
+  }
+}
+
+const encodeUpdate = (
+  input: OctopusUpdateChannelInput,
+  existing: OctopusV013ChannelDetailDto,
+): OctopusV013ChannelDetailDto => {
+  const existingType = inferOutboundType(existing.grants)
+  const typeChanged = input.type !== undefined && input.type !== existingType
+  const targetType = input.type ?? existingType
+  const keys = existing.keys.map((key) => ({ ...key }))
+  if (input.key !== undefined) {
+    if (keys[0]) keys[0].key = input.key
+    else keys.push({ name: "default", key: input.key, enabled: true })
+  }
+
+  const replacesModels =
+    input.model !== undefined || input.customModel !== undefined
+  const models = replacesModels
+    ? splitModels(input.model, input.customModel)
+    : [...existing.models]
+  const modelNames = new Set(models)
+  const keyNames = new Set(keys.map((key) => key.name))
+  const protocols = protocolForOutboundType(targetType)
+  let grants = existing.grants
+    .filter(
+      (grant) =>
+        modelNames.has(grant.model_name) && keyNames.has(grant.key_name),
+    )
+    .map((grant) => ({
+      ...grant,
+      ...(typeChanged ? { protocols } : {}),
+    }))
+
+  if (replacesModels) {
+    const grantedModels = new Set(grants.map((grant) => grant.model_name))
+    grants = [
+      ...grants,
+      ...createGrants(
+        models.filter((model) => !grantedModels.has(model)),
+        keys[0]?.name,
+        protocols,
+      ),
+    ]
+  }
+
+  return {
+    ...existing,
+    name: input.name ?? existing.name,
+    enabled: input.enabled ?? existing.enabled,
+    base_url: input.baseUrl ?? existing.base_url,
+    ...(typeChanged ? protocolPathsForOutboundType(targetType) : {}),
+    keys,
+    models,
+    grants,
+    proxy: input.proxy ?? existing.proxy,
+    custom_header: input.customHeaders ?? existing.custom_header,
+    param_override: input.paramOverride ?? existing.param_override,
+    channel_proxy: input.channelProxy ?? existing.channel_proxy,
+    match_regex: input.matchRegex ?? existing.match_regex,
+  }
+}
+
+const encodeFetchModel = (input: OctopusFetchModelInput) => ({
+  channel: {
+    name: input.source?.name ?? "",
+    dialect: "generic",
+    enabled: input.source?.enabled ?? true,
+    base_url: input.baseUrl,
+    ...protocolPathsForOutboundType(input.type),
+    proxy: input.proxy ?? false,
+    custom_header: input.source?.custom_header ?? [],
+    param_override: input.source?.param_override ?? "",
+    channel_proxy: input.source?.channel_proxy ?? "",
+    match_regex: input.source?.match_regex ?? "",
+  },
+  key: input.key,
+})
+
+/**
+ * Octopus v0.13 uses channel stats as list summaries and fetches full detail
+ * only when an editor opens.
+ * Source: https://github.com/bestruirui/octopus/blob/27aa40dc0f3b2902bce3e96ccdba019d17041606/web/src/api/channel.ts
+ */
+export const octopusV013Contract = {
+  statsEndpoint: "/api/v1/channel/stats",
+
+  detailEndpoint(channelId: number) {
+    return "/api/v1/channel/detail/" + channelId
+  },
+
+  parseDetail(value: unknown): OctopusV013ChannelDetailDto {
+    return parseChannelDetail(value)
+  },
+
+  parseStatsList(value: unknown): OctopusV013ChannelStatsDto[] {
+    if (!Array.isArray(value)) throw invalidV013Response("stats")
+    return value.map(parseChannelStats)
+  },
+
+  normalizeStatsChannel(stats: OctopusV013ChannelStatsDto): OctopusChannel {
+    return {
+      id: stats.channel_id,
+      name: stats.channel_name,
+      // The stats contract intentionally omits dialect/protocol details.
+      type: OctopusOutboundType.OpenAIChat,
+      enabled: stats.enabled,
+      base_urls: [],
+      keys: [],
+      model: stats.models.map((model) => model.model_name).join(","),
+      proxy: false,
+      auto_sync: false,
+      auto_group: OctopusAutoGroupType.None,
+      stats: {
+        channel_id: stats.channel_id,
+        input_token: stats.input_token,
+        output_token: stats.output_token,
+        input_cost: stats.input_cost,
+        output_cost: stats.output_cost,
+        wait_time: stats.wait_time,
+        request_success: stats.request_success,
+        request_failed: stats.request_failed,
+      },
+    }
+  },
+
+  normalizeChannel(
+    value: unknown,
+    stats?: OctopusV013ChannelStatsDto,
+  ): OctopusChannel {
+    const detail = parseChannelDetail(value)
+    if (stats && detail.id !== stats.channel_id) {
+      throw invalidV013Response("channel_id")
+    }
+
+    return {
+      id: detail.id,
+      name: detail.name,
+      type: inferOutboundType(detail.grants),
+      enabled: detail.enabled,
+      base_urls: [{ url: detail.base_url }],
+      keys: detail.keys.map((key) => ({
+        enabled: key.enabled,
+        channel_key: key.key,
+      })),
+      model: detail.models.join(","),
+      proxy: detail.proxy,
+      auto_sync: false,
+      auto_group: OctopusAutoGroupType.None,
+      custom_header: detail.custom_header,
+      param_override: detail.param_override,
+      channel_proxy: detail.channel_proxy,
+      match_regex: detail.match_regex,
+      ...(stats
+        ? {
+            stats: {
+              channel_id: stats.channel_id,
+              input_token: stats.input_token,
+              output_token: stats.output_token,
+              input_cost: stats.input_cost,
+              output_cost: stats.output_cost,
+              wait_time: stats.wait_time,
+              request_success: stats.request_success,
+              request_failed: stats.request_failed,
+            },
+          }
+        : {}),
+    }
+  },
+
+  createRequest(
+    operation: OctopusApiOperation,
+    baseInit: RequestInit,
+    existing?: OctopusV013ChannelDetailDto,
+  ): OctopusNativeRequest {
+    switch (operation.kind) {
+      case OCTOPUS_API_OPERATIONS.ListChannels:
+        return { endpoint: this.statsEndpoint, init: baseInit }
+      case OCTOPUS_API_OPERATIONS.CreateChannel:
+        return {
+          endpoint: "/api/v1/channel/create",
+          init: {
+            ...baseInit,
+            method: "POST",
+            body: JSON.stringify(encodeCreate(operation.input)),
+          },
+        }
+      case OCTOPUS_API_OPERATIONS.UpdateChannel:
+        if (!existing) {
+          throw new Error(
+            "Octopus v0.13 update requires current channel detail",
+          )
+        }
+        return {
+          endpoint: "/api/v1/channel/update",
+          init: {
+            ...baseInit,
+            method: "POST",
+            body: JSON.stringify(encodeUpdate(operation.input, existing)),
+          },
+        }
+      case OCTOPUS_API_OPERATIONS.DeleteChannel:
+        return {
+          endpoint: "/api/v1/channel/delete/" + operation.channelId,
+          init: { ...baseInit, method: "DELETE" },
+        }
+      case OCTOPUS_API_OPERATIONS.FetchRemoteModels:
+        return {
+          endpoint: "/api/v1/channel/fetch-model",
+          init: {
+            ...baseInit,
+            method: "POST",
+            body: JSON.stringify(encodeFetchModel(operation.input)),
+          },
+        }
+      case OCTOPUS_API_OPERATIONS.ListAvailableModels:
+        return { endpoint: "/api/v1/model/list", init: baseInit }
+      case OCTOPUS_API_OPERATIONS.ListGroups:
+        return { endpoint: "/api/v1/group/list", init: baseInit }
+    }
+  },
+
+  normalizeResponse(operation: OctopusApiOperation, data: unknown): unknown {
+    switch (operation.kind) {
+      case OCTOPUS_API_OPERATIONS.CreateChannel:
+      case OCTOPUS_API_OPERATIONS.UpdateChannel:
+        if (data === null || data === undefined) return data
+        return this.normalizeChannel(data)
+      case OCTOPUS_API_OPERATIONS.FetchRemoteModels:
+        if (!Array.isArray(data)) throw invalidV013Response("models")
+        return data.map((model) => {
+          if (!isRecord(model)) throw invalidV013Response("models")
+          return requireString(model, "name")
+        })
+      default:
+        return data
+    }
+  },
+}

--- a/src/services/protectionBypass/contracts.ts
+++ b/src/services/protectionBypass/contracts.ts
@@ -634,9 +634,20 @@ function isTempWindowNewApiSessionReadParams(
   )
 }
 
+// Octopus v0.13 reads channel inventory through stats and loads detail on demand.
+// Contract: https://github.com/bestruirui/octopus/blob/27aa40dc0f3b2902bce3e96ccdba019d17041606/web/src/api/channel.ts
+const OCTOPUS_V013_READ_ENDPOINT_METHODS = [
+  { pattern: /^\/api\/v1\/channel\/stats$/u, method: "GET" },
+  {
+    pattern: /^\/api\/v1\/channel\/detail\/[1-9]\d*$/u,
+    method: "GET",
+  },
+] as const
+
 const OCTOPUS_ENDPOINT_METHODS = [
   { pattern: new RegExp(`^${OCTOPUS_LOGIN_PATH}$`, "u"), method: "POST" },
   { pattern: /^\/api\/v1\/channel\/list$/u, method: "GET" },
+  ...OCTOPUS_V013_READ_ENDPOINT_METHODS,
   {
     pattern: /^\/api\/v1\/channel\/(?:create|update|fetch-model)$/u,
     method: "POST",
@@ -646,8 +657,9 @@ const OCTOPUS_ENDPOINT_METHODS = [
 ] as const
 
 const OCTOPUS_CONFIGURATION_TEST_ENDPOINT_METHODS = [
-  { pathname: OCTOPUS_LOGIN_PATH, method: "POST" },
-  { pathname: "/api/v1/channel/list", method: "GET" },
+  { pattern: new RegExp(`^${OCTOPUS_LOGIN_PATH}$`, "u"), method: "POST" },
+  { pattern: /^\/api\/v1\/channel\/list$/u, method: "GET" },
+  ...OCTOPUS_V013_READ_ENDPOINT_METHODS,
 ] as const
 
 /** Validates the narrow Octopus endpoint allow-list at the runtime boundary. */
@@ -690,7 +702,7 @@ function isTempWindowOctopusApiFetchParams(
     value.resourceBinding !== OCTOPUS_API_RESOURCE_BINDINGS.ConfigurationTest ||
     OCTOPUS_CONFIGURATION_TEST_ENDPOINT_METHODS.some(
       (endpoint) =>
-        endpoint.method === method && endpoint.pathname === fetchUrl.pathname,
+        endpoint.method === method && endpoint.pattern.test(fetchUrl.pathname),
     )
   return (
     fetchUrl.origin === value.originUrl &&

--- a/tests/services/apiAdapters/managedSites/octopus.test.ts
+++ b/tests/services/apiAdapters/managedSites/octopus.test.ts
@@ -62,6 +62,7 @@ const octopusApi = vi.hoisted(() => {
 
   return {
     OctopusMutationApiError,
+    getChannel: vi.fn(),
     listChannels: vi.fn(),
     searchChannels: vi.fn(),
     createChannel: vi.fn(),
@@ -914,7 +915,7 @@ describe("Octopus managed-site channel capability", () => {
   })
 
   it("loads Octopus detail from native channel data and prepares channel-worded edit drafts", async () => {
-    octopusApi.listChannels.mockResolvedValue([octopusChannel])
+    octopusApi.getChannel.mockResolvedValue(octopusChannel)
     const { octopusManagedSiteCapabilities } = await import(
       "~/services/apiAdapters/managedSites/octopus"
     )
@@ -957,6 +958,7 @@ describe("Octopus managed-site channel capability", () => {
       weight: 0,
       status: 1,
     })
+    expect(octopusApi.getChannel).toHaveBeenCalledWith(config, 7)
   })
 
   it("rejects stale Octopus resource refs from a different site or scope before native access", async () => {
@@ -979,7 +981,7 @@ describe("Octopus managed-site channel capability", () => {
       }),
     ).rejects.toThrow("Resource reference does not match this managed site")
 
-    expect(octopusApi.listChannels).not.toHaveBeenCalled()
+    expect(octopusApi.getChannel).not.toHaveBeenCalled()
     expect(octopusApi.deleteChannel).not.toHaveBeenCalled()
   })
 

--- a/tests/services/apiService/octopus.index.test.ts
+++ b/tests/services/apiService/octopus.index.test.ts
@@ -91,6 +91,13 @@ describe("Octopus API service", () => {
     password: "secret",
   }
 
+  const currentCookieSession = () => ({
+    mode: OCTOPUS_AUTH_MODES.Cookie,
+    expireAt: 1_700_000_900_000,
+    confirmed: true,
+    apiVersion: OCTOPUS_COOKIE_API_VERSIONS.V012,
+  })
+
   const currentChannelResponse = (
     overrides: Record<string, unknown> = {},
   ): Record<string, unknown> => ({
@@ -474,6 +481,64 @@ describe("Octopus API service", () => {
     })
   })
 
+  it("detects the cookie API version before mutation after a version-agnostic read", async () => {
+    const session = {
+      mode: OCTOPUS_AUTH_MODES.Cookie,
+      expireAt: 1_700_000_900_000,
+      confirmed: false,
+    }
+    mockGetValidSession.mockResolvedValue(session)
+    mockTempWindowOctopusApiFetch
+      .mockResolvedValueOnce({
+        success: true,
+        status: 200,
+        data: { code: 200, data: [] },
+      })
+      .mockResolvedValueOnce({
+        success: false,
+        status: 404,
+        error: "404 page not found",
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        status: 200,
+        data: { code: 200, data: [] },
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        status: 200,
+        data: { code: 200, data: v013ChannelDetailResponse() },
+      })
+
+    await expect(fetchAvailableModels(config)).resolves.toEqual([])
+    await expect(
+      createChannel(config, {
+        name: "V0.13 channel",
+        type: OctopusOutboundType.OpenAIChat,
+        enabled: true,
+        baseUrl: "https://upstream.example.invalid",
+        key: "credential-placeholder",
+        model: "model-a",
+      }),
+    ).resolves.toMatchObject({ success: true })
+
+    expect(
+      mockTempWindowOctopusApiFetch.mock.calls.map(
+        ([request]) => new URL(request.fetchUrl).pathname,
+      ),
+    ).toEqual([
+      "/api/v1/model/list",
+      "/api/v1/channel/list",
+      "/api/v1/channel/stats",
+      "/api/v1/channel/create",
+    ])
+    expect(
+      JSON.parse(
+        mockTempWindowOctopusApiFetch.mock.calls[3][0].fetchOptions.body,
+      ),
+    ).toMatchObject({ dialect: "generic", models: ["model-a"] })
+  })
+
   it("preserves Octopus v0.13 detail fields while applying a partial update", async () => {
     const existing = v013ChannelDetailResponse({
       keys: [
@@ -625,10 +690,7 @@ describe("Octopus API service", () => {
   })
 
   it("establishes a same-origin cookie session after 401 and retries the mutation", async () => {
-    mockGetValidSession.mockResolvedValueOnce({
-      mode: OCTOPUS_AUTH_MODES.Cookie,
-      expireAt: 1_700_000_900_000,
-    })
+    mockGetValidSession.mockResolvedValueOnce(currentCookieSession())
     mockTempWindowOctopusApiFetch
       .mockResolvedValueOnce({
         success: false,
@@ -758,10 +820,7 @@ describe("Octopus API service", () => {
   ])(
     "fails closed after cookie 401 when login returns $name",
     async ({ login, expected }) => {
-      mockGetValidSession.mockResolvedValueOnce({
-        mode: OCTOPUS_AUTH_MODES.Cookie,
-        expireAt: 1_700_000_900_000,
-      })
+      mockGetValidSession.mockResolvedValueOnce(currentCookieSession())
       mockTempWindowOctopusApiFetch
         .mockResolvedValueOnce({
           success: false,
@@ -865,10 +924,7 @@ describe("Octopus API service", () => {
   )
 
   it("selects explicit current update and model-probe payloads", async () => {
-    mockGetValidSession.mockResolvedValue({
-      mode: OCTOPUS_AUTH_MODES.Cookie,
-      expireAt: 1_700_000_900_000,
-    })
+    mockGetValidSession.mockResolvedValue(currentCookieSession())
     mockTempWindowOctopusApiFetch
       .mockResolvedValueOnce({
         success: true,
@@ -979,10 +1035,7 @@ describe("Octopus API service", () => {
   })
 
   it("includes current-only channel settings in a current model probe", async () => {
-    mockGetValidSession.mockResolvedValueOnce({
-      mode: OCTOPUS_AUTH_MODES.Cookie,
-      expireAt: 1_700_000_900_000,
-    })
+    mockGetValidSession.mockResolvedValueOnce(currentCookieSession())
     mockTempWindowOctopusApiFetch.mockResolvedValueOnce({
       success: true,
       status: 200,
@@ -1030,10 +1083,7 @@ describe("Octopus API service", () => {
   })
 
   it("rejects the removed embedding-only type before a cookie request is dispatched", async () => {
-    mockGetValidSession.mockResolvedValueOnce({
-      mode: OCTOPUS_AUTH_MODES.Cookie,
-      expireAt: 1_700_000_900_000,
-    })
+    mockGetValidSession.mockResolvedValueOnce(currentCookieSession())
 
     await expect(
       fetchRemoteModels(
@@ -1050,10 +1100,7 @@ describe("Octopus API service", () => {
   })
 
   it("classifies an invalid cookie mutation type as not dispatched", async () => {
-    mockGetValidSession.mockResolvedValueOnce({
-      mode: OCTOPUS_AUTH_MODES.Cookie,
-      expireAt: 1_700_000_900_000,
-    })
+    mockGetValidSession.mockResolvedValueOnce(currentCookieSession())
 
     const failure = await createChannel(
       config,
@@ -1078,10 +1125,7 @@ describe("Octopus API service", () => {
   })
 
   it("does not forward legacy-only update fields to the current contract", async () => {
-    mockGetValidSession.mockResolvedValueOnce({
-      mode: OCTOPUS_AUTH_MODES.Cookie,
-      expireAt: 1_700_000_900_000,
-    })
+    mockGetValidSession.mockResolvedValueOnce(currentCookieSession())
     mockTempWindowOctopusApiFetch.mockResolvedValueOnce({
       success: true,
       status: 200,
@@ -1171,10 +1215,7 @@ describe("Octopus API service", () => {
   })
 
   it("treats missing cookie transport lifecycle as possibly dispatched", async () => {
-    mockGetValidSession.mockResolvedValue({
-      mode: OCTOPUS_AUTH_MODES.Cookie,
-      expireAt: 1_700_000_900_000,
-    })
+    mockGetValidSession.mockResolvedValue(currentCookieSession())
     const transportError = new Error("temporary context failed")
     mockTempWindowOctopusApiFetch.mockRejectedValueOnce(transportError)
 
@@ -1355,10 +1396,7 @@ describe("Octopus API service", () => {
   })
 
   it("normalizes a current create response that omits model", async () => {
-    mockGetValidSession.mockResolvedValueOnce({
-      mode: OCTOPUS_AUTH_MODES.Cookie,
-      expireAt: 1_700_000_900_000,
-    })
+    mockGetValidSession.mockResolvedValueOnce(currentCookieSession())
     mockTempWindowOctopusApiFetch.mockResolvedValueOnce({
       success: true,
       status: 200,
@@ -1449,10 +1487,7 @@ describe("Octopus API service", () => {
   })
 
   it("uses current model, group, and delete endpoints after cookie auth", async () => {
-    mockGetValidSession.mockResolvedValue({
-      mode: OCTOPUS_AUTH_MODES.Cookie,
-      expireAt: 1_700_000_900_000,
-    })
+    mockGetValidSession.mockResolvedValue(currentCookieSession())
     mockTempWindowOctopusApiFetch
       .mockResolvedValueOnce({
         success: true,

--- a/tests/services/apiService/octopus.index.test.ts
+++ b/tests/services/apiService/octopus.index.test.ts
@@ -698,6 +698,14 @@ describe("Octopus API service", () => {
       ],
       expected: "stats bridge unavailable",
     },
+    {
+      name: "an HTTP v0.13 stats probe failure",
+      responses: [
+        { success: false, status: 404 },
+        { success: false, status: 503 },
+      ],
+      expected: "HTTP 503: Octopus session confirmation failed",
+    },
   ])(
     "does not dispatch a mutation after $name",
     async ({ responses, expected }) => {
@@ -725,21 +733,34 @@ describe("Octopus API service", () => {
     },
   )
 
-  it("stops a v0.13 update when current detail cannot be loaded", async () => {
-    mockGetValidSession.mockResolvedValue(v013CookieSession())
-    mockTempWindowOctopusApiFetch.mockResolvedValueOnce({
-      success: false,
-      status: 503,
-    })
+  it.each([
+    {
+      response: { success: false, status: 503 },
+      expected: "HTTP 503: Octopus request failed",
+    },
+    {
+      response: { success: false, error: "detail bridge unavailable" },
+      expected: "detail bridge unavailable",
+    },
+    {
+      response: { success: false },
+      expected: "Octopus request failed",
+    },
+  ])(
+    "stops a v0.13 update when detail loading fails as $expected",
+    async ({ response, expected }) => {
+      mockGetValidSession.mockResolvedValue(v013CookieSession())
+      mockTempWindowOctopusApiFetch.mockResolvedValueOnce(response)
 
-    await expect(
-      updateChannel(config, { id: 7, name: "Updated" }),
-    ).rejects.toMatchObject({
-      message: "HTTP 503: Octopus request failed",
-      dispatch: "not-dispatched",
-      confirmedNonApplication: true,
-    })
-  })
+      await expect(
+        updateChannel(config, { id: 7, name: "Updated" }),
+      ).rejects.toMatchObject({
+        message: expected,
+        dispatch: "not-dispatched",
+        confirmedNonApplication: true,
+      })
+    },
+  )
 
   it("preserves Octopus v0.13 detail fields while applying a partial update", async () => {
     const existing = v013ChannelDetailResponse({

--- a/tests/services/apiService/octopus.index.test.ts
+++ b/tests/services/apiService/octopus.index.test.ts
@@ -98,6 +98,13 @@ describe("Octopus API service", () => {
     apiVersion: OCTOPUS_COOKIE_API_VERSIONS.V012,
   })
 
+  const v013CookieSession = () => ({
+    mode: OCTOPUS_AUTH_MODES.Cookie,
+    expireAt: 1_700_000_900_000,
+    confirmed: true,
+    apiVersion: OCTOPUS_COOKIE_API_VERSIONS.V013,
+  })
+
   const currentChannelResponse = (
     overrides: Record<string, unknown> = {},
   ): Record<string, unknown> => ({
@@ -381,6 +388,58 @@ describe("Octopus API service", () => {
     ).toEqual(["/api/v1/channel/list", "/api/v1/channel/stats"])
   })
 
+  it("uses the stats endpoint directly for a known v0.13 session", async () => {
+    const session = v013CookieSession()
+    mockGetValidSession.mockResolvedValue(session)
+    mockTempWindowOctopusApiFetch.mockResolvedValueOnce({
+      success: true,
+      status: 200,
+      data: { code: 200, data: [v013ChannelStatsResponse()] },
+    })
+
+    await expect(listChannels(config)).resolves.toHaveLength(1)
+
+    expect(session.confirmed).toBe(true)
+    expect(
+      mockTempWindowOctopusApiFetch.mock.calls.map(
+        ([request]) => new URL(request.fetchUrl).pathname,
+      ),
+    ).toEqual(["/api/v1/channel/stats"])
+  })
+
+  it.each([
+    {
+      response: { success: false, status: 503 },
+      expected: "HTTP 503: Octopus request failed",
+    },
+    {
+      response: { success: false, error: "protected read unavailable" },
+      expected: "protected read unavailable",
+    },
+  ])(
+    "reports a v0.13 stats transport failure as $expected",
+    async ({ response, expected }) => {
+      const controller = new AbortController()
+      mockGetValidSession.mockResolvedValue(v013CookieSession())
+      mockTempWindowOctopusApiFetch.mockResolvedValueOnce(response)
+
+      await expect(
+        listChannels(config, { signal: controller.signal }),
+      ).rejects.toThrow(expected)
+    },
+  )
+
+  it("uses a local fallback for a rejected v0.13 response envelope", async () => {
+    mockGetValidSession.mockResolvedValue(v013CookieSession())
+    mockTempWindowOctopusApiFetch.mockResolvedValueOnce({
+      success: true,
+      status: 200,
+      data: { code: 500 },
+    })
+
+    await expect(listChannels(config)).rejects.toThrow("API request failed")
+  })
+
   it("loads one Octopus v0.13 channel detail only when explicitly requested", async () => {
     mockGetValidSession.mockResolvedValue({
       mode: OCTOPUS_AUTH_MODES.Cookie,
@@ -408,6 +467,87 @@ describe("Octopus API service", () => {
         ([request]) => new URL(request.fetchUrl).pathname,
       ),
     ).toEqual(["/api/v1/channel/detail/7"])
+  })
+
+  it.each([
+    {
+      response: { success: false, status: 503 },
+      expected: "HTTP 503: Octopus request failed",
+    },
+    {
+      response: { success: false, error: "detail bridge unavailable" },
+      expected: "detail bridge unavailable",
+    },
+  ])(
+    "reports a v0.13 detail transport failure as $expected",
+    async ({ response, expected }) => {
+      mockGetValidSession.mockResolvedValue(v013CookieSession())
+      mockTempWindowOctopusApiFetch.mockResolvedValueOnce(response)
+
+      await expect(getChannel(config, 7)).rejects.toThrow(expected)
+    },
+  )
+
+  it("loads v0.13 detail after list-based version discovery", async () => {
+    const session = {
+      mode: OCTOPUS_AUTH_MODES.Cookie,
+      expireAt: 1_700_000_900_000,
+      confirmed: false,
+    }
+    mockGetValidSession.mockResolvedValue(session)
+    mockTempWindowOctopusApiFetch
+      .mockResolvedValueOnce({ success: false, status: 404 })
+      .mockResolvedValueOnce({
+        success: true,
+        status: 200,
+        data: { code: 200, data: [v013ChannelStatsResponse()] },
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        status: 200,
+        data: { code: 200, data: v013ChannelDetailResponse() },
+      })
+
+    await expect(getChannel(config, 7)).resolves.toMatchObject({
+      id: 7,
+      base_urls: [{ url: "https://upstream.example.invalid" }],
+    })
+    expect(
+      mockTempWindowOctopusApiFetch.mock.calls.map(
+        ([request]) => new URL(request.fetchUrl).pathname,
+      ),
+    ).toEqual([
+      "/api/v1/channel/list",
+      "/api/v1/channel/stats",
+      "/api/v1/channel/detail/7",
+    ])
+  })
+
+  it("reports a missing current channel after list fallback", async () => {
+    mockGetValidSession.mockResolvedValue(currentCookieSession())
+    mockTempWindowOctopusApiFetch.mockResolvedValueOnce({
+      success: true,
+      status: 200,
+      data: { code: 200, data: [] },
+    })
+
+    await expect(getChannel(config, 7)).rejects.toThrow(
+      "Channel 7 was not found",
+    )
+  })
+
+  it("returns a matching current channel after list fallback", async () => {
+    mockGetValidSession.mockResolvedValue(currentCookieSession())
+    mockTempWindowOctopusApiFetch.mockResolvedValueOnce({
+      success: true,
+      status: 200,
+      data: { code: 200, data: [currentChannelResponse({ id: 7 })] },
+    })
+
+    await expect(getChannel(config, 7)).resolves.toMatchObject({
+      id: 7,
+      name: "Current",
+    })
   })
 
   it("encodes Octopus v0.13 channel creation after a harmless contract probe", async () => {
@@ -537,6 +677,68 @@ describe("Octopus API service", () => {
         mockTempWindowOctopusApiFetch.mock.calls[3][0].fetchOptions.body,
       ),
     ).toMatchObject({ dialect: "generic", models: ["model-a"] })
+  })
+
+  it.each([
+    {
+      name: "a non-404 current probe failure",
+      responses: [{ success: false, status: 503 }],
+      expected: "HTTP 503: Octopus session confirmation failed",
+    },
+    {
+      name: "a current probe bridge failure",
+      responses: [{ success: false, error: "current probe unavailable" }],
+      expected: "current probe unavailable",
+    },
+    {
+      name: "a v0.13 stats probe failure",
+      responses: [
+        { success: false, status: 404 },
+        { success: false, error: "stats bridge unavailable" },
+      ],
+      expected: "stats bridge unavailable",
+    },
+  ])(
+    "does not dispatch a mutation after $name",
+    async ({ responses, expected }) => {
+      mockGetValidSession.mockResolvedValue({
+        mode: OCTOPUS_AUTH_MODES.Cookie,
+        expireAt: 1_700_000_900_000,
+        confirmed: false,
+      })
+      for (const response of responses) {
+        mockTempWindowOctopusApiFetch.mockResolvedValueOnce(response)
+      }
+
+      await expect(
+        createChannel(config, {
+          name: "Example channel",
+          type: OctopusOutboundType.OpenAIChat,
+          baseUrl: "https://upstream.example.invalid",
+          key: "credential-placeholder",
+        }),
+      ).rejects.toMatchObject({
+        message: expected,
+        dispatch: "not-dispatched",
+        confirmedNonApplication: true,
+      })
+    },
+  )
+
+  it("stops a v0.13 update when current detail cannot be loaded", async () => {
+    mockGetValidSession.mockResolvedValue(v013CookieSession())
+    mockTempWindowOctopusApiFetch.mockResolvedValueOnce({
+      success: false,
+      status: 503,
+    })
+
+    await expect(
+      updateChannel(config, { id: 7, name: "Updated" }),
+    ).rejects.toMatchObject({
+      message: "HTTP 503: Octopus request failed",
+      dispatch: "not-dispatched",
+      confirmedNonApplication: true,
+    })
   })
 
   it("preserves Octopus v0.13 detail fields while applying a partial update", async () => {

--- a/tests/services/apiService/octopus.index.test.ts
+++ b/tests/services/apiService/octopus.index.test.ts
@@ -9,13 +9,17 @@ import {
   fetchGroups,
   fetchRemoteModels,
   fetchSiteUserGroups,
+  getChannel,
   listChannels,
   OctopusMutationApiError,
   searchChannels,
   updateChannel,
   validateOctopusConfig,
 } from "~/services/apiService/octopus"
-import { OCTOPUS_AUTH_MODES } from "~/services/apiService/octopus/auth"
+import {
+  OCTOPUS_AUTH_MODES,
+  OCTOPUS_COOKIE_API_VERSIONS,
+} from "~/services/apiService/octopus/auth"
 import {
   createAutomaticProtectionBypassExecution,
   PROTECTION_BYPASS_AUTOMATIC_TRIGGERS,
@@ -99,6 +103,68 @@ describe("Octopus API service", () => {
     model: "model-a",
     proxy: false,
     auto_sync: true,
+    ...overrides,
+  })
+
+  const v013ChannelDetailResponse = (
+    overrides: Record<string, unknown> = {},
+  ): Record<string, unknown> => ({
+    id: 7,
+    name: "V0.13 channel",
+    dialect: "generic",
+    enabled: true,
+    base_url: "https://upstream.example.invalid",
+    openai_chat_completion_path: "/v1/chat/completions",
+    openai_response_path: "/v1/responses",
+    anthropic_message_path: "/v1/messages",
+    keys: [{ name: "default", key: "credential-placeholder", enabled: true }],
+    models: ["model-a"],
+    grants: [{ model_name: "model-a", key_name: "default", protocols: 2 }],
+    proxy: false,
+    custom_header: [],
+    param_override: "",
+    channel_proxy: "",
+    match_regex: "",
+    ...overrides,
+  })
+
+  const v013ChannelStatsResponse = (
+    overrides: Record<string, unknown> = {},
+  ): Record<string, unknown> => ({
+    channel_id: 7,
+    channel_name: "V0.13 channel",
+    enabled: true,
+    models: [
+      {
+        model_id: 11,
+        model_name: "model-a",
+        input_token: 6,
+        output_token: 3,
+        input_cost: 0.15,
+        output_cost: 0.3,
+        wait_time: 1,
+        request_success: 2,
+        request_failed: 0,
+      },
+      {
+        model_id: 12,
+        model_name: "model-b",
+        input_token: 4,
+        output_token: 1,
+        input_cost: 0.1,
+        output_cost: 0.2,
+        wait_time: 0.5,
+        request_success: 1,
+        request_failed: 1,
+      },
+    ],
+    input_token: 10,
+    output_token: 4,
+    input_cost: 0.25,
+    output_cost: 0.5,
+    wait_time: 1.5,
+    request_success: 3,
+    request_failed: 1,
     ...overrides,
   })
 
@@ -258,6 +324,224 @@ describe("Octopus API service", () => {
     expect(request.fetchUrl).toBe(
       "https://octopus.example.com/api/v1/channel/list",
     )
+  })
+
+  it("uses Octopus v0.13 stats as channel summaries without loading detail", async () => {
+    const session = {
+      mode: OCTOPUS_AUTH_MODES.Cookie,
+      expireAt: 1_700_000_900_000,
+      confirmed: false,
+    } as const
+    mockGetValidSession.mockResolvedValue(session)
+    mockTempWindowOctopusApiFetch
+      .mockResolvedValueOnce({
+        success: false,
+        status: 404,
+        error: "404 page not found",
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        status: 200,
+        data: { code: 200, data: [v013ChannelStatsResponse()] },
+      })
+
+    await expect(listChannels(config)).resolves.toEqual([
+      expect.objectContaining({
+        id: 7,
+        name: "V0.13 channel",
+        type: OctopusOutboundType.OpenAIChat,
+        base_urls: [],
+        keys: [],
+        model: "model-a,model-b",
+        auto_group: OctopusAutoGroupType.None,
+        stats: {
+          channel_id: 7,
+          input_token: 10,
+          output_token: 4,
+          input_cost: 0.25,
+          output_cost: 0.5,
+          wait_time: 1.5,
+          request_success: 3,
+          request_failed: 1,
+        },
+      }),
+    ])
+
+    expect(
+      mockTempWindowOctopusApiFetch.mock.calls.map(
+        ([request]) => new URL(request.fetchUrl).pathname,
+      ),
+    ).toEqual(["/api/v1/channel/list", "/api/v1/channel/stats"])
+  })
+
+  it("loads one Octopus v0.13 channel detail only when explicitly requested", async () => {
+    mockGetValidSession.mockResolvedValue({
+      mode: OCTOPUS_AUTH_MODES.Cookie,
+      expireAt: 1_700_000_900_000,
+      confirmed: true,
+      apiVersion: OCTOPUS_COOKIE_API_VERSIONS.V013,
+    })
+    mockTempWindowOctopusApiFetch.mockResolvedValueOnce({
+      success: true,
+      status: 200,
+      data: { code: 200, data: v013ChannelDetailResponse() },
+    })
+
+    await expect(getChannel(config, 7)).resolves.toEqual(
+      expect.objectContaining({
+        id: 7,
+        name: "V0.13 channel",
+        base_urls: [{ url: "https://upstream.example.invalid" }],
+        keys: [{ enabled: true, channel_key: "credential-placeholder" }],
+        model: "model-a",
+      }),
+    )
+    expect(
+      mockTempWindowOctopusApiFetch.mock.calls.map(
+        ([request]) => new URL(request.fetchUrl).pathname,
+      ),
+    ).toEqual(["/api/v1/channel/detail/7"])
+  })
+
+  it("encodes Octopus v0.13 channel creation after a harmless contract probe", async () => {
+    const session = {
+      mode: OCTOPUS_AUTH_MODES.Cookie,
+      expireAt: 1_700_000_900_000,
+      confirmed: false,
+    }
+    mockGetValidSession.mockResolvedValue(session)
+    mockTempWindowOctopusApiFetch
+      .mockResolvedValueOnce({
+        success: false,
+        status: 404,
+        error: "404 page not found",
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        status: 200,
+        data: { code: 200, data: [] },
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        status: 200,
+        data: { code: 200, data: v013ChannelDetailResponse() },
+      })
+
+    await expect(
+      createChannel(config, {
+        name: "V0.13 channel",
+        type: OctopusOutboundType.OpenAIChat,
+        enabled: true,
+        baseUrl: "https://upstream.example.invalid",
+        key: "credential-placeholder",
+        model: "model-a",
+      }),
+    ).resolves.toMatchObject({
+      success: true,
+      data: { id: 7, name: "V0.13 channel" },
+    })
+
+    expect(
+      mockTempWindowOctopusApiFetch.mock.calls.map(
+        ([request]) => new URL(request.fetchUrl).pathname,
+      ),
+    ).toEqual([
+      "/api/v1/channel/list",
+      "/api/v1/channel/stats",
+      "/api/v1/channel/create",
+    ])
+    expect(
+      JSON.parse(
+        mockTempWindowOctopusApiFetch.mock.calls[2][0].fetchOptions.body,
+      ),
+    ).toEqual({
+      id: 0,
+      name: "V0.13 channel",
+      dialect: "generic",
+      enabled: true,
+      base_url: "https://upstream.example.invalid",
+      openai_chat_completion_path: "/v1/chat/completions",
+      openai_response_path: "/v1/responses",
+      anthropic_message_path: "/v1/messages",
+      keys: [{ name: "default", key: "credential-placeholder", enabled: true }],
+      models: ["model-a"],
+      grants: [{ model_name: "model-a", key_name: "default", protocols: 2 }],
+      proxy: false,
+      custom_header: [],
+      param_override: "",
+      channel_proxy: "",
+      match_regex: "",
+    })
+  })
+
+  it("preserves Octopus v0.13 detail fields while applying a partial update", async () => {
+    const existing = v013ChannelDetailResponse({
+      keys: [
+        { name: "default", key: "credential-placeholder", enabled: true },
+        { name: "backup", key: "credential-backup", enabled: false },
+      ],
+      custom_header: [{ header_key: "x-example", header_value: "preserve" }],
+      channel_proxy: "http://proxy.example.invalid:8080",
+    })
+    const updated = {
+      ...existing,
+      name: "Updated v0.13 channel",
+      models: ["model-a", "model-b"],
+      grants: [
+        { model_name: "model-a", key_name: "default", protocols: 2 },
+        { model_name: "model-b", key_name: "default", protocols: 2 },
+      ],
+    }
+    mockGetValidSession.mockResolvedValue({
+      mode: OCTOPUS_AUTH_MODES.Cookie,
+      expireAt: 1_700_000_900_000,
+      confirmed: false,
+    })
+    mockTempWindowOctopusApiFetch
+      .mockResolvedValueOnce({ success: false, status: 404 })
+      .mockResolvedValueOnce({
+        success: true,
+        status: 200,
+        data: { code: 200, data: [] },
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        status: 200,
+        data: { code: 200, data: existing },
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        status: 200,
+        data: { code: 200, data: updated },
+      })
+
+    await expect(
+      updateChannel(config, {
+        id: 7,
+        name: "Updated v0.13 channel",
+        type: OctopusOutboundType.OpenAIChat,
+        model: "model-a,model-b",
+      }),
+    ).resolves.toMatchObject({
+      success: true,
+      data: { id: 7, name: "Updated v0.13 channel", model: "model-a,model-b" },
+    })
+
+    expect(
+      mockTempWindowOctopusApiFetch.mock.calls.map(
+        ([request]) => new URL(request.fetchUrl).pathname,
+      ),
+    ).toEqual([
+      "/api/v1/channel/list",
+      "/api/v1/channel/stats",
+      "/api/v1/channel/detail/7",
+      "/api/v1/channel/update",
+    ])
+    expect(
+      JSON.parse(
+        mockTempWindowOctopusApiFetch.mock.calls[3][0].fetchOptions.body,
+      ),
+    ).toEqual(updated)
   })
 
   it("validates cookie configurations through a protected channel read", async () => {

--- a/tests/services/apiService/octopus.v013.test.ts
+++ b/tests/services/apiService/octopus.v013.test.ts
@@ -1,0 +1,373 @@
+import { describe, expect, it } from "vitest"
+
+import { OCTOPUS_API_OPERATIONS } from "~/services/apiService/octopus/operations"
+import { octopusV013Contract } from "~/services/apiService/octopus/v013"
+import { OctopusOutboundType } from "~/types/octopus"
+
+const detailResponse = (overrides: Record<string, unknown> = {}) => ({
+  id: 7,
+  name: "Example channel",
+  dialect: "generic",
+  enabled: true,
+  base_url: "https://upstream.example.invalid",
+  openai_chat_completion_path: "/v1/chat/completions",
+  openai_response_path: "/v1/responses",
+  anthropic_message_path: "/v1/messages",
+  keys: [{ name: "default", key: "credential-placeholder", enabled: true }],
+  models: ["model-a"],
+  grants: [{ model_name: "model-a", key_name: "default", protocols: 2 }],
+  proxy: false,
+  custom_header: [],
+  param_override: "",
+  channel_proxy: "",
+  match_regex: "",
+  ...overrides,
+})
+
+const statsResponse = (overrides: Record<string, unknown> = {}) => ({
+  channel_id: 7,
+  channel_name: "Example channel",
+  enabled: true,
+  input_token: 10,
+  output_token: 4,
+  input_cost: 0.25,
+  output_cost: 0.5,
+  wait_time: 1.5,
+  request_success: 3,
+  request_failed: 1,
+  models: [{ model_id: 11, model_name: "model-a" }],
+  ...overrides,
+})
+
+const parseRequestBody = (
+  request: ReturnType<typeof octopusV013Contract.createRequest>,
+) => JSON.parse(request.init.body as string) as Record<string, unknown>
+
+describe("Octopus v0.13 contract", () => {
+  it.each([
+    {
+      name: "OpenAI Responses",
+      protocols: 4,
+      expected: OctopusOutboundType.OpenAIResponse,
+    },
+    {
+      name: "Anthropic Messages",
+      protocols: 8,
+      expected: OctopusOutboundType.Anthropic,
+    },
+    {
+      name: "no recognized protocol",
+      protocols: 0,
+      expected: OctopusOutboundType.OpenAIChat,
+    },
+  ])("infers $name channel details", ({ protocols, expected }) => {
+    expect(
+      octopusV013Contract.normalizeChannel(
+        detailResponse({
+          grants: [{ model_name: "model-a", key_name: "default", protocols }],
+        }),
+      ).type,
+    ).toBe(expected)
+  })
+
+  it("attaches matching stats and rejects mismatched channel identities", () => {
+    const stats = octopusV013Contract.parseStatsList([statsResponse()])[0]
+
+    expect(
+      octopusV013Contract.normalizeChannel(detailResponse(), stats).stats,
+    ).toMatchObject({ channel_id: 7, request_success: 3 })
+    expect(() =>
+      octopusV013Contract.normalizeChannel(detailResponse({ id: 8 }), stats),
+    ).toThrow(/channel_id/)
+  })
+
+  it.each([
+    {
+      name: "a non-object detail",
+      parse: () => octopusV013Contract.parseDetail(null),
+      field: "response",
+    },
+    {
+      name: "a non-integer detail id",
+      parse: () => octopusV013Contract.parseDetail(detailResponse({ id: 1.5 })),
+      field: "id",
+    },
+    {
+      name: "a non-finite stats value",
+      parse: () =>
+        octopusV013Contract.parseStatsList([
+          statsResponse({ input_cost: Number.POSITIVE_INFINITY }),
+        ]),
+      field: "input_cost",
+    },
+    {
+      name: "a malformed stats model",
+      parse: () =>
+        octopusV013Contract.parseStatsList([statsResponse({ models: [null] })]),
+      field: "models",
+    },
+  ])("rejects $name", ({ parse, field }) => {
+    expect(parse).toThrow(new RegExp(field, "i"))
+  })
+
+  it.each([
+    {
+      type: OctopusOutboundType.OpenAIResponse,
+      protocols: 4,
+      chatPath: "/v1/chat/completions",
+    },
+    {
+      type: OctopusOutboundType.Anthropic,
+      protocols: 8,
+      chatPath: "/v1/chat/completions",
+    },
+    {
+      type: OctopusOutboundType.Volcengine,
+      protocols: 2,
+      chatPath: "/chat/completions",
+    },
+  ])(
+    "encodes $type create requests with the matching protocol",
+    ({ type, protocols, chatPath }) => {
+      const body = parseRequestBody(
+        octopusV013Contract.createRequest(
+          {
+            kind: OCTOPUS_API_OPERATIONS.CreateChannel,
+            input: {
+              name: "Example channel",
+              type,
+              baseUrl: "https://upstream.example.invalid",
+              key: "credential-placeholder",
+              model: "model-a, model-b",
+              customModel: "model-b,model-c",
+            },
+          },
+          {},
+        ),
+      )
+
+      expect(body).toMatchObject({
+        enabled: true,
+        openai_chat_completion_path: chatPath,
+        models: ["model-a", "model-b", "model-c"],
+        grants: [
+          {
+            model_name: "model-a",
+            key_name: "default",
+            protocols,
+          },
+          {
+            model_name: "model-b",
+            key_name: "default",
+            protocols,
+          },
+          {
+            model_name: "model-c",
+            key_name: "default",
+            protocols,
+          },
+        ],
+      })
+    },
+  )
+
+  it("rejects channel types that v0.13 cannot encode", () => {
+    expect(() =>
+      octopusV013Contract.createRequest(
+        {
+          kind: OCTOPUS_API_OPERATIONS.CreateChannel,
+          input: {
+            name: "Unsupported",
+            type: OctopusOutboundType.OpenAIEmbedding,
+            baseUrl: "https://upstream.example.invalid",
+            key: "credential-placeholder",
+          },
+        },
+        {},
+      ),
+    ).toThrow(/cannot represent/i)
+  })
+
+  it("preserves models while updating an existing key and protocol", () => {
+    const existing = octopusV013Contract.parseDetail(detailResponse())
+    const body = parseRequestBody(
+      octopusV013Contract.createRequest(
+        {
+          kind: OCTOPUS_API_OPERATIONS.UpdateChannel,
+          input: {
+            id: 7,
+            type: OctopusOutboundType.Anthropic,
+            key: "credential-updated",
+          },
+        },
+        {},
+        existing,
+      ),
+    )
+
+    expect(body).toMatchObject({
+      anthropic_message_path: "/v1/messages",
+      keys: [{ name: "default", key: "credential-updated", enabled: true }],
+      models: ["model-a"],
+      grants: [{ model_name: "model-a", key_name: "default", protocols: 8 }],
+    })
+  })
+
+  it("adds the first key while preserving grants during a partial update", () => {
+    const existing = octopusV013Contract.parseDetail(
+      detailResponse({ keys: [] }),
+    )
+    const body = parseRequestBody(
+      octopusV013Contract.createRequest(
+        {
+          kind: OCTOPUS_API_OPERATIONS.UpdateChannel,
+          input: { id: 7, key: "credential-added" },
+        },
+        {},
+        existing,
+      ),
+    )
+
+    expect(body).toMatchObject({
+      keys: [{ name: "default", key: "credential-added", enabled: true }],
+      models: ["model-a"],
+      grants: [{ model_name: "model-a", key_name: "default", protocols: 2 }],
+    })
+  })
+
+  it("does not invent grants when an update has no configured key", () => {
+    const existing = octopusV013Contract.parseDetail(
+      detailResponse({ keys: [], grants: [], models: [] }),
+    )
+    const body = parseRequestBody(
+      octopusV013Contract.createRequest(
+        {
+          kind: OCTOPUS_API_OPERATIONS.UpdateChannel,
+          input: { id: 7, model: "model-b" },
+        },
+        {},
+        existing,
+      ),
+    )
+
+    expect(body).toMatchObject({ models: ["model-b"], grants: [] })
+  })
+
+  it("requires current detail before encoding an update", () => {
+    expect(() =>
+      octopusV013Contract.createRequest(
+        {
+          kind: OCTOPUS_API_OPERATIONS.UpdateChannel,
+          input: { id: 7, name: "Updated" },
+        },
+        {},
+      ),
+    ).toThrow(/requires current channel detail/i)
+  })
+
+  it("uses safe defaults for a remote-model probe without source metadata", () => {
+    const body = parseRequestBody(
+      octopusV013Contract.createRequest(
+        {
+          kind: OCTOPUS_API_OPERATIONS.FetchRemoteModels,
+          input: {
+            type: OctopusOutboundType.OpenAIChat,
+            baseUrl: "https://upstream.example.invalid",
+            key: "credential-placeholder",
+          },
+        },
+        {},
+      ),
+    )
+
+    expect(body).toEqual({
+      channel: {
+        name: "",
+        dialect: "generic",
+        enabled: true,
+        base_url: "https://upstream.example.invalid",
+        openai_chat_completion_path: "/v1/chat/completions",
+        openai_response_path: "/v1/responses",
+        anthropic_message_path: "/v1/messages",
+        proxy: false,
+        custom_header: [],
+        param_override: "",
+        channel_proxy: "",
+        match_regex: "",
+      },
+      key: "credential-placeholder",
+    })
+  })
+
+  it("maps every non-mutating and delete endpoint", () => {
+    expect(
+      octopusV013Contract.createRequest(
+        { kind: OCTOPUS_API_OPERATIONS.ListChannels },
+        {},
+      ).endpoint,
+    ).toBe("/api/v1/channel/stats")
+    expect(
+      octopusV013Contract.createRequest(
+        { kind: OCTOPUS_API_OPERATIONS.DeleteChannel, channelId: 7 },
+        {},
+      ),
+    ).toMatchObject({
+      endpoint: "/api/v1/channel/delete/7",
+      init: { method: "DELETE" },
+    })
+    expect(
+      octopusV013Contract.createRequest(
+        { kind: OCTOPUS_API_OPERATIONS.ListAvailableModels },
+        {},
+      ).endpoint,
+    ).toBe("/api/v1/model/list")
+    expect(
+      octopusV013Contract.createRequest(
+        { kind: OCTOPUS_API_OPERATIONS.ListGroups },
+        {},
+      ).endpoint,
+    ).toBe("/api/v1/group/list")
+  })
+
+  it("normalizes mutation and remote-model responses", () => {
+    expect(
+      octopusV013Contract.normalizeResponse(
+        { kind: OCTOPUS_API_OPERATIONS.CreateChannel, input: {} as never },
+        null,
+      ),
+    ).toBeNull()
+    expect(
+      octopusV013Contract.normalizeResponse(
+        { kind: OCTOPUS_API_OPERATIONS.UpdateChannel, input: {} as never },
+        detailResponse(),
+      ),
+    ).toMatchObject({ id: 7, model: "model-a" })
+    expect(
+      octopusV013Contract.normalizeResponse(
+        { kind: OCTOPUS_API_OPERATIONS.FetchRemoteModels, input: {} as never },
+        [{ name: "model-a" }],
+      ),
+    ).toEqual(["model-a"])
+    expect(
+      octopusV013Contract.normalizeResponse(
+        { kind: OCTOPUS_API_OPERATIONS.ListGroups },
+        ["group-a"],
+      ),
+    ).toEqual(["group-a"])
+  })
+
+  it.each([null, [null], [{ name: 7 }]])(
+    "rejects malformed remote-model responses %#",
+    (response) => {
+      expect(() =>
+        octopusV013Contract.normalizeResponse(
+          {
+            kind: OCTOPUS_API_OPERATIONS.FetchRemoteModels,
+            input: {} as never,
+          },
+          response,
+        ),
+      ).toThrow(/models|name/i)
+    },
+  )
+})

--- a/tests/services/protectionBypass/contracts.test.ts
+++ b/tests/services/protectionBypass/contracts.test.ts
@@ -587,6 +587,16 @@ describe("protection bypass runtime contracts", () => {
     ["unowned endpoint", "https://example.invalid/api/v1/user/list", "GET"],
     ["wrong method", "https://example.invalid/api/v1/channel/create", "GET"],
     [
+      "invalid channel detail ID",
+      "https://example.invalid/api/v1/channel/detail/0",
+      "GET",
+    ],
+    [
+      "wrong channel detail method",
+      "https://example.invalid/api/v1/channel/detail/7",
+      "POST",
+    ],
+    [
       "query authority",
       "https://example.invalid/api/v1/channel/list?target=other",
       "GET",
@@ -628,6 +638,8 @@ describe("protection bypass runtime contracts", () => {
 
   it.each([
     ["channel list", "/api/v1/channel/list", "GET"],
+    ["channel stats", "/api/v1/channel/stats", "GET"],
+    ["channel detail", "/api/v1/channel/detail/7", "GET"],
     ["cookie login", "/api/v1/user/login", "POST"],
   ])("allows Octopus configuration-test %s", (_case, pathname, method) => {
     expect(

--- a/tests/utils/scenarioErrors.test.ts
+++ b/tests/utils/scenarioErrors.test.ts
@@ -2,8 +2,31 @@ import { describe, expect, it } from "vitest"
 
 import {
   collectCleanupError,
+  runScenarioWithCleanup,
   throwScenarioError,
 } from "~~/e2e/utils/scenarioErrors"
+
+describe("runScenarioWithCleanup", () => {
+  it("keeps the primary scenario failure before a later cleanup failure", async () => {
+    const primaryError = new Error("channel creation failed")
+    const cleanupError = new Error("channel cleanup failed")
+
+    await expect(
+      runScenarioWithCleanup({
+        run: async () => {
+          throw primaryError
+        },
+        finalizers: [async () => Promise.reject(cleanupError)],
+        cleanupMessage: "Managed-site channel cleanup failed",
+        failureMessage: "Managed-site channel scenario failed",
+      }),
+    ).rejects.toMatchObject({
+      errors: [primaryError, cleanupError],
+      message:
+        "Managed-site channel scenario failed: primary=channel creation failed; cleanup=channel cleanup failed",
+    })
+  })
+})
 
 describe("throwScenarioError", () => {
   it("preserves both the primary failure and a later cleanup failure", () => {

--- a/tests/utils/scenarioErrors.test.ts
+++ b/tests/utils/scenarioErrors.test.ts
@@ -7,6 +7,28 @@ import {
 } from "~~/e2e/utils/scenarioErrors"
 
 describe("runScenarioWithCleanup", () => {
+  it("propagates an undefined primary failure", async () => {
+    await expect(
+      runScenarioWithCleanup({
+        run: async () => Promise.reject(undefined),
+        finalizers: [],
+        cleanupMessage: "Managed-site channel cleanup failed",
+        failureMessage: "Managed-site channel scenario failed",
+      }),
+    ).rejects.toBeUndefined()
+  })
+
+  it("propagates an undefined cleanup failure", async () => {
+    await expect(
+      runScenarioWithCleanup({
+        run: async () => "created",
+        finalizers: [async () => Promise.reject(undefined)],
+        cleanupMessage: "Managed-site channel cleanup failed",
+        failureMessage: "Managed-site channel scenario failed",
+      }),
+    ).rejects.toBeUndefined()
+  })
+
   it("keeps the primary scenario failure before a later cleanup failure", async () => {
     const primaryError = new Error("channel creation failed")
     const cleanupError = new Error("channel cleanup failed")


### PR DESCRIPTION
## Summary

Octopus v0.13 no longer exposes the legacy channel list endpoint. The compatibility fallback previously expanded `/channel/stats` with a serial `/channel/detail/:id` request for every channel, which made channel refreshes slow enough for real CRUD workflows to time out.

- support Octopus v0.13 cookie-authenticated channel endpoints while preserving legacy Bearer/v0.12 behavior
- use `/channel/stats` for channel summaries and load `/channel/detail/:id` only when editing, removing the serial N+1 refresh
- preserve mutation lifecycle evidence and complete v0.13 detail fields during partial updates
- retain both primary scenario failures and managed-site cleanup failures in E2E diagnostics

## Validation

- [x] `pnpm compile`
- [x] `pnpm knip`
- [x] focused Octopus, protection-bypass, adapter, and scenario-error tests — 245 passed
- [x] authenticated real-site Octopus CRUD/search Playwright E2E — 2 passed
- [x] commit validation gates, including ESLint, Prettier, Vitest, and relevant i18n checks

## Compatibility and risk

- Legacy Bearer/v0.12 routes remain supported.
- v0.13 list summaries intentionally omit secrets and full endpoint configuration; details are fetched only when needed.
- No telemetry, user-facing copy, settings, documentation, or release-note changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for Octopus API v0.13 channel endpoints.
  - Channel listings, details, creation, and updates now work across supported Octopus API versions.
  - Individual channel details can be retrieved directly.

- **Bug Fixes**
  - Added fallback handling when legacy channel-list endpoints are unavailable.
  - Improved API-version detection and request handling.
  - Strengthened validation for channel data and configuration-test endpoints.
  - Improved reporting when scenario execution and cleanup encounter failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->