### PR TITLE
refactor(api-transport): delegate error decoding to providers

### DIFF
--- a/src/services/apiService/newApiFamily/channelManagement.ts
+++ b/src/services/apiService/newApiFamily/channelManagement.ts
@@ -1,8 +1,11 @@
 import type { ManagedSitePaginatedChannelRequestOptions } from "~/services/apiAdapters/contracts/managedSiteCapabilities"
+import {
+  fetchApi,
+  fetchApiData,
+} from "~/services/apiService/newApiFamily/request"
 import { REQUEST_CONFIG } from "~/services/apiTransport/constant"
 import { ApiError } from "~/services/apiTransport/errors"
 import { fetchAllItems } from "~/services/apiTransport/pagination"
-import { fetchApi, fetchApiData } from "~/services/apiTransport/request"
 import type {
   ApiResponse,
   ApiServiceRequest,

--- a/src/services/apiService/newApiFamily/default/accountBootstrap.ts
+++ b/src/services/apiService/newApiFamily/default/accountBootstrap.ts
@@ -4,8 +4,8 @@ import type {
   SiteStatusInfo,
   UserInfo,
 } from "~/services/apiAdapters/contracts/accountBootstrap"
+import { fetchApiData } from "~/services/apiService/newApiFamily/request"
 import { ApiError } from "~/services/apiTransport/errors"
-import { fetchApiData } from "~/services/apiTransport/request"
 import type {
   ApiServiceRequest,
   FetchApiOptions,

--- a/src/services/apiService/newApiFamily/default/accountData.ts
+++ b/src/services/apiService/newApiFamily/default/accountData.ts
@@ -17,9 +17,9 @@ import {
   type MetricAggregationCoverage,
   type TodayTimestampRange,
 } from "~/services/apiService/newApiFamily/default/accountDataUtils"
+import { fetchApiData } from "~/services/apiService/newApiFamily/request"
 import { REQUEST_CONFIG } from "~/services/apiTransport/constant"
 import { ApiError } from "~/services/apiTransport/errors"
-import { fetchApiData } from "~/services/apiTransport/request"
 import type { ApiServiceRequest } from "~/services/apiTransport/type"
 import { refreshSelectedStatus } from "~/services/checkin/autoCheckin/refresh"
 import { LogType } from "~/services/history/usageHistory/usageLogModel"

--- a/src/services/apiService/newApiFamily/default/inviteLink.ts
+++ b/src/services/apiService/newApiFamily/default/inviteLink.ts
@@ -1,4 +1,4 @@
-import { fetchApiData } from "~/services/apiTransport/request"
+import { fetchApiData } from "~/services/apiService/newApiFamily/request"
 import type { ApiServiceRequest } from "~/services/apiTransport/type"
 import {
   INVITE_LINK_FAILURE_REASONS,

--- a/src/services/apiService/newApiFamily/default/keyManagement.ts
+++ b/src/services/apiService/newApiFamily/default/keyManagement.ts
@@ -9,13 +9,16 @@ import type {
   CreateTokenResult,
   UserGroupInfo,
 } from "~/services/accountTokens/tokenProvisioningModel"
+import {
+  fetchApi,
+  fetchApiData,
+} from "~/services/apiService/newApiFamily/request"
 import { REQUEST_CONFIG } from "~/services/apiTransport/constant"
 import { API_ERROR_CODES, ApiError } from "~/services/apiTransport/errors"
 import {
   fetchAllItems,
   inferHasMoreFromNumberedPage,
 } from "~/services/apiTransport/pagination"
-import { fetchApi, fetchApiData } from "~/services/apiTransport/request"
 import type { ApiServiceRequest } from "~/services/apiTransport/type"
 import type { ApiToken } from "~/types"
 import { createLogger } from "~/utils/core/logger"

--- a/src/services/apiService/newApiFamily/default/modelPricing.ts
+++ b/src/services/apiService/newApiFamily/default/modelPricing.ts
@@ -1,4 +1,4 @@
-import { fetchApi } from "~/services/apiTransport/request"
+import { fetchApi } from "~/services/apiService/newApiFamily/request"
 import type { ApiServiceRequest } from "~/services/apiTransport/type"
 import { createLogger } from "~/utils/core/logger"
 

--- a/src/services/apiService/newApiFamily/default/redemption.ts
+++ b/src/services/apiService/newApiFamily/default/redemption.ts
@@ -1,4 +1,4 @@
-import { fetchApiData } from "~/services/apiTransport/request"
+import { fetchApiData } from "~/services/apiService/newApiFamily/request"
 import type { ApiServiceRequest } from "~/services/apiTransport/type"
 import { createLogger } from "~/utils/core/logger"
 

--- a/src/services/apiService/newApiFamily/default/siteAnnouncements.ts
+++ b/src/services/apiService/newApiFamily/default/siteAnnouncements.ts
@@ -3,7 +3,7 @@ import {
   type SiteStructuredAnnouncement,
   type SiteStructuredAnnouncementType,
 } from "~/services/apiAdapters/contracts/siteStructuredAnnouncements"
-import { fetchApiData } from "~/services/apiTransport/request"
+import { fetchApiData } from "~/services/apiService/newApiFamily/request"
 import type { ApiServiceRequest } from "~/services/apiTransport/type"
 import { AuthTypeEnum } from "~/types"
 import { createLogger } from "~/utils/core/logger"

--- a/src/services/apiService/newApiFamily/default/siteNotice.ts
+++ b/src/services/apiService/newApiFamily/default/siteNotice.ts
@@ -1,4 +1,4 @@
-import { fetchApi } from "~/services/apiTransport/request"
+import { fetchApi } from "~/services/apiService/newApiFamily/request"
 import type { ApiServiceRequest } from "~/services/apiTransport/type"
 import { AuthTypeEnum } from "~/types"
 import { createLogger } from "~/utils/core/logger"

--- a/src/services/apiService/newApiFamily/request.ts
+++ b/src/services/apiService/newApiFamily/request.ts
@@ -1,0 +1,70 @@
+import {
+  fetchApi as fetchTransportApi,
+  fetchApiData as fetchTransportApiData,
+} from "~/services/apiTransport/request"
+import type {
+  ApiResponse,
+  ApiTransportRequest,
+  FetchApiOptions,
+} from "~/services/apiTransport/type"
+import type { TempWindowResponseType } from "~/types/tempWindowFetch"
+
+import { decodeNewApiResponseError } from "./responseError"
+
+type JsonFetchApiOptions = Omit<FetchApiOptions, "responseType"> & {
+  responseType?: "json"
+}
+
+type NonJsonFetchApiOptions = Omit<FetchApiOptions, "responseType"> & {
+  responseType: Exclude<TempWindowResponseType, "json">
+}
+
+const withNewApiResponseErrorDecoder = (
+  options: FetchApiOptions,
+): FetchApiOptions => ({
+  ...options,
+  errorResponseDecoder: decodeNewApiResponseError,
+})
+
+/** Fetches and unwraps New API-family data with its response decoder installed. */
+export async function fetchApiData<T>(
+  request: ApiTransportRequest,
+  options: FetchApiOptions,
+): Promise<T> {
+  return await fetchTransportApiData<T>(
+    request,
+    withNewApiResponseErrorDecoder(options),
+  )
+}
+
+export function fetchApi<T>(
+  request: ApiTransportRequest,
+  options: FetchApiOptions,
+  normalResponseType: true,
+): Promise<T>
+export function fetchApi<T>(
+  request: ApiTransportRequest,
+  options: JsonFetchApiOptions,
+  normalResponseType?: false,
+): Promise<ApiResponse<T>>
+export function fetchApi<T>(
+  request: ApiTransportRequest,
+  options: NonJsonFetchApiOptions,
+  normalResponseType?: false,
+): Promise<T>
+export function fetchApi<T>(
+  request: ApiTransportRequest,
+  options: FetchApiOptions,
+  normalResponseType?: false,
+): Promise<ApiResponse<T> | T>
+/** Fetches a New API-family response while preserving the selected return mode. */
+export async function fetchApi<T>(
+  request: ApiTransportRequest,
+  options: FetchApiOptions,
+  normalResponseType?: boolean,
+): Promise<ApiResponse<T> | T> {
+  const decodedOptions = withNewApiResponseErrorDecoder(options)
+  return normalResponseType
+    ? await fetchTransportApi<T>(request, decodedOptions, true)
+    : await fetchTransportApi<T>(request, decodedOptions)
+}

--- a/src/services/apiService/newApiFamily/responseError.ts
+++ b/src/services/apiService/newApiFamily/responseError.ts
@@ -1,0 +1,60 @@
+import { readSafeUpstreamCode } from "~/services/apiTransport/responseError"
+import type {
+  ApiResponseErrorDecoder,
+  DecodedApiResponseError,
+} from "~/services/apiTransport/type"
+
+const NEW_API_ERROR_TYPE = "new_api_error"
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+const readMessage = (value: unknown): string | undefined =>
+  typeof value === "string" && value.trim() ? value.trim() : undefined
+
+const isFailedBusinessEnvelope = (body: Record<string, unknown>): boolean => {
+  if (body.success === false) return true
+  const code = body.code
+  return (
+    (typeof code === "number" && code !== 0) ||
+    (typeof code === "string" && code.trim() !== "" && code.trim() !== "0")
+  )
+}
+
+/**
+ * Interprets New API's `{ success, message }` and nested `new_api_error`
+ * envelopes before transport fallback.
+ * https://github.com/QuantumNous/new-api/blob/9df450fe54e1a874a5339b7c38a61014217f02c3/common/gin.go
+ * https://github.com/QuantumNous/new-api/blob/9df450fe54e1a874a5339b7c38a61014217f02c3/middleware/utils.go
+ */
+export const decodeNewApiResponseError: ApiResponseErrorDecoder = (
+  response,
+) => {
+  if (!isRecord(response.body)) return null
+
+  const body = response.body
+  const message = readMessage(body.message)
+  const upstreamCode = readSafeUpstreamCode(body.code)
+  if (isFailedBusinessEnvelope(body)) {
+    return {
+      kind: "business",
+      ...(message ? { message } : {}),
+      ...(upstreamCode ? { upstreamCode } : {}),
+    }
+  }
+  if (message) {
+    return { kind: "http", message }
+  }
+
+  if (!isRecord(body.error)) return null
+  const error = body.error
+  if (readMessage(error.type) !== NEW_API_ERROR_TYPE) return null
+
+  const nestedMessage = readMessage(error.message)
+  const nestedUpstreamCode = readSafeUpstreamCode(error.code)
+  return {
+    kind: "business",
+    ...(nestedMessage ? { message: nestedMessage } : {}),
+    ...(nestedUpstreamCode ? { upstreamCode: nestedUpstreamCode } : {}),
+  } satisfies DecodedApiResponseError
+}

--- a/src/services/apiService/newApiFamily/variants/oneHub.ts
+++ b/src/services/apiService/newApiFamily/variants/oneHub.ts
@@ -1,6 +1,7 @@
 import { normalizeApiTokenKey } from "~/services/accountTokens/apiTokenKey"
 import { syncResolvedApiTokenKeyCache } from "~/services/accountTokens/tokenKeyResolver"
 import type { UserGroupInfo } from "~/services/accountTokens/tokenProvisioningModel"
+import { fetchApiData } from "~/services/apiService/newApiFamily/request"
 import {
   transformModelPricing,
   transformUserGroup,
@@ -15,7 +16,6 @@ import {
   fetchAllItems,
   inferHasMoreFromNumberedPage,
 } from "~/services/apiTransport/pagination"
-import { fetchApiData } from "~/services/apiTransport/request"
 import type { ApiServiceRequest } from "~/services/apiTransport/type"
 import type { PricingResponse } from "~/services/modelList/pricingModel"
 import type { ApiToken } from "~/types"

--- a/src/services/apiService/newApiFamily/variants/vApi.ts
+++ b/src/services/apiService/newApiFamily/variants/vApi.ts
@@ -1,7 +1,7 @@
 import type { UserGroupInfo } from "~/services/accountTokens/tokenProvisioningModel"
 import { fetchAccountAvailableModels as fetchLegacyAccountAvailableModels } from "~/services/apiService/newApiFamily/default/keyManagement"
+import { fetchApiData } from "~/services/apiService/newApiFamily/request"
 import { ApiError } from "~/services/apiTransport/errors"
-import { fetchApiData } from "~/services/apiTransport/request"
 import type { ApiServiceRequest } from "~/services/apiTransport/type"
 import { isRecord } from "~/utils/core/object"
 

--- a/src/services/apiService/newApiFamily/variants/veloera.ts
+++ b/src/services/apiService/newApiFamily/variants/veloera.ts
@@ -11,8 +11,8 @@ import {
   fetchTodayUsage,
 } from "~/services/apiService/newApiFamily/default/accountData"
 import { getTodayTimestampRange } from "~/services/apiService/newApiFamily/default/accountDataUtils"
+import { fetchApiData } from "~/services/apiService/newApiFamily/request"
 import { ApiError } from "~/services/apiTransport/errors"
-import { fetchApiData } from "~/services/apiTransport/request"
 import type { ApiServiceRequest } from "~/services/apiTransport/type"
 import { refreshSelectedStatus } from "~/services/checkin/autoCheckin/refresh"
 import { SiteHealthStatus, type CheckInConfig } from "~/types"

--- a/src/services/apiService/newApiFamily/variants/wong.ts
+++ b/src/services/apiService/newApiFamily/variants/wong.ts
@@ -15,7 +15,7 @@ import {
   fetchTodayUsage,
 } from "~/services/apiService/newApiFamily/default/accountData"
 import { getTodayTimestampRange } from "~/services/apiService/newApiFamily/default/accountDataUtils"
-import { fetchApi } from "~/services/apiTransport/request"
+import { fetchApi } from "~/services/apiService/newApiFamily/request"
 import type { ApiServiceRequest } from "~/services/apiTransport/type"
 import { refreshSelectedStatus } from "~/services/checkin/autoCheckin/refresh"
 import {

--- a/src/services/apiTransport/compatibilityResponse.ts
+++ b/src/services/apiTransport/compatibilityResponse.ts
@@ -1,0 +1,141 @@
+import type { TempWindowResponseType } from "~/types/tempWindowFetch"
+import { t } from "~/utils/i18n/core"
+
+import { API_ERROR_CODES, ApiError, type ApiErrorCode } from "./errors"
+import { extractDataFromApiResponseBody } from "./response"
+import { resolveResponseErrorDetails } from "./responseError"
+import type {
+  ApiResponse,
+  ApiResponseErrorDecoder,
+  ApiTransportResponse,
+} from "./type"
+
+type CompatibilityTransportResponse<T> = ApiTransportResponse<T> & {
+  decodeError?: ApiError
+}
+
+/** Maps provider-declared application failures carried by a successful HTTP response. */
+function createProviderBusinessError(
+  response: ApiTransportResponse<unknown>,
+  context: {
+    endpoint: string
+    responseType: TempWindowResponseType
+    decodeApplicationError: boolean
+    errorResponseDecoder?: ApiResponseErrorDecoder
+  },
+): ApiError | null {
+  if (
+    context.responseType !== "json" ||
+    !context.decodeApplicationError ||
+    !context.errorResponseDecoder
+  ) {
+    return null
+  }
+
+  const decoded = resolveResponseErrorDetails(
+    response,
+    context.endpoint,
+    context.errorResponseDecoder,
+  )
+  if (decoded?.kind !== "business") return null
+
+  return new ApiError(
+    decoded.message || t("messages:errors.api.invalidResponseFormat"),
+    undefined,
+    context.endpoint,
+    API_ERROR_CODES.BUSINESS_ERROR,
+    decoded.upstreamCode,
+  )
+}
+
+/** Converts an unsuccessful HTTP result into the legacy shared ApiError. */
+function createCompatibilityHttpError(
+  response: ApiTransportResponse<unknown>,
+  context: {
+    endpoint: string
+    responseType: TempWindowResponseType
+    errorResponseDecoder?: ApiResponseErrorDecoder
+  },
+): ApiError {
+  let errorCode: ApiErrorCode = API_ERROR_CODES.HTTP_OTHER
+  const fixedFallback = `请求失败: ${response.status}`
+
+  if (response.status === 401) {
+    errorCode = API_ERROR_CODES.HTTP_401
+  } else if (response.status === 403) {
+    errorCode = API_ERROR_CODES.HTTP_403
+  } else if (response.status === 429) {
+    errorCode = API_ERROR_CODES.HTTP_429
+  }
+
+  if (
+    context.responseType === "json" &&
+    (response.status === 401 || response.status === 429)
+  ) {
+    const retryAfter =
+      response.status === 429 ? response.headers["retry-after"] : undefined
+    const hasRetryAfter = response.status === 429 && retryAfter !== undefined
+    const contentType = response.headers["content-type"] || ""
+    const looksLikeHtml =
+      /\btext\/html\b/i.test(contentType) ||
+      /\bapplication\/xhtml\+xml\b/i.test(contentType)
+
+    if (!hasRetryAfter && looksLikeHtml) {
+      errorCode = API_ERROR_CODES.CONTENT_TYPE_MISMATCH
+    }
+  }
+
+  const decoded =
+    context.responseType === "json" &&
+    errorCode !== API_ERROR_CODES.CONTENT_TYPE_MISMATCH
+      ? resolveResponseErrorDetails(
+          response,
+          context.endpoint,
+          context.errorResponseDecoder,
+        )
+      : null
+
+  if (decoded?.kind === "business" && response.status === 403) {
+    errorCode = API_ERROR_CODES.BUSINESS_ERROR
+  }
+
+  const message =
+    decoded?.message && (decoded.kind === "business" || response.status !== 403)
+      ? decoded.message
+      : fixedFallback
+
+  return new ApiError(
+    message,
+    response.status,
+    context.endpoint,
+    errorCode,
+    decoded?.upstreamCode,
+  )
+}
+
+/** Applies the existing envelope and error behavior above raw HTTP transport. */
+export function mapCompatibilityResponse<T>(
+  response: CompatibilityTransportResponse<T>,
+  context: {
+    endpoint: string
+    responseType: TempWindowResponseType
+    onlyData: boolean
+    decodeApplicationError: boolean
+    errorResponseDecoder?: ApiResponseErrorDecoder
+  },
+): T | ApiResponse<T> {
+  if (!response.ok) {
+    throw createCompatibilityHttpError(response, context)
+  }
+
+  if (response.decodeError) throw response.decodeError
+
+  const providerBusinessError = createProviderBusinessError(response, context)
+  if (providerBusinessError) throw providerBusinessError
+
+  if (context.responseType === "json" && context.onlyData) {
+    return extractDataFromApiResponseBody<T>(response.body, context.endpoint)
+  }
+
+  return response.body as T | ApiResponse<T>
+}

--- a/src/services/apiTransport/request.ts
+++ b/src/services/apiTransport/request.ts
@@ -4,6 +4,7 @@ import {
   startAbortableTask,
 } from "~/services/apiTransport/abortableTask"
 import { buildCompatUserIdHeaders } from "~/services/apiTransport/compatHeaders"
+import { mapCompatibilityResponse } from "~/services/apiTransport/compatibilityResponse"
 import { REQUEST_CONFIG } from "~/services/apiTransport/constant"
 import {
   API_ERROR_CODES,
@@ -137,12 +138,6 @@ export function notifyApiTransportObserver(
   }
 }
 
-interface BackendErrorDetails {
-  message: string
-  isBackendError: boolean
-  upstreamCode?: string
-}
-
 // Throttle log endpoints (`/api/log*`) to reduce burst traffic that can trigger
 // upstream rate limits (e.g. concurrent paging for usage + income).
 const LOG_REQUEST_MIN_INTERVAL_MS = 200
@@ -150,69 +145,6 @@ const LOG_REQUEST_MIN_INTERVAL_MS = 200
 const logRequestRateLimiter = createMinIntervalLimiter({
   minIntervalMs: isTestMode() ? 0 : LOG_REQUEST_MIN_INTERVAL_MS,
 })
-
-const getNonEmptyString = (value: unknown): string | undefined =>
-  typeof value === "string" && value.trim() ? value.trim() : undefined
-
-const KNOWN_BACKEND_ERROR_TYPES = new Set(["new_api_error"])
-
-const isKnownBackendErrorType = (value: unknown): boolean =>
-  typeof value === "string" && KNOWN_BACKEND_ERROR_TYPES.has(value.trim())
-
-const getSafeUpstreamCode = (value: unknown): string | undefined => {
-  if (typeof value !== "string" && typeof value !== "number") return undefined
-  const code = String(value).trim()
-  return code.length <= 64 && /^[A-Za-z0-9_.-]+$/.test(code) ? code : undefined
-}
-
-/**
- * Extracts known backend-shaped JSON errors so they are not treated as
- * WAF/challenge 403s that temp-window fallback can recover.
- */
-function extractBackendErrorDetails(body: unknown): BackendErrorDetails | null {
-  if (!body || typeof body !== "object" || Array.isArray(body)) {
-    return null
-  }
-
-  const topLevelMessage =
-    getNonEmptyString((body as { message?: unknown }).message) ??
-    getNonEmptyString((body as { msg?: unknown }).msg)
-  if (topLevelMessage) {
-    const code = (body as { code?: unknown }).code
-    const isBusinessEnvelope =
-      (typeof code === "number" && code !== 0) ||
-      (typeof code === "string" && code.trim() !== "" && code.trim() !== "0")
-
-    return {
-      message: topLevelMessage,
-      isBackendError: Boolean(
-        (body as { success?: unknown }).success === false || isBusinessEnvelope,
-      ),
-      upstreamCode: getSafeUpstreamCode(code),
-    }
-  }
-
-  const error = (body as { error?: unknown }).error
-  if (!error || typeof error !== "object" || Array.isArray(error)) {
-    return null
-  }
-
-  const message = getNonEmptyString((error as { message?: unknown }).message)
-  if (!message) {
-    return null
-  }
-
-  const isBackendError = isKnownBackendErrorType(
-    (error as { type?: unknown }).type,
-  )
-  const upstreamCode = getSafeUpstreamCode((error as { code?: unknown }).code)
-
-  return {
-    message,
-    isBackendError,
-    upstreamCode,
-  }
-}
 
 /**
  * Determine if a given endpoint string matches log API patterns.
@@ -654,91 +586,6 @@ const apiRequestResponse = async <T>(
   }
 }
 
-/** Converts an unsuccessful HTTP result into the legacy shared ApiError. */
-function createCompatibilityHttpError(
-  response: ApiTransportResponse<unknown>,
-  endpoint: string,
-  responseType: TempWindowResponseType,
-): ApiError {
-  let errorCode: ApiErrorCode = API_ERROR_CODES.HTTP_OTHER
-  let errorMessage = `请求失败: ${response.status}`
-  let backendError: BackendErrorDetails | null = null
-
-  if (response.status === 401) {
-    errorCode = API_ERROR_CODES.HTTP_401
-  } else if (response.status === 403) {
-    errorCode = API_ERROR_CODES.HTTP_403
-  } else if (response.status === 429) {
-    errorCode = API_ERROR_CODES.HTTP_429
-  }
-
-  if (
-    responseType === "json" &&
-    (response.status === 401 || response.status === 429)
-  ) {
-    const retryAfter =
-      response.status === 429 ? response.headers["retry-after"] : undefined
-    const hasRetryAfter = response.status === 429 && retryAfter !== undefined
-    const contentType = response.headers["content-type"] || ""
-    const looksLikeHtml =
-      /\btext\/html\b/i.test(contentType) ||
-      /\bapplication\/xhtml\+xml\b/i.test(contentType)
-
-    if (!hasRetryAfter && looksLikeHtml) {
-      errorCode = API_ERROR_CODES.CONTENT_TYPE_MISMATCH
-    }
-  }
-
-  if (
-    responseType === "json" &&
-    errorCode !== API_ERROR_CODES.CONTENT_TYPE_MISMATCH
-  ) {
-    backendError = extractBackendErrorDetails(response.body)
-    if (backendError) {
-      if (backendError.isBackendError || response.status !== 403) {
-        errorMessage = backendError.message
-      }
-      if (backendError.isBackendError && response.status === 403) {
-        errorCode = API_ERROR_CODES.BUSINESS_ERROR
-      }
-    }
-  }
-
-  return new ApiError(
-    errorMessage,
-    response.status,
-    endpoint,
-    errorCode,
-    backendError?.upstreamCode,
-  )
-}
-
-/** Applies the existing envelope and error behavior above raw HTTP transport. */
-function mapCompatibilityResponse<T>(
-  response: AcquiredTransportResponse<T>,
-  context: {
-    endpoint: string
-    responseType: TempWindowResponseType
-    onlyData: boolean
-  },
-): T | ApiResponse<T> {
-  if (!response.ok) {
-    throw createCompatibilityHttpError(
-      response,
-      context.endpoint,
-      context.responseType,
-    )
-  }
-
-  if (response.decodeError) throw response.decodeError
-
-  if (context.responseType === "json" && context.onlyData) {
-    return extractDataFromApiResponseBody<T>(response.body, context.endpoint)
-  }
-
-  return response.body as T | ApiResponse<T>
-}
-
 /** Normalizes a message-channel fetch result without discarding its body. */
 function normalizeMessageFetchResponse<T>(
   response: TempWindowFetch,
@@ -961,6 +808,7 @@ const _fetchApi = async <T>(
   request: ApiTransportRequest,
   options: FetchApiOptions,
   onlyData: boolean = false,
+  decodeApplicationError: boolean = onlyData,
 ): Promise<T | ApiResponse<T>> => {
   const responseType = options.responseType ?? "json"
   return await _fetchApiWithMapper<T, T | ApiResponse<T>>(
@@ -972,25 +820,20 @@ const _fetchApi = async <T>(
         endpoint: options.endpoint,
         responseType,
         onlyData,
+        decodeApplicationError,
+        errorResponseDecoder: options.errorResponseDecoder,
       }),
-    (response) => {
-      if (!response.success) {
-        throw new ApiError(
-          response.error || "Temp window fetch failed",
-          response.status,
-          options.endpoint,
-          response.code,
-        )
-      }
-      return mapCompatibilityResponse(
+    (response) =>
+      mapCompatibilityResponse(
         normalizeMessageFetchResponse<T>(response, options.endpoint),
         {
           endpoint: options.endpoint,
           responseType,
           onlyData,
+          decodeApplicationError,
+          errorResponseDecoder: options.errorResponseDecoder,
         },
-      )
-    },
+      ),
   )
 }
 
@@ -1071,7 +914,12 @@ export async function fetchApi<T>(
   options: FetchApiOptions,
   _normalResponseType?: boolean,
 ): Promise<T | ApiResponse<T>> {
-  const response = await _fetchApi<T>(request, options)
+  const response = await _fetchApi<T>(
+    request,
+    options,
+    false,
+    _normalResponseType === true,
+  )
   const responseType = options.responseType ?? "json"
   if (!_normalResponseType) {
     if (responseType !== "json") {

--- a/src/services/apiTransport/responseError.ts
+++ b/src/services/apiTransport/responseError.ts
@@ -1,0 +1,91 @@
+import type {
+  ApiResponseErrorDecoder,
+  ApiTransportResponse,
+  DecodedApiResponseError,
+} from "~/services/apiTransport/type"
+import { getErrorMessage } from "~/utils/core/error"
+
+const KNOWN_LEGACY_BACKEND_ERROR_TYPES = new Set(["new_api_error"])
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+const readMessage = (value: unknown): string | undefined =>
+  typeof value === "string" && value.trim() ? value.trim() : undefined
+
+/** Keeps only bounded scalar provider codes suitable for shared errors. */
+export const readSafeUpstreamCode = (value: unknown): string | undefined => {
+  if (typeof value !== "string" && typeof value !== "number") return undefined
+  const code = String(value).trim()
+  return code.length <= 64 && /^[A-Za-z0-9_.-]+$/.test(code) ? code : undefined
+}
+
+const isLegacyBusinessEnvelope = (body: Record<string, unknown>): boolean => {
+  const code = body.code
+  return (
+    body.success === false ||
+    (typeof code === "number" && code !== 0) ||
+    (typeof code === "string" && code.trim() !== "" && code.trim() !== "0")
+  )
+}
+
+/**
+ * Preserves the historical fetchApi/fetchApiData response behavior while
+ * provider modules migrate to explicit decoders. Remove this compatibility
+ * decoder once remaining callers either provide a provider decoder or consume
+ * the raw transport response.
+ */
+const decodeLegacyCompatibilityResponseError: ApiResponseErrorDecoder = (
+  response,
+) => {
+  if (!isRecord(response.body)) return null
+  const body = response.body
+  const topLevelMessage = readMessage(body.message) ?? readMessage(body.msg)
+  if (topLevelMessage) {
+    const upstreamCode = readSafeUpstreamCode(body.code)
+    return {
+      kind: isLegacyBusinessEnvelope(body) ? "business" : "http",
+      message: topLevelMessage,
+      ...(upstreamCode ? { upstreamCode } : {}),
+    }
+  }
+
+  if (!isRecord(body.error)) return null
+  const message = readMessage(body.error.message)
+  if (!message) return null
+
+  const type = readMessage(body.error.type)
+  const upstreamCode = readSafeUpstreamCode(body.error.code)
+  return {
+    kind:
+      type && KNOWN_LEGACY_BACKEND_ERROR_TYPES.has(type) ? "business" : "http",
+    message,
+    ...(upstreamCode ? { upstreamCode } : {}),
+  }
+}
+
+/** Applies provider priority, then legacy message fallback, without disclosure policy. */
+export function resolveResponseErrorDetails(
+  response: ApiTransportResponse<unknown>,
+  endpoint: string,
+  providerDecoder?: ApiResponseErrorDecoder,
+): DecodedApiResponseError | null {
+  const providerDetails = providerDecoder?.(response, { endpoint }) ?? null
+  if (!providerDetails) {
+    return decodeLegacyCompatibilityResponseError(response, { endpoint })
+  }
+
+  const providerMessage = getErrorMessage(providerDetails.message)
+  const message = providerMessage
+    ? providerMessage
+    : getErrorMessage(
+        decodeLegacyCompatibilityResponseError(response, { endpoint })?.message,
+      )
+  return {
+    kind: providerDetails.kind,
+    ...(message ? { message } : {}),
+    ...(providerDetails.upstreamCode
+      ? { upstreamCode: providerDetails.upstreamCode }
+      : {}),
+  }
+}

--- a/src/services/apiTransport/type.ts
+++ b/src/services/apiTransport/type.ts
@@ -21,6 +21,24 @@ export interface ApiTransportResponse<T = unknown> {
   body: T
 }
 
+export type ApiResponseErrorKind = "business" | "http"
+
+export interface DecodedApiResponseError {
+  kind: ApiResponseErrorKind
+  message?: string
+  upstreamCode?: string
+}
+
+/**
+ * Interprets one provider response without performing disclosure or redaction.
+ * Implementations must be total for unknown bodies and return null when the
+ * response does not match their protocol.
+ */
+export type ApiResponseErrorDecoder = (
+  response: ApiTransportResponse<unknown>,
+  context: { endpoint: string },
+) => DecodedApiResponseError | null
+
 export interface AuthConfig {
   /** 认证类型: cookie | access_token | none */
   authType: AuthTypeEnum
@@ -138,6 +156,8 @@ export interface FetchApiOptions {
   tempWindowFallback?: TempWindowFallbackAllowlist
   currentTabTransport?: "prefer" | "disabled"
   authTokenMode?: ApiAuthTokenMode
+  /** Process-local provider decoder; it never crosses extension messaging. */
+  errorResponseDecoder?: ApiResponseErrorDecoder
 }
 
 export interface OpenAIAuthParams {

--- a/src/services/checkin/autoCheckin/providers/anyrouter.ts
+++ b/src/services/checkin/autoCheckin/providers/anyrouter.ts
@@ -1,5 +1,5 @@
 import { CHECK_IN_PROVIDER_READINESS_REASONS } from "~/constants/checkIn"
-import { fetchApi } from "~/services/apiTransport/request"
+import { fetchApi } from "~/services/apiService/newApiFamily/request"
 import {
   AUTO_CHECKIN_PROVIDER_FALLBACK_MESSAGE_KEYS,
   isAlreadyCheckedMessage,

--- a/src/services/checkin/autoCheckin/providers/newApi.ts
+++ b/src/services/checkin/autoCheckin/providers/newApi.ts
@@ -17,10 +17,13 @@ import type {
   NewApiCheckInStatus,
 } from "~/services/apiService/newApiFamily/checkInDto"
 import { fetchSupportCheckIn } from "~/services/apiService/newApiFamily/default/accountBootstrap"
+import {
+  fetchApi,
+  fetchApiData,
+} from "~/services/apiService/newApiFamily/request"
 import { buildCompatUserIdHeaders } from "~/services/apiTransport/compatHeaders"
 import { REQUEST_CONFIG } from "~/services/apiTransport/constant"
 import { ApiError } from "~/services/apiTransport/errors"
-import { fetchApi, fetchApiData } from "~/services/apiTransport/request"
 import type { ApiServiceRequest } from "~/services/apiTransport/type"
 import type {
   AutoCheckinProvider,

--- a/src/services/checkin/autoCheckin/providers/veloera.ts
+++ b/src/services/checkin/autoCheckin/providers/veloera.ts
@@ -11,8 +11,11 @@ import {
   CHECK_IN_METHOD_TODAY_STATUSES,
   CHECK_IN_PROVIDER_READINESS_REASONS,
 } from "~/constants/checkIn"
+import {
+  fetchApi,
+  fetchApiData,
+} from "~/services/apiService/newApiFamily/request"
 import { fetchSupportCheckIn } from "~/services/apiService/newApiFamily/variants/veloeraCheckIn"
-import { fetchApi, fetchApiData } from "~/services/apiTransport/request"
 import type { ApiServiceRequest } from "~/services/apiTransport/type"
 import {
   AUTO_CHECKIN_PROVIDER_FALLBACK_MESSAGE_KEYS,

--- a/src/services/checkin/autoCheckin/providers/wong.ts
+++ b/src/services/checkin/autoCheckin/providers/wong.ts
@@ -15,11 +15,11 @@ import {
   CHECK_IN_METHOD_TODAY_STATUSES,
   CHECK_IN_PROVIDER_READINESS_REASONS,
 } from "~/constants/checkIn"
+import { fetchApi } from "~/services/apiService/newApiFamily/request"
 import type {
   WongCheckinApiResponse,
   WongCheckinStatusData,
 } from "~/services/apiService/wong"
-import { fetchApi } from "~/services/apiTransport/request"
 import type {
   AutoCheckinProvider,
   AutoCheckinProviderContext,

--- a/src/services/managedSites/providers/newApiSession.ts
+++ b/src/services/managedSites/providers/newApiSession.ts
@@ -4,13 +4,13 @@ import {
   parseNewApiDashboardAuthBundleResponse,
   type NewApiDashboardAuthBundle,
 } from "~/services/apiService/newApi/dashboardAuth"
-import { runAbortableTask } from "~/services/apiTransport/abortableTask"
-import { API_ERROR_CODES, ApiError } from "~/services/apiTransport/errors"
 import {
   fetchApi,
   fetchApiData,
-  fetchApiResponse,
-} from "~/services/apiTransport/request"
+} from "~/services/apiService/newApiFamily/request"
+import { runAbortableTask } from "~/services/apiTransport/abortableTask"
+import { API_ERROR_CODES, ApiError } from "~/services/apiTransport/errors"
+import { fetchApiResponse } from "~/services/apiTransport/request"
 import type { ApiServiceRequest } from "~/services/apiTransport/type"
 import {
   captureNewApiOwnedSession,

--- a/src/services/siteDetection/detectSiteType.ts
+++ b/src/services/siteDetection/detectSiteType.ts
@@ -4,9 +4,10 @@ import {
   getAccountSiteDomainRules,
   getAccountSiteTitleRules,
 } from "~/services/accountSiteOnboarding/registry"
+import { fetchApiData as fetchNewApiFamilyData } from "~/services/apiService/newApiFamily/request"
 import { SUB2API_AUTH_ME_ENDPOINT } from "~/services/apiService/sub2api/type"
 import { ApiError } from "~/services/apiTransport/errors"
-import { fetchApi, fetchApiData } from "~/services/apiTransport/request"
+import { fetchApi } from "~/services/apiTransport/request"
 import type { ProtectionBypassExecution } from "~/services/protectionBypass/contracts"
 import { AuthTypeEnum } from "~/types"
 import {
@@ -127,7 +128,7 @@ async function detectNewApiFamilySiteTypeFromCompatAuthError(
   protectionBypassExecution?: ProtectionBypassExecution,
 ): Promise<AccountSiteType> {
   try {
-    await fetchApiData<unknown>(
+    await fetchNewApiFamilyData<unknown>(
       {
         baseUrl: url,
         auth: { authType: AuthTypeEnum.Cookie },

--- a/tests/services/apiService/newApiFamily/accountBootstrap.test.ts
+++ b/tests/services/apiService/newApiFamily/accountBootstrap.test.ts
@@ -15,7 +15,7 @@ const { mockFetchApiData } = vi.hoisted(() => ({
   mockFetchApiData: vi.fn(),
 }))
 
-vi.mock("~/services/apiTransport/request", () => ({
+vi.mock("~/services/apiService/newApiFamily/request", () => ({
   fetchApiData: mockFetchApiData,
 }))
 

--- a/tests/services/apiService/newApiFamily/accountData.test.ts
+++ b/tests/services/apiService/newApiFamily/accountData.test.ts
@@ -61,7 +61,7 @@ vi.mock("~/services/apiTransport/constant", () => ({
   },
 }))
 
-vi.mock("~/services/apiTransport/request", () => ({
+vi.mock("~/services/apiService/newApiFamily/request", () => ({
   fetchApiData: mockFetchApiData,
 }))
 

--- a/tests/services/apiService/newApiFamily/channelManagement.test.ts
+++ b/tests/services/apiService/newApiFamily/channelManagement.test.ts
@@ -39,7 +39,7 @@ vi.mock("~/services/accounts/accountStorage", () => ({
   accountStorage: {},
 }))
 
-vi.mock("~/services/apiTransport/request", () => ({
+vi.mock("~/services/apiService/newApiFamily/request", () => ({
   fetchApi: mockFetchApi,
   fetchApiData: mockFetchApiData,
 }))

--- a/tests/services/apiService/newApiFamily/inviteLink.test.ts
+++ b/tests/services/apiService/newApiFamily/inviteLink.test.ts
@@ -12,7 +12,7 @@ const { fetchApiDataMock, loggerErrorMock } = vi.hoisted(() => ({
   loggerErrorMock: vi.fn(),
 }))
 
-vi.mock("~/services/apiTransport/request", () => ({
+vi.mock("~/services/apiService/newApiFamily/request", () => ({
   fetchApiData: fetchApiDataMock,
 }))
 

--- a/tests/services/apiService/newApiFamily/keyManagement.test.ts
+++ b/tests/services/apiService/newApiFamily/keyManagement.test.ts
@@ -36,7 +36,7 @@ vi.mock("~/services/accountTokens/tokenKeyResolver", () => ({
   syncResolvedApiTokenKeyCache: mockSyncResolvedApiTokenKeyCache,
 }))
 
-vi.mock("~/services/apiTransport/request", () => ({
+vi.mock("~/services/apiService/newApiFamily/request", () => ({
   fetchApi: mockFetchApi,
   fetchApiData: mockFetchApiData,
 }))

--- a/tests/services/apiService/newApiFamily/modelPricing.test.ts
+++ b/tests/services/apiService/newApiFamily/modelPricing.test.ts
@@ -8,7 +8,7 @@ const { fetchApiMock, loggerErrorMock } = vi.hoisted(() => ({
   loggerErrorMock: vi.fn(),
 }))
 
-vi.mock("~/services/apiTransport/request", () => ({
+vi.mock("~/services/apiService/newApiFamily/request", () => ({
   fetchApi: fetchApiMock,
 }))
 

--- a/tests/services/apiService/newApiFamily/redemption.test.ts
+++ b/tests/services/apiService/newApiFamily/redemption.test.ts
@@ -8,7 +8,7 @@ const { fetchApiDataMock, loggerErrorMock } = vi.hoisted(() => ({
   loggerErrorMock: vi.fn(),
 }))
 
-vi.mock("~/services/apiTransport/request", () => ({
+vi.mock("~/services/apiService/newApiFamily/request", () => ({
   fetchApiData: fetchApiDataMock,
 }))
 

--- a/tests/services/apiService/newApiFamily/request.test.ts
+++ b/tests/services/apiService/newApiFamily/request.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+  fetchApi,
+  fetchApiData,
+} from "~/services/apiService/newApiFamily/request"
+import { decodeNewApiResponseError } from "~/services/apiService/newApiFamily/responseError"
+import { AuthTypeEnum } from "~/types"
+
+const { mockFetchApi, mockFetchApiData } = vi.hoisted(() => ({
+  mockFetchApi: vi.fn(),
+  mockFetchApiData: vi.fn(),
+}))
+
+vi.mock("~/services/apiTransport/request", () => ({
+  fetchApi: mockFetchApi,
+  fetchApiData: mockFetchApiData,
+}))
+
+const request = {
+  baseUrl: "https://api.example.invalid",
+  auth: { authType: AuthTypeEnum.AccessToken, accessToken: "token" },
+}
+
+describe("newApiFamily request", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("injects the New API decoder into data requests", async () => {
+    mockFetchApiData.mockResolvedValueOnce({ id: 1 })
+
+    await expect(
+      fetchApiData(request, { endpoint: "/api/user/self" }),
+    ).resolves.toEqual({ id: 1 })
+    expect(mockFetchApiData).toHaveBeenCalledWith(request, {
+      endpoint: "/api/user/self",
+      errorResponseDecoder: decodeNewApiResponseError,
+    })
+  })
+
+  it("preserves normal-response mode while injecting the decoder", async () => {
+    mockFetchApi.mockResolvedValueOnce(["example-model"])
+
+    await expect(
+      fetchApi<string[]>(request, { endpoint: "/api/user/models" }, true),
+    ).resolves.toEqual(["example-model"])
+    expect(mockFetchApi).toHaveBeenCalledWith(
+      request,
+      {
+        endpoint: "/api/user/models",
+        errorResponseDecoder: decodeNewApiResponseError,
+      },
+      true,
+    )
+  })
+})

--- a/tests/services/apiService/newApiFamily/responseError.test.ts
+++ b/tests/services/apiService/newApiFamily/responseError.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest"
+
+import { decodeNewApiResponseError } from "~/services/apiService/newApiFamily/responseError"
+
+const response = (body: unknown, status = 400) => ({
+  ok: false,
+  status,
+  headers: {},
+  body,
+})
+
+describe("decodeNewApiResponseError", () => {
+  it("recognizes a failed New API envelope and preserves its message and code", () => {
+    expect(
+      decodeNewApiResponseError(
+        response({
+          success: false,
+          code: "AUTH_SESSION_LIMIT",
+          message: "Active session limit reached",
+        }),
+        { endpoint: "/api/user/login" },
+      ),
+    ).toEqual({
+      kind: "business",
+      message: "Active session limit reached",
+      upstreamCode: "AUTH_SESSION_LIMIT",
+    })
+  })
+
+  it("recognizes new_api_error even when it has no usable message", () => {
+    expect(
+      decodeNewApiResponseError(
+        response(
+          {
+            error: {
+              code: "group_forbidden",
+              message: "   ",
+              type: "new_api_error",
+            },
+          },
+          403,
+        ),
+        { endpoint: "/v1/models" },
+      ),
+    ).toEqual({
+      kind: "business",
+      upstreamCode: "group_forbidden",
+    })
+  })
+
+  it("keeps an ordinary response message without claiming a business error", () => {
+    expect(
+      decodeNewApiResponseError(
+        response({ message: "Request rejected" }, 400),
+        { endpoint: "/api/example" },
+      ),
+    ).toEqual({
+      kind: "http",
+      message: "Request rejected",
+    })
+  })
+
+  it("returns null for unknown envelopes and drops unsafe upstream codes", () => {
+    expect(
+      decodeNewApiResponseError(response({ detail: "Unknown shape" }), {
+        endpoint: "/api/example",
+      }),
+    ).toBeNull()
+
+    expect(
+      decodeNewApiResponseError(
+        response({
+          success: false,
+          code: "unsafe code!",
+          message: "Rejected",
+        }),
+        { endpoint: "/api/example" },
+      ),
+    ).toEqual({
+      kind: "business",
+      message: "Rejected",
+    })
+  })
+})

--- a/tests/services/apiService/newApiFamily/siteAnnouncements.test.ts
+++ b/tests/services/apiService/newApiFamily/siteAnnouncements.test.ts
@@ -8,7 +8,7 @@ const { fetchApiDataMock, loggerWarnMock } = vi.hoisted(() => ({
   loggerWarnMock: vi.fn(),
 }))
 
-vi.mock("~/services/apiTransport/request", () => ({
+vi.mock("~/services/apiService/newApiFamily/request", () => ({
   fetchApiData: fetchApiDataMock,
 }))
 

--- a/tests/services/apiService/newApiFamily/siteNotice.test.ts
+++ b/tests/services/apiService/newApiFamily/siteNotice.test.ts
@@ -8,7 +8,7 @@ const { fetchApiMock, loggerWarnMock } = vi.hoisted(() => ({
   loggerWarnMock: vi.fn(),
 }))
 
-vi.mock("~/services/apiTransport/request", () => ({
+vi.mock("~/services/apiService/newApiFamily/request", () => ({
   fetchApi: fetchApiMock,
 }))
 

--- a/tests/services/apiService/newApiFamily/vApi.test.ts
+++ b/tests/services/apiService/newApiFamily/vApi.test.ts
@@ -14,7 +14,7 @@ const { fetchApiDataMock, fetchLegacyAccountAvailableModelsMock } = vi.hoisted(
   }),
 )
 
-vi.mock("~/services/apiTransport/request", () => ({
+vi.mock("~/services/apiService/newApiFamily/request", () => ({
   fetchApiData: fetchApiDataMock,
 }))
 

--- a/tests/services/apiService/oneHub/index.test.ts
+++ b/tests/services/apiService/oneHub/index.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
+import { fetchApiData } from "~/services/apiService/newApiFamily/request"
 import {
   fetchAccountAvailableModels,
   fetchAccountTokens,
@@ -13,7 +14,6 @@ import {
   transformUserGroup,
 } from "~/services/apiService/oneHub/transform"
 import { PaginationLimitError } from "~/services/apiTransport/pagination"
-import { fetchApiData } from "~/services/apiTransport/request"
 
 const { mockSyncResolvedApiTokenKeyCache } = vi.hoisted(() => ({
   mockSyncResolvedApiTokenKeyCache: vi.fn(),
@@ -23,7 +23,7 @@ vi.mock("~/services/accountTokens/tokenKeyResolver", () => ({
   syncResolvedApiTokenKeyCache: mockSyncResolvedApiTokenKeyCache,
 }))
 
-vi.mock("~/services/apiTransport/request", () => ({
+vi.mock("~/services/apiService/newApiFamily/request", () => ({
   fetchApiData: vi.fn(),
 }))
 

--- a/tests/services/apiService/wong/index.test.ts
+++ b/tests/services/apiService/wong/index.test.ts
@@ -42,8 +42,12 @@ vi.mock("~/services/apiService/newApiFamily/default/accountData", () => ({
   fetchTodayUsage: mockFetchTodayUsage,
 }))
 
-vi.mock("~/services/apiTransport/request", () => ({
+vi.mock("~/services/apiService/newApiFamily/request", () => ({
   fetchApi: mockFetchApi,
+  fetchApiData: mockFetchApiData,
+}))
+
+vi.mock("~/services/apiTransport/request", () => ({
   fetchApiData: mockFetchApiData,
 }))
 

--- a/tests/services/apiTransport/request.test.ts
+++ b/tests/services/apiTransport/request.test.ts
@@ -2,6 +2,7 @@ import { http, HttpResponse } from "msw"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { RuntimeActionIds } from "~/constants/runtimeActions"
+import { decodeNewApiResponseError } from "~/services/apiService/newApiFamily/responseError"
 import { createDeferredAbortDeadline } from "~/services/apiTransport/abortableTask"
 import {
   ApiError,
@@ -2286,6 +2287,41 @@ describe("apiTransport request helpers", () => {
     )
   })
 
+  it("applies the provider decoder to a forced temp-window error response", async () => {
+    forceTempWindowRoute()
+    mockSendRuntimeMessage.mockResolvedValueOnce({
+      success: false,
+      status: 403,
+      data: {
+        error: {
+          code: "group_forbidden",
+          message: "Access denied for test group",
+          type: "new_api_error",
+        },
+      },
+    })
+
+    await expect(
+      fetchApiData(
+        {
+          baseUrl: BASE_URL,
+          auth: { authType: AuthTypeEnum.Cookie },
+          forceTempWindow: true,
+          protectionBypassExecution: backgroundProtectionBypassExecution,
+        },
+        {
+          endpoint: ENDPOINT,
+          errorResponseDecoder: decodeNewApiResponseError,
+        },
+      ),
+    ).rejects.toMatchObject({
+      statusCode: 403,
+      code: ApiErrorCodes.BUSINESS_ERROR,
+      upstreamCode: "group_forbidden",
+      message: "Access denied for test group",
+    })
+  })
+
   it("keeps the observer local when a forced temp-window route is selected", async () => {
     const lifecycle: string[] = []
     let responseObserved = false
@@ -3261,6 +3297,67 @@ describe("apiTransport request helpers", () => {
     })
   })
 
+  it("prefers a provider decoder message over the compatibility fallback", async () => {
+    server.use(
+      http.get(API_URL, () =>
+        HttpResponse.json(
+          { success: false, message: "Compatibility message" },
+          { status: 400 },
+        ),
+      ),
+    )
+
+    await expect(
+      fetchApiData(
+        {
+          baseUrl: BASE_URL,
+          auth: { authType: AuthTypeEnum.Cookie },
+        },
+        {
+          endpoint: ENDPOINT,
+          errorResponseDecoder: () => ({
+            kind: "business",
+            message: "Provider message",
+          }),
+        },
+      ),
+    ).rejects.toMatchObject({
+      statusCode: 400,
+      message: "Provider message",
+    })
+  })
+
+  it("falls back when the provider decoder has no usable message", async () => {
+    server.use(
+      http.get(API_URL, () =>
+        HttpResponse.json(
+          { success: false, message: "Compatibility message" },
+          { status: 400 },
+        ),
+      ),
+    )
+
+    await expect(
+      fetchApiData(
+        {
+          baseUrl: BASE_URL,
+          auth: { authType: AuthTypeEnum.Cookie },
+        },
+        {
+          endpoint: ENDPOINT,
+          errorResponseDecoder: () => ({
+            kind: "business",
+            message: "   ",
+          }),
+        },
+      ),
+    ).rejects.toMatchObject({
+      statusCode: 400,
+      code: ApiErrorCodes.HTTP_OTHER,
+      message: "Compatibility message",
+    })
+  })
+
   it("preserves a safe top-level backend code for provider recovery logic", async () => {
     server.use(
       http.get(API_URL, () =>
@@ -3662,6 +3759,61 @@ describe("apiTransport request helpers", () => {
     ).rejects.toMatchObject({ message: "bad request" } as any)
   })
 
+  it("lets the provider decoder own HTTP 200 business error messages", async () => {
+    server.use(
+      http.get(API_URL, () =>
+        HttpResponse.json({
+          success: false,
+          data: null,
+          message: "Compatibility message",
+        }),
+      ),
+    )
+
+    const request = {
+      baseUrl: BASE_URL,
+      auth: { authType: AuthTypeEnum.AccessToken, accessToken: "token" },
+    }
+    const options = {
+      endpoint: ENDPOINT,
+      errorResponseDecoder: () => ({
+        kind: "business" as const,
+        message: "Provider message",
+      }),
+    }
+
+    await expect(fetchApiData(request, options)).rejects.toMatchObject({
+      code: ApiErrorCodes.BUSINESS_ERROR,
+      message: "Provider message",
+    })
+    await expect(fetchApi(request, options, true)).rejects.toMatchObject({
+      code: ApiErrorCodes.BUSINESS_ERROR,
+      message: "Provider message",
+    })
+  })
+
+  it("keeps HTTP 200 error envelopes available to explicit response consumers", async () => {
+    const body = {
+      success: false,
+      data: null,
+      message: "Provider-owned response",
+    }
+    server.use(http.get(API_URL, () => HttpResponse.json(body)))
+
+    await expect(
+      fetchApi(
+        {
+          baseUrl: BASE_URL,
+          auth: { authType: AuthTypeEnum.AccessToken, accessToken: "token" },
+        },
+        {
+          endpoint: ENDPOINT,
+          errorResponseDecoder: decodeNewApiResponseError,
+        },
+      ),
+    ).resolves.toEqual(body)
+  })
+
   it("fetchApiData rejects successful JSON envelopes without data", async () => {
     server.use(
       http.get(API_URL, () => {
@@ -3711,13 +3863,57 @@ describe("apiTransport request helpers", () => {
           baseUrl: BASE_URL,
           auth: { authType: AuthTypeEnum.AccessToken, accessToken: "token" },
         },
-        { endpoint: modelsEndpoint },
+        {
+          endpoint: modelsEndpoint,
+          errorResponseDecoder: decodeNewApiResponseError,
+        },
       ),
     ).rejects.toMatchObject({
       endpoint: modelsEndpoint,
       statusCode: 403,
       code: ApiErrorCodes.BUSINESS_ERROR,
       message: "Access denied for test group",
+    })
+
+    expect(mockSendRuntimeMessage).not.toHaveBeenCalled()
+  })
+
+  it("keeps provider business classification when its message is blank", async () => {
+    const modelsEndpoint = "/v1/models"
+    const modelsUrl = "https://example.com/base/v1/models"
+
+    server.use(
+      http.get(modelsUrl, () =>
+        HttpResponse.json(
+          {
+            error: {
+              code: "group_forbidden",
+              message: "   ",
+              type: "new_api_error",
+            },
+          },
+          { status: 403 },
+        ),
+      ),
+    )
+
+    await expect(
+      fetchApiData(
+        {
+          baseUrl: BASE_URL,
+          auth: { authType: AuthTypeEnum.AccessToken, accessToken: "token" },
+        },
+        {
+          endpoint: modelsEndpoint,
+          errorResponseDecoder: decodeNewApiResponseError,
+        },
+      ),
+    ).rejects.toMatchObject({
+      endpoint: modelsEndpoint,
+      statusCode: 403,
+      code: ApiErrorCodes.BUSINESS_ERROR,
+      message: "请求失败: 403",
+      upstreamCode: "group_forbidden",
     })
 
     expect(mockSendRuntimeMessage).not.toHaveBeenCalled()

--- a/tests/services/autoCheckin/providers/anyrouter.test.ts
+++ b/tests/services/autoCheckin/providers/anyrouter.test.ts
@@ -10,7 +10,7 @@ import { userCommandExecution } from "~~/tests/services/protectionBypass/fixture
 import { createAutoCheckinMutationLifecycle } from "~~/tests/test-utils/autoCheckin"
 import { buildCheckInConfig } from "~~/tests/test-utils/checkIn"
 
-vi.mock("~/services/apiTransport/request", () => ({
+vi.mock("~/services/apiService/newApiFamily/request", () => ({
   fetchApi: vi.fn(),
 }))
 
@@ -89,7 +89,9 @@ describe("anyrouterProvider", () => {
 
   describe("checkIn", () => {
     it("propagates the popup source on a successful check-in", async () => {
-      const { fetchApi } = await import("~/services/apiTransport/request")
+      const { fetchApi } = await import(
+        "~/services/apiService/newApiFamily/request"
+      )
       const mockedFetchApi = vi.mocked(
         fetchApi as unknown as (...args: any[]) => Promise<any>,
       )
@@ -117,7 +119,9 @@ describe("anyrouterProvider", () => {
     })
 
     it("passes lightweight AnyRouter account context to fetchApi", async () => {
-      const { fetchApi } = await import("~/services/apiTransport/request")
+      const { fetchApi } = await import(
+        "~/services/apiService/newApiFamily/request"
+      )
       const mockedFetchApi = vi.mocked(
         fetchApi as unknown as (...args: any[]) => Promise<any>,
       )
@@ -156,7 +160,9 @@ describe("anyrouterProvider", () => {
     })
 
     it("returns success for English success messages", async () => {
-      const { fetchApi } = await import("~/services/apiTransport/request")
+      const { fetchApi } = await import(
+        "~/services/apiService/newApiFamily/request"
+      )
       const mockedFetchApi = vi.mocked(
         fetchApi as unknown as (...args: any[]) => Promise<any>,
       )
@@ -183,7 +189,9 @@ describe("anyrouterProvider", () => {
     })
 
     it("returns success when success is true and optional result fields are omitted", async () => {
-      const { fetchApi } = await import("~/services/apiTransport/request")
+      const { fetchApi } = await import(
+        "~/services/apiService/newApiFamily/request"
+      )
       vi.mocked(fetchApi).mockResolvedValueOnce({
         success: true,
         message: "",
@@ -196,7 +204,9 @@ describe("anyrouterProvider", () => {
     })
 
     it("does not treat an empty message as already checked", async () => {
-      const { fetchApi } = await import("~/services/apiTransport/request")
+      const { fetchApi } = await import(
+        "~/services/apiService/newApiFamily/request"
+      )
       const mockedFetchApi = vi.mocked(
         fetchApi as unknown as (...args: any[]) => Promise<any>,
       )
@@ -212,7 +222,9 @@ describe("anyrouterProvider", () => {
     })
 
     it("returns already_checked when response is success and message indicates a prior check-in", async () => {
-      const { fetchApi } = await import("~/services/apiTransport/request")
+      const { fetchApi } = await import(
+        "~/services/apiService/newApiFamily/request"
+      )
       const mockedFetchApi = vi.mocked(
         fetchApi as unknown as (...args: any[]) => Promise<any>,
       )
@@ -233,7 +245,9 @@ describe("anyrouterProvider", () => {
     })
 
     it("returns the fallback failure key when the backend fails without a message", async () => {
-      const { fetchApi } = await import("~/services/apiTransport/request")
+      const { fetchApi } = await import(
+        "~/services/apiService/newApiFamily/request"
+      )
       const mockedFetchApi = vi.mocked(
         fetchApi as unknown as (...args: any[]) => Promise<any>,
       )
@@ -263,7 +277,9 @@ describe("anyrouterProvider", () => {
       ["ret", { ret: 1, message: "queued" }],
       ["code", { code: 0, message: "queued" }],
     ])("accepts %s as an independent success signal", async (_, response) => {
-      const { fetchApi } = await import("~/services/apiTransport/request")
+      const { fetchApi } = await import(
+        "~/services/apiService/newApiFamily/request"
+      )
       const mockedFetchApi = vi.mocked(
         fetchApi as unknown as (...args: any[]) => Promise<any>,
       )
@@ -276,7 +292,9 @@ describe("anyrouterProvider", () => {
     })
 
     it("does not infer already checked from a zero ret value", async () => {
-      const { fetchApi } = await import("~/services/apiTransport/request")
+      const { fetchApi } = await import(
+        "~/services/apiService/newApiFamily/request"
+      )
       vi.mocked(fetchApi).mockResolvedValueOnce({
         code: 1,
         ret: 0,
@@ -291,7 +309,9 @@ describe("anyrouterProvider", () => {
     })
 
     it("recognizes an explicit already-checked message on a negative response", async () => {
-      const { fetchApi } = await import("~/services/apiTransport/request")
+      const { fetchApi } = await import(
+        "~/services/apiService/newApiFamily/request"
+      )
       const mockedFetchApi = vi.mocked(
         fetchApi as unknown as (...args: any[]) => Promise<any>,
       )
@@ -307,7 +327,9 @@ describe("anyrouterProvider", () => {
     })
 
     it("recognizes the msg field used by compatible deployments", async () => {
-      const { fetchApi } = await import("~/services/apiTransport/request")
+      const { fetchApi } = await import(
+        "~/services/apiService/newApiFamily/request"
+      )
       vi.mocked(fetchApi).mockResolvedValueOnce({
         ret: 0,
         msg: "already checked today",
@@ -320,7 +342,9 @@ describe("anyrouterProvider", () => {
     })
 
     it("returns failed when response indicates failure", async () => {
-      const { fetchApi } = await import("~/services/apiTransport/request")
+      const { fetchApi } = await import(
+        "~/services/apiService/newApiFamily/request"
+      )
       const mockedFetchApi = vi.mocked(
         fetchApi as unknown as (...args: any[]) => Promise<any>,
       )
@@ -336,7 +360,9 @@ describe("anyrouterProvider", () => {
     })
 
     it("maps 404 errors to endpoint-not-supported", async () => {
-      const { fetchApi } = await import("~/services/apiTransport/request")
+      const { fetchApi } = await import(
+        "~/services/apiService/newApiFamily/request"
+      )
       const mockedFetchApi = vi.mocked(
         fetchApi as unknown as (...args: any[]) => Promise<any>,
       )
@@ -354,7 +380,9 @@ describe("anyrouterProvider", () => {
     })
 
     it("returns already_checked when request throws and error message indicates already checked", async () => {
-      const { fetchApi } = await import("~/services/apiTransport/request")
+      const { fetchApi } = await import(
+        "~/services/apiService/newApiFamily/request"
+      )
       const mockedFetchApi = vi.mocked(
         fetchApi as unknown as (...args: any[]) => Promise<any>,
       )
@@ -365,7 +393,9 @@ describe("anyrouterProvider", () => {
     })
 
     it("does not treat an empty thrown message as already checked", async () => {
-      const { fetchApi } = await import("~/services/apiTransport/request")
+      const { fetchApi } = await import(
+        "~/services/apiService/newApiFamily/request"
+      )
       vi.mocked(fetchApi).mockRejectedValueOnce(new Error(""))
 
       await expect(checkInForTest(mockAccount)).resolves.toMatchObject({
@@ -374,7 +404,9 @@ describe("anyrouterProvider", () => {
     })
 
     it("handles errors gracefully", async () => {
-      const { fetchApi } = await import("~/services/apiTransport/request")
+      const { fetchApi } = await import(
+        "~/services/apiService/newApiFamily/request"
+      )
       const mockedFetchApi = vi.mocked(
         fetchApi as unknown as (...args: any[]) => Promise<any>,
       )
@@ -385,7 +417,9 @@ describe("anyrouterProvider", () => {
     })
 
     it("returns uncertain when the response is lost after dispatch", async () => {
-      const { fetchApi } = await import("~/services/apiTransport/request")
+      const { fetchApi } = await import(
+        "~/services/apiService/newApiFamily/request"
+      )
       const mutationLifecycle = createAutoCheckinMutationLifecycle()
       vi.mocked(fetchApi).mockImplementationOnce(async (request) => {
         request.observer?.onDispatch()

--- a/tests/services/autoCheckin/providers/newApi.test.ts
+++ b/tests/services/autoCheckin/providers/newApi.test.ts
@@ -5,8 +5,11 @@ import {
   resolveAccountSiteRouteUrl,
   SITE_ROUTE_KINDS,
 } from "~/services/accounts/utils/siteRouteResolver"
+import {
+  fetchApi,
+  fetchApiData,
+} from "~/services/apiService/newApiFamily/request"
 import { API_ERROR_CODES, ApiError } from "~/services/apiTransport/errors"
-import { fetchApi, fetchApiData } from "~/services/apiTransport/request"
 import { autoCheckinMethodRegistry } from "~/services/checkin/autoCheckin/providers"
 import { newApiProvider } from "~/services/checkin/autoCheckin/providers/newApi"
 import { PROTECTION_BYPASS_USER_COMMANDS } from "~/services/protectionBypass/contracts"
@@ -28,7 +31,7 @@ const { mockFetchSupportCheckIn } = vi.hoisted(() => ({
   mockFetchSupportCheckIn: vi.fn(),
 }))
 
-vi.mock("~/services/apiTransport/request", () => ({
+vi.mock("~/services/apiService/newApiFamily/request", () => ({
   fetchApi: vi.fn(),
   fetchApiData: vi.fn(),
 }))

--- a/tests/services/autoCheckin/providers/veloera.test.ts
+++ b/tests/services/autoCheckin/providers/veloera.test.ts
@@ -1,8 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { SITE_TYPES } from "~/constants/siteType"
+import {
+  fetchApi,
+  fetchApiData,
+} from "~/services/apiService/newApiFamily/request"
 import { ApiError } from "~/services/apiTransport/errors"
-import { fetchApi, fetchApiData } from "~/services/apiTransport/request"
 import { veloeraProvider } from "~/services/checkin/autoCheckin/providers/veloera"
 import { PROTECTION_BYPASS_USER_COMMANDS } from "~/services/protectionBypass/contracts"
 import { AuthTypeEnum, SiteHealthStatus, type SiteAccount } from "~/types"
@@ -14,7 +17,7 @@ const { mockFetchVeloeraCheckInSupport } = vi.hoisted(() => ({
   mockFetchVeloeraCheckInSupport: vi.fn(),
 }))
 
-vi.mock("~/services/apiTransport/request", () => ({
+vi.mock("~/services/apiService/newApiFamily/request", () => ({
   fetchApi: vi.fn(),
   fetchApiData: vi.fn(),
 }))
@@ -177,7 +180,9 @@ describe("veloeraProvider", () => {
 
   describe("checkIn", () => {
     it("propagates the popup source when the backend omits a message", async () => {
-      const { fetchApi } = await import("~/services/apiTransport/request")
+      const { fetchApi } = await import(
+        "~/services/apiService/newApiFamily/request"
+      )
       vi.mocked(fetchApi).mockResolvedValueOnce({
         success: true,
         data: { quota_awarded: 2 },
@@ -204,7 +209,9 @@ describe("veloeraProvider", () => {
     })
 
     it("returns success on successful check-in", async () => {
-      const { fetchApi } = await import("~/services/apiTransport/request")
+      const { fetchApi } = await import(
+        "~/services/apiService/newApiFamily/request"
+      )
       vi.mocked(fetchApi).mockResolvedValueOnce({
         success: true,
         data: null,
@@ -219,7 +226,9 @@ describe("veloeraProvider", () => {
     })
 
     it("returns already_checked when already checked in", async () => {
-      const { fetchApi } = await import("~/services/apiTransport/request")
+      const { fetchApi } = await import(
+        "~/services/apiService/newApiFamily/request"
+      )
       vi.mocked(fetchApi).mockResolvedValueOnce({
         success: true,
         data: null,
@@ -231,7 +240,9 @@ describe("veloeraProvider", () => {
     })
 
     it("returns the fallback failure key when the backend fails without a message", async () => {
-      const { fetchApi } = await import("~/services/apiTransport/request")
+      const { fetchApi } = await import(
+        "~/services/apiService/newApiFamily/request"
+      )
       vi.mocked(fetchApi).mockResolvedValueOnce({
         success: false,
         data: { code: 500 },
@@ -293,7 +304,9 @@ describe("veloeraProvider", () => {
     })
 
     it("handles errors gracefully", async () => {
-      const { fetchApi } = await import("~/services/apiTransport/request")
+      const { fetchApi } = await import(
+        "~/services/apiService/newApiFamily/request"
+      )
       vi.mocked(fetchApi).mockRejectedValueOnce(new Error("Network error"))
 
       const result = await checkInForTest(mockAccount)

--- a/tests/services/autoCheckin/providers/wong.test.ts
+++ b/tests/services/autoCheckin/providers/wong.test.ts
@@ -9,7 +9,7 @@ import { userCommandExecution } from "~~/tests/services/protectionBypass/fixture
 import { createAutoCheckinMutationLifecycle } from "~~/tests/test-utils/autoCheckin"
 import { buildCheckInConfig } from "~~/tests/test-utils/checkIn"
 
-vi.mock("~/services/apiTransport/request", () => ({
+vi.mock("~/services/apiService/newApiFamily/request", () => ({
   fetchApi: vi.fn(),
 }))
 
@@ -111,7 +111,9 @@ describe("wongGongyiProvider", () => {
   })
 
   it("uses a strict GET status envelope and never probes with POST", async () => {
-    const { fetchApi } = await import("~/services/apiTransport/request")
+    const { fetchApi } = await import(
+      "~/services/apiService/newApiFamily/request"
+    )
     vi.mocked(fetchApi)
       .mockResolvedValueOnce({
         success: true,
@@ -153,7 +155,9 @@ describe("wongGongyiProvider", () => {
 
   describe("checkIn", () => {
     it("propagates the popup source when POST indicates checked_in true", async () => {
-      const { fetchApi } = await import("~/services/apiTransport/request")
+      const { fetchApi } = await import(
+        "~/services/apiService/newApiFamily/request"
+      )
       const mockedFetchApi = vi.mocked(fetchApi)
 
       mockedFetchApi.mockResolvedValueOnce({
@@ -179,7 +183,9 @@ describe("wongGongyiProvider", () => {
     })
 
     it("returns already_checked when POST success=true but message indicates already checked", async () => {
-      const { fetchApi } = await import("~/services/apiTransport/request")
+      const { fetchApi } = await import(
+        "~/services/apiService/newApiFamily/request"
+      )
       const mockedFetchApi = vi.mocked(fetchApi)
 
       mockedFetchApi.mockResolvedValueOnce({
@@ -196,7 +202,9 @@ describe("wongGongyiProvider", () => {
     })
 
     it("returns failed when POST indicates enabled false", async () => {
-      const { fetchApi } = await import("~/services/apiTransport/request")
+      const { fetchApi } = await import(
+        "~/services/apiService/newApiFamily/request"
+      )
       const mockedFetchApi = vi.mocked(fetchApi)
 
       mockedFetchApi.mockResolvedValueOnce({
@@ -211,7 +219,9 @@ describe("wongGongyiProvider", () => {
     })
 
     it("returns success when POST succeeds and user was not checked in", async () => {
-      const { fetchApi } = await import("~/services/apiTransport/request")
+      const { fetchApi } = await import(
+        "~/services/apiService/newApiFamily/request"
+      )
       const mockedFetchApi = vi.mocked(fetchApi)
 
       mockedFetchApi.mockResolvedValueOnce({
@@ -228,7 +238,9 @@ describe("wongGongyiProvider", () => {
     })
 
     it("does not let ambiguous copy override an explicit unchecked status", async () => {
-      const { fetchApi } = await import("~/services/apiTransport/request")
+      const { fetchApi } = await import(
+        "~/services/apiService/newApiFamily/request"
+      )
       vi.mocked(fetchApi).mockResolvedValueOnce({
         success: true,
         message: "User was not already checked in",
@@ -242,7 +254,9 @@ describe("wongGongyiProvider", () => {
     })
 
     it("returns failed when POST returns success=false without already-checked signal", async () => {
-      const { fetchApi } = await import("~/services/apiTransport/request")
+      const { fetchApi } = await import(
+        "~/services/apiService/newApiFamily/request"
+      )
       const mockedFetchApi = vi.mocked(fetchApi)
 
       mockedFetchApi.mockResolvedValueOnce({
@@ -259,7 +273,9 @@ describe("wongGongyiProvider", () => {
     })
 
     it("returns already_checked when POST returns already checked message", async () => {
-      const { fetchApi } = await import("~/services/apiTransport/request")
+      const { fetchApi } = await import(
+        "~/services/apiService/newApiFamily/request"
+      )
       const mockedFetchApi = vi.mocked(fetchApi)
 
       mockedFetchApi.mockResolvedValueOnce({
@@ -273,7 +289,9 @@ describe("wongGongyiProvider", () => {
     })
 
     it("handles network errors gracefully", async () => {
-      const { fetchApi } = await import("~/services/apiTransport/request")
+      const { fetchApi } = await import(
+        "~/services/apiService/newApiFamily/request"
+      )
       const mockedFetchApi = vi.mocked(fetchApi)
 
       mockedFetchApi.mockRejectedValueOnce(new TypeError("Failed to fetch"))
@@ -288,7 +306,9 @@ describe("wongGongyiProvider", () => {
     })
 
     it("marks a lost response after POST dispatch as uncertain", async () => {
-      const { fetchApi } = await import("~/services/apiTransport/request")
+      const { fetchApi } = await import(
+        "~/services/apiService/newApiFamily/request"
+      )
       const mutationLifecycle = createAutoCheckinMutationLifecycle()
       vi.mocked(fetchApi).mockImplementationOnce(async (request) => {
         request.observer?.onDispatch()
@@ -307,7 +327,9 @@ describe("wongGongyiProvider", () => {
     })
 
     it("returns endpointNotSupported when API returns 404", async () => {
-      const { fetchApi } = await import("~/services/apiTransport/request")
+      const { fetchApi } = await import(
+        "~/services/apiService/newApiFamily/request"
+      )
       const mockedFetchApi = vi.mocked(fetchApi)
 
       mockedFetchApi.mockRejectedValueOnce({

--- a/tests/services/newApiService/newApiService.test.ts
+++ b/tests/services/newApiService/newApiService.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { SITE_TYPES } from "~/constants/siteType"
+import { decodeNewApiResponseError } from "~/services/apiService/newApiFamily/responseError"
 import { MANAGED_SITE_CHANNEL_MATCH_UNRESOLVED_REASONS } from "~/services/managedSites/channelMatch"
 import type { ApiToken, DisplaySiteData } from "~/types"
 import { AuthTypeEnum, SiteHealthStatus } from "~/types"
@@ -322,6 +323,7 @@ describe("newApiService", () => {
       expect(result).toEqual(mockChannelData)
       expect(mockFetchApiData).toHaveBeenCalledWith(request, {
         endpoint: "/api/channel/search?keyword=https%3A%2F%2Fapi.example.com",
+        errorResponseDecoder: decodeNewApiResponseError,
       })
     })
 


### PR DESCRIPTION
## Summary

- Introduce a provider-owned response error decoder contract for the shared API transport.
- Move New API-family response parsing, including business envelopes and nested `new_api_error` payloads, into the New API adapter boundary.
- Preserve the fallback order: provider decoder -> generic error-message extraction -> fixed request-failure text.
- Keep disclosure and redaction policy outside `getErrorMessage` and apply it only at logging or reporting boundaries.

## Behavior

Previously, the generic transport contained New API-specific response parsing.

Now, New API-family callers install their own decoder while the transport owns only orchestration and fallback behavior. Existing unmigrated callers continue through the compatibility decoder.

HTTP 200 business-error envelopes are decoded for data/unwrapped callers, while callers that explicitly consume response envelopes retain control of `{ success: false }` responses.

## Validation

- Focused Vitest coverage: 11 test files, 340 tests passed
- Export-cleanup regression coverage: 2 test files, 130 tests passed
- `pnpm run validate:staged`
- `pnpm run validate:push`
- `git diff --check`

## Scope and follow-up

This PR intentionally does not migrate every provider adapter. The legacy compatibility decoder remains until the remaining provider paths are audited and either adopt an explicit decoder or deliberately consume raw responses.

No browser E2E was added because the changed contract is isolated to transport and provider response parsing and is covered by service-level tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved handling of New API responses, including business errors, HTTP errors, and provider-specific error messages.
  - Added consistent response processing for API data and full-response requests.
  - Preserved safe upstream error codes where available.

- **Bug Fixes**
  - New API services and integrations now use the appropriate response handling, improving error reporting consistency.

- **Tests**
  - Added coverage for New API response decoding and transport-level error handling.
  - Updated existing API, check-in, and service tests to verify the revised request behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->