### PR TITLE
refactor(api-service): own provider error response decoding

### DIFF
--- a/src/services/accountTokens/tokenKeyResolver.ts
+++ b/src/services/accountTokens/tokenKeyResolver.ts
@@ -3,12 +3,10 @@ import {
   isMaskedApiTokenKey,
   normalizeApiTokenKeyValue,
 } from "~/services/accountTokens/apiTokenKey"
-import { fetchApiData } from "~/services/apiTransport/request"
 import type { ApiServiceRequest } from "~/services/apiTransport/type"
 import type { ApiToken } from "~/types"
 
 type TokenKeyLike = Pick<ApiToken, "id" | "key">
-type TokenSecretResolutionMethod = "GET" | "POST"
 type TokenSecretKeyFetcher = (
   request: ApiServiceRequest,
   tokenId: number,
@@ -45,40 +43,6 @@ const deleteTokenResolutionScopeEntries = (
     if (predicate && !predicate(cacheKey)) continue
     resolvedTokenKeyPromises.delete(cacheKey)
   }
-}
-
-/**
- * Fetches the full secret key for a token from the explicit secret endpoint.
- */
-export async function fetchTokenSecretKeyByIdWithMethod(
-  request: ApiServiceRequest,
-  tokenId: number,
-  method: TokenSecretResolutionMethod,
-): Promise<string> {
-  const response = await fetchApiData<{ key?: string }>(request, {
-    endpoint: `/api/token/${tokenId}/key`,
-    options: {
-      method,
-    },
-  })
-
-  const normalizedKey = normalizeApiTokenKeyValue(response?.key ?? "")
-  if (!normalizedKey) {
-    throw new Error("token_secret_key_missing")
-  }
-
-  return normalizedKey
-}
-
-/**
- * Fetches the full secret key for a token using the default compatible
- * backend behavior.
- */
-export async function fetchTokenSecretKeyById(
-  request: ApiServiceRequest,
-  tokenId: number,
-): Promise<string> {
-  return fetchTokenSecretKeyByIdWithMethod(request, tokenId, "POST")
 }
 
 /**
@@ -124,17 +88,6 @@ export async function resolveApiTokenKeyWithFetcher(
 
   resolvedTokenKeyPromises.set(cacheKey, promise)
   return promise
-}
-
-/**
- * Resolves a usable token secret key while preserving pass-through behavior for
- * legacy backends that still return full keys in inventory APIs.
- */
-export async function resolveApiTokenKey(
-  request: ApiServiceRequest,
-  token: TokenKeyLike,
-): Promise<string> {
-  return resolveApiTokenKeyWithFetcher(request, token, fetchTokenSecretKeyById)
 }
 
 /**

--- a/src/services/apiAdapters/managedSites/doneHub.ts
+++ b/src/services/apiAdapters/managedSites/doneHub.ts
@@ -59,6 +59,7 @@ import {
   type ManagedUpstreamResourceSummary,
 } from "~/types/managedUpstreamResource"
 import { CHANNEL_STATUS } from "~/types/newApi"
+import { getErrorMessage } from "~/utils/core/error"
 
 import { createManagedSiteConfigCapability } from "./config"
 import {
@@ -74,7 +75,10 @@ const toDoneHubMutationResponse = (response: ApiResponse<unknown>) =>
     : {
         outcome: "rejected" as const,
         diagnostic: {
-          message: response.message || "Provider rejected the mutation",
+          message: getErrorMessage(
+            response.message,
+            "Provider rejected the mutation",
+          ),
           raw: response,
         },
       }

--- a/src/services/apiAdapters/managedSites/veloera.ts
+++ b/src/services/apiAdapters/managedSites/veloera.ts
@@ -59,6 +59,7 @@ import {
 } from "~/types/managedUpstreamResource"
 import { CHANNEL_STATUS } from "~/types/newApi"
 import type { VeloeraConfig } from "~/types/veloeraConfig"
+import { getErrorMessage } from "~/utils/core/error"
 
 import { createManagedSiteConfigCapability } from "./config"
 import {
@@ -74,7 +75,10 @@ const toVeloeraMutationResponse = (response: ApiResponse<unknown>) =>
     : {
         outcome: "rejected" as const,
         diagnostic: {
-          message: response.message || "Provider rejected the mutation",
+          message: getErrorMessage(
+            response.message,
+            "Provider rejected the mutation",
+          ),
           raw: response,
         },
       }

--- a/src/services/apiService/common/providerRequest.ts
+++ b/src/services/apiService/common/providerRequest.ts
@@ -1,0 +1,71 @@
+import {
+  fetchApi as fetchTransportApi,
+  fetchApiData as fetchTransportApiData,
+} from "~/services/apiTransport/request"
+import type {
+  ApiResponse,
+  ApiResponseErrorDecoder,
+  ApiTransportRequest,
+  FetchApiOptions,
+} from "~/services/apiTransport/type"
+
+/** JSON request options whose provider decoder is owned by the request module. */
+type ProviderJsonRequestOptions = Omit<
+  FetchApiOptions,
+  "errorResponseDecoder" | "responseType"
+>
+
+/** Provider-owned JSON request modes with explicit response projections. */
+interface ProviderJsonRequests {
+  /** Decodes application errors and unwraps the response `data` field. */
+  data<T>(
+    request: ApiTransportRequest,
+    options: ProviderJsonRequestOptions,
+  ): Promise<T>
+
+  /** Preserves a successful HTTP response envelope for provider classification. */
+  envelope<T>(
+    request: ApiTransportRequest,
+    options: ProviderJsonRequestOptions,
+  ): Promise<ApiResponse<T>>
+
+  /** Decodes application errors and returns an envelope payload or bare JSON body. */
+  payload<T>(
+    request: ApiTransportRequest,
+    options: ProviderJsonRequestOptions,
+  ): Promise<T>
+}
+
+/** Creates one provider-owned JSON request module around the shared transport. */
+export function createProviderJsonRequests(
+  errorResponseDecoder: ApiResponseErrorDecoder,
+): ProviderJsonRequests {
+  const withDecoder = (
+    options: ProviderJsonRequestOptions,
+  ): FetchApiOptions & { responseType: "json" } => ({
+    ...options,
+    responseType: "json",
+    errorResponseDecoder,
+  })
+
+  return {
+    async data<T>(
+      request: ApiTransportRequest,
+      options: ProviderJsonRequestOptions,
+    ): Promise<T> {
+      return await fetchTransportApiData<T>(request, withDecoder(options))
+    },
+    async envelope<T>(
+      request: ApiTransportRequest,
+      options: ProviderJsonRequestOptions,
+    ): Promise<ApiResponse<T>> {
+      return await fetchTransportApi<T>(request, withDecoder(options), false)
+    },
+    async payload<T>(
+      request: ApiTransportRequest,
+      options: ProviderJsonRequestOptions,
+    ): Promise<T> {
+      return await fetchTransportApi<T>(request, withDecoder(options), true)
+    },
+  }
+}

--- a/src/services/apiService/common/responseError.ts
+++ b/src/services/apiService/common/responseError.ts
@@ -1,0 +1,67 @@
+import { readSafeUpstreamCode } from "~/services/apiTransport/responseError"
+import type {
+  ApiResponseErrorDecoder,
+  ApiTransportResponse,
+  DecodedApiResponseError,
+} from "~/services/apiTransport/type"
+
+type MessageEnvelopeDecoderOptions = {
+  isBusinessEnvelope(body: Record<string, unknown>): boolean
+  captureBusinessCode?: boolean
+  standaloneHttpMessage?: boolean
+  nestedError?: {
+    type: string
+    kind: DecodedApiResponseError["kind"]
+    captureCode?: boolean
+  }
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+const readMessage = (value: unknown): string | undefined =>
+  typeof value === "string" && value.trim() ? value.trim() : undefined
+
+/** Decodes a provider-selected message envelope without applying disclosure policy. */
+function decodeMessageEnvelopeResponseError(
+  response: ApiTransportResponse<unknown>,
+  options: MessageEnvelopeDecoderOptions,
+): DecodedApiResponseError | null {
+  if (!isRecord(response.body)) return null
+
+  const body = response.body
+  const message = readMessage(body.message)
+  if (options.isBusinessEnvelope(body)) {
+    const upstreamCode = options.captureBusinessCode
+      ? readSafeUpstreamCode(body.code)
+      : undefined
+    return {
+      kind: "business",
+      ...(message ? { message } : {}),
+      ...(upstreamCode ? { upstreamCode } : {}),
+    }
+  }
+  if (options.standaloneHttpMessage && message) {
+    return { kind: "http", message }
+  }
+
+  if (!options.nestedError || !isRecord(body.error)) return null
+  const error = body.error
+  if (readMessage(error.type) !== options.nestedError.type) return null
+
+  const nestedMessage = readMessage(error.message)
+  const nestedUpstreamCode = options.nestedError.captureCode
+    ? readSafeUpstreamCode(error.code)
+    : undefined
+  return {
+    kind: options.nestedError.kind,
+    ...(nestedMessage ? { message: nestedMessage } : {}),
+    ...(nestedUpstreamCode ? { upstreamCode: nestedUpstreamCode } : {}),
+  }
+}
+
+/** Creates one provider-owned decoder from its declared envelope semantics. */
+export const createMessageEnvelopeResponseErrorDecoder =
+  (options: MessageEnvelopeDecoderOptions): ApiResponseErrorDecoder =>
+  (response) =>
+    decodeMessageEnvelopeResponseError(response, options)

--- a/src/services/apiService/doneHub/index.ts
+++ b/src/services/apiService/doneHub/index.ts
@@ -2,7 +2,6 @@ import type { ManagedSitePaginatedChannelRequestOptions } from "~/services/apiAd
 import { REQUEST_CONFIG } from "~/services/apiTransport/constant"
 import { ApiError } from "~/services/apiTransport/errors"
 import { fetchAllItems } from "~/services/apiTransport/pagination"
-import { fetchApi, fetchApiData } from "~/services/apiTransport/request"
 import type {
   ApiResponse,
   ApiServiceRequest,
@@ -13,7 +12,10 @@ import type {
   ManagedSiteChannelListData,
   UpdateChannelPayload,
 } from "~/types/managedSite"
+import { getErrorMessage } from "~/utils/core/error"
 import { createLogger } from "~/utils/core/logger"
+
+import { doneHubRequests } from "./request"
 
 export {
   fetchAccountData,
@@ -31,6 +33,17 @@ const logger = createLogger("ApiService.DoneHub")
 const DONE_HUB_CHANNEL_ENDPOINT = "/api/channel/"
 const DONE_HUB_PROVIDER_MODELS_ENDPOINT = "/api/channel/provider_models_list"
 const DONE_HUB_GROUP_ENDPOINT = "/api/group/"
+
+const wrapChannelMutationError = (error: unknown, fallback: string) =>
+  new ApiError(
+    getErrorMessage(error, fallback),
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    error,
+  )
+
 type DoneHubDataResult<T> = {
   data?: T[] | null
   page?: number
@@ -152,9 +165,12 @@ export async function searchChannel(
     })
 
     const endpoint = `${DONE_HUB_CHANNEL_ENDPOINT}?${params.toString()}`
-    const result = await fetchApiData<DoneHubDataResult<unknown>>(request, {
-      endpoint,
-    })
+    const result = await doneHubRequests.data<DoneHubDataResult<unknown>>(
+      request,
+      {
+        endpoint,
+      },
+    )
 
     if (!Array.isArray(result?.data)) {
       throw new ApiError("Failed to search channels", undefined, endpoint)
@@ -202,7 +218,7 @@ export async function createChannel(
       model_mapping: channel.model_mapping ?? "{}",
     }
 
-    return await fetchApi<void>(request, {
+    return await doneHubRequests.envelope<void>(request, {
       endpoint: DONE_HUB_CHANNEL_ENDPOINT,
       options: {
         method: "POST",
@@ -211,13 +227,9 @@ export async function createChannel(
     })
   } catch (error) {
     logger.error("Failed to create channel")
-    throw new ApiError(
-      "创建渠道失败，请检查网络或 Done Hub 配置。",
-      undefined,
-      undefined,
-      undefined,
-      undefined,
+    throw wrapChannelMutationError(
       error,
+      "创建渠道失败，请检查网络或 Done Hub 配置。",
     )
   }
 }
@@ -239,7 +251,7 @@ export async function updateChannel(
       group: rest.group ?? (groups ?? []).join(","),
     }
 
-    return await fetchApi<void>(request, {
+    return await doneHubRequests.envelope<void>(request, {
       endpoint: DONE_HUB_CHANNEL_ENDPOINT,
       options: {
         method: "PUT",
@@ -248,13 +260,9 @@ export async function updateChannel(
     })
   } catch (error) {
     logger.error("Failed to update channel")
-    throw new ApiError(
-      "更新渠道失败，请检查网络或 Done Hub 配置。",
-      undefined,
-      undefined,
-      undefined,
-      undefined,
+    throw wrapChannelMutationError(
       error,
+      "更新渠道失败，请检查网络或 Done Hub 配置。",
     )
   }
 }
@@ -267,7 +275,7 @@ export async function deleteChannel(
   channelId: number,
 ) {
   try {
-    return await fetchApi<void>(request, {
+    return await doneHubRequests.envelope<void>(request, {
       endpoint: `${DONE_HUB_CHANNEL_ENDPOINT}${channelId}`,
       options: {
         method: "DELETE",
@@ -275,13 +283,9 @@ export async function deleteChannel(
     })
   } catch (error) {
     logger.error("Failed to delete channel")
-    throw new ApiError(
-      "删除渠道失败，请检查网络或 Done Hub 配置。",
-      undefined,
-      undefined,
-      undefined,
-      undefined,
+    throw wrapChannelMutationError(
       error,
+      "删除渠道失败，请检查网络或 Done Hub 配置。",
     )
   }
 }
@@ -313,10 +317,13 @@ export async function listAllChannels(
       await beforeRequest?.()
 
       const endpoint = `${endpointBase}?${params.toString()}`
-      const result = await fetchApiData<DoneHubDataResult<unknown>>(request, {
-        endpoint,
-        options: { signal: options?.signal },
-      })
+      const result = await doneHubRequests.data<DoneHubDataResult<unknown>>(
+        request,
+        {
+          endpoint,
+          options: { signal: options?.signal },
+        },
+      )
 
       if (page === pageStart) {
         totalCount =
@@ -381,7 +388,7 @@ export async function fetchChannelRaw(
   options?: Pick<RequestInit, "signal">,
 ): Promise<DoneHubChannelRaw> {
   const endpoint = `${DONE_HUB_CHANNEL_ENDPOINT}${channelId}`
-  const result = await fetchApiData<unknown>(request, {
+  const result = await doneHubRequests.data<unknown>(request, {
     endpoint,
     options,
   })
@@ -411,7 +418,7 @@ export async function fetchChannelModels(
     model_headers: "",
   }
 
-  const models = await fetchApiData<unknown>(request, {
+  const models = await doneHubRequests.data<unknown>(request, {
     endpoint: DONE_HUB_PROVIDER_MODELS_ENDPOINT,
     options: {
       method: "POST",
@@ -448,7 +455,7 @@ export async function updateChannelModels(
   options?: Pick<RequestInit, "signal">,
 ): Promise<void> {
   const channelEndpoint = `${DONE_HUB_CHANNEL_ENDPOINT}${channelId}`
-  const channel = await fetchApiData<Record<string, unknown>>(request, {
+  const channel = await doneHubRequests.data<Record<string, unknown>>(request, {
     endpoint: channelEndpoint,
     options,
   })
@@ -462,7 +469,7 @@ export async function updateChannelModels(
 
   if (!response.success) {
     throw new ApiError(
-      response.message || "Failed to update channel models",
+      getErrorMessage(response.message, "Failed to update channel models"),
       undefined,
       DONE_HUB_CHANNEL_ENDPOINT,
     )
@@ -483,7 +490,7 @@ export async function updateChannelModelMapping(
   options?: Pick<RequestInit, "signal">,
 ): Promise<void> {
   const channelEndpoint = `${DONE_HUB_CHANNEL_ENDPOINT}${channelId}`
-  const channel = await fetchApiData<Record<string, unknown>>(request, {
+  const channel = await doneHubRequests.data<Record<string, unknown>>(request, {
     endpoint: channelEndpoint,
     options,
   })
@@ -498,7 +505,10 @@ export async function updateChannelModelMapping(
 
   if (!response.success) {
     throw new ApiError(
-      response.message || "Failed to update channel model mapping",
+      getErrorMessage(
+        response.message,
+        "Failed to update channel model mapping",
+      ),
       undefined,
       DONE_HUB_CHANNEL_ENDPOINT,
     )
@@ -511,61 +521,31 @@ export async function updateDoneHubChannelFields(
   payload: Record<string, unknown>,
   options?: Pick<RequestInit, "signal">,
 ): Promise<ApiResponse<void>> {
-  return await fetchApi<void>(
-    request,
-    {
-      endpoint: DONE_HUB_CHANNEL_ENDPOINT,
-      options: {
-        method: "PUT",
-        body: JSON.stringify(payload),
-        signal: options?.signal,
-      },
+  return await doneHubRequests.envelope<void>(request, {
+    endpoint: DONE_HUB_CHANNEL_ENDPOINT,
+    options: {
+      method: "PUT",
+      body: JSON.stringify(payload),
+      signal: options?.signal,
     },
-    false,
-  )
+  })
 }
 
 /**
  * Fetch the complete list of user groups defined on DoneHub.
  *
- * DoneHub returns a paginated `DataResult[UserGroup]` for `GET /api/group/`.
- * We paginate and return the `symbol` fields for admin UI.
+ * DoneHub returns the complete group array in the envelope `data` field.
+ * https://github.com/deanxv/done-hub/blob/1c09e7d75dc170a53d47af1e88c498816a5b85fb/controller/group.go#L19-L37
  */
 export async function fetchSiteUserGroups(
   request: ApiServiceRequest,
 ): Promise<Array<string>> {
-  const pageSize = REQUEST_CONFIG.DEFAULT_PAGE_SIZE
-
-  const allGroups = await fetchAllItems<DoneHubUserGroupRaw>(
-    async (page) => {
-      const params = new URLSearchParams({
-        page: page.toString(),
-        size: pageSize.toString(),
-      })
-      const endpoint = `${DONE_HUB_GROUP_ENDPOINT}?${params.toString()}`
-      const result = await fetchApiData<DoneHubDataResult<unknown>>(request, {
-        endpoint,
-      })
-
-      const items = Array.isArray(result?.data)
-        ? (result.data as DoneHubUserGroupRaw[])
-        : []
-      const total =
-        typeof result?.total_count === "number"
-          ? result.total_count
-          : items.length
-
-      return {
-        items,
-        total,
-      }
-    },
-    {
-      pageSize,
-      startPage: 1,
-      maxPages: REQUEST_CONFIG.MAX_PAGES,
-    },
-  )
+  const result = await doneHubRequests.data<unknown>(request, {
+    endpoint: DONE_HUB_GROUP_ENDPOINT,
+  })
+  const allGroups = Array.isArray(result)
+    ? (result as DoneHubUserGroupRaw[])
+    : []
 
   const symbols = allGroups
     .map((group) => (group?.symbol ?? "").trim())

--- a/src/services/apiService/doneHub/request.ts
+++ b/src/services/apiService/doneHub/request.ts
@@ -1,0 +1,8 @@
+import { createProviderJsonRequests } from "~/services/apiService/common/providerRequest"
+
+import { decodeDoneHubResponseError } from "./responseError"
+
+/** DoneHub JSON requests with provider-owned response decoding. */
+export const doneHubRequests = createProviderJsonRequests(
+  decodeDoneHubResponseError,
+)

--- a/src/services/apiService/doneHub/responseError.ts
+++ b/src/services/apiService/doneHub/responseError.ts
@@ -1,0 +1,11 @@
+import { createMessageEnvelopeResponseErrorDecoder } from "~/services/apiService/common/responseError"
+
+/**
+ * Owns DoneHub's channel-management `{ success, message }` failure envelope.
+ * https://github.com/deanxv/done-hub/blob/1c09e7d75dc170a53d47af1e88c498816a5b85fb/common/gin.go#L211-L216
+ * https://github.com/deanxv/done-hub/blob/1c09e7d75dc170a53d47af1e88c498816a5b85fb/middleware/auth.go#L15-L98
+ */
+export const decodeDoneHubResponseError =
+  createMessageEnvelopeResponseErrorDecoder({
+    isBusinessEnvelope: (body) => body.success === false,
+  })

--- a/src/services/apiService/newApiFamily/channelManagement.ts
+++ b/src/services/apiService/newApiFamily/channelManagement.ts
@@ -1,8 +1,5 @@
 import type { ManagedSitePaginatedChannelRequestOptions } from "~/services/apiAdapters/contracts/managedSiteCapabilities"
-import {
-  fetchApi,
-  fetchApiData,
-} from "~/services/apiService/newApiFamily/request"
+import { newApiFamilyRequests } from "~/services/apiService/newApiFamily/request"
 import { REQUEST_CONFIG } from "~/services/apiTransport/constant"
 import { ApiError } from "~/services/apiTransport/errors"
 import { fetchAllItems } from "~/services/apiTransport/pagination"
@@ -70,17 +67,13 @@ export const updateChannelStatus = async (
 ) => {
   // QuantumNous/new-api router/channel-router.go maps manual status changes to
   // POST /api/channel/:id/status and rejects `status` in PUT /api/channel/.
-  return await fetchApi<boolean>(
-    request,
-    {
-      endpoint: `${CHANNEL_API_BASE}${channelId}/status`,
-      options: {
-        method: "POST",
-        body: JSON.stringify({ status }),
-      },
+  return await newApiFamilyRequests.envelope<boolean>(request, {
+    endpoint: `${CHANNEL_API_BASE}${channelId}/status`,
+    options: {
+      method: "POST",
+      body: JSON.stringify({ status }),
     },
-    false,
-  )
+  })
 }
 
 export const isNewApiManualStatus = (status: number) =>
@@ -107,9 +100,12 @@ export async function searchChannel(
   keyword: string,
 ): Promise<ManagedSiteChannelListData | null> {
   try {
-    return await fetchApiData<ManagedSiteChannelListData>(request, {
-      endpoint: `${CHANNEL_API_BASE}search?keyword=${encodeURIComponent(keyword)}`,
-    })
+    return await newApiFamilyRequests.data<ManagedSiteChannelListData>(
+      request,
+      {
+        endpoint: `${CHANNEL_API_BASE}search?keyword=${encodeURIComponent(keyword)}`,
+      },
+    )
   } catch (error) {
     if (error instanceof ApiError) {
       logger.error("API 请求失败", error)
@@ -135,7 +131,7 @@ export async function createChannel(
       channel: serializeChannelGroups(channelData.channel),
     }
 
-    return await fetchApi<void>(request, {
+    return await newApiFamilyRequests.envelope<void>(request, {
       endpoint: CHANNEL_API_BASE,
       options: {
         method: "POST",
@@ -205,7 +201,7 @@ export async function updateChannelFields(
   options?: Pick<RequestInit, "signal">,
 ) {
   const { payload } = serializeUpdateChannelPayload(channelData)
-  return await fetchApi<void>(request, {
+  return await newApiFamilyRequests.envelope<void>(request, {
     endpoint: CHANNEL_API_BASE,
     options: {
       method: "PUT",
@@ -225,7 +221,7 @@ export async function deleteChannel(
   channelId: number,
 ) {
   try {
-    return await fetchApi<void>(request, {
+    return await newApiFamilyRequests.envelope<void>(request, {
       endpoint: `${CHANNEL_API_BASE}${channelId}`,
       options: {
         method: "DELETE",
@@ -277,14 +273,14 @@ export async function listAllChannels(
 
       await beforeRequest?.()
 
-      const response = await fetchApi<ManagedSiteChannelListData>(
-        request,
-        {
-          endpoint: `${endpoint}?${params.toString()}`,
-          options: { signal: options?.signal },
-        },
-        false,
-      )
+      const response =
+        await newApiFamilyRequests.envelope<ManagedSiteChannelListData>(
+          request,
+          {
+            endpoint: `${endpoint}?${params.toString()}`,
+            options: { signal: options?.signal },
+          },
+        )
 
       if (!response.success || !response.data) {
         throw new ApiError(
@@ -333,7 +329,7 @@ export async function fetchChannel(
   channelId: number,
   options?: Pick<RequestInit, "signal">,
 ): Promise<ManagedSiteChannel> {
-  return await fetchApiData<ManagedSiteChannel>(request, {
+  return await newApiFamilyRequests.data<ManagedSiteChannel>(request, {
     endpoint: `${CHANNEL_API_BASE}${channelId}`,
     options: { signal: options?.signal },
   })
@@ -368,14 +364,10 @@ export async function fetchChannelModels(
   options?: Pick<RequestInit, "signal">,
 ): Promise<string[]> {
   const endpoint = `${CHANNEL_API_BASE}fetch_models/${channelId}`
-  const response = await fetchApi<string[]>(
-    request,
-    {
-      endpoint,
-      options,
-    },
-    false,
-  )
+  const response = await newApiFamilyRequests.envelope<string[]>(request, {
+    endpoint,
+    options,
+  })
 
   return readChannelModelResponse(response, endpoint)
 }
@@ -391,22 +383,18 @@ export async function fetchDraftChannelModels(
   options?: Pick<RequestInit, "signal">,
 ): Promise<string[]> {
   const endpoint = `${CHANNEL_API_BASE}fetch_models`
-  const response = await fetchApi<string[]>(
-    request,
-    {
-      endpoint,
-      options: {
-        method: "POST",
-        body: JSON.stringify({
-          type: draft.type,
-          base_url: draft.baseUrl,
-          key: draft.key,
-        }),
-        signal: options?.signal,
-      },
+  const response = await newApiFamilyRequests.envelope<string[]>(request, {
+    endpoint,
+    options: {
+      method: "POST",
+      body: JSON.stringify({
+        type: draft.type,
+        base_url: draft.baseUrl,
+        key: draft.key,
+      }),
+      signal: options?.signal,
     },
-    false,
-  )
+  })
 
   return readChannelModelResponse(response, endpoint)
 }
@@ -428,18 +416,14 @@ export async function updateChannelModels(
     models,
   }
 
-  const response = await fetchApi<void>(
-    request,
-    {
-      endpoint: CHANNEL_API_BASE,
-      options: {
-        method: "PUT",
-        body: JSON.stringify(payload),
-        signal: options?.signal,
-      },
+  const response = await newApiFamilyRequests.envelope<void>(request, {
+    endpoint: CHANNEL_API_BASE,
+    options: {
+      method: "PUT",
+      body: JSON.stringify(payload),
+      signal: options?.signal,
     },
-    false,
-  )
+  })
 
   if (!response.success) {
     throw new ApiError(
@@ -469,18 +453,14 @@ export async function updateChannelModelMapping(
     model_mapping: modelMappingJson,
   }
 
-  const response = await fetchApi<void>(
-    request,
-    {
-      endpoint: CHANNEL_API_BASE,
-      options: {
-        method: "PUT",
-        body: JSON.stringify(payload),
-        signal: options?.signal,
-      },
+  const response = await newApiFamilyRequests.envelope<void>(request, {
+    endpoint: CHANNEL_API_BASE,
+    options: {
+      method: "PUT",
+      body: JSON.stringify(payload),
+      signal: options?.signal,
     },
-    false,
-  )
+  })
 
   if (!response.success) {
     throw new ApiError(

--- a/src/services/apiService/newApiFamily/default/accountBootstrap.ts
+++ b/src/services/apiService/newApiFamily/default/accountBootstrap.ts
@@ -4,7 +4,7 @@ import type {
   SiteStatusInfo,
   UserInfo,
 } from "~/services/apiAdapters/contracts/accountBootstrap"
-import { fetchApiData } from "~/services/apiService/newApiFamily/request"
+import { newApiFamilyRequests } from "~/services/apiService/newApiFamily/request"
 import { ApiError } from "~/services/apiTransport/errors"
 import type {
   ApiServiceRequest,
@@ -47,7 +47,7 @@ export async function fetchSiteStatus(
   }
 
   try {
-    return await fetchApiData<SiteStatusInfo>(publicRequest, {
+    return await newApiFamilyRequests.data<SiteStatusInfo>(publicRequest, {
       endpoint: "/api/status",
       ...(signal ? { options: { signal } } : {}),
     })
@@ -91,7 +91,7 @@ export async function fetchUserInfo(request: ApiServiceRequest): Promise<{
   access_token: string
   user: UserInfo
 }> {
-  const userData = await fetchApiData<UserInfo>(request, {
+  const userData = await newApiFamilyRequests.data<UserInfo>(request, {
     endpoint: "/api/user/self",
   })
   const userId = normalizeAccountIdentity(userData.id)
@@ -119,7 +119,7 @@ export async function createAccessToken(
   request: ApiServiceRequest,
   creationPolicy?: AccessTokenCreationPolicy,
 ): Promise<string> {
-  const accessToken = await fetchApiData<string>(request, {
+  const accessToken = await newApiFamilyRequests.data<string>(request, {
     endpoint: "/api/user/token",
     ...creationPolicy,
   })

--- a/src/services/apiService/newApiFamily/default/accountData.ts
+++ b/src/services/apiService/newApiFamily/default/accountData.ts
@@ -17,7 +17,7 @@ import {
   type MetricAggregationCoverage,
   type TodayTimestampRange,
 } from "~/services/apiService/newApiFamily/default/accountDataUtils"
-import { fetchApiData } from "~/services/apiService/newApiFamily/request"
+import { newApiFamilyRequests } from "~/services/apiService/newApiFamily/request"
 import { REQUEST_CONFIG } from "~/services/apiTransport/constant"
 import { ApiError } from "~/services/apiTransport/errors"
 import type { ApiServiceRequest } from "~/services/apiTransport/type"
@@ -142,9 +142,12 @@ const classifyMetricCollection = <T>(
 export async function fetchAccountQuota(
   request: ApiServiceRequest,
 ): Promise<number> {
-  const userData = await fetchApiData<{ quota?: number }>(request, {
-    endpoint: "/api/user/self",
-  })
+  const userData = await newApiFamilyRequests.data<{ quota?: number }>(
+    request,
+    {
+      endpoint: "/api/user/self",
+    },
+  )
 
   return userData.quota || 0
 }
@@ -159,9 +162,12 @@ export async function fetchCheckInStatus(
 ): Promise<boolean | undefined> {
   const currentMonth = new Date().toISOString().slice(0, 7)
   try {
-    const checkInData = await fetchApiData<NewApiCheckInStatus>(request, {
-      endpoint: `/api/user/checkin?month=${currentMonth}`,
-    })
+    const checkInData = await newApiFamilyRequests.data<NewApiCheckInStatus>(
+      request,
+      {
+        endpoint: `/api/user/checkin?month=${currentMonth}`,
+      },
+    )
     return !checkInData.stats.checked_in_today
   } catch (error) {
     if (
@@ -325,7 +331,7 @@ const fetchPaginatedLogs = async <T>(
           resolvedQueryConfig,
         )
 
-        const logData = await fetchApiData<unknown>(request, {
+        const logData = await newApiFamilyRequests.data<unknown>(request, {
           endpoint: `${resolvedQueryConfig.endpoint}?${params.toString()}`,
         })
 
@@ -493,9 +499,12 @@ const fetchTodayUsageFast = async (
     undefined,
     resolvedQueryConfig,
   )
-  const statData = await fetchApiData<LogStatResponseData>(request, {
-    endpoint: `/api/log/self/stat?${statParams.toString()}`,
-  })
+  const statData = await newApiFamilyRequests.data<LogStatResponseData>(
+    request,
+    {
+      endpoint: `/api/log/self/stat?${statParams.toString()}`,
+    },
+  )
 
   if (typeof statData?.quota !== "number" || !Number.isFinite(statData.quota)) {
     throw new Error("Today usage stat quota is missing or non-finite")

--- a/src/services/apiService/newApiFamily/default/inviteLink.ts
+++ b/src/services/apiService/newApiFamily/default/inviteLink.ts
@@ -1,4 +1,4 @@
-import { fetchApiData } from "~/services/apiService/newApiFamily/request"
+import { newApiFamilyRequests } from "~/services/apiService/newApiFamily/request"
 import type { ApiServiceRequest } from "~/services/apiTransport/type"
 import {
   INVITE_LINK_FAILURE_REASONS,
@@ -26,7 +26,7 @@ export const defaultInviteLinkImplementation: InviteLinkImplementation = {
     try {
       // Verified against QuantumNous/new-api frontend: GET /api/user/aff returns
       // the affiliate code, and the registration page consumes /register?aff=.
-      const inviteCode = await fetchApiData<string>(request, {
+      const inviteCode = await newApiFamilyRequests.data<string>(request, {
         endpoint: INVITE_CODE_ENDPOINT,
       })
 

--- a/src/services/apiService/newApiFamily/default/keyManagement.ts
+++ b/src/services/apiService/newApiFamily/default/keyManagement.ts
@@ -1,7 +1,6 @@
 import { normalizeApiTokenKey } from "~/services/accountTokens/apiTokenKey"
 import {
   invalidateResolvedApiTokenKeyCache,
-  resolveApiTokenKey,
   syncResolvedApiTokenKeyCache,
 } from "~/services/accountTokens/tokenKeyResolver"
 import type {
@@ -9,10 +8,8 @@ import type {
   CreateTokenResult,
   UserGroupInfo,
 } from "~/services/accountTokens/tokenProvisioningModel"
-import {
-  fetchApi,
-  fetchApiData,
-} from "~/services/apiService/newApiFamily/request"
+import { resolveApiTokenKey } from "~/services/apiService/newApiFamily/default/tokenKeyResolver"
+import { newApiFamilyRequests } from "~/services/apiService/newApiFamily/request"
 import { REQUEST_CONFIG } from "~/services/apiTransport/constant"
 import { API_ERROR_CODES, ApiError } from "~/services/apiTransport/errors"
 import {
@@ -86,7 +83,7 @@ export async function fetchAccountTokens(
         p: page.toString(),
         size: REQUEST_CONFIG.DEFAULT_PAGE_SIZE.toString(),
       })
-      const tokensData = await fetchApiData<unknown>(request, {
+      const tokensData = await newApiFamilyRequests.data<unknown>(request, {
         endpoint: `/api/token/?${searchParams.toString()}`,
       })
 
@@ -148,7 +145,7 @@ export async function fetchAccountAvailableModels(
   request: ApiServiceRequest,
 ): Promise<string[]> {
   try {
-    return await fetchApiData<string[]>(request, {
+    return await newApiFamilyRequests.data<string[]>(request, {
       endpoint: "/api/user/models",
     })
   } catch (error) {
@@ -164,9 +161,12 @@ export async function fetchUserGroups(
   request: ApiServiceRequest,
 ): Promise<Record<string, UserGroupInfo>> {
   try {
-    return await fetchApiData<Record<string, UserGroupInfo>>(request, {
-      endpoint: "/api/user/self/groups",
-    })
+    return await newApiFamilyRequests.data<Record<string, UserGroupInfo>>(
+      request,
+      {
+        endpoint: "/api/user/self/groups",
+      },
+    )
   } catch (error) {
     logger.error("获取分组信息失败", error)
     throw error
@@ -181,7 +181,7 @@ export async function fetchUserGroups(
 export async function fetchCurrentUserGroup(
   request: ApiServiceRequest,
 ): Promise<string> {
-  const userData = await fetchApiData<unknown>(request, {
+  const userData = await newApiFamilyRequests.data<unknown>(request, {
     endpoint: "/api/user/self",
   })
   if (!isRecord(userData) || typeof userData.group !== "string") {
@@ -199,7 +199,7 @@ export async function fetchSiteUserGroups(
   request: ApiServiceRequest,
 ): Promise<Array<string>> {
   try {
-    return await fetchApiData<Array<string>>(request, {
+    return await newApiFamilyRequests.data<Array<string>>(request, {
       endpoint: "/api/group",
     })
   } catch (error) {
@@ -216,7 +216,7 @@ export async function createApiToken(
   tokenData: CreateTokenRequest,
 ): Promise<CreateTokenResult> {
   try {
-    const response = await fetchApi<any>(request, {
+    const response = await newApiFamilyRequests.envelope<any>(request, {
       endpoint: "/api/token/",
       options: {
         method: "POST",
@@ -249,7 +249,7 @@ export async function fetchTokenById(
   tokenId: number,
 ): Promise<ApiToken> {
   try {
-    const token = await fetchApiData<ApiToken>(request, {
+    const token = await newApiFamilyRequests.data<ApiToken>(request, {
       endpoint: `/api/token/${tokenId}`,
     })
     return normalizeApiTokenKey(token)
@@ -268,7 +268,7 @@ export async function updateApiToken(
   tokenData: CreateTokenRequest,
 ): Promise<boolean> {
   try {
-    const response = await fetchApi<any>(request, {
+    const response = await newApiFamilyRequests.envelope<any>(request, {
       endpoint: "/api/token/",
       options: {
         method: "PUT",
@@ -301,7 +301,7 @@ export async function deleteApiToken(
   tokenId: number,
 ): Promise<boolean> {
   try {
-    const response = await fetchApi<any>(request, {
+    const response = await newApiFamilyRequests.envelope<any>(request, {
       endpoint: `/api/token/${tokenId}`,
       options: {
         method: "DELETE",

--- a/src/services/apiService/newApiFamily/default/modelPricing.ts
+++ b/src/services/apiService/newApiFamily/default/modelPricing.ts
@@ -1,4 +1,4 @@
-import { fetchApi } from "~/services/apiService/newApiFamily/request"
+import { newApiFamilyRequests } from "~/services/apiService/newApiFamily/request"
 import type { ApiServiceRequest } from "~/services/apiTransport/type"
 import { createLogger } from "~/utils/core/logger"
 
@@ -12,11 +12,9 @@ interface ModelPricingImplementation {
 export const defaultModelPricingImplementation: ModelPricingImplementation = {
   fetchModelPricing: async (request) => {
     try {
-      return await fetchApi<unknown>(
-        request,
-        { endpoint: MODEL_PRICING_ENDPOINT },
-        true,
-      )
+      return await newApiFamilyRequests.payload<unknown>(request, {
+        endpoint: MODEL_PRICING_ENDPOINT,
+      })
     } catch (error) {
       logger.error("获取模型定价失败", error)
       throw error

--- a/src/services/apiService/newApiFamily/default/redemption.ts
+++ b/src/services/apiService/newApiFamily/default/redemption.ts
@@ -1,4 +1,4 @@
-import { fetchApiData } from "~/services/apiService/newApiFamily/request"
+import { newApiFamilyRequests } from "~/services/apiService/newApiFamily/request"
 import type { ApiServiceRequest } from "~/services/apiTransport/type"
 import { createLogger } from "~/utils/core/logger"
 
@@ -14,7 +14,7 @@ interface RedemptionImplementation {
 export const defaultRedemptionImplementation: RedemptionImplementation = {
   redeemCode: async (request, redemptionCode) => {
     try {
-      return await fetchApiData<number>(request, {
+      return await newApiFamilyRequests.data<number>(request, {
         endpoint: "/api/user/topup",
         options: {
           method: "POST",

--- a/src/services/apiService/newApiFamily/default/siteAnnouncements.ts
+++ b/src/services/apiService/newApiFamily/default/siteAnnouncements.ts
@@ -3,7 +3,7 @@ import {
   type SiteStructuredAnnouncement,
   type SiteStructuredAnnouncementType,
 } from "~/services/apiAdapters/contracts/siteStructuredAnnouncements"
-import { fetchApiData } from "~/services/apiService/newApiFamily/request"
+import { newApiFamilyRequests } from "~/services/apiService/newApiFamily/request"
 import type { ApiServiceRequest } from "~/services/apiTransport/type"
 import { AuthTypeEnum } from "~/types"
 import { createLogger } from "~/utils/core/logger"
@@ -75,13 +75,14 @@ export async function fetchSiteAnnouncements(
   request: ApiServiceRequest,
 ): Promise<SiteStructuredAnnouncement[]> {
   try {
-    const response = await fetchApiData<NewApiStatusAnnouncementsResponse>(
-      {
-        ...request,
-        auth: { authType: AuthTypeEnum.None },
-      },
-      { endpoint: "/api/status" },
-    )
+    const response =
+      await newApiFamilyRequests.data<NewApiStatusAnnouncementsResponse>(
+        {
+          ...request,
+          auth: { authType: AuthTypeEnum.None },
+        },
+        { endpoint: "/api/status" },
+      )
 
     if (response?.announcements_enabled === false) {
       return []

--- a/src/services/apiService/newApiFamily/default/siteNotice.ts
+++ b/src/services/apiService/newApiFamily/default/siteNotice.ts
@@ -1,4 +1,4 @@
-import { fetchApi } from "~/services/apiService/newApiFamily/request"
+import { newApiFamilyRequests } from "~/services/apiService/newApiFamily/request"
 import type { ApiServiceRequest } from "~/services/apiTransport/type"
 import { AuthTypeEnum } from "~/types"
 import { createLogger } from "~/utils/core/logger"
@@ -12,7 +12,7 @@ export async function fetchSiteNotice(
   request: ApiServiceRequest,
 ): Promise<string | null> {
   try {
-    const response = await fetchApi<string | null>(
+    const response = await newApiFamilyRequests.envelope<string | null>(
       {
         ...request,
         auth: {
@@ -21,7 +21,6 @@ export async function fetchSiteNotice(
         },
       },
       { endpoint: "/api/notice" },
-      false,
     )
 
     if (

--- a/src/services/apiService/newApiFamily/default/tokenKeyResolver.ts
+++ b/src/services/apiService/newApiFamily/default/tokenKeyResolver.ts
@@ -1,0 +1,40 @@
+import { normalizeApiTokenKeyValue } from "~/services/accountTokens/apiTokenKey"
+import { resolveApiTokenKeyWithFetcher } from "~/services/accountTokens/tokenKeyResolver"
+import { newApiFamilyRequests } from "~/services/apiService/newApiFamily/request"
+import type { ApiServiceRequest } from "~/services/apiTransport/type"
+import type { ApiToken } from "~/types"
+
+/**
+ * Fetches a New API-family token secret through its explicit reveal endpoint.
+ * New API uses POST and returns `{ success, message, data: { key } }`.
+ * https://github.com/QuantumNous/new-api/blob/32c261923a9786c64d2af087327ef057e7bde7e3/router/api-router.go#L255-L262
+ * https://github.com/QuantumNous/new-api/blob/32c261923a9786c64d2af087327ef057e7bde7e3/controller/token.go#L188-L202
+ */
+export async function fetchTokenSecretKeyById(
+  request: ApiServiceRequest,
+  tokenId: number,
+): Promise<string> {
+  const response = await newApiFamilyRequests.data<{ key?: string }>(request, {
+    endpoint: `/api/token/${tokenId}/key`,
+    options: { method: "POST" },
+  })
+
+  const normalizedKey = normalizeApiTokenKeyValue(response?.key ?? "")
+  if (!normalizedKey) {
+    throw new Error("token_secret_key_missing")
+  }
+
+  return normalizedKey
+}
+
+/** Resolves a usable New API-family token key through the shared cache. */
+export async function resolveApiTokenKey(
+  request: ApiServiceRequest,
+  token: Pick<ApiToken, "id" | "key">,
+): Promise<string> {
+  return await resolveApiTokenKeyWithFetcher(
+    request,
+    token,
+    fetchTokenSecretKeyById,
+  )
+}

--- a/src/services/apiService/newApiFamily/request.ts
+++ b/src/services/apiService/newApiFamily/request.ts
@@ -1,70 +1,8 @@
-import {
-  fetchApi as fetchTransportApi,
-  fetchApiData as fetchTransportApiData,
-} from "~/services/apiTransport/request"
-import type {
-  ApiResponse,
-  ApiTransportRequest,
-  FetchApiOptions,
-} from "~/services/apiTransport/type"
-import type { TempWindowResponseType } from "~/types/tempWindowFetch"
+import { createProviderJsonRequests } from "~/services/apiService/common/providerRequest"
 
 import { decodeNewApiResponseError } from "./responseError"
 
-type JsonFetchApiOptions = Omit<FetchApiOptions, "responseType"> & {
-  responseType?: "json"
-}
-
-type NonJsonFetchApiOptions = Omit<FetchApiOptions, "responseType"> & {
-  responseType: Exclude<TempWindowResponseType, "json">
-}
-
-const withNewApiResponseErrorDecoder = (
-  options: FetchApiOptions,
-): FetchApiOptions => ({
-  ...options,
-  errorResponseDecoder: decodeNewApiResponseError,
-})
-
-/** Fetches and unwraps New API-family data with its response decoder installed. */
-export async function fetchApiData<T>(
-  request: ApiTransportRequest,
-  options: FetchApiOptions,
-): Promise<T> {
-  return await fetchTransportApiData<T>(
-    request,
-    withNewApiResponseErrorDecoder(options),
-  )
-}
-
-export function fetchApi<T>(
-  request: ApiTransportRequest,
-  options: FetchApiOptions,
-  normalResponseType: true,
-): Promise<T>
-export function fetchApi<T>(
-  request: ApiTransportRequest,
-  options: JsonFetchApiOptions,
-  normalResponseType?: false,
-): Promise<ApiResponse<T>>
-export function fetchApi<T>(
-  request: ApiTransportRequest,
-  options: NonJsonFetchApiOptions,
-  normalResponseType?: false,
-): Promise<T>
-export function fetchApi<T>(
-  request: ApiTransportRequest,
-  options: FetchApiOptions,
-  normalResponseType?: false,
-): Promise<ApiResponse<T> | T>
-/** Fetches a New API-family response while preserving the selected return mode. */
-export async function fetchApi<T>(
-  request: ApiTransportRequest,
-  options: FetchApiOptions,
-  normalResponseType?: boolean,
-): Promise<ApiResponse<T> | T> {
-  const decodedOptions = withNewApiResponseErrorDecoder(options)
-  return normalResponseType
-    ? await fetchTransportApi<T>(request, decodedOptions, true)
-    : await fetchTransportApi<T>(request, decodedOptions)
-}
+/** New API-family JSON requests with provider-owned response decoding. */
+export const newApiFamilyRequests = createProviderJsonRequests(
+  decodeNewApiResponseError,
+)

--- a/src/services/apiService/newApiFamily/responseError.ts
+++ b/src/services/apiService/newApiFamily/responseError.ts
@@ -1,16 +1,6 @@
-import { readSafeUpstreamCode } from "~/services/apiTransport/responseError"
-import type {
-  ApiResponseErrorDecoder,
-  DecodedApiResponseError,
-} from "~/services/apiTransport/type"
+import { createMessageEnvelopeResponseErrorDecoder } from "~/services/apiService/common/responseError"
 
 const NEW_API_ERROR_TYPE = "new_api_error"
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value)
-
-const readMessage = (value: unknown): string | undefined =>
-  typeof value === "string" && value.trim() ? value.trim() : undefined
 
 const isFailedBusinessEnvelope = (body: Record<string, unknown>): boolean => {
   if (body.success === false) return true
@@ -24,37 +14,17 @@ const isFailedBusinessEnvelope = (body: Record<string, unknown>): boolean => {
 /**
  * Interprets New API's `{ success, message }` and nested `new_api_error`
  * envelopes before transport fallback.
- * https://github.com/QuantumNous/new-api/blob/9df450fe54e1a874a5339b7c38a61014217f02c3/common/gin.go
- * https://github.com/QuantumNous/new-api/blob/9df450fe54e1a874a5339b7c38a61014217f02c3/middleware/utils.go
+ * https://github.com/QuantumNous/new-api/blob/32c261923a9786c64d2af087327ef057e7bde7e3/common/gin.go#L199-L228
+ * https://github.com/QuantumNous/new-api/blob/32c261923a9786c64d2af087327ef057e7bde7e3/middleware/utils.go#L14-L37
  */
-export const decodeNewApiResponseError: ApiResponseErrorDecoder = (
-  response,
-) => {
-  if (!isRecord(response.body)) return null
-
-  const body = response.body
-  const message = readMessage(body.message)
-  const upstreamCode = readSafeUpstreamCode(body.code)
-  if (isFailedBusinessEnvelope(body)) {
-    return {
+export const decodeNewApiResponseError =
+  createMessageEnvelopeResponseErrorDecoder({
+    isBusinessEnvelope: isFailedBusinessEnvelope,
+    captureBusinessCode: true,
+    standaloneHttpMessage: true,
+    nestedError: {
+      type: NEW_API_ERROR_TYPE,
       kind: "business",
-      ...(message ? { message } : {}),
-      ...(upstreamCode ? { upstreamCode } : {}),
-    }
-  }
-  if (message) {
-    return { kind: "http", message }
-  }
-
-  if (!isRecord(body.error)) return null
-  const error = body.error
-  if (readMessage(error.type) !== NEW_API_ERROR_TYPE) return null
-
-  const nestedMessage = readMessage(error.message)
-  const nestedUpstreamCode = readSafeUpstreamCode(error.code)
-  return {
-    kind: "business",
-    ...(nestedMessage ? { message: nestedMessage } : {}),
-    ...(nestedUpstreamCode ? { upstreamCode: nestedUpstreamCode } : {}),
-  } satisfies DecodedApiResponseError
-}
+      captureCode: true,
+    },
+  })

--- a/src/services/apiService/newApiFamily/variants/oneHub.ts
+++ b/src/services/apiService/newApiFamily/variants/oneHub.ts
@@ -1,7 +1,7 @@
 import { normalizeApiTokenKey } from "~/services/accountTokens/apiTokenKey"
 import { syncResolvedApiTokenKeyCache } from "~/services/accountTokens/tokenKeyResolver"
 import type { UserGroupInfo } from "~/services/accountTokens/tokenProvisioningModel"
-import { fetchApiData } from "~/services/apiService/newApiFamily/request"
+import { newApiFamilyRequests } from "~/services/apiService/newApiFamily/request"
 import {
   transformModelPricing,
   transformUserGroup,
@@ -25,13 +25,13 @@ import { isRecord } from "~/utils/core/object"
 const logger = createLogger("NewApiFamily.OneHub")
 
 export const fetchAvailableModel = async (request: ApiServiceRequest) => {
-  return fetchApiData<OneHubModelPricing>(request, {
+  return newApiFamilyRequests.data<OneHubModelPricing>(request, {
     endpoint: "/api/available_model",
   })
 }
 
 export const fetchUserGroupMap = async (request: ApiServiceRequest) => {
-  return fetchApiData<OneHubUserGroupMap>(request, {
+  return newApiFamilyRequests.data<OneHubUserGroupMap>(request, {
     endpoint: "/api/user_group_map",
   })
 }
@@ -77,7 +77,7 @@ export const fetchAccountTokens = async (
         page: upstreamPage.toString(),
         size: REQUEST_CONFIG.DEFAULT_PAGE_SIZE.toString(),
       })
-      const tokensData = await fetchApiData<unknown>(request, {
+      const tokensData = await newApiFamilyRequests.data<unknown>(request, {
         endpoint: `/api/token/?${searchParams.toString()}`,
       })
 
@@ -120,12 +120,11 @@ export const fetchUserGroups = async (
   request: ApiServiceRequest,
 ): Promise<Record<string, UserGroupInfo>> => {
   try {
-    const response = await fetchApiData<OneHubUserGroupsResponse["data"]>(
-      request,
-      {
-        endpoint: "/api/user_group_map",
-      },
-    )
+    const response = await newApiFamilyRequests.data<
+      OneHubUserGroupsResponse["data"]
+    >(request, {
+      endpoint: "/api/user_group_map",
+    })
     return transformUserGroup(response)
   } catch (error) {
     logger.error("获取分组信息失败", error)

--- a/src/services/apiService/newApiFamily/variants/vApi.ts
+++ b/src/services/apiService/newApiFamily/variants/vApi.ts
@@ -1,6 +1,6 @@
 import type { UserGroupInfo } from "~/services/accountTokens/tokenProvisioningModel"
 import { fetchAccountAvailableModels as fetchLegacyAccountAvailableModels } from "~/services/apiService/newApiFamily/default/keyManagement"
-import { fetchApiData } from "~/services/apiService/newApiFamily/request"
+import { newApiFamilyRequests } from "~/services/apiService/newApiFamily/request"
 import { ApiError } from "~/services/apiTransport/errors"
 import type { ApiServiceRequest } from "~/services/apiTransport/type"
 import { isRecord } from "~/utils/core/object"
@@ -49,7 +49,7 @@ export const fetchAccountAvailableModels = async (
   // endpoint; `/api/user/models` is permission-gated on this generation. Keep
   // the legacy New API-family endpoint as a read-only compatibility fallback.
   try {
-    return await fetchApiData<string[]>(request, {
+    return await newApiFamilyRequests.data<string[]>(request, {
       endpoint: CURRENT_AVAILABLE_MODELS_ENDPOINT,
     })
   } catch (currentEndpointError) {
@@ -72,7 +72,7 @@ export const fetchUserGroups = async (
   // The current deployment returns `description=x N倍` strings, while older
   // V-API-compatible deployments return New API-style `{ desc, ratio }` values:
   // https://gpt.ge/api/user/self/groups
-  const rawGroups = await fetchApiData<unknown>(request, {
+  const rawGroups = await newApiFamilyRequests.data<unknown>(request, {
     endpoint: USER_GROUPS_ENDPOINT,
   })
   if (!isRecord(rawGroups)) {

--- a/src/services/apiService/newApiFamily/variants/veloera.ts
+++ b/src/services/apiService/newApiFamily/variants/veloera.ts
@@ -11,7 +11,7 @@ import {
   fetchTodayUsage,
 } from "~/services/apiService/newApiFamily/default/accountData"
 import { getTodayTimestampRange } from "~/services/apiService/newApiFamily/default/accountDataUtils"
-import { fetchApiData } from "~/services/apiService/newApiFamily/request"
+import { newApiFamilyRequests } from "~/services/apiService/newApiFamily/request"
 import { ApiError } from "~/services/apiTransport/errors"
 import type { ApiServiceRequest } from "~/services/apiTransport/type"
 import { refreshSelectedStatus } from "~/services/checkin/autoCheckin/refresh"
@@ -30,12 +30,11 @@ export async function fetchCheckInStatus(
   request: ApiServiceRequest,
 ): Promise<boolean | undefined> {
   try {
-    const checkInData = await fetchApiData<{ can_check_in?: boolean }>(
-      request,
-      {
-        endpoint: "/api/user/check_in_status",
-      },
-    )
+    const checkInData = await newApiFamilyRequests.data<{
+      can_check_in?: boolean
+    }>(request, {
+      endpoint: "/api/user/check_in_status",
+    })
     if (typeof checkInData.can_check_in === "boolean") {
       return checkInData.can_check_in
     }

--- a/src/services/apiService/newApiFamily/variants/wong.ts
+++ b/src/services/apiService/newApiFamily/variants/wong.ts
@@ -5,17 +5,15 @@ import type {
   RefreshAccountResult,
 } from "~/services/accounts/accountDataModel"
 import { determineHealthStatus } from "~/services/accounts/accountHealth"
-import {
-  fetchTokenSecretKeyByIdWithMethod,
-  resolveApiTokenKeyWithFetcher,
-} from "~/services/accountTokens/tokenKeyResolver"
+import { normalizeApiTokenKeyValue } from "~/services/accountTokens/apiTokenKey"
+import { resolveApiTokenKeyWithFetcher } from "~/services/accountTokens/tokenKeyResolver"
 import {
   fetchAccountQuota,
   fetchTodayIncome,
   fetchTodayUsage,
 } from "~/services/apiService/newApiFamily/default/accountData"
 import { getTodayTimestampRange } from "~/services/apiService/newApiFamily/default/accountDataUtils"
-import { fetchApi } from "~/services/apiService/newApiFamily/request"
+import { newApiFamilyRequests } from "~/services/apiService/newApiFamily/request"
 import type { ApiServiceRequest } from "~/services/apiTransport/type"
 import { refreshSelectedStatus } from "~/services/checkin/autoCheckin/refresh"
 import {
@@ -55,10 +53,20 @@ export async function fetchSupportCheckIn(
   return siteStatus !== undefined
 }
 
-const fetchWongTokenSecretKeyById = (
+const fetchWongTokenSecretKeyById = async (
   request: ApiServiceRequest,
   tokenId: number,
-) => fetchTokenSecretKeyByIdWithMethod(request, tokenId, "GET")
+) => {
+  const response = await newApiFamilyRequests.data<{ key?: string }>(request, {
+    // Observed canonical deployment contract; downstream forks may differ.
+    // https://wzw.pp.ua/assets/index-JGp5IMg4.js
+    endpoint: `/api/token/${tokenId}/key`,
+    options: { method: "GET" },
+  })
+  const key = normalizeApiTokenKeyValue(response?.key ?? "")
+  if (!key) throw new Error("token_secret_key_missing")
+  return key
+}
 
 const normalizeMessage = (message: unknown): string =>
   typeof message === "string" ? message : ""
@@ -90,17 +98,15 @@ export async function fetchCheckInStatus(
       : request
 
   try {
-    const response = await fetchApi<WongCheckinStatusData | undefined>(
-      normalizedRequest,
-      {
-        endpoint: ENDPOINT,
-        options: {
-          method: "GET",
-          cache: "no-store",
-        },
+    const response = await newApiFamilyRequests.envelope<
+      WongCheckinStatusData | undefined
+    >(normalizedRequest, {
+      endpoint: ENDPOINT,
+      options: {
+        method: "GET",
+        cache: "no-store",
       },
-      false,
-    )
+    })
 
     if (response.data?.enabled === false) {
       return undefined

--- a/src/services/apiService/openrouter/index.ts
+++ b/src/services/apiService/openrouter/index.ts
@@ -8,7 +8,6 @@ import { determineHealthStatus } from "~/services/accounts/accountHealth"
 import { createUnsupportedTodayStatsAvailability } from "~/services/accounts/accountTodayStats"
 import { OPENROUTER_API_BASE_URL } from "~/services/accountSiteDefinitions/identifiers"
 import { ApiError } from "~/services/apiTransport/errors"
-import { fetchApiData } from "~/services/apiTransport/request"
 import type { ApiServiceRequest } from "~/services/apiTransport/type"
 import { AuthTypeEnum, SiteHealthStatus, type AccountIdentity } from "~/types"
 import { createLogger } from "~/utils/core/logger"
@@ -19,7 +18,10 @@ import {
   OPENROUTER_KEY_ENDPOINT,
 } from "./constants"
 import { OpenRouterManagementKeyRequiredError } from "./errors"
-import { createOpenRouterManagementRequest } from "./request"
+import {
+  createOpenRouterManagementRequest,
+  openRouterRequests,
+} from "./request"
 
 export * from "./keyManagement"
 export * from "./keyManagementSchemas"
@@ -99,7 +101,7 @@ export async function validateManagementKey(
 ): Promise<OpenRouterManagementKeyValidation> {
   const request = createCredentialRequest(input)
 
-  const data = await fetchApiData<OpenRouterKeyData>(request, {
+  const data = await openRouterRequests.data<OpenRouterKeyData>(request, {
     endpoint: OPENROUTER_KEY_ENDPOINT,
     options: { method: "GET", cache: "no-store" },
     tempWindowFallback: { statusCodes: [], codes: [] },
@@ -129,11 +131,14 @@ const fetchCredits = async (
 ): Promise<OpenRouterCreditsData> => {
   const canonicalRequest = createAccountRequest(request)
 
-  return await fetchApiData<OpenRouterCreditsData>(canonicalRequest, {
-    endpoint: OPENROUTER_CREDITS_ENDPOINT,
-    options: { method: "GET", cache: "no-store" },
-    tempWindowFallback: { statusCodes: [], codes: [] },
-  })
+  return await openRouterRequests.data<OpenRouterCreditsData>(
+    canonicalRequest,
+    {
+      endpoint: OPENROUTER_CREDITS_ENDPOINT,
+      options: { method: "GET", cache: "no-store" },
+      tempWindowFallback: { statusCodes: [], codes: [] },
+    },
+  )
 }
 
 const normalizeCredits = (

--- a/src/services/apiService/openrouter/request.ts
+++ b/src/services/apiService/openrouter/request.ts
@@ -1,8 +1,15 @@
 import { OPENROUTER_API_BASE_URL } from "~/services/accountSiteDefinitions/identifiers"
+import { createProviderJsonRequests } from "~/services/apiService/common/providerRequest"
 import type { ApiServiceRequest } from "~/services/apiTransport/type"
 import { AuthTypeEnum } from "~/types"
 
 import { OpenRouterManagementKeyRequiredError } from "./errors"
+import { decodeOpenRouterResponseError } from "./responseError"
+
+/** OpenRouter JSON requests with provider-owned HTTP error decoding. */
+export const openRouterRequests = createProviderJsonRequests(
+  decodeOpenRouterResponseError,
+)
 
 /**
  * OpenRouter Management API keys use `Authorization: Bearer <management-key>`.

--- a/src/services/apiService/openrouter/responseError.ts
+++ b/src/services/apiService/openrouter/responseError.ts
@@ -1,0 +1,43 @@
+import { readSafeUpstreamCode } from "~/services/apiTransport/responseError"
+import type { ApiResponseErrorDecoder } from "~/services/apiTransport/type"
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+/** Reads the documented nested OpenRouter error without applying disclosure policy. */
+function readOpenRouterErrorDetails(
+  body: unknown,
+): { message: string; upstreamCode?: string } | null {
+  if (!isRecord(body) || !isRecord(body.error)) return null
+  const error = body.error
+  const message =
+    typeof error.message === "string" && error.message.trim()
+      ? error.message.trim()
+      : undefined
+  const upstreamCode = Number.isInteger(error.code)
+    ? readSafeUpstreamCode(error.code)
+    : undefined
+  if (!message) return null
+
+  return {
+    message,
+    ...(upstreamCode ? { upstreamCode } : {}),
+  }
+}
+
+/**
+ * Decodes OpenRouter's documented non-2xx `{ error: { code, message } }` body.
+ * https://github.com/OpenRouterTeam/docs/blob/d369fe0d5bfc87cb9f78326b18bbbd19964406fd/openapi/openapi.yaml#L25293-L25332
+ */
+export const decodeOpenRouterResponseError: ApiResponseErrorDecoder = (
+  response,
+) => {
+  if (response.ok) return null
+  const details = readOpenRouterErrorDetails(response.body)
+  if (!details) return null
+
+  return {
+    kind: "http",
+    ...details,
+  }
+}

--- a/src/services/apiService/veloera/index.ts
+++ b/src/services/apiService/veloera/index.ts
@@ -2,7 +2,6 @@ import type { ManagedSitePaginatedChannelRequestOptions } from "~/services/apiAd
 import { REQUEST_CONFIG } from "~/services/apiTransport/constant"
 import { ApiError } from "~/services/apiTransport/errors"
 import { fetchAllItems } from "~/services/apiTransport/pagination"
-import { fetchApi, fetchApiData } from "~/services/apiTransport/request"
 import type { ApiServiceRequest } from "~/services/apiTransport/type"
 import type {
   CreateChannelPayload,
@@ -10,7 +9,10 @@ import type {
   ManagedSiteChannelListData,
   UpdateChannelPayload,
 } from "~/types/managedSite"
+import { getErrorMessage } from "~/utils/core/error"
 import { createLogger } from "~/utils/core/logger"
+
+import { veloeraRequests } from "./request"
 
 export {
   fetchAccountData,
@@ -25,6 +27,16 @@ export {
 const logger = createLogger("ApiService.Veloera")
 
 const VELOERA_CHANNEL_ENDPOINT = "/api/channel"
+
+const wrapChannelMutationError = (error: unknown, fallback: string) =>
+  new ApiError(
+    getErrorMessage(error, fallback),
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    error,
+  )
 
 type VeloeraChannelInfo = {
   is_multi_key?: boolean
@@ -133,7 +145,7 @@ export async function createChannel(
       group: (groups ?? []).join(","),
     }
 
-    return await fetchApi<void>(request, {
+    return await veloeraRequests.envelope<void>(request, {
       endpoint: VELOERA_CHANNEL_ENDPOINT,
       options: {
         method: "POST",
@@ -142,13 +154,9 @@ export async function createChannel(
     })
   } catch (error) {
     logger.error("Failed to create channel")
-    throw new ApiError(
-      "创建渠道失败，请检查网络或 Veloera 配置",
-      undefined,
-      undefined,
-      undefined,
-      undefined,
+    throw wrapChannelMutationError(
       error,
+      "创建渠道失败，请检查网络或 Veloera 配置",
     )
   }
 }
@@ -170,7 +178,7 @@ export async function updateChannel(
       group: rest.group ?? (groups ?? []).join(","),
     }
 
-    return await fetchApi<void>(request, {
+    return await veloeraRequests.envelope<void>(request, {
       endpoint: VELOERA_CHANNEL_ENDPOINT,
       options: {
         method: "PUT",
@@ -179,13 +187,9 @@ export async function updateChannel(
     })
   } catch (error) {
     logger.error("Failed to update channel")
-    throw new ApiError(
-      "更新渠道失败，请检查网络或 Veloera 配置",
-      undefined,
-      undefined,
-      undefined,
-      undefined,
+    throw wrapChannelMutationError(
       error,
+      "更新渠道失败，请检查网络或 Veloera 配置",
     )
   }
 }
@@ -198,7 +202,7 @@ export async function deleteChannel(
   channelId: number,
 ) {
   try {
-    return await fetchApi<void>(request, {
+    return await veloeraRequests.envelope<void>(request, {
       endpoint: `${VELOERA_CHANNEL_ENDPOINT}/${channelId}`,
       options: {
         method: "DELETE",
@@ -206,13 +210,9 @@ export async function deleteChannel(
     })
   } catch (error) {
     logger.error("Failed to delete channel")
-    throw new ApiError(
-      "删除渠道失败，请检查网络或 Veloera 配置",
-      undefined,
-      undefined,
-      undefined,
-      undefined,
+    throw wrapChannelMutationError(
       error,
+      "删除渠道失败，请检查网络或 Veloera 配置",
     )
   }
 }
@@ -236,7 +236,7 @@ export async function listAllChannels(
       await beforeRequest?.()
 
       const endpoint = `/api/channel/?p=${page}&page_size=${pageSize}`
-      const data = await fetchApiData<unknown>(request, {
+      const data = await veloeraRequests.data<unknown>(request, {
         endpoint,
         options: { signal: options?.signal },
       })
@@ -290,7 +290,7 @@ export async function searchChannel(
 ): Promise<ManagedSiteChannelListData | null> {
   try {
     const endpoint = `/api/channel/search?keyword=${encodeURIComponent(keyword)}`
-    const data = await fetchApiData<unknown>(request, { endpoint })
+    const data = await veloeraRequests.data<unknown>(request, { endpoint })
 
     const rawItems: VeloeraChannelRaw[] | null = Array.isArray(data)
       ? (data as VeloeraChannelRaw[])
@@ -329,7 +329,7 @@ export async function fetchChannel(
   channelId: number,
 ): Promise<ManagedSiteChannel> {
   const endpoint = `${VELOERA_CHANNEL_ENDPOINT}/${channelId}`
-  const result = await fetchApiData<unknown>(request, { endpoint })
+  const result = await veloeraRequests.data<unknown>(request, { endpoint })
 
   return normalizeChannel(result as VeloeraChannelRaw)
 }
@@ -346,18 +346,14 @@ export async function fetchChannelModels(
   options?: Pick<RequestInit, "signal">,
 ): Promise<string[]> {
   const endpoint = `${VELOERA_CHANNEL_ENDPOINT}/fetch_models/${channelId}`
-  const response = await fetchApi<string[]>(
-    request,
-    {
-      endpoint,
-      options,
-    },
-    false,
-  )
+  const response = await veloeraRequests.envelope<string[]>(request, {
+    endpoint,
+    options,
+  })
 
   if (!response.success || !Array.isArray(response.data)) {
     throw new ApiError(
-      response.message || "Failed to fetch models",
+      getErrorMessage(response.message, "Failed to fetch models"),
       undefined,
       endpoint,
     )
@@ -375,25 +371,21 @@ export async function updateChannelModels(
   models: string,
   options?: Pick<RequestInit, "signal">,
 ): Promise<void> {
-  const response = await fetchApi<void>(
-    request,
-    {
-      endpoint: VELOERA_CHANNEL_ENDPOINT,
-      options: {
-        method: "PUT",
-        body: JSON.stringify({
-          id: channelId,
-          models,
-        } satisfies UpdateChannelPayload),
-        signal: options?.signal,
-      },
+  const response = await veloeraRequests.envelope<void>(request, {
+    endpoint: VELOERA_CHANNEL_ENDPOINT,
+    options: {
+      method: "PUT",
+      body: JSON.stringify({
+        id: channelId,
+        models,
+      } satisfies UpdateChannelPayload),
+      signal: options?.signal,
     },
-    false,
-  )
+  })
 
   if (!response.success) {
     throw new ApiError(
-      response.message || "Failed to update channel",
+      getErrorMessage(response.message, "Failed to update channel"),
       undefined,
       VELOERA_CHANNEL_ENDPOINT,
     )
@@ -410,26 +402,22 @@ export async function updateChannelModelMapping(
   modelMappingJson: string,
   options?: Pick<RequestInit, "signal">,
 ): Promise<void> {
-  const response = await fetchApi<void>(
-    request,
-    {
-      endpoint: VELOERA_CHANNEL_ENDPOINT,
-      options: {
-        method: "PUT",
-        body: JSON.stringify({
-          id: channelId,
-          models,
-          model_mapping: modelMappingJson,
-        } satisfies UpdateChannelPayload),
-        signal: options?.signal,
-      },
+  const response = await veloeraRequests.envelope<void>(request, {
+    endpoint: VELOERA_CHANNEL_ENDPOINT,
+    options: {
+      method: "PUT",
+      body: JSON.stringify({
+        id: channelId,
+        models,
+        model_mapping: modelMappingJson,
+      } satisfies UpdateChannelPayload),
+      signal: options?.signal,
     },
-    false,
-  )
+  })
 
   if (!response.success) {
     throw new ApiError(
-      response.message || "Failed to update channel mapping",
+      getErrorMessage(response.message, "Failed to update channel mapping"),
       undefined,
       VELOERA_CHANNEL_ENDPOINT,
     )

--- a/src/services/apiService/veloera/request.ts
+++ b/src/services/apiService/veloera/request.ts
@@ -1,0 +1,8 @@
+import { createProviderJsonRequests } from "~/services/apiService/common/providerRequest"
+
+import { decodeVeloeraResponseError } from "./responseError"
+
+/** Veloera JSON requests with provider-owned response decoding. */
+export const veloeraRequests = createProviderJsonRequests(
+  decodeVeloeraResponseError,
+)

--- a/src/services/apiService/veloera/responseError.ts
+++ b/src/services/apiService/veloera/responseError.ts
@@ -1,0 +1,16 @@
+import { createMessageEnvelopeResponseErrorDecoder } from "~/services/apiService/common/responseError"
+
+/**
+ * Owns Veloera's channel-management `{ success, message }` failure envelope.
+ * It also recognizes the provider's global nested panic response as HTTP failure.
+ * https://github.com/Veloera/Veloera/blob/6525dfce816beaa270e78f0d8b762e19e54d13b8/controller/channel.go#L351-L452
+ * https://github.com/Veloera/Veloera/blob/6525dfce816beaa270e78f0d8b762e19e54d13b8/main.go#L159-L169
+ */
+export const decodeVeloeraResponseError =
+  createMessageEnvelopeResponseErrorDecoder({
+    isBusinessEnvelope: (body) => body.success === false,
+    nestedError: {
+      type: "veloera_panic",
+      kind: "http",
+    },
+  })

--- a/src/services/apiTransport/compatibilityResponse.ts
+++ b/src/services/apiTransport/compatibilityResponse.ts
@@ -100,7 +100,10 @@ function createCompatibilityHttpError(
   }
 
   const message =
-    decoded?.message && (decoded.kind === "business" || response.status !== 403)
+    decoded?.message &&
+    (context.errorResponseDecoder ||
+      decoded.kind === "business" ||
+      response.status !== 403)
       ? decoded.message
       : fixedFallback
 

--- a/src/services/checkin/autoCheckin/providers/anyrouter.ts
+++ b/src/services/checkin/autoCheckin/providers/anyrouter.ts
@@ -1,5 +1,5 @@
 import { CHECK_IN_PROVIDER_READINESS_REASONS } from "~/constants/checkIn"
-import { fetchApi } from "~/services/apiService/newApiFamily/request"
+import { newApiFamilyRequests } from "~/services/apiService/newApiFamily/request"
 import {
   AUTO_CHECKIN_PROVIDER_FALLBACK_MESSAGE_KEYS,
   isAlreadyCheckedMessage,
@@ -44,37 +44,37 @@ const checkinAnyRouter = async (
     : account.cookieAuthSessionCookie
 
   try {
-    const response = await fetchApi<AnyrouterCheckInResponse>(
-      {
-        baseUrl: site_url,
-        ...(account.id ? { accountId: account.id } : {}),
-        ...(cookieAuthSessionCookie ? { cookieAuthSessionCookie } : {}),
-        auth: {
-          authType: AuthTypeEnum.Cookie,
-          userId: account_info.id,
+    const response =
+      await newApiFamilyRequests.payload<AnyrouterCheckInResponse>(
+        {
+          baseUrl: site_url,
+          ...(account.id ? { accountId: account.id } : {}),
+          ...(cookieAuthSessionCookie ? { cookieAuthSessionCookie } : {}),
+          auth: {
+            authType: AuthTypeEnum.Cookie,
+            userId: account_info.id,
+          },
+          tempWindowRequestSource,
+          // AnyRouter's sign-in POST relies on browser-established WAF cookies;
+          // see https://github.com/millylee/anyrouter-check-in.
+          // Keep it in one protected context instead of replaying a mutating request.
+          forceTempWindow: true,
+          ...(protectionBypassExecution ? { protectionBypassExecution } : {}),
+          ...(context.mutationLifecycle
+            ? { observer: context.mutationLifecycle }
+            : {}),
         },
-        tempWindowRequestSource,
-        // AnyRouter's sign-in POST relies on browser-established WAF cookies;
-        // see https://github.com/millylee/anyrouter-check-in.
-        // Keep it in one protected context instead of replaying a mutating request.
-        forceTempWindow: true,
-        ...(protectionBypassExecution ? { protectionBypassExecution } : {}),
-        ...(context.mutationLifecycle
-          ? { observer: context.mutationLifecycle }
-          : {}),
-      },
-      {
-        endpoint: "/api/user/sign_in",
-        options: {
-          method: "POST",
-          body: "{}",
-          headers: {
-            "X-Requested-With": "XMLHttpRequest",
+        {
+          endpoint: "/api/user/sign_in",
+          options: {
+            method: "POST",
+            body: "{}",
+            headers: {
+              "X-Requested-With": "XMLHttpRequest",
+            },
           },
         },
-      },
-      true,
-    )
+      )
 
     const rawResponseMessage = normalizeCheckinMessage(
       response.message ?? response.msg,

--- a/src/services/checkin/autoCheckin/providers/newApi.ts
+++ b/src/services/checkin/autoCheckin/providers/newApi.ts
@@ -17,10 +17,7 @@ import type {
   NewApiCheckInStatus,
 } from "~/services/apiService/newApiFamily/checkInDto"
 import { fetchSupportCheckIn } from "~/services/apiService/newApiFamily/default/accountBootstrap"
-import {
-  fetchApi,
-  fetchApiData,
-} from "~/services/apiService/newApiFamily/request"
+import { newApiFamilyRequests } from "~/services/apiService/newApiFamily/request"
 import { buildCompatUserIdHeaders } from "~/services/apiTransport/compatHeaders"
 import { REQUEST_CONFIG } from "~/services/apiTransport/constant"
 import { ApiError } from "~/services/apiTransport/errors"
@@ -342,10 +339,13 @@ async function fetchCheckedInTodayStatus(
   if (!request) return undefined
 
   try {
-    const checkInData = await fetchApiData<NewApiCheckInStatus>(request, {
-      endpoint: `${ENDPOINT}?month=${currentMonth}`,
-      ...(signal ? { options: { signal } } : {}),
-    })
+    const checkInData = await newApiFamilyRequests.data<NewApiCheckInStatus>(
+      request,
+      {
+        endpoint: `${ENDPOINT}?month=${currentMonth}`,
+        ...(signal ? { options: { signal } } : {}),
+      },
+    )
 
     if (
       typeof checkInData?.stats?.checked_in_today === "boolean" &&
@@ -902,7 +902,7 @@ async function performCheckin(
   protectionBypassExecution: ProtectionBypassExecution,
   mutationLifecycle?: AutoCheckinProviderContext["mutationLifecycle"],
 ): Promise<NewApiCheckInResponse> {
-  return await fetchApi<NewApiCheckInRecord>(
+  return await newApiFamilyRequests.envelope<NewApiCheckInRecord>(
     createCheckInRequest(
       account,
       tempWindowRequestSource,
@@ -916,7 +916,6 @@ async function performCheckin(
         body: "{}",
       },
     },
-    false,
   )
 }
 

--- a/src/services/checkin/autoCheckin/providers/veloera.ts
+++ b/src/services/checkin/autoCheckin/providers/veloera.ts
@@ -11,10 +11,7 @@ import {
   CHECK_IN_METHOD_TODAY_STATUSES,
   CHECK_IN_PROVIDER_READINESS_REASONS,
 } from "~/constants/checkIn"
-import {
-  fetchApi,
-  fetchApiData,
-} from "~/services/apiService/newApiFamily/request"
+import { newApiFamilyRequests } from "~/services/apiService/newApiFamily/request"
 import { fetchSupportCheckIn } from "~/services/apiService/newApiFamily/variants/veloeraCheckIn"
 import type { ApiServiceRequest } from "~/services/apiTransport/type"
 import {
@@ -78,10 +75,13 @@ async function fetchCheckInObservation(
   const enabled = await fetchSupportCheckIn(request, signal)
   if (enabled === false) return { enabled }
 
-  const data = await fetchApiData<{ can_check_in?: boolean }>(request, {
-    endpoint: "/api/user/check_in_status",
-    ...(signal ? { options: { signal } } : {}),
-  })
+  const data = await newApiFamilyRequests.data<{ can_check_in?: boolean }>(
+    request,
+    {
+      endpoint: "/api/user/check_in_status",
+      ...(signal ? { options: { signal } } : {}),
+    },
+  )
   if (typeof data.can_check_in === "boolean") {
     return { enabled, canCheckIn: data.can_check_in }
   }
@@ -110,7 +110,7 @@ async function checkinVeloera(
 
   try {
     // Call the check-in API endpoint
-    const response = await fetchApi<unknown>(request, {
+    const response = await newApiFamilyRequests.envelope<unknown>(request, {
       endpoint: ENDPOINT,
       options: { method: "POST" },
     })

--- a/src/services/checkin/autoCheckin/providers/wong.ts
+++ b/src/services/checkin/autoCheckin/providers/wong.ts
@@ -15,7 +15,7 @@ import {
   CHECK_IN_METHOD_TODAY_STATUSES,
   CHECK_IN_PROVIDER_READINESS_REASONS,
 } from "~/constants/checkIn"
-import { fetchApi } from "~/services/apiService/newApiFamily/request"
+import { newApiFamilyRequests } from "~/services/apiService/newApiFamily/request"
 import type {
   WongCheckinApiResponse,
   WongCheckinStatusData,
@@ -62,7 +62,7 @@ async function performCheckin(
 ): Promise<WongCheckinApiResponse> {
   const { site_url, account_info } = account
 
-  return await fetchApi<WongCheckinStatusData | undefined>(
+  return await newApiFamilyRequests.envelope<WongCheckinStatusData | undefined>(
     {
       baseUrl: site_url,
       accountId: account.id,
@@ -83,7 +83,6 @@ async function performCheckin(
         body: "{}",
       },
     },
-    false,
   )
 }
 
@@ -210,14 +209,12 @@ const getStatus: NonNullable<AutoCheckinProvider["getStatus"]> = async ({
         }
       : undefined)
   if (!statusRequest) return undefined
-  const response = await fetchApi<WongCheckinStatusData | undefined>(
-    statusRequest,
-    {
-      endpoint: ENDPOINT,
-      options: { method: "GET", cache: "no-store", signal },
-    },
-    false,
-  )
+  const response = await newApiFamilyRequests.envelope<
+    WongCheckinStatusData | undefined
+  >(statusRequest, {
+    endpoint: ENDPOINT,
+    options: { method: "GET", cache: "no-store", signal },
+  })
   if (
     typeof response.data?.enabled !== "boolean" ||
     typeof response.data.checked_in !== "boolean" ||

--- a/src/services/managedSites/providers/newApiSession.ts
+++ b/src/services/managedSites/providers/newApiSession.ts
@@ -4,10 +4,7 @@ import {
   parseNewApiDashboardAuthBundleResponse,
   type NewApiDashboardAuthBundle,
 } from "~/services/apiService/newApi/dashboardAuth"
-import {
-  fetchApi,
-  fetchApiData,
-} from "~/services/apiService/newApiFamily/request"
+import { newApiFamilyRequests } from "~/services/apiService/newApiFamily/request"
 import { runAbortableTask } from "~/services/apiTransport/abortableTask"
 import { API_ERROR_CODES, ApiError } from "~/services/apiTransport/errors"
 import { fetchApiResponse } from "~/services/apiTransport/request"
@@ -713,10 +710,10 @@ async function readNewApiVerificationMethods(
   state.methodsPromise = (async () => {
     const request = createManagedSessionRequest(baseUrl, userId)
     const results = await Promise.allSettled([
-      fetchApiData<NewApiTwoFactorStatusResponse>(request, {
+      newApiFamilyRequests.data<NewApiTwoFactorStatusResponse>(request, {
         endpoint: "/api/user/2fa/status",
       }),
-      fetchApiData<NewApiPasskeyStatusResponse>(request, {
+      newApiFamilyRequests.data<NewApiPasskeyStatusResponse>(request, {
         endpoint: "/api/user/passkey",
       }),
     ])
@@ -827,16 +824,19 @@ async function postNewApiLogin(
   await cleanupNewApiOwnedSession(config.baseUrl)
 
   const request = createCookieAuthRequest(config.baseUrl, config.userId)
-  const response = await fetchApi<NewApiLoginResponse>(request, {
-    endpoint: "/api/user/login",
-    options: {
-      method: "POST",
-      body: JSON.stringify({
-        username: config.username?.trim(),
-        password: config.password ?? "",
-      }),
+  const response = await newApiFamilyRequests.envelope<NewApiLoginResponse>(
+    request,
+    {
+      endpoint: "/api/user/login",
+      options: {
+        method: "POST",
+        body: JSON.stringify({
+          username: config.username?.trim(),
+          password: config.password ?? "",
+        }),
+      },
     },
-  })
+  )
 
   if (!isRecord(response)) {
     throw new ApiError(
@@ -970,13 +970,16 @@ async function verifyNewApiSession(
       : params
     let response: NewApiVerifyResponse
     try {
-      response = await fetchApiData<NewApiVerifyResponse>(request, {
-        endpoint: "/api/verify",
-        options: {
-          method: "POST",
-          body: JSON.stringify(requestParams),
+      response = await newApiFamilyRequests.data<NewApiVerifyResponse>(
+        request,
+        {
+          endpoint: "/api/verify",
+          options: {
+            method: "POST",
+            body: JSON.stringify(requestParams),
+          },
         },
-      })
+      )
     } catch (error) {
       throw sanitizeNewApiErrorForOrigin(error, config.baseUrl)
     }
@@ -1159,7 +1162,7 @@ export async function submitNewApiLoginTwoFactorCode(
   const request = createCookieAuthRequest(config.baseUrl, config.userId)
   let response
   try {
-    response = await fetchApi<unknown>(request, {
+    response = await newApiFamilyRequests.envelope<unknown>(request, {
       endpoint: "/api/user/login/2fa",
       options: {
         method: "POST",
@@ -1306,21 +1309,24 @@ export async function fetchNewApiChannelKey(params: {
       : undefined
     let response: { key?: string } | string
     try {
-      response = await fetchApiData<{ key?: string } | string>(sessionRequest, {
-        endpoint,
-        options: {
-          method: "POST",
-          body: JSON.stringify({}),
-          ...(securityProof
-            ? {
-                // Modern New API channel-key routes validate this scoped proof
-                // separately from the dashboard Bearer.
-                // https://github.com/QuantumNous/new-api/commit/31d70fca393ff2e09bbae012af2e3ccefdd389a1
-                headers: { "X-Security-Proof": securityProof.token },
-              }
-            : {}),
+      response = await newApiFamilyRequests.data<{ key?: string } | string>(
+        sessionRequest,
+        {
+          endpoint,
+          options: {
+            method: "POST",
+            body: JSON.stringify({}),
+            ...(securityProof
+              ? {
+                  // Modern New API channel-key routes validate this scoped proof
+                  // separately from the dashboard Bearer.
+                  // https://github.com/QuantumNous/new-api/commit/31d70fca393ff2e09bbae012af2e3ccefdd389a1
+                  headers: { "X-Security-Proof": securityProof.token },
+                }
+              : {}),
+          },
         },
-      })
+      )
     } catch (error) {
       const protectionBypassExecution = params.protectionBypassExecution
       if (

--- a/src/services/siteDetection/detectSiteType.ts
+++ b/src/services/siteDetection/detectSiteType.ts
@@ -4,7 +4,7 @@ import {
   getAccountSiteDomainRules,
   getAccountSiteTitleRules,
 } from "~/services/accountSiteOnboarding/registry"
-import { fetchApiData as fetchNewApiFamilyData } from "~/services/apiService/newApiFamily/request"
+import { newApiFamilyRequests } from "~/services/apiService/newApiFamily/request"
 import { SUB2API_AUTH_ME_ENDPOINT } from "~/services/apiService/sub2api/type"
 import { ApiError } from "~/services/apiTransport/errors"
 import { fetchApi } from "~/services/apiTransport/request"
@@ -128,7 +128,7 @@ async function detectNewApiFamilySiteTypeFromCompatAuthError(
   protectionBypassExecution?: ProtectionBypassExecution,
 ): Promise<AccountSiteType> {
   try {
-    await fetchNewApiFamilyData<unknown>(
+    await newApiFamilyRequests.data<unknown>(
       {
         baseUrl: url,
         auth: { authType: AuthTypeEnum.Cookie },

--- a/tests/services/accountTokens/tokenKeyResolver.test.ts
+++ b/tests/services/accountTokens/tokenKeyResolver.test.ts
@@ -10,18 +10,18 @@ import {
   normalizeApiTokenKeyValue,
 } from "~/services/accountTokens/apiTokenKey"
 import {
-  fetchTokenSecretKeyById,
-  fetchTokenSecretKeyByIdWithMethod,
   invalidateResolvedApiTokenKeyCache,
-  resolveApiTokenKey,
   resolveApiTokenKeyWithFetcher,
   syncResolvedApiTokenKeyCache,
 } from "~/services/accountTokens/tokenKeyResolver"
-import { fetchApiData } from "~/services/apiTransport/request"
+import {
+  fetchTokenSecretKeyById,
+  resolveApiTokenKey,
+} from "~/services/apiService/newApiFamily/default/tokenKeyResolver"
+import { newApiFamilyRequests } from "~/services/apiService/newApiFamily/request"
 import { AuthTypeEnum } from "~/types"
 
-const { mockFetchApi, mockFetchApiData } = vi.hoisted(() => ({
-  mockFetchApi: vi.fn(),
+const { mockFetchApiData } = vi.hoisted(() => ({
   mockFetchApiData: vi.fn(),
 }))
 
@@ -29,18 +29,20 @@ vi.mock("~/constants/ui", () => ({
   UI_CONSTANTS: {},
 }))
 
-vi.mock("~/services/apiTransport/request", () => ({
-  fetchApi: mockFetchApi,
-  fetchApiData: mockFetchApiData,
+vi.mock("~/services/apiService/newApiFamily/request", () => ({
+  newApiFamilyRequests: {
+    data: mockFetchApiData,
+  },
 }))
 
-const mockedFetchApiData = fetchApiData as unknown as ReturnType<typeof vi.fn>
+const mockedFetchApiData = newApiFamilyRequests.data as unknown as ReturnType<
+  typeof vi.fn
+>
 
 describe("token key resolver", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockedFetchApiData.mockReset()
-    mockFetchApi.mockReset()
   })
 
   it("normalizeApiTokenKeyValue trims whitespace without adding sk- prefixes", () => {
@@ -142,31 +144,6 @@ describe("token key resolver", () => {
       },
     })
     expect(result).toBe("resolved-secret")
-  })
-
-  it("fetchTokenSecretKeyByIdWithMethod uses the caller-provided HTTP method", async () => {
-    mockedFetchApiData.mockResolvedValueOnce({ key: "resolved-via-get" })
-
-    const request = {
-      baseUrl: "https://example.com",
-      accountId: "account-get-secret",
-      auth: {
-        authType: AuthTypeEnum.AccessToken,
-        userId: "1",
-        accessToken: "token",
-      },
-    }
-
-    await expect(
-      fetchTokenSecretKeyByIdWithMethod(request as any, 70, "GET"),
-    ).resolves.toBe("resolved-via-get")
-
-    expect(mockedFetchApiData).toHaveBeenCalledWith(request, {
-      endpoint: "/api/token/70/key",
-      options: {
-        method: "GET",
-      },
-    })
   })
 
   it("resolveApiTokenKey passes through legacy full keys without an extra fetch", async () => {

--- a/tests/services/apiAdapters/managedSites/doneHub.test.ts
+++ b/tests/services/apiAdapters/managedSites/doneHub.test.ts
@@ -297,6 +297,28 @@ describe("DoneHub managed-site channel capability", () => {
     ).rejects.toBe(responseError)
   })
 
+  it("uses fixed diagnostic copy when a DoneHub rejection message is blank", async () => {
+    const rejectionResponse = { success: false, data: null, message: "   " }
+    doneHubApi.createChannel.mockImplementationOnce(async (request) => {
+      request.observer?.onDispatch()
+      request.observer?.onResponse()
+      return rejectionResponse
+    })
+    const { doneHubManagedSiteChannels } = await import(
+      "~/services/apiAdapters/managedSites/doneHub"
+    )
+
+    await expect(
+      doneHubManagedSiteChannels.create(config, createPayload),
+    ).resolves.toEqual({
+      outcome: "rejected",
+      diagnostic: {
+        message: "Provider rejected the mutation",
+        raw: rejectionResponse,
+      },
+    })
+  })
+
   const resourceDraft: ChannelFormData = {
     name: "Resource channel",
     type: 1,

--- a/tests/services/apiAdapters/managedSites/veloera.test.ts
+++ b/tests/services/apiAdapters/managedSites/veloera.test.ts
@@ -323,6 +323,28 @@ describe("Veloera managed-site channel capability", () => {
     })
   })
 
+  it("uses fixed diagnostic copy when a Veloera rejection message is blank", async () => {
+    const rejectionResponse = { success: false, data: null, message: "   " }
+    veloeraApi.createChannel.mockImplementationOnce(async (request) => {
+      request.observer?.onDispatch()
+      request.observer?.onResponse()
+      return rejectionResponse
+    })
+    const { veloeraManagedSiteChannels } = await import(
+      "~/services/apiAdapters/managedSites/veloera"
+    )
+
+    await expect(
+      veloeraManagedSiteChannels.create(config, createPayload),
+    ).resolves.toEqual({
+      outcome: "rejected",
+      diagnostic: {
+        message: "Provider rejected the mutation",
+        raw: rejectionResponse,
+      },
+    })
+  })
+
   const resourceDraft: ChannelFormData = {
     name: "Resource channel",
     type: 1,

--- a/tests/services/apiService/doneHub/channelApi.test.ts
+++ b/tests/services/apiService/doneHub/channelApi.test.ts
@@ -55,9 +55,11 @@ const {
   mockFetchTodayUsage: vi.fn(),
 }))
 
-vi.mock("~/services/apiTransport/request", () => ({
-  fetchApiData: mockFetchApiData,
-  fetchApi: mockFetchApi,
+vi.mock("~/services/apiService/doneHub/request", () => ({
+  doneHubRequests: {
+    data: mockFetchApiData,
+    envelope: mockFetchApi,
+  },
 }))
 
 vi.mock("~/services/accounts/accountHealth", () => ({
@@ -430,7 +432,7 @@ describe("apiService doneHub channel APIs", () => {
           status: 1 as any,
         },
       }),
-    ).rejects.toThrow("创建渠道失败，请检查网络或 Done Hub 配置。")
+    ).rejects.toThrow("request failed")
   })
 
   it("updateChannel should put flat payload with group string", async () => {
@@ -512,7 +514,7 @@ describe("apiService doneHub channel APIs", () => {
         models: "gpt-4",
         groups: ["default"],
       }),
-    ).rejects.toThrow("更新渠道失败，请检查网络或 Done Hub 配置。")
+    ).rejects.toThrow("request failed")
   })
 
   it("deleteChannel should issue a DELETE request and wrap failures", async () => {
@@ -545,7 +547,7 @@ describe("apiService doneHub channel APIs", () => {
     )
 
     await expect(deleteChannel(request as any, 100)).rejects.toThrow(
-      "删除渠道失败，请检查网络或 Done Hub 配置。",
+      "request failed",
     )
   })
 
@@ -557,7 +559,6 @@ describe("apiService doneHub channel APIs", () => {
           mode: "none" as any,
           channel: { groups: ["default"] } as any,
         }),
-      message: "创建渠道失败，请检查网络或 Done Hub 配置。",
     },
     {
       operation: "update",
@@ -567,16 +568,14 @@ describe("apiService doneHub channel APIs", () => {
           name: "Updated",
           groups: ["default"],
         }),
-      message: "更新渠道失败，请检查网络或 Done Hub 配置。",
     },
     {
       operation: "delete",
       invoke: (request: any) => deleteChannel(request, 1),
-      message: "删除渠道失败，请检查网络或 Done Hub 配置。",
     },
   ])(
     "$operation mutation preserves ApiError details as cause without logging it",
-    async ({ invoke, message }) => {
+    async ({ invoke }) => {
       const request = {
         baseUrl: "https://example.com",
         auth: {
@@ -590,20 +589,64 @@ describe("apiService doneHub channel APIs", () => {
         504,
         "/api/channel/",
         API_ERROR_CODES.HTTP_OTHER,
+        "provider_limit",
       )
       mockFetchApi.mockRejectedValueOnce(cause)
 
       const error = await invoke(request).catch((caught) => caught)
 
       expect(error).toMatchObject({
-        message,
+        message: "upstream denied",
         statusCode: 504,
         endpoint: "/api/channel/",
         code: API_ERROR_CODES.HTTP_OTHER,
+        upstreamCode: "provider_limit",
         cause,
       })
       expect(mockLoggerError).toHaveBeenCalledWith(expect.any(String))
       expect(mockLoggerError.mock.calls.flat()).not.toContain(cause)
+    },
+  )
+
+  it.each([
+    {
+      operation: "create",
+      message: "创建渠道失败，请检查网络或 Done Hub 配置。",
+      invoke: (request: any) =>
+        createChannel(request, {
+          mode: "none" as any,
+          channel: { groups: ["default"] } as any,
+        }),
+    },
+    {
+      operation: "update",
+      message: "更新渠道失败，请检查网络或 Done Hub 配置。",
+      invoke: (request: any) =>
+        updateChannel(request, {
+          id: 1,
+          name: "Updated",
+          groups: ["default"],
+        }),
+    },
+    {
+      operation: "delete",
+      message: "删除渠道失败，请检查网络或 Done Hub 配置。",
+      invoke: (request: any) => deleteChannel(request, 1),
+    },
+  ])(
+    "$operation mutation uses fixed copy when the thrown message is blank",
+    async ({ invoke, message }) => {
+      const request = {
+        baseUrl: "https://example.com",
+        auth: {
+          authType: AuthTypeEnum.AccessToken,
+          accessToken: "token",
+          userId: "1",
+        },
+      }
+      mockFetchApi.mockRejectedValueOnce(new Error("   "))
+
+      await expect(invoke(request)).rejects.toThrow(message)
     },
   )
 
@@ -904,7 +947,7 @@ describe("apiService doneHub channel APIs", () => {
     ).rejects.toThrow("Failed to update channel model mapping")
   })
 
-  it("fetchSiteUserGroups should paginate /api/group/ and return symbols", async () => {
+  it("fetchSiteUserGroups should read DoneHub's bare group array", async () => {
     const request = {
       baseUrl: "https://example.com",
       auth: {
@@ -914,38 +957,19 @@ describe("apiService doneHub channel APIs", () => {
       },
     }
 
-    const firstPageGroups = Array.from({ length: 100 }, (_, index) => ({
+    const groups = Array.from({ length: 101 }, (_, index) => ({
       symbol: index === 0 ? "default" : `group-${index}`,
     }))
+    groups[100] = { symbol: "vip" }
 
-    mockFetchApiData
-      .mockResolvedValueOnce({
-        data: firstPageGroups,
-        page: 1,
-        size: 100,
-        total_count: 101,
-      })
-      .mockResolvedValueOnce({
-        data: [{ symbol: "vip" }],
-        page: 2,
-        size: 100,
-        total_count: 101,
-      })
+    mockFetchApiData.mockResolvedValueOnce(groups)
 
     const result = await fetchSiteUserGroups(request as any)
 
-    expect(mockFetchApiData).toHaveBeenCalledTimes(2)
-
-    const firstEndpoint = mockFetchApiData.mock.calls[0][1].endpoint as string
-    const secondEndpoint = mockFetchApiData.mock.calls[1][1].endpoint as string
-
-    expect(firstEndpoint).toContain("/api/group/?")
-    expect(firstEndpoint).toContain("page=1")
-    expect(firstEndpoint).toContain("size=100")
-
-    expect(secondEndpoint).toContain("/api/group/?")
-    expect(secondEndpoint).toContain("page=2")
-    expect(secondEndpoint).toContain("size=100")
+    expect(mockFetchApiData).toHaveBeenCalledOnce()
+    expect(mockFetchApiData).toHaveBeenCalledWith(request, {
+      endpoint: "/api/group/",
+    })
 
     expect(result).toHaveLength(101)
     expect(result[0]).toBe("default")
@@ -962,16 +986,12 @@ describe("apiService doneHub channel APIs", () => {
       },
     }
 
-    mockFetchApiData.mockResolvedValueOnce({
-      data: [
-        { symbol: " default " },
-        { symbol: "" },
-        { symbol: "default" },
-        { symbol: "vip" },
-      ],
-      page: 1,
-      size: 100,
-    })
+    mockFetchApiData.mockResolvedValueOnce([
+      { symbol: " default " },
+      { symbol: "" },
+      { symbol: "default" },
+      { symbol: "vip" },
+    ])
 
     await expect(fetchSiteUserGroups(request as any)).resolves.toEqual([
       "default",

--- a/tests/services/apiService/doneHub/channelApi.test.ts
+++ b/tests/services/apiService/doneHub/channelApi.test.ts
@@ -999,6 +999,21 @@ describe("apiService doneHub channel APIs", () => {
     ])
   })
 
+  it("fetchSiteUserGroups should return an empty list for a non-array payload", async () => {
+    const request = {
+      baseUrl: "https://example.com",
+      auth: {
+        authType: AuthTypeEnum.AccessToken,
+        accessToken: "token",
+        userId: "1",
+      },
+    }
+
+    mockFetchApiData.mockResolvedValueOnce({ groups: [] })
+
+    await expect(fetchSiteUserGroups(request as any)).resolves.toEqual([])
+  })
+
   it("fetchTodayUsage should delegate to the New API-family helper with DoneHub log query overrides", async () => {
     const request = {
       baseUrl: "https://example.com",

--- a/tests/services/apiService/doneHub/request.test.ts
+++ b/tests/services/apiService/doneHub/request.test.ts
@@ -1,0 +1,33 @@
+import { http, HttpResponse } from "msw"
+import { describe, expect, it } from "vitest"
+
+import { doneHubRequests } from "~/services/apiService/doneHub/request"
+import { API_ERROR_CODES } from "~/services/apiTransport/errors"
+import { AuthTypeEnum } from "~/types"
+import { server } from "~~/tests/msw/server"
+
+const baseUrl = "https://done-hub.example.invalid"
+const request = {
+  baseUrl,
+  auth: { authType: AuthTypeEnum.AccessToken, accessToken: "token" },
+}
+
+describe("doneHubRequests", () => {
+  it("owns DoneHub channel error envelopes at the request seam", async () => {
+    server.use(
+      http.get(`${baseUrl}/api/channel/1`, () =>
+        HttpResponse.json({
+          success: false,
+          message: "Channel configuration was rejected",
+        }),
+      ),
+    )
+
+    await expect(
+      doneHubRequests.data(request, { endpoint: "/api/channel/1" }),
+    ).rejects.toMatchObject({
+      message: "Channel configuration was rejected",
+      code: API_ERROR_CODES.BUSINESS_ERROR,
+    })
+  })
+})

--- a/tests/services/apiService/doneHub/responseError.test.ts
+++ b/tests/services/apiService/doneHub/responseError.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest"
+
+import { decodeDoneHubResponseError } from "~/services/apiService/doneHub/responseError"
+
+const response = (body: unknown, status = 200) => ({
+  ok: status >= 200 && status < 300,
+  status,
+  headers: {},
+  body,
+})
+
+describe("decodeDoneHubResponseError", () => {
+  it("recognizes DoneHub channel business-error envelopes", () => {
+    expect(
+      decodeDoneHubResponseError(
+        response({
+          success: false,
+          message: "Channel configuration was rejected",
+        }),
+        { endpoint: "/api/channel/" },
+      ),
+    ).toEqual({
+      kind: "business",
+      message: "Channel configuration was rejected",
+    })
+  })
+
+  it("does not claim an unverified standalone HTTP message shape", () => {
+    expect(
+      decodeDoneHubResponseError(
+        response({ message: "Unverified shape" }, 400),
+        {
+          endpoint: "/api/channel/",
+        },
+      ),
+    ).toBeNull()
+  })
+
+  it("ignores fields that are not part of DoneHub's managed error contract", () => {
+    expect(
+      decodeDoneHubResponseError(
+        response({
+          success: false,
+          message: "Channel configuration was rejected",
+          code: "unverified_code",
+        }),
+        { endpoint: "/api/channel/" },
+      ),
+    ).toEqual({
+      kind: "business",
+      message: "Channel configuration was rejected",
+    })
+  })
+
+  it("returns null for unknown envelopes and keeps blank failures classified", () => {
+    expect(
+      decodeDoneHubResponseError(response({ detail: "Unknown shape" }), {
+        endpoint: "/api/channel/",
+      }),
+    ).toBeNull()
+
+    expect(
+      decodeDoneHubResponseError(
+        response({
+          success: false,
+          message: "   ",
+        }),
+        { endpoint: "/api/channel/" },
+      ),
+    ).toEqual({ kind: "business" })
+  })
+})

--- a/tests/services/apiService/newApiFamily/accountBootstrap.test.ts
+++ b/tests/services/apiService/newApiFamily/accountBootstrap.test.ts
@@ -16,7 +16,9 @@ const { mockFetchApiData } = vi.hoisted(() => ({
 }))
 
 vi.mock("~/services/apiService/newApiFamily/request", () => ({
-  fetchApiData: mockFetchApiData,
+  newApiFamilyRequests: {
+    data: mockFetchApiData,
+  },
 }))
 
 vi.mock("~/utils/core/logger", () => ({

--- a/tests/services/apiService/newApiFamily/accountData.test.ts
+++ b/tests/services/apiService/newApiFamily/accountData.test.ts
@@ -62,7 +62,9 @@ vi.mock("~/services/apiTransport/constant", () => ({
 }))
 
 vi.mock("~/services/apiService/newApiFamily/request", () => ({
-  fetchApiData: mockFetchApiData,
+  newApiFamilyRequests: {
+    data: mockFetchApiData,
+  },
 }))
 
 vi.mock("~/services/apiService/newApiFamily/default/accountDataUtils", () => ({

--- a/tests/services/apiService/newApiFamily/channelManagement.test.ts
+++ b/tests/services/apiService/newApiFamily/channelManagement.test.ts
@@ -36,8 +36,10 @@ vi.mock("~/constants/ui", () => ({
 }))
 
 vi.mock("~/services/apiService/newApiFamily/request", () => ({
-  fetchApi: mockFetchApi,
-  fetchApiData: mockFetchApiData,
+  newApiFamilyRequests: {
+    data: mockFetchApiData,
+    envelope: mockFetchApi,
+  },
 }))
 
 const baseRequest = {
@@ -276,7 +278,6 @@ describe("newApiFamily channel management APIs", () => {
           body: JSON.stringify({ status: 1 }),
         },
       }),
-      false,
     )
   })
 
@@ -307,7 +308,6 @@ describe("newApiFamily channel management APIs", () => {
           body: JSON.stringify({ status: 2 }),
         },
       }),
-      false,
     )
   })
 
@@ -428,7 +428,6 @@ describe("newApiFamily channel management APIs", () => {
       expect.objectContaining({
         endpoint: expect.stringContaining("/api/channel/?"),
       }),
-      false,
     )
     expect(mockFetchApi).toHaveBeenNthCalledWith(
       2,
@@ -436,7 +435,6 @@ describe("newApiFamily channel management APIs", () => {
       expect.objectContaining({
         endpoint: expect.stringContaining("/api/channel/?"),
       }),
-      false,
     )
 
     const firstEndpoint = mockFetchApi.mock.calls[0][1].endpoint as string
@@ -491,11 +489,9 @@ describe("newApiFamily channel management APIs", () => {
 
     const result = await fetchChannelModels(request as any, 123)
 
-    expect(mockFetchApi).toHaveBeenCalledWith(
-      request,
-      { endpoint: "/api/channel/fetch_models/123" },
-      false,
-    )
+    expect(mockFetchApi).toHaveBeenCalledWith(request, {
+      endpoint: "/api/channel/fetch_models/123",
+    })
     expect(result).toEqual(["gpt-4"])
   })
 
@@ -517,22 +513,18 @@ describe("newApiFamily channel management APIs", () => {
         { signal },
       ),
     ).resolves.toEqual(["model-example-a", "model-example-b"])
-    expect(mockFetchApi).toHaveBeenCalledWith(
-      baseRequest,
-      {
-        endpoint: "/api/channel/fetch_models",
-        options: {
-          method: "POST",
-          body: JSON.stringify({
-            type: 1,
-            base_url: "https://upstream.example.invalid",
-            key: "credential-placeholder",
-          }),
-          signal,
-        },
+    expect(mockFetchApi).toHaveBeenCalledWith(baseRequest, {
+      endpoint: "/api/channel/fetch_models",
+      options: {
+        method: "POST",
+        body: JSON.stringify({
+          type: 1,
+          base_url: "https://upstream.example.invalid",
+          key: "credential-placeholder",
+        }),
+        signal,
       },
-      false,
-    )
+    })
   })
 
   it("preserves New API model lookup messages from provider failure envelopes", async () => {

--- a/tests/services/apiService/newApiFamily/inviteLink.test.ts
+++ b/tests/services/apiService/newApiFamily/inviteLink.test.ts
@@ -13,7 +13,9 @@ const { fetchApiDataMock, loggerErrorMock } = vi.hoisted(() => ({
 }))
 
 vi.mock("~/services/apiService/newApiFamily/request", () => ({
-  fetchApiData: fetchApiDataMock,
+  newApiFamilyRequests: {
+    data: fetchApiDataMock,
+  },
 }))
 
 vi.mock("~/utils/core/logger", () => ({

--- a/tests/services/apiService/newApiFamily/keyManagement.test.ts
+++ b/tests/services/apiService/newApiFamily/keyManagement.test.ts
@@ -32,13 +32,18 @@ const {
 
 vi.mock("~/services/accountTokens/tokenKeyResolver", () => ({
   invalidateResolvedApiTokenKeyCache: mockInvalidateResolvedApiTokenKeyCache,
-  resolveApiTokenKey: mockResolveApiTokenKey,
   syncResolvedApiTokenKeyCache: mockSyncResolvedApiTokenKeyCache,
 }))
 
+vi.mock("~/services/apiService/newApiFamily/default/tokenKeyResolver", () => ({
+  resolveApiTokenKey: mockResolveApiTokenKey,
+}))
+
 vi.mock("~/services/apiService/newApiFamily/request", () => ({
-  fetchApi: mockFetchApi,
-  fetchApiData: mockFetchApiData,
+  newApiFamilyRequests: {
+    data: mockFetchApiData,
+    envelope: mockFetchApi,
+  },
 }))
 
 vi.mock("~/utils/core/logger", () => ({

--- a/tests/services/apiService/newApiFamily/modelPricing.test.ts
+++ b/tests/services/apiService/newApiFamily/modelPricing.test.ts
@@ -9,7 +9,9 @@ const { fetchApiMock, loggerErrorMock } = vi.hoisted(() => ({
 }))
 
 vi.mock("~/services/apiService/newApiFamily/request", () => ({
-  fetchApi: fetchApiMock,
+  newApiFamilyRequests: {
+    payload: fetchApiMock,
+  },
 }))
 
 vi.mock("~/utils/core/logger", () => ({
@@ -61,11 +63,9 @@ describe("newApiFamily modelPricing", () => {
       nativePricingResponse,
     )
 
-    expect(fetchApiMock).toHaveBeenCalledWith(
-      request,
-      { endpoint: "/api/pricing" },
-      true,
-    )
+    expect(fetchApiMock).toHaveBeenCalledWith(request, {
+      endpoint: "/api/pricing",
+    })
   })
 
   it("rethrows pricing endpoint failures", async () => {

--- a/tests/services/apiService/newApiFamily/redemption.test.ts
+++ b/tests/services/apiService/newApiFamily/redemption.test.ts
@@ -9,7 +9,9 @@ const { fetchApiDataMock, loggerErrorMock } = vi.hoisted(() => ({
 }))
 
 vi.mock("~/services/apiService/newApiFamily/request", () => ({
-  fetchApiData: fetchApiDataMock,
+  newApiFamilyRequests: {
+    data: fetchApiDataMock,
+  },
 }))
 
 vi.mock("~/utils/core/logger", () => ({

--- a/tests/services/apiService/newApiFamily/request.test.ts
+++ b/tests/services/apiService/newApiFamily/request.test.ts
@@ -1,57 +1,70 @@
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import { http, HttpResponse } from "msw"
+import { describe, expect, it } from "vitest"
 
-import {
-  fetchApi,
-  fetchApiData,
-} from "~/services/apiService/newApiFamily/request"
-import { decodeNewApiResponseError } from "~/services/apiService/newApiFamily/responseError"
+import { newApiFamilyRequests } from "~/services/apiService/newApiFamily/request"
+import { API_ERROR_CODES } from "~/services/apiTransport/errors"
 import { AuthTypeEnum } from "~/types"
+import { server } from "~~/tests/msw/server"
 
-const { mockFetchApi, mockFetchApiData } = vi.hoisted(() => ({
-  mockFetchApi: vi.fn(),
-  mockFetchApiData: vi.fn(),
-}))
-
-vi.mock("~/services/apiTransport/request", () => ({
-  fetchApi: mockFetchApi,
-  fetchApiData: mockFetchApiData,
-}))
-
+const baseUrl = "https://new-api.example.invalid"
 const request = {
-  baseUrl: "https://api.example.invalid",
+  baseUrl,
   auth: { authType: AuthTypeEnum.AccessToken, accessToken: "token" },
 }
 
-describe("newApiFamily request", () => {
-  beforeEach(() => {
-    vi.clearAllMocks()
-  })
-
-  it("injects the New API decoder into data requests", async () => {
-    mockFetchApiData.mockResolvedValueOnce({ id: 1 })
+describe("newApiFamilyRequests", () => {
+  it("owns New API authentication errors at the request seam", async () => {
+    server.use(
+      http.get(`${baseUrl}/api/user/self`, () =>
+        HttpResponse.json(
+          {
+            success: false,
+            code: "AUTH_SESSION_LIMIT",
+            message: "Active session limit reached",
+          },
+          { status: 401 },
+        ),
+      ),
+    )
 
     await expect(
-      fetchApiData(request, { endpoint: "/api/user/self" }),
-    ).resolves.toEqual({ id: 1 })
-    expect(mockFetchApiData).toHaveBeenCalledWith(request, {
-      endpoint: "/api/user/self",
-      errorResponseDecoder: decodeNewApiResponseError,
+      newApiFamilyRequests.data(request, { endpoint: "/api/user/self" }),
+    ).rejects.toMatchObject({
+      message: "Active session limit reached",
+      statusCode: 401,
+      code: API_ERROR_CODES.HTTP_401,
+      upstreamCode: "AUTH_SESSION_LIMIT",
     })
   })
 
-  it("preserves normal-response mode while injecting the decoder", async () => {
-    mockFetchApi.mockResolvedValueOnce(["example-model"])
+  it("keeps successful HTTP envelopes when the caller owns classification", async () => {
+    server.use(
+      http.post(`${baseUrl}/api/user/checkin`, () =>
+        HttpResponse.json({ success: false, message: "Already checked in" }),
+      ),
+    )
 
     await expect(
-      fetchApi<string[]>(request, { endpoint: "/api/user/models" }, true),
-    ).resolves.toEqual(["example-model"])
-    expect(mockFetchApi).toHaveBeenCalledWith(
-      request,
-      {
-        endpoint: "/api/user/models",
-        errorResponseDecoder: decodeNewApiResponseError,
-      },
-      true,
+      newApiFamilyRequests.envelope(request, {
+        endpoint: "/api/user/checkin",
+        options: { method: "POST" },
+      }),
+    ).resolves.toEqual({ success: false, message: "Already checked in" })
+  })
+
+  it("unwraps envelopes in payload mode", async () => {
+    server.use(
+      http.get(`${baseUrl}/api/pricing`, () =>
+        HttpResponse.json({
+          success: true,
+          message: "",
+          data: { model: "example-model" },
+        }),
+      ),
     )
+
+    await expect(
+      newApiFamilyRequests.payload(request, { endpoint: "/api/pricing" }),
+    ).resolves.toEqual({ model: "example-model" })
   })
 })

--- a/tests/services/apiService/newApiFamily/siteAnnouncements.test.ts
+++ b/tests/services/apiService/newApiFamily/siteAnnouncements.test.ts
@@ -9,7 +9,9 @@ const { fetchApiDataMock, loggerWarnMock } = vi.hoisted(() => ({
 }))
 
 vi.mock("~/services/apiService/newApiFamily/request", () => ({
-  fetchApiData: fetchApiDataMock,
+  newApiFamilyRequests: {
+    data: fetchApiDataMock,
+  },
 }))
 
 vi.mock("~/utils/core/logger", () => ({

--- a/tests/services/apiService/newApiFamily/siteNotice.test.ts
+++ b/tests/services/apiService/newApiFamily/siteNotice.test.ts
@@ -9,7 +9,9 @@ const { fetchApiMock, loggerWarnMock } = vi.hoisted(() => ({
 }))
 
 vi.mock("~/services/apiService/newApiFamily/request", () => ({
-  fetchApi: fetchApiMock,
+  newApiFamilyRequests: {
+    envelope: fetchApiMock,
+  },
 }))
 
 vi.mock("~/utils/core/logger", () => ({
@@ -41,7 +43,6 @@ describe("newApiFamily siteNotice", () => {
         auth: expect.objectContaining({ authType: AuthTypeEnum.None }),
       }),
       { endpoint: "/api/notice" },
-      false,
     )
   })
 

--- a/tests/services/apiService/newApiFamily/tokenKeyResolver.test.ts
+++ b/tests/services/apiService/newApiFamily/tokenKeyResolver.test.ts
@@ -1,0 +1,91 @@
+import { http, HttpResponse } from "msw"
+import { describe, expect, it } from "vitest"
+
+import { fetchTokenSecretKeyById } from "~/services/apiService/newApiFamily/default/tokenKeyResolver"
+import { API_ERROR_CODES } from "~/services/apiTransport/errors"
+import { AuthTypeEnum } from "~/types"
+import { server } from "~~/tests/msw/server"
+
+const baseUrl = "https://new-api.example.invalid"
+const request = {
+  baseUrl,
+  auth: { authType: AuthTypeEnum.AccessToken, accessToken: "token" },
+}
+
+describe("New API token secret resolution", () => {
+  it("uses POST and unwraps the documented secret response", async () => {
+    let method = ""
+    server.use(
+      http.post(`${baseUrl}/api/token/7/key`, ({ request }) => {
+        method = request.method
+        return HttpResponse.json({
+          success: true,
+          message: "",
+          data: { key: "secret-placeholder" },
+        })
+      }),
+    )
+
+    await expect(fetchTokenSecretKeyById(request, 7)).resolves.toBe(
+      "secret-placeholder",
+    )
+    expect(method).toBe("POST")
+  })
+
+  it("preserves a documented HTTP 200 business error", async () => {
+    server.use(
+      http.post(`${baseUrl}/api/token/8/key`, () =>
+        HttpResponse.json({
+          success: false,
+          message: "Token does not exist",
+        }),
+      ),
+    )
+
+    await expect(fetchTokenSecretKeyById(request, 8)).rejects.toMatchObject({
+      message: "Token does not exist",
+      code: API_ERROR_CODES.BUSINESS_ERROR,
+    })
+  })
+
+  it("preserves the documented auth code on an HTTP error", async () => {
+    server.use(
+      http.post(`${baseUrl}/api/token/9/key`, () =>
+        HttpResponse.json(
+          {
+            success: false,
+            code: "AUTH_TOKEN_INVALID",
+            message: "Access token is invalid",
+          },
+          { status: 401 },
+        ),
+      ),
+    )
+
+    await expect(fetchTokenSecretKeyById(request, 9)).rejects.toMatchObject({
+      message: "Access token is invalid",
+      statusCode: 401,
+      code: API_ERROR_CODES.HTTP_401,
+      upstreamCode: "AUTH_TOKEN_INVALID",
+    })
+  })
+
+  it("uses the fixed transport fallback for an empty 429", async () => {
+    server.use(
+      http.post(
+        `${baseUrl}/api/token/10/key`,
+        () =>
+          new HttpResponse(null, {
+            status: 429,
+            headers: { "Retry-After": "60" },
+          }),
+      ),
+    )
+
+    await expect(fetchTokenSecretKeyById(request, 10)).rejects.toMatchObject({
+      message: "请求失败: 429",
+      statusCode: 429,
+      code: API_ERROR_CODES.HTTP_429,
+    })
+  })
+})

--- a/tests/services/apiService/newApiFamily/vApi.test.ts
+++ b/tests/services/apiService/newApiFamily/vApi.test.ts
@@ -15,7 +15,9 @@ const { fetchApiDataMock, fetchLegacyAccountAvailableModelsMock } = vi.hoisted(
 )
 
 vi.mock("~/services/apiService/newApiFamily/request", () => ({
-  fetchApiData: fetchApiDataMock,
+  newApiFamilyRequests: {
+    data: fetchApiDataMock,
+  },
 }))
 
 vi.mock("~/services/apiService/newApiFamily/default/keyManagement", () => ({

--- a/tests/services/apiService/oneHub/index.test.ts
+++ b/tests/services/apiService/oneHub/index.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
-import { fetchApiData } from "~/services/apiService/newApiFamily/request"
+import { newApiFamilyRequests } from "~/services/apiService/newApiFamily/request"
 import {
   fetchAccountAvailableModels,
   fetchAccountTokens,
@@ -24,7 +24,9 @@ vi.mock("~/services/accountTokens/tokenKeyResolver", () => ({
 }))
 
 vi.mock("~/services/apiService/newApiFamily/request", () => ({
-  fetchApiData: vi.fn(),
+  newApiFamilyRequests: {
+    data: vi.fn(),
+  },
 }))
 
 vi.mock("~/services/apiService/oneHub/transform", () => ({
@@ -32,7 +34,9 @@ vi.mock("~/services/apiService/oneHub/transform", () => ({
   transformUserGroup: vi.fn(),
 }))
 
-const mockedFetchApiData = fetchApiData as unknown as ReturnType<typeof vi.fn>
+const mockedFetchApiData = newApiFamilyRequests.data as unknown as ReturnType<
+  typeof vi.fn
+>
 const mockedTransformModelPricing =
   transformModelPricing as unknown as ReturnType<typeof vi.fn>
 const mockedTransformUserGroup = transformUserGroup as unknown as ReturnType<
@@ -53,7 +57,7 @@ describe("OneHub API service", () => {
     vi.clearAllMocks()
   })
 
-  it("fetchAvailableModel should call fetchApiData with correct endpoint", async () => {
+  it("fetchAvailableModel should call newApiFamilyRequests.data with correct endpoint", async () => {
     mockedFetchApiData.mockResolvedValueOnce({})
 
     await fetchAvailableModel(baseRequest as any)
@@ -63,7 +67,7 @@ describe("OneHub API service", () => {
     })
   })
 
-  it("fetchUserGroupMap should call fetchApiData with correct endpoint", async () => {
+  it("fetchUserGroupMap should call newApiFamilyRequests.data with correct endpoint", async () => {
     mockedFetchApiData.mockResolvedValueOnce({})
 
     await fetchUserGroupMap(baseRequest as any)

--- a/tests/services/apiService/openrouter/index.test.ts
+++ b/tests/services/apiService/openrouter/index.test.ts
@@ -207,6 +207,29 @@ describe("apiService OpenRouter", () => {
     },
   )
 
+  it("preserves the documented provider message for a credits 403", async () => {
+    server.use(
+      http.get(`${OPENROUTER_API_BASE_URL}/credits`, () =>
+        HttpResponse.json(
+          {
+            error: {
+              code: 403,
+              message: "Only management keys can perform this operation",
+            },
+          },
+          { status: 403 },
+        ),
+      ),
+    )
+
+    await expect(fetchAccountData(baseRequest)).rejects.toMatchObject({
+      message: "Only management keys can perform this operation",
+      statusCode: 403,
+      code: API_ERROR_CODES.HTTP_403,
+      upstreamCode: "403",
+    })
+  })
+
   it.each([
     { data: null },
     { data: {} },

--- a/tests/services/apiService/openrouter/responseError.test.ts
+++ b/tests/services/apiService/openrouter/responseError.test.ts
@@ -47,4 +47,25 @@ describe("decodeOpenRouterResponseError", () => {
       }),
     ).toBeNull()
   })
+
+  it("returns null when the nested error has no usable message", () => {
+    expect(
+      decodeOpenRouterResponseError(
+        response({ error: { code: 401, message: "  " } }, 401),
+        { endpoint: "/key" },
+      ),
+    ).toBeNull()
+  })
+
+  it("preserves a message without exposing undocumented string codes", () => {
+    expect(
+      decodeOpenRouterResponseError(
+        response({ error: { code: "403", message: "Denied" } }, 403),
+        { endpoint: "/credits" },
+      ),
+    ).toEqual({
+      kind: "http",
+      message: "Denied",
+    })
+  })
 })

--- a/tests/services/apiService/openrouter/responseError.test.ts
+++ b/tests/services/apiService/openrouter/responseError.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest"
+
+import { decodeOpenRouterResponseError } from "~/services/apiService/openrouter/responseError"
+
+const response = (body: unknown, status: number) => ({
+  ok: status >= 200 && status < 300,
+  status,
+  headers: {},
+  body,
+})
+
+describe("decodeOpenRouterResponseError", () => {
+  it("decodes the documented nested HTTP error and numeric code", () => {
+    expect(
+      decodeOpenRouterResponseError(
+        response(
+          {
+            error: {
+              code: 403,
+              message: "Only management keys can perform this operation",
+            },
+          },
+          403,
+        ),
+        { endpoint: "/credits" },
+      ),
+    ).toEqual({
+      kind: "http",
+      message: "Only management keys can perform this operation",
+      upstreamCode: "403",
+    })
+  })
+
+  it("does not interpret a successful response as an error", () => {
+    expect(
+      decodeOpenRouterResponseError(
+        response({ error: { code: 200, message: "ignored" } }, 200),
+        { endpoint: "/key" },
+      ),
+    ).toBeNull()
+  })
+
+  it("returns null for undocumented error shapes", () => {
+    expect(
+      decodeOpenRouterResponseError(response({ error: "denied" }, 401), {
+        endpoint: "/key",
+      }),
+    ).toBeNull()
+  })
+})

--- a/tests/services/apiService/veloera/channelApi.test.ts
+++ b/tests/services/apiService/veloera/channelApi.test.ts
@@ -57,9 +57,18 @@ vi.mock("~/utils/core/logger", () => ({
   }),
 }))
 
-vi.mock("~/services/apiTransport/request", () => ({
-  fetchApiData: mockFetchApiData,
-  fetchApi: mockFetchApi,
+vi.mock("~/services/apiService/veloera/request", () => ({
+  veloeraRequests: {
+    data: mockFetchApiData,
+    envelope: mockFetchApi,
+  },
+}))
+
+vi.mock("~/services/apiService/newApiFamily/request", () => ({
+  newApiFamilyRequests: {
+    data: mockFetchApiData,
+    envelope: mockFetchApi,
+  },
 }))
 
 vi.mock(
@@ -281,14 +290,10 @@ describe("apiService veloera channel APIs", () => {
     await expect(
       fetchChannelModels(request as any, 9, { signal }),
     ).resolves.toEqual(["gpt-4o", "claude-3"])
-    expect(mockFetchApi).toHaveBeenCalledWith(
-      request,
-      {
-        endpoint: "/api/channel/fetch_models/9",
-        options: { signal },
-      },
-      false,
-    )
+    expect(mockFetchApi).toHaveBeenCalledWith(request, {
+      endpoint: "/api/channel/fetch_models/9",
+      options: { signal },
+    })
   })
 
   it("fetchChannelModels should reject unsupported payloads", async () => {
@@ -328,21 +333,17 @@ describe("apiService veloera channel APIs", () => {
       signal,
     })
 
-    expect(mockFetchApi).toHaveBeenCalledWith(
-      request,
-      {
-        endpoint: "/api/channel",
-        options: {
-          method: "PUT",
-          body: JSON.stringify({
-            id: 9,
-            models: "gpt-4o,claude-3",
-          }),
-          signal,
-        },
+    expect(mockFetchApi).toHaveBeenCalledWith(request, {
+      endpoint: "/api/channel",
+      options: {
+        method: "PUT",
+        body: JSON.stringify({
+          id: 9,
+          models: "gpt-4o,claude-3",
+        }),
+        signal,
       },
-      false,
-    )
+    })
   })
 
   it("updateChannelModels should reject failed Veloera responses", async () => {
@@ -387,21 +388,17 @@ describe("apiService veloera channel APIs", () => {
       JSON.stringify({ "gpt-4o": "gpt-4o" }),
     )
 
-    expect(mockFetchApi).toHaveBeenCalledWith(
-      request,
-      {
-        endpoint: "/api/channel",
-        options: {
-          method: "PUT",
-          body: JSON.stringify({
-            id: 9,
-            models: "gpt-4o,claude-3",
-            model_mapping: JSON.stringify({ "gpt-4o": "gpt-4o" }),
-          }),
-        },
+    expect(mockFetchApi).toHaveBeenCalledWith(request, {
+      endpoint: "/api/channel",
+      options: {
+        method: "PUT",
+        body: JSON.stringify({
+          id: 9,
+          models: "gpt-4o,claude-3",
+          model_mapping: JSON.stringify({ "gpt-4o": "gpt-4o" }),
+        }),
       },
-      false,
-    )
+    })
   })
 
   it("updateChannelModelMapping should reject failed Veloera responses", async () => {
@@ -563,7 +560,7 @@ describe("apiService veloera channel APIs", () => {
     mockFetchApi.mockRejectedValueOnce(new Error("delete failed"))
 
     await expect(deleteChannel(request as any, 9)).rejects.toThrow(
-      "删除渠道失败，请检查网络或 Veloera 配置",
+      "delete failed",
     )
   })
 
@@ -575,7 +572,6 @@ describe("apiService veloera channel APIs", () => {
           mode: "none" as any,
           channel: { groups: ["default"] } as any,
         }),
-      message: "创建渠道失败，请检查网络或 Veloera 配置",
     },
     {
       operation: "update",
@@ -585,16 +581,14 @@ describe("apiService veloera channel APIs", () => {
           name: "Updated",
           groups: ["default"],
         }),
-      message: "更新渠道失败，请检查网络或 Veloera 配置",
     },
     {
       operation: "delete",
       invoke: (request: any) => deleteChannel(request, 1),
-      message: "删除渠道失败，请检查网络或 Veloera 配置",
     },
   ])(
     "$operation mutation preserves ApiError details as cause without logging it",
-    async ({ invoke, message }) => {
+    async ({ invoke }) => {
       const request = {
         baseUrl: "https://example.com",
         auth: {
@@ -608,20 +602,64 @@ describe("apiService veloera channel APIs", () => {
         502,
         "/api/channel",
         API_ERROR_CODES.HTTP_OTHER,
+        "provider_limit",
       )
       mockFetchApi.mockRejectedValueOnce(cause)
 
       const error = await invoke(request).catch((caught) => caught)
 
       expect(error).toMatchObject({
-        message,
+        message: "upstream denied",
         statusCode: 502,
         endpoint: "/api/channel",
         code: API_ERROR_CODES.HTTP_OTHER,
+        upstreamCode: "provider_limit",
         cause,
       })
       expect(mockLoggerError).toHaveBeenCalledWith(expect.any(String))
       expect(mockLoggerError.mock.calls.flat()).not.toContain(cause)
+    },
+  )
+
+  it.each([
+    {
+      operation: "create",
+      message: "创建渠道失败，请检查网络或 Veloera 配置",
+      invoke: (request: any) =>
+        createChannel(request, {
+          mode: "none" as any,
+          channel: { groups: ["default"] } as any,
+        }),
+    },
+    {
+      operation: "update",
+      message: "更新渠道失败，请检查网络或 Veloera 配置",
+      invoke: (request: any) =>
+        updateChannel(request, {
+          id: 1,
+          name: "Updated",
+          groups: ["default"],
+        }),
+    },
+    {
+      operation: "delete",
+      message: "删除渠道失败，请检查网络或 Veloera 配置",
+      invoke: (request: any) => deleteChannel(request, 1),
+    },
+  ])(
+    "$operation mutation uses fixed copy when the thrown message is blank",
+    async ({ invoke, message }) => {
+      const request = {
+        baseUrl: "https://example.com",
+        auth: {
+          authType: AuthTypeEnum.AccessToken,
+          accessToken: "token",
+          userId: "1",
+        },
+      }
+      mockFetchApi.mockRejectedValueOnce(new Error("   "))
+
+      await expect(invoke(request)).rejects.toThrow(message)
     },
   )
 

--- a/tests/services/apiService/veloera/request.test.ts
+++ b/tests/services/apiService/veloera/request.test.ts
@@ -1,0 +1,50 @@
+import { http, HttpResponse } from "msw"
+import { describe, expect, it } from "vitest"
+
+import { veloeraRequests } from "~/services/apiService/veloera/request"
+import { API_ERROR_CODES } from "~/services/apiTransport/errors"
+import { AuthTypeEnum } from "~/types"
+import { server } from "~~/tests/msw/server"
+
+const baseUrl = "https://veloera.example.invalid"
+const request = {
+  baseUrl,
+  auth: { authType: AuthTypeEnum.AccessToken, accessToken: "token" },
+}
+
+describe("veloeraRequests", () => {
+  it("owns Veloera channel error envelopes at the request seam", async () => {
+    server.use(
+      http.get(`${baseUrl}/api/channel/1`, () =>
+        HttpResponse.json({
+          success: false,
+          message: "Channel configuration was rejected",
+        }),
+      ),
+    )
+
+    await expect(
+      veloeraRequests.data(request, { endpoint: "/api/channel/1" }),
+    ).rejects.toMatchObject({
+      message: "Channel configuration was rejected",
+      code: API_ERROR_CODES.BUSINESS_ERROR,
+    })
+  })
+
+  it("uses the fixed fallback for Veloera's empty rate-limit response", async () => {
+    server.use(
+      http.get(
+        `${baseUrl}/api/channel/1`,
+        () => new HttpResponse(null, { status: 429 }),
+      ),
+    )
+
+    await expect(
+      veloeraRequests.data(request, { endpoint: "/api/channel/1" }),
+    ).rejects.toMatchObject({
+      message: "请求失败: 429",
+      statusCode: 429,
+      code: API_ERROR_CODES.HTTP_429,
+    })
+  })
+})

--- a/tests/services/apiService/veloera/responseError.test.ts
+++ b/tests/services/apiService/veloera/responseError.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest"
+
+import { decodeVeloeraResponseError } from "~/services/apiService/veloera/responseError"
+
+const response = (body: unknown, status = 200) => ({
+  ok: status >= 200 && status < 300,
+  status,
+  headers: {},
+  body,
+})
+
+describe("decodeVeloeraResponseError", () => {
+  it("recognizes Veloera channel business-error envelopes", () => {
+    expect(
+      decodeVeloeraResponseError(
+        response({
+          success: false,
+          message: "Channel configuration was rejected",
+        }),
+        { endpoint: "/api/channel" },
+      ),
+    ).toEqual({
+      kind: "business",
+      message: "Channel configuration was rejected",
+    })
+  })
+
+  it("recognizes Veloera's nested panic response as an HTTP error", () => {
+    expect(
+      decodeVeloeraResponseError(
+        response(
+          {
+            error: {
+              message: "Unexpected upstream failure",
+              type: "veloera_panic",
+            },
+          },
+          500,
+        ),
+        {
+          endpoint: "/api/channel",
+        },
+      ),
+    ).toEqual({ kind: "http", message: "Unexpected upstream failure" })
+  })
+
+  it("returns null for unknown envelopes and keeps blank failures classified", () => {
+    expect(
+      decodeVeloeraResponseError(response({ detail: "Unknown shape" }), {
+        endpoint: "/api/channel",
+      }),
+    ).toBeNull()
+
+    expect(
+      decodeVeloeraResponseError(
+        response({ message: "Unverified shape" }, 400),
+        {
+          endpoint: "/api/channel",
+        },
+      ),
+    ).toBeNull()
+
+    expect(
+      decodeVeloeraResponseError(
+        response({
+          success: false,
+          message: "   ",
+        }),
+        { endpoint: "/api/channel" },
+      ),
+    ).toEqual({ kind: "business" })
+  })
+})

--- a/tests/services/apiService/wong/index.test.ts
+++ b/tests/services/apiService/wong/index.test.ts
@@ -43,8 +43,10 @@ vi.mock("~/services/apiService/newApiFamily/default/accountData", () => ({
 }))
 
 vi.mock("~/services/apiService/newApiFamily/request", () => ({
-  fetchApi: mockFetchApi,
-  fetchApiData: mockFetchApiData,
+  newApiFamilyRequests: {
+    data: mockFetchApiData,
+    envelope: mockFetchApi,
+  },
 }))
 
 vi.mock("~/services/apiTransport/request", () => ({
@@ -142,7 +144,6 @@ describe("apiService wong", () => {
           cache: "no-store",
         }),
       }),
-      false,
     )
   })
 

--- a/tests/services/autoCheckin/providers/anyrouter.test.ts
+++ b/tests/services/autoCheckin/providers/anyrouter.test.ts
@@ -11,7 +11,9 @@ import { createAutoCheckinMutationLifecycle } from "~~/tests/test-utils/autoChec
 import { buildCheckInConfig } from "~~/tests/test-utils/checkIn"
 
 vi.mock("~/services/apiService/newApiFamily/request", () => ({
-  fetchApi: vi.fn(),
+  newApiFamilyRequests: {
+    payload: vi.fn(),
+  },
 }))
 
 const mockAccount: SiteAccount = {
@@ -89,11 +91,13 @@ describe("anyrouterProvider", () => {
 
   describe("checkIn", () => {
     it("propagates the popup source on a successful check-in", async () => {
-      const { fetchApi } = await import(
+      const { newApiFamilyRequests } = await import(
         "~/services/apiService/newApiFamily/request"
       )
       const mockedFetchApi = vi.mocked(
-        fetchApi as unknown as (...args: any[]) => Promise<any>,
+        newApiFamilyRequests.payload as unknown as (
+          ...args: any[]
+        ) => Promise<any>,
       )
       mockedFetchApi.mockResolvedValueOnce({
         code: 1,
@@ -118,12 +122,14 @@ describe("anyrouterProvider", () => {
       })
     })
 
-    it("passes lightweight AnyRouter account context to fetchApi", async () => {
-      const { fetchApi } = await import(
+    it("passes lightweight AnyRouter account context to the provider request", async () => {
+      const { newApiFamilyRequests } = await import(
         "~/services/apiService/newApiFamily/request"
       )
       const mockedFetchApi = vi.mocked(
-        fetchApi as unknown as (...args: any[]) => Promise<any>,
+        newApiFamilyRequests.payload as unknown as (
+          ...args: any[]
+        ) => Promise<any>,
       )
       mockedFetchApi.mockResolvedValueOnce({
         code: 1,
@@ -160,11 +166,13 @@ describe("anyrouterProvider", () => {
     })
 
     it("returns success for English success messages", async () => {
-      const { fetchApi } = await import(
+      const { newApiFamilyRequests } = await import(
         "~/services/apiService/newApiFamily/request"
       )
       const mockedFetchApi = vi.mocked(
-        fetchApi as unknown as (...args: any[]) => Promise<any>,
+        newApiFamilyRequests.payload as unknown as (
+          ...args: any[]
+        ) => Promise<any>,
       )
       mockedFetchApi.mockResolvedValueOnce({
         code: 1,
@@ -189,10 +197,10 @@ describe("anyrouterProvider", () => {
     })
 
     it("returns success when success is true and optional result fields are omitted", async () => {
-      const { fetchApi } = await import(
+      const { newApiFamilyRequests } = await import(
         "~/services/apiService/newApiFamily/request"
       )
-      vi.mocked(fetchApi).mockResolvedValueOnce({
+      vi.mocked(newApiFamilyRequests.payload).mockResolvedValueOnce({
         success: true,
         message: "",
       })
@@ -204,11 +212,13 @@ describe("anyrouterProvider", () => {
     })
 
     it("does not treat an empty message as already checked", async () => {
-      const { fetchApi } = await import(
+      const { newApiFamilyRequests } = await import(
         "~/services/apiService/newApiFamily/request"
       )
       const mockedFetchApi = vi.mocked(
-        fetchApi as unknown as (...args: any[]) => Promise<any>,
+        newApiFamilyRequests.payload as unknown as (
+          ...args: any[]
+        ) => Promise<any>,
       )
       mockedFetchApi.mockResolvedValueOnce({
         code: 1,
@@ -222,11 +232,13 @@ describe("anyrouterProvider", () => {
     })
 
     it("returns already_checked when response is success and message indicates a prior check-in", async () => {
-      const { fetchApi } = await import(
+      const { newApiFamilyRequests } = await import(
         "~/services/apiService/newApiFamily/request"
       )
       const mockedFetchApi = vi.mocked(
-        fetchApi as unknown as (...args: any[]) => Promise<any>,
+        newApiFamilyRequests.payload as unknown as (
+          ...args: any[]
+        ) => Promise<any>,
       )
       mockedFetchApi.mockResolvedValueOnce({
         code: 1,
@@ -245,11 +257,13 @@ describe("anyrouterProvider", () => {
     })
 
     it("returns the fallback failure key when the backend fails without a message", async () => {
-      const { fetchApi } = await import(
+      const { newApiFamilyRequests } = await import(
         "~/services/apiService/newApiFamily/request"
       )
       const mockedFetchApi = vi.mocked(
-        fetchApi as unknown as (...args: any[]) => Promise<any>,
+        newApiFamilyRequests.payload as unknown as (
+          ...args: any[]
+        ) => Promise<any>,
       )
       mockedFetchApi.mockResolvedValueOnce({
         code: 1,
@@ -277,11 +291,13 @@ describe("anyrouterProvider", () => {
       ["ret", { ret: 1, message: "queued" }],
       ["code", { code: 0, message: "queued" }],
     ])("accepts %s as an independent success signal", async (_, response) => {
-      const { fetchApi } = await import(
+      const { newApiFamilyRequests } = await import(
         "~/services/apiService/newApiFamily/request"
       )
       const mockedFetchApi = vi.mocked(
-        fetchApi as unknown as (...args: any[]) => Promise<any>,
+        newApiFamilyRequests.payload as unknown as (
+          ...args: any[]
+        ) => Promise<any>,
       )
       mockedFetchApi.mockResolvedValueOnce(response)
 
@@ -292,10 +308,10 @@ describe("anyrouterProvider", () => {
     })
 
     it("does not infer already checked from a zero ret value", async () => {
-      const { fetchApi } = await import(
+      const { newApiFamilyRequests } = await import(
         "~/services/apiService/newApiFamily/request"
       )
-      vi.mocked(fetchApi).mockResolvedValueOnce({
+      vi.mocked(newApiFamilyRequests.payload).mockResolvedValueOnce({
         code: 1,
         ret: 0,
         success: true,
@@ -309,11 +325,13 @@ describe("anyrouterProvider", () => {
     })
 
     it("recognizes an explicit already-checked message on a negative response", async () => {
-      const { fetchApi } = await import(
+      const { newApiFamilyRequests } = await import(
         "~/services/apiService/newApiFamily/request"
       )
       const mockedFetchApi = vi.mocked(
-        fetchApi as unknown as (...args: any[]) => Promise<any>,
+        newApiFamilyRequests.payload as unknown as (
+          ...args: any[]
+        ) => Promise<any>,
       )
       mockedFetchApi.mockResolvedValueOnce({
         code: 1,
@@ -327,10 +345,10 @@ describe("anyrouterProvider", () => {
     })
 
     it("recognizes the msg field used by compatible deployments", async () => {
-      const { fetchApi } = await import(
+      const { newApiFamilyRequests } = await import(
         "~/services/apiService/newApiFamily/request"
       )
-      vi.mocked(fetchApi).mockResolvedValueOnce({
+      vi.mocked(newApiFamilyRequests.payload).mockResolvedValueOnce({
         ret: 0,
         msg: "already checked today",
       })
@@ -342,11 +360,13 @@ describe("anyrouterProvider", () => {
     })
 
     it("returns failed when response indicates failure", async () => {
-      const { fetchApi } = await import(
+      const { newApiFamilyRequests } = await import(
         "~/services/apiService/newApiFamily/request"
       )
       const mockedFetchApi = vi.mocked(
-        fetchApi as unknown as (...args: any[]) => Promise<any>,
+        newApiFamilyRequests.payload as unknown as (
+          ...args: any[]
+        ) => Promise<any>,
       )
       mockedFetchApi.mockResolvedValueOnce({
         code: 1,
@@ -360,11 +380,13 @@ describe("anyrouterProvider", () => {
     })
 
     it("maps 404 errors to endpoint-not-supported", async () => {
-      const { fetchApi } = await import(
+      const { newApiFamilyRequests } = await import(
         "~/services/apiService/newApiFamily/request"
       )
       const mockedFetchApi = vi.mocked(
-        fetchApi as unknown as (...args: any[]) => Promise<any>,
+        newApiFamilyRequests.payload as unknown as (
+          ...args: any[]
+        ) => Promise<any>,
       )
       mockedFetchApi.mockRejectedValueOnce({
         statusCode: 404,
@@ -380,11 +402,13 @@ describe("anyrouterProvider", () => {
     })
 
     it("returns already_checked when request throws and error message indicates already checked", async () => {
-      const { fetchApi } = await import(
+      const { newApiFamilyRequests } = await import(
         "~/services/apiService/newApiFamily/request"
       )
       const mockedFetchApi = vi.mocked(
-        fetchApi as unknown as (...args: any[]) => Promise<any>,
+        newApiFamilyRequests.payload as unknown as (
+          ...args: any[]
+        ) => Promise<any>,
       )
       mockedFetchApi.mockRejectedValueOnce(new Error("已签到"))
 
@@ -393,10 +417,12 @@ describe("anyrouterProvider", () => {
     })
 
     it("does not treat an empty thrown message as already checked", async () => {
-      const { fetchApi } = await import(
+      const { newApiFamilyRequests } = await import(
         "~/services/apiService/newApiFamily/request"
       )
-      vi.mocked(fetchApi).mockRejectedValueOnce(new Error(""))
+      vi.mocked(newApiFamilyRequests.payload).mockRejectedValueOnce(
+        new Error(""),
+      )
 
       await expect(checkInForTest(mockAccount)).resolves.toMatchObject({
         status: "failed",
@@ -404,11 +430,13 @@ describe("anyrouterProvider", () => {
     })
 
     it("handles errors gracefully", async () => {
-      const { fetchApi } = await import(
+      const { newApiFamilyRequests } = await import(
         "~/services/apiService/newApiFamily/request"
       )
       const mockedFetchApi = vi.mocked(
-        fetchApi as unknown as (...args: any[]) => Promise<any>,
+        newApiFamilyRequests.payload as unknown as (
+          ...args: any[]
+        ) => Promise<any>,
       )
       mockedFetchApi.mockRejectedValueOnce(new Error("Network error"))
 
@@ -417,14 +445,16 @@ describe("anyrouterProvider", () => {
     })
 
     it("returns uncertain when the response is lost after dispatch", async () => {
-      const { fetchApi } = await import(
+      const { newApiFamilyRequests } = await import(
         "~/services/apiService/newApiFamily/request"
       )
       const mutationLifecycle = createAutoCheckinMutationLifecycle()
-      vi.mocked(fetchApi).mockImplementationOnce(async (request) => {
-        request.observer?.onDispatch()
-        throw new TypeError("Failed to fetch")
-      })
+      vi.mocked(newApiFamilyRequests.payload).mockImplementationOnce(
+        async (request) => {
+          request.observer?.onDispatch()
+          throw new TypeError("Failed to fetch")
+        },
+      )
 
       await expect(
         checkInForTest(mockAccount, {

--- a/tests/services/autoCheckin/providers/newApi.test.ts
+++ b/tests/services/autoCheckin/providers/newApi.test.ts
@@ -5,10 +5,7 @@ import {
   resolveAccountSiteRouteUrl,
   SITE_ROUTE_KINDS,
 } from "~/services/accounts/utils/siteRouteResolver"
-import {
-  fetchApi,
-  fetchApiData,
-} from "~/services/apiService/newApiFamily/request"
+import { newApiFamilyRequests } from "~/services/apiService/newApiFamily/request"
 import { API_ERROR_CODES, ApiError } from "~/services/apiTransport/errors"
 import { autoCheckinMethodRegistry } from "~/services/checkin/autoCheckin/providers"
 import { newApiProvider } from "~/services/checkin/autoCheckin/providers/newApi"
@@ -32,8 +29,10 @@ const { mockFetchSupportCheckIn } = vi.hoisted(() => ({
 }))
 
 vi.mock("~/services/apiService/newApiFamily/request", () => ({
-  fetchApi: vi.fn(),
-  fetchApiData: vi.fn(),
+  newApiFamilyRequests: {
+    data: vi.fn(),
+    envelope: vi.fn(),
+  },
 }))
 
 vi.mock(
@@ -110,7 +109,7 @@ const checkInForTest = (
 ) => newApiProvider.checkIn(account, context)
 
 const mockCheckInStatusSequence = (...checkedInToday: boolean[]) => {
-  const mock = vi.mocked(fetchApiData)
+  const mock = vi.mocked(newApiFamilyRequests.data)
   for (const checked of checkedInToday) {
     mock.mockResolvedValueOnce({
       stats: { checked_in_today: checked },
@@ -208,7 +207,7 @@ describe("newApiProvider", () => {
 
   describe("read-only status", () => {
     it("uses public site status to classify a disabled deployment independently of error copy", async () => {
-      vi.mocked(fetchApiData).mockRejectedValueOnce(
+      vi.mocked(newApiFamilyRequests.data).mockRejectedValueOnce(
         new ApiError(
           "check-in unavailable",
           undefined,
@@ -243,7 +242,7 @@ describe("newApiProvider", () => {
     })
 
     it("does not misclassify other business errors while public status remains enabled", async () => {
-      vi.mocked(fetchApiData).mockRejectedValueOnce(
+      vi.mocked(newApiFamilyRequests.data).mockRejectedValueOnce(
         new ApiError(
           "failed to update quota",
           undefined,
@@ -263,7 +262,7 @@ describe("newApiProvider", () => {
     })
 
     it("selects a valid disabled deployment without issuing POST", async () => {
-      vi.mocked(fetchApiData).mockResolvedValueOnce({
+      vi.mocked(newApiFamilyRequests.data).mockResolvedValueOnce({
         enabled: false,
         stats: { checked_in_today: false },
       } as any)
@@ -282,11 +281,11 @@ describe("newApiProvider", () => {
           evidence: { source: "probe", observedAt: 200 },
         },
       })
-      expect(fetchApi).not.toHaveBeenCalled()
+      expect(newApiFamilyRequests.envelope).not.toHaveBeenCalled()
     })
 
     it("treats a malformed status envelope as unknown", async () => {
-      vi.mocked(fetchApiData).mockResolvedValueOnce({
+      vi.mocked(newApiFamilyRequests.data).mockResolvedValueOnce({
         enabled: true,
         stats: {},
       } as any)
@@ -301,7 +300,7 @@ describe("newApiProvider", () => {
     })
 
     it("classifies an authenticated status read failure without hiding it", async () => {
-      vi.mocked(fetchApiData).mockRejectedValueOnce(
+      vi.mocked(newApiFamilyRequests.data).mockRejectedValueOnce(
         new ApiError("authentication required", 401),
       )
 
@@ -317,7 +316,7 @@ describe("newApiProvider", () => {
 
   describe("checkIn", () => {
     it("preserves the popup source through native page check-in and status polling", async () => {
-      vi.mocked(fetchApi).mockResolvedValueOnce({
+      vi.mocked(newApiFamilyRequests.envelope).mockResolvedValueOnce({
         success: false,
         message: "missing check-in signature header",
         data: null,
@@ -355,7 +354,9 @@ describe("newApiProvider", () => {
           reason: "clicked",
         }),
       })
-      expect(vi.mocked(fetchApi).mock.calls[0]?.[0]).toMatchObject({
+      expect(
+        vi.mocked(newApiFamilyRequests.envelope).mock.calls[0]?.[0],
+      ).toMatchObject({
         accountId: "test-id",
         tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
         protectionBypassExecution: expect.objectContaining({
@@ -364,7 +365,9 @@ describe("newApiProvider", () => {
           surface: "options",
         }),
       })
-      expect(vi.mocked(fetchApiData).mock.calls[0]?.[0]).toMatchObject({
+      expect(
+        vi.mocked(newApiFamilyRequests.data).mock.calls[0]?.[0],
+      ).toMatchObject({
         accountId: "test-id",
         tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
         protectionBypassExecution: expect.objectContaining({
@@ -394,7 +397,7 @@ describe("newApiProvider", () => {
     })
 
     it("uses native page check-in for generic check-in API failures", async () => {
-      vi.mocked(fetchApi).mockResolvedValueOnce({
+      vi.mocked(newApiFamilyRequests.envelope).mockResolvedValueOnce({
         success: false,
         message: "server rejected the check-in request",
         data: null,
@@ -414,7 +417,7 @@ describe("newApiProvider", () => {
     })
 
     it("does not treat unrelated authority errors as auth blocks for native fallback", async () => {
-      vi.mocked(fetchApi).mockResolvedValueOnce({
+      vi.mocked(newApiFamilyRequests.envelope).mockResolvedValueOnce({
         success: false,
         message: "upstream authority rejected the dynamic signature",
         data: null,
@@ -436,7 +439,7 @@ describe("newApiProvider", () => {
       vi.mocked(safeRandomUUID)
         .mockReturnValueOnce("native-checkin-test-id-first")
         .mockReturnValueOnce("native-checkin-test-id-second")
-      vi.mocked(fetchApi).mockResolvedValue({
+      vi.mocked(newApiFamilyRequests.envelope).mockResolvedValue({
         success: false,
         message: "missing check-in signature header",
         data: null,
@@ -463,7 +466,7 @@ describe("newApiProvider", () => {
     })
 
     it("keeps a failed response when public site status reports check-in disabled", async () => {
-      vi.mocked(fetchApi).mockResolvedValueOnce({
+      vi.mocked(newApiFamilyRequests.envelope).mockResolvedValueOnce({
         success: false,
         message: "check-in unavailable",
         data: null,
@@ -487,7 +490,7 @@ describe("newApiProvider", () => {
     })
 
     it("keeps a pre-dispatch error failed when public status disables check-in", async () => {
-      vi.mocked(fetchApi).mockRejectedValueOnce(
+      vi.mocked(newApiFamilyRequests.envelope).mockRejectedValueOnce(
         new Error("missing check-in signature header"),
       )
       mockFetchSupportCheckIn.mockResolvedValueOnce(false)
@@ -514,7 +517,7 @@ describe("newApiProvider", () => {
     ])(
       "does not use native page check-in for blocked failure message: %s",
       async (message) => {
-        vi.mocked(fetchApi).mockResolvedValueOnce({
+        vi.mocked(newApiFamilyRequests.envelope).mockResolvedValueOnce({
           success: false,
           message,
           data: null,
@@ -540,7 +543,7 @@ describe("newApiProvider", () => {
     it("does not use native page check-in when the API endpoint rejects POST with 405", async () => {
       const error = new ApiError("请求失败: 405", 405, "/api/user/checkin")
 
-      vi.mocked(fetchApi).mockRejectedValueOnce(error)
+      vi.mocked(newApiFamilyRequests.envelope).mockRejectedValueOnce(error)
 
       const result = await checkInForTest(mockAccount)
 
@@ -554,7 +557,7 @@ describe("newApiProvider", () => {
     })
 
     it("refuses native page check-in when temp page identity is missing", async () => {
-      vi.mocked(fetchApi).mockResolvedValueOnce({
+      vi.mocked(newApiFamilyRequests.envelope).mockResolvedValueOnce({
         success: false,
         message: "missing check-in signature header",
         data: null,
@@ -578,7 +581,7 @@ describe("newApiProvider", () => {
     })
 
     it("refuses native page check-in when temp page identity does not match", async () => {
-      vi.mocked(fetchApi).mockResolvedValueOnce({
+      vi.mocked(newApiFamilyRequests.envelope).mockResolvedValueOnce({
         success: false,
         message: "missing check-in signature header",
         data: null,
@@ -606,7 +609,7 @@ describe("newApiProvider", () => {
     })
 
     it("returns manual-required messaging when native page trigger target is missing", async () => {
-      vi.mocked(fetchApi).mockResolvedValueOnce({
+      vi.mocked(newApiFamilyRequests.envelope).mockResolvedValueOnce({
         success: false,
         message: "missing check-in signature header",
         data: null,
@@ -642,7 +645,7 @@ describe("newApiProvider", () => {
     })
 
     it("maps throttled native page actions to trigger failure messaging", async () => {
-      vi.mocked(fetchApi).mockResolvedValueOnce({
+      vi.mocked(newApiFamilyRequests.envelope).mockResolvedValueOnce({
         success: false,
         message: "missing check-in signature header",
         data: null,
@@ -668,7 +671,7 @@ describe("newApiProvider", () => {
     })
 
     it("returns native trigger failure messaging when native page action rejects after response signature failure", async () => {
-      vi.mocked(fetchApi).mockResolvedValueOnce({
+      vi.mocked(newApiFamilyRequests.envelope).mockResolvedValueOnce({
         success: false,
         message: "missing check-in signature header",
         data: null,
@@ -693,7 +696,7 @@ describe("newApiProvider", () => {
       vi.useFakeTimers()
 
       try {
-        vi.mocked(fetchApi).mockResolvedValueOnce({
+        vi.mocked(newApiFamilyRequests.envelope).mockResolvedValueOnce({
           success: false,
           message: "missing check-in signature header",
           data: null,
@@ -715,7 +718,7 @@ describe("newApiProvider", () => {
             },
           },
         })
-        vi.mocked(fetchApiData).mockResolvedValue({
+        vi.mocked(newApiFamilyRequests.data).mockResolvedValue({
           stats: { checked_in_today: false },
         } as any)
 
@@ -737,7 +740,7 @@ describe("newApiProvider", () => {
     })
 
     it("does not add native page identity matching to Turnstile replay failures", async () => {
-      vi.mocked(fetchApi).mockResolvedValueOnce({
+      vi.mocked(newApiFamilyRequests.envelope).mockResolvedValueOnce({
         success: false,
         message: "Turnstile token invalid",
         data: null,
@@ -748,7 +751,7 @@ describe("newApiProvider", () => {
         error: "Turnstile token not available",
         turnstile: { status: "timeout", hasTurnstile: true },
       })
-      vi.mocked(fetchApiData).mockResolvedValueOnce({
+      vi.mocked(newApiFamilyRequests.data).mockResolvedValueOnce({
         stats: { checked_in_today: false },
       } as any)
 
@@ -760,7 +763,7 @@ describe("newApiProvider", () => {
     })
 
     it("uses native page check-in for thrown dynamic signature errors", async () => {
-      vi.mocked(fetchApi).mockRejectedValueOnce(
+      vi.mocked(newApiFamilyRequests.envelope).mockRejectedValueOnce(
         new Error("missing check-in signature header"),
       )
       vi.mocked(tempWindowTriggerCheckinPageAction).mockResolvedValueOnce({
@@ -768,7 +771,7 @@ describe("newApiProvider", () => {
         reason: "clicked",
         identity: { userId: "123", user: { id: "123" } },
       })
-      vi.mocked(fetchApiData).mockResolvedValueOnce({
+      vi.mocked(newApiFamilyRequests.data).mockResolvedValueOnce({
         stats: { checked_in_today: true },
       } as any)
 
@@ -779,7 +782,7 @@ describe("newApiProvider", () => {
     })
 
     it("does not start a second mutation after a dispatched request loses its result", async () => {
-      vi.mocked(fetchApi).mockRejectedValueOnce(
+      vi.mocked(newApiFamilyRequests.envelope).mockRejectedValueOnce(
         new Error("missing check-in signature header"),
       )
       const mutationLifecycle = createAutoCheckinMutationLifecycle()
@@ -794,13 +797,13 @@ describe("newApiProvider", () => {
         status: CHECKIN_RESULT_STATUS.UNCERTAIN,
         rawMessage: "missing check-in signature header",
       })
-      expect(fetchApiData).not.toHaveBeenCalled()
+      expect(newApiFamilyRequests.data).not.toHaveBeenCalled()
       expect(tempWindowTriggerCheckinPageAction).not.toHaveBeenCalled()
       expect(tempWindowTurnstileFetch).not.toHaveBeenCalled()
     })
 
     it("returns native trigger failure messaging when native page action rejects after thrown signature error", async () => {
-      vi.mocked(fetchApi).mockRejectedValueOnce(
+      vi.mocked(newApiFamilyRequests.envelope).mockRejectedValueOnce(
         new Error("missing check-in signature header"),
       )
       vi.mocked(tempWindowTriggerCheckinPageAction).mockRejectedValueOnce(
@@ -818,7 +821,7 @@ describe("newApiProvider", () => {
     })
 
     it("returns the default success message key when the upstream check-in succeeds without a message", async () => {
-      vi.mocked(fetchApi).mockResolvedValueOnce({
+      vi.mocked(newApiFamilyRequests.envelope).mockResolvedValueOnce({
         success: true,
         message: "",
         data: { checkin_date: "2026-01-01", quota_awarded: 1 },
@@ -831,13 +834,15 @@ describe("newApiProvider", () => {
         messageKey: "autoCheckin:providerFallback.checkinSuccessful",
         data: { checkin_date: "2026-01-01", quota_awarded: 1 },
       })
-      expect(vi.mocked(fetchApi).mock.calls[0]?.[0]).toMatchObject({
+      expect(
+        vi.mocked(newApiFamilyRequests.envelope).mock.calls[0]?.[0],
+      ).toMatchObject({
         tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Background,
       })
     })
 
     it("treats upstream already-checked responses as already_checked results", async () => {
-      vi.mocked(fetchApi).mockResolvedValueOnce({
+      vi.mocked(newApiFamilyRequests.envelope).mockResolvedValueOnce({
         success: false,
         message: "今日已签到",
         data: { checkin_date: "2026-01-01" },
@@ -853,13 +858,13 @@ describe("newApiProvider", () => {
     })
 
     it("uses status readback to recognize already checked independently of error copy", async () => {
-      vi.mocked(fetchApi).mockResolvedValueOnce({
+      vi.mocked(newApiFamilyRequests.envelope).mockResolvedValueOnce({
         success: false,
         message: "No action is necessary today",
         data: null,
       })
       mockFetchSupportCheckIn.mockResolvedValueOnce(true)
-      vi.mocked(fetchApiData).mockResolvedValueOnce({
+      vi.mocked(newApiFamilyRequests.data).mockResolvedValueOnce({
         enabled: true,
         stats: { checked_in_today: true },
       } as any)
@@ -874,7 +879,7 @@ describe("newApiProvider", () => {
     })
 
     it("uses an incognito Turnstile temp context first for access-token accounts", async () => {
-      vi.mocked(fetchApi).mockResolvedValueOnce({
+      vi.mocked(newApiFamilyRequests.envelope).mockResolvedValueOnce({
         success: false,
         message: "Turnstile token 为空",
         data: null,
@@ -920,7 +925,7 @@ describe("newApiProvider", () => {
     })
 
     it("uses the theme-aware New API route for Turnstile-assisted verification pages", async () => {
-      vi.mocked(fetchApi).mockResolvedValueOnce({
+      vi.mocked(newApiFamilyRequests.envelope).mockResolvedValueOnce({
         success: false,
         message: "Turnstile token 为空",
         data: null,
@@ -952,7 +957,7 @@ describe("newApiProvider", () => {
     })
 
     it("falls back to normal Turnstile temp context when access-token incognito access is unavailable", async () => {
-      vi.mocked(fetchApi).mockResolvedValueOnce({
+      vi.mocked(newApiFamilyRequests.envelope).mockResolvedValueOnce({
         success: false,
         message: "Turnstile token 为空",
         data: null,
@@ -980,7 +985,7 @@ describe("newApiProvider", () => {
     })
 
     it("defaults missing authType to AccessToken for direct check-in requests", async () => {
-      vi.mocked(fetchApi).mockResolvedValueOnce({
+      vi.mocked(newApiFamilyRequests.envelope).mockResolvedValueOnce({
         success: true,
         message: "签到成功",
         data: { checkin_date: "2026-01-01", quota_awarded: 1 },
@@ -991,19 +996,18 @@ describe("newApiProvider", () => {
         authType: undefined as any,
       })
 
-      expect(fetchApi).toHaveBeenCalledWith(
+      expect(newApiFamilyRequests.envelope).toHaveBeenCalledWith(
         expect.objectContaining({
           auth: expect.objectContaining({
             authType: AuthTypeEnum.AccessToken,
           }),
         }),
         expect.any(Object),
-        false,
       )
     })
 
     it("uses cookie-auth temp-context options when Turnstile assistance runs for cookie-auth accounts", async () => {
-      vi.mocked(fetchApi).mockResolvedValueOnce({
+      vi.mocked(newApiFamilyRequests.envelope).mockResolvedValueOnce({
         success: false,
         message: "Turnstile verify failed",
         data: null,
@@ -1015,7 +1019,7 @@ describe("newApiProvider", () => {
         turnstile: { status: "timeout", hasTurnstile: true },
       })
 
-      vi.mocked(fetchApiData).mockResolvedValueOnce({
+      vi.mocked(newApiFamilyRequests.data).mockResolvedValueOnce({
         stats: { checked_in_today: false },
       } as any)
 
@@ -1062,7 +1066,7 @@ describe("newApiProvider", () => {
     })
 
     it("returns manual-required messaging with the site check-in URL when Turnstile token cannot be obtained", async () => {
-      vi.mocked(fetchApi).mockResolvedValueOnce({
+      vi.mocked(newApiFamilyRequests.envelope).mockResolvedValueOnce({
         success: false,
         message: "Turnstile 校验失败，请刷新重试！",
         data: null,
@@ -1074,7 +1078,7 @@ describe("newApiProvider", () => {
         turnstile: { status: "timeout", hasTurnstile: true },
       })
 
-      vi.mocked(fetchApiData).mockResolvedValueOnce({
+      vi.mocked(newApiFamilyRequests.data).mockResolvedValueOnce({
         stats: { checked_in_today: false },
       } as any)
 
@@ -1098,7 +1102,7 @@ describe("newApiProvider", () => {
     })
 
     it("returns already-checked when Turnstile token is missing but status confirms checked_in_today", async () => {
-      vi.mocked(fetchApi).mockResolvedValueOnce({
+      vi.mocked(newApiFamilyRequests.envelope).mockResolvedValueOnce({
         success: false,
         message: "Turnstile token 为空",
         data: null,
@@ -1121,7 +1125,7 @@ describe("newApiProvider", () => {
     })
 
     it("returns manual-required when Turnstile assistance succeeds but still cannot obtain a usable token", async () => {
-      vi.mocked(fetchApi).mockResolvedValueOnce({
+      vi.mocked(newApiFamilyRequests.envelope).mockResolvedValueOnce({
         success: false,
         message: "Turnstile token invalid",
         data: null,
@@ -1139,7 +1143,7 @@ describe("newApiProvider", () => {
         turnstile: { status: "timeout", hasTurnstile: true },
       })
 
-      vi.mocked(fetchApiData).mockResolvedValueOnce({
+      vi.mocked(newApiFamilyRequests.data).mockResolvedValueOnce({
         stats: { checked_in_today: false },
       } as any)
 
@@ -1161,7 +1165,7 @@ describe("newApiProvider", () => {
     })
 
     it("returns already-checked when assisted success payload still shows a non-token-obtained Turnstile status", async () => {
-      vi.mocked(fetchApi).mockResolvedValueOnce({
+      vi.mocked(newApiFamilyRequests.envelope).mockResolvedValueOnce({
         success: false,
         message: "Turnstile verify failed",
         data: null,
@@ -1195,7 +1199,7 @@ describe("newApiProvider", () => {
     })
 
     it("surfaces the assisted backend failure when Turnstile replay returns a concrete rejection without widget status", async () => {
-      vi.mocked(fetchApi).mockResolvedValueOnce({
+      vi.mocked(newApiFamilyRequests.envelope).mockResolvedValueOnce({
         success: false,
         message: "Turnstile verify failed",
         data: null,
@@ -1224,11 +1228,11 @@ describe("newApiProvider", () => {
           data: null,
         },
       })
-      expect(fetchApiData).toHaveBeenCalledTimes(1)
+      expect(newApiFamilyRequests.data).toHaveBeenCalledTimes(1)
     })
 
     it("falls back to the generic failure key when assisted replay returns no usable payload", async () => {
-      vi.mocked(fetchApi).mockResolvedValueOnce({
+      vi.mocked(newApiFamilyRequests.envelope).mockResolvedValueOnce({
         success: false,
         message: "Turnstile verify failed",
         data: null,
@@ -1249,11 +1253,11 @@ describe("newApiProvider", () => {
         messageKey: "autoCheckin:providerFallback.checkinFailed",
         data: undefined,
       })
-      expect(fetchApiData).toHaveBeenCalledTimes(1)
+      expect(newApiFamilyRequests.data).toHaveBeenCalledTimes(1)
     })
 
     it("falls back to a generic failure when assisted Turnstile fetch fails after token capture without an explicit error", async () => {
-      vi.mocked(fetchApi).mockResolvedValueOnce({
+      vi.mocked(newApiFamilyRequests.envelope).mockResolvedValueOnce({
         success: false,
         message: "Turnstile token invalid",
         data: null,
@@ -1278,7 +1282,7 @@ describe("newApiProvider", () => {
     })
 
     it("uses the assisted error directly when token capture succeeds but replay still fails", async () => {
-      vi.mocked(fetchApi).mockResolvedValueOnce({
+      vi.mocked(newApiFamilyRequests.envelope).mockResolvedValueOnce({
         success: false,
         message: "Turnstile token invalid",
         data: null,
@@ -1305,7 +1309,7 @@ describe("newApiProvider", () => {
     })
 
     it("preserves the popup source across preferred and fallback Turnstile attempts", async () => {
-      vi.mocked(fetchApi).mockResolvedValueOnce({
+      vi.mocked(newApiFamilyRequests.envelope).mockResolvedValueOnce({
         success: false,
         message: "Turnstile token 为空",
         data: null,
@@ -1329,7 +1333,7 @@ describe("newApiProvider", () => {
           turnstile: { status: "token_obtained", hasTurnstile: true },
         })
 
-      vi.mocked(fetchApiData).mockResolvedValueOnce({
+      vi.mocked(newApiFamilyRequests.data).mockResolvedValueOnce({
         stats: { checked_in_today: false },
       } as any)
 
@@ -1360,16 +1364,20 @@ describe("newApiProvider", () => {
       expect(
         vi.mocked(tempWindowTurnstileFetch).mock.calls[1]?.[0].useIncognito,
       ).toBeUndefined()
-      expect(vi.mocked(fetchApi).mock.calls[0]?.[0]).toMatchObject({
+      expect(
+        vi.mocked(newApiFamilyRequests.envelope).mock.calls[0]?.[0],
+      ).toMatchObject({
         tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
       })
-      expect(vi.mocked(fetchApiData).mock.calls[0]?.[0]).toMatchObject({
+      expect(
+        vi.mocked(newApiFamilyRequests.data).mock.calls[0]?.[0],
+      ).toMatchObject({
         tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
       })
     })
 
     it("falls back to manual verification when the incognito retry still cannot complete the assisted request", async () => {
-      vi.mocked(fetchApi).mockResolvedValueOnce({
+      vi.mocked(newApiFamilyRequests.envelope).mockResolvedValueOnce({
         success: false,
         message: "Turnstile token 为空",
         data: null,
@@ -1387,7 +1395,7 @@ describe("newApiProvider", () => {
           turnstile: { status: "error", hasTurnstile: true },
         })
 
-      vi.mocked(fetchApiData).mockResolvedValueOnce({
+      vi.mocked(newApiFamilyRequests.data).mockResolvedValueOnce({
         stats: { checked_in_today: false },
       } as any)
       vi.mocked(isAllowedIncognitoAccess).mockResolvedValueOnce(true)
@@ -1410,7 +1418,7 @@ describe("newApiProvider", () => {
     })
 
     it("prompts to enable incognito access when incognito retry is needed but extension is not allowed in incognito", async () => {
-      vi.mocked(fetchApi).mockResolvedValueOnce({
+      vi.mocked(newApiFamilyRequests.envelope).mockResolvedValueOnce({
         success: false,
         message: "Turnstile token 为空",
         data: null,
@@ -1422,7 +1430,7 @@ describe("newApiProvider", () => {
         turnstile: { status: "not_present", hasTurnstile: false },
       })
 
-      vi.mocked(fetchApiData).mockResolvedValueOnce({
+      vi.mocked(newApiFamilyRequests.data).mockResolvedValueOnce({
         stats: { checked_in_today: false },
       } as any)
 
@@ -1441,7 +1449,7 @@ describe("newApiProvider", () => {
     })
 
     it("does not trigger Turnstile flow for non-Turnstile failures", async () => {
-      vi.mocked(fetchApi).mockResolvedValueOnce({
+      vi.mocked(newApiFamilyRequests.envelope).mockResolvedValueOnce({
         success: false,
         message: "Something went wrong",
         data: null,
@@ -1460,7 +1468,7 @@ describe("newApiProvider", () => {
     })
 
     it("does not treat every Turnstile mention as a Turnstile-required failure", async () => {
-      vi.mocked(fetchApi).mockResolvedValueOnce({
+      vi.mocked(newApiFamilyRequests.envelope).mockResolvedValueOnce({
         success: false,
         message: "Turnstile challenge rendered on page",
         data: { reason: "manual step still needed" },
@@ -1482,7 +1490,7 @@ describe("newApiProvider", () => {
     })
 
     it("maps endpoint-style errors from the direct request to endpoint-not-supported", async () => {
-      vi.mocked(fetchApi).mockRejectedValueOnce({
+      vi.mocked(newApiFamilyRequests.envelope).mockRejectedValueOnce({
         statusCode: 404,
         message: "Not found",
       })
@@ -1496,7 +1504,7 @@ describe("newApiProvider", () => {
     })
 
     it("returns a generic failed result when the Turnstile-assisted fetch cannot start", async () => {
-      vi.mocked(fetchApi).mockResolvedValueOnce({
+      vi.mocked(newApiFamilyRequests.envelope).mockResolvedValueOnce({
         success: false,
         message: "Turnstile token invalid",
         data: null,
@@ -1514,7 +1522,7 @@ describe("newApiProvider", () => {
     })
 
     it("uses the generic failure key when the direct request fails without any upstream message", async () => {
-      vi.mocked(fetchApi).mockResolvedValueOnce({
+      vi.mocked(newApiFamilyRequests.envelope).mockResolvedValueOnce({
         success: false,
         message: "",
         data: { details: "unknown failure" },

--- a/tests/services/autoCheckin/providers/veloera.test.ts
+++ b/tests/services/autoCheckin/providers/veloera.test.ts
@@ -1,10 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { SITE_TYPES } from "~/constants/siteType"
-import {
-  fetchApi,
-  fetchApiData,
-} from "~/services/apiService/newApiFamily/request"
+import { newApiFamilyRequests } from "~/services/apiService/newApiFamily/request"
 import { ApiError } from "~/services/apiTransport/errors"
 import { veloeraProvider } from "~/services/checkin/autoCheckin/providers/veloera"
 import { PROTECTION_BYPASS_USER_COMMANDS } from "~/services/protectionBypass/contracts"
@@ -18,8 +15,10 @@ const { mockFetchVeloeraCheckInSupport } = vi.hoisted(() => ({
 }))
 
 vi.mock("~/services/apiService/newApiFamily/request", () => ({
-  fetchApi: vi.fn(),
-  fetchApiData: vi.fn(),
+  newApiFamilyRequests: {
+    data: vi.fn(),
+    envelope: vi.fn(),
+  },
 }))
 
 vi.mock("~/services/apiService/newApiFamily/variants/veloeraCheckIn", () => ({
@@ -127,7 +126,7 @@ describe("veloeraProvider", () => {
   })
 
   it("uses only the safe GET reader and rejects malformed status", async () => {
-    vi.mocked(fetchApiData)
+    vi.mocked(newApiFamilyRequests.data)
       .mockResolvedValueOnce({ can_check_in: true })
       .mockResolvedValueOnce({})
 
@@ -144,10 +143,12 @@ describe("veloeraProvider", () => {
       reason: "invalid_response",
       attemptedAt: 211,
     })
-    expect(vi.mocked(fetchApiData).mock.calls[0]?.[1]).toMatchObject({
+    expect(
+      vi.mocked(newApiFamilyRequests.data).mock.calls[0]?.[1],
+    ).toMatchObject({
       endpoint: "/api/user/check_in_status",
     })
-    expect(fetchApi).not.toHaveBeenCalled()
+    expect(newApiFamilyRequests.envelope).not.toHaveBeenCalled()
   })
 
   it("uses the public Veloera capability flag before the per-user status", async () => {
@@ -159,7 +160,7 @@ describe("veloeraProvider", () => {
       detection: { outcome: "matched" },
       status: { outcome: "known", availability: "disabled" },
     })
-    expect(fetchApiData).not.toHaveBeenCalled()
+    expect(newApiFamilyRequests.data).not.toHaveBeenCalled()
   })
 
   it("propagates the discovery abort signal to the public support probe", async () => {
@@ -180,10 +181,10 @@ describe("veloeraProvider", () => {
 
   describe("checkIn", () => {
     it("propagates the popup source when the backend omits a message", async () => {
-      const { fetchApi } = await import(
+      const { newApiFamilyRequests } = await import(
         "~/services/apiService/newApiFamily/request"
       )
-      vi.mocked(fetchApi).mockResolvedValueOnce({
+      vi.mocked(newApiFamilyRequests.envelope).mockResolvedValueOnce({
         success: true,
         data: { quota_awarded: 2 },
         message: "",
@@ -202,17 +203,19 @@ describe("veloeraProvider", () => {
         messageKey: "autoCheckin:providerFallback.checkinSuccessful",
         data: { quota_awarded: 2 },
       })
-      expect(vi.mocked(fetchApi).mock.calls[0]?.[0]).toMatchObject({
+      expect(
+        vi.mocked(newApiFamilyRequests.envelope).mock.calls[0]?.[0],
+      ).toMatchObject({
         accountId: "test-id",
         tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Popup,
       })
     })
 
     it("returns success on successful check-in", async () => {
-      const { fetchApi } = await import(
+      const { newApiFamilyRequests } = await import(
         "~/services/apiService/newApiFamily/request"
       )
-      vi.mocked(fetchApi).mockResolvedValueOnce({
+      vi.mocked(newApiFamilyRequests.envelope).mockResolvedValueOnce({
         success: true,
         data: null,
         message: "Success",
@@ -220,16 +223,18 @@ describe("veloeraProvider", () => {
 
       const result = await checkInForTest(mockAccount)
       expect(result.status).toBe("success")
-      expect(vi.mocked(fetchApi).mock.calls[0]?.[0]).toMatchObject({
+      expect(
+        vi.mocked(newApiFamilyRequests.envelope).mock.calls[0]?.[0],
+      ).toMatchObject({
         tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Background,
       })
     })
 
     it("returns already_checked when already checked in", async () => {
-      const { fetchApi } = await import(
+      const { newApiFamilyRequests } = await import(
         "~/services/apiService/newApiFamily/request"
       )
-      vi.mocked(fetchApi).mockResolvedValueOnce({
+      vi.mocked(newApiFamilyRequests.envelope).mockResolvedValueOnce({
         success: true,
         data: null,
         message: "已签到",
@@ -240,10 +245,10 @@ describe("veloeraProvider", () => {
     })
 
     it("returns the fallback failure key when the backend fails without a message", async () => {
-      const { fetchApi } = await import(
+      const { newApiFamilyRequests } = await import(
         "~/services/apiService/newApiFamily/request"
       )
-      vi.mocked(fetchApi).mockResolvedValueOnce({
+      vi.mocked(newApiFamilyRequests.envelope).mockResolvedValueOnce({
         success: false,
         data: { code: 500 },
         message: "",
@@ -264,13 +269,15 @@ describe("veloeraProvider", () => {
     })
 
     it("uses status readback to recognize an already completed check-in", async () => {
-      vi.mocked(fetchApi).mockResolvedValueOnce({
+      vi.mocked(newApiFamilyRequests.envelope).mockResolvedValueOnce({
         success: false,
         data: null,
         message: "No action was performed",
       })
       mockFetchVeloeraCheckInSupport.mockResolvedValueOnce(true)
-      vi.mocked(fetchApiData).mockResolvedValueOnce({ can_check_in: false })
+      vi.mocked(newApiFamilyRequests.data).mockResolvedValueOnce({
+        can_check_in: false,
+      })
 
       await expect(checkInForTest(mockAccount)).resolves.toMatchObject({
         status: "already_checked",
@@ -279,7 +286,7 @@ describe("veloeraProvider", () => {
     })
 
     it("does not infer endpoint support from unrelated error text", async () => {
-      vi.mocked(fetchApi).mockRejectedValueOnce(
+      vi.mocked(newApiFamilyRequests.envelope).mockRejectedValueOnce(
         new Error("Quota bucket 404 is unavailable"),
       )
 
@@ -293,7 +300,7 @@ describe("veloeraProvider", () => {
     })
 
     it("maps a structured 404 response to endpoint-not-supported", async () => {
-      vi.mocked(fetchApi).mockRejectedValueOnce(
+      vi.mocked(newApiFamilyRequests.envelope).mockRejectedValueOnce(
         new ApiError("Not found", 404, "/api/user/check_in"),
       )
 
@@ -304,10 +311,12 @@ describe("veloeraProvider", () => {
     })
 
     it("handles errors gracefully", async () => {
-      const { fetchApi } = await import(
+      const { newApiFamilyRequests } = await import(
         "~/services/apiService/newApiFamily/request"
       )
-      vi.mocked(fetchApi).mockRejectedValueOnce(new Error("Network error"))
+      vi.mocked(newApiFamilyRequests.envelope).mockRejectedValueOnce(
+        new Error("Network error"),
+      )
 
       const result = await checkInForTest(mockAccount)
       expect(result.status).toBe("failed")

--- a/tests/services/autoCheckin/providers/wong.test.ts
+++ b/tests/services/autoCheckin/providers/wong.test.ts
@@ -10,7 +10,9 @@ import { createAutoCheckinMutationLifecycle } from "~~/tests/test-utils/autoChec
 import { buildCheckInConfig } from "~~/tests/test-utils/checkIn"
 
 vi.mock("~/services/apiService/newApiFamily/request", () => ({
-  fetchApi: vi.fn(),
+  newApiFamilyRequests: {
+    envelope: vi.fn(),
+  },
 }))
 
 const mockAccount: SiteAccount = {
@@ -111,10 +113,10 @@ describe("wongGongyiProvider", () => {
   })
 
   it("uses a strict GET status envelope and never probes with POST", async () => {
-    const { fetchApi } = await import(
+    const { newApiFamilyRequests } = await import(
       "~/services/apiService/newApiFamily/request"
     )
-    vi.mocked(fetchApi)
+    vi.mocked(newApiFamilyRequests.envelope)
       .mockResolvedValueOnce({
         success: true,
         message: "",
@@ -147,7 +149,9 @@ describe("wongGongyiProvider", () => {
       reason: "invalid_response",
       attemptedAt: 222,
     })
-    expect(vi.mocked(fetchApi).mock.calls[0]?.[1]).toMatchObject({
+    expect(
+      vi.mocked(newApiFamilyRequests.envelope).mock.calls[0]?.[1],
+    ).toMatchObject({
       endpoint: "/api/user/checkin",
       options: { method: "GET" },
     })
@@ -155,10 +159,10 @@ describe("wongGongyiProvider", () => {
 
   describe("checkIn", () => {
     it("propagates the popup source when POST indicates checked_in true", async () => {
-      const { fetchApi } = await import(
+      const { newApiFamilyRequests } = await import(
         "~/services/apiService/newApiFamily/request"
       )
-      const mockedFetchApi = vi.mocked(fetchApi)
+      const mockedFetchApi = vi.mocked(newApiFamilyRequests.envelope)
 
       mockedFetchApi.mockResolvedValueOnce({
         success: false,
@@ -183,10 +187,10 @@ describe("wongGongyiProvider", () => {
     })
 
     it("returns already_checked when POST success=true but message indicates already checked", async () => {
-      const { fetchApi } = await import(
+      const { newApiFamilyRequests } = await import(
         "~/services/apiService/newApiFamily/request"
       )
-      const mockedFetchApi = vi.mocked(fetchApi)
+      const mockedFetchApi = vi.mocked(newApiFamilyRequests.envelope)
 
       mockedFetchApi.mockResolvedValueOnce({
         success: true,
@@ -202,10 +206,10 @@ describe("wongGongyiProvider", () => {
     })
 
     it("returns failed when POST indicates enabled false", async () => {
-      const { fetchApi } = await import(
+      const { newApiFamilyRequests } = await import(
         "~/services/apiService/newApiFamily/request"
       )
-      const mockedFetchApi = vi.mocked(fetchApi)
+      const mockedFetchApi = vi.mocked(newApiFamilyRequests.envelope)
 
       mockedFetchApi.mockResolvedValueOnce({
         success: true,
@@ -219,10 +223,10 @@ describe("wongGongyiProvider", () => {
     })
 
     it("returns success when POST succeeds and user was not checked in", async () => {
-      const { fetchApi } = await import(
+      const { newApiFamilyRequests } = await import(
         "~/services/apiService/newApiFamily/request"
       )
-      const mockedFetchApi = vi.mocked(fetchApi)
+      const mockedFetchApi = vi.mocked(newApiFamilyRequests.envelope)
 
       mockedFetchApi.mockResolvedValueOnce({
         success: true,
@@ -238,10 +242,10 @@ describe("wongGongyiProvider", () => {
     })
 
     it("does not let ambiguous copy override an explicit unchecked status", async () => {
-      const { fetchApi } = await import(
+      const { newApiFamilyRequests } = await import(
         "~/services/apiService/newApiFamily/request"
       )
-      vi.mocked(fetchApi).mockResolvedValueOnce({
+      vi.mocked(newApiFamilyRequests.envelope).mockResolvedValueOnce({
         success: true,
         message: "User was not already checked in",
         data: { enabled: true, checked_in: false },
@@ -254,10 +258,10 @@ describe("wongGongyiProvider", () => {
     })
 
     it("returns failed when POST returns success=false without already-checked signal", async () => {
-      const { fetchApi } = await import(
+      const { newApiFamilyRequests } = await import(
         "~/services/apiService/newApiFamily/request"
       )
-      const mockedFetchApi = vi.mocked(fetchApi)
+      const mockedFetchApi = vi.mocked(newApiFamilyRequests.envelope)
 
       mockedFetchApi.mockResolvedValueOnce({
         success: false,
@@ -273,10 +277,10 @@ describe("wongGongyiProvider", () => {
     })
 
     it("returns already_checked when POST returns already checked message", async () => {
-      const { fetchApi } = await import(
+      const { newApiFamilyRequests } = await import(
         "~/services/apiService/newApiFamily/request"
       )
-      const mockedFetchApi = vi.mocked(fetchApi)
+      const mockedFetchApi = vi.mocked(newApiFamilyRequests.envelope)
 
       mockedFetchApi.mockResolvedValueOnce({
         success: false,
@@ -289,10 +293,10 @@ describe("wongGongyiProvider", () => {
     })
 
     it("handles network errors gracefully", async () => {
-      const { fetchApi } = await import(
+      const { newApiFamilyRequests } = await import(
         "~/services/apiService/newApiFamily/request"
       )
-      const mockedFetchApi = vi.mocked(fetchApi)
+      const mockedFetchApi = vi.mocked(newApiFamilyRequests.envelope)
 
       mockedFetchApi.mockRejectedValueOnce(new TypeError("Failed to fetch"))
 
@@ -306,14 +310,16 @@ describe("wongGongyiProvider", () => {
     })
 
     it("marks a lost response after POST dispatch as uncertain", async () => {
-      const { fetchApi } = await import(
+      const { newApiFamilyRequests } = await import(
         "~/services/apiService/newApiFamily/request"
       )
       const mutationLifecycle = createAutoCheckinMutationLifecycle()
-      vi.mocked(fetchApi).mockImplementationOnce(async (request) => {
-        request.observer?.onDispatch()
-        throw new TypeError("Failed to fetch")
-      })
+      vi.mocked(newApiFamilyRequests.envelope).mockImplementationOnce(
+        async (request) => {
+          request.observer?.onDispatch()
+          throw new TypeError("Failed to fetch")
+        },
+      )
 
       await expect(
         checkInForTest(mockAccount, {
@@ -327,10 +333,10 @@ describe("wongGongyiProvider", () => {
     })
 
     it("returns endpointNotSupported when API returns 404", async () => {
-      const { fetchApi } = await import(
+      const { newApiFamilyRequests } = await import(
         "~/services/apiService/newApiFamily/request"
       )
-      const mockedFetchApi = vi.mocked(fetchApi)
+      const mockedFetchApi = vi.mocked(newApiFamilyRequests.envelope)
 
       mockedFetchApi.mockRejectedValueOnce({
         statusCode: 404,

--- a/tests/services/newApiService/newApiService.test.ts
+++ b/tests/services/newApiService/newApiService.test.ts
@@ -324,6 +324,7 @@ describe("newApiService", () => {
       expect(mockFetchApiData).toHaveBeenCalledWith(request, {
         endpoint: "/api/channel/search?keyword=https%3A%2F%2Fapi.example.com",
         errorResponseDecoder: decodeNewApiResponseError,
+        responseType: "json",
       })
     })
 
@@ -416,6 +417,7 @@ describe("newApiService", () => {
             body: expect.stringContaining('"name":"Test Channel"'),
           }),
         }),
+        false,
       )
     })
 
@@ -525,6 +527,7 @@ describe("newApiService", () => {
             body: JSON.stringify(updateData),
           },
         }),
+        false,
       )
     })
 


### PR DESCRIPTION
## Summary

Move JSON error-response ownership from the generic transport layer into provider-specific request boundaries.

The new decoders follow verified New API, Veloera, DoneHub, and OpenRouter response structures while preserving adapters that intentionally consume raw responses or perform their own parsing.

## What changed

- Replace New API-family named request exports with explicit `data`, `envelope`, and `payload` request modes.
- Move New API token-secret endpoint parsing into the New API provider layer while retaining shared caching and deduplication.
- Add provider-owned Veloera and DoneHub managed-site request/error decoders.
- Parse DoneHub's managed-site group endpoint as its actual bare-array response.
- Add strict OpenRouter management error decoding for the documented nested error shape.
- Preserve the fallback order: provider decoder, `getErrorMessage`, then a fixed local status message.
- Keep redaction at disclosure boundaries instead of removing useful diagnostic context inside provider parsers.
- Retain the legacy compatibility decoder until the remaining raw, self-parsing, and cross-provider callers establish explicit ownership.

## Compatibility and privacy

- No compatibility re-exports were added.
- Existing raw-response and provider-native parsing paths were not mechanically migrated.
- The legacy compatibility decoder remains available, so this change does not force unrelated adapters onto the new abstraction.
- Provider messages remain private diagnostic context; telemetry and other external disclosure boundaries continue to redact them.

## Validation

- `pnpm compile`
- Focused provider and adapter suite: 35 files, 609 tests passed
- Pre-commit `validate:staged` passed for all three commits
- Pre-push `validate:push` passed (`compile` and `knip`)
- `git diff --check origin/main..HEAD`
- Full repository test and coverage suites were not run locally; PR CI remains authoritative.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added provider-specific handling for DoneHub, Veloera, OpenRouter, and New API responses.
  - Added reliable token secret-key retrieval across supported API variants.
  - Group retrieval now returns the complete available group list in one request.

- **Bug Fixes**
  - Improved error messages for blank or structured provider failures.
  - Preserved upstream error details, status information, and diagnostic codes.
  - Improved check-in and channel-management request reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->