### PR TITLE
refactor(api-service): own provider error responses

### DIFF
--- a/src/features/BasicSettings/components/tabs/ManagedSite/ClaudeCodeHubSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/ManagedSite/ClaudeCodeHubSettings.tsx
@@ -8,7 +8,7 @@ import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
 import { blurInputOnEnter } from "~/hooks/useDeferredPreferenceField"
 import { usePreferenceDraft } from "~/hooks/usePreferenceDraft"
 import { validateClaudeCodeHubConfig } from "~/services/apiService/claudeCodeHub"
-import { getErrorMessage } from "~/utils/core/error"
+import { toSanitizedErrorSummary } from "~/services/verification/aiApiVerification/utils"
 import {
   createVersionedPreferenceSaveOptions,
   getPreferenceWriteFailureMessage,
@@ -109,9 +109,12 @@ export default function ClaudeCodeHubSettings() {
         )
       }
     } catch (error) {
+      const safeError =
+        toSanitizedErrorSummary(error, [adminToken]) ||
+        "Claude Code Hub request failed"
       toast.error(
         t("claudeCodeHub.validation.failed", {
-          error: getErrorMessage(error),
+          error: safeError,
         }),
       )
     } finally {

--- a/src/services/aiApi/anthropic/index.ts
+++ b/src/services/aiApi/anthropic/index.ts
@@ -11,6 +11,7 @@ import {
   rememberAnthropicBearerAuth,
   type AnthropicAuthMode,
 } from "./auth"
+import { decodeAnthropicResponseError } from "./responseError"
 
 type AnthropicAuthParams = {
   baseUrl: string
@@ -62,6 +63,7 @@ export async function fetchAnthropicModelIds(
         request,
         {
           endpoint,
+          errorResponseDecoder: decodeAnthropicResponseError,
           options: {
             signal: params.abortSignal,
             headers: createAnthropicAuthHeaders(params.apiKey, mode),

--- a/src/services/aiApi/anthropic/responseError.ts
+++ b/src/services/aiApi/anthropic/responseError.ts
@@ -1,0 +1,31 @@
+import { readSafeUpstreamCode } from "~/services/apiTransport/responseError"
+import type { ApiResponseErrorDecoder } from "~/services/apiTransport/type"
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+/**
+ * Decodes Anthropic's documented non-2xx error envelope without applying
+ * disclosure policy.
+ * https://docs.anthropic.com/en/api/errors
+ */
+export const decodeAnthropicResponseError: ApiResponseErrorDecoder = (
+  response,
+) => {
+  if (response.ok || !isRecord(response.body)) return null
+  if (response.body.type !== "error" || !isRecord(response.body.error)) {
+    return null
+  }
+
+  const error = response.body.error
+  const type = typeof error.type === "string" ? error.type.trim() : ""
+  const message = typeof error.message === "string" ? error.message.trim() : ""
+  if (!type || !message) return null
+
+  const upstreamCode = readSafeUpstreamCode(type)
+  return {
+    kind: "http",
+    message,
+    ...(upstreamCode ? { upstreamCode } : {}),
+  }
+}

--- a/src/services/aiApi/google/index.ts
+++ b/src/services/aiApi/google/index.ts
@@ -11,6 +11,7 @@ import {
   rememberGoogleBearerAuth,
   type GoogleAuthMode,
 } from "./auth"
+import { decodeGoogleResponseError } from "./responseError"
 
 type GoogleAuthParams = {
   baseUrl: string
@@ -59,6 +60,7 @@ export async function fetchGoogleModelIds(
           request,
           {
             endpoint,
+            errorResponseDecoder: decodeGoogleResponseError,
             options: {
               signal: params.abortSignal,
               headers: createGoogleAuthHeaders(params.apiKey, mode),

--- a/src/services/aiApi/google/responseError.ts
+++ b/src/services/aiApi/google/responseError.ts
@@ -1,0 +1,30 @@
+import { readSafeUpstreamCode } from "~/services/apiTransport/responseError"
+import type { ApiResponseErrorDecoder } from "~/services/apiTransport/type"
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+/**
+ * Decodes Google's documented non-2xx REST `google.rpc.Status` envelope
+ * without applying disclosure policy.
+ * https://ai.google.dev/api/rest#rest-resource:-v1beta.status
+ */
+export const decodeGoogleResponseError: ApiResponseErrorDecoder = (
+  response,
+) => {
+  if (response.ok || !isRecord(response.body)) return null
+
+  const error = response.body.error
+  if (!isRecord(error) || !Number.isInteger(error.code)) return null
+
+  const message = typeof error.message === "string" ? error.message.trim() : ""
+  if (!message) return null
+
+  const upstreamCode =
+    readSafeUpstreamCode(error.status) ?? readSafeUpstreamCode(error.code)
+  return {
+    kind: "http",
+    message,
+    ...(upstreamCode ? { upstreamCode } : {}),
+  }
+}

--- a/src/services/aiApi/openaiCompatible/index.ts
+++ b/src/services/aiApi/openaiCompatible/index.ts
@@ -9,6 +9,8 @@ import { AuthTypeEnum } from "~/types"
 import { createLogger } from "~/utils/core/logger"
 import { coerceBaseUrlToPathSuffix, normalizeHttpUrl } from "~/utils/core/url"
 
+import { decodeOpenAICompatibleResponseError } from "./responseError"
+
 /**
  * Unified logger scoped to OpenAI-compatible upstream model fetch helpers.
  */
@@ -71,6 +73,7 @@ export const discoverOpenAICompatibleModels = async (
     try {
       const models = await fetchApiData<unknown>(request, {
         endpoint,
+        errorResponseDecoder: decodeOpenAICompatibleResponseError,
         ...(params.abortSignal
           ? { options: { signal: params.abortSignal } }
           : {}),

--- a/src/services/aiApi/openaiCompatible/responseError.ts
+++ b/src/services/aiApi/openaiCompatible/responseError.ts
@@ -1,0 +1,30 @@
+import { readSafeUpstreamCode } from "~/services/apiTransport/responseError"
+import type { ApiResponseErrorDecoder } from "~/services/apiTransport/type"
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+/**
+ * Decodes OpenAI's documented non-2xx `{ error: { type, code, message } }`
+ * response without applying disclosure policy.
+ * https://platform.openai.com/docs/guides/error-codes/api-errors
+ */
+export const decodeOpenAICompatibleResponseError: ApiResponseErrorDecoder = (
+  response,
+) => {
+  if (response.ok || !isRecord(response.body)) return null
+
+  const error = response.body.error
+  if (!isRecord(error)) return null
+
+  const type = typeof error.type === "string" ? error.type.trim() : ""
+  const message = typeof error.message === "string" ? error.message.trim() : ""
+  if (!type || !message) return null
+
+  const upstreamCode = readSafeUpstreamCode(error.code)
+  return {
+    kind: "http",
+    message,
+    ...(upstreamCode ? { upstreamCode } : {}),
+  }
+}

--- a/src/services/apiAdapters/managedSites/claudeCodeHub.ts
+++ b/src/services/apiAdapters/managedSites/claudeCodeHub.ts
@@ -35,6 +35,7 @@ import {
   prepareChannelFormData,
   providerToManagedSiteChannel,
   searchChannel,
+  toClaudeCodeHubDisclosureError,
 } from "~/services/managedSites/providers/claudeCodeHub"
 import { hasUsableManagedSiteChannelKey } from "~/services/managedSites/utils/managedSite"
 import type {
@@ -57,6 +58,7 @@ import {
   type ManagedUpstreamResourceRef,
   type ManagedUpstreamResourceSummary,
 } from "~/types/managedUpstreamResource"
+import { getErrorMessage } from "~/utils/core/error"
 import { normalizeList } from "~/utils/core/string"
 
 import { createManagedSiteConfigCapability } from "./config"
@@ -85,10 +87,21 @@ const toClaudeCodeHubDiagnostic = (error: ClaudeCodeHubApiError) => {
       ? error.status
       : undefined
   return {
-    message: error.message || "Claude Code Hub mutation failed",
+    message: getErrorMessage(error, "Claude Code Hub mutation failed"),
     ...(code === undefined ? {} : { code }),
     ...(statusCode === undefined ? {} : { statusCode }),
     raw: error,
+  }
+}
+
+const runClaudeCodeHubResourceRead = async <T>(
+  config: ClaudeCodeHubConfig,
+  operation: () => Promise<T>,
+): Promise<T> => {
+  try {
+    return await operation()
+  } catch (error) {
+    throw toClaudeCodeHubDisclosureError(error, config)
   }
 }
 
@@ -365,7 +378,10 @@ const findClaudeCodeHubProviderByRef = async (
 ): Promise<ClaudeCodeHubProviderDisplay> => {
   assertClaudeCodeHubResourceRef(config, ref)
 
-  const providers = await listProviders(config)
+  const providers = await runClaudeCodeHubResourceRead(
+    config,
+    async () => await listProviders(config),
+  )
   const provider = providers.find((item) => String(item.id) === ref.resourceId)
 
   if (!provider) {
@@ -480,12 +496,18 @@ const claudeCodeHubManagedUpstreamResources: ManagedUpstreamResourcesCapability<
     list: async (config, options) =>
       toClaudeCodeHubResourceListData(
         config,
-        await listProviders(config, { signal: options?.signal }),
+        await runClaudeCodeHubResourceRead(
+          config,
+          async () => await listProviders(config, { signal: options?.signal }),
+        ),
       ),
     search: async (config, keyword) =>
       toClaudeCodeHubResourceListData(
         config,
-        await searchProviders(config, keyword),
+        await runClaudeCodeHubResourceRead(
+          config,
+          async () => await searchProviders(config, keyword),
+        ),
       ),
     getDetail: async (config, ref) => {
       const native = await findClaudeCodeHubProviderByRef(config, ref)
@@ -582,9 +604,10 @@ const claudeCodeHubManagedUpstreamResources: ManagedUpstreamResourcesCapability<
   },
   secrets: {
     revealSecret: async (config, ref) => {
-      const secret = await getUnmaskedProviderKey(
+      const secret = await runClaudeCodeHubResourceRead(
         config,
-        Number(ref.resourceId),
+        async () =>
+          await getUnmaskedProviderKey(config, Number(ref.resourceId)),
       )
       if (hasUsableManagedSiteChannelKey(secret)) {
         return {

--- a/src/services/apiAdapters/managedSites/newApi.ts
+++ b/src/services/apiAdapters/managedSites/newApi.ts
@@ -69,6 +69,7 @@ import {
 } from "~/types/managedUpstreamResource"
 import { CHANNEL_STATUS } from "~/types/newApi"
 import type { NewApiConfig } from "~/types/newApiConfig"
+import { getErrorMessage } from "~/utils/core/error"
 import { parseDelimitedList } from "~/utils/core/string"
 
 import { createManagedSiteConfigCapability } from "./config"
@@ -90,7 +91,10 @@ const toNewApiMutationResponse = <TData>(response: ApiResponse<TData>) =>
     : {
         outcome: NEW_API_MUTATION_STEP_OUTCOMES.Rejected,
         diagnostic: {
-          message: response.message || "Provider rejected the mutation",
+          message: getErrorMessage(
+            response.message,
+            "Provider rejected the mutation",
+          ),
           raw: response,
         },
       }

--- a/src/services/apiAdapters/managedSites/octopus.ts
+++ b/src/services/apiAdapters/managedSites/octopus.ts
@@ -59,6 +59,7 @@ import type {
   OctopusUpdateChannelInput,
 } from "~/types/octopus"
 import type { OctopusConfig } from "~/types/octopusConfig"
+import { getErrorMessage } from "~/utils/core/error"
 
 import { createManagedSiteConfigCapability } from "./config"
 
@@ -70,7 +71,10 @@ const toOctopusMutationResponse = <TData>(
     : {
         outcome: "rejected" as const,
         diagnostic: {
-          message: response.message || "Provider rejected the mutation",
+          message: getErrorMessage(
+            response.message,
+            "Provider rejected the mutation",
+          ),
           raw: response,
         },
       }
@@ -90,7 +94,7 @@ const toOctopusMutationDiagnostic = (error: OctopusMutationApiError) => {
       ? error.statusCode
       : undefined
   return {
-    message: error.message || "Octopus mutation failed",
+    message: getErrorMessage(error, "Octopus mutation failed"),
     ...(code === undefined ? {} : { code }),
     ...(statusCode === undefined ? {} : { statusCode }),
     raw: diagnosticRaw,

--- a/src/services/apiAdapters/managedSites/veloera.ts
+++ b/src/services/apiAdapters/managedSites/veloera.ts
@@ -92,7 +92,10 @@ const toVeloeraResponseError = (error: unknown) => {
   ) {
     return {
       outcome: "rejected" as const,
-      diagnostic: { message: error.message, raw: error },
+      diagnostic: {
+        message: getErrorMessage(error, "Provider rejected the mutation"),
+        raw: error,
+      },
     }
   }
   throw error

--- a/src/services/apiAdapters/openrouter/accountKeyResource.ts
+++ b/src/services/apiAdapters/openrouter/accountKeyResource.ts
@@ -1067,8 +1067,10 @@ export const openRouterAccountKeyResources = defineAccountKeyResourceCapability(
             !knownWorkspaceIds.has(workspaceId)
           )
             throw new Error("invalid_workspace")
-          const members = await read(config, () =>
-            drainMembers(config, workspaceId, loadOptions),
+          const members = await read(
+            config,
+            () => drainMembers(config, workspaceId, loadOptions),
+            [workspaceId],
           )
           return members.map((member) => {
             const creatorKey = `${workspaceId}\u0000${member.id}`

--- a/src/services/apiAdapters/openrouter/providerModelCatalog.ts
+++ b/src/services/apiAdapters/openrouter/providerModelCatalog.ts
@@ -5,6 +5,7 @@ import { normalizeOpenRouterModel } from "~/services/apiAdapters/openrouter/mode
 import { fetchOpenRouterPersonalizedModelCatalog } from "~/services/apiService/openrouter/personalizedModelCatalog"
 import { fetchOpenRouterPublicModelCatalog } from "~/services/apiService/openrouter/publicModelCatalog"
 import type { OpenRouterPublicModel } from "~/services/apiService/openrouter/publicModelCatalogSchemas"
+import { ApiError } from "~/services/apiTransport/errors"
 import {
   MODEL_CATALOG_SCOPES,
   MODEL_LIST_SOURCE_KINDS,
@@ -14,9 +15,33 @@ import {
   type ModelCatalogScope,
 } from "~/services/modelList/pricingModel"
 import type { ProviderModelCatalogModel } from "~/services/modelList/providerCatalogAdmission"
+import {
+  isAbortError,
+  toSanitizedErrorSummary,
+} from "~/services/verification/aiApiVerification/utils"
 
 const OPENROUTER_PUBLIC_MODEL_CATALOG_CACHE_TTL_MS = 5 * 60 * 1000
 const OPENROUTER_PROVIDER_MODEL_CATALOG_SOURCE_ID = "openrouter-public"
+
+const toCatalogDisclosureError = (
+  error: unknown,
+  secrets: string[],
+  abortSignal?: AbortSignal,
+): unknown => {
+  if (isAbortError(error, abortSignal)) return error
+  const message = toSanitizedErrorSummary(error, secrets)
+  if (error instanceof ApiError) {
+    return new ApiError(
+      message,
+      error.statusCode,
+      error.endpoint,
+      error.code,
+      error.upstreamCode,
+    )
+  }
+  if (error instanceof TypeError) return new TypeError(message)
+  return new Error(message)
+}
 
 /** Maps one OpenRouter DTO into the product-owned canonical model shape. */
 function adaptOpenRouterModel(
@@ -118,11 +143,17 @@ export const openRouterProviderModelCatalog: ProviderModelCatalogCapability = {
     cacheTtlMs: OPENROUTER_PUBLIC_MODEL_CATALOG_CACHE_TTL_MS,
   },
   async fetchPricing(request) {
-    const models = await fetchOpenRouterPublicModelCatalog(request.abortSignal)
-    return createOpenRouterCatalogPricingResponse(
-      models,
-      MODEL_CATALOG_SCOPES.PROVIDER,
-    )
+    try {
+      const models = await fetchOpenRouterPublicModelCatalog(
+        request.abortSignal,
+      )
+      return createOpenRouterCatalogPricingResponse(
+        models,
+        MODEL_CATALOG_SCOPES.PROVIDER,
+      )
+    } catch (error) {
+      throw toCatalogDisclosureError(error, [], request.abortSignal)
+    }
   },
   personalized: {
     // Ticket 01's sanitized live response recorded `private, no-store`:
@@ -131,15 +162,23 @@ export const openRouterProviderModelCatalog: ProviderModelCatalogCapability = {
     // always immediately stale and never enters the provider-wide cache.
     cacheTtlMs: 0,
     async fetchPricing(request) {
-      const models = await fetchOpenRouterPersonalizedModelCatalog({
-        accountId: request.accountId,
-        managementKey: request.credential,
-        abortSignal: request.abortSignal,
-      })
-      return createOpenRouterCatalogPricingResponse(
-        models,
-        MODEL_CATALOG_SCOPES.PERSONALIZED,
-      )
+      try {
+        const models = await fetchOpenRouterPersonalizedModelCatalog({
+          accountId: request.accountId,
+          managementKey: request.credential,
+          abortSignal: request.abortSignal,
+        })
+        return createOpenRouterCatalogPricingResponse(
+          models,
+          MODEL_CATALOG_SCOPES.PERSONALIZED,
+        )
+      } catch (error) {
+        throw toCatalogDisclosureError(
+          error,
+          [request.credential],
+          request.abortSignal,
+        )
+      }
     },
   },
 }

--- a/src/services/apiAdapters/openrouter/providerModelCatalog.ts
+++ b/src/services/apiAdapters/openrouter/providerModelCatalog.ts
@@ -28,7 +28,10 @@ const toCatalogDisclosureError = (
   secrets: string[],
   abortSignal?: AbortSignal,
 ): unknown => {
-  if (isAbortError(error, abortSignal)) return error
+  if (isAbortError(error)) return error
+  if (abortSignal?.aborted) {
+    return new DOMException("The operation was aborted", "AbortError")
+  }
   const message = toSanitizedErrorSummary(error, secrets)
   if (error instanceof ApiError) {
     return new ApiError(

--- a/src/services/apiCredentialProfiles/telemetryTransport.ts
+++ b/src/services/apiCredentialProfiles/telemetryTransport.ts
@@ -1,6 +1,6 @@
 import { TelemetryEndpointError } from "~/services/apiCredentialProfiles/telemetryAttempts"
 import { ApiError } from "~/services/apiTransport/errors"
-import { fetchApi } from "~/services/apiTransport/request"
+import { fetchApiResponse } from "~/services/apiTransport/request"
 import type { ApiAuthTokenMode } from "~/services/apiTransport/type"
 import { AuthTypeEnum } from "~/types"
 import { getErrorMessage } from "~/utils/core/error"
@@ -25,7 +25,7 @@ export async function fetchTelemetryJson(params: {
   authTokenMode?: ApiAuthTokenMode
 }): Promise<TelemetryJsonFetchResult> {
   try {
-    const json = await fetchApi<unknown>(
+    const response = await fetchApiResponse<unknown>(
       {
         baseUrl: params.baseUrl,
         auth: {
@@ -49,14 +49,22 @@ export async function fetchTelemetryJson(params: {
           : {}),
       },
     )
-    // Raw response mode: provider envelopes (success/data) stay intact so
-    // envelope-style parsers such as parseGlmQuota see the full payload.
+    if (!response.ok) {
+      throw new TelemetryEndpointError(
+        `请求失败: ${response.status}`,
+        params.endpoint,
+        response.status === 404 || response.status === 405,
+      )
+    }
 
     return {
       endpoint: params.endpoint,
-      json,
+      // Provider envelopes stay intact for the protocol-specific parsers.
+      json: response.body,
     }
   } catch (error) {
+    if (error instanceof TelemetryEndpointError) throw error
+
     if (error instanceof ApiError) {
       throw new TelemetryEndpointError(
         error.message,

--- a/src/services/apiService/aihubmix/index.ts
+++ b/src/services/apiService/aihubmix/index.ts
@@ -205,7 +205,7 @@ const extractAIHubMixData = <T>(body: unknown, endpoint: string): T => {
   if (response.success === false) {
     throw new ApiError(
       getErrorMessage(
-        response.message,
+        typeof response.message === "string" ? response.message : undefined,
         t("messages:errors.api.invalidResponseFormat"),
       ),
       undefined,

--- a/src/services/apiService/aihubmix/index.ts
+++ b/src/services/apiService/aihubmix/index.ts
@@ -26,6 +26,7 @@ import type {
   SiteStatusInfo,
   UserInfo,
 } from "~/services/apiAdapters/contracts/accountBootstrap"
+import { decodeAIHubMixResponseError } from "~/services/apiService/aihubmix/responseError"
 import {
   composeAbortSignals,
   startAbortableTask,
@@ -62,6 +63,7 @@ import {
   type AccountTodayStatsAvailability,
   type ApiToken,
 } from "~/types"
+import { getErrorMessage } from "~/utils/core/error"
 import { createLogger } from "~/utils/core/logger"
 import { joinUrl } from "~/utils/core/url"
 import { t } from "~/utils/i18n/core"
@@ -202,7 +204,10 @@ const extractAIHubMixData = <T>(body: unknown, endpoint: string): T => {
   const response = body as Partial<ApiResponse<T>>
   if (response.success === false) {
     throw new ApiError(
-      response.message || t("messages:errors.api.invalidResponseFormat"),
+      getErrorMessage(
+        response.message,
+        t("messages:errors.api.invalidResponseFormat"),
+      ),
       undefined,
       endpoint,
       API_ERROR_CODES.BUSINESS_ERROR,
@@ -252,13 +257,18 @@ const fetchAIHubMixData = async <T>(
   }
 
   if (!response.ok) {
-    const message =
-      body &&
-      typeof body === "object" &&
-      typeof (body as any).message === "string"
-        ? (body as any).message
-        : t("messages:errors.api.requestFailed", { status: response.status })
-    throw new ApiError(message, response.status, endpoint)
+    const providerError = decodeAIHubMixResponseError(
+      { ok: false, status: response.status, headers: {}, body },
+      { endpoint },
+    )
+    throw new ApiError(
+      getErrorMessage(
+        providerError?.message,
+        t("messages:errors.api.requestFailed", { status: response.status }),
+      ),
+      response.status,
+      endpoint,
+    )
   }
 
   return extractAIHubMixData<T>(body, endpoint)
@@ -541,6 +551,7 @@ export async function fetchUserInfo(request: ApiServiceRequest): Promise<{
             options: {
               cache: "no-store",
             },
+            errorResponseDecoder: decodeAIHubMixResponseError,
           },
         )
 
@@ -580,6 +591,7 @@ export async function createAccessToken(
       options: {
         cache: "no-store",
       },
+      errorResponseDecoder: decodeAIHubMixResponseError,
     },
   )
 

--- a/src/services/apiService/aihubmix/responseError.ts
+++ b/src/services/apiService/aihubmix/responseError.ts
@@ -1,0 +1,10 @@
+import { createMessageEnvelopeResponseErrorDecoder } from "~/services/apiService/common/responseError"
+
+/**
+ * Owns AIHubMix's documented `{ success, message, data }` failure envelope.
+ * https://docs.aihubmix.com/en/api/CliEndpoints/get-self
+ */
+export const decodeAIHubMixResponseError =
+  createMessageEnvelopeResponseErrorDecoder({
+    isBusinessEnvelope: (body) => body.success === false,
+  })

--- a/src/services/apiService/claudeCodeHub/index.ts
+++ b/src/services/apiService/claudeCodeHub/index.ts
@@ -9,7 +9,9 @@ import { getErrorMessage } from "~/utils/core/error"
 interface ClaudeCodeHubActionResponse<T> {
   ok: boolean
   data?: T
-  error?: unknown
+  error?: string
+  errorCode?: string
+  errorParams?: Record<string, string | number>
 }
 
 interface ActionSignalHandle {
@@ -78,44 +80,20 @@ export function normalizeClaudeCodeHubBaseUrl(baseUrl: string): string {
   return baseUrl.trim().replace(/\/+$/, "")
 }
 
-/**
- * Removes bearer tokens and configured secrets from error messages.
- */
-export function redactClaudeCodeHubSecrets(
-  message: string,
-  secrets: Array<string | undefined | null>,
-): string {
-  let redacted = message.replace(/Bearer\s+\S+/gi, "Bearer [REDACTED]")
-  for (const secret of secrets) {
-    const trimmed = secret?.trim()
-    if (!trimmed || trimmed.length < 4) continue
-    redacted = redacted.split(trimmed).join("[REDACTED]")
-  }
-  return redacted
-}
-
-/**
- * Converts unknown provider-action failures into sanitized error text.
- */
-function normalizeActionError(
-  error: unknown,
-  config: ClaudeCodeHubConfig,
-  extraSecrets: Array<string | undefined | null> = [],
-) {
-  return redactClaudeCodeHubSecrets(getErrorMessage(error), [
-    config.adminToken,
-    ...extraSecrets,
-  ])
-}
+const getClaudeCodeHubRequestErrorMessage = (error: unknown, status?: number) =>
+  getErrorMessage(
+    error,
+    status === undefined
+      ? "Claude Code Hub request failed"
+      : `Claude Code Hub request failed (${status})`,
+  )
 
 /**
  * Parses and validates a Claude Code Hub provider action response body.
+ * Upstream ErrorResult uses `error`, optional `errorCode`, and `errorParams`:
+ * https://github.com/ding113/claude-code-hub/blob/dfeb14331cb350f672e92a3684adecf1052dd476/src/actions/types.ts
  */
-async function parseActionResponse<T>(
-  response: Response,
-  config: ClaudeCodeHubConfig,
-  extraSecrets: Array<string | undefined | null>,
-): Promise<T> {
+async function parseActionResponse<T>(response: Response): Promise<T> {
   let parsed: ClaudeCodeHubActionResponse<T>
   try {
     parsed = (await response.json()) as ClaudeCodeHubActionResponse<T>
@@ -150,21 +128,22 @@ async function parseActionResponse<T>(
   }
 
   if (!response.ok || !parsed.ok) {
-    const fallbackMessage =
-      response.statusText ||
-      `Claude Code Hub request failed (${response.status})`
-    const message =
-      getErrorMessage(parsed.error, fallbackMessage) || fallbackMessage
-    throw new ClaudeCodeHubApiError(
-      redactClaudeCodeHubSecrets(message, [config.adminToken, ...extraSecrets]),
-      response.status,
-      {
-        dispatch: "dispatched",
-        responseReceived: true,
-        confirmedNonApplication: parsed.ok === false,
-        raw: parsed,
-      },
+    const fallbackMessage = `Claude Code Hub request failed (${response.status})`
+    const message = getErrorMessage(
+      typeof parsed.error === "string" ? parsed.error : undefined,
+      fallbackMessage,
     )
+    const code =
+      typeof parsed.errorCode === "string" && parsed.errorCode.trim()
+        ? parsed.errorCode.trim()
+        : undefined
+    throw new ClaudeCodeHubApiError(message, response.status, {
+      dispatch: "dispatched",
+      responseReceived: true,
+      confirmedNonApplication: parsed.ok === false,
+      raw: parsed,
+      ...(code ? { code } : {}),
+    })
   }
 
   return parsed.data as T
@@ -172,12 +151,10 @@ async function parseActionResponse<T>(
 
 /**
  * Parses a Claude Code Hub v1 JSON response and normalizes problem+json errors.
+ * Upstream ProblemJson defines `detail`, `title`, `errorCode`, and `errorParams`:
+ * https://github.com/ding113/claude-code-hub/blob/dfeb14331cb350f672e92a3684adecf1052dd476/src/lib/api/v1/_shared/error-envelope.ts
  */
-async function parseV1JsonResponse<T>(
-  response: Response,
-  config: ClaudeCodeHubConfig,
-  extraSecrets: Array<string | undefined | null>,
-): Promise<T> {
+async function parseV1JsonResponse<T>(response: Response): Promise<T> {
   let parsed: unknown
   try {
     parsed = await response.json()
@@ -189,23 +166,36 @@ async function parseV1JsonResponse<T>(
   }
 
   if (!response.ok) {
-    const fallbackMessage =
-      response.statusText ||
-      `Claude Code Hub request failed (${response.status})`
+    const fallbackMessage = `Claude Code Hub request failed (${response.status})`
     const problem =
       parsed && typeof parsed === "object"
-        ? (parsed as { detail?: unknown; error?: unknown; title?: unknown })
+        ? (parsed as {
+            detail?: unknown
+            title?: unknown
+            errorCode?: unknown
+            errorParams?: unknown
+          })
         : undefined
-    const message =
-      getErrorMessage(
-        problem?.detail ?? problem?.error ?? problem?.title,
-        fallbackMessage,
-      ) || fallbackMessage
-
-    throw new ClaudeCodeHubApiError(
-      redactClaudeCodeHubSecrets(message, [config.adminToken, ...extraSecrets]),
-      response.status,
+    const titleMessage = getErrorMessage(
+      typeof problem?.title === "string" ? problem.title : undefined,
+      fallbackMessage,
     )
+    const message = getErrorMessage(
+      typeof problem?.detail === "string" ? problem.detail : undefined,
+      titleMessage,
+    )
+    const code =
+      typeof problem?.errorCode === "string" && problem.errorCode.trim()
+        ? problem.errorCode.trim()
+        : undefined
+
+    throw new ClaudeCodeHubApiError(message, response.status, {
+      dispatch: "dispatched",
+      responseReceived: true,
+      confirmedNonApplication: true,
+      raw: parsed,
+      ...(code ? { code } : {}),
+    })
   }
 
   return parsed as T
@@ -323,7 +313,6 @@ async function callProviderAction<T>(
   action: ClaudeCodeHubProviderAction,
   payload: object = {},
   options?: {
-    secrets?: Array<string | undefined | null>
     signal?: AbortSignal
     timeoutMs?: number
   },
@@ -339,7 +328,7 @@ async function callProviderAction<T>(
         actionSignal.signal.reason ??
         new DOMException("The operation was aborted", "AbortError")
       throw new ClaudeCodeHubApiError(
-        normalizeActionError(raw, config, options?.secrets ?? []),
+        getClaudeCodeHubRequestErrorMessage(raw),
         undefined,
         {
           dispatch: "not-dispatched",
@@ -360,17 +349,13 @@ async function callProviderAction<T>(
       },
       body: JSON.stringify(payload),
     })
-    return await parseActionResponse<T>(
-      response,
-      config,
-      options?.secrets ?? [],
-    )
+    return await parseActionResponse<T>(response)
   } catch (error) {
     if (error instanceof ClaudeCodeHubApiError) {
       throw error
     }
     throw new ClaudeCodeHubApiError(
-      normalizeActionError(error, config, options?.secrets ?? []),
+      getClaudeCodeHubRequestErrorMessage(error, response?.status),
       response?.status,
       {
         dispatch: fetchStarted ? "dispatched" : "not-dispatched",
@@ -499,15 +484,22 @@ async function fetchV1ProviderList(
         },
       },
     )
-    const data = await parseV1JsonResponse<unknown>(response, config, [])
+    const data = await parseV1JsonResponse<unknown>(response)
     return extractProviderList(data)
   } catch (error) {
     if (error instanceof ClaudeCodeHubApiError) {
       throw error
     }
     throw new ClaudeCodeHubApiError(
-      normalizeActionError(error, config),
+      getClaudeCodeHubRequestErrorMessage(error, response?.status),
       response?.status,
+      {
+        dispatch: "dispatched",
+        responseReceived: response !== undefined,
+        confirmedNonApplication: false,
+        raw: error,
+        code: getOperationalErrorCode(error),
+      },
     )
   } finally {
     actionSignal.cleanup()
@@ -540,7 +532,6 @@ export async function createProvider(
   },
 ): Promise<unknown> {
   return await callProviderAction(config, "addProvider", payload, {
-    secrets: [payload.key],
     signal: options?.signal,
     timeoutMs: options?.timeoutMs,
   })
@@ -576,7 +567,7 @@ export async function getUnmaskedProviderKey(
         },
       },
     )
-    const data = await parseV1JsonResponse<unknown>(response, config, [])
+    const data = await parseV1JsonResponse<unknown>(response)
 
     const key =
       data && typeof data === "object"
@@ -595,8 +586,15 @@ export async function getUnmaskedProviderKey(
       throw error
     }
     throw new ClaudeCodeHubApiError(
-      normalizeActionError(error, config),
+      getClaudeCodeHubRequestErrorMessage(error, response?.status),
       response?.status,
+      {
+        dispatch: "dispatched",
+        responseReceived: response !== undefined,
+        confirmedNonApplication: false,
+        raw: error,
+        code: getOperationalErrorCode(error),
+      },
     )
   } finally {
     actionSignal.cleanup()
@@ -615,7 +613,6 @@ export async function updateProvider(
   },
 ): Promise<unknown> {
   return await callProviderAction(config, "editProvider", payload, {
-    secrets: [payload.key],
     signal: options?.signal,
     timeoutMs: options?.timeoutMs,
   })

--- a/src/services/apiService/octopus/index.ts
+++ b/src/services/apiService/octopus/index.ts
@@ -28,6 +28,7 @@ import {
   type TempWindowFetch,
 } from "~/types/tempWindowFetch"
 import { getCurrentTempWindowRequestSource } from "~/utils/browser/tempWindowRequestSource"
+import { getErrorMessage } from "~/utils/core/error"
 import { safeRandomUUID } from "~/utils/core/identifier"
 import { createLogger } from "~/utils/core/logger"
 import { normalizeBaseUrl } from "~/utils/core/url"
@@ -190,10 +191,15 @@ const getOctopusErrorCode = (error: unknown) => {
     : undefined
 }
 
-const getOctopusMutationErrorMessage = (error: unknown) =>
-  error instanceof Error && error.message
-    ? error.message
-    : "Octopus mutation failed"
+const getOctopusMutationErrorMessage = (error: unknown) => {
+  const providerMessage =
+    error instanceof Error
+      ? error.message
+      : typeof error === "object" && error !== null && "message" in error
+        ? (error as { message?: unknown }).message
+        : undefined
+  return getErrorMessage(providerMessage, "Octopus mutation failed")
+}
 
 const parseOctopusEnvelope = (
   endpoint: string,
@@ -211,11 +217,7 @@ const getOctopusEnvelopeData = (endpoint: string, data: unknown): unknown => {
     envelope.success === false ||
     (envelope.code !== undefined && envelope.code !== 200)
   ) {
-    throw new Error(
-      typeof envelope.message === "string"
-        ? envelope.message
-        : "API request failed",
-    )
+    throw new Error(getErrorMessage(envelope.message, "API request failed"))
   }
   return envelope.data
 }
@@ -602,9 +604,17 @@ async function fetchOctopusApi<T>(
         if (contentType.includes("application/json")) {
           // 尝试解析 JSON 错误响应
           try {
-            const errorData = JSON.parse(rawBody)
-            errorMessage =
-              errorData.message || errorData.error || JSON.stringify(errorData)
+            const errorData = JSON.parse(rawBody) as unknown
+            const errorRecord =
+              typeof errorData === "object" &&
+              errorData !== null &&
+              !Array.isArray(errorData)
+                ? (errorData as Record<string, unknown>)
+                : undefined
+            errorMessage = getErrorMessage(
+              errorRecord?.message,
+              getErrorMessage(errorRecord?.error, "Octopus request failed"),
+            )
           } catch {
             errorMessage = rawBody
           }
@@ -641,7 +651,10 @@ async function fetchOctopusApi<T>(
       responseData.success === false ||
       (responseData.code !== undefined && responseData.code !== 200)
     ) {
-      const message = (responseData.message as string) || "API request failed"
+      const message = getErrorMessage(
+        responseData.message,
+        "API request failed",
+      )
       if (isMutation) {
         throw new OctopusMutationApiError(message, {
           dispatch: "dispatched",

--- a/src/services/apiService/openrouter/keyManagement.ts
+++ b/src/services/apiService/openrouter/keyManagement.ts
@@ -9,7 +9,6 @@ import {
   OPENROUTER_KEYS_ENDPOINT,
   OPENROUTER_WORKSPACES_ENDPOINT,
 } from "./constants"
-import { OpenRouterManagementKeyRequiredError } from "./errors"
 import {
   openRouterCreateKeyInputSchema,
   openRouterCreateKeyResponseSchema,
@@ -34,6 +33,7 @@ import {
   type OpenRouterWorkspacePaginationInput,
 } from "./keyManagementSchemas"
 import { createOpenRouterManagementRequest } from "./request"
+import { createOpenRouterHttpError } from "./responseError"
 
 const managementFetchOptions = {
   currentTabTransport: "disabled" as const,
@@ -44,94 +44,6 @@ type RawResponse = unknown
 
 const KEY_RESOURCE_ENDPOINT_TEMPLATE = `${OPENROUTER_KEYS_ENDPOINT}/{hash}`
 const WORKSPACE_MEMBER_ENDPOINT_TEMPLATE = `${OPENROUTER_WORKSPACES_ENDPOINT}/{id}/members`
-const REDACTED_PROVIDER_VALUE = "[REDACTED]"
-
-interface ProviderFailureContext {
-  safeEndpoint: string
-  sensitiveValues?: Array<string | null | undefined>
-}
-
-const redactProviderValues = (message: string, values: string[]): string =>
-  values.reduce((sanitized, value) => {
-    const variants = new Set([value, encodeURIComponent(value)])
-    return [...variants].reduce(
-      (current, variant) =>
-        variant
-          ? current.split(variant).join(REDACTED_PROVIDER_VALUE)
-          : current,
-      sanitized,
-    )
-  }, message)
-
-const getBoundedUpstreamCode = (
-  value: string | undefined,
-  sensitiveValues: string[],
-): string | undefined => {
-  if (!value || value.length > 64 || !/^[A-Za-z0-9_.-]+$/.test(value)) {
-    return undefined
-  }
-  return redactProviderValues(value, sensitiveValues) === value
-    ? value
-    : undefined
-}
-
-const getProviderErrorDetails = (
-  body: unknown,
-): { message: string; upstreamCode?: string } | null => {
-  if (!body || typeof body !== "object" || Array.isArray(body)) return null
-  const error = (body as { error?: unknown }).error
-  if (!error || typeof error !== "object" || Array.isArray(error)) return null
-
-  const messageValue = (error as { message?: unknown }).message
-  const message =
-    typeof messageValue === "string" ? messageValue.trim() : undefined
-  if (!message) return null
-
-  const codeValue = (error as { code?: unknown }).code
-  const upstreamCode =
-    typeof codeValue === "string" || typeof codeValue === "number"
-      ? getBoundedUpstreamCode(String(codeValue).trim(), [])
-      : undefined
-  return { message, upstreamCode }
-}
-
-const getHttpErrorCode = (status: number) => {
-  if (status === 401) return API_ERROR_CODES.HTTP_401
-  if (status === 403) return API_ERROR_CODES.HTTP_403
-  if (status === 429) return API_ERROR_CODES.HTTP_429
-  return API_ERROR_CODES.HTTP_OTHER
-}
-
-const normalizeProviderFailure = (
-  error: unknown,
-  request: ApiServiceRequest,
-  context: ProviderFailureContext,
-): Error => {
-  const sensitiveValues = [
-    request.auth.accessToken?.trim(),
-    ...(context.sensitiveValues ?? []).map((value) => value?.trim()),
-  ].filter((value): value is string => Boolean(value))
-  const message =
-    error instanceof Error
-      ? redactProviderValues(error.message, sensitiveValues)
-      : t("messages:errors.api.invalidResponseFormat")
-
-  if (error instanceof OpenRouterManagementKeyRequiredError) return error
-  if (error instanceof ApiError) {
-    return new ApiError(
-      message,
-      error.statusCode,
-      context.safeEndpoint,
-      error.code,
-      getBoundedUpstreamCode(error.upstreamCode, sensitiveValues),
-    )
-  }
-  if (error instanceof TypeError) return new TypeError(message)
-
-  const normalized = new Error(message)
-  if (error instanceof Error) normalized.name = error.name
-  return normalized
-}
 
 const invalidResponse = (endpoint: string): ApiError =>
   new ApiError(
@@ -185,28 +97,19 @@ async function fetchRaw(
   request: ApiServiceRequest,
   endpoint: string,
   options: RequestInit,
-  failureContext?: ProviderFailureContext,
 ): Promise<RawResponse> {
-  const context = failureContext ?? { safeEndpoint: endpoint }
-  try {
-    const response = await fetchApiResponse<RawResponse>(
-      createOpenRouterManagementRequest(request),
-      { endpoint, options, ...managementFetchOptions },
+  const response = await fetchApiResponse<RawResponse>(
+    createOpenRouterManagementRequest(request),
+    { endpoint, options, ...managementFetchOptions },
+  )
+  if (!response.ok) {
+    throw createOpenRouterHttpError(
+      response,
+      endpoint,
+      `请求失败: ${response.status}`,
     )
-    if (!response.ok) {
-      const providerError = getProviderErrorDetails(response.body)
-      throw new ApiError(
-        providerError?.message ?? `请求失败: ${response.status}`,
-        response.status,
-        context.safeEndpoint,
-        getHttpErrorCode(response.status),
-        providerError?.upstreamCode,
-      )
-    }
-    return response.body
-  } catch (error) {
-    throw normalizeProviderFailure(error, request, context)
   }
+  return response.body
 }
 
 /**
@@ -233,15 +136,7 @@ export async function fetchOpenRouterKeys(
     : OPENROUTER_KEYS_ENDPOINT
   return parseResponse(
     openRouterKeyListResponseSchema,
-    await fetchRaw(
-      request,
-      endpoint,
-      { method: "GET", cache: "no-store" },
-      {
-        safeEndpoint: OPENROUTER_KEYS_ENDPOINT,
-        sensitiveValues: [parsed.data.workspaceId],
-      },
-    ),
+    await fetchRaw(request, endpoint, { method: "GET", cache: "no-store" }),
     OPENROUTER_KEYS_ENDPOINT,
   ).data
 }
@@ -277,18 +172,10 @@ export async function createOpenRouterKey(
   }
   const response = parseResponse(
     openRouterCreateKeyResponseSchema,
-    await fetchRaw(
-      request,
-      OPENROUTER_KEYS_ENDPOINT,
-      {
-        method: "POST",
-        body: JSON.stringify(body),
-      },
-      {
-        safeEndpoint: OPENROUTER_KEYS_ENDPOINT,
-        sensitiveValues: [workspaceId, creatorUserId],
-      },
-    ),
+    await fetchRaw(request, OPENROUTER_KEYS_ENDPOINT, {
+      method: "POST",
+      body: JSON.stringify(body),
+    }),
     OPENROUTER_KEYS_ENDPOINT,
   )
   return { key: response.data, plaintextKey: response.key }
@@ -304,12 +191,7 @@ export async function fetchOpenRouterKey(
   const endpoint = keyEndpoint(hash)
   return parseResponse(
     openRouterKeyResponseSchema,
-    await fetchRaw(
-      request,
-      endpoint,
-      { method: "GET", cache: "no-store" },
-      { safeEndpoint: KEY_RESOURCE_ENDPOINT_TEMPLATE, sensitiveValues: [hash] },
-    ),
+    await fetchRaw(request, endpoint, { method: "GET", cache: "no-store" }),
     KEY_RESOURCE_ENDPOINT_TEMPLATE,
   ).data
 }
@@ -337,15 +219,10 @@ export async function updateOpenRouterKey(
   }
   return parseResponse(
     openRouterKeyResponseSchema,
-    await fetchRaw(
-      request,
-      endpoint,
-      {
-        method: "PATCH",
-        body: JSON.stringify(body),
-      },
-      { safeEndpoint: KEY_RESOURCE_ENDPOINT_TEMPLATE, sensitiveValues: [hash] },
-    ),
+    await fetchRaw(request, endpoint, {
+      method: "PATCH",
+      body: JSON.stringify(body),
+    }),
     KEY_RESOURCE_ENDPOINT_TEMPLATE,
   ).data
 }
@@ -360,15 +237,7 @@ export async function deleteOpenRouterKey(
   const endpoint = keyEndpoint(hash)
   return parseResponse(
     openRouterDeleteKeyResponseSchema,
-    await fetchRaw(
-      request,
-      endpoint,
-      { method: "DELETE" },
-      {
-        safeEndpoint: KEY_RESOURCE_ENDPOINT_TEMPLATE,
-        sensitiveValues: [hash],
-      },
-    ),
+    await fetchRaw(request, endpoint, { method: "DELETE" }),
     KEY_RESOURCE_ENDPOINT_TEMPLATE,
   )
 }
@@ -405,12 +274,7 @@ export async function fetchOpenRouterWorkspaces(
     : OPENROUTER_WORKSPACES_ENDPOINT
   const response = parseResponse(
     openRouterWorkspaceListResponseSchema,
-    await fetchRaw(
-      request,
-      endpoint,
-      { method: "GET", cache: "no-store" },
-      { safeEndpoint: OPENROUTER_WORKSPACES_ENDPOINT },
-    ),
+    await fetchRaw(request, endpoint, { method: "GET", cache: "no-store" }),
     OPENROUTER_WORKSPACES_ENDPOINT,
   )
   return { data: response.data, totalCount: response.total_count }
@@ -442,15 +306,7 @@ export async function fetchOpenRouterWorkspaceMembers(
   const endpoint = params.size ? `${baseEndpoint}?${params}` : baseEndpoint
   const response = parseResponse(
     openRouterWorkspaceMemberListResponseSchema,
-    await fetchRaw(
-      request,
-      endpoint,
-      { method: "GET", cache: "no-store" },
-      {
-        safeEndpoint: WORKSPACE_MEMBER_ENDPOINT_TEMPLATE,
-        sensitiveValues: [normalizedWorkspaceId],
-      },
-    ),
+    await fetchRaw(request, endpoint, { method: "GET", cache: "no-store" }),
     WORKSPACE_MEMBER_ENDPOINT_TEMPLATE,
   )
   return { data: response.data, totalCount: response.total_count }

--- a/src/services/apiService/openrouter/personalizedModelCatalog.ts
+++ b/src/services/apiService/openrouter/personalizedModelCatalog.ts
@@ -5,6 +5,7 @@ import { AuthTypeEnum } from "~/types"
 
 import { openRouterPersonalizedModelCatalogPageSchema } from "./personalizedModelCatalogSchemas"
 import type { OpenRouterPublicModel } from "./publicModelCatalogSchemas"
+import { createOpenRouterHttpError } from "./responseError"
 
 const OPENROUTER_PERSONALIZED_MODELS_ENDPOINT = "/models/user"
 const OPENROUTER_PERSONALIZED_CATALOG_MAX_PAGES = 50
@@ -77,20 +78,10 @@ async function fetchOpenRouterPersonalizedModelCatalogPage(
   )
 
   if (!response.ok) {
-    const code =
-      response.status === 401
-        ? API_ERROR_CODES.HTTP_401
-        : response.status === 403
-          ? API_ERROR_CODES.HTTP_403
-          : response.status === 429
-            ? API_ERROR_CODES.HTTP_429
-            : API_ERROR_CODES.HTTP_OTHER
-
-    throw new ApiError(
+    throw createOpenRouterHttpError(
+      response,
+      endpoint,
       "OpenRouter personalized model catalog request failed",
-      response.status,
-      OPENROUTER_PERSONALIZED_MODELS_ENDPOINT,
-      code,
     )
   }
 

--- a/src/services/apiService/openrouter/publicModelCatalog.ts
+++ b/src/services/apiService/openrouter/publicModelCatalog.ts
@@ -7,6 +7,7 @@ import {
   openRouterPublicModelCatalogPageSchema,
   type OpenRouterPublicModel,
 } from "./publicModelCatalogSchemas"
+import { createOpenRouterHttpError } from "./responseError"
 
 const OPENROUTER_PUBLIC_MODELS_ENDPOINT = "/models?output_modalities=all"
 
@@ -81,20 +82,10 @@ async function fetchOpenRouterPublicModelCatalogPage(
     },
   )
   if (!response.ok) {
-    const code =
-      response.status === 401
-        ? API_ERROR_CODES.HTTP_401
-        : response.status === 403
-          ? API_ERROR_CODES.HTTP_403
-          : response.status === 429
-            ? API_ERROR_CODES.HTTP_429
-            : API_ERROR_CODES.HTTP_OTHER
-
-    throw new ApiError(
+    throw createOpenRouterHttpError(
+      response,
+      endpoint,
       "OpenRouter public model catalog request failed",
-      response.status,
-      "/models",
-      code,
     )
   }
 

--- a/src/services/apiService/openrouter/responseError.ts
+++ b/src/services/apiService/openrouter/responseError.ts
@@ -1,5 +1,10 @@
+import { API_ERROR_CODES, ApiError } from "~/services/apiTransport/errors"
 import { readSafeUpstreamCode } from "~/services/apiTransport/responseError"
-import type { ApiResponseErrorDecoder } from "~/services/apiTransport/type"
+import type {
+  ApiResponseErrorDecoder,
+  ApiTransportResponse,
+} from "~/services/apiTransport/type"
+import { getErrorMessage } from "~/utils/core/error"
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value)
@@ -10,13 +15,12 @@ function readOpenRouterErrorDetails(
 ): { message: string; upstreamCode?: string } | null {
   if (!isRecord(body) || !isRecord(body.error)) return null
   const error = body.error
+  if (!Number.isInteger(error.code)) return null
   const message =
     typeof error.message === "string" && error.message.trim()
       ? error.message.trim()
       : undefined
-  const upstreamCode = Number.isInteger(error.code)
-    ? readSafeUpstreamCode(error.code)
-    : undefined
+  const upstreamCode = readSafeUpstreamCode(error.code)
   if (!message) return null
 
   return {
@@ -27,7 +31,7 @@ function readOpenRouterErrorDetails(
 
 /**
  * Decodes OpenRouter's documented non-2xx `{ error: { code, message } }` body.
- * https://github.com/OpenRouterTeam/docs/blob/d369fe0d5bfc87cb9f78326b18bbbd19964406fd/openapi/openapi.yaml#L25293-L25332
+ * https://github.com/OpenRouterTeam/docs/blob/348a977a5da325fb27e11b79c5662dc88d4ed4c8/openapi/openapi.yaml
  */
 export const decodeOpenRouterResponseError: ApiResponseErrorDecoder = (
   response,
@@ -40,4 +44,27 @@ export const decodeOpenRouterResponseError: ApiResponseErrorDecoder = (
     kind: "http",
     ...details,
   }
+}
+
+const getOpenRouterHttpErrorCode = (status: number) => {
+  if (status === 401) return API_ERROR_CODES.HTTP_401
+  if (status === 403) return API_ERROR_CODES.HTTP_403
+  if (status === 429) return API_ERROR_CODES.HTTP_429
+  return API_ERROR_CODES.HTTP_OTHER
+}
+
+/** Converts one raw OpenRouter failure after provider parsing, without redaction. */
+export function createOpenRouterHttpError(
+  response: ApiTransportResponse<unknown>,
+  endpoint: string,
+  fixedFallback: string,
+): ApiError {
+  const providerError = decodeOpenRouterResponseError(response, { endpoint })
+  return new ApiError(
+    getErrorMessage(providerError?.message, fixedFallback),
+    response.status,
+    endpoint,
+    getOpenRouterHttpErrorCode(response.status),
+    providerError?.upstreamCode,
+  )
 }

--- a/src/services/apiService/sharedchat/index.ts
+++ b/src/services/apiService/sharedchat/index.ts
@@ -29,6 +29,7 @@ import {
   SHAREDCHAT_CODEX_RESET_KEY_ENDPOINT,
   SHAREDCHAT_GETME_ENDPOINT,
 } from "./constants"
+import { decodeSharedChatResponseError } from "./responseError"
 
 type SharedChatEnvelope<T> = {
   code?: unknown
@@ -173,18 +174,18 @@ const fetchSharedChatData = async <T>(
   endpoint: string,
   options: RequestInit = {},
 ): Promise<T> => {
-  const body = await fetchApi<SharedChatEnvelope<T>>(
-    request,
-    {
-      endpoint,
-      options: {
-        cache: "no-store",
-        ...options,
-      },
+  const body = await fetchApi<SharedChatEnvelope<T>>(request, {
+    endpoint,
+    errorResponseDecoder: decodeSharedChatResponseError,
+    options: {
+      cache: "no-store",
+      ...options,
     },
-    true,
+  })
+  return extractSharedChatData<T>(
+    body as unknown as SharedChatEnvelope<T>,
+    endpoint,
   )
-  return extractSharedChatData<T>(body, endpoint)
 }
 
 const getCodexQuota = async (

--- a/src/services/apiService/sharedchat/responseError.ts
+++ b/src/services/apiService/sharedchat/responseError.ts
@@ -1,0 +1,34 @@
+import type { ApiResponseErrorDecoder } from "~/services/apiTransport/type"
+import { getErrorMessage } from "~/utils/core/error"
+
+const SHAREDCHAT_SUCCESS_CODE = 1
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+/**
+ * Decodes the deployed SharedChat frontend envelope without applying disclosure policy.
+ * Verified routes return `{ code, msg, data }`, with `code === 1` as success.
+ * https://new.sharedchat.cc/frontend-api/vibe-code/quota
+ */
+export const decodeSharedChatResponseError: ApiResponseErrorDecoder = (
+  response,
+) => {
+  if (response.ok) return null
+
+  const body = isRecord(response.body) ? response.body : undefined
+  const providerMessage =
+    typeof body?.code === "number" &&
+    body.code !== SHAREDCHAT_SUCCESS_CODE &&
+    typeof body.msg === "string"
+      ? body.msg.trim()
+      : undefined
+
+  return {
+    kind: "http",
+    message: getErrorMessage(
+      providerMessage,
+      `SharedChat request failed: ${response.status}`,
+    ),
+  }
+}

--- a/src/services/apiService/sub2api/authIdentity.ts
+++ b/src/services/apiService/sub2api/authIdentity.ts
@@ -2,6 +2,7 @@ import { fetchApi } from "~/services/apiTransport/request"
 import type { ApiServiceRequest } from "~/services/apiTransport/type"
 
 import { parseSub2ApiEnvelope, parseSub2ApiUserIdentity } from "./parsing"
+import { decodeSub2ApiResponseError } from "./responseError"
 import {
   SUB2API_AUTH_ME_ENDPOINT,
   type Sub2ApiAuthMeData,
@@ -10,17 +11,14 @@ import {
 
 /** Reads Sub2API's canonical dashboard identity with an already-prepared request. */
 export async function fetchSub2ApiAuthIdentity(request: ApiServiceRequest) {
-  const body = (await fetchApi<Sub2ApiAuthMeResponse>(
-    request,
-    {
-      endpoint: SUB2API_AUTH_ME_ENDPOINT,
-      options: {
-        method: "GET",
-        cache: "no-store",
-      },
+  const body = (await fetchApi<Sub2ApiAuthMeResponse>(request, {
+    endpoint: SUB2API_AUTH_ME_ENDPOINT,
+    options: {
+      method: "GET",
+      cache: "no-store",
     },
-    true,
-  )) as Sub2ApiAuthMeResponse
+    errorResponseDecoder: decodeSub2ApiResponseError,
+  })) as unknown as Sub2ApiAuthMeResponse
   const data = parseSub2ApiEnvelope<Sub2ApiAuthMeData>(
     body,
     SUB2API_AUTH_ME_ENDPOINT,

--- a/src/services/apiService/sub2api/index.ts
+++ b/src/services/apiService/sub2api/index.ts
@@ -81,6 +81,7 @@ import {
   translateSub2ApiUpdateTokenRequest,
 } from "./parsing"
 import { getSafeErrorMessage } from "./redaction"
+import { decodeSub2ApiResponseError } from "./responseError"
 import { Sub2ApiTokenRefreshError } from "./tokenRefresh"
 import {
   SUB2API_AFFILIATE_ENDPOINT,
@@ -132,14 +133,11 @@ const fetchSub2ApiDataWithRequest = async <T>(
     request,
     endpoint,
     async (authRequest) => {
-      const body = await fetchApi<unknown>(
-        authRequest,
-        {
-          endpoint,
-          options,
-        },
-        true,
-      )
+      const body = await fetchApi<unknown>(authRequest, {
+        endpoint,
+        options,
+        errorResponseDecoder: decodeSub2ApiResponseError,
+      })
 
       return {
         data: parseSub2ApiEnvelope<T>(body, endpoint, parserOptions),
@@ -277,8 +275,8 @@ const fetchSub2ApiPublicSettings = async (
     {
       endpoint: SUB2API_PUBLIC_SETTINGS_ENDPOINT,
       options: { method: "GET", cache: "no-store" },
+      errorResponseDecoder: decodeSub2ApiResponseError,
     },
-    true,
   )
 
   return parseSub2ApiEnvelope<Sub2ApiPublicSettingsData>(
@@ -813,17 +811,14 @@ const fetchTodayUsageWithRequest = async (
   }
 
   const endpoint = createSub2ApiUsageStatsEndpoint()
-  const body = await fetchApi<unknown>(
-    request,
-    {
-      endpoint,
-      options: {
-        method: "GET",
-        cache: "no-store",
-      },
+  const body = await fetchApi<unknown>(request, {
+    endpoint,
+    options: {
+      method: "GET",
+      cache: "no-store",
     },
-    true,
-  )
+    errorResponseDecoder: decodeSub2ApiResponseError,
+  })
   const data = parseSub2ApiEnvelope<Sub2ApiUsageStatsData>(body, endpoint)
 
   return parseSub2ApiTodayUsage(data, endpoint)

--- a/src/services/apiService/sub2api/parsing.ts
+++ b/src/services/apiService/sub2api/parsing.ts
@@ -12,9 +12,11 @@ import {
   type AccountTodayStatsAvailability,
   type ApiToken,
 } from "~/types"
+import { getErrorMessage } from "~/utils/core/error"
 import { toOptionalFiniteNumber } from "~/utils/core/number"
 import { t } from "~/utils/i18n/core"
 
+import { readSub2ApiFailureEnvelope } from "./responseError"
 import type {
   Sub2ApiAuthMeData,
   Sub2ApiCreateKeyPayload,
@@ -282,14 +284,14 @@ export const parseSub2ApiEnvelope = <T>(
   }
 
   if (envelope.code !== 0) {
-    const message = envelope.message.trim()
-      ? envelope.message.trim()
-      : invalidResponseMessage
+    const failure = readSub2ApiFailureEnvelope(envelope)
+    const message = getErrorMessage(failure?.message, invalidResponseMessage)
     throw new ApiError(
       message,
       undefined,
       endpoint,
       API_ERROR_CODES.BUSINESS_ERROR,
+      failure?.upstreamCode,
     )
   }
 

--- a/src/services/apiService/sub2api/responseError.ts
+++ b/src/services/apiService/sub2api/responseError.ts
@@ -1,0 +1,58 @@
+import { readSafeUpstreamCode } from "~/services/apiTransport/responseError"
+import type { ApiResponseErrorDecoder } from "~/services/apiTransport/type"
+import { getErrorMessage } from "~/utils/core/error"
+
+import { SUB2API_SESSION_BINDING_MISMATCH_CODE } from "./browserAuth"
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+type Sub2ApiFailureEnvelope = {
+  message?: string
+  upstreamCode: string
+}
+
+/** Reads only verified Sub2API failure envelopes and machine codes. */
+export const readSub2ApiFailureEnvelope = (
+  body: unknown,
+): Sub2ApiFailureEnvelope | null => {
+  if (!isRecord(body)) return null
+
+  const isNumericFailure = typeof body.code === "number" && body.code !== 0
+  const isSessionBindingMismatch =
+    body.code === SUB2API_SESSION_BINDING_MISMATCH_CODE
+  if (!isNumericFailure && !isSessionBindingMismatch) return null
+
+  const upstreamCode = readSafeUpstreamCode(body.code)
+  if (!upstreamCode) return null
+
+  const message =
+    typeof body.message === "string" ? body.message.trim() : undefined
+  if (!message && !isSessionBindingMismatch) return null
+  return { ...(message ? { message } : {}), upstreamCode }
+}
+
+/**
+ * Decodes Sub2API HTTP failures without applying disclosure policy.
+ * The standard provider contract uses numeric `code`, string `message`, and
+ * `code === 0` for success. Session binding middleware has one documented
+ * string-code exception that auth recovery must preserve. The existing 2xx
+ * parser remains authoritative for business data.
+ * https://github.com/Wei-Shaw/sub2api/blob/b1748c4ea99ce2120401a269142aa071e18a84da/backend/internal/pkg/response/response.go
+ * https://github.com/Wei-Shaw/sub2api/blob/b1748c4ea99ce2120401a269142aa071e18a84da/backend/internal/server/middleware/session_binding.go
+ */
+export const decodeSub2ApiResponseError: ApiResponseErrorDecoder = (
+  response,
+) => {
+  if (response.ok) return null
+
+  const failure = readSub2ApiFailureEnvelope(response.body)
+  return {
+    kind: failure ? "business" : "http",
+    message: getErrorMessage(
+      failure?.message,
+      `Sub2API request failed: ${response.status}`,
+    ),
+    ...(failure ? { upstreamCode: failure.upstreamCode } : {}),
+  }
+}

--- a/src/services/apiService/voapiV2/index.ts
+++ b/src/services/apiService/voapiV2/index.ts
@@ -39,6 +39,7 @@ import {
   quotaToAmountString,
   type VoApiV2EnvelopeOptions,
 } from "./parsing"
+import { decodeVoApiV2ResponseError } from "./responseError"
 import { resyncVoApiV2AuthToken } from "./tokenResync"
 import {
   VOAPI_V2_ENDPOINTS,
@@ -82,15 +83,12 @@ async function fetchVoApiV2Data<TData>(
   options: RequestInit = {},
   parseOptions?: VoApiV2EnvelopeOptions,
 ): Promise<TData> {
-  const body = await fetchApi<unknown>(
-    request,
-    {
-      endpoint,
-      options,
-      authTokenMode: API_AUTH_TOKEN_MODES.Raw,
-    },
-    true,
-  )
+  const body = await fetchApi<unknown>(request, {
+    endpoint,
+    options,
+    authTokenMode: API_AUTH_TOKEN_MODES.Raw,
+    errorResponseDecoder: decodeVoApiV2ResponseError,
+  })
 
   return parseVoApiV2Envelope<TData>(body, endpoint, parseOptions)
 }
@@ -1003,14 +1001,16 @@ export async function submitVoApiV2CheckIn(
       endpoint: VOAPI_V2_ENDPOINTS.CheckInSubmit,
       options: { method: "POST" },
       authTokenMode: API_AUTH_TOKEN_MODES.Raw,
+      errorResponseDecoder: decodeVoApiV2ResponseError,
     },
-    true,
   )
 
+  const envelope = body as unknown as VoApiV2Envelope<VoApiV2CheckInSubmitData>
+
   if (
-    body &&
-    typeof body === "object" &&
-    body.code === VOAPI_V2_PROTOCOL_CODES.AlreadySigned
+    envelope &&
+    typeof envelope === "object" &&
+    envelope.code === VOAPI_V2_PROTOCOL_CODES.AlreadySigned
   ) {
     // Code 1 is only a repeat candidate. The provider confirms the actual
     // same-day state through the read-only stats endpoint before reporting it.
@@ -1018,7 +1018,7 @@ export async function submitVoApiV2CheckIn(
   }
 
   return parseVoApiV2Envelope<VoApiV2CheckInSubmitData>(
-    body,
+    envelope,
     VOAPI_V2_ENDPOINTS.CheckInSubmit,
   )
 }

--- a/src/services/apiService/voapiV2/parsing.ts
+++ b/src/services/apiService/voapiV2/parsing.ts
@@ -1,6 +1,8 @@
 import { UI_CONSTANTS } from "~/constants/ui"
 import { API_ERROR_CODES, ApiError } from "~/services/apiTransport/errors"
+import { getErrorMessage } from "~/utils/core/error"
 
+import { readVoApiV2EnvelopeMessage } from "./responseError"
 import { VOAPI_V2_PROTOCOL_CODES, type VoApiV2Envelope } from "./type"
 
 class VoApiV2AuthExpiredError extends ApiError {}
@@ -11,9 +13,7 @@ export type VoApiV2EnvelopeOptions = {
 }
 
 const getEnvelopeMessage = (body: VoApiV2Envelope<unknown>): string =>
-  (typeof body.msg === "string" && body.msg.trim()) ||
-  (typeof body.message === "string" && body.message.trim()) ||
-  "VoAPI v2 request failed"
+  getErrorMessage(readVoApiV2EnvelopeMessage(body), "VoAPI v2 request failed")
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value)

--- a/src/services/apiService/voapiV2/responseError.ts
+++ b/src/services/apiService/voapiV2/responseError.ts
@@ -1,0 +1,51 @@
+import { readSafeUpstreamCode } from "~/services/apiTransport/responseError"
+import type { ApiResponseErrorDecoder } from "~/services/apiTransport/type"
+import { getErrorMessage } from "~/utils/core/error"
+
+import { VOAPI_V2_PROTOCOL_CODES } from "./type"
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+/** Reads only message fields from a verified VoAPI v2 envelope. */
+export const readVoApiV2EnvelopeMessage = (
+  body: unknown,
+): string | undefined => {
+  if (!isRecord(body)) return undefined
+
+  const msg = typeof body.msg === "string" ? body.msg.trim() : undefined
+  const message =
+    typeof body.message === "string" ? body.message.trim() : undefined
+  return getErrorMessage(msg, message) || undefined
+}
+
+/**
+ * Decodes VoAPI v2 HTTP failures without applying disclosure policy.
+ * The deployed official client consumes a numeric `code` envelope with
+ * `msg`/`message`; code 0 is success and remains owned by the 2xx parser.
+ * https://demo.voapi.top/assets/invite-CM31Bfbx.js
+ */
+export const decodeVoApiV2ResponseError: ApiResponseErrorDecoder = (
+  response,
+) => {
+  if (response.ok) return null
+
+  const body = isRecord(response.body) ? response.body : undefined
+  const upstreamCode =
+    typeof body?.code === "number" &&
+    body.code !== VOAPI_V2_PROTOCOL_CODES.Success
+      ? readSafeUpstreamCode(body.code)
+      : undefined
+  const providerMessage = upstreamCode
+    ? readVoApiV2EnvelopeMessage(body)
+    : undefined
+
+  return {
+    kind: providerMessage ? "business" : "http",
+    message: getErrorMessage(
+      providerMessage,
+      `VoAPI v2 request failed: ${response.status}`,
+    ),
+    ...(providerMessage && upstreamCode ? { upstreamCode } : {}),
+  }
+}

--- a/src/services/apiTransport/compatibilityResponse.ts
+++ b/src/services/apiTransport/compatibilityResponse.ts
@@ -1,4 +1,5 @@
 import type { TempWindowResponseType } from "~/types/tempWindowFetch"
+import { getErrorMessage } from "~/utils/core/error"
 import { t } from "~/utils/i18n/core"
 
 import { API_ERROR_CODES, ApiError, type ApiErrorCode } from "./errors"
@@ -40,7 +41,10 @@ function createProviderBusinessError(
   if (decoded?.kind !== "business") return null
 
   return new ApiError(
-    decoded.message || t("messages:errors.api.invalidResponseFormat"),
+    getErrorMessage(
+      decoded.message,
+      t("messages:errors.api.invalidResponseFormat"),
+    ),
     undefined,
     context.endpoint,
     API_ERROR_CODES.BUSINESS_ERROR,
@@ -99,13 +103,7 @@ function createCompatibilityHttpError(
     errorCode = API_ERROR_CODES.BUSINESS_ERROR
   }
 
-  const message =
-    decoded?.message &&
-    (context.errorResponseDecoder ||
-      decoded.kind === "business" ||
-      response.status !== 403)
-      ? decoded.message
-      : fixedFallback
+  const message = getErrorMessage(decoded?.message, fixedFallback)
 
   return new ApiError(
     message,

--- a/src/services/apiTransport/compatibilityResponse.ts
+++ b/src/services/apiTransport/compatibilityResponse.ts
@@ -4,7 +4,10 @@ import { t } from "~/utils/i18n/core"
 
 import { API_ERROR_CODES, ApiError, type ApiErrorCode } from "./errors"
 import { extractDataFromApiResponseBody } from "./response"
-import { resolveResponseErrorDetails } from "./responseError"
+import {
+  extractHeuristicResponseErrorMessage,
+  resolveResponseErrorDetails,
+} from "./responseError"
 import type {
   ApiResponse,
   ApiResponseErrorDecoder,
@@ -15,15 +18,18 @@ type CompatibilityTransportResponse<T> = ApiTransportResponse<T> & {
   decodeError?: ApiError
 }
 
+type CompatibilityResponseContext = {
+  endpoint: string
+  responseType: TempWindowResponseType
+  onlyData: boolean
+  decodeApplicationError: boolean
+  errorResponseDecoder?: ApiResponseErrorDecoder
+}
+
 /** Maps provider-declared application failures carried by a successful HTTP response. */
 function createProviderBusinessError(
   response: ApiTransportResponse<unknown>,
-  context: {
-    endpoint: string
-    responseType: TempWindowResponseType
-    decodeApplicationError: boolean
-    errorResponseDecoder?: ApiResponseErrorDecoder
-  },
+  context: CompatibilityResponseContext,
 ): ApiError | null {
   if (
     context.responseType !== "json" ||
@@ -55,11 +61,7 @@ function createProviderBusinessError(
 /** Converts an unsuccessful HTTP result into the legacy shared ApiError. */
 function createCompatibilityHttpError(
   response: ApiTransportResponse<unknown>,
-  context: {
-    endpoint: string
-    responseType: TempWindowResponseType
-    errorResponseDecoder?: ApiResponseErrorDecoder
-  },
+  context: CompatibilityResponseContext,
 ): ApiError {
   let errorCode: ApiErrorCode = API_ERROR_CODES.HTTP_OTHER
   const fixedFallback = `请求失败: ${response.status}`
@@ -103,7 +105,16 @@ function createCompatibilityHttpError(
     errorCode = API_ERROR_CODES.BUSINESS_ERROR
   }
 
-  const message = getErrorMessage(decoded?.message, fixedFallback)
+  const heuristicMessage =
+    !decoded?.message &&
+    context.responseType === "json" &&
+    errorCode !== API_ERROR_CODES.CONTENT_TYPE_MISMATCH
+      ? extractHeuristicResponseErrorMessage(response.body)
+      : undefined
+  const message = getErrorMessage(
+    decoded?.message,
+    getErrorMessage(heuristicMessage, fixedFallback),
+  )
 
   return new ApiError(
     message,
@@ -117,13 +128,7 @@ function createCompatibilityHttpError(
 /** Applies the existing envelope and error behavior above raw HTTP transport. */
 export function mapCompatibilityResponse<T>(
   response: CompatibilityTransportResponse<T>,
-  context: {
-    endpoint: string
-    responseType: TempWindowResponseType
-    onlyData: boolean
-    decodeApplicationError: boolean
-    errorResponseDecoder?: ApiResponseErrorDecoder
-  },
+  context: CompatibilityResponseContext,
 ): T | ApiResponse<T> {
   if (!response.ok) {
     throw createCompatibilityHttpError(response, context)

--- a/src/services/apiTransport/request.ts
+++ b/src/services/apiTransport/request.ts
@@ -16,7 +16,10 @@ import {
   isReplaySafeRemoteFetch,
   observeRemoteFetchLifecycle,
 } from "~/services/apiTransport/remoteLifecycle"
-import { extractDataFromApiResponseBody } from "~/services/apiTransport/response"
+import {
+  extractDataFromApiResponseBody,
+  isApiResponseBody,
+} from "~/services/apiTransport/response"
 import {
   resolveSiteRequestLimitKey,
   withSiteApiRequestLease,
@@ -74,7 +77,10 @@ type NonJsonFetchApiOptions = Omit<FetchApiOptions, "responseType"> & {
   responseType: Exclude<TempWindowResponseType, "json">
 }
 
-type NormalizedAuthContext = AuthConfig
+type NormalizedAuthContext = Pick<
+  AuthConfig,
+  "authType" | "userId" | "accessToken" | "cookie"
+>
 
 interface AcquiredTransportResponse<T> extends ApiTransportResponse<T> {
   decodeError?: ApiError
@@ -815,28 +821,23 @@ const _fetchApi = async <T>(
   decodeApplicationError: boolean = onlyData,
 ): Promise<T | ApiResponse<T>> => {
   const responseType = options.responseType ?? "json"
+  const compatibilityContext = {
+    endpoint: options.endpoint,
+    responseType,
+    onlyData,
+    decodeApplicationError,
+    errorResponseDecoder: options.errorResponseDecoder,
+  }
+
   return await _fetchApiWithMapper<T, T | ApiResponse<T>>(
     request,
     options,
     onlyData,
-    (response) =>
-      mapCompatibilityResponse(response, {
-        endpoint: options.endpoint,
-        responseType,
-        onlyData,
-        decodeApplicationError,
-        errorResponseDecoder: options.errorResponseDecoder,
-      }),
+    (response) => mapCompatibilityResponse(response, compatibilityContext),
     (response) =>
       mapCompatibilityResponse(
         normalizeMessageFetchResponse<T>(response, options.endpoint),
-        {
-          endpoint: options.endpoint,
-          responseType,
-          onlyData,
-          decodeApplicationError,
-          errorResponseDecoder: options.errorResponseDecoder,
-        },
+        compatibilityContext,
       ),
   )
 }
@@ -934,16 +935,6 @@ export async function fetchApi<T>(
 
   if (responseType !== "json") {
     return response as T
-  }
-
-  const isApiResponseBody = (value: unknown): value is ApiResponse<unknown> => {
-    if (!value || typeof value !== "object") return false
-    const record = value as Record<string, unknown>
-    return (
-      typeof record.success === "boolean" &&
-      typeof record.message === "string" &&
-      "data" in record
-    )
   }
 
   if (isApiResponseBody(response)) {

--- a/src/services/apiTransport/response.ts
+++ b/src/services/apiTransport/response.ts
@@ -1,4 +1,5 @@
 import { API_ERROR_CODES, ApiError } from "~/services/apiTransport/errors"
+import { getErrorMessage } from "~/utils/core/error"
 import { t } from "~/utils/i18n/core"
 
 /**
@@ -37,7 +38,7 @@ export function extractDataFromApiResponseBody<T>(
   }
 
   if (body.success === false) {
-    const message = body.message || invalidResponseMessage
+    const message = getErrorMessage(body.message, invalidResponseMessage)
     throw new ApiError(
       message,
       undefined,

--- a/src/services/apiTransport/response.ts
+++ b/src/services/apiTransport/response.ts
@@ -1,19 +1,19 @@
 import { API_ERROR_CODES, ApiError } from "~/services/apiTransport/errors"
+import type { ApiResponse } from "~/services/apiTransport/type"
 import { getErrorMessage } from "~/utils/core/error"
 import { t } from "~/utils/i18n/core"
 
-/**
- * Validate whether a string is an HTTP(S) URL.
- * @param url Candidate URL string.
- * @returns true when protocol is http/https; false on invalid or other schemes.
- */
-export function isHttpUrl(url: string): boolean {
-  try {
-    const parsed = new URL(url)
-    return parsed.protocol === "http:" || parsed.protocol === "https:"
-  } catch {
-    return false
-  }
+/** Returns whether a value is the shared API response envelope. */
+export function isApiResponseBody(
+  value: unknown,
+): value is ApiResponse<unknown> {
+  if (!value || typeof value !== "object") return false
+  const record = value as Record<string, unknown>
+  return (
+    typeof record.success === "boolean" &&
+    typeof record.message === "string" &&
+    "data" in record
+  )
 }
 
 /**
@@ -23,7 +23,7 @@ export function isHttpUrl(url: string): boolean {
  * @returns Extracted `data` payload cast to T.
  */
 export function extractDataFromApiResponseBody<T>(
-  body: any,
+  body: unknown,
   endpoint?: string,
 ): T {
   const invalidResponseMessage = t("messages:errors.api.invalidResponseFormat")
@@ -37,8 +37,10 @@ export function extractDataFromApiResponseBody<T>(
     )
   }
 
-  if (body.success === false) {
-    const message = getErrorMessage(body.message, invalidResponseMessage)
+  const record = body as Record<string, unknown>
+
+  if (record.success === false) {
+    const message = getErrorMessage(record.message, invalidResponseMessage)
     throw new ApiError(
       message,
       undefined,
@@ -47,7 +49,7 @@ export function extractDataFromApiResponseBody<T>(
     )
   }
 
-  if (!("data" in body) || body.data === undefined) {
+  if (!("data" in record) || record.data === undefined) {
     throw new ApiError(
       invalidResponseMessage,
       undefined,
@@ -56,5 +58,5 @@ export function extractDataFromApiResponseBody<T>(
     )
   }
 
-  return body.data as T
+  return record.data as T
 }

--- a/src/services/apiTransport/response.ts
+++ b/src/services/apiTransport/response.ts
@@ -40,7 +40,10 @@ export function extractDataFromApiResponseBody<T>(
   const record = body as Record<string, unknown>
 
   if (record.success === false) {
-    const message = getErrorMessage(record.message, invalidResponseMessage)
+    const message =
+      typeof record.message === "string"
+        ? getErrorMessage(record.message, invalidResponseMessage)
+        : invalidResponseMessage
     throw new ApiError(
       message,
       undefined,

--- a/src/services/apiTransport/responseError.ts
+++ b/src/services/apiTransport/responseError.ts
@@ -5,14 +5,6 @@ import type {
 } from "~/services/apiTransport/type"
 import { getErrorMessage } from "~/utils/core/error"
 
-const KNOWN_LEGACY_BACKEND_ERROR_TYPES = new Set(["new_api_error"])
-
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value)
-
-const readMessage = (value: unknown): string | undefined =>
-  typeof value === "string" && value.trim() ? value.trim() : undefined
-
 /** Keeps only bounded scalar provider codes suitable for shared errors. */
 export const readSafeUpstreamCode = (value: unknown): string | undefined => {
   if (typeof value !== "string" && typeof value !== "number") return undefined
@@ -20,67 +12,16 @@ export const readSafeUpstreamCode = (value: unknown): string | undefined => {
   return code.length <= 64 && /^[A-Za-z0-9_.-]+$/.test(code) ? code : undefined
 }
 
-const isLegacyBusinessEnvelope = (body: Record<string, unknown>): boolean => {
-  const code = body.code
-  return (
-    body.success === false ||
-    (typeof code === "number" && code !== 0) ||
-    (typeof code === "string" && code.trim() !== "" && code.trim() !== "0")
-  )
-}
-
-/**
- * Preserves the historical fetchApi/fetchApiData response behavior while
- * provider modules migrate to explicit decoders. Remove this compatibility
- * decoder once remaining callers either provide a provider decoder or consume
- * the raw transport response.
- */
-const decodeLegacyCompatibilityResponseError: ApiResponseErrorDecoder = (
-  response,
-) => {
-  if (!isRecord(response.body)) return null
-  const body = response.body
-  const topLevelMessage = readMessage(body.message) ?? readMessage(body.msg)
-  if (topLevelMessage) {
-    const upstreamCode = readSafeUpstreamCode(body.code)
-    return {
-      kind: isLegacyBusinessEnvelope(body) ? "business" : "http",
-      message: topLevelMessage,
-      ...(upstreamCode ? { upstreamCode } : {}),
-    }
-  }
-
-  if (!isRecord(body.error)) return null
-  const message = readMessage(body.error.message)
-  if (!message) return null
-
-  const type = readMessage(body.error.type)
-  const upstreamCode = readSafeUpstreamCode(body.error.code)
-  return {
-    kind:
-      type && KNOWN_LEGACY_BACKEND_ERROR_TYPES.has(type) ? "business" : "http",
-    message,
-    ...(upstreamCode ? { upstreamCode } : {}),
-  }
-}
-
-/** Applies provider priority, then legacy message fallback, without disclosure policy. */
+/** Applies only the selected provider decoder, without disclosure policy. */
 export function resolveResponseErrorDetails(
   response: ApiTransportResponse<unknown>,
   endpoint: string,
   providerDecoder?: ApiResponseErrorDecoder,
 ): DecodedApiResponseError | null {
   const providerDetails = providerDecoder?.(response, { endpoint }) ?? null
-  if (!providerDetails) {
-    return decodeLegacyCompatibilityResponseError(response, { endpoint })
-  }
+  if (!providerDetails) return null
 
-  const providerMessage = getErrorMessage(providerDetails.message)
-  const message = providerMessage
-    ? providerMessage
-    : getErrorMessage(
-        decodeLegacyCompatibilityResponseError(response, { endpoint })?.message,
-      )
+  const message = getErrorMessage(providerDetails.message)
   return {
     kind: providerDetails.kind,
     ...(message ? { message } : {}),

--- a/src/services/apiTransport/responseError.ts
+++ b/src/services/apiTransport/responseError.ts
@@ -70,7 +70,6 @@ type HeuristicMessageCandidate = {
 type HeuristicQueueEntry = {
   value: object
   depth: number
-  allowGenericStrings: boolean
 }
 
 const preferHeuristicCandidate = (
@@ -102,9 +101,7 @@ export function extractHeuristicResponseErrorMessage(
   if (scalarMessage) return scalarMessage
   if (!body || typeof body !== "object") return undefined
 
-  const queue: HeuristicQueueEntry[] = [
-    { value: body, depth: 0, allowGenericStrings: true },
-  ]
+  const queue: HeuristicQueueEntry[] = [{ value: body, depth: 0 }]
   const visited = new Set<object>()
   let inspectedValues = 0
   let best: HeuristicMessageCandidate | undefined
@@ -116,8 +113,7 @@ export function extractHeuristicResponseErrorMessage(
   ) => {
     const sensitiveKey = isSensitiveHeuristicKey(key)
     const priority = HEURISTIC_MESSAGE_KEY_PRIORITY.get(key.toLowerCase())
-    const maySelect =
-      !sensitiveKey && (priority !== undefined || current.allowGenericStrings)
+    const maySelect = !sensitiveKey
     const message = maySelect ? readGenericMessageString(value) : undefined
     if (message) {
       best = preferHeuristicCandidate(best, {
@@ -128,6 +124,7 @@ export function extractHeuristicResponseErrorMessage(
     }
 
     if (
+      !sensitiveKey &&
       current.depth < MAX_HEURISTIC_DEPTH &&
       value &&
       typeof value === "object"
@@ -135,7 +132,6 @@ export function extractHeuristicResponseErrorMessage(
       queue.push({
         value,
         depth: current.depth + 1,
-        allowGenericStrings: current.allowGenericStrings && !sensitiveKey,
       })
     }
   }

--- a/src/services/apiTransport/responseError.ts
+++ b/src/services/apiTransport/responseError.ts
@@ -5,11 +5,174 @@ import type {
 } from "~/services/apiTransport/type"
 import { getErrorMessage } from "~/utils/core/error"
 
+const readMessageString = (value: unknown): string | undefined =>
+  typeof value === "string" && value.trim() ? value.trim() : undefined
+
+const MAX_HEURISTIC_MESSAGE_LENGTH = 2000
+const MIN_ENCODED_PAYLOAD_LENGTH = 80
+const CREDENTIAL_ASSIGNMENT_PATTERN =
+  /\b(?:authorization|proxy[\s_-]?authorization|(?:set[\s_-]?)?cookie|credential|session|token|access[\s_-]?token|refresh[\s_-]?token|admin[\s_-]?token|key|api[\s_-]?key|password|passwd|secret|client[\s_-]?secret|management[\s_-]?key)\s*[:=]\s*\S+/i
+
+const readGenericMessageString = (value: unknown): string | undefined => {
+  const message = readMessageString(value)
+  if (!message || message.length > MAX_HEURISTIC_MESSAGE_LENGTH)
+    return undefined
+  if (CREDENTIAL_ASSIGNMENT_PATTERN.test(message)) return undefined
+  if (/^https?:\/\/\S+$/i.test(message)) return undefined
+  if (/<\s*(?:!doctype|html|body|script)\b/i.test(message)) return undefined
+  if (
+    /^[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}$/.test(message)
+  ) {
+    return undefined
+  }
+  if (
+    message.length >= MIN_ENCODED_PAYLOAD_LENGTH &&
+    /^[A-Za-z0-9+/=_-]+$/.test(message)
+  ) {
+    return undefined
+  }
+  return message
+}
+
+const HEURISTIC_MESSAGE_KEY_PRIORITY = new Map([
+  ["message", 7],
+  ["msg", 6],
+  ["error_description", 5],
+  ["detail", 4],
+  ["error", 3],
+  ["reason", 2],
+  ["title", 1],
+])
+const MAX_HEURISTIC_DEPTH = 4
+const MAX_HEURISTIC_INSPECTIONS = 100
+
+const isSensitiveHeuristicKey = (key: string): boolean => {
+  const normalized = key.toLowerCase().replace(/[^a-z0-9]/g, "")
+  return (
+    normalized === "key" ||
+    normalized.includes("apikey") ||
+    normalized.includes("authorization") ||
+    normalized.includes("cookie") ||
+    normalized.includes("credential") ||
+    normalized.includes("password") ||
+    normalized.includes("secret") ||
+    normalized.includes("session") ||
+    normalized.includes("token")
+  )
+}
+
+type HeuristicMessageCandidate = {
+  message: string
+  keyPriority: number
+  depth: number
+}
+
+type HeuristicQueueEntry = {
+  value: object
+  depth: number
+  allowGenericStrings: boolean
+}
+
+const preferHeuristicCandidate = (
+  current: HeuristicMessageCandidate | undefined,
+  candidate: HeuristicMessageCandidate,
+): HeuristicMessageCandidate => {
+  if (!current) return candidate
+  if (candidate.keyPriority !== current.keyPriority) {
+    return candidate.keyPriority > current.keyPriority ? candidate : current
+  }
+  if (candidate.keyPriority > 0 && candidate.depth !== current.depth) {
+    return candidate.depth < current.depth ? candidate : current
+  }
+  return candidate.message.length > current.message.length ? candidate : current
+}
+
 /** Keeps only bounded scalar provider codes suitable for shared errors. */
 export const readSafeUpstreamCode = (value: unknown): string | undefined => {
   if (typeof value !== "string" && typeof value !== "number") return undefined
   const code = String(value).trim()
   return code.length <= 64 && /^[A-Za-z0-9_.-]+$/.test(code) ? code : undefined
+}
+
+/** Recovers a likely message from an already-confirmed HTTP error body. */
+export function extractHeuristicResponseErrorMessage(
+  body: unknown,
+): string | undefined {
+  const scalarMessage = readGenericMessageString(body)
+  if (scalarMessage) return scalarMessage
+  if (!body || typeof body !== "object") return undefined
+
+  const queue: HeuristicQueueEntry[] = [
+    { value: body, depth: 0, allowGenericStrings: true },
+  ]
+  const visited = new Set<object>()
+  let inspectedValues = 0
+  let best: HeuristicMessageCandidate | undefined
+
+  const inspectEntry = (
+    current: HeuristicQueueEntry,
+    key: string,
+    value: unknown,
+  ) => {
+    const sensitiveKey = isSensitiveHeuristicKey(key)
+    const priority = HEURISTIC_MESSAGE_KEY_PRIORITY.get(key.toLowerCase())
+    const maySelect =
+      !sensitiveKey && (priority !== undefined || current.allowGenericStrings)
+    const message = maySelect ? readGenericMessageString(value) : undefined
+    if (message) {
+      best = preferHeuristicCandidate(best, {
+        message,
+        keyPriority: priority ?? 0,
+        depth: current.depth,
+      })
+    }
+
+    if (
+      current.depth < MAX_HEURISTIC_DEPTH &&
+      value &&
+      typeof value === "object"
+    ) {
+      queue.push({
+        value,
+        depth: current.depth + 1,
+        allowGenericStrings: current.allowGenericStrings && !sensitiveKey,
+      })
+    }
+  }
+
+  while (queue.length && inspectedValues < MAX_HEURISTIC_INSPECTIONS) {
+    const current = queue.shift()!
+    if (visited.has(current.value)) continue
+    visited.add(current.value)
+
+    if (Array.isArray(current.value)) {
+      for (
+        let index = 0;
+        index < current.value.length &&
+        inspectedValues < MAX_HEURISTIC_INSPECTIONS;
+        index += 1
+      ) {
+        inspectedValues += 1
+        if (!(index in current.value)) continue
+        inspectEntry(current, String(index), current.value[index])
+      }
+      continue
+    }
+
+    for (const key in current.value) {
+      if (inspectedValues >= MAX_HEURISTIC_INSPECTIONS) break
+      if (!Object.prototype.hasOwnProperty.call(current.value, key)) continue
+
+      inspectedValues += 1
+      inspectEntry(
+        current,
+        key,
+        (current.value as Record<string, unknown>)[key],
+      )
+    }
+  }
+
+  return best?.message
 }
 
 /** Applies only the selected provider decoder, without disclosure policy. */

--- a/src/services/history/usageHistory/sync.ts
+++ b/src/services/history/usageHistory/sync.ts
@@ -1,8 +1,8 @@
 import { accountQueries } from "~/services/accounts/accountStorage/accountQueries"
 import { createAccountApiRequestFromStoredAccount } from "~/services/accounts/utils/apiServiceRequest"
+import { newApiFamilyRequests } from "~/services/apiService/newApiFamily/request"
 import { REQUEST_CONFIG } from "~/services/apiTransport/constant"
 import { ApiError } from "~/services/apiTransport/errors"
-import { fetchApiData } from "~/services/apiTransport/request"
 import type { ApiServiceRequest } from "~/services/apiTransport/type"
 import { LogType } from "~/services/history/usageHistory/usageLogModel"
 import type {
@@ -84,7 +84,7 @@ async function fetchConsumeLogPage(params: {
     group: "",
   })
 
-  return await fetchApiData<LogResponseData>(request, {
+  return await newApiFamilyRequests.data<LogResponseData>(request, {
     endpoint: `/api/log/self?${searchParams.toString()}`,
   })
 }

--- a/src/services/integrations/ldohSiteLookup/background.ts
+++ b/src/services/integrations/ldohSiteLookup/background.ts
@@ -49,21 +49,22 @@ function isLdohUiLifecycleExecution(
 }
 
 /**
- * Fetches the site directory from LDOH using the shared `fetchApi` wrapper.
+ * Configures the raw LDOH site-directory request.
  *
  * - Tries background fetch first (credentials include).
  * - Falls back to the temp-window flow when needed.
  */
 const LDOH_SITE_LIST_REQUEST = {
   baseUrl: LDOH_ORIGIN,
-  // Sentinel value to avoid fetchApi warning noise about missing accountId.
+  // Sentinel value to avoid shared transport warning noise about missing accountId.
   accountId: "__ldoh_site_lookup__",
   // LDOH is session-cookie based; we do not have per-account auth here.
   auth: { authType: AuthTypeEnum.None },
 } satisfies ApiServiceRequest
 
 /**
- * Fetches the site directory from LDOH using the shared `fetchApi` wrapper.
+ * Fetches the raw LDOH success body while retaining the existing protected
+ * request fallback and lifecycle ownership.
  */
 async function fetchLdohSites(
   protectionBypassExecution: ProtectionBypassExecution,

--- a/src/services/managedSites/providers/claudeCodeHub.ts
+++ b/src/services/managedSites/providers/claudeCodeHub.ts
@@ -16,6 +16,7 @@ import {
   userPreferences,
   type UserPreferences,
 } from "~/services/preferences/userPreferences"
+import { toSanitizedErrorSummary } from "~/services/verification/aiApiVerification/utils"
 import type { AccountToken, ApiToken, DisplaySiteData } from "~/types"
 import type {
   ClaudeCodeHubAllowedModel,
@@ -34,13 +35,36 @@ import {
   type ManagedSiteChannelListData,
   type UpdateChannelPayload,
 } from "~/types/managedSite"
-import { getErrorMessage } from "~/utils/core/error"
 import { createLogger } from "~/utils/core/logger"
 import { normalizeList, parseDelimitedList } from "~/utils/core/string"
 import { t } from "~/utils/i18n/core"
 
 const logger = createLogger("ClaudeCodeHubService")
 const DEFAULT_GROUP_TAG = "default"
+
+/** Creates a detached error safe for user-facing and local-log disclosure. */
+export function toClaudeCodeHubDisclosureError(
+  error: unknown,
+  config: ClaudeCodeHubConfig,
+  extraSecrets: readonly string[] = [],
+): Error {
+  const message = toSanitizedErrorSummary(error, [
+    config.adminToken,
+    ...extraSecrets,
+  ])
+  return new Error(message || "Claude Code Hub request failed")
+}
+
+const runClaudeCodeHubRead = async <T>(
+  config: ClaudeCodeHubConfig,
+  operation: () => Promise<T>,
+): Promise<T> => {
+  try {
+    return await operation()
+  } catch (error) {
+    throw toClaudeCodeHubDisclosureError(error, config)
+  }
+}
 
 /**
  * Checks whether preferences contain a usable Claude Code Hub admin config.
@@ -55,15 +79,21 @@ function hasValidClaudeCodeHubConfig(prefs: UserPreferences | null): boolean {
  * Verifies the saved Claude Code Hub config can authenticate successfully.
  */
 export async function checkValidClaudeCodeHubConfig(): Promise<boolean> {
+  let config: ClaudeCodeHubConfig | undefined
   try {
     const prefs = await userPreferences.getPreferences()
     if (!hasValidClaudeCodeHubConfig(prefs) || !prefs.claudeCodeHub) {
       return false
     }
-    const config = prefs.claudeCodeHub
+    config = prefs.claudeCodeHub
     return await claudeCodeHubApi.validateClaudeCodeHubConfig(config)
   } catch (error) {
-    logger.warn("Claude Code Hub config validation failed", error)
+    logger.warn(
+      "Claude Code Hub config validation failed",
+      config
+        ? toClaudeCodeHubDisclosureError(error, config).message
+        : toSanitizedErrorSummary(error, []),
+    )
     return false
   }
 }
@@ -79,7 +109,10 @@ export async function getClaudeCodeHubConfig(): Promise<ManagedSiteConfig | null
     }
     return null
   } catch (error) {
-    logger.error("Error getting Claude Code Hub config", error)
+    logger.error(
+      "Error getting Claude Code Hub config",
+      toSanitizedErrorSummary(error, []),
+    )
     return null
   }
 }
@@ -266,9 +299,10 @@ async function hydrateComparableChannelKey(
       key: key.trim(),
     }
   } catch (error) {
+    const disclosed = toClaudeCodeHubDisclosureError(error, config)
     logger.warn("Failed to hydrate Claude Code Hub provider key", {
       channelId: channel.id,
-      error: getErrorMessage(error),
+      error: disclosed.message,
     })
     return null
   }
@@ -384,7 +418,10 @@ export async function searchChannel(
   try {
     return await searchClaudeCodeHubChannels(config, keyword)
   } catch (error) {
-    logger.error("Failed to search Claude Code Hub providers", error)
+    logger.error(
+      "Failed to search Claude Code Hub providers",
+      toClaudeCodeHubDisclosureError(error, config).message,
+    )
     return null
   }
 }
@@ -400,9 +437,13 @@ export async function listChannels(
   },
 ): Promise<ManagedSiteChannelListData> {
   await options?.beforeRequest?.()
-  const providers = await claudeCodeHubApi.listProviders(config, {
-    ...(options?.signal ? { signal: options.signal } : {}),
-  })
+  const providers = await runClaudeCodeHubRead(
+    config,
+    async () =>
+      await claudeCodeHubApi.listProviders(config, {
+        ...(options?.signal ? { signal: options.signal } : {}),
+      }),
+  )
   return toManagedSiteChannelListData(providers)
 }
 
@@ -413,7 +454,11 @@ export async function fetchChannelSecretKey(
   config: ClaudeCodeHubConfig,
   channelId: number,
 ): Promise<string> {
-  return await claudeCodeHubApi.getUnmaskedProviderKey(config, channelId)
+  return await runClaudeCodeHubRead(
+    config,
+    async () =>
+      await claudeCodeHubApi.getUnmaskedProviderKey(config, channelId),
+  )
 }
 
 /**

--- a/src/utils/browser/tempWindowFetch.ts
+++ b/src/utils/browser/tempWindowFetch.ts
@@ -11,10 +11,7 @@ import {
   observeRemoteFetchLifecycle,
   type RemoteFetchLifecycleAssessment,
 } from "~/services/apiTransport/remoteLifecycle"
-import {
-  extractDataFromApiResponseBody,
-  isHttpUrl,
-} from "~/services/apiTransport/response"
+import { extractDataFromApiResponseBody } from "~/services/apiTransport/response"
 import {
   COOKIE_INTERCEPTOR_PERMISSIONS,
   hasCookieInterceptorPermissions,
@@ -55,6 +52,7 @@ import { isProtectionBypassFirefoxEnv } from "~/utils/browser/protectionBypass"
 import { normalizeRequestInitForMessage } from "~/utils/browser/requestInitMessage"
 import { safeRandomUUID } from "~/utils/core/identifier"
 import { createLogger } from "~/utils/core/logger"
+import { isHttpUrl } from "~/utils/core/urlParsing"
 
 /**
  * Unified logger scoped to temp window fetch helpers and fallback behavior.

--- a/tests/entrypoints/options/ClaudeCodeHubSettings.test.tsx
+++ b/tests/entrypoints/options/ClaudeCodeHubSettings.test.tsx
@@ -6,7 +6,7 @@ import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
 import ClaudeCodeHubSettings from "~/features/BasicSettings/components/tabs/ManagedSite/ClaudeCodeHubSettings"
 import { validateClaudeCodeHubConfig } from "~/services/apiService/claudeCodeHub"
 import { showUpdateToast } from "~/utils/core/toastHelpers"
-import { testI18n } from "~~/tests/test-utils/i18n"
+import { createResourceTestI18n, testI18n } from "~~/tests/test-utils/i18n"
 
 const { showUpdateToastMock, toSanitizedErrorSummaryMock } = vi.hoisted(() => ({
   showUpdateToastMock: vi.fn(),
@@ -73,9 +73,9 @@ describe("ClaudeCodeHubSettings", () => {
     toSanitizedErrorSummaryMock.mockReturnValue("safe provider failure")
   })
 
-  const renderSubject = () =>
+  const renderSubject = (i18n = testI18n) =>
     render(
-      <I18nextProvider i18n={testI18n}>
+      <I18nextProvider i18n={i18n}>
         <ClaudeCodeHubSettings />
       </I18nextProvider>,
     )
@@ -391,5 +391,43 @@ describe("ClaudeCodeHubSettings", () => {
       expect.any(Error),
       ["admin-token"],
     )
+  })
+
+  it("shows a fixed validation error when sanitization yields no message", async () => {
+    const toast = await import("react-hot-toast")
+    const i18n = await createResourceTestI18n({
+      en: {
+        settings: {
+          claudeCodeHub: {
+            validation: {
+              validate: "Validate configuration",
+              failed: "Validation failed: {{error}}",
+            },
+          },
+        },
+      },
+    })
+    toSanitizedErrorSummaryMock.mockReturnValueOnce("")
+    mockedValidateClaudeCodeHubConfig.mockRejectedValueOnce(undefined)
+    vi.mocked(useUserPreferencesContext).mockReturnValue({
+      preferences: { lastUpdated: 5 },
+      claudeCodeHubBaseUrl: "https://cch.example.invalid",
+      claudeCodeHubAdminToken: "admin-token",
+      updateClaudeCodeHubBaseUrl: vi.fn(),
+      updateClaudeCodeHubAdminToken: vi.fn(),
+      updateClaudeCodeHubConfig: vi.fn(),
+      resetClaudeCodeHubConfig: vi.fn(),
+    } as any)
+
+    renderSubject(i18n)
+    fireEvent.click(
+      screen.getByRole("button", { name: "Validate configuration" }),
+    )
+
+    await waitFor(() => {
+      expect(vi.mocked(toast.default.error)).toHaveBeenCalledWith(
+        "Validation failed: Claude Code Hub request failed",
+      )
+    })
   })
 })

--- a/tests/entrypoints/options/ClaudeCodeHubSettings.test.tsx
+++ b/tests/entrypoints/options/ClaudeCodeHubSettings.test.tsx
@@ -8,8 +8,9 @@ import { validateClaudeCodeHubConfig } from "~/services/apiService/claudeCodeHub
 import { showUpdateToast } from "~/utils/core/toastHelpers"
 import { testI18n } from "~~/tests/test-utils/i18n"
 
-const { showUpdateToastMock } = vi.hoisted(() => ({
+const { showUpdateToastMock, toSanitizedErrorSummaryMock } = vi.hoisted(() => ({
   showUpdateToastMock: vi.fn(),
+  toSanitizedErrorSummaryMock: vi.fn(),
 }))
 
 vi.mock("~/contexts/UserPreferencesContext", () => ({
@@ -18,6 +19,10 @@ vi.mock("~/contexts/UserPreferencesContext", () => ({
 
 vi.mock("~/services/apiService/claudeCodeHub", () => ({
   validateClaudeCodeHubConfig: vi.fn(),
+}))
+
+vi.mock("~/services/verification/aiApiVerification/utils", () => ({
+  toSanitizedErrorSummary: toSanitizedErrorSummaryMock,
 }))
 
 vi.mock("~/utils/core/toastHelpers", () => ({
@@ -65,6 +70,7 @@ const createDeferred = <T,>() => {
 describe("ClaudeCodeHubSettings", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    toSanitizedErrorSummaryMock.mockReturnValue("safe provider failure")
   })
 
   const renderSubject = () =>
@@ -352,5 +358,38 @@ describe("ClaudeCodeHubSettings", () => {
         "settings:claudeCodeHub.validation.failed",
       )
     })
+  })
+
+  it("redacts the draft admin token at the validation toast boundary", async () => {
+    const toast = await import("react-hot-toast")
+    mockedValidateClaudeCodeHubConfig.mockRejectedValueOnce(
+      new Error("token admin-token rejected"),
+    )
+    vi.mocked(useUserPreferencesContext).mockReturnValue({
+      preferences: { lastUpdated: 5 },
+      claudeCodeHubBaseUrl: "https://cch.example.com",
+      claudeCodeHubAdminToken: "admin-token",
+      updateClaudeCodeHubBaseUrl: vi.fn(),
+      updateClaudeCodeHubAdminToken: vi.fn(),
+      updateClaudeCodeHubConfig: vi.fn(),
+      resetClaudeCodeHubConfig: vi.fn(),
+    } as any)
+
+    renderSubject()
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "settings:claudeCodeHub.validation.validate",
+      }),
+    )
+
+    await waitFor(() => {
+      expect(vi.mocked(toast.default.error)).toHaveBeenCalledWith(
+        "settings:claudeCodeHub.validation.failed",
+      )
+    })
+    expect(toSanitizedErrorSummaryMock).toHaveBeenCalledWith(
+      expect.any(Error),
+      ["admin-token"],
+    )
   })
 })

--- a/tests/services/aiApi/anthropic/responseError.test.ts
+++ b/tests/services/aiApi/anthropic/responseError.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest"
+
+import { decodeAnthropicResponseError } from "~/services/aiApi/anthropic/responseError"
+
+const response = (body: unknown, status = 400) => ({
+  ok: status >= 200 && status < 300,
+  status,
+  headers: {},
+  body,
+})
+
+describe("decodeAnthropicResponseError", () => {
+  it("decodes Anthropic's documented error envelope", () => {
+    expect(
+      decodeAnthropicResponseError(
+        response(
+          {
+            type: "error",
+            error: {
+              type: "authentication_error",
+              message: "Invalid API key",
+            },
+            request_id: "req_example",
+          },
+          401,
+        ),
+        { endpoint: "/v1/models" },
+      ),
+    ).toEqual({
+      kind: "http",
+      message: "Invalid API key",
+      upstreamCode: "authentication_error",
+    })
+  })
+
+  it("returns null for successful and non-Anthropic envelopes", () => {
+    expect(
+      decodeAnthropicResponseError(
+        response(
+          { type: "error", error: { type: "api_error", message: "ignored" } },
+          200,
+        ),
+        { endpoint: "/v1/models" },
+      ),
+    ).toBeNull()
+    expect(
+      decodeAnthropicResponseError(
+        response({ error: { type: "api_error", message: "missing marker" } }),
+        { endpoint: "/v1/models" },
+      ),
+    ).toBeNull()
+  })
+})

--- a/tests/services/aiApi/google/responseError.test.ts
+++ b/tests/services/aiApi/google/responseError.test.ts
@@ -30,6 +30,24 @@ describe("decodeGoogleResponseError", () => {
     })
   })
 
+  it("uses the numeric status code when the symbolic status is absent", () => {
+    expect(
+      decodeGoogleResponseError(
+        response({
+          error: {
+            code: 429,
+            message: "Quota exceeded",
+          },
+        }),
+        { endpoint: "/v1beta/models" },
+      ),
+    ).toEqual({
+      kind: "http",
+      message: "Quota exceeded",
+      upstreamCode: "429",
+    })
+  })
+
   it("returns null for successful and non-Google error shapes", () => {
     expect(
       decodeGoogleResponseError(

--- a/tests/services/aiApi/google/responseError.test.ts
+++ b/tests/services/aiApi/google/responseError.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest"
+
+import { decodeGoogleResponseError } from "~/services/aiApi/google/responseError"
+
+const response = (body: unknown, status = 400) => ({
+  ok: status >= 200 && status < 300,
+  status,
+  headers: {},
+  body,
+})
+
+describe("decodeGoogleResponseError", () => {
+  it("decodes Google's documented REST error status", () => {
+    expect(
+      decodeGoogleResponseError(
+        response({
+          error: {
+            code: 400,
+            message: "API key not valid",
+            status: "INVALID_ARGUMENT",
+            details: [],
+          },
+        }),
+        { endpoint: "/v1beta/models" },
+      ),
+    ).toEqual({
+      kind: "http",
+      message: "API key not valid",
+      upstreamCode: "INVALID_ARGUMENT",
+    })
+  })
+
+  it("returns null for successful and non-Google error shapes", () => {
+    expect(
+      decodeGoogleResponseError(
+        response(
+          {
+            error: {
+              code: 400,
+              message: "ignored",
+              status: "INVALID_ARGUMENT",
+            },
+          },
+          200,
+        ),
+        { endpoint: "/v1beta/models" },
+      ),
+    ).toBeNull()
+    expect(
+      decodeGoogleResponseError(
+        response({ error: { message: "missing status fields" } }),
+        { endpoint: "/v1beta/models" },
+      ),
+    ).toBeNull()
+  })
+})

--- a/tests/services/aiApi/modelFetchers.test.ts
+++ b/tests/services/aiApi/modelFetchers.test.ts
@@ -60,6 +60,7 @@ describe("AI API model fetchers", () => {
         },
         expect.objectContaining({
           endpoint: "/v1/models?limit=200",
+          errorResponseDecoder: expect.any(Function),
           options: {
             headers: {
               "x-api-key": "synthetic-anthropic-key",
@@ -259,6 +260,7 @@ describe("AI API model fetchers", () => {
         },
         expect.objectContaining({
           endpoint: "/v1beta/models",
+          errorResponseDecoder: expect.any(Function),
           options: {
             headers: {
               "x-goog-api-key": "synthetic-google-key",

--- a/tests/services/aiApi/openaiCompatible.index.test.ts
+++ b/tests/services/aiApi/openaiCompatible.index.test.ts
@@ -5,6 +5,7 @@ import {
   fetchOpenAICompatibleModelIds,
   fetchOpenAICompatibleModels,
 } from "~/services/aiApi/openaiCompatible"
+import { decodeOpenAICompatibleResponseError } from "~/services/aiApi/openaiCompatible/responseError"
 import { ApiError } from "~/services/apiTransport/errors"
 import { AuthTypeEnum } from "~/types"
 
@@ -57,6 +58,7 @@ describe("OpenAI-compatible model fetchers", () => {
       },
       {
         endpoint: "/v1/models",
+        errorResponseDecoder: decodeOpenAICompatibleResponseError,
       },
     )
   })
@@ -86,7 +88,10 @@ describe("OpenAI-compatible model fetchers", () => {
 
       expect(mockFetchApiData).toHaveBeenCalledWith(
         expect.objectContaining({ baseUrl }),
-        { endpoint: "/v1/models" },
+        {
+          endpoint: "/v1/models",
+          errorResponseDecoder: decodeOpenAICompatibleResponseError,
+        },
       )
     },
   )
@@ -118,9 +123,11 @@ describe("OpenAI-compatible model fetchers", () => {
 
       expect(mockFetchApiData).toHaveBeenNthCalledWith(1, expectedRequest, {
         endpoint: "/v1/models",
+        errorResponseDecoder: decodeOpenAICompatibleResponseError,
       })
       expect(mockFetchApiData).toHaveBeenNthCalledWith(2, expectedRequest, {
         endpoint: "/models",
+        errorResponseDecoder: decodeOpenAICompatibleResponseError,
       })
     },
   )
@@ -173,9 +180,11 @@ describe("OpenAI-compatible model fetchers", () => {
 
     expect(mockFetchApiData).toHaveBeenNthCalledWith(1, expect.any(Object), {
       endpoint: "/v1/models",
+      errorResponseDecoder: decodeOpenAICompatibleResponseError,
     })
     expect(mockFetchApiData).toHaveBeenNthCalledWith(2, expect.any(Object), {
       endpoint: "/models",
+      errorResponseDecoder: decodeOpenAICompatibleResponseError,
     })
   })
 
@@ -201,6 +210,7 @@ describe("OpenAI-compatible model fetchers", () => {
       },
       {
         endpoint: "/v1/models",
+        errorResponseDecoder: decodeOpenAICompatibleResponseError,
         options: {
           signal: abortController.signal,
         },

--- a/tests/services/aiApi/openaiCompatible/responseError.test.ts
+++ b/tests/services/aiApi/openaiCompatible/responseError.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest"
+
+import { decodeOpenAICompatibleResponseError } from "~/services/aiApi/openaiCompatible/responseError"
+
+const response = (body: unknown, status = 400) => ({
+  ok: status >= 200 && status < 300,
+  status,
+  headers: {},
+  body,
+})
+
+describe("decodeOpenAICompatibleResponseError", () => {
+  it("decodes the documented nested OpenAI error envelope", () => {
+    expect(
+      decodeOpenAICompatibleResponseError(
+        response({
+          error: {
+            type: "invalid_request_error",
+            code: "model_not_found",
+            message: "The requested model does not exist",
+          },
+        }),
+        { endpoint: "/v1/models" },
+      ),
+    ).toEqual({
+      kind: "http",
+      message: "The requested model does not exist",
+      upstreamCode: "model_not_found",
+    })
+  })
+
+  it("does not claim successful or non-OpenAI error shapes", () => {
+    expect(
+      decodeOpenAICompatibleResponseError(
+        response({ error: { message: "ignored" } }, 200),
+        { endpoint: "/v1/models" },
+      ),
+    ).toBeNull()
+    expect(
+      decodeOpenAICompatibleResponseError(
+        response({ message: "top-level compatibility message" }),
+        { endpoint: "/v1/models" },
+      ),
+    ).toBeNull()
+    expect(
+      decodeOpenAICompatibleResponseError(
+        response({ error: { message: "generic nested message" } }),
+        { endpoint: "/v1/models" },
+      ),
+    ).toBeNull()
+    expect(
+      decodeOpenAICompatibleResponseError(
+        response({ error: "invalid_api_key" }),
+        { endpoint: "/v1/models" },
+      ),
+    ).toBeNull()
+  })
+})

--- a/tests/services/apiAdapters/managedSites/claudeCodeHub.test.ts
+++ b/tests/services/apiAdapters/managedSites/claudeCodeHub.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { CLAUDE_CODE_HUB_PROVIDER_TYPE } from "~/constants/claudeCodeHub"
 import { SITE_TYPES } from "~/constants/siteType"
+import { toPrivateManagedSiteMutationOutput } from "~/services/managedSites/mutations"
 import { CHANNEL_STATUS } from "~/types/managedSite"
 import {
   CHANNEL_MUTATION_SCENARIOS,
@@ -63,6 +64,14 @@ const claudeCodeHubProvider = vi.hoisted(() => ({
   buildChannelName: vi.fn(),
   prepareChannelFormData: vi.fn(),
   buildChannelPayload: vi.fn(),
+  toClaudeCodeHubDisclosureError: vi.fn(
+    (error, config) =>
+      new Error(
+        error instanceof Error
+          ? error.message.replaceAll(config.adminToken, "[REDACTED]")
+          : "Claude Code Hub request failed",
+      ),
+  ),
 }))
 
 const claudeCodeHubApi = vi.hoisted(() => {
@@ -335,6 +344,39 @@ describe("Claude Code Hub managed-site channel capability", () => {
       })
     },
   )
+
+  it("redacts Claude Code Hub mutation diagnostics only at disclosure", async () => {
+    const error = new claudeCodeHubApi.ClaudeCodeHubApiError(
+      "token admin-token rejected",
+      403,
+      {
+        dispatch: "dispatched",
+        responseReceived: true,
+        confirmedNonApplication: true,
+        raw: { token: "admin-token" },
+      },
+    )
+    claudeCodeHubApi.deleteProvider.mockRejectedValueOnce(error)
+    const { claudeCodeHubManagedSiteChannels } = await import(
+      "~/services/apiAdapters/managedSites/claudeCodeHub"
+    )
+
+    const mutation = await claudeCodeHubManagedSiteChannels.delete(config, 7)
+    expect(mutation).toMatchObject({
+      outcome: "rejected",
+      diagnostic: { message: "token admin-token rejected", raw: error },
+    })
+
+    const disclosed = toPrivateManagedSiteMutationOutput(mutation, {
+      knownSecrets: [config.adminToken],
+    })
+    expect(disclosed).toEqual({
+      outcome: "rejected",
+      statusCode: 403,
+      message: "token [REDACTED] rejected",
+    })
+    expect(disclosed).not.toHaveProperty("raw")
+  })
 
   it.each([99, 600, Number.NaN])(
     "ignores invalid Claude Code Hub status %s without changing certainty",
@@ -657,6 +699,53 @@ describe("Claude Code Hub managed-site channel capability", () => {
         }),
       ],
     })
+  })
+
+  it.each([
+    {
+      name: "list",
+      reject: claudeCodeHubApi.listProviders,
+      invoke: async (capabilities: any) =>
+        await capabilities.resources.items.list(config),
+    },
+    {
+      name: "search",
+      reject: claudeCodeHubApi.searchProviders,
+      invoke: async (capabilities: any) =>
+        await capabilities.resources.items.search(config, "provider"),
+    },
+    {
+      name: "reveal",
+      reject: claudeCodeHubApi.getUnmaskedProviderKey,
+      invoke: async (capabilities: any) =>
+        await capabilities.resources.secrets.revealSecret(config, {
+          managedSiteType: SITE_TYPES.CLAUDE_CODE_HUB,
+          scopeKey: "https://claude-code-hub.example.invalid",
+          resourceId: "7",
+        }),
+    },
+  ])("sanitizes direct resource $name failures", async ({ reject, invoke }) => {
+    const raw = Object.assign(new Error("token admin-token rejected"), {
+      raw: { token: "admin-token" },
+      cause: new Error("admin-token"),
+    })
+    reject.mockRejectedValueOnce(raw)
+    const { claudeCodeHubManagedSiteCapabilities } = await import(
+      "~/services/apiAdapters/managedSites/claudeCodeHub"
+    )
+
+    const failure = await invoke(claudeCodeHubManagedSiteCapabilities).catch(
+      (error: unknown) => error,
+    )
+
+    expect(failure).toBeInstanceOf(Error)
+    expect((failure as Error).message).toBe("token [REDACTED] rejected")
+    expect(failure).not.toHaveProperty("raw")
+    expect(failure).not.toHaveProperty("cause")
+    expect(Object.keys(failure as object)).toEqual([])
+    expect(
+      claudeCodeHubProvider.toClaudeCodeHubDisclosureError,
+    ).toHaveBeenCalledWith(raw, config)
   })
 
   it("maps Claude Code Hub fallback labels and secret states", async () => {

--- a/tests/services/apiAdapters/managedSites/newApi.test.ts
+++ b/tests/services/apiAdapters/managedSites/newApi.test.ts
@@ -291,6 +291,28 @@ describe("newApi managed-site channel capability", () => {
     ).rejects.toBe(responseError)
   })
 
+  it("uses fixed diagnostic copy when a New API rejection message is blank", async () => {
+    const rejectionResponse = { success: false, data: null, message: "   " }
+    channelManagement.createChannel.mockImplementationOnce(async (request) => {
+      request.observer?.onDispatch()
+      request.observer?.onResponse()
+      return rejectionResponse
+    })
+    const { newApiManagedSiteChannels } = await import(
+      "~/services/apiAdapters/managedSites/newApi"
+    )
+
+    await expect(
+      newApiManagedSiteChannels.create(config, createPayload),
+    ).resolves.toEqual({
+      outcome: "rejected",
+      diagnostic: {
+        message: "Provider rejected the mutation",
+        raw: rejectionResponse,
+      },
+    })
+  })
+
   const resourceDraft = {
     name: "Resource channel",
     type: 1,

--- a/tests/services/apiAdapters/managedSites/octopus.test.ts
+++ b/tests/services/apiAdapters/managedSites/octopus.test.ts
@@ -203,10 +203,10 @@ describe("Octopus managed-site channel capability", () => {
     await expect(mutation).rejects.toBe(programmingError)
   })
 
-  it("uses a local fallback for an empty Octopus API error message", async () => {
+  it("uses a local fallback for a blank Octopus API error message", async () => {
     const raw = { detail: "provider detail" }
     octopusApi.createChannel.mockRejectedValueOnce(
-      new octopusApi.OctopusMutationApiError("", {
+      new octopusApi.OctopusMutationApiError("   ", {
         dispatch: "dispatched",
         responseReceived: true,
         confirmedNonApplication: true,
@@ -231,7 +231,7 @@ describe("Octopus managed-site channel capability", () => {
   })
 
   it("rejects an Octopus success-false response with a local fallback", async () => {
-    const response = { success: false, data: null, message: "" }
+    const response = { success: false, data: null, message: "   " }
     octopusApi.createChannel.mockResolvedValueOnce(response)
     const { octopusManagedSiteChannels } = await import(
       "~/services/apiAdapters/managedSites/octopus"

--- a/tests/services/apiAdapters/managedSites/veloera.test.ts
+++ b/tests/services/apiAdapters/managedSites/veloera.test.ts
@@ -294,6 +294,28 @@ describe("Veloera managed-site channel capability", () => {
     ).rejects.toBe(responseError)
   })
 
+  it("uses fixed diagnostic copy when a Veloera void error message is blank", async () => {
+    const responseError = new ApiError("   ")
+    veloeraApi.updateChannelModels.mockImplementationOnce(async (request) => {
+      request.observer?.onDispatch()
+      request.observer?.onResponse()
+      throw responseError
+    })
+    const { veloeraManagedSiteChannels } = await import(
+      "~/services/apiAdapters/managedSites/veloera"
+    )
+
+    await expect(
+      veloeraManagedSiteChannels.updateModels!(config, 7, models),
+    ).resolves.toEqual({
+      outcome: "rejected",
+      diagnostic: {
+        message: "Provider rejected the mutation",
+        raw: responseError,
+      },
+    })
+  })
+
   it("keeps response-valued Veloera error identity in the diagnostic", async () => {
     const responseError = new ApiError(
       "malformed provider response",

--- a/tests/services/apiAdapters/openrouter/accountKeyResource.test.ts
+++ b/tests/services/apiAdapters/openrouter/accountKeyResource.test.ts
@@ -753,6 +753,27 @@ describe("openRouterAccountKeyResources", () => {
     )
   })
 
+  it("redacts the selected workspace from creator-option failures", async () => {
+    const workspaceId = "workspace-default-id"
+    const session = await openSession()
+    const editor = await session.openCreateEditor(workspaceId)
+    fetchOpenRouterWorkspaceMembers.mockRejectedValue(
+      new ApiError(`Workspace ${workspaceId} rejected the member request`, 403),
+    )
+
+    const error = await editor
+      .loadOptions?.(OPENROUTER_KEY_FIELD_IDS.Creator, editor.initialValues)
+      .catch((caught: unknown) => caught)
+
+    expect(error).toMatchObject({
+      failure: {
+        code: "permission_denied",
+        message: "Workspace [REDACTED] rejected the member request",
+      },
+    })
+    expect(JSON.stringify(error)).not.toContain(workspaceId)
+  })
+
   it("rejects incomplete and inconsistent member totals", async () => {
     const session = await openSession()
     const editor = await session.openCreateEditor("workspace-default-id")

--- a/tests/services/apiAdapters/openrouter/providerModelCatalog.test.ts
+++ b/tests/services/apiAdapters/openrouter/providerModelCatalog.test.ts
@@ -93,6 +93,36 @@ describe("OpenRouter provider model catalog Adapter", () => {
     expect(publicRequestCount).toBe(0)
   })
 
+  it("redacts the Management Key when personalized provider errors are disclosed", async () => {
+    server.use(
+      http.get(`${OPENROUTER_API_BASE_URL}/models/user`, () =>
+        HttpResponse.json(
+          {
+            error: {
+              code: 403,
+              message:
+                "Management key management-key-example cannot access the catalog",
+            },
+          },
+          { status: 403 },
+        ),
+      ),
+    )
+
+    const error = await openRouterProviderModelCatalog
+      .personalized!.fetchPricing({
+        accountId: "account-example-a",
+        credential: "management-key-example",
+      })
+      .catch((caught: unknown) => caught)
+
+    expect(error).toBeInstanceOf(Error)
+    expect((error as Error).message).toBe(
+      "Management key [REDACTED] cannot access the catalog",
+    )
+    expect((error as Error).cause).toBeUndefined()
+  })
+
   it("normalizes primary prices and core display facts into the product model", async () => {
     server.use(
       http.get(`${OPENROUTER_API_BASE_URL}/models`, () =>

--- a/tests/services/apiAdapters/openrouter/providerModelCatalog.test.ts
+++ b/tests/services/apiAdapters/openrouter/providerModelCatalog.test.ts
@@ -1,11 +1,14 @@
 import { http, HttpResponse } from "msw"
-import { beforeEach, describe, expect, it } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import {
   OPENROUTER_API_BASE_URL,
   SITE_TYPES,
 } from "~/services/accountSiteDefinitions/identifiers"
 import { openRouterProviderModelCatalog } from "~/services/apiAdapters/openrouter/providerModelCatalog"
+import * as personalizedModelCatalogService from "~/services/apiService/openrouter/personalizedModelCatalog"
+import * as publicModelCatalogService from "~/services/apiService/openrouter/publicModelCatalog"
+import { ApiError } from "~/services/apiTransport/errors"
 import {
   MODEL_CATALOG_SCOPES,
   MODEL_LIST_SOURCE_KINDS,
@@ -45,6 +48,7 @@ function getFact(
 
 describe("OpenRouter provider model catalog Adapter", () => {
   beforeEach(() => server.resetHandlers())
+  afterEach(() => vi.restoreAllMocks())
 
   it("normalizes the verified personalized catalog behind an account-authenticated capability", async () => {
     let publicRequestCount = 0
@@ -122,6 +126,70 @@ describe("OpenRouter provider model catalog Adapter", () => {
     )
     expect((error as Error).cause).toBeUndefined()
   })
+
+  it("returns a safe abort error when cancellation races a provider rejection", async () => {
+    const credential = "management-key-example"
+    const controller = new AbortController()
+    controller.abort(new Error(`unsafe abort reason ${credential}`))
+    vi.spyOn(
+      personalizedModelCatalogService,
+      "fetchOpenRouterPersonalizedModelCatalog",
+    ).mockRejectedValue(
+      new ApiError(`Provider rejected ${credential}`, 403, "/models/user"),
+    )
+
+    const error = await openRouterProviderModelCatalog
+      .personalized!.fetchPricing({
+        accountId: "account-example-a",
+        credential,
+        abortSignal: controller.signal,
+      })
+      .catch((caught: unknown) => caught)
+
+    expect(error).toMatchObject({
+      name: "AbortError",
+      message: "The operation was aborted",
+    })
+    expect(JSON.stringify(error)).not.toContain(credential)
+    expect((error as Error).message).not.toContain("Provider rejected")
+    expect((error as Error).message).not.toContain("unsafe abort reason")
+    expect((error as Error).cause).toBeUndefined()
+  })
+
+  it("preserves a provider abort error", async () => {
+    const abortError = new DOMException("Cancelled", "AbortError")
+    vi.spyOn(
+      publicModelCatalogService,
+      "fetchOpenRouterPublicModelCatalog",
+    ).mockRejectedValue(abortError)
+
+    await expect(openRouterProviderModelCatalog.fetchPricing({})).rejects.toBe(
+      abortError,
+    )
+  })
+
+  it.each([
+    ["network", new TypeError("Network unavailable"), TypeError],
+    ["generic", new Error("Catalog unavailable"), Error],
+  ])(
+    "preserves the %s error category at the public catalog disclosure boundary",
+    async (_label, providerError, expectedType) => {
+      vi.spyOn(
+        publicModelCatalogService,
+        "fetchOpenRouterPublicModelCatalog",
+      ).mockRejectedValue(providerError)
+
+      const error = await openRouterProviderModelCatalog
+        .fetchPricing({})
+        .catch((caught: unknown) => caught)
+
+      expect(error).toBeInstanceOf(expectedType)
+      expect((error as Error).constructor).toBe(expectedType)
+      expect(error).not.toBe(providerError)
+      expect((error as Error).message).toBe(providerError.message)
+      expect((error as Error).cause).toBeUndefined()
+    },
+  )
 
   it("normalizes primary prices and core display facts into the product model", async () => {
     server.use(

--- a/tests/services/apiCredentialProfilesTelemetry.test.ts
+++ b/tests/services/apiCredentialProfilesTelemetry.test.ts
@@ -1274,7 +1274,7 @@ describe("api credential profile telemetry", () => {
     expect(customAttempt?.endpoint).toContain("REDACTED")
   })
 
-  it("redacts the dedicated bearer token from custom telemetry errors", async () => {
+  it("does not retain provider bodies in custom telemetry errors", async () => {
     const apiKey = "shared-telemetry-secret"
     const dedicatedBearerToken = `${apiKey}-private-tail`
     const profile = await apiCredentialProfilesStorage.createProfile({
@@ -1308,7 +1308,8 @@ describe("api credential profile telemetry", () => {
 
     expect(serializedSnapshot).not.toContain(dedicatedBearerToken)
     expect(serializedSnapshot).not.toContain("private-tail")
-    expect(serializedSnapshot).toContain("[REDACTED]")
+    expect(serializedSnapshot).not.toContain("Authorization")
+    expect(serializedSnapshot).toContain("请求失败: 401")
   })
 
   it("prefers the custom configuration error when malformed custom endpoints are dropped during coercion", async () => {
@@ -1349,7 +1350,7 @@ describe("api credential profile telemetry", () => {
     )
   })
 
-  it("prefers an absolute custom endpoint error when model discovery also fails", async () => {
+  it("prefers the fixed absolute custom endpoint error when model discovery also fails", async () => {
     const profile = await apiCredentialProfilesStorage.createProfile({
       name: "Absolute Custom Error",
       apiType: API_TYPES.OPENAI_COMPATIBLE,
@@ -1383,7 +1384,7 @@ describe("api credential profile telemetry", () => {
     expect(customAttempt).toEqual(
       expect.objectContaining({
         status: "error",
-        message: expect.stringContaining("custom failed"),
+        message: "请求失败: 500",
       }),
     )
     expect(snapshot.lastError).toBe(customAttempt?.message)

--- a/tests/services/apiCredentialProfilesTelemetryTransport.test.ts
+++ b/tests/services/apiCredentialProfilesTelemetryTransport.test.ts
@@ -1,22 +1,23 @@
 import { describe, expect, it, vi } from "vitest"
 
 import { fetchTelemetryJson } from "~/services/apiCredentialProfiles/telemetryTransport"
-import { ApiError } from "~/services/apiTransport/errors"
 import { API_AUTH_TOKEN_MODES } from "~/services/apiTransport/type"
 
-const { fetchApiMock } = vi.hoisted(() => ({
-  fetchApiMock: vi.fn(),
+const { fetchApiResponseMock } = vi.hoisted(() => ({
+  fetchApiResponseMock: vi.fn(),
 }))
 
 vi.mock("~/services/apiTransport/request", () => ({
-  fetchApi: (...args: unknown[]) => fetchApiMock(...args),
+  fetchApiResponse: (...args: unknown[]) => fetchApiResponseMock(...args),
 }))
 
 describe("api credential telemetry transport", () => {
   it("passes raw authorization mode and returns the requested endpoint", async () => {
-    fetchApiMock.mockResolvedValue({
-      success: true,
-      data: { balance: 1 },
+    fetchApiResponseMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: {},
+      body: { success: true, data: { balance: 1 } },
     })
 
     await expect(
@@ -31,7 +32,7 @@ describe("api credential telemetry transport", () => {
       json: { success: true, data: { balance: 1 } },
     })
 
-    expect(fetchApiMock).toHaveBeenCalledWith(
+    expect(fetchApiResponseMock).toHaveBeenCalledWith(
       expect.objectContaining({
         baseUrl: "https://example.invalid",
         auth: expect.objectContaining({ accessToken: "token" }),
@@ -45,9 +46,12 @@ describe("api credential telemetry transport", () => {
   })
 
   it("preserves unsupported endpoint classification for 404 and 405", async () => {
-    fetchApiMock.mockRejectedValue(
-      new ApiError("method not allowed", 405, "/usage"),
-    )
+    fetchApiResponseMock.mockResolvedValue({
+      ok: false,
+      status: 405,
+      headers: {},
+      body: { message: "provider detail must not be parsed" },
+    })
 
     await expect(
       fetchTelemetryJson({
@@ -58,11 +62,14 @@ describe("api credential telemetry transport", () => {
       name: "TelemetryEndpointError",
       endpoint: "/usage",
       unsupported: true,
+      message: "请求失败: 405",
     })
   })
 
   it("classifies malformed JSON and generic network failures", async () => {
-    fetchApiMock.mockRejectedValueOnce(new SyntaxError("Unexpected token"))
+    fetchApiResponseMock.mockRejectedValueOnce(
+      new SyntaxError("Unexpected token"),
+    )
     await expect(
       fetchTelemetryJson({
         baseUrl: "https://example.invalid",
@@ -73,7 +80,7 @@ describe("api credential telemetry transport", () => {
       message: "Non-JSON response",
     })
 
-    fetchApiMock.mockRejectedValueOnce(new Error("connection closed"))
+    fetchApiResponseMock.mockRejectedValueOnce(new Error("connection closed"))
     await expect(
       fetchTelemetryJson({
         baseUrl: "https://example.invalid",

--- a/tests/services/apiService/aihubmix/index.test.ts
+++ b/tests/services/apiService/aihubmix/index.test.ts
@@ -652,6 +652,52 @@ describe("apiService AIHubMix", () => {
     })
   })
 
+  it("uses AIHubMix's documented message for cookie-session failures", async () => {
+    server.use(
+      http.get("https://aihubmix.com/call/usr/self", () =>
+        HttpResponse.json(
+          {
+            success: false,
+            message: "AIHubMix rejected the account session",
+            data: null,
+          },
+          { status: 401 },
+        ),
+      ),
+    )
+
+    await expect(
+      fetchUserInfo({
+        baseUrl: "https://aihubmix.com",
+        auth: { authType: AuthTypeEnum.Cookie },
+      }),
+    ).rejects.toMatchObject({
+      statusCode: 401,
+      message: "AIHubMix rejected the account session",
+    })
+  })
+
+  it("does not consume legacy msg fields from AIHubMix cookie-session errors", async () => {
+    server.use(
+      http.get("https://aihubmix.com/call/usr/self", () =>
+        HttpResponse.json(
+          { success: false, msg: "legacy guessed message", data: null },
+          { status: 400 },
+        ),
+      ),
+    )
+
+    await expect(
+      fetchUserInfo({
+        baseUrl: "https://aihubmix.com",
+        auth: { authType: AuthTypeEnum.Cookie },
+      }),
+    ).rejects.toMatchObject({
+      statusCode: 400,
+      message: "请求失败: 400",
+    })
+  })
+
   it("uses username as the stable cookie-authenticated account identity when AIHubMix omits id", async () => {
     server.use(
       http.get("https://aihubmix.com/call/usr/self", () =>
@@ -1409,7 +1455,10 @@ describe("apiService AIHubMix", () => {
   it("uses a localized fallback message for HTTP errors without response messages", async () => {
     server.use(
       http.get("https://aihubmix.com/api/token/", () =>
-        HttpResponse.json({ error: "unauthorized" }, { status: 401 }),
+        HttpResponse.json(
+          { success: false, message: "   ", data: null },
+          { status: 401 },
+        ),
       ),
     )
 

--- a/tests/services/apiService/aihubmix/index.test.ts
+++ b/tests/services/apiService/aihubmix/index.test.ts
@@ -2330,4 +2330,34 @@ describe("apiService AIHubMix", () => {
       message: "messages:errors.api.invalidResponseFormat",
     })
   })
+
+  it.each([
+    { name: "an object", message: { token: "provider-secret-placeholder" } },
+    { name: "a number", message: 503 },
+  ])(
+    "falls back to invalid response copy for $name business message",
+    async ({ message }) => {
+      server.use(
+        http.get("https://aihubmix.com/api/token/", () =>
+          HttpResponse.json({
+            success: false,
+            message,
+            data: null,
+          }),
+        ),
+      )
+
+      const failure = await fetchAccountTokens(baseRequest).catch(
+        (error: unknown) => error,
+      )
+
+      expect(failure).toMatchObject({
+        code: API_ERROR_CODES.BUSINESS_ERROR,
+        message: "messages:errors.api.invalidResponseFormat",
+      })
+      expect((failure as Error).message).not.toContain(
+        "provider-secret-placeholder",
+      )
+    },
+  )
 })

--- a/tests/services/apiService/aihubmix/index.test.ts
+++ b/tests/services/apiService/aihubmix/index.test.ts
@@ -677,7 +677,7 @@ describe("apiService AIHubMix", () => {
     })
   })
 
-  it("does not consume legacy msg fields from AIHubMix cookie-session errors", async () => {
+  it("falls back to the shared msg heuristic for an unrecognized AIHubMix error", async () => {
     server.use(
       http.get("https://aihubmix.com/call/usr/self", () =>
         HttpResponse.json(
@@ -694,7 +694,7 @@ describe("apiService AIHubMix", () => {
       }),
     ).rejects.toMatchObject({
       statusCode: 400,
-      message: "请求失败: 400",
+      message: "legacy guessed message",
     })
   })
 

--- a/tests/services/apiService/aihubmix/responseError.test.ts
+++ b/tests/services/apiService/aihubmix/responseError.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest"
+
+import { decodeAIHubMixResponseError } from "~/services/apiService/aihubmix/responseError"
+
+const response = (body: unknown, status = 200) => ({
+  ok: status >= 200 && status < 300,
+  status,
+  headers: {},
+  body,
+})
+
+describe("decodeAIHubMixResponseError", () => {
+  it("recognizes AIHubMix success-message business failures", () => {
+    expect(
+      decodeAIHubMixResponseError(
+        response({
+          success: false,
+          message: "AIHubMix rejected the account session",
+          data: null,
+        }),
+        { endpoint: "/call/usr/self" },
+      ),
+    ).toEqual({
+      kind: "business",
+      message: "AIHubMix rejected the account session",
+    })
+  })
+
+  it("does not guess legacy msg-only or unrelated error shapes", () => {
+    expect(
+      decodeAIHubMixResponseError(response({ success: false, msg: "denied" }), {
+        endpoint: "/call/usr/self",
+      }),
+    ).toEqual({ kind: "business" })
+    expect(
+      decodeAIHubMixResponseError(
+        response({ error: { message: "unknown shape" } }, 401),
+        { endpoint: "/call/usr/self" },
+      ),
+    ).toBeNull()
+  })
+})

--- a/tests/services/apiService/claudeCodeHub/index.test.ts
+++ b/tests/services/apiService/claudeCodeHub/index.test.ts
@@ -9,7 +9,6 @@ import {
   listProviders,
   listProvidersFromAction,
   normalizeClaudeCodeHubBaseUrl,
-  redactClaudeCodeHubSecrets,
   searchProviders,
   updateProvider,
   validateClaudeCodeHubConfig,
@@ -401,7 +400,70 @@ describe("Claude Code Hub action API adapter", () => {
     await expect(listProviders(config)).rejects.toThrow("non-JSON response")
   })
 
-  it("throws redacted errors for provider v1 search failures", async () => {
+  it("keeps canonical v1 problem details and error metadata internally", async () => {
+    const problem = {
+      type: "urn:claude-code-hub:problem:auth.forbidden",
+      title: "Forbidden",
+      status: 403,
+      detail: "bad token admin-secret",
+      instance: "/api/v1/providers",
+      errorCode: "auth.forbidden",
+      errorParams: { role: "admin" },
+    }
+    server.use(
+      http.get(PROVIDER_V1_BASE, () =>
+        HttpResponse.json(problem, { status: 403 }),
+      ),
+    )
+
+    await expect(listProviders(config)).rejects.toMatchObject({
+      message: "bad token admin-secret",
+      status: 403,
+      code: "auth.forbidden",
+      raw: problem,
+    })
+  })
+
+  it("ignores unverified v1 fields and response status text", async () => {
+    const failure = {
+      error: "legacy admin-secret",
+      message: "legacy message",
+      status: 403,
+    }
+    server.use(
+      http.get(PROVIDER_V1_BASE, () =>
+        HttpResponse.json(failure, {
+          status: 403,
+          statusText: "Forbidden",
+        }),
+      ),
+    )
+
+    await expect(listProviders(config)).rejects.toMatchObject({
+      message: "Claude Code Hub request failed (403)",
+      status: 403,
+      code: undefined,
+      raw: failure,
+    })
+  })
+
+  it("falls back from a blank v1 detail to the verified problem title", async () => {
+    server.use(
+      http.get(PROVIDER_V1_BASE, () =>
+        HttpResponse.json(
+          { detail: "   ", title: "Provider request rejected" },
+          { status: 400 },
+        ),
+      ),
+    )
+
+    await expect(listProviders(config)).rejects.toMatchObject({
+      message: "Provider request rejected",
+      status: 400,
+    })
+  })
+
+  it("preserves provider v1 search details until disclosure", async () => {
     server.use(
       http.get(PROVIDER_V1_BASE, () =>
         HttpResponse.json(
@@ -416,11 +478,11 @@ describe("Claude Code Hub action API adapter", () => {
     )
 
     await expect(searchProviders(config, "search match")).rejects.toThrow(
-      "bad token [REDACTED] while searching",
+      "bad token admin-secret while searching",
     )
   })
 
-  it("throws redacted errors for provider v1 list failures", async () => {
+  it("preserves provider v1 list details until disclosure", async () => {
     server.use(
       http.get(PROVIDER_V1_BASE, () =>
         HttpResponse.json(
@@ -435,7 +497,7 @@ describe("Claude Code Hub action API adapter", () => {
     )
 
     await expect(listProviders(config)).rejects.toThrow(
-      "bad token [REDACTED] while listing",
+      "bad token admin-secret while listing",
     )
   })
 
@@ -502,7 +564,7 @@ describe("Claude Code Hub action API adapter", () => {
     }
   })
 
-  it("throws redacted errors for provider v1 reveal failures", async () => {
+  it("preserves provider v1 reveal details until disclosure", async () => {
     server.use(
       http.get(`${PROVIDER_V1_BASE}/42/key:reveal`, () =>
         HttpResponse.json(
@@ -517,7 +579,7 @@ describe("Claude Code Hub action API adapter", () => {
     )
 
     await expect(getUnmaskedProviderKey(config, 42)).rejects.toThrow(
-      "bad token [REDACTED]",
+      "bad token admin-secret",
     )
   })
 
@@ -551,7 +613,64 @@ describe("Claude Code Hub action API adapter", () => {
     await expect(listProvidersFromAction(config)).resolves.toEqual([])
   })
 
-  it("throws redacted errors for action failures and malformed responses", async () => {
+  it("keeps a verified action error string and raw response internally", async () => {
+    const failure = {
+      ok: false,
+      error: "bad token admin-secret and key sk-real-key",
+      errorCode: "provider.invalid_key",
+      errorParams: { provider: "Provider" },
+    }
+    server.use(
+      http.post(`${PROVIDER_ACTION_BASE}/addProvider`, () =>
+        HttpResponse.json(failure, { status: 403 }),
+      ),
+    )
+
+    await expect(
+      createProvider(config, {
+        name: "Provider",
+        url: "https://api.example.com",
+        key: "sk-real-key",
+        provider_type: "openai-compatible",
+        allowed_models: [],
+      }),
+    ).rejects.toMatchObject({
+      message: "bad token admin-secret and key sk-real-key",
+      status: 403,
+      code: "provider.invalid_key",
+      raw: failure,
+    })
+  })
+
+  it("ignores unverified action error objects and uses the fixed fallback", async () => {
+    const failure = {
+      ok: false,
+      error: { detail: "unverified admin-secret" },
+    }
+    server.use(
+      http.post(`${PROVIDER_ACTION_BASE}/addProvider`, () =>
+        HttpResponse.json(failure, {
+          status: 403,
+          statusText: "Forbidden",
+        }),
+      ),
+    )
+
+    await expect(
+      createProvider(config, {
+        name: "Provider",
+        url: "https://api.example.com",
+        key: "sk-real-key",
+        provider_type: "openai-compatible",
+        allowed_models: [],
+      }),
+    ).rejects.toMatchObject({
+      message: "Claude Code Hub request failed (403)",
+      raw: failure,
+    })
+  })
+
+  it("preserves verified action strings and ignores unverified objects", async () => {
     server.use(
       http.post(`${PROVIDER_ACTION_BASE}/addProvider`, () =>
         HttpResponse.json(
@@ -572,7 +691,7 @@ describe("Claude Code Hub action API adapter", () => {
         provider_type: "openai-compatible",
         allowed_models: [],
       }),
-    ).rejects.toThrow("bad token [REDACTED] and key [REDACTED]")
+    ).rejects.toThrow("bad token admin-secret and key sk-real-key")
 
     server.use(
       http.post(`${PROVIDER_ACTION_BASE}/addProvider`, () =>
@@ -594,7 +713,7 @@ describe("Claude Code Hub action API adapter", () => {
         provider_type: "openai-compatible",
         allowed_models: [],
       }),
-    ).rejects.toThrow('{"detail":"bad token [REDACTED] and key [REDACTED]"}')
+    ).rejects.toThrow("Claude Code Hub request failed (403)")
 
     server.use(
       http.post(`${PROVIDER_ACTION_BASE}/getProviders`, () =>
@@ -604,17 +723,6 @@ describe("Claude Code Hub action API adapter", () => {
 
     await expect(listProvidersFromAction(config)).rejects.toThrow(
       "invalid action response",
-    )
-  })
-
-  it("redacts bearer tokens in arbitrary messages", () => {
-    expect(
-      redactClaudeCodeHubSecrets("Authorization Bearer admin-secret", [
-        "admin-secret",
-      ]),
-    ).toBe("Authorization Bearer [REDACTED]")
-    expect(redactClaudeCodeHubSecrets("adapter failure", ["ad"])).toBe(
-      "adapter failure",
     )
   })
 

--- a/tests/services/apiService/octopus.index.test.ts
+++ b/tests/services/apiService/octopus.index.test.ts
@@ -2333,6 +2333,19 @@ describe("Octopus API service", () => {
     })
   })
 
+  it("preserves a string message from a non-Error mutation failure", async () => {
+    const providerFailure = { message: "provider mutation failed" }
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValueOnce(providerFailure))
+
+    await expect(mutations[0].invoke()).rejects.toMatchObject({
+      name: "OctopusMutationApiError",
+      message: "provider mutation failed",
+      dispatch: "dispatched",
+      responseReceived: false,
+      raw: providerFailure,
+    })
+  })
+
   it.each(mutations)(
     "$name marks auth failure before mutation fetch as not dispatched",
     async ({ log, invoke }) => {
@@ -2626,6 +2639,23 @@ describe("Octopus API service", () => {
       "fetch",
       vi.fn().mockResolvedValueOnce(
         new Response(JSON.stringify({ message: "   ", error: "  " }), {
+          status: 500,
+          statusText: "Internal Server Error",
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    )
+
+    await expect(listChannels(config)).rejects.toThrow(
+      "HTTP 500 Internal Server Error: Octopus request failed",
+    )
+  })
+
+  it("uses a fixed HTTP error message for a non-object JSON body", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValueOnce(
+        new Response(JSON.stringify([]), {
           status: 500,
           statusText: "Internal Server Error",
           headers: { "Content-Type": "application/json" },

--- a/tests/services/apiService/octopus.index.test.ts
+++ b/tests/services/apiService/octopus.index.test.ts
@@ -434,7 +434,7 @@ describe("Octopus API service", () => {
     mockTempWindowOctopusApiFetch.mockResolvedValueOnce({
       success: true,
       status: 200,
-      data: { code: 500 },
+      data: { code: 500, message: "   " },
     })
 
     await expect(listChannels(config)).rejects.toThrow("API request failed")
@@ -2246,6 +2246,36 @@ describe("Octopus API service", () => {
     },
   )
 
+  it("uses a fixed mutation message for a blank Octopus failure envelope", async () => {
+    const envelope = { success: false, data: null, message: "   " }
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValueOnce(
+        new Response(JSON.stringify(envelope), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    )
+
+    await expect(
+      createChannel(
+        config,
+        createInput({
+          name: "Blank rejection",
+          type: OctopusOutboundType.OpenAIChat,
+          base_urls: [{ url: "https://api.example.invalid/v1" }],
+          keys: [{ enabled: true, channel_key: "sk-example" }],
+          auto_group: OctopusAutoGroupType.None,
+        }),
+      ),
+    ).rejects.toMatchObject({
+      name: "OctopusMutationApiError",
+      message: "API request failed",
+      raw: envelope,
+    })
+  })
+
   it.each(mutations)(
     "$name keeps generic HTTP client errors ambiguous after dispatch",
     async ({ log, invoke }) => {
@@ -2289,6 +2319,19 @@ describe("Octopus API service", () => {
       expect(mockLogger.error).toHaveBeenLastCalledWith(log)
     },
   )
+
+  it("uses a fixed mutation message when a dispatched failure is blank", async () => {
+    const networkError = new TypeError("   ")
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValueOnce(networkError))
+
+    await expect(mutations[0].invoke()).rejects.toMatchObject({
+      name: "OctopusMutationApiError",
+      message: "Octopus mutation failed",
+      dispatch: "dispatched",
+      responseReceived: false,
+      raw: networkError,
+    })
+  })
 
   it.each(mutations)(
     "$name marks auth failure before mutation fetch as not dispatched",
@@ -2575,6 +2618,23 @@ describe("Octopus API service", () => {
 
     await expect(listChannels(config)).rejects.toThrow(
       "HTTP 500 Internal Server Error: {not-json",
+    )
+  })
+
+  it("uses a fixed HTTP error message when Octopus JSON candidates are blank", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValueOnce(
+        new Response(JSON.stringify({ message: "   ", error: "  " }), {
+          status: 500,
+          statusText: "Internal Server Error",
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    )
+
+    await expect(listChannels(config)).rejects.toThrow(
+      "HTTP 500 Internal Server Error: Octopus request failed",
     )
   })
 

--- a/tests/services/apiService/openrouter/keyManagement.test.ts
+++ b/tests/services/apiService/openrouter/keyManagement.test.ts
@@ -651,7 +651,7 @@ describe("OpenRouter management key API", () => {
     server.use(
       http.get(`${OPENROUTER_API_BASE_URL}/keys/missing-example`, () =>
         HttpResponse.json(
-          { error: { code: "not_found", message: "Key not found" } },
+          { error: { code: 404, message: "Key not found" } },
           { status: 404 },
         ),
       ),
@@ -659,10 +659,10 @@ describe("OpenRouter management key API", () => {
 
     await expect(
       fetchOpenRouterKey(request, "missing-example"),
-    ).rejects.toMatchObject({ statusCode: 404, upstreamCode: "not_found" })
+    ).rejects.toMatchObject({ statusCode: 404, upstreamCode: "404" })
   })
 
-  it("keeps the provider message but drops an unsafe upstream code", async () => {
+  it("uses fixed copy for an undocumented OpenRouter error code", async () => {
     server.use(
       http.get(`${OPENROUTER_API_BASE_URL}/keys/missing-example`, () =>
         HttpResponse.json(
@@ -683,11 +683,11 @@ describe("OpenRouter management key API", () => {
     ).rejects.toMatchObject({
       statusCode: 404,
       upstreamCode: undefined,
-      message: "Key lookup failed",
+      message: "请求失败: 404",
     })
   })
 
-  it("redacts provider-echoed credentials and key hashes from failures", async () => {
+  it("preserves provider details until the adapter disclosure boundary", async () => {
     const opaqueHash = "hash/opaque-example"
     const managementKey = request.auth.accessToken.trim()
     server.use(
@@ -695,7 +695,7 @@ describe("OpenRouter management key API", () => {
         HttpResponse.json(
           {
             error: {
-              code: "key_forbidden",
+              code: 403,
               message: `Access denied for ${opaqueHash} using ${managementKey}`,
             },
           },
@@ -712,15 +712,15 @@ describe("OpenRouter management key API", () => {
     expect(error).toMatchObject({
       statusCode: 403,
       code: "HTTP_403",
-      upstreamCode: "key_forbidden",
-      endpoint: "/keys/{hash}",
+      upstreamCode: "403",
+      endpoint: "/keys/hash%2Fopaque-example",
     })
-    expect(error.message).toContain("Access denied for")
-    expect(error.message).not.toContain(opaqueHash)
-    expect(error.message).not.toContain(managementKey)
+    expect(error.message).toBe(
+      `Access denied for ${opaqueHash} using ${managementKey}`,
+    )
   })
 
-  it("redacts workspace IDs and uses a safe member endpoint template", async () => {
+  it("preserves provider workspace details before user disclosure", async () => {
     const opaqueWorkspaceId = "workspace/opaque example"
     server.use(
       http.get(
@@ -729,7 +729,7 @@ describe("OpenRouter management key API", () => {
           HttpResponse.json(
             {
               error: {
-                code: "workspace_failed",
+                code: 500,
                 message: `Workspace ${opaqueWorkspaceId} is unavailable`,
               },
             },
@@ -747,11 +747,10 @@ describe("OpenRouter management key API", () => {
     expect(error).toMatchObject({
       statusCode: 500,
       code: "HTTP_OTHER",
-      upstreamCode: "workspace_failed",
-      endpoint: "/workspaces/{id}/members",
+      upstreamCode: "500",
+      endpoint: "/workspaces/workspace%2Fopaque%20example/members",
     })
-    expect(error.message).toContain("Workspace")
-    expect(error.message).not.toContain(opaqueWorkspaceId)
+    expect(error.message).toBe(`Workspace ${opaqueWorkspaceId} is unavailable`)
   })
 
   it("does not replay update or delete after a failed response", async () => {

--- a/tests/services/apiService/openrouter/personalizedModelCatalog.test.ts
+++ b/tests/services/apiService/openrouter/personalizedModelCatalog.test.ts
@@ -102,6 +102,34 @@ describe("OpenRouter personalized model catalog transport", () => {
     },
   )
 
+  it("preserves documented provider details before catalog disclosure", async () => {
+    server.use(
+      http.get(`${OPENROUTER_API_BASE_URL}/models/user`, () =>
+        HttpResponse.json(
+          {
+            error: {
+              code: 403,
+              message: "Management key cannot access this catalog",
+            },
+          },
+          { status: 403 },
+        ),
+      ),
+    )
+
+    await expect(
+      fetchOpenRouterPersonalizedModelCatalog({
+        accountId: "account-example-a",
+        managementKey: "management-key-example",
+      }),
+    ).rejects.toMatchObject({
+      statusCode: 403,
+      code: API_ERROR_CODES.HTTP_403,
+      upstreamCode: "403",
+      message: "Management key cannot access this catalog",
+    })
+  })
+
   it.each([
     {
       name: "a malformed envelope",

--- a/tests/services/apiService/openrouter/publicModelCatalog.test.ts
+++ b/tests/services/apiService/openrouter/publicModelCatalog.test.ts
@@ -170,6 +170,24 @@ describe("OpenRouter public model catalog transport", () => {
     })
   })
 
+  it("preserves documented OpenRouter error details for catalog failures", async () => {
+    server.use(
+      http.get(`${OPENROUTER_API_BASE_URL}/models`, () =>
+        HttpResponse.json(
+          { error: { code: 429, message: "Catalog rate limit reached" } },
+          { status: 429 },
+        ),
+      ),
+    )
+
+    await expect(fetchOpenRouterPublicModelCatalog()).rejects.toMatchObject({
+      statusCode: 429,
+      code: API_ERROR_CODES.HTTP_429,
+      upstreamCode: "429",
+      message: "Catalog rate limit reached",
+    })
+  })
+
   it("rejects cyclic pagination", async () => {
     server.use(
       http.get(`${OPENROUTER_API_BASE_URL}/models`, ({ request }) => {

--- a/tests/services/apiService/openrouter/responseError.test.ts
+++ b/tests/services/apiService/openrouter/responseError.test.ts
@@ -57,15 +57,12 @@ describe("decodeOpenRouterResponseError", () => {
     ).toBeNull()
   })
 
-  it("preserves a message without exposing undocumented string codes", () => {
+  it("rejects undocumented string codes instead of guessing the envelope", () => {
     expect(
       decodeOpenRouterResponseError(
         response({ error: { code: "403", message: "Denied" } }, 403),
         { endpoint: "/credits" },
       ),
-    ).toEqual({
-      kind: "http",
-      message: "Denied",
-    })
+    ).toBeNull()
   })
 })

--- a/tests/services/apiService/sharedchat/index.test.ts
+++ b/tests/services/apiService/sharedchat/index.test.ts
@@ -240,6 +240,24 @@ describe("apiService SharedChat", () => {
       statusCode: 503,
       code: API_ERROR_CODES.HTTP_OTHER,
     })
+
+    server.use(
+      http.get("https://new.sharedchat.cc/frontend-api/getme", () =>
+        HttpResponse.json(
+          {
+            code: 1,
+            msg: "successful-envelope text must not be used for an HTTP error",
+          },
+          { status: 503 },
+        ),
+      ),
+    )
+
+    await expect(fetchUserInfo(baseRequest)).rejects.toMatchObject({
+      message: "SharedChat request failed: 503",
+      statusCode: 503,
+      code: API_ERROR_CODES.HTTP_OTHER,
+    })
   })
 
   it("maps codex quota into AccountData product usage and subscription fields", async () => {

--- a/tests/services/apiService/sharedchat/index.test.ts
+++ b/tests/services/apiService/sharedchat/index.test.ts
@@ -202,6 +202,46 @@ describe("apiService SharedChat", () => {
     })
   })
 
+  it("owns non-2xx SharedChat messages without consulting legacy fields", async () => {
+    server.use(
+      http.get("https://new.sharedchat.cc/frontend-api/getme", () =>
+        HttpResponse.json(
+          {
+            code: 0,
+            msg: "  SharedChat session expired  ",
+            data: null,
+          },
+          { status: 401 },
+        ),
+      ),
+    )
+
+    await expect(fetchUserInfo(baseRequest)).rejects.toMatchObject({
+      message: "SharedChat session expired",
+      statusCode: 401,
+      code: API_ERROR_CODES.HTTP_401,
+    })
+
+    server.use(
+      http.get("https://new.sharedchat.cc/frontend-api/getme", () =>
+        HttpResponse.json(
+          {
+            code: 0,
+            msg: "   ",
+            message: "legacy field must not be inferred",
+          },
+          { status: 503 },
+        ),
+      ),
+    )
+
+    await expect(fetchUserInfo(baseRequest)).rejects.toMatchObject({
+      message: "SharedChat request failed: 503",
+      statusCode: 503,
+      code: API_ERROR_CODES.HTTP_OTHER,
+    })
+  })
+
   it("maps codex quota into AccountData product usage and subscription fields", async () => {
     server.use(
       http.get("https://new.sharedchat.cc/frontend-api/vibe-code/quota", () =>

--- a/tests/services/apiService/sub2api/index.test.ts
+++ b/tests/services/apiService/sub2api/index.test.ts
@@ -297,12 +297,12 @@ describe("apiService sub2api parsing", () => {
       expect.anything(),
       expect.objectContaining({
         endpoint: expect.stringContaining("unread_only=1"),
+        errorResponseDecoder: expect.any(Function),
         options: expect.objectContaining({
           method: "GET",
           cache: "no-store",
         }),
       }),
-      true,
     )
   })
 
@@ -2887,12 +2887,12 @@ describe("apiService sub2api exported operations", () => {
       }),
       expect.objectContaining({
         endpoint: "/api/v1/auth/me",
+        errorResponseDecoder: expect.any(Function),
         options: expect.objectContaining({
           method: "GET",
           cache: "no-store",
         }),
       }),
-      true,
     )
   })
 
@@ -3318,8 +3318,8 @@ describe("apiService sub2api exported operations", () => {
       {
         endpoint: "/api/v1/settings/public",
         options: { method: "GET", cache: "no-store" },
+        errorResponseDecoder: expect.any(Function),
       },
-      true,
     )
   })
 

--- a/tests/services/apiService/sub2api/responseError.test.ts
+++ b/tests/services/apiService/sub2api/responseError.test.ts
@@ -1,0 +1,119 @@
+import { http, HttpResponse } from "msw"
+import { beforeEach, describe, expect, it } from "vitest"
+
+import { fetchCurrentUser } from "~/services/apiService/sub2api"
+import { SUB2API_SESSION_BINDING_MISMATCH_CODE } from "~/services/apiService/sub2api/browserAuth"
+import { decodeSub2ApiResponseError } from "~/services/apiService/sub2api/responseError"
+import { API_ERROR_CODES } from "~/services/apiTransport/errors"
+import type { ApiTransportResponse } from "~/services/apiTransport/type"
+import { AuthTypeEnum } from "~/types"
+import { server } from "~~/tests/msw/server"
+
+const response = (
+  body: unknown,
+  status = 400,
+): ApiTransportResponse<unknown> => ({
+  ok: false,
+  status,
+  headers: {},
+  body,
+})
+
+describe("decodeSub2ApiResponseError", () => {
+  beforeEach(() => {
+    server.resetHandlers()
+  })
+
+  it("uses only a valid failed Sub2API envelope message", () => {
+    expect(
+      decodeSub2ApiResponseError(
+        response({ code: 401, message: "  JWT expired  ", data: null }, 401),
+        { endpoint: "/api/v1/auth/me" },
+      ),
+    ).toEqual({
+      kind: "business",
+      message: "JWT expired",
+      upstreamCode: "401",
+    })
+  })
+
+  it("preserves the verified session-binding mismatch code", () => {
+    expect(
+      decodeSub2ApiResponseError(
+        response(
+          {
+            code: SUB2API_SESSION_BINDING_MISMATCH_CODE,
+            message: "Session network fingerprint changed",
+          },
+          401,
+        ),
+        { endpoint: "/api/v1/auth/me" },
+      ),
+    ).toEqual({
+      kind: "business",
+      message: "Session network fingerprint changed",
+      upstreamCode: SUB2API_SESSION_BINDING_MISMATCH_CODE,
+    })
+  })
+
+  it("preserves the session-binding mismatch code when its message is unusable", () => {
+    expect(
+      decodeSub2ApiResponseError(
+        response(
+          { code: SUB2API_SESSION_BINDING_MISMATCH_CODE, message: "   " },
+          401,
+        ),
+        { endpoint: "/api/v1/auth/me" },
+      ),
+    ).toEqual({
+      kind: "business",
+      message: "Sub2API request failed: 401",
+      upstreamCode: SUB2API_SESSION_BINDING_MISMATCH_CODE,
+    })
+  })
+
+  it.each([
+    { code: 0, message: "legacy success message" },
+    { code: 41, message: "   ", msg: "legacy msg must not be inferred" },
+    { code: "41", message: "wrong code type" },
+    { message: "missing code" },
+  ])("falls back for an unknown or unusable envelope: %#", (body) => {
+    expect(
+      decodeSub2ApiResponseError(response(body, 503), {
+        endpoint: "/api/v1/keys",
+      }),
+    ).toEqual({
+      kind: "http",
+      message: "Sub2API request failed: 503",
+    })
+  })
+
+  it("owns unusable non-2xx responses at the Sub2API request seam", async () => {
+    server.use(
+      http.get("https://sub2.example.invalid/api/v1/auth/me", () =>
+        HttpResponse.json(
+          {
+            code: 41,
+            message: "   ",
+            msg: "legacy msg must not be inferred",
+          },
+          { status: 503 },
+        ),
+      ),
+    )
+
+    await expect(
+      fetchCurrentUser({
+        baseUrl: "https://sub2.example.invalid",
+        auth: {
+          authType: AuthTypeEnum.AccessToken,
+          accessToken: "example-jwt",
+        },
+      }),
+    ).rejects.toMatchObject({
+      message: "Sub2API request failed: 503",
+      statusCode: 503,
+      code: API_ERROR_CODES.HTTP_OTHER,
+    })
+  })
+})

--- a/tests/services/apiService/voapiV2/index.test.ts
+++ b/tests/services/apiService/voapiV2/index.test.ts
@@ -147,6 +147,29 @@ describe("apiService VoAPI v2", () => {
     )
   })
 
+  it("owns unusable non-2xx responses at the VoAPI v2 request seam", async () => {
+    server.use(
+      http.get("https://example.invalid/api/user/invite-info", () =>
+        HttpResponse.json(
+          {
+            code: 0,
+            msg: "success text must not become an HTTP error",
+            error: "unrelated field",
+          },
+          { status: 503 },
+        ),
+      ),
+    )
+
+    await expect(fetchInviteLink(createVoApiV2Request())).rejects.toMatchObject(
+      {
+        message: "VoAPI v2 request failed: 503",
+        statusCode: 503,
+        code: API_ERROR_CODES.HTTP_OTHER,
+      },
+    )
+  })
+
   it("classifies an expired VoAPI v2 invite session", async () => {
     server.use(
       http.get("https://example.invalid/api/user/invite-info", () =>

--- a/tests/services/apiService/voapiV2/responseError.test.ts
+++ b/tests/services/apiService/voapiV2/responseError.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest"
+
+import { decodeVoApiV2ResponseError } from "~/services/apiService/voapiV2/responseError"
+import type { ApiTransportResponse } from "~/services/apiTransport/type"
+
+const response = (
+  body: unknown,
+  status = 400,
+): ApiTransportResponse<unknown> => ({
+  ok: false,
+  status,
+  headers: {},
+  body,
+})
+
+describe("decodeVoApiV2ResponseError", () => {
+  it("prefers the verified msg field and keeps a safe provider code", () => {
+    expect(
+      decodeVoApiV2ResponseError(
+        response(
+          {
+            code: 41,
+            msg: "  VoAPI request rejected  ",
+            message: "secondary provider message",
+          },
+          403,
+        ),
+        { endpoint: "/api/user/info" },
+      ),
+    ).toEqual({
+      kind: "business",
+      message: "VoAPI request rejected",
+      upstreamCode: "41",
+    })
+  })
+
+  it("uses the verified message fallback when msg is blank", () => {
+    expect(
+      decodeVoApiV2ResponseError(
+        response({ code: 41, msg: "  ", message: "  Request denied  " }),
+        { endpoint: "/api/keys" },
+      ),
+    ).toEqual({
+      kind: "business",
+      message: "Request denied",
+      upstreamCode: "41",
+    })
+  })
+
+  it.each([
+    { code: 0, msg: "success is not a failure envelope" },
+    { code: "41", msg: "wrong code type" },
+    { code: 41, msg: " ", message: " " },
+    { error: "unrelated shape", message: "must not be inferred" },
+  ])("uses the fixed status fallback for an unusable envelope: %#", (body) => {
+    expect(
+      decodeVoApiV2ResponseError(response(body, 503), {
+        endpoint: "/api/user/info",
+      }),
+    ).toEqual({
+      kind: "http",
+      message: "VoAPI v2 request failed: 503",
+    })
+  })
+})

--- a/tests/services/apiTransport/compatibilityResponse.test.ts
+++ b/tests/services/apiTransport/compatibilityResponse.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest"
+
+import { mapCompatibilityResponse } from "~/services/apiTransport/compatibilityResponse"
+
+describe("mapCompatibilityResponse", () => {
+  it("does not inspect the heuristic body after a provider message is found", () => {
+    const body = new Proxy<Record<string, unknown>>(
+      {},
+      {
+        ownKeys: () => {
+          throw new Error("heuristic body must not be inspected")
+        },
+      },
+    )
+
+    expect(() =>
+      mapCompatibilityResponse(
+        { ok: false, status: 400, headers: {}, body },
+        {
+          endpoint: "/api/example",
+          responseType: "json",
+          onlyData: true,
+          decodeApplicationError: true,
+          errorResponseDecoder: () => ({
+            kind: "http",
+            message: "Provider message",
+          }),
+        },
+      ),
+    ).toThrow("Provider message")
+  })
+})

--- a/tests/services/apiTransport/compatibilityResponse.test.ts
+++ b/tests/services/apiTransport/compatibilityResponse.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 
 import { mapCompatibilityResponse } from "~/services/apiTransport/compatibilityResponse"
+import { ApiError } from "~/services/apiTransport/errors"
 
 describe("mapCompatibilityResponse", () => {
   it("does not inspect the heuristic body after a provider message is found", () => {
@@ -28,5 +29,36 @@ describe("mapCompatibilityResponse", () => {
         },
       ),
     ).toThrow("Provider message")
+  })
+
+  it("uses the fixed fallback instead of a message below a sensitive key", () => {
+    const sensitiveMessage = "credential-value-must-not-be-selected"
+    let error: unknown
+
+    try {
+      mapCompatibilityResponse(
+        {
+          ok: false,
+          status: 400,
+          headers: {},
+          body: { token: { message: sensitiveMessage } },
+        },
+        {
+          endpoint: "/api/example",
+          responseType: "json",
+          onlyData: true,
+          decodeApplicationError: true,
+        },
+      )
+    } catch (caught) {
+      error = caught
+    }
+
+    expect(error).toBeInstanceOf(ApiError)
+    expect(error).toMatchObject({
+      message: "请求失败: 400",
+      endpoint: "/api/example",
+    })
+    expect((error as Error).message).not.toContain(sensitiveMessage)
   })
 })

--- a/tests/services/apiTransport/request.test.ts
+++ b/tests/services/apiTransport/request.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { RuntimeActionIds } from "~/constants/runtimeActions"
 import { decodeNewApiResponseError } from "~/services/apiService/newApiFamily/responseError"
+import { decodeVoApiV2ResponseError } from "~/services/apiService/voapiV2/responseError"
 import { createDeferredAbortDeadline } from "~/services/apiTransport/abortableTask"
 import {
   ApiError,
@@ -3302,7 +3303,7 @@ describe("apiTransport request helpers", () => {
     })
   })
 
-  it("preserves backend JSON error messages for non-2xx responses", async () => {
+  it("does not infer provider errors without an explicit decoder", async () => {
     server.use(
       http.get(API_URL, () => {
         return HttpResponse.json(
@@ -3325,12 +3326,13 @@ describe("apiTransport request helpers", () => {
       ),
     ).rejects.toMatchObject({
       statusCode: 400,
-      message: "error: invalid user new-api",
+      message: "请求失败: 400",
       code: ApiErrorCodes.HTTP_OTHER,
+      upstreamCode: undefined,
     })
   })
 
-  it("prefers a provider decoder message over the compatibility fallback", async () => {
+  it("prefers a provider decoder message over the fixed fallback", async () => {
     server.use(
       http.get(API_URL, () =>
         HttpResponse.json(
@@ -3360,7 +3362,7 @@ describe("apiTransport request helpers", () => {
     })
   })
 
-  it("falls back when the provider decoder has no usable message", async () => {
+  it("uses the fixed fallback when the provider decoder has no usable message", async () => {
     server.use(
       http.get(API_URL, () =>
         HttpResponse.json(
@@ -3387,11 +3389,11 @@ describe("apiTransport request helpers", () => {
     ).rejects.toMatchObject({
       statusCode: 400,
       code: ApiErrorCodes.HTTP_OTHER,
-      message: "Compatibility message",
+      message: "请求失败: 400",
     })
   })
 
-  it("preserves a safe top-level backend code for provider recovery logic", async () => {
+  it("does not infer a top-level provider code without a decoder", async () => {
     server.use(
       http.get(API_URL, () =>
         HttpResponse.json(
@@ -3416,12 +3418,12 @@ describe("apiTransport request helpers", () => {
     ).rejects.toMatchObject({
       statusCode: 409,
       code: ApiErrorCodes.HTTP_OTHER,
-      upstreamCode: "AUTH_SESSION_LIMIT",
-      message: "Active session limit reached",
+      upstreamCode: undefined,
+      message: "请求失败: 409",
     })
   })
 
-  it("preserves a generic nested provider message and safe code", async () => {
+  it("does not infer a generic nested provider error", async () => {
     server.use(
       http.get(API_URL, () =>
         HttpResponse.json(
@@ -3448,13 +3450,13 @@ describe("apiTransport request helpers", () => {
     ).rejects.toMatchObject({
       statusCode: 400,
       code: ApiErrorCodes.HTTP_OTHER,
-      upstreamCode: "invalid_limit",
-      message: "Limit must be non-negative",
+      upstreamCode: undefined,
+      message: "请求失败: 400",
     })
   })
 
   it.each([undefined, null, {}, [], "bad code!", "x".repeat(65)])(
-    "preserves nested messages without exposing unsafe code %j",
+    "does not infer nested errors with code %j",
     async (code) => {
       server.use(
         http.get(API_URL, () =>
@@ -3480,7 +3482,7 @@ describe("apiTransport request helpers", () => {
         ),
       ).rejects.toMatchObject({
         statusCode: 400,
-        message: "Private malformed code message",
+        message: "请求失败: 400",
         upstreamCode: undefined,
       })
     },
@@ -3517,7 +3519,7 @@ describe("apiTransport request helpers", () => {
     ).rejects.toMatchObject({
       statusCode: 403,
       code: ApiErrorCodes.HTTP_403,
-      upstreamCode: "key_forbidden",
+      upstreamCode: undefined,
       message: "请求失败: 403",
     })
   })
@@ -3792,6 +3794,27 @@ describe("apiTransport request helpers", () => {
     ).rejects.toMatchObject({ message: "bad request" } as any)
   })
 
+  it("uses invalid-response copy when a projected failure message is blank", async () => {
+    server.use(
+      http.get(API_URL, () =>
+        HttpResponse.json({ success: false, data: null, message: "   " }),
+      ),
+    )
+
+    await expect(
+      fetchApiData(
+        {
+          baseUrl: BASE_URL,
+          auth: { authType: AuthTypeEnum.AccessToken, accessToken: "token" },
+        },
+        { endpoint: ENDPOINT },
+      ),
+    ).rejects.toMatchObject({
+      code: ApiErrorCodes.BUSINESS_ERROR,
+      message: "messages:errors.api.invalidResponseFormat",
+    })
+  })
+
   it("lets the provider decoder own HTTP 200 business error messages", async () => {
     server.use(
       http.get(API_URL, () =>
@@ -3975,7 +3998,10 @@ describe("apiTransport request helpers", () => {
           baseUrl: BASE_URL,
           auth: { authType: AuthTypeEnum.AccessToken, accessToken: "token" },
         },
-        { endpoint: modelsEndpoint },
+        {
+          endpoint: modelsEndpoint,
+          errorResponseDecoder: decodeVoApiV2ResponseError,
+        },
       ),
     ).rejects.toMatchObject({
       endpoint: modelsEndpoint,

--- a/tests/services/apiTransport/request.test.ts
+++ b/tests/services/apiTransport/request.test.ts
@@ -15,10 +15,6 @@ import {
   fetchApiResponse,
 } from "~/services/apiTransport/request"
 import {
-  extractDataFromApiResponseBody,
-  isHttpUrl,
-} from "~/services/apiTransport/response"
-import {
   API_AUTH_TOKEN_MODES,
   API_TRANSPORT_CURRENT_TAB_FALLBACK_MODES,
   API_TRANSPORT_FETCH_CONTEXT_KINDS,
@@ -195,6 +191,7 @@ function mockTempWindowFallbackDisabledResponse() {
 
 async function expectTempWindowDisabledFallback(
   endpoint: string = ENDPOINT,
+  message: string = "请求失败: 403",
 ): Promise<void> {
   await expect(
     fetchApiData(
@@ -208,7 +205,7 @@ async function expectTempWindowDisabledFallback(
   ).rejects.toMatchObject({
     code: TEMP_WINDOW_HEALTH_STATUS_CODES.DISABLED,
     originalCode: "HTTP_403",
-    message: "请求失败: 403",
+    message,
   })
 }
 
@@ -3303,7 +3300,7 @@ describe("apiTransport request helpers", () => {
     })
   })
 
-  it("does not infer provider errors without an explicit decoder", async () => {
+  it("uses a top-level message as the HTTP error fallback", async () => {
     server.use(
       http.get(API_URL, () => {
         return HttpResponse.json(
@@ -3326,7 +3323,7 @@ describe("apiTransport request helpers", () => {
       ),
     ).rejects.toMatchObject({
       statusCode: 400,
-      message: "请求失败: 400",
+      message: "error: invalid user new-api",
       code: ApiErrorCodes.HTTP_OTHER,
       upstreamCode: undefined,
     })
@@ -3362,11 +3359,11 @@ describe("apiTransport request helpers", () => {
     })
   })
 
-  it("uses the fixed fallback when the provider decoder has no usable message", async () => {
+  it("uses a msg fallback when the provider decoder has no usable message", async () => {
     server.use(
       http.get(API_URL, () =>
         HttpResponse.json(
-          { success: false, message: "Compatibility message" },
+          { success: false, msg: "Heuristic message" },
           { status: 400 },
         ),
       ),
@@ -3389,7 +3386,7 @@ describe("apiTransport request helpers", () => {
     ).rejects.toMatchObject({
       statusCode: 400,
       code: ApiErrorCodes.HTTP_OTHER,
-      message: "请求失败: 400",
+      message: "Heuristic message",
     })
   })
 
@@ -3419,11 +3416,11 @@ describe("apiTransport request helpers", () => {
       statusCode: 409,
       code: ApiErrorCodes.HTTP_OTHER,
       upstreamCode: undefined,
-      message: "请求失败: 409",
+      message: "Active session limit reached",
     })
   })
 
-  it("does not infer a generic nested provider error", async () => {
+  it("uses a nested error message without exposing sibling metadata", async () => {
     server.use(
       http.get(API_URL, () =>
         HttpResponse.json(
@@ -3451,12 +3448,12 @@ describe("apiTransport request helpers", () => {
       statusCode: 400,
       code: ApiErrorCodes.HTTP_OTHER,
       upstreamCode: undefined,
-      message: "请求失败: 400",
+      message: "Limit must be non-negative",
     })
   })
 
   it.each([undefined, null, {}, [], "bad code!", "x".repeat(65)])(
-    "does not infer nested errors with code %j",
+    "extracts a nested message without inferring code semantics for %j",
     async (code) => {
       server.use(
         http.get(API_URL, () =>
@@ -3482,13 +3479,13 @@ describe("apiTransport request helpers", () => {
         ),
       ).rejects.toMatchObject({
         statusCode: 400,
-        message: "请求失败: 400",
+        message: "Private malformed code message",
         upstreamCode: undefined,
       })
     },
   )
 
-  it("does not special-case nested OpenRouter errors in shared compatibility APIs", async () => {
+  it("extracts an OpenRouter-like message without special-casing its code", async () => {
     const openRouterApiUrl = "https://openrouter.ai/api/v1/keys"
     server.use(
       http.get(openRouterApiUrl, () =>
@@ -3520,7 +3517,7 @@ describe("apiTransport request helpers", () => {
       statusCode: 403,
       code: ApiErrorCodes.HTTP_403,
       upstreamCode: undefined,
-      message: "请求失败: 403",
+      message: "Private management-key detail",
     })
   })
 
@@ -3934,7 +3931,7 @@ describe("apiTransport request helpers", () => {
     expect(mockSendRuntimeMessage).not.toHaveBeenCalled()
   })
 
-  it("keeps provider business classification when its message is blank", async () => {
+  it("keeps provider business classification while heuristic surfaces its safe code", async () => {
     const modelsEndpoint = "/v1/models"
     const modelsUrl = "https://example.com/base/v1/models"
 
@@ -3968,7 +3965,7 @@ describe("apiTransport request helpers", () => {
       endpoint: modelsEndpoint,
       statusCode: 403,
       code: ApiErrorCodes.BUSINESS_ERROR,
-      message: "请求失败: 403",
+      message: "group_forbidden",
       upstreamCode: "group_forbidden",
     })
 
@@ -4030,7 +4027,10 @@ describe("apiTransport request helpers", () => {
       }),
     )
 
-    await expectTempWindowDisabledFallback()
+    await expectTempWindowDisabledFallback(
+      ENDPOINT,
+      "Gateway denied the request",
+    )
   })
 
   it("fetchApiData should keep primitive JSON 403 errors eligible for temp-window fallback", async () => {
@@ -4041,10 +4041,10 @@ describe("apiTransport request helpers", () => {
       }),
     )
 
-    await expectTempWindowDisabledFallback()
+    await expectTempWindowDisabledFallback(ENDPOINT, "gateway denied")
   })
 
-  it("fetchApiData should keep structured 403 errors without messages eligible for temp-window fallback", async () => {
+  it("fetchApiData should keep code-only structured 403 errors eligible for temp-window fallback", async () => {
     mockTempWindowFallbackDisabledResponse()
     server.use(
       http.get(API_URL, () => {
@@ -4060,7 +4060,7 @@ describe("apiTransport request helpers", () => {
       }),
     )
 
-    await expectTempWindowDisabledFallback()
+    await expectTempWindowDisabledFallback(ENDPOINT, "gateway_denied")
   })
 
   it("fetchApiData should tag eligible errors when temp-window fallback is disabled", async () => {
@@ -4225,31 +4225,5 @@ describe("apiTransport request helpers", () => {
     expect(Array.from(new Uint8Array(await result.arrayBuffer()))).toEqual([
       4, 5, 6,
     ])
-  })
-
-  it("isHttpUrl and extractDataFromApiResponseBody guard invalid input", () => {
-    expect(isHttpUrl("https://example.com")).toBe(true)
-    expect(isHttpUrl("http://example.com")).toBe(true)
-    expect(isHttpUrl("ftp://example.com")).toBe(false)
-    expect(isHttpUrl("not-a-url")).toBe(false)
-
-    expect(() =>
-      extractDataFromApiResponseBody(null, "/api/invalid"),
-    ).toThrowError(
-      expect.objectContaining({ code: ApiErrorCodes.JSON_PARSE_ERROR }),
-    )
-
-    let businessError: unknown
-    try {
-      extractDataFromApiResponseBody(
-        { success: false, data: null, message: "" },
-        "/api/invalid",
-      )
-    } catch (error) {
-      businessError = error
-    }
-    expect(businessError).toMatchObject({
-      code: ApiErrorCodes.BUSINESS_ERROR,
-    })
   })
 })

--- a/tests/services/apiTransport/response.test.ts
+++ b/tests/services/apiTransport/response.test.ts
@@ -35,4 +35,21 @@ describe("apiTransport response helpers", () => {
       expect.objectContaining({ code: API_ERROR_CODES.BUSINESS_ERROR }),
     )
   })
+
+  it.each([{ secret: "credential-example" }, ["credential-example"], 42])(
+    "does not serialize a non-string business error message",
+    (message) => {
+      expect(() =>
+        extractDataFromApiResponseBody(
+          { success: false, data: null, message },
+          "/api/invalid",
+        ),
+      ).toThrowError(
+        expect.objectContaining({
+          code: API_ERROR_CODES.BUSINESS_ERROR,
+          message: "messages:errors.api.invalidResponseFormat",
+        }),
+      )
+    },
+  )
 })

--- a/tests/services/apiTransport/response.test.ts
+++ b/tests/services/apiTransport/response.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest"
+
+import { API_ERROR_CODES } from "~/services/apiTransport/errors"
+import {
+  extractDataFromApiResponseBody,
+  isApiResponseBody,
+} from "~/services/apiTransport/response"
+
+describe("apiTransport response helpers", () => {
+  it("recognizes only complete shared response envelopes", () => {
+    expect(
+      isApiResponseBody({ success: true, data: null, message: "success" }),
+    ).toBe(true)
+    expect(isApiResponseBody({ success: true, data: null })).toBe(false)
+    expect(
+      isApiResponseBody({ success: "true", data: null, message: "success" }),
+    ).toBe(false)
+  })
+
+  it("rejects invalid response bodies", () => {
+    expect(() =>
+      extractDataFromApiResponseBody(null, "/api/invalid"),
+    ).toThrowError(
+      expect.objectContaining({ code: API_ERROR_CODES.JSON_PARSE_ERROR }),
+    )
+  })
+
+  it("keeps blank business errors classified as business failures", () => {
+    expect(() =>
+      extractDataFromApiResponseBody(
+        { success: false, data: null, message: "" },
+        "/api/invalid",
+      ),
+    ).toThrowError(
+      expect.objectContaining({ code: API_ERROR_CODES.BUSINESS_ERROR }),
+    )
+  })
+})

--- a/tests/services/apiTransport/responseError.test.ts
+++ b/tests/services/apiTransport/responseError.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from "vitest"
+
+import { extractHeuristicResponseErrorMessage } from "~/services/apiTransport/responseError"
+
+describe("extractHeuristicResponseErrorMessage", () => {
+  it.each([
+    "message",
+    "msg",
+    "error_description",
+    "detail",
+    "error",
+    "reason",
+    "title",
+  ])("prioritizes the %s field over an unrelated string", (key) => {
+    expect(
+      extractHeuristicResponseErrorMessage({
+        [key]: "Preferred error",
+        debug:
+          "This unrelated diagnostic string is deliberately longer than the preferred error",
+      }),
+    ).toBe("Preferred error")
+  })
+
+  it("prefers higher-ranked and shallower message fields", () => {
+    expect(
+      extractHeuristicResponseErrorMessage({
+        msg: "A much longer secondary message",
+        message: "Primary message",
+      }),
+    ).toBe("Primary message")
+
+    expect(
+      extractHeuristicResponseErrorMessage({
+        message: "Shallow message",
+        nested: { message: "A much longer nested message" },
+      }),
+    ).toBe("Shallow message")
+  })
+
+  it("finds case-insensitive message fields through arrays", () => {
+    expect(
+      extractHeuristicResponseErrorMessage({
+        problem: { contexts: [{ MESSAGE: "Nested deployment error" }] },
+      }),
+    ).toBe("Nested deployment error")
+  })
+
+  it("uses the longest reasonable string when no known field exists", () => {
+    expect(
+      extractHeuristicResponseErrorMessage({
+        status: "failed",
+        context: {
+          hint: "Retry later",
+          explanation:
+            "The deployment rejected this request because its capacity is exhausted",
+        },
+      }),
+    ).toBe(
+      "The deployment rejected this request because its capacity is exhausted",
+    )
+  })
+
+  it("may surface a safe code string without interpreting its semantics", () => {
+    expect(
+      extractHeuristicResponseErrorMessage({
+        error: { code: "gateway_denied" },
+      }),
+    ).toBe("gateway_denied")
+  })
+
+  it("skips sensitive values while retaining known messages below them", () => {
+    expect(
+      extractHeuristicResponseErrorMessage({
+        hint: "Request blocked by the upstream gateway",
+        secret:
+          "credential-value-that-is-deliberately-longer-than-the-safe-error-hint",
+      }),
+    ).toBe("Request blocked by the upstream gateway")
+
+    expect(
+      extractHeuristicResponseErrorMessage({
+        session: {
+          message: "Session expired",
+          token: "credential-value-must-not-be-selected",
+        },
+      }),
+    ).toBe("Session expired")
+  })
+
+  it("rejects obvious payload strings even under known fields", () => {
+    expect(
+      extractHeuristicResponseErrorMessage({
+        message:
+          "<html><body>Access verification page with a lot of markup</body></html>",
+        redirect:
+          "https://example.invalid/a/very/long/internal/error/redirect/path",
+        session: "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJleGFtcGxlIn0.signature-value",
+        hint: "Gateway rejected the request",
+      }),
+    ).toBe("Gateway rejected the request")
+  })
+
+  it.each([
+    {
+      name: "a JWT-like value",
+      message: "aaaaaaaa.bbbbbbbb.cccccccc",
+    },
+    { name: "an encoded payload", message: "A".repeat(80) },
+    { name: "an oversized payload", message: "oversized payload ".repeat(120) },
+  ])("rejects $name", ({ message }) => {
+    expect(extractHeuristicResponseErrorMessage({ message })).toBeUndefined()
+  })
+
+  it.each([
+    "Authorization: Bearer example-secret-value",
+    "Cookie: sid=example-secret-value",
+    "access_token=example-secret-value",
+    "key=example-secret-value",
+    "credential: example-secret-value",
+    "session=example-secret-value",
+  ])("rejects credential-shaped scalar candidates: %s", (candidate) => {
+    expect(extractHeuristicResponseErrorMessage(candidate)).toBeUndefined()
+    expect(
+      extractHeuristicResponseErrorMessage({ message: candidate }),
+    ).toBeUndefined()
+  })
+
+  it("retains ordinary authentication failure messages", () => {
+    expect(
+      extractHeuristicResponseErrorMessage({
+        message: "Authorization failed because the session expired",
+      }),
+    ).toBe("Authorization failed because the session expired")
+  })
+
+  it("accepts a reasonable scalar body and rejects bodies without one", () => {
+    expect(
+      extractHeuristicResponseErrorMessage("Upstream capacity is exhausted"),
+    ).toBe("Upstream capacity is exhausted")
+    expect(
+      extractHeuristicResponseErrorMessage({
+        message: "<html><body>Access verification</body></html>",
+        authorization: "Bearer credential-value",
+        redirect: "https://example.invalid/error/details",
+      }),
+    ).toBeUndefined()
+  })
+
+  it("handles cycles without losing the best candidate", () => {
+    const body: Record<string, unknown> = {
+      hint: "Request failed safely",
+    }
+    body.self = body
+
+    expect(extractHeuristicResponseErrorMessage(body)).toBe(
+      "Request failed safely",
+    )
+  })
+
+  it("stops at the depth limit", () => {
+    expect(
+      extractHeuristicResponseErrorMessage({
+        a: { b: { c: { d: { e: { message: "Too deeply nested" } } } } },
+      }),
+    ).toBeUndefined()
+  })
+
+  it("stops at the work limit", () => {
+    const wideBody = Object.fromEntries(
+      Array.from({ length: 100 }, (_, index) => [`field${index}`, index]),
+    )
+    Object.assign(wideBody, { message: "Outside the work budget" })
+
+    expect(extractHeuristicResponseErrorMessage(wideBody)).toBeUndefined()
+  })
+})

--- a/tests/services/apiTransport/responseError.test.ts
+++ b/tests/services/apiTransport/responseError.test.ts
@@ -68,7 +68,7 @@ describe("extractHeuristicResponseErrorMessage", () => {
     ).toBe("gateway_denied")
   })
 
-  it("skips sensitive values while retaining known messages below them", () => {
+  it("skips sensitive values while retaining non-sensitive messages", () => {
     expect(
       extractHeuristicResponseErrorMessage({
         hint: "Request blocked by the upstream gateway",
@@ -76,15 +76,37 @@ describe("extractHeuristicResponseErrorMessage", () => {
           "credential-value-that-is-deliberately-longer-than-the-safe-error-hint",
       }),
     ).toBe("Request blocked by the upstream gateway")
+  })
 
+  it.each([
+    "session",
+    "token",
+    "access_token",
+    "refresh_token",
+    "authorization",
+    "cookie",
+    "credential",
+    "secret",
+  ])("rejects a known message below the sensitive %s key", (sensitiveKey) => {
     expect(
       extractHeuristicResponseErrorMessage({
-        session: {
-          message: "Session expired",
-          token: "credential-value-must-not-be-selected",
+        [sensitiveKey]: {
+          message: "credential-value-must-not-be-selected",
         },
       }),
-    ).toBe("Session expired")
+    ).toBeUndefined()
+  })
+
+  it("rejects known messages nested anywhere below a sensitive key", () => {
+    expect(
+      extractHeuristicResponseErrorMessage({
+        access_token: {
+          metadata: {
+            detail: "credential-detail-must-not-be-selected",
+          },
+        },
+      }),
+    ).toBeUndefined()
   })
 
   it("rejects obvious payload strings even under known fields", () => {
@@ -157,7 +179,13 @@ describe("extractHeuristicResponseErrorMessage", () => {
     )
   })
 
-  it("stops at the depth limit", () => {
+  it("accepts messages at the depth limit and rejects messages beyond it", () => {
+    expect(
+      extractHeuristicResponseErrorMessage({
+        a: { b: { c: { d: { message: "At the depth limit" } } } },
+      }),
+    ).toBe("At the depth limit")
+
     expect(
       extractHeuristicResponseErrorMessage({
         a: { b: { c: { d: { e: { message: "Too deeply nested" } } } } },

--- a/tests/services/ldohSiteLookup.background.test.ts
+++ b/tests/services/ldohSiteLookup.background.test.ts
@@ -138,6 +138,32 @@ describe("ldohSiteLookup background refresh", () => {
     expect(vi.mocked(writeLdohSiteListCache)).not.toHaveBeenCalled()
   })
 
+  it("uses a fixed HTTP error without parsing the provider response body", async () => {
+    vi.resetModules()
+
+    const { writeLdohSiteListCache } = await import(
+      "~/services/integrations/ldohSiteLookup/cache"
+    )
+    const { repairLdohSiteListCache } = await import(
+      "~/services/integrations/ldohSiteLookup/background"
+    )
+
+    server.use(
+      http.get(ldohSitesUrl, () =>
+        HttpResponse.json(
+          { message: "provider detail must not be parsed" },
+          { status: 418 },
+        ),
+      ),
+    )
+
+    await expect(repairLdohSiteListCache()).resolves.toMatchObject({
+      success: false,
+      error: "请求失败: 418",
+    })
+    expect(vi.mocked(writeLdohSiteListCache)).not.toHaveBeenCalled()
+  })
+
   it("invokes temp-window fallback for HTTP 403", async () => {
     vi.resetModules()
 

--- a/tests/services/ldohSiteLookup.background.test.ts
+++ b/tests/services/ldohSiteLookup.background.test.ts
@@ -138,7 +138,7 @@ describe("ldohSiteLookup background refresh", () => {
     expect(vi.mocked(writeLdohSiteListCache)).not.toHaveBeenCalled()
   })
 
-  it("uses a fixed HTTP error without parsing the provider response body", async () => {
+  it("uses the shared heuristic message for an unowned HTTP error", async () => {
     vi.resetModules()
 
     const { writeLdohSiteListCache } = await import(
@@ -151,7 +151,7 @@ describe("ldohSiteLookup background refresh", () => {
     server.use(
       http.get(ldohSitesUrl, () =>
         HttpResponse.json(
-          { message: "provider detail must not be parsed" },
+          { message: "provider detail may be surfaced" },
           { status: 418 },
         ),
       ),
@@ -159,7 +159,7 @@ describe("ldohSiteLookup background refresh", () => {
 
     await expect(repairLdohSiteListCache()).resolves.toMatchObject({
       success: false,
-      error: "请求失败: 418",
+      error: "provider detail may be surfaced",
     })
     expect(vi.mocked(writeLdohSiteListCache)).not.toHaveBeenCalled()
   })

--- a/tests/services/managedSites/providers/claudeCodeHub.test.ts
+++ b/tests/services/managedSites/providers/claudeCodeHub.test.ts
@@ -36,6 +36,10 @@ const mockUpdateProvider = vi.fn()
 const mockDeleteProvider = vi.fn()
 const mockGetUnmaskedProviderKey = vi.fn()
 const mockGetPreferences = vi.fn()
+const mockLogger = vi.hoisted(() => ({
+  warn: vi.fn(),
+  error: vi.fn(),
+}))
 
 vi.mock("~/services/managedSites/utils/fetchTokenScopedModels", () => ({
   fetchTokenScopedModels: (...args: unknown[]) =>
@@ -72,6 +76,10 @@ vi.mock("~/utils/i18n/core", () => ({
   t: (key: string) => key,
 }))
 
+vi.mock("~/utils/core/logger", () => ({
+  createLogger: () => mockLogger,
+}))
+
 describe("Claude Code Hub managed-site provider", () => {
   const storedClaudeCodeHubConfig = {
     baseUrl: "https://stored-cch.example.com",
@@ -93,6 +101,8 @@ describe("Claude Code Hub managed-site provider", () => {
     mockDeleteProvider.mockReset()
     mockGetUnmaskedProviderKey.mockReset()
     mockGetPreferences.mockReset()
+    mockLogger.warn.mockReset()
+    mockLogger.error.mockReset()
   })
 
   it("normalizes provider display records into managed-site channels", () => {
@@ -359,6 +369,37 @@ describe("Claude Code Hub managed-site provider", () => {
 
     await expect(checkValidClaudeCodeHubConfig()).resolves.toBe(false)
     expect(claudeCodeHubApi.validateClaudeCodeHubConfig).not.toHaveBeenCalled()
+  })
+
+  it("redacts saved credentials when config validation fails", async () => {
+    const claudeCodeHubApi = await import("~/services/apiService/claudeCodeHub")
+    mockGetPreferences.mockResolvedValueOnce({
+      claudeCodeHub: storedClaudeCodeHubConfig,
+    })
+    vi.mocked(
+      claudeCodeHubApi.validateClaudeCodeHubConfig,
+    ).mockRejectedValueOnce(new Error("token stored-admin-token rejected"))
+
+    await expect(checkValidClaudeCodeHubConfig()).resolves.toBe(false)
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      "Claude Code Hub config validation failed",
+      expect.not.stringContaining("stored-admin-token"),
+    )
+  })
+
+  it("logs only a normalized summary when reading preferences fails", async () => {
+    const preferencesError = new Error("preferences unavailable")
+    mockGetPreferences.mockRejectedValueOnce(preferencesError)
+
+    await expect(getClaudeCodeHubConfig()).resolves.toBeNull()
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      "Error getting Claude Code Hub config",
+      "preferences unavailable",
+    )
+    expect(mockLogger.error).not.toHaveBeenCalledWith(
+      expect.anything(),
+      preferencesError,
+    )
   })
 
   it("lists providers through the same normalized channel list shape", async () => {

--- a/tests/services/managedSites/providers/claudeCodeHub.test.ts
+++ b/tests/services/managedSites/providers/claudeCodeHub.test.ts
@@ -23,6 +23,7 @@ import {
   prepareChannelFormData,
   providerToManagedSiteChannel,
   searchChannel,
+  toClaudeCodeHubDisclosureError,
 } from "~/services/managedSites/providers/claudeCodeHub"
 import { CHANNEL_STATUS } from "~/types/managedSite"
 
@@ -400,6 +401,37 @@ describe("Claude Code Hub managed-site provider", () => {
     expect(mockSearchProviders).not.toHaveBeenCalled()
   })
 
+  it("discloses provider failures as detached sanitized errors", async () => {
+    const raw = Object.assign(
+      new Error(
+        "bad token passed-admin-token at https://passed-cch.example.com/private",
+      ),
+      {
+        raw: { adminToken: "passed-admin-token" },
+        cause: new Error("passed-admin-token"),
+      },
+    )
+    const disclosed = toClaudeCodeHubDisclosureError(
+      raw,
+      passedClaudeCodeHubConfig,
+    )
+
+    expect(disclosed).toBeInstanceOf(Error)
+    expect(disclosed.message).not.toContain("passed-admin-token")
+    expect(disclosed).not.toHaveProperty("raw")
+    expect(disclosed).not.toHaveProperty("cause")
+    expect(Object.keys(disclosed)).toEqual([])
+
+    mockListProviders.mockRejectedValueOnce(raw)
+    const failure = await listChannels(passedClaudeCodeHubConfig).catch(
+      (error: unknown) => error,
+    )
+    expect(failure).toBeInstanceOf(Error)
+    expect((failure as Error).message).toBe(disclosed.message)
+    expect(failure).not.toHaveProperty("raw")
+    expect(failure).not.toHaveProperty("cause")
+  })
+
   it("searches providers with passed admin config and maps failures to null", async () => {
     mockSearchProviders.mockResolvedValueOnce([
       {
@@ -455,6 +487,23 @@ describe("Claude Code Hub managed-site provider", () => {
     await expect(
       fetchChannelSecretKey(passedClaudeCodeHubConfig, 42),
     ).rejects.toThrow("reveal failed")
+  })
+
+  it("sanitizes provider key reveal failures at the facade boundary", async () => {
+    const raw = Object.assign(new Error("token passed-admin-token rejected"), {
+      raw: { token: "passed-admin-token" },
+    })
+    mockGetUnmaskedProviderKey.mockRejectedValueOnce(raw)
+
+    const failure = await fetchChannelSecretKey(
+      passedClaudeCodeHubConfig,
+      42,
+    ).catch((error: unknown) => error)
+
+    expect(failure).toBeInstanceOf(Error)
+    expect((failure as Error).message).not.toContain("passed-admin-token")
+    expect(failure).not.toHaveProperty("raw")
+    expect(Object.keys(failure as object)).toEqual([])
   })
 
   it("hydrates provided Claude Code Hub candidates through provider key reveal", async () => {

--- a/tests/services/managedSites/providers/claudeCodeHub.test.ts
+++ b/tests/services/managedSites/providers/claudeCodeHub.test.ts
@@ -387,6 +387,21 @@ describe("Claude Code Hub managed-site provider", () => {
     )
   })
 
+  it("logs a normalized summary when preferences fail before config is loaded", async () => {
+    const preferencesError = new Error("preferences unavailable")
+    mockGetPreferences.mockRejectedValueOnce(preferencesError)
+
+    await expect(checkValidClaudeCodeHubConfig()).resolves.toBe(false)
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      "Claude Code Hub config validation failed",
+      "preferences unavailable",
+    )
+    expect(mockLogger.warn).not.toHaveBeenCalledWith(
+      expect.anything(),
+      preferencesError,
+    )
+  })
+
   it("logs only a normalized summary when reading preferences fails", async () => {
     const preferencesError = new Error("preferences unavailable")
     mockGetPreferences.mockRejectedValueOnce(preferencesError)

--- a/tests/services/managedSites/providers/newApiSession.test.ts
+++ b/tests/services/managedSites/providers/newApiSession.test.ts
@@ -1169,7 +1169,7 @@ describe("newApiSession", () => {
     expect(verifyCalls).toBe(2)
   })
 
-  it("reports browser-session availability and propagates unexpected probe failures", async () => {
+  it("reports browser-session availability", async () => {
     server.use(
       http.get(`${BASE_CONFIG.baseUrl}/api/user/2fa/status`, () =>
         jsonData({ enabled: false }),
@@ -1182,8 +1182,9 @@ describe("newApiSession", () => {
     await expect(
       hasNewApiAuthenticatedBrowserSession(BASE_CONFIG),
     ).resolves.toBe(true)
+  })
 
-    clearNewApiManagedSessionState()
+  it("propagates unexpected browser-session probe failures", async () => {
     server.use(
       http.get(
         `${BASE_CONFIG.baseUrl}/api/user/2fa/status`,
@@ -1197,7 +1198,7 @@ describe("newApiSession", () => {
     await expect(
       hasNewApiAuthenticatedBrowserSession(BASE_CONFIG),
     ).rejects.toMatchObject({
-      message: expect.stringContaining("500"),
+      message: "boom",
     })
   })
 

--- a/tests/services/usageHistory/sync.test.ts
+++ b/tests/services/usageHistory/sync.test.ts
@@ -1,7 +1,8 @@
 import { http, HttpResponse } from "msw"
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 
 import { accountMutations } from "~/services/accounts/accountStorage/accountMutations"
+import { newApiFamilyRequests } from "~/services/apiService/newApiFamily/request"
 import { USAGE_HISTORY_LIMITS } from "~/services/history/usageHistory/constants"
 import { getDayKeyFromUnixSeconds } from "~/services/history/usageHistory/core"
 import { usageHistoryStorage } from "~/services/history/usageHistory/storage"
@@ -85,6 +86,34 @@ async function createTestAccount(baseUrl: string): Promise<string> {
 }
 
 describe("usageHistory sync (MSW)", () => {
+  it("routes log pages through the New API-family request seam", async () => {
+    const baseUrl = "https://usage-history.example.invalid"
+    const accountId = await createTestAccount(baseUrl)
+    const dataSpy = vi
+      .spyOn(newApiFamilyRequests, "data")
+      .mockResolvedValue({ items: [], total: 0 })
+
+    await syncUsageHistoryForAccount({
+      accountId,
+      trigger: "manual",
+      force: true,
+      config: {
+        enabled: true,
+        retentionDays: 30,
+        scheduleMode: USAGE_HISTORY_SCHEDULE_MODE.MANUAL,
+        syncIntervalMinutes: 60,
+      },
+    })
+
+    expect(dataSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ baseUrl }),
+      expect.objectContaining({
+        endpoint: expect.stringContaining("/api/log/self?"),
+      }),
+    )
+    dataSpy.mockRestore()
+  })
+
   it("skips disabled sync and mismatched scheduled triggers before loading accounts", async () => {
     const disabledConfig: UsageHistoryPreferences = {
       enabled: false,


### PR DESCRIPTION
## Summary

- Move error-response interpretation to provider-owned decoders based on verified provider response shapes.
- Preserve adapters that intentionally parse raw responses or already own application-level parsing.
- Add a bounded heuristic message fallback after provider decoding.
- Remove the legacy compatibility decoder after auditing its callers.

## Behavior

Before:
- Shared compatibility logic inferred provider messages and codes across unrelated response formats.
- Error fallback and disclosure responsibilities were mixed across transport consumers.

After:
- Provider-specific decoders remain authoritative.
- Unknown non-2xx JSON responses use provider decoder, then a bounded heuristic message, then a fixed local fallback.
- The heuristic does not infer business status, retryability, or machine codes.
- Credential/header-shaped strings, tokens, encoded payloads, markup, and URLs are rejected as heuristic messages.
- Redaction remains at disclosure boundaries.
- Raw-response consumers such as Sub2API token refresh and check-in parsing remain unchanged.

## Validation

- 11 focused test files, 437 tests passed after the upstream refresh.
- 4 final affected test files, 160 tests passed.
- `pnpm compile`
- `pnpm knip`
- Scoped ESLint
- Prettier and `git diff --check`
- Pre-commit staged validation and i18n checks
- Actual pre-push `validate:push` gate passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error decoding and fallback messages across AI providers and API integrations.
  * Enhanced protection for credentials, tokens, and sensitive response data in errors and telemetry.
  * Claude Code Hub failures now provide safer, sanitized diagnostics.
  * OpenRouter catalog and account errors now preserve useful status details while protecting sensitive values.
  * Telemetry requests correctly report failed and unavailable endpoints.
  * Usage history synchronization now uses a more reliable request path.
* **Tests**
  * Expanded coverage for provider errors, sanitization, telemetry, and usage-history synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->