### PR TITLE
feat(checkin): support Denxio daily check-in

### DIFF
--- a/src/constants/checkIn.ts
+++ b/src/constants/checkIn.ts
@@ -9,6 +9,7 @@ export const AUTO_CHECKIN_METHOD_IDS = {
   AnyrouterDailyCheckIn: "anyrouter:daily-checkin",
   VoApiV2DailyCheckIn: "voapi-v2:daily-checkin",
   Sub2ApiProDailyCheckIn: "sub2api-pro:daily-checkin",
+  DenxioDailyCheckIn: "denxio:daily-checkin",
 } as const
 
 export const CHECK_IN_METHOD_UNKNOWN_REASON_CODES = {

--- a/src/services/apiService/sub2api/denxioCheckIn.ts
+++ b/src/services/apiService/sub2api/denxioCheckIn.ts
@@ -1,0 +1,353 @@
+import { API_ERROR_CODES, ApiError } from "~/services/apiTransport/errors"
+import {
+  fetchApiResponse,
+  notifyApiTransportObserver,
+} from "~/services/apiTransport/request"
+import type {
+  ApiServiceRequest,
+  ApiTransportResponse,
+} from "~/services/apiTransport/type"
+
+import { executeAuthenticatedSub2ApiRequest } from "./authLifecycle"
+
+export const DENXIO_DAILY_CHECK_IN_STATUS_ENDPOINT =
+  "/api/v1/tbe-sponsor-checkin/status"
+export const DENXIO_DAILY_CHECK_IN_BEGIN_ENDPOINT =
+  "/api/v1/tbe-sponsor-checkin/normal/begin"
+export const DENXIO_DAILY_CHECK_IN_CLAIM_ENDPOINT =
+  "/api/v1/tbe-sponsor-checkin/normal/claim"
+
+export const DENXIO_DAILY_CHECK_IN_ERROR_CODES = {
+  Disabled: "TBE_SPONSOR_CHECKIN_DISABLED",
+  AlreadyChecked: "TBE_SPONSOR_CHECKIN_ALREADY_DONE",
+  NoSponsor: "TBE_SPONSOR_CHECKIN_NO_SPONSOR",
+  SessionInvalid: "TBE_SPONSOR_CHECKIN_SESSION_INVALID",
+  SessionPending: "TBE_SPONSOR_CHECKIN_SESSION_PENDING",
+} as const
+
+export const DENXIO_DAILY_CHECK_IN_RESULT_KINDS = {
+  Applied: "applied",
+  AlreadyChecked: "already_checked",
+  Disabled: "disabled",
+  RecoveryStatusUnavailable: "recovery_status_unavailable",
+  RecoveryPreconditionFailed: "recovery_precondition_failed",
+} as const
+
+const MAX_CHALLENGE_WAIT_SECONDS = 60
+
+interface DenxioDailyCheckInStatus {
+  enabled: boolean
+  checkedInToday: boolean
+}
+
+interface DenxioDailyCheckInChallenge {
+  token: string
+  waitMilliseconds: number
+}
+
+type DenxioDailyCheckInOperationResult =
+  | {
+      kind: typeof DENXIO_DAILY_CHECK_IN_RESULT_KINDS.Applied
+      rewardAmount: number
+    }
+  | { kind: typeof DENXIO_DAILY_CHECK_IN_RESULT_KINDS.AlreadyChecked }
+  | { kind: typeof DENXIO_DAILY_CHECK_IN_RESULT_KINDS.Disabled }
+  | {
+      kind: typeof DENXIO_DAILY_CHECK_IN_RESULT_KINDS.RecoveryStatusUnavailable
+    }
+  | {
+      kind: typeof DENXIO_DAILY_CHECK_IN_RESULT_KINDS.RecoveryPreconditionFailed
+    }
+
+const toRecord = (value: unknown): Record<string, unknown> | null =>
+  value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null
+
+const getHttpErrorCode = (status: number) => {
+  if (status === 401) return API_ERROR_CODES.HTTP_401
+  if (status === 403) return API_ERROR_CODES.HTTP_403
+  if (status === 429) return API_ERROR_CODES.HTTP_429
+  return API_ERROR_CODES.HTTP_OTHER
+}
+
+const createInvalidResponseError = (endpoint: string) =>
+  new ApiError(
+    "Invalid Denxio daily check-in response",
+    undefined,
+    endpoint,
+    API_ERROR_CODES.JSON_PARSE_ERROR,
+  )
+
+const parseEnvelopeData = (
+  response: ApiTransportResponse<unknown>,
+  endpoint: string,
+): Record<string, unknown> => {
+  const envelope = toRecord(response.body)
+  if (!envelope) {
+    if (!response.ok) {
+      throw new ApiError(
+        `Denxio daily check-in request failed with HTTP ${response.status}`,
+        response.status,
+        endpoint,
+        getHttpErrorCode(response.status),
+      )
+    }
+    throw createInvalidResponseError(endpoint)
+  }
+
+  if (
+    (typeof envelope.code !== "string" && typeof envelope.code !== "number") ||
+    typeof envelope.message !== "string"
+  ) {
+    throw createInvalidResponseError(endpoint)
+  }
+
+  const upstreamCode = String(envelope.code)
+  const message =
+    typeof envelope.message === "string" && envelope.message.trim()
+      ? envelope.message.trim()
+      : undefined
+  const isSuccessEnvelope = envelope.code === 0 && response.ok
+
+  if (!isSuccessEnvelope) {
+    throw new ApiError(
+      message ??
+        `Denxio daily check-in request failed with HTTP ${response.status}`,
+      response.ok ? undefined : response.status,
+      endpoint,
+      response.ok
+        ? API_ERROR_CODES.BUSINESS_ERROR
+        : getHttpErrorCode(response.status),
+      upstreamCode,
+    )
+  }
+
+  const data = toRecord(envelope.data)
+  if (!data) throw createInvalidResponseError(endpoint)
+  return data
+}
+
+/**
+ * Parses the deployment-owned status contract observed at
+ * https://api.denxio.top/checkin. The normal flow uses a read-only status,
+ * followed by a begin challenge and a delayed claim.
+ */
+export function parseDenxioDailyCheckInStatusResponse(
+  response: ApiTransportResponse<unknown>,
+): DenxioDailyCheckInStatus {
+  const data = parseEnvelopeData(
+    response,
+    DENXIO_DAILY_CHECK_IN_STATUS_ENDPOINT,
+  )
+  const config = toRecord(data.config)
+  if (
+    typeof data.normal_done !== "boolean" ||
+    typeof config?.normal_checkin_enabled !== "boolean"
+  ) {
+    throw createInvalidResponseError(DENXIO_DAILY_CHECK_IN_STATUS_ENDPOINT)
+  }
+
+  return {
+    enabled: config.normal_checkin_enabled,
+    checkedInToday: data.normal_done,
+  }
+}
+
+/** Parses one short-lived normal-check-in challenge without retaining sponsor data. */
+export function parseDenxioDailyCheckInBeginResponse(
+  response: ApiTransportResponse<unknown>,
+): DenxioDailyCheckInChallenge {
+  const data = parseEnvelopeData(response, DENXIO_DAILY_CHECK_IN_BEGIN_ENDPOINT)
+  const token = typeof data.token === "string" ? data.token.trim() : ""
+  const waitSeconds = data.wait_seconds
+  if (
+    !token ||
+    typeof waitSeconds !== "number" ||
+    !Number.isFinite(waitSeconds) ||
+    waitSeconds < 0 ||
+    waitSeconds > MAX_CHALLENGE_WAIT_SECONDS
+  ) {
+    throw createInvalidResponseError(DENXIO_DAILY_CHECK_IN_BEGIN_ENDPOINT)
+  }
+
+  return { token, waitMilliseconds: Math.ceil(waitSeconds * 1_000) }
+}
+
+/** Parses the claim result and keeps only the product-relevant reward amount. */
+export function parseDenxioDailyCheckInClaimResponse(
+  response: ApiTransportResponse<unknown>,
+): { rewardAmount: number } {
+  const data = parseEnvelopeData(response, DENXIO_DAILY_CHECK_IN_CLAIM_ENDPOINT)
+  const record = toRecord(data.record)
+  if (typeof record?.amount !== "number" || !Number.isFinite(record.amount)) {
+    throw createInvalidResponseError(DENXIO_DAILY_CHECK_IN_CLAIM_ENDPOINT)
+  }
+  return { rewardAmount: record.amount }
+}
+
+const resolveTimezone = (): string => {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC"
+  } catch {
+    return "UTC"
+  }
+}
+
+const fetchStatusWithRequest = async (
+  request: ApiServiceRequest,
+  timezone: string,
+): Promise<DenxioDailyCheckInStatus> => {
+  const response = await fetchApiResponse<unknown>(request, {
+    endpoint: `${DENXIO_DAILY_CHECK_IN_STATUS_ENDPOINT}?timezone=${encodeURIComponent(timezone)}`,
+    options: { method: "GET", cache: "no-store" },
+  })
+  return parseDenxioDailyCheckInStatusResponse(response)
+}
+
+/** Reads status without turning a passive probe into browser-auth recovery. */
+export async function fetchDenxioDailyCheckInStatus(
+  request: ApiServiceRequest,
+): Promise<DenxioDailyCheckInStatus> {
+  const timezone = resolveTimezone()
+  return executeAuthenticatedSub2ApiRequest(
+    request,
+    DENXIO_DAILY_CHECK_IN_STATUS_ENDPOINT,
+    (authenticatedRequest) =>
+      fetchStatusWithRequest(authenticatedRequest, timezone),
+    { proactiveRefresh: false, recoverUnauthorized: false },
+  )
+}
+
+class DenxioRecoveredMutationBlockedError extends Error {
+  constructor(
+    public readonly result: Exclude<
+      DenxioDailyCheckInOperationResult,
+      { kind: typeof DENXIO_DAILY_CHECK_IN_RESULT_KINDS.Applied }
+    >,
+  ) {
+    super("Denxio recovered mutation blocked by status readback")
+    this.name = "DenxioRecoveredMutationBlockedError"
+  }
+}
+
+const defaultWait = (milliseconds: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, milliseconds))
+
+/**
+ * Executes the deployment's two-stage normal check-in. Only middleware-401
+ * recovery may replay a stage, and that replay is gated by fresh status and
+ * current account intent. Network-loss failures are left to outer uncertain
+ * reconciliation and never replayed here.
+ */
+export async function performDenxioDailyCheckIn(
+  request: ApiServiceRequest,
+  options: {
+    beforeRecoveredMutation?: () => Promise<boolean>
+    wait?: (milliseconds: number) => Promise<void>
+  } = {},
+): Promise<DenxioDailyCheckInOperationResult> {
+  const timezone = resolveTimezone()
+  const beforeUnauthorizedRetry = async (
+    recoveredRequest: ApiServiceRequest,
+  ) => {
+    const status = await fetchStatusWithRequest(
+      recoveredRequest,
+      timezone,
+    ).catch(() => {
+      throw new DenxioRecoveredMutationBlockedError({
+        kind: DENXIO_DAILY_CHECK_IN_RESULT_KINDS.RecoveryStatusUnavailable,
+      })
+    })
+    if (status.checkedInToday) {
+      throw new DenxioRecoveredMutationBlockedError({
+        kind: DENXIO_DAILY_CHECK_IN_RESULT_KINDS.AlreadyChecked,
+      })
+    }
+    if (!status.enabled) {
+      throw new DenxioRecoveredMutationBlockedError({
+        kind: DENXIO_DAILY_CHECK_IN_RESULT_KINDS.Disabled,
+      })
+    }
+    if (
+      options.beforeRecoveredMutation &&
+      !(await options.beforeRecoveredMutation())
+    ) {
+      throw new DenxioRecoveredMutationBlockedError({
+        kind: DENXIO_DAILY_CHECK_IN_RESULT_KINDS.RecoveryPreconditionFailed,
+      })
+    }
+    notifyApiTransportObserver(
+      recoveredRequest.observer,
+      "onPreHandlerUnauthorized",
+    )
+  }
+
+  try {
+    const beginSession = await executeAuthenticatedSub2ApiRequest(
+      request,
+      DENXIO_DAILY_CHECK_IN_BEGIN_ENDPOINT,
+      async (authenticatedRequest) => {
+        const response = await fetchApiResponse<unknown>(authenticatedRequest, {
+          endpoint: `${DENXIO_DAILY_CHECK_IN_BEGIN_ENDPOINT}?timezone=${encodeURIComponent(timezone)}`,
+          options: {
+            method: "POST",
+            cache: "no-store",
+            body: JSON.stringify({ timezone }),
+          },
+        })
+        return {
+          challenge: parseDenxioDailyCheckInBeginResponse(response),
+          request: authenticatedRequest,
+        }
+      },
+      { beforeUnauthorizedRetry },
+    )
+
+    await (options.wait ?? defaultWait)(beginSession.challenge.waitMilliseconds)
+    if (
+      options.beforeRecoveredMutation &&
+      !(await options.beforeRecoveredMutation())
+    ) {
+      return {
+        kind: DENXIO_DAILY_CHECK_IN_RESULT_KINDS.RecoveryPreconditionFailed,
+      }
+    }
+
+    // The begin response is complete evidence for stage one. Clear it before
+    // classifying any claim-stage transport failure.
+    notifyApiTransportObserver(
+      beginSession.request.observer,
+      "onPreHandlerUnauthorized",
+    )
+    const claim = await executeAuthenticatedSub2ApiRequest(
+      beginSession.request,
+      DENXIO_DAILY_CHECK_IN_CLAIM_ENDPOINT,
+      async (authenticatedRequest) => {
+        const response = await fetchApiResponse<unknown>(authenticatedRequest, {
+          endpoint: DENXIO_DAILY_CHECK_IN_CLAIM_ENDPOINT,
+          options: {
+            method: "POST",
+            cache: "no-store",
+            body: JSON.stringify({
+              token: beginSession.challenge.token,
+              timezone,
+            }),
+          },
+        })
+        return parseDenxioDailyCheckInClaimResponse(response)
+      },
+      { beforeUnauthorizedRetry },
+    )
+
+    return {
+      kind: DENXIO_DAILY_CHECK_IN_RESULT_KINDS.Applied,
+      rewardAmount: claim.rewardAmount,
+    }
+  } catch (error) {
+    if (error instanceof DenxioRecoveredMutationBlockedError) {
+      return error.result
+    }
+    throw error
+  }
+}

--- a/src/services/checkin/autoCheckin/providers/denxio.ts
+++ b/src/services/checkin/autoCheckin/providers/denxio.ts
@@ -1,0 +1,247 @@
+import {
+  CHECK_IN_METHOD_AVAILABILITIES,
+  CHECK_IN_METHOD_STATUS_EVIDENCE_SOURCES,
+  CHECK_IN_METHOD_STATUS_OUTCOMES,
+  CHECK_IN_METHOD_TODAY_STATUSES,
+  CHECK_IN_PROVIDER_READINESS_REASONS,
+} from "~/constants/checkIn"
+import { createAccountApiRequestFromStoredAccount } from "~/services/accounts/utils/apiServiceRequest"
+import {
+  getSub2ApiAuthPersistenceStatus,
+  SUB2API_AUTH_PERSISTENCE_STATUSES,
+} from "~/services/apiService/sub2api/authSession"
+import {
+  DENXIO_DAILY_CHECK_IN_ERROR_CODES,
+  DENXIO_DAILY_CHECK_IN_RESULT_KINDS,
+  fetchDenxioDailyCheckInStatus,
+  performDenxioDailyCheckIn,
+} from "~/services/apiService/sub2api/denxioCheckIn"
+import { getSafeErrorMessage } from "~/services/apiService/sub2api/redaction"
+import { ApiError } from "~/services/apiTransport/errors"
+import type { ApiServiceRequest } from "~/services/apiTransport/type"
+import {
+  AUTO_CHECKIN_ERROR_CATEGORIES,
+  classifyAutoCheckinError,
+} from "~/services/checkin/autoCheckin/errors"
+import { detectWithStatusReadback } from "~/services/checkin/autoCheckin/providers/detection"
+import { AUTO_CHECKIN_PROVIDER_FALLBACK_MESSAGE_KEYS } from "~/services/checkin/autoCheckin/providers/shared"
+import type { AutoCheckinProviderResult } from "~/services/checkin/autoCheckin/providers/types"
+import type { SiteAccount } from "~/types"
+import {
+  AUTO_CHECKIN_SKIP_REASON,
+  CHECKIN_RESULT_STATUS,
+} from "~/types/autoCheckin"
+import { normalizeTempWindowRequestSource } from "~/utils/browser/tempWindowRequestSource"
+
+import type {
+  AutoCheckinProvider,
+  AutoCheckinProviderContext,
+  AutoCheckinProviderReadContext,
+} from "./contracts"
+
+const hasText = (value: unknown): value is string =>
+  typeof value === "string" && value.trim().length > 0
+
+const createReadRequest = (
+  context: AutoCheckinProviderReadContext,
+): ApiServiceRequest => {
+  const request =
+    context.request ??
+    (context.account
+      ? createAccountApiRequestFromStoredAccount(context.account).request
+      : null)
+  if (!request) throw new Error("Sub2API account data is unavailable")
+  return {
+    ...request,
+    ...(context.signal ? { abortSignal: context.signal } : {}),
+  }
+}
+
+const createMutationRequest = (
+  account: SiteAccount,
+  context: AutoCheckinProviderContext,
+): ApiServiceRequest => ({
+  ...createAccountApiRequestFromStoredAccount(account).request,
+  tempWindowRequestSource: normalizeTempWindowRequestSource(
+    context.tempWindowRequestSource,
+  ),
+  protectionBypassExecution: context.protectionBypassExecution,
+  ...(context.mutationLifecycle ? { observer: context.mutationLifecycle } : {}),
+})
+
+const readStatus = async (context: AutoCheckinProviderReadContext) => {
+  const status = await fetchDenxioDailyCheckInStatus(createReadRequest(context))
+  return {
+    outcome: CHECK_IN_METHOD_STATUS_OUTCOMES.Known,
+    availability: status.enabled
+      ? CHECK_IN_METHOD_AVAILABILITIES.Enabled
+      : CHECK_IN_METHOD_AVAILABILITIES.Disabled,
+    today: status.checkedInToday
+      ? CHECK_IN_METHOD_TODAY_STATUSES.Checked
+      : CHECK_IN_METHOD_TODAY_STATUSES.NotChecked,
+    evidence: {
+      source: CHECK_IN_METHOD_STATUS_EVIDENCE_SOURCES.Probe,
+      observedAt: context.observedAt,
+    },
+  } as const
+}
+
+const failed = (
+  reasonCode: AutoCheckinProviderResult["reasonCode"],
+  retryable?: boolean,
+  rawMessage?: string,
+): AutoCheckinProviderResult => ({
+  status: CHECKIN_RESULT_STATUS.FAILED,
+  reasonCode,
+  ...(typeof retryable === "boolean" ? { retryable } : {}),
+  ...(rawMessage
+    ? { rawMessage }
+    : {
+        messageKey: AUTO_CHECKIN_PROVIDER_FALLBACK_MESSAGE_KEYS.checkinFailed,
+      }),
+})
+
+const mapMutationError = (
+  error: unknown,
+  context: AutoCheckinProviderContext,
+): AutoCheckinProviderResult => {
+  const persistenceStatus = getSub2ApiAuthPersistenceStatus(error)
+  if (
+    persistenceStatus === SUB2API_AUTH_PERSISTENCE_STATUSES.IDENTITY_MISMATCH
+  ) {
+    return failed(AUTO_CHECKIN_SKIP_REASON.AUTHENTICATION_REQUIRED, false)
+  }
+  if (persistenceStatus === SUB2API_AUTH_PERSISTENCE_STATUSES.ACCOUNT_MISSING) {
+    return failed(AUTO_CHECKIN_SKIP_REASON.ACCOUNT_UNAVAILABLE, false)
+  }
+  if (persistenceStatus === SUB2API_AUTH_PERSISTENCE_STATUSES.WRITE_FAILED) {
+    return failed(AUTO_CHECKIN_SKIP_REASON.STATUS_UNAVAILABLE, false)
+  }
+
+  if (error instanceof ApiError) {
+    if (
+      error.upstreamCode === DENXIO_DAILY_CHECK_IN_ERROR_CODES.AlreadyChecked
+    ) {
+      return {
+        status: CHECKIN_RESULT_STATUS.ALREADY_CHECKED,
+        rawMessage: getSafeErrorMessage(error),
+      }
+    }
+    if (error.upstreamCode === DENXIO_DAILY_CHECK_IN_ERROR_CODES.Disabled) {
+      return failed(
+        AUTO_CHECKIN_SKIP_REASON.METHOD_DISABLED,
+        false,
+        getSafeErrorMessage(error),
+      )
+    }
+    if (error.statusCode === 401) {
+      return failed(AUTO_CHECKIN_SKIP_REASON.AUTHENTICATION_REQUIRED)
+    }
+    if (error.statusCode === 404 || error.statusCode === 405) {
+      return failed(AUTO_CHECKIN_SKIP_REASON.METHOD_UNSUPPORTED, false)
+    }
+    if (
+      error.upstreamCode === DENXIO_DAILY_CHECK_IN_ERROR_CODES.NoSponsor ||
+      error.upstreamCode === DENXIO_DAILY_CHECK_IN_ERROR_CODES.SessionInvalid ||
+      error.upstreamCode === DENXIO_DAILY_CHECK_IN_ERROR_CODES.SessionPending
+    ) {
+      return failed(
+        AUTO_CHECKIN_SKIP_REASON.STATUS_UNAVAILABLE,
+        false,
+        getSafeErrorMessage(error),
+      )
+    }
+  }
+
+  if (context.mutationLifecycle?.dispatched) {
+    return {
+      status: CHECKIN_RESULT_STATUS.UNCERTAIN,
+      messageKey: AUTO_CHECKIN_PROVIDER_FALLBACK_MESSAGE_KEYS.unknownError,
+    }
+  }
+
+  switch (classifyAutoCheckinError(error)) {
+    case AUTO_CHECKIN_ERROR_CATEGORIES.AuthenticationRequired:
+      return failed(AUTO_CHECKIN_SKIP_REASON.AUTHENTICATION_REQUIRED)
+    case AUTO_CHECKIN_ERROR_CATEGORIES.PermissionDenied:
+      return failed(AUTO_CHECKIN_SKIP_REASON.PERMISSION_DENIED)
+    case AUTO_CHECKIN_ERROR_CATEGORIES.Network:
+      return failed(AUTO_CHECKIN_SKIP_REASON.NETWORK_ERROR)
+    case AUTO_CHECKIN_ERROR_CATEGORIES.Timeout:
+      return failed(AUTO_CHECKIN_SKIP_REASON.TIMEOUT)
+    case AUTO_CHECKIN_ERROR_CATEGORIES.SourceUnavailable:
+      return failed(AUTO_CHECKIN_SKIP_REASON.SOURCE_UNAVAILABLE)
+    default:
+      return failed(AUTO_CHECKIN_SKIP_REASON.STATUS_UNAVAILABLE)
+  }
+}
+
+export const denxioProvider: AutoCheckinProvider = {
+  requiresAuthoritativeStatusBeforeMutation: true,
+
+  getReadiness(account) {
+    if (
+      !hasText(account.id) ||
+      !hasText(account.site_url) ||
+      !hasText(account.account_info?.id)
+    ) {
+      return {
+        ready: false,
+        reason: CHECK_IN_PROVIDER_READINESS_REASONS.AccountDataMissing,
+      }
+    }
+    if (!hasText(account.account_info?.access_token)) {
+      return {
+        ready: false,
+        reason: CHECK_IN_PROVIDER_READINESS_REASONS.CredentialsMissing,
+      }
+    }
+    return { ready: true }
+  },
+
+  detect(context) {
+    return detectWithStatusReadback(context, readStatus)
+  },
+
+  getStatus: readStatus,
+
+  async checkIn(account, context) {
+    const status = context.statusProof
+    if (
+      status?.availability !== CHECK_IN_METHOD_AVAILABILITIES.Enabled ||
+      status.today !== CHECK_IN_METHOD_TODAY_STATUSES.NotChecked
+    ) {
+      return failed(AUTO_CHECKIN_SKIP_REASON.STATUS_UNAVAILABLE)
+    }
+
+    try {
+      const result = await performDenxioDailyCheckIn(
+        createMutationRequest(account as SiteAccount, context),
+        { beforeRecoveredMutation: context.beforeRecoveredMutation },
+      )
+      switch (result.kind) {
+        case DENXIO_DAILY_CHECK_IN_RESULT_KINDS.Applied:
+          return {
+            status: CHECKIN_RESULT_STATUS.SUCCESS,
+            messageKey:
+              AUTO_CHECKIN_PROVIDER_FALLBACK_MESSAGE_KEYS.checkinSuccessful,
+            data: { rewardAmount: result.rewardAmount },
+          }
+        case DENXIO_DAILY_CHECK_IN_RESULT_KINDS.AlreadyChecked:
+          return {
+            status: CHECKIN_RESULT_STATUS.ALREADY_CHECKED,
+            messageKey:
+              AUTO_CHECKIN_PROVIDER_FALLBACK_MESSAGE_KEYS.alreadyCheckedToday,
+          }
+        case DENXIO_DAILY_CHECK_IN_RESULT_KINDS.Disabled:
+          return failed(AUTO_CHECKIN_SKIP_REASON.METHOD_DISABLED, false)
+        case DENXIO_DAILY_CHECK_IN_RESULT_KINDS.RecoveryStatusUnavailable:
+          return failed(AUTO_CHECKIN_SKIP_REASON.STATUS_UNAVAILABLE, false)
+        case DENXIO_DAILY_CHECK_IN_RESULT_KINDS.RecoveryPreconditionFailed:
+          return failed(AUTO_CHECKIN_SKIP_REASON.ACCOUNT_UNAVAILABLE, false)
+      }
+    } catch (error) {
+      return mapMutationError(error, context)
+    }
+  },
+}

--- a/src/services/checkin/autoCheckin/providers/index.ts
+++ b/src/services/checkin/autoCheckin/providers/index.ts
@@ -6,6 +6,7 @@ import type { CheckInMethodId } from "~/types/checkIn"
 
 import { anyrouterProvider } from "./anyrouter"
 import type { AutoCheckinProvider } from "./contracts"
+import { denxioProvider } from "./denxio"
 import {
   AUTO_CHECKIN_METHOD_DEFINITIONS,
   createAutoCheckinMethodRegistry,
@@ -20,6 +21,7 @@ const PROVIDER_BY_METHOD_ID = {
   [AUTO_CHECKIN_METHOD_IDS.NewApiDailyCheckIn]: newApiProvider,
   [AUTO_CHECKIN_METHOD_IDS.VoApiV2DailyCheckIn]: voApiV2Provider,
   [AUTO_CHECKIN_METHOD_IDS.Sub2ApiProDailyCheckIn]: sub2apiProProvider,
+  [AUTO_CHECKIN_METHOD_IDS.DenxioDailyCheckIn]: denxioProvider,
 } as const satisfies Record<CheckInMethodId, AutoCheckinProvider>
 
 export const autoCheckinMethodRegistry = createAutoCheckinMethodRegistry(

--- a/src/services/checkin/autoCheckin/providers/registry.ts
+++ b/src/services/checkin/autoCheckin/providers/registry.ts
@@ -206,6 +206,16 @@ export const AUTO_CHECKIN_METHOD_DEFINITIONS = {
     legacy: false,
     newAccountCompatibility: false,
   },
+  [AUTO_CHECKIN_METHOD_IDS.DenxioDailyCheckIn]: {
+    id: AUTO_CHECKIN_METHOD_IDS.DenxioDailyCheckIn,
+    siteTypes: [SITE_TYPES.SUB2API],
+    source: {
+      kind: AUTO_CHECKIN_METHOD_SOURCE_KINDS.ThirdParty,
+      sourceName: "登仙公益站",
+    },
+    legacy: false,
+    newAccountCompatibility: false,
+  },
 } as const satisfies Record<CheckInMethodId, AutoCheckinMethodDefinition>
 
 /** Returns the product source used to present a registered method. */

--- a/src/services/productAnalytics/autoCheckin.ts
+++ b/src/services/productAnalytics/autoCheckin.ts
@@ -139,6 +139,8 @@ const AUTO_CHECKIN_METHOD_CATEGORY_BY_ID = {
     PRODUCT_ANALYTICS_AUTO_CHECKIN_METHOD_CATEGORIES.Compatibility,
   [AUTO_CHECKIN_METHOD_IDS.Sub2ApiProDailyCheckIn]:
     PRODUCT_ANALYTICS_AUTO_CHECKIN_METHOD_CATEGORIES.StrictReadback,
+  [AUTO_CHECKIN_METHOD_IDS.DenxioDailyCheckIn]:
+    PRODUCT_ANALYTICS_AUTO_CHECKIN_METHOD_CATEGORIES.StrictReadback,
 } as const satisfies Record<
   CheckInMethodId,
   ProductAnalyticsAutoCheckinMethodCategory

--- a/tests/services/apiService/sub2api/denxioCheckIn.test.ts
+++ b/tests/services/apiService/sub2api/denxioCheckIn.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  DENXIO_DAILY_CHECK_IN_BEGIN_ENDPOINT,
+  DENXIO_DAILY_CHECK_IN_CLAIM_ENDPOINT,
+  DENXIO_DAILY_CHECK_IN_ERROR_CODES,
+  DENXIO_DAILY_CHECK_IN_STATUS_ENDPOINT,
+  parseDenxioDailyCheckInBeginResponse,
+  parseDenxioDailyCheckInClaimResponse,
+  parseDenxioDailyCheckInStatusResponse,
+} from "~/services/apiService/sub2api/denxioCheckIn"
+import { API_ERROR_CODES, type ApiError } from "~/services/apiTransport/errors"
+import type { ApiTransportResponse } from "~/services/apiTransport/type"
+
+const response = (
+  status: number,
+  body: unknown,
+): ApiTransportResponse<unknown> => ({
+  ok: status >= 200 && status < 300,
+  status,
+  headers: { "content-type": "application/json" },
+  body,
+})
+
+describe("Denxio daily check-in protocol parsing", () => {
+  it("projects the observed status envelope to the safe status contract", () => {
+    expect(
+      parseDenxioDailyCheckInStatusResponse(
+        response(200, {
+          code: 0,
+          message: "success",
+          data: {
+            today: "2026-09-04",
+            normal_done: false,
+            ad_done: false,
+            makeup_done: false,
+            recent_records: [],
+            config: {
+              normal_checkin_enabled: true,
+              ad_checkin_enabled: false,
+              ad_makeup_enabled: false,
+            },
+          },
+        }),
+      ),
+    ).toEqual({ enabled: true, checkedInToday: false })
+  })
+
+  it.each([
+    ["missing normal status", { config: { normal_checkin_enabled: true } }],
+    ["missing config", { normal_done: false }],
+    [
+      "non-boolean availability",
+      { normal_done: false, config: { normal_checkin_enabled: 1 } },
+    ],
+  ])("rejects status data with %s", (_name, data) => {
+    expect(() =>
+      parseDenxioDailyCheckInStatusResponse(
+        response(200, { code: 0, message: "success", data }),
+      ),
+    ).toThrowError(
+      expect.objectContaining({
+        code: API_ERROR_CODES.JSON_PARSE_ERROR,
+        endpoint: DENXIO_DAILY_CHECK_IN_STATUS_ENDPOINT,
+      }),
+    )
+  })
+
+  it("classifies a malformed success envelope as an invalid response", () => {
+    expect(() =>
+      parseDenxioDailyCheckInStatusResponse(
+        response(200, { message: "success", data: {} }),
+      ),
+    ).toThrowError(
+      expect.objectContaining({
+        code: API_ERROR_CODES.JSON_PARSE_ERROR,
+        endpoint: DENXIO_DAILY_CHECK_IN_STATUS_ENDPOINT,
+      }),
+    )
+  })
+
+  it("parses a bounded begin challenge without exposing sponsor data", () => {
+    expect(
+      parseDenxioDailyCheckInBeginResponse(
+        response(200, {
+          code: 0,
+          message: "success",
+          data: {
+            token: "one-time-challenge",
+            wait_seconds: 3,
+            available_at: "2026-09-04T07:00:00Z",
+            sponsor: { name: "Example Sponsor" },
+            no_sponsor_mode: false,
+            exposure_cost: 1,
+          },
+        }),
+      ),
+    ).toEqual({ token: "one-time-challenge", waitMilliseconds: 3_000 })
+  })
+
+  it.each([-1, 60.1, Number.NaN])(
+    "rejects an unsafe begin wait of %s seconds",
+    (waitSeconds) => {
+      expect(() =>
+        parseDenxioDailyCheckInBeginResponse(
+          response(200, {
+            code: 0,
+            message: "success",
+            data: { token: "one-time-challenge", wait_seconds: waitSeconds },
+          }),
+        ),
+      ).toThrowError(
+        expect.objectContaining({
+          code: API_ERROR_CODES.JSON_PARSE_ERROR,
+          endpoint: DENXIO_DAILY_CHECK_IN_BEGIN_ENDPOINT,
+        }),
+      )
+    },
+  )
+
+  it("accepts the observed claim record and retains only the reward amount", () => {
+    expect(
+      parseDenxioDailyCheckInClaimResponse(
+        response(200, {
+          code: 0,
+          message: "success",
+          data: {
+            record: {
+              id: 123,
+              amount: 0.5,
+              checkin_type: "normal",
+            },
+          },
+        }),
+      ),
+    ).toEqual({ rewardAmount: 0.5 })
+  })
+
+  it("preserves stable deployment error codes for provider policy", () => {
+    expect(() =>
+      parseDenxioDailyCheckInClaimResponse(
+        response(409, {
+          code: DENXIO_DAILY_CHECK_IN_ERROR_CODES.AlreadyChecked,
+          message: "already checked",
+        }),
+      ),
+    ).toThrowError(
+      expect.objectContaining({
+        statusCode: 409,
+        endpoint: DENXIO_DAILY_CHECK_IN_CLAIM_ENDPOINT,
+        upstreamCode: DENXIO_DAILY_CHECK_IN_ERROR_CODES.AlreadyChecked,
+      } satisfies Partial<ApiError>),
+    )
+  })
+
+  it("preserves HTTP diagnostics when an upstream failure has no envelope", () => {
+    expect(() =>
+      parseDenxioDailyCheckInClaimResponse(response(503, null)),
+    ).toThrowError(
+      expect.objectContaining({
+        statusCode: 503,
+        code: API_ERROR_CODES.HTTP_OTHER,
+        endpoint: DENXIO_DAILY_CHECK_IN_CLAIM_ENDPOINT,
+      } satisfies Partial<ApiError>),
+    )
+  })
+
+  it("rejects an HTTP success carrying a failure code", () => {
+    expect(() =>
+      parseDenxioDailyCheckInBeginResponse(
+        response(200, {
+          code: DENXIO_DAILY_CHECK_IN_ERROR_CODES.SessionPending,
+          message: "pending",
+        }),
+      ),
+    ).toThrowError(
+      expect.objectContaining({
+        code: API_ERROR_CODES.BUSINESS_ERROR,
+        endpoint: DENXIO_DAILY_CHECK_IN_BEGIN_ENDPOINT,
+        upstreamCode: DENXIO_DAILY_CHECK_IN_ERROR_CODES.SessionPending,
+      }),
+    )
+  })
+})

--- a/tests/services/apiService/sub2api/denxioCheckIn.test.ts
+++ b/tests/services/apiService/sub2api/denxioCheckIn.test.ts
@@ -79,6 +79,17 @@ describe("Denxio daily check-in protocol parsing", () => {
     )
   })
 
+  it("rejects a scalar success body as an invalid response", () => {
+    expect(() =>
+      parseDenxioDailyCheckInStatusResponse(response(200, null)),
+    ).toThrowError(
+      expect.objectContaining({
+        code: API_ERROR_CODES.JSON_PARSE_ERROR,
+        endpoint: DENXIO_DAILY_CHECK_IN_STATUS_ENDPOINT,
+      }),
+    )
+  })
+
   it("parses a bounded begin challenge without exposing sponsor data", () => {
     expect(
       parseDenxioDailyCheckInBeginResponse(
@@ -162,6 +173,37 @@ describe("Denxio daily check-in protocol parsing", () => {
         code: API_ERROR_CODES.HTTP_OTHER,
         endpoint: DENXIO_DAILY_CHECK_IN_CLAIM_ENDPOINT,
       } satisfies Partial<ApiError>),
+    )
+  })
+
+  it("uses a local fallback when an error envelope has a blank message", () => {
+    expect(() =>
+      parseDenxioDailyCheckInClaimResponse(
+        response(503, { code: 503, message: " " }),
+      ),
+    ).toThrowError(
+      expect.objectContaining({
+        message: "Denxio daily check-in request failed with HTTP 503",
+        statusCode: 503,
+        endpoint: DENXIO_DAILY_CHECK_IN_CLAIM_ENDPOINT,
+      }),
+    )
+  })
+
+  it("rejects a claim without a finite reward amount", () => {
+    expect(() =>
+      parseDenxioDailyCheckInClaimResponse(
+        response(200, {
+          code: 0,
+          message: "success",
+          data: { record: { amount: Number.NaN } },
+        }),
+      ),
+    ).toThrowError(
+      expect.objectContaining({
+        code: API_ERROR_CODES.JSON_PARSE_ERROR,
+        endpoint: DENXIO_DAILY_CHECK_IN_CLAIM_ENDPOINT,
+      }),
     )
   })
 

--- a/tests/services/apiService/sub2api/denxioCheckInTransport.test.ts
+++ b/tests/services/apiService/sub2api/denxioCheckInTransport.test.ts
@@ -1,0 +1,378 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { ACCOUNT_BROWSER_SESSION_SOURCES } from "~/services/accountBrowserSession/types"
+import {
+  SUB2API_AUTH_PERSISTENCE_STATUSES,
+  type Sub2ApiAuthSessionRequest,
+} from "~/services/apiService/sub2api/authSession"
+import { recoverSub2ApiBrowserAuth as resyncSub2ApiAuthToken } from "~/services/apiService/sub2api/browserAuth"
+import {
+  DENXIO_DAILY_CHECK_IN_BEGIN_ENDPOINT,
+  DENXIO_DAILY_CHECK_IN_CLAIM_ENDPOINT,
+  DENXIO_DAILY_CHECK_IN_STATUS_ENDPOINT,
+  fetchDenxioDailyCheckInStatus,
+  performDenxioDailyCheckIn,
+} from "~/services/apiService/sub2api/denxioCheckIn"
+import {
+  fetchApiResponse,
+  notifyApiTransportObserver,
+} from "~/services/apiTransport/request"
+import type { ApiTransportResponse } from "~/services/apiTransport/type"
+import { AuthTypeEnum } from "~/types"
+import { TEMP_WINDOW_REQUEST_SOURCES } from "~/types/tempWindowFetch"
+
+const { getLatestAuth, persistAuthUpdate } = vi.hoisted(() => ({
+  getLatestAuth: vi.fn(),
+  persistAuthUpdate: vi.fn(),
+}))
+
+vi.mock("~/services/apiTransport/request", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("~/services/apiTransport/request")>()),
+  fetchApiResponse: vi.fn(),
+  notifyApiTransportObserver: vi.fn(),
+}))
+
+vi.mock("~/services/apiService/sub2api/browserAuth", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("~/services/apiService/sub2api/browserAuth")
+    >()
+  return {
+    ...actual,
+    recoverSub2ApiBrowserAuth: vi.fn(),
+  }
+})
+
+const response = (
+  status: number,
+  body: unknown,
+): ApiTransportResponse<unknown> => ({
+  ok: status >= 200 && status < 300,
+  status,
+  headers: { "content-type": "application/json" },
+  body,
+})
+
+const statusBody = (checkedInToday = false, enabled = true) => ({
+  code: 0,
+  message: "success",
+  data: {
+    normal_done: checkedInToday,
+    config: { normal_checkin_enabled: enabled },
+  },
+})
+
+const beginBody = {
+  code: 0,
+  message: "success",
+  data: { token: "one-time-challenge", wait_seconds: 3 },
+}
+
+const claimBody = {
+  code: 0,
+  message: "success",
+  data: { record: { amount: 0.5 } },
+}
+
+const createRequest = (): Sub2ApiAuthSessionRequest => ({
+  baseUrl: "https://checkin.example.invalid",
+  accountId: "account-1",
+  auth: {
+    authType: AuthTypeEnum.AccessToken,
+    userId: "42",
+    accessToken: "example-access-token",
+  },
+  tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Background,
+  sub2apiAuthSession: { getLatestAuth, persistAuthUpdate },
+})
+
+describe("Denxio daily check-in authenticated transport", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(fetchApiResponse).mockReset()
+    vi.mocked(resyncSub2ApiAuthToken).mockReset()
+    getLatestAuth.mockResolvedValue(null)
+    persistAuthUpdate.mockResolvedValue({
+      status: SUB2API_AUTH_PERSISTENCE_STATUSES.PERSISTED,
+    })
+  })
+
+  it("uses a passive authenticated GET for status detection", async () => {
+    vi.mocked(fetchApiResponse).mockResolvedValue(response(200, statusBody()))
+
+    await expect(
+      fetchDenxioDailyCheckInStatus(createRequest()),
+    ).resolves.toEqual({ enabled: true, checkedInToday: false })
+
+    expect(fetchApiResponse).toHaveBeenCalledWith(
+      expect.objectContaining({
+        auth: expect.objectContaining({ accessToken: "example-access-token" }),
+      }),
+      {
+        endpoint: expect.stringMatching(
+          new RegExp(`^${DENXIO_DAILY_CHECK_IN_STATUS_ENDPOINT}\\?timezone=`),
+        ),
+        options: { method: "GET", cache: "no-store" },
+      },
+    )
+  })
+
+  it("does not recover a passive status 401 through browser auth", async () => {
+    vi.mocked(fetchApiResponse).mockResolvedValue(
+      response(401, { code: 401, message: "unauthorized" }),
+    )
+
+    await expect(
+      fetchDenxioDailyCheckInStatus(createRequest()),
+    ).rejects.toMatchObject({ statusCode: 401 })
+
+    expect(fetchApiResponse).toHaveBeenCalledOnce()
+    expect(resyncSub2ApiAuthToken).not.toHaveBeenCalled()
+    expect(persistAuthUpdate).not.toHaveBeenCalled()
+  })
+
+  it("runs begin, waits for the challenge, and claims with the same timezone", async () => {
+    vi.mocked(fetchApiResponse)
+      .mockResolvedValueOnce(response(200, beginBody))
+      .mockResolvedValueOnce(response(200, claimBody))
+    const wait = vi.fn(async () => {})
+    const beforeRecoveredMutation = vi.fn(async () => true)
+    const observer = {
+      onDispatch: vi.fn(),
+      onResponse: vi.fn(),
+      onPreHandlerUnauthorized: vi.fn(),
+    }
+
+    await expect(
+      performDenxioDailyCheckIn(
+        { ...createRequest(), observer },
+        {
+          wait,
+          beforeRecoveredMutation,
+        },
+      ),
+    ).resolves.toEqual({ kind: "applied", rewardAmount: 0.5 })
+
+    expect(wait).toHaveBeenCalledWith(3_000)
+    expect(beforeRecoveredMutation).toHaveBeenCalledOnce()
+    expect(fetchApiResponse).toHaveBeenCalledTimes(2)
+    const [, beginOptions] = vi.mocked(fetchApiResponse).mock.calls[0]!
+    const [, claimOptions] = vi.mocked(fetchApiResponse).mock.calls[1]!
+    expect(beginOptions.endpoint).toMatch(
+      new RegExp(`^${DENXIO_DAILY_CHECK_IN_BEGIN_ENDPOINT}\\?timezone=`),
+    )
+    expect(beginOptions.options).toMatchObject({ method: "POST" })
+    expect(claimOptions.endpoint).toBe(DENXIO_DAILY_CHECK_IN_CLAIM_ENDPOINT)
+    expect(claimOptions.options).toMatchObject({ method: "POST" })
+
+    const beginPayload = JSON.parse(String(beginOptions.options?.body))
+    const claimPayload = JSON.parse(String(claimOptions.options?.body))
+    expect(beginPayload.timezone).toBeTypeOf("string")
+    expect(claimPayload).toEqual({
+      token: "one-time-challenge",
+      timezone: beginPayload.timezone,
+    })
+    expect(notifyApiTransportObserver).toHaveBeenCalledOnce()
+    expect(notifyApiTransportObserver).toHaveBeenCalledWith(
+      observer,
+      "onPreHandlerUnauthorized",
+    )
+  })
+
+  it("persists recovered auth before status recheck and one recovered begin", async () => {
+    const order: string[] = []
+    vi.mocked(resyncSub2ApiAuthToken).mockImplementation(async () => {
+      order.push("resync")
+      return {
+        accessToken: "recovered-access-token",
+        userId: "42",
+        source: ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB,
+      }
+    })
+    persistAuthUpdate.mockImplementation(async () => {
+      order.push("persist")
+      return { status: SUB2API_AUTH_PERSISTENCE_STATUSES.PERSISTED }
+    })
+    vi.mocked(fetchApiResponse).mockImplementation(async (request, options) => {
+      const method = options.options?.method ?? "GET"
+      const token = request.auth.accessToken
+      const endpoint = options.endpoint.split("?")[0]
+      order.push(`${method}:${endpoint}:${token}`)
+      if (
+        endpoint === DENXIO_DAILY_CHECK_IN_BEGIN_ENDPOINT &&
+        token === "example-access-token"
+      ) {
+        return response(401, { code: 401, message: "unauthorized" })
+      }
+      if (endpoint === DENXIO_DAILY_CHECK_IN_STATUS_ENDPOINT) {
+        return response(200, statusBody())
+      }
+      if (endpoint === DENXIO_DAILY_CHECK_IN_BEGIN_ENDPOINT) {
+        return response(200, beginBody)
+      }
+      return response(200, claimBody)
+    })
+
+    await expect(
+      performDenxioDailyCheckIn(createRequest(), { wait: async () => {} }),
+    ).resolves.toEqual({ kind: "applied", rewardAmount: 0.5 })
+
+    expect(order).toEqual([
+      `POST:${DENXIO_DAILY_CHECK_IN_BEGIN_ENDPOINT}:example-access-token`,
+      "resync",
+      "persist",
+      `GET:${DENXIO_DAILY_CHECK_IN_STATUS_ENDPOINT}:recovered-access-token`,
+      `POST:${DENXIO_DAILY_CHECK_IN_BEGIN_ENDPOINT}:recovered-access-token`,
+      `POST:${DENXIO_DAILY_CHECK_IN_CLAIM_ENDPOINT}:recovered-access-token`,
+    ])
+    expect(resyncSub2ApiAuthToken).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseUrl: "https://checkin.example.invalid",
+        expectedUserId: "42",
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Background,
+      }),
+    )
+  })
+
+  it("rechecks status and retries only claim after claim-stage auth recovery", async () => {
+    const order: string[] = []
+    vi.mocked(resyncSub2ApiAuthToken).mockImplementation(async () => {
+      order.push("resync")
+      return {
+        accessToken: "recovered-access-token",
+        userId: "42",
+        source: ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB,
+      }
+    })
+    persistAuthUpdate.mockImplementation(async () => {
+      order.push("persist")
+      return { status: SUB2API_AUTH_PERSISTENCE_STATUSES.PERSISTED }
+    })
+    vi.mocked(fetchApiResponse).mockImplementation(async (request, options) => {
+      const method = options.options?.method ?? "GET"
+      const token = request.auth.accessToken
+      const endpoint = options.endpoint.split("?")[0]
+      order.push(`${method}:${endpoint}:${token}`)
+      if (
+        endpoint === DENXIO_DAILY_CHECK_IN_CLAIM_ENDPOINT &&
+        token === "example-access-token"
+      ) {
+        return response(401, { code: 401, message: "unauthorized" })
+      }
+      if (endpoint === DENXIO_DAILY_CHECK_IN_STATUS_ENDPOINT) {
+        return response(200, statusBody())
+      }
+      if (endpoint === DENXIO_DAILY_CHECK_IN_BEGIN_ENDPOINT) {
+        return response(200, beginBody)
+      }
+      return response(200, claimBody)
+    })
+
+    await expect(
+      performDenxioDailyCheckIn(createRequest(), { wait: async () => {} }),
+    ).resolves.toEqual({ kind: "applied", rewardAmount: 0.5 })
+
+    expect(order).toEqual([
+      `POST:${DENXIO_DAILY_CHECK_IN_BEGIN_ENDPOINT}:example-access-token`,
+      `POST:${DENXIO_DAILY_CHECK_IN_CLAIM_ENDPOINT}:example-access-token`,
+      "resync",
+      "persist",
+      `GET:${DENXIO_DAILY_CHECK_IN_STATUS_ENDPOINT}:recovered-access-token`,
+      `POST:${DENXIO_DAILY_CHECK_IN_CLAIM_ENDPOINT}:recovered-access-token`,
+    ])
+    expect(
+      vi
+        .mocked(fetchApiResponse)
+        .mock.calls.filter(([, options]) =>
+          options.endpoint.startsWith(DENXIO_DAILY_CHECK_IN_BEGIN_ENDPOINT),
+        ),
+    ).toHaveLength(1)
+  })
+
+  it.each([
+    [statusBody(true), "already_checked"],
+    [statusBody(false, false), "disabled"],
+  ] as const)(
+    "does not recover begin when the fresh status resolves to %s",
+    async (freshStatus, expectedKind) => {
+      vi.mocked(resyncSub2ApiAuthToken).mockResolvedValue({
+        accessToken: "recovered-access-token",
+        userId: "42",
+        source: ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB,
+      })
+      vi.mocked(fetchApiResponse)
+        .mockResolvedValueOnce(
+          response(401, { code: 401, message: "unauthorized" }),
+        )
+        .mockResolvedValueOnce(response(200, freshStatus))
+
+      await expect(
+        performDenxioDailyCheckIn(createRequest(), { wait: async () => {} }),
+      ).resolves.toEqual({ kind: expectedKind })
+      expect(fetchApiResponse).toHaveBeenCalledTimes(2)
+    },
+  )
+
+  it("keeps a failed recovered status read out of mutation uncertainty", async () => {
+    vi.mocked(resyncSub2ApiAuthToken).mockResolvedValue({
+      accessToken: "recovered-access-token",
+      userId: "42",
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB,
+    })
+    vi.mocked(fetchApiResponse)
+      .mockResolvedValueOnce(
+        response(401, { code: 401, message: "unauthorized" }),
+      )
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+
+    await expect(
+      performDenxioDailyCheckIn(createRequest(), { wait: async () => {} }),
+    ).resolves.toEqual({ kind: "recovery_status_unavailable" })
+    expect(fetchApiResponse).toHaveBeenCalledTimes(2)
+  })
+
+  it("revalidates account intent before a recovered begin", async () => {
+    vi.mocked(resyncSub2ApiAuthToken).mockResolvedValue({
+      accessToken: "recovered-access-token",
+      userId: "42",
+      source: ACCOUNT_BROWSER_SESSION_SOURCES.EXISTING_TAB,
+    })
+    vi.mocked(fetchApiResponse)
+      .mockResolvedValueOnce(
+        response(401, { code: 401, message: "unauthorized" }),
+      )
+      .mockResolvedValueOnce(response(200, statusBody()))
+
+    await expect(
+      performDenxioDailyCheckIn(createRequest(), {
+        wait: async () => {},
+        beforeRecoveredMutation: async () => false,
+      }),
+    ).resolves.toEqual({ kind: "recovery_precondition_failed" })
+    expect(fetchApiResponse).toHaveBeenCalledTimes(2)
+  })
+
+  it("stops after begin when the saved account is no longer eligible", async () => {
+    vi.mocked(fetchApiResponse).mockResolvedValue(response(200, beginBody))
+
+    await expect(
+      performDenxioDailyCheckIn(createRequest(), {
+        wait: async () => {},
+        beforeRecoveredMutation: async () => false,
+      }),
+    ).resolves.toEqual({ kind: "recovery_precondition_failed" })
+
+    expect(fetchApiResponse).toHaveBeenCalledOnce()
+  })
+
+  it("does not replay a claim after a transport response is lost", async () => {
+    vi.mocked(fetchApiResponse)
+      .mockResolvedValueOnce(response(200, beginBody))
+      .mockRejectedValueOnce(new TypeError("Failed to fetch"))
+
+    await expect(
+      performDenxioDailyCheckIn(createRequest(), { wait: async () => {} }),
+    ).rejects.toBeInstanceOf(TypeError)
+    expect(fetchApiResponse).toHaveBeenCalledTimes(2)
+  })
+})

--- a/tests/services/apiService/sub2api/denxioCheckInTransport.test.ts
+++ b/tests/services/apiService/sub2api/denxioCheckInTransport.test.ts
@@ -117,6 +117,29 @@ describe("Denxio daily check-in authenticated transport", () => {
     )
   })
 
+  it("falls back to UTC when the runtime timezone is unavailable", async () => {
+    const dateTimeFormat = vi
+      .spyOn(Intl, "DateTimeFormat")
+      .mockImplementation(() => {
+        throw new Error("timezone unavailable")
+      })
+    vi.mocked(fetchApiResponse).mockResolvedValue(response(200, statusBody()))
+
+    try {
+      await expect(
+        fetchDenxioDailyCheckInStatus(createRequest()),
+      ).resolves.toEqual({ enabled: true, checkedInToday: false })
+      expect(fetchApiResponse).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          endpoint: `${DENXIO_DAILY_CHECK_IN_STATUS_ENDPOINT}?timezone=UTC`,
+        }),
+      )
+    } finally {
+      dateTimeFormat.mockRestore()
+    }
+  })
+
   it("does not recover a passive status 401 through browser auth", async () => {
     vi.mocked(fetchApiResponse).mockResolvedValue(
       response(401, { code: 401, message: "unauthorized" }),
@@ -177,6 +200,24 @@ describe("Denxio daily check-in authenticated transport", () => {
       observer,
       "onPreHandlerUnauthorized",
     )
+  })
+
+  it("uses the default short challenge delay when no wait override is supplied", async () => {
+    vi.useFakeTimers()
+    vi.mocked(fetchApiResponse)
+      .mockResolvedValueOnce(response(200, beginBody))
+      .mockResolvedValueOnce(response(200, claimBody))
+
+    try {
+      const result = performDenxioDailyCheckIn(createRequest())
+      await vi.advanceTimersByTimeAsync(3_000)
+      await expect(result).resolves.toEqual({
+        kind: "applied",
+        rewardAmount: 0.5,
+      })
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it("persists recovered auth before status recheck and one recovered begin", async () => {

--- a/tests/services/autoCheckin/providers/denxio.test.ts
+++ b/tests/services/autoCheckin/providers/denxio.test.ts
@@ -7,6 +7,7 @@ import {
 } from "~/constants/checkIn"
 import { SITE_TYPES } from "~/services/accountSiteDefinitions/identifiers"
 import { fetchSub2ApiProDailyCheckInStatus } from "~/services/apiService/sub2api"
+import { SUB2API_AUTH_PERSISTENCE_STATUSES } from "~/services/apiService/sub2api/authSession"
 import {
   DENXIO_DAILY_CHECK_IN_ERROR_CODES,
   fetchDenxioDailyCheckInStatus,
@@ -94,12 +95,33 @@ describe("Denxio daily check-in method Adapter", () => {
 
   it("requires a persisted Sub2API access token", () => {
     const account = createAccount()
+    expect(denxioProvider.getReadiness(account)).toEqual({ ready: true })
     account.account_info.access_token = ""
 
     expect(denxioProvider.getReadiness(account)).toEqual({
       ready: false,
       reason: "credentials_missing",
     })
+  })
+
+  it.each(["id", "site_url", "account_info.id"] as const)(
+    "requires persisted account data: %s",
+    (field) => {
+      const account = createAccount()
+      if (field === "account_info.id") account.account_info.id = ""
+      else account[field] = ""
+
+      expect(denxioProvider.getReadiness(account)).toEqual({
+        ready: false,
+        reason: "account_data_missing",
+      })
+    },
+  )
+
+  it("rejects a status read without account or request data", async () => {
+    await expect(
+      denxioProvider.getStatus?.({ observedAt: 300 }),
+    ).rejects.toThrow("Sub2API account data is unavailable")
   })
 
   it("maps the deployment status to canonical discovery evidence", async () => {
@@ -118,6 +140,26 @@ describe("Denxio daily check-in method Adapter", () => {
       },
     })
   })
+
+  it.each([
+    [false, false, "disabled", "not_checked"],
+    [true, true, "enabled", "checked"],
+  ] as const)(
+    "maps enabled=%s and checked=%s status evidence",
+    async (enabled, checkedInToday, availability, today) => {
+      vi.mocked(fetchDenxioDailyCheckInStatus).mockResolvedValue({
+        enabled,
+        checkedInToday,
+      })
+
+      await expect(
+        denxioProvider.getStatus?.({
+          account: createAccount(),
+          observedAt: 300,
+        }),
+      ).resolves.toMatchObject({ availability, today })
+    },
+  )
 
   it("wins Sub2API discovery only when its read-only deployment probe matches", async () => {
     const account = createAccount()
@@ -179,6 +221,65 @@ describe("Denxio daily check-in method Adapter", () => {
   })
 
   it.each([
+    [{ kind: "already_checked" as const }, "already_checked", undefined],
+    [{ kind: "disabled" as const }, "failed", "method_disabled"],
+    [
+      { kind: "recovery_status_unavailable" as const },
+      "failed",
+      "status_unavailable",
+    ],
+    [
+      { kind: "recovery_precondition_failed" as const },
+      "failed",
+      "account_unavailable",
+    ],
+  ])(
+    "maps protocol result $0.kind",
+    async (protocolResult, status, reasonCode) => {
+      vi.mocked(performDenxioDailyCheckIn).mockResolvedValue(protocolResult)
+
+      await expect(
+        denxioProvider.checkIn(createAccount(), {
+          ...executionContext(),
+          statusProof: notCheckedStatus,
+        }),
+      ).resolves.toMatchObject({
+        status,
+        ...(reasonCode ? { reasonCode, retryable: false } : {}),
+      })
+    },
+  )
+
+  it.each([
+    [
+      SUB2API_AUTH_PERSISTENCE_STATUSES.IDENTITY_MISMATCH,
+      "authentication_required",
+    ],
+    [SUB2API_AUTH_PERSISTENCE_STATUSES.ACCOUNT_MISSING, "account_unavailable"],
+    [SUB2API_AUTH_PERSISTENCE_STATUSES.WRITE_FAILED, "status_unavailable"],
+  ] as const)(
+    "stops after auth persistence result %s",
+    async (persistenceStatus, reasonCode) => {
+      vi.mocked(performDenxioDailyCheckIn).mockRejectedValue(
+        Object.assign(new Error("controlled persistence failure"), {
+          result: { status: persistenceStatus },
+        }),
+      )
+
+      await expect(
+        denxioProvider.checkIn(createAccount(), {
+          ...executionContext(),
+          statusProof: notCheckedStatus,
+        }),
+      ).resolves.toMatchObject({
+        status: CHECKIN_RESULT_STATUS.FAILED,
+        reasonCode,
+        retryable: false,
+      })
+    },
+  )
+
+  it.each([
     [DENXIO_DAILY_CHECK_IN_ERROR_CODES.AlreadyChecked, "already_checked"],
     [DENXIO_DAILY_CHECK_IN_ERROR_CODES.Disabled, "failed"],
   ])("maps stable business code %s", async (upstreamCode, status) => {
@@ -219,6 +320,69 @@ describe("Denxio daily check-in method Adapter", () => {
     ).resolves.toMatchObject({
       status: CHECKIN_RESULT_STATUS.FAILED,
       rawMessage: "Bearer [REDACTED] was rejected",
+    })
+  })
+
+  it.each([
+    [new ApiError("unauthorized", 401), "authentication_required", undefined],
+    [
+      Object.assign(new Error("unauthorized"), { statusCode: 401 }),
+      "authentication_required",
+      undefined,
+    ],
+    [new ApiError("missing", 404), "method_unsupported", false],
+    [new ApiError("not allowed", 405), "method_unsupported", false],
+    [new ApiError("forbidden", 403), "permission_denied", undefined],
+    [new TypeError("Failed to fetch"), "network_error", undefined],
+    [
+      Object.assign(new Error("timed out"), { name: "TimeoutError" }),
+      "timeout",
+      undefined,
+    ],
+    [new ApiError("unavailable", 503), "source_unavailable", undefined],
+    [new Error("unexpected"), "status_unavailable", undefined],
+  ] as const)(
+    "maps mutation failure to %s",
+    async (error, reasonCode, retryable) => {
+      vi.mocked(performDenxioDailyCheckIn).mockRejectedValue(error)
+
+      await expect(
+        denxioProvider.checkIn(createAccount(), {
+          ...executionContext(),
+          statusProof: notCheckedStatus,
+        }),
+      ).resolves.toMatchObject({
+        status: CHECKIN_RESULT_STATUS.FAILED,
+        reasonCode,
+        ...(typeof retryable === "boolean" ? { retryable } : {}),
+      })
+    },
+  )
+
+  it.each([
+    DENXIO_DAILY_CHECK_IN_ERROR_CODES.NoSponsor,
+    DENXIO_DAILY_CHECK_IN_ERROR_CODES.SessionPending,
+  ])("maps unavailable session code %s", async (upstreamCode) => {
+    vi.mocked(performDenxioDailyCheckIn).mockRejectedValue(
+      new ApiError(
+        "controlled session error",
+        409,
+        "/example",
+        API_ERROR_CODES.BUSINESS_ERROR,
+        upstreamCode,
+      ),
+    )
+
+    await expect(
+      denxioProvider.checkIn(createAccount(), {
+        ...executionContext(),
+        statusProof: notCheckedStatus,
+      }),
+    ).resolves.toMatchObject({
+      status: CHECKIN_RESULT_STATUS.FAILED,
+      reasonCode: "status_unavailable",
+      retryable: false,
+      rawMessage: "controlled session error",
     })
   })
 

--- a/tests/services/autoCheckin/providers/denxio.test.ts
+++ b/tests/services/autoCheckin/providers/denxio.test.ts
@@ -1,0 +1,240 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+  CHECK_IN_METHOD_AVAILABILITIES,
+  CHECK_IN_METHOD_STATUS_OUTCOMES,
+  CHECK_IN_METHOD_TODAY_STATUSES,
+} from "~/constants/checkIn"
+import { SITE_TYPES } from "~/services/accountSiteDefinitions/identifiers"
+import { fetchSub2ApiProDailyCheckInStatus } from "~/services/apiService/sub2api"
+import {
+  DENXIO_DAILY_CHECK_IN_ERROR_CODES,
+  fetchDenxioDailyCheckInStatus,
+  performDenxioDailyCheckIn,
+} from "~/services/apiService/sub2api/denxioCheckIn"
+import { API_ERROR_CODES, ApiError } from "~/services/apiTransport/errors"
+import { discoverCheckInMethods } from "~/services/checkin/autoCheckin/discovery"
+import { denxioProvider } from "~/services/checkin/autoCheckin/providers/denxio"
+import { PROTECTION_BYPASS_USER_COMMANDS } from "~/services/protectionBypass/contracts"
+import { AuthTypeEnum } from "~/types"
+import { CHECKIN_RESULT_STATUS } from "~/types/autoCheckin"
+import { TEMP_WINDOW_REQUEST_SOURCES } from "~/types/tempWindowFetch"
+import { userCommandExecution } from "~~/tests/services/protectionBypass/fixtures"
+import { createAutoCheckinMutationLifecycle } from "~~/tests/test-utils/autoCheckin"
+import { buildSiteAccount } from "~~/tests/test-utils/factories"
+
+vi.mock(
+  "~/services/apiService/sub2api/denxioCheckIn",
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import("~/services/apiService/sub2api/denxioCheckIn")
+      >()
+    return {
+      ...actual,
+      fetchDenxioDailyCheckInStatus: vi.fn(),
+      performDenxioDailyCheckIn: vi.fn(),
+    }
+  },
+)
+
+vi.mock("~/services/apiService/sub2api", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("~/services/apiService/sub2api")>()),
+  fetchSub2ApiProDailyCheckInStatus: vi.fn(),
+}))
+
+const createAccount = () =>
+  buildSiteAccount({
+    id: "sub2api-account",
+    site_url: "https://checkin.example.invalid",
+    site_type: SITE_TYPES.SUB2API,
+    authType: AuthTypeEnum.AccessToken,
+    account_info: {
+      id: "42",
+      username: "Example User",
+      access_token: "example-access-token",
+      quota: 0,
+      today_quota_consumption: 0,
+      today_prompt_tokens: 0,
+      today_completion_tokens: 0,
+      today_requests_count: 0,
+      today_income: 0,
+    },
+  })
+
+const executionContext = () => ({
+  tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Background,
+  protectionBypassExecution: userCommandExecution(
+    PROTECTION_BYPASS_USER_COMMANDS.ManualCheckin,
+  ),
+})
+
+const notCheckedStatus = {
+  outcome: CHECK_IN_METHOD_STATUS_OUTCOMES.Known,
+  availability: CHECK_IN_METHOD_AVAILABILITIES.Enabled,
+  today: CHECK_IN_METHOD_TODAY_STATUSES.NotChecked,
+  evidence: { source: "probe" as const, observedAt: 200 },
+}
+
+describe("Denxio daily check-in method Adapter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.mocked(fetchDenxioDailyCheckInStatus).mockResolvedValue({
+      enabled: true,
+      checkedInToday: false,
+    })
+    vi.mocked(performDenxioDailyCheckIn).mockResolvedValue({
+      kind: "applied",
+      rewardAmount: 0.5,
+    })
+    vi.mocked(fetchSub2ApiProDailyCheckInStatus).mockRejectedValue(
+      new ApiError("unsupported", 404),
+    )
+  })
+
+  it("requires a persisted Sub2API access token", () => {
+    const account = createAccount()
+    account.account_info.access_token = ""
+
+    expect(denxioProvider.getReadiness(account)).toEqual({
+      ready: false,
+      reason: "credentials_missing",
+    })
+  })
+
+  it("maps the deployment status to canonical discovery evidence", async () => {
+    await expect(
+      denxioProvider.detect?.({ account: createAccount(), observedAt: 300 }),
+    ).resolves.toEqual({
+      detection: {
+        outcome: "matched",
+        evidence: { source: "probe", observedAt: 300 },
+      },
+      status: {
+        outcome: CHECK_IN_METHOD_STATUS_OUTCOMES.Known,
+        availability: CHECK_IN_METHOD_AVAILABILITIES.Enabled,
+        today: CHECK_IN_METHOD_TODAY_STATUSES.NotChecked,
+        evidence: { source: "probe", observedAt: 300 },
+      },
+    })
+  })
+
+  it("wins Sub2API discovery only when its read-only deployment probe matches", async () => {
+    const account = createAccount()
+    account.checkIn = {
+      automaticExecutionEnabled: false,
+      methodKnowledge: { methods: {} },
+      selection: { mode: "automatic" },
+    }
+
+    const result = await discoverCheckInMethods({
+      account,
+      config: account.checkIn,
+      observedAt: 300,
+    })
+
+    expect(result.decision).toEqual({
+      outcome: "resolved",
+      methodId: "denxio:daily-checkin",
+    })
+    expect(result.config.selection).toEqual({
+      mode: "automatic",
+      methodId: "denxio:daily-checkin",
+    })
+  })
+
+  it("requires same-cycle not-checked status before starting the challenge", async () => {
+    await expect(
+      denxioProvider.checkIn(createAccount(), executionContext()),
+    ).resolves.toMatchObject({
+      status: CHECKIN_RESULT_STATUS.FAILED,
+      reasonCode: "status_unavailable",
+    })
+    expect(performDenxioDailyCheckIn).not.toHaveBeenCalled()
+  })
+
+  it("forwards execution context and reports an applied claim", async () => {
+    const account = createAccount()
+    const context = {
+      ...executionContext(),
+      statusProof: notCheckedStatus,
+      beforeRecoveredMutation: vi.fn(async () => true),
+    }
+
+    await expect(
+      denxioProvider.checkIn(account, context),
+    ).resolves.toMatchObject({
+      status: CHECKIN_RESULT_STATUS.SUCCESS,
+      data: { rewardAmount: 0.5 },
+    })
+    expect(performDenxioDailyCheckIn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseUrl: "https://checkin.example.invalid",
+        accountId: "sub2api-account",
+        tempWindowRequestSource: TEMP_WINDOW_REQUEST_SOURCES.Background,
+        protectionBypassExecution: context.protectionBypassExecution,
+      }),
+      { beforeRecoveredMutation: context.beforeRecoveredMutation },
+    )
+  })
+
+  it.each([
+    [DENXIO_DAILY_CHECK_IN_ERROR_CODES.AlreadyChecked, "already_checked"],
+    [DENXIO_DAILY_CHECK_IN_ERROR_CODES.Disabled, "failed"],
+  ])("maps stable business code %s", async (upstreamCode, status) => {
+    vi.mocked(performDenxioDailyCheckIn).mockRejectedValue(
+      new ApiError(
+        "controlled deployment error",
+        409,
+        "/example",
+        API_ERROR_CODES.BUSINESS_ERROR,
+        upstreamCode,
+      ),
+    )
+
+    await expect(
+      denxioProvider.checkIn(createAccount(), {
+        ...executionContext(),
+        statusProof: notCheckedStatus,
+      }),
+    ).resolves.toMatchObject({ status })
+  })
+
+  it("redacts secrets from a preserved deployment error", async () => {
+    vi.mocked(performDenxioDailyCheckIn).mockRejectedValue(
+      new ApiError(
+        "Bearer example-secret-token was rejected",
+        409,
+        "/example",
+        API_ERROR_CODES.BUSINESS_ERROR,
+        DENXIO_DAILY_CHECK_IN_ERROR_CODES.SessionInvalid,
+      ),
+    )
+
+    await expect(
+      denxioProvider.checkIn(createAccount(), {
+        ...executionContext(),
+        statusProof: notCheckedStatus,
+      }),
+    ).resolves.toMatchObject({
+      status: CHECKIN_RESULT_STATUS.FAILED,
+      rawMessage: "Bearer [REDACTED] was rejected",
+    })
+  })
+
+  it("classifies a lost post-dispatch claim response as uncertain", async () => {
+    vi.mocked(performDenxioDailyCheckIn).mockRejectedValue(
+      new TypeError("Failed to fetch"),
+    )
+    const mutationLifecycle = createAutoCheckinMutationLifecycle()
+    mutationLifecycle.onDispatch()
+
+    await expect(
+      denxioProvider.checkIn(createAccount(), {
+        ...executionContext(),
+        statusProof: notCheckedStatus,
+        mutationLifecycle,
+      }),
+    ).resolves.toMatchObject({ status: CHECKIN_RESULT_STATUS.UNCERTAIN })
+  })
+})

--- a/tests/services/autoCheckin/providers/registry.test.ts
+++ b/tests/services/autoCheckin/providers/registry.test.ts
@@ -4,6 +4,7 @@ import { AUTO_CHECKIN_METHOD_IDS } from "~/constants/checkIn"
 import { SITE_TYPES } from "~/constants/siteType"
 import { autoCheckinMethodRegistry } from "~/services/checkin/autoCheckin/providers"
 import { anyrouterProvider } from "~/services/checkin/autoCheckin/providers/anyrouter"
+import { denxioProvider } from "~/services/checkin/autoCheckin/providers/denxio"
 import { newApiProvider } from "~/services/checkin/autoCheckin/providers/newApi"
 import {
   AUTO_CHECKIN_METHOD_SOURCE_KINDS,
@@ -51,7 +52,7 @@ describe("autoCheckinMethodRegistry", () => {
       }),
     )
 
-    expect(registrationContracts).toHaveLength(6)
+    expect(registrationContracts).toHaveLength(7)
     expect(registrationContracts).toEqual(
       expect.arrayContaining([
         {
@@ -84,6 +85,11 @@ describe("autoCheckinMethodRegistry", () => {
           candidateSiteTypes: [SITE_TYPES.SUB2API],
           provider: sub2apiProProvider,
         },
+        {
+          id: "denxio:daily-checkin",
+          candidateSiteTypes: [SITE_TYPES.SUB2API],
+          provider: denxioProvider,
+        },
       ]),
     )
 
@@ -106,6 +112,8 @@ describe("autoCheckinMethodRegistry", () => {
     expect(voApiV2Provider.detect).toBeTypeOf("function")
     expect(sub2apiProProvider.getStatus).toBeTypeOf("function")
     expect(sub2apiProProvider.detect).toBeTypeOf("function")
+    expect(denxioProvider.getStatus).toBeTypeOf("function")
+    expect(denxioProvider.detect).toBeTypeOf("function")
   })
 
   it("distinguishes official methods from third-party protocol methods", () => {
@@ -119,6 +127,12 @@ describe("autoCheckinMethodRegistry", () => {
     ).toEqual({
       kind: AUTO_CHECKIN_METHOD_SOURCE_KINDS.ThirdParty,
       sourceName: "Sub2API Pro",
+    })
+    expect(
+      getAutoCheckinMethodSource(AUTO_CHECKIN_METHOD_IDS.DenxioDailyCheckIn),
+    ).toEqual({
+      kind: AUTO_CHECKIN_METHOD_SOURCE_KINDS.ThirdParty,
+      sourceName: "登仙公益站",
     })
   })
 
@@ -187,6 +201,19 @@ describe("autoCheckinMethodRegistry", () => {
     expect(getNewAccountCompatibilityMethodIds(SITE_TYPES.ANYROUTER)).toEqual([
       "anyrouter:daily-checkin",
     ])
+    expect(getNewAccountCompatibilityMethodIds(SITE_TYPES.SUB2API)).toEqual([])
+  })
+
+  it("keeps deployment-specific Sub2API methods discovery-only", () => {
+    expect(
+      autoCheckinMethodRegistry
+        .getCandidates(SITE_TYPES.SUB2API)
+        .map(({ id }) => id),
+    ).toEqual([
+      AUTO_CHECKIN_METHOD_IDS.Sub2ApiProDailyCheckIn,
+      AUTO_CHECKIN_METHOD_IDS.DenxioDailyCheckIn,
+    ])
+    expect(getLegacyAutoCheckinMethodIds(SITE_TYPES.SUB2API)).toEqual([])
     expect(getNewAccountCompatibilityMethodIds(SITE_TYPES.SUB2API)).toEqual([])
   })
 

--- a/tests/services/autoCheckin/providers/sub2apiPro.test.ts
+++ b/tests/services/autoCheckin/providers/sub2apiPro.test.ts
@@ -12,6 +12,7 @@ import {
   performSub2ApiProDailyCheckIn,
 } from "~/services/apiService/sub2api"
 import { SUB2API_AUTH_PERSISTENCE_STATUSES } from "~/services/apiService/sub2api/authSession"
+import { fetchDenxioDailyCheckInStatus } from "~/services/apiService/sub2api/denxioCheckIn"
 import { API_ERROR_CODES, ApiError } from "~/services/apiTransport/errors"
 import { discoverCheckInMethods } from "~/services/checkin/autoCheckin/discovery"
 import { executeSelectedCheckIn } from "~/services/checkin/autoCheckin/methods"
@@ -34,6 +35,20 @@ vi.mock("~/services/apiService/sub2api", async (importOriginal) => {
     performSub2ApiProDailyCheckIn: vi.fn(),
   }
 })
+
+vi.mock(
+  "~/services/apiService/sub2api/denxioCheckIn",
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import("~/services/apiService/sub2api/denxioCheckIn")
+      >()
+    return {
+      ...actual,
+      fetchDenxioDailyCheckInStatus: vi.fn(),
+    }
+  },
+)
 
 const METHOD_ID = AUTO_CHECKIN_METHOD_IDS.Sub2ApiProDailyCheckIn
 
@@ -87,6 +102,9 @@ const notCheckedStatus = {
 describe("Sub2API Pro daily check-in method Adapter", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(fetchDenxioDailyCheckInStatus).mockRejectedValue(
+      new ApiError("unsupported", 404),
+    )
     vi.mocked(fetchSub2ApiProDailyCheckInStatus).mockResolvedValue({
       enabled: true,
       checkedInToday: false,

--- a/tests/services/productAnalytics/autoCheckin.test.ts
+++ b/tests/services/productAnalytics/autoCheckin.test.ts
@@ -371,39 +371,45 @@ describe("auto-checkin product analytics", () => {
     ])
   })
 
-  it("reports only an allow-listed method category for Sub2API Pro", () => {
-    const [group] = buildAutoCheckinAccountGroupProperties({
-      runKind: "daily",
-      entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Background,
-      accountsById: new Map([
-        ["sub2api-account", { authType: AuthTypeEnum.AccessToken }],
-      ]),
-      snapshots: [
-        {
-          accountId: "sub2api-account",
-          accountName: "Private account name",
-          siteType: "sub2api",
-          detectionEnabled: true,
-          autoCheckinEnabled: true,
-          providerAvailable: true,
-          lastResult: {
+  it.each([
+    AUTO_CHECKIN_METHOD_IDS.Sub2ApiProDailyCheckIn,
+    AUTO_CHECKIN_METHOD_IDS.DenxioDailyCheckIn,
+  ])(
+    "reports only an allow-listed category for strict method %s",
+    (methodId) => {
+      const [group] = buildAutoCheckinAccountGroupProperties({
+        runKind: "daily",
+        entrypoint: PRODUCT_ANALYTICS_ENTRYPOINTS.Background,
+        accountsById: new Map([
+          ["sub2api-account", { authType: AuthTypeEnum.AccessToken }],
+        ]),
+        snapshots: [
+          {
             accountId: "sub2api-account",
             accountName: "Private account name",
-            methodId: AUTO_CHECKIN_METHOD_IDS.Sub2ApiProDailyCheckIn,
-            status: CHECKIN_RESULT_STATUS.SUCCESS,
-            timestamp: 1,
+            siteType: "sub2api",
+            detectionEnabled: true,
+            autoCheckinEnabled: true,
+            providerAvailable: true,
+            lastResult: {
+              accountId: "sub2api-account",
+              accountName: "Private account name",
+              methodId,
+              status: CHECKIN_RESULT_STATUS.SUCCESS,
+              timestamp: 1,
+            },
           },
-        },
-      ],
-    })
+        ],
+      })
 
-    expect(group).toMatchObject({
-      method_category:
-        PRODUCT_ANALYTICS_AUTO_CHECKIN_METHOD_CATEGORIES.StrictReadback,
-    })
-    expect(JSON.stringify(group)).not.toContain("sub2api-pro:daily-checkin")
-    expect(JSON.stringify(group)).not.toContain("Private account name")
-  })
+      expect(group).toMatchObject({
+        method_category:
+          PRODUCT_ANALYTICS_AUTO_CHECKIN_METHOD_CATEGORIES.StrictReadback,
+      })
+      expect(JSON.stringify(group)).not.toContain(methodId)
+      expect(JSON.stringify(group)).not.toContain("Private account name")
+    },
+  )
 
   it("groups registered methods by privacy-reviewed category and omits unknown IDs", () => {
     const groups = buildAutoCheckinAccountGroupProperties({


### PR DESCRIPTION
## Summary

Add automatic daily check-in support for `api.denxio.top`, whose deployed Sub2API check-in flow uses a provider-specific two-stage challenge and claim protocol.

Fixes #974
Fixes #1087

## What changed

- Add a dedicated `denxio:daily-checkin` method and provider for Sub2API accounts.
- Detect Denxio through a read-only status probe.
- Implement the deployed `status -> normal/begin -> wait -> normal/claim` flow.
- Reuse Sub2API browser-auth recovery and persist recovered credentials before retrying.
- Reuse the recovered authenticated request across begin and claim stages.
- Prevent blind replay after dispatch or response loss; claim-stage recovery never re-sends begin.
- Preserve controlled upstream business errors with Sub2API secret redaction.
- Add privacy-safe `strict_readback` analytics classification.
- Add protocol, recovery, discovery, registry, compatibility, and error-path tests.

## Validation

- `pnpm compile`
- Focused Vitest coverage: 203 tests passed across 7 files, plus 59 tests after the final internal-type cleanup.
- Targeted ESLint passed.
- Pre-commit `validate:staged` passed, including lint-staged, Vitest, and i18n checks.
- Pre-push `validate:push` passed, including compile and knip.
- Verified the authenticated Denxio flow in Playwright Extension mode against the live `/checkin` page without claiming a reward.

## Compatibility and risks

- The new method is discovery-only and is not added to legacy or new-account compatibility migration.
- Existing accounts need one manual re-detection to select the new method.
- The adapter intentionally bounds `wait_seconds` to 60 seconds and requires authoritative status before mutation.
- The protocol is deployment-owned; future envelope or error-code changes require re-verification.
- No documentation or UI settings surface changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Denxio daily check-in support for eligible Sub2API accounts.
  * Added status detection, challenge handling, reward claims, and auto-check-in discovery.
  * Added clear handling for completed, disabled, unavailable, and uncertain outcomes.
  * Added analytics categorization for Denxio check-ins.

* **Bug Fixes**
  * Improved safeguards around authentication recovery and uncertain network results.

* **Tests**
  * Added coverage for response validation, transport flows, provider behavior, registry integration, and analytics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->