### PR TITLE
fix(axonhub): make channel updates schema-resilient

### DIFF
--- a/src/constants/axonHub.ts
+++ b/src/constants/axonHub.ts
@@ -6,6 +6,10 @@ export const AXON_HUB_CHANNEL_STATUS = {
   ARCHIVED: "archived",
 } as const
 
+export const AXON_HUB_GRAPHQL_ERROR_CODES = {
+  VALIDATION_FAILED: "GRAPHQL_VALIDATION_FAILED",
+} as const
+
 export type AxonHubChannelStatus =
   (typeof AXON_HUB_CHANNEL_STATUS)[keyof typeof AXON_HUB_CHANNEL_STATUS]
 
@@ -58,8 +62,18 @@ export const AXON_HUB_CHANNEL_FIELD_IDS = {
 export type AxonHubChannelFieldId =
   (typeof AXON_HUB_CHANNEL_FIELD_IDS)[keyof typeof AXON_HUB_CHANNEL_FIELD_IDS]
 
-export const AXON_HUB_EDITABLE_FIELD_IDS: readonly AxonHubChannelFieldId[] =
+export const AXON_HUB_DETAIL_FIELD_IDS: readonly AxonHubChannelFieldId[] =
   Object.freeze(Object.values(AXON_HUB_CHANNEL_FIELD_IDS))
+
+export const AXON_HUB_CREATE_FIELD_IDS: readonly AxonHubChannelFieldId[] =
+  Object.freeze([...AXON_HUB_DETAIL_FIELD_IDS])
+
+export const AXON_HUB_EDITABLE_FIELD_IDS: readonly AxonHubChannelFieldId[] =
+  Object.freeze(
+    AXON_HUB_DETAIL_FIELD_IDS.filter(
+      (fieldId) => fieldId !== AXON_HUB_CHANNEL_FIELD_IDS.EXTRA_MODEL_PREFIX,
+    ),
+  )
 
 export const AXON_HUB_TABLE_FIELD_IDS = [
   AXON_HUB_CHANNEL_FIELD_IDS.NAME,

--- a/src/features/ManagedSiteChannels/presentation/managedResourceFieldPolicy.ts
+++ b/src/features/ManagedSiteChannels/presentation/managedResourceFieldPolicy.ts
@@ -336,7 +336,10 @@ const axonHubManagedResourceFieldPolicy = defineManagedResourceFieldPolicy({
       ],
     },
     [MANAGED_RESOURCE_EDITOR_MODES.Edit]: {
-      fields: axonHubFields,
+      fields: axonHubFields.filter(
+        ({ fieldId }) =>
+          fieldId !== AXON_HUB_CHANNEL_FIELD_IDS.EXTRA_MODEL_PREFIX,
+      ),
       hiddenFields: [
         {
           fieldId: AXON_HUB_CHANNEL_FIELD_IDS.MANUAL_MODELS,

--- a/src/services/accountSiteDefinitions/definitions.ts
+++ b/src/services/accountSiteDefinitions/definitions.ts
@@ -1,5 +1,5 @@
 import {
-  AXON_HUB_EDITABLE_FIELD_IDS,
+  AXON_HUB_DETAIL_FIELD_IDS,
   AXON_HUB_TABLE_FIELD_IDS,
 } from "~/constants/axonHub"
 import {
@@ -525,7 +525,7 @@ const MANAGED_ONLY_SITE_DEFINITIONS = [
       ...LEGACY_MANAGED_CHANNEL_POLICY,
       mode: MANAGED_RESOURCE_MODES.NativeResource,
       tableFieldIds: AXON_HUB_TABLE_FIELD_IDS,
-      detailFieldIds: AXON_HUB_EDITABLE_FIELD_IDS,
+      detailFieldIds: AXON_HUB_DETAIL_FIELD_IDS,
       actions: [
         MANAGED_RESOURCE_PRODUCT_ACTIONS.Create,
         MANAGED_RESOURCE_PRODUCT_ACTIONS.DeleteSelected,

--- a/src/services/apiAdapters/managedResources/axonHub.ts
+++ b/src/services/apiAdapters/managedResources/axonHub.ts
@@ -64,6 +64,7 @@ import { resolveManagedSiteRuntimeConfigForType } from "~/services/managedSites/
 import { userPreferences } from "~/services/preferences/userPreferences"
 import type {
   AxonHubChannel,
+  AxonHubChannelMutationReceipt,
   AxonHubCreateChannelInput,
   AxonHubUpdateChannelInput,
 } from "~/types/axonHub"
@@ -119,7 +120,7 @@ export interface AxonHubNativeResourceOperations {
   ): Promise<ManagedSiteMutationResult<AxonHubChannel>>
   update(
     detail: AxonHubChannel,
-    input: AxonHubUpdateChannelInput,
+    input: AxonHubNativeChannelPatch,
     options?: ResourceOperationOptions,
   ): Promise<ManagedSiteMutationResult<AxonHubChannel>>
   delete(
@@ -132,6 +133,29 @@ type AxonHubCreateCommand = {
   input: AxonHubCreateChannelInput
   desiredStatus: AxonHubChannelStatus
 }
+
+// Keep the product-facing edit contract narrower than AxonHub's generated
+// UpdateChannelInput. Aggregate replacements such as settings, policies, and
+// endpoints are intentionally absent because an older client cannot preserve
+// members added by a newer server.
+type AxonHubNativeChannelPatch = Pick<
+  AxonHubUpdateChannelInput,
+  | "type"
+  | "baseURL"
+  | "name"
+  | "status"
+  | "credentials"
+  | "supportedModels"
+  | "manualModels"
+  | "autoSyncSupportedModels"
+  | "autoSyncModelPattern"
+  | "clearAutoSyncModelPattern"
+  | "tags"
+  | "defaultTestModel"
+  | "orderingWeight"
+  | "remark"
+  | "clearRemark"
+>
 
 // beta5 requires apiKeys for these audited regular-key types; structured
 // AWS/GCP/OAuth and unknown future types stay excluded by default.
@@ -385,6 +409,21 @@ const finishAxonHubNativeMutation = <TData>(
     diagnostic: step.diagnostic,
   })
 
+const applyAxonHubNativeChannelPatch = (
+  detail: AxonHubChannel,
+  input: Omit<AxonHubNativeChannelPatch, "status">,
+  receipt: AxonHubChannelMutationReceipt,
+): AxonHubChannel => {
+  const { clearAutoSyncModelPattern, clearRemark, ...changedValues } = input
+  return {
+    ...detail,
+    ...changedValues,
+    ...receipt,
+    ...(clearAutoSyncModelPattern ? { autoSyncModelPattern: null } : {}),
+    ...(clearRemark ? { remark: null } : {}),
+  }
+}
+
 const callRead = async <T>(operation: () => Promise<T>): Promise<T> => {
   try {
     return await operation()
@@ -548,7 +587,7 @@ export async function openAxonHubNativeResourceOperations(
         return finishAxonHubNativeMutation(sequence, createStep)
       }
 
-      const created = createStep.data
+      const created = { ...input, ...createStep.data }
       if (desiredStatus !== AXON_HUB_CHANNEL_STATUS.ENABLED) {
         return sequence.finish({ finalState: "confirmed", data: created })
       }
@@ -583,17 +622,7 @@ export async function openAxonHubNativeResourceOperations(
     update: async (detail, input, operationOptions) => {
       const { status, ...ordinaryInput } = input
       const statusChanged = status !== undefined && status !== detail.status
-      const mergedOrdinaryInput = ordinaryInput.settings
-        ? {
-            ...ordinaryInput,
-            settings: {
-              ...(detail.settings ?? {}),
-              ...ordinaryInput.settings,
-            },
-          }
-        : ordinaryInput
-      const hasOrdinaryPatch =
-        Object.keys(mergedOrdinaryInput).length > 0 || status === undefined
+      const hasOrdinaryPatch = Object.keys(ordinaryInput).length > 0
       const sequence = createManagedSiteMutationSequence({ idempotent: true })
       let updated = detail
 
@@ -610,14 +639,18 @@ export async function openAxonHubNativeResourceOperations(
             await updateAxonHubChannel(
               config,
               detail.id,
-              mergedOrdinaryInput,
+              ordinaryInput,
               requestOptions(operationOptions),
             ),
         })
         if (updateStep.outcome !== "applied") {
           return finishAxonHubNativeMutation(sequence, updateStep)
         }
-        updated = updateStep.data
+        updated = applyAxonHubNativeChannelPatch(
+          detail,
+          ordinaryInput,
+          updateStep.data,
+        )
       }
 
       if (statusChanged) {
@@ -1341,7 +1374,11 @@ const createFieldDescriptors = (
       fieldId: AXON_HUB_CHANNEL_FIELD_IDS.EXTRA_MODEL_PREFIX,
       type: MANAGED_RESOURCE_FIELD_TYPES.Text,
     },
-  ]
+  ].filter(
+    ({ fieldId }) =>
+      detail === undefined ||
+      fieldId !== AXON_HUB_CHANNEL_FIELD_IDS.EXTRA_MODEL_PREFIX,
+  )
 }
 
 const createInitialValues = (): EditableResourceProjection => ({
@@ -1410,8 +1447,6 @@ const editInitialValues = (
   [AXON_HUB_CHANNEL_FIELD_IDS.TAGS]: [...(detail.tags ?? [])],
   [AXON_HUB_CHANNEL_FIELD_IDS.ORDERING_WEIGHT]: detail.orderingWeight ?? 0,
   [AXON_HUB_CHANNEL_FIELD_IDS.REMARK]: detail.remark ?? "",
-  [AXON_HUB_CHANNEL_FIELD_IDS.EXTRA_MODEL_PREFIX]:
-    detail.settings?.extraModelPrefix ?? "",
 })
 
 const buildCreateCommand = (
@@ -1486,14 +1521,13 @@ const fieldChanged = (
 }
 
 const addNullableTextDiff = (
-  input: AxonHubUpdateChannelInput,
+  input: AxonHubNativeChannelPatch,
   values: EditableResourceProjection,
   baseline: EditableResourceProjection,
   fieldId:
-    | typeof AXON_HUB_CHANNEL_FIELD_IDS.BASE_URL
     | typeof AXON_HUB_CHANNEL_FIELD_IDS.AUTO_SYNC_MODEL_PATTERN
     | typeof AXON_HUB_CHANNEL_FIELD_IDS.REMARK,
-  clearField: "clearBaseURL" | "clearAutoSyncModelPattern" | "clearRemark",
+  clearField: "clearAutoSyncModelPattern" | "clearRemark",
 ) => {
   if (!fieldChanged(values, baseline, fieldId)) return
   const next = readString(values, fieldId)
@@ -1505,8 +1539,8 @@ const buildUpdateCommand = (
   detail: AxonHubChannel,
   baseline: EditableResourceProjection,
   values: EditableResourceProjection,
-): AxonHubUpdateChannelInput => {
-  const input: AxonHubUpdateChannelInput = {}
+): AxonHubNativeChannelPatch => {
+  const input: AxonHubNativeChannelPatch = {}
   const name = readString(values, AXON_HUB_CHANNEL_FIELD_IDS.NAME)
   const type = readString(values, AXON_HUB_CHANNEL_FIELD_IDS.TYPE)
   const status = readString(values, AXON_HUB_CHANNEL_FIELD_IDS.STATUS)
@@ -1520,13 +1554,11 @@ const buildUpdateCommand = (
     input.status = status
   }
 
-  addNullableTextDiff(
-    input,
-    values,
-    baseline,
-    AXON_HUB_CHANNEL_FIELD_IDS.BASE_URL,
-    "clearBaseURL",
-  )
+  if (fieldChanged(values, baseline, AXON_HUB_CHANNEL_FIELD_IDS.BASE_URL)) {
+    // AxonHub beta8/beta9's custom updater ignores generated clearBaseURL but
+    // applies a non-nil empty baseURL. Source: https://github.com/looplj/axonhub/blob/v1.0.0-beta9/internal/server/biz/channel.go
+    input.baseURL = readString(values, AXON_HUB_CHANNEL_FIELD_IDS.BASE_URL)
+  }
   addNullableTextDiff(
     input,
     values,
@@ -1564,8 +1596,8 @@ const buildUpdateCommand = (
   if (
     fieldChanged(values, baseline, AXON_HUB_CHANNEL_FIELD_IDS.MANUAL_MODELS)
   ) {
-    if (manualModels.length) input.manualModels = manualModels
-    else input.clearManualModels = true
+    // The same updater accepts [] but ignores generated clearManualModels.
+    input.manualModels = manualModels
   }
   const tags = normalizeList(readList(values, AXON_HUB_CHANNEL_FIELD_IDS.TAGS))
   if (fieldChanged(values, baseline, AXON_HUB_CHANNEL_FIELD_IDS.TAGS)) {
@@ -1610,19 +1642,6 @@ const buildUpdateCommand = (
     input.orderingWeight = orderingWeight
   }
 
-  const extraModelPrefix = readString(
-    values,
-    AXON_HUB_CHANNEL_FIELD_IDS.EXTRA_MODEL_PREFIX,
-  )
-  if (
-    fieldChanged(
-      values,
-      baseline,
-      AXON_HUB_CHANNEL_FIELD_IDS.EXTRA_MODEL_PREFIX,
-    )
-  ) {
-    input.settings = { extraModelPrefix }
-  }
   return input
 }
 
@@ -1636,8 +1655,8 @@ const createEditor =
 
 const editEditor = (
   detail: AxonHubChannel,
-  loadSecret?: NativeResourceEditorDefinition<AxonHubUpdateChannelInput>["loadSecret"],
-): NativeResourceEditorDefinition<AxonHubUpdateChannelInput> => {
+  loadSecret?: NativeResourceEditorDefinition<AxonHubNativeChannelPatch>["loadSecret"],
+): NativeResourceEditorDefinition<AxonHubNativeChannelPatch> => {
   const initialValues = editInitialValues(detail)
   return {
     fields: createFieldDescriptors(detail),
@@ -1743,7 +1762,7 @@ const axonHubNativeDefinition = {
   update: (
     operations: AxonHubNativeResourceOperations,
     detail: AxonHubChannel,
-    command: AxonHubUpdateChannelInput,
+    command: AxonHubNativeChannelPatch,
     options?: ResourceOperationOptions,
   ) => {
     // UpdateChannelInput.credentials.apiKeys is replacement data, so a scalar

--- a/src/services/apiAdapters/managedResources/axonHub.ts
+++ b/src/services/apiAdapters/managedResources/axonHub.ts
@@ -409,6 +409,14 @@ const finishAxonHubNativeMutation = <TData>(
     diagnostic: step.diagnostic,
   })
 
+const omitAxonHubChannelCredentials = (
+  channel: AxonHubChannel,
+): AxonHubChannel => {
+  const credentialFreeChannel = { ...channel }
+  delete credentialFreeChannel.credentials
+  return credentialFreeChannel
+}
+
 const applyAxonHubNativeChannelPatch = (
   detail: AxonHubChannel,
   input: Omit<AxonHubNativeChannelPatch, "status">,
@@ -587,7 +595,10 @@ export async function openAxonHubNativeResourceOperations(
         return finishAxonHubNativeMutation(sequence, createStep)
       }
 
-      const created = { ...input, ...createStep.data }
+      const created = omitAxonHubChannelCredentials({
+        ...input,
+        ...createStep.data,
+      })
       if (desiredStatus !== AXON_HUB_CHANNEL_STATUS.ENABLED) {
         return sequence.finish({ finalState: "confirmed", data: created })
       }

--- a/src/services/apiAdapters/managedResources/axonHubMigration.ts
+++ b/src/services/apiAdapters/managedResources/axonHubMigration.ts
@@ -22,6 +22,7 @@ import {
   mapAxonHubChannelTypeToChannelTypeStrict,
   mapChannelTypeToAxonHubChannelTypeStrict,
 } from "~/services/apiAdapters/managedResources/axonHubChannelType"
+import { hasCompleteAxonHubAdvancedDetail } from "~/services/apiService/axonHub"
 import {
   MANAGED_SITE_MUTATION_EFFECT_KINDS,
   MANAGED_SITE_MUTATION_OUTCOMES,
@@ -102,30 +103,38 @@ const hasAdvancedSettings = (channel: AxonHubChannel): boolean =>
 const toCanonicalSource = (
   channel: AxonHubChannel,
   resourceType: ManagedSiteMigrationSource["resourceType"],
-): ManagedSiteMigrationSource => ({
-  sourceSiteType: SITE_TYPES.AXON_HUB,
-  resourceType,
-  baseUrl: channel.baseURL?.trim() ?? "",
-  models: normalizeList([
-    ...(channel.supportedModels ?? []),
-    ...(channel.manualModels ?? []),
-  ]),
-  groups: [],
-  priority: DEFAULT_CHANNEL_FIELDS.priority,
-  weight: channel.orderingWeight ?? DEFAULT_CHANNEL_FIELDS.weight,
-  status:
-    channel.status === AXON_HUB_CHANNEL_STATUS.ENABLED
-      ? "enabled"
-      : channel.status === AXON_HUB_CHANNEL_STATUS.DISABLED
-        ? "disabled"
-        : "other",
-  lossSignals: {
-    hasModelMapping: Boolean(channel.settings?.modelMappings?.length),
-    hasStatusCodeMapping: false,
-    hasAdvancedSettings: hasAdvancedSettings(channel),
-    hasMultiKeyState: getAxonHubCredentialCandidates(channel).length > 1,
-  },
-})
+): ManagedSiteMigrationSource => {
+  const advancedDetailComplete = hasCompleteAxonHubAdvancedDetail(channel)
+  return {
+    sourceSiteType: SITE_TYPES.AXON_HUB,
+    resourceType,
+    baseUrl: channel.baseURL?.trim() ?? "",
+    models: normalizeList([
+      ...(channel.supportedModels ?? []),
+      ...(channel.manualModels ?? []),
+    ]),
+    groups: [],
+    priority: DEFAULT_CHANNEL_FIELDS.priority,
+    weight: channel.orderingWeight ?? DEFAULT_CHANNEL_FIELDS.weight,
+    status:
+      channel.status === AXON_HUB_CHANNEL_STATUS.ENABLED
+        ? "enabled"
+        : channel.status === AXON_HUB_CHANNEL_STATUS.DISABLED
+          ? "disabled"
+          : "other",
+    lossSignals: {
+      // A schema-validation fallback means advanced aggregates could not be
+      // inspected. Warn conservatively instead of claiming a lossless move.
+      hasModelMapping:
+        !advancedDetailComplete ||
+        Boolean(channel.settings?.modelMappings?.length),
+      hasStatusCodeMapping: false,
+      hasAdvancedSettings:
+        !advancedDetailComplete || hasAdvancedSettings(channel),
+      hasMultiKeyState: getAxonHubCredentialCandidates(channel).length > 1,
+    },
+  }
+}
 
 const toConfirmedFailureCodeFromDiagnostic = (
   diagnostic: ManagedSiteMutationDiagnostic,

--- a/src/services/apiAdapters/managedSites/axonHub.ts
+++ b/src/services/apiAdapters/managedSites/axonHub.ts
@@ -1,7 +1,7 @@
 import {
   AXON_HUB_CHANNEL_STATUS,
   AXON_HUB_CHANNEL_TYPE,
-  AxonHubChannelTypeNames,
+  AXON_HUB_GRAPHQL_ERROR_CODES,
 } from "~/constants/axonHub"
 import { SITE_TYPES } from "~/constants/siteType"
 import { MANAGED_RESOURCE_KINDS } from "~/services/accountSiteDefinitions/contracts"
@@ -10,7 +10,6 @@ import type {
   ManagedSiteChannelsCapability,
   ManagedSiteConfigCapability,
 } from "~/services/apiAdapters/contracts/managedSiteCapabilities"
-import type { ManagedUpstreamResourcesCapability } from "~/services/apiAdapters/contracts/managedUpstreamResources"
 import {
   axonHubChannelToManagedSite,
   AxonHubRequestError,
@@ -37,7 +36,6 @@ import {
   prepareChannelFormData,
   searchChannel,
 } from "~/services/managedSites/providers/axonHub"
-import { hasUsableManagedSiteChannelKey } from "~/services/managedSites/utils/managedSite"
 import type {
   AxonHubChannel,
   AxonHubCreateChannelInput,
@@ -46,26 +44,9 @@ import type {
 import type { AxonHubConfig } from "~/types/axonHubConfig"
 import {
   CHANNEL_STATUS,
-  type AxonHubChannelWithData,
-  type ChannelFormData,
   type CreateChannelPayload,
-  type ManagedSiteChannel,
-  type ManagedSiteChannelListData,
   type UpdateChannelPayload,
 } from "~/types/managedSite"
-import {
-  assertManagedUpstreamResourceRefScope,
-  createManagedUpstreamResourceRef,
-  MANAGED_UPSTREAM_RESOURCE_FIELD_TYPES,
-  MANAGED_UPSTREAM_RESOURCE_NATIVE_KINDS,
-  MANAGED_UPSTREAM_RESOURCE_SECRET_STATES,
-  MANAGED_UPSTREAM_RESOURCE_STATUSES,
-  normalizeManagedUpstreamResourceScopeKey,
-  type ManagedUpstreamResourceDetail,
-  type ManagedUpstreamResourceFieldDescriptor,
-  type ManagedUpstreamResourceRef,
-  type ManagedUpstreamResourceSummary,
-} from "~/types/managedUpstreamResource"
 import { normalizeList } from "~/utils/core/string"
 
 import { createManagedSiteConfigCapability } from "./config"
@@ -84,253 +65,10 @@ const axonHubManagedSiteChannelDrafts: ManagedSiteChannelDraftsCapability = {
   buildPayload: buildChannelPayload,
 }
 
-const assertAxonHubResourceRef = (
-  config: AxonHubConfig,
-  ref: ManagedUpstreamResourceRef,
-) =>
-  assertManagedUpstreamResourceRefScope(ref, {
-    managedSiteType: SITE_TYPES.AXON_HUB,
-    scopeKey: config.baseUrl,
-  })
-
 const toAxonHubStatus = (status?: number) =>
   status === CHANNEL_STATUS.Enable
     ? AXON_HUB_CHANNEL_STATUS.ENABLED
     : AXON_HUB_CHANNEL_STATUS.DISABLED
-
-const toChannelStatus = (status: AxonHubChannel["status"]) =>
-  status === AXON_HUB_CHANNEL_STATUS.ENABLED
-    ? CHANNEL_STATUS.Enable
-    : CHANNEL_STATUS.ManuallyDisabled
-
-const getAxonHubCredentialKey = (credentials: AxonHubChannel["credentials"]) =>
-  credentials?.apiKeys?.map((key) => key.trim()).find(Boolean) ??
-  credentials?.apiKey?.trim() ??
-  ""
-
-const getAxonHubCredentialKeys = (
-  credentials: AxonHubChannel["credentials"],
-) => [
-  ...(credentials?.apiKeys ?? []).map((key) => key.trim()).filter(Boolean),
-  ...(credentials?.apiKey?.trim() ? [credentials.apiKey.trim()] : []),
-]
-
-const getAxonHubModelList = (channel: AxonHubChannel) =>
-  normalizeList([
-    ...(channel.supportedModels ?? []),
-    ...(channel.manualModels ?? []),
-  ])
-
-const toAxonHubResourceStatus = (channel: AxonHubChannel) => {
-  switch (channel.status) {
-    case AXON_HUB_CHANNEL_STATUS.ENABLED:
-      return MANAGED_UPSTREAM_RESOURCE_STATUSES.Enabled
-    case AXON_HUB_CHANNEL_STATUS.DISABLED:
-      return MANAGED_UPSTREAM_RESOURCE_STATUSES.Disabled
-    default:
-      return MANAGED_UPSTREAM_RESOURCE_STATUSES.Unknown
-  }
-}
-
-const toAxonHubSecretState = (channel: AxonHubChannel) => {
-  const key = getAxonHubCredentialKey(channel.credentials)
-  if (!key) {
-    return MANAGED_UPSTREAM_RESOURCE_SECRET_STATES.Unavailable
-  }
-
-  return hasUsableManagedSiteChannelKey(key)
-    ? MANAGED_UPSTREAM_RESOURCE_SECRET_STATES.Available
-    : MANAGED_UPSTREAM_RESOURCE_SECRET_STATES.Masked
-}
-
-const toAxonHubResourceSummary = (
-  config: AxonHubConfig,
-  channel: AxonHubChannel,
-): ManagedUpstreamResourceSummary => {
-  const models = getAxonHubModelList(channel)
-
-  return {
-    ref: createManagedUpstreamResourceRef({
-      managedSiteType: SITE_TYPES.AXON_HUB,
-      scopeKey: normalizeManagedUpstreamResourceScopeKey(config.baseUrl),
-      resourceId: channel.id,
-    }),
-    displayName: channel.name,
-    nativeKind: MANAGED_UPSTREAM_RESOURCE_NATIVE_KINDS.Channel,
-    status: toAxonHubResourceStatus(channel),
-    typeLabel:
-      AxonHubChannelTypeNames[
-        channel.type as keyof typeof AxonHubChannelTypeNames
-      ] ?? String(channel.type),
-    endpointLabel: channel.baseURL ?? "",
-    modelCount: models.length,
-    modelPreview: models.slice(0, 3),
-    secretState: toAxonHubSecretState(channel),
-    capabilities: {
-      canCreate: true,
-      canUpdate: true,
-      canDelete: true,
-      canRevealSecret: false,
-    },
-  }
-}
-
-const rowToAxonHubNativeChannel = (row: ManagedSiteChannel): AxonHubChannel => {
-  const native = (row as Partial<AxonHubChannelWithData>)._axonHubData
-  if (native) {
-    return native
-  }
-
-  throw new Error("AxonHub channel row is missing native channel detail")
-}
-
-const toAxonHubResourceListData = (
-  config: AxonHubConfig,
-  channels: ManagedSiteChannelListData,
-) => {
-  const nativeChannels = channels.items.map(rowToAxonHubNativeChannel)
-
-  return {
-    items: nativeChannels.map((channel) =>
-      toAxonHubResourceSummary(config, channel),
-    ),
-    total: channels.total ?? nativeChannels.length,
-  }
-}
-
-const findAxonHubChannelByRef = async (
-  config: AxonHubConfig,
-  ref: ManagedUpstreamResourceRef,
-): Promise<AxonHubChannel> => {
-  assertAxonHubResourceRef(config, ref)
-  return getAxonHubChannel(config, ref.resourceId)
-}
-
-const prepareAxonHubEditDraft = (
-  detail: ManagedUpstreamResourceDetail<AxonHubChannel>,
-): ChannelFormData => {
-  const channel = detail.native
-
-  return {
-    name: channel.name,
-    type: channel.type,
-    key: getAxonHubCredentialKey(channel.credentials),
-    base_url: channel.baseURL ?? "",
-    models: getAxonHubModelList(channel),
-    groups: [],
-    priority: 0,
-    weight: channel.orderingWeight ?? 0,
-    status: toChannelStatus(channel.status),
-  }
-}
-
-const axonHubResourceFieldDescriptors: ManagedUpstreamResourceFieldDescriptor[] =
-  [
-    {
-      name: "name",
-      label: "Channel name",
-      type: MANAGED_UPSTREAM_RESOURCE_FIELD_TYPES.Text,
-      required: true,
-    },
-    {
-      name: "type",
-      label: "Channel type",
-      type: MANAGED_UPSTREAM_RESOURCE_FIELD_TYPES.Select,
-      required: true,
-      options: Object.entries(AxonHubChannelTypeNames).map(
-        ([value, label]) => ({
-          value,
-          label,
-        }),
-      ),
-    },
-    {
-      name: "key",
-      label: "API key",
-      type: MANAGED_UPSTREAM_RESOURCE_FIELD_TYPES.Secret,
-    },
-    {
-      name: "base_url",
-      label: "Base URL",
-      type: MANAGED_UPSTREAM_RESOURCE_FIELD_TYPES.Text,
-      required: true,
-    },
-  ]
-
-const buildAxonHubCredentialUpdate = (
-  native: AxonHubChannel,
-  draft: ChannelFormData,
-) => {
-  const draftKey = draft.key.trim()
-  if (hasUsableManagedSiteChannelKey(draftKey)) {
-    if (getAxonHubCredentialKeys(native.credentials).includes(draftKey)) {
-      return {
-        credentials: native.credentials ?? { apiKeys: [draftKey] },
-      }
-    }
-
-    return {
-      credentials: {
-        ...(native.credentials ?? {}),
-        apiKeys: [draftKey],
-      },
-    }
-  }
-
-  const nativeKey = getAxonHubCredentialKey(native.credentials)
-  if (hasUsableManagedSiteChannelKey(nativeKey)) {
-    return {
-      credentials: native.credentials ?? { apiKeys: [nativeKey] },
-    }
-  }
-
-  return {}
-}
-
-const toAxonHubCreateInput = (
-  draft: ChannelFormData,
-): AxonHubCreateChannelInput => {
-  const models = normalizeList(draft.models)
-  return {
-    type:
-      typeof draft.type === "string" && draft.type.trim()
-        ? draft.type
-        : AXON_HUB_CHANNEL_TYPE.OPENAI,
-    name: draft.name.trim(),
-    baseURL: draft.base_url.trim(),
-    credentials: {
-      apiKeys: [draft.key.trim()].filter(Boolean),
-    },
-    supportedModels: models,
-    manualModels: models,
-    defaultTestModel: models[0] ?? "",
-    settings: {},
-    orderingWeight: draft.weight,
-  }
-}
-
-const toAxonHubUpdateInput = (
-  detail: ManagedUpstreamResourceDetail<AxonHubChannel>,
-  draft: ChannelFormData,
-): AxonHubUpdateChannelInput => {
-  const native = detail.native
-
-  return {
-    type:
-      typeof draft.type === "string" && draft.type.trim()
-        ? draft.type
-        : native.type,
-    name: draft.name.trim(),
-    baseURL: draft.base_url.trim(),
-    ...buildAxonHubCredentialUpdate(native, draft),
-    supportedModels: native.supportedModels ?? null,
-    manualModels: native.manualModels ?? null,
-    defaultTestModel: native.defaultTestModel ?? null,
-    settings: native.settings ?? null,
-    orderingWeight: native.orderingWeight ?? null,
-    remark: native.remark ?? null,
-  }
-}
 
 const toAxonHubChannelCreateInput = (
   channelData: CreateChannelPayload,
@@ -365,26 +103,53 @@ const toAxonHubChannelCreateInput = (
 
 const toAxonHubChannelUpdateInput = (
   channelData: UpdateChannelPayload,
+  current: AxonHubChannel,
 ): AxonHubUpdateChannelInput => {
   const models = normalizeList(channelData.models?.split(",") ?? [])
   const input: AxonHubUpdateChannelInput = {}
+  const currentModels = normalizeList([
+    ...(current.supportedModels ?? []),
+    ...(current.manualModels ?? []),
+  ])
+  const currentKey =
+    current.credentials?.apiKeys?.map((key) => key.trim()).find(Boolean) ??
+    current.credentials?.apiKey?.trim() ??
+    ""
+  const listsEqual = (left: string[], right: string[]) =>
+    left.length === right.length &&
+    left.every((value, index) => value === right[index])
 
-  if (typeof channelData.type === "string") input.type = channelData.type
-  if (channelData.name !== undefined) input.name = channelData.name.trim()
+  if (
+    typeof channelData.type === "string" &&
+    channelData.type !== current.type
+  ) {
+    input.type = channelData.type
+  }
+  if (
+    channelData.name !== undefined &&
+    channelData.name.trim() !== current.name
+  ) {
+    input.name = channelData.name.trim()
+  }
   if (channelData.base_url !== undefined) {
-    input.baseURL = channelData.base_url.trim()
+    const baseURL = channelData.base_url.trim()
+    if (baseURL !== (current.baseURL ?? "")) input.baseURL = baseURL
   }
   if (channelData.key !== undefined) {
-    input.credentials = {
-      apiKeys: [channelData.key.trim()].filter(Boolean),
+    const key = channelData.key.trim()
+    if (key && key !== currentKey) {
+      input.credentials = { apiKeys: [key] }
     }
   }
-  if (models.length > 0) {
+  if (models.length > 0 && !listsEqual(models, currentModels)) {
     input.supportedModels = models
     input.manualModels = models
     input.defaultTestModel = models[0]
   }
-  if (channelData.weight !== undefined) {
+  if (
+    channelData.weight !== undefined &&
+    channelData.weight !== (current.orderingWeight ?? 0)
+  ) {
     input.orderingWeight = channelData.weight
   }
 
@@ -454,6 +219,10 @@ const runAxonHubMutationStep = async <TData>(input: {
     }
     const dispatch =
       error instanceof AxonHubRequestError ? error.dispatch : "not-dispatched"
+    const confirmedNonApplication =
+      error instanceof AxonHubRequestError &&
+      error.responseReceived &&
+      error.code === AXON_HUB_GRAPHQL_ERROR_CODES.VALIDATION_FAILED
     if (dispatch === "dispatched") {
       attempt.markPossiblyDispatched()
     }
@@ -464,10 +233,13 @@ const runAxonHubMutationStep = async <TData>(input: {
     ) {
       attempt.markResponseReceived()
     }
+    if (confirmedNonApplication) {
+      attempt.confirmNonApplication()
+    }
     attempt.complete()
     return {
       outcome:
-        dispatch === "not-dispatched"
+        dispatch === "not-dispatched" || confirmedNonApplication
           ? ("rejected" as const)
           : ("uncertain" as const),
       diagnostic: toAxonHubDiagnostic(error),
@@ -492,28 +264,31 @@ const finishAxonHubMutation = (
     diagnostic: step.diagnostic,
   })
 
+// Compatibility surface for generic ManagedSiteService callers. AxonHub's
+// dedicated channel UI uses the native resource registration; remove this
+// adapter once the remaining generic callers have migrated to that contract.
 export const axonHubManagedSiteChannels: ManagedSiteChannelsCapability<AxonHubConfig> =
   {
     search: searchChannel,
     list: listChannels,
     create: async (config, channelData) => {
+      let input: AxonHubCreateChannelInput | undefined
       const sequence = createManagedSiteMutationSequence({ idempotent: false })
       const createStep = await runAxonHubMutationStep({
         sequence,
         effect: axonHubChannelEffect(
           MANAGED_SITE_MUTATION_EFFECT_KINDS.ResourceCreated,
         ),
-        execute: async () =>
-          await createAxonHubChannel(
-            config,
-            toAxonHubChannelCreateInput(channelData),
-          ),
+        execute: async () => {
+          input = toAxonHubChannelCreateInput(channelData)
+          return await createAxonHubChannel(config, input)
+        },
       })
       if (createStep.outcome !== "applied") {
         return finishAxonHubMutation(sequence, createStep)
       }
 
-      const finalChannel = { ...createStep.data }
+      const finalChannel = { ...input!, ...createStep.data }
       if (channelData.channel.status === CHANNEL_STATUS.Enable) {
         const statusStep = await runAxonHubMutationStep({
           sequence,
@@ -540,33 +315,51 @@ export const axonHubManagedSiteChannels: ManagedSiteChannelsCapability<AxonHubCo
       })
     },
     update: async (config, channelData) => {
-      const sequence = createManagedSiteMutationSequence({ idempotent: false })
+      const sequence = createManagedSiteMutationSequence({ idempotent: true })
       let graphqlId: string | undefined
-      const updateStep = await runAxonHubMutationStep({
-        sequence,
-        effect: axonHubChannelEffect(
-          MANAGED_SITE_MUTATION_EFFECT_KINDS.ResourceUpdated,
+      let current: AxonHubChannel | undefined
+      try {
+        graphqlId = await resolveAxonHubGraphqlIdForMutation(
+          config,
           channelData.id,
-        ),
-        execute: async () => {
-          graphqlId = await resolveAxonHubGraphqlIdForMutation(
-            config,
-            channelData.id,
-          )
-          return await updateAxonHubChannel(
-            config,
-            graphqlId,
-            toAxonHubChannelUpdateInput(channelData),
-          )
-        },
-      })
-      if (updateStep.outcome !== "applied") {
-        return finishAxonHubMutation(sequence, updateStep)
+        )
+        current = await getAxonHubChannel(config, graphqlId)
+      } catch (error) {
+        if (
+          !(error instanceof AxonHubRequestError) &&
+          !isTypedOperationalPreflight(error)
+        ) {
+          throw error
+        }
+        return sequence.finish({
+          finalState: "unconfirmed",
+          diagnostic: toAxonHubDiagnostic(error),
+        })
       }
 
-      const finalChannel = { ...updateStep.data }
-      if (channelData.status !== undefined) {
-        const status = toAxonHubStatus(channelData.status)
+      const input = toAxonHubChannelUpdateInput(channelData, current)
+      let finalChannel: AxonHubChannel = current
+      if (Object.keys(input).length > 0) {
+        const updateStep = await runAxonHubMutationStep({
+          sequence,
+          effect: axonHubChannelEffect(
+            MANAGED_SITE_MUTATION_EFFECT_KINDS.ResourceUpdated,
+            channelData.id,
+          ),
+          execute: async () =>
+            await updateAxonHubChannel(config, graphqlId!, input),
+        })
+        if (updateStep.outcome !== "applied") {
+          return finishAxonHubMutation(sequence, updateStep)
+        }
+        finalChannel = { ...current, ...input, ...updateStep.data }
+      }
+
+      const status =
+        channelData.status === undefined
+          ? undefined
+          : toAxonHubStatus(channelData.status)
+      if (status !== undefined && status !== current.status) {
         const statusStep = await runAxonHubMutationStep({
           sequence,
           effect: axonHubChannelEffect(
@@ -608,179 +401,8 @@ export const axonHubManagedSiteChannels: ManagedSiteChannelsCapability<AxonHubCo
     },
   }
 
-const isRepresentableAxonHubStatus = (status: AxonHubChannel["status"]) =>
-  status === AXON_HUB_CHANNEL_STATUS.ENABLED ||
-  status === AXON_HUB_CHANNEL_STATUS.DISABLED
-
-const axonHubManagedUpstreamResources: ManagedUpstreamResourcesCapability<
-  AxonHubConfig,
-  AxonHubChannel,
-  ChannelFormData
-> = {
-  items: {
-    list: async (config, options) =>
-      toAxonHubResourceListData(
-        config,
-        await listChannels(config, { signal: options?.signal }),
-      ),
-    search: async (config, keyword) => {
-      const channels = await searchChannel(config, keyword)
-      return channels ? toAxonHubResourceListData(config, channels) : null
-    },
-    getDetail: async (config, ref) => {
-      const native = await findAxonHubChannelByRef(config, ref)
-      return {
-        summary: toAxonHubResourceSummary(config, native),
-        native,
-      }
-    },
-    create: async (config, draft) => {
-      const sequence = createManagedSiteMutationSequence({ idempotent: false })
-      const createStep = await runAxonHubMutationStep({
-        sequence,
-        effect: axonHubChannelEffect(
-          MANAGED_SITE_MUTATION_EFFECT_KINDS.ResourceCreated,
-        ),
-        execute: async () =>
-          await createAxonHubChannel(config, toAxonHubCreateInput(draft)),
-      })
-      if (createStep.outcome !== "applied") {
-        return finishAxonHubMutation(sequence, createStep)
-      }
-
-      const finalChannel = { ...createStep.data }
-      if (draft.status === CHANNEL_STATUS.Enable) {
-        const statusStep = await runAxonHubMutationStep({
-          sequence,
-          effect: axonHubChannelEffect(
-            MANAGED_SITE_MUTATION_EFFECT_KINDS.StatusUpdated,
-            createStep.data.id,
-          ),
-          execute: async () =>
-            await updateAxonHubChannelStatus(
-              config,
-              createStep.data.id,
-              AXON_HUB_CHANNEL_STATUS.ENABLED,
-            ),
-        })
-        if (statusStep.outcome !== "applied") {
-          return finishAxonHubMutation(sequence, statusStep)
-        }
-        finalChannel.status = AXON_HUB_CHANNEL_STATUS.ENABLED
-      }
-      return sequence.finish({
-        finalState: "confirmed",
-        data: toAxonHubResourceSummary(config, finalChannel),
-      })
-    },
-    update: async (config, detail, draft) => {
-      const native = detail.native
-      const sequence = createManagedSiteMutationSequence({ idempotent: false })
-      const updateStep = await runAxonHubMutationStep({
-        sequence,
-        effect: axonHubChannelEffect(
-          MANAGED_SITE_MUTATION_EFFECT_KINDS.ResourceUpdated,
-          native.id,
-        ),
-        execute: async () =>
-          await updateAxonHubChannel(
-            config,
-            native.id,
-            toAxonHubUpdateInput(detail, draft),
-          ),
-      })
-      if (updateStep.outcome !== "applied") {
-        return finishAxonHubMutation(sequence, updateStep)
-      }
-
-      const finalChannel = { ...updateStep.data }
-      const requestedStatus = toAxonHubStatus(draft.status)
-
-      if (
-        isRepresentableAxonHubStatus(native.status) &&
-        native.status !== requestedStatus
-      ) {
-        const statusStep = await runAxonHubMutationStep({
-          sequence,
-          effect: axonHubChannelEffect(
-            MANAGED_SITE_MUTATION_EFFECT_KINDS.StatusUpdated,
-            native.id,
-          ),
-          execute: async () =>
-            await updateAxonHubChannelStatus(
-              config,
-              native.id,
-              requestedStatus,
-            ),
-        })
-        if (statusStep.outcome !== "applied") {
-          return finishAxonHubMutation(sequence, statusStep)
-        }
-        finalChannel.status = requestedStatus
-      }
-
-      return sequence.finish({
-        finalState: "confirmed",
-        data: toAxonHubResourceSummary(config, finalChannel),
-      })
-    },
-    delete: async (config, ref) => {
-      assertAxonHubResourceRef(config, ref)
-      const sequence = createManagedSiteMutationSequence({ idempotent: false })
-      const step = await runAxonHubMutationStep({
-        sequence,
-        effect: axonHubChannelEffect(
-          MANAGED_SITE_MUTATION_EFFECT_KINDS.ResourceDeleted,
-          ref.resourceId,
-        ),
-        execute: async () => await deleteAxonHubChannel(config, ref.resourceId),
-        rejectResponse: (deleted) => !deleted,
-      })
-      return step.outcome === "applied"
-        ? sequence.finish({ finalState: "confirmed", data: undefined })
-        : finishAxonHubMutation(sequence, step)
-    },
-  },
-  drafts: {
-    prepareImportDraft: async (input) => {
-      if (input.source && typeof input.source === "object") {
-        return input.source as ChannelFormData
-      }
-
-      return {
-        name: input.resource?.displayName ?? "",
-        type: AXON_HUB_CHANNEL_TYPE.OPENAI,
-        key: "",
-        base_url: input.resource?.endpointLabel ?? "",
-        models: input.resource?.modelPreview ?? [],
-        groups: [],
-        priority: 0,
-        weight: 0,
-        status: CHANNEL_STATUS.Enable,
-      }
-    },
-    prepareEditDraft: prepareAxonHubEditDraft,
-    describeFields: () => axonHubResourceFieldDescriptors,
-    validateDraft: (draft) => {
-      const errors = []
-      if (!draft.name.trim()) {
-        errors.push({ field: "name", message: "Channel name is required" })
-      }
-      if (!draft.base_url?.trim()) {
-        errors.push({ field: "base_url", message: "Base URL is required" })
-      }
-
-      return {
-        valid: errors.length === 0,
-        errors,
-      }
-    },
-  },
-}
-
 export const axonHubManagedSiteCapabilities = {
   channels: axonHubManagedSiteChannels,
-  resources: axonHubManagedUpstreamResources,
   config: axonHubManagedSiteConfig,
   queries: emptyManagedSiteQueries,
   channelDrafts: axonHubManagedSiteChannelDrafts,

--- a/src/services/apiAdapters/managedSites/axonHub.ts
+++ b/src/services/apiAdapters/managedSites/axonHub.ts
@@ -221,6 +221,7 @@ const runAxonHubMutationStep = async <TData>(input: {
       error instanceof AxonHubRequestError ? error.dispatch : "not-dispatched"
     const confirmedNonApplication =
       error instanceof AxonHubRequestError &&
+      dispatch === "dispatched" &&
       error.responseReceived &&
       error.code === AXON_HUB_GRAPHQL_ERROR_CODES.VALIDATION_FAILED
     if (dispatch === "dispatched") {

--- a/src/services/apiService/axonHub/index.ts
+++ b/src/services/apiService/axonHub/index.ts
@@ -1,10 +1,10 @@
-import { AXON_HUB_CHANNEL_STATUS } from "~/constants/axonHub"
-import type {
-  ApiResponse,
-  ApiServiceRequest,
-} from "~/services/apiTransport/type"
+import {
+  AXON_HUB_CHANNEL_STATUS,
+  AXON_HUB_GRAPHQL_ERROR_CODES,
+} from "~/constants/axonHub"
 import type {
   AxonHubChannel,
+  AxonHubChannelMutationReceipt,
   AxonHubCreateChannelInput,
   AxonHubUpdateChannelInput,
 } from "~/types/axonHub"
@@ -13,11 +13,7 @@ import {
   CHANNEL_STATUS,
   type ManagedSiteChannelListData,
 } from "~/types/managedSite"
-import { getErrorMessage } from "~/utils/core/error"
-import { createLogger } from "~/utils/core/logger"
 import { normalizeList } from "~/utils/core/string"
-
-const logger = createLogger("AxonHubApiService")
 
 // Channel list responses are cached briefly, so keep this selection limited to
 // non-secret summary fields and sanitize over-returned nodes before caching.
@@ -32,11 +28,38 @@ const AXON_HUB_CHANNEL_LIST_SELECTION = `
   manualModels
 `
 
-// AxonHub v1.0.0-beta5 keeps ChannelSettingsInput as a replacement value, so
-// detail reads select every pinned settings member before callers rebuild it.
-// Its credential resolver may return null for an existing channel when the
-// caller lacks write scope. Sources: https://github.com/looplj/axonhub/blob/d061ac7df6aef0c5ec6cdfa9dc5002546a1c5a57/internal/server/gql/axonhub.graphql#L151-L205
-// and https://github.com/looplj/axonhub/blob/d061ac7df6aef0c5ec6cdfa9dc5002546a1c5a57/internal/server/gql/axonhub.resolvers.go#L50-L55
+// This is the minimum detail contract required by AxonHub editing and
+// credential handling. Optional advanced aggregates are queried separately so
+// their schema drift can safely fall back without disabling core management.
+const AXON_HUB_CHANNEL_CORE_DETAIL_SELECTION = `
+  __typename
+  id
+  createdAt
+  updatedAt
+  type
+  baseURL
+  name
+  status
+  credentials {
+    apiKey
+    apiKeys
+  }
+  supportedModels
+  autoSyncSupportedModels
+  autoSyncModelPattern
+  manualModels
+  tags
+  defaultTestModel
+  orderingWeight
+  errorMessage
+  remark
+`
+
+// Keep detail reads aligned with product-owned display, edit-safety, and
+// migration facts. In particular, do not round-trip ChannelSettings: AxonHub
+// replaces that aggregate and beta9 already added members unknown to older
+// clients. Sources: https://github.com/looplj/axonhub/blob/v1.0.0-beta8/internal/server/biz/channel.go
+// and https://github.com/looplj/axonhub/blob/v1.0.0-beta9/internal/server/gql/axonhub.graphql
 const AXON_HUB_CHANNEL_DETAIL_SELECTION = `
   __typename
   id
@@ -78,73 +101,6 @@ const AXON_HUB_CHANNEL_DETAIL_SELECTION = `
       from
       to
     }
-    autoTrimedModelPrefixes
-    hideOriginalModels
-    hideMappedModels
-    lowercaseModelId
-    proxy {
-      type
-      url
-      username
-      password
-    }
-    transformOptions {
-      forceArrayInstructions
-      forceArrayInputs
-      replaceDeveloperRoleWithSystem
-      reasoningEffortMapping {
-        from
-        to
-      }
-    }
-    headerOverrideOperations {
-      op
-      path
-      from
-      to
-      value
-      condition
-      match {
-        path
-        eq
-      }
-      index
-      splat
-    }
-    bodyOverrideOperations {
-      op
-      path
-      from
-      to
-      value
-      condition
-      match {
-        path
-        eq
-      }
-      index
-      splat
-    }
-    passThroughUserAgent
-    passThroughBody
-    rateLimit {
-      rpm
-      tpm
-      maxConcurrent
-      queueSize
-      queueTimeoutMs
-    }
-    retryableStatusCodes
-    retryableErrorPatterns {
-      pattern
-      regex
-    }
-    providerQuota {
-      opencodeGo {
-        workspaceId
-        authCookie
-      }
-    }
   }
   orderingWeight
   errorMessage
@@ -155,12 +111,17 @@ const AXON_HUB_CHANNEL_DETAIL_SELECTION = `
     baseURL
     transport
   }
-  disabledAPIKeys {
-    key
-    disabledAt
-    errorCode
-    reason
-  }
+`
+
+// Mutation responses are receipts, not detail reads. Keeping this projection
+// narrow prevents unrelated Channel fields from making every write invalid.
+const AXON_HUB_CHANNEL_MUTATION_SELECTION = `
+  __typename
+  id
+  type
+  baseURL
+  name
+  status
 `
 
 // The legacy table still needs the primary API key and model mappings, but it
@@ -187,33 +148,6 @@ const AXON_HUB_LEGACY_CHANNEL_SELECTION = `
     modelMappings {
       from
       to
-    }
-    autoTrimedModelPrefixes
-    hideOriginalModels
-    hideMappedModels
-    lowercaseModelId
-    transformOptions {
-      forceArrayInstructions
-      forceArrayInputs
-      replaceDeveloperRoleWithSystem
-      reasoningEffortMapping {
-        from
-        to
-      }
-    }
-    passThroughUserAgent
-    passThroughBody
-    rateLimit {
-      rpm
-      tpm
-      maxConcurrent
-      queueSize
-      queueTimeoutMs
-    }
-    retryableStatusCodes
-    retryableErrorPatterns {
-      pattern
-      regex
     }
   }
   orderingWeight
@@ -267,6 +201,16 @@ const GET_AXON_HUB_CHANNEL = `
   }
 `
 
+const GET_AXON_HUB_CHANNEL_CORE = `
+  query GetAxonHubChannelCore($id: ID!) {
+    node(id: $id) {
+      ... on Channel {
+        ${AXON_HUB_CHANNEL_CORE_DETAIL_SELECTION}
+      }
+    }
+  }
+`
+
 const GET_AXON_HUB_LEGACY_CHANNEL = `
   query GetAxonHubChannel($id: ID!) {
     node(id: $id) {
@@ -280,7 +224,7 @@ const GET_AXON_HUB_LEGACY_CHANNEL = `
 const CREATE_CHANNEL = `
   mutation CreateChannel($input: CreateChannelInput!) {
     createChannel(input: $input) {
-      ${AXON_HUB_CHANNEL_DETAIL_SELECTION}
+      ${AXON_HUB_CHANNEL_MUTATION_SELECTION}
     }
   }
 `
@@ -288,7 +232,7 @@ const CREATE_CHANNEL = `
 const UPDATE_CHANNEL = `
   mutation UpdateChannel($id: ID!, $input: UpdateChannelInput!) {
     updateChannel(id: $id, input: $input) {
-      ${AXON_HUB_CHANNEL_DETAIL_SELECTION}
+      ${AXON_HUB_CHANNEL_MUTATION_SELECTION}
     }
   }
 `
@@ -302,11 +246,6 @@ const UPDATE_CHANNEL_STATUS = `
     }
   }
 `
-
-const toAxonHubStatus = (status: number) =>
-  status === CHANNEL_STATUS.Enable
-    ? AXON_HUB_CHANNEL_STATUS.ENABLED
-    : AXON_HUB_CHANNEL_STATUS.DISABLED
 
 const DELETE_CHANNEL = `
   mutation DeleteChannel($id: ID!) {
@@ -394,6 +333,9 @@ const safeChannelListCache = new Map<
     expiresAt: number
   }
 >()
+const advancedDetailUnsupportedScopes = new Set<string>()
+const legacyDetailUnsupportedScopes = new Set<string>()
+const incompleteAdvancedDetails = new WeakSet<object>()
 const numericIdToGraphqlId = new Map<number, string>()
 const CHANNEL_LIST_CACHE_TTL_MS = 15_000
 const MAX_LIST_CHANNEL_PAGES = 100
@@ -412,14 +354,10 @@ export const __resetCachesForTesting = () => {
   tokenCache.clear()
   inflightSignIns.clear()
   safeChannelListCache.clear()
+  advancedDetailUnsupportedScopes.clear()
+  legacyDetailUnsupportedScopes.clear()
   numericIdToGraphqlId.clear()
 }
-
-const extractRequestConfig = (request: ApiServiceRequest): AxonHubConfig => ({
-  baseUrl: request.baseUrl,
-  email: String(request.auth.userId ?? ""),
-  password: request.auth.accessToken ?? "",
-})
 
 const reserveNumericIdSlot = (preferredNumericId: number, id: string) => {
   let numericId = preferredNumericId
@@ -479,12 +417,6 @@ export async function resolveAxonHubGraphqlIdForMutation(
     "not-dispatched",
     `Unable to resolve AxonHub GraphQL id for channel ${id}`,
   )
-}
-
-const toSafeErrorMessage = (error: unknown, fallback: string) => {
-  const message = getErrorMessage(error)
-  if (!message) return fallback
-  return message.replace(/Bearer\s+[A-Za-z0-9._-]+/g, "Bearer [redacted]")
 }
 
 const isAbortError = (error: unknown) =>
@@ -571,9 +503,6 @@ const isOutputNullableString = (value: unknown) =>
 const isOutputNullableBoolean = (value: unknown) =>
   value === null || typeof value === "boolean"
 
-const isOutputNullableInteger = (value: unknown) =>
-  value === null || (typeof value === "number" && Number.isInteger(value))
-
 const isOutputStringArray = (value: unknown) =>
   Array.isArray(value) && value.every((item) => typeof item === "string")
 
@@ -597,11 +526,16 @@ const isOutputGcpCredential = (value: unknown) =>
     typeof value.projectID === "string" &&
     typeof value.jsonData === "string")
 
-const isOutputCredentials = (value: unknown) =>
+const isOutputPrimaryCredentials = (value: unknown) =>
   value === null ||
   (isRecord(value) &&
     isOutputNullableString(value.apiKey) &&
-    isOutputNullableStringArray(value.apiKeys) &&
+    isOutputNullableStringArray(value.apiKeys))
+
+const isOutputCredentials = (value: unknown) =>
+  value === null ||
+  (isOutputPrimaryCredentials(value) &&
+    isRecord(value) &&
     isOutputGcpCredential(value.gcp) &&
     isOutputOAuthCredentials(value.oauth))
 
@@ -615,101 +549,11 @@ const isOutputModelMappings = (value: unknown) =>
         typeof mapping.to === "string",
     ))
 
-const isOutputOverrideMatch = (value: unknown) =>
-  value === null ||
-  (isRecord(value) &&
-    typeof value.path === "string" &&
-    typeof value.eq === "string")
-
-const isOutputOverrideOperations = (value: unknown) =>
-  Array.isArray(value) &&
-  value.every(
-    (operation) =>
-      isRecord(operation) &&
-      typeof operation.op === "string" &&
-      isOutputNullableString(operation.path) &&
-      isOutputNullableString(operation.from) &&
-      isOutputNullableString(operation.to) &&
-      isOutputNullableString(operation.value) &&
-      isOutputNullableString(operation.condition) &&
-      isOutputOverrideMatch(operation.match) &&
-      isOutputNullableInteger(operation.index) &&
-      isOutputNullableBoolean(operation.splat),
-  )
-
-const isOutputProxy = (value: unknown) =>
-  value === null ||
-  (isRecord(value) &&
-    typeof value.type === "string" &&
-    isOutputNullableString(value.url) &&
-    isOutputNullableString(value.username) &&
-    isOutputNullableString(value.password))
-
-const isOutputTransformOptions = (value: unknown) =>
-  value === null ||
-  (isRecord(value) &&
-    typeof value.forceArrayInstructions === "boolean" &&
-    typeof value.forceArrayInputs === "boolean" &&
-    typeof value.replaceDeveloperRoleWithSystem === "boolean" &&
-    (value.reasoningEffortMapping === null ||
-      (Array.isArray(value.reasoningEffortMapping) &&
-        value.reasoningEffortMapping.every(
-          (mapping) =>
-            isRecord(mapping) &&
-            typeof mapping.from === "string" &&
-            typeof mapping.to === "string",
-        ))))
-
-const isOutputRateLimit = (value: unknown) =>
-  value === null ||
-  (isRecord(value) &&
-    isOutputNullableInteger(value.rpm) &&
-    isOutputNullableInteger(value.tpm) &&
-    isOutputNullableInteger(value.maxConcurrent) &&
-    isOutputNullableInteger(value.queueSize) &&
-    isOutputNullableInteger(value.queueTimeoutMs))
-
-const isOutputRetryableStatusCodes = (value: unknown) =>
-  value === null ||
-  (Array.isArray(value) && value.every((code) => Number.isInteger(code)))
-
-const isOutputRetryableErrorPatterns = (value: unknown) =>
-  value === null ||
-  (Array.isArray(value) &&
-    value.every(
-      (entry) =>
-        isRecord(entry) &&
-        typeof entry.pattern === "string" &&
-        typeof entry.regex === "boolean",
-    ))
-
-const isOutputProviderQuota = (value: unknown) =>
-  value === null ||
-  (isRecord(value) &&
-    (value.opencodeGo === null ||
-      (isRecord(value.opencodeGo) &&
-        isOutputNullableString(value.opencodeGo.workspaceId) &&
-        isOutputNullableString(value.opencodeGo.authCookie))))
-
 const isOutputSettings = (value: unknown) =>
   value === null ||
   (isRecord(value) &&
     isOutputNullableString(value.extraModelPrefix) &&
-    isOutputModelMappings(value.modelMappings) &&
-    isOutputNullableStringArray(value.autoTrimedModelPrefixes) &&
-    isOutputNullableBoolean(value.hideOriginalModels) &&
-    isOutputNullableBoolean(value.hideMappedModels) &&
-    isOutputNullableBoolean(value.lowercaseModelId) &&
-    isOutputProxy(value.proxy) &&
-    isOutputTransformOptions(value.transformOptions) &&
-    isOutputOverrideOperations(value.headerOverrideOperations) &&
-    isOutputOverrideOperations(value.bodyOverrideOperations) &&
-    isOutputNullableBoolean(value.passThroughUserAgent) &&
-    isOutputNullableBoolean(value.passThroughBody) &&
-    isOutputRateLimit(value.rateLimit) &&
-    isOutputRetryableStatusCodes(value.retryableStatusCodes) &&
-    isOutputRetryableErrorPatterns(value.retryableErrorPatterns) &&
-    isOutputProviderQuota(value.providerQuota))
+    isOutputModelMappings(value.modelMappings))
 
 const isOutputPolicies = (value: unknown) =>
   value === null || (isRecord(value) && isOutputNullableString(value.stream))
@@ -724,19 +568,6 @@ const isOutputEndpoints = (value: unknown) =>
         isOutputNullableString(endpoint.path) &&
         isOutputNullableString(endpoint.baseURL) &&
         isOutputNullableString(endpoint.transport),
-    ))
-
-const isOutputDisabledApiKeys = (value: unknown) =>
-  value === null ||
-  (Array.isArray(value) &&
-    value.every(
-      (entry) =>
-        isRecord(entry) &&
-        typeof entry.key === "string" &&
-        typeof entry.disabledAt === "string" &&
-        typeof entry.errorCode === "number" &&
-        Number.isInteger(entry.errorCode) &&
-        isOutputNullableString(entry.reason),
     ))
 
 const isAuthoritativeAxonHubChannel = (
@@ -764,30 +595,50 @@ const isAuthoritativeAxonHubChannel = (
   Number.isInteger(value.orderingWeight) &&
   isOutputNullableString(value.errorMessage) &&
   isOutputNullableString(value.remark) &&
-  isOutputEndpoints(value.endpoints) &&
-  isOutputDisabledApiKeys(value.disabledAPIKeys)
+  isOutputEndpoints(value.endpoints)
 
-const isLegacyOutputCredentials = (value: unknown) =>
-  value === null ||
-  (isRecord(value) &&
-    isOutputNullableString(value.apiKey) &&
-    isOutputNullableStringArray(value.apiKeys))
+const isAxonHubChannelCoreDetail = (
+  value: unknown,
+): value is AxonHubChannel & { __typename: "Channel" } =>
+  isRecord(value) &&
+  value.__typename === "Channel" &&
+  isNonEmptyString(value.id) &&
+  typeof value.createdAt === "string" &&
+  typeof value.updatedAt === "string" &&
+  typeof value.type === "string" &&
+  isOutputNullableString(value.baseURL) &&
+  typeof value.name === "string" &&
+  typeof value.status === "string" &&
+  isOutputPrimaryCredentials(value.credentials) &&
+  isOutputStringArray(value.supportedModels) &&
+  isOutputNullableBoolean(value.autoSyncSupportedModels) &&
+  isOutputNullableString(value.autoSyncModelPattern) &&
+  isOutputNullableStringArray(value.manualModels) &&
+  isOutputNullableStringArray(value.tags) &&
+  typeof value.defaultTestModel === "string" &&
+  typeof value.orderingWeight === "number" &&
+  Number.isInteger(value.orderingWeight) &&
+  isOutputNullableString(value.errorMessage) &&
+  isOutputNullableString(value.remark)
+
+const isAxonHubChannelMutationProjection = (
+  value: unknown,
+): value is AxonHubChannelMutationReceipt =>
+  isRecord(value) &&
+  value.__typename === "Channel" &&
+  isNonEmptyString(value.id) &&
+  typeof value.type === "string" &&
+  isOutputNullableString(value.baseURL) &&
+  typeof value.name === "string" &&
+  typeof value.status === "string"
+
+const isLegacyOutputCredentials = isOutputPrimaryCredentials
 
 const isLegacyOutputSettings = (value: unknown) =>
   value === null ||
   (isRecord(value) &&
     isOutputNullableString(value.extraModelPrefix) &&
-    isOutputModelMappings(value.modelMappings) &&
-    isOutputNullableStringArray(value.autoTrimedModelPrefixes) &&
-    isOutputNullableBoolean(value.hideOriginalModels) &&
-    isOutputNullableBoolean(value.hideMappedModels) &&
-    isOutputNullableBoolean(value.lowercaseModelId) &&
-    isOutputTransformOptions(value.transformOptions) &&
-    isOutputNullableBoolean(value.passThroughUserAgent) &&
-    isOutputNullableBoolean(value.passThroughBody) &&
-    isOutputRateLimit(value.rateLimit) &&
-    isOutputRetryableStatusCodes(value.retryableStatusCodes) &&
-    isOutputRetryableErrorPatterns(value.retryableErrorPatterns))
+    isOutputModelMappings(value.modelMappings))
 
 const isLegacyAxonHubChannel = (
   value: unknown,
@@ -840,50 +691,6 @@ const sanitizeLegacyAxonHubChannel = (
             modelMappings:
               settings.modelMappings?.map(({ from, to }) => ({ from, to })) ??
               null,
-            autoTrimedModelPrefixes:
-              settings.autoTrimedModelPrefixes == null
-                ? null
-                : [...settings.autoTrimedModelPrefixes],
-            hideOriginalModels: settings.hideOriginalModels ?? null,
-            hideMappedModels: settings.hideMappedModels ?? null,
-            lowercaseModelId: settings.lowercaseModelId ?? null,
-            transformOptions:
-              settings.transformOptions == null
-                ? null
-                : {
-                    forceArrayInstructions:
-                      settings.transformOptions.forceArrayInstructions ?? null,
-                    forceArrayInputs:
-                      settings.transformOptions.forceArrayInputs ?? null,
-                    replaceDeveloperRoleWithSystem:
-                      settings.transformOptions
-                        .replaceDeveloperRoleWithSystem ?? null,
-                    reasoningEffortMapping:
-                      settings.transformOptions.reasoningEffortMapping?.map(
-                        ({ from, to }) => ({ from, to }),
-                      ) ?? null,
-                  },
-            passThroughUserAgent: settings.passThroughUserAgent ?? null,
-            passThroughBody: settings.passThroughBody ?? null,
-            rateLimit:
-              settings.rateLimit == null
-                ? null
-                : {
-                    rpm: settings.rateLimit.rpm ?? null,
-                    tpm: settings.rateLimit.tpm ?? null,
-                    maxConcurrent: settings.rateLimit.maxConcurrent ?? null,
-                    queueSize: settings.rateLimit.queueSize ?? null,
-                    queueTimeoutMs: settings.rateLimit.queueTimeoutMs ?? null,
-                  },
-            retryableStatusCodes:
-              settings.retryableStatusCodes == null
-                ? null
-                : [...settings.retryableStatusCodes],
-            retryableErrorPatterns:
-              settings.retryableErrorPatterns?.map(({ pattern, regex }) => ({
-                pattern,
-                regex: regex ?? null,
-              })) ?? null,
           },
     createdAt: value.createdAt ?? null,
     updatedAt: value.updatedAt ?? null,
@@ -891,12 +698,6 @@ const sanitizeLegacyAxonHubChannel = (
     errorMessage: value.errorMessage ?? null,
     remark: value.remark ?? null,
   }
-}
-
-const toLegacyAxonHubChannel = (value: unknown): AxonHubChannel | null => {
-  if (!isLegacyAxonHubChannel(value)) return null
-
-  return sanitizeLegacyAxonHubChannel(value)
 }
 
 const toSafeAxonHubChannelSummary = (value: unknown): AxonHubChannel | null => {
@@ -1496,6 +1297,31 @@ export async function listAxonHubChannelPage(
   )
 }
 
+const isAxonHubSchemaValidationError = (error: unknown) =>
+  error instanceof AxonHubRequestError &&
+  error.code === AXON_HUB_GRAPHQL_ERROR_CODES.VALIDATION_FAILED
+
+const requestAxonHubChannelNode = async (
+  config: AxonHubConfig,
+  id: string,
+  query: string,
+  options?: Pick<RequestInit, "signal">,
+) => {
+  const data = await graphqlRequest<unknown>(config, query, { id }, options)
+  if (!isRecord(data) || !("node" in data)) {
+    throw new AxonHubRequestError("protocol", "not-dispatched")
+  }
+  if (data.node === null) {
+    throw new AxonHubRequestError("not-found", "not-dispatched")
+  }
+  return data.node
+}
+
+/** Returns whether an AxonHub detail read included all optional aggregates. */
+export const hasCompleteAxonHubAdvancedDetail = (
+  channel: AxonHubChannel,
+): boolean => !incompleteAdvancedDetails.has(channel)
+
 /**
  * Load one native AxonHub channel by its opaque GraphQL id.
  */
@@ -1504,28 +1330,41 @@ export async function getAxonHubChannel(
   id: string,
   options?: Pick<RequestInit, "signal">,
 ): Promise<AxonHubChannel> {
-  const data = await graphqlRequest<unknown>(
-    config,
-    GET_AXON_HUB_CHANNEL,
-    { id },
-    options,
-  )
+  const scopeKey = cacheKeyForConfig(config)
+  let complete = !advancedDetailUnsupportedScopes.has(scopeKey)
+  let node: unknown
+  try {
+    node = await requestAxonHubChannelNode(
+      config,
+      id,
+      complete ? GET_AXON_HUB_CHANNEL : GET_AXON_HUB_CHANNEL_CORE,
+      options,
+    )
+  } catch (error) {
+    if (!complete || !isAxonHubSchemaValidationError(error)) throw error
+    complete = false
+    advancedDetailUnsupportedScopes.add(scopeKey)
+    node = await requestAxonHubChannelNode(
+      config,
+      id,
+      GET_AXON_HUB_CHANNEL_CORE,
+      options,
+    )
+  }
 
-  if (!isRecord(data) || !("node" in data)) {
+  if (complete) {
+    if (!isAuthoritativeAxonHubChannel(node) || node.id !== id) {
+      throw new AxonHubRequestError("protocol", "not-dispatched")
+    }
+    return node
+  }
+
+  if (!isAxonHubChannelCoreDetail(node) || node.id !== id) {
     throw new AxonHubRequestError("protocol", "not-dispatched")
   }
-  if (data.node === null) {
-    throw new AxonHubRequestError("not-found", "not-dispatched")
-  }
-  if (
-    !isRecord(data.node) ||
-    !isAuthoritativeAxonHubChannel(data.node) ||
-    data.node.id !== id
-  ) {
-    throw new AxonHubRequestError("protocol", "not-dispatched")
-  }
 
-  return data.node
+  incompleteAdvancedDetails.add(node)
+  return node
 }
 
 const getLegacyAxonHubChannel = async (
@@ -1533,25 +1372,39 @@ const getLegacyAxonHubChannel = async (
   id: string,
   options?: Pick<RequestInit, "signal">,
 ): Promise<AxonHubChannel> => {
-  const data = await graphqlRequest<unknown>(
-    config,
-    GET_AXON_HUB_LEGACY_CHANNEL,
-    { id },
-    options,
-  )
+  const scopeKey = cacheKeyForConfig(config)
+  let complete = !legacyDetailUnsupportedScopes.has(scopeKey)
+  let node: unknown
+  try {
+    node = await requestAxonHubChannelNode(
+      config,
+      id,
+      complete ? GET_AXON_HUB_LEGACY_CHANNEL : GET_AXON_HUB_CHANNEL_CORE,
+      options,
+    )
+  } catch (error) {
+    if (!complete || !isAxonHubSchemaValidationError(error)) throw error
+    complete = false
+    legacyDetailUnsupportedScopes.add(scopeKey)
+    node = await requestAxonHubChannelNode(
+      config,
+      id,
+      GET_AXON_HUB_CHANNEL_CORE,
+      options,
+    )
+  }
 
-  if (!isRecord(data) || !("node" in data)) {
+  if (complete) {
+    if (!isLegacyAxonHubChannel(node) || node.id !== id) {
+      throw new AxonHubRequestError("protocol", "not-dispatched")
+    }
+    return sanitizeLegacyAxonHubChannel(node)
+  }
+
+  if (!isAxonHubChannelCoreDetail(node) || node.id !== id) {
     throw new AxonHubRequestError("protocol", "not-dispatched")
   }
-  if (data.node === null) {
-    throw new AxonHubRequestError("not-found", "not-dispatched")
-  }
-
-  const channel = toLegacyAxonHubChannel(data.node)
-  if (!channel || channel.id !== id) {
-    throw new AxonHubRequestError("protocol", "not-dispatched")
-  }
-  return channel
+  return sanitizeLegacyAxonHubChannel(node)
 }
 
 const hydrateLegacyAxonHubChannels = async (
@@ -1726,7 +1579,10 @@ export async function createAxonHubChannel(
     { input },
     options,
   )
-  if (!isRecord(data) || !isAuthoritativeAxonHubChannel(data.createChannel)) {
+  if (
+    !isRecord(data) ||
+    !isAxonHubChannelMutationProjection(data.createChannel)
+  ) {
     throw new AxonHubRequestError("protocol", "dispatched")
   }
   invalidateChannelListCache(config)
@@ -1742,9 +1598,10 @@ export async function updateAxonHubChannel(
   input: AxonHubUpdateChannelInput,
   options?: Pick<RequestInit, "signal">,
 ) {
-  // beta5 UpdateChannelInput treats settings as replacement data and exposes
-  // only these generated append/clear fields; forward the verified input
-  // unchanged. Source: https://github.com/looplj/axonhub/blob/d061ac7df6aef0c5ec6cdfa9dc5002546a1c5a57/internal/server/gql/ent.graphql#L5993-L6033
+  // This transport forwards UpdateChannelInput unchanged. Product adapters
+  // must account for AxonHub's custom updater semantics instead of assuming
+  // every generated append/clear field is implemented. Source:
+  // https://github.com/looplj/axonhub/blob/v1.0.0-beta9/internal/server/biz/channel.go
   const data = await graphqlRequest<unknown>(
     config,
     UPDATE_CHANNEL,
@@ -1753,7 +1610,7 @@ export async function updateAxonHubChannel(
   )
   if (
     !isRecord(data) ||
-    !isAuthoritativeAxonHubChannel(data.updateChannel) ||
+    !isAxonHubChannelMutationProjection(data.updateChannel) ||
     data.updateChannel.id !== id
   ) {
     throw new AxonHubRequestError("protocol", "dispatched")
@@ -1809,132 +1666,6 @@ export async function deleteAxonHubChannel(
   }
   invalidateChannelListCache(config)
   return data.deleteChannel
-}
-
-/**
- * API-service adapter for model-sync channel listing.
- */
-export async function listAllChannels(
-  request: ApiServiceRequest,
-): Promise<ManagedSiteChannelListData> {
-  return listChannels(extractRequestConfig(request))
-}
-
-/**
- * API-service adapter for channel search.
- */
-export async function searchChannel(
-  request: ApiServiceRequest,
-  keyword: string,
-): Promise<ManagedSiteChannelListData | null> {
-  return searchChannels(extractRequestConfig(request), keyword)
-}
-
-/**
- * API-service adapter for channel creation.
- */
-export async function createChannel(
-  request: ApiServiceRequest,
-  channelData: {
-    channel: AxonHubCreateChannelInput & { status?: number }
-  },
-): Promise<ApiResponse<unknown>> {
-  try {
-    const config = extractRequestConfig(request)
-    const { status, ...input } = channelData.channel
-    const created = await createAxonHubChannel(config, input)
-    const finalChannel = { ...created }
-    invalidateChannelListCache(config)
-    if (status === CHANNEL_STATUS.Enable) {
-      const axonHubStatus = toAxonHubStatus(status)
-      await updateAxonHubChannelStatus(config, created.id, axonHubStatus)
-      finalChannel.status = axonHubStatus
-    }
-
-    return {
-      success: true,
-      data: axonHubChannelToManagedSite(finalChannel),
-      message: "success",
-    }
-  } catch (error) {
-    logger.error("Failed to create AxonHub channel", error)
-    return {
-      success: false,
-      data: null,
-      message: toSafeErrorMessage(error, "Failed to create AxonHub channel"),
-    }
-  }
-}
-
-/**
- * API-service adapter for channel updates.
- */
-export async function updateChannel(
-  request: ApiServiceRequest,
-  channelData: Omit<AxonHubUpdateChannelInput, "status"> & {
-    id: number
-    status?: number
-  },
-): Promise<ApiResponse<unknown>> {
-  try {
-    const config = extractRequestConfig(request)
-    const { id, status, ...input } = channelData
-    const graphqlId = await resolveAxonHubGraphqlIdForMutation(config, id)
-    const updated = await updateAxonHubChannel(config, graphqlId, input)
-    const finalChannel = { ...updated }
-    invalidateChannelListCache(config)
-
-    if (status !== undefined) {
-      const axonHubStatus = toAxonHubStatus(status)
-      await updateAxonHubChannelStatus(config, graphqlId, axonHubStatus)
-      finalChannel.status = axonHubStatus
-    }
-
-    return {
-      success: true,
-      data: axonHubChannelToManagedSite(finalChannel),
-      message: "success",
-    }
-  } catch (error) {
-    logger.error("Failed to update AxonHub channel", error)
-    return {
-      success: false,
-      data: null,
-      message: toSafeErrorMessage(error, "Failed to update AxonHub channel"),
-    }
-  }
-}
-
-/**
- * API-service adapter for channel deletion.
- */
-export async function deleteChannel(
-  request: ApiServiceRequest,
-  channelId: number,
-): Promise<ApiResponse<unknown>> {
-  try {
-    const config = extractRequestConfig(request)
-    const deleted = await deleteAxonHubChannel(
-      config,
-      await resolveAxonHubGraphqlIdForMutation(config, channelId),
-    )
-    if (deleted) {
-      invalidateChannelListCache(config)
-    }
-
-    return {
-      success: deleted,
-      data: deleted,
-      message: deleted ? "success" : "Failed to delete AxonHub channel",
-    }
-  } catch (error) {
-    logger.error("Failed to delete AxonHub channel", error)
-    return {
-      success: false,
-      data: null,
-      message: toSafeErrorMessage(error, "Failed to delete AxonHub channel"),
-    }
-  }
 }
 
 /**

--- a/src/services/apiService/axonHub/index.ts
+++ b/src/services/apiService/axonHub/index.ts
@@ -350,6 +350,12 @@ const invalidateChannelListCache = (config: AxonHubConfig) => {
   safeChannelListCache.delete(cacheKeyForConfig(config))
 }
 
+const invalidateDetailSchemaCapabilityCache = (config: AxonHubConfig) => {
+  const scopeKey = cacheKeyForConfig(config)
+  advancedDetailUnsupportedScopes.delete(scopeKey)
+  legacyDetailUnsupportedScopes.delete(scopeKey)
+}
+
 export const __resetCachesForTesting = () => {
   tokenCache.clear()
   inflightSignIns.clear()
@@ -814,6 +820,9 @@ export async function signIn(
   }
 
   tokenCache.set(cacheKeyForConfig(config), data.token)
+  // A successful authentication is a bounded capability-renewal boundary: a
+  // deployment may have upgraded since an optional detail shape was rejected.
+  invalidateDetailSchemaCapabilityCache(config)
   return data.token
 }
 
@@ -1356,6 +1365,7 @@ export async function getAxonHubChannel(
     if (!isAuthoritativeAxonHubChannel(node) || node.id !== id) {
       throw new AxonHubRequestError("protocol", "not-dispatched")
     }
+    advancedDetailUnsupportedScopes.delete(scopeKey)
     return node
   }
 
@@ -1398,6 +1408,7 @@ const getLegacyAxonHubChannel = async (
     if (!isLegacyAxonHubChannel(node) || node.id !== id) {
       throw new AxonHubRequestError("protocol", "not-dispatched")
     }
+    legacyDetailUnsupportedScopes.delete(scopeKey)
     return sanitizeLegacyAxonHubChannel(node)
   }
 

--- a/src/services/managedSites/managedUpstreamResourceMigration.ts
+++ b/src/services/managedSites/managedUpstreamResourceMigration.ts
@@ -65,7 +65,6 @@ const defaultManagedUpstreamResourceMigrationGates =
       SITE_TYPES.VELOERA,
       SITE_TYPES.DONE_HUB,
       SITE_TYPES.OCTOPUS,
-      SITE_TYPES.AXON_HUB,
       SITE_TYPES.CLAUDE_CODE_HUB,
       SITE_TYPES.SUB2API,
     ],

--- a/src/types/axonHub.ts
+++ b/src/types/axonHub.ts
@@ -57,15 +57,6 @@ export interface AxonHubRetryableErrorPattern {
   regex?: boolean | null
 }
 
-export interface AxonHubOpenCodeGoQuotaSettings {
-  workspaceId?: string | null
-  authCookie?: string | null
-}
-
-export interface AxonHubChannelProviderQuotaSettings {
-  opencodeGo?: AxonHubOpenCodeGoQuotaSettings | null
-}
-
 export interface AxonHubChannelSettings {
   extraModelPrefix?: string | null
   modelMappings?: AxonHubModelMapping[] | null
@@ -82,7 +73,6 @@ export interface AxonHubChannelSettings {
   rateLimit?: AxonHubChannelRateLimit | null
   retryableStatusCodes?: number[] | null
   retryableErrorPatterns?: AxonHubRetryableErrorPattern[] | null
-  providerQuota?: AxonHubChannelProviderQuotaSettings | null
 }
 
 export interface AxonHubOAuthCredentials {
@@ -164,6 +154,11 @@ export interface AxonHubChannel {
   allModelEntries?: AxonHubChannelModelEntry[] | null
   liveLimiterStats?: AxonHubChannelLimiterStats | null
 }
+
+export type AxonHubChannelMutationReceipt = Pick<
+  AxonHubChannel,
+  "id" | "type" | "baseURL" | "name" | "status"
+> & { __typename: "Channel" }
 
 export interface AxonHubCreateChannelInput {
   type: AxonHubChannelType | string

--- a/tests/features/ManagedSiteChannels/presentation/ManagedResourceEditorBody.test.tsx
+++ b/tests/features/ManagedSiteChannels/presentation/ManagedResourceEditorBody.test.tsx
@@ -247,10 +247,6 @@ const createDescriptors = (
       options: [],
     },
     { fieldId: AXON_HUB_CHANNEL_FIELD_IDS.REMARK, type: "textarea" },
-    {
-      fieldId: AXON_HUB_CHANNEL_FIELD_IDS.EXTRA_MODEL_PREFIX,
-      type: "text",
-    },
   ].reverse() as readonly ResourceFieldDescriptor[]
 
 const editPolicy =
@@ -798,12 +794,12 @@ describe("ManagedResourceEditorBody", () => {
       "Model sync",
       "Routing",
       "Metadata",
-      "Advanced",
     ]) {
       expect(
         screen.getAllByRole("group", { name: section }).at(0),
       ).toBeVisible()
     }
+    expect(screen.queryByRole("group", { name: "Advanced" })).toBeNull()
 
     const dialog = screen.getByRole("dialog", { name: "Edit native channel" })
     const closeButton = screen.getByRole("button", {

--- a/tests/features/ManagedSiteChannels/presentation/managedResourceFieldPolicy.test.ts
+++ b/tests/features/ManagedSiteChannels/presentation/managedResourceFieldPolicy.test.ts
@@ -5,6 +5,7 @@ import {
   AXON_HUB_CHANNEL_FIELD_IDS,
   AXON_HUB_CHANNEL_STATUS,
   AXON_HUB_CHANNEL_TYPE,
+  AXON_HUB_CREATE_FIELD_IDS,
   AXON_HUB_EDITABLE_FIELD_IDS,
 } from "~/constants/axonHub"
 import { SITE_TYPES } from "~/constants/siteType"
@@ -288,7 +289,11 @@ describe("managed resource field policy", () => {
 
       expect(policy).toBeDefined()
       const resolved = resolveManagedResourceFieldPolicy(
-        createDescriptors(),
+        createDescriptors().filter(
+          ({ fieldId }) =>
+            mode === "create" ||
+            fieldId !== AXON_HUB_CHANNEL_FIELD_IDS.EXTRA_MODEL_PREFIX,
+        ),
         policy!,
       )
 
@@ -301,7 +306,10 @@ describe("managed resource field policy", () => {
         ),
       ).toEqual(
         new Set(
-          AXON_HUB_EDITABLE_FIELD_IDS.filter(
+          (mode === "create"
+            ? AXON_HUB_CREATE_FIELD_IDS
+            : AXON_HUB_EDITABLE_FIELD_IDS
+          ).filter(
             (fieldId) => fieldId !== AXON_HUB_CHANNEL_FIELD_IDS.MANUAL_MODELS,
           ),
         ),
@@ -309,7 +317,12 @@ describe("managed resource field policy", () => {
       expect(
         new Set(resolved.fields.map(({ presentation }) => presentation.fieldId))
           .size,
-      ).toBe(AXON_HUB_EDITABLE_FIELD_IDS.length - 1)
+      ).toBe(
+        (mode === "create"
+          ? AXON_HUB_CREATE_FIELD_IDS
+          : AXON_HUB_EDITABLE_FIELD_IDS
+        ).length - 1,
+      )
       for (const { descriptor, presentation } of resolved.fields) {
         expect(presentation.renderer).toBe(descriptor.type)
       }
@@ -456,10 +469,6 @@ describe("managed resource field policy", () => {
     const expectedCopy = {
       tags: ["tags.help", "tags.placeholder"],
       remark: ["remark.help", "remark.placeholder"],
-      extraModelPrefix: [
-        "extraModelPrefix.help",
-        "extraModelPrefix.placeholder",
-      ],
     } as const
     for (const [fieldId, [helpKey, placeholderKey]] of Object.entries(
       expectedCopy,
@@ -474,6 +483,13 @@ describe("managed resource field policy", () => {
         `managedSiteChannels:editor.fields.${placeholderKey}`,
       )
     }
+
+    expect(
+      policy.fields.some(
+        ({ fieldId }) =>
+          fieldId === AXON_HUB_CHANNEL_FIELD_IDS.EXTRA_MODEL_PREFIX,
+      ),
+    ).toBe(false)
   })
 
   it("maps approved options to controlled labels and unknown values to one fallback", () => {

--- a/tests/services/apiAdapters/managedResources/axonHub.test.ts
+++ b/tests/services/apiAdapters/managedResources/axonHub.test.ts
@@ -4,6 +4,8 @@ import {
   AXON_HUB_CHANNEL_FIELD_IDS,
   AXON_HUB_CHANNEL_STATUS,
   AXON_HUB_CHANNEL_TYPE,
+  AXON_HUB_CREATE_FIELD_IDS,
+  AXON_HUB_DETAIL_FIELD_IDS,
   AXON_HUB_EDITABLE_FIELD_IDS,
   AXON_HUB_TABLE_FIELD_IDS,
 } from "~/constants/axonHub"
@@ -87,6 +89,7 @@ const mocks = vi.hoisted(() => {
     updateChannel: vi.fn(),
     updateStatus: vi.fn(),
     deleteChannel: vi.fn(),
+    hasCompleteAdvancedDetail: vi.fn(),
     mutationSequenceStepCounts: [] as number[],
   }
 })
@@ -108,6 +111,7 @@ vi.mock("~/services/apiService/axonHub", () => ({
   updateAxonHubChannel: mocks.updateChannel,
   updateAxonHubChannelStatus: mocks.updateStatus,
   deleteAxonHubChannel: mocks.deleteChannel,
+  hasCompleteAxonHubAdvancedDetail: mocks.hasCompleteAdvancedDetail,
 }))
 
 vi.mock("~/services/managedSites/mutations", async (importOriginal) => {
@@ -185,9 +189,6 @@ const pinnedSettings = {
   },
   retryableStatusCodes: [429, 503],
   retryableErrorPatterns: [{ pattern: "retry", regex: false }],
-  providerQuota: {
-    opencodeGo: { workspaceId: "workspace-placeholder", authCookie: null },
-  },
 } satisfies NonNullable<AxonHubChannel["settings"]>
 
 const buildDetailChannel = (
@@ -279,13 +280,6 @@ const updateFieldCases: readonly {
     value: " Updated remark ",
     expectedInput: { remark: "Updated remark" },
   },
-  {
-    fieldId: AXON_HUB_CHANNEL_FIELD_IDS.EXTRA_MODEL_PREFIX,
-    value: "",
-    expectedInput: {
-      settings: { ...pinnedSettings, extraModelPrefix: "" },
-    },
-  },
 ]
 
 const emptyFieldCases: readonly {
@@ -296,12 +290,12 @@ const emptyFieldCases: readonly {
   {
     fieldId: AXON_HUB_CHANNEL_FIELD_IDS.BASE_URL,
     value: "",
-    expectedInput: { clearBaseURL: true },
+    expectedInput: { baseURL: "" },
   },
   {
     fieldId: AXON_HUB_CHANNEL_FIELD_IDS.MANUAL_MODELS,
     value: [],
-    expectedInput: { clearManualModels: true },
+    expectedInput: { manualModels: [] },
   },
   {
     fieldId: AXON_HUB_CHANNEL_FIELD_IDS.AUTO_SYNC_MODEL_PATTERN,
@@ -407,7 +401,10 @@ const expectEditorMatchesFieldPolicy = (
     new Set(resolved.fields.map(({ presentation }) => presentation.fieldId)),
   ).toEqual(
     new Set(
-      AXON_HUB_EDITABLE_FIELD_IDS.filter(
+      (mode === "create"
+        ? AXON_HUB_CREATE_FIELD_IDS
+        : AXON_HUB_EDITABLE_FIELD_IDS
+      ).filter(
         (fieldId) => fieldId !== AXON_HUB_CHANNEL_FIELD_IDS.MANUAL_MODELS,
       ),
     ),
@@ -500,6 +497,7 @@ describe("AxonHub native managed-resource Adapter", () => {
       status: AXON_HUB_CHANNEL_STATUS.ENABLED,
     })
     mocks.deleteChannel.mockResolvedValue(true)
+    mocks.hasCompleteAdvancedDetail.mockReturnValue(true)
   })
 
   it("opens AxonHub with validated saved configuration", async () => {
@@ -783,7 +781,7 @@ describe("AxonHub native managed-resource Adapter", () => {
       },
     ])
     expect(detail.fields.map((field) => field.fieldId)).toEqual(
-      AXON_HUB_EDITABLE_FIELD_IDS,
+      AXON_HUB_DETAIL_FIELD_IDS,
     )
   })
 
@@ -1030,7 +1028,7 @@ describe("AxonHub native managed-resource Adapter", () => {
     const editor = await workspace.openCreateEditor()
 
     expect(editor.fields.map((field) => field.fieldId)).toEqual(
-      AXON_HUB_EDITABLE_FIELD_IDS,
+      AXON_HUB_CREATE_FIELD_IDS,
     )
     expect(editor.initialValues.key).toEqual({ kind: "unchanged" })
     expect(JSON.stringify(editor.initialValues)).not.toContain("saved-password")
@@ -1467,9 +1465,6 @@ describe("AxonHub native managed-resource Adapter", () => {
 
       const updateInput = mocks.updateChannel.mock.calls.at(-1)?.[2]
       expect(updateInput).toEqual(expectedInput)
-      if (fieldId === AXON_HUB_CHANNEL_FIELD_IDS.EXTRA_MODEL_PREFIX) {
-        expect(updateInput).not.toHaveProperty("clearSettings")
-      }
     },
   )
 
@@ -1644,98 +1639,22 @@ describe("AxonHub native managed-resource Adapter", () => {
 
     await editor.submit(editor.initialValues)
 
-    expect(mocks.updateChannel.mock.calls.at(-1)?.[2]).toEqual({})
+    expect(mocks.updateChannel).not.toHaveBeenCalled()
+    expect(mocks.updateStatus).not.toHaveBeenCalled()
   })
 
-  it("preserves every selected pinned setting while updating extraModelPrefix", async () => {
+  it("keeps replacement-only settings out of the edit surface", async () => {
     const detail = buildDetailChannel()
-    const original = structuredClone(detail)
     mocks.getChannel.mockResolvedValue(detail)
-    mocks.updateChannel.mockResolvedValue({
-      ...detail,
-      settings: { ...detail.settings, extraModelPrefix: "new-prefix" },
-    })
     const workspace = await openWorkspace()
     const editor = await workspace.openEditEditor(refFor(detail))
 
-    await editor.submit({
-      ...editor.initialValues,
-      extraModelPrefix: "new-prefix",
-    })
-
-    expect(mocks.updateChannel.mock.calls.at(-1)?.[2]).toEqual({
-      settings: { ...pinnedSettings, extraModelPrefix: "new-prefix" },
-    })
-    expect(mocks.updateChannel.mock.calls.at(-1)?.[2]).not.toHaveProperty(
-      "clearSettings",
+    expect(editor.fields.map((field) => field.fieldId)).not.toContain(
+      AXON_HUB_CHANNEL_FIELD_IDS.EXTRA_MODEL_PREFIX,
     )
-    expect(detail).toEqual(original)
-  })
-
-  it("keeps nested settings secrets out of the editor and merges the update into a fresh detail", async () => {
-    const openingDetail = buildDetailChannel({
-      settings: {
-        ...structuredClone(pinnedSettings),
-        proxy: {
-          ...pinnedSettings.proxy,
-          password: "opening-proxy-secret",
-        },
-        providerQuota: {
-          opencodeGo: {
-            workspaceId: "opening-workspace",
-            authCookie: "opening-auth-cookie",
-          },
-        },
-      },
-    })
-    const latestDetail = buildDetailChannel({
-      settings: {
-        ...structuredClone(pinnedSettings),
-        hideOriginalModels: false,
-        proxy: {
-          ...pinnedSettings.proxy,
-          password: "latest-proxy-secret",
-        },
-        providerQuota: {
-          opencodeGo: {
-            workspaceId: "latest-workspace",
-            authCookie: "latest-auth-cookie",
-          },
-        },
-      },
-    })
-    mocks.getChannel
-      .mockResolvedValueOnce(openingDetail)
-      .mockResolvedValueOnce(latestDetail)
-    mocks.updateChannel.mockResolvedValue({
-      ...latestDetail,
-      settings: { ...latestDetail.settings, extraModelPrefix: "new-prefix" },
-    })
-    const workspace = await openWorkspace()
-    const editor = await workspace.openEditEditor(refFor(openingDetail))
-
-    const publicEditor = JSON.stringify({
-      fields: editor.fields,
-      initialValues: editor.initialValues,
-    })
-    expect(publicEditor).not.toContain("opening-proxy-secret")
-    expect(publicEditor).not.toContain("opening-auth-cookie")
-
-    await editor.submit({
-      ...editor.initialValues,
-      extraModelPrefix: "new-prefix",
-    })
-
-    expect(mocks.getChannel).toHaveBeenCalledTimes(2)
-    expect(mocks.updateChannel.mock.calls.at(-1)?.[2]).toEqual({
-      settings: { ...latestDetail.settings, extraModelPrefix: "new-prefix" },
-    })
-    expect(
-      JSON.stringify(mocks.updateChannel.mock.calls.at(-1)?.[2]),
-    ).not.toContain("opening-proxy-secret")
-    expect(
-      JSON.stringify(mocks.updateChannel.mock.calls.at(-1)?.[2]),
-    ).not.toContain("opening-auth-cookie")
+    expect(editor.initialValues).not.toHaveProperty(
+      AXON_HUB_CHANNEL_FIELD_IDS.EXTRA_MODEL_PREFIX,
+    )
   })
 
   it("validates supported manual and default-model invariants", async () => {
@@ -2163,9 +2082,6 @@ describe("AxonHub native managed-resource Adapter", () => {
 
   it("returns a common succeeded result with exact create effect and options", async () => {
     const controller = new AbortController()
-    const created = buildDetailChannel({ id: "common-created-id" })
-    mocks.createChannel.mockResolvedValue(created)
-    const operations = await openAxonHubNativeResourceOperations()
     const input: AxonHubCreateChannelInput = {
       type: AXON_HUB_CHANNEL_TYPE.OPENAI,
       name: "Common create",
@@ -2176,6 +2092,15 @@ describe("AxonHub native managed-resource Adapter", () => {
       settings: {},
       orderingWeight: 0,
     }
+    const receipt = {
+      id: "common-created-id",
+      type: input.type,
+      name: input.name,
+      baseURL: null,
+      status: AXON_HUB_CHANNEL_STATUS.DISABLED,
+    }
+    mocks.createChannel.mockResolvedValue(receipt)
+    const operations = await openAxonHubNativeResourceOperations()
 
     const result = await operations.create(
       input,
@@ -2185,7 +2110,7 @@ describe("AxonHub native managed-resource Adapter", () => {
 
     expect(result).toEqual({
       outcome: "succeeded",
-      data: created,
+      data: { ...input, ...receipt },
       confirmedEffects: [
         {
           kind: "resource-created",
@@ -2198,6 +2123,37 @@ describe("AxonHub native managed-resource Adapter", () => {
     expect(mocks.createChannel).toHaveBeenCalledWith(config, input, {
       signal: controller.signal,
     })
+  })
+
+  it("applies a minimal update receipt without leaking clear controls", async () => {
+    const detail = buildDetailChannel({ remark: "Remove me" })
+    const receipt = {
+      id: detail.id,
+      type: detail.type,
+      name: "Renamed channel",
+      baseURL: detail.baseURL,
+      status: detail.status,
+    }
+    mocks.updateChannel.mockResolvedValue(receipt)
+    const operations = await openAxonHubNativeResourceOperations()
+
+    const result = await operations.update(detail, {
+      name: receipt.name,
+      clearRemark: true,
+    })
+
+    expect(result).toMatchObject({
+      outcome: "succeeded",
+      data: {
+        ...detail,
+        ...receipt,
+        remark: null,
+      },
+    })
+    if (result.outcome !== MANAGED_SITE_MUTATION_OUTCOMES.Succeeded) {
+      throw new Error(`Expected succeeded, received ${result.outcome}`)
+    }
+    expect(result.data).not.toHaveProperty("clearRemark")
   })
 
   it("rejects an already-aborted create before invoking the write", async () => {

--- a/tests/services/apiAdapters/managedResources/axonHub.test.ts
+++ b/tests/services/apiAdapters/managedResources/axonHub.test.ts
@@ -2110,7 +2110,14 @@ describe("AxonHub native managed-resource Adapter", () => {
 
     expect(result).toEqual({
       outcome: "succeeded",
-      data: { ...input, ...receipt },
+      data: {
+        ...receipt,
+        supportedModels: input.supportedModels,
+        manualModels: input.manualModels,
+        defaultTestModel: input.defaultTestModel,
+        settings: input.settings,
+        orderingWeight: input.orderingWeight,
+      },
       confirmedEffects: [
         {
           kind: "resource-created",
@@ -2119,6 +2126,7 @@ describe("AxonHub native managed-resource Adapter", () => {
         },
       ],
     })
+    expect(JSON.stringify(result)).not.toContain("credential-placeholder")
     expect(result).not.toHaveProperty("certainty")
     expect(mocks.createChannel).toHaveBeenCalledWith(config, input, {
       signal: controller.signal,
@@ -2340,6 +2348,8 @@ describe("AxonHub native managed-resource Adapter", () => {
       status: AXON_HUB_CHANNEL_STATUS.DISABLED,
     })
     const statusError = new mocks.RequestError("unavailable", "dispatched")
+    const { credentials: createdCredentials, ...credentialFreeCreated } =
+      created
     mocks.createChannel.mockResolvedValue(created)
     mocks.updateStatus.mockRejectedValue(statusError)
     const operations = await openAxonHubNativeResourceOperations()
@@ -2361,7 +2371,7 @@ describe("AxonHub native managed-resource Adapter", () => {
 
     expect(result).toEqual({
       outcome: "partial",
-      data: created,
+      data: credentialFreeCreated,
       confirmedEffects: [
         {
           kind: "resource-created",
@@ -2376,6 +2386,8 @@ describe("AxonHub native managed-resource Adapter", () => {
         raw: statusError,
       },
     })
+    expect(createdCredentials).toBeDefined()
+    expect(JSON.stringify(result)).not.toContain("sk-placeholder-value")
     expect(result).not.toHaveProperty("certainty")
     expect(mocks.createChannel).toHaveBeenCalledOnce()
     expect(mocks.updateStatus).toHaveBeenCalledWith(
@@ -2395,6 +2407,8 @@ describe("AxonHub native managed-resource Adapter", () => {
       "upstream-rejected",
       "not-dispatched",
     )
+    const { credentials: createdCredentials, ...credentialFreeCreated } =
+      created
     mocks.createChannel.mockResolvedValue(created)
     mocks.updateStatus.mockRejectedValue(statusError)
     const operations = await openAxonHubNativeResourceOperations()
@@ -2415,7 +2429,7 @@ describe("AxonHub native managed-resource Adapter", () => {
       ),
     ).resolves.toEqual({
       outcome: MANAGED_SITE_MUTATION_OUTCOMES.Partial,
-      data: created,
+      data: credentialFreeCreated,
       confirmedEffects: [
         {
           kind: "resource-created",
@@ -2430,6 +2444,10 @@ describe("AxonHub native managed-resource Adapter", () => {
         raw: statusError,
       },
     })
+    expect(JSON.stringify(credentialFreeCreated)).not.toContain(
+      "sk-placeholder-value",
+    )
+    expect(createdCredentials).toBeDefined()
     expect(mocks.mutationSequenceStepCounts).toEqual([2])
   })
 

--- a/tests/services/apiAdapters/managedResources/axonHubMigration.test.ts
+++ b/tests/services/apiAdapters/managedResources/axonHubMigration.test.ts
@@ -44,9 +44,14 @@ vi.mock("~/services/accountTokens/apiTokenKey", () => ({
   hasUsableApiTokenKey: mocks.hasUsableApiTokenKey,
 }))
 
-vi.mock("~/services/apiService/axonHub", () => ({
-  hasCompleteAxonHubAdvancedDetail: mocks.hasCompleteAxonHubAdvancedDetail,
-}))
+vi.mock("~/services/apiService/axonHub", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("~/services/apiService/axonHub")>()
+  return {
+    ...actual,
+    hasCompleteAxonHubAdvancedDetail: mocks.hasCompleteAxonHubAdvancedDetail,
+  }
+})
 
 const selection: ManagedSiteMigrationSelection = {
   selectionId: "selection-safe-token",

--- a/tests/services/apiAdapters/managedResources/axonHubMigration.test.ts
+++ b/tests/services/apiAdapters/managedResources/axonHubMigration.test.ts
@@ -21,6 +21,7 @@ import {
 
 const mocks = vi.hoisted(() => ({
   hasUsableApiTokenKey: vi.fn(),
+  hasCompleteAxonHubAdvancedDetail: vi.fn(),
   openAxonHubNativeResourceOperations: vi.fn(),
 }))
 
@@ -41,6 +42,10 @@ vi.mock(
 
 vi.mock("~/services/accountTokens/apiTokenKey", () => ({
   hasUsableApiTokenKey: mocks.hasUsableApiTokenKey,
+}))
+
+vi.mock("~/services/apiService/axonHub", () => ({
+  hasCompleteAxonHubAdvancedDetail: mocks.hasCompleteAxonHubAdvancedDetail,
 }))
 
 const selection: ManagedSiteMigrationSelection = {
@@ -96,6 +101,7 @@ describe("AxonHub migration type boundary", () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mocks.hasUsableApiTokenKey.mockReturnValue(true)
+    mocks.hasCompleteAxonHubAdvancedDetail.mockReturnValue(true)
     vi.spyOn(userPreferences, "getPreferences").mockResolvedValue({
       axonHub: {
         baseUrl: "https://axon.example.invalid",
@@ -290,6 +296,35 @@ describe("AxonHub migration type boundary", () => {
       ),
     ).resolves.toMatchObject({
       projection: { type: AXON_HUB_CHANNEL_TYPE.ANTHROPIC },
+    })
+  })
+
+  it("marks advanced migration loss conservatively when detail used the core fallback", async () => {
+    mocks.hasCompleteAxonHubAdvancedDetail.mockReturnValue(false)
+    const get = vi.fn().mockResolvedValue({
+      id: "resource-safe-token",
+      name: "Example channel",
+      type: AXON_HUB_CHANNEL_TYPE.OPENAI,
+      status: AXON_HUB_CHANNEL_STATUS.ENABLED,
+      baseURL: "https://source.example.invalid",
+      supportedModels: ["model-example"],
+      credentials: { apiKeys: ["credential-placeholder"] },
+    } as AxonHubChannel)
+    vi.spyOn(
+      axonHubNativeResources,
+      "openAxonHubNativeResourceOperations",
+    ).mockResolvedValue({ get } as never)
+
+    await expect(
+      axonHubManagedSiteMigrationCapability.source!.prepare(selection),
+    ).resolves.toMatchObject({
+      status: "ready",
+      source: {
+        lossSignals: {
+          hasModelMapping: true,
+          hasAdvancedSettings: true,
+        },
+      },
     })
   })
 

--- a/tests/services/apiAdapters/managedSiteMutationConformance.test.ts
+++ b/tests/services/apiAdapters/managedSiteMutationConformance.test.ts
@@ -47,6 +47,10 @@ const expectedManagedSiteTypes = [
   SITE_TYPES.SUB2API,
 ] as const
 
+const transitionalResourceSiteTypes = expectedManagedSiteTypes.filter(
+  (siteType) => siteType !== SITE_TYPES.AXON_HUB,
+)
+
 describe("managed-site mutation conformance", () => {
   it("keeps execution evidence and consumption on the mutation vocabulary", () => {
     type DispatchState =
@@ -133,7 +137,7 @@ describe("managed-site mutation conformance", () => {
       ManagedSiteMutationResult<void>
     >()
 
-    for (const siteType of MANAGED_SITE_TYPES) {
+    for (const siteType of transitionalResourceSiteTypes) {
       expect(
         getSiteTypeCapabilities(siteType).managedSites?.resources?.items,
         `${siteType} resources`,

--- a/tests/services/apiAdapters/managedSites/axonHub.test.ts
+++ b/tests/services/apiAdapters/managedSites/axonHub.test.ts
@@ -429,6 +429,45 @@ describe("AxonHub managed-site channel capability", () => {
     expect(axonHubApi.updateAxonHubChannelStatus).not.toHaveBeenCalled()
   })
 
+  it.each([
+    {
+      label: "legacy apiKey",
+      credentials: { apiKey: "legacy-key" },
+      submittedKey: "legacy-key",
+    },
+    {
+      label: "unavailable credentials",
+      credentials: undefined,
+      submittedKey: "",
+    },
+  ])(
+    "does not replace $label while patching another field",
+    async ({ credentials, submittedKey }) => {
+      axonHubApi.getAxonHubChannel.mockResolvedValueOnce({
+        ...currentChannel,
+        credentials,
+      })
+      axonHubApi.updateAxonHubChannel.mockResolvedValue({
+        id: currentChannel.id,
+      })
+      const { axonHubManagedSiteChannels } = await import(
+        "~/services/apiAdapters/managedSites/axonHub"
+      )
+
+      await axonHubManagedSiteChannels.update(config, {
+        id: 1,
+        name: "renamed",
+        key: submittedKey,
+      })
+
+      expect(axonHubApi.updateAxonHubChannel).toHaveBeenCalledWith(
+        config,
+        currentChannel.id,
+        { name: "renamed" },
+      )
+    },
+  )
+
   it("does not dispatch an AxonHub mutation when the submitted channel is unchanged", async () => {
     const { axonHubManagedSiteChannels } = await import(
       "~/services/apiAdapters/managedSites/axonHub"
@@ -592,6 +631,19 @@ describe("AxonHub managed-site channel capability", () => {
       expect(axonHubApi.deleteAxonHubChannel).not.toHaveBeenCalled()
     },
   )
+
+  it("rethrows update detail-read programming errors before dispatch", async () => {
+    const programmingError = new Error("detail invariant failed")
+    axonHubApi.getAxonHubChannel.mockRejectedValueOnce(programmingError)
+    const { axonHubManagedSiteChannels } = await import(
+      "~/services/apiAdapters/managedSites/axonHub"
+    )
+
+    await expect(
+      axonHubManagedSiteChannels.update(config, { id: 1, name: "updated" }),
+    ).rejects.toBe(programmingError)
+    expect(axonHubApi.updateAxonHubChannel).not.toHaveBeenCalled()
+  })
 
   it.each(["update", "delete"] as const)(
     "rejects %s ID-resolution schema failures without confirming a mutation attempt",

--- a/tests/services/apiAdapters/managedSites/axonHub.test.ts
+++ b/tests/services/apiAdapters/managedSites/axonHub.test.ts
@@ -3,16 +3,14 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import {
   AXON_HUB_CHANNEL_STATUS,
   AXON_HUB_CHANNEL_TYPE,
+  AXON_HUB_GRAPHQL_ERROR_CODES,
 } from "~/constants/axonHub"
-import { SITE_TYPES } from "~/constants/siteType"
-import type { AxonHubChannel } from "~/types/axonHub"
-import { CHANNEL_STATUS, type ChannelFormData } from "~/types/managedSite"
+import { CHANNEL_STATUS } from "~/types/managedSite"
 import {
   CHANNEL_MUTATION_SCENARIOS,
   testManagedSiteChannelMutationContract,
   type ChannelMutationScenario,
 } from "~~/tests/services/apiAdapters/managedSites/channelMutationContract"
-import { testManagedUpstreamResourceMutationContract } from "~~/tests/services/apiAdapters/managedSites/resourceMutationContract"
 
 const axonHubProvider = vi.hoisted(() => ({
   checkValidAxonHubConfig: vi.fn(),
@@ -98,6 +96,19 @@ describe("AxonHub managed-site channel capability", () => {
     email: "admin@example.invalid",
     password: "password",
   }
+  const currentChannel = {
+    __typename: "Channel" as const,
+    id: "gid://axonhub/Channel/1",
+    type: AXON_HUB_CHANNEL_TYPE.OPENAI,
+    name: "current",
+    baseURL: "https://current.example.invalid/v1",
+    status: AXON_HUB_CHANNEL_STATUS.DISABLED,
+    credentials: { apiKeys: ["key-current"] },
+    supportedModels: ["model-current"],
+    manualModels: ["model-current"],
+    defaultTestModel: "model-current",
+    orderingWeight: 0,
+  }
 
   const dispatchedFailureCases = [
     ["authentication", 401, "UNAUTHENTICATED", "authentication failed"],
@@ -137,13 +148,6 @@ describe("AxonHub managed-site channel capability", () => {
       message,
     })),
   ]
-  const resourceTerminalMutationCases = (["create", "update"] as const).flatMap(
-    (operation) =>
-      terminalMutationCases.map((terminalCase) => ({
-        operation,
-        ...terminalCase,
-      })),
-  )
 
   const createNativeRequestError = (input: {
     kind: (typeof dispatchedFailureCases)[number][0]
@@ -171,6 +175,7 @@ describe("AxonHub managed-site channel capability", () => {
     axonHubApi.resolveAxonHubGraphqlIdForMutation.mockResolvedValue(
       "gid://axonhub/Channel/1",
     )
+    axonHubApi.getAxonHubChannel.mockResolvedValue(currentChannel)
   })
 
   const arrangeNativeMutation =
@@ -319,6 +324,31 @@ describe("AxonHub managed-site channel capability", () => {
     expect(axonHubApi.createAxonHubChannel).not.toHaveBeenCalled()
   })
 
+  it("treats a GraphQL validation failure as confirmed non-application", async () => {
+    axonHubApi.createAxonHubChannel.mockRejectedValue(
+      createNativeRequestError({
+        kind: "upstream-rejected",
+        dispatch: "dispatched",
+        status: 422,
+        code: AXON_HUB_GRAPHQL_ERROR_CODES.VALIDATION_FAILED,
+        message: "mutation document was rejected",
+      }),
+    )
+    const { axonHubManagedSiteChannels } = await import(
+      "~/services/apiAdapters/managedSites/axonHub"
+    )
+
+    await expect(
+      axonHubManagedSiteChannels.create(config, createPayload),
+    ).resolves.toEqual({
+      outcome: "rejected",
+      diagnostic: expect.objectContaining({
+        code: AXON_HUB_GRAPHQL_ERROR_CODES.VALIDATION_FAILED,
+        statusCode: 422,
+      }),
+    })
+  })
+
   it("defaults a blank AxonHub channel type to OpenAI", async () => {
     axonHubApi.createAxonHubChannel.mockResolvedValue({
       id: "gid://axonhub/Channel/default-type",
@@ -372,6 +402,58 @@ describe("AxonHub managed-site channel capability", () => {
     )
   })
 
+  it("only forwards fields that differ from the current AxonHub channel", async () => {
+    axonHubApi.updateAxonHubChannel.mockResolvedValue({
+      id: "gid://axonhub/Channel/1",
+    })
+    const { axonHubManagedSiteChannels } = await import(
+      "~/services/apiAdapters/managedSites/axonHub"
+    )
+
+    await axonHubManagedSiteChannels.update(config, {
+      id: 1,
+      type: "openai",
+      name: " renamed ",
+      base_url: " https://current.example.invalid/v1 ",
+      key: " key-current ",
+      models: "model-current",
+      weight: 0,
+      status: CHANNEL_STATUS.ManuallyDisabled,
+    })
+
+    expect(axonHubApi.updateAxonHubChannel).toHaveBeenCalledWith(
+      config,
+      "gid://axonhub/Channel/1",
+      { name: "renamed" },
+    )
+    expect(axonHubApi.updateAxonHubChannelStatus).not.toHaveBeenCalled()
+  })
+
+  it("does not dispatch an AxonHub mutation when the submitted channel is unchanged", async () => {
+    const { axonHubManagedSiteChannels } = await import(
+      "~/services/apiAdapters/managedSites/axonHub"
+    )
+
+    await expect(
+      axonHubManagedSiteChannels.update(config, {
+        id: 1,
+        type: "openai",
+        name: "current",
+        base_url: "https://current.example.invalid/v1",
+        key: "key-current",
+        models: "model-current",
+        weight: 0,
+        status: CHANNEL_STATUS.ManuallyDisabled,
+      }),
+    ).resolves.toEqual({
+      outcome: "succeeded",
+      data: { id: "gid://axonhub/Channel/1" },
+      confirmedEffects: [],
+    })
+    expect(axonHubApi.updateAxonHubChannel).not.toHaveBeenCalled()
+    expect(axonHubApi.updateAxonHubChannelStatus).not.toHaveBeenCalled()
+  })
+
   it("treats a false AxonHub delete response as confirmed non-application", async () => {
     axonHubApi.deleteAxonHubChannel.mockResolvedValue(false)
     const { axonHubManagedSiteChannels } = await import(
@@ -388,253 +470,6 @@ describe("AxonHub managed-site channel capability", () => {
       },
     )
   })
-
-  const resourceNative: AxonHubChannel = {
-    id: "gid://axonhub/Channel/resource",
-    name: "Axon Resource",
-    type: "openai",
-    status: AXON_HUB_CHANNEL_STATUS.DISABLED,
-    baseURL: "https://resource.example.invalid/v1",
-    credentials: { apiKeys: ["sk-resource"] },
-    supportedModels: ["gpt-example"],
-    manualModels: ["gpt-example"],
-    defaultTestModel: "gpt-example",
-    settings: { passThroughBody: true },
-    orderingWeight: 3,
-    remark: "preserve",
-  }
-  const resourceDraft: ChannelFormData = {
-    name: "Axon Resource Edited",
-    type: "openai",
-    key: "sk-resource",
-    base_url: "https://resource.example.invalid/v1",
-    models: ["gpt-example"],
-    groups: [],
-    priority: 0,
-    weight: 3,
-    status: CHANNEL_STATUS.ManuallyDisabled,
-  }
-  const resourceDetail = {
-    summary: {
-      ref: {
-        managedSiteType: SITE_TYPES.AXON_HUB,
-        scopeKey: "https://axonhub.example.invalid",
-        resourceId: resourceNative.id,
-      },
-      displayName: resourceNative.name,
-      nativeKind: "channel",
-      status: "disabled",
-      secretState: "available",
-      capabilities: { canUpdate: true },
-    },
-    native: resourceNative,
-  } as const
-
-  testManagedUpstreamResourceMutationContract([
-    {
-      name: "create",
-      effect: { kind: "resource-created", resourceKind: "channel" },
-      successData: expect.objectContaining({
-        displayName: resourceNative.name,
-        nativeKind: "channel",
-      }),
-      arrange: arrangeNativeMutation(
-        axonHubApi.createAxonHubChannel,
-        resourceNative,
-      ),
-      invoke: async () => {
-        const { axonHubManagedSiteCapabilities } = await import(
-          "~/services/apiAdapters/managedSites/axonHub"
-        )
-        return await axonHubManagedSiteCapabilities.resources!.items.create(
-          config,
-          { ...resourceDraft, name: resourceNative.name },
-        )
-      },
-      assertRequestPayload: () =>
-        expect(axonHubApi.createAxonHubChannel.mock.calls.at(-1)?.[1]).toEqual(
-          expect.objectContaining({
-            name: resourceNative.name,
-            settings: {},
-          }),
-        ),
-    },
-    {
-      name: "update",
-      effect: {
-        kind: "resource-updated",
-        resourceKind: "channel",
-        resourceId: resourceNative.id,
-      },
-      successData: expect.objectContaining({
-        displayName: resourceNative.name,
-        nativeKind: "channel",
-      }),
-      arrange: arrangeNativeMutation(
-        axonHubApi.updateAxonHubChannel,
-        resourceNative,
-      ),
-      invoke: async () => {
-        const { axonHubManagedSiteCapabilities } = await import(
-          "~/services/apiAdapters/managedSites/axonHub"
-        )
-        return await axonHubManagedSiteCapabilities.resources!.items.update(
-          config,
-          resourceDetail,
-          { ...resourceDraft, name: resourceNative.name },
-        )
-      },
-      assertRequestPayload: () =>
-        expect(axonHubApi.updateAxonHubChannel.mock.calls.at(-1)?.[2]).toEqual(
-          expect.objectContaining({
-            settings: { passThroughBody: true },
-            remark: "preserve",
-            supportedModels: ["gpt-example"],
-          }),
-        ),
-    },
-    {
-      name: "delete",
-      effect: {
-        kind: "resource-deleted",
-        resourceKind: "channel",
-        resourceId: resourceNative.id,
-      },
-      successData: undefined,
-      arrange: arrangeNativeMutation(axonHubApi.deleteAxonHubChannel, true),
-      invoke: async () => {
-        const { axonHubManagedSiteCapabilities } = await import(
-          "~/services/apiAdapters/managedSites/axonHub"
-        )
-        return await axonHubManagedSiteCapabilities.resources!.items.delete(
-          config,
-          resourceDetail.summary.ref,
-        )
-      },
-      assertRequestPayload: () =>
-        expect(axonHubApi.deleteAxonHubChannel.mock.calls.at(-1)?.[1]).toBe(
-          resourceNative.id,
-        ),
-    },
-  ])
-
-  it.each(resourceTerminalMutationCases)(
-    "composes AxonHub resource $operation plus $terminal status evidence",
-    async ({ operation, terminal, kind, dispatch, status, code, message }) => {
-      const first = {
-        ...resourceNative,
-        status: AXON_HUB_CHANNEL_STATUS.DISABLED,
-      }
-      if (operation === "create") {
-        axonHubApi.createAxonHubChannel.mockResolvedValue(first)
-      } else {
-        axonHubApi.updateAxonHubChannel.mockResolvedValue(first)
-      }
-      const terminalError = kind
-        ? createNativeRequestError({ kind, dispatch, status, code, message })
-        : undefined
-      if (terminalError) {
-        axonHubApi.updateAxonHubChannelStatus.mockRejectedValue(terminalError)
-      } else {
-        axonHubApi.updateAxonHubChannelStatus.mockResolvedValue({
-          ...first,
-          status: AXON_HUB_CHANNEL_STATUS.ENABLED,
-        })
-      }
-      const { axonHubManagedSiteCapabilities } = await import(
-        "~/services/apiAdapters/managedSites/axonHub"
-      )
-      const resources = axonHubManagedSiteCapabilities.resources!
-      const result =
-        operation === "create"
-          ? await resources.items.create(config, {
-              ...resourceDraft,
-              name: resourceNative.name,
-              status: CHANNEL_STATUS.Enable,
-            })
-          : await resources.items.update(config, resourceDetail, {
-              ...resourceDraft,
-              name: resourceNative.name,
-              status: CHANNEL_STATUS.Enable,
-            })
-      const firstEffect = {
-        kind:
-          operation === "create"
-            ? ("resource-created" as const)
-            : ("resource-updated" as const),
-        resourceKind: "channel" as const,
-        ...(operation === "update" ? { resourceId: resourceNative.id } : {}),
-      }
-
-      if (terminal === "applied") {
-        expect(result).toEqual({
-          outcome: "succeeded",
-          data: expect.objectContaining({
-            status: "enabled",
-            ref: expect.objectContaining({
-              resourceId: resourceNative.id,
-            }),
-          }),
-          confirmedEffects: [
-            firstEffect,
-            {
-              kind: "status-updated",
-              resourceKind: "channel",
-              resourceId: resourceNative.id,
-            },
-          ],
-        })
-      } else {
-        expect(result).toEqual({
-          outcome: "partial",
-          confirmedEffects: [firstEffect],
-          completion: terminal,
-          diagnostic: {
-            message,
-            code,
-            statusCode: status,
-            raw: terminalError,
-          },
-        })
-      }
-    },
-  )
-
-  it.each(["create", "update"] as const)(
-    "does not dispatch AxonHub resource %s status after first-step rejection",
-    async (operation) => {
-      const error = new axonHubApi.AxonHubRequestError(
-        "upstream-rejected",
-        "not-dispatched",
-        "provider rejected",
-      )
-      if (operation === "create") {
-        axonHubApi.createAxonHubChannel.mockRejectedValue(error)
-      } else {
-        axonHubApi.updateAxonHubChannel.mockRejectedValue(error)
-      }
-      const { axonHubManagedSiteCapabilities } = await import(
-        "~/services/apiAdapters/managedSites/axonHub"
-      )
-      const resources = axonHubManagedSiteCapabilities.resources!
-      const result =
-        operation === "create"
-          ? await resources.items.create(config, {
-              ...resourceDraft,
-              status: CHANNEL_STATUS.Enable,
-            })
-          : await resources.items.update(config, resourceDetail, {
-              ...resourceDraft,
-              status: CHANNEL_STATUS.Enable,
-            })
-
-      expect(result).toEqual({
-        outcome: "rejected",
-        diagnostic: { message: "provider rejected", raw: error },
-      })
-      expect(axonHubApi.updateAxonHubChannelStatus).not.toHaveBeenCalled()
-    },
-  )
 
   it.each([
     ["create", axonHubApi.createAxonHubChannel],
@@ -907,6 +742,7 @@ describe("AxonHub managed-site channel capability", () => {
             })
           : axonHubManagedSiteChannels.update(config, {
               id: 1,
+              name: "updated",
               status: CHANNEL_STATUS.Enable,
             })
 
@@ -1000,803 +836,4 @@ describe("AxonHub managed-site channel capability", () => {
       axonHubManagedSiteCapabilities.config.get(),
     ).resolves.toBeNull()
   })
-
-  it("maps AxonHub GraphQL channels into string-id resource summaries", async () => {
-    const native = buildAxonHubChannel({
-      id: "gid://axonhub/Channel/native-string-id",
-      type: "custom_native",
-      supportedModels: ["gpt-4o"],
-      manualModels: ["claude-3-5-sonnet"],
-      orderingWeight: 7,
-    })
-    axonHubProvider.listChannels.mockResolvedValue({
-      items: [buildAxonHubChannelRow(native)],
-      total: 1,
-      type_counts: { custom_native: 1 },
-    })
-
-    const { axonHubManagedSiteCapabilities } = await import(
-      "~/services/apiAdapters/managedSites/axonHub"
-    )
-
-    await expect(
-      axonHubManagedSiteCapabilities.resources?.items.list(config),
-    ).resolves.toEqual({
-      items: [
-        expect.objectContaining({
-          ref: {
-            managedSiteType: SITE_TYPES.AXON_HUB,
-            scopeKey: "https://axonhub.example.invalid",
-            resourceId: "gid://axonhub/Channel/native-string-id",
-          },
-          displayName: "Axon Native",
-          nativeKind: "channel",
-          status: "enabled",
-          typeLabel: "custom_native",
-          endpointLabel: "https://upstream.example.invalid/v1",
-          modelCount: 2,
-          modelPreview: ["gpt-4o", "claude-3-5-sonnet"],
-          secretState: "available",
-          capabilities: {
-            canCreate: true,
-            canUpdate: true,
-            canDelete: true,
-            canRevealSecret: false,
-          },
-        }),
-      ],
-      total: 1,
-    })
-  })
-
-  it("maps AxonHub resource search results into string-id resource summaries", async () => {
-    const native = buildAxonHubChannel({
-      id: "gid://axonhub/Channel/search-string-id",
-      name: "Search Result",
-      type: "openrouter",
-      supportedModels: ["openrouter/auto"],
-      manualModels: [],
-    })
-    axonHubProvider.searchChannel.mockResolvedValue({
-      items: [buildAxonHubChannelRow(native)],
-      total: 1,
-      type_counts: { openrouter: 1 },
-    })
-
-    const { axonHubManagedSiteCapabilities } = await import(
-      "~/services/apiAdapters/managedSites/axonHub"
-    )
-
-    await expect(
-      axonHubManagedSiteCapabilities.resources?.items.search(config, "search"),
-    ).resolves.toEqual({
-      items: [
-        expect.objectContaining({
-          ref: expect.objectContaining({
-            managedSiteType: SITE_TYPES.AXON_HUB,
-            resourceId: "gid://axonhub/Channel/search-string-id",
-          }),
-          displayName: "Search Result",
-          typeLabel: "OpenRouter",
-          modelCount: 1,
-          modelPreview: ["openrouter/auto"],
-        }),
-      ],
-      total: 1,
-    })
-  })
-
-  it("returns null when AxonHub resource search misses", async () => {
-    axonHubProvider.searchChannel.mockResolvedValue(null)
-
-    const { axonHubManagedSiteCapabilities } = await import(
-      "~/services/apiAdapters/managedSites/axonHub"
-    )
-
-    await expect(
-      axonHubManagedSiteCapabilities.resources?.items.search(config, "missing"),
-    ).resolves.toBeNull()
-  })
-
-  it("maps AxonHub single-key and unavailable credential states", async () => {
-    const singleKeyNative = buildAxonHubChannel({
-      id: "gid://axonhub/Channel/single-key",
-      credentials: {
-        apiKey: "sk-single-key",
-      },
-    })
-    const noKeyNative = buildAxonHubChannel({
-      id: "gid://axonhub/Channel/no-key",
-      credentials: {},
-    })
-    axonHubProvider.listChannels.mockResolvedValue({
-      items: [
-        buildAxonHubChannelRow(singleKeyNative),
-        buildAxonHubChannelRow(noKeyNative),
-      ],
-      total: 2,
-      type_counts: { openai: 2 },
-    })
-
-    const { axonHubManagedSiteCapabilities } = await import(
-      "~/services/apiAdapters/managedSites/axonHub"
-    )
-
-    await expect(
-      axonHubManagedSiteCapabilities.resources?.items.list(config),
-    ).resolves.toEqual({
-      items: [
-        expect.objectContaining({
-          ref: expect.objectContaining({ resourceId: singleKeyNative.id }),
-          secretState: "available",
-        }),
-        expect.objectContaining({
-          ref: expect.objectContaining({ resourceId: noKeyNative.id }),
-          secretState: "unavailable",
-        }),
-      ],
-      total: 2,
-    })
-  })
-
-  it("fetches native detail before edit and preserves AxonHub-only fields on update", async () => {
-    const native = buildAxonHubChannel({
-      id: "gid://axonhub/Channel/native-string-id",
-      type: "anthropic_gcp",
-      credentials: {
-        apiKeys: ["sk-live-native"],
-        gcp: {
-          region: "us-central1",
-          projectID: "example-project",
-          jsonData: '{"client_email":"svc@example.invalid"}',
-        },
-      },
-      supportedModels: ["claude-3-5-sonnet"],
-      manualModels: ["claude-3-opus"],
-      defaultTestModel: "claude-3-opus",
-      settings: {
-        hideMappedModels: true,
-        modelMappings: [{ from: "claude-3", to: "claude-3-5-sonnet" }],
-      },
-      orderingWeight: 12,
-      remark: "native remark",
-    })
-    const updated = { ...native, name: "Axon Updated" }
-    axonHubApi.getAxonHubChannel.mockResolvedValue(native)
-    axonHubApi.updateAxonHubChannel.mockResolvedValue(updated)
-    axonHubApi.axonHubChannelToManagedSite.mockReturnValue(
-      buildAxonHubChannelRow(updated),
-    )
-
-    const { axonHubManagedSiteCapabilities } = await import(
-      "~/services/apiAdapters/managedSites/axonHub"
-    )
-    const resources = axonHubManagedSiteCapabilities.resources!
-    const ref = {
-      managedSiteType: SITE_TYPES.AXON_HUB,
-      scopeKey: "https://axonhub.example.invalid",
-      resourceId: native.id,
-    }
-    const listCallsBefore = axonHubProvider.listChannels.mock.calls.length
-
-    const detail = await resources.items.getDetail(config, ref)
-    const draft = resources.drafts.prepareEditDraft(detail)
-    await resources.items.update(config, detail, {
-      ...draft,
-      name: "Axon Updated",
-    })
-
-    expect(detail.native).toBe(native)
-    expect(axonHubApi.getAxonHubChannel).toHaveBeenCalledWith(config, native.id)
-    expect(axonHubProvider.listChannels).toHaveBeenCalledTimes(listCallsBefore)
-    expect(draft).toEqual({
-      name: "Axon Native",
-      type: "anthropic_gcp",
-      key: "sk-live-native",
-      base_url: "https://upstream.example.invalid/v1",
-      models: ["claude-3-5-sonnet", "claude-3-opus"],
-      groups: [],
-      priority: 0,
-      weight: 12,
-      status: CHANNEL_STATUS.Enable,
-    })
-    expect(axonHubApi.updateAxonHubChannel).toHaveBeenCalledWith(
-      config,
-      "gid://axonhub/Channel/native-string-id",
-      {
-        type: "anthropic_gcp",
-        name: "Axon Updated",
-        baseURL: "https://upstream.example.invalid/v1",
-        credentials: native.credentials,
-        supportedModels: ["claude-3-5-sonnet"],
-        manualModels: ["claude-3-opus"],
-        defaultTestModel: "claude-3-opus",
-        settings: native.settings,
-        orderingWeight: 12,
-        remark: "native remark",
-      },
-    )
-    expect(axonHubApi.updateAxonHubChannelStatus).not.toHaveBeenCalled()
-  })
-
-  it("rejects stale AxonHub resource refs from a different site or scope before native access", async () => {
-    const { axonHubManagedSiteCapabilities } = await import(
-      "~/services/apiAdapters/managedSites/axonHub"
-    )
-    const resources = axonHubManagedSiteCapabilities.resources!
-
-    await expect(
-      resources.items.getDetail(config, {
-        managedSiteType: SITE_TYPES.NEW_API,
-        scopeKey: "https://axonhub.example.invalid",
-        resourceId: "gid://axonhub/Channel/native-string-id",
-      }),
-    ).rejects.toThrow("Resource reference does not match this managed site")
-    await expect(
-      resources.items.delete(config, {
-        managedSiteType: SITE_TYPES.AXON_HUB,
-        scopeKey: "https://other.example.invalid",
-        resourceId: "gid://axonhub/Channel/native-string-id",
-      }),
-    ).rejects.toThrow("Resource reference does not match this managed site")
-
-    expect(axonHubProvider.listChannels).not.toHaveBeenCalled()
-    expect(axonHubApi.deleteAxonHubChannel).not.toHaveBeenCalled()
-  })
-
-  it("preserves null AxonHub settings when building resource update payloads", async () => {
-    const native = buildAxonHubChannel({
-      settings: null,
-    })
-    axonHubApi.getAxonHubChannel.mockResolvedValue(native)
-    axonHubApi.updateAxonHubChannel.mockResolvedValue(native)
-    axonHubApi.axonHubChannelToManagedSite.mockReturnValue(
-      buildAxonHubChannelRow(native),
-    )
-
-    const { axonHubManagedSiteCapabilities } = await import(
-      "~/services/apiAdapters/managedSites/axonHub"
-    )
-    const resources = axonHubManagedSiteCapabilities.resources!
-    const detail = await resources.items.getDetail(config, {
-      managedSiteType: SITE_TYPES.AXON_HUB,
-      scopeKey: "https://axonhub.example.invalid",
-      resourceId: native.id,
-    })
-
-    await resources.items.update(
-      config,
-      detail,
-      resources.drafts.prepareEditDraft(detail),
-    )
-
-    expect(axonHubApi.updateAxonHubChannel).toHaveBeenCalledWith(
-      config,
-      native.id,
-      expect.objectContaining({
-        settings: null,
-      }),
-    )
-  })
-
-  it("preserves multi-key AxonHub credentials when the draft key is unchanged", async () => {
-    const native = buildAxonHubChannel({
-      credentials: {
-        apiKeys: ["sk-primary", "sk-secondary"],
-      },
-    })
-    axonHubApi.getAxonHubChannel.mockResolvedValue(native)
-    axonHubApi.updateAxonHubChannel.mockResolvedValue({
-      ...native,
-      name: "Renamed Axon",
-    })
-    axonHubApi.axonHubChannelToManagedSite.mockReturnValue(
-      buildAxonHubChannelRow({ ...native, name: "Renamed Axon" }),
-    )
-
-    const { axonHubManagedSiteCapabilities } = await import(
-      "~/services/apiAdapters/managedSites/axonHub"
-    )
-    const resources = axonHubManagedSiteCapabilities.resources!
-    const detail = await resources.items.getDetail(config, {
-      managedSiteType: SITE_TYPES.AXON_HUB,
-      scopeKey: "https://axonhub.example.invalid",
-      resourceId: native.id,
-    })
-    const draft = resources.drafts.prepareEditDraft(detail)
-
-    expect(draft.key).toBe("sk-primary")
-
-    await resources.items.update(config, detail, {
-      ...draft,
-      name: "Renamed Axon",
-    })
-
-    expect(axonHubApi.updateAxonHubChannel).toHaveBeenLastCalledWith(
-      config,
-      native.id,
-      expect.objectContaining({
-        credentials: native.credentials,
-      }),
-    )
-  })
-
-  it("preserves native AxonHub model arrays even when the generic model draft changes", async () => {
-    const native = buildAxonHubChannel({
-      supportedModels: ["native-supported"],
-      manualModels: ["native-manual"],
-      defaultTestModel: "native-manual",
-    })
-    axonHubApi.getAxonHubChannel.mockResolvedValue(native)
-    axonHubApi.updateAxonHubChannel.mockResolvedValue(native)
-    axonHubApi.axonHubChannelToManagedSite.mockReturnValue(
-      buildAxonHubChannelRow(native),
-    )
-
-    const { axonHubManagedSiteCapabilities } = await import(
-      "~/services/apiAdapters/managedSites/axonHub"
-    )
-    const resources = axonHubManagedSiteCapabilities.resources!
-    const detail = await resources.items.getDetail(config, {
-      managedSiteType: SITE_TYPES.AXON_HUB,
-      scopeKey: "https://axonhub.example.invalid",
-      resourceId: native.id,
-    })
-
-    await resources.items.update(config, detail, {
-      ...resources.drafts.prepareEditDraft(detail),
-      models: ["draft-edited-model"],
-    })
-
-    expect(axonHubApi.updateAxonHubChannel).toHaveBeenCalledWith(
-      config,
-      native.id,
-      expect.objectContaining({
-        supportedModels: ["native-supported"],
-        manualModels: ["native-manual"],
-        defaultTestModel: "native-manual",
-      }),
-    )
-  })
-
-  it("preserves nullable AxonHub default model and ordering weight on no-op edits", async () => {
-    const native = buildAxonHubChannel({
-      supportedModels: ["native-supported"],
-      manualModels: ["native-manual"],
-      defaultTestModel: null,
-      orderingWeight: null,
-    })
-    axonHubApi.getAxonHubChannel.mockResolvedValue(native)
-    axonHubApi.updateAxonHubChannel.mockResolvedValue(native)
-    axonHubApi.axonHubChannelToManagedSite.mockReturnValue(
-      buildAxonHubChannelRow(native),
-    )
-
-    const { axonHubManagedSiteCapabilities } = await import(
-      "~/services/apiAdapters/managedSites/axonHub"
-    )
-    const resources = axonHubManagedSiteCapabilities.resources!
-    const detail = await resources.items.getDetail(config, {
-      managedSiteType: SITE_TYPES.AXON_HUB,
-      scopeKey: "https://axonhub.example.invalid",
-      resourceId: native.id,
-    })
-
-    await resources.items.update(
-      config,
-      detail,
-      resources.drafts.prepareEditDraft(detail),
-    )
-
-    expect(axonHubApi.updateAxonHubChannel).toHaveBeenCalledWith(
-      config,
-      native.id,
-      expect.objectContaining({
-        defaultTestModel: null,
-        orderingWeight: null,
-      }),
-    )
-  })
-
-  it("does not expose an editable generic models field for AxonHub resource edits", async () => {
-    const native = buildAxonHubChannel({
-      supportedModels: ["native-supported"],
-      manualModels: ["native-manual"],
-    })
-
-    const { axonHubManagedSiteCapabilities } = await import(
-      "~/services/apiAdapters/managedSites/axonHub"
-    )
-    const descriptors =
-      axonHubManagedSiteCapabilities.resources!.drafts.describeFields({
-        mode: "edit",
-        detail: {
-          summary: {
-            ref: {
-              managedSiteType: SITE_TYPES.AXON_HUB,
-              scopeKey: "https://axonhub.example.invalid",
-              resourceId: native.id,
-            },
-            displayName: native.name,
-            nativeKind: "channel",
-            status: "enabled",
-            secretState: "available",
-            capabilities: { canUpdate: true },
-          },
-          native,
-        },
-      })
-
-    expect(descriptors.map((descriptor) => descriptor.name)).not.toContain(
-      "models",
-    )
-  })
-
-  it("prepares and validates AxonHub resource import drafts", async () => {
-    const { axonHubManagedSiteCapabilities } = await import(
-      "~/services/apiAdapters/managedSites/axonHub"
-    )
-    const resources = axonHubManagedSiteCapabilities.resources!
-    const sourceDraft = {
-      name: "Source Axon",
-      type: "openai",
-      key: "sk-source",
-      base_url: "https://source.example.invalid/v1",
-      models: ["gpt-4o"],
-      groups: [],
-      priority: 0,
-      weight: 3,
-      status: CHANNEL_STATUS.Enable,
-    }
-
-    await expect(
-      resources.drafts.prepareImportDraft({ source: sourceDraft }),
-    ).resolves.toBe(sourceDraft)
-    await expect(
-      resources.drafts.prepareImportDraft({
-        resource: {
-          ref: {
-            managedSiteType: SITE_TYPES.AXON_HUB,
-            scopeKey: "https://axonhub.example.invalid",
-            resourceId: "gid://axonhub/Channel/imported",
-          },
-          displayName: "Imported Axon",
-          nativeKind: "channel",
-          status: "enabled",
-          endpointLabel: "https://imported.example.invalid/v1",
-          modelPreview: ["gpt-4o"],
-          secretState: "masked",
-          capabilities: {},
-        },
-      }),
-    ).resolves.toEqual({
-      name: "Imported Axon",
-      type: "openai",
-      key: "",
-      base_url: "https://imported.example.invalid/v1",
-      models: ["gpt-4o"],
-      groups: [],
-      priority: 0,
-      weight: 0,
-      status: CHANNEL_STATUS.Enable,
-    })
-
-    expect(
-      resources.drafts.validateDraft({
-        ...sourceDraft,
-        name: " ",
-        base_url: "",
-      }),
-    ).toEqual({
-      valid: false,
-      errors: [
-        { field: "name", message: "Channel name is required" },
-        { field: "base_url", message: "Base URL is required" },
-      ],
-    })
-  })
-
-  it("allows AxonHub resource edits when native model arrays are empty or nullable", async () => {
-    const native = buildAxonHubChannel({
-      supportedModels: null,
-      manualModels: [],
-      defaultTestModel: null,
-    })
-    axonHubApi.getAxonHubChannel.mockResolvedValue(native)
-    axonHubApi.updateAxonHubChannel.mockResolvedValue({
-      ...native,
-      name: "Renamed Axon",
-    })
-    axonHubApi.axonHubChannelToManagedSite.mockReturnValue(
-      buildAxonHubChannelRow({ ...native, name: "Renamed Axon" }),
-    )
-
-    const { axonHubManagedSiteCapabilities } = await import(
-      "~/services/apiAdapters/managedSites/axonHub"
-    )
-    const resources = axonHubManagedSiteCapabilities.resources!
-    const detail = await resources.items.getDetail(config, {
-      managedSiteType: SITE_TYPES.AXON_HUB,
-      scopeKey: "https://axonhub.example.invalid",
-      resourceId: native.id,
-    })
-    const draft = {
-      ...resources.drafts.prepareEditDraft(detail),
-      name: "Renamed Axon",
-    }
-
-    expect(resources.drafts.validateDraft(draft)).toEqual({
-      valid: true,
-      errors: [],
-    })
-
-    await resources.items.update(config, detail, draft)
-
-    expect(axonHubApi.updateAxonHubChannel).toHaveBeenCalledWith(
-      config,
-      native.id,
-      expect.objectContaining({
-        name: "Renamed Axon",
-        supportedModels: null,
-        manualModels: [],
-        defaultTestModel: null,
-      }),
-    )
-  })
-
-  it("preserves archived AxonHub status on resource edits", async () => {
-    const native = buildAxonHubChannel({
-      status: AXON_HUB_CHANNEL_STATUS.ARCHIVED,
-    })
-    axonHubApi.getAxonHubChannel.mockResolvedValue(native)
-    axonHubApi.updateAxonHubChannel.mockResolvedValue(native)
-    axonHubApi.axonHubChannelToManagedSite.mockReturnValue(
-      buildAxonHubChannelRow(native),
-    )
-
-    const { axonHubManagedSiteCapabilities } = await import(
-      "~/services/apiAdapters/managedSites/axonHub"
-    )
-    const resources = axonHubManagedSiteCapabilities.resources!
-    const detail = await resources.items.getDetail(config, {
-      managedSiteType: SITE_TYPES.AXON_HUB,
-      scopeKey: "https://axonhub.example.invalid",
-      resourceId: native.id,
-    })
-
-    const result = await resources.items.update(
-      config,
-      detail,
-      resources.drafts.prepareEditDraft(detail),
-    )
-
-    expect(axonHubApi.updateAxonHubChannelStatus).not.toHaveBeenCalled()
-    expect(result).toMatchObject({
-      outcome: "succeeded",
-      data: {
-        status: "unknown",
-      },
-      confirmedEffects: [
-        {
-          kind: "resource-updated",
-          resourceKind: "channel",
-          resourceId: native.id,
-        },
-      ],
-    })
-  })
-
-  it("updates AxonHub native status when a resource edit changes it", async () => {
-    const native = buildAxonHubChannel({
-      status: AXON_HUB_CHANNEL_STATUS.ENABLED,
-    })
-    axonHubApi.getAxonHubChannel.mockResolvedValue(native)
-    axonHubApi.updateAxonHubChannel.mockResolvedValue(native)
-    axonHubApi.axonHubChannelToManagedSite.mockReturnValue(
-      buildAxonHubChannelRow({
-        ...native,
-        status: AXON_HUB_CHANNEL_STATUS.DISABLED,
-      }),
-    )
-
-    const { axonHubManagedSiteCapabilities } = await import(
-      "~/services/apiAdapters/managedSites/axonHub"
-    )
-    const resources = axonHubManagedSiteCapabilities.resources!
-    const detail = await resources.items.getDetail(config, {
-      managedSiteType: SITE_TYPES.AXON_HUB,
-      scopeKey: "https://axonhub.example.invalid",
-      resourceId: native.id,
-    })
-
-    await resources.items.update(config, detail, {
-      ...resources.drafts.prepareEditDraft(detail),
-      status: CHANNEL_STATUS.ManuallyDisabled,
-    })
-
-    expect(axonHubApi.updateAxonHubChannelStatus).toHaveBeenCalledWith(
-      config,
-      native.id,
-      AXON_HUB_CHANNEL_STATUS.DISABLED,
-    )
-  })
-
-  it("fails closed when an AxonHub resource row is missing native channel detail", async () => {
-    axonHubProvider.listChannels.mockResolvedValue({
-      items: [
-        {
-          ...buildAxonHubChannelRow(buildAxonHubChannel()),
-          _axonHubData: undefined,
-        },
-      ],
-      total: 1,
-      type_counts: { openai: 1 },
-    })
-
-    const { axonHubManagedSiteCapabilities } = await import(
-      "~/services/apiAdapters/managedSites/axonHub"
-    )
-
-    await expect(
-      axonHubManagedSiteCapabilities.resources?.items.list(config),
-    ).rejects.toThrow("AxonHub channel row is missing native channel detail")
-  })
-
-  it("does not write masked AxonHub credentials back as real secrets", async () => {
-    const native = buildAxonHubChannel({
-      credentials: {
-        apiKeys: ["sk-********"],
-      },
-    })
-    axonHubApi.getAxonHubChannel.mockResolvedValue(native)
-    axonHubApi.updateAxonHubChannel.mockResolvedValue(native)
-    axonHubApi.axonHubChannelToManagedSite.mockReturnValue(
-      buildAxonHubChannelRow(native),
-    )
-
-    const { axonHubManagedSiteCapabilities } = await import(
-      "~/services/apiAdapters/managedSites/axonHub"
-    )
-    const resources = axonHubManagedSiteCapabilities.resources!
-    const detail = await resources.items.getDetail(config, {
-      managedSiteType: SITE_TYPES.AXON_HUB,
-      scopeKey: "https://axonhub.example.invalid",
-      resourceId: native.id,
-    })
-
-    await resources.items.update(
-      config,
-      detail,
-      resources.drafts.prepareEditDraft(detail),
-    )
-
-    expect(axonHubApi.updateAxonHubChannel).toHaveBeenCalledWith(
-      config,
-      native.id,
-      expect.not.objectContaining({
-        credentials: expect.anything(),
-      }),
-    )
-  })
-
-  it("creates and deletes resources through AxonHub GraphQL-native ids", async () => {
-    const created = buildAxonHubChannel({
-      id: "gid://axonhub/Channel/created-string-id",
-      name: "Created Axon",
-    })
-    axonHubApi.createAxonHubChannel.mockResolvedValue(created)
-    axonHubApi.deleteAxonHubChannel.mockResolvedValue(true)
-    axonHubApi.axonHubChannelToManagedSite.mockReturnValue(
-      buildAxonHubChannelRow(created),
-    )
-
-    const { axonHubManagedSiteCapabilities } = await import(
-      "~/services/apiAdapters/managedSites/axonHub"
-    )
-    const resources = axonHubManagedSiteCapabilities.resources!
-
-    await expect(
-      resources.items.create(config, {
-        name: "Created Axon",
-        type: "openai",
-        key: "sk-created",
-        base_url: "https://created.example.invalid/v1",
-        models: ["gpt-4o"],
-        groups: [],
-        priority: 0,
-        weight: 5,
-        status: CHANNEL_STATUS.Enable,
-      }),
-    ).resolves.toEqual({
-      outcome: "succeeded",
-      confirmedEffects: [
-        { kind: "resource-created", resourceKind: "channel" },
-        {
-          kind: "status-updated",
-          resourceKind: "channel",
-          resourceId: "gid://axonhub/Channel/created-string-id",
-        },
-      ],
-      data: expect.objectContaining({
-        ref: expect.objectContaining({
-          resourceId: "gid://axonhub/Channel/created-string-id",
-        }),
-      }),
-    })
-    expect(axonHubApi.createAxonHubChannel).toHaveBeenCalledWith(config, {
-      type: "openai",
-      name: "Created Axon",
-      baseURL: "https://created.example.invalid/v1",
-      credentials: { apiKeys: ["sk-created"] },
-      supportedModels: ["gpt-4o"],
-      manualModels: ["gpt-4o"],
-      defaultTestModel: "gpt-4o",
-      settings: {},
-      orderingWeight: 5,
-    })
-
-    await expect(
-      resources.items.delete(config, {
-        managedSiteType: SITE_TYPES.AXON_HUB,
-        scopeKey: "https://axonhub.example.invalid",
-        resourceId: "gid://axonhub/Channel/created-string-id",
-      }),
-    ).resolves.toEqual({
-      outcome: "succeeded",
-      data: undefined,
-      confirmedEffects: [
-        {
-          kind: "resource-deleted",
-          resourceKind: "channel",
-          resourceId: "gid://axonhub/Channel/created-string-id",
-        },
-      ],
-    })
-    expect(axonHubApi.deleteAxonHubChannel).toHaveBeenCalledWith(
-      config,
-      "gid://axonhub/Channel/created-string-id",
-    )
-  })
-})
-
-const buildAxonHubChannel = (
-  overrides: Partial<AxonHubChannel> = {},
-): AxonHubChannel => ({
-  id: "gid://axonhub/Channel/native-string-id",
-  name: "Axon Native",
-  type: "openai",
-  status: AXON_HUB_CHANNEL_STATUS.ENABLED,
-  baseURL: "https://upstream.example.invalid/v1",
-  credentials: {
-    apiKeys: ["sk-live"],
-  },
-  supportedModels: ["gpt-4o"],
-  manualModels: ["gpt-4o"],
-  defaultTestModel: "gpt-4o",
-  settings: {},
-  orderingWeight: 0,
-  remark: null,
-  ...overrides,
-})
-
-const buildAxonHubChannelRow = (native: AxonHubChannel) => ({
-  id: 408,
-  name: native.name,
-  type: native.type,
-  key:
-    native.credentials?.apiKeys?.find((key) => key.trim()) ??
-    native.credentials?.apiKey ??
-    "",
-  base_url: native.baseURL,
-  models: [...(native.supportedModels ?? []), ...(native.manualModels ?? [])]
-    .filter(Boolean)
-    .join(","),
-  status:
-    native.status === AXON_HUB_CHANNEL_STATUS.ENABLED
-      ? CHANNEL_STATUS.Enable
-      : CHANNEL_STATUS.ManuallyDisabled,
-  priority: 0,
-  weight: native.orderingWeight ?? 0,
-  group: "",
-  _axonHubData: native,
 })

--- a/tests/services/apiAdapters/managedSites/axonHub.test.ts
+++ b/tests/services/apiAdapters/managedSites/axonHub.test.ts
@@ -593,6 +593,45 @@ describe("AxonHub managed-site channel capability", () => {
     },
   )
 
+  it.each(["update", "delete"] as const)(
+    "rejects %s ID-resolution schema failures without confirming a mutation attempt",
+    async (operation) => {
+      const error = new axonHubApi.AxonHubRequestError(
+        "upstream-rejected",
+        "not-dispatched",
+        "channel lookup document was rejected",
+        {
+          responseReceived: true,
+          statusCode: 422,
+          code: AXON_HUB_GRAPHQL_ERROR_CODES.VALIDATION_FAILED,
+        },
+      )
+      axonHubApi.resolveAxonHubGraphqlIdForMutation.mockRejectedValueOnce(error)
+      const { axonHubManagedSiteChannels } = await import(
+        "~/services/apiAdapters/managedSites/axonHub"
+      )
+      const mutation =
+        operation === "update"
+          ? axonHubManagedSiteChannels.update(config, {
+              id: 1,
+              name: "updated",
+            })
+          : axonHubManagedSiteChannels.delete(config, 1)
+
+      await expect(mutation).resolves.toEqual({
+        outcome: "rejected",
+        diagnostic: {
+          message: "channel lookup document was rejected",
+          code: AXON_HUB_GRAPHQL_ERROR_CODES.VALIDATION_FAILED,
+          statusCode: 422,
+          raw: error,
+        },
+      })
+      expect(axonHubApi.updateAxonHubChannel).not.toHaveBeenCalled()
+      expect(axonHubApi.deleteAxonHubChannel).not.toHaveBeenCalled()
+    },
+  )
+
   it.each(terminalMutationCases)(
     "composes create plus enable when the status step is $terminal",
     async ({ terminal, kind, dispatch, status, code, message }) => {

--- a/tests/services/apiService/axonHub/index.test.ts
+++ b/tests/services/apiService/axonHub/index.test.ts
@@ -513,7 +513,7 @@ describe("AxonHub API service", () => {
     }
   })
 
-  it("falls back to the stable detail contract and caches advanced schema rejection", async () => {
+  it("reprobes the advanced detail contract after a successful sign-in", async () => {
     const queries: string[] = []
     let rejectedAdvancedQuery = false
 
@@ -537,11 +537,16 @@ describe("AxonHub API service", () => {
             }
             return HttpResponse.json({
               data: {
-                node: buildNativeChannelDetail(String(variables?.id), {
-                  settings: undefined,
-                  policies: undefined,
-                  endpoints: undefined,
-                }),
+                node: buildNativeChannelDetail(
+                  String(variables?.id),
+                  query.includes("query GetAxonHubChannelCore")
+                    ? {
+                        settings: undefined,
+                        policies: undefined,
+                        endpoints: undefined,
+                      }
+                    : {},
+                ),
               },
             })
           },
@@ -551,18 +556,22 @@ describe("AxonHub API service", () => {
 
     const first = await getAxonHubChannel(config, "fallback-detail-one")
     const second = await getAxonHubChannel(config, "fallback-detail-two")
+    await signIn(config)
+    const third = await getAxonHubChannel(config, "fallback-detail-three")
 
-    expect(queries).toHaveLength(3)
+    expect(queries).toHaveLength(4)
     expect(queries[0]).toContain("settings {")
-    for (const query of queries.slice(1)) {
+    for (const query of queries.slice(1, 3)) {
       expect(query).toContain("query GetAxonHubChannelCore")
       expect(query).not.toContain("settings {")
       expect(query).not.toContain("policies {")
       expect(query).not.toContain("endpoints {")
       expect(query).not.toContain("oauth {")
     }
+    expect(queries[3]).toContain("settings {")
     expect(hasCompleteAxonHubAdvancedDetail(first)).toBe(false)
     expect(hasCompleteAxonHubAdvancedDetail(second)).toBe(false)
+    expect(hasCompleteAxonHubAdvancedDetail(third)).toBe(true)
   })
 
   it("rejects malformed native detail nodes as controlled protocol failures", async () => {

--- a/tests/services/apiService/axonHub/index.test.ts
+++ b/tests/services/apiService/axonHub/index.test.ts
@@ -3031,6 +3031,118 @@ describe("AxonHub API service", () => {
     })
   })
 
+  it("falls back to and caches the stable legacy detail contract", async () => {
+    const queries: string[] = []
+    let rejectedLegacyQuery = false
+
+    useAxonHubGraphqlRoutes({
+      token: "legacy-detail-fallback-token",
+      routes: [
+        {
+          matches: matchesGraphqlOperation("query GetAxonHubChannel"),
+          respond: ({ query, variables }) => {
+            queries.push(query)
+            if (
+              !query.includes("query GetAxonHubChannelCore") &&
+              !rejectedLegacyQuery
+            ) {
+              rejectedLegacyQuery = true
+              return HttpResponse.json({
+                errors: [
+                  {
+                    message: "Cannot query optional legacy channel fields",
+                    extensions: { code: "GRAPHQL_VALIDATION_FAILED" },
+                  },
+                ],
+              })
+            }
+            return HttpResponse.json({
+              data: {
+                node: buildNativeChannelDetail(String(variables?.id), {
+                  name: "Fallback legacy channel",
+                }),
+              },
+            })
+          },
+        },
+        {
+          matches: matchesGraphqlOperation("query QueryChannels"),
+          respond: () =>
+            HttpResponse.json({
+              data: {
+                queryChannels: {
+                  edges: [{ node: nativeNullBaseUrlChannel }],
+                  pageInfo: { hasNextPage: false, endCursor: null },
+                  totalCount: 1,
+                },
+              },
+            }),
+        },
+      ],
+    })
+    const fallbackConfig = {
+      ...config,
+      email: "legacy-fallback@example.com",
+    }
+
+    const first = await listChannels(fallbackConfig)
+    const second = await listChannels(fallbackConfig)
+
+    expect(queries).toHaveLength(3)
+    expect(queries[0]).not.toContain("query GetAxonHubChannelCore")
+    for (const query of queries.slice(1)) {
+      expect(query).toContain("query GetAxonHubChannelCore")
+    }
+    expect(first.items[0].name).toBe("Fallback legacy channel")
+    expect(second.items[0].name).toBe("Fallback legacy channel")
+  })
+
+  it("rejects malformed stable detail after a legacy schema fallback", async () => {
+    useAxonHubGraphqlRoutes({
+      token: "legacy-malformed-fallback-token",
+      routes: [
+        {
+          matches: matchesGraphqlOperation("query GetAxonHubChannel"),
+          respond: ({ query }) =>
+            query.includes("query GetAxonHubChannelCore")
+              ? HttpResponse.json({
+                  data: {
+                    node: buildNativeChannelDetail("different-channel-id"),
+                  },
+                })
+              : HttpResponse.json({
+                  errors: [
+                    {
+                      message: "Cannot query optional legacy channel fields",
+                      extensions: { code: "GRAPHQL_VALIDATION_FAILED" },
+                    },
+                  ],
+                }),
+        },
+        {
+          matches: matchesGraphqlOperation("query QueryChannels"),
+          respond: () =>
+            HttpResponse.json({
+              data: {
+                queryChannels: {
+                  edges: [{ node: nativeNullBaseUrlChannel }],
+                  pageInfo: { hasNextPage: false, endCursor: null },
+                  totalCount: 1,
+                },
+              },
+            }),
+        },
+      ],
+    })
+
+    await expect(
+      listChannels({ ...config, email: "legacy-malformed@example.com" }),
+    ).rejects.toMatchObject({
+      kind: "protocol",
+      dispatch: "not-dispatched",
+    })
+  })
+
   it("rejects missing, absent, malformed, and retargeted legacy details", async () => {
     const requestedId = "legacy-detail-id"
     const detailResponses = [

--- a/tests/services/apiService/axonHub/index.test.ts
+++ b/tests/services/apiService/axonHub/index.test.ts
@@ -7,26 +7,19 @@ import {
   axonHubChannelToManagedSite,
   AxonHubRequestError,
   createAxonHubChannel,
-  createChannel as createChannelAdapter,
   deleteAxonHubChannel,
-  deleteChannel as deleteChannelAdapter,
-  fetchSiteUserGroups,
   getAxonHubChannel,
   graphqlRequest,
-  listAllChannels,
+  hasCompleteAxonHubAdvancedDetail,
   listAxonHubChannelPage,
   listChannels,
   resolveAxonHubGraphqlId,
   resolveAxonHubGraphqlIdForMutation,
-  searchChannel as searchChannelAdapter,
   searchChannels,
   signIn,
   updateAxonHubChannel,
   updateAxonHubChannelStatus,
-  updateChannel as updateChannelAdapter,
 } from "~/services/apiService/axonHub"
-import type { ApiServiceRequest } from "~/services/apiTransport/type"
-import { AuthTypeEnum } from "~/types"
 import type { AxonHubChannel, AxonHubCreateChannelInput } from "~/types/axonHub"
 import { CHANNEL_STATUS } from "~/types/managedSite"
 import { server } from "~~/tests/msw/server"
@@ -131,12 +124,6 @@ const buildPinnedChannelSettings = () => ({
   },
   retryableStatusCodes: [429],
   retryableErrorPatterns: [{ pattern: "temporary", regex: false }],
-  providerQuota: {
-    opencodeGo: {
-      workspaceId: null,
-      authCookie: null,
-    },
-  },
 })
 
 const buildPinnedChannelCredentials = (
@@ -186,15 +173,6 @@ const omitOutputField = (
   delete copy[field]
   return copy
 }
-
-const buildRequest = (): ApiServiceRequest => ({
-  baseUrl: config.baseUrl,
-  auth: {
-    authType: AuthTypeEnum.AccessToken,
-    userId: config.email,
-    accessToken: config.password,
-  },
-})
 
 type AxonHubGraphqlRoute = {
   matches: (query: string) => boolean
@@ -494,7 +472,7 @@ describe("AxonHub API service", () => {
     })
   })
 
-  it("selects every pinned beta5 settings field required for replacement preservation", async () => {
+  it("selects only product-owned settings facts from channel detail", async () => {
     let detailQuery = ""
 
     useAxonHubGraphqlRoutes({
@@ -522,39 +500,69 @@ describe("AxonHub API service", () => {
 
     expect(detailQuery).toMatch(/settings\s*\{[^}]*extraModelPrefix/s)
     expect(detailQuery).toMatch(/modelMappings\s*\{\s*from\s+to\s*\}/s)
-    expect(detailQuery).toContain("autoTrimedModelPrefixes")
-    expect(detailQuery).toContain("hideOriginalModels")
-    expect(detailQuery).toContain("hideMappedModels")
-    expect(detailQuery).toContain("lowercaseModelId")
-    expect(detailQuery).toMatch(
-      /proxy\s*\{\s*type\s+url\s+username\s+password\s*\}/s,
-    )
-    expect(detailQuery).toMatch(
-      /transformOptions\s*\{[^}]*forceArrayInstructions[^}]*forceArrayInputs[^}]*replaceDeveloperRoleWithSystem[^}]*reasoningEffortMapping\s*\{\s*from\s+to\s*\}/s,
-    )
-    for (const selection of [
+    for (const replacementOnlyField of [
+      "providerQuota",
+      "modelProtocols",
+      "proxy",
+      "transformOptions",
       "headerOverrideOperations",
       "bodyOverrideOperations",
+      "rateLimit",
     ]) {
-      expect(detailQuery).toMatch(
-        new RegExp(
-          `${selection}\\s*\\{[^}]*op[^}]*path[^}]*from[^}]*to[^}]*value[^}]*condition[^}]*match\\s*\\{\\s*path\\s+eq\\s*\\}[^}]*index[^}]*splat`,
-          "s",
-        ),
-      )
+      expect(detailQuery).not.toContain(replacementOnlyField)
     }
-    expect(detailQuery).toContain("passThroughUserAgent")
-    expect(detailQuery).toContain("passThroughBody")
-    expect(detailQuery).toMatch(
-      /rateLimit\s*\{\s*rpm\s+tpm\s+maxConcurrent\s+queueSize\s+queueTimeoutMs\s*\}/s,
-    )
-    expect(detailQuery).toContain("retryableStatusCodes")
-    expect(detailQuery).toMatch(
-      /retryableErrorPatterns\s*\{\s*pattern\s+regex\s*\}/s,
-    )
-    expect(detailQuery).toMatch(
-      /providerQuota\s*\{\s*opencodeGo\s*\{\s*workspaceId\s+authCookie\s*\}\s*\}/s,
-    )
+  })
+
+  it("falls back to the stable detail contract and caches advanced schema rejection", async () => {
+    const queries: string[] = []
+    let rejectedAdvancedQuery = false
+
+    useAxonHubGraphqlRoutes({
+      token: "detail-fallback-token",
+      routes: [
+        {
+          matches: matchesGraphqlOperation("query GetAxonHubChannel"),
+          respond: ({ query, variables }) => {
+            queries.push(query)
+            if (query.includes("settings {") && !rejectedAdvancedQuery) {
+              rejectedAdvancedQuery = true
+              return HttpResponse.json({
+                errors: [
+                  {
+                    message: "Cannot query field on ChannelSettings",
+                    extensions: { code: "GRAPHQL_VALIDATION_FAILED" },
+                  },
+                ],
+              })
+            }
+            return HttpResponse.json({
+              data: {
+                node: buildNativeChannelDetail(String(variables?.id), {
+                  settings: undefined,
+                  policies: undefined,
+                  endpoints: undefined,
+                }),
+              },
+            })
+          },
+        },
+      ],
+    })
+
+    const first = await getAxonHubChannel(config, "fallback-detail-one")
+    const second = await getAxonHubChannel(config, "fallback-detail-two")
+
+    expect(queries).toHaveLength(3)
+    expect(queries[0]).toContain("settings {")
+    for (const query of queries.slice(1)) {
+      expect(query).toContain("query GetAxonHubChannelCore")
+      expect(query).not.toContain("settings {")
+      expect(query).not.toContain("policies {")
+      expect(query).not.toContain("endpoints {")
+      expect(query).not.toContain("oauth {")
+    }
+    expect(hasCompleteAxonHubAdvancedDetail(first)).toBe(false)
+    expect(hasCompleteAxonHubAdvancedDetail(second)).toBe(false)
   })
 
   it("rejects malformed native detail nodes as controlled protocol failures", async () => {
@@ -619,14 +627,6 @@ describe("AxonHub API service", () => {
       { credentials: { apiKeys: ["valid-key", 42] } },
       { credentials: { oauth: { scopes: ["scope", false] } } },
       { settings: { modelMappings: [null] } },
-      { settings: { proxy: { type: "http", url: 42 } } },
-      { settings: { rateLimit: { rpm: "fast" } } },
-      { settings: { rateLimit: { queueTimeoutMs: 1.5 } } },
-      {
-        settings: {
-          providerQuota: { opencodeGo: { workspaceId: 42 } },
-        },
-      },
       { endpoints: [{ apiFormat: "openai", path: 42 }] },
     ]
     let responseIndex = 0
@@ -662,8 +662,7 @@ describe("AxonHub API service", () => {
     }
   })
 
-  it("rejects incomplete pinned authoritative output fields", async () => {
-    const completeSettings = buildPinnedChannelSettings()
+  it("rejects incomplete product-owned detail output fields", async () => {
     const invalidDetails = [
       omitOutputField(
         buildNativeChannelDetail("missing-created-at"),
@@ -696,27 +695,6 @@ describe("AxonHub API service", () => {
       ),
       buildNativeChannelDetail("fractional-ordering-weight", {
         orderingWeight: 1.5,
-      }),
-      buildNativeChannelDetail("missing-header-overrides", {
-        settings: omitOutputField(completeSettings, "headerOverrideOperations"),
-      }),
-      buildNativeChannelDetail("null-body-overrides", {
-        settings: { ...completeSettings, bodyOverrideOperations: null },
-      }),
-      buildNativeChannelDetail("missing-transform-boolean", {
-        settings: {
-          ...completeSettings,
-          transformOptions: omitOutputField(
-            completeSettings.transformOptions,
-            "forceArrayInputs",
-          ),
-        },
-      }),
-      buildNativeChannelDetail("missing-retry-regex", {
-        settings: {
-          ...completeSettings,
-          retryableErrorPatterns: [{ pattern: "temporary" }],
-        },
       }),
     ]
     let responseIndex = 0
@@ -896,6 +874,7 @@ describe("AxonHub API service", () => {
   })
 
   it("sends verified update and clear fields unchanged", async () => {
+    let capturedQuery = ""
     let capturedVariables: Record<string, unknown> | undefined
     const input = {
       status: AXON_HUB_CHANNEL_STATUS.DISABLED,
@@ -965,12 +944,6 @@ describe("AxonHub API service", () => {
         },
         retryableStatusCodes: [408, 429],
         retryableErrorPatterns: [{ pattern: "temporary", regex: false }],
-        providerQuota: {
-          opencodeGo: {
-            workspaceId: "workspace-example",
-            authCookie: "cookie-example",
-          },
-        },
       },
       clearBaseURL: true,
       clearManualModels: true,
@@ -988,7 +961,8 @@ describe("AxonHub API service", () => {
       routes: [
         {
           matches: matchesGraphqlOperation("mutation UpdateChannel"),
-          respond: ({ variables }) => {
+          respond: ({ query, variables }) => {
+            capturedQuery = query
             capturedVariables = variables
             return HttpResponse.json({
               data: {
@@ -1008,6 +982,20 @@ describe("AxonHub API service", () => {
     await updateAxonHubChannel(config, "opaque-update-id", input)
 
     expect(capturedVariables).toEqual({ id: "opaque-update-id", input })
+    const mutationSelection = extractSelectionBlock(
+      capturedQuery,
+      "updateChannel(id: $id, input: $input)",
+    )
+    expect([...getTopLevelSelectionNames(mutationSelection)]).toEqual([
+      "__typename",
+      "id",
+      "type",
+      "baseURL",
+      "name",
+      "status",
+    ])
+    expect(capturedQuery).not.toContain("settings")
+    expect(capturedQuery).not.toContain("credentials")
   })
 
   it("rejects malformed mutation roots with dispatched protocol failures", async () => {
@@ -1024,7 +1012,7 @@ describe("AxonHub API service", () => {
             HttpResponse.json({
               data: {
                 updateChannel: buildNativeChannelDetail("malformed-update", {
-                  settings: { modelMappings: [null] },
+                  name: 42,
                 }),
               },
             }),
@@ -1182,6 +1170,7 @@ describe("AxonHub API service", () => {
 
   it("omits or passes null create baseURL according to the native protocol", async () => {
     const capturedInputs: unknown[] = []
+    const capturedQueries: string[] = []
     const omittedBaseUrlInput: AxonHubCreateChannelInput = {
       type: "openai",
       name: "No base URL",
@@ -1200,7 +1189,8 @@ describe("AxonHub API service", () => {
       routes: [
         {
           matches: matchesGraphqlOperation("mutation CreateChannel"),
-          respond: ({ variables }) => {
+          respond: ({ query, variables }) => {
+            capturedQueries.push(query)
             capturedInputs.push(variables?.input)
             return HttpResponse.json({
               data: {
@@ -1221,6 +1211,10 @@ describe("AxonHub API service", () => {
     await createAxonHubChannel(config, nullBaseUrlInput)
 
     expect(capturedInputs).toEqual([omittedBaseUrlInput, nullBaseUrlInput])
+    expect(capturedQueries).toHaveLength(2)
+    for (const query of capturedQueries) {
+      expect(query).not.toContain("providerQuota")
+    }
   })
 
   it("normalizes a null native baseURL only in the legacy projection", () => {
@@ -2711,20 +2705,6 @@ describe("AxonHub API service", () => {
     })
     expect(result._axonHubData.settings).toMatchObject({
       modelMappings: [{ from: "model-alpha", to: "model-upstream" }],
-      transformOptions: {
-        forceArrayInstructions: true,
-        forceArrayInputs: false,
-        replaceDeveloperRoleWithSystem: true,
-        reasoningEffortMapping: [{ from: "high", to: "medium" }],
-      },
-      rateLimit: {
-        rpm: 10,
-        tpm: 20,
-        maxConcurrent: 2,
-        queueSize: 3,
-        queueTimeoutMs: 4,
-      },
-      retryableErrorPatterns: [{ pattern: "temporary", regex: false }],
     })
 
     const serialized = JSON.stringify(result)
@@ -3025,7 +3005,7 @@ describe("AxonHub API service", () => {
         model_mapping: JSON.stringify({
           "gpt-4.1": "gpt-4.1-upstream",
         }),
-        setting: expect.stringContaining('"lowercaseModelId":true'),
+        setting: expect.stringContaining('"modelMappings"'),
       }),
     )
     expect(result.items[1]).toEqual(
@@ -3299,978 +3279,6 @@ describe("AxonHub API service", () => {
         email: "repeat-cursor@example.com",
       }),
     ).rejects.toThrow("AxonHub channel pagination cursor repeated")
-  })
-
-  it("returns cached channels for blank searches and supports the search adapter wrapper", async () => {
-    let authHits = 0
-    let graphQlHits = 0
-
-    server.use(
-      http.post(AUTH_URL, () => {
-        authHits += 1
-        return HttpResponse.json({ token: "search-token" })
-      }),
-      http.post(GRAPHQL_URL, async ({ request }) => {
-        graphQlHits += 1
-        const body = (await request.json()) as {
-          query?: string
-          variables?: { id?: unknown }
-        }
-        if (body.query?.includes("query GetAxonHubChannel")) {
-          const isAlpha = body.variables?.id === "1"
-          return HttpResponse.json({
-            data: {
-              node: buildNativeChannelDetail(body.variables?.id as string, {
-                type: isAlpha ? "openai" : "anthropic",
-                baseURL: isAlpha
-                  ? "https://alpha.example.com"
-                  : "https://beta.example.com",
-                name: isAlpha ? "alpha" : "beta",
-                status: isAlpha
-                  ? AXON_HUB_CHANNEL_STATUS.ENABLED
-                  : AXON_HUB_CHANNEL_STATUS.DISABLED,
-                credentials: buildPinnedChannelCredentials({
-                  apiKey: isAlpha ? "sk-alpha" : "sk-beta",
-                }),
-                supportedModels: isAlpha ? ["gpt-4.1"] : [],
-                manualModels: isAlpha ? [] : ["claude-sonnet-4-5"],
-              }),
-            },
-          })
-        }
-
-        return HttpResponse.json({
-          data: {
-            queryChannels: {
-              edges: [
-                {
-                  node: {
-                    id: "1",
-                    type: "openai",
-                    baseURL: "https://alpha.example.com",
-                    name: "alpha",
-                    status: AXON_HUB_CHANNEL_STATUS.ENABLED,
-                    credentials: { apiKey: "sk-alpha" },
-                    supportedModels: ["gpt-4.1"],
-                    manualModels: [],
-                  },
-                },
-                {
-                  node: {
-                    id: "2",
-                    type: "anthropic",
-                    baseURL: "https://beta.example.com",
-                    name: "beta",
-                    status: AXON_HUB_CHANNEL_STATUS.DISABLED,
-                    credentials: { apiKey: "sk-beta" },
-                    supportedModels: [],
-                    manualModels: ["claude-sonnet-4-5"],
-                  },
-                },
-              ],
-              pageInfo: { hasNextPage: false, endCursor: null },
-              totalCount: 2,
-            },
-          },
-        })
-      }),
-    )
-
-    const searchConfig = {
-      ...config,
-      email: "blank-search@example.com",
-    }
-
-    await expect(searchChannels(searchConfig, "   ")).resolves.toMatchObject({
-      total: 2,
-      items: [
-        expect.objectContaining({ name: "alpha" }),
-        expect.objectContaining({ name: "beta" }),
-      ],
-    })
-
-    await expect(
-      searchChannels(searchConfig, "sk-beta"),
-    ).resolves.toMatchObject({
-      total: 1,
-      items: [expect.objectContaining({ name: "beta", key: "sk-beta" })],
-    })
-
-    await expect(
-      searchChannelAdapter(buildRequest(), "alpha"),
-    ).resolves.toMatchObject({
-      total: 1,
-      items: [expect.objectContaining({ name: "alpha" })],
-    })
-
-    expect(authHits).toBe(2)
-    expect(graphQlHits).toBe(8)
-  })
-
-  it("creates channels through the adapter wrapper and returns safe create errors", async () => {
-    let statusHits = 0
-
-    server.use(
-      http.post(AUTH_URL, () => HttpResponse.json({ token: "create-token" })),
-      http.post(GRAPHQL_URL, async ({ request }) => {
-        const body = (await request.json()) as { query?: string }
-
-        if (body.query?.includes("mutation CreateChannel")) {
-          return HttpResponse.json({
-            data: {
-              createChannel: buildNativeChannelDetail("13", {
-                baseURL: "https://created.example.com/v1",
-                name: "Created Channel",
-                status: AXON_HUB_CHANNEL_STATUS.ENABLED,
-                credentials: buildPinnedChannelCredentials({
-                  apiKeys: ["sk-created"],
-                }),
-                supportedModels: ["gpt-4.1"],
-                manualModels: ["gpt-4.1"],
-                defaultTestModel: "gpt-4.1",
-                settings: {
-                  ...buildPinnedChannelSettings(),
-                  modelMappings: [],
-                },
-                orderingWeight: 5,
-              }),
-            },
-          })
-        }
-
-        if (body.query?.includes("mutation UpdateChannelStatus")) {
-          statusHits += 1
-          return HttpResponse.json({
-            data: {
-              updateChannelStatus: {
-                __typename: "Channel",
-                id: "13",
-                status: AXON_HUB_CHANNEL_STATUS.ENABLED,
-              },
-            },
-          })
-        }
-
-        return HttpResponse.json(
-          { errors: [{ message: "Unexpected GraphQL operation" }] },
-          { status: 500 },
-        )
-      }),
-    )
-
-    await expect(
-      createChannelAdapter(buildRequest(), {
-        channel: {
-          type: "openai",
-          name: "Created Channel",
-          baseURL: "https://created.example.com/v1",
-          credentials: { apiKeys: ["sk-created"] },
-          supportedModels: ["gpt-4.1"],
-          manualModels: ["gpt-4.1"],
-          defaultTestModel: "gpt-4.1",
-          settings: {},
-          orderingWeight: 5,
-          status: CHANNEL_STATUS.Enable,
-        },
-      }),
-    ).resolves.toMatchObject({
-      success: true,
-      data: expect.objectContaining({
-        status: CHANNEL_STATUS.Enable,
-      }),
-      message: "success",
-    })
-    expect(statusHits).toBe(1)
-
-    server.use(
-      http.post(AUTH_URL, () => HttpResponse.json({ token: "create-error" })),
-      http.post(GRAPHQL_URL, async ({ request }) => {
-        const body = (await request.json()) as { query?: string }
-        if (body.query?.includes("mutation CreateChannel")) {
-          return HttpResponse.json(
-            { errors: [{ message: "create exploded" }] },
-            { status: 500 },
-          )
-        }
-
-        return HttpResponse.json(
-          { errors: [{ message: "Unexpected GraphQL operation" }] },
-          { status: 500 },
-        )
-      }),
-    )
-
-    await expect(
-      createChannelAdapter(buildRequest(), {
-        channel: {
-          type: "openai",
-          name: "Broken Channel",
-          baseURL: "https://broken.example.com/v1",
-          credentials: { apiKeys: ["sk-broken"] },
-          supportedModels: ["gpt-4.1"],
-          manualModels: ["gpt-4.1"],
-          defaultTestModel: "gpt-4.1",
-          settings: {},
-          orderingWeight: 0,
-        },
-      }),
-    ).resolves.toEqual({
-      success: false,
-      data: null,
-      message: "unavailable",
-    })
-  })
-
-  it("invalidates cached channel lists after adapter mutations", async () => {
-    let listHits = 0
-
-    server.use(
-      http.post(AUTH_URL, () => HttpResponse.json({ token: "mutation-cache" })),
-      http.post(GRAPHQL_URL, async ({ request }) => {
-        const body = (await request.json()) as { query?: string }
-
-        if (body.query?.includes("query QueryChannels")) {
-          listHits += 1
-          return HttpResponse.json({
-            data: {
-              queryChannels: {
-                edges: [],
-                pageInfo: { hasNextPage: false, endCursor: null },
-                totalCount: 0,
-              },
-            },
-          })
-        }
-
-        if (body.query?.includes("mutation CreateChannel")) {
-          return HttpResponse.json({
-            data: {
-              createChannel: buildNativeChannelDetail("13", {
-                baseURL: "https://created.example.com/v1",
-                name: "Created Channel",
-                status: AXON_HUB_CHANNEL_STATUS.ENABLED,
-                credentials: buildPinnedChannelCredentials({
-                  apiKeys: ["sk-created"],
-                }),
-                supportedModels: ["gpt-4.1"],
-                manualModels: ["gpt-4.1"],
-                defaultTestModel: "gpt-4.1",
-                settings: {
-                  ...buildPinnedChannelSettings(),
-                  modelMappings: [],
-                },
-                orderingWeight: 5,
-              }),
-            },
-          })
-        }
-
-        return HttpResponse.json(
-          { errors: [{ message: "Unexpected GraphQL operation" }] },
-          { status: 500 },
-        )
-      }),
-    )
-
-    await listChannels(config)
-    await listChannels(config)
-    expect(listHits).toBe(1)
-
-    await expect(
-      createChannelAdapter(buildRequest(), {
-        channel: {
-          type: "openai",
-          name: "Created Channel",
-          baseURL: "https://created.example.com/v1",
-          credentials: { apiKeys: ["sk-created"] },
-          supportedModels: ["gpt-4.1"],
-          manualModels: ["gpt-4.1"],
-          defaultTestModel: "gpt-4.1",
-          settings: {},
-          orderingWeight: 5,
-        },
-      }),
-    ).resolves.toMatchObject({ success: true })
-
-    await listChannels(config)
-    expect(listHits).toBe(2)
-  })
-
-  it("invalidates cached channel lists when create succeeds but status update fails", async () => {
-    let listHits = 0
-
-    useAxonHubGraphqlRoutes({
-      token: "partial-create-cache",
-      routes: [
-        {
-          matches: matchesGraphqlOperation("query QueryChannels"),
-          respond: () => {
-            listHits += 1
-            return HttpResponse.json({
-              data: {
-                queryChannels: {
-                  edges: [],
-                  pageInfo: { hasNextPage: false, endCursor: null },
-                  totalCount: 0,
-                },
-              },
-            })
-          },
-        },
-        {
-          matches: matchesGraphqlOperation("mutation CreateChannel"),
-          respond: () =>
-            HttpResponse.json({
-              data: {
-                createChannel: buildNativeChannelDetail("13", {
-                  baseURL: "https://created.example.com/v1",
-                  name: "Created Channel",
-                  status: AXON_HUB_CHANNEL_STATUS.DISABLED,
-                  credentials: buildPinnedChannelCredentials({
-                    apiKeys: ["sk-created"],
-                  }),
-                  supportedModels: ["gpt-4.1"],
-                  manualModels: ["gpt-4.1"],
-                  defaultTestModel: "gpt-4.1",
-                  settings: {
-                    ...buildPinnedChannelSettings(),
-                    modelMappings: [],
-                  },
-                  orderingWeight: 5,
-                }),
-              },
-            }),
-        },
-        {
-          matches: matchesGraphqlOperation("mutation UpdateChannelStatus"),
-          respond: () =>
-            HttpResponse.json(
-              { errors: [{ message: "status exploded" }] },
-              { status: 500 },
-            ),
-        },
-      ],
-    })
-
-    await listChannels(config)
-    await listChannels(config)
-    expect(listHits).toBe(1)
-
-    await expect(
-      createChannelAdapter(buildRequest(), {
-        channel: {
-          type: "openai",
-          name: "Created Channel",
-          baseURL: "https://created.example.com/v1",
-          credentials: { apiKeys: ["sk-created"] },
-          supportedModels: ["gpt-4.1"],
-          manualModels: ["gpt-4.1"],
-          defaultTestModel: "gpt-4.1",
-          settings: {},
-          orderingWeight: 5,
-          status: CHANNEL_STATUS.Enable,
-        },
-      }),
-    ).resolves.toMatchObject({
-      success: false,
-      message: "unavailable",
-    })
-
-    await listChannels(config)
-    expect(listHits).toBe(2)
-  })
-
-  it("invalidates cached channel lists when update succeeds but status update fails", async () => {
-    const graphqlId = "gid://axonhub/Channel/13"
-    const rowId = axonHubChannelToManagedSite({
-      id: graphqlId,
-      createdAt: null,
-      updatedAt: null,
-      type: "openai",
-      baseURL: "https://updated.example.com/v1",
-      name: "Updated Channel",
-      status: AXON_HUB_CHANNEL_STATUS.DISABLED,
-      credentials: { apiKey: "sk-updated" },
-      supportedModels: ["gpt-4.1"],
-      manualModels: [],
-      defaultTestModel: null,
-      settings: {},
-      orderingWeight: 0,
-      remark: null,
-      errorMessage: null,
-    }).id
-    let listHits = 0
-
-    useAxonHubGraphqlRoutes({
-      token: "partial-update-cache",
-      routes: [
-        {
-          matches: matchesGraphqlOperation("query QueryChannels"),
-          respond: () => {
-            listHits += 1
-            return HttpResponse.json({
-              data: {
-                queryChannels: {
-                  edges: [
-                    {
-                      node: {
-                        id: graphqlId,
-                        type: "openai",
-                        baseURL: "https://updated.example.com/v1",
-                        name: "Updated Channel",
-                        status: AXON_HUB_CHANNEL_STATUS.DISABLED,
-                        credentials: { apiKey: "sk-updated" },
-                        supportedModels: ["gpt-4.1"],
-                        manualModels: [],
-                      },
-                    },
-                  ],
-                  pageInfo: { hasNextPage: false, endCursor: null },
-                  totalCount: 1,
-                },
-              },
-            })
-          },
-        },
-        {
-          matches: matchesGraphqlOperation("query GetAxonHubChannel"),
-          respond: () =>
-            HttpResponse.json({
-              data: {
-                node: buildNativeChannelDetail(graphqlId, {
-                  baseURL: "https://updated.example.com/v1",
-                  name: "Updated Channel",
-                  status: AXON_HUB_CHANNEL_STATUS.DISABLED,
-                  credentials: buildPinnedChannelCredentials({
-                    apiKey: "sk-updated",
-                  }),
-                  supportedModels: ["gpt-4.1"],
-                  settings: buildPinnedChannelSettings(),
-                }),
-              },
-            }),
-        },
-        {
-          matches: matchesGraphqlOperation("mutation UpdateChannel("),
-          respond: () =>
-            HttpResponse.json({
-              data: {
-                updateChannel: buildNativeChannelDetail(graphqlId, {
-                  baseURL: "https://updated.example.com/v1",
-                  name: "Updated Channel",
-                  status: AXON_HUB_CHANNEL_STATUS.DISABLED,
-                  credentials: buildPinnedChannelCredentials({
-                    apiKeys: ["sk-updated"],
-                  }),
-                  supportedModels: ["gpt-4.1"],
-                  manualModels: ["gpt-4.1"],
-                  defaultTestModel: "gpt-4.1",
-                  settings: {
-                    ...buildPinnedChannelSettings(),
-                    modelMappings: [],
-                  },
-                  orderingWeight: 5,
-                }),
-              },
-            }),
-        },
-        {
-          matches: matchesGraphqlOperation("mutation UpdateChannelStatus"),
-          respond: () =>
-            HttpResponse.json(
-              { errors: [{ message: "status exploded" }] },
-              { status: 500 },
-            ),
-        },
-      ],
-    })
-
-    await listChannels(config)
-    await listChannels(config)
-    expect(listHits).toBe(1)
-
-    await expect(
-      updateChannelAdapter(buildRequest(), {
-        id: rowId,
-        type: "openai",
-        name: "Updated Channel",
-        baseURL: "https://updated.example.com/v1",
-        credentials: { apiKeys: ["sk-updated"] },
-        supportedModels: ["gpt-4.1"],
-        manualModels: ["gpt-4.1"],
-        defaultTestModel: "gpt-4.1",
-        settings: {},
-        orderingWeight: 5,
-        status: CHANNEL_STATUS.Enable,
-      }),
-    ).resolves.toMatchObject({
-      success: false,
-      message: "unavailable",
-    })
-
-    await listChannels(config)
-    expect(listHits).toBe(2)
-  })
-
-  it("updates status zero through the adapter wrapper and returns a failure message when delete returns false", async () => {
-    const graphqlId = "gid://axonhub/Channel/7"
-    const rowId = axonHubChannelToManagedSite({
-      id: graphqlId,
-      createdAt: null,
-      updatedAt: null,
-      type: "openai",
-      baseURL: "https://adapter.example.com/v1",
-      name: "Adapter Channel",
-      status: AXON_HUB_CHANNEL_STATUS.ENABLED,
-      credentials: { apiKey: "sk-adapter" },
-      supportedModels: ["gpt-4.1"],
-      manualModels: [],
-      defaultTestModel: null,
-      settings: {},
-      orderingWeight: 0,
-      remark: null,
-      errorMessage: null,
-    }).id
-    let statusHits = 0
-    let deleteHits = 0
-
-    server.use(
-      http.post(AUTH_URL, () => HttpResponse.json({ token: "adapter-token" })),
-      http.post(GRAPHQL_URL, async ({ request }) => {
-        const body = (await request.json()) as { query?: string }
-
-        if (body.query?.includes("query QueryChannels")) {
-          return HttpResponse.json({
-            data: {
-              queryChannels: {
-                edges: [
-                  {
-                    node: {
-                      id: graphqlId,
-                      type: "openai",
-                      baseURL: "https://adapter.example.com/v1",
-                      name: "Adapter Channel",
-                      status: AXON_HUB_CHANNEL_STATUS.ENABLED,
-                      credentials: { apiKey: "sk-adapter" },
-                      supportedModels: ["gpt-4.1"],
-                      manualModels: [],
-                    },
-                  },
-                ],
-                pageInfo: { hasNextPage: false, endCursor: null },
-                totalCount: 1,
-              },
-            },
-          })
-        }
-
-        if (body.query?.includes("mutation UpdateChannel(")) {
-          return HttpResponse.json({
-            data: {
-              updateChannel: buildNativeChannelDetail(graphqlId, {
-                baseURL: "https://adapter.example.com/v1",
-                name: "Adapter Channel",
-                status: AXON_HUB_CHANNEL_STATUS.ENABLED,
-                credentials: buildPinnedChannelCredentials({
-                  apiKey: "sk-adapter",
-                }),
-                supportedModels: ["gpt-4.1"],
-                defaultTestModel: "gpt-4.1",
-                settings: buildPinnedChannelSettings(),
-                orderingWeight: 0,
-              }),
-            },
-          })
-        }
-
-        if (body.query?.includes("mutation UpdateChannelStatus")) {
-          statusHits += 1
-          return HttpResponse.json({
-            data: {
-              updateChannelStatus: {
-                __typename: "Channel",
-                id: graphqlId,
-                status: AXON_HUB_CHANNEL_STATUS.DISABLED,
-              },
-            },
-          })
-        }
-
-        if (body.query?.includes("mutation DeleteChannel")) {
-          deleteHits += 1
-          return HttpResponse.json({
-            data: {
-              deleteChannel: false,
-            },
-          })
-        }
-
-        return HttpResponse.json(
-          { errors: [{ message: "Unexpected GraphQL operation" }] },
-          { status: 500 },
-        )
-      }),
-    )
-
-    await expect(
-      updateChannelAdapter(buildRequest(), {
-        id: rowId,
-        name: "Adapter Channel",
-        status: CHANNEL_STATUS.Unknown,
-      }),
-    ).resolves.toMatchObject({
-      success: true,
-      data: expect.objectContaining({
-        status: CHANNEL_STATUS.ManuallyDisabled,
-      }),
-      message: "success",
-    })
-    expect(statusHits).toBe(1)
-
-    await expect(deleteChannelAdapter(buildRequest(), rowId)).resolves.toEqual({
-      success: false,
-      data: false,
-      message: "Failed to delete AxonHub channel",
-    })
-    expect(deleteHits).toBe(1)
-  })
-
-  it("returns safe adapter errors for update/delete failures and exposes the groupless contract", async () => {
-    const graphqlId = "gid://axonhub/Channel/9"
-    const rowId = axonHubChannelToManagedSite({
-      id: graphqlId,
-      createdAt: null,
-      updatedAt: null,
-      type: "openai",
-      baseURL: "https://broken.example.com/v1",
-      name: "Broken update",
-      status: AXON_HUB_CHANNEL_STATUS.ENABLED,
-      credentials: { apiKey: "sk-broken" },
-      supportedModels: ["gpt-4.1"],
-      manualModels: [],
-      defaultTestModel: null,
-      settings: {},
-      orderingWeight: 0,
-      remark: null,
-      errorMessage: null,
-    }).id
-
-    server.use(
-      http.post(AUTH_URL, () => HttpResponse.json({ token: "adapter-fail" })),
-      http.post(GRAPHQL_URL, async ({ request }) => {
-        const body = (await request.json()) as {
-          query?: string
-        }
-
-        if (body.query?.includes("query QueryChannels")) {
-          return HttpResponse.json({
-            data: {
-              queryChannels: {
-                edges: [
-                  {
-                    node: {
-                      id: graphqlId,
-                      type: "openai",
-                      baseURL: "https://broken.example.com/v1",
-                      name: "Broken update",
-                      status: AXON_HUB_CHANNEL_STATUS.ENABLED,
-                      credentials: { apiKey: "sk-broken" },
-                      supportedModels: ["gpt-4.1"],
-                      manualModels: [],
-                    },
-                  },
-                ],
-                pageInfo: { hasNextPage: false, endCursor: null },
-                totalCount: 1,
-              },
-            },
-          })
-        }
-
-        if (body.query?.includes("mutation UpdateChannel(")) {
-          return HttpResponse.json(
-            { errors: [{ message: "update exploded" }] },
-            { status: 500 },
-          )
-        }
-
-        if (body.query?.includes("mutation DeleteChannel")) {
-          return HttpResponse.json(
-            { errors: [{ message: "delete exploded" }] },
-            { status: 500 },
-          )
-        }
-
-        return HttpResponse.json(
-          { errors: [{ message: "Unexpected GraphQL operation" }] },
-          { status: 500 },
-        )
-      }),
-    )
-
-    await expect(
-      updateChannelAdapter(buildRequest(), {
-        id: rowId,
-        name: "Broken update",
-      }),
-    ).resolves.toEqual({
-      success: false,
-      data: null,
-      message: "unavailable",
-    })
-
-    await expect(deleteChannelAdapter(buildRequest(), rowId)).resolves.toEqual({
-      success: false,
-      data: null,
-      message: "unavailable",
-    })
-
-    await expect(fetchSiteUserGroups()).resolves.toEqual([])
-  })
-
-  it("lists channels through the adapter wrapper", async () => {
-    server.use(
-      http.post(AUTH_URL, () => HttpResponse.json({ token: "adapter-list" })),
-      http.post(GRAPHQL_URL, async ({ request }) => {
-        const body = (await request.json()) as { query?: string }
-        if (body.query?.includes("query GetAxonHubChannel")) {
-          return HttpResponse.json({
-            data: {
-              node: buildNativeChannelDetail("1", {
-                baseURL: "https://alpha.example.com",
-                name: "alpha",
-                status: AXON_HUB_CHANNEL_STATUS.ENABLED,
-                credentials: buildPinnedChannelCredentials({
-                  apiKey: "sk-alpha",
-                }),
-                supportedModels: ["gpt-4.1"],
-              }),
-            },
-          })
-        }
-
-        return HttpResponse.json({
-          data: {
-            queryChannels: {
-              edges: [
-                {
-                  node: {
-                    id: "1",
-                    type: "openai",
-                    baseURL: "https://alpha.example.com",
-                    name: "alpha",
-                    status: AXON_HUB_CHANNEL_STATUS.ENABLED,
-                    credentials: { apiKey: "sk-alpha" },
-                    supportedModels: ["gpt-4.1"],
-                    manualModels: [],
-                  },
-                },
-              ],
-              pageInfo: { hasNextPage: false, endCursor: null },
-              totalCount: 1,
-            },
-          },
-        })
-      }),
-    )
-
-    await expect(listAllChannels(buildRequest())).resolves.toMatchObject({
-      total: 1,
-      items: [expect.objectContaining({ id: 1, name: "alpha" })],
-    })
-  })
-
-  it("hydrates AxonHub GraphQL ids before adapter delete mutations", async () => {
-    const graphqlId = "gid://axonhub/Channel/7"
-    const rowId = axonHubChannelToManagedSite({
-      id: graphqlId,
-      createdAt: null,
-      updatedAt: null,
-      type: "openai",
-      baseURL: "https://alpha.example.com",
-      name: "alpha",
-      status: AXON_HUB_CHANNEL_STATUS.ENABLED,
-      credentials: { apiKey: "sk-alpha" },
-      supportedModels: ["gpt-4.1"],
-      manualModels: [],
-      defaultTestModel: null,
-      settings: {},
-      orderingWeight: 0,
-      remark: null,
-      errorMessage: null,
-    }).id
-    __resetCachesForTesting()
-
-    let listHits = 0
-    let deletedId: unknown
-
-    server.use(
-      http.post(AUTH_URL, () =>
-        HttpResponse.json({ token: "adapter-delete-gid" }),
-      ),
-      http.post(GRAPHQL_URL, async ({ request }) => {
-        const body = (await request.json()) as {
-          query?: string
-          variables?: { id?: unknown }
-        }
-
-        if (body.query?.includes("query QueryChannels")) {
-          listHits += 1
-          return HttpResponse.json({
-            data: {
-              queryChannels: {
-                edges: [
-                  {
-                    node: {
-                      id: graphqlId,
-                      type: "openai",
-                      baseURL: "https://alpha.example.com",
-                      name: "alpha",
-                      status: AXON_HUB_CHANNEL_STATUS.ENABLED,
-                      credentials: { apiKey: "sk-alpha" },
-                      supportedModels: ["gpt-4.1"],
-                      manualModels: [],
-                    },
-                  },
-                ],
-                pageInfo: { hasNextPage: false, endCursor: null },
-                totalCount: 1,
-              },
-            },
-          })
-        }
-
-        if (body.query?.includes("query GetAxonHubChannel")) {
-          return HttpResponse.json({
-            data: {
-              node: buildNativeChannelDetail(graphqlId, {
-                baseURL: "https://alpha.example.com",
-                name: "alpha",
-                status: AXON_HUB_CHANNEL_STATUS.ENABLED,
-                credentials: buildPinnedChannelCredentials({
-                  apiKey: "sk-alpha",
-                }),
-                supportedModels: ["gpt-4.1"],
-              }),
-            },
-          })
-        }
-
-        if (body.query?.includes("mutation DeleteChannel")) {
-          deletedId = body.variables?.id
-          return HttpResponse.json({
-            data: {
-              deleteChannel: true,
-            },
-          })
-        }
-
-        return HttpResponse.json(
-          { errors: [{ message: "Unexpected GraphQL operation" }] },
-          { status: 500 },
-        )
-      }),
-    )
-
-    await expect(deleteChannelAdapter(buildRequest(), rowId)).resolves.toEqual({
-      success: true,
-      data: true,
-      message: "success",
-    })
-
-    expect(listHits).toBe(1)
-    expect(deletedId).toBe(graphqlId)
-  })
-
-  it("uses opaque mapped AxonHub GraphQL ids for adapter delete mutations", async () => {
-    const graphqlId = "opaque-channel-id"
-    const rowId = axonHubChannelToManagedSite({
-      id: graphqlId,
-      createdAt: null,
-      updatedAt: null,
-      type: "openai",
-      baseURL: "https://opaque.example.com",
-      name: "opaque",
-      status: AXON_HUB_CHANNEL_STATUS.ENABLED,
-      credentials: { apiKey: "sk-opaque" },
-      supportedModels: ["gpt-4.1"],
-      manualModels: [],
-      defaultTestModel: null,
-      settings: {},
-      orderingWeight: 0,
-      remark: null,
-      errorMessage: null,
-    }).id
-
-    let deletedId: unknown
-
-    server.use(
-      http.post(AUTH_URL, () =>
-        HttpResponse.json({ token: "adapter-delete-opaque" }),
-      ),
-      http.post(GRAPHQL_URL, async ({ request }) => {
-        const body = (await request.json()) as {
-          query?: string
-          variables?: { id?: unknown }
-        }
-
-        if (body.query?.includes("mutation DeleteChannel")) {
-          deletedId = body.variables?.id
-          return HttpResponse.json({
-            data: {
-              deleteChannel: true,
-            },
-          })
-        }
-
-        return HttpResponse.json(
-          { errors: [{ message: "Unexpected GraphQL operation" }] },
-          { status: 500 },
-        )
-      }),
-    )
-
-    await expect(deleteChannelAdapter(buildRequest(), rowId)).resolves.toEqual({
-      success: true,
-      data: true,
-      message: "success",
-    })
-
-    expect(deletedId).toBe(graphqlId)
-  })
-
-  it("reports an error when an AxonHub numeric row id cannot be hydrated", async () => {
-    server.use(
-      http.post(AUTH_URL, () =>
-        HttpResponse.json({ token: "adapter-delete-unmapped" }),
-      ),
-      http.post(GRAPHQL_URL, async ({ request }) => {
-        const body = (await request.json()) as { query?: string }
-
-        if (body.query?.includes("query QueryChannels")) {
-          return HttpResponse.json({
-            data: {
-              queryChannels: {
-                edges: [],
-                pageInfo: { hasNextPage: false, endCursor: null },
-                totalCount: 0,
-              },
-            },
-          })
-        }
-
-        return HttpResponse.json(
-          { errors: [{ message: "Unexpected GraphQL operation" }] },
-          { status: 500 },
-        )
-      }),
-    )
-
-    await expect(deleteChannelAdapter(buildRequest(), 999)).resolves.toEqual({
-      success: false,
-      data: null,
-      message: "Unable to resolve AxonHub GraphQL id for channel 999",
-    })
   })
 
   it("types unresolved mutation IDs as not-dispatched native failures", async () => {

--- a/tests/services/managedSites/managedUpstreamResourceService.test.ts
+++ b/tests/services/managedSites/managedUpstreamResourceService.test.ts
@@ -25,6 +25,13 @@ const expectResolvedResources = (
   resources: ManagedUpstreamResourcesCapability,
 ) => resources
 
+const expectedDisabledReason = (
+  siteType: (typeof MANAGED_SITE_TYPES)[number],
+) =>
+  siteType === SITE_TYPES.AXON_HUB
+    ? "core-slice-disabled"
+    : "feature-slice-disabled"
+
 describe("managed upstream resource service", () => {
   beforeEach(() => {
     getSiteTypeCapabilitiesMock.mockReset()
@@ -52,14 +59,13 @@ describe("managed upstream resource service", () => {
           siteType === SITE_TYPES.VELOERA ||
           siteType === SITE_TYPES.DONE_HUB ||
           siteType === SITE_TYPES.OCTOPUS ||
-          siteType === SITE_TYPES.AXON_HUB ||
           siteType === SITE_TYPES.CLAUDE_CODE_HUB ||
           siteType === SITE_TYPES.SUB2API,
       })),
     )
   })
 
-  it("resolves AxonHub core resources after its migration gate is enabled", () => {
+  it("keeps removed AxonHub legacy resources outside the core gate", () => {
     const resources = buildResourcesCapability()
     getSiteTypeCapabilitiesMock.mockReturnValue({
       siteType: SITE_TYPES.AXON_HUB,
@@ -74,9 +80,9 @@ describe("managed upstream resource service", () => {
     expect(
       resolveManagedUpstreamResourceCapabilities(SITE_TYPES.AXON_HUB),
     ).toEqual({
-      supported: true,
+      supported: false,
       siteType: SITE_TYPES.AXON_HUB,
-      capabilities: expectResolvedResources(resources),
+      reason: "core-slice-disabled",
     })
   })
 
@@ -247,7 +253,7 @@ describe("managed upstream resource service", () => {
           supported: false,
           siteType,
           feature: MANAGED_UPSTREAM_RESOURCE_FEATURES.ModelRedirect,
-          reason: "feature-slice-disabled",
+          reason: expectedDisabledReason(siteType),
         }),
       ),
     )
@@ -299,7 +305,7 @@ describe("managed upstream resource service", () => {
           supported: false,
           siteType,
           feature: MANAGED_UPSTREAM_RESOURCE_FEATURES.ModelSync,
-          reason: "feature-slice-disabled",
+          reason: expectedDisabledReason(siteType),
         }),
       ),
     )
@@ -384,7 +390,7 @@ describe("managed upstream resource service", () => {
           supported: false,
           siteType,
           feature: MANAGED_UPSTREAM_RESOURCE_FEATURES.TokenBatchExport,
-          reason: "feature-slice-disabled",
+          reason: expectedDisabledReason(siteType),
         }),
       ),
     )
@@ -444,7 +450,7 @@ describe("managed upstream resource service", () => {
         supported: false,
         siteType,
         feature: MANAGED_UPSTREAM_RESOURCE_FEATURES.TokenChannelStatus,
-        reason: "feature-slice-disabled",
+        reason: expectedDisabledReason(siteType),
       })),
     )
   })
@@ -492,7 +498,7 @@ describe("managed upstream resource service", () => {
       supported: false,
       siteType: SITE_TYPES.AXON_HUB,
       feature: MANAGED_UPSTREAM_RESOURCE_FEATURES.ChannelMigration,
-      reason: "feature-slice-disabled",
+      reason: "core-slice-disabled",
     })
   })
 
@@ -543,7 +549,7 @@ describe("managed upstream resource service", () => {
           supported: false,
           siteType,
           feature,
-          reason: "feature-slice-disabled",
+          reason: expectedDisabledReason(siteType),
         })),
       )
     }


### PR DESCRIPTION
## Summary

AxonHub channel management was tightly coupled to the complete GraphQL channel schema. Upstream schema changes or unrelated aggregate fields could make reads and full updates fail.

This change makes AxonHub channel management schema-resilient and patch-oriented.

## What changed

- Make native AxonHub channel updates submit only changed fields.
- Preserve a compatibility managedSites.channels surface without using full-resource replacement.
- Remove the obsolete AxonHub legacy resources implementation.
- Remove unused AxonHub API-service mutation wrappers.
- Stop querying and persisting the removed providerQuota field.
- Treat mutation responses as minimal receipts instead of full channel details.
- Fall back to a stable core channel detail selection when optional GraphQL fields are unsupported.
- Mark migration loss signals conservatively when advanced channel detail is unavailable.
- Keep aggregate settings and unrelated provider fields out of ordinary channel updates.
- Add regression coverage for no-op updates, partial updates, schema fallback, and migration behavior.

## Validation

- pnpm compile
- pnpm knip
- Focused Vitest: 324 tests passed
- ESLint on all changed files
- Staged validation and i18n checks
- Real AxonHub E2E: 2 passed, 1 skipped

## Compatibility

The legacy channel capability remains temporarily for generic managed-site callers. Its update path is now patch-only. It can be removed after remaining consumers migrate to the native resource contract.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added separate create, detail, and edit field handling for Axon Hub channels.
  - Updates now send only changed channel values and avoid unnecessary mutations.
  - Added fallback handling when advanced channel details are unavailable.

- **Bug Fixes**
  - Prevented the extra model prefix from being edited after channel creation.
  - Improved validation-failure reporting for unsuccessful changes.
  - Preserved data-loss warnings when advanced details cannot be retrieved.
  - Prevented credentials from appearing in channel creation results.

- **Changes**
  - Axon Hub is no longer included in migrated upstream-resource capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->