### PR TITLE
feat(managed-sites): migrate Octopus channels to native resources

### DIFF
--- a/e2e/fixtures/managedSiteChannelsIntercepted.ts
+++ b/e2e/fixtures/managedSiteChannelsIntercepted.ts
@@ -753,6 +753,7 @@ async function installAxonHubIntercepts(context: BrowserContext) {
   })
 }
 
+/** Models cookie-authenticated channel persistence and exposes its stored key for assertions. */
 async function installOctopusCookieAuthIntercepts(context: BrowserContext) {
   let channel = {
     id: 17,
@@ -932,6 +933,7 @@ export async function openInterceptedAxonHubManagedSiteChannels(params: {
   await openManagedSiteChannelsPage(params)
 }
 
+/** Opens the native Octopus workspace with a seeded cookie session and isolated channel state. */
 export async function openInterceptedOctopusManagedSiteChannels(params: {
   context: BrowserContext
   page: Page

--- a/e2e/fixtures/managedSiteChannelsIntercepted.ts
+++ b/e2e/fixtures/managedSiteChannelsIntercepted.ts
@@ -754,6 +754,18 @@ async function installAxonHubIntercepts(context: BrowserContext) {
 }
 
 async function installOctopusCookieAuthIntercepts(context: BrowserContext) {
+  let channel = {
+    id: 17,
+    name: "Example outbound",
+    type: "anthropic",
+    enabled: true,
+    base_url: "https://upstream.example.invalid",
+    key: "fixture-channel-secret",
+    model: "model-a",
+    proxy: false,
+    auto_sync: true,
+    custom_header: [],
+  }
   interceptedOctopusCookieHeader = null
   interceptedOctopusRootRequestCount = 0
   interceptedOctopusStatusRequestCount = 0
@@ -815,7 +827,14 @@ async function installOctopusCookieAuthIntercepts(context: BrowserContext) {
         return
       }
 
-      await fulfill(route, { code: 200, data: [] })
+      await fulfill(route, { code: 200, data: [channel] })
+      return
+    }
+
+    if (path === "/api/v1/channel/update" && request.method() === "POST") {
+      const payload = request.postDataJSON()
+      channel = { ...channel, ...payload }
+      await fulfill(route, { code: 200, data: channel })
       return
     }
 

--- a/e2e/fixtures/managedSiteChannelsIntercepted.ts
+++ b/e2e/fixtures/managedSiteChannelsIntercepted.ts
@@ -18,7 +18,7 @@ const INTERCEPTED_NEW_API_ORIGIN = "https://managed.example.invalid"
 const INTERCEPTED_DONE_HUB_TARGET_ORIGIN =
   "https://managed-target.example.invalid"
 const INTERCEPTED_AXON_HUB_ORIGIN = "https://axonhub.example.invalid"
-const INTERCEPTED_OCTOPUS_ORIGIN = "https://octopus.example.invalid"
+export const INTERCEPTED_OCTOPUS_ORIGIN = "https://octopus.example.invalid"
 const INTERCEPTED_OCTOPUS_COOKIE = "auth=octopus-cookie-session"
 
 export const NEW_API_CREATED_ID = 303
@@ -814,7 +814,10 @@ async function installOctopusCookieAuthIntercepts(context: BrowserContext) {
       return
     }
 
-    if (path === "/api/v1/channel/list") {
+    if (
+      path === "/api/v1/channel/list" ||
+      (path === "/api/v1/channel/update" && request.method() === "POST")
+    ) {
       interceptedOctopusCookieHeader = request.headers().cookie ?? null
       if (
         !interceptedOctopusCookieHeader?.includes(INTERCEPTED_OCTOPUS_COOKIE)
@@ -826,7 +829,9 @@ async function installOctopusCookieAuthIntercepts(context: BrowserContext) {
         })
         return
       }
+    }
 
+    if (path === "/api/v1/channel/list") {
       await fulfill(route, { code: 200, data: [channel] })
       return
     }
@@ -840,6 +845,8 @@ async function installOctopusCookieAuthIntercepts(context: BrowserContext) {
 
     await route.fulfill({ status: 404, body: "fixture route not configured" })
   })
+
+  return { getChannelKey: () => channel.key }
 }
 
 async function openManagedSiteChannelsPage(params: {
@@ -931,7 +938,7 @@ export async function openInterceptedOctopusManagedSiteChannels(params: {
   extensionId: string
 }) {
   await forceExtensionLanguage(params.page, "en")
-  await installOctopusCookieAuthIntercepts(params.context)
+  const fixture = await installOctopusCookieAuthIntercepts(params.context)
   await seedUserPreferences(await getServiceWorker(params.context), {
     managedSiteType: SITE_TYPES.OCTOPUS,
     octopus: {
@@ -941,4 +948,5 @@ export async function openInterceptedOctopusManagedSiteChannels(params: {
     },
   })
   await openManagedSiteChannelsPage(params)
+  return fixture
 }

--- a/e2e/managedSiteChannelsParity.spec.ts
+++ b/e2e/managedSiteChannelsParity.spec.ts
@@ -311,6 +311,32 @@ test("uses the current Octopus cookie session in a real extension browser", asyn
   await expect.poll(getInterceptedOctopusStatusRequestCount).toBeGreaterThan(0)
   expect(getInterceptedOctopusRootRequestCount()).toBe(0)
   await expect(page.getByText("Unable to load channels")).toBeHidden()
+  await expect(channelRowByName(page, "Example outbound")).toContainText(
+    "Anthropic",
+  )
+  const { rowTestToken } = await openManagedSiteChannelRowActions(
+    page,
+    "Example outbound",
+  )
+  await page
+    .getByTestId(getManagedSiteChannelRowEditActionTestId(rowTestToken))
+    .click()
+  await expect(
+    page.getByTestId(CHANNEL_DIALOG_TEST_IDS.typeSelect),
+  ).toContainText("Anthropic")
+  await expect(page.getByTestId(CHANNEL_DIALOG_TEST_IDS.keyInput)).toHaveValue(
+    "",
+  )
+  await page
+    .getByTestId(CHANNEL_DIALOG_TEST_IDS.nameInput)
+    .fill("Example outbound renamed")
+  await page.getByTestId(CHANNEL_DIALOG_TEST_IDS.submitButton).click()
+  await expect(page.getByTestId(CHANNEL_DIALOG_TEST_IDS.form)).toBeHidden()
+  await expect(
+    channelRowByName(page, "Example outbound renamed"),
+  ).toContainText("Anthropic")
+  await page.reload()
+  await expect(channelRowByName(page, "Example outbound renamed")).toBeVisible()
 })
 
 test("runs the AxonHub native edit and migration preview through the shared UI", async ({

--- a/e2e/managedSiteChannelsParity.spec.ts
+++ b/e2e/managedSiteChannelsParity.spec.ts
@@ -19,6 +19,7 @@ import {
   getInterceptedOctopusCookieHeader,
   getInterceptedOctopusRootRequestCount,
   getInterceptedOctopusStatusRequestCount,
+  INTERCEPTED_OCTOPUS_ORIGIN,
   NEW_API_CREATED_ID,
   openInterceptedAxonHubManagedSiteChannels,
   openInterceptedDoneHubManagedSiteChannels,
@@ -292,17 +293,19 @@ test("uses the current Octopus cookie session in a real extension browser", asyn
   extensionId,
   page,
 }) => {
-  await openInterceptedOctopusManagedSiteChannels({
+  const { getChannelKey } = await openInterceptedOctopusManagedSiteChannels({
     context,
     extensionId,
     page,
   })
   await waitForExtensionRoot(page)
 
+  const originalKey = getChannelKey()
+  expect(originalKey).not.toBe("")
   await expect(page.getByRole("table")).toBeVisible()
   await expect
     .poll(async () =>
-      (await context.cookies("https://octopus.example.invalid")).find(
+      (await context.cookies(INTERCEPTED_OCTOPUS_ORIGIN)).find(
         (cookie) => cookie.name === "auth",
       ),
     )
@@ -335,6 +338,21 @@ test("uses the current Octopus cookie session in a real extension browser", asyn
   await expect(
     channelRowByName(page, "Example outbound renamed"),
   ).toContainText("Anthropic")
+  await page.reload()
+  await expect(channelRowByName(page, "Example outbound renamed")).toBeVisible()
+  expect(getChannelKey()).toBe(originalKey)
+
+  const unauthorizedStatus = await page.evaluate(async (origin) => {
+    const response = await fetch(`${origin}/api/v1/channel/update`, {
+      method: "POST",
+      credentials: "omit",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ id: 17, name: "Unauthorized edit", key: "" }),
+    })
+    return response.status
+  }, INTERCEPTED_OCTOPUS_ORIGIN)
+  expect(unauthorizedStatus).toBe(401)
+  expect(getChannelKey()).toBe(originalKey)
   await page.reload()
   await expect(channelRowByName(page, "Example outbound renamed")).toBeVisible()
 })

--- a/src/constants/octopus.ts
+++ b/src/constants/octopus.ts
@@ -1,5 +1,26 @@
 import { OctopusOutboundType } from "~/types/octopus"
 
+/** Provider-owned fields shared by native resources and their presentation. */
+export const OCTOPUS_MANAGED_RESOURCE_FIELD_IDS = {
+  Name: "name",
+  Type: "type",
+  Status: "status",
+  BaseUrl: "baseURL",
+  Key: "key",
+  Models: "supportedModels",
+} as const
+export const OCTOPUS_MANAGED_RESOURCE_TABLE_FIELD_IDS = [
+  OCTOPUS_MANAGED_RESOURCE_FIELD_IDS.Name,
+  OCTOPUS_MANAGED_RESOURCE_FIELD_IDS.Type,
+  OCTOPUS_MANAGED_RESOURCE_FIELD_IDS.Status,
+  OCTOPUS_MANAGED_RESOURCE_FIELD_IDS.BaseUrl,
+  OCTOPUS_MANAGED_RESOURCE_FIELD_IDS.Models,
+] as const
+export const OCTOPUS_MANAGED_RESOURCE_DETAIL_FIELD_IDS = [
+  ...OCTOPUS_MANAGED_RESOURCE_TABLE_FIELD_IDS,
+  OCTOPUS_MANAGED_RESOURCE_FIELD_IDS.Key,
+] as const
+
 /** Side-effect-free page used to host Octopus cookie-auth API requests. */
 export const OCTOPUS_COOKIE_SESSION_STATUS_PATH = "/api/v1/user/status"
 

--- a/src/features/ManagedSiteChannels/presentation/managedResourceFieldPolicy.ts
+++ b/src/features/ManagedSiteChannels/presentation/managedResourceFieldPolicy.ts
@@ -18,6 +18,10 @@ import {
   ChannelTypeNames,
   NEW_API_MANAGED_RESOURCE_FIELD_IDS,
 } from "~/constants/newApi"
+import {
+  OCTOPUS_MANAGED_RESOURCE_FIELD_IDS,
+  OctopusOutboundTypeNames,
+} from "~/constants/octopus"
 import { SITE_TYPES, type ManagedSiteType } from "~/constants/siteType"
 import {
   SUB2API_API_KEY_ACCOUNT_PLATFORM_LABELS,
@@ -672,16 +676,28 @@ const claudeCodeHubTypeOptionLabelResolvers = Object.fromEntries(
   ]),
 ) satisfies Readonly<Record<string, ManagedResourceTextResolver>>
 
-const claudeCodeHubStatusOptionLabelResolvers = {
+const nativeChannelStatusOptionLabelResolvers = {
   [MANAGED_RESOURCE_STATUSES.Enabled]: (t: TFunction) =>
     t("common:status.enabled"),
   [MANAGED_RESOURCE_STATUSES.Disabled]: (t: TFunction) =>
     t("common:status.disabled"),
 } as const satisfies Readonly<Record<string, ManagedResourceTextResolver>>
 
-const claudeCodeHubFields = [
+const createNativeChannelFields = (
+  fields: {
+    readonly Name: string
+    readonly Type: string
+    readonly Status: string
+    readonly BaseUrl: string
+    readonly Key: string
+    readonly Models: string
+  },
+  typeOptionLabelResolvers: Readonly<
+    Record<string, ManagedResourceTextResolver>
+  >,
+): readonly ManagedResourceFieldPresentation[] => [
   {
-    fieldId: CLAUDE_CODE_HUB_MANAGED_RESOURCE_FIELD_IDS.Name,
+    fieldId: fields.Name,
     section: MANAGED_RESOURCE_SECTIONS.Basic,
     order: 10,
     resolveLabel: (t) => t("channelDialog:fields.name.label"),
@@ -689,27 +705,27 @@ const claudeCodeHubFields = [
     channelFieldRole: MANAGED_RESOURCE_CHANNEL_FIELD_ROLES.Name,
   },
   {
-    fieldId: CLAUDE_CODE_HUB_MANAGED_RESOURCE_FIELD_IDS.Type,
+    fieldId: fields.Type,
     section: MANAGED_RESOURCE_SECTIONS.Basic,
     order: 20,
     resolveLabel: (t) => t("channelDialog:fields.type.label"),
-    optionLabelResolvers: claudeCodeHubTypeOptionLabelResolvers,
+    optionLabelResolvers: typeOptionLabelResolvers,
     resolveOptionFallback: MANAGED_RESOURCE_UNKNOWN_OPTION_LABEL_RESOLVER,
     renderer: MANAGED_RESOURCE_FIELD_RENDERERS.Select,
     channelFieldRole: MANAGED_RESOURCE_CHANNEL_FIELD_ROLES.Type,
   },
   {
-    fieldId: CLAUDE_CODE_HUB_MANAGED_RESOURCE_FIELD_IDS.Status,
+    fieldId: fields.Status,
     section: MANAGED_RESOURCE_SECTIONS.Basic,
     order: 30,
     resolveLabel: (t) => t("channelDialog:fields.status.label"),
-    optionLabelResolvers: claudeCodeHubStatusOptionLabelResolvers,
+    optionLabelResolvers: nativeChannelStatusOptionLabelResolvers,
     resolveOptionFallback: managedResourceStatusFallbackLabelResolver,
     renderer: MANAGED_RESOURCE_FIELD_RENDERERS.Select,
     channelFieldRole: MANAGED_RESOURCE_CHANNEL_FIELD_ROLES.Status,
   },
   {
-    fieldId: CLAUDE_CODE_HUB_MANAGED_RESOURCE_FIELD_IDS.BaseUrl,
+    fieldId: fields.BaseUrl,
     section: MANAGED_RESOURCE_SECTIONS.Connection,
     order: 10,
     resolveLabel: (t) => t("channelDialog:fields.baseUrl.label"),
@@ -717,7 +733,7 @@ const claudeCodeHubFields = [
     channelFieldRole: MANAGED_RESOURCE_CHANNEL_FIELD_ROLES.BaseUrl,
   },
   {
-    fieldId: CLAUDE_CODE_HUB_MANAGED_RESOURCE_FIELD_IDS.Key,
+    fieldId: fields.Key,
     section: MANAGED_RESOURCE_SECTIONS.Connection,
     order: 20,
     resolveLabel: (t) => t("channelDialog:fields.key.label"),
@@ -726,13 +742,20 @@ const claudeCodeHubFields = [
     channelFieldRole: MANAGED_RESOURCE_CHANNEL_FIELD_ROLES.Secret,
   },
   {
-    fieldId: CLAUDE_CODE_HUB_MANAGED_RESOURCE_FIELD_IDS.Models,
+    fieldId: fields.Models,
     section: MANAGED_RESOURCE_SECTIONS.Models,
     order: 10,
     resolveLabel: (t) => t("channelDialog:fields.models.label"),
     renderer: MANAGED_RESOURCE_FIELD_RENDERERS.MultiSelect,
     channelFieldRole: MANAGED_RESOURCE_CHANNEL_FIELD_ROLES.Models,
   },
+]
+
+const claudeCodeHubFields = [
+  ...createNativeChannelFields(
+    CLAUDE_CODE_HUB_MANAGED_RESOURCE_FIELD_IDS,
+    claudeCodeHubTypeOptionLabelResolvers,
+  ),
   {
     fieldId: CLAUDE_CODE_HUB_MANAGED_RESOURCE_FIELD_IDS.GroupTag,
     section: MANAGED_RESOURCE_SECTIONS.Models,
@@ -773,6 +796,31 @@ const claudeCodeHubManagedResourceFieldPolicy =
     },
   })
 
+const octopusFields = createNativeChannelFields(
+  OCTOPUS_MANAGED_RESOURCE_FIELD_IDS,
+  Object.fromEntries(
+    Object.entries(OctopusOutboundTypeNames).map(([value, label]) => [
+      value,
+      () => label,
+    ]),
+  ),
+)
+
+const octopusManagedResourceFieldPolicy = defineManagedResourceFieldPolicy({
+  siteType: SITE_TYPES.OCTOPUS,
+  kind: MANAGED_RESOURCE_KINDS.Channel,
+  modes: {
+    [MANAGED_RESOURCE_EDITOR_MODES.Create]: {
+      fields: octopusFields,
+      hiddenFields: [],
+    },
+    [MANAGED_RESOURCE_EDITOR_MODES.Edit]: {
+      fields: octopusFields,
+      hiddenFields: [],
+    },
+  },
+})
+
 const registryKey = (siteType: ManagedSiteType, kind: ManagedResourceKind) =>
   `${siteType}:${kind}`
 
@@ -810,6 +858,7 @@ const managedResourceFieldPolicyRegistry =
     axonHubManagedResourceFieldPolicy,
     sub2ApiManagedResourceFieldPolicy,
     claudeCodeHubManagedResourceFieldPolicy,
+    octopusManagedResourceFieldPolicy,
   ])
 
 export const getManagedResourceFieldPolicy = (

--- a/src/features/ManagedSiteChannels/presentation/managedResourceMigrationPresentation.ts
+++ b/src/features/ManagedSiteChannels/presentation/managedResourceMigrationPresentation.ts
@@ -6,6 +6,7 @@ import {
 } from "~/constants/axonHub"
 import { DoneHubChannelTypeNames } from "~/constants/doneHub"
 import { ChannelTypeNames } from "~/constants/managedSite"
+import { OctopusOutboundTypeNames } from "~/constants/octopus"
 import type { ManagedSiteType } from "~/constants/siteType"
 import { SITE_TYPES } from "~/constants/siteType"
 import { VeloeraChannelTypeNames } from "~/constants/veloera"
@@ -193,6 +194,14 @@ const getTypeText = (
   siteType: ManagedSiteType,
   type: ManagedSiteMigrationSource["resourceType"] | string,
 ): string => {
+  if (siteType === SITE_TYPES.OCTOPUS) {
+    const numericType =
+      typeof type === "string" && !type.trim() ? NaN : Number(type)
+    return Number.isInteger(numericType) &&
+      hasOwn(OctopusOutboundTypeNames, numericType)
+      ? OctopusOutboundTypeNames[numericType]
+      : resolveUnsupportedChannelTypeLabel(t)
+  }
   if (siteType === SITE_TYPES.DONE_HUB && typeof type === "string") {
     const numericType = Number(type)
     if (

--- a/src/features/ManagedSiteChannels/presentation/managedResourceTablePolicy.ts
+++ b/src/features/ManagedSiteChannels/presentation/managedResourceTablePolicy.ts
@@ -4,6 +4,7 @@ import { AXON_HUB_CHANNEL_FIELD_IDS } from "~/constants/axonHub"
 import { CLAUDE_CODE_HUB_MANAGED_RESOURCE_FIELD_IDS } from "~/constants/claudeCodeHub"
 import { DONE_HUB_MANAGED_RESOURCE_FIELD_IDS } from "~/constants/doneHub"
 import { NEW_API_MANAGED_RESOURCE_FIELD_IDS } from "~/constants/newApi"
+import { OCTOPUS_MANAGED_RESOURCE_FIELD_IDS } from "~/constants/octopus"
 import { SITE_TYPES, type ManagedSiteType } from "~/constants/siteType"
 import { SUB2API_MANAGED_RESOURCE_FIELD_IDS } from "~/constants/sub2api"
 import { VELOERA_MANAGED_RESOURCE_FIELD_IDS } from "~/constants/veloera"
@@ -94,6 +95,23 @@ const requireFieldValuePresentation = (
 const nativeTablePresentationPolicies: Partial<
   Record<ManagedSiteType, NativeTablePresentationPolicy>
 > = {
+  [SITE_TYPES.OCTOPUS]: {
+    semantics: {
+      baseUrlFieldId: OCTOPUS_MANAGED_RESOURCE_FIELD_IDS.BaseUrl,
+      statusFieldId: OCTOPUS_MANAGED_RESOURCE_FIELD_IDS.Status,
+      fieldValuePresentations: {
+        [OCTOPUS_MANAGED_RESOURCE_FIELD_IDS.Type]:
+          requireFieldValuePresentation(
+            SITE_TYPES.OCTOPUS,
+            OCTOPUS_MANAGED_RESOURCE_FIELD_IDS.Type,
+          ),
+      },
+    },
+    defaultSorting: [
+      { id: MANAGED_CHANNELS_COLUMN_IDS.Identifier, desc: true },
+    ],
+    columnLayout: NATIVE_TABLE_COLUMN_LAYOUTS.Canonical,
+  },
   [SITE_TYPES.AXON_HUB]: {
     semantics: {
       baseUrlFieldId: AXON_HUB_CHANNEL_FIELD_IDS.BASE_URL,

--- a/src/services/accountSiteDefinitions/definitions.ts
+++ b/src/services/accountSiteDefinitions/definitions.ts
@@ -14,6 +14,10 @@ import {
   NEW_API_MANAGED_RESOURCE_DETAIL_FIELD_IDS,
   NEW_API_MANAGED_RESOURCE_TABLE_FIELD_IDS,
 } from "~/constants/newApi"
+import {
+  OCTOPUS_MANAGED_RESOURCE_DETAIL_FIELD_IDS,
+  OCTOPUS_MANAGED_RESOURCE_TABLE_FIELD_IDS,
+} from "~/constants/octopus"
 import { SETTINGS_ANCHORS } from "~/constants/settingsAnchors"
 import {
   SUB2API_MANAGED_RESOURCE_DETAIL_FIELD_IDS,
@@ -438,7 +442,11 @@ const MANAGED_ONLY_SITE_DEFINITIONS = [
     siteType: SITE_TYPES.OCTOPUS,
     scopes: MANAGED_SCOPE,
     adapterFamily: ACCOUNT_SITE_ADAPTER_FAMILIES.Unsupported,
-    managedResource: { ...LEGACY_MANAGED_CHANNEL_POLICY },
+    managedResource: {
+      ...LEGACY_MANAGED_CHANNEL_POLICY,
+      tableFieldIds: OCTOPUS_MANAGED_RESOURCE_TABLE_FIELD_IDS,
+      detailFieldIds: OCTOPUS_MANAGED_RESOURCE_DETAIL_FIELD_IDS,
+    },
   },
   {
     siteType: SITE_TYPES.AXON_HUB,

--- a/src/services/apiAdapters/managedResources/octopus.ts
+++ b/src/services/apiAdapters/managedResources/octopus.ts
@@ -1,0 +1,515 @@
+import {
+  OCTOPUS_MANAGED_RESOURCE_FIELD_IDS as fields,
+  OctopusOutboundTypeNames,
+  OctopusOutboundTypeOptions,
+} from "~/constants/octopus"
+import { SITE_TYPES } from "~/constants/siteType"
+import { MANAGED_RESOURCE_KINDS } from "~/services/accountSiteDefinitions/contracts"
+import {
+  MANAGED_RESOURCE_DISPLAY_FACT_KINDS as facts,
+  MANAGED_RESOURCE_FAILURE_CODES as failures,
+  MANAGED_RESOURCE_SECRET_EDIT_INTENT_KINDS as intents,
+  MANAGED_RESOURCE_CREATE_SEED_KINDS,
+  MANAGED_RESOURCE_SECRET_STATES,
+  ManagedResourceError,
+  MANAGED_RESOURCE_STATUSES as statuses,
+  type ManagedResourceRef,
+  type ResourceDisplayFacts,
+  type ResourceFailure,
+  type ResourceListQuery,
+  type ResourceOperationOptions,
+} from "~/services/apiAdapters/contracts/managedResourceNative"
+import {
+  defineNativeResourceKind,
+  type NativeResourceEditorDefinition,
+} from "~/services/apiAdapters/managedResources/factory"
+import {
+  octopusChannelEffect,
+  runOctopusMutation,
+} from "~/services/apiAdapters/managedSites/octopusMutation"
+import {
+  createChannel,
+  deleteChannel,
+  fetchRemoteModels,
+  getChannel,
+  listChannels,
+  updateChannel,
+  usesChannelProtocolPaths,
+} from "~/services/apiService/octopus"
+import { ApiError } from "~/services/apiTransport/errors"
+import {
+  MANAGED_SITE_MUTATION_OUTCOMES as outcomes,
+  type ManagedSiteMutationResult,
+} from "~/services/managedSites/mutations"
+import { buildOctopusBaseUrl } from "~/services/managedSites/providers/octopus"
+import { resolveManagedSiteRuntimeConfigForType } from "~/services/managedSites/runtimeConfig"
+import { hasUsableManagedSiteChannelKey } from "~/services/managedSites/utils/managedSite"
+import { userPreferences } from "~/services/preferences/userPreferences"
+import { normalizeManagedUpstreamResourceScopeKey } from "~/types/managedUpstreamResource"
+import {
+  OCTOPUS_CHANNEL_DETAIL_AVAILABILITY,
+  OctopusOutboundType,
+  type OctopusChannel,
+  type OctopusCreateChannelInput,
+  type OctopusFetchModelInput,
+  type OctopusUpdateChannelInput,
+} from "~/types/octopus"
+import { sanitizeSensitiveErrorText } from "~/utils/core/sanitizeSensitiveErrorText"
+
+import {
+  buildOctopusCreateCommand,
+  buildOctopusUpdateCommand,
+  isOctopusHttpUrl,
+  octopusFieldDescriptors,
+  octopusInitialValues,
+  octopusModels,
+  octopusSecretIntent,
+  octopusSecretState,
+  readOctopusString,
+  validateOctopusValues,
+} from "./octopusEditor"
+
+type UpdateCommand = Omit<OctopusUpdateChannelInput, "id" | "source">
+const aborted = (options?: ResourceOperationOptions) => {
+  if (options?.signal?.aborted)
+    throw new ManagedResourceError({ code: failures.Aborted })
+}
+const assertLocator = (id: number) => {
+  if (!Number.isSafeInteger(id) || id <= 0)
+    throw new ManagedResourceError({ code: failures.ValidationFailed })
+  return id
+}
+const mapFailure = (error: unknown): ResourceFailure => {
+  if (error instanceof ManagedResourceError) return error.failure
+  if (error instanceof Error && error.name === "AbortError")
+    return { code: failures.Aborted }
+  if (error instanceof ApiError) {
+    const code =
+      error.statusCode === 401
+        ? failures.AuthenticationFailed
+        : error.statusCode === 403
+          ? failures.PermissionDenied
+          : error.statusCode === 404
+            ? failures.NotFound
+            : !error.statusCode || error.statusCode >= 500
+              ? failures.Unavailable
+              : failures.UpstreamRejected
+    return {
+      code,
+      message: sanitizeSensitiveErrorText(error.message),
+      ...(error.upstreamCode
+        ? { upstreamCode: sanitizeSensitiveErrorText(error.upstreamCode) }
+        : {}),
+    }
+  }
+  return {
+    code: failures.Unexpected,
+    ...(error instanceof Error
+      ? { message: sanitizeSensitiveErrorText(error.message) }
+      : {}),
+  }
+}
+const redactKnownSecrets = (
+  message: string,
+  secrets: readonly (string | undefined)[],
+) => {
+  for (const secret of secrets
+    .filter((value): value is string => !!value)
+    .sort((a, b) => b.length - a.length))
+    message = message.split(secret).join("[REDACTED]")
+  return sanitizeSensitiveErrorText(message)
+}
+const read = async <T>(
+  options: ResourceOperationOptions | undefined,
+  action: () => Promise<T>,
+  secrets: readonly (string | undefined)[] = [],
+): Promise<T> => {
+  aborted(options)
+  try {
+    const result = await action()
+    aborted(options)
+    return result
+  } catch (error) {
+    const failure = mapFailure(error)
+    throw new ManagedResourceError({
+      ...failure,
+      ...(failure.message
+        ? { message: redactKnownSecrets(failure.message, secrets) }
+        : {}),
+      ...(failure.upstreamCode
+        ? { upstreamCode: redactKnownSecrets(failure.upstreamCode, secrets) }
+        : {}),
+    })
+  }
+}
+const toFacts = (
+  detail: OctopusChannel,
+  ref: ManagedResourceRef,
+): ResourceDisplayFacts => {
+  const summary =
+    detail.detailAvailability === OCTOPUS_CHANNEL_DETAIL_AVAILABILITY.Summary
+  const models = octopusModels(detail.model)
+  const status = detail.enabled ? statuses.Enabled : statuses.Disabled
+  const baseUrl = detail.base_urls[0]?.url ?? ""
+  return {
+    ref,
+    displayName: detail.name,
+    status,
+    fields: [
+      { fieldId: fields.Name, kind: facts.Text, value: detail.name },
+      ...(summary
+        ? []
+        : [
+            {
+              fieldId: fields.Type,
+              kind: facts.Text,
+              value: String(detail.type),
+            },
+          ]),
+      { fieldId: fields.Status, kind: facts.Text, value: status },
+      { fieldId: fields.BaseUrl, kind: facts.Text, value: baseUrl },
+      {
+        fieldId: fields.Key,
+        kind: facts.Secret,
+        state: summary
+          ? MANAGED_RESOURCE_SECRET_STATES.PermissionHidden
+          : octopusSecretState(detail),
+      },
+      { fieldId: fields.Models, kind: facts.List, value: models },
+    ],
+    searchValues: [
+      detail.name,
+      ...(summary
+        ? []
+        : [String(detail.type), OctopusOutboundTypeNames[detail.type] ?? ""]),
+      baseUrl,
+      ...models,
+    ],
+    actions: { canUpdate: true, canDelete: true },
+  }
+}
+const isDetail = (value: unknown): value is OctopusChannel => {
+  if (!value || typeof value !== "object") return false
+  const item = value as Partial<OctopusChannel>
+  return (
+    Number.isSafeInteger(item.id) &&
+    Number(item.id) > 0 &&
+    typeof item.name === "string" &&
+    typeof item.type === "number" &&
+    typeof item.enabled === "boolean" &&
+    typeof item.model === "string" &&
+    Array.isArray(item.base_urls) &&
+    Array.isArray(item.keys)
+  )
+}
+const uncertain = (): ManagedSiteMutationResult<OctopusChannel> => ({
+  outcome: outcomes.Uncertain,
+  diagnostic: {
+    code: failures.MutationStateUncertain,
+    message: failures.MutationStateUncertain,
+  },
+})
+
+const sanitizeMutation = <T>(
+  result: ManagedSiteMutationResult<T>,
+  secrets: readonly (string | undefined)[],
+): ManagedSiteMutationResult<T> => {
+  if (result.outcome === outcomes.Succeeded) return result
+  return {
+    ...result,
+    diagnostic: {
+      message: redactKnownSecrets(result.diagnostic.message, secrets),
+      ...(result.diagnostic.code === undefined
+        ? {}
+        : {
+            code:
+              typeof result.diagnostic.code === "string"
+                ? redactKnownSecrets(result.diagnostic.code, secrets)
+                : result.diagnostic.code,
+          }),
+      ...(result.diagnostic.statusCode === undefined
+        ? {}
+        : { statusCode: result.diagnostic.statusCode }),
+    },
+  }
+}
+
+/** Opens provider-native Octopus operations for editors and channel migration. */
+export async function openOctopusNativeResourceOperations(
+  options?: ResourceOperationOptions,
+) {
+  aborted(options)
+  const preferences = await userPreferences.getPreferences()
+  aborted(options)
+  const resolved = resolveManagedSiteRuntimeConfigForType(
+    preferences,
+    SITE_TYPES.OCTOPUS,
+  )
+  if (!resolved)
+    throw new ManagedResourceError({ code: failures.ConfigurationRequired })
+  const config = resolved.config
+  const readConfigured = <T>(
+    operationOptions: ResourceOperationOptions | undefined,
+    action: () => Promise<T>,
+    secrets: readonly (string | undefined)[] = [],
+  ) => read(operationOptions, action, [config.password, ...secrets])
+  if (!isOctopusHttpUrl(config.baseUrl))
+    throw new ManagedResourceError({ code: failures.InvalidConfiguration })
+  const scopeKey = normalizeManagedUpstreamResourceScopeKey(
+    new URL(config.baseUrl.trim()).origin,
+  )
+  const get = async (
+    id: number,
+    operationOptions?: ResourceOperationOptions,
+  ) => {
+    assertLocator(id)
+    return await readConfigured(operationOptions, async () => {
+      const detail = await getChannel(config, id, operationOptions)
+      if (!isDetail(detail) || detail.id !== id)
+        throw new ManagedResourceError({ code: failures.Unexpected })
+      return detail
+    })
+  }
+  const loadSecret = async (
+    id: number,
+    operationOptions?: ResourceOperationOptions,
+  ) => {
+    const detail = await get(id, operationOptions)
+    const key = detail.keys[0]?.channel_key
+    if (!hasUsableManagedSiteChannelKey(key))
+      throw new ManagedResourceError({ code: failures.Unavailable })
+    return key
+  }
+  return {
+    scopeKey,
+    get,
+    loadSecret,
+    prepareMigrationBaseUrl: (
+      baseUrl: string,
+      type: OctopusOutboundType,
+      operationOptions?: ResourceOperationOptions,
+    ) =>
+      readConfigured(operationOptions, async () => {
+        if (!isOctopusHttpUrl(baseUrl))
+          throw new ManagedResourceError({ code: failures.ValidationFailed })
+        const protocolPaths = await usesChannelProtocolPaths(
+          config,
+          operationOptions,
+        )
+        if (!protocolPaths) return buildOctopusBaseUrl(baseUrl)
+        // v0.13 appends /v1 protocol paths itself; imported version roots must
+        // not produce /v1/v1. Preserve other custom prefixes without guessing.
+        // Source: github.com/bestruirui/octopus/blob/27aa40dc0f3b2902bce3e96ccdba019d17041606/internal/model/channel.go
+        const url = new URL(baseUrl.trim())
+        url.pathname = url.pathname.replace(/\/+$/, "")
+        // Volcengine uses unversioned protocol paths, preserving its API prefix.
+        if (type !== OctopusOutboundType.Volcengine)
+          url.pathname = url.pathname.replace(/\/v1$/, "")
+        return url.toString().replace(/\/$/, "")
+      }),
+    list: async (
+      query?: ResourceListQuery,
+      operationOptions?: ResourceOperationOptions,
+    ) =>
+      readConfigured(operationOptions, async () => {
+        const items = await listChannels(config, operationOptions)
+        const keyword = query?.search?.trim().toLowerCase()
+        const selected = keyword
+          ? items.filter((item) =>
+              [
+                item.name,
+                ...(item.detailAvailability ===
+                OCTOPUS_CHANNEL_DETAIL_AVAILABILITY.Summary
+                  ? []
+                  : [
+                      String(item.type),
+                      OctopusOutboundTypeNames[item.type] ?? "",
+                    ]),
+                item.model,
+                ...item.base_urls.map((url) => url.url),
+              ].some((value) => value.toLowerCase().includes(keyword)),
+            )
+          : items
+        return { items: selected, total: selected.length }
+      }),
+    create: async (
+      command: OctopusCreateChannelInput,
+      operationOptions?: ResourceOperationOptions,
+    ): Promise<ManagedSiteMutationResult<OctopusChannel>> => {
+      aborted(operationOptions)
+      const result = await runOctopusMutation({
+        effect: octopusChannelEffect("resource-created"),
+        execute: () => createChannel(config, command, operationOptions),
+      })
+      // A success envelope without an identity cannot safely attribute creation.
+      // Never replay a create merely because its response lacks channel data.
+      return result.outcome === outcomes.Succeeded && !isDetail(result.data)
+        ? uncertain()
+        : sanitizeMutation(result, [config.password, command.key])
+    },
+    update: async (
+      detail: OctopusChannel,
+      command: UpdateCommand,
+      operationOptions?: ResourceOperationOptions,
+    ): Promise<ManagedSiteMutationResult<OctopusChannel>> => {
+      assertLocator(detail.id)
+      aborted(operationOptions)
+      // The codec owns primary-key/URL edits and preserves additional entries.
+      // v0.13 transport separately reloads raw detail for whole-body updates.
+      // Source: github.com/bestruirui/octopus/blob/27aa40dc0f3b2902bce3e96ccdba019d17041606/internal/op/channel.go
+      const result = await runOctopusMutation({
+        effect: octopusChannelEffect("resource-updated", detail.id),
+        execute: () =>
+          updateChannel(
+            config,
+            { ...command, id: detail.id, source: detail },
+            operationOptions,
+          ),
+      })
+      if (result.outcome !== outcomes.Succeeded)
+        return sanitizeMutation(result, [
+          config.password,
+          command.key,
+          ...detail.keys.map((key) => key.channel_key),
+        ])
+      if (isDetail(result.data) && result.data.id === detail.id) return result
+      try {
+        return { ...result, data: await get(detail.id, operationOptions) }
+      } catch {
+        return uncertain()
+      }
+    },
+    delete: async (id: number, operationOptions?: ResourceOperationOptions) => {
+      assertLocator(id)
+      aborted(operationOptions)
+      return sanitizeMutation(
+        await runOctopusMutation<null, void>({
+          effect: octopusChannelEffect("resource-deleted", id),
+          execute: () => deleteChannel(config, id, operationOptions),
+          successData: () => undefined,
+        }),
+        [config.password],
+      )
+    },
+    fetchDraftModels: (
+      command: OctopusFetchModelInput,
+      operationOptions?: ResourceOperationOptions,
+    ) =>
+      readConfigured(
+        operationOptions,
+        () => fetchRemoteModels(config, command, operationOptions),
+        [
+          command.key,
+          ...(command.source?.keys.map((key) => key.channel_key) ?? []),
+        ],
+      ),
+  }
+}
+type Operations = Awaited<
+  ReturnType<typeof openOctopusNativeResourceOperations>
+>
+const editor = <T>(
+  operations: Operations,
+  definition: NativeResourceEditorDefinition<T>,
+  detail?: OctopusChannel,
+): NativeResourceEditorDefinition<T> => ({
+  ...definition,
+  ...(detail
+    ? {
+        loadSecret: async (
+          fieldId: string,
+          options?: ResourceOperationOptions,
+        ) => {
+          if (fieldId !== fields.Key)
+            throw new ManagedResourceError({ code: failures.ValidationFailed })
+          return operations.loadSecret(detail.id, options)
+        },
+      }
+    : {}),
+  loadOptions: async (fieldId, values, options) => {
+    if (fieldId !== fields.Models)
+      throw new ManagedResourceError({ code: failures.ValidationFailed })
+    const intent = octopusSecretIntent(values)
+    const key =
+      intent.kind === intents.Replace
+        ? intent.value.trim()
+        : detail
+          ? await operations.loadSecret(detail.id, options)
+          : ""
+    const baseUrl = readOctopusString(values, fields.BaseUrl)
+    if (!isOctopusHttpUrl(baseUrl) || !hasUsableManagedSiteChannelKey(key))
+      throw new ManagedResourceError({ code: failures.ValidationFailed })
+    const models = await operations.fetchDraftModels(
+      {
+        type: Number(values[fields.Type]),
+        baseUrl,
+        key,
+        ...(detail ? { source: detail, proxy: detail.proxy } : {}),
+      },
+      options,
+    )
+    return models.map((value) => ({ value }))
+  },
+})
+export const octopusManagedResourceRegistration = defineNativeResourceKind({
+  siteType: SITE_TYPES.OCTOPUS,
+  kind: MANAGED_RESOURCE_KINDS.Channel,
+  capabilities: { canSearch: true },
+  openConfig: openOctopusNativeResourceOperations,
+  scopeKey: (operations: Operations) => operations.scopeKey,
+  encodeLocator: (id: number) => String(assertLocator(id)),
+  decodeLocator: (value: string) => assertLocator(Number(value)),
+  locatorFromListItem: (detail: OctopusChannel) => detail.id,
+  locatorFromDetail: (detail: OctopusChannel) => detail.id,
+  list: (operations: Operations, query, options) =>
+    operations.list(query, options),
+  get: (operations: Operations, id, options) => operations.get(id, options),
+  toListFacts: toFacts,
+  toDetailFacts: toFacts,
+  createSeedBindings: [
+    {
+      kind: MANAGED_RESOURCE_CREATE_SEED_KINDS.ManagedChannelImport,
+      project: (seed) => ({
+        ...octopusInitialValues(),
+        [fields.Type]: OctopusOutboundTypeOptions.some(
+          ({ value }) => String(value) === String(seed.channelType),
+        )
+          ? String(seed.channelType)
+          : octopusInitialValues()[fields.Type],
+        [fields.Name]: seed.name,
+        [fields.BaseUrl]: seed.baseUrl,
+        [fields.Key]: { kind: intents.Replace, value: seed.credential },
+        [fields.Models]: [...seed.models],
+        [fields.Status]: seed.enabled ? statuses.Enabled : statuses.Disabled,
+      }),
+    },
+  ],
+  createEditor: async (operations: Operations) =>
+    editor(operations, {
+      fields: octopusFieldDescriptors(),
+      initialValues: octopusInitialValues(),
+      validate: (values) => validateOctopusValues(values),
+      buildCommand: buildOctopusCreateCommand,
+    }),
+  editEditor: (operations: Operations, detail) =>
+    editor(
+      operations,
+      {
+        fields: octopusFieldDescriptors(detail),
+        initialValues: octopusInitialValues(detail),
+        validate: (values) => validateOctopusValues(values, detail),
+        buildCommand: (values) => buildOctopusUpdateCommand(detail, values),
+      },
+      detail,
+    ),
+  create: (
+    operations: Operations,
+    command: OctopusCreateChannelInput,
+    options,
+  ) => operations.create(command, options),
+  update: (operations: Operations, detail, command: UpdateCommand, options) =>
+    operations.update(detail, command, options),
+  delete: (operations: Operations, id, options) =>
+    operations.delete(id, options),
+  mapFailure,
+})

--- a/src/services/apiAdapters/managedResources/octopusEditor.ts
+++ b/src/services/apiAdapters/managedResources/octopusEditor.ts
@@ -38,6 +38,7 @@ const readOctopusModels = (values: EditableResourceProjection): string[] => {
       )
     : []
 }
+/** Parses explicit secret edits; malformed or absent intent leaves the existing credential unchanged. */
 export const octopusSecretIntent = (
   values: EditableResourceProjection,
 ): SecretEditIntent => {
@@ -124,6 +125,7 @@ export const octopusFieldDescriptors = (
     },
   ]
 }
+/** Validates editable fields while allowing an existing unknown type and forbidding credential clearing. */
 export const validateOctopusValues = (
   values: EditableResourceProjection,
   detail?: OctopusChannel,
@@ -155,6 +157,7 @@ export const validateOctopusValues = (
     errors.push({ fieldId: fields.Key, code: issues.InvalidValue })
   return errors.length ? { valid: false, issues: errors } : { valid: true }
 }
+/** Converts an editor projection into normalized transport fields; callers validate before dispatch. */
 export const buildOctopusCreateCommand = (
   values: EditableResourceProjection,
 ): OctopusCreateChannelInput => {
@@ -169,6 +172,7 @@ export const buildOctopusCreateCommand = (
     autoSync: true,
   }
 }
+/** Emits only changed editable fields and includes a credential only for explicit replacement. */
 export const buildOctopusUpdateCommand = (
   detail: OctopusChannel,
   values: EditableResourceProjection,

--- a/src/services/apiAdapters/managedResources/octopusEditor.ts
+++ b/src/services/apiAdapters/managedResources/octopusEditor.ts
@@ -1,0 +1,190 @@
+import {
+  OCTOPUS_MANAGED_RESOURCE_FIELD_IDS as fields,
+  OctopusOutboundTypeOptions,
+} from "~/constants/octopus"
+import {
+  MANAGED_RESOURCE_SECRET_EDIT_INTENT_KINDS as intents,
+  MANAGED_RESOURCE_FIELD_ISSUE_CODES as issues,
+  MANAGED_RESOURCE_FIELD_OPTION_LOAD_TRIGGERS,
+  MANAGED_RESOURCE_SECRET_STATES as states,
+  MANAGED_RESOURCE_STATUSES as statuses,
+  MANAGED_RESOURCE_FIELD_TYPES as types,
+  type EditableResourceProjection,
+  type ResourceFieldDescriptor,
+  type ResourceFieldIssue,
+  type ResourceValidationResult,
+  type SecretEditIntent,
+} from "~/services/apiAdapters/contracts/managedResourceNative"
+import { hasUsableManagedSiteChannelKey } from "~/services/managedSites/utils/managedSite"
+import {
+  OctopusOutboundType,
+  type OctopusChannel,
+  type OctopusCreateChannelInput,
+  type OctopusUpdateChannelInput,
+} from "~/types/octopus"
+import { normalizeList } from "~/utils/core/string"
+
+export const octopusModels = (value?: string) =>
+  normalizeList((value ?? "").split(","))
+export const readOctopusString = (
+  values: EditableResourceProjection,
+  fieldId: string,
+): string => (typeof values[fieldId] === "string" ? values[fieldId] : "")
+export const readOctopusModels = (
+  values: EditableResourceProjection,
+): string[] => {
+  const value = values[fields.Models]
+  return Array.isArray(value)
+    ? normalizeList(
+        value.filter((item): item is string => typeof item === "string"),
+      )
+    : []
+}
+export const octopusSecretIntent = (
+  values: EditableResourceProjection,
+): SecretEditIntent => {
+  const value = values[fields.Key]
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    const candidate = value as { kind?: unknown; value?: unknown }
+    if (
+      candidate.kind === intents.Replace &&
+      typeof candidate.value === "string"
+    )
+      return { kind: intents.Replace, value: candidate.value }
+    if (candidate.kind === intents.Clear) return { kind: intents.Clear }
+  }
+  return { kind: intents.Unchanged }
+}
+export const isOctopusHttpUrl = (value: string): boolean => {
+  try {
+    const url = new URL(value.trim())
+    return (
+      ["http:", "https:"].includes(url.protocol) &&
+      !url.username &&
+      !url.password
+    )
+  } catch {
+    return false
+  }
+}
+export const octopusSecretState = (detail: OctopusChannel) => {
+  const key = detail.keys[0]?.channel_key
+  return hasUsableManagedSiteChannelKey(key)
+    ? states.Available
+    : key?.trim()
+      ? states.Masked
+      : states.Unavailable
+}
+export const octopusInitialValues = (
+  detail?: OctopusChannel,
+): EditableResourceProjection => ({
+  [fields.Name]: detail?.name ?? "",
+  [fields.Type]: String(detail?.type ?? OctopusOutboundType.OpenAIChat),
+  [fields.Status]:
+    detail?.enabled === false ? statuses.Disabled : statuses.Enabled,
+  [fields.BaseUrl]: detail?.base_urls[0]?.url ?? "",
+  [fields.Key]: detail
+    ? { kind: intents.Unchanged }
+    : { kind: intents.Replace, value: "" },
+  [fields.Models]: octopusModels(detail?.model),
+})
+export const octopusFieldDescriptors = (
+  detail?: OctopusChannel,
+): readonly ResourceFieldDescriptor[] => {
+  const options: { value: string }[] = OctopusOutboundTypeOptions.map(
+    ({ value }) => ({ value: String(value) }),
+  )
+  if (detail && !options.some(({ value }) => value === String(detail.type)))
+    options.push({ value: String(detail.type) })
+  return [
+    { fieldId: fields.Name, type: types.Text, required: true },
+    { fieldId: fields.Type, type: types.Select, required: true, options },
+    {
+      fieldId: fields.Status,
+      type: types.Select,
+      required: true,
+      options: [{ value: statuses.Enabled }, { value: statuses.Disabled }],
+    },
+    { fieldId: fields.BaseUrl, type: types.Text, required: true },
+    {
+      fieldId: fields.Key,
+      type: types.Secret,
+      required: !detail,
+      secretState: detail ? octopusSecretState(detail) : states.Unavailable,
+      canLoadSecret: !!detail,
+      canReplace: true,
+      allowClear: false,
+    },
+    {
+      fieldId: fields.Models,
+      type: types.MultiSelect,
+      options: octopusModels(detail?.model).map((value) => ({ value })),
+      optionLoader: {
+        dependsOn: [fields.Type, fields.BaseUrl, fields.Key],
+        trigger: MANAGED_RESOURCE_FIELD_OPTION_LOAD_TRIGGERS.Manual,
+      },
+    },
+  ]
+}
+export const validateOctopusValues = (
+  values: EditableResourceProjection,
+  detail?: OctopusChannel,
+): ResourceValidationResult => {
+  const errors: ResourceFieldIssue[] = []
+  if (!readOctopusString(values, fields.Name).trim())
+    errors.push({ fieldId: fields.Name, code: issues.Required })
+  const type = readOctopusString(values, fields.Type)
+  if (
+    !OctopusOutboundTypeOptions.some(({ value }) => String(value) === type) &&
+    (!detail || String(detail.type) !== type)
+  )
+    errors.push({ fieldId: fields.Type, code: issues.UnsupportedOption })
+  if (
+    ![statuses.Enabled, statuses.Disabled].some(
+      (value) => value === values[fields.Status],
+    )
+  )
+    errors.push({ fieldId: fields.Status, code: issues.UnsupportedOption })
+  if (!isOctopusHttpUrl(readOctopusString(values, fields.BaseUrl)))
+    errors.push({ fieldId: fields.BaseUrl, code: issues.InvalidValue })
+  const secret = octopusSecretIntent(values)
+  if (
+    secret.kind === intents.Clear ||
+    (secret.kind === intents.Replace &&
+      !hasUsableManagedSiteChannelKey(secret.value)) ||
+    (!detail && secret.kind !== intents.Replace)
+  )
+    errors.push({ fieldId: fields.Key, code: issues.InvalidValue })
+  return errors.length ? { valid: false, issues: errors } : { valid: true }
+}
+export const buildOctopusCreateCommand = (
+  values: EditableResourceProjection,
+): OctopusCreateChannelInput => {
+  const secret = octopusSecretIntent(values)
+  return {
+    name: readOctopusString(values, fields.Name).trim(),
+    type: Number(values[fields.Type]),
+    enabled: values[fields.Status] === statuses.Enabled,
+    baseUrl: readOctopusString(values, fields.BaseUrl).trim(),
+    key: secret.kind === intents.Replace ? secret.value.trim() : "",
+    model: readOctopusModels(values).join(","),
+    autoSync: true,
+  }
+}
+export const buildOctopusUpdateCommand = (
+  detail: OctopusChannel,
+  values: EditableResourceProjection,
+): Omit<OctopusUpdateChannelInput, "id" | "source"> => {
+  const command: Omit<OctopusUpdateChannelInput, "id" | "source"> = {}
+  const next = buildOctopusCreateCommand(values)
+  if (next.name !== detail.name.trim()) command.name = next.name
+  if (next.type !== detail.type) command.type = next.type
+  if (next.enabled !== detail.enabled) command.enabled = next.enabled
+  if (next.baseUrl !== (detail.base_urls[0]?.url ?? "").trim())
+    command.baseUrl = next.baseUrl
+  if (next.model !== octopusModels(detail.model).join(","))
+    command.model = next.model
+  if (octopusSecretIntent(values).kind === intents.Replace)
+    command.key = next.key
+  return command
+}

--- a/src/services/apiAdapters/managedResources/octopusEditor.ts
+++ b/src/services/apiAdapters/managedResources/octopusEditor.ts
@@ -30,9 +30,7 @@ export const readOctopusString = (
   values: EditableResourceProjection,
   fieldId: string,
 ): string => (typeof values[fieldId] === "string" ? values[fieldId] : "")
-export const readOctopusModels = (
-  values: EditableResourceProjection,
-): string[] => {
+const readOctopusModels = (values: EditableResourceProjection): string[] => {
   const value = values[fields.Models]
   return Array.isArray(value)
     ? normalizeList(

--- a/src/services/apiAdapters/managedResources/octopusMigration.ts
+++ b/src/services/apiAdapters/managedResources/octopusMigration.ts
@@ -1,0 +1,280 @@
+import { ChannelType, DEFAULT_CHANNEL_FIELDS } from "~/constants/managedSite"
+import { SITE_TYPES } from "~/constants/siteType"
+import { MANAGED_RESOURCE_KINDS } from "~/services/accountSiteDefinitions/contracts"
+import {
+  isManagedResourceRefFor,
+  MANAGED_RESOURCE_FAILURE_CODES,
+  ManagedResourceError,
+  type ResourceOperationOptions,
+} from "~/services/apiAdapters/contracts/managedResourceNative"
+import { openOctopusNativeResourceOperations } from "~/services/apiAdapters/managedResources/octopus"
+import {
+  isOctopusHttpUrl,
+  octopusModels,
+} from "~/services/apiAdapters/managedResources/octopusEditor"
+import { MANAGED_SITE_MUTATION_OUTCOMES } from "~/services/managedSites/mutations"
+import { hasUsableManagedSiteChannelKey } from "~/services/managedSites/utils/managedSite"
+import { MANAGED_SITE_CHANNEL_MIGRATION_BLOCKED_REASON_CODES as blockers } from "~/types/managedSiteMigration"
+import {
+  MANAGED_SITE_MIGRATION_EXECUTION_FAILURE_CODES as failures,
+  type ManagedSiteMigrationCapability,
+  type ManagedSiteMigrationSelection,
+} from "~/types/managedSiteMigrationCapability"
+import { OctopusAutoGroupType, OctopusOutboundType } from "~/types/octopus"
+import { normalizeList } from "~/utils/core/string"
+
+// The canonical draft has no Responses/Embedding protocol discriminator;
+// those known source types disclose the lost mode through advanced settings.
+const sourceTypes: Readonly<Partial<Record<OctopusOutboundType, ChannelType>>> =
+  {
+    [OctopusOutboundType.OpenAIChat]: ChannelType.OpenAI,
+    [OctopusOutboundType.OpenAIResponse]: ChannelType.OpenAI,
+    [OctopusOutboundType.OpenAIEmbedding]: ChannelType.OpenAI,
+    [OctopusOutboundType.Anthropic]: ChannelType.Anthropic,
+    [OctopusOutboundType.Gemini]: ChannelType.Gemini,
+    [OctopusOutboundType.Volcengine]: ChannelType.VolcEngine,
+  }
+// Only explicit protocol matches are accepted; unknown provider families must
+// not silently become an OpenAI Chat channel.
+const targetTypes: Readonly<Partial<Record<ChannelType, OctopusOutboundType>>> =
+  {
+    [ChannelType.OpenAI]: OctopusOutboundType.OpenAIChat,
+    [ChannelType.Anthropic]: OctopusOutboundType.Anthropic,
+    [ChannelType.Gemini]: OctopusOutboundType.Gemini,
+    [ChannelType.VolcEngine]: OctopusOutboundType.Volcengine,
+  }
+const throwIfAborted = (options?: ResourceOperationOptions) => {
+  if (options?.signal?.aborted)
+    throw options.signal.reason ?? new DOMException("Aborted", "AbortError")
+}
+const withCancellation = async <T>(
+  action: () => Promise<T>,
+  options?: ResourceOperationOptions,
+): Promise<T> => {
+  throwIfAborted(options)
+  try {
+    return await action()
+  } catch (error) {
+    throwIfAborted(options)
+    if (
+      error instanceof ManagedResourceError &&
+      error.failure.code === MANAGED_RESOURCE_FAILURE_CODES.Aborted
+    )
+      throw new DOMException("Aborted", "AbortError")
+    throw error
+  }
+}
+const decodeId = (
+  selection: ManagedSiteMigrationSelection,
+  scopeKey: string,
+) => {
+  if (
+    !isManagedResourceRefFor(selection.ref, {
+      siteType: SITE_TYPES.OCTOPUS,
+      kind: MANAGED_RESOURCE_KINDS.Channel,
+      scopeKey,
+    })
+  )
+    return null
+  const id = Number(selection.ref.resourceId)
+  return Number.isSafeInteger(id) && id > 0 ? id : null
+}
+const openSelection = async (
+  selection: ManagedSiteMigrationSelection,
+  options?: ResourceOperationOptions,
+) => {
+  throwIfAborted(options)
+  const operations = await withCancellation(
+    () => openOctopusNativeResourceOperations(options),
+    options,
+  )
+  const id = decodeId(selection, operations.scopeKey)
+  if (id === null) return null
+  const detail = await withCancellation(
+    () => operations.get(id, options),
+    options,
+  )
+  return { operations, id, detail }
+}
+
+/** Canonical migration for native Octopus channels without the legacy channel facade. */
+export const octopusManagedSiteMigrationCapability: ManagedSiteMigrationCapability =
+  {
+    source: {
+      createSelectionValidationContext: async (options) => {
+        throwIfAborted(options)
+        const operations = await withCancellation(
+          () => openOctopusNativeResourceOperations(options),
+          options,
+        )
+        return {
+          isValid: (selection) =>
+            decodeId(selection, operations.scopeKey) !== null,
+        }
+      },
+      prepare: async (selection, options) => {
+        const resolved = await openSelection(selection, options)
+        if (!resolved)
+          return {
+            status: "blocked",
+            reasonCode: blockers.SOURCE_KEY_RESOLUTION_FAILED,
+          }
+        const { detail } = resolved
+        const resourceType = sourceTypes[detail.type]
+        if (resourceType === undefined)
+          return {
+            status: "blocked",
+            reasonCode: blockers.SOURCE_TYPE_UNSUPPORTED,
+          }
+        return {
+          status: "ready",
+          source: {
+            sourceSiteType: SITE_TYPES.OCTOPUS,
+            resourceType,
+            baseUrl: detail.base_urls[0]?.url.trim() ?? "",
+            models: octopusModels(detail.model),
+            groups: [],
+            priority: DEFAULT_CHANNEL_FIELDS.priority,
+            weight: DEFAULT_CHANNEL_FIELDS.weight,
+            status: detail.enabled ? "enabled" : "disabled",
+            lossSignals: {
+              hasModelMapping: false,
+              hasStatusCodeMapping: false,
+              hasMultiKeyState:
+                detail.keys.length > 1 ||
+                detail.keys.some((key) => !key.enabled),
+              hasAdvancedSettings: Boolean(
+                // v0.13 grants and protocol paths cannot be represented by one
+                // canonical channel type: github.com/bestruirui/octopus/blob/27aa40dc0f3b2902bce3e96ccdba019d17041606/internal/model/channel.go
+                detail.hasUnrepresentedProtocolSettings ||
+                  detail.base_urls.length > 1 ||
+                  detail.custom_model?.trim() ||
+                  detail.proxy ||
+                  detail.auto_sync ||
+                  detail.auto_group !== OctopusAutoGroupType.None ||
+                  detail.custom_header?.length ||
+                  detail.param_override?.trim() ||
+                  detail.channel_proxy?.trim() ||
+                  detail.match_regex?.trim() ||
+                  detail.type === OctopusOutboundType.OpenAIResponse ||
+                  detail.type === OctopusOutboundType.OpenAIEmbedding,
+              ),
+            },
+          },
+        }
+      },
+      resolveCredential: async (selection, options) => {
+        try {
+          const resolved = await openSelection(selection, options)
+          if (!resolved)
+            return {
+              status: "blocked",
+              reasonCode: blockers.SOURCE_KEY_RESOLUTION_FAILED,
+            }
+          const credential = (
+            await withCancellation(
+              () => resolved.operations.loadSecret(resolved.id, options),
+              options,
+            )
+          ).trim()
+          return hasUsableManagedSiteChannelKey(credential)
+            ? { status: "ready", credential }
+            : { status: "blocked", reasonCode: blockers.SOURCE_KEY_MISSING }
+        } catch (error) {
+          throwIfAborted(options)
+          if (error instanceof Error && error.name === "AbortError") throw error
+          return {
+            status: "blocked",
+            reasonCode: blockers.SOURCE_KEY_RESOLUTION_FAILED,
+          }
+        }
+      },
+    },
+    target: {
+      prepare: async (source, options) => {
+        throwIfAborted(options)
+        const type = targetTypes[source.resourceType]
+        if (type === undefined)
+          throw new Error(
+            "Octopus does not support this migration channel type",
+          )
+        const operations = await withCancellation(
+          () => openOctopusNativeResourceOperations(options),
+          options,
+        )
+        const baseUrl = await withCancellation(
+          () =>
+            operations.prepareMigrationBaseUrl(source.baseUrl, type, options),
+          options,
+        )
+        return {
+          projection: {
+            name: "",
+            type: String(type),
+            baseUrl,
+            models: [...source.models],
+            groups: [...DEFAULT_CHANNEL_FIELDS.groups],
+            priority: DEFAULT_CHANNEL_FIELDS.priority,
+            weight: DEFAULT_CHANNEL_FIELDS.weight,
+            status: source.status === "enabled" ? 1 : 2,
+          },
+          adjustments: {
+            remappedType: Number(type) !== Number(source.resourceType),
+            normalizedBaseUrl: baseUrl !== source.baseUrl,
+            forcedDefaultGroup:
+              source.groups.length !== 1 ||
+              source.groups[0] !== DEFAULT_CHANNEL_FIELDS.groups[0],
+            ignoredPriority:
+              source.priority !== DEFAULT_CHANNEL_FIELDS.priority,
+            ignoredWeight: source.weight !== DEFAULT_CHANNEL_FIELDS.weight,
+            simplifiedStatus: source.status === "other",
+          },
+        }
+      },
+      create: async (command, options) => {
+        throwIfAborted(options)
+        const type = Number(command.projection.type)
+        const models = normalizeList(command.projection.models)
+        if (
+          command.targetSiteType !== SITE_TYPES.OCTOPUS ||
+          String(command.projection.type).trim() === "" ||
+          !Number.isInteger(type) ||
+          sourceTypes[type as OctopusOutboundType] === undefined ||
+          !command.projection.name.trim() ||
+          !isOctopusHttpUrl(command.projection.baseUrl) ||
+          models.length === 0 ||
+          ![1, 2].includes(command.projection.status) ||
+          !hasUsableManagedSiteChannelKey(command.credential)
+        )
+          return { status: "failed", failureCode: failures.TargetRejected }
+        const operations = await withCancellation(
+          () => openOctopusNativeResourceOperations(options),
+          options,
+        )
+        const result = await withCancellation(
+          () =>
+            operations.create(
+              {
+                name: command.projection.name.trim(),
+                type,
+                baseUrl: command.projection.baseUrl.trim(),
+                key: command.credential.trim(),
+                model: models.join(","),
+                enabled: command.projection.status === 1,
+              },
+              options,
+            ),
+          options,
+        )
+        switch (result.outcome) {
+          case MANAGED_SITE_MUTATION_OUTCOMES.Succeeded:
+            return { status: "created" }
+          case MANAGED_SITE_MUTATION_OUTCOMES.Rejected:
+            return { status: "failed", failureCode: failures.TargetRejected }
+          case MANAGED_SITE_MUTATION_OUTCOMES.Partial:
+          case MANAGED_SITE_MUTATION_OUTCOMES.Uncertain:
+            return { status: "uncertain" }
+        }
+      },
+    },
+  }

--- a/src/services/apiAdapters/managedResources/registry.ts
+++ b/src/services/apiAdapters/managedResources/registry.ts
@@ -6,11 +6,13 @@ import { axonHubManagedResourceRegistration } from "./axonHub"
 import { claudeCodeHubManagedResourceRegistration } from "./claudeCodeHub"
 import { doneHubManagedResourceRegistration } from "./doneHub"
 import { newApiManagedResourceRegistration } from "./newApi"
+import { octopusManagedResourceRegistration } from "./octopus"
 import { sub2ApiManagedResourceRegistration } from "./sub2api"
 import { veloeraManagedResourceRegistration } from "./veloera"
 
 const MANAGED_RESOURCE_REGISTRATIONS = [
   newApiManagedResourceRegistration,
+  octopusManagedResourceRegistration,
   axonHubManagedResourceRegistration,
   claudeCodeHubManagedResourceRegistration,
   doneHubManagedResourceRegistration,

--- a/src/services/apiAdapters/managedSites/octopus.ts
+++ b/src/services/apiAdapters/managedSites/octopus.ts
@@ -14,14 +14,9 @@ import {
   fetchAvailableModels as fetchOctopusAvailableModels,
   getChannel,
   listChannels,
-  OctopusMutationApiError,
   searchChannels,
   updateChannel as updateOctopusChannel,
 } from "~/services/apiService/octopus"
-import {
-  createManagedSiteMutationSequence,
-  type ManagedSiteMutationConfirmedEffect,
-} from "~/services/managedSites/mutations"
 import {
   buildChannelName,
   buildChannelPayload,
@@ -53,112 +48,14 @@ import {
   type ManagedUpstreamResourceSummary,
 } from "~/types/managedUpstreamResource"
 import type {
-  OctopusApiResponse,
   OctopusChannel,
   OctopusCreateChannelInput,
   OctopusUpdateChannelInput,
 } from "~/types/octopus"
 import type { OctopusConfig } from "~/types/octopusConfig"
-import { getErrorMessage } from "~/utils/core/error"
 
 import { createManagedSiteConfigCapability } from "./config"
-
-const toOctopusMutationResponse = <TData>(
-  response: OctopusApiResponse<TData>,
-) =>
-  response.success
-    ? { outcome: "applied" as const, data: response.data }
-    : {
-        outcome: "rejected" as const,
-        diagnostic: {
-          message: getErrorMessage(
-            response.message,
-            "Provider rejected the mutation",
-          ),
-          raw: response,
-        },
-      }
-
-const toOctopusMutationDiagnostic = (error: OctopusMutationApiError) => {
-  const diagnosticRaw = error.raw
-  const code =
-    typeof error.code === "string" ||
-    (typeof error.code === "number" && Number.isSafeInteger(error.code))
-      ? error.code
-      : undefined
-  const statusCode =
-    typeof error.statusCode === "number" &&
-    Number.isSafeInteger(error.statusCode) &&
-    error.statusCode >= 100 &&
-    error.statusCode <= 599
-      ? error.statusCode
-      : undefined
-  return {
-    message: getErrorMessage(error, "Octopus mutation failed"),
-    ...(code === undefined ? {} : { code }),
-    ...(statusCode === undefined ? {} : { statusCode }),
-    raw: diagnosticRaw,
-  }
-}
-
-const runOctopusMutation = async <TData, TResult = TData>(input: {
-  effect: ManagedSiteMutationConfirmedEffect
-  execute(): Promise<OctopusApiResponse<TData>>
-  successData?: (data: TData | null | undefined) => TResult
-}) => {
-  const sequence =
-    createManagedSiteMutationSequence<ManagedSiteMutationConfirmedEffect>({
-      idempotent: false,
-    })
-  const attempt = sequence.beginStep()
-  try {
-    const response = await input.execute()
-    attempt.markPossiblyDispatched()
-    attempt.markResponseReceived()
-    const classified = toOctopusMutationResponse(response)
-    if (classified.outcome === "rejected") {
-      attempt.confirmNonApplication()
-      attempt.complete()
-      return sequence.finish({
-        finalState: "unconfirmed",
-        diagnostic: classified.diagnostic,
-      })
-    }
-    attempt.confirmEffect(input.effect)
-    attempt.complete()
-    return sequence.finish({
-      finalState: "confirmed",
-      data: input.successData
-        ? input.successData(classified.data)
-        : (classified.data as unknown as TResult),
-    })
-  } catch (error) {
-    if (!(error instanceof OctopusMutationApiError)) throw error
-    if (error.dispatch === "dispatched") attempt.markPossiblyDispatched()
-    if (error.responseReceived) attempt.markResponseReceived()
-    if (
-      error.confirmedNonApplication &&
-      error.dispatch === "dispatched" &&
-      error.responseReceived
-    ) {
-      attempt.confirmNonApplication()
-    }
-    attempt.complete()
-    return sequence.finish({
-      finalState: "unconfirmed",
-      diagnostic: toOctopusMutationDiagnostic(error),
-    })
-  }
-}
-
-const octopusChannelEffect = (
-  kind: ManagedSiteMutationConfirmedEffect["kind"],
-  resourceId?: number,
-): ManagedSiteMutationConfirmedEffect => ({
-  kind,
-  resourceKind: "channel",
-  ...(resourceId === undefined ? {} : { resourceId }),
-})
+import { octopusChannelEffect, runOctopusMutation } from "./octopusMutation"
 
 const toManagedSiteChannelListData = (
   channels: OctopusChannel[],

--- a/src/services/apiAdapters/managedSites/octopusMutation.ts
+++ b/src/services/apiAdapters/managedSites/octopusMutation.ts
@@ -6,6 +6,7 @@ import {
 import type { OctopusApiResponse } from "~/types/octopus"
 import { getErrorMessage } from "~/utils/core/error"
 
+/** Distinguishes provider rejection from application while retaining diagnostics for boundary sanitization. */
 const toOctopusMutationResponse = <TData>(
   response: OctopusApiResponse<TData>,
 ) =>
@@ -22,6 +23,7 @@ const toOctopusMutationResponse = <TData>(
         },
       }
 
+/** Retains valid provider codes and raw local diagnostics without inventing an HTTP status. */
 const toOctopusMutationDiagnostic = (error: OctopusMutationApiError) => {
   const diagnosticRaw = error.raw
   const code =
@@ -44,6 +46,7 @@ const toOctopusMutationDiagnostic = (error: OctopusMutationApiError) => {
   }
 }
 
+/** Executes a non-idempotent mutation once and preserves uncertainty when application cannot be confirmed. */
 export const runOctopusMutation = async <TData, TResult = TData>(input: {
   effect: ManagedSiteMutationConfirmedEffect
   execute(): Promise<OctopusApiResponse<TData>>
@@ -94,6 +97,7 @@ export const runOctopusMutation = async <TData, TResult = TData>(input: {
   }
 }
 
+/** Describes a confirmed channel effect, omitting identity when the provider has not supplied one. */
 export const octopusChannelEffect = (
   kind: ManagedSiteMutationConfirmedEffect["kind"],
   resourceId?: number,

--- a/src/services/apiAdapters/managedSites/octopusMutation.ts
+++ b/src/services/apiAdapters/managedSites/octopusMutation.ts
@@ -1,0 +1,104 @@
+import { OctopusMutationApiError } from "~/services/apiService/octopus"
+import {
+  createManagedSiteMutationSequence,
+  type ManagedSiteMutationConfirmedEffect,
+} from "~/services/managedSites/mutations"
+import type { OctopusApiResponse } from "~/types/octopus"
+import { getErrorMessage } from "~/utils/core/error"
+
+const toOctopusMutationResponse = <TData>(
+  response: OctopusApiResponse<TData>,
+) =>
+  response.success
+    ? { outcome: "applied" as const, data: response.data }
+    : {
+        outcome: "rejected" as const,
+        diagnostic: {
+          message: getErrorMessage(
+            response.message,
+            "Provider rejected the mutation",
+          ),
+          raw: response,
+        },
+      }
+
+const toOctopusMutationDiagnostic = (error: OctopusMutationApiError) => {
+  const diagnosticRaw = error.raw
+  const code =
+    typeof error.code === "string" ||
+    (typeof error.code === "number" && Number.isSafeInteger(error.code))
+      ? error.code
+      : undefined
+  const statusCode =
+    typeof error.statusCode === "number" &&
+    Number.isSafeInteger(error.statusCode) &&
+    error.statusCode >= 100 &&
+    error.statusCode <= 599
+      ? error.statusCode
+      : undefined
+  return {
+    message: getErrorMessage(error, "Octopus mutation failed"),
+    ...(code === undefined ? {} : { code }),
+    ...(statusCode === undefined ? {} : { statusCode }),
+    raw: diagnosticRaw,
+  }
+}
+
+export const runOctopusMutation = async <TData, TResult = TData>(input: {
+  effect: ManagedSiteMutationConfirmedEffect
+  execute(): Promise<OctopusApiResponse<TData>>
+  successData?: (data: TData | null | undefined) => TResult
+}) => {
+  const sequence =
+    createManagedSiteMutationSequence<ManagedSiteMutationConfirmedEffect>({
+      idempotent: false,
+    })
+  const attempt = sequence.beginStep()
+  try {
+    const response = await input.execute()
+    attempt.markPossiblyDispatched()
+    attempt.markResponseReceived()
+    const classified = toOctopusMutationResponse(response)
+    if (classified.outcome === "rejected") {
+      attempt.confirmNonApplication()
+      attempt.complete()
+      return sequence.finish({
+        finalState: "unconfirmed",
+        diagnostic: classified.diagnostic,
+      })
+    }
+    attempt.confirmEffect(input.effect)
+    attempt.complete()
+    return sequence.finish({
+      finalState: "confirmed",
+      data: input.successData
+        ? input.successData(classified.data)
+        : (classified.data as unknown as TResult),
+    })
+  } catch (error) {
+    if (!(error instanceof OctopusMutationApiError)) throw error
+    if (error.dispatch === "dispatched") attempt.markPossiblyDispatched()
+    if (error.responseReceived) attempt.markResponseReceived()
+    if (
+      error.confirmedNonApplication &&
+      error.dispatch === "dispatched" &&
+      error.responseReceived
+    ) {
+      attempt.confirmNonApplication()
+    }
+    attempt.complete()
+    return sequence.finish({
+      finalState: "unconfirmed",
+      diagnostic: toOctopusMutationDiagnostic(error),
+    })
+  }
+}
+
+export const octopusChannelEffect = (
+  kind: ManagedSiteMutationConfirmedEffect["kind"],
+  resourceId?: number,
+): ManagedSiteMutationConfirmedEffect => ({
+  kind,
+  resourceKind: "channel",
+  ...(resourceId === undefined ? {} : { resourceId }),
+})

--- a/src/services/apiService/octopus/index.ts
+++ b/src/services/apiService/octopus/index.ts
@@ -3,6 +3,7 @@
  * 提供与 Octopus 后端的所有 API 交互
  */
 import { OCTOPUS_LOGIN_PATH } from "~/constants/octopus"
+import { ApiError } from "~/services/apiTransport/errors"
 import type { ApiServiceRequest } from "~/services/apiTransport/type"
 import { userPreferences } from "~/services/preferences/userPreferences"
 import { createUserCommandProtectionBypassExecution } from "~/services/protectionBypass/client"
@@ -714,6 +715,28 @@ export async function listChannels(
   }
 }
 
+/** Resolves whether this deployment appends protocol paths to channel origins. */
+export async function usesChannelProtocolPaths(
+  config: OctopusConfig,
+  options?: Pick<OctopusRequestInit, "signal" | "protectionBypassExecution">,
+): Promise<boolean> {
+  options?.signal?.throwIfAborted()
+  const session = await octopusAuthManager.getValidSession(config, {
+    signal: options?.signal ?? undefined,
+  })
+  options?.signal?.throwIfAborted()
+  if (session.mode !== OCTOPUS_AUTH_MODES.Cookie) return false
+  const version = await resolveOctopusCookieApiVersion({
+    config,
+    session,
+    baseUrl: normalizeBaseUrl(config.baseUrl),
+    signal: options?.signal ?? undefined,
+    protectionBypassExecution: options?.protectionBypassExecution,
+  })
+  options?.signal?.throwIfAborted()
+  return version === OCTOPUS_COOKIE_API_VERSIONS.V013
+}
+
 /** Loads one full channel configuration for editing. */
 export async function getChannel(
   config: OctopusConfig,
@@ -754,7 +777,7 @@ export async function getChannel(
   }
 
   const channel = channels.find((item) => item.id === channelId)
-  if (!channel) throw new Error(`Channel ${channelId} was not found`)
+  if (!channel) throw new ApiError(`Channel ${channelId} was not found`, 404)
   return channel
 }
 
@@ -807,12 +830,13 @@ export async function searchChannels(
 export async function createChannel(
   config: OctopusConfig,
   data: OctopusCreateChannelInput,
+  options?: Pick<OctopusRequestInit, "signal" | "protectionBypassExecution">,
 ): Promise<OctopusApiResponse<OctopusChannel>> {
   try {
     const result = await fetchOctopusApi<OctopusChannel>(
       config,
       { kind: OCTOPUS_API_OPERATIONS.CreateChannel, input: data },
-      {},
+      options ?? {},
       "mutation",
     )
     logger.info("Channel created", { name: data.name })
@@ -855,12 +879,13 @@ export async function updateChannel(
 export async function deleteChannel(
   config: OctopusConfig,
   channelId: number,
+  options?: Pick<OctopusRequestInit, "signal" | "protectionBypassExecution">,
 ): Promise<OctopusApiResponse<null>> {
   try {
     const result = await fetchOctopusApi<null>(
       config,
       { kind: OCTOPUS_API_OPERATIONS.DeleteChannel, channelId },
-      {},
+      options ?? {},
       "mutation",
     )
     logger.info("Channel deleted", { id: channelId })

--- a/src/services/apiService/octopus/v013.ts
+++ b/src/services/apiService/octopus/v013.ts
@@ -1,4 +1,5 @@
 import {
+  OCTOPUS_CHANNEL_DETAIL_AVAILABILITY,
   OctopusAutoGroupType,
   OctopusOutboundType,
   type OctopusChannel,
@@ -234,6 +235,30 @@ const splitModels = (...values: Array<string | undefined>): string[] => {
   return [...new Set(models.map((model) => model.trim()).filter(Boolean))]
 }
 
+const hasUnrepresentedProtocolSettings = (
+  detail: OctopusV013ChannelDetailDto,
+): boolean => {
+  const type = inferOutboundType(detail.grants)
+  const paths = protocolPathsForOutboundType(type)
+  const protocol = protocolForOutboundType(type)
+  const primaryKey = detail.keys[0]?.name
+  return (
+    detail.dialect !== "generic" ||
+    detail.openai_chat_completion_path !== paths.openai_chat_completion_path ||
+    detail.openai_response_path !== paths.openai_response_path ||
+    detail.anthropic_message_path !== paths.anthropic_message_path ||
+    detail.grants.length !== detail.models.length ||
+    detail.models.some(
+      (model) =>
+        detail.grants.filter((grant) => grant.model_name === model).length !==
+        1,
+    ) ||
+    detail.grants.some(
+      (grant) => grant.protocols !== protocol || grant.key_name !== primaryKey,
+    )
+  )
+}
+
 const createGrants = (
   models: string[],
   keyName: string | undefined,
@@ -366,6 +391,7 @@ export const octopusV013Contract = {
 
   normalizeStatsChannel(stats: OctopusV013ChannelStatsDto): OctopusChannel {
     return {
+      detailAvailability: OCTOPUS_CHANNEL_DETAIL_AVAILABILITY.Summary,
       id: stats.channel_id,
       name: stats.channel_name,
       // The stats contract intentionally omits dialect/protocol details.
@@ -403,6 +429,8 @@ export const octopusV013Contract = {
       id: detail.id,
       name: detail.name,
       type: inferOutboundType(detail.grants),
+      hasUnrepresentedProtocolSettings:
+        hasUnrepresentedProtocolSettings(detail),
       enabled: detail.enabled,
       base_urls: [{ url: detail.base_url }],
       keys: detail.keys.map((key) => ({

--- a/src/services/managedSites/channelMigrationCapabilityRegistry.ts
+++ b/src/services/managedSites/channelMigrationCapabilityRegistry.ts
@@ -3,6 +3,7 @@ import { axonHubManagedSiteMigrationCapability } from "~/services/apiAdapters/ma
 import { claudeCodeHubManagedSiteMigrationCapability } from "~/services/apiAdapters/managedResources/claudeCodeHubMigration"
 import { doneHubManagedSiteMigrationCapability } from "~/services/apiAdapters/managedResources/doneHubMigration"
 import { newApiManagedSiteMigrationCapability } from "~/services/apiAdapters/managedResources/newApiMigration"
+import { octopusManagedSiteMigrationCapability } from "~/services/apiAdapters/managedResources/octopusMigration"
 import { veloeraManagedSiteMigrationCapability } from "~/services/apiAdapters/managedResources/veloeraMigration"
 import type { ManagedSiteMigrationCapability } from "~/types/managedSiteMigrationCapability"
 
@@ -10,6 +11,10 @@ const registrations: readonly {
   siteType: ManagedSiteType
   capability: ManagedSiteMigrationCapability
 }[] = [
+  {
+    siteType: SITE_TYPES.OCTOPUS,
+    capability: octopusManagedSiteMigrationCapability,
+  },
   {
     siteType: SITE_TYPES.NEW_API,
     capability: newApiManagedSiteMigrationCapability,

--- a/src/types/octopus.ts
+++ b/src/types/octopus.ts
@@ -98,7 +98,16 @@ export interface OctopusChannelStats {
 /**
  * Octopus 渠道完整对象
  */
+export const OCTOPUS_CHANNEL_DETAIL_AVAILABILITY = {
+  Summary: "summary",
+  Full: "full",
+} as const
+
 export interface OctopusChannel {
+  /** Migration cannot reproduce all native grants, dialect, or protocol paths. */
+  hasUnrepresentedProtocolSettings?: boolean
+  /** Stats-only inventories omit protocol, endpoints, and credential details. */
+  detailAvailability?: (typeof OCTOPUS_CHANNEL_DETAIL_AVAILABILITY)[keyof typeof OCTOPUS_CHANNEL_DETAIL_AVAILABILITY]
   /** 渠道唯一标识符 */
   id: number
   /** 渠道名称 */

--- a/tests/features/ManagedSiteChannels/ManagedSiteChannelsRoute.test.tsx
+++ b/tests/features/ManagedSiteChannels/ManagedSiteChannelsRoute.test.tsx
@@ -551,6 +551,7 @@ const installNativeControllers = (
 }
 
 type NativePreferenceSiteType =
+  | typeof SITE_TYPES.OCTOPUS
   | typeof SITE_TYPES.NEW_API
   | typeof SITE_TYPES.VELOERA
   | typeof SITE_TYPES.DONE_HUB
@@ -562,6 +563,14 @@ const getNativePreferenceOverrides = (
   siteType: NativePreferenceSiteType,
 ): Partial<ReturnType<typeof buildUserPreferences>> => {
   switch (siteType) {
+    case SITE_TYPES.OCTOPUS:
+      return {
+        octopus: {
+          baseUrl: "https://console.example.invalid",
+          username: "example-user",
+          password: "example-credential",
+        },
+      }
     case SITE_TYPES.NEW_API:
       return {
         newApi: {
@@ -712,6 +721,19 @@ describe("ManagedSiteChannelsRoute", () => {
     expect(screen.getByText("Native example")).toBeVisible()
     expect(legacyRender).not.toHaveBeenCalled()
     expect(useListController).toHaveBeenCalled()
+  })
+
+  it("routes the production Octopus definition through native controllers", () => {
+    installNativeControllers()
+    configureNativePreferences(SITE_TYPES.OCTOPUS)
+    render(
+      <ManagedSiteChannelsRoute
+        siteType={SITE_TYPES.OCTOPUS}
+        onReplaceRouteQuery={vi.fn()}
+      />,
+    )
+    expect(screen.getByText("Native example")).toBeVisible()
+    expect(legacyRender).not.toHaveBeenCalled()
   })
 
   it("routes the production AxonHub definition through native controllers", () => {
@@ -1102,6 +1124,9 @@ describe("ManagedSiteChannelsRoute", () => {
   })
 
   it("keeps the shared legacy and native route surfaces structurally aligned", () => {
+    vi.spyOn(nativeRegistry, "getManagedResourceRegistration").mockReturnValue(
+      null,
+    )
     const readSurface = (testToken: string) => {
       const buttons = screen.getAllByRole("button")
       const refresh = screen.getByTestId(
@@ -1173,6 +1198,10 @@ describe("ManagedSiteChannelsRoute", () => {
       }
 
       legacyFixtureScenario.current = scenario
+      vi.spyOn(
+        nativeRegistry,
+        "getManagedResourceRegistration",
+      ).mockReturnValue(null)
       render(
         <ManagedSiteChannelsRoute
           siteType={SITE_TYPES.OCTOPUS}
@@ -1712,6 +1741,9 @@ describe("ManagedSiteChannelsRoute", () => {
   })
 
   it("keeps editor shell behavior aligned between legacy and native routes", () => {
+    vi.spyOn(nativeRegistry, "getManagedResourceRegistration").mockReturnValue(
+      null,
+    )
     legacyFixtureScenario.current = "editor"
     render(
       <ManagedSiteChannelsRoute
@@ -1764,6 +1796,9 @@ describe("ManagedSiteChannelsRoute", () => {
   })
 
   it("keeps migration dialog behavior aligned between legacy and native routes", async () => {
+    vi.spyOn(nativeRegistry, "getManagedResourceRegistration").mockReturnValue(
+      null,
+    )
     legacyFixtureScenario.current = "migration"
     render(
       <ManagedSiteChannelsRoute
@@ -1814,6 +1849,9 @@ describe("ManagedSiteChannelsRoute", () => {
   })
 
   it("keeps focused search recovery aligned between legacy and native routes", async () => {
+    vi.spyOn(nativeRegistry, "getManagedResourceRegistration").mockReturnValue(
+      null,
+    )
     const user = userEvent.setup()
     legacyFixtureScenario.current = "focus"
     render(

--- a/tests/features/ManagedSiteChannels/presentation/managedResourceFieldPolicy.test.ts
+++ b/tests/features/ManagedSiteChannels/presentation/managedResourceFieldPolicy.test.ts
@@ -50,6 +50,34 @@ import zhTwManagedSiteChannels from "~/locales/zh-TW/managedSiteChannels.json"
 import { MANAGED_RESOURCE_KINDS } from "~/services/accountSiteDefinitions/contracts"
 import type { ResourceFieldDescriptor } from "~/services/apiAdapters/contracts/managedResourceNative"
 
+describe("Octopus native editor vocabulary", () => {
+  it("exposes native outbound types and only the supported channel controls", () => {
+    for (const mode of ["create", "edit"] as const) {
+      const policy = getManagedResourceFieldPolicy(
+        SITE_TYPES.OCTOPUS,
+        MANAGED_RESOURCE_KINDS.Channel,
+        mode,
+      )
+      expect(policy).toBeDefined()
+      const type = policy!.fields.find(
+        (field) => field.channelFieldRole === "type",
+      )!
+      expect(
+        type.optionLabelResolvers?.["0"]?.(((key: string) => key) as TFunction),
+      ).toBe("OpenAI Chat")
+      expect(
+        type.optionLabelResolvers?.["2"]?.(((key: string) => key) as TFunction),
+      ).toBe("Anthropic")
+      expect(
+        policy!.fields.some((field) => field.channelFieldRole === "secret"),
+      ).toBe(true)
+      expect(
+        policy!.fields.some((field) => field.channelFieldRole === "models"),
+      ).toBe(true)
+    }
+  })
+})
+
 const createDescriptors = (): readonly ResourceFieldDescriptor[] => [
   { fieldId: AXON_HUB_CHANNEL_FIELD_IDS.NAME, type: "text", required: true },
   {

--- a/tests/features/ManagedSiteChannels/presentation/managedResourceMigrationPresentation.test.ts
+++ b/tests/features/ManagedSiteChannels/presentation/managedResourceMigrationPresentation.test.ts
@@ -183,7 +183,14 @@ const preview: ManagedSiteMigrationCanonicalPreview = {
 }
 
 describe("managedResourceMigrationPresentation", () => {
-  it.each(["0", "2"])("shows the Octopus target vocabulary for %s", (type) => {
+  it.each([
+    ["0", "OpenAI Chat"],
+    ["2", "Anthropic"],
+    [" ", "Unsupported type"],
+    ["999", "Unsupported type"],
+    ["invalid", "Unsupported type"],
+    ["2.5", "Unsupported type"],
+  ])("shows the Octopus target vocabulary for %s", (type, expected) => {
     const item = preview.items[0]!
     if (item.status !== "ready") throw new Error("expected ready item")
     const mapped = mapManagedResourceMigrationPreview(
@@ -204,7 +211,7 @@ describe("managedResourceMigrationPresentation", () => {
     )
     expect(
       mapped.rows[0].comparisons.find(({ id }) => id === "type")?.target,
-    ).toBe(Number(type) === 0 ? "OpenAI Chat" : "Anthropic")
+    ).toBe(expected)
   })
   it("uses DoneHub's provider-owned vocabulary for numeric string targets", () => {
     const readyItem = preview.items[0]!

--- a/tests/features/ManagedSiteChannels/presentation/managedResourceMigrationPresentation.test.ts
+++ b/tests/features/ManagedSiteChannels/presentation/managedResourceMigrationPresentation.test.ts
@@ -183,6 +183,29 @@ const preview: ManagedSiteMigrationCanonicalPreview = {
 }
 
 describe("managedResourceMigrationPresentation", () => {
+  it.each(["0", "2"])("shows the Octopus target vocabulary for %s", (type) => {
+    const item = preview.items[0]!
+    if (item.status !== "ready") throw new Error("expected ready item")
+    const mapped = mapManagedResourceMigrationPreview(
+      {
+        ...preview,
+        targetSiteType: SITE_TYPES.OCTOPUS,
+        items: [
+          {
+            ...item,
+            target: {
+              ...item.target,
+              projection: { ...item.target.projection, type },
+            },
+          },
+        ],
+      },
+      { t, getSiteLabel: String },
+    )
+    expect(
+      mapped.rows[0].comparisons.find(({ id }) => id === "type")?.target,
+    ).toBe(Number(type) === 0 ? "OpenAI Chat" : "Anthropic")
+  })
   it("uses DoneHub's provider-owned vocabulary for numeric string targets", () => {
     const readyItem = preview.items[0]!
     if (readyItem.status !== "ready") throw new Error("expected ready item")

--- a/tests/services/apiAdapters/managedResources/axonHub.test.ts
+++ b/tests/services/apiAdapters/managedResources/axonHub.test.ts
@@ -2743,15 +2743,6 @@ describe("AxonHub native managed-resource Adapter", () => {
     ).not.toBeNull()
   })
 
-  it("leaves Octopus out of the native registration table", () => {
-    expect(
-      getManagedResourceRegistration(
-        SITE_TYPES.OCTOPUS,
-        MANAGED_RESOURCE_KINDS.Channel,
-      ),
-    ).toBeNull()
-  })
-
   it("maps native Axon detail to a secret-free canonical migration source", async () => {
     mocks.getChannel.mockResolvedValue(
       buildDetailChannel({

--- a/tests/services/apiAdapters/managedResources/octopus.test.ts
+++ b/tests/services/apiAdapters/managedResources/octopus.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { OCTOPUS_MANAGED_RESOURCE_FIELD_IDS as fields } from "~/constants/octopus"
+import type {
+  EditableResourceProjection,
+  ResourceFieldValue,
+} from "~/services/apiAdapters/contracts/managedResourceNative"
 import {
   octopusManagedResourceRegistration,
   openOctopusNativeResourceOperations,
@@ -251,14 +255,15 @@ describe("Octopus native resource", () => {
     const editor = await (
       await octopusManagedResourceRegistration.open()
     ).openCreateEditor()
-    for (const values of [
+    const drafts: EditableResourceProjection[] = [
       editor.initialValues,
       {
         ...editor.initialValues,
         [fields.BaseUrl]: "https://upstream.example.invalid",
         [fields.Key]: { kind: "unchanged" },
       },
-    ]) {
+    ]
+    for (const values of drafts) {
       await expect(
         editor.loadOptions!(fields.Models, values),
       ).rejects.toMatchObject({ failure: { code: "validation_failed" } })
@@ -291,7 +296,7 @@ describe("Octopus native resource", () => {
       },
     })
   })
-  it.each([
+  it.each<[string, ResourceFieldValue, string]>([
     [fields.Name, "", "required"],
     [fields.Type, "90", "unsupported_option"],
     [fields.Status, "unknown", "unsupported_option"],
@@ -305,7 +310,7 @@ describe("Octopus native resource", () => {
       const editor = await (
         await octopusManagedResourceRegistration.open()
       ).openCreateEditor()
-      const values = {
+      const values: EditableResourceProjection = {
         ...editor.initialValues,
         [fields.Name]: "New",
         [fields.BaseUrl]: "https://upstream.example.invalid",

--- a/tests/services/apiAdapters/managedResources/octopus.test.ts
+++ b/tests/services/apiAdapters/managedResources/octopus.test.ts
@@ -50,6 +50,360 @@ const channel: OctopusChannel = {
   param_override: "{}",
 }
 describe("Octopus native resource", () => {
+  it.each([
+    [new ApiError("Sign in again", 401), "authentication_failed"],
+    [new ApiError("Access denied", 403), "permission_denied"],
+    [new ApiError("Missing channel", 404), "not_found"],
+    [new ApiError("Invalid request", 400), "upstream_rejected"],
+    [new ApiError("Network unavailable"), "unavailable"],
+    [new Error("Unexpected response"), "unexpected"],
+    ["invalid response", "unexpected"],
+    [new DOMException("Cancelled", "AbortError"), "aborted"],
+  ])("classifies read failure %s as %s", async (error, code) => {
+    mocks.listChannels.mockRejectedValue(error)
+    const workspace = await octopusManagedResourceRegistration.open()
+    await expect(workspace.list()).rejects.toMatchObject({ failure: { code } })
+  })
+  it("rejects absent configuration and cancellation before opening", async () => {
+    mocks.getPreferences.mockResolvedValue({})
+    await expect(
+      octopusManagedResourceRegistration.open(),
+    ).rejects.toMatchObject({
+      failure: { code: "configuration_required" },
+    })
+    const controller = new AbortController()
+    controller.abort()
+    await expect(
+      openOctopusNativeResourceOperations({ signal: controller.signal }),
+    ).rejects.toMatchObject({
+      failure: { code: "aborted" },
+    })
+  })
+  it("discards a list response when cancelled during the request", async () => {
+    const controller = new AbortController()
+    mocks.listChannels.mockImplementation(async () => {
+      controller.abort()
+      return [channel]
+    })
+    const workspace = await octopusManagedResourceRegistration.open()
+    await expect(
+      workspace.list(undefined, { signal: controller.signal }),
+    ).rejects.toMatchObject({
+      failure: { code: "aborted" },
+    })
+  })
+  it.each([0, -1, 1.5, Number.MAX_SAFE_INTEGER + 1])(
+    "rejects invalid channel identity %s before transport",
+    async (id) => {
+      const operations = await openOctopusNativeResourceOperations()
+      await expect(operations.get(id)).rejects.toMatchObject({
+        failure: { code: "validation_failed" },
+      })
+      expect(mocks.getChannel).not.toHaveBeenCalled()
+    },
+  )
+  it.each([null, {}, { ...channel, id: 8 }])(
+    "rejects malformed or mismatched native detail %s",
+    async (detail) => {
+      mocks.getChannel.mockResolvedValue(detail)
+      const operations = await openOctopusNativeResourceOperations()
+      await expect(operations.get(7)).rejects.toMatchObject({
+        failure: { code: "unexpected" },
+      })
+    },
+  )
+  it("rejects invalid migration URLs before deployment discovery", async () => {
+    const operations = await openOctopusNativeResourceOperations()
+    await expect(
+      operations.prepareMigrationBaseUrl(
+        "not a URL",
+        OctopusOutboundType.OpenAIChat,
+      ),
+    ).rejects.toMatchObject({ failure: { code: "validation_failed" } })
+    expect(mocks.usesChannelProtocolPaths).not.toHaveBeenCalled()
+  })
+  it("searches native protocol names and secondary endpoints without exposing secrets", async () => {
+    mocks.listChannels.mockResolvedValue([
+      channel,
+      { ...channel, id: 8, name: "Unknown", type: 90 },
+    ])
+    const workspace = await octopusManagedResourceRegistration.open()
+    expect(
+      (await workspace.list({ search: " ANTHROPIC " })).items.map(
+        (item) => item.displayName,
+      ),
+    ).toEqual(["Example"])
+    expect(
+      (await workspace.list({ search: "backup.example.invalid" })).total,
+    ).toBe(2)
+    expect((await workspace.list({ search: "other-secret" })).total).toBe(0)
+  })
+  it("reloads detail after an update acknowledgement without a matching identity", async () => {
+    mocks.updateChannel.mockResolvedValue({
+      success: true,
+      data: { ...channel, id: 8 },
+    })
+    mocks.getChannel.mockResolvedValue({ ...channel, name: "Confirmed" })
+    const operations = await openOctopusNativeResourceOperations()
+    expect(
+      await operations.update(channel, { name: "Confirmed" }),
+    ).toMatchObject({
+      outcome: "succeeded",
+      data: { id: 7, name: "Confirmed" },
+    })
+  })
+  it("reports uncertainty when an acknowledged update cannot be reconciled", async () => {
+    mocks.updateChannel.mockResolvedValue({ success: true, data: null })
+    mocks.getChannel.mockRejectedValue(new ApiError("Unavailable", 503))
+    const operations = await openOctopusNativeResourceOperations()
+    expect(await operations.update(channel, { name: "Renamed" })).toMatchObject(
+      {
+        outcome: "uncertain",
+        diagnostic: { code: "mutation_state_uncertain" },
+      },
+    )
+    expect(mocks.updateChannel).toHaveBeenCalledTimes(1)
+  })
+  it.each(["password-placeholder", 409])(
+    "redacts mutation diagnostics while preserving safe code %s",
+    async (code) => {
+      mocks.deleteChannel.mockRejectedValue(
+        new OctopusMutationApiError("Rejected password-placeholder", {
+          dispatch: "dispatched",
+          responseReceived: true,
+          confirmedNonApplication: true,
+          code,
+          raw: { code, message: "Rejected password-placeholder" },
+        }),
+      )
+      const workspace = await octopusManagedResourceRegistration.open()
+      const ref = (await workspace.list()).items[0].ref
+      const result = await workspace.delete(ref)
+      expect(result).toMatchObject({
+        outcome: "rejected",
+        diagnostic: {
+          message: "Rejected [REDACTED]",
+          code: typeof code === "string" ? "[REDACTED]" : 409,
+        },
+      })
+      expect(JSON.stringify(result)).not.toContain("password-placeholder")
+    },
+  )
+  it("deletes a channel with a confirmed effect and no response data", async () => {
+    mocks.deleteChannel.mockResolvedValue({ success: true, data: null })
+    const workspace = await octopusManagedResourceRegistration.open()
+    const ref = (await workspace.list()).items[0].ref
+    expect(await workspace.delete(ref)).toMatchObject({
+      outcome: "succeeded",
+      data: undefined,
+      confirmedEffects: [
+        expect.objectContaining({ kind: "resource-deleted", resourceId: 7 }),
+      ],
+    })
+  })
+  it("preserves a rejected mutation without inventing an upstream code", async () => {
+    mocks.updateChannel.mockResolvedValue({
+      success: false,
+      message: "Rejected other-secret",
+    })
+    const operations = await openOctopusNativeResourceOperations()
+    const result = await operations.update(channel, { name: "Renamed" })
+    expect(result).toMatchObject({
+      outcome: "rejected",
+      diagnostic: { message: "Rejected [REDACTED]" },
+    })
+    expect(result).not.toHaveProperty("diagnostic.code")
+  })
+  it("rejects unsupported secret and model loader fields", async () => {
+    const workspace = await octopusManagedResourceRegistration.open()
+    const editor = await workspace.openEditEditor(
+      (await workspace.list()).items[0].ref,
+    )
+    await expect(editor.loadSecret!(fields.Name)).rejects.toMatchObject({
+      failure: { code: "validation_failed" },
+    })
+    await expect(
+      editor.loadOptions!(fields.Name, editor.initialValues),
+    ).rejects.toMatchObject({ failure: { code: "validation_failed" } })
+  })
+  it("loads models with the current stored primary key without exposing it in the editor", async () => {
+    mocks.getChannel.mockResolvedValue({
+      ...channel,
+      keys: [{ enabled: true, channel_key: "primary-placeholder" }],
+    })
+    mocks.fetchRemoteModels.mockResolvedValue(["model-b"])
+    const workspace = await octopusManagedResourceRegistration.open()
+    const editor = await workspace.openEditEditor(
+      (await workspace.list()).items[0].ref,
+    )
+    expect(
+      await editor.loadOptions!(fields.Models, editor.initialValues),
+    ).toEqual([{ value: "model-b" }])
+    expect(mocks.fetchRemoteModels.mock.calls[0][1]).toMatchObject({
+      key: "primary-placeholder",
+      proxy: true,
+    })
+    expect(JSON.stringify(editor.initialValues)).not.toContain(
+      "primary-placeholder",
+    )
+  })
+  it("requires a valid URL and a replacement key before probing a create draft", async () => {
+    const editor = await (
+      await octopusManagedResourceRegistration.open()
+    ).openCreateEditor()
+    for (const values of [
+      editor.initialValues,
+      {
+        ...editor.initialValues,
+        [fields.BaseUrl]: "https://upstream.example.invalid",
+        [fields.Key]: { kind: "unchanged" },
+      },
+    ]) {
+      await expect(
+        editor.loadOptions!(fields.Models, values),
+      ).rejects.toMatchObject({ failure: { code: "validation_failed" } })
+    }
+    expect(mocks.fetchRemoteModels).not.toHaveBeenCalled()
+  })
+  it("redacts all credentials in model-probe messages and upstream codes", async () => {
+    mocks.fetchRemoteModels.mockRejectedValue(
+      new ApiError(
+        "Probe rejected draft-placeholder other-secret",
+        400,
+        undefined,
+        undefined,
+        "password-placeholder",
+      ),
+    )
+    const operations = await openOctopusNativeResourceOperations()
+    await expect(
+      operations.fetchDraftModels({
+        type: 2,
+        baseUrl: "https://upstream.example.invalid",
+        key: "draft-placeholder",
+        source: channel,
+      }),
+    ).rejects.toMatchObject({
+      failure: {
+        code: "upstream_rejected",
+        message: "Probe rejected [REDACTED] [REDACTED]",
+        upstreamCode: "[REDACTED]",
+      },
+    })
+  })
+  it.each([
+    [fields.Name, "", "required"],
+    [fields.Type, "90", "unsupported_option"],
+    [fields.Status, "unknown", "unsupported_option"],
+    [fields.BaseUrl, "not a URL", "invalid_value"],
+    [fields.Key, { kind: "clear" }, "invalid_value"],
+    [fields.Key, { kind: "replace", value: "sk-****" }, "invalid_value"],
+    [fields.Key, { kind: "unchanged" }, "invalid_value"],
+  ])(
+    "validates invalid create field %s without dispatching",
+    async (field, value, code) => {
+      const editor = await (
+        await octopusManagedResourceRegistration.open()
+      ).openCreateEditor()
+      const values = {
+        ...editor.initialValues,
+        [fields.Name]: "New",
+        [fields.BaseUrl]: "https://upstream.example.invalid",
+        [fields.Key]: { kind: "replace", value: "secret-placeholder" },
+        [field]: value,
+      }
+      expect(editor.validate(values)).toMatchObject({
+        valid: false,
+        issues: expect.arrayContaining([{ fieldId: field, code }]),
+      })
+      expect(mocks.createChannel).not.toHaveBeenCalled()
+    },
+  )
+  it("normalizes models and submits changed type and enabled state", async () => {
+    const workspace = await octopusManagedResourceRegistration.open()
+    const editor = await workspace.openEditEditor(
+      (await workspace.list()).items[0].ref,
+    )
+    await editor.submit({
+      ...editor.initialValues,
+      [fields.Type]: "0",
+      [fields.Status]: "disabled",
+      [fields.Models]: [" model-b ", "model-b", "model-c"],
+    })
+    expect(mocks.updateChannel.mock.calls[0][1]).toMatchObject({
+      type: 0,
+      enabled: false,
+      model: "model-b,model-c",
+    })
+  })
+  it("shows a missing primary credential as unavailable rather than masked", async () => {
+    mocks.getChannel.mockResolvedValue({
+      ...channel,
+      enabled: false,
+      keys: [],
+      base_urls: [],
+    })
+    const workspace = await octopusManagedResourceRegistration.open()
+    const editor = await workspace.openEditEditor(
+      (await workspace.list()).items[0].ref,
+    )
+    expect(
+      editor.fields.find((field) => field.fieldId === fields.Key),
+    ).toMatchObject({ secretState: "unavailable" })
+    expect(editor.initialValues[fields.Status]).toBe("disabled")
+    await expect(editor.loadSecret!(fields.Key)).rejects.toMatchObject({
+      failure: { code: "unavailable" },
+    })
+  })
+  it("defaults an unsupported imported type while preserving disabled status and creating the resource", async () => {
+    mocks.createChannel.mockResolvedValue({
+      success: true,
+      data: { ...channel, id: 12, type: 0, enabled: false },
+    })
+    const workspace = await octopusManagedResourceRegistration.open()
+    const editor = await workspace.openCreateEditor({
+      seed: {
+        kind: "managed-channel-import",
+        name: "Imported",
+        channelType: "90",
+        enabled: false,
+        baseUrl: "https://upstream.example.invalid",
+        credential: "secret-placeholder",
+        models: [],
+        notes: "",
+        priority: 0,
+        orderingWeight: 0,
+      },
+    })
+    expect(editor.initialValues[fields.Type]).toBe("0")
+    expect(editor.initialValues[fields.Status]).toBe("disabled")
+    expect(await editor.submit(editor.initialValues)).toMatchObject({
+      outcome: "succeeded",
+      data: { displayName: "Example", status: "disabled" },
+    })
+    expect(mocks.createChannel.mock.calls[0][1]).toMatchObject({
+      type: 0,
+      enabled: false,
+      key: "secret-placeholder",
+      model: "",
+    })
+  })
+  it("probes a new draft without an existing channel source", async () => {
+    mocks.fetchRemoteModels.mockResolvedValue(["model-a"])
+    const editor = await (
+      await octopusManagedResourceRegistration.open()
+    ).openCreateEditor()
+    expect(
+      await editor.loadOptions!(fields.Models, {
+        ...editor.initialValues,
+        [fields.BaseUrl]: "https://upstream.example.invalid",
+        [fields.Key]: { kind: "replace", value: "draft-placeholder" },
+      }),
+    ).toEqual([{ value: "model-a" }])
+    expect(mocks.fetchRemoteModels.mock.calls[0][1]).not.toHaveProperty(
+      "source",
+    )
+  })
   it("keeps useful private read diagnostics while redacting known credentials", async () => {
     mocks.listChannels.mockRejectedValue(
       new ApiError(

--- a/tests/services/apiAdapters/managedResources/octopus.test.ts
+++ b/tests/services/apiAdapters/managedResources/octopus.test.ts
@@ -341,6 +341,21 @@ describe("Octopus native resource", () => {
       model: "model-b,model-c",
     })
   })
+  it.each([null, "model-b"])(
+    "normalizes a non-list model draft %s to an empty model selection",
+    async (models) => {
+      const workspace = await octopusManagedResourceRegistration.open()
+      const editor = await workspace.openEditEditor(
+        (await workspace.list()).items[0].ref,
+      )
+      const result = await editor.submit({
+        ...editor.initialValues,
+        [fields.Models]: models,
+      })
+      expect(result.outcome).toBe("succeeded")
+      expect(mocks.updateChannel.mock.calls[0][1]).toMatchObject({ model: "" })
+    },
+  )
   it("shows a missing primary credential as unavailable rather than masked", async () => {
     mocks.getChannel.mockResolvedValue({
       ...channel,

--- a/tests/services/apiAdapters/managedResources/octopus.test.ts
+++ b/tests/services/apiAdapters/managedResources/octopus.test.ts
@@ -1,0 +1,358 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { OCTOPUS_MANAGED_RESOURCE_FIELD_IDS as fields } from "~/constants/octopus"
+import {
+  octopusManagedResourceRegistration,
+  openOctopusNativeResourceOperations,
+} from "~/services/apiAdapters/managedResources/octopus"
+import { OctopusMutationApiError } from "~/services/apiService/octopus"
+import { ApiError } from "~/services/apiTransport/errors"
+import {
+  OCTOPUS_CHANNEL_DETAIL_AVAILABILITY,
+  OctopusOutboundType,
+  type OctopusChannel,
+} from "~/types/octopus"
+
+const mocks = vi.hoisted(() => ({
+  getPreferences: vi.fn(),
+  listChannels: vi.fn(),
+  getChannel: vi.fn(),
+  createChannel: vi.fn(),
+  updateChannel: vi.fn(),
+  deleteChannel: vi.fn(),
+  fetchRemoteModels: vi.fn(),
+  usesChannelProtocolPaths: vi.fn(),
+}))
+vi.mock("~/services/preferences/userPreferences", () => ({
+  userPreferences: { getPreferences: mocks.getPreferences },
+}))
+vi.mock("~/services/apiService/octopus", async (original) => ({
+  ...(await original<typeof import("~/services/apiService/octopus")>()),
+  ...mocks,
+}))
+const channel: OctopusChannel = {
+  id: 7,
+  name: "Example",
+  type: 2,
+  enabled: true,
+  base_urls: [
+    { url: "https://upstream.example.invalid", delay: 3 },
+    { url: "https://backup.example.invalid" },
+  ],
+  keys: [
+    { id: 9, enabled: false, channel_key: "sk-****" },
+    { id: 10, enabled: true, channel_key: "other-secret" },
+  ],
+  model: "model-a",
+  proxy: true,
+  auto_sync: false,
+  auto_group: 2,
+  param_override: "{}",
+}
+describe("Octopus native resource", () => {
+  it("keeps useful private read diagnostics while redacting known credentials", async () => {
+    mocks.listChannels.mockRejectedValue(
+      new ApiError(
+        "Upstream temporarily busy: password-placeholder",
+        503,
+        undefined,
+        undefined,
+        "RATE_LIMITED",
+      ),
+    )
+    const workspace = await octopusManagedResourceRegistration.open()
+    await expect(workspace.list()).rejects.toMatchObject({
+      failure: {
+        code: "unavailable",
+        message: "Upstream temporarily busy: [REDACTED]",
+        upstreamCode: "RATE_LIMITED",
+      },
+    })
+  })
+  it.each([
+    [
+      true,
+      "https://upstream.example.invalid/v1/",
+      "https://upstream.example.invalid",
+    ],
+    [
+      true,
+      "https://upstream.example.invalid",
+      "https://upstream.example.invalid",
+    ],
+    [
+      true,
+      "https://upstream.example.invalid/custom/v2",
+      "https://upstream.example.invalid/custom/v2",
+    ],
+    [
+      false,
+      "https://upstream.example.invalid",
+      "https://upstream.example.invalid/v1",
+    ],
+  ])(
+    "adapts imported base URLs to protocol-path mode %s",
+    async (protocolPaths, baseUrl, expected) => {
+      mocks.usesChannelProtocolPaths.mockResolvedValue(protocolPaths)
+      const operations = await openOctopusNativeResourceOperations()
+      expect(
+        await operations.prepareMigrationBaseUrl(
+          baseUrl,
+          OctopusOutboundType.OpenAIChat,
+        ),
+      ).toBe(expected)
+    },
+  )
+  it.each(["/v1", "/api/v3"])(
+    "keeps the Volcengine API prefix %s for unversioned protocol paths",
+    async (path) => {
+      mocks.usesChannelProtocolPaths.mockResolvedValue(true)
+      const operations = await openOctopusNativeResourceOperations()
+      expect(
+        await operations.prepareMigrationBaseUrl(
+          `https://upstream.example.invalid${path}/`,
+          OctopusOutboundType.Volcengine,
+        ),
+      ).toBe(`https://upstream.example.invalid${path}`)
+    },
+  )
+  beforeEach(() => {
+    vi.resetAllMocks()
+    mocks.getPreferences.mockResolvedValue({
+      octopus: {
+        baseUrl: "http://hub.example.invalid",
+        username: "admin",
+        password: "password-placeholder",
+      },
+    })
+    mocks.listChannels.mockResolvedValue([channel])
+    mocks.getChannel.mockResolvedValue(channel)
+    mocks.updateChannel.mockResolvedValue({
+      success: true,
+      data: { ...channel, name: "Renamed" },
+    })
+  })
+  it("exposes native type and never exposes keys in facts", async () => {
+    const workspace = await octopusManagedResourceRegistration.open()
+    const page = await workspace.list()
+    expect(page.items[0].fields).toContainEqual({
+      fieldId: fields.Type,
+      kind: "text",
+      value: "2",
+    })
+    expect(JSON.stringify(page)).not.toContain("other-secret")
+    expect(JSON.stringify(page)).not.toContain("sk-****")
+  })
+  it("updates only changed fields using the fresh native source", async () => {
+    const workspace = await octopusManagedResourceRegistration.open()
+    const ref = (await workspace.list()).items[0].ref
+    const editor = await workspace.openEditEditor(ref)
+    await editor.submit({ ...editor.initialValues, [fields.Name]: "Renamed" })
+    expect(mocks.updateChannel.mock.calls[0][1]).toEqual({
+      id: 7,
+      name: "Renamed",
+      source: channel,
+    })
+  })
+  it("keeps unknown native types editable without converting them", async () => {
+    mocks.getChannel.mockResolvedValue({ ...channel, type: 90 })
+    const workspace = await octopusManagedResourceRegistration.open()
+    const editor = await workspace.openEditEditor(
+      (await workspace.list()).items[0].ref,
+    )
+    expect(editor.initialValues[fields.Type]).toBe("90")
+    expect(editor.validate(editor.initialValues)).toEqual({ valid: true })
+  })
+  it("treats create responses without identity as uncertain and prevents replay", async () => {
+    mocks.createChannel.mockResolvedValue({ success: true, data: null })
+    const editor = await (
+      await octopusManagedResourceRegistration.open()
+    ).openCreateEditor()
+    const values = {
+      ...editor.initialValues,
+      [fields.Name]: "New",
+      [fields.BaseUrl]: "http://upstream.example.invalid",
+      [fields.Key]: { kind: "replace" as const, value: "secret-placeholder" },
+    }
+    expect((await editor.submit(values)).outcome).toBe("uncertain")
+    await editor.submit(values)
+    expect(mocks.createChannel).toHaveBeenCalledTimes(1)
+  })
+  it("rejects scope mismatches before reading or mutating", async () => {
+    const workspace = await octopusManagedResourceRegistration.open()
+    const ref = (await workspace.list()).items[0].ref
+    await expect(
+      workspace.get({ ...ref, scopeKey: "https://other.example.invalid" }),
+    ).rejects.toMatchObject({ failure: { code: "validation_failed" } })
+    expect(mocks.getChannel).not.toHaveBeenCalled()
+  })
+  it("keeps stats-only lists lazy and does not search fabricated protocol defaults", async () => {
+    mocks.listChannels.mockResolvedValue([
+      {
+        ...channel,
+        detailAvailability: OCTOPUS_CHANNEL_DETAIL_AVAILABILITY.Summary,
+        type: 0,
+        base_urls: [],
+        keys: [],
+      },
+    ])
+    const workspace = await octopusManagedResourceRegistration.open()
+    const row = (await workspace.list()).items[0]
+    expect(row.fields.some((field) => field.fieldId === fields.Type)).toBe(
+      false,
+    )
+    expect(row.fields).toContainEqual({
+      fieldId: fields.Key,
+      kind: "secret",
+      state: "permission-hidden",
+    })
+    expect(
+      (await workspace.list({ search: "OpenAI Chat" })).items,
+    ).toHaveLength(0)
+    expect(mocks.getChannel).not.toHaveBeenCalled()
+    const editor = await workspace.openEditEditor(row.ref)
+    expect(editor.initialValues[fields.Type]).toBe("2")
+  })
+  it("loads a usable secret on demand and rejects masked credentials", async () => {
+    const workspace = await octopusManagedResourceRegistration.open()
+    const editor = await workspace.openEditEditor(
+      (await workspace.list()).items[0].ref,
+    )
+    await expect(editor.loadSecret!(fields.Key)).rejects.toMatchObject({
+      failure: { code: "unavailable" },
+    })
+    mocks.getChannel.mockResolvedValue({
+      ...channel,
+      keys: [{ enabled: true, channel_key: "secret-placeholder" }],
+    })
+    await expect(editor.loadSecret!(fields.Key)).resolves.toBe(
+      "secret-placeholder",
+    )
+  })
+  it("probes models with native type and an explicit replacement credential", async () => {
+    mocks.fetchRemoteModels.mockResolvedValue(["model-b"])
+    const workspace = await octopusManagedResourceRegistration.open()
+    const editor = await workspace.openEditEditor(
+      (await workspace.list()).items[0].ref,
+    )
+    expect(
+      editor.fields.find((field) => field.fieldId === fields.Models),
+    ).toMatchObject({
+      optionLoader: {
+        dependsOn: [fields.Type, fields.BaseUrl, fields.Key],
+        trigger: "manual",
+      },
+    })
+    const options = { signal: new AbortController().signal }
+    expect(
+      await editor.loadOptions!(
+        fields.Models,
+        {
+          ...editor.initialValues,
+          [fields.Key]: { kind: "replace", value: "secret-placeholder" },
+        },
+        options,
+      ),
+    ).toEqual([{ value: "model-b" }])
+    expect(mocks.fetchRemoteModels.mock.calls[0][1]).toMatchObject({
+      type: 2,
+      key: "secret-placeholder",
+      source: channel,
+    })
+    expect(mocks.fetchRemoteModels.mock.calls[0][2]).toBe(options)
+  })
+  it("preserves new secondary endpoints and credentials from the submit-time detail", async () => {
+    const workspace = await octopusManagedResourceRegistration.open()
+    const editor = await workspace.openEditEditor(
+      (await workspace.list()).items[0].ref,
+    )
+    const latest = {
+      ...channel,
+      keys: [...channel.keys, { enabled: true, channel_key: "third-secret" }],
+    }
+    mocks.getChannel.mockResolvedValue(latest)
+    await editor.submit({
+      ...editor.initialValues,
+      [fields.BaseUrl]: "https://new.example.invalid",
+      [fields.Key]: { kind: "replace", value: "replacement-placeholder" },
+    })
+    expect(mocks.updateChannel.mock.calls[0][1]).toEqual({
+      id: 7,
+      baseUrl: "https://new.example.invalid",
+      key: "replacement-placeholder",
+      source: latest,
+    })
+  })
+  it("retains uncertainty and redacts credentials after a dispatched server failure", async () => {
+    mocks.updateChannel.mockRejectedValue(
+      new OctopusMutationApiError(
+        "Request failed other-secret password-placeholder",
+        {
+          dispatch: "dispatched",
+          responseReceived: true,
+          confirmedNonApplication: false,
+          raw: { secret: "other-secret" },
+          statusCode: 500,
+        },
+      ),
+    )
+    const workspace = await octopusManagedResourceRegistration.open()
+    const editor = await workspace.openEditEditor(
+      (await workspace.list()).items[0].ref,
+    )
+    const result = await editor.submit({
+      ...editor.initialValues,
+      [fields.Name]: "Renamed",
+    })
+    expect(result.outcome).toBe("uncertain")
+    expect(JSON.stringify(result)).not.toContain("other-secret")
+    expect(JSON.stringify(result)).not.toContain("password-placeholder")
+    await editor.submit(editor.initialValues)
+    expect(mocks.updateChannel).toHaveBeenCalledTimes(1)
+  })
+  it.each(["https://user:password@hub.example.invalid", "file:///example"])(
+    "rejects unsafe configuration %s",
+    async (baseUrl) => {
+      mocks.getPreferences.mockResolvedValue({
+        octopus: {
+          baseUrl,
+          username: "admin",
+          password: "password-placeholder",
+        },
+      })
+      await expect(
+        octopusManagedResourceRegistration.open(),
+      ).rejects.toMatchObject({ failure: { code: "invalid_configuration" } })
+    },
+  )
+  it("rejects aborted submission before dispatch", async () => {
+    const workspace = await octopusManagedResourceRegistration.open()
+    const editor = await workspace.openEditEditor(
+      (await workspace.list()).items[0].ref,
+    )
+    const controller = new AbortController()
+    controller.abort()
+    await expect(
+      editor.submit(editor.initialValues, { signal: controller.signal }),
+    ).rejects.toMatchObject({ failure: { code: "aborted" } })
+    expect(mocks.updateChannel).not.toHaveBeenCalled()
+  })
+  it("preserves the provider-mapped import type", async () => {
+    const workspace = await octopusManagedResourceRegistration.open()
+    const editor = await workspace.openCreateEditor({
+      seed: {
+        kind: "managed-channel-import",
+        name: "Imported",
+        channelType: "2",
+        enabled: true,
+        baseUrl: "https://upstream.example.invalid",
+        credential: "secret-placeholder",
+        models: ["model-a"],
+        notes: "",
+        priority: 0,
+        orderingWeight: 0,
+      },
+    })
+    expect(editor.initialValues[fields.Type]).toBe("2")
+  })
+})

--- a/tests/services/apiAdapters/managedResources/octopusMigration.test.ts
+++ b/tests/services/apiAdapters/managedResources/octopusMigration.test.ts
@@ -1,0 +1,350 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { ChannelType } from "~/constants/managedSite"
+import { SITE_TYPES } from "~/constants/siteType"
+import { MANAGED_RESOURCE_KINDS } from "~/services/accountSiteDefinitions/contracts"
+import {
+  MANAGED_RESOURCE_FAILURE_CODES,
+  ManagedResourceError,
+} from "~/services/apiAdapters/contracts/managedResourceNative"
+import { octopusManagedSiteMigrationCapability as capability } from "~/services/apiAdapters/managedResources/octopusMigration"
+import { resolveManagedSiteMigrationCapability } from "~/services/managedSites/channelMigrationCapabilityRegistry"
+import { MANAGED_SITE_MUTATION_OUTCOMES } from "~/services/managedSites/mutations"
+import { MANAGED_SITE_CHANNEL_MIGRATION_BLOCKED_REASON_CODES as blockers } from "~/types/managedSiteMigration"
+import type { ManagedSiteMigrationSource } from "~/types/managedSiteMigrationCapability"
+import {
+  OctopusAutoGroupType,
+  OctopusOutboundType,
+  type OctopusChannel,
+} from "~/types/octopus"
+
+const mocks = vi.hoisted(() => ({
+  get: vi.fn(),
+  loadSecret: vi.fn(),
+  create: vi.fn(),
+  open: vi.fn(),
+  prepareMigrationBaseUrl: vi.fn(),
+}))
+vi.mock(
+  "~/services/apiAdapters/managedResources/octopus",
+  async (original) => ({
+    ...(await original<
+      typeof import("~/services/apiAdapters/managedResources/octopus")
+    >()),
+    openOctopusNativeResourceOperations: mocks.open,
+  }),
+)
+
+const selection = {
+  selectionId: "17",
+  displayName: "Source channel",
+  ref: {
+    siteType: SITE_TYPES.OCTOPUS,
+    kind: MANAGED_RESOURCE_KINDS.Channel,
+    scopeKey: "https://site.example.invalid",
+    resourceId: "17",
+  },
+}
+const channel: OctopusChannel = {
+  id: 17,
+  name: "Source channel",
+  type: OctopusOutboundType.Anthropic,
+  enabled: true,
+  base_urls: [{ url: "https://upstream.example.invalid/v1" }],
+  keys: [{ enabled: true, channel_key: "credential-placeholder" }],
+  model: "model-a, model-b",
+  proxy: false,
+  auto_sync: false,
+  auto_group: OctopusAutoGroupType.None,
+}
+const source: ManagedSiteMigrationSource = {
+  sourceSiteType: SITE_TYPES.NEW_API,
+  resourceType: ChannelType.OpenAI,
+  baseUrl: "http://upstream.example.invalid",
+  models: ["model-a"],
+  groups: ["vip"],
+  priority: 4,
+  weight: 5,
+  status: "other",
+  lossSignals: {
+    hasModelMapping: false,
+    hasStatusCodeMapping: false,
+    hasAdvancedSettings: false,
+    hasMultiKeyState: false,
+  },
+}
+
+describe("Octopus native migration", () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    mocks.open.mockResolvedValue({
+      scopeKey: selection.ref.scopeKey,
+      get: mocks.get,
+      loadSecret: mocks.loadSecret,
+      create: mocks.create,
+      prepareMigrationBaseUrl: mocks.prepareMigrationBaseUrl,
+    })
+    mocks.get.mockResolvedValue(channel)
+    mocks.prepareMigrationBaseUrl.mockResolvedValue(
+      "http://upstream.example.invalid/v1",
+    )
+  })
+
+  it("registers Octopus canonical source and target migration", () => {
+    expect(resolveManagedSiteMigrationCapability(SITE_TYPES.OCTOPUS)).toBe(
+      capability,
+    )
+  })
+
+  it("prepares native source facts without resolving a secret", async () => {
+    const prepared = await capability.source!.prepare(selection)
+    expect(prepared).toMatchObject({
+      status: "ready",
+      source: {
+        resourceType: ChannelType.Anthropic,
+        models: ["model-a", "model-b"],
+        baseUrl: "https://upstream.example.invalid/v1",
+      },
+    })
+    expect(JSON.stringify(prepared)).not.toContain("credential-placeholder")
+    expect(mocks.loadSecret).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    { scopeKey: "https://other.example.invalid" },
+    { resourceId: "0" },
+    { resourceId: "1.2" },
+    { resourceId: "invalid" },
+    { siteType: SITE_TYPES.NEW_API },
+  ])(
+    "blocks an invalid source reference %j before accessing it",
+    async (ref) => {
+      const invalid = { ...selection, ref: { ...selection.ref, ...ref } }
+      expect(
+        (await capability.source!.createSelectionValidationContext!()).isValid(
+          invalid,
+        ),
+      ).toBe(false)
+      await expect(capability.source!.prepare(invalid)).resolves.toEqual({
+        status: "blocked",
+        reasonCode: blockers.SOURCE_KEY_RESOLUTION_FAILED,
+      })
+      expect(mocks.get).not.toHaveBeenCalled()
+    },
+  )
+
+  it("blocks unknown provider types", async () => {
+    mocks.get.mockResolvedValue({ ...channel, type: 900 })
+    await expect(capability.source!.prepare(selection)).resolves.toEqual({
+      status: "blocked",
+      reasonCode: blockers.SOURCE_TYPE_UNSUPPORTED,
+    })
+  })
+
+  it.each([
+    {
+      base_urls: [
+        ...channel.base_urls,
+        { url: "https://alternate.example.invalid" },
+      ],
+    },
+    { custom_model: "custom-model" },
+    { custom_header: [{ header_key: "example", header_value: "placeholder" }] },
+    { param_override: "{}" },
+    { channel_proxy: "http://proxy.example.invalid" },
+    { match_regex: "model.*" },
+    { proxy: true },
+    { auto_sync: true },
+    { auto_group: OctopusAutoGroupType.Exact },
+    { type: OctopusOutboundType.OpenAIResponse },
+    { type: OctopusOutboundType.OpenAIEmbedding },
+    { hasUnrepresentedProtocolSettings: true },
+  ])(
+    "discloses native settings that the canonical draft cannot preserve %j",
+    async (detail) => {
+      mocks.get.mockResolvedValue({ ...channel, ...detail })
+      await expect(
+        capability.source!.prepare(selection),
+      ).resolves.toMatchObject({
+        source: { lossSignals: { hasAdvancedSettings: true } },
+      })
+    },
+  )
+
+  it("discloses multiple keys and resolves the execution secret independently", async () => {
+    mocks.get.mockResolvedValue({
+      ...channel,
+      keys: [
+        ...channel.keys,
+        { enabled: false, channel_key: "other-placeholder" },
+      ],
+    })
+    await expect(capability.source!.prepare(selection)).resolves.toMatchObject({
+      source: { lossSignals: { hasMultiKeyState: true } },
+    })
+    mocks.loadSecret.mockResolvedValue(" resolved-placeholder ")
+    await expect(
+      capability.source!.resolveCredential(selection),
+    ).resolves.toEqual({ status: "ready", credential: "resolved-placeholder" })
+    mocks.loadSecret.mockResolvedValue("sk-********")
+    await expect(
+      capability.source!.resolveCredential(selection),
+    ).resolves.toEqual({
+      status: "blocked",
+      reasonCode: blockers.SOURCE_KEY_MISSING,
+    })
+    mocks.loadSecret.mockRejectedValue(new Error("unavailable"))
+    await expect(
+      capability.source!.resolveCredential(selection),
+    ).resolves.toEqual({
+      status: "blocked",
+      reasonCode: blockers.SOURCE_KEY_RESOLUTION_FAILED,
+    })
+  })
+
+  it("propagates cancellation without converting it to a credential blocker", async () => {
+    const controller = new AbortController()
+    const reason = new Error("cancelled")
+    controller.abort(reason)
+    await expect(
+      capability.source!.resolveCredential(selection, {
+        signal: controller.signal,
+      }),
+    ).rejects.toBe(reason)
+    const abort = new DOMException("cancelled", "AbortError")
+    mocks.loadSecret.mockRejectedValue(abort)
+    await expect(capability.source!.resolveCredential(selection)).rejects.toBe(
+      abort,
+    )
+    mocks.loadSecret.mockRejectedValue(
+      new ManagedResourceError({
+        code: MANAGED_RESOURCE_FAILURE_CODES.Aborted,
+      }),
+    )
+    await expect(
+      capability.source!.resolveCredential(selection),
+    ).rejects.toMatchObject({ name: "AbortError" })
+  })
+
+  it("normalizes target defaults and retains HTTP upstream compatibility", async () => {
+    await expect(capability.target!.prepare(source)).resolves.toMatchObject({
+      projection: {
+        type: String(OctopusOutboundType.OpenAIChat),
+        baseUrl: "http://upstream.example.invalid/v1",
+        groups: ["default"],
+        priority: 0,
+        weight: 0,
+        status: 2,
+      },
+      adjustments: {
+        normalizedBaseUrl: true,
+        forcedDefaultGroup: true,
+        ignoredPriority: true,
+        ignoredWeight: true,
+        simplifiedStatus: true,
+      },
+    })
+    await expect(
+      capability.target!.prepare({
+        ...source,
+        resourceType: ChannelType.Unknown,
+      }),
+    ).rejects.toThrow("does not support")
+  })
+
+  it("uses the target generation's URL preparation without appending another version path", async () => {
+    mocks.prepareMigrationBaseUrl.mockResolvedValue(
+      "http://upstream.example.invalid",
+    )
+    const controller = new AbortController()
+    const options = { signal: controller.signal }
+    await expect(
+      capability.target!.prepare(
+        { ...source, baseUrl: "http://upstream.example.invalid/v1" },
+        options,
+      ),
+    ).resolves.toMatchObject({
+      projection: { baseUrl: "http://upstream.example.invalid" },
+      adjustments: { normalizedBaseUrl: true },
+    })
+    expect(mocks.prepareMigrationBaseUrl).toHaveBeenCalledWith(
+      "http://upstream.example.invalid/v1",
+      OctopusOutboundType.OpenAIChat,
+      options,
+    )
+  })
+
+  it.each(["/api/v3", "/v1"])(
+    "passes the mapped protocol when preserving a versioned upstream root %s",
+    async (path) => {
+      const baseUrl = `https://upstream.example.invalid${path}`
+      mocks.prepareMigrationBaseUrl.mockResolvedValue(baseUrl)
+      await expect(
+        capability.target!.prepare({
+          ...source,
+          resourceType: ChannelType.VolcEngine,
+          baseUrl,
+        }),
+      ).resolves.toMatchObject({
+        projection: { type: String(OctopusOutboundType.Volcengine), baseUrl },
+        adjustments: { normalizedBaseUrl: false },
+      })
+      expect(mocks.prepareMigrationBaseUrl).toHaveBeenCalledWith(
+        baseUrl,
+        OctopusOutboundType.Volcengine,
+        undefined,
+      )
+    },
+  )
+
+  it.each([
+    [MANAGED_SITE_MUTATION_OUTCOMES.Succeeded, "created"],
+    [MANAGED_SITE_MUTATION_OUTCOMES.Rejected, "failed"],
+    [MANAGED_SITE_MUTATION_OUTCOMES.Partial, "uncertain"],
+    [MANAGED_SITE_MUTATION_OUTCOMES.Uncertain, "uncertain"],
+  ])(
+    "maps native create outcome %s without replaying",
+    async (outcome, status) => {
+      mocks.create.mockResolvedValue({ outcome })
+      const { projection } = await capability.target!.prepare(source)
+      await expect(
+        capability.target!.create({
+          source,
+          targetSiteType: SITE_TYPES.OCTOPUS,
+          projection: { ...projection, name: "Migrated channel" },
+          credential: "credential-placeholder",
+        }),
+      ).resolves.toMatchObject({ status })
+      expect(mocks.create).toHaveBeenCalledTimes(1)
+      expect(mocks.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: "Migrated channel",
+          type: OctopusOutboundType.OpenAIChat,
+          model: "model-a",
+          enabled: false,
+          key: "credential-placeholder",
+        }),
+        undefined,
+      )
+    },
+  )
+
+  it.each([
+    { type: "999" },
+    { name: " " },
+    { baseUrl: "javascript:invalid" },
+    { baseUrl: "https://user:password@example.invalid" },
+    { models: [] },
+  ])("rejects malformed target projections %j", async (overrides) => {
+    const { projection } = await capability.target!.prepare(source)
+    await expect(
+      capability.target!.create({
+        source,
+        targetSiteType: SITE_TYPES.OCTOPUS,
+        projection: { ...projection, name: "Migrated channel", ...overrides },
+        credential: "credential-placeholder",
+      }),
+    ).resolves.toMatchObject({ status: "failed" })
+    expect(mocks.create).not.toHaveBeenCalled()
+  })
+})

--- a/tests/services/apiService/octopus.index.test.ts
+++ b/tests/services/apiService/octopus.index.test.ts
@@ -14,6 +14,7 @@ import {
   OctopusMutationApiError,
   searchChannels,
   updateChannel,
+  usesChannelProtocolPaths,
   validateOctopusConfig,
 } from "~/services/apiService/octopus"
 import {
@@ -1365,6 +1366,54 @@ describe("Octopus API service", () => {
         mockTempWindowOctopusApiFetch.mock.calls[0][0].fetchOptions.body,
       ),
     ).toEqual({ id: 7 })
+  })
+
+  it("reuses the confirmed deployment generation when resolving protocol path behavior", async () => {
+    mockGetValidSession.mockResolvedValue(v013CookieSession())
+    await expect(usesChannelProtocolPaths(config)).resolves.toBe(true)
+    mockGetValidSession.mockResolvedValue(currentCookieSession())
+    await expect(usesChannelProtocolPaths(config)).resolves.toBe(false)
+    expect(mockTempWindowOctopusApiFetch).not.toHaveBeenCalled()
+    const controller = new AbortController()
+    controller.abort()
+    await expect(
+      usesChannelProtocolPaths(config, { signal: controller.signal }),
+    ).rejects.toMatchObject({ name: "AbortError" })
+    expect(mockGetValidSession).toHaveBeenCalledTimes(2)
+  })
+
+  it("passes the cancellation signal and protection execution into create and delete", async () => {
+    const execution = createAutomaticProtectionBypassExecution(
+      PROTECTION_BYPASS_FEATURES.ManagedSiteModelSync,
+      PROTECTION_BYPASS_AUTOMATIC_TRIGGERS.Scheduled,
+      PROTECTION_BYPASS_SURFACES.Background,
+    )
+    const signal = new AbortController().signal
+    mockGetValidSession.mockResolvedValue(currentCookieSession())
+    mockTempWindowOctopusApiFetch.mockResolvedValue({
+      success: true,
+      status: 200,
+      data: { code: 200, data: null },
+    })
+    await createChannel(
+      config,
+      {
+        name: "Example",
+        type: OctopusOutboundType.OpenAIChat,
+        baseUrl: "https://upstream.example.invalid",
+        key: "credential-placeholder",
+      },
+      { signal, protectionBypassExecution: execution },
+    )
+    await deleteChannel(config, 7, {
+      signal,
+      protectionBypassExecution: execution,
+    })
+    expect(mockTempWindowOctopusApiFetch).toHaveBeenCalledTimes(2)
+    for (const [request] of mockTempWindowOctopusApiFetch.mock.calls) {
+      expect(request.protectionBypassExecution).toBe(execution)
+      expect(request.fetchOptions.signal).toBe(signal)
+    }
   })
 
   it("preserves one model-sync execution across cookie login and retry", async () => {

--- a/tests/services/apiService/octopus.v013.test.ts
+++ b/tests/services/apiService/octopus.v013.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from "vitest"
 
 import { OCTOPUS_API_OPERATIONS } from "~/services/apiService/octopus/operations"
 import { octopusV013Contract } from "~/services/apiService/octopus/v013"
-import { OctopusOutboundType } from "~/types/octopus"
+import {
+  OCTOPUS_CHANNEL_DETAIL_AVAILABILITY,
+  OctopusOutboundType,
+} from "~/types/octopus"
 
 const detailResponse = (overrides: Record<string, unknown> = {}) => ({
   id: 7,
@@ -44,6 +47,36 @@ const parseRequestBody = (
 ) => JSON.parse(request.init.body as string) as Record<string, unknown>
 
 describe("Octopus v0.13 contract", () => {
+  it.each([
+    { dialect: "custom" },
+    { openai_chat_completion_path: "/custom/chat" },
+    { grants: [{ model_name: "model-a", key_name: "default", protocols: 6 }] },
+    { grants: [] },
+    {
+      grants: [{ model_name: "model-a", key_name: "secondary", protocols: 2 }],
+    },
+  ])(
+    "marks protocol details that single-type migration cannot represent: %j",
+    (overrides) => {
+      expect(
+        octopusV013Contract.normalizeChannel(detailResponse(overrides))
+          .hasUnrepresentedProtocolSettings,
+      ).toBe(true)
+      expect(
+        octopusV013Contract.normalizeChannel(detailResponse())
+          .hasUnrepresentedProtocolSettings,
+      ).toBe(false)
+    },
+  )
+  it("marks stats inventories as summaries so missing protocol data is not treated as a native type", () => {
+    const stats = octopusV013Contract.parseStatsList([statsResponse()])[0]
+    expect(
+      octopusV013Contract.normalizeStatsChannel(stats).detailAvailability,
+    ).toBe(OCTOPUS_CHANNEL_DETAIL_AVAILABILITY.Summary)
+    expect(
+      octopusV013Contract.normalizeChannel(detailResponse()).detailAvailability,
+    ).not.toBe(OCTOPUS_CHANNEL_DETAIL_AVAILABILITY.Summary)
+  })
   it.each([
     {
       name: "OpenAI Responses",


### PR DESCRIPTION
## Summary

Continue the managed-site native-resource migration by moving Octopus channel management and migration onto the provider-native resource registration.

- Before: Octopus channel management used the legacy channel route. After: list/search, create/edit/delete, lazy secret/model loading, and migration use the native resource workspace and Octopus-owned contracts.
- Preserve unchanged credentials, additional keys/URLs, and advanced settings by loading full detail before updates; keep legacy JWT and cookie API version compatibility and HTTP/LAN support.
- Add migration compatibility/loss warnings, native target-type labels, and version-aware base-URL normalization to avoid duplicated /v1 paths while preserving Volcengine paths.
- Share mutation handling with the existing Octopus adapter and reuse the existing editor and telemetry. Removing all legacy entry points is outside this PR.

## Validation

- Real deployment: `AAH_E2E_MANAGED_SITE_TARGET=octopus AAH_E2E_REAL_SITE_CATEGORY=managed-site pnpm exec playwright test e2e/realSite/managedSiteChannels.spec.ts --project=chromium --workers=1 --reporter=list` — passed on `eb142d48375ac004b8f16998ea09ba14b8348eee`: 2 passed (build + live CRUD/search), 1 pre-existing token-status skip, 1.0 minute. Temporary-channel cleanup completed.
- Intercepted extension E2E: Octopus channel edit preserves the existing key and persists changes after reload.
- Focused native resource, migration, transport, route, and presentation tests passed during implementation; staged validation (format, lint, related tests, and i18n) passed.
- Pre-push `pnpm compile && pnpm knip` — passed. The initial push was blocked by one unused export; keeping that editor helper private resolved it without changing runtime logic.

## Scope and limitations

Real-site coverage exercises channel CRUD/search and cleanup, not cross-site migration or paid model requests. The existing Octopus token-channel-status case is intentionally skipped by the suite. Migration compatibility and lossy-field behavior are covered at the adapter boundary with unit tests.

No linked issue is closed by this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added native Octopus channel management for listing, creating, editing, deleting, model discovery, and secure credential handling.
  - Added support for OpenAI Chat and Anthropic channel types.
  - Added Octopus channel migration with validation, compatibility checks, and warnings for settings that cannot be preserved.
  - Added support for multiple Octopus API protocol versions and summary channel data.

- **Bug Fixes**
  - Improved mutation error reporting, cancellation behavior, and protection of sensitive information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->