### PR TITLE
fix(checkin): persist capability loss and refine safe retries

### DIFF
--- a/.scratch/checkin-method-discovery/spec.md
+++ b/.scratch/checkin-method-discovery/spec.md
@@ -9,6 +9,18 @@
 
 ## 1. Goals and Non-Goals
 
+### 2026-09-06 execution recovery amendment
+
+This amendment refines issue #1270's blanket exclusion of `unknown` and `skipped` from retries. It changes execution policy and account-state merging, without changing account V7, the backup envelope, or persisted result shapes.
+
+- Authoritative method-unsupported evidence from either selected status readback or a definitive mutation failure is persisted. The merge preserves manual/automatic selection, automatic intent, custom URLs, and newer discovery facts. A missing account or failed write produces a visible, non-retryable account-unavailable failure instead of silently losing the write.
+- Before a mutation is sent, a required status query may be retried within the scheduler's existing daily attempt limit only for classified network, timeout, or source-unavailable failures. Authentication, permission, identity, credential-persistence, malformed-response, and missing-status problems do not enter ordinary automatic retry.
+- Internal `blocked` results distinguish failed execution prerequisites/local persistence from deliberate `skipped` outcomes. The scheduler persists them using the existing `failed` result and explicit `retryable` field. Legacy persisted failures retain their existing compatibility behavior.
+- A retry still requires a fresh usable status read before mutation. An uncertain mutation is never replayed inline; a later retry requires a provider's verified idempotency policy and authoritative enabled/not-checked reconciliation. Disabled or unresolved reconciliation never admits a retry.
+- Existing providers retain best-effort status readback on first attempts where their protocol permits it. Explicit unsupported or authentication/permission evidence stops execution even on that compatibility path.
+
+Issue #1270 acceptance wording should therefore require **evidence-based safe retry admission**, rather than prohibiting every unknown observation from being queried again. The focused acceptance seams are selected execution, account-state persistence, and the scheduler's public run/retry behavior.
+
 ### Goals
 
 Establish a general check-in method model for each account so the system can:

--- a/src/constants/checkIn.ts
+++ b/src/constants/checkIn.ts
@@ -121,4 +121,5 @@ export const CHECK_IN_EXECUTION_SKIP_REASONS = {
 export const CHECK_IN_METHOD_EXECUTION_RESULT_KINDS = {
   Executed: "executed",
   Skipped: "skipped",
+  Blocked: "blocked",
 } as const

--- a/src/services/checkin/autoCheckin/methods.ts
+++ b/src/services/checkin/autoCheckin/methods.ts
@@ -1,10 +1,12 @@
 import {
   CHECK_IN_EXECUTION_SKIP_REASONS,
+  CHECK_IN_METHOD_AVAILABILITIES,
   CHECK_IN_METHOD_DETECTION_EVIDENCE_SOURCES,
   CHECK_IN_METHOD_DETECTION_OUTCOMES,
   CHECK_IN_METHOD_EXECUTION_RESULT_KINDS,
   CHECK_IN_METHOD_STATUS_OUTCOMES,
   CHECK_IN_METHOD_TODAY_STATUSES,
+  CHECK_IN_METHOD_UNKNOWN_REASON_CODES,
   CHECK_IN_PROVIDER_READINESS_REASONS,
 } from "~/constants/checkIn"
 import type { AccountSiteType } from "~/constants/siteType"
@@ -44,6 +46,7 @@ import type {
   CheckInConfig,
   CheckInExecutionSkipReason,
   CheckInMethodId,
+  CheckInMethodUnknownReason,
 } from "~/types/checkIn"
 
 export { setCheckInSelection } from "~/services/checkin/autoCheckin/discovery"
@@ -74,8 +77,12 @@ type ExecuteSelectedCheckInResult =
   | {
       kind: typeof CHECK_IN_METHOD_EXECUTION_RESULT_KINDS.Skipped
       reason: CheckInExecutionSkipReason
-      /** Whether a bounded retry can safely repeat this pre-mutation check. */
-      retryable?: boolean
+    }
+  | {
+      /** Execution or local state recovery failed; persisted as an existing failed result. */
+      kind: typeof CHECK_IN_METHOD_EXECUTION_RESULT_KINDS.Blocked
+      reason: CheckInExecutionSkipReason
+      retryable: boolean
     }
 
 const resolveSelectedCheckInRegistration = (input: {
@@ -150,8 +157,49 @@ const canSafelyRetryProviderResult = (
 const canRetryStatusConfirmationFailure = (
   reason: CheckInExecutionSkipReason,
 ): boolean =>
-  reason !== CHECK_IN_EXECUTION_SKIP_REASONS.AuthenticationRequired &&
-  reason !== CHECK_IN_EXECUTION_SKIP_REASONS.PermissionDenied
+  reason === CHECK_IN_EXECUTION_SKIP_REASONS.NetworkError ||
+  reason === CHECK_IN_EXECUTION_SKIP_REASONS.Timeout ||
+  reason === CHECK_IN_EXECUTION_SKIP_REASONS.SourceUnavailable
+
+const statusReadFailure = (
+  reason: CheckInExecutionSkipReason,
+): ExecuteSelectedCheckInResult =>
+  reason === CHECK_IN_EXECUTION_SKIP_REASONS.AuthenticationRequired ||
+  reason === CHECK_IN_EXECUTION_SKIP_REASONS.PermissionDenied
+    ? { kind: CHECK_IN_METHOD_EXECUTION_RESULT_KINDS.Skipped, reason }
+    : {
+        kind: CHECK_IN_METHOD_EXECUTION_RESULT_KINDS.Blocked,
+        reason,
+        retryable: canRetryStatusConfirmationFailure(reason),
+      }
+
+const toUnknownStatusSkipReason = (
+  reason: CheckInMethodUnknownReason,
+): CheckInExecutionSkipReason => {
+  switch (reason) {
+    case CHECK_IN_METHOD_UNKNOWN_REASON_CODES.AuthenticationRequired:
+    case CHECK_IN_METHOD_UNKNOWN_REASON_CODES.IdentityMismatch:
+      return CHECK_IN_EXECUTION_SKIP_REASONS.AuthenticationRequired
+    case CHECK_IN_METHOD_UNKNOWN_REASON_CODES.PermissionDenied:
+      return CHECK_IN_EXECUTION_SKIP_REASONS.PermissionDenied
+    case CHECK_IN_METHOD_UNKNOWN_REASON_CODES.CredentialPersistenceFailed:
+      return CHECK_IN_EXECUTION_SKIP_REASONS.AccountUnavailable
+    case CHECK_IN_METHOD_UNKNOWN_REASON_CODES.Network:
+      return CHECK_IN_EXECUTION_SKIP_REASONS.NetworkError
+    case CHECK_IN_METHOD_UNKNOWN_REASON_CODES.Timeout:
+      return CHECK_IN_EXECUTION_SKIP_REASONS.Timeout
+    case CHECK_IN_METHOD_UNKNOWN_REASON_CODES.SourceUnavailable:
+      return CHECK_IN_EXECUTION_SKIP_REASONS.SourceUnavailable
+    case CHECK_IN_METHOD_UNKNOWN_REASON_CODES.InvalidResponse:
+      return CHECK_IN_EXECUTION_SKIP_REASONS.StatusUnavailable
+  }
+}
+
+const accountStateWriteFailure = (): ExecuteSelectedCheckInResult => ({
+  kind: CHECK_IN_METHOD_EXECUTION_RESULT_KINDS.Blocked,
+  reason: CHECK_IN_EXECUTION_SKIP_REASONS.AccountUnavailable,
+  retryable: false,
+})
 
 const createMutationLifecycle = (): AutoCheckinMutationLifecycle => {
   const lifecycle: AutoCheckinMutationLifecycle = {
@@ -174,6 +222,34 @@ const createMutationLifecycle = (): AutoCheckinMutationLifecycle => {
 type RevalidateCheckInAccount = (
   refreshedConfig?: CheckInConfig,
 ) => Promise<SiteAccount | null>
+
+/** Saves authoritative capability loss through the account-state merge used by status readback. */
+const persistUnsupportedMethod = async (
+  account: SiteAccount,
+  methodId: CheckInMethodId,
+  revalidateAccount?: RevalidateCheckInAccount,
+): Promise<boolean> => {
+  if (!revalidateAccount) return true
+  try {
+    return (
+      (await revalidateAccount(
+        replaceCheckInMethodDetection({
+          config: account.checkIn,
+          methodId,
+          detection: {
+            outcome: CHECK_IN_METHOD_DETECTION_OUTCOMES.Unsupported,
+            evidence: {
+              source: CHECK_IN_METHOD_DETECTION_EVIDENCE_SOURCES.Probe,
+              observedAt: Date.now(),
+            },
+          },
+        }),
+      )) !== null
+    )
+  } catch {
+    return false
+  }
+}
 
 const hasSameCheckInAccountIdentity = (
   currentAccount: SiteAccount,
@@ -278,7 +354,8 @@ const reconcileUncertainResult = async (input: {
     }
     return {
       ...input.providerResult,
-      ...(input.retryAfterNotChecked
+      ...(input.retryAfterNotChecked &&
+      status.availability === CHECK_IN_METHOD_AVAILABILITIES.Enabled
         ? {
             status: CHECKIN_RESULT_STATUS.FAILED,
             retryable: true,
@@ -371,7 +448,6 @@ export async function executeSelectedCheckIn(input: {
     return {
       kind: CHECK_IN_METHOD_EXECUTION_RESULT_KINDS.Skipped,
       reason: CHECK_IN_EXECUTION_SKIP_REASONS.StatusUnavailable,
-      retryable: false,
     }
   }
 
@@ -384,17 +460,27 @@ export async function executeSelectedCheckIn(input: {
         observedAt: Date.now(),
       })
       if (status) {
-        if (
-          requiresAuthoritativeStatus &&
-          status.outcome !== CHECK_IN_METHOD_STATUS_OUTCOMES.Known
-        ) {
-          return {
-            kind: CHECK_IN_METHOD_EXECUTION_RESULT_KINDS.Skipped,
-            reason: CHECK_IN_EXECUTION_SKIP_REASONS.StatusUnavailable,
-            retryable: true,
+        if (status.outcome === CHECK_IN_METHOD_STATUS_OUTCOMES.Unknown) {
+          const reason = toUnknownStatusSkipReason(status.reason)
+          if (
+            requiresAuthoritativeStatus ||
+            reason === CHECK_IN_EXECUTION_SKIP_REASONS.AuthenticationRequired ||
+            reason === CHECK_IN_EXECUTION_SKIP_REASONS.PermissionDenied ||
+            reason === CHECK_IN_EXECUTION_SKIP_REASONS.AccountUnavailable
+          ) {
+            return statusReadFailure(reason)
           }
         }
         if (status.outcome === CHECK_IN_METHOD_STATUS_OUTCOMES.Known) {
+          if (
+            requiresAuthoritativeStatus &&
+            status.availability !== CHECK_IN_METHOD_AVAILABILITIES.Disabled &&
+            status.today === undefined
+          ) {
+            return statusReadFailure(
+              CHECK_IN_EXECUTION_SKIP_REASONS.StatusUnavailable,
+            )
+          }
           statusProof = status
         }
         refreshedConfig = replaceCheckInMethodStatus({
@@ -403,48 +489,30 @@ export async function executeSelectedCheckIn(input: {
           status,
         })
       } else if (requiresAuthoritativeStatus) {
-        return {
-          kind: CHECK_IN_METHOD_EXECUTION_RESULT_KINDS.Skipped,
-          reason: CHECK_IN_EXECUTION_SKIP_REASONS.StatusUnavailable,
-          retryable: true,
-        }
+        return statusReadFailure(
+          CHECK_IN_EXECUTION_SKIP_REASONS.StatusUnavailable,
+        )
       }
     } catch (error) {
       const reason = toStatusReadSkipReason(error)
+      if (reason === CHECK_IN_EXECUTION_SKIP_REASONS.MethodUnsupported) {
+        if (
+          !(await persistUnsupportedMethod(
+            input.account,
+            registration.id,
+            input.revalidateAccount,
+          ))
+        ) {
+          return accountStateWriteFailure()
+        }
+        return { kind: CHECK_IN_METHOD_EXECUTION_RESULT_KINDS.Skipped, reason }
+      }
       if (
         requiresAuthoritativeStatus ||
         reason === CHECK_IN_EXECUTION_SKIP_REASONS.AuthenticationRequired ||
         reason === CHECK_IN_EXECUTION_SKIP_REASONS.PermissionDenied
       ) {
-        if (
-          reason === CHECK_IN_EXECUTION_SKIP_REASONS.MethodUnsupported &&
-          input.revalidateAccount
-        ) {
-          try {
-            await input.revalidateAccount(
-              replaceCheckInMethodDetection({
-                config: input.account.checkIn,
-                methodId: registration.id,
-                detection: {
-                  outcome: CHECK_IN_METHOD_DETECTION_OUTCOMES.Unsupported,
-                  evidence: {
-                    source: CHECK_IN_METHOD_DETECTION_EVIDENCE_SOURCES.Probe,
-                    observedAt: Date.now(),
-                  },
-                },
-              }),
-            )
-          } catch {
-            // Preserve the authoritative execution result when local persistence is unavailable.
-          }
-        }
-        return {
-          kind: CHECK_IN_METHOD_EXECUTION_RESULT_KINDS.Skipped,
-          reason,
-          retryable:
-            input.requireStatusConfirmationBeforeMutation === true &&
-            canRetryStatusConfirmationFailure(reason),
-        }
+        return statusReadFailure(reason)
       }
     }
   }
@@ -505,6 +573,20 @@ export async function executeSelectedCheckIn(input: {
     ...(statusProof ? { statusProof } : {}),
     ...(beforeRecoveredMutation ? { beforeRecoveredMutation } : {}),
   })
+  if (
+    providerResult.status === CHECKIN_RESULT_STATUS.FAILED &&
+    providerResult.reasonCode === AUTO_CHECKIN_SKIP_REASON.METHOD_UNSUPPORTED
+  ) {
+    if (
+      !(await persistUnsupportedMethod(
+        currentAccount,
+        registration.id,
+        input.revalidateAccount,
+      ))
+    ) {
+      return accountStateWriteFailure()
+    }
+  }
   const result =
     providerResult.status === CHECKIN_RESULT_STATUS.UNCERTAIN
       ? await reconcileUncertainResult({

--- a/src/services/checkin/autoCheckin/scheduler.ts
+++ b/src/services/checkin/autoCheckin/scheduler.ts
@@ -1128,18 +1128,19 @@ class AutoCheckinScheduler {
           ),
         requireStatusConfirmationBeforeMutation,
       })
-      if (execution.kind === CHECK_IN_METHOD_EXECUTION_RESULT_KINDS.Skipped) {
+      if (execution.kind !== CHECK_IN_METHOD_EXECUTION_RESULT_KINDS.Executed) {
         const reasonCode = toSchedulerSkipReason(execution.reason)
-        const retryablePreMutationFailure = execution.retryable === true
+        const blocked =
+          execution.kind === CHECK_IN_METHOD_EXECUTION_RESULT_KINDS.Blocked
         return {
           result: buildResult(
-            retryablePreMutationFailure
+            blocked
               ? CHECKIN_RESULT_STATUS.FAILED
               : CHECKIN_RESULT_STATUS.SKIPPED,
             {
               messageKey: getAutoCheckinSkipReasonTranslationKey(reasonCode),
               reasonCode,
-              ...(retryablePreMutationFailure ? { retryable: true } : {}),
+              ...(blocked ? { retryable: execution.retryable } : {}),
             },
           ),
         }

--- a/src/services/checkin/autoCheckin/state.ts
+++ b/src/services/checkin/autoCheckin/state.ts
@@ -1,4 +1,6 @@
 import {
+  CHECK_IN_METHOD_DETECTION_EVIDENCE_SOURCES,
+  CHECK_IN_METHOD_DETECTION_OUTCOMES,
   CHECK_IN_METHOD_STATUS_EVIDENCE_SOURCES,
   CHECK_IN_METHOD_STATUS_OUTCOMES,
   CHECK_IN_METHOD_TODAY_STATUSES,
@@ -207,7 +209,7 @@ export function mergeDiscoveredCheckInDraft(input: {
   }
 }
 
-/** Applies refreshed Status facts without rolling back user or discovery state. */
+/** Applies status and authoritative capability loss without rolling back user choices or newer discovery. */
 export function mergeRefreshedCheckInStatus(input: {
   latest: CheckInConfig
   refreshed: CheckInConfig
@@ -219,7 +221,25 @@ export function mergeRefreshedCheckInStatus(input: {
     input.refreshed.methodKnowledge.methods,
   ) as Array<[CheckInMethodId, CheckInMethodKnowledge]>) {
     const latestKnowledge = methods[methodId]
-    if (!latestKnowledge || !refreshedKnowledge.status) continue
+    if (!latestKnowledge) continue
+    const detection = refreshedKnowledge.detection
+    const latestDetection = latestKnowledge.detection
+    const latestDetectionTimestamp =
+      latestDetection.outcome === CHECK_IN_METHOD_DETECTION_OUTCOMES.Unknown
+        ? latestDetection.attemptedAt
+        : latestDetection.evidence.source ===
+            CHECK_IN_METHOD_DETECTION_EVIDENCE_SOURCES.Probe
+          ? latestDetection.evidence.observedAt
+          : undefined
+    if (
+      detection.outcome === CHECK_IN_METHOD_DETECTION_OUTCOMES.Unsupported &&
+      (latestDetectionTimestamp === undefined ||
+        detection.evidence.observedAt > latestDetectionTimestamp)
+    ) {
+      methods[methodId] = { ...latestKnowledge, detection }
+      changed = true
+    }
+    if (!refreshedKnowledge.status) continue
     const latestTimestamp = getCheckInMethodStatusTimestamp(
       latestKnowledge.status,
     )
@@ -234,7 +254,7 @@ export function mergeRefreshedCheckInStatus(input: {
       continue
     }
     methods[methodId] = {
-      ...latestKnowledge,
+      ...methods[methodId]!,
       status: refreshedKnowledge.status,
     }
     changed = true

--- a/tests/services/accountStorage.test.ts
+++ b/tests/services/accountStorage.test.ts
@@ -1446,6 +1446,63 @@ describe("accountStorage core behaviors", () => {
     )
   })
 
+  it.each([100, 300])(
+    "persists only newer unsupported evidence while retaining manual intent (latest %s)",
+    async (observedAt) => {
+      const methodId = "new-api:daily-checkin" as const
+      const account = createAccount({
+        id: "unsupported-execution",
+        checkIn: {
+          automaticExecutionEnabled: true,
+          selection: { mode: "manual", methodId },
+          customCheckIn: { url: "https://check-in.example.invalid" },
+          methodKnowledge: {
+            methods: {
+              [methodId]: {
+                detection: {
+                  outcome: "matched",
+                  evidence: { source: "probe", observedAt },
+                },
+              },
+            },
+          },
+        },
+      })
+      seedStorage([account])
+      await accountStorage.prepareAccountForSelectedCheckIn(account.id, {
+        ...account.checkIn,
+        selection: { mode: "automatic" },
+        automaticExecutionEnabled: false,
+        customCheckIn: undefined,
+        methodKnowledge: {
+          methods: {
+            [methodId]: {
+              detection: {
+                outcome: "unsupported",
+                evidence: { source: "probe", observedAt: 200 },
+              },
+            },
+          },
+        },
+      })
+      const persisted = await accountStorage.getAccountById(account.id)
+      expect(persisted?.checkIn).toMatchObject({
+        selection: account.checkIn.selection,
+        automaticExecutionEnabled: true,
+        customCheckIn: account.checkIn.customCheckIn,
+        methodKnowledge: {
+          methods: {
+            [methodId]: {
+              detection: {
+                outcome: observedAt < 200 ? "unsupported" : "matched",
+              },
+            },
+          },
+        },
+      })
+    },
+  )
+
   it("prepares the current account without writing when no refreshed check-in is provided", async () => {
     const account = createAccount({ id: "prepare-current" })
     seedStorage([account])

--- a/tests/services/accountStorage.test.ts
+++ b/tests/services/accountStorage.test.ts
@@ -1446,9 +1446,14 @@ describe("accountStorage core behaviors", () => {
     )
   })
 
-  it.each([100, 300])(
-    "persists only newer unsupported evidence while retaining manual intent (latest %s)",
-    async (observedAt) => {
+  it.each([
+    [100, "matched", "unsupported"],
+    [300, "matched", "matched"],
+    [100, "unknown", "unsupported"],
+    [300, "unknown", "unknown"],
+  ] as const)(
+    "persists only newer unsupported evidence while retaining manual intent (latest %s, %s)",
+    async (observedAt, latestOutcome, expectedOutcome) => {
       const methodId = "new-api:daily-checkin" as const
       const account = createAccount({
         id: "unsupported-execution",
@@ -1459,10 +1464,17 @@ describe("accountStorage core behaviors", () => {
           methodKnowledge: {
             methods: {
               [methodId]: {
-                detection: {
-                  outcome: "matched",
-                  evidence: { source: "probe", observedAt },
-                },
+                detection:
+                  latestOutcome === "unknown"
+                    ? {
+                        outcome: "unknown",
+                        reason: "network",
+                        attemptedAt: observedAt,
+                      }
+                    : {
+                        outcome: "matched",
+                        evidence: { source: "probe", observedAt },
+                      },
               },
             },
           },
@@ -1494,7 +1506,7 @@ describe("accountStorage core behaviors", () => {
           methods: {
             [methodId]: {
               detection: {
-                outcome: observedAt < 200 ? "unsupported" : "matched",
+                outcome: expectedOutcome,
               },
             },
           },

--- a/tests/services/autoCheckin/checkInMethods.test.ts
+++ b/tests/services/autoCheckin/checkInMethods.test.ts
@@ -8,6 +8,7 @@ import {
   CHECK_IN_METHOD_UNKNOWN_REASON_CODES,
 } from "~/constants/checkIn"
 import { SITE_TYPES } from "~/constants/siteType"
+import { ApiError } from "~/services/apiTransport/errors"
 import { createCompatibilityCheckInConfig } from "~/services/checkin/autoCheckin/compatibilityConfig"
 import {
   discoverCheckInMethods,
@@ -930,9 +931,9 @@ describe("check-in methods compatibility activation", () => {
       })
 
       expect(result).toMatchObject({
-        kind: "skipped",
+        kind: "blocked",
         reason: expectedReason,
-        retryable: true,
+        retryable: expectedReason !== "status_unavailable",
       })
       expect(checkInRequest).not.toHaveBeenCalled()
     },
@@ -954,9 +955,9 @@ describe("check-in methods compatibility activation", () => {
     })
 
     expect(result).toMatchObject({
-      kind: "skipped",
+      kind: "blocked",
       reason: "status_unavailable",
-      retryable: true,
+      retryable: false,
     })
     expect(checkInRequest).not.toHaveBeenCalled()
   })
@@ -981,12 +982,86 @@ describe("check-in methods compatibility activation", () => {
     })
 
     expect(result).toMatchObject({
-      kind: "skipped",
+      kind: "blocked",
       reason: "status_unavailable",
-      retryable: true,
+      retryable: false,
     })
     expect(checkInRequest).not.toHaveBeenCalled()
   })
+
+  it.each([
+    "authentication_required",
+    "permission_denied",
+    "identity_mismatch",
+    "credential_persistence_failed",
+  ] as const)(
+    "does not retry a status observation requiring repair: %s",
+    async (reason) => {
+      const registration = getNewApiExecutionRegistration()
+      vi.spyOn(registration.provider, "getStatus").mockResolvedValue({
+        outcome: "unknown",
+        reason,
+        attemptedAt: 200,
+      })
+      const mutate = vi
+        .spyOn(registration.provider, "checkIn")
+        .mockResolvedValue({ status: "success" })
+      const result = await executeSelectedCheckIn({
+        account: createNewApiExecutionAccount(),
+        globalAutomaticExecutionEnabled: true,
+        context: createExecutionContext(),
+        requireStatusConfirmationBeforeMutation: true,
+      })
+      expect(result).not.toHaveProperty("retryable", true)
+      expect(mutate).not.toHaveBeenCalled()
+    },
+  )
+
+  it("does not submit a retry when a known observation lacks today's status", async () => {
+    const registration = getNewApiExecutionRegistration()
+    vi.spyOn(registration.provider, "getStatus").mockResolvedValue({
+      outcome: "known",
+      availability: "enabled",
+      evidence: { source: "probe", observedAt: Date.now() },
+    })
+    const mutate = vi
+      .spyOn(registration.provider, "checkIn")
+      .mockResolvedValue({ status: "success" })
+    await expect(
+      executeSelectedCheckIn({
+        account: createNewApiExecutionAccount(),
+        globalAutomaticExecutionEnabled: true,
+        context: createExecutionContext(),
+        requireStatusConfirmationBeforeMutation: true,
+      }),
+    ).resolves.toMatchObject({
+      kind: "blocked",
+      reason: "status_unavailable",
+      retryable: false,
+    })
+    expect(mutate).not.toHaveBeenCalled()
+  })
+
+  it.each([404, 405])(
+    "stops the compatibility first attempt after authoritative status HTTP %s",
+    async (statusCode) => {
+      const registration = getNewApiExecutionRegistration()
+      vi.spyOn(registration.provider, "getStatus").mockRejectedValue(
+        new ApiError("unsupported", statusCode),
+      )
+      const mutate = vi
+        .spyOn(registration.provider, "checkIn")
+        .mockResolvedValue({ status: "success" })
+      await expect(
+        executeSelectedCheckIn({
+          account: createNewApiExecutionAccount(),
+          globalAutomaticExecutionEnabled: true,
+          context: createExecutionContext(),
+        }),
+      ).resolves.toEqual({ kind: "skipped", reason: "method_unsupported" })
+      expect(mutate).not.toHaveBeenCalled()
+    },
+  )
 
   it("marks a failed mutation retryable only when the next attempt can confirm status", async () => {
     const registration = getNewApiExecutionRegistration()
@@ -1359,7 +1434,6 @@ describe("check-in methods compatibility activation", () => {
     expect(result).toMatchObject({
       kind: "skipped",
       reason: "status_unavailable",
-      retryable: false,
     })
     expect(checkInRequest).not.toHaveBeenCalled()
   })

--- a/tests/services/autoCheckin/checkInMethods.test.ts
+++ b/tests/services/autoCheckin/checkInMethods.test.ts
@@ -990,13 +990,22 @@ describe("check-in methods compatibility activation", () => {
   })
 
   it.each([
-    "authentication_required",
-    "permission_denied",
-    "identity_mismatch",
-    "credential_persistence_failed",
+    [
+      "authentication_required",
+      { kind: "skipped", reason: "authentication_required" },
+    ],
+    ["permission_denied", { kind: "skipped", reason: "permission_denied" }],
+    [
+      "identity_mismatch",
+      { kind: "skipped", reason: "authentication_required" },
+    ],
+    [
+      "credential_persistence_failed",
+      { kind: "blocked", reason: "account_unavailable", retryable: false },
+    ],
   ] as const)(
     "does not retry a status observation requiring repair: %s",
-    async (reason) => {
+    async (reason, expected) => {
       const registration = getNewApiExecutionRegistration()
       vi.spyOn(registration.provider, "getStatus").mockResolvedValue({
         outcome: "unknown",
@@ -1006,13 +1015,47 @@ describe("check-in methods compatibility activation", () => {
       const mutate = vi
         .spyOn(registration.provider, "checkIn")
         .mockResolvedValue({ status: "success" })
-      const result = await executeSelectedCheckIn({
-        account: createNewApiExecutionAccount(),
-        globalAutomaticExecutionEnabled: true,
-        context: createExecutionContext(),
-        requireStatusConfirmationBeforeMutation: true,
+      for (const requireStatusConfirmationBeforeMutation of [false, true]) {
+        const result = await executeSelectedCheckIn({
+          account: createNewApiExecutionAccount(),
+          globalAutomaticExecutionEnabled: true,
+          context: createExecutionContext(),
+          requireStatusConfirmationBeforeMutation,
+        })
+        expect(result).toEqual(expected)
+      }
+      expect(mutate).not.toHaveBeenCalled()
+    },
+  )
+
+  it.each([
+    ["network", "network_error"],
+    ["timeout", "timeout"],
+    ["source_unavailable", "source_unavailable"],
+  ] as const)(
+    "allows status-only recovery for a transient %s observation",
+    async (reason, expectedReason) => {
+      const registration = getNewApiExecutionRegistration()
+      vi.spyOn(registration.provider, "getStatus").mockResolvedValue({
+        outcome: "unknown",
+        reason,
+        attemptedAt: 200,
       })
-      expect(result).not.toHaveProperty("retryable", true)
+      const mutate = vi
+        .spyOn(registration.provider, "checkIn")
+        .mockResolvedValue({ status: "success" })
+      await expect(
+        executeSelectedCheckIn({
+          account: createNewApiExecutionAccount(),
+          globalAutomaticExecutionEnabled: true,
+          context: createExecutionContext(),
+          requireStatusConfirmationBeforeMutation: true,
+        }),
+      ).resolves.toEqual({
+        kind: "blocked",
+        reason: expectedReason,
+        retryable: true,
+      })
       expect(mutate).not.toHaveBeenCalled()
     },
   )

--- a/tests/services/autoCheckin/providers/sub2apiPro.test.ts
+++ b/tests/services/autoCheckin/providers/sub2apiPro.test.ts
@@ -18,6 +18,7 @@ import { discoverCheckInMethods } from "~/services/checkin/autoCheckin/discovery
 import { executeSelectedCheckIn } from "~/services/checkin/autoCheckin/methods"
 import { autoCheckinMethodRegistry } from "~/services/checkin/autoCheckin/providers"
 import { sub2apiProProvider } from "~/services/checkin/autoCheckin/providers/sub2apiPro"
+import { mergeRefreshedCheckInStatus } from "~/services/checkin/autoCheckin/state"
 import { PROTECTION_BYPASS_USER_COMMANDS } from "~/services/protectionBypass/contracts"
 import { AuthTypeEnum } from "~/types"
 import { CHECKIN_RESULT_STATUS } from "~/types/autoCheckin"
@@ -348,6 +349,150 @@ describe("Sub2API Pro daily check-in method Adapter", () => {
     })
   })
 
+  it("persists mutation-time capability loss without replacing manual selection", async () => {
+    let account = createAccount()
+    account.checkIn.selection = { mode: "manual", methodId: METHOD_ID }
+    vi.mocked(performSub2ApiProDailyCheckIn).mockRejectedValue(
+      new ApiError("unsupported", 404),
+    )
+    const result = await executeSelectedCheckIn({
+      account,
+      globalAutomaticExecutionEnabled: true,
+      context: executionContext(),
+      revalidateAccount: async (refreshed) => {
+        if (refreshed)
+          account = {
+            ...account,
+            checkIn: mergeRefreshedCheckInStatus({
+              latest: account.checkIn,
+              refreshed,
+            }),
+          }
+        return account
+      },
+    })
+    expect(result).toMatchObject({
+      kind: "executed",
+      retryable: false,
+      result: { reasonCode: "method_unsupported" },
+    })
+    expect(account.checkIn.selection).toEqual({
+      mode: "manual",
+      methodId: METHOD_ID,
+    })
+    expect(
+      account.checkIn.methodKnowledge.methods[METHOD_ID]?.detection.outcome,
+    ).toBe("unsupported")
+    vi.mocked(performSub2ApiProDailyCheckIn).mockClear()
+    await expect(
+      executeSelectedCheckIn({
+        account,
+        globalAutomaticExecutionEnabled: true,
+        context: executionContext(),
+      }),
+    ).resolves.toMatchObject({ kind: "skipped", reason: "method_unsupported" })
+    expect(performSub2ApiProDailyCheckIn).not.toHaveBeenCalled()
+  })
+
+  it.each([false, true])(
+    "allows bounded status recovery before a mutation (retry %s)",
+    async (retry) => {
+      vi.mocked(fetchSub2ApiProDailyCheckInStatus).mockRejectedValue(
+        new TypeError("Failed to fetch"),
+      )
+      await expect(
+        executeSelectedCheckIn({
+          account: createAccount(),
+          globalAutomaticExecutionEnabled: true,
+          context: executionContext(),
+          requireStatusConfirmationBeforeMutation: retry,
+        }),
+      ).resolves.toMatchObject({
+        kind: "blocked",
+        reason: "network_error",
+        retryable: true,
+      })
+      expect(performSub2ApiProDailyCheckIn).not.toHaveBeenCalled()
+    },
+  )
+
+  it.each([
+    SUB2API_AUTH_PERSISTENCE_STATUSES.IDENTITY_MISMATCH,
+    SUB2API_AUTH_PERSISTENCE_STATUSES.WRITE_FAILED,
+    SUB2API_AUTH_PERSISTENCE_STATUSES.ACCOUNT_MISSING,
+  ])(
+    "does not retry an unclassified status failure from auth persistence: %s",
+    async (status) => {
+      vi.mocked(fetchSub2ApiProDailyCheckInStatus).mockRejectedValue(
+        Object.assign(new Error("controlled auth failure"), {
+          result: { status },
+        }),
+      )
+      const result = await executeSelectedCheckIn({
+        account: createAccount(),
+        globalAutomaticExecutionEnabled: true,
+        context: executionContext(),
+      })
+      expect(result).not.toHaveProperty("retryable", true)
+      expect(performSub2ApiProDailyCheckIn).not.toHaveBeenCalled()
+    },
+  )
+
+  it.each([404, 405])(
+    "never retries an authoritative HTTP %s capability loss",
+    async (code) => {
+      vi.mocked(fetchSub2ApiProDailyCheckInStatus).mockRejectedValue(
+        new ApiError("unsupported", code),
+      )
+      const result = await executeSelectedCheckIn({
+        account: createAccount(),
+        globalAutomaticExecutionEnabled: true,
+        context: executionContext(),
+        requireStatusConfirmationBeforeMutation: true,
+      })
+      expect(result).toMatchObject({
+        kind: "skipped",
+        reason: "method_unsupported",
+      })
+      expect(result).not.toHaveProperty("retryable", true)
+      expect(performSub2ApiProDailyCheckIn).not.toHaveBeenCalled()
+    },
+  )
+
+  it.each(["status", "mutation"])(
+    "reports a local failure when %s capability loss cannot be saved",
+    async (phase) => {
+      const account = createAccount()
+      if (phase === "status")
+        vi.mocked(fetchSub2ApiProDailyCheckInStatus).mockRejectedValue(
+          new ApiError("unsupported", 404),
+        )
+      else
+        vi.mocked(performSub2ApiProDailyCheckIn).mockRejectedValue(
+          new ApiError("unsupported", 404),
+        )
+      await expect(
+        executeSelectedCheckIn({
+          account,
+          globalAutomaticExecutionEnabled: true,
+          context: executionContext(),
+          revalidateAccount: async (config) => {
+            if (
+              config?.methodKnowledge.methods[METHOD_ID]?.detection.outcome ===
+              "unsupported"
+            )
+              return null
+            return account
+          },
+        }),
+      ).resolves.toMatchObject({
+        kind: "blocked",
+        reason: "account_unavailable",
+        retryable: false,
+      })
+    },
+  )
+
   it("reuses the same-cycle status proof before sending one mutation", async () => {
     const registration = autoCheckinMethodRegistry.resolveById(METHOD_ID)
     if (!registration?.provider.getStatus) throw new Error("Missing Adapter")
@@ -526,6 +671,25 @@ describe("Sub2API Pro daily check-in method Adapter", () => {
       expect(revalidateAccount).toHaveBeenCalledTimes(2)
     },
   )
+
+  it("does not queue another mutation when reconciliation reports the method disabled", async () => {
+    vi.mocked(fetchSub2ApiProDailyCheckInStatus)
+      .mockResolvedValueOnce({ enabled: true, checkedInToday: false })
+      .mockResolvedValueOnce({ enabled: false, checkedInToday: false })
+    vi.mocked(performSub2ApiProDailyCheckIn).mockImplementation(
+      async (_request) => {
+        _request.observer?.onDispatch?.()
+        throw new TypeError("Failed to fetch")
+      },
+    )
+    const result = await executeSelectedCheckIn({
+      account: createAccount(),
+      globalAutomaticExecutionEnabled: true,
+      context: executionContext(),
+    })
+    expect(result).toMatchObject({ kind: "executed", retryable: false })
+    expect(performSub2ApiProDailyCheckIn).toHaveBeenCalledOnce()
+  })
 
   it("turns authoritative not-checked reconciliation into one later safe retry", async () => {
     const registration = autoCheckinMethodRegistry.resolveById(METHOD_ID)

--- a/tests/services/autoCheckin/providers/sub2apiPro.test.ts
+++ b/tests/services/autoCheckin/providers/sub2apiPro.test.ts
@@ -459,9 +459,14 @@ describe("Sub2API Pro daily check-in method Adapter", () => {
     },
   )
 
-  it.each(["status", "mutation"])(
-    "reports a local failure when %s capability loss cannot be saved",
-    async (phase) => {
+  it.each([
+    ["status", "returns null"],
+    ["mutation", "returns null"],
+    ["status", "throws"],
+    ["mutation", "throws"],
+  ])(
+    "reports a local failure when %s capability persistence %s",
+    async (phase, failure) => {
       const account = createAccount()
       if (phase === "status")
         vi.mocked(fetchSub2ApiProDailyCheckInStatus).mockRejectedValue(
@@ -480,8 +485,10 @@ describe("Sub2API Pro daily check-in method Adapter", () => {
             if (
               config?.methodKnowledge.methods[METHOD_ID]?.detection.outcome ===
               "unsupported"
-            )
+            ) {
+              if (failure === "throws") throw new Error("storage write failed")
               return null
+            }
             return account
           },
         }),

--- a/tests/services/autoCheckin/scheduler.test.ts
+++ b/tests/services/autoCheckin/scheduler.test.ts
@@ -1652,6 +1652,58 @@ describe("autoCheckinScheduler daily+retry behavior", () => {
     vi.useRealTimers()
   })
 
+  it.each([
+    { reason: "network_error", retryable: true },
+    { reason: "account_unavailable", retryable: false },
+    { reason: "status_unavailable", retryable: false },
+  ])(
+    "persists blocked $reason as a failure with explicit retry policy",
+    async ({ reason, retryable }) => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date(2024, 0, 1, 9, 30, 0))
+      mockedUserPreferences.getPreferences.mockResolvedValue({
+        autoCheckin: {
+          ...DEFAULT_PREFERENCES.autoCheckin,
+          globalEnabled: true,
+          retryStrategy: {
+            enabled: true,
+            intervalMinutes: 30,
+            maxAttemptsPerDay: 3,
+          },
+        },
+      })
+      const account = {
+        id: "blocked-account",
+        disabled: false,
+        site_name: "Example Site",
+        site_type: SITE_TYPES.VELOERA,
+        account_info: { username: "example-user" },
+        checkIn: runnableCheckIn(),
+      }
+      mockedAccountStorage.getAllAccounts.mockResolvedValue([account])
+      resolveProviderForTest.mockReturnValue({
+        getReadiness: vi.fn(() => ({ ready: true })),
+        checkIn: vi.fn(),
+      })
+      mockedMethods.executeSelectedCheckIn.mockResolvedValueOnce({
+        kind: "blocked",
+        reason,
+        retryable,
+      })
+      await runCheckinsForTest({ runType: AUTO_CHECKIN_RUN_TYPE.DAILY })
+      expect(storedStatus.perAccount[account.id]).toMatchObject({
+        status: "failed",
+        reasonCode: reason,
+        retryable,
+        messageKey: `autoCheckin:skipReasons.${reason}`,
+      })
+      expect(storedStatus.retryState?.pendingAccountIds ?? []).toEqual(
+        retryable ? [account.id] : [],
+      )
+      vi.useRealTimers()
+    },
+  )
+
   it("keeps a bounded retry queued when authoritative status is temporarily unavailable", async () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date(2024, 0, 1, 9, 30, 0))
@@ -1704,7 +1756,7 @@ describe("autoCheckinScheduler daily+retry behavior", () => {
       checkIn: vi.fn(),
     })
     mockedMethods.executeSelectedCheckIn.mockResolvedValueOnce({
-      kind: "skipped",
+      kind: "blocked",
       reason: "network_error",
       retryable: true,
     })


### PR DESCRIPTION
## Summary

When a selected check-in method stops being supported, capability-loss evidence could be discarded during account-state persistence, leaving later runs to use stale support information. Persist authoritative unsupported results from status reads and definitive mutation failures while preserving user selection, automatic intent, custom URLs, and newer discovery evidence.

Unify retry admission for status-first execution: classified network, timeout, and source-unavailable failures can receive bounded retries, including on the initial run. Unsupported methods, authentication/permission problems, malformed or missing status, and local persistence failures do not enter ordinary automatic retry. Uncertain mutations still require read-only reconciliation; a later retry additionally requires verified provider idempotency and enabled/not-checked evidence.

Closes #1270.

This completes the remaining execution-recovery gaps after the account-level method model, discovery/selection, Sub2API Pro adapter, auth durability, and recovery UX landed in #1340, #1343, #1350, #1352, #1354, and #1357. The agreed acceptance refinement replaces the blanket ban on retrying unknown observations with evidence-based admission: bounded retries may repeat safe pre-mutation status queries for classified transient failures; unsupported, disabled, authentication/permission, malformed or missing status, and unresolved mutation outcomes do not authorize an automatic mutation retry. No storage migration is required.

## Compatibility

- No account schema, backup envelope, persisted result shape, or data migration changes.
- Internal blocked outcomes map to the existing failed result with explicit retryability; deliberate skips remain skipped.
- Existing providers retain permitted best-effort first-attempt status reads. Historical persisted failure compatibility remains intact.
- Failed capability-state writes produce a visible non-retryable account-unavailable result.

## Validation

- Focused Vitest regression pass: 21 test files and 861 tests covering check-in methods/providers, scheduler, account storage, auto-detection, V7 migration, and analytics/privacy.
- Commit hook reran all four staged test files after the final regression cases were added.
- TypeScript compile passed on the committed head.
- Pre-commit formatting, ESLint, i18n extraction, and locale completeness checks passed.
- CI browser E2E passed for all default shards and the DNR-required/bookmarks-required variants.
- Pre-push TypeScript compile and knip passed.
- Feedback regression pass: 294 tests across account storage, method execution, and Sub2API Pro provider tests; exact repair outcomes and all 11 previously uncovered patch lines are covered.
- Commit 5465547e1: all 23 remote checks passed, Codecov patch coverage is 100%, and CodeRabbit completed its review with no new actionable comments. Issue #1270 now records the agreed retry acceptance refinement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved check-in recovery when status confirmation is unavailable, allowing retries only for recognized temporary failures.
  * Provider-reported unsupported methods are now recorded reliably while preserving manual selections, custom URLs, and newer account information.
  * Blocked executions now produce clearer failure outcomes and accurate retry behavior.
  * Prevented additional execution attempts when a method is disabled or capability loss cannot be safely reconciled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
