### PR TITLE
fix(e2e): follow New API manual token recovery

### DIFF
--- a/e2e/newApiAccountRecoveryUserFlow.spec.ts
+++ b/e2e/newApiAccountRecoveryUserFlow.spec.ts
@@ -18,16 +18,25 @@ const scenarios = [
     name: "saves an automatically detected token without opening security settings",
     method: null,
     existingToken: false,
+    clipboardWriteDelayMs: 0,
   },
   {
     name: "recovers a blocked token exchange through password verification and token regeneration",
     method: "password",
     existingToken: true,
+    clipboardWriteDelayMs: 0,
   },
   {
     name: "recovers a blocked token exchange by generating a token with authenticator verification",
     method: "2fa",
     existingToken: false,
+    clipboardWriteDelayMs: 0,
+  },
+  {
+    name: "waits for a delayed clipboard copy to replace an old token before saving",
+    method: "password",
+    existingToken: true,
+    clipboardWriteDelayMs: 500,
   },
 ] as const
 
@@ -234,11 +243,20 @@ function securityPageHtml(scenario: (typeof scenarios)[number]) {
         method: "POST", headers: { "X-Security-Proof": "verified" },
       }).then((response) => response.json());
       if (!token.success) return;
+      if (${scenario.clipboardWriteDelayMs} > 0) {
+        await navigator.clipboard.writeText("e2e-previous-clipboard-token");
+      }
       byId("generated-access-token").value = token.data;
       byId("verification").hidden = true;
       byId("token-dialog").hidden = false;
     };
-    byId("copy").onclick = () => navigator.clipboard.writeText(byId("generated-access-token").value);
+    byId("copy").onclick = async () => {
+      // Model a clipboard write that completes after Playwright's click returns.
+      if (${scenario.clipboardWriteDelayMs} > 0) {
+        await new Promise((resolve) => setTimeout(resolve, ${scenario.clipboardWriteDelayMs}));
+      }
+      await navigator.clipboard.writeText(byId("generated-access-token").value);
+    };
     byId("close").onclick = () => { byId("token-dialog").hidden = true; };
     byId("close-icon").onclick = byId("close").onclick;
   </script>

--- a/e2e/newApiAccountRecoveryUserFlow.spec.ts
+++ b/e2e/newApiAccountRecoveryUserFlow.spec.ts
@@ -1,0 +1,246 @@
+import { SITE_TYPES } from "~/constants/siteType"
+import { expect, test } from "~~/e2e/fixtures/extensionTest"
+import {
+  E2E_NEW_API_RC22_AUTH,
+  forceExtensionLanguage,
+  seedUserPreferences,
+  stubLlmMetadataIndex,
+  stubNewApiSiteRoutes,
+} from "~~/e2e/utils/commonUserFlows"
+import { getServiceWorker } from "~~/e2e/utils/extensionState"
+import { waitForSavedAccount } from "~~/e2e/utils/realSite/accountAdd"
+import { createCompatibleRealSiteAccountFixturePreparer } from "~~/e2e/utils/realSite/compatibleAccountSaveFlow"
+import type { CompatibleApiRealSiteConfig } from "~~/e2e/utils/realSite/compatibleApi"
+import { createNewApiAccountRecovery } from "~~/e2e/utils/realSite/newApiAccountRecovery"
+
+const scenarios = [
+  {
+    name: "saves an automatically detected token without opening security settings",
+    method: null,
+    existingToken: false,
+  },
+  {
+    name: "recovers a blocked token exchange through password verification and token regeneration",
+    method: "password",
+    existingToken: true,
+  },
+  {
+    name: "recovers a blocked token exchange by generating a token with authenticator verification",
+    method: "2fa",
+    existingToken: false,
+  },
+] as const
+
+for (const scenario of scenarios) {
+  test(`New API real-site account flow ${scenario.name}`, async ({
+    context,
+    page,
+    extensionId,
+  }) => {
+    const baseUrl = "https://new-api-account-recovery.example.invalid"
+    const managementToken = "e2e-account-management-token"
+    const needsRecovery = scenario.method !== null
+    const config: CompatibleApiRealSiteConfig = {
+      baseUrl,
+      loginUrl: `${baseUrl}/login`,
+      loginApiUrl: `${baseUrl}/api/user/login`,
+      login2faApiUrl: `${baseUrl}/api/user/login/2fa`,
+      username: "e2e-user",
+      password: "e2e-password",
+      totpSecret: scenario.method === "2fa" ? "JBSWY3DPEHPK3PXP" : undefined,
+    }
+    let blockedTokenRequests = 0
+    let verifiedTokenRequests = 0
+    let verificationRequests = 0
+    let automaticTokenRequests = 0
+    let securityPageRequests = 0
+
+    await forceExtensionLanguage(page, "en")
+    await stubLlmMetadataIndex(context)
+    await stubNewApiSiteRoutes(context, {
+      baseUrl,
+      dashboardAuthMode: "auth-bundle",
+      accessToken: managementToken,
+    })
+    await context.route(`${baseUrl}/api/user/token`, (route) => {
+      const request = route.request()
+      const verified =
+        request.method() === "POST" &&
+        request.headers()["x-security-proof"] === "verified"
+      const automatic = !needsRecovery && request.method() === "GET"
+      if (verified) verifiedTokenRequests += 1
+      else if (automatic) automaticTokenRequests += 1
+      else blockedTokenRequests += 1
+      return route.fulfill({
+        status: verified || automatic ? 200 : 403,
+        json:
+          verified || automatic
+            ? { success: true, data: managementToken }
+            : {
+                success: false,
+                code: "SECURITY_PROOF_REQUIRED",
+                message: "Security verification required",
+              },
+      })
+    })
+    await context.route(`${baseUrl}/api/verify`, (route) => {
+      verificationRequests += 1
+      const body = route.request().postDataJSON()
+      const valid =
+        body.method === scenario.method &&
+        (scenario.method === "password"
+          ? body.password === config.password
+          : /^\d{6}$/u.test(body.code))
+      return route.fulfill({
+        status: valid ? 200 : 403,
+        json: { success: valid },
+      })
+    })
+    await context.route(`${baseUrl}/security`, (route) => {
+      securityPageRequests += 1
+      return route.fulfill({
+        contentType: "text/html",
+        body: securityPageHtml(scenario),
+      })
+    })
+    const serviceWorker = await getServiceWorker(context)
+    await seedUserPreferences(serviceWorker, {
+      autoFillCurrentSiteUrlOnAccountAdd: false,
+      autoProvisionKeyOnAccountAdd: false,
+      tempWindowFallback: { enabled: false },
+    })
+    const recovery = createNewApiAccountRecovery({ page, config })
+
+    const prepareAccount = createCompatibleRealSiteAccountFixturePreparer({
+      context,
+      page,
+      extensionId,
+      serviceWorker,
+      config,
+      ...recovery,
+      prepareDetectedDialog: async (dialog) => {
+        if (!needsRecovery) return recovery.prepareDetectedDialog(dialog)
+
+        await expect(
+          dialog.dialog.getByText("Enter an Access Token manually", {
+            exact: true,
+          }),
+        ).toBeVisible()
+        // tabs.create may navigate before Playwright attaches route interception.
+        // Verify the browser's actual target before replaying that exact URL.
+        const interceptedNavigation = context
+          .waitForEvent("page")
+          .then(async (securityPage) => {
+            let requestedUrl = ""
+            await expect
+              .poll(async () => {
+                requestedUrl = await serviceWorker.evaluate(async () => {
+                  const [tab] = await chrome.tabs.query({
+                    active: true,
+                    currentWindow: true,
+                  })
+                  return tab?.pendingUrl ?? tab?.url ?? ""
+                })
+                return requestedUrl
+              })
+              .toBe(`${baseUrl}/security#security-access`)
+            await securityPage.goto(requestedUrl)
+          })
+        await Promise.all([
+          interceptedNavigation,
+          recovery.prepareDetectedDialog(dialog),
+        ])
+      },
+      siteType: SITE_TYPES.NEW_API,
+      login: async (sitePage) => {
+        await sitePage.goto(baseUrl)
+        return { user: { id: 1, username: "e2e-user" } }
+      },
+    })
+
+    const savedAccount = await prepareAccount()
+    expect(savedAccount.accountId).toBeTruthy()
+    const stored = await waitForSavedAccount({
+      serviceWorker,
+      siteType: SITE_TYPES.NEW_API,
+      baseUrl,
+    })
+    expect(stored.account_info.access_token).toBe(managementToken)
+    expect(stored.account_info.username).toBe("e2e-user")
+    expect(JSON.stringify(stored)).not.toContain(
+      E2E_NEW_API_RC22_AUTH.dashboardToken,
+    )
+    expect(blockedTokenRequests).toBe(needsRecovery ? 1 : 0)
+    expect(verificationRequests).toBe(needsRecovery ? 1 : 0)
+    expect(verifiedTokenRequests).toBe(needsRecovery ? 1 : 0)
+    expect(automaticTokenRequests).toBe(needsRecovery ? 0 : 1)
+    expect(securityPageRequests > 0).toBe(needsRecovery)
+  })
+}
+
+/**
+ * Match the upstream's rotation, verification, and one-time copy UI, including
+ * its labelled tabpanel and duplicate close actions. The extension stays real.
+ * https://github.com/QuantumNous/new-api/tree/bee45b58a3c0b77e8dc81e6b5aeb4474aa9058d1/web/src/features/security
+ */
+function securityPageHtml(scenario: (typeof scenarios)[number]) {
+  const method = scenario.method === "2fa" ? "2fa" : "password"
+  const methodLabel = method === "2fa" ? "Authenticator code" : "Password"
+  const inputLabel =
+    method === "2fa" ? "Authenticator code or backup code" : "Password"
+  return `<!doctype html><html><body>
+  <section id="security-access"><h2>Sessions &amp; Access</h2>
+    <div data-slot="card"><h4>Access Token</h4>
+      <button id="generate">${scenario.existingToken ? "Regenerate" : "Generate"}</button>
+    </div>
+  </section>
+  <div role="alertdialog" aria-label="Regenerate access token?" id="confirmation" hidden>
+    <p>This will immediately invalidate your existing access token.</p>
+    <button id="confirm">Regenerate token</button>
+  </div>
+  <div role="dialog" aria-label="Security verification" id="verification" hidden>
+    <div role="tablist"><button role="tab" id="verification-tab" aria-selected="true">${methodLabel}</button></div>
+    <form id="verify-form"><div role="tabpanel" aria-labelledby="verification-tab">
+      <label for="verification-input">${inputLabel}</label>
+      <input id="verification-input" type="${method === "password" ? "password" : "text"}" autocomplete="off">
+      </div><button type="submit">Verify</button>
+    </form>
+  </div>
+  <div role="dialog" aria-label="Access Token" id="token-dialog" hidden>
+    <p>Save this token now. You won't be able to view it again after closing this dialog.</p>
+    <label for="generated-access-token">Token</label><input id="generated-access-token" readonly>
+    <button id="copy" aria-label="Copy token">Copy token</button>
+    <button id="close">Close</button>
+    <button data-slot="dialog-close" aria-label="Close" id="close-icon">×</button>
+  </div>
+  <script>
+    const byId = (id) => document.getElementById(id);
+    byId("generate").onclick = () => {
+      byId("${scenario.existingToken ? "confirmation" : "verification"}").hidden = false;
+    };
+    byId("confirm").onclick = () => {
+      byId("confirmation").hidden = true;
+      byId("verification").hidden = false;
+    };
+    byId("verify-form").onsubmit = async (event) => {
+      event.preventDefault();
+      const proof = await fetch("/api/verify", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ method: "${method}", ${method === "2fa" ? "code" : "password"}: byId("verification-input").value }),
+      }).then((response) => response.json());
+      if (!proof.success) return;
+      const token = await fetch("/api/user/token", {
+        method: "POST", headers: { "X-Security-Proof": "verified" },
+      }).then((response) => response.json());
+      if (!token.success) return;
+      byId("generated-access-token").value = token.data;
+      byId("verification").hidden = true;
+      byId("token-dialog").hidden = false;
+    };
+    byId("copy").onclick = () => navigator.clipboard.writeText(byId("generated-access-token").value);
+    byId("close").onclick = () => { byId("token-dialog").hidden = true; };
+    byId("close-icon").onclick = byId("close").onclick;
+  </script>
+</body></html>`
+}

--- a/e2e/realSite/newApiAccountAdd.spec.ts
+++ b/e2e/realSite/newApiAccountAdd.spec.ts
@@ -16,6 +16,7 @@ import {
   loginToRealNewApiSite,
   resolveNewApiRealSiteConfig,
 } from "~~/e2e/utils/realSite/newApi"
+import { createNewApiAccountRecovery } from "~~/e2e/utils/realSite/newApiAccountRecovery"
 import {
   createReusedRealSiteAccountFixturePreparer,
   createSharedRealSiteAccountFixtureCache,
@@ -86,6 +87,7 @@ test.describe("real-site E2E: New API account add flow", () => {
                 extensionId,
                 serviceWorker,
                 config,
+                ...createNewApiAccountRecovery({ page, config }),
                 siteType: SITE_TYPES.NEW_API,
                 login: loginToRealNewApiSite,
               }),

--- a/e2e/utils/commonUserFlows.ts
+++ b/e2e/utils/commonUserFlows.ts
@@ -1,4 +1,9 @@
-import type { BrowserContext, Page, Worker } from "@playwright/test"
+import type {
+  BrowserContext,
+  ConsoleMessage,
+  Page,
+  Worker,
+} from "@playwright/test"
 
 import { SITE_TYPES } from "~/constants/siteType"
 import {
@@ -101,6 +106,7 @@ export const E2E_NEW_API_RC22_AUTH = {
 /** Scenario-specific console-error patterns that should not fail the test. */
 export type ExtensionPageGuardOptions = {
   ignoreConsoleErrorPatterns?: RegExp[]
+  ignoreConsoleError?: (message: ConsoleMessage) => boolean
 }
 
 const E2E_SPONSOR_CATALOG_PAYLOAD = {
@@ -138,6 +144,7 @@ function installExtensionPageGuardsWithOptions(
 
     const text = message.text()
     if (
+      options.ignoreConsoleError?.(message) ||
       options.ignoreConsoleErrorPatterns?.some((pattern) => pattern.test(text))
     ) {
       return

--- a/e2e/utils/realSite/compatibleAccountSaveFlow.ts
+++ b/e2e/utils/realSite/compatibleAccountSaveFlow.ts
@@ -16,6 +16,10 @@ type CompatibleRealSiteLoginResult = {
   cleanupOwnedSession?: () => Promise<void>
 }
 
+/**
+ * Log in and save a compatible site's detected account, passing optional dialog
+ * recovery and owned-session cleanup to the shared account flow.
+ */
 export async function runCompatibleRealSiteAccountSaveFlow(params: {
   page: Page
   extensionId: string
@@ -51,6 +55,7 @@ export async function runCompatibleRealSiteAccountSaveFlow(params: {
   })
 }
 
+/** Prepare an account fixture in a site tab that is closed on every exit. */
 export function createCompatibleRealSiteAccountFixturePreparer(params: {
   context: BrowserContext
   page: Page

--- a/e2e/utils/realSite/compatibleAccountSaveFlow.ts
+++ b/e2e/utils/realSite/compatibleAccountSaveFlow.ts
@@ -5,6 +5,7 @@ import { expect } from "~~/e2e/fixtures/extensionTest"
 import type { AccountFixture } from "~~/e2e/scenarios/accountFixtures"
 import type { ExtensionPageGuardOptions } from "~~/e2e/utils/commonUserFlows"
 import type { getServiceWorker } from "~~/e2e/utils/extensionState"
+import type { AccountAddDialog } from "~~/e2e/utils/realSite/accountAdd"
 import { runRealSiteAccountSaveFlow } from "~~/e2e/utils/realSite/accountSaveFlow"
 import type { CompatibleApiRealSiteConfig } from "~~/e2e/utils/realSite/compatibleApi"
 
@@ -24,6 +25,7 @@ export async function runCompatibleRealSiteAccountSaveFlow(params: {
   siteType: AccountSiteType
   expectedDetectedSiteType?: AccountSiteType
   extensionPageGuardOptions?: ExtensionPageGuardOptions
+  prepareDetectedDialog?: (dialog: AccountAddDialog) => Promise<void>
   login: (
     page: Page,
     config: CompatibleApiRealSiteConfig,
@@ -42,6 +44,7 @@ export async function runCompatibleRealSiteAccountSaveFlow(params: {
       const loginResult = await params.login(sitePage, params.config)
       expect(loginResult.user).toBeTruthy()
       return {
+        prepareDetectedDialog: params.prepareDetectedDialog,
         cleanupDetectableSite: loginResult.cleanupOwnedSession,
       }
     },
@@ -57,6 +60,7 @@ export function createCompatibleRealSiteAccountFixturePreparer(params: {
   siteType: AccountSiteType
   expectedDetectedSiteType?: AccountSiteType
   extensionPageGuardOptions?: ExtensionPageGuardOptions
+  prepareDetectedDialog?: (dialog: AccountAddDialog) => Promise<void>
   login: (
     page: Page,
     config: CompatibleApiRealSiteConfig,
@@ -74,6 +78,7 @@ export function createCompatibleRealSiteAccountFixturePreparer(params: {
         siteType: params.siteType,
         expectedDetectedSiteType: params.expectedDetectedSiteType,
         extensionPageGuardOptions: params.extensionPageGuardOptions,
+        prepareDetectedDialog: params.prepareDetectedDialog,
         login: params.login,
       })
     } finally {

--- a/e2e/utils/realSite/newApiAccountRecovery.ts
+++ b/e2e/utils/realSite/newApiAccountRecovery.ts
@@ -151,12 +151,17 @@ async function copyNewApiAccessToken(
   await tokenDialog
     .getByRole("button", { name: /^(Copy token|复制令牌)$/u })
     .click()
-  const token = await page.evaluate(() => navigator.clipboard.readText())
   const displayedToken = await tokenDialog
     .getByLabel(/^(Token|令牌)$/u, { exact: true })
     .inputValue()
+  let token = ""
   // Boolean assertions keep plaintext credentials out of failure reports.
-  expect(token.length > 0 && token === displayedToken).toBe(true)
+  await expect
+    .poll(async () => {
+      token = await page.evaluate(() => navigator.clipboard.readText())
+      return token.length > 0 && token === displayedToken
+    })
+    .toBe(true)
   await tokenDialog
     .getByRole("button", { name: /^(Close|关闭)$/u })
     // The footer and dialog's close icon perform the same action upstream.
@@ -165,6 +170,10 @@ async function copyNewApiAccessToken(
   return token
 }
 
+/**
+ * Prefer configured authenticator verification when offered by the site,
+ * otherwise use its password challenge. Fail if neither method is available.
+ */
 async function completeNewApiSecurityVerification(
   dialog: Locator,
   config: CompatibleApiRealSiteConfig,
@@ -204,6 +213,7 @@ async function completeNewApiSecurityVerification(
   await dialog.getByRole("button", { name: /^(Verify|验证)$/u }).click()
 }
 
+/** Fill a credential without exposing it through Playwright action error logs. */
 async function fillSecret(input: Locator, value: string, label: string) {
   await expect(input, `New API ${label} input must be editable`).toBeEditable()
   try {

--- a/e2e/utils/realSite/newApiAccountRecovery.ts
+++ b/e2e/utils/realSite/newApiAccountRecovery.ts
@@ -1,0 +1,215 @@
+import type { Locator, Page } from "@playwright/test"
+
+import { generateNewApiTotpCode } from "~/services/managedSites/providers/newApiTotp"
+import { expect } from "~~/e2e/fixtures/extensionTest"
+import type { ExtensionPageGuardOptions } from "~~/e2e/utils/commonUserFlows"
+import type { AccountAddDialog } from "~~/e2e/utils/realSite/accountAdd"
+import type { CompatibleApiRealSiteConfig } from "~~/e2e/utils/realSite/compatibleApi"
+
+/**
+ * Follow the same manual-token recovery offered to a user after auto-detection.
+ * Only the token endpoint's expected 403 is allowed through the console guard;
+ * the flow must still reach either a saveable account or the recovery guidance.
+ */
+export function createNewApiAccountRecovery(params: {
+  page: Page
+  config: CompatibleApiRealSiteConfig
+}): {
+  extensionPageGuardOptions: ExtensionPageGuardOptions
+  prepareDetectedDialog: (dialog: AccountAddDialog) => Promise<void>
+} {
+  const baseUrl = `${params.config.baseUrl.replace(/\/+$/u, "")}/`
+  const tokenUrl = new URL("api/user/token", baseUrl).href
+
+  return {
+    extensionPageGuardOptions: {
+      ignoreConsoleError: (message) =>
+        message.location().url === tokenUrl &&
+        /^Failed to load resource: .*status of 403\b/u.test(message.text()),
+    },
+    prepareDetectedDialog: async (dialog) => {
+      const recoveryHeading = dialog.dialog.getByText(
+        "Enter an Access Token manually",
+        { exact: true },
+      )
+      await expect
+        .poll(
+          async () =>
+            ((await dialog.confirmAddButton.isVisible()) &&
+              (await dialog.confirmAddButton.isEnabled())) ||
+            (await recoveryHeading.isVisible()),
+          { timeout: 30_000 },
+        )
+        .toBe(true)
+
+      if (!(await recoveryHeading.isVisible())) return
+
+      const fields = [
+        dialog.siteUrlInput,
+        dialog.siteNameInput,
+        dialog.usernameInput,
+        dialog.userIdInput,
+      ]
+      const detectedValues = await Promise.all(
+        fields.map((field) => field.inputValue()),
+      )
+      expect(detectedValues.every((value) => value.trim().length > 0)).toBe(
+        true,
+      )
+      await expect(dialog.accessTokenInput).toBeEmpty()
+
+      const context = params.page.context()
+      await context.grantPermissions(["clipboard-read", "clipboard-write"], {
+        origin: new URL(baseUrl).origin,
+      })
+      const [securityPage] = await Promise.all([
+        context.waitForEvent("page"),
+        dialog.dialog
+          .getByRole("button", {
+            name: "Open site security settings",
+            exact: true,
+          })
+          .click(),
+      ])
+
+      try {
+        await expect(securityPage).toHaveURL(
+          new URL("security#security-access", baseUrl).href,
+        )
+        await expect(dialog.accessTokenInput).toHaveAttribute(
+          "type",
+          "password",
+        )
+        await expect(dialog.accessTokenInput).toBeInViewport()
+        await expect(dialog.accessTokenInput).toBeFocused()
+
+        const token = await copyNewApiAccessToken(securityPage, params.config)
+        await params.page.bringToFront()
+        for (const [index, field] of fields.entries()) {
+          await expect(field).toHaveValue(detectedValues[index])
+        }
+        await fillSecret(dialog.accessTokenInput, token, "Access Token")
+        await expect
+          .poll(
+            async () => (await dialog.accessTokenInput.inputValue()) === token,
+          )
+          .toBe(true)
+      } finally {
+        // A generated token is displayed once in plaintext by the upstream UI.
+        // Close this page even on failure, before Playwright captures screenshots.
+        await securityPage.close()
+      }
+    },
+  }
+}
+
+/**
+ * New API's security UI owns verification and one-time token display.
+ * https://github.com/QuantumNous/new-api/tree/bee45b58a3c0b77e8dc81e6b5aeb4474aa9058d1/web/src/features/security
+ */
+async function copyNewApiAccessToken(
+  page: Page,
+  config: CompatibleApiRealSiteConfig,
+) {
+  const tokenCard = page.locator('[data-slot="card"]').filter({
+    has: page.getByRole("heading", { name: /^(Access Token|访问令牌)$/u }),
+  })
+  const generateButton = tokenCard.getByRole("button", {
+    name: /^(Generate|Regenerate|生成|重新生成)$/u,
+  })
+  await expect(generateButton).toBeEnabled({ timeout: 30_000 })
+  const regenerating = /^(Regenerate|重新生成)$/u.test(
+    (await generateButton.innerText()).trim(),
+  )
+  await generateButton.click()
+
+  if (regenerating) {
+    const confirmation = page.getByRole("alertdialog")
+    await expect(confirmation).toContainText(
+      /invalidate your existing access token|现有.*令牌.*失效/u,
+    )
+    await confirmation
+      .getByRole("button", { name: /^(Regenerate token|重新生成令牌)$/u })
+      .click()
+  }
+
+  const tokenDialog = page.getByRole("dialog", {
+    name: /^(Access Token|访问令牌)$/u,
+  })
+  const verificationDialog = page.getByRole("dialog", {
+    name: /^(Security verification|安全验证)$/u,
+  })
+  await expect(tokenDialog.or(verificationDialog).first()).toBeVisible()
+  if (!(await tokenDialog.isVisible())) {
+    await completeNewApiSecurityVerification(verificationDialog, config)
+  }
+
+  await expect(tokenDialog).toBeVisible()
+  await expect(tokenDialog).toContainText(
+    /won't be able to view it again|关闭.*无法再次查看/u,
+  )
+  await tokenDialog
+    .getByRole("button", { name: /^(Copy token|复制令牌)$/u })
+    .click()
+  const token = await page.evaluate(() => navigator.clipboard.readText())
+  const displayedToken = await tokenDialog
+    .getByLabel(/^(Token|令牌)$/u, { exact: true })
+    .inputValue()
+  // Boolean assertions keep plaintext credentials out of failure reports.
+  expect(token.length > 0 && token === displayedToken).toBe(true)
+  await tokenDialog
+    .getByRole("button", { name: /^(Close|关闭)$/u })
+    // The footer and dialog's close icon perform the same action upstream.
+    .first()
+    .click()
+  return token
+}
+
+async function completeNewApiSecurityVerification(
+  dialog: Locator,
+  config: CompatibleApiRealSiteConfig,
+) {
+  await expect(dialog.getByRole("tab").first()).toBeVisible()
+  const totpTab = dialog.getByRole("tab", {
+    name: /^(Authenticator code|身份验证器代码)$/u,
+  })
+  const passwordTab = dialog.getByRole("tab", { name: /^(Password|密码)$/u })
+
+  if (
+    config.totpSecret &&
+    (await totpTab.count()) &&
+    (await totpTab.isEnabled())
+  ) {
+    await totpTab.click()
+    await fillSecret(
+      dialog
+        .getByLabel(/Authenticator code|认证器验证码|身份验证器代码/u)
+        .and(dialog.locator("input")),
+      generateNewApiTotpCode(config.totpSecret),
+      "authenticator code",
+    )
+  } else if ((await passwordTab.count()) && (await passwordTab.isEnabled())) {
+    await passwordTab.click()
+    await fillSecret(
+      dialog.getByLabel(/^(Password|密码)$/u).and(dialog.locator("input")),
+      config.password,
+      "password",
+    )
+  } else {
+    throw new Error(
+      "New API security verification has no supported configured method. Enable password verification or configure AAH_E2E_NEW_API_TOTP_SECRET for the test account.",
+    )
+  }
+
+  await dialog.getByRole("button", { name: /^(Verify|验证)$/u }).click()
+}
+
+async function fillSecret(input: Locator, value: string, label: string) {
+  await expect(input, `New API ${label} input must be editable`).toBeEditable()
+  try {
+    await input.fill(value)
+  } catch {
+    // Locator action errors can contain the fill value in their call log.
+    throw new Error(`Could not fill the New API ${label} field.`)
+  }
+}

--- a/tests/utils/newApiAccountRecovery.test.ts
+++ b/tests/utils/newApiAccountRecovery.test.ts
@@ -1,0 +1,47 @@
+import type { ConsoleMessage, Page } from "@playwright/test"
+import { describe, expect, it, vi } from "vitest"
+
+import { installExtensionPageGuards } from "~~/e2e/utils/commonUserFlows"
+import { createNewApiAccountRecovery } from "~~/e2e/utils/realSite/newApiAccountRecovery"
+
+describe("New API account recovery console guard", () => {
+  const baseUrl = "https://new-api.example.invalid"
+
+  it.each([
+    ["token verification response", `${baseUrl}/api/user/token`, 403, false],
+    ["other account endpoint", `${baseUrl}/api/user/self`, 403, true],
+    ["other site", "https://other.example.invalid/api/user/token", 403, true],
+    ["token server failure", `${baseUrl}/api/user/token`, 500, true],
+    ["unrelated token request", `${baseUrl}/api/user/token/status`, 403, true],
+  ])(
+    "handles %s without hiding unrelated failures",
+    (_label, url, status, throws) => {
+      const handlers = new Map<string, (message: ConsoleMessage) => void>()
+      const page = {
+        on: vi.fn((event, handler) => handlers.set(event, handler)),
+      } as unknown as Page
+      const recovery = createNewApiAccountRecovery({
+        page,
+        config: {
+          baseUrl,
+          loginUrl: `${baseUrl}/login`,
+          loginApiUrl: `${baseUrl}/api/user/login`,
+          login2faApiUrl: `${baseUrl}/api/user/login/2fa`,
+          username: "test-user",
+          password: "test-password",
+        },
+      })
+      installExtensionPageGuards(page, recovery.extensionPageGuardOptions)
+      const message = {
+        type: () => "error",
+        text: () =>
+          `Failed to load resource: the server responded with a status of ${status} ()`,
+        location: () => ({ url, lineNumber: 0, columnNumber: 0 }),
+      } as ConsoleMessage
+      const emit = () => handlers.get("console")!(message)
+
+      if (throws) expect(emit).toThrow(`status of ${status}`)
+      else expect(emit).not.toThrow()
+    },
+  )
+})


### PR DESCRIPTION
After #1408, New API sites requiring security verification display a manual Access Token recovery guide. The real-site account test treated the token endpoint's HTTP 403 as fatal and kept waiting for the automatic-add button.

The E2E scenario now follows the existing recovery flow: open the site's security settings, complete password or configured authenticator verification, confirm regeneration when necessary, copy the token, and save the preserved extension form. Clipboard reads wait until the copied value matches the generated token. The console exception is limited to HTTP 403 from the configured token endpoint; generated-token tabs close before failure screenshots, and secret input errors exclude their values.

Browser regressions cover automatic acquisition, password regeneration, authenticator generation, and delayed clipboard writes replacing an old token. They also verify retained account fields and persistence of the management token instead of the dashboard JWT.

Related: #1408 and the [original failing job](https://github.com/qixing-jk/all-api-hub/actions/runs/34126992827/job/101757949441).

Validation:

- [Real-Site E2E on GitHub Actions](https://github.com/qixing-jk/all-api-hub/actions/runs/34142693669), head `408569d439dadd74362dc58e6771e01406522bae`: all five New API account workflows passed, with no test skips.
- Five Chromium user-flow regressions and 34 targeted Vitest tests passed locally. The delayed-copy regression failed before the clipboard polling fix and passed afterward.
- Commit and push hooks passed: Prettier, ESLint, TypeScript, and Knip.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for New API account recovery, including automatic token detection, password verification, authenticator verification, token regeneration, and delayed clipboard handling.
  * Added validation for expected and unexpected security-related console errors.
  * Improved end-to-end checks for saving recovered account details and management tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

