### PR TITLE
fix(managed-sites): preserve upstream configuration during channel updates

### DIFF
--- a/e2e/fixtures/managedSiteChannelsIntercepted.ts
+++ b/e2e/fixtures/managedSiteChannelsIntercepted.ts
@@ -320,9 +320,13 @@ async function fulfillGraphQLError(route: Route, message: string) {
 
 async function installNewApiManagedSiteChannelsIntercepts(
   context: BrowserContext,
+  nativeFields?: Record<string, unknown>,
 ) {
   interceptedNewApiChannels = interceptedNewApiChannelTemplates.map(
-    (template) => ({ ...template }),
+    (template) => ({
+      ...template,
+      ...(template.id === 101 ? nativeFields : {}),
+    }),
   )
   interceptedNewApiCreatedChannel = null
   interceptedNewApiUpdatePayload = null
@@ -501,9 +505,13 @@ async function installNewApiManagedSiteChannelsIntercepts(
 
 async function installDoneHubManagedSiteChannelsIntercepts(
   context: BrowserContext,
+  nativeFields?: Record<string, unknown>,
 ) {
   interceptedDoneHubChannels = interceptedDoneHubChannelTemplates.map(
-    (template) => ({ ...template }),
+    (template) => ({
+      ...template,
+      ...(template.id === DONE_HUB_PRIMARY_ID ? nativeFields : {}),
+    }),
   )
 
   await context.route(
@@ -763,7 +771,10 @@ async function installAxonHubIntercepts(context: BrowserContext) {
 }
 
 /** Models cookie-authenticated channel persistence and exposes its stored key for assertions. */
-async function installOctopusCookieAuthIntercepts(context: BrowserContext) {
+async function installOctopusCookieAuthIntercepts(
+  context: BrowserContext,
+  nativeDetail?: Record<string, unknown>,
+) {
   let channel = {
     id: 17,
     name: "Example outbound",
@@ -842,12 +853,48 @@ async function installOctopusCookieAuthIntercepts(context: BrowserContext) {
     }
 
     if (path === "/api/v1/channel/list") {
+      if (nativeDetail) {
+        await route.fulfill({ status: 404, body: "Use v0.13 stats" })
+        return
+      }
       await fulfill(route, { code: 200, data: [channel] })
+      return
+    }
+
+    if (nativeDetail && path === "/api/v1/channel/stats") {
+      await fulfill(route, {
+        code: 200,
+        data: [
+          {
+            channel_id: nativeDetail.id,
+            channel_name: nativeDetail.name,
+            enabled: nativeDetail.enabled,
+            input_token: 0,
+            output_token: 0,
+            input_cost: 0,
+            output_cost: 0,
+            wait_time: 0,
+            request_success: 0,
+            request_failed: 0,
+            models: [{ model_id: 1, model_name: "model-a" }],
+          },
+        ],
+      })
+      return
+    }
+    if (nativeDetail && path === `/api/v1/channel/detail/${nativeDetail.id}`) {
+      await fulfill(route, { code: 200, data: nativeDetail })
       return
     }
 
     if (path === "/api/v1/channel/update" && request.method() === "POST") {
       const payload = request.postDataJSON()
+      if (nativeDetail) {
+        // Whole-body replacement makes missing upstream members observable.
+        nativeDetail = payload
+        await fulfill(route, { code: 200, data: nativeDetail })
+        return
+      }
       channel = { ...channel, ...payload }
       await fulfill(route, { code: 200, data: channel })
       return
@@ -856,7 +903,10 @@ async function installOctopusCookieAuthIntercepts(context: BrowserContext) {
     await route.fulfill({ status: 404, body: "fixture route not configured" })
   })
 
-  return { getChannelKey: () => channel.key }
+  return {
+    getChannelKey: () => channel.key,
+    getNativeDetail: () => nativeDetail,
+  }
 }
 
 async function openManagedSiteChannelsPage(params: {
@@ -878,9 +928,13 @@ export async function openInterceptedNewApiManagedSiteChannels(params: {
   context: BrowserContext
   page: Page
   extensionId: string
+  nativeFields?: Record<string, unknown>
 }) {
   await forceExtensionLanguage(params.page, "en")
-  await installNewApiManagedSiteChannelsIntercepts(params.context)
+  await installNewApiManagedSiteChannelsIntercepts(
+    params.context,
+    params.nativeFields,
+  )
   await seedUserPreferences(await getServiceWorker(params.context), {
     managedSiteType: SITE_TYPES.NEW_API,
     newApi: {
@@ -905,9 +959,13 @@ export async function openInterceptedDoneHubManagedSiteChannels(params: {
   page: Page
   extensionId: string
   channelId?: number
+  nativeFields?: Record<string, unknown>
 }) {
   await forceExtensionLanguage(params.page, "en")
-  await installDoneHubManagedSiteChannelsIntercepts(params.context)
+  await installDoneHubManagedSiteChannelsIntercepts(
+    params.context,
+    params.nativeFields,
+  )
   await seedUserPreferences(await getServiceWorker(params.context), {
     managedSiteType: SITE_TYPES.DONE_HUB,
     doneHub: {
@@ -947,9 +1005,13 @@ export async function openInterceptedOctopusManagedSiteChannels(params: {
   context: BrowserContext
   page: Page
   extensionId: string
+  nativeDetail?: Record<string, unknown>
 }) {
   await forceExtensionLanguage(params.page, "en")
-  const fixture = await installOctopusCookieAuthIntercepts(params.context)
+  const fixture = await installOctopusCookieAuthIntercepts(
+    params.context,
+    params.nativeDetail,
+  )
   await seedUserPreferences(await getServiceWorker(params.context), {
     managedSiteType: SITE_TYPES.OCTOPUS,
     octopus: {

--- a/e2e/managedSiteMinimalUpdates.spec.ts
+++ b/e2e/managedSiteMinimalUpdates.spec.ts
@@ -215,7 +215,7 @@ for (const scenario of cases) {
   })
 }
 
-test("New API preserves required full-update fields and omits unchanged status and credentials", async ({
+test("New API retains native fields during full updates and omits unchanged status and credentials", async ({
   context,
   page,
   extensionId,

--- a/e2e/managedSiteMinimalUpdates.spec.ts
+++ b/e2e/managedSiteMinimalUpdates.spec.ts
@@ -1,0 +1,247 @@
+import type { BrowserContext, Page } from "@playwright/test"
+
+import { CHANNEL_DIALOG_TEST_IDS } from "~/components/dialogs/ChannelDialog/testIds"
+import { OPTIONS_PAGE_PATH } from "~/constants/extensionPages"
+import { MENU_ITEM_IDS } from "~/constants/optionsMenuIds"
+import { SITE_TYPES } from "~/constants/siteType"
+import { expect, test } from "~~/e2e/fixtures/extensionTest"
+import {
+  AXON_HUB_PRIMARY_ID,
+  DONE_HUB_PRIMARY_ID,
+  openInterceptedAxonHubManagedSiteChannels,
+  openInterceptedDoneHubManagedSiteChannels,
+  openInterceptedNewApiManagedSiteChannels,
+  openInterceptedOctopusManagedSiteChannels,
+} from "~~/e2e/fixtures/managedSiteChannelsIntercepted"
+import {
+  channelRowByName,
+  openManagedSiteChannelRowActions,
+} from "~~/e2e/scenarios/managedSiteChannels"
+import {
+  forceExtensionLanguage,
+  seedUserPreferences,
+} from "~~/e2e/utils/commonUserFlows"
+import { getServiceWorker } from "~~/e2e/utils/extensionState"
+
+type BrowserParams = {
+  context: BrowserContext
+  page: Page
+  extensionId: string
+}
+
+/** Provides native HTTP responses, including fields an older editor does not own. */
+async function openSelectiveSite(
+  params: BrowserParams,
+  site: "veloera" | "claudeCodeHub" | "sub2api",
+) {
+  const origin = `https://${site.toLowerCase()}.example.invalid`
+  let resource: Record<string, unknown> = {
+    id: 17,
+    name: "Minimal primary",
+    type: 1,
+    base_url: "https://upstream.example.invalid",
+    models: "model-a",
+    group: "default",
+    priority: 3,
+    weight: 2,
+    status: 1,
+    key: "",
+    model_prefix: "keep-prefix",
+    system_prompt: "keep-policy",
+  }
+  if (site === "claudeCodeHub")
+    resource = {
+      id: 17,
+      name: "Minimal primary",
+      url: "https://upstream.example.invalid",
+      maskedKey: "sk-****",
+      providerType: "claude",
+      isEnabled: true,
+      weight: 2,
+      priority: 3,
+      groupTag: "default",
+      allowedModels: [{ matchType: "exact", pattern: "model-a" }],
+      futurePolicy: { enabled: true },
+    }
+  if (site === "sub2api")
+    resource = {
+      id: 17,
+      name: "Minimal primary",
+      platform: "openai",
+      type: "apikey",
+      status: "active",
+      concurrency: 3,
+      priority: 2,
+      notes: "Keep notes",
+      credentials_status: { has_api_key: true },
+      credentials: {
+        base_url: "https://upstream.example.invalid",
+        model_mapping: { "model-a": "model-a" },
+        future_credential_option: true,
+      },
+    }
+  await params.context.route(`${origin}/**`, async (route) => {
+    const request = route.request()
+    const path = new URL(request.url()).pathname
+    const isList =
+      path ===
+      (site === "veloera"
+        ? "/api/channel/"
+        : site === "claudeCodeHub"
+          ? "/api/v1/providers"
+          : "/api/v1/admin/accounts")
+    let data: unknown
+    if (["PUT", "PATCH"].includes(request.method())) {
+      resource = { ...resource, ...request.postDataJSON() }
+      data = resource
+    } else if (path.includes("group")) {
+      data = ["default"]
+    } else if (isList) {
+      data =
+        site === "veloera"
+          ? [resource]
+          : { items: [resource], total: 1, pages: 1 }
+    } else if (path.endsWith("/17")) {
+      data = resource
+    } else {
+      await route.fulfill({ status: 404, body: "Unexpected fixture request" })
+      return
+    }
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify(
+        site === "claudeCodeHub"
+          ? data
+          : site === "sub2api"
+            ? { code: 0, data }
+            : { success: true, data },
+      ),
+    })
+  })
+  await forceExtensionLanguage(params.page, "en")
+  const config = {
+    baseUrl: origin,
+    adminToken: "fixture-admin-token",
+    userId: "1",
+  }
+  await seedUserPreferences(await getServiceWorker(params.context), {
+    managedSiteType:
+      site === "veloera"
+        ? SITE_TYPES.VELOERA
+        : site === "claudeCodeHub"
+          ? SITE_TYPES.CLAUDE_CODE_HUB
+          : SITE_TYPES.SUB2API,
+    ...(site === "veloera"
+      ? { veloera: config }
+      : site === "claudeCodeHub"
+        ? { claudeCodeHub: config }
+        : { sub2apiManagedSite: config }),
+  })
+  await params.page.goto(
+    `chrome-extension://${params.extensionId}/${OPTIONS_PAGE_PATH}#${MENU_ITEM_IDS.MANAGED_SITE_CHANNELS}`,
+  )
+}
+
+test.use({ viewport: { width: 1440, height: 1000 }, locale: "en-US" })
+
+const cases = [
+  {
+    name: "AxonHub",
+    open: openInterceptedAxonHubManagedSiteChannels,
+    original: "Example primary",
+    expected: { id: AXON_HUB_PRIMARY_ID, input: { name: "Minimal renamed" } },
+  },
+  {
+    name: "DoneHub",
+    open: openInterceptedDoneHubManagedSiteChannels,
+    original: "DoneHub primary",
+    expected: { id: DONE_HUB_PRIMARY_ID, name: "Minimal renamed" },
+  },
+  {
+    name: "Octopus",
+    open: openInterceptedOctopusManagedSiteChannels,
+    original: "Example outbound",
+    expected: { id: 17, name: "Minimal renamed" },
+  },
+  {
+    name: "Veloera",
+    open: (params: BrowserParams) => openSelectiveSite(params, "veloera"),
+    original: "Minimal primary",
+    expected: { id: 17, name: "Minimal renamed" },
+  },
+  {
+    name: "Claude Code Hub",
+    open: (params: BrowserParams) => openSelectiveSite(params, "claudeCodeHub"),
+    original: "Minimal primary",
+    expected: { name: "Minimal renamed" },
+  },
+  {
+    name: "Sub2API",
+    open: (params: BrowserParams) => openSelectiveSite(params, "sub2api"),
+    original: "Minimal primary",
+    expected: { name: "Minimal renamed" },
+  },
+] as const
+
+for (const scenario of cases) {
+  test(`${scenario.name} sends only the renamed field and required identity`, async ({
+    context,
+    page,
+    extensionId,
+  }) => {
+    await scenario.open({ context, page, extensionId })
+    await openManagedSiteChannelRowActions(page, scenario.original)
+    await page.getByRole("menuitem", { name: "Edit", exact: true }).click()
+    await page
+      .getByTestId(CHANNEL_DIALOG_TEST_IDS.nameInput)
+      .fill("Minimal renamed")
+    const updates: unknown[] = []
+    context.on("request", (request) => {
+      if (
+        ["PUT", "PATCH"].includes(request.method()) ||
+        (request.method() === "POST" &&
+          request.url().includes("/channel/update"))
+      )
+        updates.push(request.postDataJSON())
+      else if (
+        request.method() === "POST" &&
+        request.postData()?.includes("mutation UpdateChannel(")
+      )
+        updates.push(request.postDataJSON().variables)
+    })
+    await page.getByTestId(CHANNEL_DIALOG_TEST_IDS.submitButton).click()
+    await expect(channelRowByName(page, "Minimal renamed")).toBeVisible()
+    expect(updates).toEqual([scenario.expected])
+  })
+}
+
+test("New API preserves required full-update fields and omits unchanged status and credentials", async ({
+  context,
+  page,
+  extensionId,
+}) => {
+  await openInterceptedNewApiManagedSiteChannels({ context, page, extensionId })
+  await openManagedSiteChannelRowActions(page, "Example primary")
+  await page.getByRole("menuitem", { name: "Edit", exact: true }).click()
+  await page
+    .getByTestId(CHANNEL_DIALOG_TEST_IDS.nameInput)
+    .fill("Minimal renamed")
+  const updates: unknown[] = []
+  context.on("request", (request) => {
+    if (request.method() === "PUT") updates.push(request.postDataJSON())
+  })
+  await page.getByTestId(CHANNEL_DIALOG_TEST_IDS.submitButton).click()
+  await expect(channelRowByName(page, "Minimal renamed")).toBeVisible()
+  expect(updates).toEqual([
+    {
+      id: 101,
+      name: "Minimal renamed",
+      type: 1,
+      base_url: "https://upstream.example.invalid/v1",
+      models: "model-a,model-b",
+      group: "default,example",
+      priority: 3,
+      weight: 2,
+    },
+  ])
+})

--- a/e2e/managedSiteUpstreamCompatibility.spec.ts
+++ b/e2e/managedSiteUpstreamCompatibility.spec.ts
@@ -1,0 +1,186 @@
+import type { Page } from "@playwright/test"
+
+import { CHANNEL_DIALOG_TEST_IDS } from "~/components/dialogs/ChannelDialog/testIds"
+import { expect, test } from "~~/e2e/fixtures/extensionTest"
+import {
+  AXON_HUB_PRIMARY_ID,
+  getInterceptedAxonHubUpdateVariables,
+  getInterceptedNewApiUpdatePayload,
+  openInterceptedAxonHubManagedSiteChannels,
+  openInterceptedDoneHubManagedSiteChannels,
+  openInterceptedNewApiManagedSiteChannels,
+  openInterceptedOctopusManagedSiteChannels,
+} from "~~/e2e/fixtures/managedSiteChannelsIntercepted"
+import {
+  channelRowByName,
+  openManagedSiteChannelRowActions,
+} from "~~/e2e/scenarios/managedSiteChannels"
+
+const renamed = "Upstream compatibility renamed"
+
+async function renameChannel(page: Page, name: string) {
+  await openManagedSiteChannelRowActions(page, name)
+  await page.getByRole("menuitem", { name: "Edit", exact: true }).click()
+  await page.getByTestId(CHANNEL_DIALOG_TEST_IDS.nameInput).fill(renamed)
+  await page.getByTestId(CHANNEL_DIALOG_TEST_IDS.submitButton).click()
+  await expect(channelRowByName(page, renamed)).toBeVisible()
+}
+
+test.use({ viewport: { width: 1440, height: 1000 }, locale: "en-US" })
+
+test("DoneHub retains upstream fields when a model edit requires a complete update", async ({
+  context,
+  page,
+  extensionId,
+}) => {
+  const nativeFields = {
+    future_policy: { limits: [3, 7], enabled: false },
+    setting: JSON.stringify({ future_setting: "keep" }),
+  }
+  await openInterceptedDoneHubManagedSiteChannels({
+    context,
+    page,
+    extensionId,
+    nativeFields,
+  })
+  await openManagedSiteChannelRowActions(page, "DoneHub primary")
+  await page.getByRole("menuitem", { name: "Edit", exact: true }).click()
+  await page
+    .getByTestId(CHANNEL_DIALOG_TEST_IDS.modelsInput)
+    .fill("model-added")
+  await page.getByTestId(CHANNEL_DIALOG_TEST_IDS.modelsInput).press("Enter")
+  const updates: unknown[] = []
+  context.on("request", (request) => {
+    if (request.method() === "PUT" && request.url().includes("/api/channel/"))
+      updates.push(request.postDataJSON())
+  })
+  const save = page.getByTestId(CHANNEL_DIALOG_TEST_IDS.submitButton)
+  await save.click()
+  await expect(save).toBeHidden()
+  expect(updates).toEqual([
+    expect.objectContaining({
+      ...nativeFields,
+      models: "model-donehub-a,model-added",
+    }),
+  ])
+})
+
+test("New API retains upstream fields and opaque settings in a complete update", async ({
+  context,
+  page,
+  extensionId,
+}) => {
+  const nativeFields = {
+    future_policy: { limits: [3, 7], enabled: false },
+    setting: JSON.stringify({ future_setting: { mode: "upstream" } }),
+  }
+  await openInterceptedNewApiManagedSiteChannels({
+    context,
+    page,
+    extensionId,
+    nativeFields,
+  })
+  await renameChannel(page, "Example primary")
+  expect(getInterceptedNewApiUpdatePayload()).toMatchObject({
+    ...nativeFields,
+    name: renamed,
+  })
+  expect(getInterceptedNewApiUpdatePayload()).not.toHaveProperty("key")
+})
+
+test("Octopus v0.13 retains upstream detail and nested fields through a complete update", async ({
+  context,
+  page,
+  extensionId,
+}) => {
+  const nativeDetail = {
+    id: 17,
+    name: "Example v0.13",
+    dialect: "generic",
+    enabled: true,
+    base_url: "https://upstream.example.invalid",
+    openai_chat_completion_path: "/v1/chat/completions",
+    openai_response_path: "/v1/responses",
+    anthropic_message_path: "/v1/messages",
+    keys: [
+      {
+        name: "default",
+        key: "fixture-key",
+        enabled: true,
+        future_key_policy: { mode: "upstream" },
+      },
+    ],
+    models: ["model-a"],
+    grants: [
+      {
+        model_name: "model-a",
+        key_name: "default",
+        protocols: 2,
+        future_grant_policy: ["keep"],
+      },
+    ],
+    proxy: false,
+    custom_header: [
+      {
+        header_key: "X-Example",
+        header_value: "value",
+        future_header_policy: false,
+      },
+    ],
+    param_override: "",
+    channel_proxy: "",
+    match_regex: "",
+    future_policy: { limits: [3, 7], enabled: false },
+  }
+  const fixture = await openInterceptedOctopusManagedSiteChannels({
+    context,
+    page,
+    extensionId,
+    nativeDetail,
+  })
+  await renameChannel(page, nativeDetail.name)
+  expect(fixture.getNativeDetail()).toEqual({ ...nativeDetail, name: renamed })
+})
+
+test("AxonHub can rename when an upstream optional GraphQL field is unavailable", async ({
+  context,
+  page,
+  extensionId,
+}) => {
+  await openInterceptedAxonHubManagedSiteChannels({
+    context,
+    page,
+    extensionId,
+  })
+  let rejectedAdvancedQueries = 0
+  let coreQueries = 0
+  await context.route("**/admin/graphql", async (route) => {
+    const query = route.request().postDataJSON().query as string
+    if (query.includes("query GetAxonHubChannel(")) {
+      rejectedAdvancedQueries += 1
+      await route.fulfill({
+        status: 400,
+        contentType: "application/json",
+        body: JSON.stringify({
+          errors: [
+            {
+              message:
+                'Cannot query field "extraModelPrefix" on type "ChannelSettings".',
+              extensions: { code: "GRAPHQL_VALIDATION_FAILED" },
+            },
+          ],
+        }),
+      })
+      return
+    }
+    if (query.includes("query GetAxonHubChannelCore(")) coreQueries += 1
+    await route.fallback()
+  })
+  await renameChannel(page, "Example primary")
+  expect(rejectedAdvancedQueries).toBe(1)
+  expect(coreQueries).toBeGreaterThan(0)
+  expect(getInterceptedAxonHubUpdateVariables()).toEqual({
+    id: AXON_HUB_PRIMARY_ID,
+    input: { name: renamed },
+  })
+})

--- a/e2e/realSite/managedSiteChannels.spec.ts
+++ b/e2e/realSite/managedSiteChannels.spec.ts
@@ -140,6 +140,11 @@ test.describe("real-site E2E: managed-site channel management", () => {
         { annotation: { type: "skip", description: skipReason } },
         async () => {},
       )
+      test.skip(
+        `${target.label} preserves unrelated fields after renaming`,
+        { annotation: { type: "skip", description: skipReason } },
+        async () => {},
+      )
       continue
     }
 
@@ -149,7 +154,7 @@ test.describe("real-site E2E: managed-site channel management", () => {
       page,
     }) => {
       const serviceWorker = await getServiceWorker(context)
-      const config = managedSite.config
+      const config = managedSite.config!
       const runId = buildRealSiteRunId()
       const runPrefix = buildManagedSiteE2ePrefix({
         label: target.label.replace(/\s+/g, ""),
@@ -174,6 +179,34 @@ test.describe("real-site E2E: managed-site channel management", () => {
         label: target.label,
         runPrefix,
         cleanupPrefix,
+      })
+    })
+
+    test(`${target.label} preserves unrelated fields after renaming`, async ({
+      context,
+      extensionId,
+      page,
+    }) => {
+      const config = managedSite.config!
+      const runPrefix = buildManagedSiteE2ePrefix({
+        label: `${target.label.replace(/\s+/g, "")} Preserve`,
+        runId: buildRealSiteRunId(),
+      })
+      await seedUserPreferences(await getServiceWorker(context), {
+        managedSiteType: target.siteType,
+        [target.preferenceKey]: config,
+        autoFillCurrentSiteUrlOnAccountAdd: false,
+        autoProvisionKeyOnAccountAdd: false,
+        openChangelogOnUpdate: false,
+      })
+      await runManagedSiteChannelsCrudScenario({
+        page,
+        extensionId,
+        siteType: target.siteType,
+        label: target.label,
+        runPrefix,
+        cleanupPrefix: runPrefix,
+        verifyRenamePreservation: { baseUrl: config.baseUrl },
       })
     })
 

--- a/e2e/scenarios/managedSiteChannels.ts
+++ b/e2e/scenarios/managedSiteChannels.ts
@@ -28,6 +28,10 @@ import {
 } from "~~/e2e/utils/accountLifecycle"
 import { waitForExtensionRoot } from "~~/e2e/utils/lazyLoading"
 import {
+  assertManagedChannelPreserved,
+  captureManagedChannelSnapshot,
+} from "~~/e2e/utils/realSite/managedChannelPreservation"
+import {
   collectCleanupError,
   runScenarioWithCleanup,
   throwScenarioError,
@@ -45,6 +49,7 @@ type ManagedSiteChannelScenarioContext<TSiteType extends ManagedSiteType> = {
   tokenName?: string
   tokenCleanupPrefix?: string
   beforeDeleteConfirm?: () => void | Promise<void>
+  verifyRenamePreservation?: { baseUrl: string }
 }
 
 const CRUD_MODEL = "gpt-4o-mini"
@@ -173,14 +178,37 @@ export async function runManagedSiteChannelsCrudScenario<
       })
       await expectPaginationSummary(context.page, "1", "1", "1")
 
-      await openSingleVisibleChannelEditDialog(context.page, channelName)
+      const captureSnapshot = (name: string) =>
+        captureManagedChannelSnapshot({
+          page: context.page,
+          siteType: context.siteType,
+          baseUrl: context.verifyRenamePreservation!.baseUrl,
+          name,
+          read: () => openSingleVisibleChannelEditDialog(context.page, name),
+        })
+      const before = context.verifyRenamePreservation
+        ? await captureSnapshot(channelName)
+        : undefined
+      if (!before)
+        await openSingleVisibleChannelEditDialog(context.page, channelName)
       await context.page
         .getByTestId(CHANNEL_DIALOG_TEST_IDS.nameInput)
         .fill(editedChannelName)
-      if (shouldEditModelsInManagedSiteCrudScenario(context.siteType)) {
+      if (
+        !context.verifyRenamePreservation &&
+        shouldEditModelsInManagedSiteCrudScenario(context.siteType)
+      ) {
         await fillModelInput(context.page, CRUD_UPDATED_MODEL)
       }
       await submitChannelDialogAndWaitForClose(context.page)
+
+      if (before) {
+        const after = await captureSnapshot(editedChannelName)
+        await context.page
+          .getByRole("button", { name: "Cancel", exact: true })
+          .click()
+        assertManagedChannelPreserved(context.siteType, before, after)
+      }
 
       await expect(
         channelRowByName(context.page, editedChannelName),

--- a/e2e/scenarios/managedSiteChannels.ts
+++ b/e2e/scenarios/managedSiteChannels.ts
@@ -205,7 +205,7 @@ export async function runManagedSiteChannelsCrudScenario<
       if (before) {
         const after = await captureSnapshot(editedChannelName)
         await context.page
-          .getByRole("button", { name: "Cancel", exact: true })
+          .getByTestId(CHANNEL_DIALOG_TEST_IDS.cancelButton)
           .click()
         assertManagedChannelPreserved(context.siteType, before, after)
       }

--- a/e2e/utils/realSite/managedChannelPreservation.ts
+++ b/e2e/utils/realSite/managedChannelPreservation.ts
@@ -1,0 +1,105 @@
+import { isDeepStrictEqual } from "node:util"
+import type { Page } from "@playwright/test"
+
+import { SITE_TYPES, type ManagedSiteType } from "~/constants/siteType"
+
+type Snapshot = Record<string, unknown>
+const isRecord = (value: unknown): value is Snapshot =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+/** Retains the server response rather than the extension's editable projection. */
+export function extractManagedChannelSnapshot(
+  siteType: ManagedSiteType,
+  body: unknown,
+  name: string,
+): Snapshot | null {
+  if (!isRecord(body) || body.success === false || body.errors) return null
+  const data = siteType === SITE_TYPES.CLAUDE_CODE_HUB ? body : body.data
+  const candidate =
+    siteType === SITE_TYPES.AXON_HUB
+      ? isRecord(data)
+        ? data.node
+        : undefined
+      : Array.isArray(data)
+        ? data.find((item) => isRecord(item) && item.name === name)
+        : data
+  return isRecord(candidate) &&
+    candidate.name === name &&
+    (typeof candidate.id === "number" || typeof candidate.id === "string")
+    ? candidate
+    : null
+}
+
+/** Collects a fresh native read triggered by opening the test resource's editor. */
+export async function captureManagedChannelSnapshot(params: {
+  page: Page
+  siteType: ManagedSiteType
+  baseUrl: string
+  name: string
+  read: () => Promise<void>
+}): Promise<Snapshot> {
+  const origin = new URL(params.baseUrl).origin
+  let snapshot: Snapshot | null = null
+  const response = params.page.context().waitForEvent("response", {
+    timeout: 30_000,
+    predicate: async (response) => {
+      const request = response.request()
+      const url = new URL(response.url())
+      if (url.origin !== origin || !response.ok()) return false
+      if (params.siteType === SITE_TYPES.AXON_HUB) {
+        if (
+          url.pathname !== "/admin/graphql" ||
+          !/query GetAxonHubChannel(?:Core)?\(/u.test(request.postData() ?? "")
+        )
+          return false
+      } else {
+        if (request.method() !== "GET") return false
+        const path = url.pathname
+        const isDetail =
+          /\/api\/channel\/\d+$/u.test(path) ||
+          /\/api\/v1\/providers\/\d+$/u.test(path) ||
+          /\/api\/v1\/admin\/accounts\/\d+$/u.test(path) ||
+          (params.siteType === SITE_TYPES.OCTOPUS &&
+            /\/api\/v1\/channel\/(?:list|detail\/\d+)$/u.test(path))
+        if (!isDetail) return false
+      }
+      try {
+        const candidate = extractManagedChannelSnapshot(
+          params.siteType,
+          await response.json(),
+          params.name,
+        )
+        if (!candidate) return false
+        snapshot = candidate
+        return true
+      } catch {
+        return false
+      }
+    },
+  })
+  await Promise.all([response, params.read()])
+  if (!snapshot) throw new Error("No native channel detail was captured")
+  return snapshot
+}
+
+/** Reports field names only: native snapshots can contain real credentials. */
+export function assertManagedChannelPreserved(
+  siteType: ManagedSiteType,
+  before: Snapshot,
+  after: Snapshot,
+): void {
+  const updateTimestamp =
+    siteType === SITE_TYPES.AXON_HUB || siteType === SITE_TYPES.CLAUDE_CODE_HUB
+      ? "updatedAt"
+      : "updated_at"
+  const changed = [...new Set([...Object.keys(before), ...Object.keys(after)])]
+    .filter((field) => field !== "name" && field !== updateTimestamp)
+    .filter(
+      (field) =>
+        Object.hasOwn(before, field) !== Object.hasOwn(after, field) ||
+        !isDeepStrictEqual(before[field], after[field]),
+    )
+    .sort()
+  if (changed.length)
+    throw new Error(`Unrelated channel fields changed: ${changed.join(", ")}`)
+}

--- a/src/components/dialogs/ChannelDialog/components/ChannelEditorShell.tsx
+++ b/src/components/dialogs/ChannelDialog/components/ChannelEditorShell.tsx
@@ -58,6 +58,7 @@ export function ChannelEditorShell({
         onClick={handleClose}
         disabled={isSubmitting}
         type="button"
+        data-testid={CHANNEL_DIALOG_TEST_IDS.cancelButton}
       >
         {closeLabel}
       </Button>

--- a/src/components/dialogs/ChannelDialog/testIds.ts
+++ b/src/components/dialogs/ChannelDialog/testIds.ts
@@ -8,5 +8,6 @@ export const CHANNEL_DIALOG_TEST_IDS = {
   baseUrlInput: "channel-dialog-base-url-input",
   modelsInput: "channel-dialog-models-input",
   statusSelect: "channel-dialog-status-select",
+  cancelButton: "channel-dialog-cancel-button",
   submitButton: "channel-dialog-submit-button",
 } as const

--- a/src/services/apiAdapters/managedResources/newApiEditor.ts
+++ b/src/services/apiAdapters/managedResources/newApiEditor.ts
@@ -90,6 +90,7 @@ type NewApiFamilyEditorPolicy = {
   typeOptions: readonly { value: number; label: string }[]
   unsupportedCreateTypes: ReadonlySet<number>
   baseUrlRequiredTypes: ReadonlySet<number>
+  groupsRequired?: boolean
 }
 
 const newApiEditorPolicy: NewApiFamilyEditorPolicy = {
@@ -232,6 +233,13 @@ const typeOptions = (
   return options
 }
 
+const requiresNonEmptyGroups = (
+  policy: NewApiFamilyEditorPolicy,
+  existing?: NewApiFamilyChannelFields,
+) =>
+  policy.groupsRequired === true &&
+  (existing === undefined || parseNewApiResourceList(existing.group).length > 0)
+
 const fieldDescriptors = (
   policy: NewApiFamilyEditorPolicy,
   detail?: NewApiFamilyChannelFields,
@@ -286,6 +294,7 @@ const fieldDescriptors = (
     {
       fieldId: editorFields.Groups,
       type: MANAGED_RESOURCE_FIELD_TYPES.MultiSelect,
+      ...(requiresNonEmptyGroups(policy, detail) ? { required: true } : {}),
       options: normalizeList([
         ...parseNewApiResourceList(detail?.group),
         ...groupSuggestions,
@@ -365,6 +374,15 @@ const validateValues = (
   if (readList(values, editorFields.Models).length === 0) {
     issues.push({
       fieldId: editorFields.Models,
+      code: MANAGED_RESOURCE_FIELD_ISSUE_CODES.Required,
+    })
+  }
+  if (
+    requiresNonEmptyGroups(policy, existing) &&
+    readList(values, editorFields.Groups).length === 0
+  ) {
+    issues.push({
+      fieldId: editorFields.Groups,
       code: MANAGED_RESOURCE_FIELD_ISSUE_CODES.Required,
     })
   }

--- a/src/services/apiAdapters/managedResources/veloera.ts
+++ b/src/services/apiAdapters/managedResources/veloera.ts
@@ -102,6 +102,11 @@ const veloeraEditor = createNewApiFamilyEditorBindings({
   typeOptions: VeloeraChannelTypeOptions,
   unsupportedCreateTypes: new Set([VeloeraChannelType.VertexAi]),
   baseUrlRequiredTypes: new Set(),
+  // Veloera's update model stores group as a non-pointer string, so GORM
+  // silently ignores an attempted empty value. Reject clearing an existing
+  // group while keeping legacy channels that are already empty editable.
+  // https://github.com/Veloera/Veloera/blob/6525dfce816beaa270e78f0d8b762e19e54d13b8/model/channel.go
+  groupsRequired: true,
 })
 const mapFailure = (error: unknown): ResourceFailure => {
   if (error instanceof ManagedResourceError) return error.failure
@@ -224,7 +229,9 @@ const toUpdatePayload = (
   }
   const payload: VeloeraUpdateChannelPayload = { id: detail.id }
   // Veloera uses GORM's selective Updates, then reloads the saved channel
-  // before updating abilities. Unedited provider fields need not be replayed.
+  // before updating abilities. Its base URL, priority, and weight fields are
+  // pointers, so explicit empty and zero values remain present during updates.
+  // Unedited provider fields need not be replayed.
   // https://github.com/Veloera/Veloera/blob/6525dfce816beaa270e78f0d8b762e19e54d13b8/model/channel.go
   for (const field of Object.keys(editable) as (keyof typeof editable)[]) {
     if (editable[field] !== detail[field]) {

--- a/src/services/apiAdapters/managedResources/veloera.ts
+++ b/src/services/apiAdapters/managedResources/veloera.ts
@@ -212,9 +212,7 @@ const toUpdatePayload = (
   detail: VeloeraChannel,
   draft: NewApiFamilyChannelCommand,
 ): VeloeraUpdateChannelPayload => {
-  const payload: VeloeraUpdateChannelPayload = {
-    ...detail,
-    id: detail.id,
+  const editable = {
     name: draft.name.trim(),
     type: draft.type,
     base_url: draft.base_url.trim(),
@@ -224,10 +222,22 @@ const toUpdatePayload = (
     weight: draft.weight,
     status: draft.status,
   }
+  const payload: VeloeraUpdateChannelPayload = { id: detail.id }
+  // Veloera uses GORM's selective Updates, then reloads the saved channel
+  // before updating abilities. Unedited provider fields need not be replayed.
+  // https://github.com/Veloera/Veloera/blob/6525dfce816beaa270e78f0d8b762e19e54d13b8/model/channel.go
+  for (const field of Object.keys(editable) as (keyof typeof editable)[]) {
+    if (editable[field] !== detail[field]) {
+      Object.assign(payload, { [field]: editable[field] })
+    }
+  }
+  // The controller validates Vertex's region when the type is submitted.
+  // https://github.com/Veloera/Veloera/blob/6525dfce816beaa270e78f0d8b762e19e54d13b8/controller/channel.go
+  if (payload.type === VeloeraChannelType.VertexAi) {
+    payload.other = detail.other
+  }
   if (hasUsableManagedSiteChannelKey(draft.key)) {
     payload.key = draft.key.trim()
-  } else {
-    delete payload.key
   }
   return payload
 }

--- a/src/services/apiService/octopus/v013.ts
+++ b/src/services/apiService/octopus/v013.ts
@@ -111,6 +111,7 @@ const requireArray = (value: Record<string, unknown>, field: string) => {
 const parseCustomHeader = (value: unknown): OctopusCustomHeader => {
   if (!isRecord(value)) throw invalidV013Response("custom_header")
   return {
+    ...value,
     header_key: requireString(value, "header_key"),
     header_value: requireString(value, "header_value"),
   }
@@ -119,6 +120,7 @@ const parseCustomHeader = (value: unknown): OctopusCustomHeader => {
 const parseChannelKey = (value: unknown): OctopusV013ChannelKeyDto => {
   if (!isRecord(value)) throw invalidV013Response("keys")
   return {
+    ...value,
     name: requireString(value, "name"),
     key: requireString(value, "key"),
     enabled: requireBoolean(value, "enabled"),
@@ -128,6 +130,7 @@ const parseChannelKey = (value: unknown): OctopusV013ChannelKeyDto => {
 const parseChannelGrant = (value: unknown): OctopusV013ChannelGrantDto => {
   if (!isRecord(value)) throw invalidV013Response("grants")
   return {
+    ...value,
     model_name: requireString(value, "model_name"),
     key_name: requireString(value, "key_name"),
     protocols: requireInteger(value, "protocols"),
@@ -159,7 +162,12 @@ const parseChannelStats = (value: unknown): OctopusV013ChannelStatsDto => {
 
 const parseChannelDetail = (value: unknown): OctopusV013ChannelDetailDto => {
   if (!isRecord(value)) throw invalidV013Response()
+  // Updates replace the native detail body. Validate the fields we consume
+  // without stripping upstream-owned members, including nested key/grant/header
+  // members, so additions in newer servers survive unrelated edits.
+  // https://github.com/bestruirui/octopus/blob/27aa40dc0f3b2902bce3e96ccdba019d17041606/internal/op/channel.go
   return {
+    ...value,
     id: requireInteger(value, "id"),
     name: requireString(value, "name"),
     dialect: requireString(value, "dialect"),
@@ -316,7 +324,8 @@ const encodeUpdate = (
   let grants = existing.grants
     .filter(
       (grant) =>
-        modelNames.has(grant.model_name) && keyNames.has(grant.key_name),
+        !replacesModels ||
+        (modelNames.has(grant.model_name) && keyNames.has(grant.key_name)),
     )
     .map((grant) => ({
       ...grant,

--- a/src/services/apiService/veloera/index.ts
+++ b/src/services/apiService/veloera/index.ts
@@ -104,7 +104,7 @@ export async function createChannel(
  * Update a channel for a Veloera-managed site.
  *
  * Veloera expects the update payload to be flat and typically uses `group` instead
- * of `groups`. Native update planning supplies the complete provider payload.
+ * of `groups`. Native update planning supplies only changed editable fields.
  */
 export async function updateChannel(
   request: ApiServiceRequest,

--- a/src/types/veloera.ts
+++ b/src/types/veloera.ts
@@ -36,7 +36,7 @@ export type VeloeraCreateChannelPayload = Omit<
   "id"
 > & { status: number } & Record<string, unknown>
 
-/** Full channel updates retain fields the common editor does not expose. */
+/** Minimal channel update containing only fields intentionally changed by the editor. */
 export type VeloeraUpdateChannelPayload = Partial<VeloeraChannelFields> & {
   id: number
 } & Record<string, unknown>

--- a/tests/components/dialogs/ChannelDialog/ChannelEditorShell.test.tsx
+++ b/tests/components/dialogs/ChannelDialog/ChannelEditorShell.test.tsx
@@ -42,7 +42,7 @@ describe("ChannelEditorShell", () => {
     )
     await user.click(submit)
     expect(onSubmit).toHaveBeenCalledTimes(1)
-    await user.click(screen.getByRole("button", { name: "Cancel" }))
+    await user.click(screen.getByTestId(CHANNEL_DIALOG_TEST_IDS.cancelButton))
     expect(onClose).toHaveBeenCalledTimes(1)
   })
 

--- a/tests/services/apiAdapters/managedResources/veloera.test.ts
+++ b/tests/services/apiAdapters/managedResources/veloera.test.ts
@@ -9,6 +9,7 @@ import { MANAGED_RESOURCE_KINDS } from "~/services/accountSiteDefinitions/contra
 import {
   MANAGED_RESOURCE_CREATE_SEED_KINDS,
   MANAGED_RESOURCE_FAILURE_CODES,
+  MANAGED_RESOURCE_FIELD_ISSUE_CODES,
   ManagedResourceError,
 } from "~/services/apiAdapters/contracts/managedResourceNative"
 import {
@@ -430,6 +431,50 @@ describe("Veloera native managed resource", () => {
       other: "us-central1",
     })
     expect(mocks.update.mock.calls[0][1]).not.toHaveProperty("model_prefix")
+  })
+
+  it("preserves explicit empty and zero-valued edits while rejecting a cleared group", async () => {
+    const operations = await openVeloeraNativeResourceOperations()
+    await operations.update(
+      { ...channel, priority: 12, weight: 8 },
+      {
+        ...createDraft("Primary channel"),
+        base_url: " ",
+        groups: ["default", "vip"],
+        priority: 0,
+        weight: 0,
+      },
+    )
+    expect(mocks.update.mock.calls[0][1]).toMatchObject({
+      id: channel.id,
+      base_url: "",
+      priority: 0,
+      weight: 0,
+    })
+
+    const workspace = await veloeraManagedResourceRegistration.open()
+    const ref = (await workspace.list()).items[0]!.ref
+    const editor = await workspace.openEditEditor(ref)
+    expect(
+      editor.validate({
+        ...editor.initialValues,
+        [VELOERA_MANAGED_RESOURCE_FIELD_IDS.Groups]: [],
+      }),
+    ).toEqual({
+      valid: false,
+      issues: [
+        {
+          fieldId: VELOERA_MANAGED_RESOURCE_FIELD_IDS.Groups,
+          code: MANAGED_RESOURCE_FIELD_ISSUE_CODES.Required,
+        },
+      ],
+    })
+
+    mocks.get.mockResolvedValueOnce({ ...channel, group: "" })
+    const legacyEditor = await workspace.openEditEditor(ref)
+    expect(legacyEditor.validate(legacyEditor.initialValues)).toEqual({
+      valid: true,
+    })
   })
 
   it("projects partial updates and preserves the saved key while returning rejections unchanged", async () => {

--- a/tests/services/apiAdapters/managedResources/veloera.test.ts
+++ b/tests/services/apiAdapters/managedResources/veloera.test.ts
@@ -384,7 +384,7 @@ describe("Veloera native managed resource", () => {
     expect(mocks.get).toHaveBeenLastCalledWith(config, channel.id, { signal })
   })
 
-  it("preserves latest Veloera-only fields and omits an unchanged masked key", async () => {
+  it("sends only a renamed field without replaying Veloera-only fields or a masked key", async () => {
     const openedDetail = {
       ...channel,
       model_prefix: "opened-",
@@ -410,15 +410,26 @@ describe("Veloera native managed resource", () => {
 
     expect(mocks.update).toHaveBeenCalledWith(
       config,
-      expect.objectContaining({
+      {
         id: channel.id,
         name: "Renamed channel",
-        model_prefix: "latest-",
-        system_prompt: "Latest policy",
-      }),
+      },
       undefined,
     )
     expect(mocks.update.mock.calls.at(-1)?.[1]).not.toHaveProperty("key")
+  })
+
+  it("includes the required region only when changing to Vertex", async () => {
+    const operations = await openVeloeraNativeResourceOperations()
+    await operations.update(
+      { ...channel, other: "us-central1", model_prefix: "keep-prefix" },
+      { ...createDraft("Vertex channel"), type: VeloeraChannelType.VertexAi },
+    )
+    expect(mocks.update.mock.calls[0][1]).toMatchObject({
+      type: VeloeraChannelType.VertexAi,
+      other: "us-central1",
+    })
+    expect(mocks.update.mock.calls[0][1]).not.toHaveProperty("model_prefix")
   })
 
   it("projects partial updates and preserves the saved key while returning rejections unchanged", async () => {

--- a/tests/services/apiService/octopus.v013.test.ts
+++ b/tests/services/apiService/octopus.v013.test.ts
@@ -48,6 +48,85 @@ const parseRequestBody = (
 
 describe("Octopus v0.13 contract", () => {
   it.each([
+    { name: "Renamed channel" },
+    { key: "replacement-key" },
+    { model: "model-a,model-b" },
+  ])(
+    "retains upstream-owned fields through parsing and update serialization: %j",
+    (patch) => {
+      const futurePolicy = { mode: "upstream", options: [1, 2] }
+      const original = detailResponse({
+        future_policy: futurePolicy,
+        keys: [
+          {
+            name: "default",
+            key: "credential-placeholder",
+            enabled: true,
+            future_key_policy: { limit: 8 },
+          },
+        ],
+        grants: [
+          {
+            model_name: "model-a",
+            key_name: "default",
+            protocols: 2,
+            future_grant_policy: "keep",
+          },
+        ],
+        custom_header: [
+          {
+            header_key: "X-Example",
+            header_value: "value",
+            future_header_policy: false,
+          },
+        ],
+      })
+      const body = parseRequestBody(
+        octopusV013Contract.createRequest(
+          {
+            kind: OCTOPUS_API_OPERATIONS.UpdateChannel,
+            input: { id: 7, ...patch },
+          },
+          {},
+          octopusV013Contract.parseDetail(original),
+        ),
+      )
+      expect(body).toMatchObject({
+        future_policy: futurePolicy,
+        keys: [expect.objectContaining({ future_key_policy: { limit: 8 } })],
+        custom_header: original.custom_header,
+      })
+      expect(body.grants).toContainEqual(
+        expect.objectContaining({ future_grant_policy: "keep" }),
+      )
+      expect(original.keys[0].key).toBe("credential-placeholder")
+    },
+  )
+
+  it("does not reinterpret upstream grant associations while renaming", () => {
+    const original = detailResponse({
+      grants: [
+        {
+          model_name: "upstream-managed-model",
+          key_name: "upstream-managed-key",
+          protocols: 2,
+        },
+      ],
+    })
+    const body = parseRequestBody(
+      octopusV013Contract.createRequest(
+        {
+          kind: OCTOPUS_API_OPERATIONS.UpdateChannel,
+          input: { id: 7, name: "Renamed channel" },
+        },
+        {},
+        octopusV013Contract.parseDetail(original),
+      ),
+    )
+    expect(body).toEqual({ ...original, name: "Renamed channel" })
+  })
+
+  it.each([
     { dialect: "custom" },
     { openai_chat_completion_path: "/custom/chat" },
     { grants: [{ model_name: "model-a", key_name: "default", protocols: 6 }] },

--- a/tests/utils/managedChannelPreservation.test.ts
+++ b/tests/utils/managedChannelPreservation.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest"
+
+import { SITE_TYPES } from "~/constants/siteType"
+import {
+  assertManagedChannelPreserved,
+  extractManagedChannelSnapshot,
+} from "~~/e2e/utils/realSite/managedChannelPreservation"
+
+describe("managed channel preservation evidence", () => {
+  it.each([
+    [
+      SITE_TYPES.NEW_API,
+      {
+        success: true,
+        data: { id: 1, name: "fixture", future: { keep: false } },
+      },
+    ],
+    [
+      SITE_TYPES.DONE_HUB,
+      {
+        success: true,
+        data: { id: 1, name: "fixture", future: { keep: false } },
+      },
+    ],
+    [
+      SITE_TYPES.VELOERA,
+      {
+        success: true,
+        data: { id: 1, name: "fixture", future: { keep: false } },
+      },
+    ],
+    [
+      SITE_TYPES.SUB2API,
+      { code: 0, data: { id: 1, name: "fixture", future: { keep: false } } },
+    ],
+    [
+      SITE_TYPES.OCTOPUS,
+      {
+        code: 200,
+        data: [{ id: 1, name: "fixture", future: { keep: false } }],
+      },
+    ],
+    [
+      SITE_TYPES.AXON_HUB,
+      { data: { node: { id: 1, name: "fixture", future: { keep: false } } } },
+    ],
+    [
+      SITE_TYPES.CLAUDE_CODE_HUB,
+      { id: 1, name: "fixture", future: { keep: false } },
+    ],
+  ] as const)("retains raw fields for %s", (site, body) => {
+    expect(extractManagedChannelSnapshot(site, body, "fixture")).toEqual({
+      id: 1,
+      name: "fixture",
+      future: { keep: false },
+    })
+  })
+
+  it("does not accept a GraphQL mutation receipt or another resource", () => {
+    expect(
+      extractManagedChannelSnapshot(
+        SITE_TYPES.AXON_HUB,
+        { data: { updateChannel: { id: 1, name: "fixture" } } },
+        "fixture",
+      ),
+    ).toBeNull()
+    expect(
+      extractManagedChannelSnapshot(
+        SITE_TYPES.NEW_API,
+        { data: { id: 1, name: "other" } },
+        "fixture",
+      ),
+    ).toBeNull()
+  })
+
+  it("ignores only the renamed field and the provider update timestamp", () => {
+    expect(() =>
+      assertManagedChannelPreserved(
+        SITE_TYPES.AXON_HUB,
+        {
+          id: 1,
+          name: "before",
+          updatedAt: "before",
+          future: { enabled: false },
+        },
+        {
+          id: 1,
+          name: "after",
+          updatedAt: "after",
+          future: { enabled: false },
+        },
+      ),
+    ).not.toThrow()
+  })
+
+  it("detects dropped nested fields without exposing credentials", () => {
+    const before = {
+      id: 1,
+      name: "before",
+      credentials: { key: "secret-never-print", future: 1 },
+    }
+    const after = {
+      id: 1,
+      name: "after",
+      credentials: { key: "secret-never-print" },
+    }
+    expect(() =>
+      assertManagedChannelPreserved(SITE_TYPES.SUB2API, before, after),
+    ).toThrow("Unrelated channel fields changed: credentials")
+    try {
+      assertManagedChannelPreserved(SITE_TYPES.SUB2API, before, after)
+    } catch (error) {
+      expect(String(error)).not.toContain("secret-never-print")
+    }
+  })
+
+  it("detects removed top-level fields, reordered arrays, and identity changes", () => {
+    expect(() =>
+      assertManagedChannelPreserved(
+        SITE_TYPES.OCTOPUS,
+        { id: 1, future: true, keys: [1, 2] },
+        { id: 2, keys: [2, 1] },
+      ),
+    ).toThrow("Unrelated channel fields changed: future, id, keys")
+  })
+})


### PR DESCRIPTION
Channel edits could discard configuration added by newer upstream versions. Octopus v0.13 rebuilt channel details from locally defined fields before submitting a complete update, dropping unknown fields even when only renaming a channel.

- Preserve upstream fields in Octopus v0.13 channel details, including nested keys, grants, and headers. Preserve existing grant associations during unrelated edits.
- Send only changed editable fields to Veloera, retaining the region required when switching to Vertex AI.
- Keep New API and DoneHub complete-object updates, with browser coverage verifying that unknown configuration survives.
- Verify that AxonHub can fall back to core details and save edits when an optional GraphQL field is unavailable.
- Add shared real-site coverage that compares native channel snapshots before and after a rename, ignoring only the edited name and provider update timestamp.

Validation:
- Targeted Veloera and Octopus unit tests passed.
- 11 intercepted browser E2E tests passed, covering seven managed-site rename flows and compatibility scenarios.
- Six real-site preservation tests passed: New API, Veloera, DoneHub, Octopus, AxonHub, and Claude Code Hub.
- Sub2API real-site preservation was skipped because `AAH_E2E_SUB2API_ADMIN_TOKEN` is not configured.
- TypeScript, lint, formatting, i18n, and pre-push checks passed.

Real-site tests create run-scoped temporary channels and clean them up after the scenario. They do not print credentials; live deployment behavior was verified for the six configured sites.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Channel renames now preserve provider-owned fields, nested settings, credentials, grants, and headers.
  * Updates send only changed editable fields, reducing unintended overwrites.
  * Veloera updates retain required provider-specific region data and preserve explicit empty or zero values.
  * Required group settings are now validated when applicable.
  * Octopus channel updates preserve existing grant associations and previously unknown fields.

* **Tests**
  * Added end-to-end and service coverage for minimal updates and upstream-field preservation across supported providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->