### PR TITLE
feat(shield): customize verification window dimensions

### DIFF
--- a/src/constants/basicSettingsTabs.ts
+++ b/src/constants/basicSettingsTabs.ts
@@ -17,6 +17,7 @@ export type BasicSettingsTabId =
 
 export const BASIC_SETTINGS_ANCHOR_TO_TAB: Record<string, BasicSettingsTabId> =
   {
+    [SETTINGS_ANCHORS.SHIELD_WINDOW_SIZE]: "refresh",
     "general-display": "general",
     display: "general",
     appearance: "general",

--- a/src/constants/settingsAnchors.ts
+++ b/src/constants/settingsAnchors.ts
@@ -4,6 +4,7 @@ export const SETTINGS_ANCHORS = {
   AUTO_PROVISION_KEY_MODE: "auto-provision-key-mode",
   SHIELD_SETTINGS: "shield-settings",
   SHIELD_HISTORY: "shield-history",
+  SHIELD_WINDOW_SIZE: "shield-window-size",
   TASK_NOTIFICATIONS: "task-notifications",
   TASK_NOTIFICATIONS_ENABLED: "task-notifications-enabled",
   TASK_NOTIFICATION_CHANNELS: "task-notification-channels",

--- a/src/entrypoints/background/tempWindowPool.ts
+++ b/src/entrypoints/background/tempWindowPool.ts
@@ -13,7 +13,10 @@ import {
   type ApiErrorCode,
 } from "~/services/apiTransport/errors"
 import { applyLocalRemoteFetchResultEvidence } from "~/services/apiTransport/remoteLifecycle"
-import { DEFAULT_TEMP_CONTEXT_PREFERENCE } from "~/services/preferences/tempWindowFallbackPreferences"
+import {
+  DEFAULT_TEMP_CONTEXT_PREFERENCE,
+  normalizeTempWindowFallbackPreferences,
+} from "~/services/preferences/tempWindowFallbackPreferences"
 import {
   userPreferences,
   type TempWindowFallbackPreferences,
@@ -246,6 +249,20 @@ async function resolveTempContextPreferenceMode(): Promise<
   } catch {
     return DEFAULT_TEMP_CONTEXT_PREFERENCE
   }
+}
+
+/** Reads window dimensions at creation time, including for legacy preferences. */
+async function resolveTempWindowSize() {
+  let storedPreferences: unknown
+  try {
+    storedPreferences = (await userPreferences.getPreferences())
+      .tempWindowFallback
+  } catch {
+    // Window creation remains available when preference storage is unavailable.
+  }
+  const { windowWidth, windowHeight } =
+    normalizeTempWindowFallbackPreferences(storedPreferences)
+  return { width: windowWidth, height: windowHeight }
 }
 
 /**
@@ -2550,8 +2567,7 @@ async function openPopupWindowTempContext(params: {
       popupWindow = await createWindow({
         url: TEMP_CONTEXT_INITIAL_URL,
         type: "popup",
-        width: 420,
-        height: 520,
+        ...(await resolveTempWindowSize()),
         focused: false,
         incognito: Boolean(params.incognito),
       })
@@ -2980,8 +2996,7 @@ async function openTabInCompositeWindowLocked(params: {
       compositeWindow = await createWindow({
         url: initialUrl,
         type: "normal",
-        width: 420,
-        height: 520,
+        ...(await resolveTempWindowSize()),
         focused: false,
       })
     } catch (error) {

--- a/src/features/BasicSettings/components/tabs/Refresh/Refresh.search.ts
+++ b/src/features/BasicSettings/components/tabs/Refresh/Refresh.search.ts
@@ -167,6 +167,22 @@ export const refreshSearchControls: OptionsSearchItemDefinition[] = [
       keywords: ["automatic", "temporary page"],
     },
   ),
+  buildControlDefinition(
+    "control:shield-window-size",
+    "refresh",
+    SHIELD_SETTINGS_TARGET_IDS.windowSize,
+    "settings:refresh.shieldWindowSizeTitle",
+    546,
+    {
+      descriptionKey: "settings:refresh.shieldWindowSizeDesc",
+      breadcrumbsKeys: shieldBreadcrumbs,
+      keywordKeys: [
+        "settings:refresh.shieldWindowWidth",
+        "settings:refresh.shieldWindowHeight",
+      ],
+      keywords: ["window", "size", "width", "height", "captcha"],
+    },
+  ),
   ...SHIELD_AUTOMATIC_FEATURE_ITEMS.map(
     ({ feature, titleKey, keyword }, index) =>
       buildControlDefinition(

--- a/src/features/BasicSettings/components/tabs/Refresh/ShieldSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/Refresh/ShieldSettings.tsx
@@ -41,6 +41,7 @@ import { openSettingsTab } from "~/utils/navigation"
 
 import { ProtectionBypassDevTrigger } from "./ProtectionBypassDevTrigger"
 import ProtectionBypassHistory from "./ProtectionBypassHistory"
+import { ShieldWindowSizeSettings } from "./ShieldWindowSizeSettings"
 
 /** Compares complete automatic-feature preference maps. */
 function hasSameAutomaticFeatureBypass(
@@ -304,6 +305,7 @@ export default function ShieldSettings() {
               </div>
             }
           />
+          <ShieldWindowSizeSettings />
           <CardItem
             id={SHIELD_SETTINGS_TARGET_IDS.automaticFeatures}
             title={t("refresh.shieldAutomaticFeaturesTitle")}

--- a/src/features/BasicSettings/components/tabs/Refresh/ShieldWindowSizeSettings.tsx
+++ b/src/features/BasicSettings/components/tabs/Refresh/ShieldWindowSizeSettings.tsx
@@ -1,0 +1,109 @@
+import { useTranslation } from "react-i18next"
+
+import { Button, CardItem, Input } from "~/components/ui"
+import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
+import { useDeferredPreferenceDraft } from "~/hooks/useDeferredPreferenceDraft"
+import {
+  DEFAULT_TEMP_WINDOW_SIZE,
+  isValidTempWindowDimension,
+  normalizeTempWindowFallbackPreferences,
+  TEMP_WINDOW_SIZE_LIMITS,
+} from "~/services/preferences/tempWindowFallbackPreferences"
+import { showUpdateToast } from "~/utils/feedback/preferenceFeedback"
+
+import { SHIELD_SETTINGS_TARGET_IDS } from "./searchTargets"
+
+/** Edits the initial dimensions shared by verification windows. */
+export function ShieldWindowSizeSettings() {
+  const { t } = useTranslation("settings")
+  const { preferences, tempWindowFallback, updateTempWindowFallback } =
+    useUserPreferencesContext()
+  const savedPreferences =
+    normalizeTempWindowFallbackPreferences(tempWindowFallback)
+  const sizeDraft = useDeferredPreferenceDraft({
+    savedValue: {
+      width: String(savedPreferences.windowWidth),
+      height: String(savedPreferences.windowHeight),
+    },
+    savedVersion: preferences?.lastUpdated ?? 0,
+    onCommit: async (draft) => {
+      const windowWidth = Number(draft.width)
+      const windowHeight = Number(draft.height)
+      if (
+        !isValidTempWindowDimension(windowWidth) ||
+        !isValidTempWindowDimension(windowHeight)
+      ) {
+        return { ok: false }
+      }
+      const result = await updateTempWindowFallback({
+        windowWidth,
+        windowHeight,
+      })
+      showUpdateToast(result, t("refresh.shieldWindowSizeTitle"))
+      return { ok: result.ok }
+    },
+  })
+
+  return (
+    <CardItem
+      id={SHIELD_SETTINGS_TARGET_IDS.windowSize}
+      title={t("refresh.shieldWindowSizeTitle")}
+      description={t("refresh.shieldWindowSizeDesc")}
+      rightContent={
+        <form
+          onSubmit={(event) => {
+            event.preventDefault()
+            void sizeDraft.commit()
+          }}
+        >
+          <fieldset
+            disabled={sizeDraft.isCommitting}
+            className="flex flex-wrap items-end justify-end gap-2"
+          >
+            {(
+              [
+                ["width", t("refresh.shieldWindowWidth")],
+                ["height", t("refresh.shieldWindowHeight")],
+              ] as const
+            ).map(([dimension, label]) => (
+              <label key={dimension} className="flex flex-col gap-1 text-sm">
+                {label}
+                <Input
+                  type="number"
+                  required
+                  min={TEMP_WINDOW_SIZE_LIMITS.min}
+                  max={TEMP_WINDOW_SIZE_LIMITS.max}
+                  step={1}
+                  className="w-24"
+                  value={sizeDraft.draft[dimension]}
+                  onChange={(event) =>
+                    sizeDraft.setDraft({
+                      ...sizeDraft.draft,
+                      [dimension]: event.target.value,
+                    })
+                  }
+                />
+              </label>
+            ))}
+            <Button
+              type="button"
+              size="sm"
+              variant="outline"
+              onClick={() =>
+                sizeDraft.setDraft({
+                  width: String(DEFAULT_TEMP_WINDOW_SIZE.windowWidth),
+                  height: String(DEFAULT_TEMP_WINDOW_SIZE.windowHeight),
+                })
+              }
+            >
+              {t("refresh.shieldWindowSizeReset")}
+            </Button>
+            <Button type="submit" size="sm" disabled={!sizeDraft.isDirty}>
+              {t("common:actions.save")}
+            </Button>
+          </fieldset>
+        </form>
+      }
+    />
+  )
+}

--- a/src/features/BasicSettings/components/tabs/Refresh/searchTargets.ts
+++ b/src/features/BasicSettings/components/tabs/Refresh/searchTargets.ts
@@ -6,6 +6,7 @@ export const SHIELD_SETTINGS_TARGET_IDS = {
   history: SETTINGS_ANCHORS.SHIELD_HISTORY,
   enabled: "shield-enabled",
   method: "shield-method",
+  windowSize: SETTINGS_ANCHORS.SHIELD_WINDOW_SIZE,
   automaticFeatures: "shield-automatic-features",
   feature: {
     account_refresh: "shield-automatic-feature-account-refresh",
@@ -22,6 +23,7 @@ export const SHIELD_SETTINGS_TARGET_IDS = {
   history: string
   enabled: string
   method: string
+  windowSize: string
   automaticFeatures: string
   feature: Record<ProtectionBypassAutomaticFeature, string>
 }

--- a/src/locales/de/settings.json
+++ b/src/locales/de/settings.json
@@ -507,6 +507,11 @@
     "shieldPermissionWarningTitle": "Berechtigungen für Cookies, Webanfragen und Blockierung von Webanfragen erforderlich",
     "shieldPopupFirefoxNote": "In Firefox würde das Starten dieser Funktion über das Erweiterungs-Popup das Popup schließen. Dieser Einstiegspunkt ist daher nicht verfügbar. Verwenden Sie stattdessen die Seitenleiste oder die Einstellungsseite.",
     "shieldTitle": "Unterstützung bei der Website-Verifizierung",
+    "shieldWindowHeight": "Höhe (px)",
+    "shieldWindowSizeDesc": "Breite und Höhe in Pixeln einstellen und speichern. Gilt für neu geöffnete Verifizierungsfenster; bestehende Fenster und Tabs behalten ihre Größe.",
+    "shieldWindowSizeReset": "Standardwerte wiederherstellen",
+    "shieldWindowSizeTitle": "Größe des Verifizierungsfensters",
+    "shieldWindowWidth": "Breite (px)",
     "title": "Aktualisierungseinstellungen"
   },
   "releaseUpdate": {

--- a/src/locales/en/settings.json
+++ b/src/locales/en/settings.json
@@ -507,6 +507,11 @@
     "shieldPermissionWarningTitle": "Cookies, Web Request, and Web Request Blocking permissions required",
     "shieldPopupFirefoxNote": "On Firefox, starting this feature from the extension popup would close the popup, so this entry point is unavailable. Use the side panel or settings page instead.",
     "shieldTitle": "Website verification assistance",
+    "shieldWindowHeight": "Height (px)",
+    "shieldWindowSizeDesc": "Set the width and height in pixels, then save. Applies to newly opened verification windows; existing windows and tabs keep their size.",
+    "shieldWindowSizeReset": "Restore defaults",
+    "shieldWindowSizeTitle": "Verification window size",
+    "shieldWindowWidth": "Width (px)",
     "title": "Refresh Settings"
   },
   "releaseUpdate": {

--- a/src/locales/es-419/settings.json
+++ b/src/locales/es-419/settings.json
@@ -508,6 +508,11 @@
     "shieldPermissionWarningTitle": "Se requieren los permisos Cookies, Web Request y Web Request Blocking",
     "shieldPopupFirefoxNote": "En Firefox, iniciar esta función desde la ventana emergente de la extensión cerraría la ventana. Usa el panel lateral o la página de ajustes.",
     "shieldTitle": "Asistencia para verificar el sitio",
+    "shieldWindowHeight": "Alto (px)",
+    "shieldWindowSizeDesc": "Configura el ancho y el alto en píxeles y guarda. Se aplica a las nuevas ventanas de verificación; las ventanas y pestañas existentes conservan su tamaño.",
+    "shieldWindowSizeReset": "Restaurar valores predeterminados",
+    "shieldWindowSizeTitle": "Tamaño de la ventana de verificación",
+    "shieldWindowWidth": "Ancho (px)",
     "title": "Ajustes de actualización"
   },
   "releaseUpdate": {

--- a/src/locales/ja/settings.json
+++ b/src/locales/ja/settings.json
@@ -506,6 +506,11 @@
     "shieldPermissionWarningTitle": "Cookies、Web Request、Web Request Blocking の権限が必要です",
     "shieldPopupFirefoxNote": "Firefox では、拡張機能のポップアップからこの機能を開始するとポップアップが閉じるため、この入口は利用できません。サイドパネルまたは設定ページを使用してください。",
     "shieldTitle": "サイト認証の補助",
+    "shieldWindowHeight": "高さ（px）",
+    "shieldWindowSizeDesc": "幅と高さをピクセル単位で設定して保存します。次に開く認証ウィンドウに適用されます。既存のウィンドウとタブのサイズは変わりません。",
+    "shieldWindowSizeReset": "既定値に戻す",
+    "shieldWindowSizeTitle": "認証ウィンドウのサイズ",
+    "shieldWindowWidth": "幅（px）",
     "title": "更新設定"
   },
   "releaseUpdate": {

--- a/src/locales/pt-BR/settings.json
+++ b/src/locales/pt-BR/settings.json
@@ -508,6 +508,11 @@
     "shieldPermissionWarningTitle": "São necessárias permissões para cookies, solicitações da Web e bloqueio de solicitações da Web",
     "shieldPopupFirefoxNote": "No Firefox, iniciar esse recurso a partir do pop-up de extensão fecharia o pop-up, portanto, esse ponto de entrada não estará disponível. Use o painel lateral ou a página de configurações.",
     "shieldTitle": "Assistência para verificação de site",
+    "shieldWindowHeight": "Altura (px)",
+    "shieldWindowSizeDesc": "Defina a largura e a altura em pixels e salve. Aplica-se às novas janelas de verificação; janelas e abas existentes mantêm seu tamanho.",
+    "shieldWindowSizeReset": "Restaurar padrões",
+    "shieldWindowSizeTitle": "Tamanho da janela de verificação",
+    "shieldWindowWidth": "Largura (px)",
     "title": "Atualizar configurações"
   },
   "releaseUpdate": {

--- a/src/locales/vi/settings.json
+++ b/src/locales/vi/settings.json
@@ -506,6 +506,11 @@
     "shieldPermissionWarningTitle": "Cần các quyền Cookies, Web Request và Web Request Blocking",
     "shieldPopupFirefoxNote": "Trên Firefox, bắt đầu tính năng này từ popup của tiện ích sẽ làm popup đóng lại, nên không thể dùng điểm truy cập này. Hãy dùng thanh bên hoặc trang cài đặt.",
     "shieldTitle": "Hỗ trợ xác minh trang web",
+    "shieldWindowHeight": "Chiều cao (px)",
+    "shieldWindowSizeDesc": "Đặt chiều rộng và chiều cao theo pixel rồi lưu. Áp dụng cho cửa sổ xác minh mở mới; cửa sổ và thẻ hiện có giữ nguyên kích thước.",
+    "shieldWindowSizeReset": "Khôi phục mặc định",
+    "shieldWindowSizeTitle": "Kích thước cửa sổ xác minh",
+    "shieldWindowWidth": "Chiều rộng (px)",
     "title": "Cài đặt làm mới"
   },
   "releaseUpdate": {

--- a/src/locales/zh-CN/settings.json
+++ b/src/locales/zh-CN/settings.json
@@ -506,6 +506,11 @@
     "shieldPermissionWarningTitle": "需要 Cookies、Web Request 和 Web Request Blocking 权限",
     "shieldPopupFirefoxNote": "在 Firefox 中，从扩展弹窗启动此功能会导致弹窗关闭，因此该入口不可用。请改用侧边栏或设置页。",
     "shieldTitle": "网站验证辅助",
+    "shieldWindowHeight": "高度（像素）",
+    "shieldWindowSizeDesc": "设置宽度和高度（像素）后保存，下次新建验证窗口时生效；已有窗口和标签页保持原尺寸。",
+    "shieldWindowSizeReset": "恢复默认值",
+    "shieldWindowSizeTitle": "验证窗口尺寸",
+    "shieldWindowWidth": "宽度（像素）",
     "title": "刷新设置"
   },
   "releaseUpdate": {

--- a/src/locales/zh-TW/settings.json
+++ b/src/locales/zh-TW/settings.json
@@ -506,6 +506,11 @@
     "shieldPermissionWarningTitle": "需要 Cookies、Web Request 和 Web Request Blocking 權限",
     "shieldPopupFirefoxNote": "在 Firefox 中，從擴充套件彈出視窗啟動此功能會導致彈出視窗關閉，因此無法使用這個入口。請改用側邊欄或設定頁。",
     "shieldTitle": "網站驗證輔助",
+    "shieldWindowHeight": "高度（像素）",
+    "shieldWindowSizeDesc": "設定寬度和高度（像素）後儲存，下次建立驗證視窗時生效；現有視窗和分頁保持原尺寸。",
+    "shieldWindowSizeReset": "恢復預設值",
+    "shieldWindowSizeTitle": "驗證視窗尺寸",
+    "shieldWindowWidth": "寬度（像素）",
     "title": "重新整理設定"
   },
   "releaseUpdate": {

--- a/src/services/preferences/tempWindowFallbackPreferences.ts
+++ b/src/services/preferences/tempWindowFallbackPreferences.ts
@@ -10,6 +10,19 @@ import {
 export const DEFAULT_TEMP_CONTEXT_PREFERENCE =
   TEMP_CONTEXT_PREFERENCE_MODES.Auto
 
+export const DEFAULT_TEMP_WINDOW_SIZE = { windowWidth: 600, windowHeight: 720 }
+export const TEMP_WINDOW_SIZE_LIMITS = { min: 320, max: 4096 }
+
+/** Accepts only usable integer window dimensions from settings or stored data. */
+export function isValidTempWindowDimension(value: unknown): value is number {
+  return (
+    typeof value === "number" &&
+    Number.isInteger(value) &&
+    value >= TEMP_WINDOW_SIZE_LIMITS.min &&
+    value <= TEMP_WINDOW_SIZE_LIMITS.max
+  )
+}
+
 export const DEFAULT_AUTOMATIC_FEATURE_BYPASS = Object.fromEntries(
   Object.values(PROTECTION_BYPASS_AUTOMATIC_FEATURES).map((feature) => [
     feature,
@@ -21,6 +34,8 @@ export interface TempWindowFallbackPreferences {
   enabled: boolean
   automaticFeatureBypass: Record<ProtectionBypassAutomaticFeature, boolean>
   tempContextMode: TempContextPreferenceMode
+  windowWidth: number
+  windowHeight: number
 }
 
 interface LegacyTempWindowFallbackPreferences {
@@ -28,6 +43,8 @@ interface LegacyTempWindowFallbackPreferences {
   automaticFeatureBypass?: unknown
   useForAutoRefresh?: unknown
   tempContextMode?: unknown
+  windowWidth?: unknown
+  windowHeight?: unknown
 }
 
 /** Narrows persisted mode values to supported temporary-context preferences. */
@@ -68,6 +85,12 @@ export function normalizeTempWindowFallbackPreferences(
   ) as Record<ProtectionBypassAutomaticFeature, boolean>
 
   return {
+    windowWidth: isValidTempWindowDimension(source.windowWidth)
+      ? source.windowWidth
+      : DEFAULT_TEMP_WINDOW_SIZE.windowWidth,
+    windowHeight: isValidTempWindowDimension(source.windowHeight)
+      ? source.windowHeight
+      : DEFAULT_TEMP_WINDOW_SIZE.windowHeight,
     enabled: typeof source.enabled === "boolean" ? source.enabled : true,
     automaticFeatureBypass,
     tempContextMode: isTempContextPreferenceMode(source.tempContextMode)

--- a/src/services/preferences/userPreferences.ts
+++ b/src/services/preferences/userPreferences.ts
@@ -19,6 +19,7 @@ import {
 import {
   DEFAULT_AUTOMATIC_FEATURE_BYPASS,
   DEFAULT_TEMP_CONTEXT_PREFERENCE,
+  DEFAULT_TEMP_WINDOW_SIZE,
   normalizeTempWindowFallbackPreferences,
   type TempWindowFallbackPreferences,
 } from "~/services/preferences/tempWindowFallbackPreferences"
@@ -632,6 +633,7 @@ export const DEFAULT_PREFERENCES: UserPreferences = {
   logging: getDefaultLoggingPreferences(),
   preferencesVersion: CURRENT_PREFERENCES_VERSION,
   tempWindowFallback: {
+    ...DEFAULT_TEMP_WINDOW_SIZE,
     enabled: true,
     automaticFeatureBypass: DEFAULT_AUTOMATIC_FEATURE_BYPASS,
     tempContextMode: DEFAULT_TEMP_CONTEXT_PREFERENCE,

--- a/tests/entrypoints/background/tempWindowPoolWindowFallback.test.ts
+++ b/tests/entrypoints/background/tempWindowPoolWindowFallback.test.ts
@@ -832,6 +832,8 @@ describe("tempWindowPool window fallback", () => {
       expect.objectContaining({
         type: "normal",
         url: "about:blank",
+        width: 600,
+        height: 720,
       }),
     )
     expect(createTabMock).not.toHaveBeenCalled()
@@ -899,6 +901,47 @@ describe("tempWindowPool window fallback", () => {
     )
     expect(createTabMock).not.toHaveBeenCalled()
   })
+
+  it.each(["composite", "window"] as const)(
+    "opens %s verification windows with persisted custom dimensions",
+    async (mode) => {
+      tempContextMode = mode
+      getPreferencesMock.mockResolvedValue({
+        tempWindowFallback: {
+          tempContextMode: mode,
+          windowWidth: 800,
+          windowHeight: 1000,
+        },
+      })
+      createWindowMock.mockResolvedValueOnce({ id: 105, tabs: [{ id: 106 }] })
+      tabsQueryMock.mockResolvedValueOnce([{ id: 106 }])
+      const { handleTempWindowFetch } = await import(
+        "~~/tests/entrypoints/background/tempWindowPoolTestAdapter"
+      )
+      const sendResponse = vi.fn()
+      const request = handleTempWindowFetch(
+        {
+          originUrl: "https://example.invalid",
+          fetchUrl: "https://example.invalid/api/test",
+          fetchOptions: { method: "GET" },
+          requestId: "custom-size",
+        },
+        sendResponse,
+      )
+      await vi.advanceTimersByTimeAsync(500)
+      await request
+      expect(createWindowMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: mode === "composite" ? "normal" : "popup",
+          width: 800,
+          height: 1000,
+        }),
+      )
+      expect(sendResponse).toHaveBeenCalledWith(
+        expect.objectContaining({ success: true }),
+      )
+    },
+  )
 
   it("reuses a live composite window for automatic mode while unfocused", async () => {
     tempContextMode = "composite"

--- a/tests/entrypoints/options/ShieldSettings.test.tsx
+++ b/tests/entrypoints/options/ShieldSettings.test.tsx
@@ -182,6 +182,80 @@ describe("ShieldSettings", () => {
   const updateTempWindowFallback = vi.fn()
   let focusObservationController = createFocusObservationController()
 
+  it("saves custom window dimensions on submit and restores defaults", async () => {
+    const user = userEvent.setup()
+    const { rerender } = render(<ShieldSettings />, {
+      withUserPreferencesProvider: false,
+      withThemeProvider: false,
+    })
+    const width = screen.getByRole("spinbutton", {
+      name: "settings:refresh.shieldWindowWidth",
+    })
+    const height = screen.getByRole("spinbutton", {
+      name: "settings:refresh.shieldWindowHeight",
+    })
+    expect(width).toHaveValue(600)
+    expect(height).toHaveValue(720)
+    await user.clear(width)
+    await user.type(width, "800")
+    await user.clear(height)
+    await user.type(height, "1000")
+    expect(updateTempWindowFallback).not.toHaveBeenCalled()
+    await user.click(
+      screen.getByRole("button", { name: "common:actions.save" }),
+    )
+    expect(updateTempWindowFallback).toHaveBeenLastCalledWith({
+      windowWidth: 800,
+      windowHeight: 1000,
+    })
+    const context = useUserPreferencesContextMock.mock.results.at(-1)!.value
+    useUserPreferencesContextMock.mockReturnValue({
+      ...context,
+      tempWindowFallback: {
+        ...context.tempWindowFallback,
+        windowWidth: 800,
+        windowHeight: 1000,
+      },
+    })
+    rerender(<ShieldSettings />)
+    await user.click(
+      screen.getByRole("button", {
+        name: "settings:refresh.shieldWindowSizeReset",
+      }),
+    )
+    expect(width).toHaveValue(600)
+    expect(height).toHaveValue(720)
+    await user.click(
+      screen.getByRole("button", { name: "common:actions.save" }),
+    )
+    expect(updateTempWindowFallback).toHaveBeenLastCalledWith({
+      windowWidth: 600,
+      windowHeight: 720,
+    })
+  })
+
+  it("does not save empty or out-of-range window dimensions", async () => {
+    const user = userEvent.setup()
+    render(<ShieldSettings />, {
+      withUserPreferencesProvider: false,
+      withThemeProvider: false,
+    })
+    const height = screen.getByRole("spinbutton", {
+      name: "settings:refresh.shieldWindowHeight",
+    })
+    await user.clear(height)
+    await user.click(
+      screen.getByRole("button", { name: "common:actions.save" }),
+    )
+    expect(height).toBeInvalid()
+    await user.type(height, "9999")
+    await user.click(
+      screen.getByRole("button", { name: "common:actions.save" }),
+    )
+    expect(height).toBeInvalid()
+    expect(updateTempWindowFallback).not.toHaveBeenCalled()
+  })
+
   beforeEach(() => {
     vi.clearAllMocks()
     focusObservationController = createFocusObservationController()

--- a/tests/features/BasicSettings/Refresh.search.test.ts
+++ b/tests/features/BasicSettings/Refresh.search.test.ts
@@ -36,6 +36,16 @@ describe("refresh settings search definitions", () => {
   })
 
   it("keeps website verification labels aligned with stable rendered targets", () => {
+    expect(refreshSearchControls).toContainEqual(
+      expect.objectContaining({
+        targetId: SHIELD_SETTINGS_TARGET_IDS.windowSize,
+        titleKey: "settings:refresh.shieldWindowSizeTitle",
+        tabId: "refresh",
+      }),
+    )
+    expect(
+      BASIC_SETTINGS_ANCHOR_TO_TAB[SHIELD_SETTINGS_TARGET_IDS.windowSize],
+    ).toBe("refresh")
     expect(refreshSearchSections).toContainEqual(
       expect.objectContaining({
         id: "section:shield-settings",

--- a/tests/services/configMigration/preferences/preferencesMigration.test.ts
+++ b/tests/services/configMigration/preferences/preferencesMigration.test.ts
@@ -1449,6 +1449,8 @@ describe("preferencesMigration", () => {
 
       expect(migrated.preferencesVersion).toBe(27)
       expect(migrated.tempWindowFallback).toEqual({
+        windowWidth: 600,
+        windowHeight: 720,
         enabled: false,
         tempContextMode: "tab",
         automaticFeatureBypass: {

--- a/tests/services/productAnalytics/settings.test.ts
+++ b/tests/services/productAnalytics/settings.test.ts
@@ -5,6 +5,7 @@ import {
   TEMP_CONTEXT_MODES,
   TEMP_CONTEXT_PREFERENCE_MODES,
 } from "~/constants/tempContextMode"
+import { DEFAULT_TEMP_WINDOW_SIZE } from "~/services/preferences/tempWindowFallbackPreferences"
 import {
   createDefaultPreferences,
   type UserPreferences,
@@ -265,6 +266,7 @@ describe("settings product analytics snapshots", () => {
         },
       },
       tempWindowFallback: {
+        ...DEFAULT_TEMP_WINDOW_SIZE,
         enabled: true,
         automaticFeatureBypass: {
           account_refresh: true,
@@ -867,6 +869,7 @@ describe("settings product analytics snapshots", () => {
         lastModified: 1,
       },
       tempWindowFallback: {
+        ...DEFAULT_TEMP_WINDOW_SIZE,
         enabled: true,
         automaticFeatureBypass: {
           account_refresh: false,

--- a/tests/services/protectionBypass/policy.test.ts
+++ b/tests/services/protectionBypass/policy.test.ts
@@ -4,7 +4,10 @@ import {
   TEMP_CONTEXT_MODES,
   TEMP_CONTEXT_PREFERENCE_MODES,
 } from "~/constants/tempContextMode"
-import { normalizeTempWindowFallbackPreferences } from "~/services/preferences/tempWindowFallbackPreferences"
+import {
+  DEFAULT_TEMP_WINDOW_SIZE,
+  normalizeTempWindowFallbackPreferences,
+} from "~/services/preferences/tempWindowFallbackPreferences"
 import {
   getTempContextTaskMetadata,
   NEW_API_SESSION_READ_ACTIONS,
@@ -199,6 +202,7 @@ describe("canonical protection-bypass surfaces", () => {
 
 describe("normalizeProtectionBypassPreferences", () => {
   const source = {
+    ...DEFAULT_TEMP_WINDOW_SIZE,
     enabled: false,
     automaticFeatureBypass: {
       account_refresh: false,

--- a/tests/services/userPreferences.sharedPreferences.test.ts
+++ b/tests/services/userPreferences.sharedPreferences.test.ts
@@ -170,6 +170,8 @@ describe("userPreferences shared preference timestamps", () => {
       )) as any
       expect(storedAfter.preferencesVersion).toBe(27)
       expect(storedAfter.tempWindowFallback).toEqual({
+        windowWidth: 600,
+        windowHeight: 720,
         enabled: false,
         automaticFeatureBypass: {
           account_refresh: true,
@@ -222,6 +224,8 @@ describe("userPreferences shared preference timestamps", () => {
       const exported = await userPreferences.exportPreferences()
       expect(storageSetSpy).toHaveBeenCalledTimes(1)
       expect(storedAfter.tempWindowFallback).toEqual({
+        windowWidth: 600,
+        windowHeight: 720,
         enabled: false,
         automaticFeatureBypass: {
           account_refresh: true,

--- a/tests/services/userPreferences.test.ts
+++ b/tests/services/userPreferences.test.ts
@@ -126,6 +126,29 @@ describe("userPreferences", () => {
   })
 
   describe("temporary window fallback preferences", () => {
+    it("uses taller defaults for existing preferences and preserves custom dimensions", () => {
+      expect(normalizeTempWindowFallbackPreferences({})).toMatchObject({
+        windowWidth: 600,
+        windowHeight: 720,
+      })
+      expect(
+        normalizeTempWindowFallbackPreferences({
+          windowWidth: 800,
+          windowHeight: 1000,
+        }),
+      ).toMatchObject({ windowWidth: 800, windowHeight: 1000 })
+    })
+    it.each([null, "900", 0, -1, 319, 4097, 800.5, NaN, Infinity])(
+      "replaces invalid stored dimensions %s with defaults",
+      (value) => {
+        expect(
+          normalizeTempWindowFallbackPreferences({
+            windowWidth: value,
+            windowHeight: value,
+          }),
+        ).toMatchObject({ windowWidth: 600, windowHeight: 720 })
+      },
+    )
     it.each(Object.values(TEMP_CONTEXT_MODES))(
       "preserves stored concrete mode %s",
       (tempContextMode) => {

--- a/tests/services/webdavSelectiveSync.test.ts
+++ b/tests/services/webdavSelectiveSync.test.ts
@@ -1487,6 +1487,8 @@ describe("WebDAV preference convergence", () => {
 
       expect(storageSetSpy).toHaveBeenCalledTimes(1)
       expect(storedAfterImport.tempWindowFallback).toEqual({
+        windowWidth: 600,
+        windowHeight: 720,
         enabled: false,
         automaticFeatureBypass: {
           account_refresh: false,

--- a/tests/test-utils/factories.ts
+++ b/tests/test-utils/factories.ts
@@ -8,6 +8,7 @@
 
 import { ChannelType } from "~/constants/newApi"
 import { SITE_TYPES } from "~/constants/siteType"
+import { DEFAULT_TEMP_WINDOW_SIZE } from "~/services/preferences/tempWindowFallbackPreferences"
 import {
   createDefaultPreferences,
   DEFAULT_PREFERENCES,
@@ -371,6 +372,7 @@ export function buildTempWindowPrefs(
   overrides: Partial<TempWindowFallbackPreferences> = {},
 ): TempWindowFallbackPreferences {
   const base: TempWindowFallbackPreferences = {
+    ...DEFAULT_TEMP_WINDOW_SIZE,
     enabled: true,
     automaticFeatureBypass: {
       account_refresh: true,

--- a/tests/utils/tempWindowFetch.fallback.test.ts
+++ b/tests/utils/tempWindowFetch.fallback.test.ts
@@ -23,6 +23,10 @@ import {
   tempWindowTurnstileFetch,
 } from "~/utils/browser/tempWindowFetch"
 
+const { DEFAULT_TEMP_WINDOW_SIZE } = await vi.hoisted(
+  () => import("~/services/preferences/tempWindowFallbackPreferences"),
+)
+
 const mocks = vi.hoisted(() => ({
   sendRuntimeMessageMock: vi.fn(),
   onRuntimeMessageMock: vi.fn(() => vi.fn()),
@@ -45,6 +49,7 @@ const mocks = vi.hoisted(() => ({
     error: vi.fn(),
   },
   defaultTempWindowFallback: {
+    ...DEFAULT_TEMP_WINDOW_SIZE,
     enabled: true,
     automaticFeatureBypass: {
       account_refresh: true,


### PR DESCRIPTION
Verification windows previously opened at 420 × 520, which could leave verification controls out of view. Increase the default size to 600 × 720 and let users configure width and height in website verification settings.

- Accept integer dimensions from 320 to 4096 pixels.
- Provide restore-default controls and localized settings search.
- Apply saved dimensions to newly created standalone and shared verification windows.

Validation:
- Focused tests and TypeScript checks passed.
- Staged lint and i18n checks passed.
- Final file tree remained unchanged during commit consolidation.
- Real-site captcha visibility has not been manually verified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added settings to customize the width and height of new website verification windows.
  - Added validation, saved preferences, and a reset-to-default option.
  - Custom dimensions now apply to popup and composite verification windows.
  - Added settings search support and translations across supported languages.
  - New windows use a default size of 600×720 pixels.

- **Bug Fixes**
  - Invalid or missing dimensions now safely fall back to the default 600×720 size.
  - Existing verification windows retain their current dimensions when preferences change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->