### PR TITLE
fix(key-management): keep repaired keys importable before checks finish

### DIFF
--- a/src/features/KeyManagement/components/RepairMissingKeysDialog/useRepairCreatedKeyManagedSiteImport.ts
+++ b/src/features/KeyManagement/components/RepairMissingKeysDialog/useRepairCreatedKeyManagedSiteImport.ts
@@ -98,7 +98,7 @@ const countCreatedReferences = (
   if (
     !progress ||
     progress.schemaVersion !== ACCOUNT_KEY_REPAIR_PROGRESS_SCHEMA_VERSION ||
-    progress.state !== ACCOUNT_KEY_REPAIR_JOB_STATES.Completed
+    progress.state === ACCOUNT_KEY_REPAIR_JOB_STATES.Idle
   ) {
     return 0
   }
@@ -244,7 +244,7 @@ export function useRepairCreatedKeyManagedSiteImport({
         isResolving ||
         isBatchImportOpen ||
         !progress ||
-        progress.state !== ACCOUNT_KEY_REPAIR_JOB_STATES.Completed
+        createdReferenceCount === 0
       ) {
         return
       }
@@ -313,6 +313,7 @@ export function useRepairCreatedKeyManagedSiteImport({
       accounts,
       isBatchImportOpen,
       isCurrentSessionResult,
+      createdReferenceCount,
       isResolving,
       progress,
     ],

--- a/src/features/KeyManagement/components/RepairMissingKeysDialog/useRepairCreatedKeyManagedSiteImport.ts
+++ b/src/features/KeyManagement/components/RepairMissingKeysDialog/useRepairCreatedKeyManagedSiteImport.ts
@@ -228,15 +228,19 @@ export function useRepairCreatedKeyManagedSiteImport({
     [accounts, progress],
   )
 
-  const closeBatchImport = useCallback(() => {
-    if (isResolving) return
+  const resetBatchImport = useCallback(() => {
     setIsBatchImportOpen(false)
     setBatchImportItems([])
     setBatchImportIntent(null)
     activeJobIdRef.current = null
     activeTargetFingerprintRef.current = null
     activeItemsRef.current = []
-  }, [isResolving])
+  }, [])
+
+  const closeBatchImport = useCallback(() => {
+    if (isResolving) return
+    resetBatchImport()
+  }, [isResolving, resetBatchImport])
 
   const prepareBatchImport = useCallback(
     async (includeCompletedReferences = false) => {
@@ -385,14 +389,9 @@ export function useRepairCreatedKeyManagedSiteImport({
 
   useEffect(() => {
     if (isOpen) return
-    setIsBatchImportOpen(false)
-    setBatchImportItems([])
-    setBatchImportIntent(null)
+    resetBatchImport()
     setImportFeedback(null)
-    activeJobIdRef.current = null
-    activeTargetFingerprintRef.current = null
-    activeItemsRef.current = []
-  }, [isOpen])
+  }, [isOpen, resetBatchImport])
 
   return {
     batchImportIntent,

--- a/src/features/KeyManagement/components/RepairMissingKeysDialog/useRepairCreatedKeyManagedSiteImport.ts
+++ b/src/features/KeyManagement/components/RepairMissingKeysDialog/useRepairCreatedKeyManagedSiteImport.ts
@@ -222,6 +222,8 @@ export function useRepairCreatedKeyManagedSiteImport({
   const activeJobIdRef = useRef<string | null>(null)
   const activeTargetFingerprintRef = useRef<string | null>(null)
   const activeItemsRef = useRef<ManagedSiteTokenBatchExportItemInput[]>([])
+  const preparationGenerationRef = useRef(0)
+  const preparationInFlightRef = useRef(false)
 
   const createdReferenceCount = useMemo(
     () => countCreatedReferences(progress, accounts),
@@ -229,6 +231,9 @@ export function useRepairCreatedKeyManagedSiteImport({
   )
 
   const resetBatchImport = useCallback(() => {
+    preparationGenerationRef.current += 1
+    preparationInFlightRef.current = false
+    setIsResolving(false)
     setIsBatchImportOpen(false)
     setBatchImportItems([])
     setBatchImportIntent(null)
@@ -245,7 +250,8 @@ export function useRepairCreatedKeyManagedSiteImport({
   const prepareBatchImport = useCallback(
     async (includeCompletedReferences = false) => {
       if (
-        isResolving ||
+        !isOpen ||
+        preparationInFlightRef.current ||
         isBatchImportOpen ||
         !progress ||
         createdReferenceCount === 0
@@ -255,8 +261,12 @@ export function useRepairCreatedKeyManagedSiteImport({
 
       setIsResolving(true)
       setImportFeedback(null)
+      preparationInFlightRef.current = true
+      const generation = ++preparationGenerationRef.current
+      const isStale = () => generation !== preparationGenerationRef.current
       try {
         const runtimeConfig = await getCurrentManagedSiteRuntimeConfig()
+        if (isStale()) return
         if (!runtimeConfig) {
           setImportFeedback({
             action: "configure-managed-site",
@@ -268,6 +278,7 @@ export function useRepairCreatedKeyManagedSiteImport({
 
         const target =
           await createManagedSiteTokenBatchImportTarget(runtimeConfig)
+        if (isStale()) return
         const visibleProgress = getVisibleProgress(progress, accounts)
         const candidate = await resolveRepairCreatedKeyBatchImportCandidate({
           progress: visibleProgress,
@@ -279,6 +290,7 @@ export function useRepairCreatedKeyManagedSiteImport({
           forceCompleteVerification: includeCompletedReferences,
           includeCompletedReferences,
         })
+        if (isStale()) return
         if (!candidate) {
           const absenceReason = getRepairCreatedKeyBatchImportAbsenceReason({
             progress: visibleProgress,
@@ -305,12 +317,16 @@ export function useRepairCreatedKeyManagedSiteImport({
         setBatchImportIntent(candidate.intent)
         setIsBatchImportOpen(true)
       } catch {
+        if (isStale()) return
         setImportFeedback({
           reason: "failed",
           variant: "destructive",
         })
       } finally {
-        setIsResolving(false)
+        if (!isStale()) {
+          preparationInFlightRef.current = false
+          setIsResolving(false)
+        }
       }
     },
     [
@@ -318,7 +334,7 @@ export function useRepairCreatedKeyManagedSiteImport({
       isBatchImportOpen,
       isCurrentSessionResult,
       createdReferenceCount,
-      isResolving,
+      isOpen,
       progress,
     ],
   )
@@ -386,6 +402,14 @@ export function useRepairCreatedKeyManagedSiteImport({
   useEffect(() => {
     setImportFeedback(null)
   }, [managedSiteType])
+
+  useEffect(
+    () => () => {
+      preparationGenerationRef.current += 1
+      preparationInFlightRef.current = false
+    },
+    [],
+  )
 
   useEffect(() => {
     if (isOpen) return

--- a/src/features/KeyManagement/components/RepairMissingKeysDialog/useRepairMissingKeysJob.ts
+++ b/src/features/KeyManagement/components/RepairMissingKeysDialog/useRepairMissingKeysJob.ts
@@ -146,6 +146,7 @@ export function useRepairMissingKeysJob({
   const startInFlightRef = useRef(false)
   const startRequestIdRef = useRef(0)
   const progressRevisionRef = useRef(0)
+  const progressReadInFlightRef = useRef<object | null>(null)
 
   const setProgress = useCallback(
     (update: SetStateAction<AccountKeyRepairProgress | null>) => {
@@ -154,6 +155,9 @@ export function useRepairMissingKeysJob({
       if (next && current?.jobId === next.jobId) {
         if (
           (current.updatedAt ?? 0) > (next.updatedAt ?? 0) ||
+          (typeof update !== "function" &&
+            current.updatedAt !== undefined &&
+            current.updatedAt === next.updatedAt) ||
           (current.state !== ACCOUNT_KEY_REPAIR_JOB_STATES.Running &&
             current.state !== ACCOUNT_KEY_REPAIR_JOB_STATES.Idle &&
             next.state === ACCOUNT_KEY_REPAIR_JOB_STATES.Running)
@@ -175,7 +179,10 @@ export function useRepairMissingKeysJob({
   )
 
   const readProgress = useCallback(
-    async (isCancelled: () => boolean, onSuccess?: () => void) => {
+    async (isCancelled: () => boolean) => {
+      if (progressReadInFlightRef.current) return
+      const request = {}
+      progressReadInFlightRef.current = request
       const revision = progressRevisionRef.current
       const isStale = () =>
         isCancelled() || revision !== progressRevisionRef.current
@@ -186,12 +193,16 @@ export function useRepairMissingKeysJob({
         if (isStale()) return
         if (response?.success && response.data) {
           setProgress(response.data)
-          onSuccess?.()
+          setFailure((current) => (current === "load" ? null : current))
         } else {
           setFailure("load")
         }
       } catch {
         if (!isStale()) setFailure("load")
+      } finally {
+        if (progressReadInFlightRef.current === request) {
+          progressReadInFlightRef.current = null
+        }
       }
     },
     [setProgress],
@@ -358,6 +369,7 @@ export function useRepairMissingKeysJob({
 
     return () => {
       cancelled = true
+      progressReadInFlightRef.current = null
     }
   }, [isOpen, readProgress])
 
@@ -367,22 +379,10 @@ export function useRepairMissingKeysJob({
     }
 
     let cancelled = false
-    let inFlight = false
     // Broadcasts are best-effort. Reconcile while visible so a missed terminal
     // notification (including a restarted worker) cannot leave the UI running.
-    const timer = setInterval(async () => {
-      if (inFlight) return
-      inFlight = true
-      try {
-        await readProgress(
-          () => cancelled,
-          () => {
-            setFailure((current) => (current === "load" ? null : current))
-          },
-        )
-      } finally {
-        inFlight = false
-      }
+    const timer = setInterval(() => {
+      void readProgress(() => cancelled)
     }, REPAIR_PROGRESS_POLL_INTERVAL_MS)
 
     return () => {

--- a/src/features/KeyManagement/components/RepairMissingKeysDialog/useRepairMissingKeysJob.ts
+++ b/src/features/KeyManagement/components/RepairMissingKeysDialog/useRepairMissingKeysJob.ts
@@ -1,5 +1,11 @@
 import type { TFunction } from "i18next"
-import { useCallback, useEffect, useRef, useState } from "react"
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type SetStateAction,
+} from "react"
 
 import { RuntimeMessageTypes } from "~/constants/runtimeActions"
 import {
@@ -121,9 +127,8 @@ export function useRepairMissingKeysJob({
   startOnOpen,
   t,
 }: UseRepairMissingKeysJobOptions) {
-  const [progress, setProgress] = useState<AccountKeyRepairProgress | null>(
-    null,
-  )
+  const [progress, setProgressState] =
+    useState<AccountKeyRepairProgress | null>(null)
   const [failure, setFailure] = useState<"start" | "cancel" | "load" | null>(
     null,
   )
@@ -138,6 +143,40 @@ export function useRepairMissingKeysJob({
   const hasAutoStartedRef = useRef(false)
   const startInFlightRef = useRef(false)
   const startRequestIdRef = useRef(0)
+  const progressRevisionRef = useRef(0)
+
+  const setProgress = useCallback(
+    (update: SetStateAction<AccountKeyRepairProgress | null>) => {
+      const current = progressRef.current
+      const next = typeof update === "function" ? update(current) : update
+      if (!next) {
+        progressRef.current = null
+        progressRevisionRef.current += 1
+        setProgressState(null)
+        return
+      }
+      if (current?.jobId === next.jobId) {
+        if (
+          (current.updatedAt ?? 0) > (next.updatedAt ?? 0) ||
+          (current.state !== ACCOUNT_KEY_REPAIR_JOB_STATES.Running &&
+            current.state !== ACCOUNT_KEY_REPAIR_JOB_STATES.Idle &&
+            next.state === ACCOUNT_KEY_REPAIR_JOB_STATES.Running)
+        ) {
+          return
+        }
+      } else if (
+        current?.startedAt !== undefined &&
+        next.startedAt !== undefined &&
+        current.startedAt > next.startedAt
+      ) {
+        return
+      }
+      progressRef.current = next
+      progressRevisionRef.current += 1
+      setProgressState(next)
+    },
+    [],
+  )
 
   isDialogOpenRef.current = isOpen
 
@@ -214,7 +253,7 @@ export function useRepairMissingKeysJob({
         }
       }
     }
-  }, [renameAutoTemplateTokens])
+  }, [renameAutoTemplateTokens, setProgress])
 
   const handleCancelAudit = useCallback(async () => {
     if (cancelInFlightRef.current) {
@@ -258,7 +297,7 @@ export function useRepairMissingKeysJob({
         setIsCancelling(false)
       }
     }
-  }, [invalidatePendingStart])
+  }, [invalidatePendingStart, setProgress])
 
   useEffect(() => {
     isDialogOpenRef.current = isOpen
@@ -285,10 +324,6 @@ export function useRepairMissingKeysJob({
   }, [isOpen])
 
   useEffect(() => {
-    progressRef.current = progress
-  }, [progress])
-
-  useEffect(() => {
     accountsRef.current = accounts
   }, [accounts])
 
@@ -301,12 +336,13 @@ export function useRepairMissingKeysJob({
       if (!payload) return
       setProgress(payload)
     })
-  }, [isOpen])
+  }, [isOpen, setProgress])
 
   useEffect(() => {
     if (!isOpen) return
 
     let cancelled = false
+    const revision = progressRevisionRef.current
     setFailure(null)
 
     void (async () => {
@@ -314,7 +350,7 @@ export function useRepairMissingKeysJob({
         const response = await sendAccountKeyRepairMessage(
           AccountKeyRepairMessageTypes.GetProgress,
         )
-        if (cancelled) return
+        if (cancelled || revision !== progressRevisionRef.current) return
         if (response?.success && response.data) {
           setProgress(response.data)
           return
@@ -322,7 +358,7 @@ export function useRepairMissingKeysJob({
 
         setFailure("load")
       } catch {
-        if (!cancelled) {
+        if (!cancelled && revision === progressRevisionRef.current) {
           setFailure("load")
         }
       }
@@ -331,7 +367,46 @@ export function useRepairMissingKeysJob({
     return () => {
       cancelled = true
     }
-  }, [isOpen])
+  }, [isOpen, setProgress])
+
+  useEffect(() => {
+    if (!isOpen || progress?.state !== ACCOUNT_KEY_REPAIR_JOB_STATES.Running) {
+      return
+    }
+
+    let cancelled = false
+    let inFlight = false
+    // Broadcasts are best-effort. Reconcile while visible so a missed terminal
+    // notification (including a restarted worker) cannot leave the UI running.
+    const timer = setInterval(async () => {
+      if (inFlight) return
+      inFlight = true
+      const revision = progressRevisionRef.current
+      try {
+        const response = await sendAccountKeyRepairMessage(
+          AccountKeyRepairMessageTypes.GetProgress,
+        )
+        if (cancelled || revision !== progressRevisionRef.current) return
+        if (response?.success && response.data) {
+          setProgress(response.data)
+          setFailure((current) => (current === "load" ? null : current))
+        } else {
+          setFailure("load")
+        }
+      } catch {
+        if (!cancelled && revision === progressRevisionRef.current) {
+          setFailure("load")
+        }
+      } finally {
+        inFlight = false
+      }
+    }, 3000)
+
+    return () => {
+      cancelled = true
+      clearInterval(timer)
+    }
+  }, [isOpen, progress?.jobId, progress?.state, setProgress])
 
   useEffect(() => {
     if (!isOpen) {

--- a/src/features/KeyManagement/components/RepairMissingKeysDialog/useRepairMissingKeysJob.ts
+++ b/src/features/KeyManagement/components/RepairMissingKeysDialog/useRepairMissingKeysJob.ts
@@ -32,6 +32,8 @@ import { onRuntimeMessage } from "~/utils/browser/browserApi"
 
 import { hasRepairAttentionOutcomes } from "./repairMissingKeysDialogHelpers"
 
+const REPAIR_PROGRESS_POLL_INTERVAL_MS = 3000
+
 const repairMissingKeysAnalyticsContext = {
   featureId: PRODUCT_ANALYTICS_FEATURE_IDS.KeyManagement,
   actionId: PRODUCT_ANALYTICS_ACTION_IDS.RepairMissingAccountKeys,
@@ -149,13 +151,7 @@ export function useRepairMissingKeysJob({
     (update: SetStateAction<AccountKeyRepairProgress | null>) => {
       const current = progressRef.current
       const next = typeof update === "function" ? update(current) : update
-      if (!next) {
-        progressRef.current = null
-        progressRevisionRef.current += 1
-        setProgressState(null)
-        return
-      }
-      if (current?.jobId === next.jobId) {
+      if (next && current?.jobId === next.jobId) {
         if (
           (current.updatedAt ?? 0) > (next.updatedAt ?? 0) ||
           (current.state !== ACCOUNT_KEY_REPAIR_JOB_STATES.Running &&
@@ -166,7 +162,7 @@ export function useRepairMissingKeysJob({
         }
       } else if (
         current?.startedAt !== undefined &&
-        next.startedAt !== undefined &&
+        next?.startedAt !== undefined &&
         current.startedAt > next.startedAt
       ) {
         return
@@ -176,6 +172,29 @@ export function useRepairMissingKeysJob({
       setProgressState(next)
     },
     [],
+  )
+
+  const readProgress = useCallback(
+    async (isCancelled: () => boolean, onSuccess?: () => void) => {
+      const revision = progressRevisionRef.current
+      const isStale = () =>
+        isCancelled() || revision !== progressRevisionRef.current
+      try {
+        const response = await sendAccountKeyRepairMessage(
+          AccountKeyRepairMessageTypes.GetProgress,
+        )
+        if (isStale()) return
+        if (response?.success && response.data) {
+          setProgress(response.data)
+          onSuccess?.()
+        } else {
+          setFailure("load")
+        }
+      } catch {
+        if (!isStale()) setFailure("load")
+      }
+    },
+    [setProgress],
   )
 
   isDialogOpenRef.current = isOpen
@@ -199,6 +218,20 @@ export function useRepairMissingKeysJob({
 
     setIsStarting(true)
     setFailure(null)
+    const reportStartFailure = () => {
+      void trackProductAnalyticsActionCompleted({
+        ...repairMissingKeysAnalyticsContext,
+        result: PRODUCT_ANALYTICS_RESULTS.Failure,
+        errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
+        insights: getRepairStartFailureInsights(
+          progressRef.current,
+          accountsRef.current,
+        ),
+      })
+      if (isDialogOpenRef.current && startRequestIdRef.current === requestId) {
+        setFailure("start")
+      }
+    }
     try {
       const response = await sendAccountKeyRepairMessage(
         AccountKeyRepairMessageTypes.Start,
@@ -220,31 +253,9 @@ export function useRepairMissingKeysJob({
         return
       }
 
-      void trackProductAnalyticsActionCompleted({
-        ...repairMissingKeysAnalyticsContext,
-        result: PRODUCT_ANALYTICS_RESULTS.Failure,
-        errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
-        insights: getRepairStartFailureInsights(
-          progressRef.current,
-          accountsRef.current,
-        ),
-      })
-      if (isDialogOpenRef.current && startRequestIdRef.current === requestId) {
-        setFailure("start")
-      }
+      reportStartFailure()
     } catch {
-      void trackProductAnalyticsActionCompleted({
-        ...repairMissingKeysAnalyticsContext,
-        result: PRODUCT_ANALYTICS_RESULTS.Failure,
-        errorCategory: PRODUCT_ANALYTICS_ERROR_CATEGORIES.Unknown,
-        insights: getRepairStartFailureInsights(
-          progressRef.current,
-          accountsRef.current,
-        ),
-      })
-      if (isDialogOpenRef.current && startRequestIdRef.current === requestId) {
-        setFailure("start")
-      }
+      reportStartFailure()
     } finally {
       if (startRequestIdRef.current === requestId) {
         startInFlightRef.current = false
@@ -342,32 +353,13 @@ export function useRepairMissingKeysJob({
     if (!isOpen) return
 
     let cancelled = false
-    const revision = progressRevisionRef.current
     setFailure(null)
-
-    void (async () => {
-      try {
-        const response = await sendAccountKeyRepairMessage(
-          AccountKeyRepairMessageTypes.GetProgress,
-        )
-        if (cancelled || revision !== progressRevisionRef.current) return
-        if (response?.success && response.data) {
-          setProgress(response.data)
-          return
-        }
-
-        setFailure("load")
-      } catch {
-        if (!cancelled && revision === progressRevisionRef.current) {
-          setFailure("load")
-        }
-      }
-    })()
+    void readProgress(() => cancelled)
 
     return () => {
       cancelled = true
     }
-  }, [isOpen, setProgress])
+  }, [isOpen, readProgress])
 
   useEffect(() => {
     if (!isOpen || progress?.state !== ACCOUNT_KEY_REPAIR_JOB_STATES.Running) {
@@ -381,32 +373,23 @@ export function useRepairMissingKeysJob({
     const timer = setInterval(async () => {
       if (inFlight) return
       inFlight = true
-      const revision = progressRevisionRef.current
       try {
-        const response = await sendAccountKeyRepairMessage(
-          AccountKeyRepairMessageTypes.GetProgress,
+        await readProgress(
+          () => cancelled,
+          () => {
+            setFailure((current) => (current === "load" ? null : current))
+          },
         )
-        if (cancelled || revision !== progressRevisionRef.current) return
-        if (response?.success && response.data) {
-          setProgress(response.data)
-          setFailure((current) => (current === "load" ? null : current))
-        } else {
-          setFailure("load")
-        }
-      } catch {
-        if (!cancelled && revision === progressRevisionRef.current) {
-          setFailure("load")
-        }
       } finally {
         inFlight = false
       }
-    }, 3000)
+    }, REPAIR_PROGRESS_POLL_INTERVAL_MS)
 
     return () => {
       cancelled = true
       clearInterval(timer)
     }
-  }, [isOpen, progress?.jobId, progress?.state, setProgress])
+  }, [isOpen, progress?.jobId, progress?.state, readProgress])
 
   useEffect(() => {
     if (!isOpen) {

--- a/src/features/KeyManagement/components/RepairMissingKeysDialog/useRepairMissingKeysJob.ts
+++ b/src/features/KeyManagement/components/RepairMissingKeysDialog/useRepairMissingKeysJob.ts
@@ -136,7 +136,9 @@ export function useRepairMissingKeysJob({
   )
   const [isStarting, setIsStarting] = useState(false)
   const [isCancelling, setIsCancelling] = useState(false)
-  const startedAnalyticsJobIdRef = useRef<string | null>(null)
+  const [startedAnalyticsJobId, setStartedAnalyticsJobId] = useState<
+    string | null
+  >(null)
   const completedAnalyticsJobIdRef = useRef<string | null>(null)
   const cancelInFlightRef = useRef(false)
   const progressRef = useRef<AccountKeyRepairProgress | null>(null)
@@ -147,9 +149,13 @@ export function useRepairMissingKeysJob({
   const startRequestIdRef = useRef(0)
   const progressRevisionRef = useRef(0)
   const progressReadInFlightRef = useRef<object | null>(null)
+  const supersededJobIdsRef = useRef(new Set<string>())
 
-  const setProgress = useCallback(
-    (update: SetStateAction<AccountKeyRepairProgress | null>) => {
+  const applyProgress = useCallback(
+    (
+      update: SetStateAction<AccountKeyRepairProgress | null>,
+      authoritative = false,
+    ) => {
       const current = progressRef.current
       const next = typeof update === "function" ? update(current) : update
       if (next && current?.jobId === next.jobId) {
@@ -164,18 +170,32 @@ export function useRepairMissingKeysJob({
         ) {
           return
         }
-      } else if (
-        current?.startedAt !== undefined &&
-        next?.startedAt !== undefined &&
-        current.startedAt > next.startedAt
-      ) {
-        return
+      } else if (next && current) {
+        if (
+          !authoritative &&
+          (supersededJobIdsRef.current.has(next.jobId) ||
+            (current.startedAt !== undefined &&
+              next.startedAt !== undefined &&
+              current.startedAt > next.startedAt))
+        ) {
+          return
+        }
+        // A current response can establish a job despite clock rollback. Remember
+        // the replaced identity so delayed broadcasts cannot restore that job.
+        supersededJobIdsRef.current.add(current.jobId)
+        supersededJobIdsRef.current.delete(next.jobId)
       }
       progressRef.current = next
       progressRevisionRef.current += 1
       setProgressState(next)
     },
     [],
+  )
+
+  const setProgress = useCallback(
+    (update: SetStateAction<AccountKeyRepairProgress | null>) =>
+      applyProgress(update),
+    [applyProgress],
   )
 
   const readProgress = useCallback(
@@ -192,7 +212,7 @@ export function useRepairMissingKeysJob({
         )
         if (isStale()) return
         if (response?.success && response.data) {
-          setProgress(response.data)
+          applyProgress(response.data, true)
           setFailure((current) => (current === "load" ? null : current))
         } else {
           setFailure("load")
@@ -205,7 +225,7 @@ export function useRepairMissingKeysJob({
         }
       }
     },
-    [setProgress],
+    [applyProgress],
   )
 
   isDialogOpenRef.current = isOpen
@@ -251,7 +271,7 @@ export function useRepairMissingKeysJob({
         },
       )
       if (response?.success && response.data) {
-        startedAnalyticsJobIdRef.current = response.data.jobId
+        setStartedAnalyticsJobId(response.data.jobId)
         void trackProductAnalyticsActionStarted(
           repairMissingKeysAnalyticsContext,
         )
@@ -259,7 +279,7 @@ export function useRepairMissingKeysJob({
           isDialogOpenRef.current &&
           startRequestIdRef.current === requestId
         ) {
-          setProgress(response.data)
+          applyProgress(response.data, true)
         }
         return
       }
@@ -275,7 +295,7 @@ export function useRepairMissingKeysJob({
         }
       }
     }
-  }, [renameAutoTemplateTokens, setProgress])
+  }, [renameAutoTemplateTokens, applyProgress])
 
   const handleCancelAudit = useCallback(async () => {
     if (cancelInFlightRef.current) {
@@ -340,7 +360,7 @@ export function useRepairMissingKeysJob({
 
   useEffect(() => {
     if (!isOpen) {
-      startedAnalyticsJobIdRef.current = null
+      setStartedAnalyticsJobId(null)
       completedAnalyticsJobIdRef.current = null
     }
   }, [isOpen])
@@ -412,7 +432,7 @@ export function useRepairMissingKeysJob({
     ) {
       return
     }
-    if (startedAnalyticsJobIdRef.current !== progress.jobId) return
+    if (startedAnalyticsJobId !== progress.jobId) return
     if (completedAnalyticsJobIdRef.current === progress.jobId) return
 
     completedAnalyticsJobIdRef.current = progress.jobId
@@ -428,7 +448,7 @@ export function useRepairMissingKeysJob({
         statusKind: getRepairProgressStatusKind(progress),
       },
     })
-  }, [progress])
+  }, [progress, startedAnalyticsJobId])
 
   return {
     error:

--- a/src/services/accounts/accountKeyAutoProvisioning/repair.ts
+++ b/src/services/accounts/accountKeyAutoProvisioning/repair.ts
@@ -1115,7 +1115,9 @@ class AccountKeyRepairRunner {
       }
       const pendingProgress = {
         ...nextProgress,
-        updatedAt: Date.now(),
+        // Preserve ordering when multiple updates share a millisecond or the
+        // wall clock moves backwards, without changing the persisted schema.
+        updatedAt: Math.max(Date.now(), (base.updatedAt ?? 0) + 1),
       }
       await this.persistProgressWithRollback(pendingProgress, previousProgress)
     })

--- a/src/services/managedSites/repairCreatedKeyBatchImport.ts
+++ b/src/services/managedSites/repairCreatedKeyBatchImport.ts
@@ -91,7 +91,6 @@ type CreatedReferenceResolution =
   | { absenceReason: RepairCreatedKeyBatchImportAbsenceReason }
   | {
       absenceReason: null
-      references: CreatedResourceReferenceEntry[]
       candidateReferences: CreatedResourceReferenceEntry[]
       targetReceipts: Map<string, AccountKeyRepairManagedSiteImportStatus>
     }
@@ -108,19 +107,20 @@ const getOriginKey = (siteUrl: string) =>
     stripTrailingSlashes: false,
   })
 
-const buildBlockedReference = (params: {
-  ref: AccountKeyResourceRef
-  accountLabel: string
-  label: string
-  detailCode: ManagedSiteTokenBatchExportBlockedDetailCode
-}): ManagedSiteTokenBatchExportItemInput => ({
+const buildBlockedReference = (
+  reference: Pick<
+    CreatedResourceReferenceEntry,
+    "ref" | "accountLabel" | "label"
+  >,
+  detailCode: ManagedSiteTokenBatchExportBlockedDetailCode,
+): ManagedSiteTokenBatchExportItemInput => ({
   kind: MANAGED_SITE_TOKEN_BATCH_EXPORT_INPUT_KINDS.BLOCKED_REFERENCE,
-  id: buildAccountKeyResourceRuntimeKeyId(params.ref),
-  accountLabel: params.accountLabel,
-  keyLabel: params.label,
+  id: buildAccountKeyResourceRuntimeKeyId(reference.ref),
+  accountLabel: reference.accountLabel,
+  keyLabel: reference.label,
   blockingReasonCode:
     MANAGED_SITE_TOKEN_BATCH_EXPORT_BLOCKED_REASON_CODES.INPUT_PREPARATION_FAILED,
-  blockingDetailCode: params.detailCode,
+  blockingDetailCode: detailCode,
 })
 
 const buildResolvedReference = (params: {
@@ -240,7 +240,6 @@ const resolveCreatedReferenceState = (
 
   return {
     absenceReason: null,
-    references,
     candidateReferences,
     targetReceipts,
   }
@@ -304,13 +303,10 @@ export async function resolveRepairCreatedKeyBatchImportCandidate(
         reference.ref.accountId !== reference.accountId ||
         reference.ref.siteType !== reference.resultSiteType
       ) {
-        return buildBlockedReference({
-          ref: reference.ref,
-          accountLabel: reference.accountLabel,
-          label: reference.label,
-          detailCode:
-            MANAGED_SITE_TOKEN_BATCH_EXPORT_BLOCKED_DETAIL_CODES.SOURCE_ACCOUNT_UNAVAILABLE,
-        })
+        return buildBlockedReference(
+          reference,
+          MANAGED_SITE_TOKEN_BATCH_EXPORT_BLOCKED_DETAIL_CODES.SOURCE_ACCOUNT_UNAVAILABLE,
+        )
       }
 
       const createdSecret =
@@ -333,13 +329,10 @@ export async function resolveRepairCreatedKeyBatchImportCandidate(
       try {
         const session = await getAccountKeyResourceSession(account)
         if (!session?.runtimeKey) {
-          return buildBlockedReference({
-            ref: reference.ref,
-            accountLabel: reference.accountLabel,
-            label: reference.label,
-            detailCode:
-              MANAGED_SITE_TOKEN_BATCH_EXPORT_BLOCKED_DETAIL_CODES.SOURCE_KEY_INVENTORY_UNAVAILABLE,
-          })
+          return buildBlockedReference(
+            reference,
+            MANAGED_SITE_TOKEN_BATCH_EXPORT_BLOCKED_DETAIL_CODES.SOURCE_KEY_INVENTORY_UNAVAILABLE,
+          )
         }
 
         const runtimeResolution = await session.runtimeKey.resolve(
@@ -350,13 +343,10 @@ export async function resolveRepairCreatedKeyBatchImportCandidate(
             ACCOUNT_KEY_RUNTIME_KEY_RESOLUTION_KINDS.Resolved ||
           runtimeResolution.secret.trim().length === 0
         ) {
-          return buildBlockedReference({
-            ref: reference.ref,
-            accountLabel: reference.accountLabel,
-            label: reference.label,
-            detailCode:
-              MANAGED_SITE_TOKEN_BATCH_EXPORT_BLOCKED_DETAIL_CODES.CREATED_KEY_UNAVAILABLE,
-          })
+          return buildBlockedReference(
+            reference,
+            MANAGED_SITE_TOKEN_BATCH_EXPORT_BLOCKED_DETAIL_CODES.CREATED_KEY_UNAVAILABLE,
+          )
         }
 
         return buildResolvedReference({
@@ -369,13 +359,10 @@ export async function resolveRepairCreatedKeyBatchImportCandidate(
         logger.warn("Failed to resolve a repair-created runtime key", {
           error: sanitizeSensitiveErrorText(getErrorMessage(error)),
         })
-        return buildBlockedReference({
-          ref: reference.ref,
-          accountLabel: reference.accountLabel,
-          label: reference.label,
-          detailCode:
-            MANAGED_SITE_TOKEN_BATCH_EXPORT_BLOCKED_DETAIL_CODES.SOURCE_KEY_INVENTORY_UNAVAILABLE,
-        })
+        return buildBlockedReference(
+          reference,
+          MANAGED_SITE_TOKEN_BATCH_EXPORT_BLOCKED_DETAIL_CODES.SOURCE_KEY_INVENTORY_UNAVAILABLE,
+        )
       }
     },
   )
@@ -386,13 +373,10 @@ export async function resolveRepairCreatedKeyBatchImportCandidate(
       error: sanitizeSensitiveErrorText(getErrorMessage(result.reason)),
     })
     const reference = resolution.candidateReferences[index]!
-    return buildBlockedReference({
-      ref: reference.ref,
-      accountLabel: reference.accountLabel,
-      label: reference.label,
-      detailCode:
-        MANAGED_SITE_TOKEN_BATCH_EXPORT_BLOCKED_DETAIL_CODES.SOURCE_KEY_INVENTORY_UNAVAILABLE,
-    })
+    return buildBlockedReference(
+      reference,
+      MANAGED_SITE_TOKEN_BATCH_EXPORT_BLOCKED_DETAIL_CODES.SOURCE_KEY_INVENTORY_UNAVAILABLE,
+    )
   })
 
   const hasReconciliationReceipt = resolution.candidateReferences.some(

--- a/src/services/managedSites/repairCreatedKeyBatchImport.ts
+++ b/src/services/managedSites/repairCreatedKeyBatchImport.ts
@@ -201,13 +201,14 @@ const resolveCreatedReferenceState = (
 ): CreatedReferenceResolution => {
   if (
     progress.schemaVersion !== ACCOUNT_KEY_REPAIR_PROGRESS_SCHEMA_VERSION ||
-    progress.state !== ACCOUNT_KEY_REPAIR_JOB_STATES.Completed
+    progress.state === ACCOUNT_KEY_REPAIR_JOB_STATES.Idle
   ) {
     return {
       absenceReason: REPAIR_CREATED_KEY_BATCH_IMPORT_ABSENCE_REASONS.NOT_READY,
     }
   }
 
+  // Confirmed resource identities are usable independently of unfinished accounts.
   const references = getCreatedReferenceEntries(progress)
   if (references.length === 0) {
     return {

--- a/tests/entrypoints/options/KeyManagementRepairMissingKeys.test.tsx
+++ b/tests/entrypoints/options/KeyManagementRepairMissingKeys.test.tsx
@@ -799,7 +799,7 @@ describe("KeyManagement repair missing keys entry point", () => {
     expect(screen.getByText("Another Site")).toBeInTheDocument()
   })
 
-  it("shows repair-created import only after completed progress has exact references", async () => {
+  it("shows confirmed repair-created keys before completion and retains import afterwards", async () => {
     sendRuntimeActionMessageMock.mockImplementation(async (message: any) => {
       if (message === AccountKeyRepairMessageTypes.GetProgress) {
         return { success: true, data: idleProgress }
@@ -830,10 +830,10 @@ describe("KeyManagement repair missing keys entry point", () => {
       )
     })
     expect(
-      screen.queryByTestId(
+      await screen.findByTestId(
         KEY_MANAGEMENT_TEST_IDS.repairCreatedManagedSiteImportButton,
       ),
-    ).not.toBeInTheDocument()
+    ).toBeVisible()
 
     const completedWithReferences: AccountKeyRepairProgress = {
       ...startProgress,

--- a/tests/entrypoints/options/KeyManagementRepairMissingKeys.test.tsx
+++ b/tests/entrypoints/options/KeyManagementRepairMissingKeys.test.tsx
@@ -294,6 +294,7 @@ const startProgress: AccountKeyRepairProgress = {
 
 const completedProgress: AccountKeyRepairProgress = {
   ...startProgress,
+  updatedAt: 2,
   state: ACCOUNT_KEY_REPAIR_JOB_STATES.Completed,
   finishedAt: 2,
   summary: { ...emptySummary(), complete: 2 },
@@ -331,6 +332,7 @@ const multiOutcomeProgress: AccountKeyRepairProgress = {
 
 const failedProgress: AccountKeyRepairProgress = {
   ...multiOutcomeProgress,
+  updatedAt: 2,
   jobId: "job-1",
   state: ACCOUNT_KEY_REPAIR_JOB_STATES.Failed,
   finishedAt: 2,
@@ -776,6 +778,7 @@ describe("KeyManagement repair missing keys entry point", () => {
     // Progress subscription updates the UI.
     const updated: AccountKeyRepairProgress = {
       ...startProgress,
+      updatedAt: 2,
       totals: { ...startProgress.totals, processedAccounts: 3 },
       summary: { ...startProgress.summary, complete: 2 },
       results: [
@@ -837,6 +840,7 @@ describe("KeyManagement repair missing keys entry point", () => {
 
     const completedWithReferences: AccountKeyRepairProgress = {
       ...startProgress,
+      updatedAt: 2,
       state: ACCOUNT_KEY_REPAIR_JOB_STATES.Completed,
       finishedAt: 2,
       results: startProgress.results.map((result) =>
@@ -1640,6 +1644,7 @@ describe("KeyManagement repair missing keys entry point", () => {
         type: RuntimeMessageTypes.AccountKeyRepairProgress,
         payload: {
           ...runningCoverageProgress,
+          updatedAt: 3,
           summary: {
             ...runningCoverageProgress.summary,
             invalidResources: 0,

--- a/tests/features/KeyManagement/components/RepairMissingKeysDialog/index.test.tsx
+++ b/tests/features/KeyManagement/components/RepairMissingKeysDialog/index.test.tsx
@@ -386,7 +386,7 @@ describe("RepairMissingKeysDialog", () => {
     }))
   })
 
-  it("ignores a stale import action before repair completion", async () => {
+  it("ignores an import action without confirmed created keys", async () => {
     const account = buildAccount()
     const progress = buildRepairProgress(ACCOUNT_KEY_REPAIR_JOB_STATES.Running)
     const { result } = renderHook(() =>
@@ -812,98 +812,110 @@ describe("RepairMissingKeysDialog", () => {
     )
   })
 
-  it("resolves current-session created keys lazily and opens the shared trusted review", async () => {
-    const user = userEvent.setup()
-    const account = buildAccount()
-    mockProgress = buildRepairProgress(ACCOUNT_KEY_REPAIR_JOB_STATES.Running, {
-      jobId: "repair-job",
-    })
-    mockResolveRepairCreatedKeyBatchImportCandidate.mockResolvedValue(
-      buildRepairImportCandidate(account),
-    )
+  it.each([
+    ACCOUNT_KEY_REPAIR_JOB_STATES.Running,
+    ACCOUNT_KEY_REPAIR_JOB_STATES.Completed,
+    ACCOUNT_KEY_REPAIR_JOB_STATES.Cancelled,
+    ACCOUNT_KEY_REPAIR_JOB_STATES.Failed,
+  ])(
+    "opens confirmed created keys for review while the job is %s",
+    async (state) => {
+      const user = userEvent.setup()
+      const account = buildAccount()
+      mockProgress = buildRepairProgress(
+        ACCOUNT_KEY_REPAIR_JOB_STATES.Running,
+        {
+          jobId: "repair-job",
+        },
+      )
+      mockResolveRepairCreatedKeyBatchImportCandidate.mockResolvedValue(
+        buildRepairImportCandidate(account),
+      )
 
-    const view = render(
-      <RepairMissingKeysDialog
-        isOpen
-        onClose={vi.fn()}
-        accounts={[account]}
-        startOnOpen={false}
-      />,
-    )
+      const view = render(
+        <RepairMissingKeysDialog
+          isOpen
+          onClose={vi.fn()}
+          accounts={[account]}
+          startOnOpen={false}
+        />,
+      )
 
-    await screen.findByRole("progressbar", {
-      name: "keyManagement:repairMissingKeys.progressLabel",
-    })
-    mockProgress = buildCreatedProgress(account)
-    view.rerender(
-      <RepairMissingKeysDialog
-        isOpen
-        onClose={vi.fn()}
-        accounts={[account]}
-        startOnOpen={false}
-      />,
-    )
+      await screen.findByRole("progressbar", {
+        name: "keyManagement:repairMissingKeys.progressLabel",
+      })
+      mockProgress = buildCreatedProgress(account)
+      mockProgress.state = state
+      view.rerender(
+        <RepairMissingKeysDialog
+          isOpen
+          onClose={vi.fn()}
+          accounts={[account]}
+          startOnOpen={false}
+        />,
+      )
 
-    const openButton = await screen.findByTestId(
-      KEY_MANAGEMENT_TEST_IDS.repairCreatedManagedSiteImportButton,
-    )
-    const importCard = screen.getByTestId(
-      KEY_MANAGEMENT_TEST_IDS.repairCreatedManagedSiteImportCard,
-    )
-    expect(importCard).toBeVisible()
-    expect(importCard).toHaveTextContent(
-      "keyManagement:repairMissingKeys.managedSiteImport.target",
-    )
-    expect(
-      screen.getByTestId(
-        KEY_MANAGEMENT_TEST_IDS.repairCreatedManagedSiteImportTargetSwitcher,
-      ),
-    ).toHaveAttribute("role", "combobox")
-    expect(
-      mockResolveRepairCreatedKeyBatchImportCandidate,
-    ).not.toHaveBeenCalled()
-
-    await user.click(openButton)
-
-    await waitFor(() => {
+      const openButton = await screen.findByTestId(
+        KEY_MANAGEMENT_TEST_IDS.repairCreatedManagedSiteImportButton,
+      )
+      const importCard = screen.getByTestId(
+        KEY_MANAGEMENT_TEST_IDS.repairCreatedManagedSiteImportCard,
+      )
+      expect(importCard).toBeVisible()
+      expect(importCard).toHaveTextContent(
+        "keyManagement:repairMissingKeys.managedSiteImport.target",
+      )
+      expect(
+        screen.getByTestId(
+          KEY_MANAGEMENT_TEST_IDS.repairCreatedManagedSiteImportTargetSwitcher,
+        ),
+      ).toHaveAttribute("role", "combobox")
       expect(
         mockResolveRepairCreatedKeyBatchImportCandidate,
-      ).toHaveBeenCalledWith(
+      ).not.toHaveBeenCalled()
+
+      await user.click(openButton)
+
+      await waitFor(() => {
+        expect(
+          mockResolveRepairCreatedKeyBatchImportCandidate,
+        ).toHaveBeenCalledWith(
+          expect.objectContaining({
+            progress: mockProgress,
+            accounts: [account],
+            targetFingerprint: "a".repeat(64),
+            freshness: "current-session",
+          }),
+        )
+      })
+      expect(
+        mockManagedSiteTokenBatchExportDialog.mock.calls.at(-1)?.[0],
+      ).toEqual(
         expect.objectContaining({
-          progress: mockProgress,
-          accounts: [account],
-          targetFingerprint: "a".repeat(64),
-          freshness: "current-session",
+          isOpen: true,
+          intent: {
+            source: MANAGED_SITE_TOKEN_BATCH_IMPORT_SOURCES.REPAIR_CREATED,
+            verification:
+              MANAGED_SITE_TOKEN_BATCH_IMPORT_VERIFICATIONS.TRUSTED_NEW,
+          },
         }),
       )
-    })
-    expect(
-      mockManagedSiteTokenBatchExportDialog.mock.calls.at(-1)?.[0],
-    ).toEqual(
-      expect.objectContaining({
-        isOpen: true,
-        intent: {
-          source: MANAGED_SITE_TOKEN_BATCH_IMPORT_SOURCES.REPAIR_CREATED,
-          verification:
-            MANAGED_SITE_TOKEN_BATCH_IMPORT_VERIFICATIONS.TRUSTED_NEW,
-        },
-      }),
-    )
-    expect(screen.getByTestId("repair-created-batch-dialog")).toBeVisible()
+      expect(screen.getByTestId("repair-created-batch-dialog")).toBeVisible()
 
-    await user.click(
-      screen.getByRole("button", { name: "Close repair import" }),
-    )
+      await user.click(
+        screen.getByRole("button", { name: "Close repair import" }),
+      )
 
-    expect(
-      await screen.findByTestId(
-        KEY_MANAGEMENT_TEST_IDS.repairCreatedManagedSiteImportButton,
-      ),
-    ).toBeVisible()
-    expect(mockUseRepairMissingKeysJob).toHaveBeenLastCalledWith(
-      expect.objectContaining({ isOpen: true }),
-    )
-  })
+      expect(
+        await screen.findByTestId(
+          KEY_MANAGEMENT_TEST_IDS.repairCreatedManagedSiteImportButton,
+        ),
+      ).toBeVisible()
+      expect(mockUseRepairMissingKeysJob).toHaveBeenLastCalledWith(
+        expect.objectContaining({ isOpen: true }),
+      )
+    },
+  )
 
   it("opens a stored current-version result with complete verification", async () => {
     const user = userEvent.setup()

--- a/tests/features/KeyManagement/components/RepairMissingKeysDialog/useRepairCreatedKeyManagedSiteImport.test.tsx
+++ b/tests/features/KeyManagement/components/RepairMissingKeysDialog/useRepairCreatedKeyManagedSiteImport.test.tsx
@@ -152,6 +152,151 @@ const languageI18n = await createResourceTestI18n({
 })
 
 describe("useRepairCreatedKeyManagedSiteImport", () => {
+  it.each(["configuration", "target"])(
+    "stops preparation closed during %s loading",
+    async (stage) => {
+      let finish!: (value: unknown) => void
+      mocks.getCurrentManagedSiteRuntimeConfig.mockReset().mockResolvedValue({})
+      mocks.createManagedSiteTokenBatchImportTarget
+        .mockReset()
+        .mockResolvedValue({ targetFingerprint: "a".repeat(64) })
+      mocks.resolveRepairCreatedKeyBatchImportCandidate.mockClear()
+      const loader =
+        stage === "configuration"
+          ? mocks.getCurrentManagedSiteRuntimeConfig
+          : mocks.createManagedSiteTokenBatchImportTarget
+      loader.mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            finish = resolve
+          }),
+      )
+      const account = createAccount()
+      const ref = {
+        accountId: account.id,
+        siteType: account.siteType,
+        scopeKey: "account",
+        resourceId: "key",
+      }
+      const { result, rerender } = renderHook(
+        ({ isOpen }) =>
+          useRepairCreatedKeyManagedSiteImport({
+            accounts: [account],
+            isOpen,
+            isCurrentSessionResult: true,
+            managedSiteType: SITE_TYPES.NEW_API,
+            progress: createProgress(account, ref),
+            setProgress: vi.fn(),
+            t: testI18n.t,
+          }),
+        { initialProps: { isOpen: true } },
+      )
+      let pending!: Promise<void>
+      act(() => {
+        pending = result.current.openBatchImport()
+      })
+      await waitFor(() => expect(finish).toBeTypeOf("function"))
+      rerender({ isOpen: false })
+      await act(async () => {
+        finish({ targetFingerprint: "a".repeat(64) })
+        await pending
+      })
+      expect(
+        mocks.resolveRepairCreatedKeyBatchImportCandidate,
+      ).not.toHaveBeenCalled()
+      expect(result.current.isResolving).toBe(false)
+      expect(result.current.isBatchImportOpen).toBe(false)
+    },
+  )
+
+  it.each(["success", "failure"])(
+    "ignores stale preparation %s after closing and reopening",
+    async (outcome) => {
+      let finishOld!: (value: unknown) => void
+      let failOld!: (reason: Error) => void
+      mocks.getCurrentManagedSiteRuntimeConfig.mockResolvedValue({})
+      mocks.createManagedSiteTokenBatchImportTarget.mockResolvedValue({
+        targetFingerprint: "a".repeat(64),
+      })
+      mocks.resolveRepairCreatedKeyBatchImportCandidate.mockImplementationOnce(
+        () =>
+          new Promise((resolve, reject) => {
+            finishOld = resolve
+            failOld = reject
+          }),
+      )
+      const account = createAccount()
+      const ref = {
+        accountId: account.id,
+        siteType: account.siteType,
+        scopeKey: "account",
+        resourceId: "key",
+      }
+      const { result, rerender } = renderHook(
+        ({ isOpen }) =>
+          useRepairCreatedKeyManagedSiteImport({
+            accounts: [account],
+            isOpen,
+            isCurrentSessionResult: true,
+            managedSiteType: SITE_TYPES.NEW_API,
+            progress: createProgress(account, ref),
+            setProgress: vi.fn(),
+            t: testI18n.t,
+          }),
+        { initialProps: { isOpen: true } },
+      )
+      let pending!: Promise<void>
+      act(() => {
+        pending = result.current.openBatchImport()
+      })
+      await waitFor(() => expect(finishOld).toBeTypeOf("function"))
+      rerender({ isOpen: false })
+      rerender({ isOpen: true })
+      expect(result.current.isResolving).toBe(false)
+      let finishNew!: (value: unknown) => void
+      mocks.resolveRepairCreatedKeyBatchImportCandidate.mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            finishNew = resolve
+          }),
+      )
+      let newPending!: Promise<void>
+      act(() => {
+        newPending = result.current.openBatchImport()
+      })
+      await waitFor(() => expect(finishNew).toBeTypeOf("function"))
+      await act(async () => {
+        if (outcome === "success")
+          finishOld({
+            items: [],
+            intent: {
+              source: MANAGED_SITE_TOKEN_BATCH_IMPORT_SOURCES.REPAIR_CREATED,
+              verification:
+                MANAGED_SITE_TOKEN_BATCH_IMPORT_VERIFICATIONS.TRUSTED_NEW,
+            },
+          })
+        else failOld(new Error("stale failure"))
+        await pending
+      })
+      expect(result.current.isBatchImportOpen).toBe(false)
+      expect(result.current.importFeedback).toBeNull()
+      expect(result.current.isResolving).toBe(true)
+      await act(async () => {
+        finishNew({
+          items: [],
+          intent: {
+            source: MANAGED_SITE_TOKEN_BATCH_IMPORT_SOURCES.REPAIR_CREATED,
+            verification:
+              MANAGED_SITE_TOKEN_BATCH_IMPORT_VERIFICATIONS.TRUSTED_NEW,
+          },
+        })
+        await newPending
+      })
+      expect(result.current.isBatchImportOpen).toBe(true)
+      expect(result.current.isResolving).toBe(false)
+    },
+  )
+
   it("retranslates configuration feedback without preparing or importing again", async () => {
     mocks.getCurrentManagedSiteRuntimeConfig.mockResolvedValueOnce(null)
     const account = createAccount()

--- a/tests/features/KeyManagement/components/RepairMissingKeysDialog/useRepairMissingKeysJob.test.tsx
+++ b/tests/features/KeyManagement/components/RepairMissingKeysDialog/useRepairMissingKeysJob.test.tsx
@@ -2,6 +2,7 @@ import { act, waitFor } from "@testing-library/react"
 import type { TFunction } from "i18next"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
+import { RuntimeMessageTypes } from "~/constants/runtimeActions"
 import { SITE_TYPES } from "~/constants/siteType"
 import { useRepairMissingKeysJob } from "~/features/KeyManagement/components/RepairMissingKeysDialog/useRepairMissingKeysJob"
 import enKeyManagement from "~/locales/en/keyManagement.json"
@@ -25,6 +26,7 @@ import {
   ACCOUNT_KEY_REPAIR_JOB_STATES,
   ACCOUNT_KEY_REPAIR_PROGRESS_SCHEMA_VERSION,
 } from "~/types/accountKeyAutoProvisioning"
+import { onRuntimeMessage } from "~/utils/browser/browserApi"
 import { buildCompleteTodayStatsAvailability } from "~~/tests/test-utils/accountTodayStats"
 import { buildCheckInConfig } from "~~/tests/test-utils/checkIn"
 import { createResourceTestI18n, testI18n } from "~~/tests/test-utils/i18n"
@@ -127,6 +129,144 @@ const languageI18n = await createResourceTestI18n({
 describe("useRepairMissingKeysJob", () => {
   beforeEach(() => {
     vi.clearAllMocks()
+  })
+
+  it.each([
+    AccountKeyRepairMessageTypes.GetProgress,
+    AccountKeyRepairMessageTypes.Start,
+  ])(
+    "keeps completion received before the %s response",
+    async (messageType) => {
+      let resolveLoad!: (value: {
+        success: true
+        data: AccountKeyRepairProgress
+      }) => void
+      sendAccountKeyRepairMessageMock.mockImplementation((type) =>
+        type === messageType
+          ? new Promise((resolve) => {
+              resolveLoad = resolve
+            })
+          : Promise.resolve({ success: true, data: buildProgress() }),
+      )
+      const { result } = renderHook(() =>
+        useRepairMissingKeysJob({
+          accounts: [buildAccount()],
+          isOpen: true,
+          startOnOpen: messageType === AccountKeyRepairMessageTypes.Start,
+          t: testI18n.t,
+        }),
+      )
+      const completed = buildProgress({
+        state: ACCOUNT_KEY_REPAIR_JOB_STATES.Completed,
+        updatedAt: 20,
+      })
+      await waitFor(() => expect(onRuntimeMessage).toHaveBeenCalled())
+      await act(async () => {
+        const listener = vi.mocked(onRuntimeMessage).mock.calls.at(-1)![0]
+        listener(
+          {
+            type: RuntimeMessageTypes.AccountKeyRepairProgress,
+            payload: completed,
+          },
+          {} as never,
+          vi.fn(),
+        )
+        resolveLoad({ success: true, data: buildProgress({ updatedAt: 10 }) })
+      })
+      expect(result.current.progress).toEqual(completed)
+    },
+  )
+
+  it("does not overlap progress queries or apply their results after closing", async () => {
+    let resolvePoll!: (value: {
+      success: true
+      data: AccountKeyRepairProgress
+    }) => void
+    const running = buildProgress()
+    sendAccountKeyRepairMessageMock
+      .mockResolvedValueOnce({ success: true, data: running })
+      .mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            resolvePoll = resolve
+          }),
+      )
+    const { result, rerender, unmount } = renderHook(
+      ({ isOpen }) =>
+        useRepairMissingKeysJob({
+          accounts: [buildAccount()],
+          isOpen,
+          startOnOpen: false,
+          t: testI18n.t,
+        }),
+      { initialProps: { isOpen: false } },
+    )
+    await waitFor(() => expect(result.current).toBeTruthy())
+    vi.useFakeTimers()
+    try {
+      await act(async () => {
+        rerender({ isOpen: true })
+      })
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(12000)
+      })
+      expect(sendAccountKeyRepairMessageMock).toHaveBeenCalledTimes(2)
+      rerender({ isOpen: false })
+      await act(async () => {
+        resolvePoll({
+          success: true,
+          data: buildProgress({
+            state: ACCOUNT_KEY_REPAIR_JOB_STATES.Completed,
+          }),
+        })
+        await vi.advanceTimersByTimeAsync(12000)
+      })
+      expect(result.current.progress).toEqual(running)
+      expect(sendAccountKeyRepairMessageMock).toHaveBeenCalledTimes(2)
+    } finally {
+      unmount()
+      vi.useRealTimers()
+    }
+  })
+
+  it("recovers completion when the runtime notification is missed", async () => {
+    const running = buildProgress()
+    const completed = buildProgress({
+      state: ACCOUNT_KEY_REPAIR_JOB_STATES.Completed,
+    })
+    sendAccountKeyRepairMessageMock
+      .mockResolvedValueOnce({ success: true, data: running })
+      .mockResolvedValue({ success: true, data: completed })
+    const { result, unmount, rerender } = renderHook(
+      ({ isOpen }) =>
+        useRepairMissingKeysJob({
+          accounts: [buildAccount()],
+          isOpen,
+          startOnOpen: false,
+          t: testI18n.t,
+        }),
+      { initialProps: { isOpen: false } },
+    )
+    await waitFor(() => expect(result.current).toBeTruthy())
+    vi.useFakeTimers()
+    try {
+      await act(async () => {
+        rerender({ isOpen: true })
+      })
+      expect(result.current.progress).toEqual(running)
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5000)
+      })
+      expect(result.current.progress).toEqual(completed)
+      const calls = sendAccountKeyRepairMessageMock.mock.calls.length
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(10000)
+      })
+      expect(sendAccountKeyRepairMessageMock).toHaveBeenCalledTimes(calls)
+    } finally {
+      unmount()
+      vi.useRealTimers()
+    }
   })
 
   it("retranslates cancellation failure while preserving progress without reading it again", async () => {

--- a/tests/features/KeyManagement/components/RepairMissingKeysDialog/useRepairMissingKeysJob.test.tsx
+++ b/tests/features/KeyManagement/components/RepairMissingKeysDialog/useRepairMissingKeysJob.test.tsx
@@ -285,9 +285,81 @@ describe("useRepairMissingKeysJob", () => {
           {} as never,
           vi.fn(),
         )
+      })
+      await act(async () => {
         resolveLoad({ success: true, data: buildProgress({ updatedAt: 10 }) })
       })
       expect(result.current.progress).toEqual(completed)
+      if (messageType === AccountKeyRepairMessageTypes.Start) {
+        expect(trackProductAnalyticsActionCompletedMock).toHaveBeenCalledTimes(
+          1,
+        )
+      }
+    },
+  )
+
+  it.each(["start", "reopen"])(
+    "accepts the current job after clock rollback on %s and ignores the old job afterwards",
+    async (source) => {
+      const previous = buildProgress({
+        jobId: "previous",
+        startedAt: 1000,
+        updatedAt: 1001,
+        state: ACCOUNT_KEY_REPAIR_JOB_STATES.Completed,
+      })
+      sendAccountKeyRepairMessageMock.mockResolvedValueOnce({
+        success: true,
+        data: previous,
+      })
+      const { result, rerender } = renderHook(
+        ({ isOpen }) =>
+          useRepairMissingKeysJob({
+            accounts: [buildAccount()],
+            isOpen,
+            startOnOpen: false,
+            t: testI18n.t,
+          }),
+        { initialProps: { isOpen: true } },
+      )
+      await waitFor(() => expect(result.current.progress).toEqual(previous))
+      const clock = vi.spyOn(Date, "now").mockReturnValue(500)
+      try {
+        const next = buildProgress({
+          jobId: "next",
+          startedAt: Date.now(),
+          updatedAt: Date.now(),
+        })
+        sendAccountKeyRepairMessageMock.mockResolvedValue({
+          success: true,
+          data: next,
+        })
+        if (source === "start") {
+          await act(async () => {
+            await result.current.handleStartAudit()
+          })
+        } else {
+          rerender({ isOpen: false })
+          await act(async () => {
+            rerender({ isOpen: true })
+          })
+        }
+        expect(result.current.progress).toEqual(next)
+        act(() => {
+          result.current.setProgress(previous)
+        })
+        expect(result.current.progress).toEqual(next)
+        const completed = {
+          ...next,
+          updatedAt: 501,
+          state: ACCOUNT_KEY_REPAIR_JOB_STATES.Completed,
+        }
+        act(() => {
+          result.current.setProgress(completed)
+        })
+        expect(result.current.progress).toEqual(completed)
+      } finally {
+        clock.mockRestore()
+      }
     },
   )
 

--- a/tests/features/KeyManagement/components/RepairMissingKeysDialog/useRepairMissingKeysJob.test.tsx
+++ b/tests/features/KeyManagement/components/RepairMissingKeysDialog/useRepairMissingKeysJob.test.tsx
@@ -131,6 +131,120 @@ describe("useRepairMissingKeysJob", () => {
     vi.clearAllMocks()
   })
 
+  it("ignores a delayed older job without replacing the current job", async () => {
+    const current = buildProgress({
+      jobId: "new",
+      startedAt: 30,
+      updatedAt: 31,
+    })
+    sendAccountKeyRepairMessageMock.mockResolvedValue({
+      success: true,
+      data: current,
+    })
+    const { result } = renderHook(() =>
+      useRepairMissingKeysJob({
+        accounts: [buildAccount()],
+        isOpen: true,
+        startOnOpen: false,
+        t: testI18n.t,
+      }),
+    )
+    await waitFor(() => expect(result.current.progress).toEqual(current))
+    act(() => {
+      vi.mocked(onRuntimeMessage).mock.calls.at(-1)![0](
+        {
+          type: RuntimeMessageTypes.AccountKeyRepairProgress,
+          payload: buildProgress({
+            jobId: "old",
+            startedAt: 10,
+            updatedAt: 11,
+            state: ACCOUNT_KEY_REPAIR_JOB_STATES.Completed,
+          }),
+        },
+        {} as never,
+        vi.fn(),
+      )
+    })
+    expect(result.current.progress).toEqual(current)
+  })
+
+  it("does not overlap a reopened dialog's initial read with polling", async () => {
+    let finishRead!: (value: {
+      success: true
+      data: AccountKeyRepairProgress
+    }) => void
+    const running = buildProgress()
+    sendAccountKeyRepairMessageMock
+      .mockResolvedValueOnce({ success: true, data: running })
+      .mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            finishRead = resolve
+          }),
+      )
+    const { result, rerender, unmount } = renderHook(
+      ({ isOpen }) =>
+        useRepairMissingKeysJob({
+          accounts: [buildAccount()],
+          isOpen,
+          startOnOpen: false,
+          t: testI18n.t,
+        }),
+      { initialProps: { isOpen: true } },
+    )
+    await waitFor(() => expect(result.current.progress).toEqual(running))
+    rerender({ isOpen: false })
+    vi.useFakeTimers()
+    try {
+      await act(async () => {
+        rerender({ isOpen: true })
+      })
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(6000)
+      })
+      expect(sendAccountKeyRepairMessageMock).toHaveBeenCalledTimes(2)
+      await act(async () => {
+        finishRead({ success: true, data: running })
+      })
+    } finally {
+      unmount()
+      vi.useRealTimers()
+    }
+  })
+
+  it("preserves local changes when an equal-version snapshot is delivered again", async () => {
+    const progress = buildProgress({
+      updatedAt: 20,
+      state: ACCOUNT_KEY_REPAIR_JOB_STATES.Completed,
+    })
+    sendAccountKeyRepairMessageMock.mockResolvedValue({
+      success: true,
+      data: progress,
+    })
+    const { result } = renderHook(() =>
+      useRepairMissingKeysJob({
+        accounts: [buildAccount()],
+        isOpen: true,
+        startOnOpen: false,
+        t: testI18n.t,
+      }),
+    )
+    await waitFor(() => expect(result.current.progress).toEqual(progress))
+    act(() => {
+      result.current.setProgress(
+        (current) =>
+          current && {
+            ...current,
+            summary: { ...current.summary, deleteApplied: 1 },
+          },
+      )
+    })
+    act(() => {
+      result.current.setProgress(progress)
+    })
+    expect(result.current.progress?.summary.deleteApplied).toBe(1)
+  })
+
   it.each([
     AccountKeyRepairMessageTypes.GetProgress,
     AccountKeyRepairMessageTypes.Start,

--- a/tests/features/KeyManagement/components/RepairMissingKeysDialog/useRepairMissingKeysJob.test.tsx
+++ b/tests/features/KeyManagement/components/RepairMissingKeysDialog/useRepairMissingKeysJob.test.tsx
@@ -229,6 +229,63 @@ describe("useRepairMissingKeysJob", () => {
     }
   })
 
+  it.each(["rejected", "unsuccessful"])(
+    "recovers from a %s progress query without losing the current result",
+    async (failureKind) => {
+      const running = buildProgress()
+      sendAccountKeyRepairMessageMock.mockResolvedValueOnce({
+        success: true,
+        data: running,
+      })
+      if (failureKind === "rejected") {
+        sendAccountKeyRepairMessageMock.mockRejectedValueOnce(
+          new Error("read failed"),
+        )
+      } else {
+        sendAccountKeyRepairMessageMock.mockResolvedValueOnce({
+          success: false,
+          error: "read failed",
+        })
+      }
+      sendAccountKeyRepairMessageMock.mockResolvedValue({
+        success: true,
+        data: running,
+      })
+      const { result, rerender, unmount } = renderHook(
+        ({ isOpen }) =>
+          useRepairMissingKeysJob({
+            accounts: [buildAccount()],
+            isOpen,
+            startOnOpen: false,
+            t: testI18n.t,
+          }),
+        { initialProps: { isOpen: false } },
+      )
+      await waitFor(() => expect(result.current).toBeTruthy())
+      vi.useFakeTimers()
+      try {
+        await act(async () => {
+          rerender({ isOpen: true })
+        })
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(3000)
+        })
+        expect(result.current.error).toBe(
+          testI18n.t("keyManagement:repairMissingKeys.messages.loadFailed"),
+        )
+        expect(result.current.progress).toEqual(running)
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(3000)
+        })
+        expect(result.current.error).toBe("")
+        expect(result.current.progress).toEqual(running)
+      } finally {
+        unmount()
+        vi.useRealTimers()
+      }
+    },
+  )
+
   it("recovers completion when the runtime notification is missed", async () => {
     const running = buildProgress()
     const completed = buildProgress({

--- a/tests/services/accountKeyRepair.test.ts
+++ b/tests/services/accountKeyRepair.test.ts
@@ -273,6 +273,28 @@ describe("accountKeyRepair", () => {
     )
   })
 
+  it("orders progress snapshots even when the clock does not advance", async () => {
+    const { startAccountKeyRepair } = await import(
+      "~/services/accounts/accountKeyAutoProvisioning/repair"
+    )
+    const dateNow = vi.spyOn(Date, "now").mockReturnValue(1000)
+    try {
+      await startAccountKeyRepair()
+      await waitForStoredState(ACCOUNT_KEY_REPAIR_JOB_STATES.Completed)
+      const snapshots = mocks.sendRuntimeMessage.mock.calls.map(
+        ([message]) => message.payload as AccountKeyRepairProgress,
+      )
+      expect(snapshots.length).toBeGreaterThan(1)
+      for (let index = 1; index < snapshots.length; index++) {
+        expect(snapshots[index].updatedAt).toBeGreaterThan(
+          snapshots[index - 1].updatedAt!,
+        )
+      }
+    } finally {
+      dateNow.mockRestore()
+    }
+  })
+
   it("returns the required current-schema idle progress", async () => {
     const { accountKeyRepairRunner } = await import(
       "~/services/accounts/accountKeyAutoProvisioning/repair"

--- a/tests/services/managedSites/repairCreatedKeyBatchImport.test.ts
+++ b/tests/services/managedSites/repairCreatedKeyBatchImport.test.ts
@@ -890,11 +890,11 @@ describe("resolveRepairCreatedKeyBatchImportCandidate", () => {
   it("rejects idle progress and progress without exact created outcomes", () => {
     const account = createAccount()
     const ref = createRef()
-    const running = createProgress(account, ref)
-    running.state = ACCOUNT_KEY_REPAIR_JOB_STATES.Idle
+    const idle = createProgress(account, ref)
+    idle.state = ACCOUNT_KEY_REPAIR_JOB_STATES.Idle
     expect(
       getRepairCreatedKeyBatchImportAbsenceReason({
-        progress: running,
+        progress: idle,
         targetFingerprint: TARGET_A,
       }),
     ).toBe(REPAIR_CREATED_KEY_BATCH_IMPORT_ABSENCE_REASONS.NOT_READY)

--- a/tests/services/managedSites/repairCreatedKeyBatchImport.test.ts
+++ b/tests/services/managedSites/repairCreatedKeyBatchImport.test.ts
@@ -170,54 +170,65 @@ describe("resolveRepairCreatedKeyBatchImportCandidate", () => {
     mocks.resolveRepairCreatedRuntimeSecret.mockResolvedValue(null)
   })
 
-  it("resolves an exact current-schema created ref through the current native session", async () => {
-    const account = createAccount()
-    const ref = createRef()
-    const resolve = vi.fn().mockResolvedValue({
-      kind: ACCOUNT_KEY_RUNTIME_KEY_RESOLUTION_KINDS.Resolved,
-      secret: "resolved-runtime-secret",
-    })
-    const open = vi.fn().mockResolvedValue(createSession(resolve))
-    mocks.createDisplayAccountApiContext.mockReturnValue({
-      request: { baseUrl: account.baseUrl },
-      capabilities: {
-        account: { keyResources: { open } },
-      },
-    })
+  it.each([
+    ACCOUNT_KEY_REPAIR_JOB_STATES.Running,
+    ACCOUNT_KEY_REPAIR_JOB_STATES.Completed,
+    ACCOUNT_KEY_REPAIR_JOB_STATES.Cancelled,
+    ACCOUNT_KEY_REPAIR_JOB_STATES.Failed,
+  ])(
+    "resolves exact created refs through the native session for %s jobs",
+    async (state) => {
+      const account = createAccount()
+      const ref = createRef()
+      const resolve = vi.fn().mockResolvedValue({
+        kind: ACCOUNT_KEY_RUNTIME_KEY_RESOLUTION_KINDS.Resolved,
+        secret: "resolved-runtime-secret",
+      })
+      const open = vi.fn().mockResolvedValue(createSession(resolve))
+      mocks.createDisplayAccountApiContext.mockReturnValue({
+        request: { baseUrl: account.baseUrl },
+        capabilities: {
+          account: { keyResources: { open } },
+        },
+      })
 
-    const candidate = await resolveRepairCreatedKeyBatchImportCandidate({
-      progress: createProgress(account, ref),
-      accounts: [account],
-      targetFingerprint: TARGET_A,
-      freshness: REPAIR_CREATED_KEY_BATCH_IMPORT_FRESHNESS.CURRENT_SESSION,
-    })
+      const progress = createProgress(account, ref)
+      progress.state = state
+      const candidate = await resolveRepairCreatedKeyBatchImportCandidate({
+        progress,
+        accounts: [account],
+        targetFingerprint: TARGET_A,
+        freshness: REPAIR_CREATED_KEY_BATCH_IMPORT_FRESHNESS.CURRENT_SESSION,
+      })
 
-    expect(candidate?.intent.verification).toBe(
-      MANAGED_SITE_TOKEN_BATCH_IMPORT_VERIFICATIONS.TRUSTED_NEW,
-    )
-    const resolvedItems =
-      candidate?.items.filter(isResolvedManagedSiteTokenBatchExportItemInput) ??
-      []
-    expect(resolvedItems).toHaveLength(1)
-    const runtimeKey = resolvedItems[0]
-      .runtimeKey as AccountKeyResourceRuntimeKey
-    expect(isAccountKeyResourceRuntimeKey(runtimeKey)).toBe(true)
-    expect(runtimeKey).toMatchObject({
-      accountId: account.id,
-      label: "Created key",
-      resourceRef: ref,
-      secret: "resolved-runtime-secret",
-    })
-    expect(open).toHaveBeenCalledWith({
-      account: {
-        id: account.id,
-        name: account.name,
-        siteType: account.siteType,
-      },
-      request: { baseUrl: account.baseUrl },
-    })
-    expect(resolve).toHaveBeenCalledWith(ref)
-  })
+      expect(candidate?.intent.verification).toBe(
+        MANAGED_SITE_TOKEN_BATCH_IMPORT_VERIFICATIONS.TRUSTED_NEW,
+      )
+      const resolvedItems =
+        candidate?.items.filter(
+          isResolvedManagedSiteTokenBatchExportItemInput,
+        ) ?? []
+      expect(resolvedItems).toHaveLength(1)
+      const runtimeKey = resolvedItems[0]
+        .runtimeKey as AccountKeyResourceRuntimeKey
+      expect(isAccountKeyResourceRuntimeKey(runtimeKey)).toBe(true)
+      expect(runtimeKey).toMatchObject({
+        accountId: account.id,
+        label: "Created key",
+        resourceRef: ref,
+        secret: "resolved-runtime-secret",
+      })
+      expect(open).toHaveBeenCalledWith({
+        account: {
+          id: account.id,
+          name: account.name,
+          siteType: account.siteType,
+        },
+        request: { baseUrl: account.baseUrl },
+      })
+      expect(resolve).toHaveBeenCalledWith(ref)
+    },
+  )
 
   it("uses the current repair job's transient created secret before opening a session", async () => {
     const account = createAccount()
@@ -861,11 +872,26 @@ describe("resolveRepairCreatedKeyBatchImportCandidate", () => {
     )
   })
 
-  it("rejects non-completed progress and progress without exact created outcomes", () => {
+  it.each([
+    ACCOUNT_KEY_REPAIR_JOB_STATES.Running,
+    ACCOUNT_KEY_REPAIR_JOB_STATES.Cancelled,
+    ACCOUNT_KEY_REPAIR_JOB_STATES.Failed,
+  ])("keeps confirmed created references available in %s jobs", (state) => {
+    const progress = createProgress(createAccount(), createRef())
+    progress.state = state
+    expect(
+      getRepairCreatedKeyBatchImportAbsenceReason({
+        progress,
+        targetFingerprint: TARGET_A,
+      }),
+    ).toBeNull()
+  })
+
+  it("rejects idle progress and progress without exact created outcomes", () => {
     const account = createAccount()
     const ref = createRef()
     const running = createProgress(account, ref)
-    running.state = ACCOUNT_KEY_REPAIR_JOB_STATES.Running
+    running.state = ACCOUNT_KEY_REPAIR_JOB_STATES.Idle
     expect(
       getRepairCreatedKeyBatchImportAbsenceReason({
         progress: running,


### PR DESCRIPTION
Key checks can remain running while some accounts are still pending, hiding the managed-site import action for keys already created successfully.

Allow confirmed repair-created keys to enter import review while the job is running, cancelled, or failed. Preserve existing availability checks and import receipts. Prevent stale responses from overwriting completed progress, and periodically reconcile visible running jobs when notifications are missed.

Consolidate progress response handling, failure reporting, and import reset logic without changing behavior.

Backend requests may still remain pending; this change keeps confirmed results usable without introducing request deadlines.

Validation:
- Focused key-repair, progress, and import regression tests passed.
- TypeScript, knip, and commit checks passed.
- Regression tests cover stale import preparation, shared progress reads, monotonic snapshots, delayed messages from older jobs, completion before the Start response, and new jobs after clock rollback.
- Remote checks passed for `42c44d5ff94c8ec9f0fa7c7fb4dad5bc144418c8`; Codecov patch coverage is 100%.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved repair progress updates so completion is detected reliably, including when notifications are delayed or missed.
  - Prevented stale or out-of-order progress from overwriting newer results and improved recovery from temporary query failures.
  - Repair-created imports are now available once created references are confirmed, without waiting for the repair job to finish.
  - Imports without confirmed created keys are ignored, reducing incorrect import options.
  - Cancelled or outdated import preparation is now safely ignored when closing or reopening the dialog.
  - Progress updates now remain correctly ordered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

