### PR TITLE
feat(donehub): add grouped advanced channel settings

### DIFF
--- a/e2e/doneHubAdvancedEditor.spec.ts
+++ b/e2e/doneHubAdvancedEditor.spec.ts
@@ -1,0 +1,237 @@
+import { CHANNEL_DIALOG_TEST_IDS } from "~/components/dialogs/ChannelDialog/testIds"
+import { DoneHubChannelType } from "~/constants/doneHub"
+import { expect, test } from "~~/e2e/fixtures/extensionTest"
+import { openInterceptedDoneHubManagedSiteChannels } from "~~/e2e/fixtures/managedSiteChannelsIntercepted"
+import {
+  channelRowByName,
+  openManagedSiteChannelRowActions,
+} from "~~/e2e/scenarios/managedSiteChannels"
+
+test.use({ actionTimeout: 10_000 })
+
+for (const width of [1440, 460]) {
+  test(`DoneHub advanced settings remain editable and preserve native data at ${width}px`, async ({
+    context,
+    page,
+    extensionId,
+  }, testInfo) => {
+    await page.setViewportSize({ width, height: 1000 })
+    await openInterceptedDoneHubManagedSiteChannels({
+      context,
+      page,
+      extensionId,
+      nativeFields: {
+        type: DoneHubChannelType.Custom,
+        tag: "",
+        compatible_response: true,
+        allow_extra_body: true,
+        plugin: {
+          customize: { "16": "/custom/responses", "1": "/custom/chat" },
+          untouched: { enabled: true },
+        },
+        model_mapping: '{"alias":"upstream-model"}',
+        proxy: "socks5://proxy.example:1080",
+        test_model: "model-donehub-a",
+        model_headers: '{"X-Project":"example"}',
+        custom_parameter: '{"temperature":0.7}',
+        disabled_stream: ["model-donehub-a"],
+        future_setting: { keep: true },
+      },
+    })
+    await openManagedSiteChannelRowActions(page, "DoneHub primary")
+    await page.getByRole("menuitem", { name: "Edit", exact: true }).click()
+    const dialog = page.getByRole("dialog")
+    await expect(
+      dialog.getByRole("button", { name: "Basic & connection", exact: true }),
+    ).toHaveAttribute("aria-expanded", "true")
+    await expect(
+      dialog.getByRole("button", { name: "Models", exact: true }),
+    ).toHaveAttribute("aria-expanded", "true")
+    await page.screenshot({
+      path: testInfo.outputPath(`donehub-overview-${width}.png`),
+    })
+    for (const section of ["API compatibility", "Network & requests"]) {
+      const toggle = dialog.getByRole("button", { name: section, exact: true })
+      await expect(toggle).toHaveAttribute("aria-expanded", "false")
+      await toggle.click()
+    }
+    await dialog
+      .getByRole("switch", { name: "Responses API compatibility" })
+      .click()
+    await dialog
+      .getByRole("textbox", { name: "Responses request path" })
+      .fill("/responses-v2")
+    const mapping = dialog.getByRole("group", {
+      name: "Model mapping",
+      exact: true,
+    })
+    await mapping.scrollIntoViewIfNeeded()
+    const keyBox = await mapping
+      .getByRole("textbox", { name: "Model mapping: row 1 key", exact: true })
+      .boundingBox()
+    const valueBox = await mapping
+      .getByRole("textbox", { name: "Model mapping: row 1 value", exact: true })
+      .boundingBox()
+    expect(keyBox).not.toBeNull()
+    expect(valueBox).not.toBeNull()
+    if (width < 640)
+      expect(valueBox!.y).toBeGreaterThan(keyBox!.y + keyBox!.height)
+    else expect(valueBox!.y).toBe(keyBox!.y)
+    await page.screenshot({
+      path: testInfo.outputPath(`donehub-models-${width}.png`),
+    })
+    await mapping.getByRole("button", { name: "Add row", exact: true }).click()
+    await mapping
+      .getByRole("textbox", { name: "Model mapping: row 2 key", exact: true })
+      .fill("second-alias")
+    await mapping
+      .getByRole("textbox", { name: "Model mapping: row 2 value", exact: true })
+      .fill("second-model")
+    await mapping
+      .getByRole("button", { name: "Add mapped names to model list" })
+      .click()
+    const testModel = dialog.getByRole("combobox", {
+      name: "Test model",
+      exact: true,
+    })
+    await testModel.scrollIntoViewIfNeeded()
+    const inputGroup = dialog.locator('[data-slot="input-group"]').filter({
+      has: page.getByRole("combobox", { name: "Test model", exact: true }),
+    })
+    const groupBox = await inputGroup.boundingBox()
+    const iconBox = await inputGroup
+      .locator('[data-slot="combobox-trigger-icon"]')
+      .boundingBox()
+    expect(groupBox).not.toBeNull()
+    expect(iconBox).not.toBeNull()
+    expect(
+      groupBox!.x + groupBox!.width - (iconBox!.x + iconBox!.width),
+    ).toBeLessThan(20)
+    expect(
+      Math.abs(
+        iconBox!.y + iconBox!.height / 2 - (groupBox!.y + groupBox!.height / 2),
+      ),
+    ).toBeLessThan(2)
+    await inputGroup.getByRole("button").click()
+    await expect(page.getByRole("listbox")).toBeVisible()
+    await testModel.press("Escape")
+    await testModel.fill("")
+    await testModel.press("ArrowDown")
+    await page
+      .getByRole("option", { name: "second-alias", exact: true })
+      .click()
+    await expect(testModel).toHaveValue("second-alias")
+    await testModel.fill("manual-chat-model")
+    await testModel.press("Tab")
+    await expect(testModel).toHaveValue("manual-chat-model")
+    await dialog
+      .getByRole("textbox", { name: "Proxy URL", exact: true })
+      .fill("")
+    await dialog
+      .getByRole("button", {
+        name: "Custom request headers: remove row 1",
+        exact: true,
+      })
+      .click()
+    await dialog
+      .getByRole("switch", { name: "Forward extra body fields" })
+      .click()
+    const parameters = dialog.getByRole("textbox", {
+      name: "Extra request parameters",
+      exact: true,
+    })
+    await parameters.fill('{"unfinished":')
+    const requestsToggle = dialog.getByRole("button", {
+      name: "Network & requests",
+      exact: true,
+    })
+    // Invalid drafts must remain visible rather than being hidden by a collapse.
+    await expect(requestsToggle).toHaveAttribute("aria-expanded", "true")
+    await parameters.fill("{broken")
+    await expect(
+      dialog
+        .getByRole("alert")
+        .filter({ hasText: "Enter a valid JSON object." }),
+    ).toBeVisible()
+    await expect(
+      page.getByTestId(CHANNEL_DIALOG_TEST_IDS.submitButton),
+    ).toBeDisabled()
+    await parameters.fill('{"overwrite":true,"temperature":0.5}')
+    await dialog
+      .getByRole("button", { name: "Format JSON", exact: true })
+      .click()
+    await expect(parameters).toHaveValue(
+      '{\n  "overwrite": true,\n  "temperature": 0.5\n}',
+    )
+    await requestsToggle.click()
+    await expect(parameters).toBeHidden()
+    await requestsToggle.click()
+    await expect(parameters).toHaveValue(
+      '{\n  "overwrite": true,\n  "temperature": 0.5\n}',
+    )
+
+    await page
+      .getByTestId(CHANNEL_DIALOG_TEST_IDS.nameInput)
+      .fill("Advanced updated")
+    const updates: Record<string, unknown>[] = []
+    context.on("request", (request) => {
+      if (
+        request.method() === "PUT" &&
+        new URL(request.url()).pathname === "/api/channel/"
+      )
+        updates.push(request.postDataJSON())
+    })
+    await page.getByTestId(CHANNEL_DIALOG_TEST_IDS.submitButton).click()
+    await expect(channelRowByName(page, "Advanced updated")).toBeVisible()
+    expect(updates).toHaveLength(1)
+    expect(updates[0]).toMatchObject({
+      compatible_response: false,
+      allow_extra_body: false,
+      proxy: "",
+      test_model: "manual-chat-model",
+      model_headers: "{}",
+      disabled_stream: ["model-donehub-a"],
+      model_mapping: '{"alias":"upstream-model","second-alias":"second-model"}',
+      models: "model-donehub-a,alias,second-alias",
+      plugin: {
+        customize: { "16": "/responses-v2", "1": "/custom/chat" },
+        untouched: { enabled: true },
+      },
+      future_setting: { keep: true },
+    })
+    await openManagedSiteChannelRowActions(page, "Advanced updated")
+    await page.getByRole("menuitem", { name: "Edit", exact: true }).click()
+    for (const section of ["API compatibility", "Network & requests"]) {
+      await dialog.getByRole("button", { name: section, exact: true }).click()
+    }
+    await expect(
+      dialog.getByRole("textbox", { name: "Responses request path" }),
+    ).toHaveValue("/responses-v2")
+    await expect(
+      dialog.getByRole("switch", { name: "Responses API compatibility" }),
+    ).not.toBeChecked()
+    await expect(
+      dialog.getByRole("textbox", {
+        name: "Model mapping: row 2 value",
+        exact: true,
+      }),
+    ).toHaveValue("second-model")
+    await expect(
+      dialog.getByRole("combobox", { name: "Test model", exact: true }),
+    ).toHaveValue("manual-chat-model")
+    await dialog
+      .getByRole("textbox", { name: "Extra request parameters", exact: true })
+      .scrollIntoViewIfNeeded()
+    expect(
+      await dialog.evaluate(
+        (element) => element.scrollWidth <= element.clientWidth + 1,
+      ),
+    ).toBe(true)
+    await expect(
+      page.getByTestId(CHANNEL_DIALOG_TEST_IDS.submitButton),
+    ).toBeInViewport()
+    await page.screenshot({
+      path: testInfo.outputPath(`donehub-advanced-${width}.png`),
+    })
+  })
+}

--- a/e2e/fixtures/managedSiteChannelsIntercepted.ts
+++ b/e2e/fixtures/managedSiteChannelsIntercepted.ts
@@ -968,6 +968,7 @@ export async function openInterceptedDoneHubManagedSiteChannels(params: {
   )
   await seedUserPreferences(await getServiceWorker(params.context), {
     managedSiteType: SITE_TYPES.DONE_HUB,
+    autoCheckin: { globalEnabled: false, pretriggerDailyOnUiOpen: false },
     doneHub: {
       baseUrl: INTERCEPTED_DONE_HUB_TARGET_ORIGIN,
       adminToken: "fixture-target-admin-token",

--- a/e2e/realSite/README.md
+++ b/e2e/realSite/README.md
@@ -135,6 +135,18 @@ AAH_E2E_DONE_HUB_ADMIN_TOKEN=replace-with-admin-access-token
 AAH_E2E_DONE_HUB_ADMIN_USER_ID=1
 ```
 
+With the DoneHub managed-site credentials above configured, run the advanced
+channel editor check directly (it is not part of the managed-site matrix):
+
+```bash
+pnpm exec playwright test e2e/realSite/doneHubAdvancedEditor.spec.ts --project=chromium --workers=1
+```
+
+The check creates a disabled temporary channel, edits advanced settings through
+the UI, rereads the server values, then clears the settings and verifies unrelated
+fields survived. Cleanup deletes the temporary channel. Its upstream URL and key
+are nonfunctional fixtures, so this checks persistence, not live model routing.
+
 ## Veloera
 
 ```env

--- a/e2e/realSite/doneHubAdvancedEditor.spec.ts
+++ b/e2e/realSite/doneHubAdvancedEditor.spec.ts
@@ -1,0 +1,296 @@
+import { isDeepStrictEqual } from "node:util"
+
+import { CHANNEL_DIALOG_TEST_IDS } from "~/components/dialogs/ChannelDialog/testIds"
+import { DoneHubChannelType } from "~/constants/doneHub"
+import { OPTIONS_PAGE_PATH } from "~/constants/extensionPages"
+import { MENU_ITEM_IDS } from "~/constants/optionsMenuIds"
+import { SITE_TYPES } from "~/constants/siteType"
+import { expect, test } from "~~/e2e/fixtures/extensionTest"
+import { openManagedSiteChannelRowActions } from "~~/e2e/scenarios/managedSiteChannels"
+import {
+  forceExtensionLanguage,
+  seedUserPreferences,
+  stubLlmMetadataIndex,
+} from "~~/e2e/utils/commonUserFlows"
+import { getServiceWorker } from "~~/e2e/utils/extensionState"
+import { resolveDoneHubManagedSiteConfig } from "~~/e2e/utils/realSite/managedSiteConfig"
+import { runScenarioWithCleanup } from "~~/e2e/utils/scenarioErrors"
+
+const managedSite = resolveDoneHubManagedSiteConfig()
+
+test.use({ trace: "off", video: "off" })
+
+test("DoneHub advanced settings persist and clear on a real server", async ({
+  context,
+  page,
+  extensionId,
+}) => {
+  test.skip(
+    !managedSite.config,
+    "Missing DoneHub managed-site test credentials",
+  )
+  test.setTimeout(120_000)
+  page.setDefaultTimeout(15_000)
+  const config = managedSite.config!
+  const name = `AAH E2E DoneHub Advanced ${crypto.randomUUID()}`
+  const model = `aah-e2e-${crypto.randomUUID()}`
+  let channelId: number | undefined
+
+  // Only setup/read/cleanup use the native API; every tested edit uses the UI.
+  // Do not print native payloads: even a test site can contain real credentials.
+  const api = async (path: string, method = "GET", data?: unknown) => {
+    const response = await fetch(
+      `${config.baseUrl.replace(/\/$/u, "")}${path}`,
+      {
+        method,
+        headers: {
+          Authorization: `Bearer ${config.adminToken}`,
+          "New-Api-User": config.userId,
+          "Content-Type": "application/json",
+        },
+        body: data === undefined ? undefined : JSON.stringify(data),
+        signal: AbortSignal.timeout(20_000),
+      },
+    )
+    if (!response.ok)
+      throw new Error(`DoneHub ${method} failed: HTTP ${response.status}`)
+    const body = await response.json()
+    if (body.success !== true) throw new Error(`DoneHub ${method} was rejected`)
+    return body.data
+  }
+  const findCreatedChannels = async () => {
+    const result = await api(
+      `/api/channel/?name=${encodeURIComponent(name)}&page=1&page_size=100`,
+    )
+    return (result.data as Array<{ id: number; name: string }>).filter(
+      (channel) => channel.name === name,
+    )
+  }
+  const read = async (): Promise<Record<string, unknown>> =>
+    await api(`/api/channel/${channelId}`)
+  const dialog = page.getByRole("dialog")
+  const open = async () => {
+    const url = new URL(
+      `chrome-extension://${extensionId}/${OPTIONS_PAGE_PATH}`,
+    )
+    url.searchParams.set("channelId", String(channelId))
+    url.hash = MENU_ITEM_IDS.MANAGED_SITE_CHANNELS
+    await page.goto(url.toString())
+    await openManagedSiteChannelRowActions(page, name)
+    await page.getByRole("menuitem", { name: "Edit", exact: true }).click()
+    await expect(dialog).toBeVisible()
+    for (const section of [
+      "API compatibility",
+      "Models",
+      "Network & requests",
+    ]) {
+      const toggle = dialog.getByRole("button", { name: section, exact: true })
+      if ((await toggle.getAttribute("aria-expanded")) !== "true")
+        await toggle.click()
+    }
+  }
+  const save = async () => {
+    await page.getByTestId(CHANNEL_DIALOG_TEST_IDS.submitButton).click()
+    await expect(dialog).toBeHidden({ timeout: 30_000 })
+  }
+  const setJsonMap = async (label: string, json: string) => {
+    const group = dialog.getByRole("group", { name: label, exact: true })
+    await group.getByRole("button", { name: "Edit JSON", exact: true }).click()
+    await group.getByRole("textbox", { name: label, exact: true }).fill(json)
+  }
+  const assertPreserved = (
+    before: Record<string, unknown>,
+    after: Record<string, unknown>,
+  ) => {
+    const edited = new Set([
+      "compatible_response",
+      "plugin",
+      "model_mapping",
+      "proxy",
+      "test_model",
+      "model_headers",
+      "custom_parameter",
+      "allow_extra_body",
+      "disabled_stream",
+      "updated_at",
+    ])
+    const changed = [
+      ...new Set([...Object.keys(before), ...Object.keys(after)]),
+    ].filter(
+      (key) => !edited.has(key) && !isDeepStrictEqual(before[key], after[key]),
+    )
+    expect(changed, "Untouched native fields must survive both saves").toEqual(
+      [],
+    )
+    const pluginWithoutResponses = (value: unknown) => {
+      const plugin = structuredClone(value) as {
+        customize?: Record<string, unknown>
+      }
+      if (plugin.customize) delete plugin.customize["16"]
+      return plugin
+    }
+    expect(
+      isDeepStrictEqual(
+        pluginWithoutResponses(before.plugin),
+        pluginWithoutResponses(after.plugin),
+      ),
+      "Other plugin settings must survive",
+    ).toBe(true)
+  }
+
+  await runScenarioWithCleanup({
+    run: async () => {
+      await api("/api/channel/", "POST", {
+        name,
+        type: DoneHubChannelType.Custom,
+        status: 2,
+        key: "sk-aah-e2e-nonfunctional",
+        base_url: "https://aah-e2e.example.invalid",
+        models: model,
+        group: "default",
+        priority: 7,
+        weight: 3,
+        model_mapping: "{}",
+        plugin: {
+          customize: { "1": "/preserved/chat", "16": "/initial/responses" },
+        },
+      })
+      const channels = await findCreatedChannels()
+      expect(channels).toHaveLength(1)
+      channelId = channels[0].id
+      const before = await read()
+      expect(before.status, "Temporary channel must stay disabled").toBe(2)
+      await forceExtensionLanguage(page, "en")
+      await stubLlmMetadataIndex(context)
+      await seedUserPreferences(await getServiceWorker(context), {
+        managedSiteType: SITE_TYPES.DONE_HUB,
+        doneHub: config,
+        openChangelogOnUpdate: false,
+      })
+      await open()
+      await dialog
+        .getByRole("switch", { name: "Responses API compatibility" })
+        .check()
+      await dialog
+        .getByRole("textbox", { name: "Responses request path" })
+        .fill("/smoke/responses")
+      await setJsonMap(
+        "Model mapping",
+        JSON.stringify({ [model]: "upstream-smoke-model" }),
+      )
+      await setJsonMap("Custom request headers", '{"X-AAH-Smoke":"round-trip"}')
+      await dialog
+        .getByRole("textbox", { name: "Proxy URL", exact: true })
+        .fill("http://127.0.0.1:9")
+      await dialog
+        .getByRole("combobox", { name: "Test model", exact: true })
+        .fill("manual-smoke-model")
+      await dialog
+        .getByRole("combobox", { name: "Test model", exact: true })
+        .press("Tab")
+      await dialog
+        .getByRole("textbox", { name: "Extra request parameters", exact: true })
+        .fill('{"overwrite":true,"temperature":0.5}')
+      await dialog
+        .getByRole("switch", { name: "Forward extra body fields" })
+        .check()
+      const streamModels = dialog.getByRole("combobox", {
+        name: "Models excluded from streaming",
+        exact: true,
+      })
+      await streamModels.fill(model)
+      await streamModels.press("Enter")
+      await save()
+      const saved = await read()
+      expect(saved).toMatchObject({
+        compatible_response: true,
+        allow_extra_body: true,
+        proxy: "http://127.0.0.1:9",
+        test_model: "manual-smoke-model",
+        disabled_stream: [model],
+        plugin: { customize: { "16": "/smoke/responses" } },
+      })
+      expect(JSON.parse(String(saved.model_mapping))).toEqual({
+        [model]: "upstream-smoke-model",
+      })
+      expect(JSON.parse(String(saved.model_headers))).toEqual({
+        "X-AAH-Smoke": "round-trip",
+      })
+      expect(JSON.parse(String(saved.custom_parameter))).toEqual({
+        overwrite: true,
+        temperature: 0.5,
+      })
+      assertPreserved(before, saved)
+      await open()
+      await expect(
+        dialog.getByRole("combobox", { name: "Test model", exact: true }),
+      ).toHaveValue("manual-smoke-model")
+      await expect(
+        dialog.getByRole("textbox", { name: "Responses request path" }),
+      ).toHaveValue("/smoke/responses")
+      await expect(
+        dialog.getByRole("switch", { name: "Responses API compatibility" }),
+      ).toBeChecked()
+      await dialog
+        .getByRole("switch", { name: "Responses API compatibility" })
+        .uncheck()
+      await dialog
+        .getByRole("switch", { name: "Forward extra body fields" })
+        .uncheck()
+      await dialog
+        .getByRole("textbox", { name: "Responses request path" })
+        .fill("")
+      await dialog
+        .getByRole("textbox", { name: "Proxy URL", exact: true })
+        .fill("")
+      await dialog
+        .getByRole("combobox", { name: "Test model", exact: true })
+        .fill("")
+      await dialog
+        .getByRole("textbox", { name: "Extra request parameters", exact: true })
+        .fill("")
+      await setJsonMap("Model mapping", "{}")
+      await setJsonMap("Custom request headers", "{}")
+      await streamModels.fill("")
+      await streamModels.press("Backspace")
+      await save()
+      const cleared = await read()
+      expect(cleared).toMatchObject({
+        compatible_response: false,
+        allow_extra_body: false,
+        proxy: "",
+        test_model: "",
+        disabled_stream: [],
+      })
+      expect(JSON.parse(String(cleared.model_mapping))).toEqual({})
+      expect(JSON.parse(String(cleared.model_headers))).toEqual({})
+      expect(["", "{}", null]).toContain(cleared.custom_parameter)
+      expect(
+        (cleared.plugin as { customize: Record<string, unknown> }).customize[
+          "16"
+        ],
+      ).toBe("")
+      assertPreserved(saved, cleared)
+      await open()
+      await expect(
+        dialog.getByRole("textbox", { name: "Proxy URL", exact: true }),
+      ).toHaveValue("")
+      await expect(
+        dialog.getByRole("switch", { name: "Responses API compatibility" }),
+      ).not.toBeChecked()
+      await page.getByTestId(CHANNEL_DIALOG_TEST_IDS.cancelButton).click()
+    },
+    finalizers: [
+      async () => {
+        for (const channel of await findCreatedChannels())
+          await api(`/api/channel/${channel.id}`, "DELETE")
+        expect(
+          await findCreatedChannels(),
+          "Temporary channel cleanup must be confirmed",
+        ).toEqual([])
+      },
+    ],
+    cleanupMessage: "DoneHub advanced editor cleanup failed",
+    failureMessage: "DoneHub advanced editor live smoke failed",
+  })
+})

--- a/src/components/ui/input-group.tsx
+++ b/src/components/ui/input-group.tsx
@@ -150,6 +150,7 @@ function InputGroupInput({
   return (
     <Input
       data-slot="input-group-control"
+      containerClassName="min-w-0 flex-1"
       className={cn(
         "flex-1 rounded-none border-0 bg-transparent shadow-none focus-visible:ring-0 dark:bg-transparent",
         className,

--- a/src/constants/doneHub.ts
+++ b/src/constants/doneHub.ts
@@ -122,7 +122,40 @@ export const DONE_HUB_MANAGED_RESOURCE_FIELD_IDS = {
   Groups: "doneHub.groups",
   Priority: "doneHub.priority",
   Weight: "doneHub.weight",
+  CompatibleResponse: "doneHub.compatibleResponse",
+  ResponsesPath: "doneHub.responsesPath",
+  ModelMapping: "doneHub.modelMapping",
+  Proxy: "doneHub.proxy",
+  TestModel: "doneHub.testModel",
+  ModelHeaders: "doneHub.modelHeaders",
+  CustomParameter: "doneHub.customParameter",
+  AllowExtraBody: "doneHub.allowExtraBody",
+  DisabledStream: "doneHub.disabledStream",
 } as const
+
+/** Mirrors the upstream editor's type-specific field availability, retaining hidden values. */
+export function isDoneHubAdvancedFieldApplicable(
+  fieldId: string,
+  type: number,
+): boolean {
+  // https://github.com/deanxv/done-hub/blob/b99c6a9661fde5198504795354762f2ee2fd0189/web/src/views/Channel/type/Config.js
+  if (fieldId === DONE_HUB_MANAGED_RESOURCE_FIELD_IDS.ResponsesPath)
+    return type === DoneHubChannelType.Custom
+  if (fieldId === DONE_HUB_MANAGED_RESOURCE_FIELD_IDS.ModelMapping)
+    return !new Set<number>([
+      DoneHubChannelType.Midjourney,
+      DoneHubChannelType.Suno,
+    ]).has(type)
+  if (fieldId === DONE_HUB_MANAGED_RESOURCE_FIELD_IDS.TestModel)
+    return !new Set<number>([
+      DoneHubChannelType.AzureSpeech,
+      DoneHubChannelType.Midjourney,
+      DoneHubChannelType.StabilityAI,
+      DoneHubChannelType.Suno,
+      DoneHubChannelType.Jina,
+    ]).has(type)
+  return true
+}
 
 export const DONE_HUB_MANAGED_RESOURCE_TABLE_FIELD_IDS = [
   DONE_HUB_MANAGED_RESOURCE_FIELD_IDS.Id,

--- a/src/features/ManagedSiteChannels/presentation/ManagedResourceAdvancedField.tsx
+++ b/src/features/ManagedSiteChannels/presentation/ManagedResourceAdvancedField.tsx
@@ -1,0 +1,180 @@
+import type { TFunction } from "i18next"
+import { useId } from "react"
+
+import { Button, CompactMultiSelect, Label } from "~/components/ui"
+import {
+  Combobox,
+  ComboboxContent,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxList,
+} from "~/components/ui/combobox"
+import {
+  readResourceList,
+  readResourceString,
+} from "~/features/ResourceEditor/resourceEditorProjection"
+import { ResourceJsonField } from "~/features/ResourceEditor/ResourceJsonField"
+import type {
+  EditableResourceProjection,
+  ResourceFieldValue,
+} from "~/services/apiAdapters/contracts/managedResourceNative"
+
+import type { ManagedResourceFieldPresentation } from "./managedResourceFieldPolicy"
+
+/** Reuses structured JSON and model suggestion controls selected by presentation policy. */
+export function ManagedResourceAdvancedField({
+  t,
+  presentation,
+  values,
+  disabled,
+  errorMessage,
+  onValueChange,
+}: {
+  t: TFunction
+  presentation: ManagedResourceFieldPresentation
+  values: EditableResourceProjection
+  disabled: boolean
+  errorMessage?: string
+  onValueChange: (fieldId: string, value: ResourceFieldValue) => void
+}) {
+  const id = useId()
+  const fieldId = presentation.fieldId
+  const label = presentation.resolveLabel(t)
+  const help = presentation.resolveHelp?.(t)
+  const value = readResourceString(values, fieldId)
+  const suggestions = presentation.suggestionSourceFieldId
+    ? readResourceList(values, presentation.suggestionSourceFieldId)
+    : []
+  const describedBy = `${id}-help${errorMessage ? ` ${id}-error` : ""}`
+  if (
+    presentation.advancedControl === "string-map" ||
+    presentation.advancedControl === "json"
+  ) {
+    const targetFieldId = presentation.mapKeysTargetFieldId
+    const currentModels = targetFieldId
+      ? readResourceList(values, targetFieldId)
+      : []
+    let missingModels: string[] = []
+    if (targetFieldId) {
+      try {
+        const mapping: unknown = JSON.parse(value || "{}")
+        if (mapping && typeof mapping === "object" && !Array.isArray(mapping)) {
+          missingModels = Object.entries(mapping)
+            .filter(
+              ([key, mapped]) =>
+                key.trim() &&
+                typeof mapped === "string" &&
+                !currentModels.includes(key),
+            )
+            .map(([key]) => key)
+        }
+      } catch {
+        /* Invalid JSON is explained by the adapter's field validation. */
+      }
+    }
+    return (
+      <ResourceJsonField
+        t={t}
+        label={label}
+        help={help}
+        placeholder={presentation.resolvePlaceholder?.(t)}
+        value={value}
+        onChange={(next) => onValueChange(fieldId, next)}
+        disabled={disabled}
+        stringMap={presentation.advancedControl === "string-map"}
+        errorMessage={errorMessage}
+        actions={
+          targetFieldId && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              disabled={disabled || missingModels.length === 0}
+              onClick={() =>
+                onValueChange(targetFieldId, [
+                  ...new Set([...currentModels, ...missingModels]),
+                ])
+              }
+            >
+              {t("managedSiteChannels:editor.doneHub.modelMapping.addModels")}
+            </Button>
+          )
+        }
+      />
+    )
+  }
+  return (
+    <div className="space-y-2">
+      <Label htmlFor={id}>{label}</Label>
+      {presentation.advancedControl === "model-input" ? (
+        <Combobox
+          items={[...new Set([...suggestions, ...(value ? [value] : [])])]}
+          value={value || null}
+          inputValue={value}
+          onInputValueChange={(next, details) => {
+            // This is a free-form model name. Closing the suggestion popup
+            // must not clear text that was not selected from the inventory.
+            if (
+              details.reason === "input-change" ||
+              details.reason === "item-press"
+            )
+              onValueChange(fieldId, next)
+            else details.cancel()
+          }}
+          onValueChange={(next, details) => {
+            if (details.reason === "item-press" && next !== null)
+              onValueChange(fieldId, next)
+          }}
+          disabled={disabled}
+        >
+          <ComboboxInput
+            id={id}
+            className="w-full"
+            placeholder={presentation.resolvePlaceholder?.(t)}
+            aria-describedby={describedBy}
+            aria-invalid={Boolean(errorMessage)}
+            disabled={disabled}
+          />
+          <ComboboxContent>
+            <ComboboxList>
+              {(item: string) => (
+                <ComboboxItem key={item} value={item}>
+                  {item}
+                </ComboboxItem>
+              )}
+            </ComboboxList>
+          </ComboboxContent>
+        </Combobox>
+      ) : (
+        <CompactMultiSelect
+          id={id}
+          aria-label={label}
+          aria-describedby={describedBy}
+          aria-invalid={Boolean(errorMessage)}
+          displayMode="chips"
+          options={suggestions.map((model) => ({ value: model, label: model }))}
+          selected={readResourceList(values, fieldId)}
+          onChange={(next) => onValueChange(fieldId, next)}
+          disabled={disabled}
+          allowCustom
+          parseCommaStrings
+        />
+      )}
+      <p
+        id={`${id}-help`}
+        className="text-muted-foreground text-xs leading-relaxed"
+      >
+        {help}
+      </p>
+      {errorMessage && (
+        <p
+          id={`${id}-error`}
+          role="alert"
+          className="text-xs text-red-600 dark:text-red-400"
+        >
+          {errorMessage}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/src/features/ManagedSiteChannels/presentation/ManagedResourceEditorBody.tsx
+++ b/src/features/ManagedSiteChannels/presentation/ManagedResourceEditorBody.tsx
@@ -11,6 +11,7 @@ import type {
   ResourceOperationOptions,
 } from "~/services/apiAdapters/contracts/managedResourceNative"
 
+import { ManagedResourceAdvancedField } from "./ManagedResourceAdvancedField"
 import {
   canRenderManagedResourceChannelField,
   ManagedResourceChannelField,
@@ -62,6 +63,10 @@ const SECTION_LABEL_RESOLVERS = {
     t("managedSiteChannels:editor.sections.metadata"),
   [MANAGED_RESOURCE_SECTIONS.Advanced]: (t: TFunction) =>
     t("managedSiteChannels:editor.sections.advanced"),
+  [MANAGED_RESOURCE_SECTIONS.Compatibility]: (t: TFunction) =>
+    t("managedSiteChannels:editor.sections.compatibility"),
+  [MANAGED_RESOURCE_SECTIONS.Requests]: (t: TFunction) =>
+    t("managedSiteChannels:editor.sections.requests"),
 } as const satisfies Record<ManagedResourceSection, ManagedResourceTextResolver>
 
 const ISSUE_LABEL_RESOLVERS = {
@@ -142,6 +147,19 @@ export function ManagedResourceEditorBody({
         optionControl,
       }) => {
         const fieldId = descriptor.fieldId
+        const channelPresentation =
+          presentation as ManagedResourceFieldPresentation
+        if (channelPresentation.advancedControl)
+          return (
+            <ManagedResourceAdvancedField
+              t={t}
+              presentation={channelPresentation}
+              values={values}
+              disabled={disabled || Boolean(descriptor.readOnly)}
+              errorMessage={errorMessage}
+              onValueChange={onValueChange}
+            />
+          )
         const channelFieldRole = channelFieldRoles.get(fieldId)
         if (
           !channelFieldRole ||

--- a/src/features/ManagedSiteChannels/presentation/managedResourceFieldPolicy.ts
+++ b/src/features/ManagedSiteChannels/presentation/managedResourceFieldPolicy.ts
@@ -14,6 +14,7 @@ import {
   DONE_HUB_MANAGED_RESOURCE_FIELD_IDS,
   DoneHubChannelStatus,
   DoneHubChannelTypeNames,
+  isDoneHubAdvancedFieldApplicable,
 } from "~/constants/doneHub"
 import {
   ChannelTypeNames,
@@ -48,6 +49,7 @@ import {
 import {
   MANAGED_RESOURCE_FIELD_TYPES,
   MANAGED_RESOURCE_STATUSES,
+  type EditableResourceProjection,
   type ResourceFieldDescriptor,
 } from "~/services/apiAdapters/contracts/managedResourceNative"
 import { CHANNEL_STATUS } from "~/types/newApi"
@@ -85,6 +87,8 @@ export const MANAGED_RESOURCE_SECTIONS = {
   Routing: "routing",
   Metadata: "metadata",
   Advanced: "advanced",
+  Compatibility: "compatibility",
+  Requests: "requests",
 } as const
 
 export type ManagedResourceSection =
@@ -96,6 +100,9 @@ export type ManagedResourceFieldPresentation =
   ResourceFieldPresentation<ManagedResourceSection> & {
     /** Selects an existing channel control without coupling it to a provider field ID. */
     channelFieldRole?: ManagedResourceChannelFieldRole
+    advancedControl?: "string-map" | "json" | "model-input" | "model-list"
+    suggestionSourceFieldId?: string
+    mapKeysTargetFieldId?: string
   }
 export type ManagedResourceTextResolver = ResourceFieldTextResolver
 export type ManagedResourceEditorFieldPolicy = Omit<
@@ -123,6 +130,8 @@ export const MANAGED_RESOURCE_SECTION_ORDER: Readonly<
   routing: 4,
   metadata: 5,
   advanced: 6,
+  compatibility: 7,
+  requests: 10,
 }
 
 /** Defines static frontend-owned presentation without accepting Adapter layout metadata. */
@@ -524,11 +533,173 @@ const veloeraFields = createNewApiFamilyFields(
   createStatusOptionLabelResolvers(VeloeraChannelStatus),
 )
 
-const doneHubFields = createNewApiFamilyFields(
-  DONE_HUB_MANAGED_RESOURCE_FIELD_IDS,
-  doneHubTypeOptionLabelResolvers,
-  createStatusOptionLabelResolvers(DoneHubChannelStatus),
-)
+const doneHubFields: readonly ManagedResourceFieldPresentation[] = [
+  ...createNewApiFamilyFields(
+    DONE_HUB_MANAGED_RESOURCE_FIELD_IDS,
+    doneHubTypeOptionLabelResolvers,
+    createStatusOptionLabelResolvers(DoneHubChannelStatus),
+  ).map((field) =>
+    field.section === MANAGED_RESOURCE_SECTIONS.Connection
+      ? {
+          ...field,
+          section: MANAGED_RESOURCE_SECTIONS.Basic,
+          order: field.order + 30,
+        }
+      : {
+          ...field,
+          ...((
+            [
+              DONE_HUB_MANAGED_RESOURCE_FIELD_IDS.Type,
+              DONE_HUB_MANAGED_RESOURCE_FIELD_IDS.Status,
+              DONE_HUB_MANAGED_RESOURCE_FIELD_IDS.Priority,
+              DONE_HUB_MANAGED_RESOURCE_FIELD_IDS.Weight,
+            ] as string[]
+          ).includes(field.fieldId) && { width: "half" as const }),
+        },
+  ),
+  {
+    fieldId: DONE_HUB_MANAGED_RESOURCE_FIELD_IDS.CompatibleResponse,
+    section: MANAGED_RESOURCE_SECTIONS.Compatibility,
+    order: 10,
+    renderer: MANAGED_RESOURCE_FIELD_RENDERERS.Boolean,
+    resolveLabel: (t) =>
+      t("managedSiteChannels:editor.doneHub.compatibleResponse.label"),
+    resolveHelp: (t) =>
+      t("managedSiteChannels:editor.doneHub.compatibleResponse.help"),
+  },
+  {
+    fieldId: DONE_HUB_MANAGED_RESOURCE_FIELD_IDS.ResponsesPath,
+    section: MANAGED_RESOURCE_SECTIONS.Compatibility,
+    order: 20,
+    renderer: MANAGED_RESOURCE_FIELD_RENDERERS.Text,
+    resolveLabel: (t) =>
+      t("managedSiteChannels:editor.doneHub.responsesPath.label"),
+    resolveHelp: (t) =>
+      t("managedSiteChannels:editor.doneHub.responsesPath.help"),
+    resolvePlaceholder: (t) =>
+      t("managedSiteChannels:editor.doneHub.responsesPath.placeholder"),
+    visibleWhen: (values) =>
+      isDoneHubAdvancedFieldApplicable(
+        DONE_HUB_MANAGED_RESOURCE_FIELD_IDS.ResponsesPath,
+        Number(values[DONE_HUB_MANAGED_RESOURCE_FIELD_IDS.Type]),
+      ),
+  },
+  {
+    fieldId: DONE_HUB_MANAGED_RESOURCE_FIELD_IDS.ModelMapping,
+    section: MANAGED_RESOURCE_SECTIONS.Models,
+    order: 30,
+    renderer: MANAGED_RESOURCE_FIELD_RENDERERS.Textarea,
+    resolveLabel: (t) =>
+      t("managedSiteChannels:editor.doneHub.modelMapping.label"),
+    resolveHelp: (t) =>
+      t("managedSiteChannels:editor.doneHub.modelMapping.help"),
+    resolvePlaceholder: (t) =>
+      t("managedSiteChannels:editor.doneHub.modelMapping.placeholder"),
+    visibleWhen: (values) =>
+      isDoneHubAdvancedFieldApplicable(
+        DONE_HUB_MANAGED_RESOURCE_FIELD_IDS.ModelMapping,
+        Number(values[DONE_HUB_MANAGED_RESOURCE_FIELD_IDS.Type]),
+      ),
+    advancedControl: "string-map",
+    mapKeysTargetFieldId: DONE_HUB_MANAGED_RESOURCE_FIELD_IDS.Models,
+    issueLabelResolvers: {
+      invalid_value: (t) =>
+        t("managedSiteChannels:editor.doneHub.modelMapping.invalid"),
+    },
+  },
+  {
+    fieldId: DONE_HUB_MANAGED_RESOURCE_FIELD_IDS.TestModel,
+    section: MANAGED_RESOURCE_SECTIONS.Models,
+    order: 40,
+    renderer: MANAGED_RESOURCE_FIELD_RENDERERS.Text,
+    resolveLabel: (t) =>
+      t("managedSiteChannels:editor.doneHub.testModel.label"),
+    resolveHelp: (t) => t("managedSiteChannels:editor.doneHub.testModel.help"),
+    resolvePlaceholder: (t) =>
+      t("managedSiteChannels:editor.doneHub.testModel.placeholder"),
+    visibleWhen: (values) =>
+      isDoneHubAdvancedFieldApplicable(
+        DONE_HUB_MANAGED_RESOURCE_FIELD_IDS.TestModel,
+        Number(values[DONE_HUB_MANAGED_RESOURCE_FIELD_IDS.Type]),
+      ),
+    advancedControl: "model-input",
+    suggestionSourceFieldId: DONE_HUB_MANAGED_RESOURCE_FIELD_IDS.Models,
+    issueLabelResolvers: {
+      invalid_value: (t) =>
+        t("managedSiteChannels:editor.doneHub.testModel.invalid"),
+    },
+  },
+  {
+    fieldId: DONE_HUB_MANAGED_RESOURCE_FIELD_IDS.DisabledStream,
+    section: MANAGED_RESOURCE_SECTIONS.Models,
+    order: 50,
+    renderer: MANAGED_RESOURCE_FIELD_RENDERERS.MultiSelect,
+    resolveLabel: (t) =>
+      t("managedSiteChannels:editor.doneHub.disabledStream.label"),
+    resolveHelp: (t) =>
+      t("managedSiteChannels:editor.doneHub.disabledStream.help"),
+    advancedControl: "model-list",
+    suggestionSourceFieldId: DONE_HUB_MANAGED_RESOURCE_FIELD_IDS.Models,
+  },
+  {
+    fieldId: DONE_HUB_MANAGED_RESOURCE_FIELD_IDS.Proxy,
+    section: MANAGED_RESOURCE_SECTIONS.Requests,
+    order: 60,
+    renderer: MANAGED_RESOURCE_FIELD_RENDERERS.Text,
+    resolveLabel: (t) => t("managedSiteChannels:editor.doneHub.proxy.label"),
+    resolveHelp: (t) => t("managedSiteChannels:editor.doneHub.proxy.help"),
+    resolvePlaceholder: (t) =>
+      t("managedSiteChannels:editor.doneHub.proxy.placeholder"),
+    issueLabelResolvers: {
+      invalid_value: (t) =>
+        t("managedSiteChannels:editor.doneHub.proxy.invalid"),
+    },
+  },
+  {
+    fieldId: DONE_HUB_MANAGED_RESOURCE_FIELD_IDS.ModelHeaders,
+    section: MANAGED_RESOURCE_SECTIONS.Requests,
+    order: 70,
+    renderer: MANAGED_RESOURCE_FIELD_RENDERERS.Textarea,
+    resolveLabel: (t) =>
+      t("managedSiteChannels:editor.doneHub.modelHeaders.label"),
+    resolveHelp: (t) =>
+      t("managedSiteChannels:editor.doneHub.modelHeaders.help"),
+    resolvePlaceholder: (t) =>
+      t("managedSiteChannels:editor.doneHub.modelHeaders.placeholder"),
+    advancedControl: "string-map",
+    issueLabelResolvers: {
+      invalid_value: (t) =>
+        t("managedSiteChannels:editor.doneHub.modelHeaders.invalid"),
+    },
+  },
+  {
+    fieldId: DONE_HUB_MANAGED_RESOURCE_FIELD_IDS.AllowExtraBody,
+    section: MANAGED_RESOURCE_SECTIONS.Requests,
+    order: 80,
+    renderer: MANAGED_RESOURCE_FIELD_RENDERERS.Boolean,
+    resolveLabel: (t) =>
+      t("managedSiteChannels:editor.doneHub.allowExtraBody.label"),
+    resolveHelp: (t) =>
+      t("managedSiteChannels:editor.doneHub.allowExtraBody.help"),
+  },
+  {
+    fieldId: DONE_HUB_MANAGED_RESOURCE_FIELD_IDS.CustomParameter,
+    section: MANAGED_RESOURCE_SECTIONS.Requests,
+    order: 90,
+    renderer: MANAGED_RESOURCE_FIELD_RENDERERS.Textarea,
+    resolveLabel: (t) =>
+      t("managedSiteChannels:editor.doneHub.customParameter.label"),
+    resolveHelp: (t) =>
+      t("managedSiteChannels:editor.doneHub.customParameter.help"),
+    resolvePlaceholder: (t) =>
+      t("managedSiteChannels:editor.doneHub.customParameter.placeholder"),
+    advancedControl: "json",
+    issueLabelResolvers: {
+      invalid_value: (t) =>
+        t("managedSiteChannels:editor.doneHub.customParameter.invalid"),
+    },
+  },
+]
 
 const newApiManagedResourceFieldPolicy = defineManagedResourceFieldPolicy({
   siteType: SITE_TYPES.NEW_API,
@@ -560,16 +731,59 @@ const veloeraManagedResourceFieldPolicy = defineManagedResourceFieldPolicy({
   },
 })
 
+/** Summarizes visible configured controls without exposing connection or request values. */
+const doneHubSectionSummary =
+  (section: ManagedResourceSection) =>
+  (t: TFunction, values: EditableResourceProjection) => {
+    const labels = doneHubFields
+      .filter((field) => {
+        if (field.section !== section || !(field.visibleWhen?.(values) ?? true))
+          return false
+        const value = values[field.fieldId]
+        return Array.isArray(value)
+          ? value.length > 0
+          : typeof value === "string"
+            ? !["", "{}"].includes(value.trim())
+            : value === true
+      })
+      .map((field) => field.resolveLabel(t))
+    return labels.length ? labels.join(" · ") : t("ui:resourceEditor.optional")
+  }
+
+const doneHubSections = {
+  basic: {
+    columns: 2,
+    defaultOpen: true,
+    resolveLabel: (t: TFunction) =>
+      t("managedSiteChannels:editor.sections.basicConnection"),
+  },
+  models: {
+    defaultOpen: true,
+    resolveSummary: doneHubSectionSummary(MANAGED_RESOURCE_SECTIONS.Models),
+  },
+  routing: { columns: 2 },
+  compatibility: {
+    resolveSummary: doneHubSectionSummary(
+      MANAGED_RESOURCE_SECTIONS.Compatibility,
+    ),
+  },
+  requests: {
+    resolveSummary: doneHubSectionSummary(MANAGED_RESOURCE_SECTIONS.Requests),
+  },
+} satisfies ManagedResourceEditorFieldPolicy["sections"]
+
 const doneHubManagedResourceFieldPolicy = defineManagedResourceFieldPolicy({
   siteType: SITE_TYPES.DONE_HUB,
   kind: MANAGED_RESOURCE_KINDS.Channel,
   modes: {
     [MANAGED_RESOURCE_EDITOR_MODES.Create]: {
       fields: doneHubFields,
+      sections: doneHubSections,
       hiddenFields: [],
     },
     [MANAGED_RESOURCE_EDITOR_MODES.Edit]: {
       fields: doneHubFields,
+      sections: doneHubSections,
       hiddenFields: [],
     },
   },

--- a/src/features/ResourceEditor/NativeResourceEditorBody.tsx
+++ b/src/features/ResourceEditor/NativeResourceEditorBody.tsx
@@ -595,10 +595,26 @@ export function NativeResourceEditorBody<TSection extends string>({
   return (
     <div className="space-y-5">
       {[...fieldsBySection.entries()].map(([section, sectionFields]) => {
-        const label = sectionLabelResolvers[section](t)
-        const content = sectionFields.map(renderField)
-        const override = renderSectionOverride?.(section, label, content)
         const sectionPolicy = policy.sections?.[section]
+        const label =
+          sectionPolicy?.resolveLabel?.(t) ?? sectionLabelResolvers[section](t)
+        const content = sectionFields.map((field) =>
+          sectionPolicy?.columns === 2 ? (
+            <div
+              key={field.descriptor.fieldId}
+              className={
+                field.presentation.width === "half"
+                  ? "min-w-0"
+                  : "min-w-0 sm:col-span-2"
+              }
+            >
+              {renderField(field)}
+            </div>
+          ) : (
+            renderField(field)
+          ),
+        )
+        const override = renderSectionOverride?.(section, label, content)
         return override !== undefined ? (
           <Fragment key={section}>{override}</Fragment>
         ) : sectionPolicy ? (
@@ -607,6 +623,7 @@ export function NativeResourceEditorBody<TSection extends string>({
             label={label}
             summary={sectionPolicy.resolveSummary?.(t, values)}
             defaultOpen={sectionPolicy.defaultOpen}
+            columns={sectionPolicy.columns}
             hasErrors={sectionFields.some(({ descriptor }) =>
               issuesByFieldId.has(descriptor.fieldId),
             )}

--- a/src/features/ResourceEditor/ResourceEditorSection.tsx
+++ b/src/features/ResourceEditor/ResourceEditorSection.tsx
@@ -32,7 +32,9 @@ export function ResourceEditorSection({
   return (
     <Collapsible
       open={open}
-      onOpenChange={setExpanded}
+      onOpenChange={(nextOpen) => {
+        if (nextOpen || !hasErrors) setExpanded(nextOpen)
+      }}
       className="border-border min-w-0 rounded-lg border"
     >
       <CollapsibleTrigger

--- a/src/features/ResourceEditor/ResourceEditorSection.tsx
+++ b/src/features/ResourceEditor/ResourceEditorSection.tsx
@@ -12,12 +12,14 @@ export function ResourceEditorSection({
   label,
   summary,
   defaultOpen = false,
+  columns,
   hasErrors,
   children,
 }: {
   label: string
   summary?: string
   defaultOpen?: boolean
+  columns?: 2
   hasErrors: boolean
   children: ReactNode
 }) {
@@ -53,7 +55,13 @@ export function ResourceEditorSection({
         )}
       </CollapsibleTrigger>
       <CollapsibleContent forceMount hidden={!open}>
-        <fieldset className="min-w-0 space-y-4 px-3 pb-3">
+        <fieldset
+          className={
+            columns === 2
+              ? "grid min-w-0 grid-cols-1 gap-4 px-3 pb-3 sm:grid-cols-2"
+              : "min-w-0 space-y-4 px-3 pb-3"
+          }
+        >
           <legend className="sr-only">{label}</legend>
           {children}
         </fieldset>

--- a/src/features/ResourceEditor/ResourceJsonField.tsx
+++ b/src/features/ResourceEditor/ResourceJsonField.tsx
@@ -1,0 +1,248 @@
+import type { TFunction } from "i18next"
+import { Plus, Trash2 } from "lucide-react"
+import { useId, useState, type ReactNode } from "react"
+
+import { Button, Input, Label, Textarea } from "~/components/ui"
+
+const parseRows = (value: string): [string, string][] | undefined => {
+  try {
+    const parsed: unknown = JSON.parse(value.trim() || "{}")
+    if (
+      Array.isArray(parsed) &&
+      parsed.every(
+        (row) =>
+          Array.isArray(row) &&
+          row.length === 2 &&
+          row.every((cell) => typeof cell === "string"),
+      )
+    ) {
+      return parsed as [string, string][]
+    }
+    if (
+      parsed &&
+      typeof parsed === "object" &&
+      !Array.isArray(parsed) &&
+      Object.values(parsed).every((item) => typeof item === "string")
+    ) {
+      return Object.entries(parsed) as [string, string][]
+    }
+  } catch {
+    /* Keep malformed existing JSON available for repair in text mode. */
+  }
+  return undefined
+}
+
+/** Edits JSON objects with an optional row view; incomplete rows remain invalid drafts. */
+export function ResourceJsonField({
+  t,
+  label,
+  help,
+  placeholder,
+  value,
+  onChange,
+  disabled,
+  errorMessage,
+  stringMap = false,
+  actions,
+}: {
+  t: TFunction
+  label: string
+  help?: string
+  placeholder?: string
+  value: string
+  onChange: (value: string) => void
+  disabled?: boolean
+  errorMessage?: string
+  stringMap?: boolean
+  actions?: ReactNode
+}) {
+  const id = useId()
+  const rows = parseRows(value)
+  const [jsonMode, setJsonMode] = useState(
+    () => stringMap && rows === undefined,
+  )
+  const showRows = stringMap && !jsonMode && rows !== undefined
+  const describedBy = `${id}-help${errorMessage ? ` ${id}-error` : ""}`
+  const updateRows = (next: [string, string][]) => {
+    const valid =
+      next.every(([key]) => key.trim()) &&
+      new Set(next.map(([key]) => key.trim())).size === next.length
+    // Arrays preserve duplicate/unfinished rows until the user fixes them;
+    // the adapter requires an object and will not submit these drafts.
+    onChange(
+      JSON.stringify(
+        valid
+          ? Object.fromEntries(next.map(([key, item]) => [key.trim(), item]))
+          : next,
+      ),
+    )
+  }
+  let canFormat = false
+  try {
+    JSON.parse(value)
+    canFormat = true
+  } catch {
+    /* No formatting action for invalid JSON. */
+  }
+  return (
+    <fieldset className="min-w-0 space-y-2">
+      <legend className="sr-only">{label}</legend>
+      <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-1">
+        <span className="text-sm font-medium">{label}</span>
+        <div className="flex flex-wrap items-center gap-1">
+          {actions}
+          {stringMap && (
+            <Button
+              type="button"
+              variant="dashed"
+              size="sm"
+              disabled={disabled || (!showRows && rows === undefined)}
+              onClick={() => setJsonMode(showRows)}
+            >
+              {t(
+                showRows
+                  ? "managedSiteChannels:editor.json.editJson"
+                  : "managedSiteChannels:editor.json.editRows",
+              )}
+            </Button>
+          )}
+          {!showRows && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              disabled={disabled || !canFormat}
+              onClick={() =>
+                onChange(JSON.stringify(JSON.parse(value), null, 2))
+              }
+            >
+              {t("managedSiteChannels:editor.json.format")}
+            </Button>
+          )}
+        </div>
+      </div>
+      {showRows ? (
+        <div className="space-y-2">
+          {rows.map(([key, item], index) => (
+            <div
+              key={index}
+              className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-end gap-2 sm:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto]"
+            >
+              <div className="col-span-2 min-w-0 space-y-1 sm:col-span-1">
+                <Label
+                  htmlFor={`${id}-${index}-key`}
+                  className="text-muted-foreground text-xs"
+                >
+                  {t("managedSiteChannels:editor.json.key")}
+                </Label>
+                <Input
+                  id={`${id}-${index}-key`}
+                  aria-label={t("managedSiteChannels:editor.json.keyAt", {
+                    field: label,
+                    index: index + 1,
+                  })}
+                  placeholder={t("managedSiteChannels:editor.json.key")}
+                  value={key}
+                  disabled={disabled}
+                  aria-describedby={describedBy}
+                  aria-invalid={Boolean(errorMessage)}
+                  onChange={(event) =>
+                    updateRows(
+                      rows.map((row, i) =>
+                        i === index ? [event.target.value, item] : row,
+                      ),
+                    )
+                  }
+                />
+              </div>
+              <div className="min-w-0 space-y-1">
+                <Label
+                  htmlFor={`${id}-${index}-value`}
+                  className="text-muted-foreground text-xs"
+                >
+                  {t("managedSiteChannels:editor.json.value")}
+                </Label>
+                <Input
+                  id={`${id}-${index}-value`}
+                  aria-label={t("managedSiteChannels:editor.json.valueAt", {
+                    field: label,
+                    index: index + 1,
+                  })}
+                  placeholder={t("managedSiteChannels:editor.json.value")}
+                  value={item}
+                  disabled={disabled}
+                  aria-describedby={describedBy}
+                  aria-invalid={Boolean(errorMessage)}
+                  onChange={(event) =>
+                    updateRows(
+                      rows.map((row, i) =>
+                        i === index ? [key, event.target.value] : row,
+                      ),
+                    )
+                  }
+                />
+              </div>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                disabled={disabled}
+                aria-label={t("managedSiteChannels:editor.json.removeAt", {
+                  field: label,
+                  index: index + 1,
+                })}
+                onClick={() => updateRows(rows.filter((_, i) => i !== index))}
+              >
+                <Trash2 className="size-4" />
+              </Button>
+            </div>
+          ))}
+          <Button
+            type="button"
+            variant="dashed"
+            size="sm"
+            className="w-full"
+            disabled={disabled}
+            onClick={() => updateRows([...rows, ["", ""]])}
+          >
+            <Plus className="mr-1 size-4" />
+            {t("managedSiteChannels:editor.json.addRow")}
+          </Button>
+        </div>
+      ) : (
+        <>
+          <Label htmlFor={id} className="sr-only">
+            {label}
+          </Label>
+          <Textarea
+            id={id}
+            rows={5}
+            className="font-mono text-xs"
+            value={value}
+            placeholder={placeholder}
+            disabled={disabled}
+            spellCheck={false}
+            aria-describedby={describedBy}
+            aria-invalid={Boolean(errorMessage)}
+            onChange={(event) => onChange(event.target.value)}
+          />
+        </>
+      )}
+      <p
+        id={`${id}-help`}
+        className="text-muted-foreground text-xs leading-relaxed"
+      >
+        {help}
+      </p>
+      {errorMessage && (
+        <p
+          id={`${id}-error`}
+          role="alert"
+          className="text-xs text-red-600 dark:text-red-400"
+        >
+          {errorMessage}
+        </p>
+      )}
+    </fieldset>
+  )
+}

--- a/src/features/ResourceEditor/resourceFieldPolicy.ts
+++ b/src/features/ResourceEditor/resourceFieldPolicy.ts
@@ -17,6 +17,8 @@ type ResourceFieldPresentationBase<TSection extends string = string> = {
   resolveLabel: ResourceFieldTextResolver
   resolveHelp?: ResourceFieldTextResolver
   resolvePlaceholder?: ResourceFieldTextResolver
+  /** Half-width controls share a row in a section with two columns. */
+  width?: "half"
   rows?: number
   /** Structured editing of an existing line-based projection; persistence stays adapter-owned. */
   textEntries?: {
@@ -74,6 +76,8 @@ export type ResourceEditorFieldPolicy<TSection extends string = string> = {
     Record<
       TSection,
       {
+        columns?: 2
+        resolveLabel?: ResourceFieldTextResolver
         defaultOpen?: boolean
         resolveSummary?: (
           t: TFunction,

--- a/src/locales/de/managedSiteChannels.json
+++ b/src/locales/de/managedSiteChannels.json
@@ -59,6 +59,56 @@
     "deleteTitlePlural": "Kanäle löschen?"
   },
   "editor": {
+    "doneHub": {
+      "allowExtraBody": {
+        "help": "Zusätzliche Felder der Clientanfrage, etwa extra_body-Parameter, an den Anbieter weiterleiten.",
+        "label": "Zusätzliche Felder weiterleiten"
+      },
+      "compatibleResponse": {
+        "help": "Aktiviert: DoneHub wandelt Responses-Anfragen in Chat Completions um. Deaktiviert: Native Responses werden bevorzugt; bei fehlender Unterstützung ist weiterhin ein Rückfall möglich.",
+        "label": "Responses-API-Kompatibilität"
+      },
+      "customParameter": {
+        "help": "JSON-Objekt eingeben. Standardmäßig werden nur fehlende Felder ergänzt. overwrite: true überschreibt Felder; per_model: true konfiguriert pro Modell; pre_add: true wendet die Werte am Anfrageeingang an. Leer löscht die Konfiguration.",
+        "invalid": "Gültiges JSON-Objekt eingeben.",
+        "label": "Zusätzliche Anfrageparameter",
+        "placeholder": "{\n  \"overwrite\": true,\n  \"temperature\": 0.7\n}"
+      },
+      "disabledStream": {
+        "help": "Streaming-Anfragen für diese Modelle überspringen den Kanal; sie werden nicht in nicht-streamende Anfragen umgewandelt. Modelle auswählen oder Namen eingeben. Eine leere Liste stellt das normale Routing wieder her.",
+        "label": "Vom Streaming ausgeschlossene Modelle"
+      },
+      "modelHeaders": {
+        "help": "Feste Anfrageheader mit Textwerten hinzufügen. Authentifizierungsheader verwaltet der Kanal. Leer lassen oder alle Zeilen entfernen, um die Konfiguration zu löschen.",
+        "invalid": "JSON-Objekt mit eindeutigen, nicht leeren Schlüsseln und Textwerten eingeben.",
+        "label": "Benutzerdefinierte Anfrageheader",
+        "placeholder": "{\"X-Project\": \"example\"}"
+      },
+      "modelMapping": {
+        "addModels": "Zugeordnete Namen zur Modellliste hinzufügen",
+        "help": "Schlüssel sind angefragte Modellnamen, Werte die Namen beim Anbieter. Fügen Sie die Schlüssel zur Modellliste hinzu. Ein + vor dem Wert rechnet nach dem angefragten Modell ab.",
+        "invalid": "JSON-Objekt mit eindeutigen, nicht leeren Schlüsseln und Textwerten eingeben.",
+        "label": "Modellzuordnung",
+        "placeholder": "{\"alias\": \"upstream-model\"}"
+      },
+      "proxy": {
+        "help": "Für Verbindungen vom DoneHub-Server zum Anbieter. Unterstützt HTTP und SOCKS5; %s erzeugt eine Sitzungskennung aus dem Kanalschlüssel. Leer entfernt den Kanalproxy.",
+        "invalid": "Gültige HTTP- oder SOCKS5-Proxy-URL eingeben.",
+        "label": "Proxy-URL",
+        "placeholder": "socks5://127.0.0.1:1080"
+      },
+      "responsesPath": {
+        "help": "Nur für native Responses-Anfragen bei benutzerdefinierten Kanälen. Leer nutzt /v1/responses; disable sperrt diese Anfrage. Im Kompatibilitätsmodus nicht verwendet.",
+        "label": "Responses-Anfragepfad",
+        "placeholder": "/v1/responses"
+      },
+      "testModel": {
+        "help": "Chatmodell dieses Kanals auswählen oder Namen eingeben. Ohne Modell kann DoneHub die Kanalgeschwindigkeit nicht testen. Maximal 50 Zeichen.",
+        "invalid": "Modellnamen dürfen höchstens 50 Zeichen enthalten.",
+        "label": "Testmodell",
+        "placeholder": "gpt-4o-mini"
+      }
+    },
     "fields": {
       "autoSyncModelPattern": {
         "help": "Nur passende Modelle synchronisieren. Präfix mit (?i), um Groß- und Kleinschreibung zu ignorieren; Lassen Sie das Feld leer, um alle Modelle zu synchronisieren.",
@@ -119,6 +169,17 @@
         "placeholder": "Tags hinzufügen..."
       }
     },
+    "json": {
+      "addRow": "Zeile hinzufügen",
+      "editJson": "JSON bearbeiten",
+      "editRows": "Zeilen bearbeiten",
+      "format": "JSON formatieren",
+      "key": "Schlüssel",
+      "keyAt": "{{field}}: Schlüssel in Zeile {{index}}",
+      "removeAt": "{{field}}: Zeile {{index}} entfernen",
+      "value": "Wert",
+      "valueAt": "{{field}}: Wert in Zeile {{index}}"
+    },
     "options": {
       "channelType": {
         "anthropic": "Anthropic",
@@ -178,9 +239,12 @@
     "sections": {
       "advanced": "Erweitert",
       "basic": "Grundlagen",
+      "basicConnection": "Grundlagen & Verbindung",
+      "compatibility": "API-Kompatibilität",
       "connection": "Verbindung",
       "metadata": "Metadaten",
       "models": "Modelle",
+      "requests": "Netzwerk & Anfragen",
       "routing": "Routing",
       "sync": "Modellsynchronisierung"
     },

--- a/src/locales/en/managedSiteChannels.json
+++ b/src/locales/en/managedSiteChannels.json
@@ -59,6 +59,56 @@
     "deleteTitlePlural": "Delete channels?"
   },
   "editor": {
+    "doneHub": {
+      "allowExtraBody": {
+        "help": "Forward extra fields in client requests, such as extra_body parameters, to the upstream.",
+        "label": "Forward extra body fields"
+      },
+      "compatibleResponse": {
+        "help": "When enabled, DoneHub converts Responses requests to Chat Completions. When disabled, it prefers native Responses but may still fall back if unsupported.",
+        "label": "Responses API compatibility"
+      },
+      "customParameter": {
+        "help": "Enter a JSON object. By default, only missing fields are added. overwrite: true replaces fields; per_model: true configures by model; pre_add: true applies at request entry. Leave blank to clear.",
+        "invalid": "Enter a valid JSON object.",
+        "label": "Extra request parameters",
+        "placeholder": "{\n  \"overwrite\": true,\n  \"temperature\": 0.7\n}"
+      },
+      "disabledStream": {
+        "help": "Streaming requests for these models skip this channel; they are not converted to non-streaming. Select models or enter names. Clear the list to restore normal routing.",
+        "label": "Models excluded from streaming"
+      },
+      "modelHeaders": {
+        "help": "Add fixed upstream headers with text values. Authentication headers are handled by the channel. Leave blank or remove all rows to clear.",
+        "invalid": "Enter a JSON object with unique, non-empty keys and text values.",
+        "label": "Custom request headers",
+        "placeholder": "{\"X-Project\": \"example\"}"
+      },
+      "modelMapping": {
+        "addModels": "Add mapped names to model list",
+        "help": "Keys are requested model names; values are upstream names. Add the keys to the channel model list. Prefix a value with + to bill using the requested model.",
+        "invalid": "Enter a JSON object with unique, non-empty keys and text values.",
+        "label": "Model mapping",
+        "placeholder": "{\"alias\": \"upstream-model\"}"
+      },
+      "proxy": {
+        "help": "Used by the DoneHub server to reach the upstream. Supports HTTP and SOCKS5; %s generates a session identifier from the channel key. Leave blank to remove the channel proxy.",
+        "invalid": "Enter a valid HTTP or SOCKS5 proxy URL.",
+        "label": "Proxy URL",
+        "placeholder": "socks5://127.0.0.1:1080"
+      },
+      "responsesPath": {
+        "help": "For native Responses requests on Custom channels only. Leave blank for /v1/responses or enter disable to block this request. Not used in compatibility mode.",
+        "label": "Responses request path",
+        "placeholder": "/v1/responses"
+      },
+      "testModel": {
+        "help": "Choose a chat model from this channel or enter a name. DoneHub cannot test channel speed when blank. Maximum 50 characters.",
+        "invalid": "Model names must be at most 50 characters.",
+        "label": "Test model",
+        "placeholder": "gpt-4o-mini"
+      }
+    },
     "fields": {
       "autoSyncModelPattern": {
         "help": "Only sync matching models. Prefix with (?i) to ignore case; leave empty to sync all models.",
@@ -119,6 +169,17 @@
         "placeholder": "Add tags..."
       }
     },
+    "json": {
+      "addRow": "Add row",
+      "editJson": "Edit JSON",
+      "editRows": "Edit rows",
+      "format": "Format JSON",
+      "key": "Key",
+      "keyAt": "{{field}}: row {{index}} key",
+      "removeAt": "{{field}}: remove row {{index}}",
+      "value": "Value",
+      "valueAt": "{{field}}: row {{index}} value"
+    },
     "options": {
       "channelType": {
         "anthropic": "Anthropic",
@@ -178,9 +239,12 @@
     "sections": {
       "advanced": "Advanced",
       "basic": "Basic",
+      "basicConnection": "Basic & connection",
+      "compatibility": "API compatibility",
       "connection": "Connection",
       "metadata": "Metadata",
       "models": "Models",
+      "requests": "Network & requests",
       "routing": "Routing",
       "sync": "Model sync"
     },

--- a/src/locales/es-419/managedSiteChannels.json
+++ b/src/locales/es-419/managedSiteChannels.json
@@ -59,6 +59,56 @@
     "deleteTitlePlural": "¿Eliminar canales?"
   },
   "editor": {
+    "doneHub": {
+      "allowExtraBody": {
+        "help": "Reenvía al proveedor los campos adicionales del cliente, como los parámetros extra_body.",
+        "label": "Reenviar campos adicionales"
+      },
+      "compatibleResponse": {
+        "help": "Al activarlo, DoneHub convierte solicitudes Responses a Chat Completions. Al desactivarlo, prioriza Responses nativo, pero puede usar compatibilidad si no está disponible.",
+        "label": "Compatibilidad con Responses API"
+      },
+      "customParameter": {
+        "help": "Ingresa un objeto JSON. Por defecto solo se agregan campos faltantes. overwrite: true reemplaza campos; per_model: true configura por modelo; pre_add: true aplica al inicio de la solicitud. Deja vacío para borrar.",
+        "invalid": "Ingresa un objeto JSON válido.",
+        "label": "Parámetros adicionales",
+        "placeholder": "{\n  \"overwrite\": true,\n  \"temperature\": 0.7\n}"
+      },
+      "disabledStream": {
+        "help": "Las solicitudes de streaming de estos modelos omiten este canal; no se convierten a solicitudes sin streaming. Selecciona modelos o escribe nombres. Vacía la lista para restaurar el enrutamiento normal.",
+        "label": "Modelos excluidos del streaming"
+      },
+      "modelHeaders": {
+        "help": "Agrega encabezados fijos con valores de texto. El canal gestiona los encabezados de autenticación. Deja vacío o elimina todas las filas para borrar la configuración.",
+        "invalid": "Ingresa un objeto JSON con claves únicas, no vacías, y valores de texto.",
+        "label": "Encabezados personalizados",
+        "placeholder": "{\"X-Project\": \"example\"}"
+      },
+      "modelMapping": {
+        "addModels": "Agregar nombres mapeados a la lista de modelos",
+        "help": "Las claves son los modelos solicitados y los valores, los modelos del proveedor. Agrega las claves a la lista de modelos del canal. El prefijo + en el valor permite cobrar según el modelo solicitado.",
+        "invalid": "Ingresa un objeto JSON con claves únicas, no vacías, y valores de texto.",
+        "label": "Mapeo de modelos",
+        "placeholder": "{\"alias\": \"upstream-model\"}"
+      },
+      "proxy": {
+        "help": "Lo usa el servidor DoneHub para conectarse al proveedor. Admite HTTP y SOCKS5; %s genera un identificador de sesión a partir de la clave del canal. Déjalo vacío para quitar el proxy del canal.",
+        "invalid": "Ingresa una URL de proxy HTTP o SOCKS5 válida.",
+        "label": "URL del proxy",
+        "placeholder": "socks5://127.0.0.1:1080"
+      },
+      "responsesPath": {
+        "help": "Solo para solicitudes Responses nativas en canales personalizados. Deja vacío para /v1/responses o escribe disable para bloquearlas. No se usa en modo de compatibilidad.",
+        "label": "Ruta de solicitudes Responses",
+        "placeholder": "/v1/responses"
+      },
+      "testModel": {
+        "help": "Elige un modelo de chat del canal o escribe un nombre. Sin modelo, DoneHub no puede medir la velocidad del canal. Máximo 50 caracteres.",
+        "invalid": "El nombre del modelo no debe superar los 50 caracteres.",
+        "label": "Modelo de prueba",
+        "placeholder": "gpt-4o-mini"
+      }
+    },
     "fields": {
       "autoSyncModelPattern": {
         "help": "Sincroniza solo los modelos que coincidan. Añade el prefijo (?i) para ignorar mayúsculas y minúsculas; déjalo vacío para sincronizar todos los modelos.",
@@ -119,6 +169,17 @@
         "placeholder": "Añadir etiquetas..."
       }
     },
+    "json": {
+      "addRow": "Agregar fila",
+      "editJson": "Editar JSON",
+      "editRows": "Editar filas",
+      "format": "Formatear JSON",
+      "key": "Clave",
+      "keyAt": "{{field}}: clave de fila {{index}}",
+      "removeAt": "{{field}}: eliminar fila {{index}}",
+      "value": "Valor",
+      "valueAt": "{{field}}: valor de fila {{index}}"
+    },
     "options": {
       "channelType": {
         "anthropic": "Anthropic",
@@ -178,9 +239,12 @@
     "sections": {
       "advanced": "Opciones avanzadas",
       "basic": "Información básica",
+      "basicConnection": "Datos básicos y conexión",
+      "compatibility": "Compatibilidad de API",
       "connection": "Conexión y credenciales",
       "metadata": "Metadatos",
       "models": "Modelos",
+      "requests": "Red y solicitudes",
       "routing": "Enrutamiento",
       "sync": "Sincronización de modelos"
     },

--- a/src/locales/ja/managedSiteChannels.json
+++ b/src/locales/ja/managedSiteChannels.json
@@ -59,6 +59,56 @@
     "deleteTitlePlural": "チャネルを削除しますか？"
   },
   "editor": {
+    "doneHub": {
+      "allowExtraBody": {
+        "help": "extra_body など、クライアントの追加フィールドを上流へ転送します。",
+        "label": "追加フィールドを転送"
+      },
+      "compatibleResponse": {
+        "help": "有効にすると、DoneHub は Responses リクエストを Chat Completions に変換します。無効時は上流のネイティブ Responses を優先しますが、非対応の場合は互換モードに切り替わることがあります。",
+        "label": "Responses API 互換モード"
+      },
+      "customParameter": {
+        "help": "JSON オブジェクトを入力してください。通常は不足フィールドのみ追加します。overwrite: true で上書き、per_model: true でモデル別設定、pre_add: true でリクエスト入口に適用します。空欄で解除します。",
+        "invalid": "有効な JSON オブジェクトを入力してください。",
+        "label": "追加リクエストパラメーター",
+        "placeholder": "{\n  \"overwrite\": true,\n  \"temperature\": 0.7\n}"
+      },
+      "disabledStream": {
+        "help": "これらのモデルのストリーミング要求では、このチャネルをスキップします。非ストリーミングには変換しません。モデルの選択または名前の入力が可能です。一覧を空にすると通常のルーティングに戻ります。",
+        "label": "ストリーミング対象外のモデル"
+      },
+      "modelHeaders": {
+        "help": "上流に固定ヘッダーを追加します。値は文字列にしてください。認証ヘッダーはチャネル側で処理します。空欄または全行削除で解除します。",
+        "invalid": "空でない一意のキーと文字列の値を持つ JSON オブジェクトを入力してください。",
+        "label": "カスタムリクエストヘッダー",
+        "placeholder": "{\"X-Project\": \"example\"}"
+      },
+      "modelMapping": {
+        "addModels": "マッピング名をモデル一覧に追加",
+        "help": "キーは要求されたモデル名、値は上流のモデル名です。キーをチャネルのモデル一覧に追加してください。値の先頭に + を付けると、要求されたモデルで課金します。",
+        "invalid": "空でない一意のキーと文字列の値を持つ JSON オブジェクトを入力してください。",
+        "label": "モデルマッピング",
+        "placeholder": "{\"alias\": \"upstream-model\"}"
+      },
+      "proxy": {
+        "help": "DoneHub サーバーから上流への接続に使用します。HTTP と SOCKS5 に対応し、%s はチャネルキーからセッション ID を生成します。空欄でチャネル専用プロキシを解除します。",
+        "invalid": "有効な HTTP または SOCKS5 プロキシ URL を入力してください。",
+        "label": "プロキシ URL",
+        "placeholder": "socks5://127.0.0.1:1080"
+      },
+      "responsesPath": {
+        "help": "カスタムチャネルのネイティブ Responses 専用です。空欄は /v1/responses、disable はこのリクエストを無効にします。互換モードでは使用しません。",
+        "label": "Responses リクエストパス",
+        "placeholder": "/v1/responses"
+      },
+      "testModel": {
+        "help": "チャネルのチャットモデルを選択するか、名前を入力してください。空欄では DoneHub の速度テストを実行できません。最大 50 文字です。",
+        "invalid": "モデル名は 50 文字以内にしてください。",
+        "label": "速度テスト用モデル",
+        "placeholder": "gpt-4o-mini"
+      }
+    },
     "fields": {
       "autoSyncModelPattern": {
         "help": "このパターンに一致するモデルだけを同期します。大文字と小文字を区別しない場合は先頭に (?i) を付け、すべて同期する場合は空欄にします。",
@@ -119,6 +169,17 @@
         "placeholder": "タグを追加..."
       }
     },
+    "json": {
+      "addRow": "行を追加",
+      "editJson": "JSON を編集",
+      "editRows": "行で編集",
+      "format": "JSON を整形",
+      "key": "キー",
+      "keyAt": "{{field}}：{{index}} 行目のキー",
+      "removeAt": "{{field}}：{{index}} 行目を削除",
+      "value": "値",
+      "valueAt": "{{field}}：{{index}} 行目の値"
+    },
     "options": {
       "channelType": {
         "anthropic": "Anthropic",
@@ -178,9 +239,12 @@
     "sections": {
       "advanced": "詳細設定",
       "basic": "基本情報",
+      "basicConnection": "基本設定と接続",
+      "compatibility": "API 互換性",
       "connection": "接続と認証情報",
       "metadata": "メタデータ",
       "models": "モデル",
+      "requests": "ネットワークとリクエスト",
       "routing": "ルーティング",
       "sync": "モデル同期"
     },

--- a/src/locales/pt-BR/managedSiteChannels.json
+++ b/src/locales/pt-BR/managedSiteChannels.json
@@ -59,6 +59,56 @@
     "deleteTitlePlural": "Excluir canais?"
   },
   "editor": {
+    "doneHub": {
+      "allowExtraBody": {
+        "help": "Encaminha ao provedor campos extras das solicitações do cliente, como parâmetros extra_body.",
+        "label": "Encaminhar campos extras"
+      },
+      "compatibleResponse": {
+        "help": "Quando ativado, o DoneHub converte solicitações Responses em Chat Completions. Quando desativado, prioriza Responses nativo, mas ainda pode recorrer à compatibilidade se não houver suporte.",
+        "label": "Compatibilidade com a Responses API"
+      },
+      "customParameter": {
+        "help": "Insira um objeto JSON. Por padrão, apenas campos ausentes são adicionados. overwrite: true substitui campos; per_model: true configura por modelo; pre_add: true aplica na entrada da solicitação. Deixe em branco para limpar.",
+        "invalid": "Insira um objeto JSON válido.",
+        "label": "Parâmetros adicionais",
+        "placeholder": "{\n  \"overwrite\": true,\n  \"temperature\": 0.7\n}"
+      },
+      "disabledStream": {
+        "help": "Solicitações de streaming para esses modelos ignoram o canal; não são convertidas para solicitações sem streaming. Selecione modelos ou digite nomes. Limpe a lista para restaurar o roteamento normal.",
+        "label": "Modelos excluídos do streaming"
+      },
+      "modelHeaders": {
+        "help": "Adicione cabeçalhos fixos com valores de texto. O canal gerencia os cabeçalhos de autenticação. Deixe em branco ou remova todas as linhas para limpar.",
+        "invalid": "Insira um objeto JSON com chaves únicas, não vazias, e valores de texto.",
+        "label": "Cabeçalhos personalizados",
+        "placeholder": "{\"X-Project\": \"example\"}"
+      },
+      "modelMapping": {
+        "addModels": "Adicionar nomes mapeados à lista de modelos",
+        "help": "As chaves são os modelos solicitados e os valores são os nomes no provedor. Adicione as chaves à lista de modelos do canal. O prefixo + no valor usa o modelo solicitado para cobrança.",
+        "invalid": "Insira um objeto JSON com chaves únicas, não vazias, e valores de texto.",
+        "label": "Mapeamento de modelos",
+        "placeholder": "{\"alias\": \"upstream-model\"}"
+      },
+      "proxy": {
+        "help": "Usado pelo servidor DoneHub para acessar o provedor. Aceita HTTP e SOCKS5; %s gera um identificador de sessão a partir da chave do canal. Deixe em branco para remover o proxy do canal.",
+        "invalid": "Insira uma URL de proxy HTTP ou SOCKS5 válida.",
+        "label": "URL do proxy",
+        "placeholder": "socks5://127.0.0.1:1080"
+      },
+      "responsesPath": {
+        "help": "Apenas para solicitações Responses nativas em canais personalizados. Deixe em branco para /v1/responses ou digite disable para bloqueá-las. Não usado no modo de compatibilidade.",
+        "label": "Caminho de solicitações Responses",
+        "placeholder": "/v1/responses"
+      },
+      "testModel": {
+        "help": "Escolha um modelo de chat do canal ou digite um nome. Sem modelo, o DoneHub não consegue testar a velocidade do canal. Máximo de 50 caracteres.",
+        "invalid": "O nome do modelo deve ter no máximo 50 caracteres.",
+        "label": "Modelo de teste",
+        "placeholder": "gpt-4o-mini"
+      }
+    },
     "fields": {
       "autoSyncModelPattern": {
         "help": "Sincronize somente modelos correspondentes. Comece com (?i) para ignorar maiúsculas e minúsculas; deixe em branco para sincronizar todos os modelos.",
@@ -119,6 +169,17 @@
         "placeholder": "Adicionar tags..."
       }
     },
+    "json": {
+      "addRow": "Adicionar linha",
+      "editJson": "Editar JSON",
+      "editRows": "Editar linhas",
+      "format": "Formatar JSON",
+      "key": "Chave",
+      "keyAt": "{{field}}: chave da linha {{index}}",
+      "removeAt": "{{field}}: remover linha {{index}}",
+      "value": "Valor",
+      "valueAt": "{{field}}: valor da linha {{index}}"
+    },
     "options": {
       "channelType": {
         "anthropic": "Anthropic",
@@ -178,9 +239,12 @@
     "sections": {
       "advanced": "Avançado",
       "basic": "Básico",
+      "basicConnection": "Básico e conexão",
+      "compatibility": "Compatibilidade de API",
       "connection": "Conexão",
       "metadata": "Metadados",
       "models": "Modelos",
+      "requests": "Rede e requisições",
       "routing": "Roteamento",
       "sync": "Sincronização de modelos"
     },

--- a/src/locales/vi/managedSiteChannels.json
+++ b/src/locales/vi/managedSiteChannels.json
@@ -59,6 +59,56 @@
     "deleteTitlePlural": "Xóa các kênh này?"
   },
   "editor": {
+    "doneHub": {
+      "allowExtraBody": {
+        "help": "Chuyển tiếp trường bổ sung trong yêu cầu của máy khách, như tham số extra_body, tới nhà cung cấp.",
+        "label": "Chuyển tiếp trường bổ sung"
+      },
+      "compatibleResponse": {
+        "help": "Khi bật, DoneHub chuyển yêu cầu Responses thành Chat Completions. Khi tắt, ưu tiên Responses gốc nhưng vẫn có thể dùng chế độ tương thích nếu không được hỗ trợ.",
+        "label": "Tương thích Responses API"
+      },
+      "customParameter": {
+        "help": "Nhập đối tượng JSON. Mặc định chỉ bổ sung trường còn thiếu. overwrite: true ghi đè trường; per_model: true cấu hình theo mô hình; pre_add: true áp dụng khi nhận yêu cầu. Để trống để xóa.",
+        "invalid": "Nhập đối tượng JSON hợp lệ.",
+        "label": "Tham số yêu cầu bổ sung",
+        "placeholder": "{\n  \"overwrite\": true,\n  \"temperature\": 0.7\n}"
+      },
+      "disabledStream": {
+        "help": "Yêu cầu streaming cho các mô hình này sẽ bỏ qua kênh, không chuyển thành yêu cầu không streaming. Chọn mô hình hoặc nhập tên. Xóa danh sách để khôi phục định tuyến bình thường.",
+        "label": "Mô hình không dùng streaming"
+      },
+      "modelHeaders": {
+        "help": "Thêm header cố định với giá trị văn bản. Kênh tự xử lý header xác thực. Để trống hoặc xóa mọi dòng để xóa cấu hình.",
+        "invalid": "Nhập đối tượng JSON có khóa duy nhất, không rỗng và giá trị văn bản.",
+        "label": "Header yêu cầu tùy chỉnh",
+        "placeholder": "{\"X-Project\": \"example\"}"
+      },
+      "modelMapping": {
+        "addModels": "Thêm tên ánh xạ vào danh sách mô hình",
+        "help": "Khóa là tên mô hình được yêu cầu, giá trị là tên mô hình phía nhà cung cấp. Thêm các khóa vào danh sách mô hình của kênh. Thêm + trước giá trị để tính phí theo mô hình được yêu cầu.",
+        "invalid": "Nhập đối tượng JSON có khóa duy nhất, không rỗng và giá trị văn bản.",
+        "label": "Ánh xạ mô hình",
+        "placeholder": "{\"alias\": \"upstream-model\"}"
+      },
+      "proxy": {
+        "help": "Máy chủ DoneHub dùng proxy này để kết nối nhà cung cấp. Hỗ trợ HTTP và SOCKS5; %s tạo mã phiên từ khóa kênh. Để trống để bỏ proxy riêng của kênh.",
+        "invalid": "Nhập URL proxy HTTP hoặc SOCKS5 hợp lệ.",
+        "label": "URL proxy",
+        "placeholder": "socks5://127.0.0.1:1080"
+      },
+      "responsesPath": {
+        "help": "Chỉ dành cho yêu cầu Responses gốc trên kênh tùy chỉnh. Để trống để dùng /v1/responses hoặc nhập disable để chặn yêu cầu này. Không dùng trong chế độ tương thích.",
+        "label": "Đường dẫn yêu cầu Responses",
+        "placeholder": "/v1/responses"
+      },
+      "testModel": {
+        "help": "Chọn mô hình chat trong kênh hoặc nhập tên. DoneHub không thể đo tốc độ kênh khi để trống. Tối đa 50 ký tự.",
+        "invalid": "Tên mô hình không được quá 50 ký tự.",
+        "label": "Mô hình kiểm tra",
+        "placeholder": "gpt-4o-mini"
+      }
+    },
     "fields": {
       "autoSyncModelPattern": {
         "help": "Chỉ đồng bộ các mô hình khớp với mẫu này. Thêm tiền tố (?i) để không phân biệt chữ hoa chữ thường; để trống để đồng bộ tất cả mô hình.",
@@ -119,6 +169,17 @@
         "placeholder": "Thêm thẻ..."
       }
     },
+    "json": {
+      "addRow": "Thêm dòng",
+      "editJson": "Sửa JSON",
+      "editRows": "Sửa từng dòng",
+      "format": "Định dạng JSON",
+      "key": "Khóa",
+      "keyAt": "{{field}}: khóa dòng {{index}}",
+      "removeAt": "{{field}}: xóa dòng {{index}}",
+      "value": "Giá trị",
+      "valueAt": "{{field}}: giá trị dòng {{index}}"
+    },
     "options": {
       "channelType": {
         "anthropic": "Anthropic",
@@ -178,9 +239,12 @@
     "sections": {
       "advanced": "Nâng cao",
       "basic": "Thông tin cơ bản",
+      "basicConnection": "Cơ bản và kết nối",
+      "compatibility": "Tương thích API",
       "connection": "Kết nối và thông tin xác thực",
       "metadata": "Siêu dữ liệu",
       "models": "Mô hình",
+      "requests": "Mạng và yêu cầu",
       "routing": "Định tuyến",
       "sync": "Đồng bộ mô hình"
     },

--- a/src/locales/zh-CN/managedSiteChannels.json
+++ b/src/locales/zh-CN/managedSiteChannels.json
@@ -59,6 +59,56 @@
     "deleteTitlePlural": "删除这些渠道？"
   },
   "editor": {
+    "doneHub": {
+      "allowExtraBody": {
+        "help": "将客户端请求中的额外字段（例如 extra_body 参数）转发给上游。",
+        "label": "允许额外字段透传"
+      },
+      "compatibleResponse": {
+        "help": "开启后，DoneHub 将 Responses 请求转换为 Chat Completions。关闭时优先使用上游原生 Responses，不支持时仍可能回退兼容模式。",
+        "label": "兼容 Responses API"
+      },
+      "customParameter": {
+        "help": "填写 JSON 对象，默认只补充缺失字段。overwrite: true 覆盖同名字段；per_model: true 按模型配置；pre_add: true 在请求入口应用。留空清除。",
+        "invalid": "请输入有效的 JSON 对象。",
+        "label": "额外请求参数",
+        "placeholder": "{\n  \"overwrite\": true,\n  \"temperature\": 0.7\n}"
+      },
+      "disabledStream": {
+        "help": "流式请求使用这些模型时会跳过此渠道，不会自动改为非流式。可选择已有模型或输入名称；清空后恢复正常路由。",
+        "label": "禁用流式的模型"
+      },
+      "modelHeaders": {
+        "help": "向上游添加固定请求头，值必须为文本。鉴权头由渠道自身处理；留空或删除所有行可清除配置。",
+        "invalid": "请输入 JSON 对象，键名须唯一且非空，值必须为文本。",
+        "label": "自定义请求头",
+        "placeholder": "{\"X-Project\": \"example\"}"
+      },
+      "modelMapping": {
+        "addModels": "将映射名称加入模型列表",
+        "help": "键为用户请求的模型名，值为上游模型名。请将键加入渠道模型列表；值以 + 开头时，按用户请求的模型计费。",
+        "invalid": "请输入 JSON 对象，键名须唯一且非空，值必须为文本。",
+        "label": "模型映射",
+        "placeholder": "{\"alias\": \"upstream-model\"}"
+      },
+      "proxy": {
+        "help": "由 DoneHub 服务器访问上游时使用，支持 HTTP 和 SOCKS5。%s 会按渠道密钥生成会话标识；留空移除渠道专用代理。",
+        "invalid": "请输入有效的 HTTP 或 SOCKS5 代理地址。",
+        "label": "代理地址",
+        "placeholder": "socks5://127.0.0.1:1080"
+      },
+      "responsesPath": {
+        "help": "仅用于自定义渠道的原生 Responses 请求。留空使用 /v1/responses，填写 disable 禁用该请求；开启兼容模式时不使用此路径。",
+        "label": "Responses 请求路径",
+        "placeholder": "/v1/responses"
+      },
+      "testModel": {
+        "help": "选择渠道中的聊天模型，也可输入模型名。留空时 DoneHub 无法为此渠道测速，最多 50 个字符。",
+        "invalid": "模型名称不能超过 50 个字符。",
+        "label": "测速模型",
+        "placeholder": "gpt-4o-mini"
+      }
+    },
     "fields": {
       "autoSyncModelPattern": {
         "help": "仅同步匹配此规则的模型；使用 (?i) 前缀可忽略大小写，留空则同步全部模型。",
@@ -119,6 +169,17 @@
         "placeholder": "添加标签..."
       }
     },
+    "json": {
+      "addRow": "添加一行",
+      "editJson": "编辑 JSON",
+      "editRows": "逐行编辑",
+      "format": "格式化 JSON",
+      "key": "键",
+      "keyAt": "{{field}}：第 {{index}} 行键",
+      "removeAt": "{{field}}：删除第 {{index}} 行",
+      "value": "值",
+      "valueAt": "{{field}}：第 {{index}} 行值"
+    },
     "options": {
       "channelType": {
         "anthropic": "Anthropic",
@@ -178,9 +239,12 @@
     "sections": {
       "advanced": "高级",
       "basic": "基础信息",
+      "basicConnection": "基础与连接",
+      "compatibility": "接口兼容",
       "connection": "连接与凭据",
       "metadata": "元数据",
       "models": "模型",
+      "requests": "网络与请求",
       "routing": "路由",
       "sync": "模型同步"
     },

--- a/src/locales/zh-TW/managedSiteChannels.json
+++ b/src/locales/zh-TW/managedSiteChannels.json
@@ -59,6 +59,56 @@
     "deleteTitlePlural": "刪除這些渠道？"
   },
   "editor": {
+    "doneHub": {
+      "allowExtraBody": {
+        "help": "將用戶端請求中的額外欄位（例如 extra_body 參數）轉送給上游。",
+        "label": "允許額外欄位透傳"
+      },
+      "compatibleResponse": {
+        "help": "開啟後，DoneHub 將 Responses 請求轉換為 Chat Completions。關閉時優先使用上游原生 Responses，不支援時仍可能回退相容模式。",
+        "label": "相容 Responses API"
+      },
+      "customParameter": {
+        "help": "填入 JSON 物件，預設只補充缺少的欄位。overwrite: true 覆蓋同名欄位；per_model: true 依模型設定；pre_add: true 在請求入口套用。留空清除。",
+        "invalid": "請輸入有效的 JSON 物件。",
+        "label": "額外請求參數",
+        "placeholder": "{\n  \"overwrite\": true,\n  \"temperature\": 0.7\n}"
+      },
+      "disabledStream": {
+        "help": "串流請求使用這些模型時會略過此渠道，不會自動改為非串流。可選擇現有模型或輸入名稱；清空後恢復正常路由。",
+        "label": "停用串流的模型"
+      },
+      "modelHeaders": {
+        "help": "向上游加入固定請求標頭，值必須為文字。驗證標頭由渠道自行處理；留空或刪除所有列可清除設定。",
+        "invalid": "請輸入 JSON 物件，鍵名須唯一且非空，值必須為文字。",
+        "label": "自訂請求標頭",
+        "placeholder": "{\"X-Project\": \"example\"}"
+      },
+      "modelMapping": {
+        "addModels": "將對應名稱加入模型清單",
+        "help": "鍵為使用者請求的模型名稱，值為上游模型名稱。請將鍵加入渠道模型清單；值以 + 開頭時，按使用者請求的模型計費。",
+        "invalid": "請輸入 JSON 物件，鍵名須唯一且非空，值必須為文字。",
+        "label": "模型對應",
+        "placeholder": "{\"alias\": \"upstream-model\"}"
+      },
+      "proxy": {
+        "help": "由 DoneHub 伺服器存取上游時使用，支援 HTTP 和 SOCKS5。%s 會依渠道金鑰產生工作階段識別碼；留空移除渠道專用代理。",
+        "invalid": "請輸入有效的 HTTP 或 SOCKS5 代理位址。",
+        "label": "代理位址",
+        "placeholder": "socks5://127.0.0.1:1080"
+      },
+      "responsesPath": {
+        "help": "僅用於自訂渠道的原生 Responses 請求。留空使用 /v1/responses，填入 disable 停用此請求；開啟相容模式時不使用此路徑。",
+        "label": "Responses 請求路徑",
+        "placeholder": "/v1/responses"
+      },
+      "testModel": {
+        "help": "選擇渠道中的聊天模型，也可輸入模型名稱。留空時 DoneHub 無法為此渠道測速，最多 50 個字元。",
+        "invalid": "模型名稱不能超過 50 個字元。",
+        "label": "測速模型",
+        "placeholder": "gpt-4o-mini"
+      }
+    },
     "fields": {
       "autoSyncModelPattern": {
         "help": "僅同步符合此規則的模型；使用 (?i) 前綴可忽略大小寫，留空則同步所有模型。",
@@ -119,6 +169,17 @@
         "placeholder": "新增標籤..."
       }
     },
+    "json": {
+      "addRow": "新增一列",
+      "editJson": "編輯 JSON",
+      "editRows": "逐列編輯",
+      "format": "格式化 JSON",
+      "key": "鍵",
+      "keyAt": "{{field}}：第 {{index}} 列鍵",
+      "removeAt": "{{field}}：刪除第 {{index}} 列",
+      "value": "值",
+      "valueAt": "{{field}}：第 {{index}} 列值"
+    },
     "options": {
       "channelType": {
         "anthropic": "Anthropic",
@@ -178,9 +239,12 @@
     "sections": {
       "advanced": "進階",
       "basic": "基本資訊",
+      "basicConnection": "基本與連線",
+      "compatibility": "介面相容",
       "connection": "連線與憑據",
       "metadata": "中繼資料",
       "models": "模型",
+      "requests": "網路與請求",
       "routing": "路由",
       "sync": "模型同步"
     },

--- a/src/services/apiAdapters/managedResources/doneHub.ts
+++ b/src/services/apiAdapters/managedResources/doneHub.ts
@@ -28,6 +28,7 @@ import { doneHubManagedSiteCapabilities } from "~/services/apiAdapters/managedSi
 import { toManagedSiteApiServiceRequest } from "~/services/apiAdapters/managedSites/request"
 import {
   fetchChannelRaw,
+  fetchDoneHubProviderModels,
   normalizeDoneHubChannel,
 } from "~/services/apiService/doneHub"
 import { API_ERROR_CODES, ApiError } from "~/services/apiTransport/errors"
@@ -42,14 +43,18 @@ import { hasUsableManagedSiteChannelKey } from "~/services/managedSites/utils/ch
 import { userPreferences } from "~/services/preferences/userPreferences"
 import type {
   DoneHubChannel,
+  DoneHubChannelCommand,
   DoneHubUpdateChannelPayload,
 } from "~/types/doneHub"
 import { type DoneHubChannelRaw } from "~/types/doneHub"
 import type { DoneHubConfig } from "~/types/doneHubConfig"
 import { normalizeManagedUpstreamResourceScopeKey } from "~/types/managedUpstreamResource"
-import type { NewApiFamilyChannelCommand } from "~/types/newApiFamilyChannelEditor"
 import { normalizeList } from "~/utils/core/string"
 
+import {
+  buildDoneHubAdvancedPayload,
+  withDoneHubAdvancedEditor,
+} from "./doneHubEditor"
 import {
   doneHubChannelOperations,
   doneHubManagedResourceModels,
@@ -78,12 +83,12 @@ type DoneHubNativeResourceOperations = {
     options?: ResourceOperationOptions,
   ): Promise<string>
   create(
-    draft: NewApiFamilyChannelCommand,
+    draft: DoneHubChannelCommand,
     options?: ResourceOperationOptions,
   ): Promise<ManagedSiteMutationResult<DoneHubNativeDetail>>
   update(
     detail: DoneHubNativeDetail,
-    command: NewApiFamilyChannelCommand,
+    command: DoneHubChannelCommand,
     options?: ResourceOperationOptions,
   ): Promise<ManagedSiteMutationResult<DoneHubNativeDetail>>
   delete(
@@ -101,6 +106,11 @@ type DoneHubNativeResourceOperations = {
   loadEditorGroups(
     options?: ResourceOperationOptions,
   ): Promise<readonly string[]>
+  fetchEditorModels(
+    draft: DoneHubChannelCommand,
+    locator?: number,
+    options?: ResourceOperationOptions,
+  ): Promise<string[]>
 }
 
 const channels = doneHubChannelOperations
@@ -252,7 +262,7 @@ const loadChannelSecret = async (
 
 const createChannel = async (
   nativeConfig: DoneHubNativeConfig,
-  draft: NewApiFamilyChannelCommand,
+  draft: DoneHubChannelCommand,
   options?: ResourceOperationOptions,
 ): Promise<ManagedSiteMutationResult<DoneHubNativeDetail>> =>
   await attributeCreatedNativeResource({
@@ -264,7 +274,10 @@ const createChannel = async (
     create: async () =>
       await channels.create(
         nativeConfig.config,
-        buildChannelPayload(draft),
+        {
+          ...buildChannelPayload(draft),
+          ...buildDoneHubAdvancedPayload(draft),
+        },
         options,
       ),
     identity: (item) => item.id,
@@ -276,7 +289,7 @@ const sameList = (left: string[], right: string[]) =>
 
 const planDoneHubUpdate = (
   detail: DoneHubNativeDetail,
-  draft: NewApiFamilyChannelCommand,
+  draft: DoneHubChannelCommand,
 ): DoneHubUpdateChannelPayload & Record<string, unknown> => {
   const current = normalizeDoneHubChannel(detail)
   const models = normalizeList(draft.models)
@@ -286,7 +299,16 @@ const planDoneHubUpdate = (
   const partial: DoneHubUpdateChannelPayload & Record<string, unknown> = {
     id: current.id,
   }
-  let requiresFullUpdate = false
+  const advanced = buildDoneHubAdvancedPayload(draft, detail)
+  Object.assign(partial, advanced)
+  // GORM struct updates omit false/zero values. Clearing advanced fields must
+  // use the existing latest-detail full-write path as well.
+  let requiresFullUpdate = Object.values(advanced).some(
+    (value) =>
+      value === false ||
+      value === "" ||
+      (Array.isArray(value) && value.length === 0),
+  )
 
   const addSelectiveString = (
     field: "name" | "base_url" | "group",
@@ -366,13 +388,14 @@ const planDoneHubUpdate = (
     priority: draft.priority,
     weight: draft.weight,
     status: draft.status,
+    ...advanced,
   }
 }
 
 const updateChannel = async (
   nativeConfig: DoneHubNativeConfig,
   detail: DoneHubNativeDetail,
-  draft: NewApiFamilyChannelCommand,
+  draft: DoneHubChannelCommand,
   options?: ResourceOperationOptions,
 ): Promise<ManagedSiteMutationResult<DoneHubNativeDetail>> => {
   const payload = planDoneHubUpdate(detail, draft)
@@ -424,6 +447,34 @@ export async function openDoneHubNativeResourceOperations(): Promise<DoneHubNati
       return await doneHubManagedResourceModels.fetchDraftModels(
         nativeConfig.config,
         probe,
+        options,
+      )
+    },
+    fetchEditorModels: async (draft, locator, options) => {
+      const detail =
+        locator === undefined
+          ? undefined
+          : await getChannel(nativeConfig, locator, options)
+      const key = draft.key || detail?.key
+      if (!hasUsableManagedSiteChannelKey(key))
+        throw new ManagedResourceError({
+          code: MANAGED_RESOURCE_FAILURE_CODES.ValidationFailed,
+          fieldIssues: [
+            {
+              fieldId: DONE_HUB_MANAGED_RESOURCE_FIELD_IDS.Key,
+              code: "required",
+            },
+          ],
+        })
+      return await fetchDoneHubProviderModels(
+        toManagedSiteApiServiceRequest(nativeConfig.config, options),
+        {
+          ...detail,
+          ...buildDoneHubAdvancedPayload(draft, detail),
+          type: Number(draft.type),
+          base_url: draft.base_url,
+          key,
+        },
         options,
       )
     },
@@ -484,16 +535,30 @@ const doneHubNativeDefinition = {
     doneHubResourceFacts.toFacts(normalizeDoneHubChannel(detail), ref, {
       inventory: false,
     }),
-  createEditor: doneHubEditor.createEditor,
-  editEditor: (
+  createEditor: async (
+    operations: DoneHubNativeResourceOperations,
+    options?: ResourceOperationOptions,
+  ) =>
+    withDoneHubAdvancedEditor(
+      await doneHubEditor.createEditor(operations, options),
+      undefined,
+      (draft, options) =>
+        operations.fetchEditorModels(draft, undefined, options),
+    ),
+  editEditor: async (
     operations: DoneHubNativeResourceOperations,
     detail: DoneHubNativeDetail,
     options?: ResourceOperationOptions,
   ) =>
-    doneHubEditor.editEditor(
-      operations,
-      normalizeDoneHubChannel(detail),
-      options,
+    withDoneHubAdvancedEditor(
+      await doneHubEditor.editEditor(
+        operations,
+        normalizeDoneHubChannel(detail),
+        options,
+      ),
+      detail,
+      (draft, options) =>
+        operations.fetchEditorModels(draft, detail.id, options),
     ),
   sanitizeEditDetail: (detail: DoneHubNativeDetail) =>
     doneHubEditor.sanitizeEditDetail(
@@ -501,13 +566,13 @@ const doneHubNativeDefinition = {
     ) as DoneHubNativeDetail,
   create: (
     operations: DoneHubNativeResourceOperations,
-    draft: NewApiFamilyChannelCommand,
+    draft: DoneHubChannelCommand,
     options?: ResourceOperationOptions,
   ) => operations.create(draft, options),
   update: (
     operations: DoneHubNativeResourceOperations,
     detail: DoneHubNativeDetail,
-    draft: NewApiFamilyChannelCommand,
+    draft: DoneHubChannelCommand,
     options?: ResourceOperationOptions,
   ) => operations.update(detail, draft, options),
   delete: (

--- a/src/services/apiAdapters/managedResources/doneHubEditor.ts
+++ b/src/services/apiAdapters/managedResources/doneHubEditor.ts
@@ -1,0 +1,206 @@
+import {
+  DONE_HUB_MANAGED_RESOURCE_FIELD_IDS as fields,
+  isDoneHubAdvancedFieldApplicable,
+} from "~/constants/doneHub"
+import {
+  MANAGED_RESOURCE_FIELD_TYPES as types,
+  type EditableResourceProjection,
+  type ResourceFieldDescriptor,
+  type ResourceFieldIssue,
+  type ResourceOperationOptions,
+} from "~/services/apiAdapters/contracts/managedResourceNative"
+import type { NativeResourceEditorDefinition } from "~/services/apiAdapters/managedResources/factory"
+import type { DoneHubChannelCommand, DoneHubChannelRaw } from "~/types/doneHub"
+import type { NewApiFamilyChannelCommand } from "~/types/newApiFamilyChannelEditor"
+
+const advancedFields = [
+  [fields.CompatibleResponse, "compatible_response", types.Boolean],
+  [fields.ResponsesPath, "responses_path", types.Text],
+  [fields.ModelMapping, "model_mapping", types.Textarea],
+  [fields.Proxy, "proxy", types.Text],
+  [fields.TestModel, "test_model", types.Text],
+  [fields.ModelHeaders, "model_headers", types.Textarea],
+  [fields.CustomParameter, "custom_parameter", types.Textarea],
+  [fields.AllowExtraBody, "allow_extra_body", types.Boolean],
+  [fields.DisabledStream, "disabled_stream", types.MultiSelect],
+] as const
+
+const asObject = (value: unknown): Record<string, unknown> =>
+  value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {}
+
+const readText = (value: unknown) => (typeof value === "string" ? value : "")
+
+const isJsonObject = (value: string, stringsOnly: boolean) => {
+  if (!value.trim()) return true
+  try {
+    const parsed: unknown = JSON.parse(value)
+    return (
+      parsed !== null &&
+      typeof parsed === "object" &&
+      !Array.isArray(parsed) &&
+      (!stringsOnly ||
+        Object.entries(parsed).every(
+          ([key, item]) => key.trim() && typeof item === "string",
+        ))
+    )
+  } catch {
+    return false
+  }
+}
+
+const isProxyUrl = (value: string) => {
+  if (!value.trim()) return true
+  try {
+    const url = new URL(value.replaceAll("%s", "session"))
+    return (
+      ["http:", "https:", "socks5:", "socks5h:"].includes(url.protocol) &&
+      Boolean(url.hostname)
+    )
+  } catch {
+    return false
+  }
+}
+
+/** Adds DoneHub-native fields without changing the shared New API-family command. */
+export function withDoneHubAdvancedEditor(
+  base: NativeResourceEditorDefinition<NewApiFamilyChannelCommand>,
+  detail?: DoneHubChannelRaw,
+  loadModels?: (
+    command: DoneHubChannelCommand,
+    options?: ResourceOperationOptions,
+  ) => Promise<string[]>,
+): NativeResourceEditorDefinition<DoneHubChannelCommand> {
+  // Native fields and the custom-channel Responses route:
+  // https://github.com/deanxv/done-hub/blob/b99c6a9661fde5198504795354762f2ee2fd0189/model/channel.go
+  // https://github.com/deanxv/done-hub/blob/b99c6a9661fde5198504795354762f2ee2fd0189/web/src/views/Channel/type/Plugin.json
+  const initialValues: EditableResourceProjection = {
+    ...base.initialValues,
+    ...Object.fromEntries(
+      advancedFields.map(([id, native, type]) => {
+        const value =
+          native === "responses_path"
+            ? asObject(asObject(detail?.plugin).customize)["16"]
+            : detail?.[native]
+        return [
+          id,
+          type === types.Boolean
+            ? value === true
+            : type === types.MultiSelect
+              ? Array.isArray(value)
+                ? value.filter(
+                    (item): item is string => typeof item === "string",
+                  )
+                : []
+              : readText(value),
+        ]
+      }),
+    ),
+  }
+  const changed = (values: EditableResourceProjection, id: string) =>
+    values[id] !== undefined &&
+    JSON.stringify(values[id]) !== JSON.stringify(initialValues[id])
+  const applicable = (values: EditableResourceProjection, id: string) =>
+    isDoneHubAdvancedFieldApplicable(id, Number(values[fields.Type]))
+
+  const buildCommand = (
+    values: EditableResourceProjection,
+  ): DoneHubChannelCommand => ({
+    ...base.buildCommand(values),
+    advanced: Object.fromEntries(
+      advancedFields
+        .filter(([id]) => applicable(values, id) && changed(values, id))
+        .map(([id, native]) => {
+          const value = values[id]
+          if (id === fields.ModelMapping || id === fields.ModelHeaders) {
+            return [
+              native,
+              JSON.stringify(JSON.parse(readText(value).trim() || "{}")),
+            ]
+          }
+          return [native, typeof value === "string" ? value.trim() : value]
+        }),
+    ),
+  })
+
+  return {
+    ...base,
+    fields: [
+      ...base.fields.map((field) =>
+        field.fieldId === fields.Models &&
+        field.type === types.MultiSelect &&
+        field.optionLoader
+          ? {
+              ...field,
+              optionLoader: {
+                ...field.optionLoader,
+                dependsOn: [
+                  ...field.optionLoader.dependsOn,
+                  fields.Proxy,
+                  fields.ModelHeaders,
+                  fields.CustomParameter,
+                ],
+              },
+            }
+          : field,
+      ),
+      ...advancedFields.map(
+        ([fieldId, , type]): ResourceFieldDescriptor =>
+          type === types.MultiSelect
+            ? { fieldId, type, options: [] }
+            : { fieldId, type },
+      ),
+    ],
+    initialValues,
+    validate: (values) => {
+      const basic = base.validate(values)
+      const issues: ResourceFieldIssue[] = basic.valid ? [] : [...basic.issues]
+      for (const [id, , type] of advancedFields) {
+        // An unrelated edit must retain unknown/legacy settings without normalizing them.
+        if (!changed(values, id) || !applicable(values, id)) continue
+        const value = values[id]
+        const text = readText(value)
+        let valid =
+          type === types.Boolean
+            ? typeof value === "boolean"
+            : type === types.MultiSelect
+              ? Array.isArray(value) &&
+                value.every((item) => typeof item === "string" && item.trim())
+              : typeof value === "string"
+        if (id === fields.ModelMapping || id === fields.ModelHeaders)
+          valid &&= isJsonObject(text, true)
+        if (id === fields.CustomParameter) valid &&= isJsonObject(text, false)
+        if (id === fields.Proxy) valid &&= isProxyUrl(text)
+        if (id === fields.TestModel) valid &&= text.trim().length <= 50
+        if (!valid) issues.push({ fieldId: id, code: "invalid_value" })
+      }
+      return issues.length ? { valid: false, issues } : { valid: true }
+    },
+    buildCommand,
+    loadOptions: async (fieldId, values, options) => {
+      if (fieldId === fields.Models && loadModels)
+        return (await loadModels(buildCommand(values), options)).map(
+          (value) => ({ value }),
+        )
+      return await base.loadOptions!(fieldId, values, options)
+    },
+  }
+}
+
+/** Merges only the edited route with the latest provider plugin object. */
+export function buildDoneHubAdvancedPayload(
+  command: DoneHubChannelCommand,
+  detail?: DoneHubChannelRaw,
+): Record<string, unknown> {
+  const { responses_path, ...fields } = command.advanced ?? {}
+  if (responses_path === undefined) return fields
+  const plugin = asObject(detail?.plugin)
+  return {
+    ...fields,
+    plugin: {
+      ...plugin,
+      customize: { ...asObject(plugin.customize), "16": responses_path },
+    },
+  }
+}

--- a/src/services/apiAdapters/managedResources/doneHubEditor.ts
+++ b/src/services/apiAdapters/managedResources/doneHubEditor.ts
@@ -3,6 +3,8 @@ import {
   isDoneHubAdvancedFieldApplicable,
 } from "~/constants/doneHub"
 import {
+  MANAGED_RESOURCE_FAILURE_CODES,
+  ManagedResourceError,
   MANAGED_RESOURCE_FIELD_TYPES as types,
   type EditableResourceProjection,
   type ResourceFieldDescriptor,
@@ -124,6 +126,32 @@ export function withDoneHubAdvancedEditor(
     ),
   })
 
+  const validateAdvanced = (
+    values: EditableResourceProjection,
+  ): ResourceFieldIssue[] => {
+    const issues: ResourceFieldIssue[] = []
+    for (const [id, , type] of advancedFields) {
+      // An unrelated edit must retain unknown/legacy settings without normalizing them.
+      if (!changed(values, id) || !applicable(values, id)) continue
+      const value = values[id]
+      const text = readText(value)
+      let valid =
+        type === types.Boolean
+          ? typeof value === "boolean"
+          : type === types.MultiSelect
+            ? Array.isArray(value) &&
+              value.every((item) => typeof item === "string" && item.trim())
+            : typeof value === "string"
+      if (id === fields.ModelMapping || id === fields.ModelHeaders)
+        valid &&= isJsonObject(text, true)
+      if (id === fields.CustomParameter) valid &&= isJsonObject(text, false)
+      if (id === fields.Proxy) valid &&= isProxyUrl(text)
+      if (id === fields.TestModel) valid &&= text.trim().length <= 50
+      if (!valid) issues.push({ fieldId: id, code: "invalid_value" })
+    }
+    return issues
+  }
+
   return {
     ...base,
     fields: [
@@ -156,33 +184,22 @@ export function withDoneHubAdvancedEditor(
     validate: (values) => {
       const basic = base.validate(values)
       const issues: ResourceFieldIssue[] = basic.valid ? [] : [...basic.issues]
-      for (const [id, , type] of advancedFields) {
-        // An unrelated edit must retain unknown/legacy settings without normalizing them.
-        if (!changed(values, id) || !applicable(values, id)) continue
-        const value = values[id]
-        const text = readText(value)
-        let valid =
-          type === types.Boolean
-            ? typeof value === "boolean"
-            : type === types.MultiSelect
-              ? Array.isArray(value) &&
-                value.every((item) => typeof item === "string" && item.trim())
-              : typeof value === "string"
-        if (id === fields.ModelMapping || id === fields.ModelHeaders)
-          valid &&= isJsonObject(text, true)
-        if (id === fields.CustomParameter) valid &&= isJsonObject(text, false)
-        if (id === fields.Proxy) valid &&= isProxyUrl(text)
-        if (id === fields.TestModel) valid &&= text.trim().length <= 50
-        if (!valid) issues.push({ fieldId: id, code: "invalid_value" })
-      }
+      issues.push(...validateAdvanced(values))
       return issues.length ? { valid: false, issues } : { valid: true }
     },
     buildCommand,
     loadOptions: async (fieldId, values, options) => {
-      if (fieldId === fields.Models && loadModels)
+      if (fieldId === fields.Models && loadModels) {
+        const issues = validateAdvanced(values)
+        if (issues.length)
+          throw new ManagedResourceError({
+            code: MANAGED_RESOURCE_FAILURE_CODES.ValidationFailed,
+            fieldIssues: issues,
+          })
         return (await loadModels(buildCommand(values), options)).map(
           (value) => ({ value }),
         )
+      }
       return await base.loadOptions!(fieldId, values, options)
     },
   }

--- a/src/services/apiService/doneHub/index.ts
+++ b/src/services/apiService/doneHub/index.ts
@@ -337,17 +337,19 @@ export async function fetchChannelModels(
   return await fetchDoneHubProviderModels(request, channel, options)
 }
 
-const fetchDoneHubProviderModels = async (
+/** Probes native channel settings, including unsaved proxy and fixed headers. */
+export const fetchDoneHubProviderModels = async (
   request: ApiServiceRequest,
   channel: DoneHubChannelRaw,
   options?: Pick<RequestInit, "signal">,
 ): Promise<string[]> => {
   const requestData = {
     ...channel,
-    // Keep request payload minimal and aligned with DoneHub's admin UI call.
+    // Catalog probing does not need model selection or mappings. Retain
+    // connection settings so drafts work before saving the channel.
     models: "",
     model_mapping: "",
-    model_headers: "",
+    model_headers: channel.model_headers ?? "",
   }
 
   const models = await doneHubRequests.data<unknown>(request, {

--- a/src/types/doneHub.ts
+++ b/src/types/doneHub.ts
@@ -1,3 +1,20 @@
+import type { NewApiFamilyChannelCommand } from "~/types/newApiFamilyChannelEditor"
+
+/** Only edited advanced fields are carried to the latest-detail update planner. */
+export type DoneHubChannelCommand = NewApiFamilyChannelCommand & {
+  advanced?: Partial<{
+    compatible_response: boolean
+    responses_path: string
+    model_mapping: string
+    proxy: string
+    test_model: string
+    model_headers: string
+    custom_parameter: string
+    allow_extra_body: boolean
+    disabled_stream: string[]
+  }>
+}
+
 /** Fields consumed from DoneHub's native channel inventory. */
 type DoneHubChannelFields = {
   id: number

--- a/tests/features/ManagedSiteChannels/components/ManagedResourceCreateDialog.test.tsx
+++ b/tests/features/ManagedSiteChannels/components/ManagedResourceCreateDialog.test.tsx
@@ -86,6 +86,38 @@ const createEditor = (
 })
 
 describe("ManagedResourceCreateDialog", () => {
+  it("explains invalid edited fields immediately while saving is disabled", async () => {
+    const user = userEvent.setup()
+    const submit = vi.fn()
+    render(
+      <ManagedResourceCreateDialog
+        isOpen
+        siteType={SITE_TYPES.DONE_HUB}
+        kind={MANAGED_RESOURCE_KINDS.Channel}
+        editor={createEditor(submit, {
+          validate: (values) =>
+            values.name === "Imported channel"
+              ? { valid: true }
+              : {
+                  valid: false,
+                  issues: [{ fieldId: "name", code: "invalid_value" }],
+                },
+        })}
+        onClose={vi.fn()}
+        onCloseComplete={vi.fn()}
+        onSuccess={vi.fn()}
+      />,
+    )
+    await user.click(screen.getByRole("button", { name: "Edit native name" }))
+    expect(
+      screen.getByTestId("native-resource-editor-issues"),
+    ).toHaveTextContent("name:invalid_value")
+    expect(
+      screen.getByTestId(CHANNEL_DIALOG_TEST_IDS.submitButton),
+    ).toBeDisabled()
+    expect(submit).not.toHaveBeenCalled()
+  })
+
   beforeEach(() => {
     getManagedResourceFieldPolicyMock.mockReset()
     getManagedResourceFieldPolicyMock.mockReturnValue({

--- a/tests/features/ManagedSiteChannels/presentation/DoneHubAdvancedEditor.test.tsx
+++ b/tests/features/ManagedSiteChannels/presentation/DoneHubAdvancedEditor.test.tsx
@@ -1,0 +1,256 @@
+import { screen, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { useState } from "react"
+import { describe, expect, it } from "vitest"
+
+import {
+  DoneHubChannelType,
+  DONE_HUB_MANAGED_RESOURCE_FIELD_IDS as fields,
+} from "~/constants/doneHub"
+import { SITE_TYPES } from "~/constants/siteType"
+import { ManagedResourceEditorBody } from "~/features/ManagedSiteChannels/presentation/ManagedResourceEditorBody"
+import { getManagedResourceFieldPolicy } from "~/features/ManagedSiteChannels/presentation/managedResourceFieldPolicy"
+import enChannelDialog from "~/locales/en/channelDialog.json"
+import enCommon from "~/locales/en/common.json"
+import enManaged from "~/locales/en/managedSiteChannels.json"
+import enUi from "~/locales/en/ui.json"
+import { MANAGED_RESOURCE_KINDS } from "~/services/accountSiteDefinitions/contracts"
+import type { EditableResourceProjection } from "~/services/apiAdapters/contracts/managedResourceNative"
+import { withDoneHubAdvancedEditor } from "~/services/apiAdapters/managedResources/doneHubEditor"
+import { createResourceTestI18n } from "~~/tests/test-utils/i18n"
+import { render } from "~~/tests/test-utils/render"
+
+const i18n = await createResourceTestI18n({
+  en: {
+    channelDialog: enChannelDialog,
+    common: enCommon,
+    managedSiteChannels: enManaged,
+    ui: enUi,
+  },
+})
+const policy = getManagedResourceFieldPolicy(
+  SITE_TYPES.DONE_HUB,
+  MANAGED_RESOURCE_KINDS.Channel,
+  "edit",
+)!
+const editor = withDoneHubAdvancedEditor({
+  fields: [
+    { fieldId: fields.Name, type: "text" },
+    { fieldId: fields.BaseUrl, type: "text" },
+    {
+      fieldId: fields.Key,
+      type: "secret",
+      canReplace: true,
+      canLoadSecret: false,
+      allowClear: false,
+      secretState: "unavailable",
+    },
+    {
+      fieldId: fields.Groups,
+      type: "multi-select",
+      options: [{ value: "default" }],
+    },
+    {
+      fieldId: fields.Type,
+      type: "select",
+      options: [DoneHubChannelType.Custom, DoneHubChannelType.Midjourney].map(
+        (value) => ({ value: String(value) }),
+      ),
+    },
+    { fieldId: fields.Status, type: "select", options: [{ value: "1" }] },
+    {
+      fieldId: fields.Models,
+      type: "multi-select",
+      options: [{ value: "model-a" }],
+    },
+    { fieldId: fields.Priority, type: "number" },
+    { fieldId: fields.Weight, type: "number" },
+  ],
+  initialValues: {
+    [fields.Type]: String(DoneHubChannelType.Custom),
+    [fields.Status]: "1",
+    [fields.Models]: ["model-a"],
+    [fields.Priority]: 0,
+    [fields.Weight]: 1,
+  },
+  validate: () => ({ valid: true }),
+  buildCommand: () => ({
+    name: "Test",
+    type: DoneHubChannelType.Custom,
+    key: "",
+    base_url: "",
+    models: [],
+    groups: [],
+    priority: 0,
+    weight: 1,
+    status: 1,
+  }),
+})
+
+/** Exercises provider validation and the actual shared editor with controlled drafts. */
+function Editor({
+  initial = {},
+  disabled = false,
+}: {
+  initial?: EditableResourceProjection
+  disabled?: boolean
+}) {
+  const [values, setValues] = useState({ ...editor.initialValues, ...initial })
+  const validation = editor.validate(values)
+  return (
+    <ManagedResourceEditorBody
+      t={i18n.t}
+      mode="edit"
+      descriptors={editor.fields}
+      policy={policy}
+      values={values}
+      disabled={disabled}
+      fieldIssues={validation.valid ? [] : validation.issues}
+      onValueChange={(fieldId, value) =>
+        setValues((current) => ({ ...current, [fieldId]: value }))
+      }
+    />
+  )
+}
+const renderEditor = (
+  initial?: EditableResourceProjection,
+  disabled?: boolean,
+) =>
+  render(<Editor initial={initial} disabled={disabled} />, {
+    withUserPreferencesProvider: false,
+    withThemeProvider: false,
+  })
+
+describe("DoneHub advanced editor interactions", () => {
+  it("repairs mappings, adds their names once, selects and retains a manual test model, and preserves collapsed drafts", async () => {
+    const user = userEvent.setup()
+    renderEditor({ [fields.ModelMapping]: '{"alias":"upstream"}' })
+    const mapping = screen.getByRole("group", {
+      name: "Model mapping",
+    })
+    const addModels = within(mapping).getByRole("button", {
+      name: "Add mapped names to model list",
+    })
+    await user.click(addModels)
+    expect(addModels).toBeDisabled()
+    await user.click(within(mapping).getByRole("button", { name: "Edit JSON" }))
+    const raw = within(mapping).getByRole("textbox", {
+      name: "Model mapping",
+    })
+    await user.clear(raw)
+    await user.type(raw, "broken")
+    expect(within(mapping).getByRole("alert")).toHaveTextContent(
+      enManaged.editor.doneHub.modelMapping.invalid,
+    )
+    expect(addModels).toBeDisabled()
+    await user.clear(raw)
+    await user.paste('{"alias":"upstream","second":"model-b"}')
+    await user.click(within(mapping).getByRole("button", { name: "Edit rows" }))
+    await user.click(addModels)
+    expect(addModels).toBeDisabled()
+    const testModel = screen.getByRole("combobox", {
+      name: "Test model",
+    })
+    await user.click(testModel)
+    await user.keyboard("{ArrowDown}")
+    await user.click(await screen.findByRole("option", { name: "second" }))
+    expect(testModel).toHaveValue("second")
+    await user.clear(testModel)
+    await user.type(testModel, "manual-model")
+    await user.tab()
+    expect(testModel).toHaveValue("manual-model")
+    const streaming = screen.getByRole("combobox", {
+      name: "Models excluded from streaming",
+    })
+    await user.type(streaming, "custom-stream-model")
+    await user.keyboard("{Enter}")
+    expect(
+      screen.getByText("custom-stream-model", { exact: true }),
+    ).toBeVisible()
+    const models = screen.getByRole("button", { name: "Models" })
+    await user.click(models)
+    expect(testModel).not.toBeVisible()
+    await user.click(models)
+    expect(testModel).toHaveValue("manual-model")
+    await user.click(within(mapping).getByRole("button", { name: "Edit JSON" }))
+    expect(
+      within(mapping).getByRole("textbox", {
+        name: "Model mapping",
+      }),
+    ).toHaveValue('{"alias":"upstream","second":"model-b"}')
+    await user.clear(testModel)
+    await user.type(testModel, "x".repeat(51))
+    await user.tab()
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      enManaged.editor.doneHub.testModel.invalid,
+    )
+    expect(models).toHaveAttribute("aria-expanded", "true")
+  })
+
+  it("validates requests, keeps errors expanded, and retains request drafts after closing sections", async () => {
+    const user = userEvent.setup()
+    renderEditor()
+    const requests = screen.getByRole("button", {
+      name: "Network & requests",
+    })
+    expect(requests).toHaveAttribute("aria-expanded", "false")
+    await user.click(requests)
+    const proxy = screen.getByRole("textbox", {
+      name: "Proxy URL",
+    })
+    await user.type(proxy, "bad proxy")
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      enManaged.editor.doneHub.proxy.invalid,
+    )
+    await user.clear(proxy)
+    await user.type(proxy, "socks5://proxy.example:1080")
+    const headers = screen.getByRole("group", {
+      name: "Custom request headers",
+    })
+    await user.click(within(headers).getByRole("button", { name: "Edit JSON" }))
+    const rawHeaders = within(headers).getByRole("textbox", {
+      name: "Custom request headers",
+    })
+    await user.type(rawHeaders, "invalid")
+    expect(within(headers).getByRole("alert")).toHaveTextContent(
+      enManaged.editor.doneHub.modelHeaders.invalid,
+    )
+    await user.clear(rawHeaders)
+    await user.paste('{"X-Project":"test"}')
+    const parameters = screen.getByRole("textbox", {
+      name: "Extra request parameters",
+    })
+    await user.type(parameters, "invalid")
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      enManaged.editor.doneHub.customParameter.invalid,
+    )
+    await user.click(requests)
+    expect(parameters).toBeVisible()
+    await user.clear(parameters)
+    await user.paste('{"temperature":0.5}')
+    await user.click(screen.getAllByRole("button", { name: "Format JSON" })[1])
+    expect(parameters).toHaveValue('{\n  "temperature": 0.5\n}')
+    await user.click(
+      screen.getByRole("switch", { name: "Forward extra body fields" }),
+    )
+    await user.click(requests)
+    await user.click(requests)
+    expect(rawHeaders).toHaveValue('{"X-Project":"test"}')
+    expect(
+      screen.getByRole("switch", { name: "Forward extra body fields" }),
+    ).toBeChecked()
+    await user.click(screen.getByRole("button", { name: "API compatibility" }))
+    await user.click(
+      screen.getByRole("switch", { name: "Responses API compatibility" }),
+    )
+    await user.type(
+      screen.getByRole("textbox", { name: "Responses request path" }),
+      "/custom/responses",
+    )
+    expect(
+      screen.getByRole("switch", { name: "Responses API compatibility" }),
+    ).toBeChecked()
+    await user.click(screen.getByRole("button", { name: "Routing" }))
+    expect(screen.getByRole("spinbutton", { name: "Priority" })).toBeVisible()
+  })
+})

--- a/tests/features/ManagedSiteChannels/presentation/DoneHubAdvancedEditor.test.tsx
+++ b/tests/features/ManagedSiteChannels/presentation/DoneHubAdvancedEditor.test.tsx
@@ -122,7 +122,7 @@ const renderEditor = (
   })
 
 describe("DoneHub advanced editor interactions", () => {
-  it("repairs mappings, adds their names once, selects and retains a manual test model, and preserves collapsed drafts", async () => {
+  it("repairs mappings, adds their names once, and offers those names as test models", async () => {
     const user = userEvent.setup()
     renderEditor({ [fields.ModelMapping]: '{"alias":"upstream"}' })
     const mapping = screen.getByRole("group", {
@@ -155,6 +155,21 @@ describe("DoneHub advanced editor interactions", () => {
     await user.keyboard("{ArrowDown}")
     await user.click(await screen.findByRole("option", { name: "second" }))
     expect(testModel).toHaveValue("second")
+    const models = screen.getByRole("button", { name: "Models" })
+    await user.click(models)
+    await user.click(models)
+    await user.click(within(mapping).getByRole("button", { name: "Edit JSON" }))
+    expect(
+      within(mapping).getByRole("textbox", {
+        name: "Model mapping",
+      }),
+    ).toHaveValue('{"alias":"upstream","second":"model-b"}')
+  })
+
+  it("retains custom model drafts after collapsing and validates long test model names", async () => {
+    const user = userEvent.setup()
+    renderEditor()
+    const testModel = screen.getByRole("combobox", { name: "Test model" })
     await user.clear(testModel)
     await user.type(testModel, "manual-model")
     await user.tab()
@@ -172,14 +187,8 @@ describe("DoneHub advanced editor interactions", () => {
     expect(testModel).not.toBeVisible()
     await user.click(models)
     expect(testModel).toHaveValue("manual-model")
-    await user.click(within(mapping).getByRole("button", { name: "Edit JSON" }))
-    expect(
-      within(mapping).getByRole("textbox", {
-        name: "Model mapping",
-      }),
-    ).toHaveValue('{"alias":"upstream","second":"model-b"}')
     await user.clear(testModel)
-    await user.type(testModel, "x".repeat(51))
+    await user.paste("x".repeat(51))
     await user.tab()
     expect(screen.getByRole("alert")).toHaveTextContent(
       enManaged.editor.doneHub.testModel.invalid,

--- a/tests/features/ManagedSiteChannels/presentation/managedResourceFieldPolicy.test.ts
+++ b/tests/features/ManagedSiteChannels/presentation/managedResourceFieldPolicy.test.ts
@@ -220,6 +220,41 @@ describe("managed resource field policy", () => {
     )
   })
 
+  it("summarizes visible DoneHub settings without exposing their values", () => {
+    const policy = getManagedResourceFieldPolicy(
+      SITE_TYPES.DONE_HUB,
+      MANAGED_RESOURCE_KINDS.Channel,
+      "edit",
+    )!
+    const fields = DONE_HUB_MANAGED_RESOURCE_FIELD_IDS
+    const requests = policy.sections!.requests!.resolveSummary!
+    expect(requests(resolveKey, {})).toBe("ui:resourceEditor.optional")
+    expect(
+      requests(resolveKey, {
+        [fields.Proxy]: "https://private-proxy.example",
+        [fields.ModelHeaders]: '{"Authorization":"private-token"}',
+        [fields.AllowExtraBody]: false,
+        [fields.CustomParameter]: "{}",
+      }),
+    ).toBe(
+      "managedSiteChannels:editor.doneHub.proxy.label · managedSiteChannels:editor.doneHub.modelHeaders.label",
+    )
+    const compatibility = policy.sections!.compatibility!.resolveSummary!
+    expect(
+      compatibility(resolveKey, {
+        [fields.Type]: String(DoneHubChannelType.OpenAI),
+        [fields.ResponsesPath]: "/preserved-hidden-path",
+        [fields.CompatibleResponse]: false,
+      }),
+    ).toBe("ui:resourceEditor.optional")
+    expect(
+      compatibility(resolveKey, {
+        [fields.Type]: String(DoneHubChannelType.Custom),
+        [fields.ResponsesPath]: "/preserved-hidden-path",
+      }),
+    ).toBe("managedSiteChannels:editor.doneHub.responsesPath.label")
+  })
+
   it("resolves DoneHub-owned type labels without canonical id collisions", () => {
     const policy = getManagedResourceFieldPolicy(
       SITE_TYPES.DONE_HUB,

--- a/tests/features/ResourceEditor/ResourceJsonField.test.tsx
+++ b/tests/features/ResourceEditor/ResourceJsonField.test.tsx
@@ -1,0 +1,113 @@
+import { screen, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import type { TFunction } from "i18next"
+import { useState } from "react"
+import { describe, expect, it, vi } from "vitest"
+
+import { ResourceJsonField } from "~/features/ResourceEditor/ResourceJsonField"
+import enManagedSiteChannels from "~/locales/en/managedSiteChannels.json"
+import { createResourceTestI18n } from "~~/tests/test-utils/i18n"
+import { render } from "~~/tests/test-utils/render"
+
+/** Supplies a controlled field so assertions follow actual user edits. */
+function Harness({
+  t,
+  initial,
+  onChange,
+}: {
+  t: TFunction
+  initial: string
+  onChange: (value: string) => void
+}) {
+  const [value, setValue] = useState(initial)
+  return (
+    <ResourceJsonField
+      t={t}
+      label="Model mapping"
+      value={value}
+      stringMap
+      onChange={(next) => {
+        setValue(next)
+        onChange(next)
+      }}
+    />
+  )
+}
+
+describe("structured JSON resource fields", () => {
+  it("keeps duplicate rows recoverable instead of overwriting another mapping", async () => {
+    const user = userEvent.setup()
+    const i18n = await createResourceTestI18n({
+      en: { managedSiteChannels: enManagedSiteChannels },
+    })
+    const onChange = vi.fn()
+    render(
+      <Harness t={i18n.t} initial='{"alias":"first"}' onChange={onChange} />,
+      { withUserPreferencesProvider: false, withThemeProvider: false },
+    )
+    const group = screen.getByRole("group", { name: "Model mapping" })
+    await user.click(within(group).getByRole("button", { name: "Add row" }))
+    await user.type(
+      screen.getByRole("textbox", { name: "Model mapping: row 2 key" }),
+      "alias",
+    )
+    await user.type(
+      screen.getByRole("textbox", { name: "Model mapping: row 2 value" }),
+      "second",
+    )
+    expect(
+      screen.getByRole("textbox", { name: "Model mapping: row 1 value" }),
+    ).toHaveValue("first")
+    expect(
+      screen.getByRole("textbox", { name: "Model mapping: row 2 value" }),
+    ).toHaveValue("second")
+    await user.clear(
+      screen.getByRole("textbox", { name: "Model mapping: row 2 key" }),
+    )
+    await user.type(
+      screen.getByRole("textbox", { name: "Model mapping: row 2 key" }),
+      "other",
+    )
+    expect(JSON.parse(onChange.mock.lastCall![0])).toEqual({
+      alias: "first",
+      other: "second",
+    })
+    await user.click(
+      screen.getByRole("button", { name: "Model mapping: remove row 1" }),
+    )
+    await user.click(
+      screen.getByRole("button", { name: "Model mapping: remove row 1" }),
+    )
+    expect(JSON.parse(onChange.mock.lastCall![0])).toEqual({})
+  })
+
+  it("repairs malformed saved JSON and switches between paste and row editing without losing values", async () => {
+    const user = userEvent.setup()
+    const i18n = await createResourceTestI18n({
+      en: { managedSiteChannels: enManagedSiteChannels },
+    })
+    const onChange = vi.fn()
+    render(<Harness t={i18n.t} initial="{broken" onChange={onChange} />, {
+      withUserPreferencesProvider: false,
+      withThemeProvider: false,
+    })
+    expect(screen.getByRole("textbox", { name: "Model mapping" })).toHaveValue(
+      "{broken",
+    )
+    expect(screen.getByRole("button", { name: "Format JSON" })).toBeDisabled()
+    expect(onChange).not.toHaveBeenCalled()
+    const input = screen.getByRole("textbox", { name: "Model mapping" })
+    await user.clear(input)
+    await user.paste('{"alias":"corrected"}')
+    // The repaired JSON can be viewed as rows, then edited as JSON again.
+    await user.click(screen.getByRole("button", { name: "Edit rows" }))
+    expect(
+      screen.getByRole("textbox", { name: "Model mapping: row 1 value" }),
+    ).toHaveValue("corrected")
+    await user.click(screen.getByRole("button", { name: "Edit JSON" }))
+    await user.click(screen.getByRole("button", { name: "Format JSON" }))
+    expect(screen.getByRole("textbox", { name: "Model mapping" })).toHaveValue(
+      '{\n  "alias": "corrected"\n}',
+    )
+  })
+})

--- a/tests/services/apiAdapters/managedResources/doneHub.test.ts
+++ b/tests/services/apiAdapters/managedResources/doneHub.test.ts
@@ -142,6 +142,74 @@ describe("DoneHub native managed resource", () => {
     )
   })
 
+  it.each([
+    "doneHub.modelHeaders",
+    "doneHub.modelMapping",
+    "doneHub.customParameter",
+  ])(
+    "reports invalid %s as field validation during discovery and recovers after repair",
+    async (fieldId) => {
+      mocks.fetchEditorModels.mockResolvedValue(["recovered-model"])
+      const workspace = await doneHubManagedResourceRegistration.open()
+      const editor = await workspace.openEditEditor(
+        (await workspace.list()).items[0].ref,
+      )
+      await expect(
+        editor.loadOptions!("doneHub.models", {
+          ...editor.initialValues,
+          [fieldId]: "{broken",
+        }),
+      ).rejects.toMatchObject({
+        failure: {
+          code: MANAGED_RESOURCE_FAILURE_CODES.ValidationFailed,
+          fieldIssues: [{ fieldId, code: "invalid_value" }],
+        },
+      })
+      expect(mocks.fetchEditorModels).not.toHaveBeenCalled()
+      expect(
+        await editor.loadOptions!("doneHub.models", {
+          ...editor.initialValues,
+          [fieldId]: "{}",
+        }),
+      ).toEqual([{ value: "recovered-model" }])
+    },
+  )
+
+  it("discovers create-draft models with a supplied key and rejects missing credentials", async () => {
+    mocks.fetchEditorModels.mockResolvedValue(["draft-model"])
+    const workspace = await doneHubManagedResourceRegistration.open()
+    const editor = await workspace.openCreateEditor()
+    const values = {
+      ...editor.initialValues,
+      "doneHub.name": "Draft",
+      "doneHub.baseUrl": "http://upstream.example",
+      "doneHub.key": { kind: "replace" as const, value: "draft-key" },
+    }
+    expect(await editor.loadOptions!("doneHub.models", values)).toEqual([
+      { value: "draft-model" },
+    ])
+    expect(mocks.fetchEditorModels).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ key: "draft-key" }),
+      undefined,
+    )
+    mocks.fetchEditorModels.mockClear()
+    await expect(
+      editor.loadOptions!("doneHub.models", {
+        ...values,
+        "doneHub.key": { kind: "unchanged" },
+      }),
+    ).rejects.toMatchObject({
+      failure: { code: MANAGED_RESOURCE_FAILURE_CODES.ValidationFailed },
+    })
+    expect(mocks.fetchEditorModels).not.toHaveBeenCalled()
+    await expect(
+      editor.loadOptions!("unsupported", values),
+    ).rejects.toMatchObject({
+      failure: { code: MANAGED_RESOURCE_FAILURE_CODES.ValidationFailed },
+    })
+  })
+
   it("uses edited proxy and headers for model discovery without saving or exposing the credential", async () => {
     mocks.fetchEditorModels.mockResolvedValue(["discovered-model"])
     const workspace = await doneHubManagedResourceRegistration.open()
@@ -294,6 +362,7 @@ describe("DoneHub native managed resource", () => {
     ["doneHub.customParameter", "[1,2]"],
     ["doneHub.customParameter", "{broken"],
     ["doneHub.proxy", "ftp://proxy.example"],
+    ["doneHub.proxy", "not a URL"],
   ])(
     "rejects invalid advanced input in %s before any mutation",
     async (fieldId, value) => {

--- a/tests/services/apiAdapters/managedResources/doneHub.test.ts
+++ b/tests/services/apiAdapters/managedResources/doneHub.test.ts
@@ -33,6 +33,7 @@ const mocks = vi.hoisted(() => ({
   fetchModels: vi.fn(),
   fetchDraftModels: vi.fn(),
   fetchSiteUserGroups: vi.fn(),
+  fetchEditorModels: vi.fn(),
 }))
 
 vi.mock("~/services/preferences/userPreferences", () => ({
@@ -62,6 +63,7 @@ vi.mock("~/services/apiAdapters/managedSites/doneHub", () => ({
 vi.mock("~/services/apiService/doneHub", async (original) => ({
   ...(await original<typeof import("~/services/apiService/doneHub")>()),
   fetchChannelRaw: mocks.fetchChannelRaw,
+  fetchDoneHubProviderModels: mocks.fetchEditorModels,
 }))
 
 const config = {
@@ -106,6 +108,209 @@ const expectFailureCode = async (promise: Promise<unknown>, code: string) => {
 }
 
 describe("DoneHub native managed resource", () => {
+  it("creates native advanced settings from an editor draft", async () => {
+    mocks.list
+      .mockResolvedValueOnce({ items: [], total: 0 })
+      .mockResolvedValue({ items: [channel], total: 1 })
+    const workspace = await doneHubManagedResourceRegistration.open()
+    const editor = await workspace.openCreateEditor()
+    const values = {
+      ...editor.initialValues,
+      "doneHub.name": "Advanced created",
+      "doneHub.type": String(DoneHubChannelType.Custom),
+      "doneHub.baseUrl": "https://upstream.example",
+      "doneHub.key": { kind: "replace" as const, value: "create-key" },
+      "doneHub.models": ["model-a"],
+      "doneHub.compatibleResponse": true,
+      "doneHub.responsesPath": "/native/responses",
+      "doneHub.proxy": "socks5://localhost:1080",
+      "doneHub.modelHeaders": '{"X-Project":"fixture"}',
+      "doneHub.customParameter": '{"overwrite":true,"temperature":0.5}',
+    }
+    expect(editor.validate(values)).toEqual({ valid: true })
+    await editor.submit(values)
+    expect(mocks.create).toHaveBeenCalledWith(
+      config,
+      expect.objectContaining({
+        compatible_response: true,
+        proxy: "socks5://localhost:1080",
+        model_headers: '{"X-Project":"fixture"}',
+        custom_parameter: '{"overwrite":true,"temperature":0.5}',
+        plugin: { customize: { "16": "/native/responses" } },
+      }),
+      undefined,
+    )
+  })
+
+  it("uses edited proxy and headers for model discovery without saving or exposing the credential", async () => {
+    mocks.fetchEditorModels.mockResolvedValue(["discovered-model"])
+    const workspace = await doneHubManagedResourceRegistration.open()
+    const editor = await workspace.openEditEditor(
+      (await workspace.list()).items[0].ref,
+    )
+    const result = await editor.loadOptions!("doneHub.models", {
+      ...editor.initialValues,
+      "doneHub.proxy": "socks5://new-proxy:1080",
+      "doneHub.modelHeaders": '{"X-Project":"changed"}',
+    })
+    expect(result).toEqual([{ value: "discovered-model" }])
+    expect(mocks.fetchEditorModels).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        proxy: "socks5://new-proxy:1080",
+        model_headers: '{"X-Project":"changed"}',
+        key: "credential-placeholder",
+      }),
+      undefined,
+    )
+    expect(mocks.update).not.toHaveBeenCalled()
+    expect(JSON.stringify(editor.initialValues)).not.toContain(
+      "credential-placeholder",
+    )
+  })
+
+  it("does not submit hidden Responses or model settings after switching to an incompatible channel type", async () => {
+    const saved = {
+      ...channel,
+      type: DoneHubChannelType.Custom,
+      plugin: { customize: { "16": "/keep/responses" } },
+      test_model: "old-chat",
+    }
+    mocks.fetchChannelRaw.mockResolvedValue({ ...saved, key: "saved-key" })
+    const workspace = await doneHubManagedResourceRegistration.open()
+    const editor = await workspace.openEditEditor(
+      (await workspace.list()).items[0].ref,
+    )
+    await editor.submit({
+      ...editor.initialValues,
+      "doneHub.type": String(DoneHubChannelType.Midjourney),
+      "doneHub.baseUrl": "https://midjourney.example",
+      "doneHub.responsesPath": "/changed/responses",
+      "doneHub.modelMapping": "{unfinished",
+      "doneHub.testModel": "changed-chat",
+    })
+    const payload = mocks.update.mock.calls[0][1]
+    expect(payload).not.toHaveProperty("plugin")
+    expect(payload).not.toHaveProperty("test_model")
+    expect(payload).not.toHaveProperty("model_mapping")
+  })
+
+  it("round-trips advanced values and preserves fresh fields when switches and lists are cleared", async () => {
+    const saved = {
+      ...channel,
+      key: "saved-key",
+      compatible_response: true,
+      allow_extra_body: true,
+      test_model: "model-a",
+      model_mapping: '{"alias":"model-a"}',
+      model_headers: '{"X-Project":"example"}',
+      custom_parameter: '{"temperature":0.7}',
+      disabled_stream: ["model-a"],
+    }
+    mocks.fetchChannelRaw.mockResolvedValueOnce(saved).mockResolvedValue({
+      ...saved,
+      key: "fresh-key",
+      proxy: "socks5://fresh.example:1080",
+      future_field: { fresh: true },
+    })
+    const workspace = await doneHubManagedResourceRegistration.open()
+    const ref = (await workspace.list()).items[0].ref
+    const editor = await workspace.openEditEditor(ref)
+    expect(editor.initialValues["doneHub.compatibleResponse"]).toBe(true)
+    expect(editor.initialValues["doneHub.testModel"]).toBe("model-a")
+    expect(editor.initialValues["doneHub.disabledStream"]).toEqual(["model-a"])
+    const values = {
+      ...editor.initialValues,
+      "doneHub.compatibleResponse": false,
+      "doneHub.allowExtraBody": false,
+      "doneHub.testModel": "",
+      "doneHub.modelMapping": "{}",
+      "doneHub.modelHeaders": "{}",
+      "doneHub.customParameter": "",
+      "doneHub.disabledStream": [],
+    }
+    expect(editor.validate(values)).toEqual({ valid: true })
+    await editor.submit(values)
+    expect(mocks.update).toHaveBeenCalledWith(
+      config,
+      expect.objectContaining({
+        compatible_response: false,
+        allow_extra_body: false,
+        test_model: "",
+        model_mapping: "{}",
+        model_headers: "{}",
+        custom_parameter: "",
+        disabled_stream: [],
+        proxy: "socks5://fresh.example:1080",
+        key: "fresh-key",
+        future_field: { fresh: true },
+      }),
+      undefined,
+    )
+  })
+
+  it("merges an edited Responses path with fresh plugin settings", async () => {
+    const saved = {
+      ...channel,
+      type: DoneHubChannelType.Custom,
+      key: "saved-key",
+      base_url: "https://upstream.example",
+      plugin: {
+        customize: { "16": "/old/responses", "1": "/old/chat" },
+        extra: { enabled: true },
+      },
+    }
+    mocks.fetchChannelRaw.mockResolvedValueOnce(saved).mockResolvedValue({
+      ...saved,
+      plugin: {
+        ...saved.plugin,
+        customize: { "16": "/old/responses", "1": "/fresh/chat" },
+      },
+    })
+    const workspace = await doneHubManagedResourceRegistration.open()
+    const editor = await workspace.openEditEditor(
+      (await workspace.list()).items[0].ref,
+    )
+    expect(editor.initialValues["doneHub.responsesPath"]).toBe("/old/responses")
+    await editor.submit({
+      ...editor.initialValues,
+      "doneHub.responsesPath": "",
+    })
+    expect(mocks.update).toHaveBeenCalledWith(
+      config,
+      expect.objectContaining({
+        plugin: {
+          customize: { "16": "", "1": "/fresh/chat" },
+          extra: { enabled: true },
+        },
+      }),
+      undefined,
+    )
+  })
+
+  it.each([
+    ["doneHub.modelMapping", '[ ["alias", "one"], ["alias", "two"] ]'],
+    ["doneHub.modelHeaders", '{"X-Project":5}'],
+    ["doneHub.customParameter", "[1,2]"],
+    ["doneHub.customParameter", "{broken"],
+    ["doneHub.proxy", "ftp://proxy.example"],
+  ])(
+    "rejects invalid advanced input in %s before any mutation",
+    async (fieldId, value) => {
+      const workspace = await doneHubManagedResourceRegistration.open()
+      const editor = await workspace.openEditEditor(
+        (await workspace.list()).items[0].ref,
+      )
+      const values = { ...editor.initialValues, [fieldId]: value }
+      expect(editor.validate(values)).toEqual({
+        valid: false,
+        issues: expect.arrayContaining([{ fieldId, code: "invalid_value" }]),
+      })
+      await editor.submit(values)
+      expect(mocks.update).not.toHaveBeenCalled()
+    },
+  )
+
   beforeEach(() => {
     vi.resetAllMocks()
     mocks.getPreferences.mockResolvedValue({ doneHub: config })

--- a/tests/services/apiService/doneHub/channelApi.test.ts
+++ b/tests/services/apiService/doneHub/channelApi.test.ts
@@ -78,30 +78,33 @@ vi.mock("~/utils/i18n/core", () => ({
 }))
 
 describe("apiService doneHub channel APIs", () => {
-  it("keeps proxy and fixed headers in an unsaved model probe", async () => {
-    mockFetchApiData.mockResolvedValue(["model-a"])
-    const request = {
-      baseUrl: "https://donehub.example",
-      auth: { authType: AuthTypeEnum.AccessToken, accessToken: "admin" },
-    }
-    await fetchDoneHubProviderModels(request, {
-      type: 1,
-      base_url: "https://upstream.example",
-      key: "channel-key",
-      proxy: "socks5://proxy:1080",
-      model_headers: '{"X-Project":"draft"}',
-      models: "old-model",
-      model_mapping: '{"old-model":"mapped"}',
-    })
-    const options = mockFetchApiData.mock.calls[0][1]
-    expect(JSON.parse(options.options.body)).toMatchObject({
-      proxy: "socks5://proxy:1080",
-      model_headers: '{"X-Project":"draft"}',
-      models: "",
-      model_mapping: "",
-    })
-    expect(mockFetchApiData).toHaveBeenCalledTimes(1)
-  })
+  it.each(["http", "https"])(
+    "keeps proxy and fixed headers in an unsaved model probe over %s",
+    async (protocol) => {
+      mockFetchApiData.mockResolvedValue(["model-a"])
+      const request = {
+        baseUrl: `${protocol}://donehub.example`,
+        auth: { authType: AuthTypeEnum.AccessToken, accessToken: "admin" },
+      }
+      await fetchDoneHubProviderModels(request, {
+        type: 1,
+        base_url: "https://upstream.example",
+        key: "channel-key",
+        proxy: "socks5://proxy:1080",
+        model_headers: '{"X-Project":"draft"}',
+        models: "old-model",
+        model_mapping: '{"old-model":"mapped"}',
+      })
+      const options = mockFetchApiData.mock.calls[0][1]
+      expect(JSON.parse(options.options.body)).toMatchObject({
+        proxy: "socks5://proxy:1080",
+        model_headers: '{"X-Project":"draft"}',
+        models: "",
+        model_mapping: "",
+      })
+      expect(mockFetchApiData).toHaveBeenCalledTimes(1)
+    },
+  )
 
   beforeEach(() => {
     vi.clearAllMocks()

--- a/tests/services/apiService/doneHub/channelApi.test.ts
+++ b/tests/services/apiService/doneHub/channelApi.test.ts
@@ -5,6 +5,7 @@ import {
   createChannel,
   deleteChannel,
   fetchChannelModels,
+  fetchDoneHubProviderModels,
   fetchDraftChannelModels,
   fetchSiteUserGroups,
   fetchTodayIncome,
@@ -77,6 +78,31 @@ vi.mock("~/utils/i18n/core", () => ({
 }))
 
 describe("apiService doneHub channel APIs", () => {
+  it("keeps proxy and fixed headers in an unsaved model probe", async () => {
+    mockFetchApiData.mockResolvedValue(["model-a"])
+    const request = {
+      baseUrl: "https://donehub.example",
+      auth: { authType: AuthTypeEnum.AccessToken, accessToken: "admin" },
+    }
+    await fetchDoneHubProviderModels(request, {
+      type: 1,
+      base_url: "https://upstream.example",
+      key: "channel-key",
+      proxy: "socks5://proxy:1080",
+      model_headers: '{"X-Project":"draft"}',
+      models: "old-model",
+      model_mapping: '{"old-model":"mapped"}',
+    })
+    const options = mockFetchApiData.mock.calls[0][1]
+    expect(JSON.parse(options.options.body)).toMatchObject({
+      proxy: "socks5://proxy:1080",
+      model_headers: '{"X-Project":"draft"}',
+      models: "",
+      model_mapping: "",
+    })
+    expect(mockFetchApiData).toHaveBeenCalledTimes(1)
+  })
+
   beforeEach(() => {
     vi.clearAllMocks()
     mockFetchApiData.mockReset()


### PR DESCRIPTION
Adds DoneHub advanced channel settings in a compact, grouped editor: Responses compatibility and custom paths, model mapping, test models, streaming exclusions, proxy settings, request headers, extra parameters, and extra-body forwarding.

The editor reuses shared collapsible sections, supports structured JSON editing and responsive layouts, and fixes the test-model dropdown arrow alignment. Updates preserve untouched native fields and support clearing configured values. Model discovery uses unsaved proxy and header settings.

Validation:
- Focused unit/component tests, TypeScript, Knip, and staged checks passed.
- Translation extraction and completeness checks passed across all eight locales.
- Intercepted browser workflows passed at 1440px and 460px, covering editing, validation, clearing, save/reopen, draft preservation, and dropdown alignment.

A real-site persistence test and its run instructions are included. It was not rerun during this handoff and does not verify live model routing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added advanced DoneHub channel settings for compatibility, model mapping, requests, proxies, headers, custom parameters, and streaming controls.
  - Added JSON editing with row-based editing, formatting, validation, and draft preservation.
  - Added model suggestions and conditional fields based on channel type.
  - Added responsive two-column layouts and improved input sizing for channel forms.
  - Added localized labels and guidance across supported languages.

- **Bug Fixes**
  - Invalid settings now display clear errors and prevent saving.
  - Advanced settings persist correctly when editing or clearing channels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->