### PR TITLE
feat(accounts): group sorting controls and add settings shortcut

### DIFF
--- a/e2e/accountManagementCommonFlows.spec.ts
+++ b/e2e/accountManagementCommonFlows.spec.ts
@@ -356,6 +356,9 @@ test("keeps account management controls reachable across constrained widths", as
         const sortControlsBox = await accountListSortControls.boundingBox()
         const utilitiesBox = await accountListUtilities.boundingBox()
         const clearSortActionBox = await clearSortAction.boundingBox()
+        const activeSortBox = await page
+          .getByTestId(getAccountManagementSortButtonTestId("balance"))
+          .boundingBox()
         const headerButtons = await readElementBounds(
           accountListHeader.getByRole("button"),
         )
@@ -390,16 +393,16 @@ test("keeps account management controls reachable across constrained widths", as
           ),
           clearSortPlacementMatches:
             clearSortStaysWithinSortTier &&
-            (layout === "inline" ||
-              Boolean(
-                sortControlsBox &&
-                  clearSortActionBox &&
-                  Math.abs(
-                    clearSortActionBox.x +
-                      clearSortActionBox.width -
-                      (sortControlsBox.x + sortControlsBox.width),
-                  ) <= 1,
-              )),
+            Boolean(
+              activeSortBox &&
+                clearSortActionBox &&
+                Math.abs(
+                  clearSortActionBox.x -
+                    (activeSortBox.x + activeSortBox.width),
+                ) <= 1 &&
+                Math.abs(clearSortActionBox.y - activeSortBox.y) <= 1 &&
+                Math.abs(clearSortActionBox.height - activeSortBox.height) <= 1,
+            ),
           buttonsContained: Boolean(
             listBox &&
               headerButtons.every((box) =>

--- a/src/constants/basicSettingsTabs.ts
+++ b/src/constants/basicSettingsTabs.ts
@@ -49,7 +49,7 @@ export const BASIC_SETTINGS_ANCHOR_TO_TAB: Record<string, BasicSettingsTabId> =
     [SETTINGS_ANCHORS.AUTO_PROVISION_KEY]: "accountManagement",
     [SETTINGS_ANCHORS.AUTO_PROVISION_KEY_ENABLED]: "accountManagement",
     [SETTINGS_ANCHORS.AUTO_PROVISION_KEY_MODE]: "accountManagement",
-    "sorting-priority": "accountManagement",
+    [SETTINGS_ANCHORS.SORTING_PRIORITY]: "accountManagement",
     sorting: "accountManagement",
     "auto-refresh": "refresh",
     refresh: "refresh",

--- a/src/constants/settingsAnchors.ts
+++ b/src/constants/settingsAnchors.ts
@@ -1,5 +1,6 @@
 export const SETTINGS_ANCHORS = {
   MANAGED_SITE_DEPLOYMENT_DOCS: "managed-site-deployment-docs",
+  SORTING_PRIORITY: "sorting-priority",
   AUTO_PROVISION_KEY: "auto-provision-key-on-account-add",
   AUTO_PROVISION_KEY_ENABLED: "auto-provision-key-toggle",
   AUTO_PROVISION_KEY_MODE: "auto-provision-key-mode",

--- a/src/features/AccountManagement/components/AccountList/AccountListHeader.tsx
+++ b/src/features/AccountManagement/components/AccountList/AccountListHeader.tsx
@@ -4,6 +4,7 @@ import {
   ChevronUp,
   ListChecks,
   ListOrdered,
+  Settings2,
   XIcon,
 } from "lucide-react"
 import { useTranslation } from "react-i18next"
@@ -16,12 +17,14 @@ import {
   DATA_TYPE_CREATED_AT,
   DATA_TYPE_INCOME,
 } from "~/constants"
+import { SETTINGS_ANCHORS } from "~/constants/settingsAnchors"
 import {
   ACCOUNT_MANAGEMENT_TEST_IDS,
   getAccountManagementSortButtonTestId,
 } from "~/features/AccountManagement/testIds"
 import { cn } from "~/lib/utils"
 import type { ActiveSortField, SortField, SortOrder } from "~/types"
+import { openSettingsTab } from "~/utils/navigation"
 
 interface AccountListHeaderProps {
   displayedResultCount: number
@@ -45,6 +48,7 @@ interface AccountListHeaderProps {
 interface AccountListSortButtonProps {
   activeSortField: ActiveSortField
   disabled: boolean
+  onClearSort: () => void
   field: SortField
   label: string
   onSort: (field: SortField) => void
@@ -56,36 +60,58 @@ interface AccountListSortButtonProps {
 function AccountListSortButton({
   activeSortField,
   disabled,
+  onClearSort,
   field,
   label,
   onSort,
   sortLabel,
   sortOrder,
 }: AccountListSortButtonProps) {
+  const { t } = useTranslation("account")
   const isActive = activeSortField === field
 
   return (
-    <IconButton
-      onClick={() => onSort(field)}
-      variant="ghost"
-      size="none"
-      disabled={disabled}
-      aria-label={`${sortLabel} ${label}`}
-      data-testid={getAccountManagementSortButtonTestId(field)}
+    <div
       className={cn(
-        "min-h-6 space-x-0.5 rounded-md px-1.5 text-xs font-medium sm:space-x-1",
-        isActive &&
-          "bg-blue-100/80 font-semibold text-blue-700 hover:bg-blue-100 dark:bg-blue-950/60 dark:text-blue-300 dark:hover:bg-blue-950/80",
+        "inline-flex h-7 shrink-0 items-center rounded-md",
+        isActive && "bg-blue-100/80 dark:bg-blue-950/60",
       )}
     >
-      <span>{label}</span>
-      {isActive &&
-        (sortOrder === "asc" ? (
-          <ChevronUp className="h-2.5 w-2.5 sm:h-3 sm:w-3" />
-        ) : (
-          <ChevronDown className="h-2.5 w-2.5 sm:h-3 sm:w-3" />
-        ))}
-    </IconButton>
+      <IconButton
+        onClick={() => onSort(field)}
+        variant="ghost"
+        size="none"
+        disabled={disabled}
+        aria-label={`${sortLabel} ${label}`}
+        data-testid={getAccountManagementSortButtonTestId(field)}
+        className={cn(
+          "h-7 space-x-0.5 rounded-md px-1.5 text-xs font-medium focus-visible:relative focus-visible:z-10 sm:space-x-1",
+          isActive &&
+            "font-semibold text-blue-700 hover:bg-blue-100 dark:text-blue-300 dark:hover:bg-blue-950/80",
+          isActive && !disabled && "rounded-r-none",
+        )}
+      >
+        <span>{label}</span>
+        {isActive &&
+          (sortOrder === "asc" ? (
+            <ChevronUp className="h-2.5 w-2.5 sm:h-3 sm:w-3" />
+          ) : (
+            <ChevronDown className="h-2.5 w-2.5 sm:h-3 sm:w-3" />
+          ))}
+      </IconButton>
+      {isActive && !disabled && (
+        <IconButton
+          variant="ghost"
+          size="none"
+          className="size-7 rounded-l-none rounded-r-md border-l border-blue-200/70 text-blue-700 hover:bg-blue-100 focus-visible:relative focus-visible:z-10 dark:border-blue-800/60 dark:text-blue-300 dark:hover:bg-blue-950/80"
+          onClick={onClearSort}
+          aria-label={t("account:list.clearSort")}
+          data-testid={ACCOUNT_MANAGEMENT_TEST_IDS.accountListClearSortButton}
+        >
+          <XIcon aria-hidden="true" className="size-3" />
+        </IconButton>
+      )}
+    </div>
   )
 }
 
@@ -108,7 +134,7 @@ export function AccountListHeader({
   sortField,
   sortOrder,
 }: AccountListHeaderProps) {
-  const { t } = useTranslation(["account", "common"])
+  const { t } = useTranslation(["account", "common", "settings"])
   const reorderLabel = isReorderMode
     ? t("account:list.reorderDone")
     : t("account:list.reorder")
@@ -119,6 +145,7 @@ export function AccountListHeader({
     <AccountListSortButton
       activeSortField={sortField}
       disabled={inSearchMode}
+      onClearSort={onClearSort}
       field={field}
       label={label}
       onSort={onSort}
@@ -202,22 +229,22 @@ export function AccountListHeader({
               )}
             </div>
           </div>
-          {sortField !== null && !inSearchMode ? (
-            <Button
-              type="button"
+          <Tooltip content={t("settings:sorting.title")}>
+            <IconButton
               variant="ghost"
-              size="sm"
-              className="h-7 shrink-0 px-2 text-xs font-normal text-gray-500 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-200"
-              leftIcon={<XIcon aria-hidden="true" className="size-3" />}
-              onClick={onClearSort}
-              aria-label={t("account:list.clearSort")}
-              data-testid={
-                ACCOUNT_MANAGEMENT_TEST_IDS.accountListClearSortButton
+              size="none"
+              className="size-7 shrink-0 rounded-md"
+              aria-label={t("settings:sorting.title")}
+              onClick={() =>
+                void openSettingsTab("accountManagement", {
+                  anchor: SETTINGS_ANCHORS.SORTING_PRIORITY,
+                  preserveHistory: true,
+                })
               }
             >
-              {t("account:list.clearSort")}
-            </Button>
-          ) : null}
+              <Settings2 aria-hidden="true" className="size-3.5" />
+            </IconButton>
+          </Tooltip>
         </div>
 
         <div

--- a/src/features/BasicSettings/components/tabs/AccountManagement/AccountManagement.search.ts
+++ b/src/features/BasicSettings/components/tabs/AccountManagement/AccountManagement.search.ts
@@ -41,7 +41,7 @@ export const accountManagementSearchSections: OptionsSearchItemDefinition[] = [
   buildSectionDefinition(
     "section:sorting-priority",
     "accountManagement",
-    "sorting-priority",
+    SETTINGS_ANCHORS.SORTING_PRIORITY,
     "settings:sorting.title",
     224,
   ),

--- a/src/features/BasicSettings/components/tabs/AccountManagement/AccountManagementTab.tsx
+++ b/src/features/BasicSettings/components/tabs/AccountManagement/AccountManagementTab.tsx
@@ -54,9 +54,7 @@ export default function AccountManagementTab() {
       <AutoFillCurrentSiteUrlOnAccountAddSettings />
       <DuplicateAccountWarningOnAddSettings />
 
-      <section id="sorting-priority">
-        <SortingPrioritySettings />
-      </section>
+      <SortingPrioritySettings />
     </div>
   )
 }

--- a/src/features/BasicSettings/components/tabs/AccountManagement/SortingPrioritySettings/index.tsx
+++ b/src/features/BasicSettings/components/tabs/AccountManagement/SortingPrioritySettings/index.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from "react-i18next"
 
 import { SettingSection } from "~/components/SettingSection"
 import { Card, CardContent } from "~/components/ui"
+import { SETTINGS_ANCHORS } from "~/constants/settingsAnchors"
 import { useUserPreferencesContext } from "~/contexts/UserPreferencesContext"
 import { SortingCriteriaType, type SortingFieldConfig } from "~/types/sorting"
 import { showUpdateToast } from "~/utils/feedback/preferenceFeedback"
@@ -157,7 +158,7 @@ export default function SortingPrioritySettings() {
 
   return (
     <SettingSection
-      id="sorting-priority"
+      id={SETTINGS_ANCHORS.SORTING_PRIORITY}
       title={t("sorting.title")}
       description={t("sorting.description")}
       onReset={resetSortingPriorityConfig}

--- a/tests/features/AccountManagement/components/AccountList.test.tsx
+++ b/tests/features/AccountManagement/components/AccountList.test.tsx
@@ -35,6 +35,7 @@ import {
   ACCOUNT_TODAY_METRIC_REASONS,
   ACCOUNT_TODAY_METRIC_STATUSES,
 } from "~/types/accountTodayStats"
+import { openSettingsTab } from "~/utils/navigation"
 import { buildCompleteTodayStatsAvailability } from "~~/tests/test-utils/accountTodayStats"
 import { buildDisplaySiteData, buildTag } from "~~/tests/test-utils/factories"
 import { testI18n } from "~~/tests/test-utils/i18n"
@@ -120,6 +121,11 @@ const {
   },
   useSensorMock: vi.fn(),
   useSortableMock: vi.fn(),
+}))
+
+vi.mock("~/utils/navigation", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("~/utils/navigation")>()),
+  openSettingsTab: vi.fn(),
 }))
 
 vi.mock("@dnd-kit/core", () => ({
@@ -794,6 +800,20 @@ describe("AccountList", () => {
     )
 
     expect(handleSort).toHaveBeenCalledWith("name")
+  })
+
+  it("opens sorting priority settings from the account list", async () => {
+    const user = userEvent.setup()
+    render(<AccountList />)
+
+    await user.click(
+      screen.getByRole("button", { name: "settings:sorting.title" }),
+    )
+
+    expect(openSettingsTab).toHaveBeenCalledWith("accountManagement", {
+      anchor: "sorting-priority",
+      preserveHistory: true,
+    })
   })
 
   it("shows a clear sort action when field sorting is active", async () => {


### PR DESCRIPTION
Unify the active sort label, direction arrow, and clear action into one visual control, with separate click and keyboard focus targets. Add a shortcut directly to sorting priority settings.

Keep responsive wrapping, align control heights, and remove the duplicate sorting settings anchor.

Validation:
- 69 focused component and settings navigation tests passed.
- Chromium responsive layout test passed at desktop and narrow widths using seeded extension data.
- TypeScript, Knip, and i18n checks passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a settings control to the account list header for quick access to sorting preferences.
  * Active sort controls now include an inline option to clear sorting.
  * Sorting settings open directly to the sorting-priority section while preserving navigation history.

* **Bug Fixes**
  * Improved sort-control alignment and reachability on constrained screen widths.

* **Tests**
  * Added coverage verifying navigation to sorting preferences and responsive control placement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->