### PR TITLE
fix: keep key imports responsive and eliminate duplicate requests

### DIFF
--- a/e2e/channelDialogLoading.spec.ts
+++ b/e2e/channelDialogLoading.spec.ts
@@ -1,10 +1,99 @@
 import { CHANNEL_DIALOG_TEST_IDS } from "~/components/dialogs/ChannelDialog/testIds"
+import { OPTIONS_PAGE_PATH } from "~/constants/extensionPages"
+import { MENU_ITEM_IDS } from "~/constants/optionsMenuIds"
+import { API_CREDENTIAL_PROFILES_TEST_IDS } from "~/features/ApiCredentialProfiles/testIds"
 import { expect, test } from "~~/e2e/fixtures/extensionTest"
-import { openInterceptedNewApiManagedSiteChannels } from "~~/e2e/fixtures/managedSiteChannelsIntercepted"
+import {
+  openInterceptedDoneHubManagedSiteChannels,
+  openInterceptedNewApiManagedSiteChannels,
+} from "~~/e2e/fixtures/managedSiteChannelsIntercepted"
 import { openManagedSiteChannelRowActions } from "~~/e2e/scenarios/managedSiteChannels"
+import {
+  createStoredApiCredentialProfile,
+  seedApiCredentialProfiles,
+} from "~~/e2e/utils/commonUserFlows"
+import { getServiceWorker } from "~~/e2e/utils/extensionState"
 
 const primaryDetail =
   /^https:\/\/managed\.example\.invalid\/api\/channel\/101(?:\?.*)?$/
+
+for (const provider of ["new-api", "done-hub"] as const) {
+  test(`${provider} loads channel groups once when opening an editor`, async ({
+    context,
+    page,
+    extensionId,
+  }) => {
+    await (
+      provider === "new-api"
+        ? openInterceptedNewApiManagedSiteChannels
+        : openInterceptedDoneHubManagedSiteChannels
+    )({ context, page, extensionId })
+    const requests: string[] = []
+    context.on("request", (request) => {
+      if (/\/api\/group\/?$/.test(new URL(request.url()).pathname)) {
+        requests.push(request.url())
+      }
+    })
+    const channelName =
+      provider === "new-api" ? "Example primary" : "DoneHub primary"
+    await openManagedSiteChannelRowActions(page, channelName)
+    await page.getByRole("menuitem", { name: "Edit", exact: true }).click()
+    const dialog = page.getByRole("dialog")
+    await expect(
+      dialog.getByTestId(CHANNEL_DIALOG_TEST_IDS.nameInput),
+    ).toHaveValue(channelName)
+    await expect.poll(() => requests.length).toBeGreaterThan(0)
+    await expect(
+      dialog
+        .getByRole("group", { name: "Models", exact: true })
+        .getByRole("status"),
+    ).toHaveCount(0)
+    await dialog
+      .getByTestId(CHANNEL_DIALOG_TEST_IDS.nameInput)
+      .fill("Unchanged groups")
+    await expect(
+      dialog.getByTestId(CHANNEL_DIALOG_TEST_IDS.submitButton),
+    ).toBeEnabled()
+    expect(requests).toHaveLength(1)
+    await dialog.getByTestId(CHANNEL_DIALOG_TEST_IDS.cancelButton).click()
+    await expect(dialog).toBeHidden()
+    await seedApiCredentialProfiles(await getServiceWorker(context), [
+      createStoredApiCredentialProfile({
+        id: "group-request-source",
+        name: "Group request source",
+        baseUrl: "https://group-source.example.invalid",
+        apiKey: "sk-group-source",
+      }),
+    ])
+    await context.route(
+      "https://group-source.example.invalid/v1/models",
+      (route) => route.fulfill({ json: { data: [{ id: "model-a" }] } }),
+    )
+    requests.length = 0
+    await page.goto(
+      `chrome-extension://${extensionId}/${OPTIONS_PAGE_PATH}#${MENU_ITEM_IDS.API_CREDENTIAL_PROFILES}`,
+    )
+    await page
+      .getByTestId(API_CREDENTIAL_PROFILES_TEST_IDS.importToManagedSiteButton)
+      .click()
+    await expect(
+      dialog.getByTestId(CHANNEL_DIALOG_TEST_IDS.nameInput),
+    ).toBeVisible()
+    await expect.poll(() => requests.length).toBeGreaterThan(0)
+    await expect(
+      dialog
+        .getByRole("group", { name: "Models", exact: true })
+        .getByRole("status"),
+    ).toHaveCount(0)
+    await dialog
+      .getByTestId(CHANNEL_DIALOG_TEST_IDS.nameInput)
+      .fill("Imported groups")
+    await expect(
+      dialog.getByTestId(CHANNEL_DIALOG_TEST_IDS.submitButton),
+    ).toBeEnabled()
+    expect(requests).toHaveLength(1)
+  })
+}
 
 for (const width of [1280, 420]) {
   test(`channel loading and inline retry remain usable at ${width}px`, async ({

--- a/src/components/dialogs/ChannelDialog/hooks/useChannelDialog.ts
+++ b/src/components/dialogs/ChannelDialog/hooks/useChannelDialog.ts
@@ -471,6 +471,7 @@ export function useChannelDialog() {
       )
       const formData = await managedSite.channelDrafts.prepareFormData(
         buildManagedSiteChannelDraftSource(resolvedRuntimeKey),
+        { purpose: "native-editor" },
       )
       if (!shouldContinue()) {
         return cancelOpen()
@@ -569,6 +570,7 @@ export function useChannelDialog() {
       ].filter(Boolean) as string[]
       const formData = await managedSite.channelDrafts.prepareFormData(
         buildManagedSiteCredentialDraftSource(credentials),
+        { purpose: "native-editor" },
       )
 
       const duplicateState = await resolvePrefilledDialogDuplicateState({

--- a/src/features/KeyManagement/hooks/useKeyManagement.ts
+++ b/src/features/KeyManagement/hooks/useKeyManagement.ts
@@ -384,6 +384,13 @@ export function useKeyManagement(routeParams?: Record<string, string>) {
   const selectionEpochRef = useRef(0)
   const accountRequestEpochRef = useRef<Record<string, number>>({})
   const managedSiteStatusRunIdRef = useRef(0)
+  const managedSiteStatusControllersRef = useRef(new Set<AbortController>())
+  const cancelManagedSiteStatusChecks = useCallback(() => {
+    for (const controller of managedSiteStatusControllersRef.current)
+      controller.abort()
+    managedSiteStatusControllersRef.current.clear()
+    managedSiteStatusRunIdRef.current += 1
+  }, [])
   const isMountedRef = useRef(true)
   const tokenLoadErrorCategoriesRef = useRef<
     Record<string, ProductAnalyticsErrorCategory>
@@ -423,6 +430,16 @@ export function useKeyManagement(routeParams?: Record<string, string>) {
 
   const invalidateManagedSiteStatuses = useCallback(
     (shouldRemove: (identityKey: string) => boolean) => {
+      // Replacement checks need a new run id even for an account reload, so
+      // a late response cannot restore invalidated status or secret evidence.
+      managedSiteStatusRunIdRef.current += 1
+      for (const identityKey of Object.keys(
+        resolvedChannelKeysByIdentityKeyRef.current,
+      )) {
+        if (shouldRemove(identityKey)) {
+          delete resolvedChannelKeysByIdentityKeyRef.current[identityKey]
+        }
+      }
       updateManagedSiteTokenStatuses((prev) => {
         let didChange = false
         const next: Record<string, ManagedSiteTokenStatusState> = {}
@@ -572,6 +589,21 @@ export function useKeyManagement(routeParams?: Record<string, string>) {
         return resultsByIdentityKey
       }
 
+      if (force) {
+        for (const target of targets) {
+          // A refresh must not use keys resolved before a backend credential
+          // change. Keep only evidence explicitly supplied by this operation.
+          delete resolvedChannelKeysByIdentityKeyRef.current[target.identityKey]
+          target.resolvedChannelKeysByResourceKey =
+            resolvedChannelKeysByIdentityKey[target.identityKey]
+        }
+      }
+
+      const controller = new AbortController()
+      managedSiteStatusControllersRef.current.add(controller)
+      const requestScheduling = {
+        priority: force ? ("foreground" as const) : ("background" as const),
+      }
       const operationContext = createManagedSiteOperationContext()
       const runId = force
         ? managedSiteStatusRunIdRef.current + 1
@@ -604,13 +636,21 @@ export function useKeyManagement(routeParams?: Record<string, string>) {
       await Promise.allSettled(
         Array.from({ length: workerCount }, async () => {
           while (queue.length > 0) {
+            if (controller.signal.aborted || !isMountedRef.current) return
             const target = queue.shift()
 
             if (!target) {
               return
             }
 
+            if (
+              managedSiteTokenStatusesRef.current[target.identityKey]?.runId !==
+              runId
+            )
+              continue
             const result = await getManagedSiteTokenChannelStatus({
+              signal: controller.signal,
+              requestScheduling,
               runtimeKey: target.runtimeKey,
               resolvedChannelKeysByResourceKey:
                 target.resolvedChannelKeysByResourceKey,
@@ -673,6 +713,7 @@ export function useKeyManagement(routeParams?: Record<string, string>) {
         }),
       )
 
+      managedSiteStatusControllersRef.current.delete(controller)
       return resultsByIdentityKey
     },
     [
@@ -1780,15 +1821,34 @@ export function useKeyManagement(routeParams?: Record<string, string>) {
 
     return () => {
       isMountedRef.current = false
-      managedSiteStatusRunIdRef.current += 1
+      cancelManagedSiteStatusChecks()
     }
-  }, [])
+  }, [cancelManagedSiteStatusChecks])
 
   useEffect(() => {
-    managedSiteStatusRunIdRef.current += 1
+    cancelManagedSiteStatusChecks()
     resolvedChannelKeysByIdentityKeyRef.current = {}
     updateManagedSiteTokenStatuses(() => ({}))
-  }, [managedSiteConfigFingerprint, updateManagedSiteTokenStatuses])
+  }, [
+    cancelManagedSiteStatusChecks,
+    managedSiteConfigFingerprint,
+    updateManagedSiteTokenStatuses,
+  ])
+
+  useEffect(() => {
+    cancelManagedSiteStatusChecks()
+    // Keep completed results until an inventory refresh invalidates them, but
+    // remove canceled entries so their keys can be checked again.
+    updateManagedSiteTokenStatuses((prev) =>
+      Object.fromEntries(
+        Object.entries(prev).filter(([, entry]) => !entry.isChecking),
+      ),
+    )
+  }, [
+    selectedAccount,
+    cancelManagedSiteStatusChecks,
+    updateManagedSiteTokenStatuses,
+  ])
 
   useEffect(() => {
     if (

--- a/src/features/KeyManagement/hooks/useKeyManagement.ts
+++ b/src/features/KeyManagement/hooks/useKeyManagement.ts
@@ -385,10 +385,14 @@ export function useKeyManagement(routeParams?: Record<string, string>) {
   const accountRequestEpochRef = useRef<Record<string, number>>({})
   const managedSiteStatusRunIdRef = useRef(0)
   const managedSiteStatusControllersRef = useRef(new Set<AbortController>())
+  const managedSiteStatusTargetControllersRef = useRef(
+    new Map<string, AbortController>(),
+  )
   const cancelManagedSiteStatusChecks = useCallback(() => {
     for (const controller of managedSiteStatusControllersRef.current)
       controller.abort()
     managedSiteStatusControllersRef.current.clear()
+    managedSiteStatusTargetControllersRef.current.clear()
     managedSiteStatusRunIdRef.current += 1
   }, [])
   const isMountedRef = useRef(true)
@@ -430,6 +434,12 @@ export function useKeyManagement(routeParams?: Record<string, string>) {
 
   const invalidateManagedSiteStatuses = useCallback(
     (shouldRemove: (identityKey: string) => boolean) => {
+      for (const [
+        identityKey,
+        controller,
+      ] of managedSiteStatusTargetControllersRef.current) {
+        if (shouldRemove(identityKey)) controller.abort()
+      }
       // Replacement checks need a new run id even for an account reload, so
       // a late response cannot restore invalidated status or secret evidence.
       managedSiteStatusRunIdRef.current += 1
@@ -591,6 +601,9 @@ export function useKeyManagement(routeParams?: Record<string, string>) {
 
       if (force) {
         for (const target of targets) {
+          managedSiteStatusTargetControllersRef.current
+            .get(target.identityKey)
+            ?.abort()
           // A refresh must not use keys resolved before a backend credential
           // change. Keep only evidence explicitly supplied by this operation.
           delete resolvedChannelKeysByIdentityKeyRef.current[target.identityKey]
@@ -604,7 +617,6 @@ export function useKeyManagement(routeParams?: Record<string, string>) {
       const requestScheduling = {
         priority: force ? ("foreground" as const) : ("background" as const),
       }
-      const operationContext = createManagedSiteOperationContext()
       const runId = force
         ? managedSiteStatusRunIdRef.current + 1
         : managedSiteStatusRunIdRef.current
@@ -648,21 +660,51 @@ export function useKeyManagement(routeParams?: Record<string, string>) {
               runId
             )
               continue
-            const result = await getManagedSiteTokenChannelStatus({
-              signal: controller.signal,
-              requestScheduling,
-              runtimeKey: target.runtimeKey,
-              resolvedChannelKeysByResourceKey:
-                target.resolvedChannelKeysByResourceKey,
-              operationContext,
-              protectionBypassExecution:
-                protectionBypassExecution ??
-                createAutomaticProtectionBypassExecution(
-                  PROTECTION_BYPASS_FEATURES.KeyManagement,
-                  PROTECTION_BYPASS_AUTOMATIC_TRIGGERS.UiLifecycle,
-                  PROTECTION_BYPASS_SURFACES.Options,
-                ),
+            const targetController = new AbortController()
+            const cancelTarget = () => targetController.abort()
+            controller.signal.addEventListener("abort", cancelTarget, {
+              once: true,
             })
+            managedSiteStatusTargetControllersRef.current.set(
+              target.identityKey,
+              targetController,
+            )
+            let result: Awaited<
+              ReturnType<typeof getManagedSiteTokenChannelStatus>
+            >
+            try {
+              result = await getManagedSiteTokenChannelStatus({
+                signal: targetController.signal,
+                requestScheduling,
+                runtimeKey: target.runtimeKey,
+                resolvedChannelKeysByResourceKey:
+                  target.resolvedChannelKeysByResourceKey,
+                // Each target owns cancellation of its operation cache. Pending
+                // transport reads still share work across independent consumers.
+                operationContext: createManagedSiteOperationContext(),
+                protectionBypassExecution:
+                  protectionBypassExecution ??
+                  createAutomaticProtectionBypassExecution(
+                    PROTECTION_BYPASS_FEATURES.KeyManagement,
+                    PROTECTION_BYPASS_AUTOMATIC_TRIGGERS.UiLifecycle,
+                    PROTECTION_BYPASS_SURFACES.Options,
+                  ),
+              })
+            } catch (error) {
+              if (targetController.signal.aborted) continue
+              throw error
+            } finally {
+              controller.signal.removeEventListener("abort", cancelTarget)
+              if (
+                managedSiteStatusTargetControllersRef.current.get(
+                  target.identityKey,
+                ) === targetController
+              ) {
+                managedSiteStatusTargetControllersRef.current.delete(
+                  target.identityKey,
+                )
+              }
+            }
             const displayResult = toDisplayManagedSiteTokenStatusResult(result)
 
             if (!isMountedRef.current) {

--- a/src/services/accounts/utils/apiServiceRequest.ts
+++ b/src/services/accounts/utils/apiServiceRequest.ts
@@ -47,6 +47,7 @@ import {
   createDeferredAbortDeadline,
   runAbortableTask,
 } from "~/services/apiTransport/abortableTask"
+import type { RequestScheduling } from "~/services/apiTransport/requestScheduling"
 import type { ApiServiceRequest } from "~/services/apiTransport/type"
 import { normalizeInviteLinkError } from "~/services/inviteLinks/errors"
 import type { ProtectionBypassExecution } from "~/services/protectionBypass/contracts"
@@ -451,6 +452,7 @@ export async function fetchDisplayAccountInviteLink(
 }
 
 export interface ResolveDisplayAccountTokenForSecretOptions {
+  requestScheduling?: RequestScheduling
   abortSignal?: AbortSignal
   protectionBypassExecution?: ProtectionBypassExecution
   secretSource?: AccountRuntimeKeySecretSource
@@ -480,6 +482,9 @@ const buildSecretResolutionRequest = (
   options: ResolveDisplayAccountTokenForSecretOptions,
 ): ApiServiceRequest => ({
   ...request,
+  ...(options.requestScheduling
+    ? { requestScheduling: options.requestScheduling }
+    : {}),
   ...(options.abortSignal ? { abortSignal: options.abortSignal } : {}),
   ...(options.protectionBypassExecution
     ? { protectionBypassExecution: options.protectionBypassExecution }

--- a/src/services/aiApi/openaiCompatible/index.ts
+++ b/src/services/aiApi/openaiCompatible/index.ts
@@ -59,6 +59,9 @@ export const discoverOpenAICompatibleModels = async (
   params: OpenAIAuthParams,
 ): Promise<OpenAICompatibleModelDiscovery> => {
   const request = {
+    ...(params.requestScheduling
+      ? { requestScheduling: params.requestScheduling }
+      : {}),
     baseUrl: params.baseUrl,
     auth: {
       authType: AuthTypeEnum.AccessToken,

--- a/src/services/apiAdapters/contracts/managedResourceMatching.ts
+++ b/src/services/apiAdapters/contracts/managedResourceMatching.ts
@@ -1,6 +1,7 @@
 import type { TFunction } from "i18next"
 
 import type { ManagedSiteType } from "~/constants/siteType"
+import type { ScheduledReadOptions } from "~/services/apiTransport/requestScheduling"
 import type { ManagedSiteRuntimeConfigValue } from "~/services/managedSites/runtimeConfig"
 import type {
   ManagedResourceMatchCandidate,
@@ -43,6 +44,7 @@ export interface ManagedResourceMatchingCapability<
   search(
     config: TConfig,
     baseUrl: string,
+    options?: ScheduledReadOptions,
   ): Promise<ManagedResourceMatchList | null>
   fetchSecretKey?(
     config: TConfig,

--- a/src/services/apiAdapters/contracts/managedSiteCapabilities.ts
+++ b/src/services/apiAdapters/contracts/managedSiteCapabilities.ts
@@ -1,4 +1,5 @@
 import type { ManagedSiteType } from "~/constants/siteType"
+import type { ScheduledReadOptions } from "~/services/apiTransport/requestScheduling"
 import type { ManagedSiteOperationContext } from "~/services/managedSites/operationContext"
 import type { ManagedSiteRuntimeConfigValue } from "~/services/managedSites/runtimeConfig"
 import type { ProtectionBypassExecution } from "~/services/protectionBypass/contracts"
@@ -10,7 +11,7 @@ import type {
 import type { ManagedResourceMatchingCapability } from "./managedResourceMatching"
 import type { ManagedResourceModelsCapability } from "./managedResourceModels"
 
-export type ManagedSiteChannelRequestOptions = {
+export type ManagedSiteChannelRequestOptions = ScheduledReadOptions & {
   signal?: AbortSignal
   protectionBypassExecution?: ProtectionBypassExecution
   bypassSiteRequestLimit?: boolean
@@ -26,7 +27,7 @@ export type ManagedSitePaginatedChannelRequestOptions =
     pageStart?: number
   }
 
-export type ManagedSiteChannelSecretReadOptions = {
+export type ManagedSiteChannelSecretReadOptions = ScheduledReadOptions & {
   protectionBypassExecution: ProtectionBypassExecution
   signal?: AbortSignal
 }
@@ -59,7 +60,9 @@ export type ManagedSiteQueriesCapability<
   }
 }
 
-export type ManagedSiteChannelDraftRequestOptions = {
+export type ManagedSiteChannelDraftRequestOptions = ScheduledReadOptions & {
+  /** Native editors own group loading; matching also needs no draft groups. */
+  purpose?: "import" | "matching" | "native-editor"
   operationContext?: ManagedSiteOperationContext
 }
 

--- a/src/services/apiAdapters/managedResources/doneHubOperations.ts
+++ b/src/services/apiAdapters/managedResources/doneHubOperations.ts
@@ -110,21 +110,29 @@ const fetchDoneHubMutationPayload = async (
   }
 }
 
-const fetchSecretKey = async (config: DoneHubConfig, channelId: number) => {
+const fetchSecretKey = async (
+  config: DoneHubConfig,
+  channelId: number,
+  options?: ManagedSiteChannelRequestOptions,
+) => {
+  options?.signal?.throwIfAborted()
   const channel = await fetchChannelRaw(
-    toManagedSiteApiServiceRequest(config),
+    toManagedSiteApiServiceRequest(config, options),
     channelId,
   )
+  options?.signal?.throwIfAborted()
   return channel.key ?? ""
 }
 
 const hydrateComparableKeys = async <T extends { id: number; key?: string }>(
   config: DoneHubConfig,
   candidates: T[],
+  options?: ManagedSiteChannelRequestOptions,
 ) => {
   const hydratedCandidates: T[] = []
 
   for (const candidate of candidates) {
+    options?.signal?.throwIfAborted()
     if (hasUsableManagedSiteChannelKey(candidate.key)) {
       hydratedCandidates.push(candidate)
       continue
@@ -133,6 +141,7 @@ const hydrateComparableKeys = async <T extends { id: number; key?: string }>(
     const key = await fetchSecretKey(
       config,
       requireNumericManagedResourceId(candidate.id),
+      options,
     )
     hydratedCandidates.push({ ...candidate, key })
   }

--- a/src/services/apiAdapters/managedResources/octopusModelSync.ts
+++ b/src/services/apiAdapters/managedResources/octopusModelSync.ts
@@ -28,6 +28,7 @@ import {
   ProbeFilterUnavailableError,
 } from "~/services/models/modelSync/channelModelFilterEvaluator"
 import { runWithChannelProcessingTimeout } from "~/services/models/modelSync/channelProcessingTimeout"
+import { runModelSyncBatch } from "~/services/models/modelSync/runModelSyncBatch"
 import {
   createModelSyncWriteFailureBoundary,
   type ModelSyncWriteFailureBoundary,
@@ -37,7 +38,6 @@ import type { ChannelResourceConfigMap } from "~/types/channelConfig"
 import {
   type ExecutionItemResult,
   type ExecutionResult,
-  type ExecutionStatistics,
 } from "~/types/managedSiteModelSync"
 import type { OctopusChannel, OctopusFetchModelInput } from "~/types/octopus"
 import type { OctopusConfig } from "~/types/octopusConfig"
@@ -349,22 +349,10 @@ async function runOctopusBatchWithClient(
     channelConfigs,
     onProgress,
   } = options
-  const startedAt = Date.now()
-  const total = channels.length
-  const results: (ExecutionItemResult | undefined)[] = new Array(total)
-
-  let completed = 0
-  let nextIndex = 0
-
-  const worker = async () => {
-    while (true) {
-      const currentIndex = nextIndex
-      if (currentIndex >= total) {
-        return
-      }
-      nextIndex++
-
-      const channel = channels[currentIndex]
+  return await runModelSyncBatch(
+    channels,
+    { concurrency, onProgress },
+    async (channel) => {
       let result: ExecutionItemResult
       const writeFailureBoundary = createModelSyncWriteFailureBoundary()
 
@@ -415,42 +403,9 @@ async function runOctopusBatchWithClient(
           finishedAt: Date.now(),
         }
       }
-
-      results[currentIndex] = result
-      completed++
-
-      await onProgress?.({
-        completed,
-        total,
-        lastResult: result,
-      })
-    }
-  }
-
-  // Cap workers to total channels to avoid spinning idle workers
-  const workerCount = Math.max(1, Math.min(concurrency, total))
-  const workers = Array.from({ length: workerCount }, () => worker())
-  await Promise.all(workers)
-
-  const items = results.filter((item): item is ExecutionItemResult => !!item)
-
-  const endedAt = Date.now()
-  const successCount = items.filter((item) => item.ok).length
-  const failureCount = total - successCount
-
-  const statistics: ExecutionStatistics = {
-    total,
-    successCount,
-    failureCount,
-    durationMs: endedAt - startedAt,
-    startedAt,
-    endedAt,
-  }
-
-  return {
-    items,
-    statistics,
-  }
+      return result
+    },
+  )
 }
 
 /** Binds one Octopus config and protection intent to the complete sync workflow. */

--- a/src/services/apiAdapters/managedSites/axonHub.ts
+++ b/src/services/apiAdapters/managedSites/axonHub.ts
@@ -10,6 +10,7 @@ import {
   getAxonHubChannelSecretKey,
   listAxonHubChannelPage,
 } from "~/services/apiService/axonHub"
+import { sharePendingConfigRead } from "~/services/apiTransport/requestScheduling"
 import {
   assertManagedResourceRefForSite,
   createManagedChannelResourceRef,
@@ -35,13 +36,17 @@ const axonHubManagedSiteChannelDrafts: ManagedSiteChannelDraftsCapability = {
   prepareFormData: prepareChannelFormData,
 }
 
-const matching: ManagedResourceMatchingCapability<AxonHubConfig> = {
-  search: async (config) => {
+const readMatchingInventory = sharePendingConfigRead(
+  async (config: AxonHubConfig, options) => {
     const items: ManagedResourceMatchCandidate[] = []
     const cursors = new Set<string>()
     let cursor: string | undefined
     do {
-      const page = await listAxonHubChannelPage(config, { cursor, limit: 100 })
+      const page = await listAxonHubChannelPage(
+        config,
+        { cursor, limit: 100 },
+        options,
+      )
       items.push(
         ...page.items.map((channel) => ({
           ref: createManagedChannelResourceRef(
@@ -66,6 +71,10 @@ const matching: ManagedResourceMatchingCapability<AxonHubConfig> = {
     } while (cursor)
     return { items, total: items.length, type_counts: {} }
   },
+)
+
+const matching: ManagedResourceMatchingCapability<AxonHubConfig> = {
+  search: (config, _keyword, options) => readMatchingInventory(config, options),
   fetchSecretKey,
   hydrateComparableKeys: async (config, candidates, options) => {
     for (const candidate of candidates) {

--- a/src/services/apiAdapters/managedSites/claudeCodeHub.ts
+++ b/src/services/apiAdapters/managedSites/claudeCodeHub.ts
@@ -46,9 +46,9 @@ const claudeCodeHubManagedSiteChannelDrafts: ManagedSiteChannelDraftsCapability 
   { prepareFormData: prepareChannelFormData }
 
 const matching: ManagedResourceMatchingCapability<ClaudeCodeHubConfig> = {
-  search: async (config, keyword) =>
+  search: async (config, keyword, options) =>
     runClaudeCodeHubResourceRead(config, async () => {
-      const items = (await searchProviders(config, keyword)).map(
+      const items = (await searchProviders(config, keyword, options)).map(
         (provider) => ({
           ref: createManagedChannelResourceRef(
             SITE_TYPES.CLAUDE_CODE_HUB,
@@ -74,16 +74,18 @@ const matching: ManagedResourceMatchingCapability<ClaudeCodeHubConfig> = {
       )
       return { items, total: items.length, type_counts: {} }
     }),
-  fetchSecretKey: async (config, ref) =>
+  fetchSecretKey: async (config, ref, options) =>
     fetchChannelSecretKey(
       config,
       requireManagedResourceChannelId(SITE_TYPES.CLAUDE_CODE_HUB, config, ref),
+      options,
     ),
-  hydrateComparableKeys: async (config, candidates) => {
+  hydrateComparableKeys: async (config, candidates, options) => {
     const target = { siteType: SITE_TYPES.CLAUDE_CODE_HUB, config }
     const hydrated = await hydrateComparableChannelKeys(
       config,
       toNativeNumericMatchCandidates(candidates, target),
+      options,
     )
     return hydrated.map((candidate) =>
       toManagedResourceMatchCandidate(candidate, target),

--- a/src/services/apiAdapters/managedSites/cliProxyApi.ts
+++ b/src/services/apiAdapters/managedSites/cliProxyApi.ts
@@ -7,6 +7,10 @@ import {
   getCliProxyApiResource,
 } from "~/services/apiAdapters/managedResources/cliProxyApi"
 import { listAllCliProxyApiProviders } from "~/services/apiService/cliProxyApi"
+import {
+  sharePendingConfigRead,
+  type ScheduledReadOptions,
+} from "~/services/apiTransport/requestScheduling"
 import { getManagedSiteRuntimeConfigForType } from "~/services/managedSites/runtimeConfig"
 import { fetchManagedSiteImportModels } from "~/services/managedSites/utils/fetchManagedSiteImportModels"
 import { API_TYPES } from "~/services/verification/aiApiVerification"
@@ -14,6 +18,10 @@ import type { CliProxyApiConfig } from "~/types/cliProxyApiConfig"
 import { transformNormalizedUrlPath } from "~/utils/core/urlParsing"
 
 import { createManagedSiteConfigCapability } from "./config"
+
+const readMatchingInventory = sharePendingConfigRead(
+  listAllCliProxyApiProviders,
+)
 
 /** Match the request paths appended by CLIProxyAPI's native executors. */
 function importedProviderUrl(baseUrl: string, kind: string): string {
@@ -52,8 +60,8 @@ export const cliProxyApiCapabilities = {
   ),
   matching: {
     exactMatchBasis: "url-key",
-    search: async (config, baseUrl) => {
-      const resources = (await listAllCliProxyApiProviders(config)).filter(
+    search: async (config, baseUrl, options?: ScheduledReadOptions) => {
+      const resources = (await readMatchingInventory(config, options)).filter(
         (item) => (item.value["base-url"] ?? "").includes(baseUrl),
       )
       const items = resources.flatMap((resource) =>
@@ -70,21 +78,25 @@ export const cliProxyApiCapabilities = {
       )
       return { items, total: items.length, type_counts: {} }
     },
-    fetchSecretKey: async (config, ref) => {
+    fetchSecretKey: async (config, ref, options?: ScheduledReadOptions) => {
       if (
         ref.siteType !== SITE_TYPES.CLI_PROXY_API ||
         ref.kind !== "channel" ||
         ref.scopeKey !== cliProxyApiScope(config)
       )
         throw new Error("Invalid resource reference")
-      const resource = await getCliProxyApiResource(config, ref.resourceId)
+      const resource = await getCliProxyApiResource(
+        config,
+        ref.resourceId,
+        options,
+      )
       const keys = cliProxyApiKeys(resource)
       if (keys.length !== 1) throw new Error("Multiple provider credentials")
       return keys[0]
     },
   },
   channelDrafts: {
-    prepareFormData: async (source) => {
+    prepareFormData: async (source, options?: ScheduledReadOptions) => {
       const kind =
         source.apiType === API_TYPES.ANTHROPIC
           ? "claude-api-key"
@@ -95,7 +107,7 @@ export const cliProxyApiCapabilities = {
               : "openai-compatibility"
       const { models, fetchFailed } =
         kind === "openai-compatibility" || kind === "codex-api-key"
-          ? await fetchManagedSiteImportModels(source)
+          ? await fetchManagedSiteImportModels(source, options)
           : { models: [...source.modelHints], fetchFailed: false }
       return {
         name: source.name,

--- a/src/services/apiAdapters/managedSites/doneHub.ts
+++ b/src/services/apiAdapters/managedSites/doneHub.ts
@@ -58,16 +58,18 @@ const doneHubManagedSiteChannelDrafts: ManagedSiteChannelDraftsCapability = {
 }
 
 const matching: ManagedResourceMatchingCapability<DoneHubConfig> = {
-  fetchSecretKey: async (config, ref) =>
+  fetchSecretKey: async (config, ref, options) =>
     doneHubChannelOperations.fetchSecretKey(
       config,
       requireManagedResourceChannelId(SITE_TYPES.DONE_HUB, config, ref),
+      options,
     ),
-  hydrateComparableKeys: async (config, candidates) => {
+  hydrateComparableKeys: async (config, candidates, options) => {
     const target = { siteType: SITE_TYPES.DONE_HUB, config }
     const hydrated = await doneHubChannelOperations.hydrateComparableKeys(
       config,
       toNativeNumericMatchCandidates(candidates, target),
+      options,
     )
     return hydrated.map((candidate) =>
       toManagedResourceMatchCandidate(candidate, target),

--- a/src/services/apiAdapters/managedSites/doneHub.ts
+++ b/src/services/apiAdapters/managedSites/doneHub.ts
@@ -40,8 +40,10 @@ const doneHubKeyManagement = createNewApiKeyManagement(SITE_TYPES.DONE_HUB)
 
 const doneHubManagedSiteQueries: ManagedSiteQueriesCapability<DoneHubConfig> = {
   siteUserGroups: {
-    fetch: async (config) =>
-      await fetchSiteUserGroups(toManagedSiteApiServiceRequest(config)),
+    fetch: async (config, options) =>
+      await fetchSiteUserGroups(
+        toManagedSiteApiServiceRequest(config, options),
+      ),
   },
   accountAvailableModels: {
     fetch: async (config) =>
@@ -71,9 +73,12 @@ const matching: ManagedResourceMatchingCapability<DoneHubConfig> = {
       toManagedResourceMatchCandidate(candidate, target),
     )
   },
-  search: async (config, keyword) =>
+  search: async (config, keyword, options) =>
     toManagedResourceMatchList(
-      await searchChannel(toManagedSiteApiServiceRequest(config), keyword),
+      await searchChannel(
+        toManagedSiteApiServiceRequest(config, options),
+        keyword,
+      ),
       { siteType: SITE_TYPES.DONE_HUB, config },
     ),
 }

--- a/src/services/apiAdapters/managedSites/newApi.ts
+++ b/src/services/apiAdapters/managedSites/newApi.ts
@@ -67,9 +67,9 @@ const matching: ManagedResourceMatchingCapability<NewApiConfig> = {
       toManagedResourceMatchCandidate(candidate, target),
     )
   },
-  search: async (config, keyword) =>
+  search: async (config, keyword, options) =>
     toManagedResourceMatchList(
-      await newApiChannelOperations.search(config, keyword),
+      await newApiChannelOperations.search(config, keyword, options),
       { siteType: SITE_TYPES.NEW_API, config },
     ),
   fetchSecretKey: async (config, ref, options) =>

--- a/src/services/apiAdapters/managedSites/octopus.ts
+++ b/src/services/apiAdapters/managedSites/octopus.ts
@@ -35,22 +35,24 @@ const octopusManagedSiteChannelDrafts: ManagedSiteChannelDraftsCapability = {
 }
 
 const matching: ManagedResourceMatchingCapability<OctopusConfig> = {
-  search: async (config, keyword) => {
-    const items = (await searchChannels(config, keyword)).map((channel) => ({
-      ref: createManagedChannelResourceRef(
-        SITE_TYPES.OCTOPUS,
-        config.baseUrl,
-        channel.id,
-      ),
-      name: channel.name,
-      type: channel.type,
-      base_url: channel.base_urls[0]?.url ?? "",
-      models: channel.model ?? "",
-      key: channel.keys
-        .map((key) => key.channel_key)
-        .filter(Boolean)
-        .join("\n"),
-    }))
+  search: async (config, keyword, options) => {
+    const items = (await searchChannels(config, keyword, options)).map(
+      (channel) => ({
+        ref: createManagedChannelResourceRef(
+          SITE_TYPES.OCTOPUS,
+          config.baseUrl,
+          channel.id,
+        ),
+        name: channel.name,
+        type: channel.type,
+        base_url: channel.base_urls[0]?.url ?? "",
+        models: channel.model ?? "",
+        key: channel.keys
+          .map((key) => key.channel_key)
+          .filter(Boolean)
+          .join("\n"),
+      }),
+    )
     return { items, total: items.length, type_counts: {} }
   },
 }

--- a/src/services/apiAdapters/managedSites/request.ts
+++ b/src/services/apiAdapters/managedSites/request.ts
@@ -1,3 +1,4 @@
+import type { RequestScheduling } from "~/services/apiTransport/requestScheduling"
 import type {
   ApiServiceRequest,
   ApiTransportRequestObserver,
@@ -18,6 +19,7 @@ type ManagedSiteApiServiceConfig = {
 }
 
 type ManagedSiteApiServiceRequestOptions = {
+  requestScheduling?: RequestScheduling
   signal?: AbortSignal | null
   bypassSiteRequestLimit?: boolean
   observer?: ApiTransportRequestObserver
@@ -37,6 +39,9 @@ export function toManagedSiteApiServiceRequest(
       accessToken: config.adminToken,
       userId: config.userId,
     },
+    ...(options?.requestScheduling
+      ? { requestScheduling: options.requestScheduling }
+      : {}),
     ...(options?.signal ? { abortSignal: options.signal } : {}),
     ...(options?.bypassSiteRequestLimit
       ? { bypassSiteRequestLimit: true }

--- a/src/services/apiAdapters/managedSites/sub2api.ts
+++ b/src/services/apiAdapters/managedSites/sub2api.ts
@@ -11,6 +11,7 @@ import {
   toNativeNumericMatchCandidates,
 } from "~/services/apiAdapters/managedResources/matchingInputs"
 import { requireManagedResourceChannelId } from "~/services/apiAdapters/managedResources/resourceIds"
+import { sharePendingConfigRead } from "~/services/apiTransport/requestScheduling"
 import {
   MANAGED_SITE_CHANNEL_MATCH_UNRESOLVED_REASONS,
   MatchResolutionUnresolvedError,
@@ -202,12 +203,14 @@ const channelDrafts: ManagedSiteChannelDraftsCapability = {
   prepareFormData: prepareChannelFormData,
 }
 
+const readMatchingInventory = sharePendingConfigRead(listSub2ApiApiKeyAccounts)
+
 const matching: ManagedResourceMatchingCapability<Sub2ApiManagedSiteConfig> = {
   // Native API-key accounts have URL/key identity; no channel model inventory.
   exactMatchBasis: "url-key",
   // The upstream search is name-only; inspect the URL bucket from a full API-key inventory.
-  search: async (config) => {
-    const data = await listSub2ApiApiKeyAccounts(config)
+  search: async (config, _keyword, options) => {
+    const data = await readMatchingInventory(config, options)
     const items = data.items
       .filter((account) => account.type === "apikey")
       .map((account) => ({

--- a/src/services/apiAdapters/managedSites/veloera.ts
+++ b/src/services/apiAdapters/managedSites/veloera.ts
@@ -17,6 +17,7 @@ import {
   fetchSiteUserGroups,
 } from "~/services/apiService/newApiFamily/default/keyManagement"
 import { listAllChannels } from "~/services/apiService/veloera"
+import { sharePendingConfigRead } from "~/services/apiTransport/requestScheduling"
 import {
   checkValidVeloeraConfig,
   prepareChannelFormData,
@@ -35,8 +36,10 @@ const veloeraManagedSiteConfig: ManagedSiteConfigCapability<VeloeraConfig> =
 
 const veloeraManagedSiteQueries: ManagedSiteQueriesCapability<VeloeraConfig> = {
   siteUserGroups: {
-    fetch: async (config) =>
-      await fetchSiteUserGroups(toManagedSiteApiServiceRequest(config)),
+    fetch: async (config, options) =>
+      await fetchSiteUserGroups(
+        toManagedSiteApiServiceRequest(config, options),
+      ),
   },
   accountAvailableModels: {
     fetch: async (config) =>
@@ -47,6 +50,14 @@ const veloeraManagedSiteQueries: ManagedSiteQueriesCapability<VeloeraConfig> = {
 const veloeraManagedSiteChannelDrafts: ManagedSiteChannelDraftsCapability = {
   prepareFormData: prepareChannelFormData,
 }
+
+const readMatchingInventory = sharePendingConfigRead(
+  (config: VeloeraConfig, options) =>
+    listAllChannels(toManagedSiteApiServiceRequest(config, options), {
+      signal: options.signal,
+      requireCompleteInventory: true,
+    }),
+)
 
 const matching: ManagedResourceMatchingCapability<VeloeraConfig> = {
   fetchSecretKey: async (config, ref, options) =>
@@ -66,13 +77,11 @@ const matching: ManagedResourceMatchingCapability<VeloeraConfig> = {
       toManagedResourceMatchCandidate(candidate, target),
     )
   },
-  search: async (config) =>
-    toManagedResourceMatchList(
-      await listAllChannels(toManagedSiteApiServiceRequest(config), {
-        requireCompleteInventory: true,
-      }),
-      { siteType: SITE_TYPES.VELOERA, config },
-    ),
+  search: async (config, _keyword, options) =>
+    toManagedResourceMatchList(await readMatchingInventory(config, options), {
+      siteType: SITE_TYPES.VELOERA,
+      config,
+    }),
 }
 
 export const veloeraManagedSiteCapabilities = {

--- a/src/services/apiAdapters/nativeResources/concurrency.ts
+++ b/src/services/apiAdapters/nativeResources/concurrency.ts
@@ -1,28 +1,16 @@
-/** Maps every item with a bounded worker pool and preserves original input order. */
+import PQueue from "p-queue"
+
+/** Maps every item with bounded concurrency and preserves original input order. */
 export async function mapSettledWithConcurrency<TItem, TResult>(
   items: readonly TItem[],
   limit: number,
   mapper: (item: TItem, index: number) => Promise<TResult>,
 ): Promise<PromiseSettledResult<TResult>[]> {
-  const results = new Array<PromiseSettledResult<TResult>>(items.length)
-  let nextIndex = 0
-
-  const runWorker = async () => {
-    while (nextIndex < items.length) {
-      const index = nextIndex
-      nextIndex += 1
-      try {
-        results[index] = {
-          status: "fulfilled",
-          value: await mapper(items[index], index),
-        }
-      } catch (reason) {
-        results[index] = { status: "rejected", reason }
-      }
-    }
-  }
-
-  const workerCount = Math.min(items.length, Math.max(1, Math.floor(limit)))
-  await Promise.all(Array.from({ length: workerCount }, runWorker))
-  return results
+  if (items.length === 0) return []
+  const queue = new PQueue({
+    concurrency: Math.min(items.length, Math.max(1, Math.floor(limit))),
+  })
+  return await Promise.allSettled(
+    items.map((item, index) => queue.add(() => mapper(item, index))),
+  )
 }

--- a/src/services/apiService/octopus/index.ts
+++ b/src/services/apiService/octopus/index.ts
@@ -4,6 +4,10 @@
  */
 import { OCTOPUS_LOGIN_PATH } from "~/constants/octopus"
 import { ApiError } from "~/services/apiTransport/errors"
+import {
+  sharePendingConfigRead,
+  type ScheduledReadOptions,
+} from "~/services/apiTransport/requestScheduling"
 import type { ApiServiceRequest } from "~/services/apiTransport/type"
 import { userPreferences } from "~/services/preferences/userPreferences"
 import { createUserCommandProtectionBypassExecution } from "~/services/protectionBypass/client"
@@ -806,14 +810,32 @@ export async function validateOctopusConfig(
   }
 }
 
-/**
- * 搜索渠道（按名称过滤）
- */
+// Search fetches the full inventory before filtering. Keep protection intent in
+// its identity so interactive and automatic execution never borrow each other's policy.
+const readSearchInventory = sharePendingConfigRead(
+  (
+    {
+      protectionBypassExecution,
+      ...config
+    }: OctopusConfig & Pick<OctopusRequestInit, "protectionBypassExecution">,
+    options,
+  ) => listChannels(config, { ...options, protectionBypassExecution }),
+)
+
+/** 搜索渠道（按名称或上游 URL 过滤）。 */
 export async function searchChannels(
   config: OctopusConfig,
   keyword: string,
+  options?: ScheduledReadOptions &
+    Pick<OctopusRequestInit, "protectionBypassExecution">,
 ): Promise<OctopusChannel[]> {
-  const channels = await listChannels(config)
+  const channels = await readSearchInventory(
+    {
+      ...config,
+      protectionBypassExecution: options?.protectionBypassExecution,
+    },
+    options,
+  )
   const lowerKeyword = keyword.trim().toLowerCase()
   if (!lowerKeyword) return channels
   return channels.filter(

--- a/src/services/apiTransport/request.ts
+++ b/src/services/apiTransport/request.ts
@@ -807,6 +807,7 @@ const _fetchApiWithMapper = async <T, TResult>(
       siteRequestLimitKey,
       startRequest,
       admissionAbort.signal,
+      request.requestScheduling,
     )
   } finally {
     admissionAbort.dispose()

--- a/src/services/apiTransport/requestScheduling.ts
+++ b/src/services/apiTransport/requestScheduling.ts
@@ -1,0 +1,115 @@
+/** Process-local scheduling intent, read again when a queued request dispatches. */
+export interface RequestScheduling {
+  readonly priority: "foreground" | "background"
+}
+
+export interface ScheduledReadOptions {
+  signal?: AbortSignal
+  requestScheduling?: RequestScheduling
+}
+
+/**
+ * Shares only pending reads for identical serializable connection configs. Each wrapper
+ * owns its request identity; credentials and URL paths must not be collapsed.
+ * Nested values retain their serialized identity. Completed or orphaned reads
+ * never prevent a later read from seeing edits.
+ */
+export function sharePendingConfigRead<TConfig extends object, TResult>(
+  execute: (
+    config: TConfig,
+    options: Required<ScheduledReadOptions>,
+  ) => Promise<TResult>,
+) {
+  const pending = new Map<string, SharedRead<TResult>>()
+  return (
+    config: TConfig,
+    options: ScheduledReadOptions = {},
+  ): Promise<TResult> => {
+    if (options.signal?.aborted) return Promise.reject(options.signal.reason)
+    const key = JSON.stringify(
+      Object.entries(config).sort(([left], [right]) =>
+        left.localeCompare(right),
+      ),
+    )
+    let read = pending.get(key)
+    if (!read || read.signal.aborted) {
+      const created = new SharedRead<TResult>(async (sharedOptions) => {
+        try {
+          return await execute(config, sharedOptions)
+        } finally {
+          if (pending.get(key) === created) pending.delete(key)
+        }
+      })
+      pending.set(key, created)
+      read = created
+    }
+    return read.read(options)
+  }
+}
+
+/** A shared read retains work while any consumer still needs it. */
+export class SharedRead<T> {
+  private readonly controller = new AbortController()
+  private readonly consumers = new Map<symbol, RequestScheduling | undefined>()
+  private result?: Promise<T>
+
+  constructor(
+    private readonly execute: (
+      options: Required<ScheduledReadOptions>,
+    ) => Promise<T>,
+  ) {}
+
+  /** Exposes cancellation of the underlying read for cache eviction. */
+  get signal() {
+    return this.controller.signal
+  }
+
+  /** Joins once, promotes queued work for active consumers, and detaches on cancellation. */
+  read(options: ScheduledReadOptions = {}): Promise<T> {
+    if (options.signal?.aborted) return Promise.reject(options.signal.reason)
+    if (this.signal.aborted) return Promise.reject(this.signal.reason)
+    const id = Symbol()
+    this.consumers.set(id, options.requestScheduling)
+    const consumers = this.consumers
+    const requestScheduling: RequestScheduling = {
+      get priority() {
+        return [...consumers.values()].some(
+          (intent) => intent?.priority !== "background",
+        )
+          ? "foreground"
+          : "background"
+      },
+    }
+    return new Promise<T>((resolve, reject) => {
+      const cleanup = () => {
+        options.signal?.removeEventListener("abort", cancel)
+        this.consumers.delete(id)
+      }
+      const cancel = () => {
+        cleanup()
+        if (!this.consumers.size) this.controller.abort()
+        reject(
+          options.signal?.reason ?? new DOMException("Aborted", "AbortError"),
+        )
+      }
+      options.signal?.addEventListener("abort", cancel, { once: true })
+      if (!this.result) {
+        try {
+          this.result = this.execute({ signal: this.signal, requestScheduling })
+        } catch (error) {
+          this.result = Promise.reject(error)
+        }
+      }
+      void this.result.then(
+        (value) => {
+          cleanup()
+          resolve(value)
+        },
+        (error) => {
+          cleanup()
+          reject(error)
+        },
+      )
+    })
+  }
+}

--- a/src/services/apiTransport/siteRequestLimiter.ts
+++ b/src/services/apiTransport/siteRequestLimiter.ts
@@ -1,3 +1,4 @@
+import type { RequestScheduling } from "~/services/apiTransport/requestScheduling"
 import { isTestMode } from "~/utils/core/environment"
 import { normalizeUrlForOriginKey } from "~/utils/core/urlParsing"
 
@@ -14,6 +15,7 @@ type QueueItem = {
   reject: (reason?: unknown) => void
   signal?: AbortSignal
   abortListener?: () => void
+  scheduling?: RequestScheduling
 }
 
 type SiteRequestLease<T> = {
@@ -24,6 +26,7 @@ type SiteRequestLease<T> = {
 }
 
 type SiteLimiterState = {
+  foregroundStreak: number
   activeCount: number
   tokens: number
   lastRefillAt: number
@@ -37,6 +40,9 @@ const SITE_API_REQUEST_LIMITS = {
   requestsPerMinute: 18,
   burst: 4,
 } as const satisfies SiteRequestLimiterConfig
+
+// Reserve one dispatch for waiting background work after five foreground requests.
+const MAX_FOREGROUND_STREAK = 5
 
 const IDLE_STATE_TTL_MS = 5 * 60 * 1000
 
@@ -104,7 +110,7 @@ function resolveNonNegativeNumber(
 }
 
 /**
- * Creates a per-site FIFO token-bucket limiter. Each lease retains its
+ * Creates a per-site priority token-bucket limiter with FIFO within each lane. Each lease retains its
  * concurrency slot until completion, even if its caller result settles first.
  *
  * Defaults are chosen to stay below New API's dashboard/web default of
@@ -139,6 +145,7 @@ export function createSiteRequestLeaseLimiter(
       _key: string,
       task: () => SiteRequestLease<T>,
       signal?: AbortSignal,
+      _scheduling?: RequestScheduling,
     ): Promise<T> => {
       if (signal?.aborted) throw getAbortReason(signal)
       return await runWithoutLimit(task)
@@ -161,6 +168,7 @@ export function createSiteRequestLeaseLimiter(
     let state = states.get(key)
     if (!state) {
       state = {
+        foregroundStreak: 0,
         activeCount: 0,
         tokens: capacity,
         lastRefillAt: Date.now(),
@@ -219,7 +227,22 @@ export function createSiteRequestLeaseLimiter(
 
       // Abort dispatch is synchronous: queued handlers remove their item before
       // this turn, and this turn detaches the handler before starting the task.
-      const item = state.queue.shift()!
+      const foregroundIndex = state.queue.findIndex(
+        (item) => item.scheduling?.priority !== "background",
+      )
+      const backgroundIndex = state.queue.findIndex(
+        (item) => item.scheduling?.priority === "background",
+      )
+      const index =
+        backgroundIndex >= 0 &&
+        (foregroundIndex < 0 || state.foregroundStreak >= MAX_FOREGROUND_STREAK)
+          ? backgroundIndex
+          : Math.max(0, foregroundIndex)
+      const [item] = state.queue.splice(index, 1)
+      state.foregroundStreak =
+        item.scheduling?.priority === "background" || backgroundIndex < 0
+          ? 0
+          : state.foregroundStreak + 1
       detachAbortListener(item)
 
       state.tokens -= 1
@@ -247,6 +270,7 @@ export function createSiteRequestLeaseLimiter(
     key: string,
     task: () => SiteRequestLease<T>,
     signal?: AbortSignal,
+    scheduling?: RequestScheduling,
   ): Promise<T> => {
     if (signal?.aborted) throw getAbortReason(signal)
     if (!key) return await runWithoutLimit(task)
@@ -259,6 +283,7 @@ export function createSiteRequestLeaseLimiter(
         resolve: (value) => resolve(value as T),
         reject,
         signal,
+        scheduling,
       }
 
       if (signal) {
@@ -286,6 +311,7 @@ const wrapLeaseLimiterForTasks =
     key: string,
     task: () => Promise<T>,
     signal?: AbortSignal,
+    scheduling?: RequestScheduling,
   ): Promise<T> =>
     await limiter(
       key,
@@ -305,6 +331,7 @@ const wrapLeaseLimiterForTasks =
         }
       },
       signal,
+      scheduling,
     )
 
 /** Creates a limiter that retains its slot until each task promise settles. */
@@ -327,8 +354,9 @@ export async function withSiteApiRequestLimit<T>(
   key: string,
   task: () => Promise<T>,
   signal?: AbortSignal,
+  scheduling?: RequestScheduling,
 ): Promise<T> {
-  return await productionSiteRequestLimiter(key, task, signal)
+  return await productionSiteRequestLimiter(key, task, signal, scheduling)
 }
 
 /**
@@ -339,6 +367,7 @@ export async function withSiteApiRequestLease<T>(
   key: string,
   task: () => SiteRequestLease<T>,
   signal?: AbortSignal,
+  scheduling?: RequestScheduling,
 ): Promise<T> {
-  return await productionSiteRequestLeaseLimiter(key, task, signal)
+  return await productionSiteRequestLeaseLimiter(key, task, signal, scheduling)
 }

--- a/src/services/apiTransport/type.ts
+++ b/src/services/apiTransport/type.ts
@@ -1,4 +1,5 @@
 import type { DeferredAbortDeadline } from "~/services/apiTransport/abortableTask"
+import type { RequestScheduling } from "~/services/apiTransport/requestScheduling"
 import type { ProtectionBypassExecution } from "~/services/protectionBypass/contracts"
 import { type AuthTypeEnum } from "~/types"
 import type {
@@ -132,6 +133,7 @@ export interface ApiTransportRequestObserver {
 }
 
 export interface ApiTransportRequest {
+  requestScheduling?: RequestScheduling
   auth: AuthConfig
   baseUrl: string
   data?: Record<string, any>
@@ -171,6 +173,7 @@ export interface FetchApiOptions {
 }
 
 export interface OpenAIAuthParams {
+  requestScheduling?: RequestScheduling
   baseUrl: string
   apiKey: string
   abortSignal?: AbortSignal

--- a/src/services/managedSites/channelMatchResolver.ts
+++ b/src/services/managedSites/channelMatchResolver.ts
@@ -5,6 +5,10 @@ import {
 } from "~/services/apiAdapters/contracts/managedResourceNative"
 import type { ManagedSiteCapabilities } from "~/services/apiAdapters/contracts/managedSiteCapabilities"
 import {
+  SharedRead,
+  type ScheduledReadOptions,
+} from "~/services/apiTransport/requestScheduling"
+import {
   getRecoverableManagedSiteChannelCandidate,
   MANAGED_SITE_CHANNEL_MATCH_UNRESOLVED_REASONS,
   MANAGED_SITE_CHANNEL_MODELS_MATCH_REASONS,
@@ -45,6 +49,51 @@ export interface ManagedSiteChannelMatchRequestCache {
   resolvedChannelKeysByResourceKey: Record<string, string>
 }
 
+// Only pending searches cross operation boundaries: a later import must see
+// resources created or edited since the previous check completed.
+const pendingSearches = new WeakMap<
+  ManagedSiteChannelMatchContext["matching"],
+  Map<string, SharedRead<ManagedResourceMatchList | null>>
+>()
+
+/** Shares a pending read only for the same adapter, config and search target. */
+function getPendingSearch(
+  managedSite: ManagedSiteChannelMatchContext,
+  managedConfig: ManagedSiteRuntimeConfigValue,
+  searchBaseUrl: string,
+  options: ScheduledReadOptions,
+): Promise<ManagedResourceMatchList | null> {
+  let searches = pendingSearches.get(managedSite.matching)
+  if (!searches) {
+    searches = new Map()
+    pendingSearches.set(managedSite.matching, searches)
+  }
+  const key = JSON.stringify([
+    managedSite.siteType,
+    Object.entries(managedConfig).sort(([left], [right]) =>
+      left.localeCompare(right),
+    ),
+    searchBaseUrl,
+  ])
+  const existing = searches.get(key)
+  if (existing && !existing.signal.aborted) return existing.read(options)
+  const read = new SharedRead<ManagedResourceMatchList | null>(
+    async (sharedOptions) => {
+      try {
+        return await managedSite.matching.search(
+          managedConfig,
+          searchBaseUrl,
+          sharedOptions,
+        )
+      } finally {
+        if (searches.get(key) === read) searches.delete(key)
+      }
+    },
+  )
+  searches.set(key, read)
+  return read.read(options)
+}
+
 export const createManagedSiteChannelMatchRequestCache =
   (): ManagedSiteChannelMatchRequestCache => ({
     searchResultsByTargetKey: new Map(),
@@ -52,7 +101,7 @@ export const createManagedSiteChannelMatchRequestCache =
     resolvedChannelKeysByResourceKey: {},
   })
 
-interface ResolveManagedSiteChannelMatchParams {
+interface ResolveManagedSiteChannelMatchParams extends ScheduledReadOptions {
   managedSite: ManagedSiteChannelMatchContext
   managedConfig: ManagedSiteRuntimeConfigValue
   accountBaseUrl: string
@@ -99,13 +148,15 @@ const applyResolvedChannelKeys = <
   })
 }
 
-const fetchRecoverableCandidateSecretKey = async (params: {
-  managedSite: ManagedSiteChannelMatchContext
-  managedConfig: ManagedSiteRuntimeConfigValue
-  resourceRef: ManagedResourceRef
-  requestCache?: ManagedSiteChannelMatchRequestCache
-  protectionBypassExecution: ProtectionBypassExecution
-}) => {
+const fetchRecoverableCandidateSecretKey = async (
+  params: ScheduledReadOptions & {
+    managedSite: ManagedSiteChannelMatchContext
+    managedConfig: ManagedSiteRuntimeConfigValue
+    resourceRef: ManagedResourceRef
+    requestCache?: ManagedSiteChannelMatchRequestCache
+    protectionBypassExecution: ProtectionBypassExecution
+  },
+) => {
   assertManagedResourceRefForSite(params.resourceRef, {
     siteType: params.managedSite.siteType,
     config: params.managedConfig,
@@ -124,6 +175,8 @@ const fetchRecoverableCandidateSecretKey = async (params: {
       params.resourceRef,
       {
         protectionBypassExecution: params.protectionBypassExecution,
+        signal: params.signal,
+        requestScheduling: params.requestScheduling,
       },
     )
     params.requestCache?.channelSecretKeysByResourceKey.set(
@@ -158,6 +211,7 @@ const fetchRecoverableCandidateSecretKey = async (params: {
 export async function resolveManagedSiteChannelMatch(
   params: ResolveManagedSiteChannelMatchParams,
 ): Promise<ManagedSiteChannelMatchResolution> {
+  params.signal?.throwIfAborted()
   const {
     managedSite,
     managedConfig,
@@ -189,9 +243,11 @@ export async function resolveManagedSiteChannelMatch(
 
   if (!searchResultsPromise) {
     const cache = requestCache
-    searchResultsPromise = managedSite.matching.search(
+    searchResultsPromise = getPendingSearch(
+      managedSite,
       managedConfig,
       searchBaseUrl,
+      params,
     )
     cache?.searchResultsByTargetKey.set(searchCacheKey, searchResultsPromise)
     searchResultsPromise.catch(() => {
@@ -205,7 +261,9 @@ export async function resolveManagedSiteChannelMatch(
     })
   }
 
+  params.signal?.throwIfAborted()
   const searchResults = await searchResultsPromise
+  params.signal?.throwIfAborted()
 
   if (!searchResults) {
     return {
@@ -410,6 +468,7 @@ export async function resolveManagedSiteChannelMatch(
     )
 
     for (const recoverableCandidate of recoverableCandidates) {
+      params.signal?.throwIfAborted()
       try {
         mergedResolvedChannelKeysByResourceKey[
           getManagedResourceRefKey(recoverableCandidate.ref)
@@ -419,6 +478,8 @@ export async function resolveManagedSiteChannelMatch(
           resourceRef: recoverableCandidate.ref,
           requestCache,
           protectionBypassExecution: params.protectionBypassExecution,
+          signal: params.signal,
+          requestScheduling: params.requestScheduling,
         })
         if (requestCache) {
           requestCache.resolvedChannelKeysByResourceKey[
@@ -429,6 +490,7 @@ export async function resolveManagedSiteChannelMatch(
             ]
         }
       } catch (error) {
+        params.signal?.throwIfAborted()
         if (!(error instanceof MatchResolutionUnresolvedError)) {
           throw error
         }
@@ -506,7 +568,11 @@ export async function resolveManagedSiteChannelMatch(
           await managedSite.matching.hydrateComparableKeys(
             managedConfig,
             recoverableCandidates,
-            { protectionBypassExecution: params.protectionBypassExecution },
+            {
+              protectionBypassExecution: params.protectionBypassExecution,
+              signal: params.signal,
+              requestScheduling: params.requestScheduling,
+            },
           )
 
         const requestedKeys = new Set(
@@ -541,6 +607,7 @@ export async function resolveManagedSiteChannelMatch(
 
         refreshAssessmentsWithResolvedKeys()
       } catch (error) {
+        params.signal?.throwIfAborted()
         if (!(error instanceof MatchResolutionUnresolvedError)) {
           throw error
         }

--- a/src/services/managedSites/providers/axonHub.ts
+++ b/src/services/managedSites/providers/axonHub.ts
@@ -1,4 +1,5 @@
 import { AXON_HUB_CHANNEL_TYPE } from "~/constants/axonHub"
+import type { ManagedSiteChannelDraftRequestOptions } from "~/services/apiAdapters/contracts/managedSiteCapabilities"
 import * as axonHubApi from "~/services/apiService/axonHub"
 import { fetchManagedSiteImportModels } from "~/services/managedSites/utils/fetchManagedSiteImportModels"
 import {
@@ -45,9 +46,10 @@ export async function checkValidAxonHubConfig(): Promise<boolean> {
  */
 export async function prepareChannelFormData(
   source: ManagedSiteChannelDraftSource,
+  options?: ManagedSiteChannelDraftRequestOptions,
 ): Promise<ManagedSiteChannelDraft> {
   const { models: availableModels, fetchFailed } =
-    await fetchManagedSiteImportModels(source)
+    await fetchManagedSiteImportModels(source, options)
 
   return {
     name: source.name,

--- a/src/services/managedSites/providers/claudeCodeHub.ts
+++ b/src/services/managedSites/providers/claudeCodeHub.ts
@@ -1,6 +1,8 @@
 import { CLAUDE_CODE_HUB_PROVIDER_TYPE } from "~/constants/claudeCodeHub"
+import type { ManagedSiteChannelDraftRequestOptions } from "~/services/apiAdapters/contracts/managedSiteCapabilities"
 import { requireNumericManagedResourceId } from "~/services/apiAdapters/managedResources/resourceIds"
 import * as claudeCodeHubApi from "~/services/apiService/claudeCodeHub"
+import type { ScheduledReadOptions } from "~/services/apiTransport/requestScheduling"
 import {
   MANAGED_SITE_CHANNEL_MATCH_UNRESOLVED_REASONS,
   MatchResolutionUnresolvedError,
@@ -84,7 +86,11 @@ export async function checkValidClaudeCodeHubConfig(): Promise<boolean> {
  */
 async function hydrateComparableChannelKey<
   T extends { id: number; key?: string },
->(config: ClaudeCodeHubConfig, channel: T): Promise<T | null> {
+>(
+  config: ClaudeCodeHubConfig,
+  channel: T,
+  options?: ScheduledReadOptions,
+): Promise<T | null> {
   if (hasUsableManagedSiteChannelKey(channel.key)) {
     return channel
   }
@@ -93,6 +99,7 @@ async function hydrateComparableChannelKey<
     const key = await claudeCodeHubApi.getUnmaskedProviderKey(
       config,
       requireNumericManagedResourceId(channel.id),
+      options,
     )
     if (!hasUsableManagedSiteChannelKey(key)) {
       throw new Error("Claude Code Hub returned an unusable provider key")
@@ -102,6 +109,7 @@ async function hydrateComparableChannelKey<
       key: key.trim(),
     }
   } catch (error) {
+    options?.signal?.throwIfAborted()
     const disclosed = toClaudeCodeHubDisclosureError(error, config)
     logger.warn("Failed to hydrate Claude Code Hub provider key", {
       channelId: channel.id,
@@ -116,16 +124,25 @@ async function hydrateComparableChannelKey<
  */
 export async function hydrateComparableChannelKeys<
   T extends { id: number; key?: string },
->(config: ClaudeCodeHubConfig, candidates: T[]): Promise<T[]> {
+>(
+  config: ClaudeCodeHubConfig,
+  candidates: T[],
+  options?: ScheduledReadOptions,
+): Promise<T[]> {
   const hydratedCandidates: T[] = []
 
   for (const candidate of candidates) {
+    options?.signal?.throwIfAborted()
     if (hasUsableManagedSiteChannelKey(candidate.key)) {
       hydratedCandidates.push(candidate)
       continue
     }
 
-    const hydratedChannel = await hydrateComparableChannelKey(config, candidate)
+    const hydratedChannel = await hydrateComparableChannelKey(
+      config,
+      candidate,
+      options,
+    )
     if (hydratedChannel) {
       hydratedCandidates.push(hydratedChannel)
       continue
@@ -145,11 +162,12 @@ export async function hydrateComparableChannelKeys<
 export async function fetchChannelSecretKey(
   config: ClaudeCodeHubConfig,
   channelId: number,
+  options?: ScheduledReadOptions,
 ): Promise<string> {
   return await runClaudeCodeHubRead(
     config,
     async () =>
-      await claudeCodeHubApi.getUnmaskedProviderKey(config, channelId),
+      await claudeCodeHubApi.getUnmaskedProviderKey(config, channelId, options),
   )
 }
 
@@ -158,9 +176,10 @@ export async function fetchChannelSecretKey(
  */
 export async function prepareChannelFormData(
   source: ManagedSiteChannelDraftSource,
+  options?: ManagedSiteChannelDraftRequestOptions,
 ): Promise<ManagedSiteChannelDraft> {
   const { models: availableModels, fetchFailed } =
-    await fetchManagedSiteImportModels(source)
+    await fetchManagedSiteImportModels(source, options)
 
   return {
     name: source.name,

--- a/src/services/managedSites/providers/claudeCodeHub.ts
+++ b/src/services/managedSites/providers/claudeCodeHub.ts
@@ -41,10 +41,15 @@ export function toClaudeCodeHubDisclosureError(
 const runClaudeCodeHubRead = async <T>(
   config: ClaudeCodeHubConfig,
   operation: () => Promise<T>,
+  options?: ScheduledReadOptions,
 ): Promise<T> => {
+  options?.signal?.throwIfAborted()
   try {
-    return await operation()
+    const result = await operation()
+    options?.signal?.throwIfAborted()
+    return result
   } catch (error) {
+    options?.signal?.throwIfAborted()
     throw toClaudeCodeHubDisclosureError(error, config)
   }
 }
@@ -168,6 +173,7 @@ export async function fetchChannelSecretKey(
     config,
     async () =>
       await claudeCodeHubApi.getUnmaskedProviderKey(config, channelId, options),
+    options,
   )
 }
 

--- a/src/services/managedSites/providers/defaultChannelGroups.ts
+++ b/src/services/managedSites/providers/defaultChannelGroups.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_CHANNEL_FIELDS } from "~/constants/managedSiteChannelDraft"
+import type { ManagedSiteChannelDraftRequestOptions } from "~/services/apiAdapters/contracts/managedSiteCapabilities"
 import type { ManagedSiteOperationContext } from "~/services/managedSites/operationContext"
 import { normalizeList } from "~/utils/core/string"
 
@@ -12,6 +13,7 @@ type ResolveDefaultChannelGroupsParams = {
   getConfig: () => Promise<ManagedSiteConfig | null>
   fetchSiteUserGroups: (config: ManagedSiteConfig) => Promise<string[]>
   onError?: (error: unknown) => void
+  purpose?: ManagedSiteChannelDraftRequestOptions["purpose"]
   operationContext?: ManagedSiteOperationContext
 }
 
@@ -27,7 +29,14 @@ export async function resolveDefaultChannelGroups({
   fetchSiteUserGroups,
   onError,
   operationContext,
+  purpose,
 }: ResolveDefaultChannelGroupsParams): Promise<string[]> {
+  // Native import seeds do not consume draft groups. The editor loads its own
+  // group options, so querying here would duplicate that request.
+  if (purpose === "matching" || purpose === "native-editor") {
+    return [...DEFAULT_CHANNEL_FIELDS.groups]
+  }
+
   const requestCache = operationContext?.defaultChannelGroups
 
   if (requestCache?.resolvedGroups) {

--- a/src/services/managedSites/providers/doneHubService.ts
+++ b/src/services/managedSites/providers/doneHubService.ts
@@ -95,7 +95,7 @@ export async function prepareChannelFormData(
   options?: ManagedSiteChannelDraftRequestOptions,
 ): Promise<ManagedSiteChannelDraft> {
   const { models: availableModels, fetchFailed } =
-    await fetchManagedSiteImportModels(source)
+    await fetchManagedSiteImportModels(source, options)
 
   const resolvedGroups = await resolveDefaultChannelGroups({
     getConfig: getDoneHubConfig,
@@ -109,6 +109,7 @@ export async function prepareChannelFormData(
         },
       }),
     operationContext: options?.operationContext,
+    purpose: options?.purpose,
     onError: (error) => {
       logger.warn("Failed to resolve Done Hub default groups", error)
     },

--- a/src/services/managedSites/providers/newApi.ts
+++ b/src/services/managedSites/providers/newApi.ts
@@ -112,12 +112,13 @@ export async function prepareChannelFormData(
   // Channel import prefill must reflect only the selected key's live upstream
   // model list; on failure we keep the dialog editable and require manual input.
   const { models: availableModels, fetchFailed } =
-    await fetchManagedSiteImportModels(source)
+    await fetchManagedSiteImportModels(source, options)
 
   const resolvedGroups = await resolveDefaultChannelGroups({
     getConfig: getNewApiConfig,
     fetchSiteUserGroups: fetchNewApiConfigUserGroups,
     operationContext: options?.operationContext,
+    purpose: options?.purpose,
     onError: (error) => {
       logger.warn("Failed to resolve New API default groups", error)
     },

--- a/src/services/managedSites/providers/octopus.ts
+++ b/src/services/managedSites/providers/octopus.ts
@@ -2,6 +2,7 @@
  * Octopus configuration validation and managed-channel draft preparation.
  */
 import { DEFAULT_OCTOPUS_CHANNEL_FIELDS } from "~/constants/octopus"
+import type { ManagedSiteChannelDraftRequestOptions } from "~/services/apiAdapters/contracts/managedSiteCapabilities"
 import { fetchManagedSiteImportModels } from "~/services/managedSites/utils/fetchManagedSiteImportModels"
 import {
   userPreferences,
@@ -61,9 +62,10 @@ export async function checkValidOctopusConfig(): Promise<boolean> {
  */
 export async function prepareChannelFormData(
   source: ManagedSiteChannelDraftSource,
+  options?: ManagedSiteChannelDraftRequestOptions,
 ): Promise<ManagedSiteChannelDraft> {
   const { models: availableModels, fetchFailed } =
-    await fetchManagedSiteImportModels(source)
+    await fetchManagedSiteImportModels(source, options)
 
   return {
     name: source.name,

--- a/src/services/managedSites/providers/veloera.ts
+++ b/src/services/managedSites/providers/veloera.ts
@@ -92,7 +92,7 @@ export async function prepareChannelFormData(
   options?: ManagedSiteChannelDraftRequestOptions,
 ): Promise<ManagedSiteChannelDraft> {
   const { models: availableModels, fetchFailed } =
-    await fetchManagedSiteImportModels(source)
+    await fetchManagedSiteImportModels(source, options)
   const resolvedModels =
     availableModels.length > 0 ? availableModels : source.modelHints
 
@@ -108,6 +108,7 @@ export async function prepareChannelFormData(
         },
       }),
     operationContext: options?.operationContext,
+    purpose: options?.purpose,
     onError: (error) => {
       logger.warn("Failed to resolve Veloera default groups", error)
     },

--- a/src/services/managedSites/tokenChannelStatus.ts
+++ b/src/services/managedSites/tokenChannelStatus.ts
@@ -8,6 +8,7 @@ import type { ManagedResourceSecretVerificationRecovery } from "~/services/apiAd
 import type { ManagedResourceRef } from "~/services/apiAdapters/contracts/managedResourceNative"
 import type { ManagedSiteCapabilities } from "~/services/apiAdapters/contracts/managedSiteCapabilities"
 import { getManagedSiteCapabilities } from "~/services/apiAdapters/registry"
+import type { ScheduledReadOptions } from "~/services/apiTransport/requestScheduling"
 import { buildManagedSiteChannelDraftSource } from "~/services/managedSites/channelDraftSource"
 import {
   getManagedSiteChannelExactMatch,
@@ -100,7 +101,7 @@ export type ManagedSiteTokenChannelStatus =
         }
     )
 
-interface GetManagedSiteTokenChannelStatusParams {
+interface GetManagedSiteTokenChannelStatusParams extends ScheduledReadOptions {
   runtimeKey: AccountRuntimeKey
   managedSite?: ManagedSiteCapabilities
   managedConfig?: ManagedSiteRuntimeConfigValue | null
@@ -209,6 +210,7 @@ export function resolveManagedSiteTokenChannelStatusWithVerifiedKey(
 export async function getManagedSiteTokenChannelStatus(
   params: GetManagedSiteTokenChannelStatusParams,
 ): Promise<ManagedSiteTokenChannelStatus> {
+  params.signal?.throwIfAborted()
   const { runtimeKey } = params
   const managedSite =
     params.managedSite ??
@@ -222,6 +224,7 @@ export async function getManagedSiteTokenChannelStatus(
     }
   }
 
+  params.signal?.throwIfAborted()
   let resolvedRuntimeKey = runtimeKey
   let secretsToRedact = collectSecrets(runtimeKey, managedConfig)
 
@@ -240,7 +243,11 @@ export async function getManagedSiteTokenChannelStatus(
       resolvedRuntimeKey = await resolveDisplayAccountRuntimeKeySecret(
         runtimeKey.account,
         runtimeKey,
-        { protectionBypassExecution: params.protectionBypassExecution },
+        {
+          protectionBypassExecution: params.protectionBypassExecution,
+          abortSignal: params.signal,
+          requestScheduling: params.requestScheduling,
+        },
       )
     }
     secretsToRedact = Array.from(
@@ -250,6 +257,7 @@ export async function getManagedSiteTokenChannelStatus(
       ]),
     )
   } catch (error) {
+    params.signal?.throwIfAborted()
     const diagnostic = toSanitizedErrorSummary(error, secretsToRedact)
 
     logger.warn("Managed-site token secret resolution failed", {
@@ -268,6 +276,7 @@ export async function getManagedSiteTokenChannelStatus(
   }
 
   try {
+    params.signal?.throwIfAborted()
     const source = buildManagedSiteChannelDraftSource({
       ...resolvedRuntimeKey,
       baseUrl: isAccountTokenRuntimeKey(resolvedRuntimeKey)
@@ -276,7 +285,11 @@ export async function getManagedSiteTokenChannelStatus(
     })
     const formData = await managedSite.channelDrafts.prepareFormData(source, {
       operationContext: params.operationContext,
+      purpose: "matching",
+      signal: params.signal,
+      requestScheduling: params.requestScheduling,
     })
+    params.signal?.throwIfAborted()
     const searchBaseUrl = normalizeManagedSiteChannelBaseUrl(formData.base_url)
 
     if (!searchBaseUrl) {
@@ -299,8 +312,11 @@ export async function getManagedSiteTokenChannelStatus(
       resolvedChannelKeysByResourceKey: params.resolvedChannelKeysByResourceKey,
       resolveHiddenKeys: true,
       requestCache: params.operationContext?.channelMatch,
+      signal: params.signal,
+      requestScheduling: params.requestScheduling,
       protectionBypassExecution: params.protectionBypassExecution,
     })
+    params.signal?.throwIfAborted()
     const assessment = toManagedSiteVerifiedKeyAssessment(resolution)
     const exactMatch = getManagedSiteChannelExactMatch(
       resolution,
@@ -389,6 +405,7 @@ export async function getManagedSiteTokenChannelStatus(
       ...resolvedChannelKeys,
     }
   } catch (error) {
+    params.signal?.throwIfAborted()
     const diagnostic = toSanitizedErrorSummary(error, secretsToRedact)
 
     logger.warn("Managed-site token status check failed", {

--- a/src/services/managedSites/utils/fetchManagedSiteImportModels.ts
+++ b/src/services/managedSites/utils/fetchManagedSiteImportModels.ts
@@ -1,4 +1,8 @@
 import { fetchOpenAICompatibleModelIds } from "~/services/aiApi/openaiCompatible"
+import {
+  sharePendingConfigRead,
+  type ScheduledReadOptions,
+} from "~/services/apiTransport/requestScheduling"
 import type { ManagedSiteChannelDraftSource } from "~/types/managedSiteChannelDraft"
 import { createLogger } from "~/utils/core/logger"
 import { normalizeList } from "~/utils/core/string"
@@ -10,25 +14,46 @@ type ManagedSiteImportModelsResult = {
   fetchFailed: boolean
 }
 
+const readPendingModels = sharePendingConfigRead(fetchUncachedModels)
+
+/**
+ * Shares only in-flight model reads between status checks and exports. Each new
+ * read after completion fetches live models for the selected path and credential.
+ */
+export async function fetchManagedSiteImportModels(
+  source: Pick<ManagedSiteChannelDraftSource, "baseUrl" | "apiKey">,
+  options: ScheduledReadOptions = {},
+): Promise<ManagedSiteImportModelsResult> {
+  const result = await readPendingModels(
+    { baseUrl: source.baseUrl, apiKey: source.apiKey },
+    options,
+  )
+  return { ...result, models: [...result.models] }
+}
+
 /**
  * Fetches live upstream models for the selected API key only.
  *
  * Existing model hints are not live API results. Each destination decides
  * whether to use them as a fallback when preparing its import draft.
  */
-export async function fetchManagedSiteImportModels(
+async function fetchUncachedModels(
   source: Pick<ManagedSiteChannelDraftSource, "baseUrl" | "apiKey">,
+  options: ScheduledReadOptions = {},
 ): Promise<ManagedSiteImportModelsResult> {
   try {
     const upstreamModels = await fetchOpenAICompatibleModelIds({
       baseUrl: source.baseUrl,
       apiKey: source.apiKey,
+      abortSignal: options.signal,
+      requestScheduling: options.requestScheduling,
     })
     return {
       models: normalizeList(upstreamModels ?? []),
       fetchFailed: false,
     }
   } catch (error) {
+    if (options.signal?.aborted) throw options.signal.reason
     logger.warn("Failed to fetch upstream models", error)
     return {
       models: [],

--- a/src/services/models/modelSync/modelSyncService.ts
+++ b/src/services/models/modelSync/modelSyncService.ts
@@ -15,6 +15,7 @@ import {
 } from "~/services/managedSites/mutations"
 import { type ManagedSiteRuntimeConfig } from "~/services/managedSites/runtimeConfig"
 import { collectManagedConfigSecrets } from "~/services/managedSites/utils/resourceSecrets"
+import { runModelSyncBatch } from "~/services/models/modelSync/runModelSyncBatch"
 import type { ProtectionBypassExecution } from "~/services/protectionBypass/contracts"
 import type { ChannelResourceConfigMap } from "~/types/channelConfig"
 import type { ChannelModelFilterRule } from "~/types/channelModelFilters"
@@ -26,7 +27,6 @@ import {
   type BatchExecutionOptions,
   type ExecutionItemResult,
   type ExecutionResult,
-  type ExecutionStatistics,
 } from "~/types/managedSiteModelSync"
 import { createLogger } from "~/utils/core/logger"
 
@@ -534,22 +534,10 @@ export class ModelSyncService {
     }
     const { concurrency, maxRetries, channelProcessingTimeout, onProgress } =
       options
-    const startedAt = Date.now()
-    const total = channels.length
-    const results: (ExecutionItemResult | undefined)[] = new Array(total)
-
-    let completed = 0
-    let nextIndex = 0
-
-    const worker = async () => {
-      while (true) {
-        const currentIndex = nextIndex
-        if (currentIndex >= total) {
-          return
-        }
-        nextIndex++ // single shared index for lightweight work stealing
-
-        const channel = channels[currentIndex]
+    return await runModelSyncBatch(
+      channels,
+      { concurrency, onProgress },
+      async (channel) => {
         let result: ExecutionItemResult
         const writeFailureBoundary = createModelSyncWriteFailureBoundary()
 
@@ -585,42 +573,9 @@ export class ModelSyncService {
             finishedAt: Date.now(),
           }
         }
-
-        results[currentIndex] = result
-        completed++
-
-        await onProgress?.({
-          completed,
-          total,
-          lastResult: result,
-        })
-      }
-    }
-
-    // Cap workers to total channels to avoid spinning idle workers
-    const workerCount = Math.max(1, Math.min(concurrency, total))
-    const workers = Array.from({ length: workerCount }, () => worker())
-    await Promise.all(workers)
-
-    const items = results.filter((item): item is ExecutionItemResult => !!item)
-
-    const endedAt = Date.now()
-    const successCount = items.filter((item) => item.ok).length
-    const failureCount = total - successCount
-
-    const statistics: ExecutionStatistics = {
-      total,
-      successCount,
-      failureCount,
-      durationMs: endedAt - startedAt,
-      startedAt,
-      endedAt,
-    }
-
-    return {
-      items,
-      statistics,
-    }
+        return result
+      },
+    )
   }
 
   /**

--- a/src/services/models/modelSync/runModelSyncBatch.ts
+++ b/src/services/models/modelSync/runModelSyncBatch.ts
@@ -19,6 +19,7 @@ export async function runModelSyncBatch<T>(
   const results = new Array<ExecutionItemResult>(total)
   let completed = 0
   let nextIndex = 0
+  let progressTail = Promise.resolve()
 
   const worker = async () => {
     while (nextIndex < total) {
@@ -26,7 +27,15 @@ export async function runModelSyncBatch<T>(
       const result = await execute(channels[index])
       results[index] = result
       completed++
-      await options.onProgress?.({ completed, total, lastResult: result })
+      const progress = { completed, total, lastResult: result }
+      const persisted = progressTail.then(() => options.onProgress?.(progress))
+      // Preserve completion order without letting one failed callback suppress
+      // progress from other workers that are still finishing their items.
+      progressTail = persisted.then(
+        () => {},
+        () => {},
+      )
+      await persisted
     }
   }
 

--- a/src/services/models/modelSync/runModelSyncBatch.ts
+++ b/src/services/models/modelSync/runModelSyncBatch.ts
@@ -1,0 +1,54 @@
+import type {
+  BatchExecutionOptions,
+  ExecutionItemResult,
+  ExecutionResult,
+} from "~/types/managedSiteModelSync"
+
+/**
+ * Shares model-sync ordering, progress and statistics across providers.
+ * A rejected item or progress callback ends its worker and rejects the batch;
+ * other workers retain their in-flight work and continue processing.
+ */
+export async function runModelSyncBatch<T>(
+  channels: readonly T[],
+  options: Pick<BatchExecutionOptions, "concurrency" | "onProgress">,
+  execute: (channel: T) => Promise<ExecutionItemResult>,
+): Promise<ExecutionResult> {
+  const startedAt = Date.now()
+  const total = channels.length
+  const results = new Array<ExecutionItemResult>(total)
+  let completed = 0
+  let nextIndex = 0
+
+  const worker = async () => {
+    while (nextIndex < total) {
+      const index = nextIndex++
+      const result = await execute(channels[index])
+      results[index] = result
+      completed++
+      await options.onProgress?.({ completed, total, lastResult: result })
+    }
+  }
+
+  await Promise.all(
+    Array.from(
+      { length: Math.max(1, Math.min(options.concurrency, total)) },
+      worker,
+    ),
+  )
+
+  const items = results.filter((item): item is ExecutionItemResult => !!item)
+  const endedAt = Date.now()
+  const successCount = items.filter((item) => item.ok).length
+  return {
+    items,
+    statistics: {
+      total,
+      successCount,
+      failureCount: total - successCount,
+      durationMs: endedAt - startedAt,
+      startedAt,
+      endedAt,
+    },
+  }
+}

--- a/tests/components/UseChannelDialog.duplicateChannelWarning.test.tsx
+++ b/tests/components/UseChannelDialog.duplicateChannelWarning.test.tsx
@@ -4,7 +4,10 @@ import {
   useChannelDialog,
   useChannelDialogContext,
 } from "~/components/dialogs/ChannelDialog"
-import { ChannelType } from "~/constants/newApi"
+import {
+  ChannelType,
+  NEW_API_MANAGED_RESOURCE_FIELD_IDS,
+} from "~/constants/newApi"
 import { SITE_TYPES } from "~/constants/siteType"
 import {
   buildAccountKeyResourceRuntimeKey,
@@ -22,12 +25,14 @@ import { MANAGED_RESOURCE_KINDS } from "~/services/accountSiteDefinitions/contra
 import { MANAGED_RESOURCE_CREATE_SEED_KINDS } from "~/services/apiAdapters/contracts/managedResourceNative"
 import type { ManagedSiteCapabilities } from "~/services/apiAdapters/contracts/managedSiteCapabilities"
 import { TOKEN_PROVISIONING_BLOCK_REASONS } from "~/services/apiAdapters/contracts/tokenProvisioning"
+import { createNewApiCreateEditor } from "~/services/apiAdapters/managedResources/newApiEditor"
 import * as nativeResourceRegistry from "~/services/apiAdapters/managedResources/registry"
 import * as managedSiteRegistry from "~/services/apiAdapters/registry"
 import {
   MANAGED_SITE_CHANNEL_MATCH_UNRESOLVED_REASONS,
   MatchResolutionUnresolvedError,
 } from "~/services/managedSites/channelMatch"
+import { resolveDefaultChannelGroups } from "~/services/managedSites/providers/defaultChannelGroups"
 import {
   MANAGED_SITE_TOKEN_CHANNEL_STATUS_UNKNOWN_REASONS,
   MANAGED_SITE_TOKEN_CHANNEL_STATUSES,
@@ -348,6 +353,66 @@ describe("useChannelDialog", () => {
     registrationSpy?.mockRestore()
     registrationSpy = undefined
   })
+
+  it.each(["account", "credentials"] as const)(
+    "queries destination groups once across %s import preparation and editor options",
+    async (entrypoint) => {
+      const fetchGroups = vi.fn(async () => ["default", "vip"])
+      const service = buildManagedSiteCapabilitiesMock({
+        channelDrafts: {
+          prepareFormData: async (_source, options) =>
+            buildPreparedFormData({
+              groups: await resolveDefaultChannelGroups({
+                getConfig: async () => ({
+                  baseUrl: "https://managed.example.com",
+                  adminToken: "admin-token",
+                  userId: "1",
+                }),
+                fetchSiteUserGroups: fetchGroups,
+                purpose: options?.purpose,
+              }),
+            }),
+        },
+      })
+      getManagedSiteCapabilitiesSpy.mockReturnValue(service)
+      nativeOpenCreateEditorMock.mockImplementation(async () => ({
+        ...(await createNewApiCreateEditor({
+          canLoadSecret: false,
+          loadSecret: vi.fn(),
+          fetchModels: vi.fn(),
+          fetchDraftModels: vi.fn(),
+          loadEditorGroups: fetchGroups,
+        })),
+        submit: vi.fn(),
+      }))
+      const { result } = await renderChannelDialogHook()
+      await act(async () => {
+        const opened =
+          entrypoint === "account"
+            ? await result.current.dialog.openWithAccount(
+                buildDisplaySiteData(),
+                buildDisplayAccountTokenRuntimeKey(
+                  buildDisplaySiteData(),
+                  buildApiToken(),
+                ),
+              )
+            : await result.current.dialog.openWithCredentials({
+                name: "Imported credential",
+                baseUrl: "https://upstream.example.com",
+                apiKey: "sk-test",
+              })
+        expect(opened.opened).toBe(true)
+      })
+      const editor = result.current.context.state.nativeCreate!.editor
+      expect(
+        await editor.loadOptions!(
+          NEW_API_MANAGED_RESOURCE_FIELD_IDS.Groups,
+          editor.initialValues,
+        ),
+      ).toEqual([{ value: "default" }, { value: "vip" }])
+      expect(fetchGroups).toHaveBeenCalledTimes(1)
+    },
+  )
 
   it("shows warning and cancels when user does not continue", async () => {
     const existingChannel = buildManagedResourceMatchCandidate()
@@ -775,12 +840,15 @@ describe("useChannelDialog", () => {
 
     expect(ensureAccountApiTokenSpy).not.toHaveBeenCalled()
     expect(mockFetchAccountTokens).not.toHaveBeenCalled()
-    expect(prepareChannelFormDataMock).toHaveBeenCalledWith({
-      name: "Account | Token (auto)",
-      baseUrl: "https://upstream.example.com",
-      apiKey: providedToken.key,
-      modelHints: [],
-    })
+    expect(prepareChannelFormDataMock).toHaveBeenCalledWith(
+      {
+        name: "Account | Token (auto)",
+        baseUrl: "https://upstream.example.com",
+        apiKey: providedToken.key,
+        modelHints: [],
+      },
+      { purpose: "native-editor" },
+    )
     expect(result.current.context.state.isOpen).toBe(true)
   })
 
@@ -1500,12 +1568,15 @@ describe("useChannelDialog", () => {
       await result.current.context.handleDefaultTokenQuickCreateSuccess()
     })
 
-    expect(prepareChannelFormDataMock).toHaveBeenCalledWith({
-      name: "Account | Created token (auto)",
-      baseUrl: "https://upstream.example.com",
-      apiKey: createdToken.key,
-      modelHints: [],
-    })
+    expect(prepareChannelFormDataMock).toHaveBeenCalledWith(
+      {
+        name: "Account | Created token (auto)",
+        baseUrl: "https://upstream.example.com",
+        apiKey: createdToken.key,
+        modelHints: [],
+      },
+      { purpose: "native-editor" },
+    )
     expect(result.current.context.state).toMatchObject({
       isOpen: true,
       nativeCreate: {
@@ -1562,12 +1633,15 @@ describe("useChannelDialog", () => {
     })
 
     expect(mockFetchAccountTokens).toHaveBeenCalledTimes(1)
-    expect(prepareChannelFormDataMock).toHaveBeenCalledWith({
-      name: "Account | Created token (auto)",
-      baseUrl: "https://upstream.example.com",
-      apiKey: createdToken.key,
-      modelHints: [],
-    })
+    expect(prepareChannelFormDataMock).toHaveBeenCalledWith(
+      {
+        name: "Account | Created token (auto)",
+        baseUrl: "https://upstream.example.com",
+        apiKey: createdToken.key,
+        modelHints: [],
+      },
+      { purpose: "native-editor" },
+    )
     expect(result.current.context.state).toMatchObject({
       isOpen: true,
       nativeCreate: {
@@ -2437,12 +2511,15 @@ describe("useChannelDialog", () => {
         toastId: "toast-id",
       }),
     )
-    expect(prepareChannelFormDataMock).toHaveBeenCalledWith({
-      name: "Account | Token (auto)",
-      baseUrl: "https://upstream.example.com",
-      apiKey: "sk-ensured-token",
-      modelHints: [],
-    })
+    expect(prepareChannelFormDataMock).toHaveBeenCalledWith(
+      {
+        name: "Account | Token (auto)",
+        baseUrl: "https://upstream.example.com",
+        apiKey: "sk-ensured-token",
+        modelHints: [],
+      },
+      { purpose: "native-editor" },
+    )
     expect(result.current.context.state).toMatchObject({
       isOpen: true,
       nativeCreate: {

--- a/tests/entrypoints/options/pages/KeyManagement/useKeyManagement.test.tsx
+++ b/tests/entrypoints/options/pages/KeyManagement/useKeyManagement.test.tsx
@@ -2242,7 +2242,7 @@ describe("useKeyManagement enabled account filtering", () => {
     )
   })
 
-  it("shares a managed-site match request cache across status checks in the same batch", async () => {
+  it("isolates operation caches for independently cancellable status targets", async () => {
     const mockedUseAccountData = vi.mocked(useAccountData)
     const account = createDisplayAccount({
       id: "managed-cache-acc",
@@ -2294,7 +2294,9 @@ describe("useKeyManagement enabled account filtering", () => {
       | { operationContext?: unknown }
       | undefined
     expect(firstParams).toHaveProperty("operationContext")
-    expect(firstParams?.operationContext).toBe(secondParams?.operationContext)
+    expect(firstParams?.operationContext).not.toBe(
+      secondParams?.operationContext,
+    )
   })
 
   it("reveals the resolved full key when the inventory value is masked", async () => {
@@ -4372,7 +4374,74 @@ describe("useKeyManagement enabled account filtering", () => {
     expect(getManagedSiteTokenChannelStatusMock).toHaveBeenCalledTimes(1)
   })
 
-  it("cancels checks for the previous account and checks unfinished keys when returning", async () => {
+  it("cancels only superseded target reads while other checks and queued keys continue", async () => {
+    const account = createDisplayAccount({ id: "superseded-status-account" })
+    vi.mocked(useAccountData).mockReturnValue({
+      enabledDisplayData: [account],
+    } as any)
+    mockedUseUserPreferencesContext.mockReturnValue({
+      managedSiteType: "new-api",
+      preferences: buildUserPreferences({
+        newApi: {
+          baseUrl: "https://managed.example",
+          adminToken: "admin-token",
+          userId: "1",
+        },
+      }),
+    })
+    vi.mocked(getSiteTypeCapabilities).mockReturnValue(
+      createAdapterWithKeyManagement({
+        fetchTokens: vi
+          .fn()
+          .mockResolvedValue(
+            Array.from({ length: 6 }, (_, index) =>
+              createToken({ id: 800 + index, key: `key-${index}` }),
+            ),
+          ),
+      }) as any,
+    )
+    const active = new Map<number, AbortSignal>()
+    getManagedSiteTokenChannelStatusMock.mockImplementation(
+      ({
+        signal,
+        runtimeKey,
+      }: {
+        signal: AbortSignal
+        runtimeKey: { tokenId: number }
+      }) => {
+        active.set(runtimeKey.tokenId, signal)
+        return new Promise((_, reject) =>
+          signal.addEventListener("abort", () => reject(signal.reason), {
+            once: true,
+          }),
+        )
+      },
+    )
+    const { result, unmount } = renderHook(() => useKeyManagement(), {
+      wrapper: createWrapper(),
+    })
+    act(() => result.current.setSelectedAccount(account.id))
+    await waitFor(() => expect(active.size).toBe(4))
+    const superseded = active.get(800)!
+    getManagedSiteTokenChannelStatusMock.mockResolvedValueOnce({
+      status: managedSiteTokenChannelStatuses.NOT_ADDED,
+    })
+    await act(async () => {
+      await result.current.refreshManagedSiteTokenStatusForToken(
+        result.current.tokens.find((token) => token.id === 800)!,
+      )
+    })
+    expect(superseded.aborted).toBe(true)
+    expect([801, 802, 803].every((id) => !active.get(id)!.aborted)).toBe(true)
+    await waitFor(() => expect(active.has(804)).toBe(true))
+    expect(
+      result.current.managedSiteTokenStatuses[`${account.id}:800`]?.result
+        ?.status,
+    ).toBe(managedSiteTokenChannelStatuses.NOT_ADDED)
+    unmount()
+  })
+
+  it("cancels previous account checks and refreshes its inventory when returning", async () => {
     const firstAccount = createDisplayAccount({ id: "first-status-account" })
     const secondAccount = createDisplayAccount({ id: "second-status-account" })
     vi.mocked(useAccountData).mockReturnValue({
@@ -4431,6 +4500,8 @@ describe("useKeyManagement enabled account filtering", () => {
     getManagedSiteTokenChannelStatusMock.mockResolvedValue({
       status: managedSiteTokenChannelStatuses.NOT_ADDED,
     })
+    const callsBeforeReturn =
+      getManagedSiteTokenChannelStatusMock.mock.calls.length
     act(() => result.current.setSelectedAccount(firstAccount.id))
     await waitFor(() =>
       expect(
@@ -4440,6 +4511,13 @@ describe("useKeyManagement enabled account filtering", () => {
     )
     expect(signals.every((signal) => signal.aborted)).toBe(true)
     expect(getManagedSiteTokenChannelStatusMock).toHaveBeenCalledTimes(15)
+    // Returning reloads the account inventory and invalidates even completed
+    // evidence, so all six keys must be checked against the current backend.
+    expect(
+      getManagedSiteTokenChannelStatusMock.mock.calls
+        .slice(callsBeforeReturn)
+        .map(([params]) => params.runtimeKey.tokenId),
+    ).toEqual([800, 801, 802, 803, 804, 805])
   })
 
   it.each(["unmount", "config"])(

--- a/tests/entrypoints/options/pages/KeyManagement/useKeyManagement.test.tsx
+++ b/tests/entrypoints/options/pages/KeyManagement/useKeyManagement.test.tsx
@@ -3247,10 +3247,7 @@ describe("useKeyManagement enabled account filtering", () => {
     expect(getManagedSiteTokenChannelStatusMock).toHaveBeenCalledTimes(2)
     expect(getManagedSiteTokenChannelStatusMock).toHaveBeenLastCalledWith(
       expect.objectContaining({
-        resolvedChannelKeysByResourceKey: {
-          [getManagedResourceRefKey(matchingResourceRef(77))]:
-            "verified-channel-key",
-        },
+        resolvedChannelKeysByResourceKey: undefined,
         protectionBypassExecution: userCommandExecution(
           PROTECTION_BYPASS_USER_COMMANDS.ManageApiKeys,
         ),
@@ -3702,171 +3699,196 @@ describe("useKeyManagement enabled account filtering", () => {
     expect(firstRefreshResult).toBeUndefined()
   })
 
-  it("reuses resolved channel keys from previous managed-site status checks", async () => {
-    const mockedUseAccountData = vi.mocked(useAccountData)
-    const account = createDisplayAccount({
-      id: "resolved-cache-acc",
-      name: "Resolved Cache Account",
-    })
-
-    mockedUseAccountData.mockReturnValue({
-      enabledDisplayData: [account],
-    } as any)
-
-    const fetchAccountTokens = vi.fn().mockResolvedValue([
-      createToken({
-        id: 604,
-        key: "token-604",
-        name: "Token 604",
-        expired_time: 0,
-      }),
-    ])
-    vi.mocked(getSiteTypeCapabilities).mockReturnValue(
-      createAdapterWithKeyManagement({
-        fetchTokens: fetchAccountTokens,
-      }) as any,
-    )
-    getManagedSiteTokenChannelStatusMock
-      .mockResolvedValueOnce({
-        status: managedSiteTokenChannelStatuses.ADDED,
-        matchedChannel: {
-          ref: matchingResourceRef(56),
-          name: "Managed Channel 56",
-        },
-        resolvedChannelKeysByResourceKey: {
-          [getManagedResourceRefKey(matchingResourceRef(56))]:
-            "resolved-channel-key",
-        },
-      })
-      .mockResolvedValueOnce({
-        status: managedSiteTokenChannelStatuses.ADDED,
-        matchedChannel: {
-          ref: matchingResourceRef(56),
-          name: "Managed Channel 56",
-        },
+  it.each(["single", "all", "account"])(
+    "discards previous channel keys on %s refresh",
+    async (refresh) => {
+      const mockedUseAccountData = vi.mocked(useAccountData)
+      const account = createDisplayAccount({
+        id: "resolved-cache-acc",
+        name: "Resolved Cache Account",
       })
 
-    const { result } = renderHook(() => useKeyManagement(), {
-      wrapper: createWrapper(),
-    })
+      mockedUseAccountData.mockReturnValue({
+        enabledDisplayData: [account],
+      } as any)
 
-    act(() => {
-      result.current.setSelectedAccount(account.id)
-    })
-
-    await waitFor(() =>
-      expect(getManagedSiteTokenChannelStatusMock).toHaveBeenCalledTimes(1),
-    )
-
-    await act(async () => {
-      await result.current.refreshManagedSiteTokenStatusForToken(
-        result.current.tokens[0]!,
+      const fetchAccountTokens = vi.fn().mockResolvedValue([
+        createToken({
+          id: 604,
+          key: "token-604",
+          name: "Token 604",
+          expired_time: 0,
+        }),
+      ])
+      vi.mocked(getSiteTypeCapabilities).mockReturnValue(
+        createAdapterWithKeyManagement({
+          fetchTokens: fetchAccountTokens,
+        }) as any,
       )
-    })
+      getManagedSiteTokenChannelStatusMock
+        .mockResolvedValueOnce({
+          status: managedSiteTokenChannelStatuses.ADDED,
+          matchedChannel: {
+            ref: matchingResourceRef(56),
+            name: "Managed Channel 56",
+          },
+          resolvedChannelKeysByResourceKey: {
+            [getManagedResourceRefKey(matchingResourceRef(56))]:
+              "resolved-channel-key",
+          },
+        })
+        .mockResolvedValueOnce({
+          status: managedSiteTokenChannelStatuses.ADDED,
+          matchedChannel: {
+            ref: matchingResourceRef(56),
+            name: "Managed Channel 56",
+          },
+        })
 
-    await waitFor(() =>
-      expect(getManagedSiteTokenChannelStatusMock).toHaveBeenCalledTimes(2),
-    )
-    expect(getManagedSiteTokenChannelStatusMock).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        resolvedChannelKeysByResourceKey: {
-          [getManagedResourceRefKey(matchingResourceRef(56))]:
-            "resolved-channel-key",
-        },
-      }),
-    )
-  })
-
-  it("does not cache resolved channel keys from stale managed-site status checks", async () => {
-    const mockedUseAccountData = vi.mocked(useAccountData)
-    const account = createDisplayAccount({
-      id: "stale-resolved-cache-acc",
-      name: "Stale Resolved Cache Account",
-    })
-
-    mockedUseAccountData.mockReturnValue({
-      enabledDisplayData: [account],
-    } as any)
-
-    let resolveInitialStatus: (
-      value: Awaited<ReturnType<typeof getManagedSiteTokenChannelStatusMock>>,
-    ) => void = () => {}
-    const initialStatus = new Promise<
-      Awaited<ReturnType<typeof getManagedSiteTokenChannelStatusMock>>
-    >((resolve) => {
-      resolveInitialStatus = resolve
-    })
-
-    const fetchAccountTokens = vi.fn().mockResolvedValue([
-      createToken({
-        id: 605,
-        key: "token-605",
-        name: "Token 605",
-        expired_time: 0,
-      }),
-    ])
-    vi.mocked(getSiteTypeCapabilities).mockReturnValue(
-      createAdapterWithKeyManagement({
-        fetchTokens: fetchAccountTokens,
-      }) as any,
-    )
-    getManagedSiteTokenChannelStatusMock
-      .mockReturnValueOnce(initialStatus)
-      .mockResolvedValueOnce({
-        status: managedSiteTokenChannelStatuses.NOT_ADDED,
-      })
-      .mockResolvedValueOnce({
-        status: managedSiteTokenChannelStatuses.NOT_ADDED,
+      const { result } = renderHook(() => useKeyManagement(), {
+        wrapper: createWrapper(),
       })
 
-    const { result } = renderHook(() => useKeyManagement(), {
-      wrapper: createWrapper(),
-    })
+      act(() => {
+        result.current.setSelectedAccount(account.id)
+      })
 
-    act(() => {
-      result.current.setSelectedAccount(account.id)
-    })
-
-    await waitFor(() =>
-      expect(getManagedSiteTokenChannelStatusMock).toHaveBeenCalledTimes(1),
-    )
-
-    await act(async () => {
-      await result.current.refreshManagedSiteTokenStatusForToken(
-        result.current.tokens[0]!,
+      await waitFor(() =>
+        expect(getManagedSiteTokenChannelStatusMock).toHaveBeenCalledTimes(1),
       )
-    })
 
-    await act(async () => {
-      resolveInitialStatus({
-        status: managedSiteTokenChannelStatuses.ADDED,
-        matchedChannel: {
-          ref: matchingResourceRef(57),
-          name: "Managed Channel 57",
-        },
-        resolvedChannelKeysByResourceKey: {
-          [getManagedResourceRefKey(matchingResourceRef(57))]:
-            "stale-resolved-channel-key",
-        },
+      await act(async () => {
+        if (refresh === "single") {
+          await result.current.refreshManagedSiteTokenStatusForToken(
+            result.current.tokens[0]!,
+          )
+        } else if (refresh === "all") {
+          await result.current.refreshManagedSiteTokenStatuses()
+        } else {
+          await result.current.loadTokens()
+        }
       })
-      await initialStatus
-    })
 
-    await act(async () => {
-      await result.current.refreshManagedSiteTokenStatusForToken(
-        result.current.tokens[0]!,
+      await waitFor(() =>
+        expect(getManagedSiteTokenChannelStatusMock).toHaveBeenCalledTimes(2),
       )
-    })
+      expect(getManagedSiteTokenChannelStatusMock).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          resolvedChannelKeysByResourceKey: undefined,
+        }),
+      )
+    },
+  )
 
-    await waitFor(() =>
-      expect(getManagedSiteTokenChannelStatusMock).toHaveBeenCalledTimes(3),
-    )
-    expect(getManagedSiteTokenChannelStatusMock).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        resolvedChannelKeysByResourceKey: undefined,
-      }),
-    )
-  })
+  it.each(["single", "account"])(
+    "ignores old status results after %s refresh",
+    async (refresh) => {
+      const mockedUseAccountData = vi.mocked(useAccountData)
+      const account = createDisplayAccount({
+        id: "stale-resolved-cache-acc",
+        name: "Stale Resolved Cache Account",
+      })
+
+      mockedUseAccountData.mockReturnValue({
+        enabledDisplayData: [account],
+      } as any)
+
+      let resolveInitialStatus: (
+        value: Awaited<ReturnType<typeof getManagedSiteTokenChannelStatusMock>>,
+      ) => void = () => {}
+      const initialStatus = new Promise<
+        Awaited<ReturnType<typeof getManagedSiteTokenChannelStatusMock>>
+      >((resolve) => {
+        resolveInitialStatus = resolve
+      })
+
+      const fetchAccountTokens = vi.fn().mockResolvedValue([
+        createToken({
+          id: 605,
+          key: "token-605",
+          name: "Token 605",
+          expired_time: 0,
+        }),
+      ])
+      vi.mocked(getSiteTypeCapabilities).mockReturnValue(
+        createAdapterWithKeyManagement({
+          fetchTokens: fetchAccountTokens,
+        }) as any,
+      )
+      getManagedSiteTokenChannelStatusMock
+        .mockReturnValueOnce(initialStatus)
+        .mockResolvedValueOnce({
+          status: managedSiteTokenChannelStatuses.NOT_ADDED,
+        })
+        .mockResolvedValueOnce({
+          status: managedSiteTokenChannelStatuses.NOT_ADDED,
+        })
+
+      const { result } = renderHook(() => useKeyManagement(), {
+        wrapper: createWrapper(),
+      })
+
+      act(() => {
+        result.current.setSelectedAccount(account.id)
+      })
+
+      await waitFor(() =>
+        expect(getManagedSiteTokenChannelStatusMock).toHaveBeenCalledTimes(1),
+      )
+
+      await act(async () => {
+        if (refresh === "single") {
+          await result.current.refreshManagedSiteTokenStatusForToken(
+            result.current.tokens[0]!,
+          )
+        } else {
+          await result.current.loadTokens()
+        }
+      })
+      await waitFor(() =>
+        expect(
+          result.current.managedSiteTokenStatuses[
+            "stale-resolved-cache-acc:605"
+          ]?.result?.status,
+        ).toBe(managedSiteTokenChannelStatuses.NOT_ADDED),
+      )
+
+      await act(async () => {
+        resolveInitialStatus({
+          status: managedSiteTokenChannelStatuses.ADDED,
+          matchedChannel: {
+            ref: matchingResourceRef(57),
+            name: "Managed Channel 57",
+          },
+          resolvedChannelKeysByResourceKey: {
+            [getManagedResourceRefKey(matchingResourceRef(57))]:
+              "stale-resolved-channel-key",
+          },
+        })
+        await initialStatus
+      })
+
+      expect(
+        result.current.managedSiteTokenStatuses["stale-resolved-cache-acc:605"]
+          ?.result?.status,
+      ).toBe(managedSiteTokenChannelStatuses.NOT_ADDED)
+
+      await act(async () => {
+        await result.current.refreshManagedSiteTokenStatusForToken(
+          result.current.tokens[0]!,
+        )
+      })
+
+      await waitFor(() =>
+        expect(getManagedSiteTokenChannelStatusMock).toHaveBeenCalledTimes(3),
+      )
+      expect(getManagedSiteTokenChannelStatusMock).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          resolvedChannelKeysByResourceKey: undefined,
+        }),
+      )
+    },
+  )
 
   it("invalidates managed-site status when a token is deleted", async () => {
     const mockedUseAccountData = vi.mocked(useAccountData)
@@ -4349,6 +4371,155 @@ describe("useKeyManagement enabled account filtering", () => {
     ).toEqual(originalStatus)
     expect(getManagedSiteTokenChannelStatusMock).toHaveBeenCalledTimes(1)
   })
+
+  it("cancels checks for the previous account and checks unfinished keys when returning", async () => {
+    const firstAccount = createDisplayAccount({ id: "first-status-account" })
+    const secondAccount = createDisplayAccount({ id: "second-status-account" })
+    vi.mocked(useAccountData).mockReturnValue({
+      enabledDisplayData: [firstAccount, secondAccount],
+    } as any)
+    mockedUseUserPreferencesContext.mockReturnValue({
+      managedSiteType: "new-api",
+      preferences: buildUserPreferences({
+        newApi: {
+          baseUrl: "https://managed.example",
+          adminToken: "admin-token",
+          userId: "1",
+        },
+      }),
+    })
+    vi.mocked(getSiteTypeCapabilities).mockReturnValue(
+      createAdapterWithKeyManagement({
+        fetchTokens: vi
+          .fn()
+          .mockResolvedValue(
+            Array.from({ length: 6 }, (_, index) =>
+              createToken({ id: 800 + index, key: `key-${index}` }),
+            ),
+          ),
+      }) as any,
+    )
+    const signals: AbortSignal[] = []
+    getManagedSiteTokenChannelStatusMock.mockImplementation(
+      ({ signal }: { signal: AbortSignal }) => {
+        signals.push(signal)
+        return new Promise((_, reject) =>
+          signal.addEventListener("abort", () => reject(signal.reason), {
+            once: true,
+          }),
+        )
+      },
+    )
+    const { result } = renderHook(() => useKeyManagement(), {
+      wrapper: createWrapper(),
+    })
+    getManagedSiteTokenChannelStatusMock.mockResolvedValueOnce({
+      status: managedSiteTokenChannelStatuses.ADDED,
+    })
+    act(() => result.current.setSelectedAccount(firstAccount.id))
+    await waitFor(() => expect(signals).toHaveLength(4))
+    const firstSignals = [...signals]
+
+    act(() => result.current.setSelectedAccount(secondAccount.id))
+    await waitFor(() => expect(signals).toHaveLength(8))
+    expect(firstSignals.every((signal) => signal.aborted)).toBe(true)
+    expect(
+      result.current.managedSiteTokenStatuses[`${firstAccount.id}:800`]?.result
+        ?.status,
+    ).toBe(managedSiteTokenChannelStatuses.ADDED)
+
+    getManagedSiteTokenChannelStatusMock.mockResolvedValue({
+      status: managedSiteTokenChannelStatuses.NOT_ADDED,
+    })
+    act(() => result.current.setSelectedAccount(firstAccount.id))
+    await waitFor(() =>
+      expect(
+        result.current.managedSiteTokenStatuses[`${firstAccount.id}:805`]
+          ?.result?.status,
+      ).toBe(managedSiteTokenChannelStatuses.NOT_ADDED),
+    )
+    expect(signals.every((signal) => signal.aborted)).toBe(true)
+    expect(getManagedSiteTokenChannelStatusMock).toHaveBeenCalledTimes(15)
+  })
+
+  it.each(["unmount", "config"])(
+    "cancels obsolete automatic checks on %s and does not start remaining tokens",
+    async (reason) => {
+      const account = createDisplayAccount({ id: "cancel-status-acc" })
+      vi.mocked(useAccountData).mockReturnValue({
+        enabledDisplayData: [account],
+      } as any)
+      const context = {
+        managedSiteType: "new-api",
+        preferences: buildUserPreferences({
+          newApi: {
+            baseUrl: "https://managed.example",
+            adminToken: "admin-token",
+            userId: "1",
+          },
+        }),
+      }
+      mockedUseUserPreferencesContext.mockImplementation(() => context)
+      vi.mocked(getSiteTypeCapabilities).mockReturnValue(
+        createAdapterWithKeyManagement({
+          fetchTokens: vi.fn().mockResolvedValue(
+            Array.from({ length: 6 }, (_, i) =>
+              createToken({
+                id: 800 + i,
+                key: `token-${i}`,
+                expired_time: 0,
+              }),
+            ),
+          ),
+        }) as any,
+      )
+      const signals: AbortSignal[] = []
+      getManagedSiteTokenChannelStatusMock.mockImplementation(
+        ({
+          signal,
+          requestScheduling,
+        }: {
+          signal: AbortSignal
+          requestScheduling: { priority: string }
+        }) => {
+          expect(requestScheduling.priority).toBe("background")
+          signals.push(signal)
+          return new Promise((_, reject) =>
+            signal.addEventListener("abort", () => reject(signal.reason), {
+              once: true,
+            }),
+          )
+        },
+      )
+      const { result, rerender, unmount } = renderHook(
+        () => useKeyManagement(),
+        { wrapper: createWrapper() },
+      )
+      act(() => result.current.setSelectedAccount(account.id))
+      await waitFor(() => expect(signals).toHaveLength(4))
+      const oldSignals = [...signals]
+      if (reason === "unmount") unmount()
+      else {
+        context.preferences = {
+          ...context.preferences,
+          newApi: {
+            ...context.preferences.newApi,
+            baseUrl: "https://managed-2.example",
+          },
+        }
+        rerender()
+        await waitFor(() => expect(signals).toHaveLength(8))
+        unmount()
+      }
+      expect(oldSignals.every((signal) => signal.aborted)).toBe(true)
+      await act(async () => {
+        await Promise.resolve()
+      })
+      expect(getManagedSiteTokenChannelStatusMock).toHaveBeenCalledTimes(
+        reason === "unmount" ? 4 : 8,
+      )
+    },
+  )
 
   it("invalidates cached managed-site status when managed-site preferences change", async () => {
     const mockedUseAccountData = vi.mocked(useAccountData)

--- a/tests/entrypoints/options/pages/KeyManagement/useKeyManagement.test.tsx
+++ b/tests/entrypoints/options/pages/KeyManagement/useKeyManagement.test.tsx
@@ -4441,6 +4441,83 @@ describe("useKeyManagement enabled account filtering", () => {
     unmount()
   })
 
+  it("skips superseded queued targets and permits retry after unexpected setup failures", async () => {
+    const account = createDisplayAccount({ id: "queued-status-account" })
+    vi.mocked(useAccountData).mockReturnValue({
+      enabledDisplayData: [account],
+    } as any)
+    mockedUseUserPreferencesContext.mockReturnValue({
+      managedSiteType: "new-api",
+      preferences: buildUserPreferences({
+        newApi: {
+          baseUrl: "https://managed.example",
+          adminToken: "admin-token",
+          userId: "1",
+        },
+      }),
+    })
+    vi.mocked(getSiteTypeCapabilities).mockReturnValue(
+      createAdapterWithKeyManagement({
+        fetchTokens: vi
+          .fn()
+          .mockResolvedValue(
+            Array.from({ length: 6 }, (_, index) =>
+              createToken({ id: 800 + index, key: `key-${index}` }),
+            ),
+          ),
+      }) as any,
+    )
+    const pending = new Map<
+      number,
+      { resolve: (value: any) => void; reject: (error: Error) => void }
+    >()
+    getManagedSiteTokenChannelStatusMock.mockImplementation(
+      ({ runtimeKey }: { runtimeKey: { tokenId: number } }) =>
+        new Promise((resolve, reject) =>
+          pending.set(runtimeKey.tokenId, { resolve, reject }),
+        ),
+    )
+    const { result, unmount } = renderHook(() => useKeyManagement(), {
+      wrapper: createWrapper(),
+    })
+    act(() => result.current.setSelectedAccount(account.id))
+    await waitFor(() => expect(pending.size).toBe(4))
+    const status = { status: managedSiteTokenChannelStatuses.NOT_ADDED }
+    getManagedSiteTokenChannelStatusMock.mockResolvedValueOnce(status)
+    await act(async () => {
+      await result.current.refreshManagedSiteTokenStatusForToken(
+        result.current.tokens.find((token) => token.id === 804)!,
+      )
+      pending.get(800)!.resolve(status)
+      pending.get(801)!.reject(new Error("configuration read failed"))
+    })
+    await waitFor(() => expect(pending.has(805)).toBe(true))
+    expect(
+      getManagedSiteTokenChannelStatusMock.mock.calls.filter(
+        ([params]) => params.runtimeKey.tokenId === 804,
+      ),
+    ).toHaveLength(1)
+    getManagedSiteTokenChannelStatusMock.mockResolvedValueOnce(status)
+    await act(async () => {
+      await result.current.refreshManagedSiteTokenStatusForToken(
+        result.current.tokens.find((token) => token.id === 801)!,
+      )
+      for (const entry of pending.values()) entry.resolve(status)
+    })
+    await waitFor(() =>
+      expect(
+        result.current.managedSiteTokenStatuses[`${account.id}:801`]?.result
+          ?.status,
+      ).toBe(status.status),
+    )
+    expect(
+      getManagedSiteTokenChannelStatusMock.mock.calls.filter(
+        ([params]) => params.runtimeKey.tokenId === 801,
+      ),
+    ).toHaveLength(2)
+    unmount()
+  })
+
   it("cancels previous account checks and refreshes its inventory when returning", async () => {
     const firstAccount = createDisplayAccount({ id: "first-status-account" })
     const secondAccount = createDisplayAccount({ id: "second-status-account" })

--- a/tests/features/AccountManagement/components/AccountActionButtons.shareAndLocate.test.tsx
+++ b/tests/features/AccountManagement/components/AccountActionButtons.shareAndLocate.test.tsx
@@ -476,6 +476,7 @@ describe("AccountActionButtons", () => {
     expect(managedService.matching.search).toHaveBeenCalledWith(
       expect.any(Object),
       "https://api.example.com",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
     )
     expect(openManagedSiteChannelsPageMock).toHaveBeenCalledTimes(1)
   })
@@ -577,6 +578,7 @@ describe("AccountActionButtons", () => {
     expect(managedService.matching.search).toHaveBeenCalledWith(
       expect.any(Object),
       "https://runtime.example.invalid",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
     )
     expect(openManagedSiteChannelsPageMock).toHaveBeenCalledTimes(1)
   })
@@ -749,6 +751,7 @@ describe("AccountActionButtons", () => {
     expect(managedService.matching.search).toHaveBeenCalledWith(
       expect.any(Object),
       "https://api.example.com",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
     )
     expect(openManagedSiteChannelsPageMock).toHaveBeenCalledTimes(1)
   })

--- a/tests/services/accounts/apiServiceRequest.test.ts
+++ b/tests/services/accounts/apiServiceRequest.test.ts
@@ -1317,6 +1317,27 @@ describe("fetchDisplayAccountTokens", () => {
     expect(token.key).toBe("plain-secret")
   })
 
+  it("keeps live scheduling intent when resolving a token secret", async () => {
+    const requestScheduling = {
+      priority: "background" as "background" | "foreground",
+    }
+    const token = { id: 1, key: "", status: 1, name: "Key" }
+    resolveTokenKey.mockImplementationOnce(async ({ request }) => {
+      expect(request.requestScheduling).toBe(requestScheduling)
+      requestScheduling.priority = "foreground"
+      expect(request.requestScheduling.priority).toBe("foreground")
+      return "resolved-secret"
+    })
+
+    await expect(
+      resolveDisplayAccountTokenForSecret(ACCOUNT as any, token as any, {
+        requestScheduling,
+      }),
+    ).resolves.toMatchObject({ key: "sk-resolved-secret" })
+    expect(resolveTokenKey).toHaveBeenCalledTimes(1)
+    expect(token.key).toBe("")
+  })
+
   it("does not synthesize sk-prefixes for non-compatible account types", async () => {
     const token = { id: 1, key: "plain-secret", status: 1, name: "Plain" }
     resolveTokenKey.mockResolvedValue("plain-secret")

--- a/tests/services/aiApi/openaiCompatible.index.test.ts
+++ b/tests/services/aiApi/openaiCompatible.index.test.ts
@@ -104,6 +104,30 @@ describe("OpenAI-compatible model fetchers", () => {
     expect(mockFetchApiData).toHaveBeenCalledTimes(1)
   })
 
+  it("preserves live scheduling intent across model route fallback", async () => {
+    const requestScheduling = {
+      priority: "background" as "background" | "foreground",
+    }
+    mockFetchApiData
+      .mockImplementationOnce(async (request) => {
+        expect(request.requestScheduling).toBe(requestScheduling)
+        requestScheduling.priority = "foreground"
+        throw new ApiError("canonical route unavailable", 404)
+      })
+      .mockImplementationOnce(async (request) => {
+        expect(request.requestScheduling).toBe(requestScheduling)
+        expect(request.requestScheduling.priority).toBe("foreground")
+        return [{ id: "custom-model" }]
+      })
+
+    await expect(
+      discoverOpenAICompatibleModels({ ...params, requestScheduling }),
+    ).resolves.toMatchObject({
+      models: [{ id: "custom-model" }],
+    })
+    expect(mockFetchApiData).toHaveBeenCalledTimes(2)
+  })
+
   it.each([404, 405])(
     "falls back to /models when the canonical route returns %s",
     async (statusCode) => {

--- a/tests/services/apiAdapters/managedSites/cliProxyApi.test.ts
+++ b/tests/services/apiAdapters/managedSites/cliProxyApi.test.ts
@@ -4,6 +4,7 @@ import { cliProxyApiRef } from "~/services/apiAdapters/managedResources/cliProxy
 import { cliProxyApiCapabilities } from "~/services/apiAdapters/managedSites/cliProxyApi"
 import type { CliProxyApiResource } from "~/services/apiService/cliProxyApi"
 import { API_TYPES } from "~/services/verification/aiApiVerification"
+import { createDeferred } from "~~/tests/test-utils/deferred"
 
 const mocks = vi.hoisted(() => ({
   list: vi.fn(),
@@ -52,6 +53,138 @@ beforeEach(() => {
 })
 
 describe("CLIProxyAPI configuration and credential matching", () => {
+  it("shares equivalent configs but isolates credentials and deployment paths", async () => {
+    const inventory = createDeferred<CliProxyApiResource[]>()
+    mocks.list.mockReturnValue(inventory.promise)
+    const search = cliProxyApiCapabilities.matching.search
+    const requests = [
+      search(config, "first.example"),
+      search(
+        { adminToken: config.adminToken, baseUrl: config.baseUrl },
+        "second.example",
+      ),
+      search({ ...config, adminToken: "other-admin" }, "first.example"),
+      search(
+        { ...config, baseUrl: `${config.baseUrl}/other` },
+        "first.example",
+      ),
+    ]
+    expect(mocks.list).toHaveBeenCalledTimes(3)
+    inventory.resolve([])
+    await expect(Promise.all(requests)).resolves.toEqual(
+      Array.from({ length: 4 }, () => ({
+        items: [],
+        total: 0,
+        type_counts: {},
+      })),
+    )
+  })
+
+  it("replaces an orphaned read without a late response evicting its replacement", async () => {
+    const oldInventory = createDeferred<CliProxyApiResource[]>()
+    const newInventory = createDeferred<CliProxyApiResource[]>()
+    mocks.list
+      .mockReturnValueOnce(oldInventory.promise)
+      .mockReturnValueOnce(newInventory.promise)
+    const controller = new AbortController()
+    const firstOutcome = Promise.allSettled([
+      cliProxyApiCapabilities.matching.search(config, "first.example", {
+        signal: controller.signal,
+      }),
+    ])
+    const readSignal = mocks.list.mock.calls[0][1].signal as AbortSignal
+    controller.abort()
+    expect(readSignal.aborted).toBe(true)
+    expect(await firstOutcome).toEqual([
+      {
+        status: "rejected",
+        reason: expect.objectContaining({ name: "AbortError" }),
+      },
+    ])
+    const replacement = cliProxyApiCapabilities.matching.search(
+      config,
+      "first.example",
+    )
+    oldInventory.resolve([])
+    await oldInventory.promise
+    const joined = cliProxyApiCapabilities.matching.search(
+      config,
+      "second.example",
+    )
+    expect(mocks.list).toHaveBeenCalledTimes(2)
+    newInventory.resolve([])
+    await Promise.all([replacement, joined])
+  })
+
+  it("does not dispatch canceled consumers and retries failed inventory reads", async () => {
+    const controller = new AbortController()
+    controller.abort()
+    await expect(
+      cliProxyApiCapabilities.matching.search(config, "", {
+        signal: controller.signal,
+      }),
+    ).rejects.toMatchObject({ name: "AbortError" })
+    expect(mocks.list).not.toHaveBeenCalled()
+    mocks.list.mockRejectedValueOnce(new Error("temporarily unavailable"))
+    await expect(
+      cliProxyApiCapabilities.matching.search(config, ""),
+    ).rejects.toThrow("temporarily unavailable")
+    mocks.list.mockResolvedValueOnce([])
+    await expect(
+      cliProxyApiCapabilities.matching.search(config, ""),
+    ).resolves.toMatchObject({ items: [], total: 0 })
+    expect(mocks.list).toHaveBeenCalledTimes(2)
+  })
+
+  it("shares pending inventories across search URLs without canceling another consumer", async () => {
+    const inventory = createDeferred<CliProxyApiResource[]>()
+    mocks.list.mockReturnValueOnce(inventory.promise)
+    const controller = new AbortController()
+    const first = cliProxyApiCapabilities.matching.search(
+      config,
+      "upstream.example",
+      {
+        signal: controller.signal,
+        requestScheduling: { priority: "background" },
+      },
+    )
+    const firstOutcome = Promise.allSettled([first])
+    const second = cliProxyApiCapabilities.matching.search(
+      config,
+      "other.example",
+    )
+    controller.abort()
+    const readOptions = mocks.list.mock.calls[0][1]
+    expect(mocks.list).toHaveBeenCalledTimes(1)
+    expect(readOptions.signal.aborted).toBe(false)
+    expect(readOptions.requestScheduling.priority).toBe("foreground")
+    inventory.resolve([
+      resource,
+      {
+        id: "other",
+        kind: "codex-api-key",
+        value: { "base-url": "https://other.example", "api-key": "other-key" },
+      },
+    ])
+    expect(await firstOutcome).toEqual([
+      {
+        status: "rejected",
+        reason: expect.objectContaining({ name: "AbortError" }),
+      },
+    ])
+    await expect(second).resolves.toMatchObject({
+      total: 1,
+      items: [{ base_url: "https://other.example", key: "other-key" }],
+    })
+
+    // A later import must see any edits made after the shared read completed.
+    mocks.list.mockResolvedValueOnce([])
+    await expect(
+      cliProxyApiCapabilities.matching.search(config, "other.example"),
+    ).resolves.toMatchObject({ total: 0, items: [] })
+    expect(mocks.list).toHaveBeenCalledTimes(2)
+  })
+
   it("validates configuration using an authenticated inventory read", async () => {
     expect(await cliProxyApiCapabilities.config.checkValid()).toBe(true)
     expect(mocks.list).toHaveBeenCalledWith(config)

--- a/tests/services/apiAdapters/managedSites/doneHub.test.ts
+++ b/tests/services/apiAdapters/managedSites/doneHub.test.ts
@@ -1,12 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { doneHubManagedResourceModels } from "~/services/apiAdapters/managedResources/doneHubOperations"
+import { PROTECTION_BYPASS_USER_COMMANDS } from "~/services/protectionBypass/contracts"
 import { AuthTypeEnum } from "~/types"
 import {
   CHANNEL_MUTATION_SCENARIOS,
   testManagedSiteChannelMutationContract,
   type ChannelMutationScenario,
 } from "~~/tests/services/apiAdapters/managedSites/channelMutationContract"
+import { userCommandExecution } from "~~/tests/services/protectionBypass/fixtures"
 import { modelResourceRef } from "~~/tests/test-utils/managedModelResource"
 import {
   buildManagedResourceMatchCandidate,
@@ -501,6 +503,52 @@ describe("DoneHub managed-site channel capability", () => {
       newApiKeyManagement.doneHubKeyManagement.fetchAvailableModels,
     ).toHaveBeenCalledWith(request)
   })
+
+  it.each(["fetch", "hydrate"])(
+    "cancels DoneHub matching %s reads without reading more keys",
+    async (mode) => {
+      const { doneHubManagedSiteCapabilities } = await import(
+        "~/services/apiAdapters/managedSites/doneHub"
+      )
+      const controller = new AbortController()
+      const options = {
+        signal: controller.signal,
+        requestScheduling: { priority: "background" as const },
+        protectionBypassExecution: userCommandExecution(
+          PROTECTION_BYPASS_USER_COMMANDS.ManageApiKeys,
+        ),
+      }
+      const candidates = [7, 8].map((id) =>
+        buildManagedResourceMatchCandidate({
+          ref: matchingResourceRef(id, {
+            siteType: "done-hub",
+            scopeKey: config.baseUrl,
+          }),
+          key: "sk-***",
+        }),
+      )
+      doneHubApi.fetchChannelRaw.mockImplementationOnce(async (request) => {
+        expect(request.abortSignal).toBe(controller.signal)
+        expect(request.requestScheduling).toBe(options.requestScheduling)
+        controller.abort()
+        return { id: 7, key: "sk-canceled" }
+      })
+      const result =
+        mode === "fetch"
+          ? doneHubManagedSiteCapabilities.matching.fetchSecretKey!(
+              config,
+              candidates[0].ref,
+              options,
+            )
+          : doneHubManagedSiteCapabilities.matching.hydrateComparableKeys!(
+              config,
+              candidates,
+              options,
+            )
+      await expect(result).rejects.toMatchObject({ name: "AbortError" })
+      expect(doneHubApi.fetchChannelRaw).toHaveBeenCalledOnce()
+    },
+  )
 
   it("preserves complete DoneHub matching references when hydrating native channel secrets", async () => {
     const { doneHubManagedSiteCapabilities } = await import(

--- a/tests/services/apiAdapters/managedSites/doneHub.test.ts
+++ b/tests/services/apiAdapters/managedSites/doneHub.test.ts
@@ -489,6 +489,14 @@ describe("DoneHub managed-site channel capability", () => {
     )
 
     expect(doneHubApi.fetchSiteUserGroups).toHaveBeenCalledWith(request)
+    const controller = new AbortController()
+    await doneHubManagedSiteCapabilities.queries.siteUserGroups!.fetch(config, {
+      signal: controller.signal,
+    })
+    expect(doneHubApi.fetchSiteUserGroups).toHaveBeenLastCalledWith({
+      ...request,
+      abortSignal: controller.signal,
+    })
     expect(
       newApiKeyManagement.doneHubKeyManagement.fetchAvailableModels,
     ).toHaveBeenCalledWith(request)

--- a/tests/services/apiAdapters/managedSites/nativeMatching.test.ts
+++ b/tests/services/apiAdapters/managedSites/nativeMatching.test.ts
@@ -25,6 +25,7 @@ import {
 } from "~/services/managedSites/providers/sub2api"
 import { PROTECTION_BYPASS_USER_COMMANDS } from "~/services/protectionBypass/contracts"
 import { userCommandExecution } from "~~/tests/services/protectionBypass/fixtures"
+import { createDeferred } from "~~/tests/test-utils/deferred"
 import {
   buildManagedResourceMatchCandidate,
   matchingResourceRef,
@@ -78,6 +79,60 @@ const secretProviders = [
 
 describe("native managed-resource matching", () => {
   beforeEach(() => vi.clearAllMocks())
+
+  it("shares the complete AxonHub pagination across different upstream URLs", async () => {
+    const page =
+      createDeferred<Awaited<ReturnType<typeof listAxonHubChannelPage>>>()
+    vi.mocked(listAxonHubChannelPage)
+      .mockReturnValueOnce(page.promise)
+      .mockResolvedValue({ items: [] })
+    const matching = axonHubManagedSiteCapabilities.matching
+    const first = matching.search(axonConfig, "https://first.example")
+    const second = matching.search({ ...axonConfig }, "https://second.example")
+    expect(listAxonHubChannelPage).toHaveBeenCalledTimes(1)
+    page.resolve({ items: [], nextCursor: "last-page" })
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      { items: [], total: 0, type_counts: {} },
+      { items: [], total: 0, type_counts: {} },
+    ])
+    expect(listAxonHubChannelPage).toHaveBeenCalledTimes(2)
+  })
+
+  it.each([
+    {
+      site: "Sub2API",
+      read: vi.mocked(listSub2ApiApiKeyAccounts),
+      search: (url: string) =>
+        sub2ApiManagedSiteCapabilities.matching.search(subConfig, url),
+    },
+    {
+      site: "Veloera",
+      read: vi.mocked(listAllChannels),
+      search: (url: string) =>
+        veloeraManagedSiteCapabilities.matching.search(
+          { ...subConfig, userId: "1" },
+          url,
+        ),
+    },
+  ])(
+    "shares $site inventory across different upstream URLs",
+    async ({ read, search }) => {
+      const inventory = createDeferred<{
+        items: never[]
+        total: number
+        type_counts: Record<string, number>
+      }>()
+      read.mockReturnValue(inventory.promise)
+      const first = search("https://first.example")
+      const second = search("https://second.example")
+      expect(read).toHaveBeenCalledTimes(1)
+      inventory.resolve({ items: [], total: 0, type_counts: {} })
+      await expect(Promise.all([first, second])).resolves.toEqual([
+        { items: [], total: 0, type_counts: {} },
+        { items: [], total: 0, type_counts: {} },
+      ])
+    },
+  )
 
   it.each(secretProviders)(
     "validates the entire $capabilities.siteType hydration selection before revealing its first key",
@@ -175,10 +230,14 @@ describe("native managed-resource matching", () => {
         PROTECTION_BYPASS_USER_COMMANDS.ManageSiteChannels,
       ),
     })
-    expect(listAxonHubChannelPage).toHaveBeenLastCalledWith(axonConfig, {
-      cursor: "page-2",
-      limit: 100,
-    })
+    expect(listAxonHubChannelPage).toHaveBeenLastCalledWith(
+      axonConfig,
+      {
+        cursor: "page-2",
+        limit: 100,
+      },
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    )
     expect(result.key.channel).toEqual({
       ref: matchingResourceRef("Channel:opaque-id", {
         siteType: SITE_TYPES.AXON_HUB,
@@ -285,6 +344,7 @@ describe("native managed-resource matching", () => {
       "https://upstream.example",
     )
     expect(listAllChannels).toHaveBeenCalledWith(expect.anything(), {
+      signal: expect.any(AbortSignal),
       requireCompleteInventory: true,
     })
     expect(result?.items[0]).not.toHaveProperty("balance")
@@ -581,8 +641,18 @@ describe("native managed-resource matching", () => {
     ).resolves.toEqual([{ ...masked, key: "hydrated-key" }, usable])
     expect(masked.key).toBe("********")
     expect(getUnmaskedProviderKey).toHaveBeenCalledTimes(2)
-    expect(getUnmaskedProviderKey).toHaveBeenNthCalledWith(1, subConfig, 7)
-    expect(getUnmaskedProviderKey).toHaveBeenNthCalledWith(2, subConfig, 8)
+    expect(getUnmaskedProviderKey).toHaveBeenNthCalledWith(
+      1,
+      subConfig,
+      7,
+      undefined,
+    )
+    expect(getUnmaskedProviderKey).toHaveBeenNthCalledWith(
+      2,
+      subConfig,
+      8,
+      undefined,
+    )
   })
 
   it("redacts the Claude Code Hub admin key from failed matching reads", async () => {

--- a/tests/services/apiAdapters/managedSites/octopus.test.ts
+++ b/tests/services/apiAdapters/managedSites/octopus.test.ts
@@ -139,7 +139,11 @@ describe("Octopus managed-site channel capability", () => {
       total: 2,
       type_counts: {},
     })
-    expect(octopusApi.searchChannels).toHaveBeenCalledWith(config, "upstream")
+    expect(octopusApi.searchChannels).toHaveBeenCalledWith(
+      config,
+      "upstream",
+      undefined,
+    )
   })
 
   it("updates scheduled model lists through the common mutation boundary without changing the payload", async () => {

--- a/tests/services/apiAdapters/managedSites/veloera.test.ts
+++ b/tests/services/apiAdapters/managedSites/veloera.test.ts
@@ -557,6 +557,14 @@ describe("Veloera managed-site channel capability", () => {
     }
 
     await veloeraManagedSiteCapabilities.queries.siteUserGroups!.fetch(config)
+    const controller = new AbortController()
+    await veloeraManagedSiteCapabilities.queries.siteUserGroups!.fetch(config, {
+      signal: controller.signal,
+    })
+    expect(keyManagement.fetchSiteUserGroups).toHaveBeenLastCalledWith({
+      ...request,
+      abortSignal: controller.signal,
+    })
     await veloeraManagedSiteCapabilities.queries.accountAvailableModels!.fetch(
       config,
     )

--- a/tests/services/apiService/octopus.index.test.ts
+++ b/tests/services/apiService/octopus.index.test.ts
@@ -42,6 +42,7 @@ import {
   type OctopusUpdateChannelInput,
   type OctopusUpdateChannelRequest,
 } from "~/types/octopus"
+import { createDeferred } from "~~/tests/test-utils/deferred"
 
 const {
   mockGetValidSession,
@@ -1888,6 +1889,67 @@ describe("Octopus API service", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2)
     expect(mockGetValidSession).toHaveBeenCalledTimes(2)
     expect(mockClearCache).toHaveBeenCalledTimes(1)
+  })
+
+  it("shares pending search inventories while filtering each keyword independently", async () => {
+    const response = createDeferred<Response>()
+    const fetchMock = vi.fn().mockReturnValue(response.promise)
+    vi.stubGlobal("fetch", fetchMock)
+    const first = searchChannels(config, "first.example")
+    const second = searchChannels({ ...config }, "SECONDARY.EXAMPLE")
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalled())
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    response.resolve(
+      new Response(
+        JSON.stringify({
+          success: true,
+          data: [
+            {
+              id: 1,
+              name: "First",
+              base_urls: [{ url: "https://first.example" }],
+            },
+            {
+              id: 2,
+              name: "Second",
+              base_urls: [
+                { url: "https://other.example" },
+                { url: "https://secondary.example" },
+              ],
+            },
+          ],
+        }),
+        { headers: { "Content-Type": "application/json" } },
+      ),
+    )
+    await expect(first).resolves.toMatchObject([{ id: 1 }])
+    await expect(second).resolves.toMatchObject([{ id: 2 }])
+  })
+
+  it("keeps search inventories separate for different protection execution intents", async () => {
+    const gate = createDeferred<void>()
+    const fetchMock = vi.fn().mockImplementation(async () => {
+      await gate.promise
+      return new Response(JSON.stringify({ success: true, data: [] }), {
+        headers: { "Content-Type": "application/json" },
+      })
+    })
+    vi.stubGlobal("fetch", fetchMock)
+    const searches = [
+      PROTECTION_BYPASS_SURFACES.Options,
+      PROTECTION_BYPASS_SURFACES.Background,
+    ].map((surface) =>
+      searchChannels(config, "", {
+        protectionBypassExecution: createAutomaticProtectionBypassExecution(
+          PROTECTION_BYPASS_FEATURES.ManagedSiteChannels,
+          PROTECTION_BYPASS_AUTOMATIC_TRIGGERS.BackgroundRecovery,
+          surface,
+        ),
+      }),
+    )
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
+    gate.resolve()
+    await expect(Promise.all(searches)).resolves.toEqual([[], []])
   })
 
   it("filters searched channels by trimmed name and upstream URL without matching secrets", async () => {

--- a/tests/services/apiTransport/request.test.ts
+++ b/tests/services/apiTransport/request.test.ts
@@ -416,6 +416,26 @@ describe("apiTransport request helpers", () => {
     expect(capturedAuthorization).toBe("manual-header")
   })
 
+  it("preserves live scheduling intent through transport admission", async () => {
+    server.use(
+      http.get("https://priority.example/api/user/self", () =>
+        HttpResponse.json({ success: true, data: {} }),
+      ),
+    )
+    const requestScheduling = {
+      priority: "background" as "background" | "foreground",
+    }
+    await fetchApiData(
+      {
+        baseUrl: "https://priority.example",
+        auth: { authType: AuthTypeEnum.AccessToken, accessToken: "token" },
+        requestScheduling,
+      },
+      { endpoint: "/api/user/self" },
+    )
+    expect(mockWithSiteApiRequestLimit.mock.calls[0][3]).toBe(requestScheduling)
+  })
+
   it("fetchApiData applies the site API limiter with a normalized origin key", async () => {
     server.use(
       http.get(/^https:\/\/example\.com\/base\//, () => {
@@ -441,6 +461,7 @@ describe("apiTransport request helpers", () => {
     expect(mockWithSiteApiRequestLimit).toHaveBeenCalledWith(
       "https://example.com",
       expect.any(Function),
+      undefined,
       undefined,
     )
   })
@@ -499,6 +520,7 @@ describe("apiTransport request helpers", () => {
         "https://example.invalid",
         expect.any(Function),
         expectedSignal,
+        undefined,
       )
     },
   )
@@ -724,6 +746,7 @@ describe("apiTransport request helpers", () => {
         "https://example.invalid",
         expect.any(Function),
         abortDeadline.signal,
+        undefined,
       )
 
       await vi.advanceTimersByTimeAsync(1_000)
@@ -4126,6 +4149,7 @@ describe("apiTransport request helpers", () => {
       expect(mockWithSiteApiRequestLimit).toHaveBeenCalledWith(
         "https://example.com",
         expect.any(Function),
+        undefined,
         undefined,
       )
 

--- a/tests/services/apiTransport/requestScheduling.test.ts
+++ b/tests/services/apiTransport/requestScheduling.test.ts
@@ -7,6 +7,22 @@ describe("shared scheduled reads", () => {
   beforeEach(() => vi.useFakeTimers())
   afterEach(() => vi.useRealTimers())
 
+  it("shares synchronous executor failures and detaches rejected consumers", async () => {
+    const error = new Error("request setup failed")
+    const execute = vi.fn(() => {
+      throw error
+    })
+    const read = new SharedRead(execute)
+    const controller = new AbortController()
+    await Promise.all([
+      expect(read.read({ signal: controller.signal })).rejects.toBe(error),
+      expect(read.read()).rejects.toBe(error),
+    ])
+    expect(execute).toHaveBeenCalledTimes(1)
+    controller.abort()
+    expect(read.signal.aborted).toBe(false)
+  })
+
   it("promotes a queued list lookup for export and keeps it when the list unmounts", async () => {
     const limit = createSiteRequestLimiter({
       maxConcurrentPerSite: 1,

--- a/tests/services/apiTransport/requestScheduling.test.ts
+++ b/tests/services/apiTransport/requestScheduling.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { SharedRead } from "~/services/apiTransport/requestScheduling"
+import { createSiteRequestLimiter } from "~/services/apiTransport/siteRequestLimiter"
+
+describe("shared scheduled reads", () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => vi.useRealTimers())
+
+  it("promotes a queued list lookup for export and keeps it when the list unmounts", async () => {
+    const limit = createSiteRequestLimiter({
+      maxConcurrentPerSite: 1,
+      requestsPerMinute: 60,
+      burst: 1,
+    })
+    const events: string[] = []
+    await limit("site", async () => {})
+    const background = limit(
+      "site",
+      async () => {
+        events.push("other-check")
+      },
+      undefined,
+      { priority: "background" },
+    )
+    const fetch = vi.fn(async () => {
+      events.push("export")
+      return "models"
+    })
+    const read = new SharedRead(({ signal, requestScheduling }) =>
+      limit("site", fetch, signal, requestScheduling),
+    )
+    const controller = new AbortController()
+    const automatic = read.read({
+      signal: controller.signal,
+      requestScheduling: { priority: "background" },
+    })
+    const canceled = expect(automatic).rejects.toMatchObject({
+      name: "AbortError",
+    })
+    const exported = read.read()
+    controller.abort()
+    await canceled
+    expect(read.signal.aborted).toBe(false)
+    await vi.advanceTimersByTimeAsync(1000)
+    await expect(exported).resolves.toBe("models")
+    expect(events).toEqual(["export"])
+    expect(fetch).toHaveBeenCalledTimes(1)
+    await vi.advanceTimersByTimeAsync(1000)
+    await background
+  })
+
+  it("removes orphaned queued reads without consuming the next rate-limit token", async () => {
+    const limit = createSiteRequestLimiter({
+      maxConcurrentPerSite: 1,
+      requestsPerMinute: 60,
+      burst: 1,
+    })
+    await limit("site", async () => {})
+    const fetch = vi.fn(async () => "unused")
+    const read = new SharedRead(({ signal, requestScheduling }) =>
+      limit("site", fetch, signal, requestScheduling),
+    )
+    const controller = new AbortController()
+    const pending = read.read({
+      signal: controller.signal,
+      requestScheduling: { priority: "background" },
+    })
+    const canceled = expect(pending).rejects.toMatchObject({
+      name: "AbortError",
+    })
+    controller.abort()
+    await canceled
+    const next = vi.fn(async () => "export")
+    const exported = limit("site", next)
+    await vi.advanceTimersByTimeAsync(1000)
+    await expect(exported).resolves.toBe("export")
+    expect(fetch).not.toHaveBeenCalled()
+    expect(next).toHaveBeenCalledTimes(1)
+  })
+
+  it("waits for every consumer to detach before aborting shared work", async () => {
+    const execute = vi.fn(
+      ({ signal }: { signal: AbortSignal }) =>
+        new Promise<string>((_, reject) => {
+          signal.addEventListener("abort", () => reject(signal.reason), {
+            once: true,
+          })
+        }),
+    )
+    const read = new SharedRead(execute)
+    const a = new AbortController()
+    const b = new AbortController()
+    const first = expect(read.read({ signal: a.signal })).rejects.toMatchObject(
+      { name: "AbortError" },
+    )
+    const second = expect(
+      read.read({ signal: b.signal }),
+    ).rejects.toMatchObject({ name: "AbortError" })
+    a.abort()
+    expect(read.signal.aborted).toBe(false)
+    b.abort()
+    expect(read.signal.aborted).toBe(true)
+    await Promise.all([first, second])
+    expect(execute).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/services/apiTransport/siteRequestLimiter.test.ts
+++ b/tests/services/apiTransport/siteRequestLimiter.test.ts
@@ -81,6 +81,101 @@ describe("createSiteRequestLimiter", () => {
     ])
   })
 
+  it("dispatches an export before queued automatic checks without bypassing rate limits", async () => {
+    const limiter = createSiteRequestLimiter({
+      maxConcurrentPerSite: 1,
+      requestsPerMinute: 60,
+      burst: 1,
+    })
+    const events: string[] = []
+    const first = limiter("site", async () => {
+      events.push("active")
+    })
+    const background = limiter(
+      "site",
+      async () => {
+        events.push("automatic")
+      },
+      undefined,
+      { priority: "background" },
+    )
+    const exported = limiter("site", async () => {
+      events.push("export")
+    })
+    await first
+    await vi.advanceTimersByTimeAsync(999)
+    expect(events).toEqual(["active"])
+    await vi.advanceTimersByTimeAsync(1)
+    expect(events).toEqual(["active", "export"])
+    await vi.advanceTimersByTimeAsync(1000)
+    await Promise.all([background, exported])
+    expect(events).toEqual(["active", "export", "automatic"])
+  })
+
+  it("starts export at the next refill despite twenty waiting automatic checks", async () => {
+    const limiter = createSiteRequestLimiter({
+      maxConcurrentPerSite: 1,
+      requestsPerMinute: 60,
+      burst: 1,
+    })
+    await limiter("site", async () => {})
+    const pending = Array.from({ length: 20 }, () =>
+      limiter("site", async () => {}, undefined, { priority: "background" }),
+    )
+    const start = Date.now()
+    const dispatch = vi.fn(async () => Date.now() - start)
+    const exported = limiter("site", dispatch)
+    await vi.advanceTimersByTimeAsync(999)
+    expect(dispatch).not.toHaveBeenCalled()
+    await vi.advanceTimersByTimeAsync(1)
+    await expect(exported).resolves.toBe(1000)
+    await vi.advanceTimersByTimeAsync(20_000)
+    await Promise.all(pending)
+  })
+
+  it("observes promotion of shared queued work and gives background work bounded turns", async () => {
+    const limiter = createSiteRequestLimiter({
+      maxConcurrentPerSite: 1,
+      requestsPerMinute: 60,
+      burst: 1,
+    })
+    const events: string[] = []
+    const scheduling = { priority: "background" as "background" | "foreground" }
+    const requests = [limiter("site", async () => {})]
+    requests.push(
+      limiter(
+        "site",
+        async () => {
+          events.push("background")
+        },
+        undefined,
+        { priority: "background" },
+      ),
+    )
+    requests.push(
+      limiter(
+        "site",
+        async () => {
+          events.push("shared-export")
+        },
+        undefined,
+        scheduling,
+      ),
+    )
+    for (let i = 0; i < 8; i++)
+      requests.push(
+        limiter("site", async () => {
+          events.push(`foreground-${i}`)
+        }),
+      )
+    scheduling.priority = "foreground"
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(events[0]).toBe("shared-export")
+    await vi.advanceTimersByTimeAsync(10_000)
+    await Promise.all(requests)
+    expect(events.indexOf("background")).toBeLessThanOrEqual(5)
+  })
+
   it("keeps FIFO order for queued same-site work", async () => {
     const limiter = createSiteRequestLimiter({
       maxConcurrentPerSite: 1,

--- a/tests/services/doneHubService/doneHubService.more.test.ts
+++ b/tests/services/doneHubService/doneHubService.more.test.ts
@@ -86,6 +86,7 @@ describe("doneHubService additional flows", () => {
         baseUrl: "https://proxy.example.com",
         apiKey: "done-hub-key",
       }),
+      undefined,
     )
     expect(mockResolveDefaultChannelGroups).toHaveBeenCalled()
     expect(result).toMatchObject({
@@ -170,6 +171,7 @@ describe("doneHubService additional flows", () => {
         baseUrl: "https://aihubmix.com",
         apiKey: token.key,
       }),
+      undefined,
     )
     expect(result.base_url).toBe("https://aihubmix.com")
   })

--- a/tests/services/managedSites/channelMatchResolver.test.ts
+++ b/tests/services/managedSites/channelMatchResolver.test.ts
@@ -14,7 +14,10 @@ import {
   resolveManagedSiteChannelMatch as resolveManagedSiteChannelMatchImpl,
 } from "~/services/managedSites/channelMatchResolver"
 import { getManagedResourceRefKey } from "~/services/managedSites/managedResourceIdentity"
-import type { ManagedResourceMatchCandidate } from "~/types/managedResourceMatching"
+import type {
+  ManagedResourceMatchCandidate,
+  ManagedResourceMatchList,
+} from "~/types/managedResourceMatching"
 import {
   buildManagedResourceMatchCandidate,
   matchingResourceRef,
@@ -154,6 +157,7 @@ describe("resolveManagedSiteChannelMatch", () => {
     expect(searchChannel).toHaveBeenCalledWith(
       managedConfig,
       "https://api.example.com",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
     )
     expect(getManagedSiteChannelExactMatch(result)?.ref).toEqual(
       matchingResourceRef(65),
@@ -1040,6 +1044,74 @@ describe("resolveManagedSiteChannelMatch", () => {
     },
   )
 
+  it("shares pending searches across list and export contexts but refreshes completed searches", async () => {
+    let finish!: (value: ManagedResourceMatchList) => void
+    const search = vi.fn(
+      () =>
+        new Promise<ManagedResourceMatchList>((resolve) => {
+          finish = resolve
+        }),
+    )
+    const managedSite = createManagedSiteCapabilitiesStub({
+      matching: { search },
+    })
+    const params = {
+      managedSite,
+      managedConfig,
+      accountBaseUrl: "https://api.example.com",
+      models: [],
+    }
+    const first = resolveManagedSiteChannelMatch({
+      ...params,
+      requestCache: createManagedSiteChannelMatchRequestCache(),
+    })
+    const second = resolveManagedSiteChannelMatch({
+      ...params,
+      requestCache: createManagedSiteChannelMatchRequestCache(),
+    })
+    expect(search).toHaveBeenCalledTimes(1)
+    finish({ items: [], total: 0, type_counts: {} })
+    await Promise.all([first, second])
+    const fresh = resolveManagedSiteChannelMatch(params)
+    expect(search).toHaveBeenCalledTimes(2)
+    finish({ items: [], total: 0, type_counts: {} })
+    await fresh
+  })
+
+  it("isolates pending searches by credentials and discards rejected searches", async () => {
+    let reject!: (error: Error) => void
+    const search = vi.fn(
+      () =>
+        new Promise<null>((_, fail) => {
+          reject = fail
+        }),
+    )
+    const managedSite = createManagedSiteCapabilitiesStub({
+      matching: { search },
+    })
+    const params = {
+      managedSite,
+      managedConfig,
+      accountBaseUrl: "https://api.example.com",
+      models: [],
+    }
+    const first = resolveManagedSiteChannelMatch(params)
+    const firstFailure = expect(first).rejects.toThrow("offline")
+    const rejectFirst = reject
+    const isolated = resolveManagedSiteChannelMatch({
+      ...params,
+      managedConfig: { ...managedConfig, adminToken: "changed-token" },
+    })
+    const isolatedFailure = expect(isolated).rejects.toThrow("offline")
+    expect(search).toHaveBeenCalledTimes(2)
+    rejectFirst(new Error("offline"))
+    reject(new Error("offline"))
+    await Promise.all([firstFailure, isolatedFailure])
+    search.mockResolvedValueOnce(null)
+    await resolveManagedSiteChannelMatch(params)
+    expect(search).toHaveBeenCalledTimes(3)
+  })
+
   it("reuses cached channel searches and hidden-key resolutions across concurrent match checks", async () => {
     const maskedCandidate = buildManagedResourceMatchCandidate({
       ref: matchingResourceRef(72),
@@ -1104,8 +1176,9 @@ describe("resolveManagedSiteChannelMatch", () => {
       total: 1,
       type_counts: {},
     })
-    await Promise.resolve()
-    expect(fetchChannelSecretKey).toHaveBeenCalledTimes(1)
+    await vi.waitFor(() =>
+      expect(fetchChannelSecretKey).toHaveBeenCalledTimes(1),
+    )
 
     resolveSecret("sk-match")
     const results = await Promise.all([firstResultPromise, secondResultPromise])

--- a/tests/services/managedSites/fetchManagedSiteImportModels.test.ts
+++ b/tests/services/managedSites/fetchManagedSiteImportModels.test.ts
@@ -16,6 +16,90 @@ describe("fetchManagedSiteImportModels", () => {
     fetchOpenAICompatibleModelIdsMock.mockReset()
   })
 
+  it("shares pending reads but fetches fresh models immediately after completion", async () => {
+    let resolve!: (models: string[]) => void
+    fetchOpenAICompatibleModelIdsMock.mockImplementationOnce(
+      () =>
+        new Promise<string[]>((done) => {
+          resolve = done
+        }),
+    )
+    const source = {
+      baseUrl: "https://shared.example.com",
+      apiKey: "sk-shared",
+    }
+    const automatic = fetchManagedSiteImportModels(source)
+    const exportSource = {
+      ...source,
+      name: "Export draft",
+      modelHints: ["hint"],
+    }
+    const exported = fetchManagedSiteImportModels(exportSource)
+    expect(fetchOpenAICompatibleModelIdsMock).toHaveBeenCalledTimes(1)
+    resolve(["gpt-4o"])
+    const [first, second] = await Promise.all([automatic, exported])
+    first.models.push("local-edit")
+    expect(second.models).toEqual(["gpt-4o"])
+    fetchOpenAICompatibleModelIdsMock.mockResolvedValueOnce(["new-model"])
+    expect((await fetchManagedSiteImportModels(source)).models).toEqual([
+      "new-model",
+    ])
+    expect(fetchOpenAICompatibleModelIdsMock).toHaveBeenCalledTimes(2)
+  })
+
+  it("promotes shared model discovery and preserves export when its automatic consumer cancels", async () => {
+    let finish!: (models: string[]) => void
+    fetchOpenAICompatibleModelIdsMock.mockImplementationOnce(
+      () =>
+        new Promise<string[]>((resolve) => {
+          finish = resolve
+        }),
+    )
+    const source = {
+      baseUrl: "https://promoted.example",
+      apiKey: "sk-promoted",
+    }
+    const controller = new AbortController()
+    const automatic = fetchManagedSiteImportModels(source, {
+      signal: controller.signal,
+      requestScheduling: { priority: "background" },
+    })
+    const canceled = expect(automatic).rejects.toMatchObject({
+      name: "AbortError",
+    })
+    const request = fetchOpenAICompatibleModelIdsMock.mock.calls[0][0]
+    expect(request.requestScheduling.priority).toBe("background")
+    const exported = fetchManagedSiteImportModels(source)
+    expect(request.requestScheduling.priority).toBe("foreground")
+    controller.abort()
+    await canceled
+    expect(request.abortSignal.aborted).toBe(false)
+    finish(["model"])
+    expect((await exported).models).toEqual(["model"])
+    expect(fetchOpenAICompatibleModelIdsMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("isolates source paths and credentials and retries failed lookups", async () => {
+    fetchOpenAICompatibleModelIdsMock.mockRejectedValueOnce(
+      new Error("offline"),
+    )
+    const source = {
+      baseUrl: "https://isolated.example.com/v1",
+      apiKey: "sk-a",
+    }
+    expect((await fetchManagedSiteImportModels(source)).fetchFailed).toBe(true)
+    fetchOpenAICompatibleModelIdsMock.mockResolvedValue(["model"])
+    await Promise.all([
+      fetchManagedSiteImportModels(source),
+      fetchManagedSiteImportModels({ ...source, apiKey: "sk-b" }),
+      fetchManagedSiteImportModels({
+        ...source,
+        baseUrl: "https://isolated.example.com/other",
+      }),
+    ])
+    expect(fetchOpenAICompatibleModelIdsMock).toHaveBeenCalledTimes(4)
+  })
+
   it("normalizes the fetched upstream model list for the selected token", async () => {
     fetchOpenAICompatibleModelIdsMock.mockResolvedValueOnce([
       " gpt-4o ",
@@ -34,10 +118,13 @@ describe("fetchManagedSiteImportModels", () => {
       fetchFailed: false,
     })
 
-    expect(fetchOpenAICompatibleModelIdsMock).toHaveBeenCalledWith({
-      baseUrl: "https://example.com",
-      apiKey: "sk-token",
-    })
+    expect(fetchOpenAICompatibleModelIdsMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        baseUrl: "https://example.com",
+        apiKey: "sk-token",
+        abortSignal: expect.any(AbortSignal),
+      }),
+    )
   })
 
   it("returns a structured fetch failure when the upstream lookup throws", async () => {

--- a/tests/services/managedSites/providers/axonHub.test.ts
+++ b/tests/services/managedSites/providers/axonHub.test.ts
@@ -117,7 +117,10 @@ describe("AxonHub managed-site provider", () => {
       }),
     )
 
-    expect(mockFetchManagedSiteImportModels).toHaveBeenCalledWith(source)
+    expect(mockFetchManagedSiteImportModels).toHaveBeenCalledWith(
+      source,
+      undefined,
+    )
   })
 
   it("uses the AIHubMix API origin for managed-site channel imports", async () => {
@@ -149,6 +152,7 @@ describe("AxonHub managed-site provider", () => {
         baseUrl: "https://aihubmix.com",
         apiKey: token.key,
       }),
+      undefined,
     )
   })
 

--- a/tests/services/managedSites/providers/claudeCodeHub.test.ts
+++ b/tests/services/managedSites/providers/claudeCodeHub.test.ts
@@ -197,6 +197,7 @@ describe("Claude Code Hub managed-site provider", () => {
         baseUrl: "https://aihubmix.com",
         apiKey: token.key,
       }),
+      undefined,
     )
   })
 
@@ -291,6 +292,7 @@ describe("Claude Code Hub managed-site provider", () => {
     expect(mockGetUnmaskedProviderKey).toHaveBeenCalledWith(
       passedClaudeCodeHubConfig,
       42,
+      undefined,
     )
   })
 
@@ -314,6 +316,7 @@ describe("Claude Code Hub managed-site provider", () => {
     const failure = await fetchChannelSecretKey(
       passedClaudeCodeHubConfig,
       42,
+      undefined,
     ).catch((error: unknown) => error)
 
     expect(failure).toBeInstanceOf(Error)
@@ -378,6 +381,7 @@ describe("Claude Code Hub managed-site provider", () => {
     expect(mockGetUnmaskedProviderKey).toHaveBeenCalledWith(
       passedClaudeCodeHubConfig,
       31,
+      undefined,
     )
   })
 

--- a/tests/services/managedSites/providers/claudeCodeHub.test.ts
+++ b/tests/services/managedSites/providers/claudeCodeHub.test.ts
@@ -296,6 +296,20 @@ describe("Claude Code Hub managed-site provider", () => {
     )
   })
 
+  it("preserves cancellation when a provider key read rejects", async () => {
+    const controller = new AbortController()
+    const reason = new DOMException("Canceled key read", "AbortError")
+    mockGetUnmaskedProviderKey.mockImplementationOnce(async () => {
+      controller.abort(reason)
+      throw reason
+    })
+    await expect(
+      fetchChannelSecretKey(passedClaudeCodeHubConfig, 42, {
+        signal: controller.signal,
+      }),
+    ).rejects.toBe(reason)
+  })
+
   it("surfaces provider key reveal failures from edit flows", async () => {
     mockGetPreferences.mockResolvedValue({
       claudeCodeHub: storedClaudeCodeHubConfig,

--- a/tests/services/managedSites/providers/defaultChannelGroups.test.ts
+++ b/tests/services/managedSites/providers/defaultChannelGroups.test.ts
@@ -7,6 +7,22 @@ describe("resolveDefaultChannelGroups", () => {
     vi.clearAllMocks()
   })
 
+  it("does not fetch import-only groups for a status assessment", async () => {
+    const { resolveDefaultChannelGroups } = await import(
+      "~/services/managedSites/providers/defaultChannelGroups"
+    )
+    const getConfig = vi.fn()
+    expect(
+      await resolveDefaultChannelGroups({
+        getConfig,
+        fetchSiteUserGroups: mockFetchSiteUserGroups,
+        purpose: "matching",
+      }),
+    ).toEqual(["default"])
+    expect(getConfig).not.toHaveBeenCalled()
+    expect(mockFetchSiteUserGroups).not.toHaveBeenCalled()
+  })
+
   it("prefers the managed site's default group case-insensitively", async () => {
     const { resolveDefaultChannelGroups } = await import(
       "~/services/managedSites/providers/defaultChannelGroups"

--- a/tests/services/managedSites/tokenChannelStatus.test.ts
+++ b/tests/services/managedSites/tokenChannelStatus.test.ts
@@ -510,7 +510,7 @@ describe("getManagedSiteTokenChannelStatus", () => {
       })
       expect(managedSite.channelDrafts.prepareFormData).toHaveBeenCalledWith(
         expect.objectContaining({ baseUrl, apiKey: secret }),
-        expect.anything(),
+        expect.objectContaining({ purpose: "matching" }),
       )
       expect(resolveDisplayAccountRuntimeKeySecretMock).not.toHaveBeenCalled()
     },

--- a/tests/services/modelSync/runModelSyncBatch.test.ts
+++ b/tests/services/modelSync/runModelSyncBatch.test.ts
@@ -18,6 +18,32 @@ const resultFor = (id: number): ExecutionItemResult => ({
 })
 
 describe("runModelSyncBatch", () => {
+  it("serializes delayed progress persistence in completion order", async () => {
+    const gate = createDeferred<void>()
+    const firstStarted = createDeferred<void>()
+    const persisted: number[] = []
+    const onProgress = vi.fn(async ({ completed }: { completed: number }) => {
+      if (completed === 1) {
+        firstStarted.resolve()
+        await gate.promise
+      }
+      persisted.push(completed)
+    })
+    const batch = runModelSyncBatch(
+      [1, 2],
+      { concurrency: 2, onProgress },
+      async (id) => resultFor(id),
+    )
+    await firstStarted.promise
+    try {
+      expect(onProgress).toHaveBeenCalledTimes(1)
+    } finally {
+      gate.resolve()
+      await batch
+    }
+    expect(persisted).toEqual([1, 2])
+  })
+
   it("does not dispatch the next channel until progress persistence finishes", async () => {
     const gate = createDeferred<void>()
     const progressStarted = createDeferred<void>()
@@ -56,7 +82,8 @@ describe("runModelSyncBatch", () => {
         return resultFor(id)
       },
     )
-    await vi.waitFor(() => expect(started).toEqual([1, 2, 3]))
+    await vi.waitFor(() => expect(onProgress).toHaveBeenCalledTimes(1))
+    expect(started).toEqual([1, 2])
     const settled = vi.fn()
     void batch.then(settled)
     expect(settled).not.toHaveBeenCalled()

--- a/tests/services/modelSync/runModelSyncBatch.test.ts
+++ b/tests/services/modelSync/runModelSyncBatch.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { runModelSyncBatch } from "~/services/models/modelSync/runModelSyncBatch"
+import type { ExecutionItemResult } from "~/types/managedSiteModelSync"
+import { createDeferred } from "~~/tests/test-utils/deferred"
+
+const resultFor = (id: number): ExecutionItemResult => ({
+  resourceRef: {
+    siteType: "new-api",
+    kind: "channel",
+    scopeKey: "https://example.com",
+    resourceId: String(id),
+  },
+  channelName: String(id),
+  ok: id !== 2,
+  attempts: 1,
+  finishedAt: 1,
+})
+
+describe("runModelSyncBatch", () => {
+  it("does not dispatch the next channel until progress persistence finishes", async () => {
+    const gate = createDeferred<void>()
+    const progressStarted = createDeferred<void>()
+    const execute = vi.fn(async (id: number) => resultFor(id))
+    const batch = runModelSyncBatch(
+      [1, 2],
+      {
+        concurrency: 1,
+        onProgress: async ({ completed }) => {
+          if (completed === 1) {
+            progressStarted.resolve()
+            await gate.promise
+          }
+        },
+      },
+      execute,
+    )
+    await progressStarted.promise
+    expect(execute).toHaveBeenCalledTimes(1)
+    gate.resolve()
+    await batch
+    expect(execute).toHaveBeenCalledTimes(2)
+  })
+
+  it("holds each slot through progress persistence and preserves input order", async () => {
+    const gate = createDeferred<void>()
+    const started: number[] = []
+    const onProgress = vi.fn(async ({ lastResult }) => {
+      if (lastResult.channelName === "1") await gate.promise
+    })
+    const batch = runModelSyncBatch(
+      [1, 2, 3],
+      { concurrency: 2, onProgress },
+      async (id) => {
+        started.push(id)
+        return resultFor(id)
+      },
+    )
+    await vi.waitFor(() => expect(started).toEqual([1, 2, 3]))
+    const settled = vi.fn()
+    void batch.then(settled)
+    expect(settled).not.toHaveBeenCalled()
+    gate.resolve()
+    const result = await batch
+    expect(result.items).toEqual([1, 2, 3].map(resultFor))
+    expect(result.statistics).toMatchObject({
+      total: 3,
+      successCount: 2,
+      failureCount: 1,
+    })
+    expect(
+      onProgress.mock.calls.map(([progress]) => progress.completed),
+    ).toEqual([1, 2, 3])
+  })
+
+  it.each(["execute", "progress"])(
+    "rejects on %s failure while other workers continue",
+    async (failureAt) => {
+      const gate = createDeferred<void>()
+      const continued = createDeferred<void>()
+      const failure = new Error("failed")
+      const started: number[] = []
+      const batch = runModelSyncBatch(
+        [1, 2, 3],
+        {
+          concurrency: 2,
+          onProgress: ({ lastResult }) => {
+            if (failureAt === "progress" && lastResult.channelName === "1")
+              throw failure
+            if (lastResult.channelName === "3") continued.resolve()
+          },
+        },
+        async (id) => {
+          started.push(id)
+          if (id === 1 && failureAt === "execute") throw failure
+          if (id === 2) await gate.promise
+          return resultFor(id)
+        },
+      )
+      await expect(batch).rejects.toBe(failure)
+      expect(started).toEqual([1, 2])
+      gate.resolve()
+      await continued.promise
+      expect(started).toEqual([1, 2, 3])
+    },
+  )
+})

--- a/tests/services/newApiService/newApiService.test.ts
+++ b/tests/services/newApiService/newApiService.test.ts
@@ -1069,6 +1069,29 @@ describe("newApiService", () => {
   // ========================================================================
 
   describe("prepareChannelFormData", () => {
+    beforeEach(() => {
+      mockFetchOpenAICompatibleModelIds.mockReset()
+    })
+
+    it("skips destination group requests when preparing a status check", async () => {
+      const { prepareChannelFormData } = await import(
+        "~/services/managedSites/providers/newApi"
+      )
+      mockFetchOpenAICompatibleModelIds.mockResolvedValueOnce(["gpt-4"])
+      const result = await prepareChannelFormData(
+        {
+          name: "Check",
+          baseUrl: "https://status.example.com",
+          apiKey: "sk-status",
+          modelHints: [],
+        },
+        { purpose: "matching" },
+      )
+      expect(result.models).toEqual(["gpt-4"])
+      expect(mockFetchSiteUserGroups).not.toHaveBeenCalled()
+      expect(mockGetPreferences).not.toHaveBeenCalled()
+    })
+
     it("should prefer the target site's default group", async () => {
       const { prepareChannelFormData } = await import(
         "~/services/managedSites/providers/newApi"
@@ -1176,10 +1199,12 @@ describe("newApiService", () => {
         ),
       )
 
-      expect(mockFetchOpenAICompatibleModelIds).toHaveBeenCalledWith({
-        baseUrl: "https://aihubmix.com",
-        apiKey: token.key,
-      })
+      expect(mockFetchOpenAICompatibleModelIds).toHaveBeenCalledWith(
+        expect.objectContaining({
+          baseUrl: "https://aihubmix.com",
+          apiKey: token.key,
+        }),
+      )
       expect(result.base_url).toBe("https://aihubmix.com")
     })
 

--- a/tests/services/octopusService/octopusService.more.test.ts
+++ b/tests/services/octopusService/octopusService.more.test.ts
@@ -181,6 +181,7 @@ describe("octopus additional flows", () => {
         baseUrl: "https://aihubmix.com",
         apiKey: token.key,
       }),
+      undefined,
     )
     expect(result.base_url).toBe("https://aihubmix.com/v1")
   })

--- a/tests/services/veloeraService/veloeraService.test.ts
+++ b/tests/services/veloeraService/veloeraService.test.ts
@@ -276,10 +276,12 @@ describe("veloeraService", () => {
         ),
       )
 
-      expect(mockFetchOpenAICompatibleModelIds).toHaveBeenCalledWith({
-        baseUrl: "https://aihubmix.com",
-        apiKey: token.key,
-      })
+      expect(mockFetchOpenAICompatibleModelIds).toHaveBeenCalledWith(
+        expect.objectContaining({
+          baseUrl: "https://aihubmix.com",
+          apiKey: token.key,
+        }),
+      )
       expect(result.base_url).toBe("https://aihubmix.com")
     })
   })


### PR DESCRIPTION
Automatic key-status checks could delay explicit imports, repeat model and channel lookups, and retain stale matching evidence after refresh. Imports now receive request priority within existing site limits, while obsolete checks are canceled.

- Share pending model and channel inventory reads; completed reads do not become a cross-operation result cache.
- Invalidate resolved matching keys on refresh and prevent late responses from restoring stale status.
- Load destination groups only in the editor and propagate cancellation through DoneHub and Veloera, eliminating duplicate group requests.
- Consolidate batch concurrency and model-sync execution while preserving result order, progress persistence, and failure behavior.

Validation:
- Targeted Vitest suites passed.
- All 6 channel-dialog browser tests passed, including request-count checks for editing and importing.
- TypeScript, Knip, extension E2E build, and commit hooks passed.

No configuration or storage migration is required. Remote CI is pending.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added prioritized and cancellable managed-site requests for more responsive foreground actions.
  - Concurrent inventory and model lookups now share in-progress requests, reducing duplicate network activity.
  - Channel editors use live model information and avoid unnecessary destination-group lookups.
  - Managed-site matching and credential checks now respond more reliably to cancellation and configuration changes.
  - Model synchronization now provides bounded concurrency, progress reporting, and consolidated results.

- **Bug Fixes**
  - Prevented stale or canceled checks from affecting current key-status results.
  - Improved retry behavior after failed or canceled lookups.
  - Prevented duplicate channel-group requests when opening channel editors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->